### PR TITLE
feat(share): unify share sheet on select-then-send recipients model

### DIFF
--- a/mobile/lib/blocs/share_sheet/reportable_sites.dart
+++ b/mobile/lib/blocs/share_sheet/reportable_sites.dart
@@ -6,7 +6,6 @@
 /// [ShareSheetBloc].
 abstract class ShareSheetBlocReportableSites {
   static const String onContactsLoadRequested = '_onContactsLoadRequested';
-  static const String onQuickSendRequested = '_onQuickSendRequested';
   static const String onSendRequested = '_onSendRequested';
   static const String onSaveRequested = '_onSaveRequested';
   static const String onAddVideoToClipsRequested =

--- a/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
+++ b/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
@@ -204,7 +204,7 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
     if (state.selectedRecipients.isEmpty || state.isSending) return;
 
     // Deliberate compose-then-send: the awaited flow keeps a visible
-    // "sending" spinner (isSending) and surfaces failures in-sheet.
+    // "sending" spinner (isSending) and reports the outcome in-sheet.
     emit(state.copyWith(isSending: true, clearActionResult: true));
 
     try {
@@ -218,24 +218,41 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
         personalMessage: message?.isEmpty == true ? null : message,
       );
 
+      if (isClosed) return;
+
       final delivered = [
         for (final r in recipients)
           if (results[r.pubkey]?.success ?? false) r,
       ];
-      final failed = [
-        for (final r in recipients)
-          if (!(results[r.pubkey]?.success ?? false)) r,
-      ];
+      final failedCount = recipients.length - delivered.length;
 
-      if (failed.isEmpty) {
-        final single = recipients.length == 1 ? recipients.single : null;
+      // The send is dismiss-and-forget: a recipient publish that fails is
+      // already durably enqueued (VideoSharingService -> DmRepository.
+      // sendMessage enqueues before publish) and OutgoingDmRetryService
+      // replays the SAME rumor id on the next app-foreground. Re-sending from
+      // the sheet would mint a NEW rumor id the receiver can't dedup against
+      // that replay, double-delivering — so we never keep recipients selected
+      // for a manual retry. We report what was delivered and let the queue
+      // finish the rest.
+      if (delivered.isNotEmpty) {
+        if (failedCount > 0) {
+          Log.warning(
+            'Partial share: ${delivered.length} delivered, $failedCount '
+            'queued for background retry',
+            name: 'ShareSheetBloc',
+            category: LogCategory.ui,
+          );
+        }
+        final single = delivered.length == 1 && recipients.length == 1
+            ? delivered.single
+            : null;
         emit(
           state.copyWith(
             isSending: false,
             selectedRecipients: const [],
             actionResult: ShareSheetSendSuccess(
               recipientNames: [
-                for (final r in recipients) r.displayName ?? 'user',
+                for (final r in delivered) r.displayName ?? 'user',
               ],
               recipientPubkey: single?.pubkey,
               conversationId: single == null
@@ -245,23 +262,13 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
           ),
         );
       } else {
-        // Keep only the failed recipients selected so a retry doesn't
-        // re-send to people who already received the video.
         emit(
           state.copyWith(
             isSending: false,
-            selectedRecipients: failed,
+            selectedRecipients: const [],
             actionResult: ShareSheetSendFailure(),
           ),
         );
-        if (delivered.isNotEmpty) {
-          Log.warning(
-            'Partial share failure: ${delivered.length} delivered, '
-            '${failed.length} failed',
-            name: 'ShareSheetBloc',
-            category: LogCategory.ui,
-          );
-        }
       }
     } catch (e, stackTrace) {
       _addUnexpectedError(
@@ -274,8 +281,13 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
         name: 'ShareSheetBloc',
         category: LogCategory.ui,
       );
+      if (isClosed) return;
       emit(
-        state.copyWith(isSending: false, actionResult: ShareSheetSendFailure()),
+        state.copyWith(
+          isSending: false,
+          selectedRecipients: const [],
+          actionResult: ShareSheetSendFailure(),
+        ),
       );
     }
   }

--- a/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
+++ b/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
@@ -27,8 +27,8 @@ part 'share_sheet_state.dart';
 ///
 /// Manages:
 /// - Contact loading (recent + followed users)
-/// - Recipient selection
-/// - Quick-send and send-with-message flows
+/// - Recipient selection (select-then-send: tapping a contact only selects;
+///   the DM goes out on an explicit [ShareSheetSendRequested])
 /// - One-shot actions (save, copy link, copy JSON, copy event ID, share via)
 ///
 /// Emits [ShareSheetActionResult] as one-shot side effects for the UI
@@ -53,14 +53,6 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
        _videoClipImportService = videoClipImportService,
        super(const ShareSheetState()) {
     on<ShareSheetContactsLoadRequested>(_onContactsLoadRequested);
-    on<ShareSheetQuickSendRequested>(
-      _onQuickSendRequested,
-      // Concurrent (not droppable): each tap gives instant optimistic feedback
-      // and its send runs in the background, so tapping several people in a row
-      // confirms each immediately instead of dropping taps during an in-flight
-      // send. See #5391.
-      transformer: concurrent(),
-    );
     on<ShareSheetRecipientSelected>(_onRecipientSelected);
     on<ShareSheetRecipientCleared>(_onRecipientCleared);
     on<ShareSheetSendRequested>(_onSendRequested, transformer: droppable());
@@ -195,68 +187,6 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
   }
 
   // --------------------------------------------------------------------------
-  // Quick-send (tap contact → send immediately, no message)
-  // --------------------------------------------------------------------------
-
-  Future<void> _onQuickSendRequested(
-    ShareSheetQuickSendRequested event,
-    Emitter<ShareSheetState> emit,
-  ) async {
-    final user = event.recipient;
-    if (state.sentPubkeys.contains(user.pubkey)) return;
-
-    final recipientName = user.displayName ?? 'user';
-
-    // Optimistic: confirm instantly (checkmark + toast) and clear any selected
-    // recipient so More Actions stays visible. The actual NIP-17 send (crypto +
-    // relay publish) runs in the background below — the rumor is enqueued
-    // durably before publishing, so the send survives a crash and is retried.
-    // This is what removes the felt wait-for-network lag. See #5391.
-    emit(
-      state.copyWith(
-        sentPubkeys: {...state.sentPubkeys, user.pubkey},
-        clearRecipient: true,
-        actionResult: ShareSheetSendSuccess(recipientName),
-      ),
-    );
-
-    try {
-      final result = await _videoSharingService.shareVideoWithUser(
-        video: _video,
-        recipientPubkey: user.pubkey,
-      );
-      // Success was already shown optimistically; nothing more to emit. If the
-      // sheet was dismissed mid-send, the bloc is closed — don't emit.
-      if (result.success || isClosed) return;
-      // Roll back the optimistic checkmark and surface the failure.
-      emit(
-        state.copyWith(
-          sentPubkeys: {...state.sentPubkeys}..remove(user.pubkey),
-          actionResult: ShareSheetSendFailure(),
-        ),
-      );
-    } catch (e, stackTrace) {
-      _addUnexpectedError(
-        e,
-        stackTrace,
-        ShareSheetBlocReportableSites.onQuickSendRequested,
-      );
-      Log.error(
-        'Failed to quick-send video: $e',
-        name: 'ShareSheetBloc',
-        category: LogCategory.ui,
-      );
-      if (isClosed) return;
-      emit(
-        state.copyWith(
-          sentPubkeys: {...state.sentPubkeys}..remove(user.pubkey),
-          actionResult: ShareSheetSendFailure(),
-        ),
-      );
-    }
-  }
-
-  // --------------------------------------------------------------------------
   // Send with optional message
   // --------------------------------------------------------------------------
 
@@ -266,9 +196,8 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
   ) async {
     if (state.selectedRecipient == null || state.isSending) return;
 
-    // Send-with-message is a deliberate compose-then-send: it keeps the
-    // awaited flow with a visible "sending" spinner (isSending) and surfaces
-    // failures in-sheet. Only the no-feedback quick-send tap is optimistic.
+    // Deliberate compose-then-send: the awaited flow keeps a visible
+    // "sending" spinner (isSending) and surfaces failures in-sheet.
     emit(state.copyWith(isSending: true, clearActionResult: true));
 
     try {
@@ -288,7 +217,8 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
             isSending: false,
             actionResult: ShareSheetSendSuccess(
               recipientName,
-              shouldDismiss: true,
+              recipientPubkey: recipient.pubkey,
+              conversationId: result.conversationId,
             ),
           ),
         );

--- a/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
+++ b/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
@@ -53,8 +53,7 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
        _videoClipImportService = videoClipImportService,
        super(const ShareSheetState()) {
     on<ShareSheetContactsLoadRequested>(_onContactsLoadRequested);
-    on<ShareSheetRecipientSelected>(_onRecipientSelected);
-    on<ShareSheetRecipientCleared>(_onRecipientCleared);
+    on<ShareSheetRecipientToggled>(_onRecipientToggled);
     on<ShareSheetSendRequested>(_onSendRequested, transformer: droppable());
     on<ShareSheetSaveRequested>(_onSaveRequested, transformer: droppable());
     on<ShareSheetAddVideoToClipsRequested>(
@@ -162,28 +161,36 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
   // Recipient selection
   // --------------------------------------------------------------------------
 
-  void _onRecipientSelected(
-    ShareSheetRecipientSelected event,
+  void _onRecipientToggled(
+    ShareSheetRecipientToggled event,
     Emitter<ShareSheetState> emit,
   ) {
-    final updatedContacts = List<ShareableUser>.from(state.contacts)
-      ..removeWhere((c) => c.pubkey == event.recipient.pubkey)
-      ..insert(0, event.recipient);
+    final recipient = event.recipient;
+    final updatedSelection = state.isSelected(recipient)
+        ? [
+            for (final r in state.selectedRecipients)
+              if (r.pubkey != recipient.pubkey) r,
+          ]
+        : [...state.selectedRecipients, recipient];
+
+    // Find People can pick someone who isn't in the contacts row yet —
+    // surface them at the front so their selection tick is visible.
+    // Existing contacts stay in place: reordering under the user's
+    // finger while multi-selecting is disorienting.
+    final inContacts = state.contacts.any(
+      (c) => c.pubkey == recipient.pubkey,
+    );
+    final updatedContacts = inContacts
+        ? state.contacts
+        : [recipient, ...state.contacts];
 
     emit(
       state.copyWith(
-        selectedRecipient: event.recipient,
+        selectedRecipients: updatedSelection,
         contacts: updatedContacts,
         clearActionResult: true,
       ),
     );
-  }
-
-  void _onRecipientCleared(
-    ShareSheetRecipientCleared event,
-    Emitter<ShareSheetState> emit,
-  ) {
-    emit(state.copyWith(clearRecipient: true, clearActionResult: true));
   }
 
   // --------------------------------------------------------------------------
@@ -194,41 +201,67 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
     ShareSheetSendRequested event,
     Emitter<ShareSheetState> emit,
   ) async {
-    if (state.selectedRecipient == null || state.isSending) return;
+    if (state.selectedRecipients.isEmpty || state.isSending) return;
 
     // Deliberate compose-then-send: the awaited flow keeps a visible
     // "sending" spinner (isSending) and surfaces failures in-sheet.
     emit(state.copyWith(isSending: true, clearActionResult: true));
 
     try {
-      final recipient = state.selectedRecipient!;
+      final recipients = state.selectedRecipients;
       final message = event.message?.trim();
 
-      final result = await _videoSharingService.shareVideoWithUser(
+      // Fans out one DM per recipient (each gets its own gift wrap).
+      final results = await _videoSharingService.shareVideoWithMultipleUsers(
         video: _video,
-        recipientPubkey: recipient.pubkey,
+        recipientPubkeys: [for (final r in recipients) r.pubkey],
         personalMessage: message?.isEmpty == true ? null : message,
       );
 
-      final recipientName = recipient.displayName ?? 'user';
-      if (result.success) {
+      final delivered = [
+        for (final r in recipients)
+          if (results[r.pubkey]?.success ?? false) r,
+      ];
+      final failed = [
+        for (final r in recipients)
+          if (!(results[r.pubkey]?.success ?? false)) r,
+      ];
+
+      if (failed.isEmpty) {
+        final single = recipients.length == 1 ? recipients.single : null;
         emit(
           state.copyWith(
             isSending: false,
+            selectedRecipients: const [],
             actionResult: ShareSheetSendSuccess(
-              recipientName,
-              recipientPubkey: recipient.pubkey,
-              conversationId: result.conversationId,
+              recipientNames: [
+                for (final r in recipients) r.displayName ?? 'user',
+              ],
+              recipientPubkey: single?.pubkey,
+              conversationId: single == null
+                  ? null
+                  : results[single.pubkey]?.conversationId,
             ),
           ),
         );
       } else {
+        // Keep only the failed recipients selected so a retry doesn't
+        // re-send to people who already received the video.
         emit(
           state.copyWith(
             isSending: false,
+            selectedRecipients: failed,
             actionResult: ShareSheetSendFailure(),
           ),
         );
+        if (delivered.isNotEmpty) {
+          Log.warning(
+            'Partial share failure: ${delivered.length} delivered, '
+            '${failed.length} failed',
+            name: 'ShareSheetBloc',
+            category: LogCategory.ui,
+          );
+        }
       }
     } catch (e, stackTrace) {
       _addUnexpectedError(

--- a/mobile/lib/blocs/share_sheet/share_sheet_event.dart
+++ b/mobile/lib/blocs/share_sheet/share_sheet_event.dart
@@ -18,17 +18,10 @@ class ShareSheetContactsLoadRequested extends ShareSheetEvent {
   const ShareSheetContactsLoadRequested();
 }
 
-/// A contact was tapped for quick-send (no message).
-class ShareSheetQuickSendRequested extends ShareSheetEvent {
-  const ShareSheetQuickSendRequested(this.recipient);
-
-  final ShareableUser recipient;
-
-  @override
-  List<Object?> get props => [recipient.pubkey];
-}
-
-/// A recipient was selected (from Find People or contact tap for message).
+/// A recipient was selected (contact-row tap or Find People pick).
+///
+/// Selection never sends — it reveals the message composer; the send
+/// happens only on an explicit [ShareSheetSendRequested].
 class ShareSheetRecipientSelected extends ShareSheetEvent {
   const ShareSheetRecipientSelected(this.recipient);
 

--- a/mobile/lib/blocs/share_sheet/share_sheet_event.dart
+++ b/mobile/lib/blocs/share_sheet/share_sheet_event.dart
@@ -18,12 +18,13 @@ class ShareSheetContactsLoadRequested extends ShareSheetEvent {
   const ShareSheetContactsLoadRequested();
 }
 
-/// A recipient was selected (contact-row tap or Find People pick).
+/// A recipient was toggled (contact-row tap or Find People pick).
 ///
-/// Selection never sends — it reveals the message composer; the send
-/// happens only on an explicit [ShareSheetSendRequested].
-class ShareSheetRecipientSelected extends ShareSheetEvent {
-  const ShareSheetRecipientSelected(this.recipient);
+/// Adds the user to the selection, or removes them when already
+/// selected. Selection never sends — it reveals the message composer;
+/// the send happens only on an explicit [ShareSheetSendRequested].
+class ShareSheetRecipientToggled extends ShareSheetEvent {
+  const ShareSheetRecipientToggled(this.recipient);
 
   final ShareableUser recipient;
 
@@ -31,12 +32,7 @@ class ShareSheetRecipientSelected extends ShareSheetEvent {
   List<Object?> get props => [recipient.pubkey];
 }
 
-/// Recipient selection was cleared.
-class ShareSheetRecipientCleared extends ShareSheetEvent {
-  const ShareSheetRecipientCleared();
-}
-
-/// Send video with an optional message to the selected recipient.
+/// Send video with an optional message to all selected recipients.
 class ShareSheetSendRequested extends ShareSheetEvent {
   const ShareSheetSendRequested({this.message});
 

--- a/mobile/lib/blocs/share_sheet/share_sheet_state.dart
+++ b/mobile/lib/blocs/share_sheet/share_sheet_state.dart
@@ -28,13 +28,22 @@ sealed class ShareSheetActionResult {
 }
 
 class ShareSheetSendSuccess extends ShareSheetActionResult {
-  ShareSheetSendSuccess(this.recipientName, {this.shouldDismiss = false});
+  ShareSheetSendSuccess(
+    this.recipientName, {
+    required this.recipientPubkey,
+    this.conversationId,
+  });
 
   final String recipientName;
 
-  /// Whether the UI should dismiss the sheet after this success.
-  /// True for send-with-message, false for quick-send.
-  final bool shouldDismiss;
+  /// Recipient pubkey, passed as the conversation participant when the
+  /// success snackbar's "View chat" action navigates to the DM thread.
+  final String recipientPubkey;
+
+  /// NIP-17 conversation ID for "View chat" navigation. Null when the send
+  /// went over the legacy NIP-04 path, which has no conversation ID — the
+  /// snackbar then shows no action.
+  final String? conversationId;
 }
 
 class ShareSheetSendFailure extends ShareSheetActionResult {
@@ -122,7 +131,6 @@ class ShareSheetState extends Equatable {
     this.status = ShareSheetStatus.initial,
     this.contacts = const [],
     this.selectedRecipient,
-    this.sentPubkeys = const {},
     this.isSending = false,
     this.actionResult,
   });
@@ -135,9 +143,6 @@ class ShareSheetState extends Equatable {
 
   /// Currently selected recipient for message-send flow.
   final ShareableUser? selectedRecipient;
-
-  /// Pubkeys that have already been sent to (quick-send).
-  final Set<String> sentPubkeys;
 
   /// Whether a send operation is in progress.
   final bool isSending;
@@ -153,7 +158,6 @@ class ShareSheetState extends Equatable {
     ShareSheetStatus? status,
     List<ShareableUser>? contacts,
     ShareableUser? selectedRecipient,
-    Set<String>? sentPubkeys,
     bool? isSending,
     ShareSheetActionResult? actionResult,
     bool clearRecipient = false,
@@ -165,7 +169,6 @@ class ShareSheetState extends Equatable {
       selectedRecipient: clearRecipient
           ? null
           : (selectedRecipient ?? this.selectedRecipient),
-      sentPubkeys: sentPubkeys ?? this.sentPubkeys,
       isSending: isSending ?? this.isSending,
       actionResult: clearActionResult
           ? null
@@ -178,7 +181,6 @@ class ShareSheetState extends Equatable {
     status,
     contacts,
     selectedRecipient,
-    sentPubkeys,
     isSending,
     actionResult,
   ];

--- a/mobile/lib/blocs/share_sheet/share_sheet_state.dart
+++ b/mobile/lib/blocs/share_sheet/share_sheet_state.dart
@@ -28,21 +28,23 @@ sealed class ShareSheetActionResult {
 }
 
 class ShareSheetSendSuccess extends ShareSheetActionResult {
-  ShareSheetSendSuccess(
-    this.recipientName, {
-    required this.recipientPubkey,
+  ShareSheetSendSuccess({
+    required this.recipientNames,
+    this.recipientPubkey,
     this.conversationId,
   });
 
-  final String recipientName;
+  /// Display names of everyone the video was sent to, in selection order.
+  final List<String> recipientNames;
 
   /// Recipient pubkey, passed as the conversation participant when the
   /// success snackbar's "View chat" action navigates to the DM thread.
-  final String recipientPubkey;
+  /// Set only for a single-recipient send.
+  final String? recipientPubkey;
 
-  /// NIP-17 conversation ID for "View chat" navigation. Null when the send
-  /// went over the legacy NIP-04 path, which has no conversation ID — the
-  /// snackbar then shows no action.
+  /// NIP-17 conversation ID for "View chat" navigation. Set only for a
+  /// single-recipient NIP-17 send — multi-recipient sends and legacy
+  /// NIP-04 sends have no single thread to open, so no action is shown.
   final String? conversationId;
 }
 
@@ -130,7 +132,7 @@ class ShareSheetState extends Equatable {
   const ShareSheetState({
     this.status = ShareSheetStatus.initial,
     this.contacts = const [],
-    this.selectedRecipient,
+    this.selectedRecipients = const [],
     this.isSending = false,
     this.actionResult,
   });
@@ -141,8 +143,8 @@ class ShareSheetState extends Equatable {
   /// Loaded contacts (recent + followed users).
   final List<ShareableUser> contacts;
 
-  /// Currently selected recipient for message-send flow.
-  final ShareableUser? selectedRecipient;
+  /// Recipients selected for the message-send flow, in selection order.
+  final List<ShareableUser> selectedRecipients;
 
   /// Whether a send operation is in progress.
   final bool isSending;
@@ -154,21 +156,22 @@ class ShareSheetState extends Equatable {
   /// Whether contacts have finished loading.
   bool get contactsLoaded => status == ShareSheetStatus.ready;
 
+  /// Whether [user] is currently selected.
+  bool isSelected(ShareableUser user) =>
+      selectedRecipients.any((r) => r.pubkey == user.pubkey);
+
   ShareSheetState copyWith({
     ShareSheetStatus? status,
     List<ShareableUser>? contacts,
-    ShareableUser? selectedRecipient,
+    List<ShareableUser>? selectedRecipients,
     bool? isSending,
     ShareSheetActionResult? actionResult,
-    bool clearRecipient = false,
     bool clearActionResult = false,
   }) {
     return ShareSheetState(
       status: status ?? this.status,
       contacts: contacts ?? this.contacts,
-      selectedRecipient: clearRecipient
-          ? null
-          : (selectedRecipient ?? this.selectedRecipient),
+      selectedRecipients: selectedRecipients ?? this.selectedRecipients,
       isSending: isSending ?? this.isSending,
       actionResult: clearActionResult
           ? null
@@ -180,7 +183,7 @@ class ShareSheetState extends Equatable {
   List<Object?> get props => [
     status,
     contacts,
-    selectedRecipient,
+    selectedRecipients,
     isSending,
     actionResult,
   ];

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -711,6 +711,15 @@
             }
         }
     },
+    "shareSelectedRecipientAnnouncement": "{name} ተመርጧል",
+    "@shareSelectedRecipientAnnouncement": {
+        "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
     "shareMessageHint": "አማራጭ መልእክት አክል...",
     "videoActionUnlike": "ከቪዲዮ በተቃራኒ",
     "videoActionLike": "ልክ እንደ ቪዲዮ",

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -678,6 +678,7 @@
     "listAttributionFallback": "ዝርዝር",
     "shareVideoLabel": "ቪዲዮ አጋራ",
     "sharePostSharedWith": "ልጥፍ ለ{recipientName} ተጋርቷል።",
+    "sharePostSharedWithCount": "{count, plural, one{ልጥፍ ለ{count} ሰው ተጋርቷል።} other{ልጥፍ ለ{count} ሰዎች ተጋርቷል።}}",
     "@sharePostSharedWith": {
         "placeholders": {
             "recipientName": {

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -704,14 +704,6 @@
     "shareSent": "ተልኳል።",
     "shareContactFallback": "ተገናኝ",
     "shareUserFallback": "ተጠቃሚ",
-    "shareSendingTo": "ወደ {name} በመላክ ላይ",
-    "@shareSendingTo": {
-        "placeholders": {
-            "name": {
-                "type": "String"
-            }
-        }
-    },
     "shareSelectedRecipientAnnouncement": "{name} ተመርጧል",
     "@shareSelectedRecipientAnnouncement": {
         "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -616,14 +616,6 @@
     "shareSent": "تم الإرسال",
     "shareContactFallback": "جهة اتصال",
     "shareUserFallback": "مستخدم",
-    "shareSendingTo": "جاري الإرسال إلى {name}",
-    "@shareSendingTo": {
-        "placeholders": {
-            "name": {
-                "type": "String"
-            }
-        }
-    },
     "shareSelectedRecipientAnnouncement": "تم تحديد {name}",
     "@shareSelectedRecipientAnnouncement": {
         "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -596,6 +596,7 @@
     "listAttributionFallback": "قائمة",
     "shareVideoLabel": "مشاركة الفيديو",
     "sharePostSharedWith": "تمت مشاركة المنشور مع {recipientName}",
+    "sharePostSharedWithCount": "{count, plural, one{تمت مشاركة المنشور مع شخص واحد} two{تمت مشاركة المنشور مع شخصين} few{تمت مشاركة المنشور مع {count} أشخاص} many{تمت مشاركة المنشور مع {count} شخصًا} other{تمت مشاركة المنشور مع {count} شخص}}",
     "@sharePostSharedWith": {
         "placeholders": {
             "recipientName": {

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -623,6 +623,15 @@
             }
         }
     },
+    "shareSelectedRecipientAnnouncement": "تم تحديد {name}",
+    "@shareSelectedRecipientAnnouncement": {
+        "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
     "shareMessageHint": "أضف رسالة اختيارية...",
     "videoActionUnlike": "إلغاء الإعجاب بالفيديو",
     "videoActionLike": "الإعجاب بالفيديو",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -658,6 +658,15 @@
             }
         }
     },
+    "shareSelectedRecipientAnnouncement": "Избран е {name}",
+    "@shareSelectedRecipientAnnouncement": {
+        "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
     "shareMessageHint": "Добави съобщение (по избор)...",
     "videoActionUnlike": "Премахни харесването",
     "videoActionLike": "Харесай видеото",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -651,14 +651,6 @@
     "shareSent": "Изпратено",
     "shareContactFallback": "Контакт",
     "shareUserFallback": "Потребител",
-    "shareSendingTo": "Изпращане до {name}",
-    "@shareSendingTo": {
-        "placeholders": {
-            "name": {
-                "type": "String"
-            }
-        }
-    },
     "shareSelectedRecipientAnnouncement": "Избран е {name}",
     "@shareSelectedRecipientAnnouncement": {
         "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -625,6 +625,7 @@
     "listAttributionFallback": "Списък",
     "shareVideoLabel": "Сподели видео",
     "sharePostSharedWith": "Публикация, споделена с {recipientName}",
+    "sharePostSharedWithCount": "{count, plural, one{Публикация, споделена с {count} човек} other{Публикация, споделена с {count} души}}",
     "@sharePostSharedWith": {
         "placeholders": {
             "recipientName": {

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -623,6 +623,15 @@
             }
         }
     },
+    "shareSelectedRecipientAnnouncement": "{name} ausgewählt",
+    "@shareSelectedRecipientAnnouncement": {
+        "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
     "shareMessageHint": "Optionale Nachricht hinzufügen...",
     "videoActionUnlike": "Like entfernen",
     "videoActionLike": "Video liken",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -596,6 +596,7 @@
     "listAttributionFallback": "Liste",
     "shareVideoLabel": "Video teilen",
     "sharePostSharedWith": "Beitrag mit {recipientName} geteilt",
+    "sharePostSharedWithCount": "{count, plural, one{Beitrag mit {count} Person geteilt} other{Beitrag mit {count} Personen geteilt}}",
     "@sharePostSharedWith": {
         "placeholders": {
             "recipientName": {

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -616,14 +616,6 @@
     "shareSent": "Gesendet",
     "shareContactFallback": "Kontakt",
     "shareUserFallback": "Nutzer",
-    "shareSendingTo": "Wird an {name} gesendet",
-    "@shareSendingTo": {
-        "placeholders": {
-            "name": {
-                "type": "String"
-            }
-        }
-    },
     "shareSelectedRecipientAnnouncement": "{name} ausgewählt",
     "@shareSelectedRecipientAnnouncement": {
         "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -790,14 +790,6 @@
   "shareSent": "Sent",
   "shareContactFallback": "Contact",
   "shareUserFallback": "User",
-  "shareSendingTo": "Sending to {name}",
-  "@shareSendingTo": {
-    "placeholders": {
-      "name": {
-        "type": "String"
-      }
-    }
-  },
   "shareSelectedRecipientAnnouncement": "Selected {name}",
   "@shareSelectedRecipientAnnouncement": {
     "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -756,6 +756,15 @@
   "listAttributionFallback": "List",
   "shareVideoLabel": "Share video",
   "sharePostSharedWith": "Post shared with {recipientName}",
+  "sharePostSharedWithCount": "{count, plural, one{Post shared with {count} person} other{Post shared with {count} people}}",
+  "@sharePostSharedWithCount": {
+    "description": "Snackbar after sharing a video to two or more people at once. Only used for count >= 2.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "@sharePostSharedWith": {
     "placeholders": {
       "recipientName": {

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -789,6 +789,15 @@
       }
     }
   },
+  "shareSelectedRecipientAnnouncement": "Selected {name}",
+  "@shareSelectedRecipientAnnouncement": {
+    "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
   "shareMessageHint": "Add optional message...",
   "videoActionUnlike": "Unlike video",
   "videoActionLike": "Like video",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -623,6 +623,15 @@
             }
         }
     },
+    "shareSelectedRecipientAnnouncement": "{name} seleccionado",
+    "@shareSelectedRecipientAnnouncement": {
+        "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
     "shareMessageHint": "Agregá un mensaje (opcional)...",
     "videoActionUnlike": "Sacar me gusta",
     "videoActionLike": "Dar me gusta",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -596,6 +596,7 @@
     "listAttributionFallback": "Lista",
     "shareVideoLabel": "Compartir video",
     "sharePostSharedWith": "Publicación compartida con {recipientName}",
+    "sharePostSharedWithCount": "{count, plural, one{Publicación compartida con {count} persona} other{Publicación compartida con {count} personas}}",
     "@sharePostSharedWith": {
         "placeholders": {
             "recipientName": {

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -616,14 +616,6 @@
     "shareSent": "Enviado",
     "shareContactFallback": "Contacto",
     "shareUserFallback": "Usuario",
-    "shareSendingTo": "Enviando a {name}",
-    "@shareSendingTo": {
-        "placeholders": {
-            "name": {
-                "type": "String"
-            }
-        }
-    },
     "shareSelectedRecipientAnnouncement": "{name} seleccionado",
     "@shareSelectedRecipientAnnouncement": {
         "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -442,6 +442,15 @@
     "shareContactFallback": "Contact",
     "shareUserFallback": "User",
     "shareSendingTo": "Ipinapadala kay {name}",
+    "shareSelectedRecipientAnnouncement": "Napili si {name}",
+    "@shareSelectedRecipientAnnouncement": {
+        "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
     "shareMessageHint": "Magdagdag ng optional na mensahe...",
     "videoActionUnlike": "I-unlike ang video",
     "videoActionLike": "I-like ang video",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -442,7 +442,6 @@
     "shareSent": "Naipadala",
     "shareContactFallback": "Contact",
     "shareUserFallback": "User",
-    "shareSendingTo": "Ipinapadala kay {name}",
     "shareSelectedRecipientAnnouncement": "Napili si {name}",
     "@shareSelectedRecipientAnnouncement": {
         "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -429,6 +429,7 @@
     "listAttributionFallback": "List",
     "shareVideoLabel": "I-share ang video",
     "sharePostSharedWith": "Naipadala ang post kay {recipientName}",
+    "sharePostSharedWithCount": "{count, plural, one{Naipadala ang post sa {count} tao} other{Naipadala ang post sa {count} tao}}",
     "shareFailedToSend": "Nabigong ipadala ang video",
     "shareAddedToBookmarks": "Naidagdag sa bookmarks",
     "shareRemovedFromBookmarks": "Tinanggal sa bookmarks",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -616,14 +616,6 @@
     "shareSent": "Envoyé",
     "shareContactFallback": "Contact",
     "shareUserFallback": "Utilisateur",
-    "shareSendingTo": "Envoi à {name}",
-    "@shareSendingTo": {
-        "placeholders": {
-            "name": {
-                "type": "String"
-            }
-        }
-    },
     "shareSelectedRecipientAnnouncement": "{name} sélectionné",
     "@shareSelectedRecipientAnnouncement": {
         "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -623,6 +623,15 @@
             }
         }
     },
+    "shareSelectedRecipientAnnouncement": "{name} sélectionné",
+    "@shareSelectedRecipientAnnouncement": {
+        "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
     "shareMessageHint": "Ajouter un message (facultatif)...",
     "videoActionUnlike": "Ne plus aimer la vidéo",
     "videoActionLike": "Aimer la vidéo",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -596,6 +596,7 @@
     "listAttributionFallback": "Liste",
     "shareVideoLabel": "Partager la vidéo",
     "sharePostSharedWith": "Post partagé avec {recipientName}",
+    "sharePostSharedWithCount": "{count, plural, one{Post partagé avec {count} personne} other{Post partagé avec {count} personnes}}",
     "@sharePostSharedWith": {
         "placeholders": {
             "recipientName": {

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -596,6 +596,7 @@
     "listAttributionFallback": "Daftar",
     "shareVideoLabel": "Bagikan video",
     "sharePostSharedWith": "Postingan dibagikan dengan {recipientName}",
+    "sharePostSharedWithCount": "{count, plural, other{Postingan dibagikan dengan {count} orang}}",
     "@sharePostSharedWith": {
         "placeholders": {
             "recipientName": {

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -616,14 +616,6 @@
     "shareSent": "Terkirim",
     "shareContactFallback": "Kontak",
     "shareUserFallback": "Pengguna",
-    "shareSendingTo": "Mengirim ke {name}",
-    "@shareSendingTo": {
-        "placeholders": {
-            "name": {
-                "type": "String"
-            }
-        }
-    },
     "shareSelectedRecipientAnnouncement": "{name} dipilih",
     "@shareSelectedRecipientAnnouncement": {
         "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -623,6 +623,15 @@
             }
         }
     },
+    "shareSelectedRecipientAnnouncement": "{name} dipilih",
+    "@shareSelectedRecipientAnnouncement": {
+        "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
     "shareMessageHint": "Tambahkan pesan opsional...",
     "videoActionUnlike": "Batalkan suka video",
     "videoActionLike": "Suka video",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -596,6 +596,7 @@
     "listAttributionFallback": "Lista",
     "shareVideoLabel": "Condividi video",
     "sharePostSharedWith": "Post condiviso con {recipientName}",
+    "sharePostSharedWithCount": "{count, plural, one{Post condiviso con {count} persona} other{Post condiviso con {count} persone}}",
     "@sharePostSharedWith": {
         "placeholders": {
             "recipientName": {

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -623,6 +623,15 @@
             }
         }
     },
+    "shareSelectedRecipientAnnouncement": "{name} selezionato",
+    "@shareSelectedRecipientAnnouncement": {
+        "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
     "shareMessageHint": "Aggiungi un messaggio opzionale...",
     "videoActionUnlike": "Togli il mi piace al video",
     "videoActionLike": "Metti mi piace al video",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -616,14 +616,6 @@
     "shareSent": "Inviato",
     "shareContactFallback": "Contatto",
     "shareUserFallback": "Utente",
-    "shareSendingTo": "Invio a {name}",
-    "@shareSendingTo": {
-        "placeholders": {
-            "name": {
-                "type": "String"
-            }
-        }
-    },
     "shareSelectedRecipientAnnouncement": "{name} selezionato",
     "@shareSelectedRecipientAnnouncement": {
         "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -623,6 +623,15 @@
             }
         }
     },
+    "shareSelectedRecipientAnnouncement": "{name}を選択しました",
+    "@shareSelectedRecipientAnnouncement": {
+        "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
     "shareMessageHint": "メッセージを追加 (任意)...",
     "videoActionUnlike": "いいねを取り消す",
     "videoActionLike": "いいね",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -596,6 +596,7 @@
     "listAttributionFallback": "リスト",
     "shareVideoLabel": "動画を共有",
     "sharePostSharedWith": "{recipientName}に投稿を共有したよ",
+    "sharePostSharedWithCount": "{count, plural, other{{count}人に投稿を共有したよ}}",
     "@sharePostSharedWith": {
         "placeholders": {
             "recipientName": {

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -616,14 +616,6 @@
     "shareSent": "送信済み",
     "shareContactFallback": "連絡先",
     "shareUserFallback": "ユーザー",
-    "shareSendingTo": "{name}に送信中",
-    "@shareSendingTo": {
-        "placeholders": {
-            "name": {
-                "type": "String"
-            }
-        }
-    },
     "shareSelectedRecipientAnnouncement": "{name}を選択しました",
     "@shareSelectedRecipientAnnouncement": {
         "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -370,6 +370,7 @@
     "listAttributionFallback": "리스트",
     "shareVideoLabel": "영상 공유",
     "sharePostSharedWith": "{recipientName}님과 게시물을 공유했어요",
+    "sharePostSharedWithCount": "{count, plural, other{{count}명과 게시물을 공유했어요}}",
     "shareFailedToSend": "영상을 보내지 못했어요",
     "shareAddedToBookmarks": "북마크에 추가했어요",
     "shareRemovedFromBookmarks": "북마크에서 뺐어요",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -383,6 +383,15 @@
     "shareContactFallback": "연락처",
     "shareUserFallback": "사용자",
     "shareSendingTo": "{name}님에게 보내는 중",
+    "shareSelectedRecipientAnnouncement": "{name}님 선택됨",
+    "@shareSelectedRecipientAnnouncement": {
+        "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
     "shareMessageHint": "메시지 추가 (선택)...",
     "videoActionUnlike": "좋아요 취소",
     "videoActionLike": "좋아요",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -383,7 +383,6 @@
     "shareSent": "보냄",
     "shareContactFallback": "연락처",
     "shareUserFallback": "사용자",
-    "shareSendingTo": "{name}님에게 보내는 중",
     "shareSelectedRecipientAnnouncement": "{name}님 선택됨",
     "@shareSelectedRecipientAnnouncement": {
         "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -623,6 +623,15 @@
             }
         }
     },
+    "shareSelectedRecipientAnnouncement": "{name} geselecteerd",
+    "@shareSelectedRecipientAnnouncement": {
+        "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
     "shareMessageHint": "Voeg optioneel een bericht toe...",
     "videoActionUnlike": "Like verwijderen",
     "videoActionLike": "Video liken",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -596,6 +596,7 @@
     "listAttributionFallback": "Lijst",
     "shareVideoLabel": "Video delen",
     "sharePostSharedWith": "Post gedeeld met {recipientName}",
+    "sharePostSharedWithCount": "{count, plural, one{Post gedeeld met {count} persoon} other{Post gedeeld met {count} personen}}",
     "@sharePostSharedWith": {
         "placeholders": {
             "recipientName": {

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -616,14 +616,6 @@
     "shareSent": "Verzonden",
     "shareContactFallback": "Contact",
     "shareUserFallback": "Gebruiker",
-    "shareSendingTo": "Versturen naar {name}",
-    "@shareSendingTo": {
-        "placeholders": {
-            "name": {
-                "type": "String"
-            }
-        }
-    },
     "shareSelectedRecipientAnnouncement": "{name} geselecteerd",
     "@shareSelectedRecipientAnnouncement": {
         "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -596,6 +596,7 @@
     "listAttributionFallback": "Lista",
     "shareVideoLabel": "Udostępnij film",
     "sharePostSharedWith": "Post udostępniony z {recipientName}",
+    "sharePostSharedWithCount": "{count, plural, one{Post udostępniony z {count} osobą} few{Post udostępniony z {count} osobami} many{Post udostępniony z {count} osobami} other{Post udostępniony z {count} osobami}}",
     "@sharePostSharedWith": {
         "placeholders": {
             "recipientName": {

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -616,14 +616,6 @@
     "shareSent": "Wysłano",
     "shareContactFallback": "Kontakt",
     "shareUserFallback": "Użytkownik",
-    "shareSendingTo": "Wysyłanie do {name}",
-    "@shareSendingTo": {
-        "placeholders": {
-            "name": {
-                "type": "String"
-            }
-        }
-    },
     "shareSelectedRecipientAnnouncement": "Wybrano {name}",
     "@shareSelectedRecipientAnnouncement": {
         "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -623,6 +623,15 @@
             }
         }
     },
+    "shareSelectedRecipientAnnouncement": "Wybrano {name}",
+    "@shareSelectedRecipientAnnouncement": {
+        "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
     "shareMessageHint": "Dodaj opcjonalną wiadomość...",
     "videoActionUnlike": "Cofnij polubienie",
     "videoActionLike": "Polub film",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -616,14 +616,6 @@
     "shareSent": "Enviado",
     "shareContactFallback": "Contato",
     "shareUserFallback": "Usuário",
-    "shareSendingTo": "Enviando para {name}",
-    "@shareSendingTo": {
-        "placeholders": {
-            "name": {
-                "type": "String"
-            }
-        }
-    },
     "shareSelectedRecipientAnnouncement": "{name} selecionado",
     "@shareSelectedRecipientAnnouncement": {
         "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -623,6 +623,15 @@
             }
         }
     },
+    "shareSelectedRecipientAnnouncement": "{name} selecionado",
+    "@shareSelectedRecipientAnnouncement": {
+        "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
     "shareMessageHint": "Adicione uma mensagem opcional...",
     "videoActionUnlike": "Descurtir vídeo",
     "videoActionLike": "Curtir vídeo",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -596,6 +596,7 @@
     "listAttributionFallback": "Lista",
     "shareVideoLabel": "Compartilhar vídeo",
     "sharePostSharedWith": "Post compartilhado com {recipientName}",
+    "sharePostSharedWithCount": "{count, plural, one{Post compartilhado com {count} pessoa} other{Post compartilhado com {count} pessoas}}",
     "@sharePostSharedWith": {
         "placeholders": {
             "recipientName": {

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -596,6 +596,7 @@
     "listAttributionFallback": "Listă",
     "shareVideoLabel": "Partajează videoclipul",
     "sharePostSharedWith": "Postare partajată cu {recipientName}",
+    "sharePostSharedWithCount": "{count, plural, one{Postare partajată cu {count} persoană} few{Postare partajată cu {count} persoane} other{Postare partajată cu {count} de persoane}}",
     "@sharePostSharedWith": {
         "placeholders": {
             "recipientName": {

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -623,6 +623,15 @@
             }
         }
     },
+    "shareSelectedRecipientAnnouncement": "{name} selectat",
+    "@shareSelectedRecipientAnnouncement": {
+        "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
     "shareMessageHint": "Adaugă un mesaj opțional...",
     "videoActionUnlike": "Retrage aprecierea",
     "videoActionLike": "Apreciază videoclipul",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -616,14 +616,6 @@
     "shareSent": "Trimis",
     "shareContactFallback": "Contact",
     "shareUserFallback": "Utilizator",
-    "shareSendingTo": "Se trimite către {name}",
-    "@shareSendingTo": {
-        "placeholders": {
-            "name": {
-                "type": "String"
-            }
-        }
-    },
     "shareSelectedRecipientAnnouncement": "{name} selectat",
     "@shareSelectedRecipientAnnouncement": {
         "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -596,6 +596,7 @@
     "listAttributionFallback": "Lista",
     "shareVideoLabel": "Dela video",
     "sharePostSharedWith": "Inlägg delat med {recipientName}",
+    "sharePostSharedWithCount": "{count, plural, one{Inlägg delat med {count} person} other{Inlägg delat med {count} personer}}",
     "@sharePostSharedWith": {
         "placeholders": {
             "recipientName": {

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -616,14 +616,6 @@
     "shareSent": "Skickat",
     "shareContactFallback": "Kontakt",
     "shareUserFallback": "Användare",
-    "shareSendingTo": "Skickar till {name}",
-    "@shareSendingTo": {
-        "placeholders": {
-            "name": {
-                "type": "String"
-            }
-        }
-    },
     "shareSelectedRecipientAnnouncement": "{name} vald",
     "@shareSelectedRecipientAnnouncement": {
         "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -623,6 +623,15 @@
             }
         }
     },
+    "shareSelectedRecipientAnnouncement": "{name} vald",
+    "@shareSelectedRecipientAnnouncement": {
+        "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
     "shareMessageHint": "Lägg till valfritt meddelande...",
     "videoActionUnlike": "Sluta gilla videon",
     "videoActionLike": "Gilla videon",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -616,14 +616,6 @@
     "shareSent": "Gönderildi",
     "shareContactFallback": "Kişi",
     "shareUserFallback": "Kullanıcı",
-    "shareSendingTo": "{name} kişisine gönderiliyor",
-    "@shareSendingTo": {
-        "placeholders": {
-            "name": {
-                "type": "String"
-            }
-        }
-    },
     "shareSelectedRecipientAnnouncement": "{name} seçildi",
     "@shareSelectedRecipientAnnouncement": {
         "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -596,6 +596,7 @@
     "listAttributionFallback": "Liste",
     "shareVideoLabel": "Videoyu paylaş",
     "sharePostSharedWith": "Gönderi {recipientName} ile paylaşıldı",
+    "sharePostSharedWithCount": "{count, plural, one{Gönderi {count} kişiyle paylaşıldı} other{Gönderi {count} kişiyle paylaşıldı}}",
     "@sharePostSharedWith": {
         "placeholders": {
             "recipientName": {

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -623,6 +623,15 @@
             }
         }
     },
+    "shareSelectedRecipientAnnouncement": "{name} seçildi",
+    "@shareSelectedRecipientAnnouncement": {
+        "description": "Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
     "shareMessageHint": "Opsiyonel mesaj ekle...",
     "videoActionUnlike": "Beğenmekten vazgeç",
     "videoActionLike": "Videoyu beğen",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -2614,6 +2614,12 @@ abstract class AppLocalizations {
   /// **'Post shared with {recipientName}'**
   String sharePostSharedWith(String recipientName);
 
+  /// Snackbar after sharing a video to two or more people at once. Only used for count >= 2.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, one{Post shared with {count} person} other{Post shared with {count} people}}'**
+  String sharePostSharedWithCount(int count);
+
   /// No description provided for @shareFailedToSend.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -2692,6 +2692,12 @@ abstract class AppLocalizations {
   /// **'Sending to {name}'**
   String shareSendingTo(String name);
 
+  /// Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.
+  ///
+  /// In en, this message translates to:
+  /// **'Selected {name}'**
+  String shareSelectedRecipientAnnouncement(String name);
+
   /// No description provided for @shareMessageHint.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -2692,12 +2692,6 @@ abstract class AppLocalizations {
   /// **'User'**
   String get shareUserFallback;
 
-  /// No description provided for @shareSendingTo.
-  ///
-  /// In en, this message translates to:
-  /// **'Sending to {name}'**
-  String shareSendingTo(String name);
-
   /// Screen reader announcement when a person is selected in the share sheet. Selection opens the optional message composer but does not send the video.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -1483,11 +1483,6 @@ class AppLocalizationsAm extends AppLocalizations {
   String get shareUserFallback => 'ተጠቃሚ';
 
   @override
-  String shareSendingTo(String name) {
-    return 'ወደ $name በመላክ ላይ';
-  }
-
-  @override
   String shareSelectedRecipientAnnouncement(String name) {
     return '$name ተመርጧል';
   }

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -1477,6 +1477,11 @@ class AppLocalizationsAm extends AppLocalizations {
   }
 
   @override
+  String shareSelectedRecipientAnnouncement(String name) {
+    return '$name ተመርጧል';
+  }
+
+  @override
   String get shareMessageHint => 'አማራጭ መልእክት አክል...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -1436,6 +1436,17 @@ class AppLocalizationsAm extends AppLocalizations {
   }
 
   @override
+  String sharePostSharedWithCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'ልጥፍ ለ$count ሰዎች ተጋርቷል።',
+      one: 'ልጥፍ ለ$count ሰው ተጋርቷል።',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get shareFailedToSend => 'ቪዲዮ መላክ አልተሳካም።';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -1507,11 +1507,6 @@ class AppLocalizationsAr extends AppLocalizations {
   String get shareUserFallback => 'مستخدم';
 
   @override
-  String shareSendingTo(String name) {
-    return 'جاري الإرسال إلى $name';
-  }
-
-  @override
   String shareSelectedRecipientAnnouncement(String name) {
     return 'تم تحديد $name';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -1457,6 +1457,20 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String sharePostSharedWithCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'تمت مشاركة المنشور مع $count شخص',
+      many: 'تمت مشاركة المنشور مع $count شخصًا',
+      few: 'تمت مشاركة المنشور مع $count أشخاص',
+      two: 'تمت مشاركة المنشور مع شخصين',
+      one: 'تمت مشاركة المنشور مع شخص واحد',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get shareFailedToSend => 'فشل إرسال الفيديو';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -1498,6 +1498,11 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String shareSelectedRecipientAnnouncement(String name) {
+    return 'تم تحديد $name';
+  }
+
+  @override
   String get shareMessageHint => 'أضف رسالة اختيارية...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -1496,6 +1496,17 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
+  String sharePostSharedWithCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Публикация, споделена с $count души',
+      one: 'Публикация, споделена с $count човек',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get shareFailedToSend => 'Не успяхме да изпратим видеото';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -1537,6 +1537,11 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
+  String shareSelectedRecipientAnnouncement(String name) {
+    return 'Избран е $name';
+  }
+
+  @override
   String get shareMessageHint => 'Добави съобщение (по избор)...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -1543,11 +1543,6 @@ class AppLocalizationsBg extends AppLocalizations {
   String get shareUserFallback => 'Потребител';
 
   @override
-  String shareSendingTo(String name) {
-    return 'Изпращане до $name';
-  }
-
-  @override
   String shareSelectedRecipientAnnouncement(String name) {
     return 'Избран е $name';
   }

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -1535,6 +1535,11 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String shareSelectedRecipientAnnouncement(String name) {
+    return '$name ausgewählt';
+  }
+
+  @override
   String get shareMessageHint => 'Optionale Nachricht hinzufügen...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -1541,11 +1541,6 @@ class AppLocalizationsDe extends AppLocalizations {
   String get shareUserFallback => 'Nutzer';
 
   @override
-  String shareSendingTo(String name) {
-    return 'Wird an $name gesendet';
-  }
-
-  @override
   String shareSelectedRecipientAnnouncement(String name) {
     return '$name ausgewählt';
   }

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -1492,6 +1492,17 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String sharePostSharedWithCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Beitrag mit $count Personen geteilt',
+      one: 'Beitrag mit $count Person geteilt',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get shareFailedToSend => 'Video konnte nicht gesendet werden';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -1515,6 +1515,11 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String shareSelectedRecipientAnnouncement(String name) {
+    return 'Selected $name';
+  }
+
+  @override
   String get shareMessageHint => 'Add optional message...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -1521,11 +1521,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get shareUserFallback => 'User';
 
   @override
-  String shareSendingTo(String name) {
-    return 'Sending to $name';
-  }
-
-  @override
   String shareSelectedRecipientAnnouncement(String name) {
     return 'Selected $name';
   }

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -1474,6 +1474,17 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String sharePostSharedWithCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Post shared with $count people',
+      one: 'Post shared with $count person',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get shareFailedToSend => 'Failed to send video';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -1535,6 +1535,11 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String shareSelectedRecipientAnnouncement(String name) {
+    return '$name seleccionado';
+  }
+
+  @override
   String get shareMessageHint => 'Agregá un mensaje (opcional)...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -1494,6 +1494,17 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String sharePostSharedWithCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Publicación compartida con $count personas',
+      one: 'Publicación compartida con $count persona',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get shareFailedToSend => 'No se pudo enviar el video';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -1541,11 +1541,6 @@ class AppLocalizationsEs extends AppLocalizations {
   String get shareUserFallback => 'Usuario';
 
   @override
-  String shareSendingTo(String name) {
-    return 'Enviando a $name';
-  }
-
-  @override
   String shareSelectedRecipientAnnouncement(String name) {
     return '$name seleccionado';
   }

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -1542,6 +1542,11 @@ class AppLocalizationsFil extends AppLocalizations {
   }
 
   @override
+  String shareSelectedRecipientAnnouncement(String name) {
+    return 'Napili si $name';
+  }
+
+  @override
   String get shareMessageHint => 'Magdagdag ng optional na mensahe...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -1501,6 +1501,17 @@ class AppLocalizationsFil extends AppLocalizations {
   }
 
   @override
+  String sharePostSharedWithCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Naipadala ang post sa $count tao',
+      one: 'Naipadala ang post sa $count tao',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get shareFailedToSend => 'Nabigong ipadala ang video';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -1548,11 +1548,6 @@ class AppLocalizationsFil extends AppLocalizations {
   String get shareUserFallback => 'User';
 
   @override
-  String shareSendingTo(String name) {
-    return 'Ipinapadala kay $name';
-  }
-
-  @override
   String shareSelectedRecipientAnnouncement(String name) {
     return 'Napili si $name';
   }

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -1542,6 +1542,11 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String shareSelectedRecipientAnnouncement(String name) {
+    return '$name sélectionné';
+  }
+
+  @override
   String get shareMessageHint => 'Ajouter un message (facultatif)...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -1501,6 +1501,17 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String sharePostSharedWithCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Post partagé avec $count personnes',
+      one: 'Post partagé avec $count personne',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get shareFailedToSend => 'Échec de l\'envoi de la vidéo';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -1548,11 +1548,6 @@ class AppLocalizationsFr extends AppLocalizations {
   String get shareUserFallback => 'Utilisateur';
 
   @override
-  String shareSendingTo(String name) {
-    return 'Envoi à $name';
-  }
-
-  @override
   String shareSelectedRecipientAnnouncement(String name) {
     return '$name sélectionné';
   }

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -1496,11 +1496,6 @@ class AppLocalizationsId extends AppLocalizations {
   String get shareUserFallback => 'Pengguna';
 
   @override
-  String shareSendingTo(String name) {
-    return 'Mengirim ke $name';
-  }
-
-  @override
   String shareSelectedRecipientAnnouncement(String name) {
     return '$name dipilih';
   }

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -1450,6 +1450,16 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
+  String sharePostSharedWithCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Postingan dibagikan dengan $count orang',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get shareFailedToSend => 'Gagal mengirim video';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -1491,6 +1491,11 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
+  String shareSelectedRecipientAnnouncement(String name) {
+    return '$name dipilih';
+  }
+
+  @override
   String get shareMessageHint => 'Tambahkan pesan opsional...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -1538,6 +1538,11 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String shareSelectedRecipientAnnouncement(String name) {
+    return '$name selezionato';
+  }
+
+  @override
   String get shareMessageHint => 'Aggiungi un messaggio opzionale...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -1544,11 +1544,6 @@ class AppLocalizationsIt extends AppLocalizations {
   String get shareUserFallback => 'Utente';
 
   @override
-  String shareSendingTo(String name) {
-    return 'Invio a $name';
-  }
-
-  @override
   String shareSelectedRecipientAnnouncement(String name) {
     return '$name selezionato';
   }

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -1496,6 +1496,17 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String sharePostSharedWithCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Post condiviso con $count persone',
+      one: 'Post condiviso con $count persona',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get shareFailedToSend => 'Impossibile inviare il video';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -1383,6 +1383,16 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
+  String sharePostSharedWithCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count人に投稿を共有したよ',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get shareFailedToSend => '動画の送信がうまくいかなかった';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -1429,11 +1429,6 @@ class AppLocalizationsJa extends AppLocalizations {
   String get shareUserFallback => 'ユーザー';
 
   @override
-  String shareSendingTo(String name) {
-    return '$nameに送信中';
-  }
-
-  @override
   String shareSelectedRecipientAnnouncement(String name) {
     return '$nameを選択しました';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -1424,6 +1424,11 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
+  String shareSelectedRecipientAnnouncement(String name) {
+    return '$nameを選択しました';
+  }
+
+  @override
   String get shareMessageHint => 'メッセージを追加 (任意)...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -1437,11 +1437,6 @@ class AppLocalizationsKo extends AppLocalizations {
   String get shareUserFallback => '사용자';
 
   @override
-  String shareSendingTo(String name) {
-    return '$name님에게 보내는 중';
-  }
-
-  @override
   String shareSelectedRecipientAnnouncement(String name) {
     return '$name님 선택됨';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -1432,6 +1432,11 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
+  String shareSelectedRecipientAnnouncement(String name) {
+    return '$name님 선택됨';
+  }
+
+  @override
   String get shareMessageHint => '메시지 추가 (선택)...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -1391,6 +1391,16 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
+  String sharePostSharedWithCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count명과 게시물을 공유했어요',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get shareFailedToSend => '영상을 보내지 못했어요';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -1524,6 +1524,11 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String shareSelectedRecipientAnnouncement(String name) {
+    return '$name geselecteerd';
+  }
+
+  @override
   String get shareMessageHint => 'Voeg optioneel een bericht toe...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -1482,6 +1482,17 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String sharePostSharedWithCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Post gedeeld met $count personen',
+      one: 'Post gedeeld met $count persoon',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get shareFailedToSend => 'Video versturen mislukt';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -1530,11 +1530,6 @@ class AppLocalizationsNl extends AppLocalizations {
   String get shareUserFallback => 'Gebruiker';
 
   @override
-  String shareSendingTo(String name) {
-    return 'Versturen naar $name';
-  }
-
-  @override
   String shareSelectedRecipientAnnouncement(String name) {
     return '$name geselecteerd';
   }

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -1536,6 +1536,11 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
+  String shareSelectedRecipientAnnouncement(String name) {
+    return 'Wybrano $name';
+  }
+
+  @override
   String get shareMessageHint => 'Dodaj opcjonalną wiadomość...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -1495,6 +1495,19 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
+  String sharePostSharedWithCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Post udostępniony z $count osobami',
+      many: 'Post udostępniony z $count osobami',
+      few: 'Post udostępniony z $count osobami',
+      one: 'Post udostępniony z $count osobą',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get shareFailedToSend => 'Nie udało się wysłać filmu';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -1544,11 +1544,6 @@ class AppLocalizationsPl extends AppLocalizations {
   String get shareUserFallback => 'Użytkownik';
 
   @override
-  String shareSendingTo(String name) {
-    return 'Wysyłanie do $name';
-  }
-
-  @override
   String shareSelectedRecipientAnnouncement(String name) {
     return 'Wybrano $name';
   }

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -1533,6 +1533,11 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String shareSelectedRecipientAnnouncement(String name) {
+    return '$name selecionado';
+  }
+
+  @override
   String get shareMessageHint => 'Adicione uma mensagem opcional...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -1492,6 +1492,17 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String sharePostSharedWithCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Post compartilhado com $count pessoas',
+      one: 'Post compartilhado com $count pessoa',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get shareFailedToSend => 'Falha ao enviar vídeo';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -1539,11 +1539,6 @@ class AppLocalizationsPt extends AppLocalizations {
   String get shareUserFallback => 'Usuário';
 
   @override
-  String shareSendingTo(String name) {
-    return 'Enviando para $name';
-  }
-
-  @override
   String shareSelectedRecipientAnnouncement(String name) {
     return '$name selecionado';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -1510,6 +1510,18 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String sharePostSharedWithCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Postare partajată cu $count de persoane',
+      few: 'Postare partajată cu $count persoane',
+      one: 'Postare partajată cu $count persoană',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get shareFailedToSend => 'N-am putut trimite videoclipul';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -1559,11 +1559,6 @@ class AppLocalizationsRo extends AppLocalizations {
   String get shareUserFallback => 'Utilizator';
 
   @override
-  String shareSendingTo(String name) {
-    return 'Se trimite către $name';
-  }
-
-  @override
   String shareSelectedRecipientAnnouncement(String name) {
     return '$name selectat';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -1552,6 +1552,11 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String shareSelectedRecipientAnnouncement(String name) {
+    return '$name selectat';
+  }
+
+  @override
   String get shareMessageHint => 'Adaugă un mesaj opțional...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -1470,6 +1470,17 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String sharePostSharedWithCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Inlägg delat med $count personer',
+      one: 'Inlägg delat med $count person',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get shareFailedToSend => 'Kunde inte skicka video';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -1517,11 +1517,6 @@ class AppLocalizationsSv extends AppLocalizations {
   String get shareUserFallback => 'Användare';
 
   @override
-  String shareSendingTo(String name) {
-    return 'Skickar till $name';
-  }
-
-  @override
   String shareSelectedRecipientAnnouncement(String name) {
     return '$name vald';
   }

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -1511,6 +1511,11 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String shareSelectedRecipientAnnouncement(String name) {
+    return '$name vald';
+  }
+
+  @override
   String get shareMessageHint => 'Lägg till valfritt meddelande...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -1456,6 +1456,17 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
+  String sharePostSharedWithCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Gönderi $count kişiyle paylaşıldı',
+      one: 'Gönderi $count kişiyle paylaşıldı',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get shareFailedToSend => 'Video gönderilemedi';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -1503,11 +1503,6 @@ class AppLocalizationsTr extends AppLocalizations {
   String get shareUserFallback => 'Kullanıcı';
 
   @override
-  String shareSendingTo(String name) {
-    return '$name kişisine gönderiliyor';
-  }
-
-  @override
   String shareSelectedRecipientAnnouncement(String name) {
     return '$name seçildi';
   }

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -1497,6 +1497,11 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
+  String shareSelectedRecipientAnnouncement(String name) {
+    return '$name seçildi';
+  }
+
+  @override
   String get shareMessageHint => 'Opsiyonel mesaj ekle...';
 
   @override

--- a/mobile/lib/router/app_shell.dart
+++ b/mobile/lib/router/app_shell.dart
@@ -345,6 +345,14 @@ class _AppShellState extends ConsumerState<AppShell> with RouteAware {
     final environment = ref.watch(currentEnvironmentProvider);
 
     return Scaffold(
+      // Don't resize the shell body for the keyboard when a modal route is on
+      // top (e.g. the share sheet's message composer). The modal handles its
+      // own keyboard avoidance; letting the shell also shrink re-lays-out the
+      // full-screen feed video + overlay every keyboard frame, which is very
+      // laggy on older devices (Galaxy S10, reported on #5758). While the feed
+      // is the topmost route the default resize behaviour is preserved so its
+      // own bottom composers still lift above the keyboard.
+      resizeToAvoidBottomInset: ModalRoute.of(context)?.isCurrent ?? true,
       // Home tab uses FeedModeSwitch overlay (menu + mode dropdown + search)
       // instead of the standard AppBar, for full-screen video UX.
       // Inbox uses its own segmented toggle header.

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -723,6 +723,17 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
               );
 
               return Scaffold(
+                // Keep resizing for our OWN bottom composers (inline comment
+                // bar, DM reply bar) while this feed is the topmost route, but
+                // stop resizing when a modal is on top (e.g. the share sheet's
+                // message composer). The modal lifts itself above the keyboard;
+                // letting this Scaffold also shrink re-lays-out the full-screen
+                // reel + overlay every keyboard frame — very laggy on older
+                // devices (Galaxy S10, #5758). isCurrent flips reactively when
+                // the modal pushes/pops, so the composer behaviour above is
+                // unchanged.
+                resizeToAvoidBottomInset:
+                    ModalRoute.of(context)?.isCurrent ?? true,
                 // Paint the Scaffold with [VineTheme.surfaceBackground]
                 // (`#00150D`, the same green the comment bar uses).
                 // This is what shows wherever the Scaffold body leaks

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -353,6 +353,19 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
   /// pauses so the user can type without the video playing under the keyboard.
   bool _replyComposerFocused = false;
 
+  /// Whether the inline comment composer is focused.
+  bool _inlineComposerFocused = false;
+
+  /// Whether one of THIS screen's own bottom composers (inline comment or DM
+  /// reply) currently holds focus. Drives `resizeToAvoidBottomInset`: we only
+  /// want the reel to shrink for a keyboard we opened. A keyboard opened by a
+  /// modal on top — the share sheet's message field lives on the ROOT
+  /// navigator while this feed sits on a nested one, so `ModalRoute.isCurrent`
+  /// never flips — must NOT resize the reel, which re-lays-out the full-screen
+  /// video + overlay and janks badly on older devices (Galaxy S10, #5758).
+  bool get _ownComposerFocused =>
+      _replyComposerFocused || _inlineComposerFocused;
+
   /// Emoji currently being animated by the full-screen reaction overlay (null
   /// when idle). [_reactionNonce] remounts the overlay so repeated taps replay.
   String? _reactionEmoji;
@@ -671,10 +684,12 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
               // user. The bar lives in the body — NOT in
               // `Scaffold.bottomNavigationBar` — because Scaffold pins
               // bottomNavigationBar to `size.height - barHeight` and does
-              // not push it above the keyboard. Putting the bar inside
-              // the body lets Scaffold's default `resizeToAvoidBottomInset`
-              // shrink the body when the keyboard opens, which slides the
-              // bar up with it. The feed's MediaQuery is intentionally
+              // not push it above the keyboard. Putting the bar inside the
+              // body lets `resizeToAvoidBottomInset` shrink the body when the
+              // keyboard opens, which slides the bar up with it — which is
+              // why that flag is gated on [_ownComposerFocused] (true while
+              // this bar or the DM reply bar is focused). The feed's
+              // MediaQuery is intentionally
               // left untouched: the home feed's overlays sit at
               // `bottom: 20 + viewPadding.bottom (= 34) = 54` above the
               // nav bar, and the fullscreen overlays use the same formula
@@ -723,17 +738,14 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
               );
 
               return Scaffold(
-                // Keep resizing for our OWN bottom composers (inline comment
-                // bar, DM reply bar) while this feed is the topmost route, but
-                // stop resizing when a modal is on top (e.g. the share sheet's
-                // message composer). The modal lifts itself above the keyboard;
-                // letting this Scaffold also shrink re-lays-out the full-screen
-                // reel + overlay every keyboard frame — very laggy on older
-                // devices (Galaxy S10, #5758). isCurrent flips reactively when
-                // the modal pushes/pops, so the composer behaviour above is
-                // unchanged.
-                resizeToAvoidBottomInset:
-                    ModalRoute.of(context)?.isCurrent ?? true,
+                // Only resize for a keyboard that one of OUR OWN bottom
+                // composers opened (inline comment bar, DM reply bar). A
+                // keyboard owned by a modal on top — most importantly the
+                // share sheet's message field — must NOT shrink this Scaffold,
+                // because that re-lays-out the full-screen reel + overlay every
+                // keyboard frame and janks on older devices (#5758). See
+                // [_ownComposerFocused].
+                resizeToAvoidBottomInset: _ownComposerFocused,
                 // Paint the Scaffold with [VineTheme.surfaceBackground]
                 // (`#00150D`, the same green the comment bar uses).
                 // This is what shows wherever the Scaffold body leaks
@@ -852,7 +864,17 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                             ],
                           ),
                         ),
-                        if (showCommentBar) const InlineCommentComposerBar(),
+                        if (showCommentBar)
+                          InlineCommentComposerBar(
+                            onFocusChanged: (focused) {
+                              if (mounted &&
+                                  focused != _inlineComposerFocused) {
+                                setState(
+                                  () => _inlineComposerFocused = focused,
+                                );
+                              }
+                            },
+                          ),
                         if (showDmReplyBar)
                           ReelReplyBridge(
                             setComposerFocused: (focused) {

--- a/mobile/lib/services/video_sharing_service.dart
+++ b/mobile/lib/services/video_sharing_service.dart
@@ -108,9 +108,12 @@ class VideoSharingService {
 
       final dmContent = _createShareMessage(video, personalMessage);
 
-      // Prefer NIP-17 when DmRepository is available
+      // Prefer NIP-17 when DmRepository is available. `await` (not a bare
+      // `return`) so an async throw from the send is caught here and mapped
+      // to a ShareResult.failure instead of escaping to the fan-out loop and
+      // aborting the remaining recipients.
       if (_dmRepository != null) {
-        return _shareViaNip17(
+        return await _shareViaNip17(
           video: video,
           recipientPubkey: recipientPubkey,
           content: dmContent,
@@ -118,7 +121,7 @@ class VideoSharingService {
       }
 
       // Fallback to NIP-04 (legacy)
-      return _shareViaNip04(
+      return await _shareViaNip04(
         video: video,
         recipientPubkey: recipientPubkey,
         content: dmContent,
@@ -147,6 +150,12 @@ class VideoSharingService {
       videoDTag: video.vineId,
       videoEventId: video.id,
       relayHint: video.sourceRelay,
+      // A shared video is a NIP-17-native action. Skip the plaintext kind-4
+      // fallback so we don't publish the sender↔recipient link and real
+      // timestamp in the clear on the (unauthenticated) relay — which would
+      // defeat NIP-17's metadata protection for exactly this message — and so
+      // NIP-17 and NIP-04 copies can't render as a duplicate on the recipient.
+      skipNip04Fallback: true,
     );
 
     if (result.success) {
@@ -228,13 +237,25 @@ class VideoSharingService {
   }) async {
     final results = <String, ShareResult>{};
 
+    // Sequential (not parallel) so N recipients' gift-wrap publishes are spaced
+    // out under the relay's per-connection burst limit. Each iteration is
+    // guarded so one recipient's failure — or an unexpected throw — becomes a
+    // failure entry for that recipient instead of aborting the remaining sends.
     for (final pubkey in recipientPubkeys) {
-      final result = await shareVideoWithUser(
-        video: video,
-        recipientPubkey: pubkey,
-        personalMessage: personalMessage,
-      );
-      results[pubkey] = result;
+      try {
+        results[pubkey] = await shareVideoWithUser(
+          video: video,
+          recipientPubkey: pubkey,
+          personalMessage: personalMessage,
+        );
+      } catch (e) {
+        Log.error(
+          'Failed to share video with $pubkey: $e',
+          name: 'VideoSharingService',
+          category: LogCategory.video,
+        );
+        results[pubkey] = ShareResult.failure('Error sharing video: $e');
+      }
     }
 
     return results;

--- a/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
@@ -53,11 +53,11 @@ part 'share_with_section.dart';
 /// Shows a share icon that opens a unified share bottom sheet with:
 /// - Video context/preview header
 /// - "Share with" horizontal contact row with "Find people" search.
-///   Tapping a contact selects it (tick on the avatar) — nothing is sent
-///   until the explicit send button; tapping the selected contact again
-///   deselects it.
-/// - Message composer shown while a recipient is selected (replaces the
-///   actions row)
+///   Tapping contacts toggles their selection (tick on the avatar) —
+///   nothing is sent until the explicit send button, which fans the
+///   video out to every selected person as separate DMs.
+/// - Message composer shown while any recipient is selected (replaces
+///   the actions row)
 /// - "More actions" horizontal row (Save, download, Add to List, Copy,
 ///   Share via, debug tools)
 class ShareActionButton extends StatelessWidget {
@@ -196,17 +196,15 @@ class _UnifiedShareSheetState extends ConsumerState<_UnifiedShareSheet> {
             listener: _handleActionResult,
           ),
           // Screen readers get no signal from the tick/composer swap when a
-          // recipient is (re)selected — announce it.
+          // recipient is added — announce it.
           BlocListener<ShareSheetBloc, ShareSheetState>(
             listenWhen: (prev, curr) =>
-                curr.selectedRecipient != null &&
-                prev.selectedRecipient?.pubkey !=
-                    curr.selectedRecipient?.pubkey,
+                curr.selectedRecipients.length > prev.selectedRecipients.length,
             listener: (context, state) {
               SemanticsService.sendAnnouncement(
                 View.of(context),
                 context.l10n.shareSelectedRecipientAnnouncement(
-                  state.selectedRecipient!.displayName ??
+                  state.selectedRecipients.last.displayName ??
                       context.l10n.shareUserFallback,
                 ),
                 Directionality.of(context),
@@ -238,12 +236,16 @@ class _UnifiedShareSheetState extends ConsumerState<_UnifiedShareSheet> {
 
     switch (result) {
       case ShareSheetSendSuccess(
-        :final recipientName,
+        :final recipientNames,
         :final recipientPubkey,
         :final conversationId,
       ):
-        final sharedWithText = context.l10n.sharePostSharedWith(recipientName);
+        final sharedWithText = recipientNames.length == 1
+            ? context.l10n.sharePostSharedWith(recipientNames.single)
+            : context.l10n.sharePostSharedWithCount(recipientNames.length);
         final viewChatLabel = context.l10n.dmReelReplyViewChat;
+        // "View chat" only when there is a single thread to open.
+        final showViewChat = conversationId != null && recipientPubkey != null;
         // The snackbar action outlives the sheet, so capture a context that
         // survives the pop for the conversation push.
         final hostContext = Navigator.of(context, rootNavigator: true).context;
@@ -251,16 +253,16 @@ class _UnifiedShareSheetState extends ConsumerState<_UnifiedShareSheet> {
         messenger.showSnackBar(
           DivineSnackbarContainer.snackBar(
             sharedWithText,
-            actionLabel: conversationId == null ? null : viewChatLabel,
-            onActionPressed: conversationId == null
-                ? null
-                : () {
+            actionLabel: showViewChat ? viewChatLabel : null,
+            onActionPressed: showViewChat
+                ? () {
                     if (!hostContext.mounted) return;
                     hostContext.push(
                       ConversationPage.pathForId(conversationId),
                       extra: [recipientPubkey],
                     );
-                  },
+                  }
+                : null,
           ),
         );
       case ShareSheetSendFailure():
@@ -369,7 +371,7 @@ class _UnifiedShareSheetState extends ConsumerState<_UnifiedShareSheet> {
       contacts: _shareSheetBloc.state.contacts,
     );
     if (selectedUser != null && mounted) {
-      _shareSheetBloc.add(ShareSheetRecipientSelected(selectedUser));
+      _shareSheetBloc.add(ShareSheetRecipientToggled(selectedUser));
     }
   }
 
@@ -663,22 +665,24 @@ class _UnifiedShareSheetView extends StatelessWidget {
                     _ShareWithSection(
                       contacts: state.contacts,
                       contactsLoaded: state.contactsLoaded,
-                      selectedRecipient: state.selectedRecipient,
+                      selectedPubkeys: {
+                        for (final r in state.selectedRecipients) r.pubkey,
+                      },
                       onFindPeople: onFindPeople,
-                      // Select-then-send: a tap only selects (tick + message
-                      // composer). Tapping the selected contact again
-                      // deselects and drops the draft; tapping a different
-                      // contact switches the recipient and keeps the draft.
+                      // Select-then-send, multi-select: each tap toggles a
+                      // recipient's tick. Nothing sends until the explicit
+                      // send button. The draft survives selection changes
+                      // and is dropped only when the last recipient is
+                      // deselected.
                       onContactTapped: (user) {
-                        if (state.selectedRecipient?.pubkey == user.pubkey) {
-                          messageController.clear();
-                          bloc.add(const ShareSheetRecipientCleared());
-                        } else {
-                          bloc.add(ShareSheetRecipientSelected(user));
-                        }
+                        final deselectingLast =
+                            state.selectedRecipients.length == 1 &&
+                            state.isSelected(user);
+                        if (deselectingLast) messageController.clear();
+                        bloc.add(ShareSheetRecipientToggled(user));
                       },
                     ),
-                    if (state.selectedRecipient != null)
+                    if (state.selectedRecipients.isNotEmpty)
                       _MessageInput(
                         controller: messageController,
                         isSending: state.isSending,
@@ -688,7 +692,7 @@ class _UnifiedShareSheetView extends StatelessWidget {
                           ),
                         ),
                       ),
-                    if (state.selectedRecipient == null) ...[
+                    if (state.selectedRecipients.isEmpty) ...[
                       const Divider(color: VineTheme.cardBackground, height: 1),
                       _MoreActionsSection(
                         video: video,

--- a/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
@@ -1,10 +1,11 @@
 // ABOUTME: Share action button for video feed overlay.
-// ABOUTME: Opens unified share sheet with horizontal contacts row, message
-// ABOUTME: input, and more actions (save, copy, share via, report, etc.).
+// ABOUTME: Opens unified share sheet: tap a contact to select it (never an
+// ABOUTME: instant send), compose an optional message, send explicitly.
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -19,6 +20,7 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/providers/video_clip_import_provider.dart';
+import 'package:openvine/screens/inbox/conversation/conversation_page.dart';
 import 'package:openvine/screens/video_metadata/video_metadata_edit_screen.dart';
 import 'package:openvine/services/video_clip_import_service.dart';
 import 'package:openvine/services/video_sharing_service.dart';
@@ -50,10 +52,14 @@ part 'share_with_section.dart';
 ///
 /// Shows a share icon that opens a unified share bottom sheet with:
 /// - Video context/preview header
-/// - "Share with" horizontal contact row with "Find people" search
-/// - Optional message input when a recipient is selected
+/// - "Share with" horizontal contact row with "Find people" search.
+///   Tapping a contact selects it (tick on the avatar) — nothing is sent
+///   until the explicit send button; tapping the selected contact again
+///   deselects it.
+/// - Message composer shown while a recipient is selected (replaces the
+///   actions row)
 /// - "More actions" horizontal row (Save, download, Add to List, Copy,
-///   Share via, Report, debug tools)
+///   Share via, debug tools)
 class ShareActionButton extends StatelessWidget {
   const ShareActionButton({required this.video, this.onInteracted, super.key});
 
@@ -181,10 +187,33 @@ class _UnifiedShareSheetState extends ConsumerState<_UnifiedShareSheet> {
 
     return BlocProvider.value(
       value: _shareSheetBloc,
-      child: BlocListener<ShareSheetBloc, ShareSheetState>(
-        listenWhen: (prev, curr) =>
-            curr.actionResult != null && prev.actionResult != curr.actionResult,
-        listener: _handleActionResult,
+      child: MultiBlocListener(
+        listeners: [
+          BlocListener<ShareSheetBloc, ShareSheetState>(
+            listenWhen: (prev, curr) =>
+                curr.actionResult != null &&
+                prev.actionResult != curr.actionResult,
+            listener: _handleActionResult,
+          ),
+          // Screen readers get no signal from the tick/composer swap when a
+          // recipient is (re)selected — announce it.
+          BlocListener<ShareSheetBloc, ShareSheetState>(
+            listenWhen: (prev, curr) =>
+                curr.selectedRecipient != null &&
+                prev.selectedRecipient?.pubkey !=
+                    curr.selectedRecipient?.pubkey,
+            listener: (context, state) {
+              SemanticsService.sendAnnouncement(
+                View.of(context),
+                context.l10n.shareSendingTo(
+                  state.selectedRecipient!.displayName ??
+                      context.l10n.shareUserFallback,
+                ),
+                Directionality.of(context),
+              );
+            },
+          ),
+        ],
         child: _UnifiedShareSheetView(
           video: widget.video,
           messageController: _messageController,
@@ -208,16 +237,33 @@ class _UnifiedShareSheetState extends ConsumerState<_UnifiedShareSheet> {
     final messenger = ScaffoldMessenger.of(context);
 
     switch (result) {
-      case ShareSheetSendSuccess(:final recipientName, :final shouldDismiss):
-        if (shouldDismiss) _safePop(context);
+      case ShareSheetSendSuccess(
+        :final recipientName,
+        :final recipientPubkey,
+        :final conversationId,
+      ):
+        final sharedWithText = context.l10n.sharePostSharedWith(recipientName);
+        final viewChatLabel = context.l10n.dmReelReplyViewChat;
+        // The snackbar action outlives the sheet, so capture a context that
+        // survives the pop for the conversation push.
+        final hostContext = Navigator.of(context, rootNavigator: true).context;
+        _safePop(context);
         messenger.showSnackBar(
           DivineSnackbarContainer.snackBar(
-            context.l10n.sharePostSharedWith(recipientName),
+            sharedWithText,
+            actionLabel: conversationId == null ? null : viewChatLabel,
+            onActionPressed: conversationId == null
+                ? null
+                : () {
+                    if (!hostContext.mounted) return;
+                    hostContext.push(
+                      ConversationPage.pathForId(conversationId),
+                      extra: [recipientPubkey],
+                    );
+                  },
           ),
         );
       case ShareSheetSendFailure():
-        // Replace the optimistic "shared with" toast with the failure so the
-        // two don't stack when a quick-send is rolled back.
         messenger
           ..hideCurrentSnackBar()
           ..showSnackBar(
@@ -618,15 +664,23 @@ class _UnifiedShareSheetView extends StatelessWidget {
                       contacts: state.contacts,
                       contactsLoaded: state.contactsLoaded,
                       selectedRecipient: state.selectedRecipient,
-                      sentPubkeys: state.sentPubkeys,
                       onFindPeople: onFindPeople,
-                      onContactTapped: (user) =>
-                          bloc.add(ShareSheetQuickSendRequested(user)),
+                      // Select-then-send: a tap only selects (tick + message
+                      // composer). Tapping the selected contact again
+                      // deselects and drops the draft; tapping a different
+                      // contact switches the recipient and keeps the draft.
+                      onContactTapped: (user) {
+                        if (state.selectedRecipient?.pubkey == user.pubkey) {
+                          messageController.clear();
+                          bloc.add(const ShareSheetRecipientCleared());
+                        } else {
+                          bloc.add(ShareSheetRecipientSelected(user));
+                        }
+                      },
                     ),
                     if (state.selectedRecipient != null)
                       _MessageInput(
                         controller: messageController,
-                        recipient: state.selectedRecipient!,
                         isSending: state.isSending,
                         onSend: () => bloc.add(
                           ShareSheetSendRequested(

--- a/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
@@ -266,6 +266,9 @@ class _UnifiedShareSheetState extends ConsumerState<_UnifiedShareSheet> {
           ),
         );
       case ShareSheetSendFailure():
+        // Dismiss too: the send is durably queued and retried in the
+        // background, so there is no in-sheet manual retry to keep open for.
+        _safePop(context);
         messenger
           ..hideCurrentSnackBar()
           ..showSnackBar(

--- a/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
@@ -205,7 +205,7 @@ class _UnifiedShareSheetState extends ConsumerState<_UnifiedShareSheet> {
             listener: (context, state) {
               SemanticsService.sendAnnouncement(
                 View.of(context),
-                context.l10n.shareSendingTo(
+                context.l10n.shareSelectedRecipientAnnouncement(
                   state.selectedRecipient!.displayName ??
                       context.l10n.shareUserFallback,
                 ),

--- a/mobile/lib/widgets/video_feed_item/actions/share_sheet_message_input.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_sheet_message_input.dart
@@ -92,12 +92,18 @@ class _SendButton extends StatelessWidget {
                   color: VineTheme.onPrimary,
                 ),
               )
-            // 20 matches the DM conversation composer's send icon
-            // (message_input_bar.dart) and the sending spinner above.
-            : const DivineIcon(
-                icon: DivineIconName.arrowUp,
-                size: 20,
-                color: VineTheme.onPrimary,
+            // Center loosens the Container's tight 40x40 constraints —
+            // without it the SvgPicture is forced to fill the circle and
+            // the size below is silently ignored. The arrow glyph fills
+            // only ~66%x78% of its SVG viewBox, so 26.667 renders the
+            // ~18x20pt glyph the Figma spec shows — the same value the
+            // reel-reply and comment composers use for this asset.
+            : const Center(
+                child: DivineIcon(
+                  icon: DivineIconName.arrowUp,
+                  size: 26.667,
+                  color: VineTheme.onPrimary,
+                ),
               ),
       ),
     );

--- a/mobile/lib/widgets/video_feed_item/actions/share_sheet_message_input.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_sheet_message_input.dart
@@ -95,13 +95,12 @@ class _SendButton extends StatelessWidget {
             // Center loosens the Container's tight 40x40 constraints —
             // without it the SvgPicture is forced to fill the circle and
             // the size below is silently ignored. The arrow glyph fills
-            // only ~66%x78% of its SVG viewBox, so 26.667 renders the
-            // ~18x20pt glyph the Figma spec shows — the same value the
-            // reel-reply and comment composers use for this asset.
+            // only ~66%x78% of its SVG viewBox, so 28 renders a ~18x22pt
+            // glyph (device-tuned; Figma spec draws ~18x20).
             : const Center(
                 child: DivineIcon(
                   icon: DivineIconName.arrowUp,
-                  size: 26.667,
+                  size: 28,
                   color: VineTheme.onPrimary,
                 ),
               ),

--- a/mobile/lib/widgets/video_feed_item/actions/share_sheet_message_input.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_sheet_message_input.dart
@@ -92,9 +92,11 @@ class _SendButton extends StatelessWidget {
                   color: VineTheme.onPrimary,
                 ),
               )
+            // 20 matches the DM conversation composer's send icon
+            // (message_input_bar.dart) and the sending spinner above.
             : const DivineIcon(
                 icon: DivineIconName.arrowUp,
-                size: 22,
+                size: 20,
                 color: VineTheme.onPrimary,
               ),
       ),

--- a/mobile/lib/widgets/video_feed_item/actions/share_sheet_message_input.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_sheet_message_input.dart
@@ -7,13 +7,11 @@ part of 'share_action_button.dart';
 class _MessageInput extends StatelessWidget {
   const _MessageInput({
     required this.controller,
-    required this.recipient,
     required this.isSending,
     required this.onSend,
   });
 
   final TextEditingController controller;
-  final ShareableUser recipient;
   final bool isSending;
   final VoidCallback onSend;
 
@@ -21,71 +19,46 @@ class _MessageInput extends StatelessWidget {
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 4, 16, 12),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        mainAxisSize: MainAxisSize.min,
+      child: Row(
+        spacing: 8,
         children: [
-          Padding(
-            padding: const EdgeInsets.only(bottom: 8),
-            child: Row(
-              spacing: 8,
-              children: [
-                UserAvatar(
-                  imageUrl: recipient.picture,
-                  name: recipient.displayName,
-                  size: 24,
+          Expanded(
+            child: TextField(
+              controller: controller,
+              // Selection reveals the composer; pop the keyboard right away
+              // so compose-and-send is a single uninterrupted gesture.
+              autofocus: true,
+              style: const TextStyle(
+                color: VineTheme.whiteText,
+                fontSize: 14,
+              ),
+              decoration: InputDecoration(
+                hintText: context.l10n.shareMessageHint,
+                hintStyle: const TextStyle(color: VineTheme.secondaryText),
+                filled: true,
+                fillColor: VineTheme.containerLow,
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(24),
+                  borderSide: BorderSide.none,
                 ),
-                Text(
-                  context.l10n.shareSendingTo(
-                    recipient.displayName ?? context.l10n.shareUserFallback,
-                  ),
-                  style: const TextStyle(
-                    color: VineTheme.secondaryText,
-                    fontSize: 13,
-                  ),
-                ),
-              ],
-            ),
-          ),
-          Row(
-            spacing: 8,
-            children: [
-              Expanded(
-                child: TextField(
-                  controller: controller,
-                  style: const TextStyle(
-                    color: VineTheme.whiteText,
-                    fontSize: 14,
-                  ),
-                  decoration: InputDecoration(
-                    hintText: context.l10n.shareMessageHint,
-                    hintStyle: const TextStyle(color: VineTheme.secondaryText),
-                    filled: true,
-                    fillColor: VineTheme.containerLow,
-                    border: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(24),
-                      borderSide: BorderSide.none,
-                    ),
-                    contentPadding: const EdgeInsets.symmetric(
-                      vertical: 10,
-                      horizontal: 16,
-                    ),
-                  ),
-                  maxLines: 4,
-                  minLines: 1,
-                  maxLength: 500,
-                  buildCounter:
-                      (
-                        context, {
-                        required currentLength,
-                        required isFocused,
-                        required maxLength,
-                      }) => null,
+                contentPadding: const EdgeInsets.symmetric(
+                  vertical: 10,
+                  horizontal: 16,
                 ),
               ),
-              _SendButton(isSending: isSending, onTap: onSend),
-            ],
+              maxLines: 4,
+              minLines: 1,
+              maxLength: 500,
+              buildCounter:
+                  (
+                    context, {
+                    required currentLength,
+                    required isFocused,
+                    required maxLength,
+                  }) => null,
+            ),
           ),
+          _SendButton(isSending: isSending, onTap: onSend),
         ],
       ),
     );

--- a/mobile/lib/widgets/video_feed_item/actions/share_with_section.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_with_section.dart
@@ -17,7 +17,6 @@ class _ShareWithSection extends StatelessWidget {
     required this.contacts,
     required this.contactsLoaded,
     required this.selectedRecipient,
-    required this.sentPubkeys,
     required this.onFindPeople,
     required this.onContactTapped,
   });
@@ -25,7 +24,6 @@ class _ShareWithSection extends StatelessWidget {
   final List<ShareableUser> contacts;
   final bool contactsLoaded;
   final ShareableUser? selectedRecipient;
-  final Set<String> sentPubkeys;
   final VoidCallback onFindPeople;
   final ValueChanged<ShareableUser> onContactTapped;
 
@@ -84,20 +82,14 @@ class _ShareWithSection extends StatelessWidget {
                       child: _ContactItem(
                         user: contact,
                         isSelected: false,
-                        isSent: false,
                         onTap: () {},
                       ),
                     );
                   }
 
-                  final isSelected =
-                      selectedRecipient?.pubkey == contact.pubkey;
-                  final isSent = sentPubkeys.contains(contact.pubkey);
-
                   return _ContactItem(
                     user: contact,
-                    isSelected: isSelected,
-                    isSent: isSent,
+                    isSelected: selectedRecipient?.pubkey == contact.pubkey,
                     onTap: () => onContactTapped(contact),
                   );
                 },
@@ -167,23 +159,22 @@ class _ContactItem extends StatelessWidget {
   const _ContactItem({
     required this.user,
     required this.isSelected,
-    required this.isSent,
     required this.onTap,
   });
 
   final ShareableUser user;
   final bool isSelected;
-  final bool isSent;
   final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
     return Semantics(
       button: true,
+      selected: isSelected,
       label: user.displayName ?? context.l10n.shareContactFallback,
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
-        onTap: isSent ? null : onTap,
+        onTap: onTap,
         child: SizedBox(
           width: _ShareWithSection._itemWidth,
           child: Column(
@@ -192,15 +183,12 @@ class _ContactItem extends StatelessWidget {
             children: [
               Stack(
                 children: [
-                  Opacity(
-                    opacity: isSent ? 0.5 : 1.0,
-                    child: UserAvatar(
-                      imageUrl: user.picture,
-                      name: user.displayName,
-                      size: _ShareWithSection._avatarSize,
-                    ),
+                  UserAvatar(
+                    imageUrl: user.picture,
+                    name: user.displayName,
+                    size: _ShareWithSection._avatarSize,
                   ),
-                  if (isSelected || isSent)
+                  if (isSelected)
                     Positioned(
                       right: 0,
                       bottom: 0,
@@ -221,11 +209,9 @@ class _ContactItem extends StatelessWidget {
                 ],
               ),
               Text(
-                isSent
-                    ? context.l10n.shareSent
-                    : (user.displayName ?? context.l10n.shareUserFallback),
+                user.displayName ?? context.l10n.shareUserFallback,
                 style: TextStyle(
-                  color: (isSelected || isSent)
+                  color: isSelected
                       ? VineTheme.vineGreen
                       : VineTheme.secondaryText,
                   fontSize: 11,

--- a/mobile/lib/widgets/video_feed_item/actions/share_with_section.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_with_section.dart
@@ -16,14 +16,14 @@ class _ShareWithSection extends StatelessWidget {
   const _ShareWithSection({
     required this.contacts,
     required this.contactsLoaded,
-    required this.selectedRecipient,
+    required this.selectedPubkeys,
     required this.onFindPeople,
     required this.onContactTapped,
   });
 
   final List<ShareableUser> contacts;
   final bool contactsLoaded;
-  final ShareableUser? selectedRecipient;
+  final Set<String> selectedPubkeys;
   final VoidCallback onFindPeople;
   final ValueChanged<ShareableUser> onContactTapped;
 
@@ -89,7 +89,7 @@ class _ShareWithSection extends StatelessWidget {
 
                   return _ContactItem(
                     user: contact,
-                    isSelected: selectedRecipient?.pubkey == contact.pubkey,
+                    isSelected: selectedPubkeys.contains(contact.pubkey),
                     onTap: () => onContactTapped(contact),
                   );
                 },

--- a/mobile/lib/widgets/video_feed_item/inline_comment_composer_bar.dart
+++ b/mobile/lib/widgets/video_feed_item/inline_comment_composer_bar.dart
@@ -23,7 +23,13 @@ import 'package:openvine/l10n/l10n.dart';
 /// bar height. Visibility is owned by the parent screen, which gates on
 /// "active video present" and "user signed in".
 class InlineCommentComposerBar extends StatefulWidget {
-  const InlineCommentComposerBar({super.key});
+  const InlineCommentComposerBar({super.key, this.onFocusChanged});
+
+  /// Notifies the parent screen when this composer gains/loses focus, so it
+  /// can drive `Scaffold.resizeToAvoidBottomInset` only while THIS field is
+  /// focused — the reel must not resize (and jank) for a keyboard owned by a
+  /// modal on top (e.g. the share sheet). See [PooledFullscreenVideoFeedScreen].
+  final ValueChanged<bool>? onFocusChanged;
 
   @override
   State<InlineCommentComposerBar> createState() =>
@@ -48,6 +54,7 @@ class _InlineCommentComposerBarState extends State<InlineCommentComposerBar> {
   void initState() {
     super.initState();
     _controller.addListener(_handleTextChanged);
+    _focusNode.addListener(_handleFocusChanged);
   }
 
   @override
@@ -55,8 +62,14 @@ class _InlineCommentComposerBarState extends State<InlineCommentComposerBar> {
     _controller
       ..removeListener(_handleTextChanged)
       ..dispose();
-    _focusNode.dispose();
+    _focusNode
+      ..removeListener(_handleFocusChanged)
+      ..dispose();
     super.dispose();
+  }
+
+  void _handleFocusChanged() {
+    widget.onFocusChanged?.call(_focusNode.hasFocus);
   }
 
   void _handleTextChanged() {

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -2653,6 +2653,10 @@ class DmRepository {
   /// citation can't be built, falls back to a plain-text [sendMessage] so the
   /// share still goes through (the URL remains in [baseContent]).
   ///
+  /// [skipNip04Fallback] forwards to [sendMessage]: pass `true` to suppress the
+  /// legacy plaintext kind-4 copy (recommended for shares — see the caller in
+  /// `VideoSharingService`).
+  ///
   /// Throws the same errors as [sendMessage].
   Future<NIP17SendResult> sendSharedVideo({
     required String recipientPubkey,
@@ -2663,6 +2667,7 @@ class DmRepository {
     String? videoEventId,
     String? relayHint,
     String? replyToId,
+    bool skipNip04Fallback = false,
   }) async {
     final citation = DmSharedVideoCitation.build(
       videoKind: videoKind,
@@ -2689,6 +2694,7 @@ class DmRepository {
         recipientPubkey: recipientPubkey,
         content: baseContent,
         replyToId: replyToId,
+        skipNip04Fallback: skipNip04Fallback,
       );
     }
 
@@ -2697,6 +2703,7 @@ class DmRepository {
       content: '$baseContent\n${citation.nostrUri}',
       additionalTags: [citation.qTag],
       replyToId: replyToId,
+      skipNip04Fallback: skipNip04Fallback,
     );
   }
 

--- a/mobile/test/blocs/share_sheet/share_sheet_bloc_test.dart
+++ b/mobile/test/blocs/share_sheet/share_sheet_bloc_test.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Tests for ShareSheetBloc
-// ABOUTME: Verifies contact loading, quick-send, send-with-message,
+// ABOUTME: Verifies contact loading, recipient selection, send-with-message,
 // ABOUTME: save, copy, and share-via action flows
 
 import 'package:bloc_test/bloc_test.dart';
@@ -140,7 +140,6 @@ void main() {
       expect(bloc.state.status, equals(ShareSheetStatus.initial));
       expect(bloc.state.contacts, isEmpty);
       expect(bloc.state.selectedRecipient, isNull);
-      expect(bloc.state.sentPubkeys, isEmpty);
       expect(bloc.state.isSending, isFalse);
       expect(bloc.state.actionResult, isNull);
       bloc.close();
@@ -366,136 +365,12 @@ void main() {
     });
 
     // -----------------------------------------------------------------------
-    // Quick-send
-    // -----------------------------------------------------------------------
-
-    group('ShareSheetQuickSendRequested', () {
-      const otherRecipient = ShareableUser(
-        pubkey:
-            'ffff456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
-        displayName: 'Bob',
-      );
-
-      blocTest<ShareSheetBloc, ShareSheetState>(
-        'optimistically marks sent and emits success immediately, no wait',
-        setUp: () {
-          when(
-            () => mockSharingService.shareVideoWithUser(
-              video: any(named: 'video'),
-              recipientPubkey: any(named: 'recipientPubkey'),
-            ),
-          ).thenAnswer((_) async => ShareResult.createSuccess('msg-event-id'));
-        },
-        seed: () => const ShareSheetState(status: ShareSheetStatus.ready),
-        build: createBloc,
-        act: (bloc) =>
-            bloc.add(const ShareSheetQuickSendRequested(testRecipient)),
-        // A single optimistic emit: marked sent + success toast, no isSending
-        // step. The background send succeeds, so nothing more is emitted.
-        expect: () => [
-          isA<ShareSheetState>()
-              .having((s) => s.isSending, 'isSending', isFalse)
-              .having((s) => s.selectedRecipient, 'selectedRecipient', isNull)
-              .having(
-                (s) => s.sentPubkeys.contains(testRecipient.pubkey),
-                'sentPubkeys contains recipient',
-                isTrue,
-              )
-              .having(
-                (s) => s.actionResult,
-                'actionResult',
-                isA<ShareSheetSendSuccess>()
-                    .having((r) => r.recipientName, 'name', 'Alice')
-                    .having((r) => r.shouldDismiss, 'shouldDismiss', isFalse),
-              ),
-        ],
-      );
-
-      blocTest<ShareSheetBloc, ShareSheetState>(
-        'rolls back the optimistic mark and emits failure when send fails',
-        setUp: () {
-          when(
-            () => mockSharingService.shareVideoWithUser(
-              video: any(named: 'video'),
-              recipientPubkey: any(named: 'recipientPubkey'),
-            ),
-          ).thenAnswer((_) async => ShareResult.failure('Relay offline'));
-        },
-        seed: () => const ShareSheetState(status: ShareSheetStatus.ready),
-        build: createBloc,
-        act: (bloc) =>
-            bloc.add(const ShareSheetQuickSendRequested(testRecipient)),
-        expect: () => [
-          // Optimistic success first…
-          isA<ShareSheetState>()
-              .having(
-                (s) => s.sentPubkeys.contains(testRecipient.pubkey),
-                'optimistically sent',
-                isTrue,
-              )
-              .having(
-                (s) => s.actionResult,
-                'actionResult',
-                isA<ShareSheetSendSuccess>(),
-              ),
-          // …then rolled back with a failure once the background send fails.
-          isA<ShareSheetState>()
-              .having(
-                (s) => s.sentPubkeys.contains(testRecipient.pubkey),
-                'rolled back',
-                isFalse,
-              )
-              .having(
-                (s) => s.actionResult,
-                'actionResult',
-                isA<ShareSheetSendFailure>(),
-              ),
-        ],
-      );
-
-      blocTest<ShareSheetBloc, ShareSheetState>(
-        'confirms multiple recipients tapped in a row (concurrent)',
-        setUp: () {
-          when(
-            () => mockSharingService.shareVideoWithUser(
-              video: any(named: 'video'),
-              recipientPubkey: any(named: 'recipientPubkey'),
-            ),
-          ).thenAnswer((_) async => ShareResult.createSuccess('msg-event-id'));
-        },
-        seed: () => const ShareSheetState(status: ShareSheetStatus.ready),
-        build: createBloc,
-        act: (bloc) => bloc
-          ..add(const ShareSheetQuickSendRequested(testRecipient))
-          ..add(const ShareSheetQuickSendRequested(otherRecipient)),
-        verify: (bloc) {
-          expect(
-            bloc.state.sentPubkeys,
-            containsAll([testRecipient.pubkey, otherRecipient.pubkey]),
-          );
-        },
-      );
-
-      blocTest<ShareSheetBloc, ShareSheetState>(
-        'ignores event when pubkey already sent',
-        seed: () => ShareSheetState(
-          status: ShareSheetStatus.ready,
-          sentPubkeys: {testRecipient.pubkey},
-        ),
-        build: createBloc,
-        act: (bloc) =>
-            bloc.add(const ShareSheetQuickSendRequested(testRecipient)),
-        expect: () => <ShareSheetState>[],
-      );
-    });
-
-    // -----------------------------------------------------------------------
     // Send with message
     // -----------------------------------------------------------------------
 
     group('ShareSheetSendRequested', () {
       blocTest<ShareSheetBloc, ShareSheetState>(
-        'emits success with shouldDismiss true when send succeeds',
+        'emits success carrying the conversation id when send succeeds',
         setUp: () {
           when(
             () => mockSharingService.shareVideoWithUser(
@@ -503,7 +378,12 @@ void main() {
               recipientPubkey: any(named: 'recipientPubkey'),
               personalMessage: any(named: 'personalMessage'),
             ),
-          ).thenAnswer((_) async => ShareResult.createSuccess('msg-event-id'));
+          ).thenAnswer(
+            (_) async => ShareResult.createSuccess(
+              'msg-event-id',
+              conversationId: 'conversation-1',
+            ),
+          );
         },
         seed: () => const ShareSheetState(
           status: ShareSheetStatus.ready,
@@ -523,12 +403,54 @@ void main() {
               .having(
                 (s) => s.actionResult,
                 'actionResult',
-                isA<ShareSheetSendSuccess>().having(
-                  (r) => r.shouldDismiss,
-                  'shouldDismiss',
-                  isTrue,
-                ),
+                isA<ShareSheetSendSuccess>()
+                    .having((r) => r.recipientName, 'name', 'Alice')
+                    .having(
+                      (r) => r.recipientPubkey,
+                      'recipientPubkey',
+                      testRecipient.pubkey,
+                    )
+                    .having(
+                      (r) => r.conversationId,
+                      'conversationId',
+                      'conversation-1',
+                    ),
               ),
+        ],
+      );
+
+      blocTest<ShareSheetBloc, ShareSheetState>(
+        'emits success with null conversation id on the legacy NIP-04 path',
+        setUp: () {
+          when(
+            () => mockSharingService.shareVideoWithUser(
+              video: any(named: 'video'),
+              recipientPubkey: any(named: 'recipientPubkey'),
+              personalMessage: any(named: 'personalMessage'),
+            ),
+          ).thenAnswer((_) async => ShareResult.createSuccess('msg-event-id'));
+        },
+        seed: () => const ShareSheetState(
+          status: ShareSheetStatus.ready,
+          selectedRecipient: testRecipient,
+        ),
+        build: createBloc,
+        act: (bloc) => bloc.add(const ShareSheetSendRequested()),
+        expect: () => [
+          isA<ShareSheetState>().having(
+            (s) => s.isSending,
+            'isSending',
+            isTrue,
+          ),
+          isA<ShareSheetState>().having(
+            (s) => s.actionResult,
+            'actionResult',
+            isA<ShareSheetSendSuccess>().having(
+              (r) => r.conversationId,
+              'conversationId',
+              isNull,
+            ),
+          ),
         ],
       );
 

--- a/mobile/test/blocs/share_sheet/share_sheet_bloc_test.dart
+++ b/mobile/test/blocs/share_sheet/share_sheet_bloc_test.dart
@@ -547,7 +547,8 @@ void main() {
       );
 
       blocTest<ShareSheetBloc, ShareSheetState>(
-        'keeps only failed recipients selected on partial failure',
+        'on partial failure reports the delivered recipients and clears the '
+        'selection (durable queue retries the rest, no manual re-send)',
         setUp: () => stubMultiSend({
           testRecipient.pubkey: ShareResult.createSuccess('msg-1'),
           otherRecipient.pubkey: ShareResult.failure('Relay offline'),
@@ -567,10 +568,42 @@ void main() {
           isA<ShareSheetState>()
               .having((s) => s.isSending, 'isSending', isFalse)
               .having(
-                (s) => s.selectedRecipients.map((r) => r.pubkey),
-                'only the failed recipient stays selected',
-                [otherRecipient.pubkey],
+                (s) => s.selectedRecipients,
+                'selection cleared',
+                isEmpty,
               )
+              .having(
+                (s) => s.actionResult,
+                'actionResult',
+                // Reports only the delivered recipient; no View chat because
+                // more than one recipient was targeted.
+                isA<ShareSheetSendSuccess>()
+                    .having((r) => r.recipientNames, 'names', ['Alice'])
+                    .having((r) => r.conversationId, 'conversationId', isNull),
+              ),
+        ],
+      );
+
+      blocTest<ShareSheetBloc, ShareSheetState>(
+        'emits failure and clears the selection when every recipient fails',
+        setUp: () => stubMultiSend({
+          testRecipient.pubkey: ShareResult.failure('Relay offline'),
+          otherRecipient.pubkey: ShareResult.failure('Relay offline'),
+        }),
+        seed: () => const ShareSheetState(
+          status: ShareSheetStatus.ready,
+          selectedRecipients: [testRecipient, otherRecipient],
+        ),
+        build: createBloc,
+        act: (bloc) => bloc.add(const ShareSheetSendRequested()),
+        expect: () => [
+          isA<ShareSheetState>().having(
+            (s) => s.isSending,
+            'isSending',
+            isTrue,
+          ),
+          isA<ShareSheetState>()
+              .having((s) => s.selectedRecipients, 'selection cleared', isEmpty)
               .having(
                 (s) => s.actionResult,
                 'actionResult',
@@ -629,6 +662,7 @@ void main() {
           ),
           isA<ShareSheetState>()
               .having((s) => s.isSending, 'isSending', isFalse)
+              .having((s) => s.selectedRecipients, 'selection cleared', isEmpty)
               .having(
                 (s) => s.actionResult,
                 'actionResult',

--- a/mobile/test/blocs/share_sheet/share_sheet_bloc_test.dart
+++ b/mobile/test/blocs/share_sheet/share_sheet_bloc_test.dart
@@ -139,7 +139,7 @@ void main() {
       final bloc = createBloc();
       expect(bloc.state.status, equals(ShareSheetStatus.initial));
       expect(bloc.state.contacts, isEmpty);
-      expect(bloc.state.selectedRecipient, isNull);
+      expect(bloc.state.selectedRecipients, isEmpty);
       expect(bloc.state.isSending, isFalse);
       expect(bloc.state.actionResult, isNull);
       bloc.close();
@@ -322,44 +322,98 @@ void main() {
     // Recipient selection
     // -----------------------------------------------------------------------
 
-    group('ShareSheetRecipientSelected', () {
+    group('ShareSheetRecipientToggled', () {
+      const otherRecipient = ShareableUser(
+        pubkey:
+            'bbbb456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+        displayName: 'Bob',
+      );
+
       blocTest<ShareSheetBloc, ShareSheetState>(
-        'sets selected recipient and adds to front of contacts',
-        seed: () => const ShareSheetState(status: ShareSheetStatus.ready),
+        'adds an unselected contact to the selection without reordering '
+        'contacts',
+        seed: () => const ShareSheetState(
+          status: ShareSheetStatus.ready,
+          contacts: [otherRecipient, testRecipient],
+        ),
         build: createBloc,
         act: (bloc) =>
-            bloc.add(const ShareSheetRecipientSelected(testRecipient)),
+            bloc.add(const ShareSheetRecipientToggled(testRecipient)),
         expect: () => [
           isA<ShareSheetState>()
               .having(
-                (s) => s.selectedRecipient?.pubkey,
-                'selected pubkey',
-                testRecipient.pubkey,
+                (s) => s.selectedRecipients.map((r) => r.pubkey),
+                'selected pubkeys',
+                [testRecipient.pubkey],
               )
               .having(
                 (s) => s.contacts.first.pubkey,
-                'first contact',
-                testRecipient.pubkey,
+                'first contact unchanged',
+                otherRecipient.pubkey,
               ),
         ],
       );
-    });
 
-    group('ShareSheetRecipientCleared', () {
       blocTest<ShareSheetBloc, ShareSheetState>(
-        'clears selected recipient',
+        'accumulates multiple selected recipients in tap order',
         seed: () => const ShareSheetState(
           status: ShareSheetStatus.ready,
-          selectedRecipient: testRecipient,
+          contacts: [testRecipient, otherRecipient],
         ),
         build: createBloc,
-        act: (bloc) => bloc.add(const ShareSheetRecipientCleared()),
+        act: (bloc) => bloc
+          ..add(const ShareSheetRecipientToggled(testRecipient))
+          ..add(const ShareSheetRecipientToggled(otherRecipient)),
+        skip: 1,
         expect: () => [
           isA<ShareSheetState>().having(
-            (s) => s.selectedRecipient,
-            'selectedRecipient',
-            isNull,
+            (s) => s.selectedRecipients.map((r) => r.pubkey),
+            'selected pubkeys',
+            [testRecipient.pubkey, otherRecipient.pubkey],
           ),
+        ],
+      );
+
+      blocTest<ShareSheetBloc, ShareSheetState>(
+        'removes an already-selected recipient, keeping the others',
+        seed: () => const ShareSheetState(
+          status: ShareSheetStatus.ready,
+          contacts: [testRecipient, otherRecipient],
+          selectedRecipients: [testRecipient, otherRecipient],
+        ),
+        build: createBloc,
+        act: (bloc) =>
+            bloc.add(const ShareSheetRecipientToggled(testRecipient)),
+        expect: () => [
+          isA<ShareSheetState>().having(
+            (s) => s.selectedRecipients.map((r) => r.pubkey),
+            'selected pubkeys',
+            [otherRecipient.pubkey],
+          ),
+        ],
+      );
+
+      blocTest<ShareSheetBloc, ShareSheetState>(
+        'inserts a Find People pick missing from contacts at the front',
+        seed: () => const ShareSheetState(
+          status: ShareSheetStatus.ready,
+          contacts: [otherRecipient],
+        ),
+        build: createBloc,
+        act: (bloc) =>
+            bloc.add(const ShareSheetRecipientToggled(testRecipient)),
+        expect: () => [
+          isA<ShareSheetState>()
+              .having(
+                (s) => s.selectedRecipients.map((r) => r.pubkey),
+                'selected pubkeys',
+                [testRecipient.pubkey],
+              )
+              .having(
+                (s) => s.contacts.map((c) => c.pubkey),
+                'contacts',
+                [testRecipient.pubkey, otherRecipient.pubkey],
+              ),
         ],
       );
     });
@@ -369,25 +423,33 @@ void main() {
     // -----------------------------------------------------------------------
 
     group('ShareSheetSendRequested', () {
+      const otherRecipient = ShareableUser(
+        pubkey:
+            'bbbb456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+        displayName: 'Bob',
+      );
+
+      void stubMultiSend(Map<String, ShareResult> results) {
+        when(
+          () => mockSharingService.shareVideoWithMultipleUsers(
+            video: any(named: 'video'),
+            recipientPubkeys: any(named: 'recipientPubkeys'),
+            personalMessage: any(named: 'personalMessage'),
+          ),
+        ).thenAnswer((_) async => results);
+      }
+
       blocTest<ShareSheetBloc, ShareSheetState>(
-        'emits success carrying the conversation id when send succeeds',
-        setUp: () {
-          when(
-            () => mockSharingService.shareVideoWithUser(
-              video: any(named: 'video'),
-              recipientPubkey: any(named: 'recipientPubkey'),
-              personalMessage: any(named: 'personalMessage'),
-            ),
-          ).thenAnswer(
-            (_) async => ShareResult.createSuccess(
-              'msg-event-id',
-              conversationId: 'conversation-1',
-            ),
-          );
-        },
+        'emits success carrying the conversation id for a single recipient',
+        setUp: () => stubMultiSend({
+          testRecipient.pubkey: ShareResult.createSuccess(
+            'msg-event-id',
+            conversationId: 'conversation-1',
+          ),
+        }),
         seed: () => const ShareSheetState(
           status: ShareSheetStatus.ready,
-          selectedRecipient: testRecipient,
+          selectedRecipients: [testRecipient],
         ),
         build: createBloc,
         act: (bloc) =>
@@ -401,10 +463,15 @@ void main() {
           isA<ShareSheetState>()
               .having((s) => s.isSending, 'isSending', isFalse)
               .having(
+                (s) => s.selectedRecipients,
+                'selection cleared',
+                isEmpty,
+              )
+              .having(
                 (s) => s.actionResult,
                 'actionResult',
                 isA<ShareSheetSendSuccess>()
-                    .having((r) => r.recipientName, 'name', 'Alice')
+                    .having((r) => r.recipientNames, 'names', ['Alice'])
                     .having(
                       (r) => r.recipientPubkey,
                       'recipientPubkey',
@@ -420,19 +487,74 @@ void main() {
       );
 
       blocTest<ShareSheetBloc, ShareSheetState>(
-        'emits success with null conversation id on the legacy NIP-04 path',
-        setUp: () {
-          when(
-            () => mockSharingService.shareVideoWithUser(
-              video: any(named: 'video'),
-              recipientPubkey: any(named: 'recipientPubkey'),
-              personalMessage: any(named: 'personalMessage'),
-            ),
-          ).thenAnswer((_) async => ShareResult.createSuccess('msg-event-id'));
-        },
+        'fans out to every selected recipient with no View chat target',
+        setUp: () => stubMultiSend({
+          testRecipient.pubkey: ShareResult.createSuccess('msg-1'),
+          otherRecipient.pubkey: ShareResult.createSuccess('msg-2'),
+        }),
         seed: () => const ShareSheetState(
           status: ShareSheetStatus.ready,
-          selectedRecipient: testRecipient,
+          selectedRecipients: [testRecipient, otherRecipient],
+        ),
+        build: createBloc,
+        act: (bloc) => bloc.add(const ShareSheetSendRequested(message: 'yo')),
+        expect: () => [
+          isA<ShareSheetState>().having(
+            (s) => s.isSending,
+            'isSending',
+            isTrue,
+          ),
+          isA<ShareSheetState>()
+              .having(
+                (s) => s.selectedRecipients,
+                'selection cleared',
+                isEmpty,
+              )
+              .having(
+                (s) => s.actionResult,
+                'actionResult',
+                isA<ShareSheetSendSuccess>()
+                    .having((r) => r.recipientNames, 'names', [
+                      'Alice',
+                      'Bob',
+                    ])
+                    .having(
+                      (r) => r.conversationId,
+                      'conversationId',
+                      isNull,
+                    )
+                    .having(
+                      (r) => r.recipientPubkey,
+                      'recipientPubkey',
+                      isNull,
+                    ),
+              ),
+        ],
+        verify: (_) {
+          final captured = verify(
+            () => mockSharingService.shareVideoWithMultipleUsers(
+              video: any(named: 'video'),
+              recipientPubkeys: captureAny(named: 'recipientPubkeys'),
+              personalMessage: captureAny(named: 'personalMessage'),
+            ),
+          ).captured;
+          expect(
+            captured[0],
+            equals([testRecipient.pubkey, otherRecipient.pubkey]),
+          );
+          expect(captured[1], equals('yo'));
+        },
+      );
+
+      blocTest<ShareSheetBloc, ShareSheetState>(
+        'keeps only failed recipients selected on partial failure',
+        setUp: () => stubMultiSend({
+          testRecipient.pubkey: ShareResult.createSuccess('msg-1'),
+          otherRecipient.pubkey: ShareResult.failure('Relay offline'),
+        }),
+        seed: () => const ShareSheetState(
+          status: ShareSheetStatus.ready,
+          selectedRecipients: [testRecipient, otherRecipient],
         ),
         build: createBloc,
         act: (bloc) => bloc.add(const ShareSheetSendRequested()),
@@ -442,62 +564,59 @@ void main() {
             'isSending',
             isTrue,
           ),
-          isA<ShareSheetState>().having(
-            (s) => s.actionResult,
-            'actionResult',
-            isA<ShareSheetSendSuccess>().having(
-              (r) => r.conversationId,
-              'conversationId',
-              isNull,
-            ),
-          ),
+          isA<ShareSheetState>()
+              .having((s) => s.isSending, 'isSending', isFalse)
+              .having(
+                (s) => s.selectedRecipients.map((r) => r.pubkey),
+                'only the failed recipient stays selected',
+                [otherRecipient.pubkey],
+              )
+              .having(
+                (s) => s.actionResult,
+                'actionResult',
+                isA<ShareSheetSendFailure>(),
+              ),
         ],
       );
 
       blocTest<ShareSheetBloc, ShareSheetState>(
         'sends null personalMessage when message is whitespace only',
-        setUp: () {
-          when(
-            () => mockSharingService.shareVideoWithUser(
-              video: any(named: 'video'),
-              recipientPubkey: any(named: 'recipientPubkey'),
-              personalMessage: any(named: 'personalMessage'),
-            ),
-          ).thenAnswer((_) async => ShareResult.createSuccess('msg-event-id'));
-        },
+        setUp: () => stubMultiSend({
+          testRecipient.pubkey: ShareResult.createSuccess('msg-event-id'),
+        }),
         seed: () => const ShareSheetState(
           status: ShareSheetStatus.ready,
-          selectedRecipient: testRecipient,
+          selectedRecipients: [testRecipient],
         ),
         build: createBloc,
         act: (bloc) => bloc.add(const ShareSheetSendRequested(message: '   ')),
         verify: (_) {
           final captured = verify(
-            () => mockSharingService.shareVideoWithUser(
+            () => mockSharingService.shareVideoWithMultipleUsers(
               video: any(named: 'video'),
-              recipientPubkey: captureAny(named: 'recipientPubkey'),
+              recipientPubkeys: captureAny(named: 'recipientPubkeys'),
               personalMessage: captureAny(named: 'personalMessage'),
             ),
           ).captured;
-          expect(captured[0], equals(testRecipient.pubkey));
+          expect(captured[0], equals([testRecipient.pubkey]));
           expect(captured[1], isNull, reason: 'whitespace trimmed to null');
         },
       );
 
       blocTest<ShareSheetBloc, ShareSheetState>(
-        'emits failure when shareVideoWithUser throws an exception',
+        'emits failure when the sharing service throws an exception',
         setUp: () {
           when(
-            () => mockSharingService.shareVideoWithUser(
+            () => mockSharingService.shareVideoWithMultipleUsers(
               video: any(named: 'video'),
-              recipientPubkey: any(named: 'recipientPubkey'),
+              recipientPubkeys: any(named: 'recipientPubkeys'),
               personalMessage: any(named: 'personalMessage'),
             ),
           ).thenThrow(Exception('Unexpected error'));
         },
         seed: () => const ShareSheetState(
           status: ShareSheetStatus.ready,
-          selectedRecipient: testRecipient,
+          selectedRecipients: [testRecipient],
         ),
         build: createBloc,
         act: (bloc) => bloc.add(const ShareSheetSendRequested()),
@@ -530,7 +649,7 @@ void main() {
         'does nothing when already sending',
         seed: () => const ShareSheetState(
           status: ShareSheetStatus.ready,
-          selectedRecipient: testRecipient,
+          selectedRecipients: [testRecipient],
           isSending: true,
         ),
         build: createBloc,

--- a/mobile/test/router/app_shell_obscured_test.dart
+++ b/mobile/test/router/app_shell_obscured_test.dart
@@ -195,4 +195,51 @@ void main() {
       expect(container.read(shellObscuredProvider), isFalse);
     },
   );
+
+  testWidgets(
+    'shell stops resizing for the keyboard while a modal (e.g. the share '
+    'sheet) is on top, so the home feed does not re-layout (#5758)',
+    (tester) async {
+      await tester.pumpWidget(
+        _buildSubject(
+          mockAuthService: mockAuthService,
+          sharedPreferences: sharedPreferences,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      Scaffold shellScaffold() => tester.widget<Scaffold>(
+        find
+            .descendant(
+              of: find.byType(AppShell),
+              matching: find.byType(Scaffold),
+            )
+            .first,
+      );
+
+      // Shell is the topmost route: keep resizing so keyboard-driven UI on the
+      // active tab still lifts above the keyboard.
+      expect(shellScaffold().resizeToAvoidBottomInset, isTrue);
+
+      // Open a modal over the shell — the share sheet is one of these. Its own
+      // keyboard avoidance lifts it above the keyboard; the shell must NOT also
+      // shrink, which would re-layout the full-screen feed video + overlay
+      // (the Galaxy S10 lag reported on #5758).
+      final shellContext = tester.element(find.byType(AppShell));
+      unawaited(
+        showModalBottomSheet<void>(
+          context: shellContext,
+          isScrollControlled: true,
+          builder: (_) => const SizedBox(height: 200),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(shellScaffold().resizeToAvoidBottomInset, isFalse);
+
+      // Restored once the modal closes.
+      Navigator.of(shellContext).pop();
+      await tester.pumpAndSettle();
+      expect(shellScaffold().resizeToAvoidBottomInset, isTrue);
+    },
+  );
 }

--- a/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
+++ b/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
@@ -432,6 +432,57 @@ void main() {
         expect(find.byType(InfiniteVideoFeed), findsOneWidget);
       });
 
+      testWidgets(
+        'stops resizing for the keyboard while a modal (e.g. the share sheet) '
+        'is on top, so the reel does not re-layout (#5758)',
+        (tester) async {
+          final videos = createTestVideos();
+
+          await tester.pumpWidget(
+            buildSubject(
+              state: FullscreenFeedState(
+                status: FullscreenFeedStatus.ready,
+                videos: videos,
+              ),
+            ),
+          );
+
+          Scaffold feedScaffold() =>
+              tester.widget<Scaffold>(find.byType(Scaffold).first);
+
+          // Feed is the topmost route: keep resizing so its own bottom
+          // composers can lift above the keyboard.
+          expect(feedScaffold().resizeToAvoidBottomInset, isTrue);
+
+          // Open a modal over the feed (the share sheet is one of these).
+          // The feed keeps videos animating, so pumpAndSettle never quiesces;
+          // pump fixed frames past the modal's transition instead.
+          final feedContext = tester.element(find.byType(FeedVideos));
+          unawaited(
+            showModalBottomSheet<void>(
+              context: feedContext,
+              isScrollControlled: true,
+              builder: (_) => const SizedBox(height: 200),
+            ),
+          );
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 400));
+
+          // The modal owns its keyboard avoidance; the feed must not also
+          // shrink (which would re-layout the full-screen reel + overlay).
+          expect(feedScaffold().resizeToAvoidBottomInset, isFalse);
+
+          // Restored once the modal closes.
+          final navigator = tester.state<NavigatorState>(
+            find.byType(Navigator).first,
+          );
+          navigator.pop();
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 400));
+          expect(feedScaffold().resizeToAvoidBottomInset, isTrue);
+        },
+      );
+
       testWidgets('passes route traffic attribution to FeedVideos', (
         tester,
       ) async {

--- a/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
+++ b/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
@@ -34,6 +34,7 @@ import 'package:openvine/services/view_event_publisher.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/video_feed_item/actions/actions.dart';
 import 'package:openvine/widgets/video_feed_item/feed_videos.dart';
+import 'package:openvine/widgets/video_feed_item/inline_comment_composer_bar.dart';
 import 'package:openvine/widgets/video_feed_item/moderated_content_overlay.dart';
 
 import '../../helpers/test_provider_overrides.dart';
@@ -433,53 +434,70 @@ void main() {
       });
 
       testWidgets(
-        'stops resizing for the keyboard while a modal (e.g. the share sheet) '
-        'is on top, so the reel does not re-layout (#5758)',
+        'resizes for the keyboard only while its OWN composer is focused — '
+        'not for a modal (e.g. the share sheet) on top (#5758)',
         (tester) async {
+          final mockAuth = createMockAuthService();
+          when(() => mockAuth.isAuthenticated).thenReturn(true);
+          when(
+            () => mockAuth.currentPublicKeyHex,
+          ).thenReturn('a' * 64);
+
           final videos = createTestVideos();
 
           await tester.pumpWidget(
             buildSubject(
+              mockAuthService: mockAuth,
               state: FullscreenFeedState(
                 status: FullscreenFeedStatus.ready,
                 videos: videos,
               ),
             ),
           );
+          await tester.pump();
 
           Scaffold feedScaffold() =>
               tester.widget<Scaffold>(find.byType(Scaffold).first);
 
-          // Feed is the topmost route: keep resizing so its own bottom
-          // composers can lift above the keyboard.
-          expect(feedScaffold().resizeToAvoidBottomInset, isTrue);
+          // Idle: nothing focused → no resize (the reel never shrinks).
+          expect(feedScaffold().resizeToAvoidBottomInset, isFalse);
 
-          // Open a modal over the feed (the share sheet is one of these).
-          // The feed keeps videos animating, so pumpAndSettle never quiesces;
-          // pump fixed frames past the modal's transition instead.
+          // A modal (the share sheet is one) opening its own keyboard must NOT
+          // make the feed resize — that is the jank we are fixing. The feed
+          // keeps videos animating, so pumpAndSettle never quiesces; pump
+          // fixed frames past the modal transition instead.
           final feedContext = tester.element(find.byType(FeedVideos));
           unawaited(
             showModalBottomSheet<void>(
               context: feedContext,
               isScrollControlled: true,
-              builder: (_) => const SizedBox(height: 200),
+              builder: (_) => const TextField(autofocus: true),
             ),
           );
           await tester.pump();
           await tester.pump(const Duration(milliseconds: 400));
-
-          // The modal owns its keyboard avoidance; the feed must not also
-          // shrink (which would re-layout the full-screen reel + overlay).
           expect(feedScaffold().resizeToAvoidBottomInset, isFalse);
 
-          // Restored once the modal closes.
-          final navigator = tester.state<NavigatorState>(
-            find.byType(Navigator).first,
-          );
-          navigator.pop();
+          tester.state<NavigatorState>(find.byType(Navigator).first).pop();
           await tester.pump();
           await tester.pump(const Duration(milliseconds: 400));
+
+          // Focusing the feed's OWN inline comment composer DOES resize, so it
+          // can lift above the keyboard.
+          final composerField = find.descendant(
+            of: find.byType(InlineCommentComposerBar),
+            matching: find.byType(TextField),
+          );
+          expect(composerField, findsOneWidget);
+          await tester.tap(composerField);
+          await tester.pump();
           expect(feedScaffold().resizeToAvoidBottomInset, isTrue);
+
+          // Dispose the feed so its playback timers are cancelled before the
+          // per-test pending-timer invariant runs.
+          await tester.pumpWidget(const SizedBox.shrink());
+          await tester.pump();
+          await tester.pump(Duration.zero);
         },
       );
 

--- a/mobile/test/services/video_sharing_service_test.dart
+++ b/mobile/test/services/video_sharing_service_test.dart
@@ -380,6 +380,7 @@ void main() {
           videoDTag: any(named: 'videoDTag'),
           videoEventId: any(named: 'videoEventId'),
           relayHint: any(named: 'relayHint'),
+          skipNip04Fallback: any(named: 'skipNip04Fallback'),
         ),
       ).thenAnswer(
         (_) async => NIP17SendResult.success(
@@ -410,7 +411,8 @@ void main() {
       expect(result.messageEventId, equals('nip17-msg-id'));
       expect(result.conversationId, isNotNull);
 
-      // Verify NIP-17 was used, NOT NIP-04
+      // Verify NIP-17 was used, NOT NIP-04, and that the plaintext kind-4
+      // fallback is suppressed for shares (no sender↔recipient metadata leak).
       verify(
         () => mockDmRepository.sendSharedVideo(
           recipientPubkey: _recipientPubkey,
@@ -420,6 +422,7 @@ void main() {
           videoDTag: any(named: 'videoDTag'),
           videoEventId: any(named: 'videoEventId'),
           relayHint: any(named: 'relayHint'),
+          skipNip04Fallback: true,
         ),
       ).called(1);
       verifyNever(
@@ -430,6 +433,75 @@ void main() {
         ),
       );
     });
+
+    test(
+      'shareVideoWithMultipleUsers: one recipient failing does not abort the '
+      'rest, and each outcome is reported',
+      () async {
+        when(() => mockAuthService.isAuthenticated).thenReturn(true);
+        when(
+          () => mockProfileRepository.fetchFreshProfile(
+            pubkey: any(named: 'pubkey'),
+          ),
+        ).thenAnswer((_) async => null);
+
+        final goodA = 'a' * 64;
+        final bad = 'b' * 64;
+        final goodC = 'c' * 64;
+
+        when(
+          () => mockDmRepository.sendSharedVideo(
+            recipientPubkey: any(named: 'recipientPubkey'),
+            baseContent: any(named: 'baseContent'),
+            videoKind: any(named: 'videoKind'),
+            videoAuthorPubkey: any(named: 'videoAuthorPubkey'),
+            videoDTag: any(named: 'videoDTag'),
+            videoEventId: any(named: 'videoEventId'),
+            relayHint: any(named: 'relayHint'),
+            skipNip04Fallback: any(named: 'skipNip04Fallback'),
+          ),
+        ).thenAnswer((invocation) async {
+          final pubkey = invocation.namedArguments[#recipientPubkey] as String;
+          if (pubkey == bad) throw StateError('boom');
+          return NIP17SendResult.success(
+            rumorEventId: 'rumor-$pubkey',
+            messageEventId: 'msg-$pubkey',
+            recipientPubkey: pubkey,
+          );
+        });
+
+        final now = DateTime.now();
+        final results = await nip17Service.shareVideoWithMultipleUsers(
+          video: VideoEvent(
+            id: _testVideoId,
+            pubkey: _testPubkey,
+            createdAt: now.millisecondsSinceEpoch ~/ 1000,
+            timestamp: now,
+            content: 'Test',
+          ),
+          recipientPubkeys: [goodA, bad, goodC],
+        );
+
+        // The middle recipient threw, but the loop still attempted all three
+        // and reports a per-recipient result for each.
+        expect(results.keys, containsAll(<String>[goodA, bad, goodC]));
+        expect(results[goodA]!.success, isTrue);
+        expect(results[bad]!.success, isFalse);
+        expect(results[goodC]!.success, isTrue);
+        verify(
+          () => mockDmRepository.sendSharedVideo(
+            recipientPubkey: goodC,
+            baseContent: any(named: 'baseContent'),
+            videoKind: any(named: 'videoKind'),
+            videoAuthorPubkey: any(named: 'videoAuthorPubkey'),
+            videoDTag: any(named: 'videoDTag'),
+            videoEventId: any(named: 'videoEventId'),
+            relayHint: any(named: 'relayHint'),
+            skipNip04Fallback: any(named: 'skipNip04Fallback'),
+          ),
+        ).called(1);
+      },
+    );
 
     test(
       'returns success without waiting on the recents profile fetch (#5391)',
@@ -444,6 +516,7 @@ void main() {
             videoDTag: any(named: 'videoDTag'),
             videoEventId: any(named: 'videoEventId'),
             relayHint: any(named: 'relayHint'),
+            skipNip04Fallback: any(named: 'skipNip04Fallback'),
           ),
         ).thenAnswer(
           (_) async => NIP17SendResult.success(
@@ -491,6 +564,7 @@ void main() {
           videoDTag: any(named: 'videoDTag'),
           videoEventId: any(named: 'videoEventId'),
           relayHint: any(named: 'relayHint'),
+          skipNip04Fallback: any(named: 'skipNip04Fallback'),
         ),
       ).thenAnswer(
         (_) async => const NIP17SendResult.failure('Relay rejected'),
@@ -523,6 +597,7 @@ void main() {
           videoDTag: any(named: 'videoDTag'),
           videoEventId: any(named: 'videoEventId'),
           relayHint: any(named: 'relayHint'),
+          skipNip04Fallback: any(named: 'skipNip04Fallback'),
         ),
       ).thenAnswer(
         (_) async => NIP17SendResult.success(
@@ -559,6 +634,7 @@ void main() {
           videoDTag: any(named: 'videoDTag'),
           videoEventId: any(named: 'videoEventId'),
           relayHint: any(named: 'relayHint'),
+          skipNip04Fallback: any(named: 'skipNip04Fallback'),
         ),
       ).captured;
 
@@ -576,6 +652,7 @@ void main() {
           videoDTag: any(named: 'videoDTag'),
           videoEventId: any(named: 'videoEventId'),
           relayHint: any(named: 'relayHint'),
+          skipNip04Fallback: any(named: 'skipNip04Fallback'),
         ),
       ).thenAnswer(
         (_) async => NIP17SendResult.success(
@@ -614,6 +691,7 @@ void main() {
           videoDTag: any(named: 'videoDTag'),
           videoEventId: any(named: 'videoEventId'),
           relayHint: any(named: 'relayHint'),
+          skipNip04Fallback: any(named: 'skipNip04Fallback'),
         ),
       ).captured;
 
@@ -633,6 +711,7 @@ void main() {
           videoDTag: any(named: 'videoDTag'),
           videoEventId: any(named: 'videoEventId'),
           relayHint: any(named: 'relayHint'),
+          skipNip04Fallback: any(named: 'skipNip04Fallback'),
         ),
       ).thenAnswer(
         (_) async => NIP17SendResult.success(
@@ -670,6 +749,7 @@ void main() {
           videoDTag: any(named: 'videoDTag'),
           videoEventId: any(named: 'videoEventId'),
           relayHint: any(named: 'relayHint'),
+          skipNip04Fallback: any(named: 'skipNip04Fallback'),
         ),
       ).captured;
 
@@ -689,6 +769,7 @@ void main() {
           videoDTag: any(named: 'videoDTag'),
           videoEventId: any(named: 'videoEventId'),
           relayHint: any(named: 'relayHint'),
+          skipNip04Fallback: any(named: 'skipNip04Fallback'),
         ),
       ).thenAnswer(
         (_) async => NIP17SendResult.success(
@@ -732,6 +813,7 @@ void main() {
           videoDTag: any(named: 'videoDTag'),
           videoEventId: any(named: 'videoEventId'),
           relayHint: any(named: 'relayHint'),
+          skipNip04Fallback: any(named: 'skipNip04Fallback'),
         ),
       ).thenAnswer(
         (_) async => NIP17SendResult.success(

--- a/mobile/test/widgets/share_video_menu_comprehensive_test.dart
+++ b/mobile/test/widgets/share_video_menu_comprehensive_test.dart
@@ -655,8 +655,9 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text(l10n.shareFailedToSend), findsOneWidget);
-      // The sheet stays open so the user can retry.
-      expect(find.text(l10n.shareWithTitle), findsOneWidget);
+      // The sheet dismisses on failure: the send is durably queued and
+      // retried in the background, so there is no in-sheet manual retry.
+      expect(find.text(l10n.shareWithTitle), findsNothing);
     });
   });
 

--- a/mobile/test/widgets/share_video_menu_comprehensive_test.dart
+++ b/mobile/test/widgets/share_video_menu_comprehensive_test.dart
@@ -559,9 +559,9 @@ void main() {
       expect(find.text(l10n.shareMessageHint), findsOneWidget);
       expect(find.text(l10n.shareSheetMoreActions), findsNothing);
       verifyNever(
-        () => mockVideoSharingService.shareVideoWithUser(
+        () => mockVideoSharingService.shareVideoWithMultipleUsers(
           video: any(named: 'video'),
-          recipientPubkey: any(named: 'recipientPubkey'),
+          recipientPubkeys: any(named: 'recipientPubkeys'),
           personalMessage: any(named: 'personalMessage'),
         ),
       );
@@ -571,15 +571,17 @@ void main() {
       tester,
     ) async {
       when(
-        () => mockVideoSharingService.shareVideoWithUser(
+        () => mockVideoSharingService.shareVideoWithMultipleUsers(
           video: any(named: 'video'),
-          recipientPubkey: any(named: 'recipientPubkey'),
+          recipientPubkeys: any(named: 'recipientPubkeys'),
           personalMessage: any(named: 'personalMessage'),
         ),
       ).thenAnswer(
-        (_) async => ShareResult.createSuccess(
-          '2222222222222222222222222222222222222222222222222222222222222222',
-        ),
+        (_) async => {
+          testContact.pubkey: ShareResult.createSuccess(
+            '2222222222222222222222222222222222222222222222222222222222222222',
+          ),
+        },
       );
 
       await tester.pumpWidget(buildSubjectWithContacts());
@@ -592,13 +594,13 @@ void main() {
       await tester.pumpAndSettle();
 
       final captured = verify(
-        () => mockVideoSharingService.shareVideoWithUser(
+        () => mockVideoSharingService.shareVideoWithMultipleUsers(
           video: any(named: 'video'),
-          recipientPubkey: captureAny(named: 'recipientPubkey'),
+          recipientPubkeys: captureAny(named: 'recipientPubkeys'),
           personalMessage: any(named: 'personalMessage'),
         ),
       ).captured;
-      expect(captured.single, equals(testContact.pubkey));
+      expect(captured.single, equals([testContact.pubkey]));
 
       // Sheet dismissed, success snackbar shown
       expect(find.text(l10n.shareWithTitle), findsNothing);
@@ -622,9 +624,9 @@ void main() {
       expect(find.text(l10n.shareMessageHint), findsNothing);
       expect(find.text(l10n.shareSheetMoreActions), findsOneWidget);
       verifyNever(
-        () => mockVideoSharingService.shareVideoWithUser(
+        () => mockVideoSharingService.shareVideoWithMultipleUsers(
           video: any(named: 'video'),
-          recipientPubkey: any(named: 'recipientPubkey'),
+          recipientPubkeys: any(named: 'recipientPubkeys'),
           personalMessage: any(named: 'personalMessage'),
         ),
       );
@@ -632,12 +634,16 @@ void main() {
 
     testWidgets('send shows failure snackbar on error', (tester) async {
       when(
-        () => mockVideoSharingService.shareVideoWithUser(
+        () => mockVideoSharingService.shareVideoWithMultipleUsers(
           video: any(named: 'video'),
-          recipientPubkey: any(named: 'recipientPubkey'),
+          recipientPubkeys: any(named: 'recipientPubkeys'),
           personalMessage: any(named: 'personalMessage'),
         ),
-      ).thenAnswer((_) async => ShareResult.failure('Network timeout'));
+      ).thenAnswer(
+        (_) async => {
+          testContact.pubkey: ShareResult.failure('Network timeout'),
+        },
+      );
 
       await tester.pumpWidget(buildSubjectWithContacts());
       await tester.tap(find.byType(ShareActionButton));

--- a/mobile/test/widgets/share_video_menu_comprehensive_test.dart
+++ b/mobile/test/widgets/share_video_menu_comprehensive_test.dart
@@ -496,17 +496,19 @@ void main() {
     );
   });
 
-  group('Quick-send behavior', () {
+  group('Select-then-send behavior', () {
     const testContact = ShareableUser(
       pubkey:
           '1111111111111111111111111111111111111111111111111111111111111111',
       displayName: 'Alice',
     );
     late _MockFollowRepository mockFollowRepository;
+    late AppLocalizations l10n;
 
     setUp(() {
       mockFollowRepository = _MockFollowRepository();
       when(() => mockFollowRepository.followingPubkeys).thenReturn([]);
+      l10n = lookupAppLocalizations(const Locale('en'));
     });
 
     Widget buildSubjectWithContacts() {
@@ -538,19 +540,11 @@ void main() {
       );
     }
 
-    testWidgets('tapping contact quick-sends video', (tester) async {
-      when(
-        () => mockVideoSharingService.shareVideoWithUser(
-          video: any(named: 'video'),
-          recipientPubkey: any(named: 'recipientPubkey'),
-          personalMessage: any(named: 'personalMessage'),
-        ),
-      ).thenAnswer(
-        (_) async => ShareResult.createSuccess(
-          '2222222222222222222222222222222222222222222222222222222222222222',
-        ),
-      );
+    Finder sendButton() => find.byWidgetPredicate(
+      (widget) => widget is DivineIcon && widget.icon == DivineIconName.arrowUp,
+    );
 
+    testWidgets('tapping contact selects it and never sends', (tester) async {
       await tester.pumpWidget(buildSubjectWithContacts());
       await tester.tap(find.byType(ShareActionButton));
       await tester.pumpAndSettle();
@@ -558,24 +552,24 @@ void main() {
       // Verify contact appears in horizontal row
       expect(find.text('Alice'), findsOneWidget);
 
-      // Tap contact — should quick-send immediately
+      // Tap contact — selects and reveals the message composer
       await tester.tap(find.text('Alice'));
       await tester.pumpAndSettle();
 
-      // Verify shareVideoWithUser was called
-      verify(
+      expect(find.text(l10n.shareMessageHint), findsOneWidget);
+      expect(find.text(l10n.shareSheetMoreActions), findsNothing);
+      verifyNever(
         () => mockVideoSharingService.shareVideoWithUser(
           video: any(named: 'video'),
           recipientPubkey: any(named: 'recipientPubkey'),
           personalMessage: any(named: 'personalMessage'),
         ),
-      ).called(1);
-
-      // Verify success snackbar
-      expect(find.text('Post shared with Alice'), findsOneWidget);
+      );
     });
 
-    testWidgets('sent contact shows Sent label', (tester) async {
+    testWidgets('explicit send delivers to the selected contact', (
+      tester,
+    ) async {
       when(
         () => mockVideoSharingService.shareVideoWithUser(
           video: any(named: 'video'),
@@ -594,48 +588,49 @@ void main() {
 
       await tester.tap(find.text('Alice'));
       await tester.pumpAndSettle();
+      await tester.tap(sendButton());
+      await tester.pumpAndSettle();
 
-      // Contact label replaced with 'Sent'
-      expect(find.text('Sent'), findsOneWidget);
-      expect(find.text('Alice'), findsNothing);
-    });
-
-    testWidgets('sent contact ignores subsequent taps', (tester) async {
-      when(
+      final captured = verify(
         () => mockVideoSharingService.shareVideoWithUser(
           video: any(named: 'video'),
-          recipientPubkey: any(named: 'recipientPubkey'),
+          recipientPubkey: captureAny(named: 'recipientPubkey'),
           personalMessage: any(named: 'personalMessage'),
         ),
-      ).thenAnswer(
-        (_) async => ShareResult.createSuccess(
-          '2222222222222222222222222222222222222222222222222222222222222222',
-        ),
-      );
+      ).captured;
+      expect(captured.single, equals(testContact.pubkey));
 
+      // Sheet dismissed, success snackbar shown
+      expect(find.text(l10n.shareWithTitle), findsNothing);
+      expect(find.text(l10n.sharePostSharedWith('Alice')), findsOneWidget);
+    });
+
+    testWidgets('tapping the selected contact again deselects it', (
+      tester,
+    ) async {
       await tester.pumpWidget(buildSubjectWithContacts());
       await tester.tap(find.byType(ShareActionButton));
       await tester.pumpAndSettle();
 
-      // First tap — sends
+      await tester.tap(find.text('Alice'));
+      await tester.pumpAndSettle();
+      expect(find.text(l10n.shareMessageHint), findsOneWidget);
+
       await tester.tap(find.text('Alice'));
       await tester.pumpAndSettle();
 
-      // Second tap on 'Sent' — should be ignored
-      await tester.tap(find.text('Sent'));
-      await tester.pumpAndSettle();
-
-      // shareVideoWithUser only called once
-      verify(
+      expect(find.text(l10n.shareMessageHint), findsNothing);
+      expect(find.text(l10n.shareSheetMoreActions), findsOneWidget);
+      verifyNever(
         () => mockVideoSharingService.shareVideoWithUser(
           video: any(named: 'video'),
           recipientPubkey: any(named: 'recipientPubkey'),
           personalMessage: any(named: 'personalMessage'),
         ),
-      ).called(1);
+      );
     });
 
-    testWidgets('quick-send shows failure snackbar on error', (tester) async {
+    testWidgets('send shows failure snackbar on error', (tester) async {
       when(
         () => mockVideoSharingService.shareVideoWithUser(
           video: any(named: 'video'),
@@ -650,8 +645,12 @@ void main() {
 
       await tester.tap(find.text('Alice'));
       await tester.pumpAndSettle();
+      await tester.tap(sendButton());
+      await tester.pumpAndSettle();
 
-      expect(find.text('Failed to send video'), findsOneWidget);
+      expect(find.text(l10n.shareFailedToSend), findsOneWidget);
+      // The sheet stays open so the user can retry.
+      expect(find.text(l10n.shareWithTitle), findsOneWidget);
     });
   });
 

--- a/mobile/test/widgets/video_feed_item/actions/share_action_button_test.dart
+++ b/mobile/test/widgets/video_feed_item/actions/share_action_button_test.dart
@@ -308,6 +308,199 @@ void main() {
         expect(find.text('Save with Watermark'), findsOneWidget);
       });
 
+      group('recipient selection', () {
+        const alice = ShareableUser(
+          pubkey:
+              'fedcba9876543210fedcba9876543210'
+              'fedcba9876543210fedcba9876543210',
+          displayName: 'Alice',
+        );
+        const bob = ShareableUser(
+          pubkey:
+              '11111111111111111111111111111111'
+              '11111111111111111111111111111111',
+          displayName: 'Bob',
+        );
+
+        late AppLocalizations l10n;
+
+        setUp(() {
+          l10n = lookupAppLocalizations(const Locale('en'));
+          when(
+            () => mockVideoSharingService.recentlySharedWith,
+          ).thenReturn([alice, bob]);
+        });
+
+        Future<void> pumpOpenSheet(WidgetTester tester) async {
+          final mockAuth = createMockAuthService();
+
+          await tester.pumpWidget(
+            testMaterialApp(
+              home: Scaffold(body: ShareActionButton(video: testVideo)),
+              additionalOverrides: [
+                videoSharingServiceProvider.overrideWith(
+                  (ref) => mockVideoSharingService,
+                ),
+              ],
+              mockAuthService: mockAuth,
+              mockProfileRepository: mockProfileRepository,
+              mockFollowRepository: mockFollowRepository,
+            ),
+          );
+
+          await tester.tap(find.byType(ShareActionButton));
+          await tester.pumpAndSettle();
+        }
+
+        testWidgets(
+          'tapping a contact selects it and swaps more actions for the '
+          'message composer without sending',
+          (tester) async {
+            await pumpOpenSheet(tester);
+            expect(find.text('More actions'), findsOneWidget);
+
+            await tester.tap(find.text('Alice'));
+            await tester.pumpAndSettle();
+
+            expect(find.byType(TextField), findsOneWidget);
+            expect(find.text('More actions'), findsNothing);
+            verifyNever(
+              () => mockVideoSharingService.shareVideoWithUser(
+                video: any(named: 'video'),
+                recipientPubkey: any(named: 'recipientPubkey'),
+                personalMessage: any(named: 'personalMessage'),
+              ),
+            );
+          },
+        );
+
+        testWidgets(
+          'tapping the selected contact again deselects, restores more '
+          'actions, and drops the draft',
+          (tester) async {
+            await pumpOpenSheet(tester);
+
+            await tester.tap(find.text('Alice'));
+            await tester.pumpAndSettle();
+            await tester.enterText(find.byType(TextField), 'draft text');
+
+            await tester.tap(find.text('Alice'));
+            await tester.pumpAndSettle();
+
+            expect(find.byType(TextField), findsNothing);
+            expect(find.text('More actions'), findsOneWidget);
+
+            // Re-selecting shows an empty composer — the draft was dropped.
+            await tester.tap(find.text('Alice'));
+            await tester.pumpAndSettle();
+            final field = tester.widget<TextField>(find.byType(TextField));
+            expect(field.controller!.text, isEmpty);
+          },
+        );
+
+        testWidgets(
+          'tapping a different contact switches the selection and keeps '
+          'the draft',
+          (tester) async {
+            await pumpOpenSheet(tester);
+
+            await tester.tap(find.text('Alice'));
+            await tester.pumpAndSettle();
+            await tester.enterText(find.byType(TextField), 'draft text');
+
+            await tester.tap(find.text('Bob'));
+            await tester.pumpAndSettle();
+
+            final blocContext = tester.element(find.text('Share with'));
+            expect(
+              blocContext.read<ShareSheetBloc>().state.selectedRecipient,
+              isA<ShareableUser>().having(
+                (u) => u.pubkey,
+                'pubkey',
+                bob.pubkey,
+              ),
+            );
+            final field = tester.widget<TextField>(find.byType(TextField));
+            expect(field.controller!.text, equals('draft text'));
+          },
+        );
+
+        testWidgets(
+          'send success dismisses the sheet and shows a snackbar with a '
+          'View chat action',
+          (tester) async {
+            when(
+              () => mockVideoSharingService.shareVideoWithUser(
+                video: any(named: 'video'),
+                recipientPubkey: any(named: 'recipientPubkey'),
+                personalMessage: any(named: 'personalMessage'),
+              ),
+            ).thenAnswer(
+              (_) async => ShareResult.createSuccess(
+                'msg-event-id',
+                conversationId: 'conversation-1',
+              ),
+            );
+
+            await pumpOpenSheet(tester);
+
+            await tester.tap(find.text('Alice'));
+            await tester.pumpAndSettle();
+
+            await tester.tap(
+              find.byWidgetPredicate(
+                (widget) =>
+                    widget is DivineIcon &&
+                    widget.icon == DivineIconName.arrowUp,
+              ),
+            );
+            await tester.pumpAndSettle();
+
+            expect(find.text('Share with'), findsNothing);
+            expect(
+              find.text(l10n.sharePostSharedWith('Alice')),
+              findsOneWidget,
+            );
+            expect(find.text(l10n.dmReelReplyViewChat), findsOneWidget);
+          },
+        );
+
+        testWidgets(
+          'send success without a conversation id shows no View chat action',
+          (tester) async {
+            when(
+              () => mockVideoSharingService.shareVideoWithUser(
+                video: any(named: 'video'),
+                recipientPubkey: any(named: 'recipientPubkey'),
+                personalMessage: any(named: 'personalMessage'),
+              ),
+            ).thenAnswer(
+              (_) async => ShareResult.createSuccess('msg-event-id'),
+            );
+
+            await pumpOpenSheet(tester);
+
+            await tester.tap(find.text('Alice'));
+            await tester.pumpAndSettle();
+
+            await tester.tap(
+              find.byWidgetPredicate(
+                (widget) =>
+                    widget is DivineIcon &&
+                    widget.icon == DivineIconName.arrowUp,
+              ),
+            );
+            await tester.pumpAndSettle();
+
+            expect(
+              find.text(l10n.sharePostSharedWith('Alice')),
+              findsOneWidget,
+            );
+            expect(find.text(l10n.dmReelReplyViewChat), findsNothing);
+          },
+        );
+      });
+
       testWidgets(
         'lifts message field above the keyboard when a recipient is selected',
         (tester) async {

--- a/mobile/test/widgets/video_feed_item/actions/share_action_button_test.dart
+++ b/mobile/test/widgets/video_feed_item/actions/share_action_button_test.dart
@@ -365,9 +365,9 @@ void main() {
             expect(find.byType(TextField), findsOneWidget);
             expect(find.text('More actions'), findsNothing);
             verifyNever(
-              () => mockVideoSharingService.shareVideoWithUser(
+              () => mockVideoSharingService.shareVideoWithMultipleUsers(
                 video: any(named: 'video'),
-                recipientPubkey: any(named: 'recipientPubkey'),
+                recipientPubkeys: any(named: 'recipientPubkeys'),
                 personalMessage: any(named: 'personalMessage'),
               ),
             );
@@ -375,8 +375,8 @@ void main() {
         );
 
         testWidgets(
-          'tapping the selected contact again deselects, restores more '
-          'actions, and drops the draft',
+          'tapping the last selected contact again deselects, restores '
+          'more actions, and drops the draft',
           (tester) async {
             await pumpOpenSheet(tester);
 
@@ -399,7 +399,7 @@ void main() {
         );
 
         testWidgets(
-          'tapping a different contact switches the selection and keeps '
+          'tapping more contacts adds them to the selection and keeps '
           'the draft',
           (tester) async {
             await pumpOpenSheet(tester);
@@ -413,15 +413,81 @@ void main() {
 
             final blocContext = tester.element(find.text('Share with'));
             expect(
-              blocContext.read<ShareSheetBloc>().state.selectedRecipient,
-              isA<ShareableUser>().having(
+              blocContext.read<ShareSheetBloc>().state.selectedRecipients.map(
                 (u) => u.pubkey,
-                'pubkey',
-                bob.pubkey,
               ),
+              equals([alice.pubkey, bob.pubkey]),
             );
             final field = tester.widget<TextField>(find.byType(TextField));
             expect(field.controller!.text, equals('draft text'));
+          },
+        );
+
+        testWidgets(
+          'deselecting one of several recipients keeps the composer open',
+          (tester) async {
+            await pumpOpenSheet(tester);
+
+            await tester.tap(find.text('Alice'));
+            await tester.pumpAndSettle();
+            await tester.tap(find.text('Bob'));
+            await tester.pumpAndSettle();
+            await tester.enterText(find.byType(TextField), 'draft text');
+
+            await tester.tap(find.text('Alice'));
+            await tester.pumpAndSettle();
+
+            final blocContext = tester.element(find.text('Share with'));
+            expect(
+              blocContext.read<ShareSheetBloc>().state.selectedRecipients.map(
+                (u) => u.pubkey,
+              ),
+              equals([bob.pubkey]),
+            );
+            final field = tester.widget<TextField>(find.byType(TextField));
+            expect(field.controller!.text, equals('draft text'));
+          },
+        );
+
+        testWidgets(
+          'sending to multiple recipients shows the plural snackbar with '
+          'no View chat action',
+          (tester) async {
+            when(
+              () => mockVideoSharingService.shareVideoWithMultipleUsers(
+                video: any(named: 'video'),
+                recipientPubkeys: any(named: 'recipientPubkeys'),
+                personalMessage: any(named: 'personalMessage'),
+              ),
+            ).thenAnswer(
+              (_) async => {
+                alice.pubkey: ShareResult.createSuccess('msg-1'),
+                bob.pubkey: ShareResult.createSuccess('msg-2'),
+              },
+            );
+
+            await pumpOpenSheet(tester);
+
+            await tester.tap(find.text('Alice'));
+            await tester.pumpAndSettle();
+            await tester.tap(find.text('Bob'));
+            await tester.pumpAndSettle();
+
+            await tester.tap(
+              find.byWidgetPredicate(
+                (widget) =>
+                    widget is DivineIcon &&
+                    widget.icon == DivineIconName.arrowUp,
+              ),
+            );
+            await tester.pumpAndSettle();
+
+            expect(find.text('Share with'), findsNothing);
+            expect(
+              find.text(l10n.sharePostSharedWithCount(2)),
+              findsOneWidget,
+            );
+            expect(find.text(l10n.dmReelReplyViewChat), findsNothing);
           },
         );
 
@@ -430,16 +496,18 @@ void main() {
           'View chat action',
           (tester) async {
             when(
-              () => mockVideoSharingService.shareVideoWithUser(
+              () => mockVideoSharingService.shareVideoWithMultipleUsers(
                 video: any(named: 'video'),
-                recipientPubkey: any(named: 'recipientPubkey'),
+                recipientPubkeys: any(named: 'recipientPubkeys'),
                 personalMessage: any(named: 'personalMessage'),
               ),
             ).thenAnswer(
-              (_) async => ShareResult.createSuccess(
-                'msg-event-id',
-                conversationId: 'conversation-1',
-              ),
+              (_) async => {
+                alice.pubkey: ShareResult.createSuccess(
+                  'msg-event-id',
+                  conversationId: 'conversation-1',
+                ),
+              },
             );
 
             await pumpOpenSheet(tester);
@@ -469,13 +537,15 @@ void main() {
           'send success without a conversation id shows no View chat action',
           (tester) async {
             when(
-              () => mockVideoSharingService.shareVideoWithUser(
+              () => mockVideoSharingService.shareVideoWithMultipleUsers(
                 video: any(named: 'video'),
-                recipientPubkey: any(named: 'recipientPubkey'),
+                recipientPubkeys: any(named: 'recipientPubkeys'),
                 personalMessage: any(named: 'personalMessage'),
               ),
             ).thenAnswer(
-              (_) async => ShareResult.createSuccess('msg-event-id'),
+              (_) async => {
+                alice.pubkey: ShareResult.createSuccess('msg-event-id'),
+              },
             );
 
             await pumpOpenSheet(tester);
@@ -531,7 +601,7 @@ void main() {
           // Select a recipient so the message TextField is shown.
           final blocContext = tester.element(find.text('Share with'));
           blocContext.read<ShareSheetBloc>().add(
-            const ShareSheetRecipientSelected(
+            const ShareSheetRecipientToggled(
               ShareableUser(
                 pubkey:
                     'fedcba9876543210fedcba9876543210'


### PR DESCRIPTION
## Description

Implements the **"Select recipients model, Open DMs"** flow from the Figma spec ([UI Design → Share with Divine user](https://www.figma.com/design/rp1DsDEUuCaicW0lk6I2aZ/UI-Design?node-id=8712-54870&m=dev)), unifying the share sheet's two divergent send paths — with **multi-select**.

**Before:** tapping a contact in the "Share with" row DM'd the video instantly (no message, no confirmation, no undo — and a NIP-17 DM can't be un-published), while picking the same person via Find People selected them and offered an optional message composer. Two behaviors for the same person, two taps apart. While composing, tapping any avatar still fired an instant send, dropping the typed message; and once a recipient was selected there was no way to deselect.

**After:**
- Tapping contacts — in the row or via Find People — **toggles** their selection: green tick per selected avatar, More Actions swap for the message composer ("Add optional message...", autofocused), nothing is sent. Pick as many people as you want; tapping a ticked contact removes them. The draft survives selection changes and is dropped only when the last recipient is deselected.
- Selection no longer reorders the contacts row (reordering under the finger was disorienting); Find People picks not already in the row are inserted at the front so their tick is visible.
- The DMs go out only on the explicit send button, which **fans out one gift-wrapped DM per selected person** (reviving the previously dead `VideoSharingService.shareVideoWithMultipleUsers`). On partial failure, the sheet dismisses and clears selection; delivered recipients are reported immediately and the durable outgoing-DM queue retries anything still pending, avoiding duplicate manual re-sends.
- On success the sheet dismisses with a snackbar — "Post shared with {name}" for one person (with a **View chat** action into the conversation), or a new localized plural "Post shared with {count} people" for several (`sharePostSharedWithCount`, translated for all 18 locales).
- Each added recipient is announced to screen readers ("{name} selected" — thanks @NotThatKindOfDrLiz for the accurate announcement key), and contact tiles expose `Semantics(selected:)`.

Removed as dead code: `ShareSheetQuickSendRequested` + its optimistic machinery, `sentPubkeys` and the "Sent"/dimmed contact UI, `ShareSheetRecipientCleared` (deselect is just toggling), `ShareSheetSendSuccess.shouldDismiss`, and the "Sending to {name}" chip (the ticks indicate recipients, per Figma).

Also from on-device testing: the composer send arrow was rendering stretched to the full 40px circle — the `Container`'s tight constraints silently overrode the `SvgPicture` size. Fixed with `Center` and tuned to 28px on device.

**Related Issue:** Closes #5760

## Nostr / DM correctness audit

Audited the multi-recipient fan-out end to end (NIP-17/59/44/18/19, the Flutter layer, the funnelcake relay, and divine-web). **Wire format is protocol-correct**: each recipient gets an independent unsigned kind-14 rumor (distinct id, only their own `p` tag), sender-signed kind-13 seal, kind-1059 wrap with a **fresh ephemeral key per recipient**, NIP-44 v2, plus a self-wrap — and `relay.divine.video` accepts 1059/10050/4 while rejecting bare 13/14 (the old "#4974 prod rejects 10050" finding is now stale; it's live). Three real defects were found and fixed in this PR:

- **Escaping throw aborted the fan-out.** `shareVideoWithUser` returned without `await`, so an async throw skipped its catch (verified empirically) and, with no per-recipient guard, one bad recipient aborted the rest. Now awaited + guarded per recipient.
- **Double-send on manual retry.** A failed recipient stayed selected for a manual re-send, but the durable outgoing-DM queue already replays the *same* rumor id on app-foreground; a manual re-send minted a *new* rumor id the receiver couldn't dedup → duplicate. Send is now dismiss-and-forget: report what was delivered, clear the selection, and let the durable queue finish the rest.
- **NIP-04 metadata leak on shares.** First-contact shares also fired a plaintext kind-4 copy (real sender pubkey + timestamp) on the unauthenticated relay. Shares now `skipNip04Fallback: true`, which also closes the cross-protocol duplicate window.

Backend/web posture items are tracked separately (not mobile-fixable here): divine-funnelcake#591 (NIP-42 AUTH for kind-1059 reads) and divine-web#457 (render the NIP-18 `q`-tag share as a card). Deferred by design: flipping `FF_PUBLISH_DM_RELAY_LIST` (now backend-unblocked) is a global DM-routing change that belongs in its own PR; the fan-out stays sequential to respect the relay burst limit.

## Out of Scope

- A long-press instant-send fast path (Instagram-style) — can be layered on later if wanted
- Persisting the "recents" contact source across app restarts (still in-memory/session-only)
- Deleting the legacy never-constructed `ShareVideoMenu` widget (#5759)

## Verification

- `flutter analyze lib test integration_test` — clean
- `flutter test test/blocs/share_sheet/` — 41 passed (toggle semantics, multi fan-out, partial-failure clears selection for durable retry, whitespace-message trim, View-chat conversation id)
- `flutter test test/widgets/video_feed_item/actions/ test/widgets/share_video_menu_comprehensive_test.dart test/widgets/find_people_sheet_test.dart` — 123 passed (multi-select ticks, draft survival, plural snackbar, no instant send anywhere)
- `flutter test test/l10n/arb_consistency_test.dart` — new plural key present in every locale
- `dart format` — no changes

## Testing on a real device

The point of the change is *when the DM actually leaves the phone*, so the most valuable check is watching the recipient side while you drive the sender side.

**Setup**
- Build on device: `cd mobile && flutter run`.
- Use two or three accounts: sender on the device, recipients somewhere you can watch DMs arrive.
- Follow at least three accounts so the row has contacts to multi-select. Recents reset on app restart (pre-existing, unchanged).

**Core flow**
1. Home feed → share arrow → tap a contact in the row.
   Expect: green tick, More actions replaced by the composer, keyboard up. **Nothing sent.**
2. Tap two more contacts.
   Expect: each gets its own tick and stays selected (nothing deselects); the draft you typed stays put.
3. Tap one of the ticked contacts again.
   Expect: only that person's tick clears; the composer stays open while others remain selected. Deselect all → composer closes, More actions return, draft dropped.
4. "Find people" → search → pick someone you don't follow.
   Expect: they appear at the **front** of the row with a tick; existing contacts don't shuffle.
5. Select 2–3 people, type a note, tap send.
   Expect: snackbar "Post shared with N people" (no View chat), sheet dismisses; **each** recipient gets their own single bubble — video card with the note under it.
6. Select exactly one person and send.
   Expect: "Post shared with {name}" + **View chat** action that opens that conversation.
7. Airplane mode → select two people → send.
   Expect: "Failed to send video" snackbar, sheet dismisses, and the selection is cleared. Reconnect and let the durable outgoing-DM queue retry in the background; do not manually re-send the same recipients from the sheet.

**Regression sweep**
- With nobody selected, every More-actions item still works (Save, Save Video, Copy, Share via; own-video: Edit, Delete, Save to Gallery, Save with Watermark; Add to Clips on original vines).
- Composer sits above the keyboard (guard for #5688), send arrow renders at its intended size in the green circle.
- Repeat step 1 from the fullscreen feed — same sheet, same behavior.
- Gone for good: instant sends from an avatar tap, dimmed "Sent" avatars, selection reordering the row.

**Accessibility (VoiceOver / TalkBack)**
- Adding a recipient announces "{name} selected".
- Ticked contacts read as *selected* in the row.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

