### PR TITLE
feat(video-editor): implement the stop-motion recorder and editor

### DIFF
--- a/mobile/integration_test/thumbnail_integration_test.dart
+++ b/mobile/integration_test/thumbnail_integration_test.dart
@@ -133,7 +133,7 @@ void main() {
           }
 
           final clip = clips.first;
-          final filePath = await clip.video.safeFilePath();
+          final filePath = await clip.requireVideo.safeFilePath();
           Log.debug('📹 Clip created: $filePath');
           Log.debug('📦 File size: ${File(filePath).lengthSync()} bytes');
 

--- a/mobile/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/mobile/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/app-check.git",
       "state" : {
-        "revision" : "61b85103a1aeed8218f17c794687781505fbbef5",
-        "version" : "11.2.0"
+        "revision" : "bb4002485ff867768dec13bf904a2ddb050bd1b1",
+        "version" : "11.3.0"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "60da361632d0de02786f709bdc0c4df340f7613e",
-        "version" : "8.1.0"
+        "revision" : "c46e5f8b7c23265f17c24ca7f9fa1b13ded7a822",
+        "version" : "8.1.1"
       }
     },
     {
@@ -158,8 +158,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/promises.git",
       "state" : {
-        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
-        "version" : "2.4.0"
+        "revision" : "f4a19a3c313dc2616c70bb49d29a799fb16be837",
+        "version" : "2.4.1"
       }
     },
     {
@@ -185,8 +185,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-certificates.git",
       "state" : {
-        "revision" : "24ccdeeeed4dfaae7955fcac9dbf5489ed4f1a25",
-        "version" : "1.18.0"
+        "revision" : "bde8ca32a096825dfce37467137c903418c1893d",
+        "version" : "1.19.1"
       }
     },
     {

--- a/mobile/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/mobile/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/app-check.git",
       "state" : {
-        "revision" : "bb4002485ff867768dec13bf904a2ddb050bd1b1",
-        "version" : "11.3.0"
+        "revision" : "61b85103a1aeed8218f17c794687781505fbbef5",
+        "version" : "11.2.0"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "c46e5f8b7c23265f17c24ca7f9fa1b13ded7a822",
-        "version" : "8.1.1"
+        "revision" : "60da361632d0de02786f709bdc0c4df340f7613e",
+        "version" : "8.1.0"
       }
     },
     {
@@ -158,8 +158,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/promises.git",
       "state" : {
-        "revision" : "f4a19a3c313dc2616c70bb49d29a799fb16be837",
-        "version" : "2.4.1"
+        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
+        "version" : "2.4.0"
       }
     },
     {
@@ -185,8 +185,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-certificates.git",
       "state" : {
-        "revision" : "bde8ca32a096825dfce37467137c903418c1893d",
-        "version" : "1.19.1"
+        "revision" : "24ccdeeeed4dfaae7955fcac9dbf5489ed4f1a25",
+        "version" : "1.18.0"
       }
     },
     {

--- a/mobile/lib/blocs/clips_library/clips_library_bloc.dart
+++ b/mobile/lib/blocs/clips_library/clips_library_bloc.dart
@@ -352,9 +352,10 @@ class ClipsLibraryBloc extends Bloc<ClipsLibraryEvent, ClipsLibraryState> {
     var failureCount = 0;
 
     for (final clip in clipsToSave) {
+      DivineVideoClip? materialized;
       try {
         // Stop-motion clips render their mp4 on demand before saving.
-        final materialized = await StopMotionRenderService.materialize(clip);
+        materialized = await StopMotionRenderService.materialize(clip);
         if (materialized == null) {
           failureCount++;
           continue;
@@ -391,6 +392,11 @@ class ClipsLibraryBloc extends Bloc<ClipsLibraryEvent, ClipsLibraryState> {
           ),
         );
         return;
+      } finally {
+        await StopMotionRenderService.cleanupMaterializedOutput(
+          sourceClip: clip,
+          materializedClip: materialized,
+        );
       }
     }
 

--- a/mobile/lib/blocs/clips_library/clips_library_bloc.dart
+++ b/mobile/lib/blocs/clips_library/clips_library_bloc.dart
@@ -9,6 +9,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/services/clip_library_service.dart';
 import 'package:openvine/services/gallery_save_service.dart';
+import 'package:openvine/services/video_editor/stop_motion_render_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -24,6 +25,7 @@ class ClipsLibraryBloc extends Bloc<ClipsLibraryEvent, ClipsLibraryState> {
     required ClipLibraryService clipLibraryService,
     required GallerySaveService gallerySaveService,
     required SharedPreferences sharedPreferences,
+    this.clipTypeFilter = LibraryClipTypeFilter.all,
   }) : _clipLibraryService = clipLibraryService,
        _gallerySaveService = gallerySaveService,
        _sharedPreferences = sharedPreferences,
@@ -57,6 +59,17 @@ class ClipsLibraryBloc extends Bloc<ClipsLibraryEvent, ClipsLibraryState> {
   final ClipLibraryService _clipLibraryService;
   final GallerySaveService _gallerySaveService;
   final SharedPreferences _sharedPreferences;
+
+  /// Restricts which clip types this library instance loads. Set by the
+  /// recorder entry-point to the mode's type; [LibraryClipTypeFilter.all]
+  /// (both types) for the standalone library.
+  final LibraryClipTypeFilter clipTypeFilter;
+
+  /// Applies [clipTypeFilter] to a freshly loaded clip list.
+  List<DivineVideoClip> _applyTypeFilter(List<DivineVideoClip> clips) {
+    if (clipTypeFilter == LibraryClipTypeFilter.all) return clips;
+    return clips.where(clipTypeFilter.matches).toList();
+  }
 
   static ClipSort _readPersistedSort(SharedPreferences prefs) {
     final saved = prefs.getString(_sortPrefsKey);
@@ -105,7 +118,7 @@ class ClipsLibraryBloc extends Bloc<ClipsLibraryEvent, ClipsLibraryState> {
     emit(state.copyWith(status: ClipsLibraryStatus.loading));
 
     try {
-      final clips = await _clipLibraryService.getAllClips();
+      final clips = _applyTypeFilter(await _clipLibraryService.getAllClips());
 
       Log.debug(
         '📚 Loaded ${clips.length} clips from library',
@@ -176,6 +189,12 @@ class ClipsLibraryBloc extends Bloc<ClipsLibraryEvent, ClipsLibraryState> {
       selectedIds.remove(clip.id);
       selectedDuration -= clip.duration;
     } else {
+      // No mixing: a clip of a different type than the current selection
+      // (stop-motion vs normal video) cannot be added — the two can't share
+      // one editor timeline. The grid also disables such clips; this guards
+      // the event path.
+      final selectedType = state.selectedIsStopMotion;
+      if (selectedType != null && clip.isStopMotion != selectedType) return;
       selectedIds.add(clip.id);
       selectedDuration += clip.duration;
     }
@@ -228,7 +247,7 @@ class ClipsLibraryBloc extends Bloc<ClipsLibraryEvent, ClipsLibraryState> {
       }
 
       // Reload clips and clear selection
-      final clips = await _clipLibraryService.getAllClips();
+      final clips = _applyTypeFilter(await _clipLibraryService.getAllClips());
 
       emit(
         state.copyWith(
@@ -274,7 +293,7 @@ class ClipsLibraryBloc extends Bloc<ClipsLibraryEvent, ClipsLibraryState> {
       await _clipLibraryService.softDelete(event.clip.id);
 
       // Reload clips
-      final clips = await _clipLibraryService.getAllClips();
+      final clips = _applyTypeFilter(await _clipLibraryService.getAllClips());
 
       // Remove from selection if selected
       final selectedIds = Set<String>.from(state.selectedClipIds);
@@ -334,7 +353,15 @@ class ClipsLibraryBloc extends Bloc<ClipsLibraryEvent, ClipsLibraryState> {
 
     for (final clip in clipsToSave) {
       try {
-        final result = await _gallerySaveService.saveVideoToGallery(clip.video);
+        // Stop-motion clips render their mp4 on demand before saving.
+        final materialized = await StopMotionRenderService.materialize(clip);
+        if (materialized == null) {
+          failureCount++;
+          continue;
+        }
+        final result = await _gallerySaveService.saveVideoToGallery(
+          materialized.requireVideo,
+        );
 
         switch (result) {
           case GallerySaveSuccess():
@@ -585,7 +612,7 @@ class ClipsLibraryBloc extends Bloc<ClipsLibraryEvent, ClipsLibraryState> {
   /// Reloads both the active and trashed clip lists. Used after restore
   /// so both views reflect the change.
   Future<void> _reloadClipsAndTrash(Emitter<ClipsLibraryState> emit) async {
-    final clips = await _clipLibraryService.getAllClips();
+    final clips = _applyTypeFilter(await _clipLibraryService.getAllClips());
     final trashed = await _clipLibraryService.getTrashedClips();
     emit(
       state.copyWith(

--- a/mobile/lib/blocs/clips_library/clips_library_bloc.dart
+++ b/mobile/lib/blocs/clips_library/clips_library_bloc.dart
@@ -71,6 +71,9 @@ class ClipsLibraryBloc extends Bloc<ClipsLibraryEvent, ClipsLibraryState> {
     return clips.where(clipTypeFilter.matches).toList();
   }
 
+  Future<List<DivineVideoClip>> _getFilteredTrashedClips() async =>
+      _applyTypeFilter(await _clipLibraryService.getTrashedClips());
+
   static ClipSort _readPersistedSort(SharedPreferences prefs) {
     final saved = prefs.getString(_sortPrefsKey);
     if (saved == null) return ClipSort.newestCreation;
@@ -516,7 +519,7 @@ class ClipsLibraryBloc extends Bloc<ClipsLibraryEvent, ClipsLibraryState> {
   ) async {
     emit(state.copyWith(status: ClipsLibraryStatus.trashLoading));
     try {
-      final trashed = await _clipLibraryService.getTrashedClips();
+      final trashed = await _getFilteredTrashedClips();
       emit(
         state.copyWith(
           status: ClipsLibraryStatus.trashLoaded,
@@ -566,7 +569,7 @@ class ClipsLibraryBloc extends Bloc<ClipsLibraryEvent, ClipsLibraryState> {
   ) async {
     try {
       await _clipLibraryService.hardDelete(event.clip.id);
-      final trashed = await _clipLibraryService.getTrashedClips();
+      final trashed = await _getFilteredTrashedClips();
       emit(
         state.copyWith(
           status: ClipsLibraryStatus.trashLoaded,
@@ -589,7 +592,7 @@ class ClipsLibraryBloc extends Bloc<ClipsLibraryEvent, ClipsLibraryState> {
     Emitter<ClipsLibraryState> emit,
   ) async {
     try {
-      final trashed = await _clipLibraryService.getTrashedClips();
+      final trashed = await _getFilteredTrashedClips();
       for (final clip in trashed) {
         await _clipLibraryService.hardDelete(clip.id);
       }
@@ -619,7 +622,7 @@ class ClipsLibraryBloc extends Bloc<ClipsLibraryEvent, ClipsLibraryState> {
   /// so both views reflect the change.
   Future<void> _reloadClipsAndTrash(Emitter<ClipsLibraryState> emit) async {
     final clips = _applyTypeFilter(await _clipLibraryService.getAllClips());
-    final trashed = await _clipLibraryService.getTrashedClips();
+    final trashed = await _getFilteredTrashedClips();
     emit(
       state.copyWith(
         status:

--- a/mobile/lib/blocs/clips_library/clips_library_state.dart
+++ b/mobile/lib/blocs/clips_library/clips_library_state.dart
@@ -40,6 +40,44 @@ enum ClipSort {
   }
 }
 
+/// Which clip types the library shows.
+///
+/// Opened from the recorder, the library is scoped to the type that matches
+/// the current recorder mode — stop-motion stills and normal video clips
+/// cannot share one editor timeline. Opened standalone it shows [all] types
+/// (mixing is instead blocked at selection time, see
+/// [ClipsLibraryState.selectedIsStopMotion]).
+enum LibraryClipTypeFilter {
+  all,
+  stopMotion,
+  video;
+
+  static const _queryValues = <LibraryClipTypeFilter, String>{
+    LibraryClipTypeFilter.stopMotion: 'stop_motion',
+    LibraryClipTypeFilter.video: 'video',
+  };
+
+  /// Query-parameter value for this filter, or `null` for [all] — the default,
+  /// which is left off the URL entirely.
+  String? get queryValue => _queryValues[this];
+
+  /// Parses [value] back to a filter, defaulting to [all] for null/unknown.
+  static LibraryClipTypeFilter fromQuery(String? value) {
+    if (value == null) return LibraryClipTypeFilter.all;
+    for (final entry in _queryValues.entries) {
+      if (entry.value == value) return entry.key;
+    }
+    return LibraryClipTypeFilter.all;
+  }
+
+  /// Whether [clip] belongs to this filter.
+  bool matches(DivineVideoClip clip) => switch (this) {
+    LibraryClipTypeFilter.all => true,
+    LibraryClipTypeFilter.stopMotion => clip.isStopMotion,
+    LibraryClipTypeFilter.video => !clip.isStopMotion,
+  };
+}
+
 /// Operation status for clips library actions.
 enum ClipsLibraryStatus {
   /// Initial state, no operation in progress.
@@ -191,6 +229,19 @@ final class ClipsLibraryState extends Equatable {
   List<DivineVideoClip> get selectedClips {
     final clipsById = {for (final c in clips) c.id: c};
     return [for (final id in selectedClipIds) ?clipsById[id]];
+  }
+
+  /// Type of the current selection: `true` when stop-motion clips are
+  /// selected, `false` for normal video clips, `null` when nothing is
+  /// selected. Drives the no-mixing rule — stop-motion stills and normal
+  /// clips cannot coexist in one editor timeline, so once one type is
+  /// selected the other becomes non-selectable.
+  bool? get selectedIsStopMotion {
+    if (selectedClipIds.isEmpty) return null;
+    for (final clip in clips) {
+      if (selectedClipIds.contains(clip.id)) return clip.isStopMotion;
+    }
+    return null;
   }
 
   /// Creates a copy of this state with the given fields replaced.

--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
@@ -4,6 +4,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:models/models.dart' show AudioEvent;
 import 'package:openvine/constants/video_editor_timeline_constants.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/stop_motion/stop_motion_frame_ops.dart';
 import 'package:openvine/models/video_editor/editor_overlay_snapshot.dart';
 import 'package:openvine/observability/reportable_error.dart';
 import 'package:openvine/services/audio_extraction_service.dart';
@@ -140,11 +141,15 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
 
     // Clip selection
     on<ClipEditorClipSelected>(_onClipSelected);
+    on<ClipEditorFrameSelected>(_onFrameSelected);
 
     // Multi-select
     on<ClipEditorMultiSelectStarted>(_onMultiSelectStarted);
     on<ClipEditorMultiSelectClipToggled>(_onMultiSelectClipToggled);
     on<ClipEditorMultiSelectCancelled>(_onMultiSelectCancelled);
+    on<ClipEditorFrameMultiSelectStarted>(_onFrameMultiSelectStarted);
+    on<ClipEditorFrameMultiSelectToggled>(_onFrameMultiSelectToggled);
+    on<ClipEditorFrameMultiSelectionSet>(_onFrameMultiSelectionSet);
     on<ClipEditorSelectedClipsRemoved>(_onSelectedClipsRemoved);
     on<ClipEditorSelectedClipsMergeRequested>(
       _onSelectedClipsMergeRequested,
@@ -290,7 +295,27 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
     final newClips = List<DivineVideoClip>.of(state.clips)
       ..[index] = event.clip;
 
-    emit(state.copyWith(clips: List.unmodifiable(newClips)));
+    // A frame delete/reorder replaces the stop-motion clip with a shorter or
+    // reordered frame list; clamp the selection so it never points past the end.
+    final selected = state.selectedFrameIndex;
+    final frames = event.clip.stopMotionFrames;
+    final clampedSelection = selected != null && frames != null
+        ? selected.clamp(0, frames.length - 1)
+        : selected;
+    final prunedMultiSelection = frames != null
+        ? {
+            for (final index in state.selectedFrameIndexes)
+              if (index < frames.length) index,
+          }
+        : state.selectedFrameIndexes;
+
+    emit(
+      state.copyWith(
+        clips: List.unmodifiable(newClips),
+        selectedFrameIndex: clampedSelection,
+        selectedFrameIndexes: prunedMultiSelection,
+      ),
+    );
   }
 
   void _onClipThumbnailUpdated(
@@ -326,6 +351,29 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
       state.copyWith(
         currentClipIndex: event.index,
         splitPosition: Duration.zero,
+        clearSelectedFrameIndex: true,
+      ),
+    );
+  }
+
+  void _onFrameSelected(
+    ClipEditorFrameSelected event,
+    Emitter<ClipEditorState> emit,
+  ) {
+    final clips = state.clips;
+    if (!isStopMotionComposition(clips)) return;
+    final frames = clips.first.stopMotionFrames;
+    if (frames == null ||
+        event.frameIndex < 0 ||
+        event.frameIndex >= frames.length) {
+      return;
+    }
+
+    emit(
+      state.copyWith(
+        currentClipIndex: 0,
+        isEditing: true,
+        selectedFrameIndex: event.frameIndex,
       ),
     );
   }
@@ -369,8 +417,63 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
     Emitter<ClipEditorState> emit,
   ) {
     emit(
-      state.copyWith(isMultiSelectMode: false, selectedClipIds: const {}),
+      state.copyWith(
+        isMultiSelectMode: false,
+        selectedClipIds: const {},
+        selectedFrameIndexes: const {},
+      ),
     );
+  }
+
+  void _onFrameMultiSelectStarted(
+    ClipEditorFrameMultiSelectStarted event,
+    Emitter<ClipEditorState> emit,
+  ) {
+    if (!isStopMotionComposition(state.clips)) return;
+    final frames = state.clips.first.stopMotionFrames ?? const [];
+    final initial = event.initialFrameIndex;
+    emit(
+      state.copyWith(
+        isMultiSelectMode: true,
+        isEditing: false,
+        clearSelectedFrameIndex: true,
+        selectedFrameIndexes: {
+          if (initial != null && initial >= 0 && initial < frames.length)
+            initial,
+        },
+      ),
+    );
+  }
+
+  void _onFrameMultiSelectToggled(
+    ClipEditorFrameMultiSelectToggled event,
+    Emitter<ClipEditorState> emit,
+  ) {
+    if (!state.isMultiSelectMode) return;
+    if (!isStopMotionComposition(state.clips)) return;
+    final frames = state.clips.first.stopMotionFrames ?? const [];
+    if (event.frameIndex < 0 || event.frameIndex >= frames.length) return;
+
+    final selected = Set<int>.of(state.selectedFrameIndexes);
+    if (!selected.remove(event.frameIndex)) {
+      selected.add(event.frameIndex);
+    }
+    emit(state.copyWith(selectedFrameIndexes: selected));
+  }
+
+  void _onFrameMultiSelectionSet(
+    ClipEditorFrameMultiSelectionSet event,
+    Emitter<ClipEditorState> emit,
+  ) {
+    if (!state.isMultiSelectMode) return;
+    if (!isStopMotionComposition(state.clips)) return;
+    final frames = state.clips.first.stopMotionFrames ?? const [];
+    if (event.frameIndexes.any(
+      (index) => index < 0 || index >= frames.length,
+    )) {
+      return;
+    }
+    emit(state.copyWith(selectedFrameIndexes: event.frameIndexes));
   }
 
   void _onSelectedClipsRemoved(
@@ -549,7 +652,7 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
       name: 'ClipEditorBloc',
       category: LogCategory.video,
     );
-    emit(state.copyWith(isEditing: false));
+    emit(state.copyWith(isEditing: false, clearSelectedFrameIndex: true));
   }
 
   void _onEditingToggled(
@@ -1061,7 +1164,7 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
     if (index == -1) return;
 
     final clip = state.clips[index];
-    final videoPath = clip.video.file?.path;
+    final videoPath = clip.requireVideo.file?.path;
 
     if (videoPath == null) {
       Log.warning(
@@ -1227,7 +1330,7 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
     if (index == -1) return;
 
     final clip = state.clips[index];
-    final videoPath = clip.video.file?.path;
+    final videoPath = clip.requireVideo.file?.path;
 
     if (videoPath == null) {
       Log.warning(
@@ -1345,7 +1448,7 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
       return;
     }
 
-    final videoPath = clip.video.file?.path;
+    final videoPath = clip.requireVideo.file?.path;
     final extractionSpeed = _effectiveAudioExtractionSpeed(clip);
 
     if (videoPath == null) {
@@ -1397,7 +1500,7 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
       }
 
       final currentClip = currentClips[currentIndex];
-      final currentVideoPath = currentClip.video.file?.path;
+      final currentVideoPath = currentClip.requireVideo.file?.path;
       final currentExtractionSpeed = _effectiveAudioExtractionSpeed(
         currentClip,
       );

--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
@@ -299,9 +299,11 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
     // reordered frame list; clamp the selection so it never points past the end.
     final selected = state.selectedFrameIndex;
     final frames = event.clip.stopMotionFrames;
-    final clampedSelection = selected != null && frames != null
-        ? selected.clamp(0, frames.length - 1)
-        : selected;
+    final clampedSelection = frames == null
+        ? selected
+        : frames.isEmpty
+        ? null
+        : selected?.clamp(0, frames.length - 1);
     final prunedMultiSelection = frames != null
         ? {
             for (final index in state.selectedFrameIndexes)
@@ -313,6 +315,10 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
       state.copyWith(
         clips: List.unmodifiable(newClips),
         selectedFrameIndex: clampedSelection,
+        clearSelectedFrameIndex:
+            selected != null &&
+            event.clip.video == null &&
+            (frames == null || frames.isEmpty),
         selectedFrameIndexes: prunedMultiSelection,
       ),
     );
@@ -1130,10 +1136,9 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
         );
       }
       final error = switch (e) {
-        StateError() || TypeError() || RangeError() => Reportable(
-          e,
-          context: '_onSaveClipToLibraryRequested',
-        ),
+        StateError() ||
+        TypeError() ||
+        RangeError() => Reportable(e, context: '_onSaveClipToLibraryRequested'),
         _ => e,
       };
       addError(error, stackTrace);

--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_event.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_event.dart
@@ -87,6 +87,18 @@ class ClipEditorClipSelected extends ClipEditorEvent {
   List<Object?> get props => [index];
 }
 
+/// Selects the still at [frameIndex] in a frames-only stop-motion clip, opening
+/// the per-frame action bar. Enters editing mode on the (single) stop-motion
+/// clip. Ignored when the composition is not stop-motion.
+class ClipEditorFrameSelected extends ClipEditorEvent {
+  const ClipEditorFrameSelected(this.frameIndex);
+
+  final int frameIndex;
+
+  @override
+  List<Object?> get props => [frameIndex];
+}
+
 // === MULTI-SELECT ===
 
 /// Enter multi-select mode, optionally pre-selecting [initialClipId].
@@ -115,6 +127,43 @@ class ClipEditorMultiSelectClipToggled extends ClipEditorEvent {
 /// Exit multi-select mode and clear the selection.
 class ClipEditorMultiSelectCancelled extends ClipEditorEvent {
   const ClipEditorMultiSelectCancelled();
+}
+
+/// Enter frame multi-select mode on a stop-motion composition, optionally
+/// pre-selecting the still at [initialFrameIndex].
+///
+/// Exits single-frame editing mode. While active, tapping a still toggles its
+/// membership in the selection.
+class ClipEditorFrameMultiSelectStarted extends ClipEditorEvent {
+  const ClipEditorFrameMultiSelectStarted([this.initialFrameIndex]);
+
+  final int? initialFrameIndex;
+
+  @override
+  List<Object?> get props => [initialFrameIndex];
+}
+
+/// Toggle a still's membership in the frame multi-select selection.
+class ClipEditorFrameMultiSelectToggled extends ClipEditorEvent {
+  const ClipEditorFrameMultiSelectToggled(this.frameIndex);
+
+  final int frameIndex;
+
+  @override
+  List<Object?> get props => [frameIndex];
+}
+
+/// Replace the frame multi-select selection wholesale.
+///
+/// Dispatched after a block move so the selection follows the stills to their
+/// new contiguous position.
+class ClipEditorFrameMultiSelectionSet extends ClipEditorEvent {
+  const ClipEditorFrameMultiSelectionSet(this.frameIndexes);
+
+  final Set<int> frameIndexes;
+
+  @override
+  List<Object?> get props => [frameIndexes];
 }
 
 /// Remove every clip currently in the multi-select selection.

--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_state.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_state.dart
@@ -40,6 +40,8 @@ class ClipEditorState extends Equatable {
     this.isSavingClipToLibrary = false,
     this.savingClipToLibraryClipId,
     this.lastClipLibrarySave,
+    this.selectedFrameIndex,
+    this.selectedFrameIndexes = const {},
   });
 
   /// Local copy of clips managed by this editor session.
@@ -200,6 +202,16 @@ class ClipEditorState extends Equatable {
   /// Consumed by the widget layer to surface a success/failure snackbar.
   final ClipLibrarySaveResult? lastClipLibrarySave;
 
+  /// Index of the currently selected still in a frames-only stop-motion clip,
+  /// or `null` when no frame is selected (or the composition is not
+  /// stop-motion). Drives the per-frame action bar and tile highlight.
+  final int? selectedFrameIndex;
+
+  /// Indexes of the stills selected while [isMultiSelectMode] is active on a
+  /// stop-motion composition — the frame counterpart of [selectedClipIds].
+  /// Always empty outside frame multi-select.
+  final Set<int> selectedFrameIndexes;
+
   /// Total wall-clock duration of all clips (respecting trim and playback speed).
   Duration get totalDuration =>
       clips.fold(Duration.zero, (sum, clip) => sum + clip.playbackDuration);
@@ -246,6 +258,9 @@ class ClipEditorState extends Equatable {
     String? savingClipToLibraryClipId,
     bool clearSavingClipToLibraryClipId = false,
     ClipLibrarySaveResult? lastClipLibrarySave,
+    int? selectedFrameIndex,
+    bool clearSelectedFrameIndex = false,
+    Set<int>? selectedFrameIndexes,
   }) {
     return ClipEditorState(
       clips: clips ?? this.clips,
@@ -298,6 +313,10 @@ class ClipEditorState extends Equatable {
           ? null
           : (savingClipToLibraryClipId ?? this.savingClipToLibraryClipId),
       lastClipLibrarySave: lastClipLibrarySave ?? this.lastClipLibrarySave,
+      selectedFrameIndex: clearSelectedFrameIndex
+          ? null
+          : (selectedFrameIndex ?? this.selectedFrameIndex),
+      selectedFrameIndexes: selectedFrameIndexes ?? this.selectedFrameIndexes,
     );
   }
 
@@ -340,6 +359,8 @@ class ClipEditorState extends Equatable {
     savingClipToLibraryClipId,
     // Identity-only: each ClipLibrarySaveResult is a fresh instance per save.
     identityHashCode(lastClipLibrarySave),
+    selectedFrameIndex,
+    selectedFrameIndexes,
   ];
 }
 

--- a/mobile/lib/blocs/video_editor/transition_boundary/transition_boundary_cubit.dart
+++ b/mobile/lib/blocs/video_editor/transition_boundary/transition_boundary_cubit.dart
@@ -84,7 +84,7 @@ class TransitionBoundaryCubit extends Cubit<TransitionBoundaryState> {
     required bool tail,
   }) async {
     try {
-      final videoPath = await clip.video.safeFilePath();
+      final videoPath = await clip.requireVideo.safeFilePath();
       if (videoPath.isEmpty) return null;
 
       final side = tail ? 'tail' : 'head';

--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -1638,6 +1638,12 @@ class VideoRecorderBloc
       return;
     }
 
+    // An assemble owns the captured stills once it starts: it reads the frame
+    // list, saves it, then clears it. A still added to that list mid-assemble
+    // is either missed by the save or re-persisted afterwards as a phantom
+    // one-frame session, so the capture is dropped instead.
+    if (state.stopMotionStatus == StopMotionStatus.assembling) return;
+
     unawaited(HapticService.recordingFeedback());
     // Shutter feedback must fire NOW — the native capture below takes
     // hundreds of ms, and blinking only once the frame lands feels laggy
@@ -1669,7 +1675,21 @@ class VideoRecorderBloc
       return;
     }
 
+    // "Next" stays tappable while the native capture runs, so an assemble can
+    // claim the session across the await above. Adding this still now would
+    // either race the in-flight save or — once the assemble cleared the list —
+    // re-persist it as a phantom one-frame session, so it is dropped with its
+    // file. Only idle (still shooting) and failure (assemble bailed, stills
+    // retained) still own the session here.
+    if (state.stopMotionStatus == StopMotionStatus.assembling ||
+        state.stopMotionStatus == StopMotionStatus.ready) {
+      unawaited(_deleteFrameFile(photo.filePath));
+      return;
+    }
+
     final framePaths = [...state.stopMotionFrames, photo.filePath];
+    // Back to idle so a retry after a failed assemble re-emits the failure the
+    // status listener only fires on transitions.
     emit(
       state.copyWith(
         stopMotionFrames: framePaths,

--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -233,9 +233,7 @@ class VideoRecorderBloc
     on<VideoRecorderRecorderModeSet>(_onRecorderModeSet);
     on<VideoRecorderTimerCycled>(_onTimerCycled);
     on<VideoRecorderResetRequested>(_onResetRequested);
-    on<VideoRecorderShowLastClipOverlayToggled>(
-      _onShowLastClipOverlayToggled,
-    );
+    on<VideoRecorderShowLastClipOverlayToggled>(_onShowLastClipOverlayToggled);
     on<VideoRecorderGridLinesToggled>(_onGridLinesToggled);
     on<VideoRecorderStopMotionFrameCaptured>(
       _onStopMotionFrameCaptured,
@@ -267,6 +265,7 @@ class VideoRecorderBloc
   CountdownSoundService? _countdownSoundService;
   Timer? _focusPointTimer;
   Timer? _zoomIndicatorTimer;
+  Future<void> _stopMotionSessionWrite = Future.value();
   bool _remoteRecordControlEnabled = false;
 
   /// How long the zoom ruler stays visible after the last pinch activity
@@ -752,10 +751,7 @@ class VideoRecorderBloc
     }
 
     emit(
-      state.copyWith(
-        isStartingRecording: true,
-        baseZoomLevel: state.zoomLevel,
-      ),
+      state.copyWith(isStartingRecording: true, baseZoomLevel: state.zoomLevel),
     );
     unawaited(HapticService.recordingFeedback());
 
@@ -1718,7 +1714,11 @@ class VideoRecorderBloc
 
     // Fire-and-forget so shooting stays instant; the library row is upserted
     // by the stable session id, so an out-of-order write just re-writes it.
-    unawaited(_persistStopMotionSession(framePaths));
+    unawaited(
+      _enqueueStopMotionSessionWrite(
+        () => _persistStopMotionSession(framePaths),
+      ),
+    );
   }
 
   /// Removes the last captured stop-motion frame, deletes its file, and
@@ -1740,13 +1740,35 @@ class VideoRecorderBloc
       // Whole session undone — drop its library row. The frame file is deleted
       // above, so a row-only delete is correct here.
       unawaited(
-        _readClipManager().removeStopMotionSessionFromLibrary(
-          _stopMotionSessionId(frames.first),
+        _enqueueStopMotionSessionWrite(
+          () => _readClipManager().removeStopMotionSessionFromLibrary(
+            _stopMotionSessionId(frames.first),
+          ),
         ),
       );
     } else {
-      unawaited(_persistStopMotionSession(remaining));
+      unawaited(
+        _enqueueStopMotionSessionWrite(
+          () => _persistStopMotionSession(remaining),
+        ),
+      );
     }
+  }
+
+  Future<void> _enqueueStopMotionSessionWrite(
+    Future<void> Function() operation,
+  ) {
+    final run = _stopMotionSessionWrite
+        .catchError((Object e, StackTrace s) {
+          Log.warning(
+            '⚠️ Previous stop-motion session write failed: $e',
+            name: 'VideoRecorderBloc',
+            category: LogCategory.video,
+          );
+        })
+        .then((_) => operation());
+    _stopMotionSessionWrite = run;
+    return run;
   }
 
   /// Upserts the current capture session (the stills at [framePaths]) as a
@@ -1868,8 +1890,10 @@ class VideoRecorderBloc
   Future<void> _discardStopMotionSession(List<String> framePaths) async {
     if (framePaths.isEmpty) return;
     await _deleteFrameFiles(framePaths);
-    await _readClipManager().removeStopMotionSessionFromLibrary(
-      _stopMotionSessionId(framePaths.first),
+    await _enqueueStopMotionSessionWrite(
+      () => _readClipManager().removeStopMotionSessionFromLibrary(
+        _stopMotionSessionId(framePaths.first),
+      ),
     );
   }
 
@@ -2196,6 +2220,15 @@ class VideoRecorderBloc
     _focusPointTimer = null;
     _zoomIndicatorTimer?.cancel();
     _zoomIndicatorTimer = null;
+    try {
+      await _stopMotionSessionWrite;
+    } catch (e) {
+      Log.warning(
+        '🧹 Stop-motion session write cleanup failed: $e',
+        name: 'VideoRecorderBloc',
+        category: LogCategory.system,
+      );
+    }
     try {
       await _audioPlaybackService?.dispose();
       _audioPlaybackService = null;

--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -22,6 +22,8 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:models/models.dart' as model show AspectRatio, AudioSourceKind;
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/stop_motion/stop_motion_frame_ops.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
 import 'package:openvine/models/video_recorder/video_recorder_flash_mode.dart';
 import 'package:openvine/models/video_recorder/video_recorder_mode.dart';
@@ -33,6 +35,7 @@ import 'package:openvine/services/haptic_service.dart';
 import 'package:openvine/services/performance_monitoring_service.dart';
 import 'package:openvine/services/video_recorder/camera/camera_base_service.dart';
 import 'package:openvine/services/video_thumbnail_service.dart';
+import 'package:path/path.dart' as p;
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:sound_service/sound_service.dart';
@@ -47,6 +50,9 @@ const _kLastUsedCameraLensKey = 'camera_last_used_lens';
 
 /// SharedPreferences key for the last-used video stabilization mode.
 const _kLastUsedStabilizationModeKey = 'camera_last_used_stabilization';
+
+/// SharedPreferences key for the last grid-lines on/off choice.
+const _kGridLinesEnabledKey = 'camera_grid_lines_enabled';
 
 /// Factory for creating a [CountdownSoundService].
 ///
@@ -231,6 +237,15 @@ class VideoRecorderBloc
       _onShowLastClipOverlayToggled,
     );
     on<VideoRecorderGridLinesToggled>(_onGridLinesToggled);
+    on<VideoRecorderStopMotionFrameCaptured>(
+      _onStopMotionFrameCaptured,
+      transformer: droppable(),
+    );
+    on<VideoRecorderStopMotionFrameUndone>(_onStopMotionFrameUndone);
+    on<VideoRecorderStopMotionAssembleRequested>(
+      _onStopMotionAssembleRequested,
+      transformer: droppable(),
+    );
     on<_VideoRecorderCameraStateChanged>(_onCameraStateChanged);
     on<_VideoRecorderRemoteRecordTriggered>(_onRemoteRecordTriggered);
     on<_VideoRecorderAutoStopped>(_onAutoStopped);
@@ -295,6 +310,20 @@ class VideoRecorderBloc
     );
     if (!event.fromEditor && savedMode != state.recorderMode) {
       _applyRecorderMode(emit, savedMode, keepAutosavedDraft: true);
+    } else if (event.fromEditor &&
+        state.recorderMode != VideoRecorderMode.stopMotion &&
+        isStopMotionComposition(_readClipManager().clips)) {
+      // Opened over a stop-motion composition to add more stills: switch to the
+      // stills shutter so the "+" camera captures photos, not a video. Set only
+      // the mode field (plus its grid default) — routing through
+      // _applyRecorderMode would clear the clip manager (the composition being
+      // edited).
+      emit(
+        state.copyWith(
+          recorderMode: VideoRecorderMode.stopMotion,
+          showGridLines: _gridLinesEnabledFor(VideoRecorderMode.stopMotion),
+        ),
+      );
     }
 
     final savedLensString = prefs.getString(_kLastUsedCameraLensKey);
@@ -677,6 +706,11 @@ class VideoRecorderBloc
       return;
     }
 
+    if (state.recorderMode.capturesStills) {
+      add(const VideoRecorderStopMotionFrameCaptured());
+      return;
+    }
+
     switch (state.recordingState) {
       case VideoRecorderState.idle:
         add(const VideoRecorderRecordingStartRequested());
@@ -690,6 +724,11 @@ class VideoRecorderBloc
     VideoRecorderRecordingStartRequested event,
     Emitter<VideoRecorderBlocState> emit,
   ) async {
+    // Stop-motion captures stills via VideoRecorderStopMotionFrameCaptured;
+    // a video-record start here would be a no-op at best and corrupt the
+    // session at worst.
+    if (state.recorderMode.capturesStills) return;
+
     final clipManager = _readClipManager();
     final remainingDuration = clipManager.remainingDuration;
 
@@ -1466,17 +1505,23 @@ class VideoRecorderBloc
     required bool keepAutosavedDraft,
   }) {
     final previousMode = state.recorderMode;
+    final previousFrames = state.stopMotionFrames;
     emit(
       state.copyWith(
         recorderMode: mode,
         aspectRatio: mode.defaultAspectRatio,
-        showGridLines: mode.supportGridLines,
+        showGridLines: _gridLinesEnabledFor(mode),
         timerDuration: mode.supportsCountdownTimer
             ? state.timerDuration
             : TimerDuration.off,
         countdownValue: 0,
+        stopMotionFrames: const [],
+        stopMotionStatus: StopMotionStatus.idle,
       ),
     );
+    if (previousFrames.isNotEmpty) {
+      unawaited(_deleteFrameFiles(previousFrames));
+    }
     final prefs = _readSharedPreferences();
     prefs.setString(VideoRecorderMode.persistenceKey, mode.name);
 
@@ -1523,7 +1568,11 @@ class VideoRecorderBloc
       name: 'VideoRecorderBloc',
       category: LogCategory.video,
     );
+    final frames = state.stopMotionFrames;
     emit(const VideoRecorderBlocState());
+    if (frames.isNotEmpty) {
+      unawaited(_deleteFrameFiles(frames));
+    }
   }
 
   void _onShowLastClipOverlayToggled(
@@ -1537,7 +1586,237 @@ class VideoRecorderBloc
     VideoRecorderGridLinesToggled event,
     Emitter<VideoRecorderBlocState> emit,
   ) {
-    emit(state.copyWith(showGridLines: !state.showGridLines));
+    final enabled = !state.showGridLines;
+    emit(state.copyWith(showGridLines: enabled));
+    _readSharedPreferences().setBool(_kGridLinesEnabledKey, enabled);
+  }
+
+  /// Whether a grid-supporting [mode] should show the grid: the user's last
+  /// persisted choice, defaulting to on.
+  bool _gridLinesEnabledFor(VideoRecorderMode mode) =>
+      mode.supportGridLines &&
+      (_readSharedPreferences().getBool(_kGridLinesEnabledKey) ?? true);
+
+  // === Stop-motion handlers ===
+
+  /// Hold duration of one captured still: the editor's default
+  /// frames-per-image at the render frame rate, so the library preview, the
+  /// timeline, and the assembled clip all agree.
+  static final Duration _stopMotionPerFrame =
+      StopMotionFrameOps.framesPerImageToDuration(
+        StopMotionFrameOps.defaultFramesPerImage,
+      );
+
+  /// Stable library-clip id for the capture session that begins with
+  /// [firstFramePath]. The first frame's filename is unique per session and
+  /// unchanged while the session grows, so the eager saves during capture and
+  /// the final assemble all upsert the same library row (no duplicate).
+  String _stopMotionSessionId(String firstFramePath) =>
+      'clip_sm_${p.basenameWithoutExtension(firstFramePath)}';
+
+  /// Captures one still, appends it to [state.stopMotionFrames], and persists
+  /// the growing session to the library.
+  ///
+  /// No video is rendered here — encoding one video per tap is far too slow
+  /// (seconds per frame). Frames are encoded into a single video only at
+  /// publish. The session is upserted to the library on every frame (not just
+  /// on the "Next"/assemble tap) so the recording is preserved the instant it
+  /// is shot, even if the user backs out before assembling.
+  Future<void> _onStopMotionFrameCaptured(
+    VideoRecorderStopMotionFrameCaptured event,
+    Emitter<VideoRecorderBlocState> emit,
+  ) async {
+    if (!_cameraService.isInitialized || _cameraService.isSwitchingCamera) {
+      return;
+    }
+
+    unawaited(HapticService.recordingFeedback());
+    // Shutter feedback must fire NOW — the native capture below takes
+    // hundreds of ms, and blinking only once the frame lands feels laggy
+    // compared to the system camera.
+    emit(
+      state.copyWith(stopMotionShutterTick: state.stopMotionShutterTick + 1),
+    );
+
+    final photo = await _cameraService.capturePhoto();
+    if (photo == null) {
+      Log.warning(
+        '📷 Stop-motion frame capture returned no result',
+        name: 'VideoRecorderBloc',
+        category: LogCategory.video,
+      );
+      return;
+    }
+
+    final framePaths = [...state.stopMotionFrames, photo.filePath];
+    emit(
+      state.copyWith(
+        stopMotionFrames: framePaths,
+        stopMotionStatus: StopMotionStatus.idle,
+      ),
+    );
+
+    // Fire-and-forget so shooting stays instant; the library row is upserted
+    // by the stable session id, so an out-of-order write just re-writes it.
+    unawaited(_persistStopMotionSession(framePaths));
+  }
+
+  /// Removes the last captured stop-motion frame, deletes its file, and
+  /// re-syncs the session's library row to the remaining frames (dropping the
+  /// row entirely once every frame has been undone).
+  Future<void> _onStopMotionFrameUndone(
+    VideoRecorderStopMotionFrameUndone event,
+    Emitter<VideoRecorderBlocState> emit,
+  ) async {
+    final frames = state.stopMotionFrames;
+    if (frames.isEmpty) return;
+
+    final removed = frames.last;
+    final remaining = frames.sublist(0, frames.length - 1);
+    emit(state.copyWith(stopMotionFrames: remaining));
+    unawaited(_deleteFrameFile(removed));
+
+    if (remaining.isEmpty) {
+      // Whole session undone — drop its library row. The frame file is deleted
+      // above, so a row-only delete is correct here.
+      unawaited(
+        _readClipManager().removeStopMotionSessionFromLibrary(
+          _stopMotionSessionId(frames.first),
+        ),
+      );
+    } else {
+      unawaited(_persistStopMotionSession(remaining));
+    }
+  }
+
+  /// Upserts the current capture session (the stills at [framePaths]) as a
+  /// single library clip. Shared by capture and undo; keyed by
+  /// [_stopMotionSessionId] so every call targets the same row.
+  Future<void> _persistStopMotionSession(List<String> framePaths) async {
+    if (framePaths.isEmpty) return;
+    // Skip unreadable captures (interrupted writes leave empty files) so a
+    // corrupt still never persists into the session's library clip.
+    final frames = StopMotionFrameOps.existingFrames([
+      for (final path in framePaths)
+        StopMotionClipFrame(path: path, duration: _stopMotionPerFrame),
+    ]);
+    if (frames.isEmpty) return;
+    final saved = await _readClipManager().saveStopMotionSessionToLibrary(
+      id: _stopMotionSessionId(framePaths.first),
+      frames: frames,
+      originalAspectRatio: state.aspectRatio.value,
+      targetAspectRatio: state.aspectRatio,
+      duration: _stopMotionPerFrame * frames.length,
+      thumbnailPath: frames.first.path,
+      lensMetadata: _cameraService.currentLensMetadata,
+    );
+    if (!saved) {
+      Log.warning(
+        '⚠️ Stop-motion session save to library failed',
+        name: 'VideoRecorderBloc',
+        category: LogCategory.video,
+      );
+    }
+  }
+
+  /// Saves the captured frames as a frames-based stop-motion clip in the clip
+  /// manager (and the library), then emits [StopMotionStatus.ready].
+  ///
+  /// The frames are the source of truth; no mp4 is rendered here. The editor
+  /// previews the frames via the stop-motion player and only renders an mp4 at
+  /// publish.
+  Future<void> _onStopMotionAssembleRequested(
+    VideoRecorderStopMotionAssembleRequested event,
+    Emitter<VideoRecorderBlocState> emit,
+  ) async {
+    final frames = state.stopMotionFrames;
+    if (frames.isEmpty) return;
+
+    emit(state.copyWith(stopMotionStatus: StopMotionStatus.assembling));
+
+    try {
+      await _ingestStopMotionClip(frames);
+    } catch (e, stackTrace) {
+      Log.warning(
+        '⚠️ Stop-motion ingest failed',
+        name: 'VideoRecorderBloc',
+        category: LogCategory.video,
+      );
+      addError(e, stackTrace);
+      emit(state.copyWith(stopMotionStatus: StopMotionStatus.failure));
+      return;
+    }
+
+    emit(
+      state.copyWith(
+        stopMotionStatus: StopMotionStatus.ready,
+        stopMotionFrames: const [],
+      ),
+    );
+  }
+
+  /// Adds the captured [framePaths] to the clip manager as a frames-based
+  /// stop-motion clip and saves it to the library. Frame files are kept (not
+  /// deleted) since they are the clip's source of truth.
+  ///
+  /// Reuses the capture session's library id so the row already written during
+  /// capture is updated in place rather than duplicated.
+  Future<void> _ingestStopMotionClip(List<String> framePaths) async {
+    final clipManager = _readClipManager();
+
+    // Drop unreadable captures; a session with no readable still is a failed
+    // assemble (surfaced by the caller's failure snackbar).
+    final frames = StopMotionFrameOps.existingFrames([
+      for (final path in framePaths)
+        StopMotionClipFrame(path: path, duration: _stopMotionPerFrame),
+    ]);
+    if (frames.isEmpty) {
+      throw StateError('No readable stop-motion stills to assemble');
+    }
+
+    final clip = clipManager.addStopMotionClip(
+      id: _stopMotionSessionId(framePaths.first),
+      frames: frames,
+      originalAspectRatio: state.aspectRatio.value,
+      targetAspectRatio: state.aspectRatio,
+      duration: _stopMotionPerFrame * frames.length,
+      thumbnailPath: frames.first.path,
+      lensMetadata: _cameraService.currentLensMetadata,
+    );
+
+    final updatedClip = clipManager.clips.firstWhere(
+      (c) => c.id == clip.id,
+      orElse: () => clip,
+    );
+    final saved = await clipManager.saveClipToLibrary(updatedClip);
+    if (!saved) {
+      Log.warning(
+        '⚠️ Stop-motion clip save to library failed for ${clip.id}',
+        name: 'VideoRecorderBloc',
+        category: LogCategory.video,
+      );
+    }
+  }
+
+  /// Deletes all captured stop-motion frame files, ignoring errors.
+  Future<void> _deleteFrameFiles(List<String> paths) async {
+    for (final path in paths) {
+      await _deleteFrameFile(path);
+    }
+  }
+
+  /// Deletes a captured stop-motion frame file, ignoring errors.
+  Future<void> _deleteFrameFile(String path) async {
+    try {
+      final file = File(path);
+      if (file.existsSync()) await file.delete();
+    } catch (e) {
+      Log.warning(
+        '⚠️ Failed to delete stop-motion frame $path: $e',
+        name: 'VideoRecorderBloc',
+        category: LogCategory.video,
+      );
+    }
   }
 
   void _onCameraStateChanged(
@@ -1582,6 +1861,13 @@ class VideoRecorderBloc
         showLastClipOverlay: state.showLastClipOverlay,
         recorderMode: state.recorderMode,
         showGridLines: state.showGridLines,
+        // Preserve the in-progress stop-motion capture session: a camera-field
+        // re-sync must not wipe already-captured frames, or the session would
+        // split into several one-frame recordings (and lose frames on
+        // assemble).
+        stopMotionFrames: state.stopMotionFrames,
+        stopMotionStatus: state.stopMotionStatus,
+        stopMotionShutterTick: state.stopMotionShutterTick,
       ),
     );
   }

--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -1504,6 +1504,14 @@ class VideoRecorderBloc
     VideoRecorderMode mode, {
     required bool keepAutosavedDraft,
   }) {
+    // An assemble owns the captured stills until it resolves: it saves them to
+    // the library across an await, while this method deletes them and clears
+    // the clip manager. Switching mode mid-assemble would delete the stills out
+    // from under the save and leave the library row pointing at missing files,
+    // so the switch is dropped instead. The mode wheel is already gated while
+    // assembling; this keeps the invariant if anything else ever dispatches.
+    if (state.stopMotionStatus == StopMotionStatus.assembling) return;
+
     final previousMode = state.recorderMode;
     final previousFrames = state.stopMotionFrames;
     emit(
@@ -1648,6 +1656,19 @@ class VideoRecorderBloc
       return;
     }
 
+    // Only the still that just landed is checked — the ones already in state
+    // were checked as they landed. Re-validating the whole list on every tap
+    // costs two sync syscalls per existing frame (O(n²) over a session) on the
+    // main isolate and can't learn anything new about them.
+    if (!StopMotionFrameOps.isReadableImage(photo.filePath)) {
+      Log.warning(
+        '📷 Stop-motion frame capture wrote an unreadable file',
+        name: 'VideoRecorderBloc',
+        category: LogCategory.video,
+      );
+      return;
+    }
+
     final framePaths = [...state.stopMotionFrames, photo.filePath];
     emit(
       state.copyWith(
@@ -1692,15 +1713,18 @@ class VideoRecorderBloc
   /// Upserts the current capture session (the stills at [framePaths]) as a
   /// single library clip. Shared by capture and undo; keyed by
   /// [_stopMotionSessionId] so every call targets the same row.
+  ///
+  /// [framePaths] are taken as readable — each still is checked as it is
+  /// captured, so re-sweeping the accumulated session on every shutter tap
+  /// would stat the same files repeatedly without learning anything new. The
+  /// assemble re-checks the whole set (see [_ingestStopMotionClip]), which is
+  /// where a still that goes missing mid-session gets dropped.
   Future<void> _persistStopMotionSession(List<String> framePaths) async {
     if (framePaths.isEmpty) return;
-    // Skip unreadable captures (interrupted writes leave empty files) so a
-    // corrupt still never persists into the session's library clip.
-    final frames = StopMotionFrameOps.existingFrames([
+    final frames = [
       for (final path in framePaths)
         StopMotionClipFrame(path: path, duration: _stopMotionPerFrame),
-    ]);
-    if (frames.isEmpty) return;
+    ];
     final saved = await _readClipManager().saveStopMotionSessionToLibrary(
       id: _stopMotionSessionId(framePaths.first),
       frames: frames,

--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -1520,7 +1520,7 @@ class VideoRecorderBloc
       ),
     );
     if (previousFrames.isNotEmpty) {
-      unawaited(_deleteFrameFiles(previousFrames));
+      unawaited(_discardStopMotionSession(previousFrames));
     }
     final prefs = _readSharedPreferences();
     prefs.setString(VideoRecorderMode.persistenceKey, mode.name);
@@ -1571,7 +1571,7 @@ class VideoRecorderBloc
     final frames = state.stopMotionFrames;
     emit(const VideoRecorderBlocState());
     if (frames.isNotEmpty) {
-      unawaited(_deleteFrameFiles(frames));
+      unawaited(_discardStopMotionSession(frames));
     }
   }
 
@@ -1796,6 +1796,18 @@ class VideoRecorderBloc
         category: LogCategory.video,
       );
     }
+  }
+
+  /// Discards an abandoned capture session: deletes its frame files and drops
+  /// the library row eagerly saved during capture. A mode switch or reset
+  /// otherwise leaves an orphaned library clip whose source frames are gone.
+  /// Mirrors the empty-session branch of [_onStopMotionFrameUndone].
+  Future<void> _discardStopMotionSession(List<String> framePaths) async {
+    if (framePaths.isEmpty) return;
+    await _deleteFrameFiles(framePaths);
+    await _readClipManager().removeStopMotionSessionFromLibrary(
+      _stopMotionSessionId(framePaths.first),
+    );
   }
 
   /// Deletes all captured stop-motion frame files, ignoring errors.

--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -1864,6 +1864,7 @@ class VideoRecorderBloc
         isCameraInitialized: _cameraService.isInitialized,
         hasFlash: _cameraService.hasFlash,
         canSwitchCamera: _cameraService.canSwitchCamera,
+        isFrontCamera: _cameraService.currentLens.isFrontFacing,
         previewTextureId: _cameraService.textureId,
         videoStabilizationMode: _cameraService.videoStabilizationMode,
         availableVideoStabilizationModes:

--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -1641,8 +1641,13 @@ class VideoRecorderBloc
     // An assemble owns the captured stills once it starts: it reads the frame
     // list, saves it, then clears it. A still added to that list mid-assemble
     // is either missed by the save or re-persisted afterwards as a phantom
-    // one-frame session, so the capture is dropped instead.
-    if (state.stopMotionStatus == StopMotionStatus.assembling) return;
+    // one-frame session, so the capture is dropped instead. `ready` (assemble
+    // done, navigation pending) is dropped here too so a tap in that ~1-frame
+    // window skips the native capture the after-await guard would only delete.
+    if (state.stopMotionStatus == StopMotionStatus.assembling ||
+        state.stopMotionStatus == StopMotionStatus.ready) {
+      return;
+    }
 
     unawaited(HapticService.recordingFeedback());
     // Shutter feedback must fire NOW — the native capture below takes
@@ -1675,13 +1680,17 @@ class VideoRecorderBloc
       return;
     }
 
-    // "Next" stays tappable while the native capture runs, so an assemble can
-    // claim the session across the await above. Adding this still now would
-    // either race the in-flight save or — once the assemble cleared the list —
-    // re-persist it as a phantom one-frame session, so it is dropped with its
-    // file. Only idle (still shooting) and failure (assemble bailed, stills
-    // retained) still own the session here.
-    if (state.stopMotionStatus == StopMotionStatus.assembling ||
+    // The recorder can move off this session across the await above. "Next"
+    // stays tappable, so an assemble can claim it (status → assembling, then
+    // ready); the mode wheel stays live during an idle capture, so a swipe can
+    // discard it (_applyRecorderMode clears the frames and leaves stop-motion,
+    // status idle). In every case the session this still belonged to is gone,
+    // so appending it now would race the in-flight save or re-persist a phantom
+    // one-frame session — on the new mode, for a swipe — so it is dropped with
+    // its file. Only idle (still shooting) and failure (assemble bailed, stills
+    // retained) while still in stop-motion own the session here.
+    if (!state.recorderMode.capturesStills ||
+        state.stopMotionStatus == StopMotionStatus.assembling ||
         state.stopMotionStatus == StopMotionStatus.ready) {
       unawaited(_deleteFrameFile(photo.filePath));
       return;

--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -326,6 +326,15 @@ class VideoRecorderBloc
       );
     }
 
+    // A completed assemble leaves status at `ready` until it navigates to the
+    // editor; backing out re-inits without a mode change, so nothing above
+    // clears it and `_emitCameraSync` preserves it — the capture guard would
+    // then swallow every shutter tap. Reset to idle (the frames are already
+    // saved and cleared) so the shutter starts a fresh session.
+    if (state.stopMotionStatus == StopMotionStatus.ready) {
+      emit(state.copyWith(stopMotionStatus: StopMotionStatus.idle));
+    }
+
     final savedLensString = prefs.getString(_kLastUsedCameraLensKey);
     final initialLens = savedLensString != null
         ? DivineCameraLens.fromNativeString(savedLensString)

--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -1686,6 +1686,7 @@ class VideoRecorderBloc
         name: 'VideoRecorderBloc',
         category: LogCategory.video,
       );
+      unawaited(_deleteFrameFile(photo.filePath));
       return;
     }
 

--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -1686,7 +1686,7 @@ class VideoRecorderBloc
         name: 'VideoRecorderBloc',
         category: LogCategory.video,
       );
-      unawaited(_deleteFrameFile(photo.filePath));
+      await _deleteFrameFile(photo.filePath);
       return;
     }
 

--- a/mobile/lib/blocs/video_recorder/video_recorder_event.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_event.dart
@@ -277,6 +277,33 @@ final class VideoRecorderGridLinesToggled extends VideoRecorderEvent {
   const VideoRecorderGridLinesToggled();
 }
 
+// === Stop-motion events ===
+
+/// Captures a single still in stop-motion mode and appends it to
+/// [VideoRecorderBlocState.stopMotionFrames]. No video is rendered here —
+/// frames are encoded into one video only on
+/// [VideoRecorderStopMotionAssembleRequested] (assemble-at-end), so capture
+/// stays instant.
+///
+/// Registered with `transformer: droppable()` so rapid taps can't fire
+/// overlapping captures.
+final class VideoRecorderStopMotionFrameCaptured extends VideoRecorderEvent {
+  const VideoRecorderStopMotionFrameCaptured();
+}
+
+/// Removes the most recently captured stop-motion frame and deletes its file.
+final class VideoRecorderStopMotionFrameUndone extends VideoRecorderEvent {
+  const VideoRecorderStopMotionFrameUndone();
+}
+
+/// Encodes all captured stop-motion frames into a single video, adds it to the
+/// clip manager, and signals the UI (via [StopMotionStatus.ready]) to open the
+/// editor.
+final class VideoRecorderStopMotionAssembleRequested
+    extends VideoRecorderEvent {
+  const VideoRecorderStopMotionAssembleRequested();
+}
+
 // === Internal events dispatched from service callbacks ===
 
 /// Internal event: camera service reported a state change

--- a/mobile/lib/blocs/video_recorder/video_recorder_state.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_state.dart
@@ -33,6 +33,7 @@ class VideoRecorderBlocState extends Equatable {
     this.canRecord = false,
     this.isCameraInitialized = false,
     this.canSwitchCamera = true,
+    this.isFrontCamera = false,
     this.isSwitchingCamera = false,
     this.previewTextureId,
     this.hasFlash = true,
@@ -81,6 +82,13 @@ class VideoRecorderBlocState extends Equatable {
 
   /// Whether camera switching is available.
   final bool canSwitchCamera;
+
+  /// Whether the active lens is front-facing.
+  ///
+  /// Drives the stop-motion onion-skin overlay: the live preview is mirrored
+  /// for the front camera, so the ghost of the last still is flipped to match
+  /// it (see [VideoRecorderGhostFrame]).
+  final bool isFrontCamera;
 
   /// Whether a front/back lens switch is currently in progress.
   ///
@@ -263,6 +271,7 @@ class VideoRecorderBlocState extends Equatable {
     bool? canRecord,
     bool? isCameraInitialized,
     bool? canSwitchCamera,
+    bool? isFrontCamera,
     bool? isSwitchingCamera,
     int? previewTextureId,
     bool? hasFlash,
@@ -303,6 +312,7 @@ class VideoRecorderBlocState extends Equatable {
       canRecord: canRecord ?? this.canRecord,
       isCameraInitialized: isCameraInitialized ?? this.isCameraInitialized,
       canSwitchCamera: canSwitchCamera ?? this.canSwitchCamera,
+      isFrontCamera: isFrontCamera ?? this.isFrontCamera,
       isSwitchingCamera: isSwitchingCamera ?? this.isSwitchingCamera,
       previewTextureId: previewTextureId ?? this.previewTextureId,
       hasFlash: hasFlash ?? this.hasFlash,
@@ -353,6 +363,7 @@ class VideoRecorderBlocState extends Equatable {
     canRecord,
     isCameraInitialized,
     canSwitchCamera,
+    isFrontCamera,
     isSwitchingCamera,
     previewTextureId,
     hasFlash,

--- a/mobile/lib/blocs/video_recorder/video_recorder_state.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_state.dart
@@ -1,5 +1,20 @@
 part of 'video_recorder_bloc.dart';
 
+/// Lifecycle of the stop-motion "assemble captured frames into one video" step.
+enum StopMotionStatus {
+  /// No assembly in progress.
+  idle,
+
+  /// Captured frames are being encoded into a single video.
+  assembling,
+
+  /// Assembly finished; the clip is in the manager and the editor can open.
+  ready,
+
+  /// Assembly failed.
+  failure,
+}
+
 /// State for [VideoRecorderBloc].
 ///
 /// Ports the legacy `VideoRecorderProviderState` verbatim and adds the mutable
@@ -47,6 +62,9 @@ class VideoRecorderBlocState extends Equatable {
     this.snapTime,
     this.showZoomIndicator = false,
     this.isPinchActive = false,
+    this.stopMotionFrames = const [],
+    this.stopMotionStatus = StopMotionStatus.idle,
+    this.stopMotionShutterTick = 0,
   });
 
   /// Recorder mode from the camera.
@@ -197,6 +215,27 @@ class VideoRecorderBlocState extends Equatable {
   /// by the ruler's drag scrubber.
   final bool isPinchActive;
 
+  /// Captured stop-motion frame file paths, in capture order.
+  ///
+  /// Each shutter tap in stop-motion mode appends one still here; they are
+  /// encoded into a single video only on finish (assemble-at-end), so capture
+  /// stays instant.
+  final List<String> stopMotionFrames;
+
+  /// Lifecycle of the stop-motion assemble step.
+  final StopMotionStatus stopMotionStatus;
+
+  /// Number of captured stop-motion frames.
+  int get stopMotionFrameCount => stopMotionFrames.length;
+
+  /// Incremented the instant a stop-motion shutter fires — before the native
+  /// photo capture resolves — so shutter feedback (blink) is immediate rather
+  /// than delayed by the capture write (~400ms).
+  final int stopMotionShutterTick;
+
+  /// Path of the most recently captured stop-motion frame, if any.
+  String? get stopMotionLastFrame => stopMotionFrames.lastOrNull;
+
   /// Whether currently recording.
   bool get isRecording => recordingState == VideoRecorderState.recording;
 
@@ -248,6 +287,9 @@ class VideoRecorderBlocState extends Equatable {
     DateTime? snapTime,
     bool? showZoomIndicator,
     bool? isPinchActive,
+    List<String>? stopMotionFrames,
+    StopMotionStatus? stopMotionStatus,
+    int? stopMotionShutterTick,
   }) {
     return VideoRecorderBlocState(
       recorderMode: recorderMode ?? this.recorderMode,
@@ -292,6 +334,10 @@ class VideoRecorderBlocState extends Equatable {
       snapTime: snapTime ?? this.snapTime,
       showZoomIndicator: showZoomIndicator ?? this.showZoomIndicator,
       isPinchActive: isPinchActive ?? this.isPinchActive,
+      stopMotionFrames: stopMotionFrames ?? this.stopMotionFrames,
+      stopMotionStatus: stopMotionStatus ?? this.stopMotionStatus,
+      stopMotionShutterTick:
+          stopMotionShutterTick ?? this.stopMotionShutterTick,
     );
   }
 
@@ -331,5 +377,8 @@ class VideoRecorderBlocState extends Equatable {
     snapTime,
     showZoomIndicator,
     isPinchActive,
+    stopMotionFrames,
+    stopMotionStatus,
+    stopMotionShutterTick,
   ];
 }

--- a/mobile/lib/constants/video_editor_constants.dart
+++ b/mobile/lib/constants/video_editor_constants.dart
@@ -50,6 +50,23 @@ class VideoEditorConstants {
   /// Maximum recording duration for videos.
   static const maxDuration = Duration(seconds: 6, milliseconds: 300);
 
+  /// Minimum duration a rendered stop-motion video must reach.
+  ///
+  /// Very short clips (a single still ≈ 83ms) make looping players stutter and
+  /// oscillate. The renderer repeats the captured sequence an integer number of
+  /// times until the output is at least this long, preserving the per-frame
+  /// timing and keeping the loop seamless.
+  static const stopMotionMinOutputDuration = Duration(seconds: 1);
+
+  /// Minimum spacing between playback-position updates the frames-only
+  /// stop-motion playhead pushes into the editor timeline.
+  ///
+  /// The playhead ticker fires at the display refresh rate, but the timeline
+  /// only needs a coarse position stream to chase (it animates between
+  /// updates). Throttling to this interval keeps scrolling smooth without
+  /// flooding the bloc with ~60 position events per second.
+  static const stopMotionPlayheadEmitInterval = Duration(milliseconds: 40);
+
   /// Default time offset for extracting video thumbnails.
   static const defaultThumbnailExtractTime = Duration(milliseconds: 200);
 

--- a/mobile/lib/constants/video_editor_timeline_constants.dart
+++ b/mobile/lib/constants/video_editor_timeline_constants.dart
@@ -38,6 +38,14 @@ abstract class TimelineConstants {
   /// Maximum pixels per second when zoomed in.
   static const double maxPixelsPerSecond = 600;
 
+  /// Maximum pixels per second on a stop-motion composition. Stills are held
+  /// for a handful of output frames (tens of ms), so meaningful zoom levels
+  /// sit far above what second-long video clips ever need.
+  static const double stopMotionMaxPixelsPerSecond = 2400;
+
+  /// Tile width the initial stop-motion zoom aims to give the average still.
+  static const double stopMotionTargetTileWidth = 56;
+
   /// Width of the playhead indicator line.
   static const double playheadWidth = 2;
 

--- a/mobile/lib/extensions/divine_video_clip_player_mapping.dart
+++ b/mobile/lib/extensions/divine_video_clip_player_mapping.dart
@@ -11,7 +11,7 @@ extension DivineVideoClipPlayerMapping on DivineVideoClip {
   /// Returns the preview-player clip for this editor clip, or `null` when the
   /// clip has no resolvable file path (skipped by the timeline).
   player.VideoClip? toPlayerVideoClip({Duration? start, Duration? end}) {
-    final path = video.file?.path;
+    final path = video?.file?.path;
     if (path == null) return null;
     return player.VideoClip(
       uri: path,

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -3365,6 +3365,14 @@
             }
         }
     },
+    "videoRecorderLibraryOpenStopMotionLabel": "{frameCount, plural, =0{የስቶፕ-ሞሽን ቤተ-መዝገብ ክፈት} =1{የስቶፕ-ሞሽን ቤተ-መዝገብ ክፈት፣ 1 ፍሬም} other{የስቶፕ-ሞሽን ቤተ-መዝገብ ክፈት፣ {frameCount} ፍሬሞች}}",
+    "@videoRecorderLibraryOpenStopMotionLabel": {
+        "placeholders": {
+            "frameCount": {
+                "type": "int"
+            }
+        }
+    },
     "videoEditorCameraLabel": "ካሜራ",
     "videoEditorOpenCameraSemanticLabel": "ካሜራ ክፈት",
     "videoEditorLibraryLabel": "ቤተ መፃህፍት",

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -3343,6 +3343,8 @@
     "videoRecorderCaptureCloseLabel": "ገጠመ",
     "videoRecorderCaptureNextLabel": "ቀጥሎ",
     "videoRecorderLipSyncAddAudioFirst": "ከመቅረጽ በፊት ኦዲዮ ያክሉ",
+    "videoRecorderStopMotionAssembling": "ቪዲዮዎን በመፍጠር ላይ…",
+    "videoRecorderStopMotionAssembleFailed": "ቪዲዮውን መፍጠር አልተቻለም። እንደገና ይሞክሩ።",
     "videoRecorderToggleFlashLabel": "ብልጭታ ቀያይር",
     "videoRecorderCycleTimerLabel": "የዑደት ሰዓት ቆጣሪ",
     "videoRecorderToggleAspectRatioLabel": "ምጥጥን ቀያይር",
@@ -4209,6 +4211,9 @@
     "videoEditorMergeLabel": "አዋህድ",
     "videoEditorMergeSelectedClipsSemanticLabel": "የተመረጡ ቅንጥቦችን አዋህድ",
     "videoEditorDeleteSelectedClipsSemanticLabel": "የተመረጡ ቅንጥቦችን ሰርዝ",
+    "videoEditorDeleteSelectedFramesSemanticLabel": "የተመረጡ ፍሬሞችን ሰርዝ",
+    "videoEditorReverseSelectedFramesSemanticLabel": "የተመረጡ ፍሬሞችን አገላብጥ",
+    "videoEditorStopMotionTooShortSnackbar": "ቪዲዮው ቢያንስ {seconds} ሰከንድ መሆን አለበት — ጥቂት ተጨማሪ ፍሬሞችን ያንሱ።",
     "videoEditorMergeProgressLabel": "ትንሽ ይቆዩ፣ ቅንጥቦችዎን እያዋሃድን ነው",
     "videoEditorMergeFailed": "ቅንጥቦችን ማዋሃድ አልተቻለም። እባክዎ እንደገና ይሞክሩ።",
     "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device.",
@@ -4687,5 +4692,13 @@
   "authSignInErrorNetwork": "አገልጋዩ ጋር መድረስ አልተቻለም። ግንኙነትዎን አረጋግጠው እንደገና ይሞክሩ።",
   "authSignInErrorGeneric": "የሆነ ችግር ተፈጥሯል። እባክዎ እንደገና ይሞክሩ።",
   "authSignInOptionsHintPrefix": "ባለፈው ጊዜ እንዴት እንደገቡ እርግጠኛ አይደሉም? ",
-  "authSignInOptionsHintCta": "ሁሉንም የመግቢያ አማራጮች ይመልከቱ"
+  "authSignInOptionsHintCta": "ሁሉንም የመግቢያ አማራጮች ይመልከቱ",
+    "videoEditorStopMotionFramesPerImageLabel": "በአንድ ምስል ፍሬሞች",
+    "videoEditorStopMotionFramesPerImageValueSemanticLabel": "በአንድ ምስል {count} ፍሬሞች",
+    "videoEditorStopMotionIncreaseFramesPerImageSemanticLabel": "በአንድ ምስል ፍሬሞችን ጨምር",
+    "videoEditorStopMotionDecreaseFramesPerImageSemanticLabel": "በአንድ ምስል ፍሬሞችን ቀንስ",
+    "videoEditorStopMotionFrameSemanticLabel": "የስቶፕ-ሞሽን ፍሬም {position} ከ{total}",
+    "videoEditorStopMotionFramesCount": "{count, plural, other{{count} ፍሬሞች}}",
+    "videoEditorStopMotionFramesPerImageButtonLabel": "ፍሬሞች",
+    "libraryStopMotionClipLabel": "የስቶፕ-ሞሽን ክሊፕ"
 }

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -3077,6 +3077,14 @@
             }
         }
     },
+    "videoRecorderLibraryOpenStopMotionLabel": "{frameCount, plural, =0{فتح مكتبة الحركة الإيقافية} one{فتح مكتبة الحركة الإيقافية، إطار واحد} two{فتح مكتبة الحركة الإيقافية، إطاران} few{فتح مكتبة الحركة الإيقافية، {frameCount} إطارات} many{فتح مكتبة الحركة الإيقافية، {frameCount} إطارًا} other{فتح مكتبة الحركة الإيقافية، {frameCount} إطار}}",
+    "@videoRecorderLibraryOpenStopMotionLabel": {
+        "placeholders": {
+            "frameCount": {
+                "type": "int"
+            }
+        }
+    },
     "videoRecorderRecordingTapToStopLabel": "جاري التسجيل. اضغط في أي مكان للإيقاف",
     "videoRecorderStartRecordingTooltip": "بدء التسجيل",
     "videoRecorderStopRecordingTooltip": "إيقاف التسجيل",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -3047,6 +3047,8 @@
     "videoRecorderCaptureCloseLabel": "إغلاق",
     "videoRecorderCaptureNextLabel": "التالي",
     "videoRecorderLipSyncAddAudioFirst": "أضف صوتًا قبل التسجيل",
+    "videoRecorderStopMotionAssembling": "جارٍ إنشاء الفيديو…",
+    "videoRecorderStopMotionAssembleFailed": "تعذّر إنشاء الفيديو. حاول مرة أخرى.",
     "videoRecorderClipDeletedMessage": "تم نقل المقطع إلى المهملات",
     "videoRecorderClipUndoLabel": "تراجع",
     "libraryTrashTitle": "المحذوفة مؤخرًا",
@@ -4084,6 +4086,9 @@
     "videoEditorMergeLabel": "دمج",
     "videoEditorMergeSelectedClipsSemanticLabel": "دمج المقاطع المحددة",
     "videoEditorDeleteSelectedClipsSemanticLabel": "حذف المقاطع المحددة",
+    "videoEditorDeleteSelectedFramesSemanticLabel": "حذف الإطارات المحددة",
+    "videoEditorReverseSelectedFramesSemanticLabel": "عكس الإطارات المحددة",
+    "videoEditorStopMotionTooShortSnackbar": "يجب أن يكون الفيديو {seconds} ثانية على الأقل — التقط بضعة إطارات إضافية.",
     "videoEditorMergeProgressLabel": "لحظة من فضلك، نقوم بدمج مقاطعك",
     "videoEditorMergeFailed": "تعذّر دمج المقاطع. يُرجى المحاولة مرة أخرى.",
     "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device.",
@@ -4562,5 +4567,13 @@
   "authSignInErrorNetwork": "تعذّر الوصول إلى الخادم. تحقق من اتصالك وحاول مرة أخرى.",
   "authSignInErrorGeneric": "حدث خطأ ما. حاول مرة أخرى.",
   "authSignInOptionsHintPrefix": "لست متأكدًا كيف سجّلت الدخول آخر مرة؟ ",
-  "authSignInOptionsHintCta": "عرض جميع خيارات تسجيل الدخول"
+  "authSignInOptionsHintCta": "عرض جميع خيارات تسجيل الدخول",
+    "videoEditorStopMotionFramesPerImageLabel": "الإطارات لكل صورة",
+    "videoEditorStopMotionFramesPerImageValueSemanticLabel": "{count} إطارات لكل صورة",
+    "videoEditorStopMotionIncreaseFramesPerImageSemanticLabel": "زيادة الإطارات لكل صورة",
+    "videoEditorStopMotionDecreaseFramesPerImageSemanticLabel": "تقليل الإطارات لكل صورة",
+    "videoEditorStopMotionFrameSemanticLabel": "إطار الحركة الإيقافية {position} من {total}",
+    "videoEditorStopMotionFramesCount": "{count, plural, one{إطار واحد} two{إطاران} few{{count} إطارات} other{{count} إطار}}",
+    "videoEditorStopMotionFramesPerImageButtonLabel": "إطارات",
+    "libraryStopMotionClipLabel": "مقطع الحركة الإيقافية"
 }

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -3043,6 +3043,14 @@
             }
         }
     },
+    "videoRecorderLibraryOpenStopMotionLabel": "{frameCount, plural, =0{Отвори стоп-моушън библиотеката} one{Отвори стоп-моушън библиотеката, 1 кадър} other{Отвори стоп-моушън библиотеката, {frameCount} кадъра}}",
+    "@videoRecorderLibraryOpenStopMotionLabel": {
+        "placeholders": {
+            "frameCount": {
+                "type": "int"
+            }
+        }
+    },
     "videoEditorCameraLabel": "Камера",
     "videoEditorOpenCameraSemanticLabel": "Отвори камерата",
     "videoEditorLibraryLabel": "Библиотека",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -3021,6 +3021,8 @@
     "videoRecorderCaptureCloseLabel": "Затвори",
     "videoRecorderCaptureNextLabel": "Следваща",
     "videoRecorderLipSyncAddAudioFirst": "Добавете аудио преди запис",
+    "videoRecorderStopMotionAssembling": "Създаване на видеото…",
+    "videoRecorderStopMotionAssembleFailed": "Видеото не можа да се създаде. Опитайте отново.",
     "videoRecorderToggleFlashLabel": "Превключване на светкавицата",
     "videoRecorderCycleTimerLabel": "Цикъл таймер",
     "videoRecorderToggleAspectRatioLabel": "Превключване на пропорциите",
@@ -4215,6 +4217,9 @@
     "videoEditorMergeLabel": "Обедини",
     "videoEditorMergeSelectedClipsSemanticLabel": "Обединяване на избраните клипове",
     "videoEditorDeleteSelectedClipsSemanticLabel": "Изтриване на избраните клипове",
+    "videoEditorDeleteSelectedFramesSemanticLabel": "Изтриване на избраните кадри",
+    "videoEditorReverseSelectedFramesSemanticLabel": "Обръщане на избраните кадри",
+    "videoEditorStopMotionTooShortSnackbar": "Видеото трябва да е поне {seconds}с — заснеми още няколко кадъра.",
     "videoEditorMergeProgressLabel": "Един момент, обединяваме клиповете ти",
     "videoEditorMergeFailed": "Клиповете не могат да бъдат обединени. Опитай отново.",
     "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device.",
@@ -4693,5 +4698,13 @@
   "authSignInErrorNetwork": "Сървърът е недостъпен. Провери връзката си и опитай отново.",
   "authSignInErrorGeneric": "Нещо се обърка. Опитай отново.",
   "authSignInOptionsHintPrefix": "Не си сигурен как влезе последния път? ",
-  "authSignInOptionsHintCta": "Виж всички опции за вход"
+  "authSignInOptionsHintCta": "Виж всички опции за вход",
+    "videoEditorStopMotionFramesPerImageLabel": "Кадри на изображение",
+    "videoEditorStopMotionFramesPerImageValueSemanticLabel": "{count} кадъра на изображение",
+    "videoEditorStopMotionIncreaseFramesPerImageSemanticLabel": "Увеличаване на кадрите на изображение",
+    "videoEditorStopMotionDecreaseFramesPerImageSemanticLabel": "Намаляване на кадрите на изображение",
+    "videoEditorStopMotionFrameSemanticLabel": "Стоп-моушън кадър {position} от {total}",
+    "videoEditorStopMotionFramesCount": "{count, plural, =1{1 кадър} other{{count} кадъра}}",
+    "videoEditorStopMotionFramesPerImageButtonLabel": "Кадри",
+    "libraryStopMotionClipLabel": "Стоп-моушън клип"
 }

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2793,6 +2793,14 @@
             }
         }
     },
+    "videoRecorderLibraryOpenStopMotionLabel": "{frameCount, plural, =0{Stop-Motion-Mediathek öffnen} one{Stop-Motion-Mediathek öffnen, 1 Frame} other{Stop-Motion-Mediathek öffnen, {frameCount} Frames}}",
+    "@videoRecorderLibraryOpenStopMotionLabel": {
+        "placeholders": {
+            "frameCount": {
+                "type": "int"
+            }
+        }
+    },
     "videoEditorCameraLabel": "Kamera",
     "videoEditorLibraryLabel": "Mediathek",
     "videoEditorTextLabel": "Text",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2771,6 +2771,8 @@
     "videoRecorderCaptureCloseLabel": "Schließen",
     "videoRecorderCaptureNextLabel": "Weiter",
     "videoRecorderLipSyncAddAudioFirst": "Audio vor der Aufnahme hinzufügen",
+    "videoRecorderStopMotionAssembling": "Video wird erstellt…",
+    "videoRecorderStopMotionAssembleFailed": "Video konnte nicht erstellt werden. Bitte erneut versuchen.",
     "videoRecorderToggleFlashLabel": "Blitz ein-/ausschalten",
     "videoRecorderCycleTimerLabel": "Timer wechseln",
     "videoRecorderToggleAspectRatioLabel": "Seitenverhältnis wechseln",
@@ -4084,6 +4086,9 @@
     "videoEditorMergeLabel": "Zusammenführen",
     "videoEditorMergeSelectedClipsSemanticLabel": "Ausgewählte Clips zusammenführen",
     "videoEditorDeleteSelectedClipsSemanticLabel": "Ausgewählte Clips löschen",
+    "videoEditorDeleteSelectedFramesSemanticLabel": "Ausgewählte Frames löschen",
+    "videoEditorReverseSelectedFramesSemanticLabel": "Ausgewählte Frames umkehren",
+    "videoEditorStopMotionTooShortSnackbar": "Dein Video braucht mindestens {seconds}s – nimm noch ein paar Frames auf.",
     "videoEditorMergeProgressLabel": "Einen Moment, wir führen deine Clips zusammen",
     "videoEditorMergeFailed": "Clips konnten nicht zusammengeführt werden. Bitte versuche es erneut.",
     "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device.",
@@ -4562,5 +4567,13 @@
   "authSignInErrorNetwork": "Server nicht erreichbar. Prüf deine Verbindung und versuch es noch mal.",
   "authSignInErrorGeneric": "Etwas ist schiefgelaufen. Bitte versuch es noch mal.",
   "authSignInOptionsHintPrefix": "Nicht sicher, wie du letztes Mal reingekommen bist? ",
-  "authSignInOptionsHintCta": "Alle Anmeldeoptionen ansehen"
+  "authSignInOptionsHintCta": "Alle Anmeldeoptionen ansehen",
+    "videoEditorStopMotionFramesPerImageLabel": "Frames pro Bild",
+    "videoEditorStopMotionFramesPerImageValueSemanticLabel": "{count} Frames pro Bild",
+    "videoEditorStopMotionIncreaseFramesPerImageSemanticLabel": "Frames pro Bild erhöhen",
+    "videoEditorStopMotionDecreaseFramesPerImageSemanticLabel": "Frames pro Bild verringern",
+    "videoEditorStopMotionFrameSemanticLabel": "Stop-Motion-Bild {position} von {total}",
+    "videoEditorStopMotionFramesCount": "{count, plural, =1{1 Frame} other{{count} Frames}}",
+    "videoEditorStopMotionFramesPerImageButtonLabel": "Frames",
+    "libraryStopMotionClipLabel": "Stop-Motion-Clip"
 }

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -4713,6 +4713,15 @@
       }
     }
   },
+  "videoRecorderLibraryOpenStopMotionLabel": "{frameCount, plural, =0{Open stop-motion library} one{Open stop-motion library, 1 frame} other{Open stop-motion library, {frameCount} frames}}",
+  "@videoRecorderLibraryOpenStopMotionLabel": {
+    "description": "Screen-reader label for the recorder's library button during a stop-motion session. The count is captured stills (frames), not clips. The zero case covers opening a previous session's library before the first still of this one is shot.",
+    "placeholders": {
+      "frameCount": {
+        "type": "int"
+      }
+    }
+  },
   "videoEditorCameraLabel": "Camera",
   "videoEditorOpenCameraSemanticLabel": "Open camera",
   "videoEditorLibraryLabel": "Library",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -4685,6 +4685,14 @@
   "@videoRecorderLipSyncAddAudioFirst": {
     "description": "Snackbar shown when the user taps the record button in lip-sync mode without first selecting a sound."
   },
+  "videoRecorderStopMotionAssembling": "Creating your video…",
+  "@videoRecorderStopMotionAssembling": {
+    "description": "Loading label shown while captured stop-motion frames are being encoded into one video."
+  },
+  "videoRecorderStopMotionAssembleFailed": "Couldn't create the video. Try again.",
+  "@videoRecorderStopMotionAssembleFailed": {
+    "description": "Snackbar shown when assembling captured stop-motion frames into a video failed."
+  },
   "videoRecorderToggleFlashLabel": "Toggle flash",
   "videoRecorderCycleTimerLabel": "Cycle timer",
   "videoRecorderToggleAspectRatioLabel": "Toggle aspect ratio",
@@ -4822,6 +4830,48 @@
   },
   "videoEditorDeleteLabel": "Delete",
   "videoEditorDeleteSelectedItemSemanticLabel": "Delete selected item",
+  "videoEditorStopMotionFramesPerImageLabel": "Frames per image",
+  "@videoEditorStopMotionFramesPerImageLabel": {
+    "description": "Label for the stop-motion control that sets how many output frames each captured still is held for."
+  },
+  "videoEditorStopMotionFramesCount": "{count, plural, =1{1 frame} other{{count} frames}}",
+  "@videoEditorStopMotionFramesCount": {
+    "description": "Short frames-per-image value shown on the stop-motion preview badge and action button (e.g. '2 frames').",
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "videoEditorStopMotionFramesPerImageButtonLabel": "Frames",
+  "@videoEditorStopMotionFramesPerImageButtonLabel": {
+    "description": "Short label under the stop-motion frames-per-image action button in the timeline edit bar."
+  },
+  "libraryStopMotionClipLabel": "Stop-motion clip",
+  "@libraryStopMotionClipLabel": {
+    "description": "Accessibility label for the badge that marks a clip in the library as a stop-motion recording."
+  },
+  "videoEditorStopMotionFramesPerImageValueSemanticLabel": "{count} frames per image",
+  "@videoEditorStopMotionFramesPerImageValueSemanticLabel": {
+    "description": "Accessibility value announcing the current stop-motion hold length, in output frames per still.",
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "videoEditorStopMotionIncreaseFramesPerImageSemanticLabel": "Increase frames per image",
+  "@videoEditorStopMotionIncreaseFramesPerImageSemanticLabel": {
+    "description": "Accessibility label for the button that lengthens each stop-motion still's hold."
+  },
+  "videoEditorStopMotionDecreaseFramesPerImageSemanticLabel": "Decrease frames per image",
+  "@videoEditorStopMotionDecreaseFramesPerImageSemanticLabel": {
+    "description": "Accessibility label for the button that shortens each stop-motion still's hold."
+  },
+  "videoEditorStopMotionFrameSemanticLabel": "Stop-motion frame {position} of {total}",
+  "@videoEditorStopMotionFrameSemanticLabel": {
+    "description": "Accessibility label for a single still tile in the stop-motion timeline strip.",
+    "placeholders": {
+      "position": { "type": "int" },
+      "total": { "type": "int" }
+    }
+  },
   "videoEditorEditLabel": "Edit",
   "videoEditorEditSelectedItemSemanticLabel": "Edit selected item",
   "videoEditorDuplicateLabel": "Duplicate",
@@ -5165,6 +5215,23 @@
   "videoEditorDeleteSelectedClipsSemanticLabel": "Delete selected clips",
   "@videoEditorDeleteSelectedClipsSemanticLabel": {
     "description": "Accessibility label for the button that deletes the selected clips."
+  },
+  "videoEditorDeleteSelectedFramesSemanticLabel": "Delete selected frames",
+  "@videoEditorDeleteSelectedFramesSemanticLabel": {
+    "description": "Semantic label for the delete button while stop-motion stills are multi-selected."
+  },
+  "videoEditorReverseSelectedFramesSemanticLabel": "Reverse selected frames",
+  "@videoEditorReverseSelectedFramesSemanticLabel": {
+    "description": "Semantic label for the reverse button while stop-motion stills are multi-selected."
+  },
+  "videoEditorStopMotionTooShortSnackbar": "Your video needs at least {seconds}s — capture a few more frames.",
+  "@videoEditorStopMotionTooShortSnackbar": {
+    "description": "Snackbar shown when Done is pressed on a stop-motion composition shorter than the minimum output duration.",
+    "placeholders": {
+      "seconds": {
+        "type": "int"
+      }
+    }
   },
   "videoEditorMergeProgressLabel": "One moment, we're merging your clips",
   "@videoEditorMergeProgressLabel": {

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2779,6 +2779,8 @@
     "videoRecorderCaptureCloseLabel": "Cerrar",
     "videoRecorderCaptureNextLabel": "Siguiente",
     "videoRecorderLipSyncAddAudioFirst": "Agrega audio antes de grabar",
+    "videoRecorderStopMotionAssembling": "Creando tu vídeo…",
+    "videoRecorderStopMotionAssembleFailed": "No se pudo crear el vídeo. Inténtalo de nuevo.",
     "videoRecorderToggleFlashLabel": "Activar o desactivar flash",
     "videoRecorderCycleTimerLabel": "Cambiar temporizador",
     "videoRecorderToggleAspectRatioLabel": "Cambiar relación de aspecto",
@@ -4084,6 +4086,9 @@
     "videoEditorMergeLabel": "Combinar",
     "videoEditorMergeSelectedClipsSemanticLabel": "Combinar clips seleccionados",
     "videoEditorDeleteSelectedClipsSemanticLabel": "Eliminar clips seleccionados",
+    "videoEditorDeleteSelectedFramesSemanticLabel": "Eliminar fotogramas seleccionados",
+    "videoEditorReverseSelectedFramesSemanticLabel": "Invertir fotogramas seleccionados",
+    "videoEditorStopMotionTooShortSnackbar": "Tu video necesita al menos {seconds}s: captura algunos fotogramas más.",
     "videoEditorMergeProgressLabel": "Un momento, estamos combinando tus clips",
     "videoEditorMergeFailed": "No se pudieron combinar los clips. Inténtalo de nuevo.",
     "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device.",
@@ -4562,5 +4567,13 @@
   "authSignInErrorNetwork": "No se puede conectar con el servidor. Comprueba tu conexión e inténtalo de nuevo.",
   "authSignInErrorGeneric": "Algo salió mal. Inténtalo de nuevo.",
   "authSignInOptionsHintPrefix": "¿No sabes cómo entraste la última vez? ",
-  "authSignInOptionsHintCta": "Ver todas las opciones de inicio de sesión"
+  "authSignInOptionsHintCta": "Ver todas las opciones de inicio de sesión",
+    "videoEditorStopMotionFramesPerImageLabel": "Fotogramas por imagen",
+    "videoEditorStopMotionFramesPerImageValueSemanticLabel": "{count} fotogramas por imagen",
+    "videoEditorStopMotionIncreaseFramesPerImageSemanticLabel": "Aumentar fotogramas por imagen",
+    "videoEditorStopMotionDecreaseFramesPerImageSemanticLabel": "Reducir fotogramas por imagen",
+    "videoEditorStopMotionFrameSemanticLabel": "Fotograma de stop motion {position} de {total}",
+    "videoEditorStopMotionFramesCount": "{count, plural, =1{1 fotograma} other{{count} fotogramas}}",
+    "videoEditorStopMotionFramesPerImageButtonLabel": "Fotogramas",
+    "libraryStopMotionClipLabel": "Clip de stop motion"
 }

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2801,6 +2801,14 @@
             }
         }
     },
+    "videoRecorderLibraryOpenStopMotionLabel": "{frameCount, plural, =0{Abrir biblioteca de stop motion} one{Abrir biblioteca de stop motion, 1 fotograma} other{Abrir biblioteca de stop motion, {frameCount} fotogramas}}",
+    "@videoRecorderLibraryOpenStopMotionLabel": {
+        "placeholders": {
+            "frameCount": {
+                "type": "int"
+            }
+        }
+    },
     "videoEditorCameraLabel": "Cámara",
     "videoEditorLibraryLabel": "Biblioteca",
     "videoEditorTextLabel": "Texto",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1723,6 +1723,8 @@
     "videoRecorderCaptureCloseLabel": "Isara",
     "videoRecorderCaptureNextLabel": "Susunod",
     "videoRecorderLipSyncAddAudioFirst": "Magdagdag ng audio bago mag-record",
+    "videoRecorderStopMotionAssembling": "Ginagawa ang iyong video…",
+    "videoRecorderStopMotionAssembleFailed": "Hindi magawa ang video. Subukan ulit.",
     "videoRecorderToggleFlashLabel": "I-toggle ang flash",
     "videoRecorderCycleTimerLabel": "I-cycle ang timer",
     "videoRecorderToggleAspectRatioLabel": "I-toggle ang aspect ratio",
@@ -2667,6 +2669,9 @@
     "videoEditorMergeLabel": "Pagsamahin",
     "videoEditorMergeSelectedClipsSemanticLabel": "Pagsamahin ang mga napiling clip",
     "videoEditorDeleteSelectedClipsSemanticLabel": "Tanggalin ang mga napiling clip",
+    "videoEditorDeleteSelectedFramesSemanticLabel": "Tanggalin ang mga napiling frame",
+    "videoEditorReverseSelectedFramesSemanticLabel": "Baligtarin ang mga napiling frame",
+    "videoEditorStopMotionTooShortSnackbar": "Kailangang hindi bababa sa {seconds} segundo ang video mo — kumuha pa ng ilang frame.",
     "videoEditorMergeProgressLabel": "Sandali lang, pinagsasama namin ang iyong mga clip",
     "videoEditorMergeFailed": "Hindi mapagsama ang mga clip. Pakisubukang muli.",
     "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device.",
@@ -3145,5 +3150,13 @@
   "authSignInErrorNetwork": "Hindi maabot ang server. Tingnan ang iyong koneksyon at subukan ulit.",
   "authSignInErrorGeneric": "May nangyaring mali. Subukan ulit.",
   "authSignInOptionsHintPrefix": "Hindi sigurado kung paano ka nakapasok noong huli? ",
-  "authSignInOptionsHintCta": "Tingnan ang lahat ng opsyon sa pag-sign in"
+  "authSignInOptionsHintCta": "Tingnan ang lahat ng opsyon sa pag-sign in",
+    "videoEditorStopMotionFramesPerImageLabel": "Mga frame kada larawan",
+    "videoEditorStopMotionFramesPerImageValueSemanticLabel": "{count} na frame kada larawan",
+    "videoEditorStopMotionIncreaseFramesPerImageSemanticLabel": "Dagdagan ang mga frame kada larawan",
+    "videoEditorStopMotionDecreaseFramesPerImageSemanticLabel": "Bawasan ang mga frame kada larawan",
+    "videoEditorStopMotionFrameSemanticLabel": "Stop-motion frame {position} ng {total}",
+    "videoEditorStopMotionFramesCount": "{count, plural, other{{count} frame}}",
+    "videoEditorStopMotionFramesPerImageButtonLabel": "Mga frame",
+    "libraryStopMotionClipLabel": "Stop-motion na clip"
 }

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1738,6 +1738,7 @@
     "videoRecorderStabilizationModeAuto": "Auto",
     "videoRecorderLibraryEmptyLabel": "Clip library, walang clip",
     "videoRecorderLibraryOpenLabel": "{clipCount, plural, one{Buksan ang clip library, 1 clip} other{Buksan ang clip library, {clipCount} clip}}",
+    "videoRecorderLibraryOpenStopMotionLabel": "{frameCount, plural, =0{Buksan ang stop-motion library} other{Buksan ang stop-motion library, {frameCount} frame}}",
     "videoEditorCameraLabel": "Camera",
     "videoEditorOpenCameraSemanticLabel": "Buksan ang camera",
     "videoEditorLibraryLabel": "Library",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2793,6 +2793,14 @@
             }
         }
     },
+    "videoRecorderLibraryOpenStopMotionLabel": "{frameCount, plural, =0{Ouvrir la bibliothèque stop-motion} one{Ouvrir la bibliothèque stop-motion, 1 image} other{Ouvrir la bibliothèque stop-motion, {frameCount} images}}",
+    "@videoRecorderLibraryOpenStopMotionLabel": {
+        "placeholders": {
+            "frameCount": {
+                "type": "int"
+            }
+        }
+    },
     "videoEditorCameraLabel": "Caméra",
     "videoEditorLibraryLabel": "Bibliothèque",
     "videoEditorTextLabel": "Texte",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2771,6 +2771,8 @@
     "videoRecorderCaptureCloseLabel": "Fermer",
     "videoRecorderCaptureNextLabel": "Suivant",
     "videoRecorderLipSyncAddAudioFirst": "Ajoutez de l'audio avant d'enregistrer",
+    "videoRecorderStopMotionAssembling": "Création de la vidéo…",
+    "videoRecorderStopMotionAssembleFailed": "Impossible de créer la vidéo. Réessayez.",
     "videoRecorderToggleFlashLabel": "Activer/désactiver le flash",
     "videoRecorderCycleTimerLabel": "Changer le minuteur",
     "videoRecorderToggleAspectRatioLabel": "Changer le format d'image",
@@ -4084,6 +4086,9 @@
     "videoEditorMergeLabel": "Fusionner",
     "videoEditorMergeSelectedClipsSemanticLabel": "Fusionner les clips sélectionnés",
     "videoEditorDeleteSelectedClipsSemanticLabel": "Supprimer les clips sélectionnés",
+    "videoEditorDeleteSelectedFramesSemanticLabel": "Supprimer les images sélectionnées",
+    "videoEditorReverseSelectedFramesSemanticLabel": "Inverser les images sélectionnées",
+    "videoEditorStopMotionTooShortSnackbar": "Ta vidéo doit durer au moins {seconds}s — capture encore quelques images.",
     "videoEditorMergeProgressLabel": "Un instant, nous fusionnons vos clips",
     "videoEditorMergeFailed": "Impossible de fusionner les clips. Veuillez réessayer.",
     "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device.",
@@ -4562,5 +4567,13 @@
   "authSignInErrorNetwork": "Impossible de joindre le serveur. Vérifie ta connexion et réessaie.",
   "authSignInErrorGeneric": "Une erreur s'est produite. Réessaie.",
   "authSignInOptionsHintPrefix": "Tu ne sais plus comment tu t'es connecté la dernière fois ? ",
-  "authSignInOptionsHintCta": "Voir toutes les options de connexion"
+  "authSignInOptionsHintCta": "Voir toutes les options de connexion",
+    "videoEditorStopMotionFramesPerImageLabel": "Images par photo",
+    "videoEditorStopMotionFramesPerImageValueSemanticLabel": "{count} images par photo",
+    "videoEditorStopMotionIncreaseFramesPerImageSemanticLabel": "Augmenter les images par photo",
+    "videoEditorStopMotionDecreaseFramesPerImageSemanticLabel": "Réduire les images par photo",
+    "videoEditorStopMotionFrameSemanticLabel": "Image stop-motion {position} sur {total}",
+    "videoEditorStopMotionFramesCount": "{count, plural, =1{1 image} other{{count} images}}",
+    "videoEditorStopMotionFramesPerImageButtonLabel": "Images",
+    "libraryStopMotionClipLabel": "Clip stop-motion"
 }

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -3054,6 +3054,8 @@
     "videoRecorderCaptureCloseLabel": "Tutup",
     "videoRecorderCaptureNextLabel": "Berikutnya",
     "videoRecorderLipSyncAddAudioFirst": "Tambahkan audio sebelum merekam",
+    "videoRecorderStopMotionAssembling": "Membuat video Anda…",
+    "videoRecorderStopMotionAssembleFailed": "Tidak dapat membuat video. Coba lagi.",
     "videoRecorderClipDeletedMessage": "Klip dipindahkan ke sampah",
     "videoRecorderClipUndoLabel": "Urungkan",
     "libraryTrashTitle": "Baru-baru ini dihapus",
@@ -4084,6 +4086,9 @@
     "videoEditorMergeLabel": "Gabungkan",
     "videoEditorMergeSelectedClipsSemanticLabel": "Gabungkan klip yang dipilih",
     "videoEditorDeleteSelectedClipsSemanticLabel": "Hapus klip yang dipilih",
+    "videoEditorDeleteSelectedFramesSemanticLabel": "Hapus bingkai yang dipilih",
+    "videoEditorReverseSelectedFramesSemanticLabel": "Balikkan bingkai yang dipilih",
+    "videoEditorStopMotionTooShortSnackbar": "Videomu harus minimal {seconds} detik — ambil beberapa bingkai lagi.",
     "videoEditorMergeProgressLabel": "Sebentar, kami sedang menggabungkan klipmu",
     "videoEditorMergeFailed": "Tidak dapat menggabungkan klip. Silakan coba lagi.",
     "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device.",
@@ -4562,5 +4567,13 @@
   "authSignInErrorNetwork": "Tidak dapat menjangkau server. Periksa koneksimu dan coba lagi.",
   "authSignInErrorGeneric": "Ada yang salah. Coba lagi.",
   "authSignInOptionsHintPrefix": "Tidak yakin bagaimana kamu masuk terakhir kali? ",
-  "authSignInOptionsHintCta": "Lihat semua opsi masuk"
+  "authSignInOptionsHintCta": "Lihat semua opsi masuk",
+    "videoEditorStopMotionFramesPerImageLabel": "Bingkai per gambar",
+    "videoEditorStopMotionFramesPerImageValueSemanticLabel": "{count} bingkai per gambar",
+    "videoEditorStopMotionIncreaseFramesPerImageSemanticLabel": "Tambah bingkai per gambar",
+    "videoEditorStopMotionDecreaseFramesPerImageSemanticLabel": "Kurangi bingkai per gambar",
+    "videoEditorStopMotionFrameSemanticLabel": "Bingkai stop-motion {position} dari {total}",
+    "videoEditorStopMotionFramesCount": "{count, plural, other{{count} bingkai}}",
+    "videoEditorStopMotionFramesPerImageButtonLabel": "Bingkai",
+    "libraryStopMotionClipLabel": "Klip stop-motion"
 }

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -3084,6 +3084,14 @@
             }
         }
     },
+    "videoRecorderLibraryOpenStopMotionLabel": "{frameCount, plural, =0{Buka perpustakaan stop-motion} other{Buka perpustakaan stop-motion, {frameCount} bingkai}}",
+    "@videoRecorderLibraryOpenStopMotionLabel": {
+        "placeholders": {
+            "frameCount": {
+                "type": "int"
+            }
+        }
+    },
     "videoRecorderRecordingTapToStopLabel": "Merekam. Ketuk di mana saja untuk berhenti",
     "videoRecorderStartRecordingTooltip": "Mulai merekam",
     "videoRecorderStopRecordingTooltip": "Hentikan perekaman",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2771,6 +2771,8 @@
     "videoRecorderCaptureCloseLabel": "Chiudi",
     "videoRecorderCaptureNextLabel": "Avanti",
     "videoRecorderLipSyncAddAudioFirst": "Aggiungi audio prima di registrare",
+    "videoRecorderStopMotionAssembling": "Creazione del video…",
+    "videoRecorderStopMotionAssembleFailed": "Impossibile creare il video. Riprova.",
     "videoRecorderToggleFlashLabel": "Attiva/disattiva flash",
     "videoRecorderCycleTimerLabel": "Cambia timer",
     "videoRecorderToggleAspectRatioLabel": "Cambia rapporto d'aspetto",
@@ -4084,6 +4086,9 @@
     "videoEditorMergeLabel": "Unisci",
     "videoEditorMergeSelectedClipsSemanticLabel": "Unisci le clip selezionate",
     "videoEditorDeleteSelectedClipsSemanticLabel": "Elimina le clip selezionate",
+    "videoEditorDeleteSelectedFramesSemanticLabel": "Elimina i fotogrammi selezionati",
+    "videoEditorReverseSelectedFramesSemanticLabel": "Inverti i fotogrammi selezionati",
+    "videoEditorStopMotionTooShortSnackbar": "Il tuo video deve durare almeno {seconds}s: scatta ancora qualche fotogramma.",
     "videoEditorMergeProgressLabel": "Un momento, stiamo unendo le tue clip",
     "videoEditorMergeFailed": "Impossibile unire le clip. Riprova.",
     "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device.",
@@ -4562,5 +4567,13 @@
   "authSignInErrorNetwork": "Impossibile raggiungere il server. Controlla la connessione e riprova.",
   "authSignInErrorGeneric": "Qualcosa è andato storto. Riprova.",
   "authSignInOptionsHintPrefix": "Non sai come hai effettuato l'accesso l'ultima volta? ",
-  "authSignInOptionsHintCta": "Vedi tutte le opzioni di accesso"
+  "authSignInOptionsHintCta": "Vedi tutte le opzioni di accesso",
+    "videoEditorStopMotionFramesPerImageLabel": "Fotogrammi per immagine",
+    "videoEditorStopMotionFramesPerImageValueSemanticLabel": "{count} fotogrammi per immagine",
+    "videoEditorStopMotionIncreaseFramesPerImageSemanticLabel": "Aumenta fotogrammi per immagine",
+    "videoEditorStopMotionDecreaseFramesPerImageSemanticLabel": "Riduci fotogrammi per immagine",
+    "videoEditorStopMotionFrameSemanticLabel": "Fotogramma stop-motion {position} di {total}",
+    "videoEditorStopMotionFramesCount": "{count, plural, =1{1 fotogramma} other{{count} fotogrammi}}",
+    "videoEditorStopMotionFramesPerImageButtonLabel": "Fotogrammi",
+    "libraryStopMotionClipLabel": "Clip stop-motion"
 }

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2793,6 +2793,14 @@
             }
         }
     },
+    "videoRecorderLibraryOpenStopMotionLabel": "{frameCount, plural, =0{Apri libreria stop-motion} one{Apri libreria stop-motion, 1 fotogramma} other{Apri libreria stop-motion, {frameCount} fotogrammi}}",
+    "@videoRecorderLibraryOpenStopMotionLabel": {
+        "placeholders": {
+            "frameCount": {
+                "type": "int"
+            }
+        }
+    },
     "videoEditorCameraLabel": "Fotocamera",
     "videoEditorLibraryLabel": "Libreria",
     "videoEditorTextLabel": "Testo",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -3047,6 +3047,8 @@
     "videoRecorderCaptureCloseLabel": "閉じる",
     "videoRecorderCaptureNextLabel": "次へ",
     "videoRecorderLipSyncAddAudioFirst": "録画する前にオーディオを追加してください",
+    "videoRecorderStopMotionAssembling": "動画を作成しています…",
+    "videoRecorderStopMotionAssembleFailed": "動画を作成できませんでした。もう一度お試しください。",
     "videoRecorderClipDeletedMessage": "クリップをゴミ箱に移動しました",
     "videoRecorderClipUndoLabel": "元に戻す",
     "libraryTrashTitle": "最近削除した項目",
@@ -4084,6 +4086,9 @@
     "videoEditorMergeLabel": "結合",
     "videoEditorMergeSelectedClipsSemanticLabel": "選択したクリップを結合",
     "videoEditorDeleteSelectedClipsSemanticLabel": "選択したクリップを削除",
+    "videoEditorDeleteSelectedFramesSemanticLabel": "選択したフレームを削除",
+    "videoEditorReverseSelectedFramesSemanticLabel": "選択したフレームを逆順にする",
+    "videoEditorStopMotionTooShortSnackbar": "動画は{seconds}秒以上必要です。もう少しフレームを撮影してください。",
     "videoEditorMergeProgressLabel": "少々お待ちください。クリップを結合しています",
     "videoEditorMergeFailed": "クリップを結合できませんでした。もう一度お試しください。",
     "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device.",
@@ -4562,5 +4567,13 @@
   "authSignInErrorNetwork": "サーバーに接続できません。接続を確認してもう一度お試しください。",
   "authSignInErrorGeneric": "問題が発生しました。もう一度お試しください。",
   "authSignInOptionsHintPrefix": "前回どうやってログインしたか分かりませんか? ",
-  "authSignInOptionsHintCta": "すべてのサインイン方法を見る"
+  "authSignInOptionsHintCta": "すべてのサインイン方法を見る",
+    "videoEditorStopMotionFramesPerImageLabel": "1枚あたりのフレーム数",
+    "videoEditorStopMotionFramesPerImageValueSemanticLabel": "1枚あたり{count}フレーム",
+    "videoEditorStopMotionIncreaseFramesPerImageSemanticLabel": "1枚あたりのフレーム数を増やす",
+    "videoEditorStopMotionDecreaseFramesPerImageSemanticLabel": "1枚あたりのフレーム数を減らす",
+    "videoEditorStopMotionFrameSemanticLabel": "ストップモーションのフレーム {total}枚中{position}枚目",
+    "videoEditorStopMotionFramesCount": "{count, plural, other{{count}フレーム}}",
+    "videoEditorStopMotionFramesPerImageButtonLabel": "フレーム",
+    "libraryStopMotionClipLabel": "ストップモーションクリップ"
 }

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -3077,6 +3077,14 @@
             }
         }
     },
+    "videoRecorderLibraryOpenStopMotionLabel": "{frameCount, plural, =0{ストップモーションライブラリを開く} other{ストップモーションライブラリを開く、{frameCount}フレーム}}",
+    "@videoRecorderLibraryOpenStopMotionLabel": {
+        "placeholders": {
+            "frameCount": {
+                "type": "int"
+            }
+        }
+    },
     "videoRecorderRecordingTapToStopLabel": "録画中。どこかタップして停止",
     "videoRecorderStartRecordingTooltip": "録画を開始",
     "videoRecorderStopRecordingTooltip": "録画を停止",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -2378,6 +2378,8 @@
     "videoRecorderCaptureCloseLabel": "닫기",
     "videoRecorderCaptureNextLabel": "다음",
     "videoRecorderLipSyncAddAudioFirst": "녹화하기 전에 오디오를 추가하세요",
+    "videoRecorderStopMotionAssembling": "동영상을 만드는 중…",
+    "videoRecorderStopMotionAssembleFailed": "동영상을 만들지 못했습니다. 다시 시도해 주세요.",
     "videoRecorderClipDeletedMessage": "클립이 휴지통으로 이동되었습니다",
     "videoRecorderClipUndoLabel": "실행 취소",
     "libraryTrashTitle": "최근 삭제된 항목",
@@ -3408,6 +3410,9 @@
     "videoEditorMergeLabel": "병합",
     "videoEditorMergeSelectedClipsSemanticLabel": "선택한 클립 병합",
     "videoEditorDeleteSelectedClipsSemanticLabel": "선택한 클립 삭제",
+    "videoEditorDeleteSelectedFramesSemanticLabel": "선택한 프레임 삭제",
+    "videoEditorReverseSelectedFramesSemanticLabel": "선택한 프레임 순서 뒤집기",
+    "videoEditorStopMotionTooShortSnackbar": "영상은 최소 {seconds}초여야 해요. 프레임을 몇 장 더 찍어 주세요.",
     "videoEditorMergeProgressLabel": "잠시만요, 클립을 병합하고 있어요",
     "videoEditorMergeFailed": "클립을 병합할 수 없습니다. 다시 시도해 주세요.",
     "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device.",
@@ -3886,5 +3891,13 @@
   "authSignInErrorNetwork": "서버에 연결할 수 없습니다. 연결을 확인하고 다시 시도해 주세요.",
   "authSignInErrorGeneric": "문제가 발생했습니다. 다시 시도해 주세요.",
   "authSignInOptionsHintPrefix": "지난번에 어떻게 로그인했는지 기억나지 않나요? ",
-  "authSignInOptionsHintCta": "모든 로그인 옵션 보기"
+  "authSignInOptionsHintCta": "모든 로그인 옵션 보기",
+    "videoEditorStopMotionFramesPerImageLabel": "이미지당 프레임",
+    "videoEditorStopMotionFramesPerImageValueSemanticLabel": "이미지당 {count}프레임",
+    "videoEditorStopMotionIncreaseFramesPerImageSemanticLabel": "이미지당 프레임 늘리기",
+    "videoEditorStopMotionDecreaseFramesPerImageSemanticLabel": "이미지당 프레임 줄이기",
+    "videoEditorStopMotionFrameSemanticLabel": "스톱모션 프레임 {total}개 중 {position}개",
+    "videoEditorStopMotionFramesCount": "{count, plural, other{{count}프레임}}",
+    "videoEditorStopMotionFramesPerImageButtonLabel": "프레임",
+    "libraryStopMotionClipLabel": "스톱모션 클립"
 }

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -2408,6 +2408,14 @@
             }
         }
     },
+    "videoRecorderLibraryOpenStopMotionLabel": "{frameCount, plural, =0{스톱모션 보관함 열기} other{스톱모션 보관함 열기, {frameCount}개 프레임}}",
+    "@videoRecorderLibraryOpenStopMotionLabel": {
+        "placeholders": {
+            "frameCount": {
+                "type": "int"
+            }
+        }
+    },
     "videoRecorderRecordingTapToStopLabel": "녹화 중. 아무 곳이나 탭하여 중지",
     "videoRecorderStartRecordingTooltip": "녹화 시작",
     "videoRecorderStopRecordingTooltip": "녹화 중지",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2793,6 +2793,14 @@
             }
         }
     },
+    "videoRecorderLibraryOpenStopMotionLabel": "{frameCount, plural, =0{Stop-motion-bibliotheek openen} one{Stop-motion-bibliotheek openen, 1 frame} other{Stop-motion-bibliotheek openen, {frameCount} frames}}",
+    "@videoRecorderLibraryOpenStopMotionLabel": {
+        "placeholders": {
+            "frameCount": {
+                "type": "int"
+            }
+        }
+    },
     "videoEditorCameraLabel": "Camera",
     "videoEditorLibraryLabel": "Bibliotheek",
     "videoEditorTextLabel": "Tekst",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2771,6 +2771,8 @@
     "videoRecorderCaptureCloseLabel": "Sluiten",
     "videoRecorderCaptureNextLabel": "Volgende",
     "videoRecorderLipSyncAddAudioFirst": "Voeg audio toe vóór de opname",
+    "videoRecorderStopMotionAssembling": "Je video wordt gemaakt…",
+    "videoRecorderStopMotionAssembleFailed": "Kan de video niet maken. Probeer het opnieuw.",
     "videoRecorderToggleFlashLabel": "Flitser in-/uitschakelen",
     "videoRecorderCycleTimerLabel": "Timer wisselen",
     "videoRecorderToggleAspectRatioLabel": "Beeldverhouding wisselen",
@@ -4084,6 +4086,9 @@
     "videoEditorMergeLabel": "Samenvoegen",
     "videoEditorMergeSelectedClipsSemanticLabel": "Geselecteerde clips samenvoegen",
     "videoEditorDeleteSelectedClipsSemanticLabel": "Geselecteerde clips verwijderen",
+    "videoEditorDeleteSelectedFramesSemanticLabel": "Geselecteerde frames verwijderen",
+    "videoEditorReverseSelectedFramesSemanticLabel": "Geselecteerde frames omkeren",
+    "videoEditorStopMotionTooShortSnackbar": "Je video moet minstens {seconds}s duren – leg nog een paar frames vast.",
     "videoEditorMergeProgressLabel": "Een moment, we voegen je clips samen",
     "videoEditorMergeFailed": "Kan clips niet samenvoegen. Probeer het opnieuw.",
     "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device.",
@@ -4562,5 +4567,13 @@
   "authSignInErrorNetwork": "Kan de server niet bereiken. Controleer je verbinding en probeer het opnieuw.",
   "authSignInErrorGeneric": "Er ging iets mis. Probeer het opnieuw.",
   "authSignInOptionsHintPrefix": "Weet je niet meer hoe je de vorige keer inlogde? ",
-  "authSignInOptionsHintCta": "Bekijk alle inlogopties"
+  "authSignInOptionsHintCta": "Bekijk alle inlogopties",
+    "videoEditorStopMotionFramesPerImageLabel": "Frames per beeld",
+    "videoEditorStopMotionFramesPerImageValueSemanticLabel": "{count} frames per beeld",
+    "videoEditorStopMotionIncreaseFramesPerImageSemanticLabel": "Frames per beeld verhogen",
+    "videoEditorStopMotionDecreaseFramesPerImageSemanticLabel": "Frames per beeld verlagen",
+    "videoEditorStopMotionFrameSemanticLabel": "Stop-motion-beeld {position} van {total}",
+    "videoEditorStopMotionFramesCount": "{count, plural, =1{1 frame} other{{count} frames}}",
+    "videoEditorStopMotionFramesPerImageButtonLabel": "Frames",
+    "libraryStopMotionClipLabel": "Stop-motion-clip"
 }

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2793,6 +2793,14 @@
             }
         }
     },
+    "videoRecorderLibraryOpenStopMotionLabel": "{frameCount, plural, =0{Otwórz bibliotekę poklatkową} one{Otwórz bibliotekę poklatkową, 1 klatka} few{Otwórz bibliotekę poklatkową, {frameCount} klatki} many{Otwórz bibliotekę poklatkową, {frameCount} klatek} other{Otwórz bibliotekę poklatkową, {frameCount} klatki}}",
+    "@videoRecorderLibraryOpenStopMotionLabel": {
+        "placeholders": {
+            "frameCount": {
+                "type": "int"
+            }
+        }
+    },
     "videoEditorCameraLabel": "Kamera",
     "videoEditorLibraryLabel": "Biblioteka",
     "videoEditorTextLabel": "Tekst",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2771,6 +2771,8 @@
     "videoRecorderCaptureCloseLabel": "Zamknij",
     "videoRecorderCaptureNextLabel": "Dalej",
     "videoRecorderLipSyncAddAudioFirst": "Dodaj audio przed nagraniem",
+    "videoRecorderStopMotionAssembling": "Tworzenie filmu…",
+    "videoRecorderStopMotionAssembleFailed": "Nie udało się utworzyć filmu. Spróbuj ponownie.",
     "videoRecorderToggleFlashLabel": "Przełącz lampę błyskową",
     "videoRecorderCycleTimerLabel": "Zmień timer",
     "videoRecorderToggleAspectRatioLabel": "Przełącz proporcje",
@@ -4084,6 +4086,9 @@
     "videoEditorMergeLabel": "Scal",
     "videoEditorMergeSelectedClipsSemanticLabel": "Scal zaznaczone klipy",
     "videoEditorDeleteSelectedClipsSemanticLabel": "Usuń zaznaczone klipy",
+    "videoEditorDeleteSelectedFramesSemanticLabel": "Usuń zaznaczone klatki",
+    "videoEditorReverseSelectedFramesSemanticLabel": "Odwróć zaznaczone klatki",
+    "videoEditorStopMotionTooShortSnackbar": "Twój film musi trwać co najmniej {seconds}s – dodaj jeszcze kilka klatek.",
     "videoEditorMergeProgressLabel": "Chwila, scalamy Twoje klipy",
     "videoEditorMergeFailed": "Nie udało się scalić klipów. Spróbuj ponownie.",
     "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device.",
@@ -4562,5 +4567,13 @@
   "authSignInErrorNetwork": "Nie można połączyć się z serwerem. Sprawdź połączenie i spróbuj ponownie.",
   "authSignInErrorGeneric": "Coś poszło nie tak. Spróbuj ponownie.",
   "authSignInOptionsHintPrefix": "Nie wiesz, jak zalogowałeś się ostatnim razem? ",
-  "authSignInOptionsHintCta": "Zobacz wszystkie opcje logowania"
+  "authSignInOptionsHintCta": "Zobacz wszystkie opcje logowania",
+    "videoEditorStopMotionFramesPerImageLabel": "Klatki na obraz",
+    "videoEditorStopMotionFramesPerImageValueSemanticLabel": "{count} klatek na obraz",
+    "videoEditorStopMotionIncreaseFramesPerImageSemanticLabel": "Zwiększ liczbę klatek na obraz",
+    "videoEditorStopMotionDecreaseFramesPerImageSemanticLabel": "Zmniejsz liczbę klatek na obraz",
+    "videoEditorStopMotionFrameSemanticLabel": "Klatka poklatkowa {position} z {total}",
+    "videoEditorStopMotionFramesCount": "{count, plural, =1{1 klatka} few{{count} klatki} many{{count} klatek} other{{count} klatki}}",
+    "videoEditorStopMotionFramesPerImageButtonLabel": "Klatki",
+    "libraryStopMotionClipLabel": "Klip poklatkowy"
 }

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2771,6 +2771,8 @@
     "videoRecorderCaptureCloseLabel": "Fechar",
     "videoRecorderCaptureNextLabel": "Próximo",
     "videoRecorderLipSyncAddAudioFirst": "Adicione áudio antes de gravar",
+    "videoRecorderStopMotionAssembling": "Criando seu vídeo…",
+    "videoRecorderStopMotionAssembleFailed": "Não foi possível criar o vídeo. Tente novamente.",
     "videoRecorderToggleFlashLabel": "Alternar flash",
     "videoRecorderCycleTimerLabel": "Alternar temporizador",
     "videoRecorderToggleAspectRatioLabel": "Alternar proporção",
@@ -4084,6 +4086,9 @@
     "videoEditorMergeLabel": "Mesclar",
     "videoEditorMergeSelectedClipsSemanticLabel": "Mesclar clipes selecionados",
     "videoEditorDeleteSelectedClipsSemanticLabel": "Excluir clipes selecionados",
+    "videoEditorDeleteSelectedFramesSemanticLabel": "Excluir quadros selecionados",
+    "videoEditorReverseSelectedFramesSemanticLabel": "Inverter quadros selecionados",
+    "videoEditorStopMotionTooShortSnackbar": "Seu vídeo precisa de pelo menos {seconds}s — capture mais alguns quadros.",
     "videoEditorMergeProgressLabel": "Um momento, estamos mesclando seus clipes",
     "videoEditorMergeFailed": "Não foi possível mesclar os clipes. Tente novamente.",
     "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device.",
@@ -4562,5 +4567,13 @@
   "authSignInErrorNetwork": "Não foi possível conectar ao servidor. Verifique sua conexão e tente de novo.",
   "authSignInErrorGeneric": "Algo deu errado. Tente de novo.",
   "authSignInOptionsHintPrefix": "Não sabe como entrou da última vez? ",
-  "authSignInOptionsHintCta": "Ver todas as opções de login"
+  "authSignInOptionsHintCta": "Ver todas as opções de login",
+    "videoEditorStopMotionFramesPerImageLabel": "Quadros por imagem",
+    "videoEditorStopMotionFramesPerImageValueSemanticLabel": "{count} quadros por imagem",
+    "videoEditorStopMotionIncreaseFramesPerImageSemanticLabel": "Aumentar quadros por imagem",
+    "videoEditorStopMotionDecreaseFramesPerImageSemanticLabel": "Reduzir quadros por imagem",
+    "videoEditorStopMotionFrameSemanticLabel": "Quadro de stop motion {position} de {total}",
+    "videoEditorStopMotionFramesCount": "{count, plural, =1{1 quadro} other{{count} quadros}}",
+    "videoEditorStopMotionFramesPerImageButtonLabel": "Quadros",
+    "libraryStopMotionClipLabel": "Clipe de stop motion"
 }

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2793,6 +2793,14 @@
             }
         }
     },
+    "videoRecorderLibraryOpenStopMotionLabel": "{frameCount, plural, =0{Abrir biblioteca de stop motion} one{Abrir biblioteca de stop motion, 1 quadro} other{Abrir biblioteca de stop motion, {frameCount} quadros}}",
+    "@videoRecorderLibraryOpenStopMotionLabel": {
+        "placeholders": {
+            "frameCount": {
+                "type": "int"
+            }
+        }
+    },
     "videoEditorCameraLabel": "Câmera",
     "videoEditorLibraryLabel": "Biblioteca",
     "videoEditorTextLabel": "Texto",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2793,6 +2793,14 @@
             }
         }
     },
+    "videoRecorderLibraryOpenStopMotionLabel": "{frameCount, plural, =0{Deschide biblioteca stop-motion} one{Deschide biblioteca stop-motion, 1 cadru} few{Deschide biblioteca stop-motion, {frameCount} cadre} other{Deschide biblioteca stop-motion, {frameCount} de cadre}}",
+    "@videoRecorderLibraryOpenStopMotionLabel": {
+        "placeholders": {
+            "frameCount": {
+                "type": "int"
+            }
+        }
+    },
     "videoEditorCameraLabel": "Cameră",
     "videoEditorLibraryLabel": "Bibliotecă",
     "videoEditorTextLabel": "Text",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2771,6 +2771,8 @@
     "videoRecorderCaptureCloseLabel": "Închide",
     "videoRecorderCaptureNextLabel": "Următorul",
     "videoRecorderLipSyncAddAudioFirst": "Adaugă audio înainte de înregistrare",
+    "videoRecorderStopMotionAssembling": "Se creează videoclipul…",
+    "videoRecorderStopMotionAssembleFailed": "Videoclipul nu a putut fi creat. Încearcă din nou.",
     "videoRecorderToggleFlashLabel": "Activează/dezactivează blițul",
     "videoRecorderCycleTimerLabel": "Schimbă temporizatorul",
     "videoRecorderToggleAspectRatioLabel": "Schimbă raportul de aspect",
@@ -4084,6 +4086,9 @@
     "videoEditorMergeLabel": "Îmbină",
     "videoEditorMergeSelectedClipsSemanticLabel": "Îmbină clipurile selectate",
     "videoEditorDeleteSelectedClipsSemanticLabel": "Șterge clipurile selectate",
+    "videoEditorDeleteSelectedFramesSemanticLabel": "Șterge cadrele selectate",
+    "videoEditorReverseSelectedFramesSemanticLabel": "Inversează cadrele selectate",
+    "videoEditorStopMotionTooShortSnackbar": "Videoclipul tău trebuie să dureze cel puțin {seconds}s — capturează încă câteva cadre.",
     "videoEditorMergeProgressLabel": "Un moment, îți îmbinăm clipurile",
     "videoEditorMergeFailed": "Clipurile nu au putut fi îmbinate. Încearcă din nou.",
     "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device.",
@@ -4562,5 +4567,13 @@
   "authSignInErrorNetwork": "Serverul nu poate fi contactat. Verifică-ți conexiunea și încearcă din nou.",
   "authSignInErrorGeneric": "Ceva n-a mers bine. Încearcă din nou.",
   "authSignInOptionsHintPrefix": "Nu știi sigur cum te-ai conectat data trecută? ",
-  "authSignInOptionsHintCta": "Vezi toate opțiunile de conectare"
+  "authSignInOptionsHintCta": "Vezi toate opțiunile de conectare",
+    "videoEditorStopMotionFramesPerImageLabel": "Cadre pe imagine",
+    "videoEditorStopMotionFramesPerImageValueSemanticLabel": "{count} cadre pe imagine",
+    "videoEditorStopMotionIncreaseFramesPerImageSemanticLabel": "Mărește cadrele pe imagine",
+    "videoEditorStopMotionDecreaseFramesPerImageSemanticLabel": "Micșorează cadrele pe imagine",
+    "videoEditorStopMotionFrameSemanticLabel": "Cadru stop-motion {position} din {total}",
+    "videoEditorStopMotionFramesCount": "{count, plural, =1{1 cadru} other{{count} cadre}}",
+    "videoEditorStopMotionFramesPerImageButtonLabel": "Cadre",
+    "libraryStopMotionClipLabel": "Clip stop-motion"
 }

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2771,6 +2771,8 @@
     "videoRecorderCaptureCloseLabel": "Stäng",
     "videoRecorderCaptureNextLabel": "Nästa",
     "videoRecorderLipSyncAddAudioFirst": "Lägg till ljud innan inspelning",
+    "videoRecorderStopMotionAssembling": "Skapar din video…",
+    "videoRecorderStopMotionAssembleFailed": "Det gick inte att skapa videon. Försök igen.",
     "videoRecorderToggleFlashLabel": "Växla blixt",
     "videoRecorderCycleTimerLabel": "Växla timer",
     "videoRecorderToggleAspectRatioLabel": "Växla bildförhållande",
@@ -4084,6 +4086,9 @@
     "videoEditorMergeLabel": "Slå samman",
     "videoEditorMergeSelectedClipsSemanticLabel": "Slå samman markerade klipp",
     "videoEditorDeleteSelectedClipsSemanticLabel": "Ta bort markerade klipp",
+    "videoEditorDeleteSelectedFramesSemanticLabel": "Ta bort markerade bildrutor",
+    "videoEditorReverseSelectedFramesSemanticLabel": "Vänd markerade bildrutor",
+    "videoEditorStopMotionTooShortSnackbar": "Din video måste vara minst {seconds}s – ta några bildrutor till.",
     "videoEditorMergeProgressLabel": "Ett ögonblick, vi slår samman dina klipp",
     "videoEditorMergeFailed": "Det gick inte att slå samman klippen. Försök igen.",
     "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device.",
@@ -4562,5 +4567,13 @@
   "authSignInErrorNetwork": "Kan inte nå servern. Kontrollera din anslutning och försök igen.",
   "authSignInErrorGeneric": "Något gick fel. Försök igen.",
   "authSignInOptionsHintPrefix": "Osäker på hur du loggade in förra gången? ",
-  "authSignInOptionsHintCta": "Se alla inloggningsalternativ"
+  "authSignInOptionsHintCta": "Se alla inloggningsalternativ",
+    "videoEditorStopMotionFramesPerImageLabel": "Bildrutor per bild",
+    "videoEditorStopMotionFramesPerImageValueSemanticLabel": "{count} bildrutor per bild",
+    "videoEditorStopMotionIncreaseFramesPerImageSemanticLabel": "Öka bildrutor per bild",
+    "videoEditorStopMotionDecreaseFramesPerImageSemanticLabel": "Minska bildrutor per bild",
+    "videoEditorStopMotionFrameSemanticLabel": "Stop motion-bild {position} av {total}",
+    "videoEditorStopMotionFramesCount": "{count, plural, =1{1 bildruta} other{{count} bildrutor}}",
+    "videoEditorStopMotionFramesPerImageButtonLabel": "Bildrutor",
+    "libraryStopMotionClipLabel": "Stop motion-klipp"
 }

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2793,6 +2793,14 @@
             }
         }
     },
+    "videoRecorderLibraryOpenStopMotionLabel": "{frameCount, plural, =0{Öppna stop motion-bibliotek} one{Öppna stop motion-bibliotek, 1 bildruta} other{Öppna stop motion-bibliotek, {frameCount} bildrutor}}",
+    "@videoRecorderLibraryOpenStopMotionLabel": {
+        "placeholders": {
+            "frameCount": {
+                "type": "int"
+            }
+        }
+    },
     "videoEditorCameraLabel": "Kamera",
     "videoEditorLibraryLabel": "Bibliotek",
     "videoEditorTextLabel": "Text",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -3084,6 +3084,14 @@
             }
         }
     },
+    "videoRecorderLibraryOpenStopMotionLabel": "{frameCount, plural, =0{Stop motion kütüphanesini aç} one{Stop motion kütüphanesini aç, 1 kare} other{Stop motion kütüphanesini aç, {frameCount} kare}}",
+    "@videoRecorderLibraryOpenStopMotionLabel": {
+        "placeholders": {
+            "frameCount": {
+                "type": "int"
+            }
+        }
+    },
     "videoRecorderRecordingTapToStopLabel": "Kaydediliyor. Durdurmak için herhangi bir yere dokunun",
     "videoRecorderStartRecordingTooltip": "Kaydı başlat",
     "videoRecorderStopRecordingTooltip": "Kaydı durdur",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -3054,6 +3054,8 @@
     "videoRecorderCaptureCloseLabel": "Kapat",
     "videoRecorderCaptureNextLabel": "İleri",
     "videoRecorderLipSyncAddAudioFirst": "Kayıttan önce ses ekleyin",
+    "videoRecorderStopMotionAssembling": "Videon oluşturuluyor…",
+    "videoRecorderStopMotionAssembleFailed": "Video oluşturulamadı. Tekrar deneyin.",
     "videoRecorderClipDeletedMessage": "Klip çöp kutusuna taşındı",
     "videoRecorderClipUndoLabel": "Geri al",
     "libraryTrashTitle": "Son silinenler",
@@ -4084,6 +4086,9 @@
     "videoEditorMergeLabel": "Birleştir",
     "videoEditorMergeSelectedClipsSemanticLabel": "Seçili klipleri birleştir",
     "videoEditorDeleteSelectedClipsSemanticLabel": "Seçili klipleri sil",
+    "videoEditorDeleteSelectedFramesSemanticLabel": "Seçili kareleri sil",
+    "videoEditorReverseSelectedFramesSemanticLabel": "Seçili kareleri ters çevir",
+    "videoEditorStopMotionTooShortSnackbar": "Videon en az {seconds}sn olmalı — birkaç kare daha çek.",
     "videoEditorMergeProgressLabel": "Bir saniye, kliplerini birleştiriyoruz",
     "videoEditorMergeFailed": "Klipler birleştirilemedi. Lütfen tekrar dene.",
     "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device.",
@@ -4562,5 +4567,13 @@
   "authSignInErrorNetwork": "Sunucuya ulaşılamıyor. Bağlantını kontrol edip tekrar dene.",
   "authSignInErrorGeneric": "Bir şeyler ters gitti. Lütfen tekrar dene.",
   "authSignInOptionsHintPrefix": "Geçen sefer nasıl giriş yaptığını hatırlamıyor musun? ",
-  "authSignInOptionsHintCta": "Tüm giriş seçeneklerini gör"
+  "authSignInOptionsHintCta": "Tüm giriş seçeneklerini gör",
+    "videoEditorStopMotionFramesPerImageLabel": "Görüntü başına kare",
+    "videoEditorStopMotionFramesPerImageValueSemanticLabel": "Görüntü başına {count} kare",
+    "videoEditorStopMotionIncreaseFramesPerImageSemanticLabel": "Görüntü başına kareyi artır",
+    "videoEditorStopMotionDecreaseFramesPerImageSemanticLabel": "Görüntü başına kareyi azalt",
+    "videoEditorStopMotionFrameSemanticLabel": "Stop motion karesi {position}/{total}",
+    "videoEditorStopMotionFramesCount": "{count, plural, other{{count} kare}}",
+    "videoEditorStopMotionFramesPerImageButtonLabel": "Kare",
+    "libraryStopMotionClipLabel": "Stop motion klibi"
 }

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -13896,6 +13896,18 @@ abstract class AppLocalizations {
   /// **'Add audio before recording'**
   String get videoRecorderLipSyncAddAudioFirst;
 
+  /// Loading label shown while captured stop-motion frames are being encoded into one video.
+  ///
+  /// In en, this message translates to:
+  /// **'Creating your video…'**
+  String get videoRecorderStopMotionAssembling;
+
+  /// Snackbar shown when assembling captured stop-motion frames into a video failed.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t create the video. Try again.'**
+  String get videoRecorderStopMotionAssembleFailed;
+
   /// No description provided for @videoRecorderToggleFlashLabel.
   ///
   /// In en, this message translates to:
@@ -14459,6 +14471,54 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Delete selected item'**
   String get videoEditorDeleteSelectedItemSemanticLabel;
+
+  /// Label for the stop-motion control that sets how many output frames each captured still is held for.
+  ///
+  /// In en, this message translates to:
+  /// **'Frames per image'**
+  String get videoEditorStopMotionFramesPerImageLabel;
+
+  /// Short frames-per-image value shown on the stop-motion preview badge and action button (e.g. '2 frames').
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 frame} other{{count} frames}}'**
+  String videoEditorStopMotionFramesCount(int count);
+
+  /// Short label under the stop-motion frames-per-image action button in the timeline edit bar.
+  ///
+  /// In en, this message translates to:
+  /// **'Frames'**
+  String get videoEditorStopMotionFramesPerImageButtonLabel;
+
+  /// Accessibility label for the badge that marks a clip in the library as a stop-motion recording.
+  ///
+  /// In en, this message translates to:
+  /// **'Stop-motion clip'**
+  String get libraryStopMotionClipLabel;
+
+  /// Accessibility value announcing the current stop-motion hold length, in output frames per still.
+  ///
+  /// In en, this message translates to:
+  /// **'{count} frames per image'**
+  String videoEditorStopMotionFramesPerImageValueSemanticLabel(int count);
+
+  /// Accessibility label for the button that lengthens each stop-motion still's hold.
+  ///
+  /// In en, this message translates to:
+  /// **'Increase frames per image'**
+  String get videoEditorStopMotionIncreaseFramesPerImageSemanticLabel;
+
+  /// Accessibility label for the button that shortens each stop-motion still's hold.
+  ///
+  /// In en, this message translates to:
+  /// **'Decrease frames per image'**
+  String get videoEditorStopMotionDecreaseFramesPerImageSemanticLabel;
+
+  /// Accessibility label for a single still tile in the stop-motion timeline strip.
+  ///
+  /// In en, this message translates to:
+  /// **'Stop-motion frame {position} of {total}'**
+  String videoEditorStopMotionFrameSemanticLabel(int position, int total);
 
   /// No description provided for @videoEditorEditLabel.
   ///
@@ -15135,6 +15195,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Delete selected clips'**
   String get videoEditorDeleteSelectedClipsSemanticLabel;
+
+  /// Semantic label for the delete button while stop-motion stills are multi-selected.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete selected frames'**
+  String get videoEditorDeleteSelectedFramesSemanticLabel;
+
+  /// Semantic label for the reverse button while stop-motion stills are multi-selected.
+  ///
+  /// In en, this message translates to:
+  /// **'Reverse selected frames'**
+  String get videoEditorReverseSelectedFramesSemanticLabel;
+
+  /// Snackbar shown when Done is pressed on a stop-motion composition shorter than the minimum output duration.
+  ///
+  /// In en, this message translates to:
+  /// **'Your video needs at least {seconds}s — capture a few more frames.'**
+  String videoEditorStopMotionTooShortSnackbar(int seconds);
 
   /// Status text shown while the selected clips are being concatenated into a single clip.
   ///

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -13986,6 +13986,12 @@ abstract class AppLocalizations {
   /// **'{clipCount, plural, one{Open clip library, 1 clip} other{Open clip library, {clipCount} clips}}'**
   String videoRecorderLibraryOpenLabel(int clipCount);
 
+  /// Screen-reader label for the recorder's library button during a stop-motion session. The count is captured stills (frames), not clips. The zero case covers opening a previous session's library before the first still of this one is shot.
+  ///
+  /// In en, this message translates to:
+  /// **'{frameCount, plural, =0{Open stop-motion library} one{Open stop-motion library, 1 frame} other{Open stop-motion library, {frameCount} frames}}'**
+  String videoRecorderLibraryOpenStopMotionLabel(int frameCount);
+
   /// No description provided for @videoEditorCameraLabel.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -7922,6 +7922,18 @@ class AppLocalizationsAm extends AppLocalizations {
   }
 
   @override
+  String videoRecorderLibraryOpenStopMotionLabel(int frameCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      frameCount,
+      locale: localeName,
+      other: 'የስቶፕ-ሞሽን ቤተ-መዝገብ ክፈት፣ $frameCount ፍሬሞች',
+      one: 'የስቶፕ-ሞሽን ቤተ-መዝገብ ክፈት፣ 1 ፍሬም',
+      zero: 'የስቶፕ-ሞሽን ቤተ-መዝገብ ክፈት',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get videoEditorCameraLabel => 'ካሜራ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -7868,6 +7868,13 @@ class AppLocalizationsAm extends AppLocalizations {
   String get videoRecorderLipSyncAddAudioFirst => 'ከመቅረጽ በፊት ኦዲዮ ያክሉ';
 
   @override
+  String get videoRecorderStopMotionAssembling => 'ቪዲዮዎን በመፍጠር ላይ…';
+
+  @override
+  String get videoRecorderStopMotionAssembleFailed =>
+      'ቪዲዮውን መፍጠር አልተቻለም። እንደገና ይሞክሩ።';
+
+  @override
   String get videoRecorderToggleFlashLabel => 'ብልጭታ ቀያይር';
 
   @override
@@ -8176,6 +8183,43 @@ class AppLocalizationsAm extends AppLocalizations {
 
   @override
   String get videoEditorDeleteSelectedItemSemanticLabel => 'የተመረጠውን ንጥል ሰርዝ';
+
+  @override
+  String get videoEditorStopMotionFramesPerImageLabel => 'በአንድ ምስል ፍሬሞች';
+
+  @override
+  String videoEditorStopMotionFramesCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count ፍሬሞች',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get videoEditorStopMotionFramesPerImageButtonLabel => 'ፍሬሞች';
+
+  @override
+  String get libraryStopMotionClipLabel => 'የስቶፕ-ሞሽን ክሊፕ';
+
+  @override
+  String videoEditorStopMotionFramesPerImageValueSemanticLabel(int count) {
+    return 'በአንድ ምስል $count ፍሬሞች';
+  }
+
+  @override
+  String get videoEditorStopMotionIncreaseFramesPerImageSemanticLabel =>
+      'በአንድ ምስል ፍሬሞችን ጨምር';
+
+  @override
+  String get videoEditorStopMotionDecreaseFramesPerImageSemanticLabel =>
+      'በአንድ ምስል ፍሬሞችን ቀንስ';
+
+  @override
+  String videoEditorStopMotionFrameSemanticLabel(int position, int total) {
+    return 'የስቶፕ-ሞሽን ፍሬም $position ከ$total';
+  }
 
   @override
   String get videoEditorEditLabel => 'አርትዕ';
@@ -8560,6 +8604,18 @@ class AppLocalizationsAm extends AppLocalizations {
 
   @override
   String get videoEditorDeleteSelectedClipsSemanticLabel => 'የተመረጡ ቅንጥቦችን ሰርዝ';
+
+  @override
+  String get videoEditorDeleteSelectedFramesSemanticLabel => 'የተመረጡ ፍሬሞችን ሰርዝ';
+
+  @override
+  String get videoEditorReverseSelectedFramesSemanticLabel =>
+      'የተመረጡ ፍሬሞችን አገላብጥ';
+
+  @override
+  String videoEditorStopMotionTooShortSnackbar(int seconds) {
+    return 'ቪዲዮው ቢያንስ $seconds ሰከንድ መሆን አለበት — ጥቂት ተጨማሪ ፍሬሞችን ያንሱ።';
+  }
 
   @override
   String get videoEditorMergeProgressLabel => 'ትንሽ ይቆዩ፣ ቅንጥቦችዎን እያዋሃድን ነው';

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -8038,6 +8038,21 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String videoRecorderLibraryOpenStopMotionLabel(int frameCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      frameCount,
+      locale: localeName,
+      other: 'فتح مكتبة الحركة الإيقافية، $frameCount إطار',
+      many: 'فتح مكتبة الحركة الإيقافية، $frameCount إطارًا',
+      few: 'فتح مكتبة الحركة الإيقافية، $frameCount إطارات',
+      two: 'فتح مكتبة الحركة الإيقافية، إطاران',
+      one: 'فتح مكتبة الحركة الإيقافية، إطار واحد',
+      zero: 'فتح مكتبة الحركة الإيقافية',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get videoEditorCameraLabel => 'الكاميرا';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -7983,6 +7983,13 @@ class AppLocalizationsAr extends AppLocalizations {
   String get videoRecorderLipSyncAddAudioFirst => 'أضف صوتًا قبل التسجيل';
 
   @override
+  String get videoRecorderStopMotionAssembling => 'جارٍ إنشاء الفيديو…';
+
+  @override
+  String get videoRecorderStopMotionAssembleFailed =>
+      'تعذّر إنشاء الفيديو. حاول مرة أخرى.';
+
+  @override
   String get videoRecorderToggleFlashLabel => 'تبديل الفلاش';
 
   @override
@@ -8295,6 +8302,46 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get videoEditorDeleteSelectedItemSemanticLabel => 'حذف العنصر المحدد';
+
+  @override
+  String get videoEditorStopMotionFramesPerImageLabel => 'الإطارات لكل صورة';
+
+  @override
+  String videoEditorStopMotionFramesCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count إطار',
+      few: '$count إطارات',
+      two: 'إطاران',
+      one: 'إطار واحد',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get videoEditorStopMotionFramesPerImageButtonLabel => 'إطارات';
+
+  @override
+  String get libraryStopMotionClipLabel => 'مقطع الحركة الإيقافية';
+
+  @override
+  String videoEditorStopMotionFramesPerImageValueSemanticLabel(int count) {
+    return '$count إطارات لكل صورة';
+  }
+
+  @override
+  String get videoEditorStopMotionIncreaseFramesPerImageSemanticLabel =>
+      'زيادة الإطارات لكل صورة';
+
+  @override
+  String get videoEditorStopMotionDecreaseFramesPerImageSemanticLabel =>
+      'تقليل الإطارات لكل صورة';
+
+  @override
+  String videoEditorStopMotionFrameSemanticLabel(int position, int total) {
+    return 'إطار الحركة الإيقافية $position من $total';
+  }
 
   @override
   String get videoEditorEditLabel => 'تحرير';
@@ -8690,6 +8737,19 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String get videoEditorDeleteSelectedClipsSemanticLabel =>
       'حذف المقاطع المحددة';
+
+  @override
+  String get videoEditorDeleteSelectedFramesSemanticLabel =>
+      'حذف الإطارات المحددة';
+
+  @override
+  String get videoEditorReverseSelectedFramesSemanticLabel =>
+      'عكس الإطارات المحددة';
+
+  @override
+  String videoEditorStopMotionTooShortSnackbar(int seconds) {
+    return 'يجب أن يكون الفيديو $seconds ثانية على الأقل — التقط بضعة إطارات إضافية.';
+  }
 
   @override
   String get videoEditorMergeProgressLabel => 'لحظة من فضلك، نقوم بدمج مقاطعك';

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -8163,6 +8163,18 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
+  String videoRecorderLibraryOpenStopMotionLabel(int frameCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      frameCount,
+      locale: localeName,
+      other: 'Отвори стоп-моушън библиотеката, $frameCount кадъра',
+      one: 'Отвори стоп-моушън библиотеката, 1 кадър',
+      zero: 'Отвори стоп-моушън библиотеката',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get videoEditorCameraLabel => 'Камера';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -8105,6 +8105,13 @@ class AppLocalizationsBg extends AppLocalizations {
   String get videoRecorderLipSyncAddAudioFirst => 'Добавете аудио преди запис';
 
   @override
+  String get videoRecorderStopMotionAssembling => 'Създаване на видеото…';
+
+  @override
+  String get videoRecorderStopMotionAssembleFailed =>
+      'Видеото не можа да се създаде. Опитайте отново.';
+
+  @override
   String get videoRecorderToggleFlashLabel => 'Превключване на светкавицата';
 
   @override
@@ -8425,6 +8432,44 @@ class AppLocalizationsBg extends AppLocalizations {
   @override
   String get videoEditorDeleteSelectedItemSemanticLabel =>
       'Изтриване на избрания елемент';
+
+  @override
+  String get videoEditorStopMotionFramesPerImageLabel => 'Кадри на изображение';
+
+  @override
+  String videoEditorStopMotionFramesCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count кадъра',
+      one: '1 кадър',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get videoEditorStopMotionFramesPerImageButtonLabel => 'Кадри';
+
+  @override
+  String get libraryStopMotionClipLabel => 'Стоп-моушън клип';
+
+  @override
+  String videoEditorStopMotionFramesPerImageValueSemanticLabel(int count) {
+    return '$count кадъра на изображение';
+  }
+
+  @override
+  String get videoEditorStopMotionIncreaseFramesPerImageSemanticLabel =>
+      'Увеличаване на кадрите на изображение';
+
+  @override
+  String get videoEditorStopMotionDecreaseFramesPerImageSemanticLabel =>
+      'Намаляване на кадрите на изображение';
+
+  @override
+  String videoEditorStopMotionFrameSemanticLabel(int position, int total) {
+    return 'Стоп-моушън кадър $position от $total';
+  }
 
   @override
   String get videoEditorEditLabel => 'Редактиране';
@@ -8835,6 +8880,19 @@ class AppLocalizationsBg extends AppLocalizations {
   @override
   String get videoEditorDeleteSelectedClipsSemanticLabel =>
       'Изтриване на избраните клипове';
+
+  @override
+  String get videoEditorDeleteSelectedFramesSemanticLabel =>
+      'Изтриване на избраните кадри';
+
+  @override
+  String get videoEditorReverseSelectedFramesSemanticLabel =>
+      'Обръщане на избраните кадри';
+
+  @override
+  String videoEditorStopMotionTooShortSnackbar(int seconds) {
+    return 'Видеото трябва да е поне $secondsс — заснеми още няколко кадъра.';
+  }
 
   @override
   String get videoEditorMergeProgressLabel =>

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -8126,6 +8126,13 @@ class AppLocalizationsDe extends AppLocalizations {
       'Audio vor der Aufnahme hinzufügen';
 
   @override
+  String get videoRecorderStopMotionAssembling => 'Video wird erstellt…';
+
+  @override
+  String get videoRecorderStopMotionAssembleFailed =>
+      'Video konnte nicht erstellt werden. Bitte erneut versuchen.';
+
+  @override
   String get videoRecorderToggleFlashLabel => 'Blitz ein-/ausschalten';
 
   @override
@@ -8445,6 +8452,44 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get videoEditorDeleteSelectedItemSemanticLabel =>
       'Ausgewähltes Element löschen';
+
+  @override
+  String get videoEditorStopMotionFramesPerImageLabel => 'Frames pro Bild';
+
+  @override
+  String videoEditorStopMotionFramesCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count Frames',
+      one: '1 Frame',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get videoEditorStopMotionFramesPerImageButtonLabel => 'Frames';
+
+  @override
+  String get libraryStopMotionClipLabel => 'Stop-Motion-Clip';
+
+  @override
+  String videoEditorStopMotionFramesPerImageValueSemanticLabel(int count) {
+    return '$count Frames pro Bild';
+  }
+
+  @override
+  String get videoEditorStopMotionIncreaseFramesPerImageSemanticLabel =>
+      'Frames pro Bild erhöhen';
+
+  @override
+  String get videoEditorStopMotionDecreaseFramesPerImageSemanticLabel =>
+      'Frames pro Bild verringern';
+
+  @override
+  String videoEditorStopMotionFrameSemanticLabel(int position, int total) {
+    return 'Stop-Motion-Bild $position von $total';
+  }
 
   @override
   String get videoEditorEditLabel => 'Bearbeiten';
@@ -8850,6 +8895,19 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get videoEditorDeleteSelectedClipsSemanticLabel =>
       'Ausgewählte Clips löschen';
+
+  @override
+  String get videoEditorDeleteSelectedFramesSemanticLabel =>
+      'Ausgewählte Frames löschen';
+
+  @override
+  String get videoEditorReverseSelectedFramesSemanticLabel =>
+      'Ausgewählte Frames umkehren';
+
+  @override
+  String videoEditorStopMotionTooShortSnackbar(int seconds) {
+    return 'Dein Video braucht mindestens ${seconds}s – nimm noch ein paar Frames auf.';
+  }
 
   @override
   String get videoEditorMergeProgressLabel =>

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -8182,6 +8182,18 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String videoRecorderLibraryOpenStopMotionLabel(int frameCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      frameCount,
+      locale: localeName,
+      other: 'Stop-Motion-Mediathek öffnen, $frameCount Frames',
+      one: 'Stop-Motion-Mediathek öffnen, 1 Frame',
+      zero: 'Stop-Motion-Mediathek öffnen',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get videoEditorCameraLabel => 'Kamera';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -8073,6 +8073,18 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String videoRecorderLibraryOpenStopMotionLabel(int frameCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      frameCount,
+      locale: localeName,
+      other: 'Open stop-motion library, $frameCount frames',
+      one: 'Open stop-motion library, 1 frame',
+      zero: 'Open stop-motion library',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get videoEditorCameraLabel => 'Camera';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -8017,6 +8017,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get videoRecorderLipSyncAddAudioFirst => 'Add audio before recording';
 
   @override
+  String get videoRecorderStopMotionAssembling => 'Creating your video…';
+
+  @override
+  String get videoRecorderStopMotionAssembleFailed =>
+      'Couldn\'t create the video. Try again.';
+
+  @override
   String get videoRecorderToggleFlashLabel => 'Toggle flash';
 
   @override
@@ -8330,6 +8337,44 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get videoEditorDeleteSelectedItemSemanticLabel =>
       'Delete selected item';
+
+  @override
+  String get videoEditorStopMotionFramesPerImageLabel => 'Frames per image';
+
+  @override
+  String videoEditorStopMotionFramesCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count frames',
+      one: '1 frame',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get videoEditorStopMotionFramesPerImageButtonLabel => 'Frames';
+
+  @override
+  String get libraryStopMotionClipLabel => 'Stop-motion clip';
+
+  @override
+  String videoEditorStopMotionFramesPerImageValueSemanticLabel(int count) {
+    return '$count frames per image';
+  }
+
+  @override
+  String get videoEditorStopMotionIncreaseFramesPerImageSemanticLabel =>
+      'Increase frames per image';
+
+  @override
+  String get videoEditorStopMotionDecreaseFramesPerImageSemanticLabel =>
+      'Decrease frames per image';
+
+  @override
+  String videoEditorStopMotionFrameSemanticLabel(int position, int total) {
+    return 'Stop-motion frame $position of $total';
+  }
 
   @override
   String get videoEditorEditLabel => 'Edit';
@@ -8729,6 +8774,19 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get videoEditorDeleteSelectedClipsSemanticLabel =>
       'Delete selected clips';
+
+  @override
+  String get videoEditorDeleteSelectedFramesSemanticLabel =>
+      'Delete selected frames';
+
+  @override
+  String get videoEditorReverseSelectedFramesSemanticLabel =>
+      'Reverse selected frames';
+
+  @override
+  String videoEditorStopMotionTooShortSnackbar(int seconds) {
+    return 'Your video needs at least ${seconds}s — capture a few more frames.';
+  }
 
   @override
   String get videoEditorMergeProgressLabel =>

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -8164,6 +8164,18 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String videoRecorderLibraryOpenStopMotionLabel(int frameCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      frameCount,
+      locale: localeName,
+      other: 'Abrir biblioteca de stop motion, $frameCount fotogramas',
+      one: 'Abrir biblioteca de stop motion, 1 fotograma',
+      zero: 'Abrir biblioteca de stop motion',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get videoEditorCameraLabel => 'Cámara';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -8107,6 +8107,13 @@ class AppLocalizationsEs extends AppLocalizations {
       'Agrega audio antes de grabar';
 
   @override
+  String get videoRecorderStopMotionAssembling => 'Creando tu vídeo…';
+
+  @override
+  String get videoRecorderStopMotionAssembleFailed =>
+      'No se pudo crear el vídeo. Inténtalo de nuevo.';
+
+  @override
   String get videoRecorderToggleFlashLabel => 'Activar o desactivar flash';
 
   @override
@@ -8425,6 +8432,45 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get videoEditorDeleteSelectedItemSemanticLabel =>
       'Eliminar elemento seleccionado';
+
+  @override
+  String get videoEditorStopMotionFramesPerImageLabel =>
+      'Fotogramas por imagen';
+
+  @override
+  String videoEditorStopMotionFramesCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count fotogramas',
+      one: '1 fotograma',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get videoEditorStopMotionFramesPerImageButtonLabel => 'Fotogramas';
+
+  @override
+  String get libraryStopMotionClipLabel => 'Clip de stop motion';
+
+  @override
+  String videoEditorStopMotionFramesPerImageValueSemanticLabel(int count) {
+    return '$count fotogramas por imagen';
+  }
+
+  @override
+  String get videoEditorStopMotionIncreaseFramesPerImageSemanticLabel =>
+      'Aumentar fotogramas por imagen';
+
+  @override
+  String get videoEditorStopMotionDecreaseFramesPerImageSemanticLabel =>
+      'Reducir fotogramas por imagen';
+
+  @override
+  String videoEditorStopMotionFrameSemanticLabel(int position, int total) {
+    return 'Fotograma de stop motion $position de $total';
+  }
 
   @override
   String get videoEditorEditLabel => 'Editar';
@@ -8831,6 +8877,19 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get videoEditorDeleteSelectedClipsSemanticLabel =>
       'Eliminar clips seleccionados';
+
+  @override
+  String get videoEditorDeleteSelectedFramesSemanticLabel =>
+      'Eliminar fotogramas seleccionados';
+
+  @override
+  String get videoEditorReverseSelectedFramesSemanticLabel =>
+      'Invertir fotogramas seleccionados';
+
+  @override
+  String videoEditorStopMotionTooShortSnackbar(int seconds) {
+    return 'Tu video necesita al menos ${seconds}s: captura algunos fotogramas más.';
+  }
 
   @override
   String get videoEditorMergeProgressLabel =>

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -8180,6 +8180,17 @@ class AppLocalizationsFil extends AppLocalizations {
   }
 
   @override
+  String videoRecorderLibraryOpenStopMotionLabel(int frameCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      frameCount,
+      locale: localeName,
+      other: 'Buksan ang stop-motion library, $frameCount frame',
+      zero: 'Buksan ang stop-motion library',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get videoEditorCameraLabel => 'Camera';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -8124,6 +8124,13 @@ class AppLocalizationsFil extends AppLocalizations {
       'Magdagdag ng audio bago mag-record';
 
   @override
+  String get videoRecorderStopMotionAssembling => 'Ginagawa ang iyong video…';
+
+  @override
+  String get videoRecorderStopMotionAssembleFailed =>
+      'Hindi magawa ang video. Subukan ulit.';
+
+  @override
   String get videoRecorderToggleFlashLabel => 'I-toggle ang flash';
 
   @override
@@ -8444,6 +8451,44 @@ class AppLocalizationsFil extends AppLocalizations {
   @override
   String get videoEditorDeleteSelectedItemSemanticLabel =>
       'Burahin ang napiling item';
+
+  @override
+  String get videoEditorStopMotionFramesPerImageLabel =>
+      'Mga frame kada larawan';
+
+  @override
+  String videoEditorStopMotionFramesCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count frame',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get videoEditorStopMotionFramesPerImageButtonLabel => 'Mga frame';
+
+  @override
+  String get libraryStopMotionClipLabel => 'Stop-motion na clip';
+
+  @override
+  String videoEditorStopMotionFramesPerImageValueSemanticLabel(int count) {
+    return '$count na frame kada larawan';
+  }
+
+  @override
+  String get videoEditorStopMotionIncreaseFramesPerImageSemanticLabel =>
+      'Dagdagan ang mga frame kada larawan';
+
+  @override
+  String get videoEditorStopMotionDecreaseFramesPerImageSemanticLabel =>
+      'Bawasan ang mga frame kada larawan';
+
+  @override
+  String videoEditorStopMotionFrameSemanticLabel(int position, int total) {
+    return 'Stop-motion frame $position ng $total';
+  }
 
   @override
   String get videoEditorEditLabel => 'I-edit';
@@ -8848,6 +8893,19 @@ class AppLocalizationsFil extends AppLocalizations {
   @override
   String get videoEditorDeleteSelectedClipsSemanticLabel =>
       'Tanggalin ang mga napiling clip';
+
+  @override
+  String get videoEditorDeleteSelectedFramesSemanticLabel =>
+      'Tanggalin ang mga napiling frame';
+
+  @override
+  String get videoEditorReverseSelectedFramesSemanticLabel =>
+      'Baligtarin ang mga napiling frame';
+
+  @override
+  String videoEditorStopMotionTooShortSnackbar(int seconds) {
+    return 'Kailangang hindi bababa sa $seconds segundo ang video mo — kumuha pa ng ilang frame.';
+  }
 
   @override
   String get videoEditorMergeProgressLabel =>

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -8195,6 +8195,18 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String videoRecorderLibraryOpenStopMotionLabel(int frameCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      frameCount,
+      locale: localeName,
+      other: 'Ouvrir la bibliothèque stop-motion, $frameCount images',
+      one: 'Ouvrir la bibliothèque stop-motion, 1 image',
+      zero: 'Ouvrir la bibliothèque stop-motion',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get videoEditorCameraLabel => 'Caméra';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -8137,6 +8137,13 @@ class AppLocalizationsFr extends AppLocalizations {
       'Ajoutez de l\'audio avant d\'enregistrer';
 
   @override
+  String get videoRecorderStopMotionAssembling => 'Création de la vidéo…';
+
+  @override
+  String get videoRecorderStopMotionAssembleFailed =>
+      'Impossible de créer la vidéo. Réessayez.';
+
+  @override
   String get videoRecorderToggleFlashLabel => 'Activer/désactiver le flash';
 
   @override
@@ -8463,6 +8470,44 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get videoEditorDeleteSelectedItemSemanticLabel =>
       'Supprimer l\'élément sélectionné';
+
+  @override
+  String get videoEditorStopMotionFramesPerImageLabel => 'Images par photo';
+
+  @override
+  String videoEditorStopMotionFramesCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count images',
+      one: '1 image',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get videoEditorStopMotionFramesPerImageButtonLabel => 'Images';
+
+  @override
+  String get libraryStopMotionClipLabel => 'Clip stop-motion';
+
+  @override
+  String videoEditorStopMotionFramesPerImageValueSemanticLabel(int count) {
+    return '$count images par photo';
+  }
+
+  @override
+  String get videoEditorStopMotionIncreaseFramesPerImageSemanticLabel =>
+      'Augmenter les images par photo';
+
+  @override
+  String get videoEditorStopMotionDecreaseFramesPerImageSemanticLabel =>
+      'Réduire les images par photo';
+
+  @override
+  String videoEditorStopMotionFrameSemanticLabel(int position, int total) {
+    return 'Image stop-motion $position sur $total';
+  }
 
   @override
   String get videoEditorEditLabel => 'Modifier';
@@ -8870,6 +8915,19 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get videoEditorDeleteSelectedClipsSemanticLabel =>
       'Supprimer les clips sélectionnés';
+
+  @override
+  String get videoEditorDeleteSelectedFramesSemanticLabel =>
+      'Supprimer les images sélectionnées';
+
+  @override
+  String get videoEditorReverseSelectedFramesSemanticLabel =>
+      'Inverser les images sélectionnées';
+
+  @override
+  String videoEditorStopMotionTooShortSnackbar(int seconds) {
+    return 'Ta vidéo doit durer au moins ${seconds}s — capture encore quelques images.';
+  }
 
   @override
   String get videoEditorMergeProgressLabel =>

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -8060,6 +8060,17 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
+  String videoRecorderLibraryOpenStopMotionLabel(int frameCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      frameCount,
+      locale: localeName,
+      other: 'Buka perpustakaan stop-motion, $frameCount bingkai',
+      zero: 'Buka perpustakaan stop-motion',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get videoEditorCameraLabel => 'Kamera';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -8003,6 +8003,13 @@ class AppLocalizationsId extends AppLocalizations {
       'Tambahkan audio sebelum merekam';
 
   @override
+  String get videoRecorderStopMotionAssembling => 'Membuat video Anda…';
+
+  @override
+  String get videoRecorderStopMotionAssembleFailed =>
+      'Tidak dapat membuat video. Coba lagi.';
+
+  @override
   String get videoRecorderToggleFlashLabel => 'Ganti flash';
 
   @override
@@ -8318,6 +8325,43 @@ class AppLocalizationsId extends AppLocalizations {
   @override
   String get videoEditorDeleteSelectedItemSemanticLabel =>
       'Hapus item yang dipilih';
+
+  @override
+  String get videoEditorStopMotionFramesPerImageLabel => 'Bingkai per gambar';
+
+  @override
+  String videoEditorStopMotionFramesCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count bingkai',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get videoEditorStopMotionFramesPerImageButtonLabel => 'Bingkai';
+
+  @override
+  String get libraryStopMotionClipLabel => 'Klip stop-motion';
+
+  @override
+  String videoEditorStopMotionFramesPerImageValueSemanticLabel(int count) {
+    return '$count bingkai per gambar';
+  }
+
+  @override
+  String get videoEditorStopMotionIncreaseFramesPerImageSemanticLabel =>
+      'Tambah bingkai per gambar';
+
+  @override
+  String get videoEditorStopMotionDecreaseFramesPerImageSemanticLabel =>
+      'Kurangi bingkai per gambar';
+
+  @override
+  String videoEditorStopMotionFrameSemanticLabel(int position, int total) {
+    return 'Bingkai stop-motion $position dari $total';
+  }
 
   @override
   String get videoEditorEditLabel => 'Edit';
@@ -8721,6 +8765,19 @@ class AppLocalizationsId extends AppLocalizations {
   @override
   String get videoEditorDeleteSelectedClipsSemanticLabel =>
       'Hapus klip yang dipilih';
+
+  @override
+  String get videoEditorDeleteSelectedFramesSemanticLabel =>
+      'Hapus bingkai yang dipilih';
+
+  @override
+  String get videoEditorReverseSelectedFramesSemanticLabel =>
+      'Balikkan bingkai yang dipilih';
+
+  @override
+  String videoEditorStopMotionTooShortSnackbar(int seconds) {
+    return 'Videomu harus minimal $seconds detik — ambil beberapa bingkai lagi.';
+  }
 
   @override
   String get videoEditorMergeProgressLabel =>

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -8163,6 +8163,18 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String videoRecorderLibraryOpenStopMotionLabel(int frameCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      frameCount,
+      locale: localeName,
+      other: 'Apri libreria stop-motion, $frameCount fotogrammi',
+      one: 'Apri libreria stop-motion, 1 fotogramma',
+      zero: 'Apri libreria stop-motion',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get videoEditorCameraLabel => 'Fotocamera';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -8106,6 +8106,13 @@ class AppLocalizationsIt extends AppLocalizations {
       'Aggiungi audio prima di registrare';
 
   @override
+  String get videoRecorderStopMotionAssembling => 'Creazione del video…';
+
+  @override
+  String get videoRecorderStopMotionAssembleFailed =>
+      'Impossibile creare il video. Riprova.';
+
+  @override
   String get videoRecorderToggleFlashLabel => 'Attiva/disattiva flash';
 
   @override
@@ -8426,6 +8433,45 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get videoEditorDeleteSelectedItemSemanticLabel =>
       'Elimina elemento selezionato';
+
+  @override
+  String get videoEditorStopMotionFramesPerImageLabel =>
+      'Fotogrammi per immagine';
+
+  @override
+  String videoEditorStopMotionFramesCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count fotogrammi',
+      one: '1 fotogramma',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get videoEditorStopMotionFramesPerImageButtonLabel => 'Fotogrammi';
+
+  @override
+  String get libraryStopMotionClipLabel => 'Clip stop-motion';
+
+  @override
+  String videoEditorStopMotionFramesPerImageValueSemanticLabel(int count) {
+    return '$count fotogrammi per immagine';
+  }
+
+  @override
+  String get videoEditorStopMotionIncreaseFramesPerImageSemanticLabel =>
+      'Aumenta fotogrammi per immagine';
+
+  @override
+  String get videoEditorStopMotionDecreaseFramesPerImageSemanticLabel =>
+      'Riduci fotogrammi per immagine';
+
+  @override
+  String videoEditorStopMotionFrameSemanticLabel(int position, int total) {
+    return 'Fotogramma stop-motion $position di $total';
+  }
 
   @override
   String get videoEditorEditLabel => 'Modifica';
@@ -8833,6 +8879,19 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get videoEditorDeleteSelectedClipsSemanticLabel =>
       'Elimina le clip selezionate';
+
+  @override
+  String get videoEditorDeleteSelectedFramesSemanticLabel =>
+      'Elimina i fotogrammi selezionati';
+
+  @override
+  String get videoEditorReverseSelectedFramesSemanticLabel =>
+      'Inverti i fotogrammi selezionati';
+
+  @override
+  String videoEditorStopMotionTooShortSnackbar(int seconds) {
+    return 'Il tuo video deve durare almeno ${seconds}s: scatta ancora qualche fotogramma.';
+  }
 
   @override
   String get videoEditorMergeProgressLabel =>

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -7709,6 +7709,13 @@ class AppLocalizationsJa extends AppLocalizations {
   String get videoRecorderLipSyncAddAudioFirst => '録画する前にオーディオを追加してください';
 
   @override
+  String get videoRecorderStopMotionAssembling => '動画を作成しています…';
+
+  @override
+  String get videoRecorderStopMotionAssembleFailed =>
+      '動画を作成できませんでした。もう一度お試しください。';
+
+  @override
   String get videoRecorderToggleFlashLabel => 'フラッシュを切り替え';
 
   @override
@@ -8015,6 +8022,43 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get videoEditorDeleteSelectedItemSemanticLabel => '選択したアイテムを削除';
+
+  @override
+  String get videoEditorStopMotionFramesPerImageLabel => '1枚あたりのフレーム数';
+
+  @override
+  String videoEditorStopMotionFramesCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$countフレーム',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get videoEditorStopMotionFramesPerImageButtonLabel => 'フレーム';
+
+  @override
+  String get libraryStopMotionClipLabel => 'ストップモーションクリップ';
+
+  @override
+  String videoEditorStopMotionFramesPerImageValueSemanticLabel(int count) {
+    return '1枚あたり$countフレーム';
+  }
+
+  @override
+  String get videoEditorStopMotionIncreaseFramesPerImageSemanticLabel =>
+      '1枚あたりのフレーム数を増やす';
+
+  @override
+  String get videoEditorStopMotionDecreaseFramesPerImageSemanticLabel =>
+      '1枚あたりのフレーム数を減らす';
+
+  @override
+  String videoEditorStopMotionFrameSemanticLabel(int position, int total) {
+    return 'ストップモーションのフレーム $total枚中$position枚目';
+  }
 
   @override
   String get videoEditorEditLabel => '編集';
@@ -8390,6 +8434,17 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get videoEditorDeleteSelectedClipsSemanticLabel => '選択したクリップを削除';
+
+  @override
+  String get videoEditorDeleteSelectedFramesSemanticLabel => '選択したフレームを削除';
+
+  @override
+  String get videoEditorReverseSelectedFramesSemanticLabel => '選択したフレームを逆順にする';
+
+  @override
+  String videoEditorStopMotionTooShortSnackbar(int seconds) {
+    return '動画は$seconds秒以上必要です。もう少しフレームを撮影してください。';
+  }
 
   @override
   String get videoEditorMergeProgressLabel => '少々お待ちください。クリップを結合しています';

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -7762,6 +7762,17 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
+  String videoRecorderLibraryOpenStopMotionLabel(int frameCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      frameCount,
+      locale: localeName,
+      other: 'ストップモーションライブラリを開く、$frameCountフレーム',
+      zero: 'ストップモーションライブラリを開く',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get videoEditorCameraLabel => 'カメラ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -7732,6 +7732,13 @@ class AppLocalizationsKo extends AppLocalizations {
   String get videoRecorderLipSyncAddAudioFirst => '녹화하기 전에 오디오를 추가하세요';
 
   @override
+  String get videoRecorderStopMotionAssembling => '동영상을 만드는 중…';
+
+  @override
+  String get videoRecorderStopMotionAssembleFailed =>
+      '동영상을 만들지 못했습니다. 다시 시도해 주세요.';
+
+  @override
   String get videoRecorderToggleFlashLabel => '플래시 전환';
 
   @override
@@ -8037,6 +8044,43 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get videoEditorDeleteSelectedItemSemanticLabel => '선택한 항목 삭제';
+
+  @override
+  String get videoEditorStopMotionFramesPerImageLabel => '이미지당 프레임';
+
+  @override
+  String videoEditorStopMotionFramesCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count프레임',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get videoEditorStopMotionFramesPerImageButtonLabel => '프레임';
+
+  @override
+  String get libraryStopMotionClipLabel => '스톱모션 클립';
+
+  @override
+  String videoEditorStopMotionFramesPerImageValueSemanticLabel(int count) {
+    return '이미지당 $count프레임';
+  }
+
+  @override
+  String get videoEditorStopMotionIncreaseFramesPerImageSemanticLabel =>
+      '이미지당 프레임 늘리기';
+
+  @override
+  String get videoEditorStopMotionDecreaseFramesPerImageSemanticLabel =>
+      '이미지당 프레임 줄이기';
+
+  @override
+  String videoEditorStopMotionFrameSemanticLabel(int position, int total) {
+    return '스톱모션 프레임 $total개 중 $position개';
+  }
 
   @override
   String get videoEditorEditLabel => '편집';
@@ -8416,6 +8460,17 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get videoEditorDeleteSelectedClipsSemanticLabel => '선택한 클립 삭제';
+
+  @override
+  String get videoEditorDeleteSelectedFramesSemanticLabel => '선택한 프레임 삭제';
+
+  @override
+  String get videoEditorReverseSelectedFramesSemanticLabel => '선택한 프레임 순서 뒤집기';
+
+  @override
+  String videoEditorStopMotionTooShortSnackbar(int seconds) {
+    return '영상은 최소 $seconds초여야 해요. 프레임을 몇 장 더 찍어 주세요.';
+  }
 
   @override
   String get videoEditorMergeProgressLabel => '잠시만요, 클립을 병합하고 있어요';

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -7785,6 +7785,17 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
+  String videoRecorderLibraryOpenStopMotionLabel(int frameCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      frameCount,
+      locale: localeName,
+      other: '스톱모션 보관함 열기, $frameCount개 프레임',
+      zero: '스톱모션 보관함 열기',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get videoEditorCameraLabel => '카메라';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -8068,6 +8068,13 @@ class AppLocalizationsNl extends AppLocalizations {
       'Voeg audio toe vóór de opname';
 
   @override
+  String get videoRecorderStopMotionAssembling => 'Je video wordt gemaakt…';
+
+  @override
+  String get videoRecorderStopMotionAssembleFailed =>
+      'Kan de video niet maken. Probeer het opnieuw.';
+
+  @override
   String get videoRecorderToggleFlashLabel => 'Flitser in-/uitschakelen';
 
   @override
@@ -8382,6 +8389,44 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get videoEditorDeleteSelectedItemSemanticLabel =>
       'Geselecteerd item verwijderen';
+
+  @override
+  String get videoEditorStopMotionFramesPerImageLabel => 'Frames per beeld';
+
+  @override
+  String videoEditorStopMotionFramesCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count frames',
+      one: '1 frame',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get videoEditorStopMotionFramesPerImageButtonLabel => 'Frames';
+
+  @override
+  String get libraryStopMotionClipLabel => 'Stop-motion-clip';
+
+  @override
+  String videoEditorStopMotionFramesPerImageValueSemanticLabel(int count) {
+    return '$count frames per beeld';
+  }
+
+  @override
+  String get videoEditorStopMotionIncreaseFramesPerImageSemanticLabel =>
+      'Frames per beeld verhogen';
+
+  @override
+  String get videoEditorStopMotionDecreaseFramesPerImageSemanticLabel =>
+      'Frames per beeld verlagen';
+
+  @override
+  String videoEditorStopMotionFrameSemanticLabel(int position, int total) {
+    return 'Stop-motion-beeld $position van $total';
+  }
 
   @override
   String get videoEditorEditLabel => 'Bewerken';
@@ -8787,6 +8832,19 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get videoEditorDeleteSelectedClipsSemanticLabel =>
       'Geselecteerde clips verwijderen';
+
+  @override
+  String get videoEditorDeleteSelectedFramesSemanticLabel =>
+      'Geselecteerde frames verwijderen';
+
+  @override
+  String get videoEditorReverseSelectedFramesSemanticLabel =>
+      'Geselecteerde frames omkeren';
+
+  @override
+  String videoEditorStopMotionTooShortSnackbar(int seconds) {
+    return 'Je video moet minstens ${seconds}s duren – leg nog een paar frames vast.';
+  }
 
   @override
   String get videoEditorMergeProgressLabel =>

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -8124,6 +8124,18 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String videoRecorderLibraryOpenStopMotionLabel(int frameCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      frameCount,
+      locale: localeName,
+      other: 'Stop-motion-bibliotheek openen, $frameCount frames',
+      one: 'Stop-motion-bibliotheek openen, 1 frame',
+      zero: 'Stop-motion-bibliotheek openen',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get videoEditorCameraLabel => 'Camera';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -8261,6 +8261,20 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
+  String videoRecorderLibraryOpenStopMotionLabel(int frameCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      frameCount,
+      locale: localeName,
+      other: 'Otwórz bibliotekę poklatkową, $frameCount klatki',
+      many: 'Otwórz bibliotekę poklatkową, $frameCount klatek',
+      few: 'Otwórz bibliotekę poklatkową, $frameCount klatki',
+      one: 'Otwórz bibliotekę poklatkową, 1 klatka',
+      zero: 'Otwórz bibliotekę poklatkową',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get videoEditorCameraLabel => 'Kamera';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -8205,6 +8205,13 @@ class AppLocalizationsPl extends AppLocalizations {
   String get videoRecorderLipSyncAddAudioFirst => 'Dodaj audio przed nagraniem';
 
   @override
+  String get videoRecorderStopMotionAssembling => 'Tworzenie filmu…';
+
+  @override
+  String get videoRecorderStopMotionAssembleFailed =>
+      'Nie udało się utworzyć filmu. Spróbuj ponownie.';
+
+  @override
   String get videoRecorderToggleFlashLabel => 'Przełącz lampę błyskową';
 
   @override
@@ -8520,6 +8527,46 @@ class AppLocalizationsPl extends AppLocalizations {
   @override
   String get videoEditorDeleteSelectedItemSemanticLabel =>
       'Usuń wybrany element';
+
+  @override
+  String get videoEditorStopMotionFramesPerImageLabel => 'Klatki na obraz';
+
+  @override
+  String videoEditorStopMotionFramesCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count klatki',
+      many: '$count klatek',
+      few: '$count klatki',
+      one: '1 klatka',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get videoEditorStopMotionFramesPerImageButtonLabel => 'Klatki';
+
+  @override
+  String get libraryStopMotionClipLabel => 'Klip poklatkowy';
+
+  @override
+  String videoEditorStopMotionFramesPerImageValueSemanticLabel(int count) {
+    return '$count klatek na obraz';
+  }
+
+  @override
+  String get videoEditorStopMotionIncreaseFramesPerImageSemanticLabel =>
+      'Zwiększ liczbę klatek na obraz';
+
+  @override
+  String get videoEditorStopMotionDecreaseFramesPerImageSemanticLabel =>
+      'Zmniejsz liczbę klatek na obraz';
+
+  @override
+  String videoEditorStopMotionFrameSemanticLabel(int position, int total) {
+    return 'Klatka poklatkowa $position z $total';
+  }
 
   @override
   String get videoEditorEditLabel => 'Edytuj';
@@ -8925,6 +8972,19 @@ class AppLocalizationsPl extends AppLocalizations {
   @override
   String get videoEditorDeleteSelectedClipsSemanticLabel =>
       'Usuń zaznaczone klipy';
+
+  @override
+  String get videoEditorDeleteSelectedFramesSemanticLabel =>
+      'Usuń zaznaczone klatki';
+
+  @override
+  String get videoEditorReverseSelectedFramesSemanticLabel =>
+      'Odwróć zaznaczone klatki';
+
+  @override
+  String videoEditorStopMotionTooShortSnackbar(int seconds) {
+    return 'Twój film musi trwać co najmniej ${seconds}s – dodaj jeszcze kilka klatek.';
+  }
 
   @override
   String get videoEditorMergeProgressLabel => 'Chwila, scalamy Twoje klipy';

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -8141,6 +8141,18 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String videoRecorderLibraryOpenStopMotionLabel(int frameCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      frameCount,
+      locale: localeName,
+      other: 'Abrir biblioteca de stop motion, $frameCount quadros',
+      one: 'Abrir biblioteca de stop motion, 1 quadro',
+      zero: 'Abrir biblioteca de stop motion',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get videoEditorCameraLabel => 'Câmera';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -8084,6 +8084,13 @@ class AppLocalizationsPt extends AppLocalizations {
       'Adicione áudio antes de gravar';
 
   @override
+  String get videoRecorderStopMotionAssembling => 'Criando seu vídeo…';
+
+  @override
+  String get videoRecorderStopMotionAssembleFailed =>
+      'Não foi possível criar o vídeo. Tente novamente.';
+
+  @override
   String get videoRecorderToggleFlashLabel => 'Alternar flash';
 
   @override
@@ -8400,6 +8407,44 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get videoEditorDeleteSelectedItemSemanticLabel =>
       'Excluir item selecionado';
+
+  @override
+  String get videoEditorStopMotionFramesPerImageLabel => 'Quadros por imagem';
+
+  @override
+  String videoEditorStopMotionFramesCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count quadros',
+      one: '1 quadro',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get videoEditorStopMotionFramesPerImageButtonLabel => 'Quadros';
+
+  @override
+  String get libraryStopMotionClipLabel => 'Clipe de stop motion';
+
+  @override
+  String videoEditorStopMotionFramesPerImageValueSemanticLabel(int count) {
+    return '$count quadros por imagem';
+  }
+
+  @override
+  String get videoEditorStopMotionIncreaseFramesPerImageSemanticLabel =>
+      'Aumentar quadros por imagem';
+
+  @override
+  String get videoEditorStopMotionDecreaseFramesPerImageSemanticLabel =>
+      'Reduzir quadros por imagem';
+
+  @override
+  String videoEditorStopMotionFrameSemanticLabel(int position, int total) {
+    return 'Quadro de stop motion $position de $total';
+  }
 
   @override
   String get videoEditorEditLabel => 'Editar';
@@ -8802,6 +8847,19 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get videoEditorDeleteSelectedClipsSemanticLabel =>
       'Excluir clipes selecionados';
+
+  @override
+  String get videoEditorDeleteSelectedFramesSemanticLabel =>
+      'Excluir quadros selecionados';
+
+  @override
+  String get videoEditorReverseSelectedFramesSemanticLabel =>
+      'Inverter quadros selecionados';
+
+  @override
+  String videoEditorStopMotionTooShortSnackbar(int seconds) {
+    return 'Seu vídeo precisa de pelo menos ${seconds}s — capture mais alguns quadros.';
+  }
 
   @override
   String get videoEditorMergeProgressLabel =>

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -8207,6 +8207,13 @@ class AppLocalizationsRo extends AppLocalizations {
       'Adaugă audio înainte de înregistrare';
 
   @override
+  String get videoRecorderStopMotionAssembling => 'Se creează videoclipul…';
+
+  @override
+  String get videoRecorderStopMotionAssembleFailed =>
+      'Videoclipul nu a putut fi creat. Încearcă din nou.';
+
+  @override
   String get videoRecorderToggleFlashLabel => 'Activează/dezactivează blițul';
 
   @override
@@ -8532,6 +8539,44 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String get videoEditorDeleteSelectedItemSemanticLabel =>
       'Șterge elementul selectat';
+
+  @override
+  String get videoEditorStopMotionFramesPerImageLabel => 'Cadre pe imagine';
+
+  @override
+  String videoEditorStopMotionFramesCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count cadre',
+      one: '1 cadru',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get videoEditorStopMotionFramesPerImageButtonLabel => 'Cadre';
+
+  @override
+  String get libraryStopMotionClipLabel => 'Clip stop-motion';
+
+  @override
+  String videoEditorStopMotionFramesPerImageValueSemanticLabel(int count) {
+    return '$count cadre pe imagine';
+  }
+
+  @override
+  String get videoEditorStopMotionIncreaseFramesPerImageSemanticLabel =>
+      'Mărește cadrele pe imagine';
+
+  @override
+  String get videoEditorStopMotionDecreaseFramesPerImageSemanticLabel =>
+      'Micșorează cadrele pe imagine';
+
+  @override
+  String videoEditorStopMotionFrameSemanticLabel(int position, int total) {
+    return 'Cadru stop-motion $position din $total';
+  }
 
   @override
   String get videoEditorEditLabel => 'Editează';
@@ -8938,6 +8983,19 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String get videoEditorDeleteSelectedClipsSemanticLabel =>
       'Șterge clipurile selectate';
+
+  @override
+  String get videoEditorDeleteSelectedFramesSemanticLabel =>
+      'Șterge cadrele selectate';
+
+  @override
+  String get videoEditorReverseSelectedFramesSemanticLabel =>
+      'Inversează cadrele selectate';
+
+  @override
+  String videoEditorStopMotionTooShortSnackbar(int seconds) {
+    return 'Videoclipul tău trebuie să dureze cel puțin ${seconds}s — capturează încă câteva cadre.';
+  }
 
   @override
   String get videoEditorMergeProgressLabel =>

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -8265,6 +8265,19 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String videoRecorderLibraryOpenStopMotionLabel(int frameCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      frameCount,
+      locale: localeName,
+      other: 'Deschide biblioteca stop-motion, $frameCount de cadre',
+      few: 'Deschide biblioteca stop-motion, $frameCount cadre',
+      one: 'Deschide biblioteca stop-motion, 1 cadru',
+      zero: 'Deschide biblioteca stop-motion',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get videoEditorCameraLabel => 'Cameră';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -8086,6 +8086,18 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String videoRecorderLibraryOpenStopMotionLabel(int frameCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      frameCount,
+      locale: localeName,
+      other: 'Öppna stop motion-bibliotek, $frameCount bildrutor',
+      one: 'Öppna stop motion-bibliotek, 1 bildruta',
+      zero: 'Öppna stop motion-bibliotek',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get videoEditorCameraLabel => 'Kamera';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -8030,6 +8030,13 @@ class AppLocalizationsSv extends AppLocalizations {
       'Lägg till ljud innan inspelning';
 
   @override
+  String get videoRecorderStopMotionAssembling => 'Skapar din video…';
+
+  @override
+  String get videoRecorderStopMotionAssembleFailed =>
+      'Det gick inte att skapa videon. Försök igen.';
+
+  @override
   String get videoRecorderToggleFlashLabel => 'Växla blixt';
 
   @override
@@ -8345,6 +8352,44 @@ class AppLocalizationsSv extends AppLocalizations {
   @override
   String get videoEditorDeleteSelectedItemSemanticLabel =>
       'Ta bort valt objekt';
+
+  @override
+  String get videoEditorStopMotionFramesPerImageLabel => 'Bildrutor per bild';
+
+  @override
+  String videoEditorStopMotionFramesCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count bildrutor',
+      one: '1 bildruta',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get videoEditorStopMotionFramesPerImageButtonLabel => 'Bildrutor';
+
+  @override
+  String get libraryStopMotionClipLabel => 'Stop motion-klipp';
+
+  @override
+  String videoEditorStopMotionFramesPerImageValueSemanticLabel(int count) {
+    return '$count bildrutor per bild';
+  }
+
+  @override
+  String get videoEditorStopMotionIncreaseFramesPerImageSemanticLabel =>
+      'Öka bildrutor per bild';
+
+  @override
+  String get videoEditorStopMotionDecreaseFramesPerImageSemanticLabel =>
+      'Minska bildrutor per bild';
+
+  @override
+  String videoEditorStopMotionFrameSemanticLabel(int position, int total) {
+    return 'Stop motion-bild $position av $total';
+  }
 
   @override
   String get videoEditorEditLabel => 'Redigera';
@@ -8747,6 +8792,19 @@ class AppLocalizationsSv extends AppLocalizations {
   @override
   String get videoEditorDeleteSelectedClipsSemanticLabel =>
       'Ta bort markerade klipp';
+
+  @override
+  String get videoEditorDeleteSelectedFramesSemanticLabel =>
+      'Ta bort markerade bildrutor';
+
+  @override
+  String get videoEditorReverseSelectedFramesSemanticLabel =>
+      'Vänd markerade bildrutor';
+
+  @override
+  String videoEditorStopMotionTooShortSnackbar(int seconds) {
+    return 'Din video måste vara minst ${seconds}s – ta några bildrutor till.';
+  }
 
   @override
   String get videoEditorMergeProgressLabel =>

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -8062,6 +8062,18 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
+  String videoRecorderLibraryOpenStopMotionLabel(int frameCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      frameCount,
+      locale: localeName,
+      other: 'Stop motion kütüphanesini aç, $frameCount kare',
+      one: 'Stop motion kütüphanesini aç, 1 kare',
+      zero: 'Stop motion kütüphanesini aç',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get videoEditorCameraLabel => 'Kamera';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -8006,6 +8006,13 @@ class AppLocalizationsTr extends AppLocalizations {
   String get videoRecorderLipSyncAddAudioFirst => 'Kayıttan önce ses ekleyin';
 
   @override
+  String get videoRecorderStopMotionAssembling => 'Videon oluşturuluyor…';
+
+  @override
+  String get videoRecorderStopMotionAssembleFailed =>
+      'Video oluşturulamadı. Tekrar deneyin.';
+
+  @override
   String get videoRecorderToggleFlashLabel => 'Flaşı değiştir';
 
   @override
@@ -8317,6 +8324,43 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get videoEditorDeleteSelectedItemSemanticLabel => 'Seçili öğeyi sil';
+
+  @override
+  String get videoEditorStopMotionFramesPerImageLabel => 'Görüntü başına kare';
+
+  @override
+  String videoEditorStopMotionFramesCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count kare',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get videoEditorStopMotionFramesPerImageButtonLabel => 'Kare';
+
+  @override
+  String get libraryStopMotionClipLabel => 'Stop motion klibi';
+
+  @override
+  String videoEditorStopMotionFramesPerImageValueSemanticLabel(int count) {
+    return 'Görüntü başına $count kare';
+  }
+
+  @override
+  String get videoEditorStopMotionIncreaseFramesPerImageSemanticLabel =>
+      'Görüntü başına kareyi artır';
+
+  @override
+  String get videoEditorStopMotionDecreaseFramesPerImageSemanticLabel =>
+      'Görüntü başına kareyi azalt';
+
+  @override
+  String videoEditorStopMotionFrameSemanticLabel(int position, int total) {
+    return 'Stop motion karesi $position/$total';
+  }
 
   @override
   String get videoEditorEditLabel => 'Düzenle';
@@ -8716,6 +8760,19 @@ class AppLocalizationsTr extends AppLocalizations {
   @override
   String get videoEditorDeleteSelectedClipsSemanticLabel =>
       'Seçili klipleri sil';
+
+  @override
+  String get videoEditorDeleteSelectedFramesSemanticLabel =>
+      'Seçili kareleri sil';
+
+  @override
+  String get videoEditorReverseSelectedFramesSemanticLabel =>
+      'Seçili kareleri ters çevir';
+
+  @override
+  String videoEditorStopMotionTooShortSnackbar(int seconds) {
+    return 'Videon en az ${seconds}sn olmalı — birkaç kare daha çek.';
+  }
 
   @override
   String get videoEditorMergeProgressLabel =>

--- a/mobile/lib/models/divine_video_clip.dart
+++ b/mobile/lib/models/divine_video_clip.dart
@@ -446,7 +446,16 @@ class DivineVideoClip {
           : null,
       stopMotionFrames: stopMotionFrames,
       libraryTitle: json['libraryTitle'] as String?,
-      duration: Duration(milliseconds: durationMs),
+      // Frame holds are persisted in microseconds; recompute the clip duration
+      // from them (rather than the ms-truncated `durationMs`) so a reloaded
+      // stop-motion clip's duration matches its frames exactly on the frame
+      // grid. Falls back to `durationMs` for normal video clips.
+      duration: stopMotionFrames != null && stopMotionFrames.isNotEmpty
+          ? stopMotionFrames.fold<Duration>(
+              Duration.zero,
+              (sum, frame) => sum + frame.duration,
+            )
+          : Duration(milliseconds: durationMs),
       recordedAt: DateTime.parse(rawRecordedAt),
       thumbnailPath: resolvePath(
         json['thumbnailPath'] as String?,

--- a/mobile/lib/models/divine_video_clip.dart
+++ b/mobile/lib/models/divine_video_clip.dart
@@ -140,7 +140,12 @@ class DivineVideoClip {
   double get durationInSeconds => duration.inMilliseconds / 1000.0;
 
   /// Whether this is a frames-based stop-motion clip (no rendered mp4 yet).
-  bool get isStopMotion => stopMotionFrames != null;
+  ///
+  /// Video-first: once [materialize] has rendered the stills into an mp4 the
+  /// clip is a normal video clip, even if it still carries [stopMotionFrames]
+  /// (e.g. a draft persisted before frames were cleared). A clip with a
+  /// [video] is never "still-based".
+  bool get isStopMotion => video == null && stopMotionFrames != null;
 
   /// The rendered [video], asserting it exists.
   ///
@@ -229,6 +234,13 @@ class DivineVideoClip {
   /// and freezes the editor, so restore/undo paths use this to drop orphaned
   /// clips. See `restoreDraft` and `VideoEditorCanvas._syncMainCapabilities`.
   bool get hasResolvableVideoFile {
+    // Video-first: a materialized stop-motion clip carries a rendered mp4 (and
+    // may still carry its now-transient stills). Resolve against the mp4 so a
+    // clip whose throwaway stills were cleaned up isn't wrongly dropped as
+    // orphaned once it has a playable video.
+    final path = video?.file?.path;
+    if (path != null) return File(path).existsSync();
+
     // Frames-only stop-motion clips have no video by design; their stills are
     // the source of truth. Without this branch every history sync would treat
     // the clip as orphaned and step the editor history backwards, silently
@@ -238,8 +250,7 @@ class DivineVideoClip {
       return frames.isNotEmpty &&
           frames.every((frame) => File(frame.path).existsSync());
     }
-    final path = video?.file?.path;
-    return path != null && File(path).existsSync();
+    return false;
   }
 
   /// Whether this clip was recorded with a front-facing camera.
@@ -262,6 +273,7 @@ class DivineVideoClip {
     String? id,
     EditorVideo? video,
     List<StopMotionClipFrame>? stopMotionFrames,
+    bool clearStopMotionFrames = false,
     String? libraryTitle,
     bool clearLibraryTitle = false,
     Duration? duration,
@@ -296,7 +308,9 @@ class DivineVideoClip {
     return DivineVideoClip(
       id: id ?? this.id,
       video: video ?? this.video,
-      stopMotionFrames: stopMotionFrames ?? this.stopMotionFrames,
+      stopMotionFrames: clearStopMotionFrames
+          ? null
+          : (stopMotionFrames ?? this.stopMotionFrames),
       libraryTitle: clearLibraryTitle
           ? null
           : (libraryTitle ?? this.libraryTitle),

--- a/mobile/lib/models/divine_video_clip.dart
+++ b/mobile/lib/models/divine_video_clip.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 import 'package:divine_camera/divine_camera.dart'
     show CameraLensMetadata, DivineCameraLens;
 import 'package:models/models.dart' as model show AspectRatio;
+import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/utils/path_resolver.dart';
 import 'package:path/path.dart' as p;
 import 'package:pro_video_editor/pro_video_editor.dart';
@@ -15,11 +16,12 @@ import 'package:unified_logger/unified_logger.dart';
 class DivineVideoClip {
   DivineVideoClip({
     required this.id,
-    required this.video,
     required this.duration,
     required this.recordedAt,
     required this.targetAspectRatio,
     required double? originalAspectRatio,
+    this.video,
+    this.stopMotionFrames,
     this.libraryTitle,
     this.thumbnailPath,
     Duration? thumbnailTimestamp,
@@ -38,11 +40,24 @@ class DivineVideoClip {
     this.proofManifestJson,
     this.deletedAt,
     this.transition,
-  }) : _thumbnailTimestamp = thumbnailTimestamp,
+  }) : assert(
+         video != null || stopMotionFrames != null,
+         'A clip must have either a video file or stop-motion frames',
+       ),
+       _thumbnailTimestamp = thumbnailTimestamp,
        _originalAspectRatio = originalAspectRatio;
 
   final String id;
-  final EditorVideo video;
+
+  /// Rendered video for a normal clip, or `null` for a stop-motion clip whose
+  /// source of truth is [stopMotionFrames] (an mp4 is rendered on demand at
+  /// publish / gallery save).
+  final EditorVideo? video;
+
+  /// Captured stop-motion stills (source of truth) for a frames-based clip, or
+  /// `null` for a normal video clip.
+  final List<StopMotionClipFrame>? stopMotionFrames;
+
   final String? libraryTitle;
   final Duration duration;
   final DateTime recordedAt;
@@ -124,6 +139,26 @@ class DivineVideoClip {
 
   double get durationInSeconds => duration.inMilliseconds / 1000.0;
 
+  /// Whether this is a frames-based stop-motion clip (no rendered mp4 yet).
+  bool get isStopMotion => stopMotionFrames != null;
+
+  /// The rendered [video], asserting it exists.
+  ///
+  /// Use at call sites that only ever handle normal video clips (e.g. the
+  /// video editor pipeline, which stop-motion clips never enter).
+  ///
+  /// Throws [StateError] if this is a stop-motion clip whose mp4 has not been
+  /// rendered yet — that signals a frames-clip leaked into a video-only path.
+  EditorVideo get requireVideo {
+    final video = this.video;
+    if (video == null) {
+      throw StateError(
+        'requireVideo on a stop-motion clip ($id) without a rendered video',
+      );
+    }
+    return video;
+  }
+
   /// Effective duration after trimming (clamped to zero).
   Duration get trimmedDuration {
     final result = duration - trimStart - trimEnd;
@@ -183,7 +218,8 @@ class DivineVideoClip {
   bool get isProcessing =>
       processingCompleter != null && !processingCompleter!.isCompleted;
 
-  /// Whether this clip's source video file currently exists on disk.
+  /// Whether this clip's source media currently exists on disk: the video
+  /// file, or — for a frames-only stop-motion clip — every captured still.
   ///
   /// A clip can outlive its media: when a clip is removed, [FileCleanupService]
   /// deletes its source file as soon as no clip/draft row references it — but
@@ -193,7 +229,16 @@ class DivineVideoClip {
   /// and freezes the editor, so restore/undo paths use this to drop orphaned
   /// clips. See `restoreDraft` and `VideoEditorCanvas._syncMainCapabilities`.
   bool get hasResolvableVideoFile {
-    final path = video.file?.path;
+    // Frames-only stop-motion clips have no video by design; their stills are
+    // the source of truth. Without this branch every history sync would treat
+    // the clip as orphaned and step the editor history backwards, silently
+    // undoing frame edits.
+    final frames = stopMotionFrames;
+    if (frames != null) {
+      return frames.isNotEmpty &&
+          frames.every((frame) => File(frame.path).existsSync());
+    }
+    final path = video?.file?.path;
     return path != null && File(path).existsSync();
   }
 
@@ -216,6 +261,7 @@ class DivineVideoClip {
   DivineVideoClip copyWith({
     String? id,
     EditorVideo? video,
+    List<StopMotionClipFrame>? stopMotionFrames,
     String? libraryTitle,
     bool clearLibraryTitle = false,
     Duration? duration,
@@ -250,6 +296,7 @@ class DivineVideoClip {
     return DivineVideoClip(
       id: id ?? this.id,
       video: video ?? this.video,
+      stopMotionFrames: stopMotionFrames ?? this.stopMotionFrames,
       libraryTitle: clearLibraryTitle
           ? null
           : (libraryTitle ?? this.libraryTitle),
@@ -292,10 +339,14 @@ class DivineVideoClip {
   Map<String, dynamic> toJson() {
     // Store only filenames (relative paths) for iOS compatibility
     // iOS changes the container path on app updates, so absolute paths break
-    final videoPath = video.file?.path;
+    final videoPath = video?.file?.path;
     return {
       'id': id,
       'filePath': videoPath != null ? p.basename(videoPath) : null,
+      if (stopMotionFrames != null)
+        'stopMotionFrames': [
+          for (final frame in stopMotionFrames!) frame.toJson(),
+        ],
       if (libraryTitle != null) 'libraryTitle': libraryTitle,
       'durationMs': duration.inMilliseconds,
       'recordedAt': recordedAt.toIso8601String(),
@@ -335,37 +386,51 @@ class DivineVideoClip {
     final aspectRatioName =
         (json['targetAspectRatio'] ?? json['aspectRatio']) as String?;
     final thumbnailTimestampMs = json['thumbnailTimestampMs'] as int?;
-
-    // A clip's only persisted video source is its file path; without it the
-    // clip can't be reconstructed (`EditorVideo` requires a non-null source).
-    // Validate the required fields up front and throw a typed error so the
-    // loader can skip this single corrupt row instead of a cryptic
-    // `Null is not a subtype of String` cast aborting the whole library/draft
-    // load.
-    final id = json['id'] as String?;
     final filePath = json['filePath'] as String?;
+    final stopMotionFramesJson = json['stopMotionFrames'] as List<dynamic>?;
+    final stopMotionFrames = stopMotionFramesJson
+        ?.map(
+          (e) => StopMotionClipFrame.fromJson(
+            e as Map<String, dynamic>,
+            documentsPath,
+            useOriginalPath: useOriginalPath,
+          ),
+        )
+        .toList();
+
+    // A clip's video source is either a persisted file path or, for
+    // stop-motion clips, the captured [stopMotionFrames] (an mp4 is rendered
+    // on demand). A clip with neither can't be reconstructed (`EditorVideo`
+    // requires a non-null source). Validate the required fields up front and
+    // throw a typed error so the loader can skip this single corrupt row
+    // instead of a cryptic `Null is not a subtype of String` cast aborting the
+    // whole library/draft load.
+    final id = json['id'] as String?;
     final rawRecordedAt = (json['recordedAt'] ?? json['createdAt']) as String?;
     final durationMs = json['durationMs'] as int?;
     if (id == null ||
-        filePath == null ||
+        (filePath == null && stopMotionFrames == null) ||
         rawRecordedAt == null ||
         durationMs == null) {
       throw const FormatException(
         'DivineVideoClip JSON is missing a required field '
-        '(id, filePath, recordedAt, or durationMs); cannot reconstruct '
-        'the clip.',
+        '(id, a video source [filePath or stopMotionFrames], recordedAt, or '
+        'durationMs); cannot reconstruct the clip.',
       );
     }
 
     return DivineVideoClip(
       id: id,
-      video: EditorVideo.file(
-        resolvePath(
-          filePath,
-          documentsPath,
-          useOriginalPath: useOriginalPath,
-        ),
-      ),
+      video: filePath != null
+          ? EditorVideo.file(
+              resolvePath(
+                filePath,
+                documentsPath,
+                useOriginalPath: useOriginalPath,
+              ),
+            )
+          : null,
+      stopMotionFrames: stopMotionFrames,
       libraryTitle: json['libraryTitle'] as String?,
       duration: Duration(milliseconds: durationMs),
       recordedAt: DateTime.parse(rawRecordedAt),

--- a/mobile/lib/models/stop_motion/stop_motion_frame_ops.dart
+++ b/mobile/lib/models/stop_motion/stop_motion_frame_ops.dart
@@ -148,11 +148,15 @@ abstract class StopMotionFrameOps {
     int framesPerImage,
   ) {
     if (index < 0 || index >= frames.length) return frames;
-    final next = [...frames];
-    next[index] = next[index].copyWith(
+    final updated = frames[index].copyWith(
       duration: framesPerImageToDuration(framesPerImage),
       holdOverridden: true,
     );
+    // Re-selecting the current hold changes nothing; return the source instance
+    // so the commit's `identical` no-op guard skips a redundant history entry.
+    if (updated == frames[index]) return frames;
+    final next = [...frames];
+    next[index] = updated;
     return next;
   }
 
@@ -222,12 +226,23 @@ abstract class StopMotionFrameOps {
   ) {
     if (indexes.isEmpty) return frames;
     final duration = framesPerImageToDuration(framesPerImage);
-    return [
-      for (var i = 0; i < frames.length; i++)
-        indexes.contains(i)
-            ? frames[i].copyWith(duration: duration, holdOverridden: true)
-            : frames[i],
-    ];
+    final next = <StopMotionClipFrame>[];
+    var changed = false;
+    for (var i = 0; i < frames.length; i++) {
+      if (indexes.contains(i)) {
+        final updated = frames[i].copyWith(
+          duration: duration,
+          holdOverridden: true,
+        );
+        if (updated != frames[i]) changed = true;
+        next.add(updated);
+      } else {
+        next.add(frames[i]);
+      }
+    }
+    // No selected still actually changed hold: return the source instance so
+    // the commit's `identical` no-op guard skips a redundant history entry.
+    return changed ? next : frames;
   }
 
   /// Applies [framesPerImage] as the global default: every still that has *not*
@@ -238,10 +253,20 @@ abstract class StopMotionFrameOps {
     int framesPerImage,
   ) {
     final duration = framesPerImageToDuration(framesPerImage);
-    return [
-      for (final frame in frames)
-        frame.holdOverridden ? frame : frame.copyWith(duration: duration),
-    ];
+    final next = <StopMotionClipFrame>[];
+    var changed = false;
+    for (final frame in frames) {
+      if (frame.holdOverridden) {
+        next.add(frame);
+      } else {
+        final updated = frame.copyWith(duration: duration);
+        if (updated != frame) changed = true;
+        next.add(updated);
+      }
+    }
+    // No non-overridden still actually changed hold: return the source instance
+    // so the commit's `identical` no-op guard skips a redundant history entry.
+    return changed ? next : frames;
   }
 
   /// The global-default frames-per-image: the value shared by every

--- a/mobile/lib/models/stop_motion/stop_motion_frame_ops.dart
+++ b/mobile/lib/models/stop_motion/stop_motion_frame_ops.dart
@@ -314,6 +314,9 @@ abstract class StopMotionFrameOps {
   /// when no readable still remains. Normal video clips pass through
   /// unchanged.
   static DivineVideoClip? sanitizedClip(DivineVideoClip clip) {
+    // A materialized clip has a rendered mp4; its stills are no longer the
+    // source of truth, so don't drop it for missing (already-cleaned) stills.
+    if (clip.video != null) return clip;
     final frames = clip.stopMotionFrames;
     if (frames == null) return clip;
     final readable = existingFrames(frames);

--- a/mobile/lib/models/stop_motion/stop_motion_frame_ops.dart
+++ b/mobile/lib/models/stop_motion/stop_motion_frame_ops.dart
@@ -322,11 +322,15 @@ abstract class StopMotionFrameOps {
   ) {
     return [
       for (final frame in frames)
-        if (_isReadableImage(frame.path)) frame,
+        if (isReadableImage(frame.path)) frame,
     ];
   }
 
-  static bool _isReadableImage(String path) {
+  /// Whether the still at [path] exists on disk and is non-empty.
+  ///
+  /// Two synchronous syscalls; check a single still as it is captured rather
+  /// than re-sweeping an accumulated session (see [existingFrames]).
+  static bool isReadableImage(String path) {
     try {
       final file = File(path);
       return file.existsSync() && file.lengthSync() > 0;
@@ -345,8 +349,11 @@ abstract class StopMotionFrameOps {
     final frames = clip.stopMotionFrames;
     if (frames == null) return clip;
     final readable = existingFrames(frames);
-    if (readable.length == frames.length) return clip;
+    // Ordered before the length check: an already-empty frame list satisfies
+    // `readable.length == frames.length` (0 == 0) and would otherwise pass
+    // through as a valid stop-motion clip with nothing to render.
     if (readable.isEmpty) return null;
+    if (readable.length == frames.length) return clip;
     return clipWithFrames(clip, readable);
   }
 

--- a/mobile/lib/models/stop_motion/stop_motion_frame_ops.dart
+++ b/mobile/lib/models/stop_motion/stop_motion_frame_ops.dart
@@ -1,0 +1,346 @@
+// ABOUTME: Pure frame-list operations for a stop-motion DivineVideoClip
+// ABOUTME: Keeps the frame list and the clip's cached duration in sync
+
+import 'dart:io';
+
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
+import 'package:openvine/services/video_editor/stop_motion_render_service.dart';
+
+/// Frame-level operations for a stop-motion [DivineVideoClip].
+///
+/// A stop-motion clip stores its stills as [StopMotionClipFrame]s; each still is
+/// held for a whole number of output frames ("frames per image") at
+/// [StopMotionRenderService.defaultFrameRate]. These helpers rebuild the frame
+/// list and keep the clip's cached [DivineVideoClip.duration] consistent with
+/// it.
+abstract class StopMotionFrameOps {
+  StopMotionFrameOps._();
+
+  /// Lowest number of output frames a still may be held for.
+  static const int minFramesPerImage = 1;
+
+  /// Highest number of output frames a still may be held for.
+  static const int maxFramesPerImage = 300;
+
+  /// Default hold for a freshly captured still: 1 output frame at 24fps.
+  static const int defaultFramesPerImage = 1;
+
+  /// Hold duration for a still shown for [framesPerImage] output frames at the
+  /// default frame rate. [framesPerImage] is clamped to
+  /// [minFramesPerImage]..[maxFramesPerImage].
+  static Duration framesPerImageToDuration(int framesPerImage) {
+    final clamped = framesPerImage.clamp(minFramesPerImage, maxFramesPerImage);
+    return Duration(
+      microseconds:
+          (clamped *
+                  Duration.microsecondsPerSecond /
+                  StopMotionRenderService.defaultFrameRate)
+              .round(),
+    );
+  }
+
+  /// Inverse of [framesPerImageToDuration]: the number of output frames a still
+  /// held for [duration] represents, rounded and clamped to the valid range.
+  static int durationToFramesPerImage(Duration duration) {
+    final raw =
+        duration.inMicroseconds *
+        StopMotionRenderService.defaultFrameRate /
+        Duration.microsecondsPerSecond;
+    return raw.round().clamp(minFramesPerImage, maxFramesPerImage);
+  }
+
+  /// Sum of every frame's hold time — the clip's playback duration.
+  static Duration totalDuration(List<StopMotionClipFrame> frames) =>
+      frames.fold(Duration.zero, (sum, frame) => sum + frame.duration);
+
+  /// Index at which stills captured with the playhead at [position] should be
+  /// inserted into [frames], so they land at that timeline position rather than
+  /// at the end.
+  ///
+  /// The playhead sitting inside frame *i*'s hold inserts the new stills right
+  /// after frame *i*. Clamped to `0..frames.length`, so a playhead at the start
+  /// prepends and one at/after the end appends.
+  static int insertIndexAtPosition(
+    List<StopMotionClipFrame> frames,
+    Duration position,
+  ) {
+    if (position <= Duration.zero) return 0;
+    var acc = Duration.zero;
+    for (var i = 0; i < frames.length; i++) {
+      acc += frames[i].duration;
+      if (position < acc) return i + 1;
+    }
+    return frames.length;
+  }
+
+  /// [frames] with [inserted] spliced in at [index] (clamped to the list
+  /// bounds).
+  static List<StopMotionClipFrame> insertFramesAt(
+    List<StopMotionClipFrame> frames,
+    int index,
+    List<StopMotionClipFrame> inserted,
+  ) {
+    if (inserted.isEmpty) return frames;
+    final at = index.clamp(0, frames.length);
+    return [...frames.sublist(0, at), ...inserted, ...frames.sublist(at)];
+  }
+
+  /// [frames] with the still at [index] removed.
+  ///
+  /// Returns the list unchanged when [index] is out of range or removing it
+  /// would empty the clip — a stop-motion clip must keep at least one still.
+  static List<StopMotionClipFrame> removeFrame(
+    List<StopMotionClipFrame> frames,
+    int index,
+  ) {
+    if (index < 0 || index >= frames.length || frames.length <= 1) {
+      return frames;
+    }
+    return [...frames]..removeAt(index);
+  }
+
+  /// [frames] with the stills at [indexes] removed.
+  ///
+  /// Returns the list unchanged when [indexes] is empty, contains an
+  /// out-of-range index, or removing them would empty the clip — a
+  /// stop-motion clip must keep at least one still.
+  static List<StopMotionClipFrame> removeFrames(
+    List<StopMotionClipFrame> frames,
+    Set<int> indexes,
+  ) {
+    if (indexes.isEmpty ||
+        indexes.any((index) => index < 0 || index >= frames.length) ||
+        indexes.length >= frames.length) {
+      return frames;
+    }
+    return [
+      for (var i = 0; i < frames.length; i++)
+        if (!indexes.contains(i)) frames[i],
+    ];
+  }
+
+  /// [frames] with the still at [from] moved to [to].
+  static List<StopMotionClipFrame> reorderFrame(
+    List<StopMotionClipFrame> frames,
+    int from,
+    int to,
+  ) {
+    if (from < 0 ||
+        from >= frames.length ||
+        to < 0 ||
+        to >= frames.length ||
+        from == to) {
+      return frames;
+    }
+    final next = [...frames];
+    final moved = next.removeAt(from);
+    next.insert(to, moved);
+    return next;
+  }
+
+  /// [frames] with the still at [index] held for [framesPerImage] output
+  /// frames, marked as an individual override so later global changes leave
+  /// it untouched.
+  static List<StopMotionClipFrame> setFrameHold(
+    List<StopMotionClipFrame> frames,
+    int index,
+    int framesPerImage,
+  ) {
+    if (index < 0 || index >= frames.length) return frames;
+    final next = [...frames];
+    next[index] = next[index].copyWith(
+      duration: framesPerImageToDuration(framesPerImage),
+      holdOverridden: true,
+    );
+    return next;
+  }
+
+  /// [frames] with the selected stills' order reversed among their own slots:
+  /// the indexes in [indexes] keep their positions, but the stills sitting on
+  /// them swap into reverse order (frame multi-select "reverse").
+  ///
+  /// Returns the list unchanged when fewer than two stills are selected or an
+  /// index is out of range.
+  static List<StopMotionClipFrame> reverseFrames(
+    List<StopMotionClipFrame> frames,
+    Set<int> indexes,
+  ) {
+    if (indexes.length < 2 ||
+        indexes.any((index) => index < 0 || index >= frames.length)) {
+      return frames;
+    }
+    final slots = indexes.toList()..sort();
+    final next = [...frames];
+    for (var k = 0; k < slots.length; k++) {
+      next[slots[k]] = frames[slots[slots.length - 1 - k]];
+    }
+    return next;
+  }
+
+  /// Moves the stills at [indexes] as one contiguous block (in their current
+  /// relative order) to [insertSlot] — an insertion position within the list
+  /// of *remaining* stills (`0..remaining.length`, clamped).
+  ///
+  /// Returns the list unchanged when the selection is empty or contains an
+  /// out-of-range index.
+  static List<StopMotionClipFrame> moveFrames(
+    List<StopMotionClipFrame> frames,
+    Set<int> indexes,
+    int insertSlot,
+  ) {
+    if (indexes.isEmpty ||
+        indexes.any((index) => index < 0 || index >= frames.length)) {
+      return frames;
+    }
+    final selected = <StopMotionClipFrame>[];
+    final remaining = <StopMotionClipFrame>[];
+    for (var i = 0; i < frames.length; i++) {
+      (indexes.contains(i) ? selected : remaining).add(frames[i]);
+    }
+    final slot = insertSlot.clamp(0, remaining.length);
+    final result = [
+      ...remaining.sublist(0, slot),
+      ...selected,
+      ...remaining.sublist(slot),
+    ];
+    // A move that lands everything back where it was is a no-op; return the
+    // original instance so `identical` checks (edit commit, history) skip it.
+    for (var i = 0; i < frames.length; i++) {
+      if (!identical(result[i], frames[i])) return result;
+    }
+    return frames;
+  }
+
+  /// [frames] with every still at [indexes] held for [framesPerImage] output
+  /// frames, each marked as an individual override (see [setFrameHold]).
+  /// Out-of-range indexes are ignored.
+  static List<StopMotionClipFrame> setFramesHold(
+    List<StopMotionClipFrame> frames,
+    Set<int> indexes,
+    int framesPerImage,
+  ) {
+    if (indexes.isEmpty) return frames;
+    final duration = framesPerImageToDuration(framesPerImage);
+    return [
+      for (var i = 0; i < frames.length; i++)
+        indexes.contains(i)
+            ? frames[i].copyWith(duration: duration, holdOverridden: true)
+            : frames[i],
+    ];
+  }
+
+  /// Applies [framesPerImage] as the global default: every still that has *not*
+  /// been individually overridden ([StopMotionClipFrame.holdOverridden]) is set
+  /// to that hold; overridden stills keep their own hold.
+  static List<StopMotionClipFrame> setGlobalHold(
+    List<StopMotionClipFrame> frames,
+    int framesPerImage,
+  ) {
+    final duration = framesPerImageToDuration(framesPerImage);
+    return [
+      for (final frame in frames)
+        frame.holdOverridden ? frame : frame.copyWith(duration: duration),
+    ];
+  }
+
+  /// The global-default frames-per-image: the value shared by every
+  /// *non-overridden* still. When there are no non-overridden stills or they
+  /// disagree (merged sets, all stills individually overridden), falls back to
+  /// the most common hold across *all* stills — ties broken by first
+  /// occurrence — so the global control always displays a value.
+  static int globalDefaultFramesPerImage(List<StopMotionClipFrame> frames) {
+    int? shared;
+    var agree = true;
+    final counts = <int, int>{};
+    for (final frame in frames) {
+      final framesPerImage = durationToFramesPerImage(frame.duration);
+      counts[framesPerImage] = (counts[framesPerImage] ?? 0) + 1;
+      if (frame.holdOverridden) continue;
+      if (shared == null) {
+        shared = framesPerImage;
+      } else if (shared != framesPerImage) {
+        agree = false;
+      }
+    }
+    if (shared != null && agree) return shared;
+    var best = defaultFramesPerImage;
+    var bestCount = 0;
+    for (final entry in counts.entries) {
+      if (entry.value > bestCount) {
+        best = entry.key;
+        bestCount = entry.value;
+      }
+    }
+    return best;
+  }
+
+  /// [clip] with its stop-motion [frames] replaced and its cached [duration]
+  /// recomputed from the new frame holds.
+  static DivineVideoClip clipWithFrames(
+    DivineVideoClip clip,
+    List<StopMotionClipFrame> frames,
+  ) {
+    return clip.copyWith(
+      stopMotionFrames: frames,
+      duration: totalDuration(frames),
+    );
+  }
+
+  /// [frames] whose image file still exists on disk and is non-empty.
+  ///
+  /// Captured stills can go missing (file cleanup) or corrupt (an interrupted
+  /// capture leaves an empty file); such frames render as broken tiles and
+  /// fail the publish render, so session-entry points filter them out.
+  static List<StopMotionClipFrame> existingFrames(
+    List<StopMotionClipFrame> frames,
+  ) {
+    return [
+      for (final frame in frames)
+        if (_isReadableImage(frame.path)) frame,
+    ];
+  }
+
+  static bool _isReadableImage(String path) {
+    try {
+      final file = File(path);
+      return file.existsSync() && file.lengthSync() > 0;
+    } on FileSystemException {
+      return false;
+    }
+  }
+
+  /// [clip] with unreadable stills dropped (see [existingFrames]), or `null`
+  /// when no readable still remains. Normal video clips pass through
+  /// unchanged.
+  static DivineVideoClip? sanitizedClip(DivineVideoClip clip) {
+    final frames = clip.stopMotionFrames;
+    if (frames == null) return clip;
+    final readable = existingFrames(frames);
+    if (readable.length == frames.length) return clip;
+    if (readable.isEmpty) return null;
+    return clipWithFrames(clip, readable);
+  }
+
+  /// Collapses multiple stop-motion [clips] into one frames clip — the first
+  /// clip with every set's stills concatenated in selection order (and the
+  /// duration recomputed).
+  ///
+  /// The frame-first editor (strip, preview, hold controls) edits exactly one
+  /// frames clip, the same shape a recorder session produces, so a multi-set
+  /// library selection must enter the editor as a single clip. Returns `null`
+  /// when merging does not apply: fewer than two clips, or any normal video
+  /// clip in the list.
+  static DivineVideoClip? mergeClips(List<DivineVideoClip> clips) {
+    if (clips.length < 2) return null;
+    if (!clips.every((clip) => clip.isStopMotion)) return null;
+    return clipWithFrames(clips.first, [
+      for (final clip in clips) ...clip.stopMotionFrames!,
+    ]);
+  }
+}
+
+/// Whether every clip in [clips] is a frames-only stop-motion clip, so the
+/// editor should switch to frame-first editing.
+bool isStopMotionComposition(List<DivineVideoClip> clips) =>
+    clips.isNotEmpty && clips.every((clip) => clip.isStopMotion);

--- a/mobile/lib/models/stop_motion_clip_frame.dart
+++ b/mobile/lib/models/stop_motion_clip_frame.dart
@@ -60,17 +60,30 @@ class StopMotionClipFrame {
     String documentsPath, {
     bool useOriginalPath = false,
   }) {
+    // Validate up front and throw a typed [FormatException] — the same contract
+    // as [DivineVideoClip.fromJson] — so the loader can skip a single corrupt
+    // frame row instead of a raw `TypeError` aborting the whole library/draft
+    // load with a cryptic `Null is not a subtype of String`.
+    final rawPath = json['path'] as String?;
     final durationUs = json['durationUs'] as int?;
+    final durationMs = json['durationMs'] as int?;
+    if (rawPath == null || (durationUs == null && durationMs == null)) {
+      throw const FormatException(
+        'StopMotionClipFrame JSON is missing a required field '
+        '(path and a duration [durationUs or durationMs]); cannot '
+        'reconstruct the frame.',
+      );
+    }
     return StopMotionClipFrame(
       path: resolvePath(
-        json['path'] as String,
+        rawPath,
         documentsPath,
         useOriginalPath: useOriginalPath,
       )!,
       duration: durationUs != null
           // Fallback: clips persisted before the microsecond key existed.
           ? Duration(microseconds: durationUs)
-          : Duration(milliseconds: json['durationMs'] as int),
+          : Duration(milliseconds: durationMs!),
       // Absent for clips saved before per-frame holds existed → follows global.
       holdOverridden: json['holdOverridden'] as bool? ?? false,
     );

--- a/mobile/lib/models/stop_motion_clip_frame.dart
+++ b/mobile/lib/models/stop_motion_clip_frame.dart
@@ -1,0 +1,93 @@
+// ABOUTME: One captured still in a stop-motion clip (image path + hold time)
+// ABOUTME: Source-of-truth frame for a frames-based DivineVideoClip
+
+import 'package:openvine/utils/path_resolver.dart';
+import 'package:path/path.dart' as p;
+
+/// A single captured still in a stop-motion clip, together with how long it is
+/// held during playback.
+///
+/// Deliberately distinct from `pro_video_editor`'s `StopMotionFrame` (which
+/// wraps an editor layer image): this is the persisted, source-of-truth frame
+/// for a frames-based [DivineVideoClip]. Per-frame [duration] can vary; the
+/// global "frames per image" control is a *default* that only rewrites frames
+/// whose hold has not been set individually — see [holdOverridden].
+class StopMotionClipFrame {
+  const StopMotionClipFrame({
+    required this.path,
+    required this.duration,
+    this.holdOverridden = false,
+  });
+
+  /// Absolute path to the captured JPEG still.
+  final String path;
+
+  /// How long this frame is held during playback.
+  final Duration duration;
+
+  /// Whether the user set this frame's hold individually. When `true`, the
+  /// global frames-per-image control leaves it untouched; when `false`, the
+  /// frame follows the global default.
+  final bool holdOverridden;
+
+  StopMotionClipFrame copyWith({
+    String? path,
+    Duration? duration,
+    bool? holdOverridden,
+  }) => StopMotionClipFrame(
+    path: path ?? this.path,
+    duration: duration ?? this.duration,
+    holdOverridden: holdOverridden ?? this.holdOverridden,
+  );
+
+  /// Serializes to JSON, storing only the basename for iOS path stability
+  /// (mirrors [DivineVideoClip.toJson]).
+  ///
+  /// The hold is stored in microseconds: frame holds are fractions of the
+  /// output frame grid (2 frames @ 24fps = 83333µs) and a millisecond
+  /// round-trip would silently shift them off the grid — and make history
+  /// snapshots compare unequal to the live clip state on every sync.
+  Map<String, dynamic> toJson() => {
+    'path': p.basename(path),
+    'durationUs': duration.inMicroseconds,
+    'holdOverridden': holdOverridden,
+  };
+
+  /// Restores a frame, resolving [path] against [documentsPath] the same way
+  /// [DivineVideoClip.fromJson] resolves clip file paths.
+  factory StopMotionClipFrame.fromJson(
+    Map<String, dynamic> json,
+    String documentsPath, {
+    bool useOriginalPath = false,
+  }) {
+    final durationUs = json['durationUs'] as int?;
+    return StopMotionClipFrame(
+      path: resolvePath(
+        json['path'] as String,
+        documentsPath,
+        useOriginalPath: useOriginalPath,
+      )!,
+      duration: durationUs != null
+          // Fallback: clips persisted before the microsecond key existed.
+          ? Duration(microseconds: durationUs)
+          : Duration(milliseconds: json['durationMs'] as int),
+      // Absent for clips saved before per-frame holds existed → follows global.
+      holdOverridden: json['holdOverridden'] as bool? ?? false,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is StopMotionClipFrame &&
+      other.path == path &&
+      other.duration == duration &&
+      other.holdOverridden == holdOverridden;
+
+  @override
+  int get hashCode => Object.hash(path, duration, holdOverridden);
+
+  @override
+  String toString() =>
+      'StopMotionClipFrame(path: $path, duration: $duration, '
+      'holdOverridden: $holdOverridden)';
+}

--- a/mobile/lib/models/video_recorder/video_recorder_mode.dart
+++ b/mobile/lib/models/video_recorder/video_recorder_mode.dart
@@ -3,9 +3,9 @@ import 'package:models/models.dart' as model show AspectRatio;
 enum VideoRecorderMode {
   upload,
   capture,
+  stopMotion,
   lipSync,
-  classic,
-  ;
+  classic;
 
   /// SharedPreferences key for the last-used recorder mode.
   ///
@@ -21,6 +21,7 @@ enum VideoRecorderMode {
   String get label => switch (this) {
     .upload => 'Upload',
     .capture => 'Capture',
+    .stopMotion => 'Stop Motion',
     .lipSync => 'Lip Sync',
     .classic => 'Classic',
   };
@@ -28,6 +29,7 @@ enum VideoRecorderMode {
   bool get hasRecordingLimit => switch (this) {
     .upload => false,
     .capture => false,
+    .stopMotion => false,
     .lipSync => false,
     .classic => true,
   };
@@ -35,6 +37,7 @@ enum VideoRecorderMode {
   bool get hasVideoEditor => switch (this) {
     .upload => false,
     .capture => true,
+    .stopMotion => true,
     .lipSync => true,
     .classic => false,
   };
@@ -42,6 +45,7 @@ enum VideoRecorderMode {
   bool get supportGridLines => switch (this) {
     .upload => false,
     .capture => false,
+    .stopMotion => true,
     .lipSync => false,
     .classic => true,
   };
@@ -49,6 +53,15 @@ enum VideoRecorderMode {
   bool get supportsCountdownTimer => switch (this) {
     .upload => false,
     .capture => true,
+    .stopMotion => false,
+    .lipSync => true,
+    .classic => false,
+  };
+
+  bool get supportsVideoStabilization => switch (this) {
+    .upload => false,
+    .capture => true,
+    .stopMotion => false,
     .lipSync => true,
     .classic => false,
   };
@@ -56,7 +69,12 @@ enum VideoRecorderMode {
   model.AspectRatio get defaultAspectRatio => switch (this) {
     .upload => .vertical,
     .capture => .vertical,
+    .stopMotion => .vertical,
     .lipSync => .vertical,
     .classic => .square,
   };
+
+  /// Whether this mode captures still photos (stop-motion) instead of
+  /// recording video. Drives the shutter behavior and capture UI.
+  bool get capturesStills => this == stopMotion;
 }

--- a/mobile/lib/providers/clip_manager_provider.dart
+++ b/mobile/lib/providers/clip_manager_provider.dart
@@ -11,6 +11,7 @@ import 'package:models/models.dart' as model show AspectRatio;
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/models/clip_manager_state.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/providers/database_provider.dart';
 import 'package:openvine/providers/social_providers.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
@@ -264,6 +265,60 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
     return clip;
   }
 
+  /// Adds a frames-based stop-motion clip to the manager.
+  ///
+  /// The captured stills ([frames]) are the clip's source of truth; no mp4
+  /// exists yet — the editor previews the frames via the stop-motion player and
+  /// an mp4 is rendered only at publish. Trimming and proof generation are
+  /// skipped (both operate on a rendered video).
+  DivineVideoClip addStopMotionClip({
+    required List<StopMotionClipFrame> frames,
+    required double originalAspectRatio,
+    required model.AspectRatio targetAspectRatio,
+    required Duration duration,
+    String? id,
+    String? thumbnailPath,
+    CameraLensMetadata? lensMetadata,
+  }) {
+    // A new clip supersedes any pending undo from a previous tap.
+    if (state.pendingDeletion != null) {
+      _cancelPendingDeletionTimer();
+      unawaited(_commitPendingDeletion());
+    }
+
+    final clip = DivineVideoClip(
+      // Reuse the session id when the frames were already persisted to the
+      // library during capture, so assembling updates that row instead of
+      // creating a second one.
+      id:
+          id ??
+          'clip_${DateTime.now().millisecondsSinceEpoch}_${_clipCounter++}',
+      stopMotionFrames: frames,
+      duration: duration,
+      recordedAt: .now(),
+      thumbnailPath: thumbnailPath,
+      targetAspectRatio: targetAspectRatio,
+      originalAspectRatio: originalAspectRatio,
+      lensMetadata: lensMetadata,
+    );
+
+    _clips.add(clip);
+    Log.info(
+      '📎 Added stop-motion clip: ${clip.id}, ${frames.length} frame(s)',
+      name: 'ClipManagerNotifier',
+      category: .video,
+    );
+
+    state = state.copyWith(
+      clips: List.unmodifiable(_clips),
+      activeRecordingDuration: .zero,
+    );
+
+    _triggerAutosave();
+
+    return clip;
+  }
+
   /// Generates a ProofMode / C2PA attestation for a single clip.
   ///
   /// Waits for any pending processing (e.g. trimming) to finish first,
@@ -274,7 +329,7 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
       // Wait for trimming to finish before proofing the final file
       await clip.processingCompleter?.future;
 
-      final videoFile = clip.video.file;
+      final videoFile = clip.video?.file;
       if (videoFile == null) return;
 
       Log.debug(
@@ -918,6 +973,53 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
         stackTrace: stackTrace,
       );
       return false;
+    }
+  }
+
+  /// Persists the in-progress stop-motion capture session as a single library
+  /// clip so the recording is preserved the instant it is shot — before the
+  /// user assembles it and opens the editor.
+  ///
+  /// [id] is stable for the lifetime of a capture session (derived from the
+  /// first frame), so repeated calls upsert the same library row as frames are
+  /// added. Assembling later reuses the same [id] (see [addStopMotionClip]),
+  /// updating this row rather than creating a duplicate.
+  ///
+  /// Returns true if the row was saved.
+  Future<bool> saveStopMotionSessionToLibrary({
+    required String id,
+    required List<StopMotionClipFrame> frames,
+    required double originalAspectRatio,
+    required model.AspectRatio targetAspectRatio,
+    required Duration duration,
+    String? thumbnailPath,
+    CameraLensMetadata? lensMetadata,
+  }) {
+    final clip = DivineVideoClip(
+      id: id,
+      stopMotionFrames: frames,
+      duration: duration,
+      recordedAt: DateTime.now(),
+      thumbnailPath: thumbnailPath,
+      targetAspectRatio: targetAspectRatio,
+      originalAspectRatio: originalAspectRatio,
+      lensMetadata: lensMetadata,
+    );
+    return saveClipToLibrary(clip);
+  }
+
+  /// Removes an abandoned stop-motion session's library row (its frames were
+  /// all undone). Deletes the row only; the frame files are owned and cleaned
+  /// up by the recorder.
+  Future<void> removeStopMotionSessionFromLibrary(String id) async {
+    try {
+      await ref.read(clipLibraryServiceProvider).deleteClipRow(id);
+    } catch (e) {
+      Log.warning(
+        '⚠️ Failed to remove stop-motion session $id from library: $e',
+        name: 'ClipManagerNotifier',
+        category: .video,
+      );
     }
   }
 }

--- a/mobile/lib/providers/clip_manager_provider.dart
+++ b/mobile/lib/providers/clip_manager_provider.dart
@@ -283,7 +283,7 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
     // A new clip supersedes any pending undo from a previous tap.
     if (state.pendingDeletion != null) {
       _cancelPendingDeletionTimer();
-      unawaited(_commitPendingDeletion());
+      unawaited(commitPendingDeletion());
     }
 
     final clip = DivineVideoClip(

--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -941,6 +941,22 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
         continue;
       }
 
+      // Stop-motion clips have no video to extract from; their first still is
+      // already a usable thumbnail image. Repair from it instead of reaching
+      // for requireVideo, which throws on a frames-only clip.
+      if (clip.isStopMotion) {
+        final frames = clip.stopMotionFrames;
+        final firstFramePath = frames != null && frames.isNotEmpty
+            ? frames.first.path
+            : null;
+        clipsWithThumbnails.add(
+          firstFramePath != null
+              ? clip.copyWith(thumbnailPath: firstFramePath)
+              : clip,
+        );
+        continue;
+      }
+
       Log.info(
         '🖼️ Regenerating thumbnail for clip ${clip.id}',
         name: 'VideoEditorNotifier',

--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -16,6 +16,7 @@ import 'package:openvine/extensions/complete_parameters_extensions.dart';
 import 'package:openvine/models/content_label.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/divine_video_draft.dart';
+import 'package:openvine/models/stop_motion/stop_motion_frame_ops.dart';
 import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
 import 'package:openvine/models/video_metadata/video_metadata_expiration.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
@@ -910,9 +911,15 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
     // carry it. Restoring such a clip hands a dead path to the native player,
     // which fails the whole composition (COMPOSITION_ERROR) and freezes the
     // editor — so an orphaned clip must never re-enter the timeline.
-    final restorableClips = draft.clips
-        .where((clip) => clip.hasResolvableVideoFile)
-        .toList();
+    // Stop-motion clips are salvaged per still instead: unreadable frames
+    // are dropped and the clip survives while one readable still remains.
+    final restorableClips = [
+      for (final clip in draft.clips)
+        if (clip.isStopMotion)
+          ?StopMotionFrameOps.sanitizedClip(clip)
+        else if (clip.hasResolvableVideoFile)
+          clip,
+    ];
     if (restorableClips.length != draft.clips.length) {
       Log.warning(
         '⚠️ Dropped ${draft.clips.length - restorableClips.length} clip(s) '
@@ -940,7 +947,7 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
         category: LogCategory.video,
       );
 
-      final videoPath = clip.video.file!.path;
+      final videoPath = clip.requireVideo.file!.path;
       final result = await VideoThumbnailService.extractThumbnail(
         videoPath: videoPath,
         targetTimestamp: clip.thumbnailTimestamp,

--- a/mobile/lib/providers/video_publish_provider.dart
+++ b/mobile/lib/providers/video_publish_provider.dart
@@ -42,6 +42,7 @@ import 'package:openvine/services/draft_storage_service.dart';
 import 'package:openvine/services/mention_resolution_service.dart';
 import 'package:openvine/services/native_proofmode_service.dart';
 import 'package:openvine/services/nostr_creator_binding_service.dart';
+import 'package:openvine/services/video_editor/stop_motion_render_service.dart';
 import 'package:openvine/services/video_editor/video_editor_render_service.dart';
 import 'package:openvine/services/video_publish/publish_error_kind.dart';
 import 'package:openvine/services/video_publish/video_publish_service.dart';
@@ -243,9 +244,14 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
 
     for (final draft in pendingDrafts) {
       // Check if video file still exists before attempting resume
-      if (!kIsWeb && draft.clips.isNotEmpty) {
+      // Stop-motion drafts have no rendered video until publish, so there is
+      // no file to verify here — skip the existence check for them.
+      final firstClipVideo = draft.clips.isNotEmpty
+          ? draft.clips.first.video
+          : null;
+      if (!kIsWeb && firstClipVideo != null) {
         try {
-          final videoPath = await draft.clips.first.video.safeFilePath();
+          final videoPath = await firstClipVideo.safeFilePath();
           final videoFile = File(videoPath);
           if (!videoFile.existsSync()) {
             Log.warning(
@@ -374,9 +380,48 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
       DivineVideoClip? finalRenderedClip = draft.finalRenderedClip;
       String? proofManifestJson = draft.proofManifestJson;
 
+      // Stop-motion clips are stored as frames; render them to an mp4 (≥1s)
+      // on demand here so every downstream consumer sees a normal video clip.
+      // The failure copy is read up front (before any await, so no
+      // BuildContext-across-async-gap) but only when a stop-motion render is
+      // actually needed — a normal publish never depends on l10n being wired
+      // up, and materialize is a no-op passthrough for a clip that already
+      // has a video.
+      final needsStopMotionRender =
+          (finalRenderedClip?.isStopMotion ?? false) ||
+          (finalRenderedClip == null &&
+              draft.clips.length == 1 &&
+              draft.clips.first.isStopMotion);
+      final stopMotionFailedMessage = needsStopMotionRender
+          ? context.l10n.videoRecorderStopMotionAssembleFailed
+          : null;
+
+      if (finalRenderedClip != null && finalRenderedClip.isStopMotion) {
+        final materialized = await StopMotionRenderService.materialize(
+          finalRenderedClip,
+        );
+        if (materialized == null) {
+          setError(stopMotionFailedMessage!);
+          return;
+        }
+        finalRenderedClip = materialized;
+      }
+
       if (finalRenderedClip == null) {
         if (draft.clips.length == 1) {
-          finalRenderedClip = draft.clips.first;
+          final singleClip = draft.clips.first;
+          if (singleClip.isStopMotion) {
+            final materialized = await StopMotionRenderService.materialize(
+              singleClip,
+            );
+            if (materialized == null) {
+              setError(stopMotionFailedMessage!);
+              return;
+            }
+            finalRenderedClip = materialized;
+          } else {
+            finalRenderedClip = singleClip;
+          }
         } else {
           // Multiple clips without rendered output - render now
           Log.info(
@@ -634,7 +679,7 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
     required DivineVideoClip clip,
     String? existingProofManifestJson,
   }) async {
-    final filePath = await clip.video.safeFilePath();
+    final filePath = await clip.requireVideo.safeFilePath();
 
     Log.info(
       '🔐 Generating proof manifest for video',

--- a/mobile/lib/router/providers/page_context_provider.dart
+++ b/mobile/lib/router/providers/page_context_provider.dart
@@ -276,7 +276,13 @@ RouteContext? parseKnownRoute(String path) {
 }
 
 RouteContext? _parseRoute(String path, {required bool knownOnly}) {
-  final pathOnly = path.split('#').first.split('?').first;
+  // Callers pass full router locations, which may carry query parameters
+  // (e.g. /clips-only?type=video). Segment matching below must only ever see
+  // the path portion — otherwise the last segment becomes
+  // "clips-only?type=video", matches nothing, and the route falls through to
+  // the RouteType.home fallback (which the normalizer then "corrects" by
+  // yanking the user to /home/0).
+  final pathOnly = Uri.tryParse(path)?.path ?? path;
   final segments = pathOnly.split('/').where((s) => s.isNotEmpty).toList();
 
   if (segments.isEmpty) {

--- a/mobile/lib/router/providers/route_normalization_provider.dart
+++ b/mobile/lib/router/providers/route_normalization_provider.dart
@@ -66,7 +66,8 @@ final routeNormalizationProvider = Provider<void>((ref) {
 
   // Set up listener on router delegate to detect navigation changes
   void listener() {
-    final loc = router.routeInformationProvider.value.uri.toString();
+    final uri = router.routeInformationProvider.value.uri;
+    final loc = uri.toString();
     if (shouldSkipRouteNormalization(loc)) {
       Log.info(
         '🔄 RouteNormalizationProvider: skipping normalization for $loc',
@@ -77,24 +78,32 @@ final routeNormalizationProvider = Provider<void>((ref) {
 
     // Parse and rebuild to get canonical form. Unknown or incomplete routes
     // are left to GoRouter instead of being rewritten to home.
-    final parsed = parseKnownRoute(loc);
+    // Only the *path* is normalized; query parameters are route input
+    // (e.g. the library's ?type= clip filter) and must survive untouched.
+    final parsed = parseKnownRoute(uri.path);
     if (parsed == null) {
       return;
     }
-    final canonical = buildRoute(parsed);
+    final canonicalPath = buildRoute(parsed);
 
     // If not canonical, schedule post-frame redirect
-    if (canonical != loc) {
+    if (canonicalPath != uri.path) {
       SchedulerBinding.instance.addPostFrameCallback((_) {
-        // Check again before redirecting to avoid loops if location changed
-        final now = router.routeInformationProvider.value.uri.toString();
-        if (now != canonical) {
-          Log.info(
-            '🔄 Normalizing route from $now to $canonical',
-            name: 'RouteNormalizationProvider',
-          );
-          router.go(canonical);
-        }
+        // Re-check before redirecting: skip when navigation moved on in the
+        // meantime (redirecting then would yank the user off the new route)
+        // or the location already became canonical.
+        final now = router.routeInformationProvider.value.uri;
+        if (now.toString() != loc || now.path == canonicalPath) return;
+
+        final canonical = Uri(
+          path: canonicalPath,
+          query: now.query.isEmpty ? null : now.query,
+        ).toString();
+        Log.info(
+          '🔄 Normalizing route from $now to $canonical',
+          name: 'RouteNormalizationProvider',
+        );
+        router.go(canonical);
       });
     }
   }

--- a/mobile/lib/router/routes/library_routes.dart
+++ b/mobile/lib/router/routes/library_routes.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Split from app_router.dart (#4508)
 
 import 'package:go_router/go_router.dart';
+import 'package:openvine/blocs/clips_library/clips_library_bloc.dart';
 import 'package:openvine/router/fade_upwards_page.dart';
 import 'package:openvine/screens/library_screen.dart';
 
@@ -26,7 +27,14 @@ List<RouteBase> libraryRoutes() {
       name: LibraryScreen.clipsOnlyRouteName,
       pageBuilder: (_, state) => fadeUpwardsPage(
         state: state,
-        child: const LibraryScreen(tabsMode: LibraryTabsMode.clipsOnly),
+        // `type` scopes the clips to the recorder's mode (stop-motion vs normal);
+        // absent → both types (the standalone default).
+        child: LibraryScreen(
+          tabsMode: LibraryTabsMode.clipsOnly,
+          clipTypeFilter: LibraryClipTypeFilter.fromQuery(
+            state.uri.queryParameters['type'],
+          ),
+        ),
       ),
     ),
     GoRoute(

--- a/mobile/lib/screens/library_screen.dart
+++ b/mobile/lib/screens/library_screen.dart
@@ -11,6 +11,7 @@ import 'package:openvine/blocs/clips_library/clips_library_bloc.dart';
 import 'package:openvine/blocs/drafts_library/drafts_library_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/stop_motion/stop_motion_frame_ops.dart';
 import 'package:openvine/models/video_publish/video_publish_state.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
@@ -55,6 +56,7 @@ class LibraryScreen extends ConsumerWidget {
     this.initialTabIndex = 0,
     this.selectionMode = false,
     this.tabsMode = LibraryTabsMode.allTabs,
+    this.clipTypeFilter = LibraryClipTypeFilter.all,
     this.editorClips = const [],
     this.scrollController,
   });
@@ -76,6 +78,11 @@ class LibraryScreen extends ConsumerWidget {
   /// Controls whether all tabs are shown or only the clips content.
   final LibraryTabsMode tabsMode;
 
+  /// Restricts which clip types the clips tab shows. Set by the recorder
+  /// entry-point to the current mode's type (stop-motion vs normal video);
+  /// [LibraryClipTypeFilter.all] for the standalone library.
+  final LibraryClipTypeFilter clipTypeFilter;
+
   /// Current editor clips, used to calculate remaining duration and
   /// target aspect ratio in selection mode.
   final List<DivineVideoClip> editorClips;
@@ -96,7 +103,11 @@ class LibraryScreen extends ConsumerWidget {
     return MultiBlocProvider(
       providers: [
         BlocProvider<ClipsLibraryBloc>(
-          key: ValueKey((clipLibraryService, gallerySaveService)),
+          key: ValueKey((
+            clipLibraryService,
+            gallerySaveService,
+            clipTypeFilter,
+          )),
           create: (_) {
             final editorClipIds = selectionMode
                 ? editorClips.map((c) => c.id).toSet()
@@ -105,6 +116,7 @@ class LibraryScreen extends ConsumerWidget {
               clipLibraryService: clipLibraryService,
               gallerySaveService: gallerySaveService,
               sharedPreferences: ref.read(sharedPreferencesProvider),
+              clipTypeFilter: clipTypeFilter,
             )..add(
               ClipsLibraryLoadRequested(
                 preSelectedIds: editorClipIds,
@@ -313,7 +325,16 @@ class _LibraryViewState extends ConsumerState<_LibraryView>
       await ref.read(videoPublishProvider.notifier).clearAll();
 
       final clipManagerNotifier = ref.read(clipManagerProvider.notifier);
-      for (final clip in selectedClips) {
+      // Drop unreadable stills (deleted / zero-byte captures), then collapse
+      // multiple stop-motion sets into one frames clip: the frame-first
+      // editor edits a single frames list (the shape a recorder session
+      // produces), so each set's stills line up on one timeline.
+      final usableClips = [
+        for (final clip in selectedClips)
+          ?StopMotionFrameOps.sanitizedClip(clip),
+      ];
+      final merged = StopMotionFrameOps.mergeClips(usableClips);
+      for (final clip in merged != null ? [merged] : usableClips) {
         clipManagerNotifier.insertClip(clipManagerNotifier.clips.length, clip);
       }
     }

--- a/mobile/lib/screens/video_editor/video_clip_transform_screen.dart
+++ b/mobile/lib/screens/video_editor/video_clip_transform_screen.dart
@@ -46,7 +46,7 @@ class _VideoClipTransformScreenState extends State<VideoClipTransformScreen> {
   }
 
   Future<void> _initialize() async {
-    final path = widget.clip.video.file?.path;
+    final path = widget.clip.requireVideo.file?.path;
     if (path == null) {
       Log.warning(
         '⚠️ Transform preview skipped: clip ${widget.clip.id} has no file',
@@ -59,7 +59,7 @@ class _VideoClipTransformScreenState extends State<VideoClipTransformScreen> {
 
     try {
       final metadata = await ProVideoEditor.instance.getMetadata(
-        widget.clip.video,
+        widget.clip.requireVideo,
       );
 
       final player = DivineVideoPlayerController(useTexture: true);

--- a/mobile/lib/screens/video_editor/video_editor_screen.dart
+++ b/mobile/lib/screens/video_editor/video_editor_screen.dart
@@ -10,6 +10,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:models/models.dart';
+import 'package:openvine/blocs/clips_library/clips_library_bloc.dart';
 import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
 import 'package:openvine/blocs/video_editor/draw_editor/video_editor_draw_bloc.dart';
 import 'package:openvine/blocs/video_editor/filter_editor/video_editor_filter_bloc.dart';
@@ -25,7 +26,9 @@ import 'package:openvine/extensions/video_editor_history_extensions.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/mixins/codec_heavy_surface_guard.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/stop_motion/stop_motion_frame_ops.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
+import 'package:openvine/providers/social_providers.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/repositories/sticker_repository.dart';
 import 'package:openvine/screens/library_screen.dart';
@@ -302,12 +305,17 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen>
   /// clips can be rolled back if the user cancels (`result != true`).
   /// On success or cancel, calls [_syncClipsToEditor] to keep the
   /// [ClipEditorBloc] in sync.
-  Future<void> _openCamera({required ClipEditorBloc clipEditorBloc}) async {
-    final initialIds = ref
-        .read(clipManagerProvider)
-        .clips
-        .map((c) => c.id)
-        .toSet();
+  Future<void> _openCamera({
+    required ClipEditorBloc clipEditorBloc,
+    required Duration playhead,
+  }) async {
+    final initialClips = ref.read(clipManagerProvider).clips;
+    final initialIds = initialClips.map((c) => c.id).toSet();
+    // A stop-motion composition adds the new stills into its single frames clip
+    // at the playhead; a normal composition just keeps the appended clip.
+    final stopMotionTarget = isStopMotionComposition(initialClips)
+        ? initialClips.first
+        : null;
 
     final result = await Navigator.push<bool>(
       context,
@@ -322,19 +330,74 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen>
       ),
     );
 
+    final notifier = ref.read(clipManagerProvider.notifier);
     if (result != true) {
-      final notifier = ref.read(clipManagerProvider.notifier);
-      final newClips = ref
-          .read(clipManagerProvider)
-          .clips
+      final newClips = notifier.clips
           .where((c) => !initialIds.contains(c.id))
           .toList();
       for (final clip in newClips) {
         await notifier.removeClipById(clip.id);
       }
+    } else if (stopMotionTarget != null) {
+      await _insertCapturedStopMotionFrames(
+        target: stopMotionTarget,
+        initialIds: initialIds,
+        playhead: playhead,
+      );
     }
 
     _syncClipsToEditor(clipEditorBloc: clipEditorBloc);
+  }
+
+  /// Splices stills captured over a stop-motion composition into its frames
+  /// clip [target] at the [playhead] position, then drops the throwaway clip
+  /// (and its library row) the recorder created for the capture session.
+  Future<void> _insertCapturedStopMotionFrames({
+    required DivineVideoClip target,
+    required Set<String> initialIds,
+    required Duration playhead,
+  }) async {
+    final notifier = ref.read(clipManagerProvider.notifier);
+    final clips = notifier.clips;
+    final added = clips
+        .where((c) => !initialIds.contains(c.id) && c.isStopMotion)
+        .toList();
+    final capturedFrames = [
+      for (final clip in added) ...?clip.stopMotionFrames,
+    ];
+    if (capturedFrames.isEmpty) return;
+
+    final targetFrames = target.stopMotionFrames ?? const [];
+    // Fresh captures arrive with the app default hold; adopt the session's
+    // global default so they don't drift from the stills already in the clip.
+    final newFrames = StopMotionFrameOps.setGlobalHold(
+      capturedFrames,
+      StopMotionFrameOps.globalDefaultFramesPerImage(targetFrames),
+    );
+    final index = StopMotionFrameOps.insertIndexAtPosition(
+      targetFrames,
+      playhead,
+    );
+    final merged = StopMotionFrameOps.clipWithFrames(
+      target,
+      StopMotionFrameOps.insertFramesAt(targetFrames, index, newFrames),
+    );
+
+    final addedIds = added.map((c) => c.id).toSet();
+    notifier.replaceClips([
+      for (final clip in clips)
+        if (clip.id == target.id)
+          merged
+        else if (!addedIds.contains(clip.id))
+          clip,
+    ]);
+
+    // The recorder saved each capture session as its own library set; those
+    // stills now live in [target], so drop the throwaway rows (files kept).
+    final libraryService = ref.read(clipLibraryServiceProvider);
+    for (final id in addedIds) {
+      await libraryService.deleteClipRow(id);
+    }
   }
 
   Future<void> _openClipsEditor({
@@ -347,6 +410,12 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen>
       ..add(const VideoEditorExternalPauseRequested(isPaused: true));
     final currentClips = ref.read(clipManagerProvider).clips;
 
+    // Clip types can't be mixed in one composition, so the picker only
+    // offers the type the session already edits.
+    final clipTypeFilter = isStopMotionComposition(currentClips)
+        ? LibraryClipTypeFilter.stopMotion
+        : LibraryClipTypeFilter.video;
+
     final newClips = await VineBottomSheet.show<List<DivineVideoClip>>(
       context: context,
       maxChildSize: 1,
@@ -355,6 +424,7 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen>
       buildScrollBody: (scrollController) => LibraryScreen(
         initialTabIndex: 1,
         selectionMode: true,
+        clipTypeFilter: clipTypeFilter,
         editorClips: currentClips,
         scrollController: scrollController,
       ),
@@ -370,7 +440,22 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen>
       );
 
       final clipManager = ref.read(clipManagerProvider.notifier);
-      clipManager.addMultipleClips(newClips);
+      // Drop unreadable stills, then collapse stop-motion sets added to a
+      // stop-motion session into the session's single frames clip — the
+      // frame-first editor edits exactly one frames list (see
+      // StopMotionFrameOps.mergeClips).
+      final usableClips = [
+        for (final clip in newClips) ?StopMotionFrameOps.sanitizedClip(clip),
+      ];
+      final merged = StopMotionFrameOps.mergeClips([
+        ...ref.read(clipManagerProvider).clips,
+        ...usableClips,
+      ]);
+      if (merged != null) {
+        clipManager.replaceClips([merged]);
+      } else {
+        clipManager.addMultipleClips(usableClips);
+      }
 
       _syncClipsToEditor(clipEditorBloc: clipEditorBloc);
     }
@@ -795,8 +880,13 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen>
               bodySizeNotifier: _bodySizeNotifier,
               zoomMatrixNotifier: _zoomMatrixNotifier,
               fromLibrary: widget.fromLibrary,
-              onOpenCamera: () =>
-                  _openCamera(clipEditorBloc: context.read<ClipEditorBloc>()),
+              onOpenCamera: () => _openCamera(
+                clipEditorBloc: context.read<ClipEditorBloc>(),
+                playhead: context
+                    .read<VideoEditorMainBloc>()
+                    .state
+                    .currentPosition,
+              ),
               onOpenClipsEditor: () {
                 final mainBloc = context.read<VideoEditorMainBloc>();
                 final clipEditorBloc = context.read<ClipEditorBloc>();

--- a/mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart
@@ -86,7 +86,11 @@ class _VideoMetadataCoverScreenState
   }
 
   Future<void> _initializePlayer() async {
-    final localPath = await widget.clip.video.safeFilePath();
+    // Stop-motion clips have no scrubable video; their cover is the first
+    // captured frame (already set as the thumbnail).
+    final video = widget.clip.video;
+    if (video == null) return;
+    final localPath = await video.safeFilePath();
 
     if (!mounted) return;
 
@@ -241,14 +245,21 @@ class _VideoMetadataCoverScreenState
 
     var didSucceed = false;
     try {
-      final videoPath = await widget.clip.video.safeFilePath();
+      final video = widget.clip.video;
+      if (video == null) {
+        // Stop-motion: the cover is the first captured frame; nothing to
+        // re-extract. Close without changes.
+        if (mounted) Navigator.of(context).pop();
+        return;
+      }
+      final videoPath = await video.safeFilePath();
       if (videoPath.isNotEmpty) {
         final result = await VideoThumbnailService.extractThumbnail(
           videoPath: videoPath,
           targetTimestamp: _selectedPosition,
         );
         if (result != null && mounted) {
-          if (widget.clip.video.networkUrl != null) {
+          if (video.networkUrl != null) {
             // Published video — return the local path to the caller.
             // The Blossom upload and republish happen when the user presses Update.
             Navigator.of(context).pop(result.path);

--- a/mobile/lib/screens/video_metadata/video_metadata_preview_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_preview_screen.dart
@@ -13,6 +13,7 @@ import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/providers/video_publish_provider.dart';
 import 'package:openvine/screens/feed/feed_mode_switch.dart';
+import 'package:openvine/widgets/stop_motion/stop_motion_player.dart';
 import 'package:openvine/widgets/video_feed_item/video_feed_item.dart';
 import 'package:openvine/widgets/video_metadata/modes/capture/video_metadata_capture_bottom_bar.dart';
 import 'package:openvine/widgets/video_metadata/modes/capture/video_metadata_capture_preview_thumbnail.dart';
@@ -79,11 +80,18 @@ class _VideoMetadataPreviewScreenState
   /// Creates a [DivineVideoPlayerController], initializes it, enables
   /// looping, and starts playback automatically.
   Future<void> _initializePlayer() async {
+    // Stop-motion clips play their frames via [StopMotionPlayer]; there is no
+    // video to load into the native player.
+    if (widget.clip.isStopMotion) return;
+
+    final video = widget.clip.video;
+    if (video == null) return;
+
     _controller = DivineVideoPlayerController(useTexture: true);
     if (mounted) await _controller!.initialize();
     if (mounted) {
       await _controller!.setSource(
-        VideoClip.file(await widget.clip.video.safeFilePath()),
+        VideoClip.file(await video.safeFilePath()),
       );
     }
     if (mounted) await _controller!.setLooping(looping: true);
@@ -150,6 +158,7 @@ class _VideoPreviewContent extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final aspectRatio = clip.targetAspectRatio.value;
+    final stopMotionFrames = clip.stopMotionFrames;
 
     // Hero animation from metadata screen
     return Hero(
@@ -161,10 +170,20 @@ class _VideoPreviewContent extends ConsumerWidget {
           aspectRatio: aspectRatio,
           child: ClipRRect(
             borderRadius: BorderRadius.circular(16),
-            child: DivineVideoPlayer(
-              controller: controller,
-              placeholder: VideoMetadataCapturePreviewThumbnail(clip: clip),
-            ),
+            child: stopMotionFrames != null
+                ? StopMotionPlayer(
+                    frames: stopMotionFrames,
+                    cacheHeight:
+                        (MediaQuery.sizeOf(context).height *
+                                MediaQuery.devicePixelRatioOf(context))
+                            .round(),
+                  )
+                : DivineVideoPlayer(
+                    controller: controller,
+                    placeholder: VideoMetadataCapturePreviewThumbnail(
+                      clip: clip,
+                    ),
+                  ),
           ),
         ),
       ),

--- a/mobile/lib/screens/video_metadata/video_metadata_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_screen.dart
@@ -135,8 +135,12 @@ class _VideoMetadataScreenState extends ConsumerState<VideoMetadataScreen> {
       child: GestureDetector(
         onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
         child: switch (recorderMode) {
-          // Lip-sync shares capture's editor + metadata flow.
-          .capture || .lipSync => const VideoMetadataCaptureStack(),
+          // Lip-sync shares capture's editor + metadata flow. Stop-motion
+          // produces a normal video clip, so it shares the same capture-mode
+          // metadata UI.
+          .capture ||
+          .stopMotion ||
+          .lipSync => const VideoMetadataCaptureStack(),
           .classic => const VideoMetadataClassicStack(),
           // Deliberately unreachable: upload mode has no record button, so no
           // clips can be created and the user cannot navigate to the metadata

--- a/mobile/lib/screens/video_recorder_screen.dart
+++ b/mobile/lib/screens/video_recorder_screen.dart
@@ -29,6 +29,7 @@ import 'package:openvine/widgets/video_recorder/modes/classic/video_recorder_cla
 import 'package:openvine/widgets/video_recorder/modes/lip_sync/video_recorder_lip_sync_stack.dart';
 import 'package:openvine/widgets/video_recorder/modes/upload/video_recorder_upload_stack.dart';
 import 'package:openvine/widgets/video_recorder/video_recorder_bottom_bar.dart';
+import 'package:openvine/widgets/video_recorder/video_recorder_library_button.dart';
 import 'package:openvine/widgets/video_recorder/video_recorder_navigation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -419,7 +420,11 @@ class _VideoRecorderViewState extends ConsumerState<VideoRecorderView>
                         (VideoRecorderBloc b) => b.state.recorderMode,
                       )) {
                         .upload => const VideoRecorderUploadStack(),
-                        .capture => VideoRecorderCaptureStack(
+                        // Stop-motion reuses the capture stack — each shutter
+                        // tap captures a still that becomes a 1-frame video
+                        // clip, so the capture flow (clips, library, editor,
+                        // ghost) applies unchanged.
+                        .capture || .stopMotion => VideoRecorderCaptureStack(
                           fromEditor: widget.fromEditor,
                         ),
                         .lipSync => const VideoRecorderLipSyncStack(),
@@ -434,7 +439,20 @@ class _VideoRecorderViewState extends ConsumerState<VideoRecorderView>
                       child: VideoRecorderBottomBar(),
                     )
                   else
-                    SizedBox(height: MediaQuery.viewPaddingOf(context).bottom),
+                    // Editor-hosted recorder: no mode wheel and no library
+                    // navigation, but the library button still renders as a
+                    // read-only capture counter (last still + count badge).
+                    const Padding(
+                      padding: .symmetric(vertical: 22),
+                      child: SafeArea(
+                        top: false,
+                        child: Row(
+                          children: [
+                            VideoRecorderLibraryButton(interactive: false),
+                          ],
+                        ),
+                      ),
+                    ),
                 ],
               ),
             ),

--- a/mobile/lib/services/clip_library_service.dart
+++ b/mobile/lib/services/clip_library_service.dart
@@ -283,8 +283,15 @@ class ClipLibraryService {
       category: LogCategory.video,
     );
 
+    // A set that went through the editor also has an autosave-draft copy
+    // (row id `<autoSaveId>:<clipId>`) which the library surfaces via
+    // getLibraryClips(includeAutosaveDraftId:). Remove it alongside the plain
+    // library row, or the DB row (and, since it still references the media, its
+    // source files) survives "empty trash" and reappears on the next reload.
+    final autosaveRowId = _autosaveDraftRowId(id);
     final clip = await getClipById(id);
-    if (clip == null) {
+    final autosaveClip = await getClipById(autosaveRowId);
+    if (clip == null && autosaveClip == null) {
       Log.info(
         '🗑️ Clip already deleted, skipping: $id',
         name: 'ClipLibraryService',
@@ -294,9 +301,12 @@ class ClipLibraryService {
     }
 
     await _clipsDao.deleteClip(id);
+    await _clipsDao.deleteClip(autosaveRowId);
 
-    await FileCleanupService.deleteRecordingClipFiles(
-      clip,
+    // Reap files only after both rows are gone, so a leftover row can't keep
+    // the media referenced.
+    await FileCleanupService.deleteRecordingClipsFiles(
+      [?clip, ?autosaveClip],
       draftsDao: _draftsDao,
       clipsDao: _clipsDao,
     );
@@ -387,7 +397,12 @@ class ClipLibraryService {
     final clips = [...activeClips, ...trashedClips];
 
     // Clear active + trashed library rows first, then delete files.
+    // clearLibraryClips only removes `draft_id IS NULL` rows, so the
+    // autosave-draft copies a set picks up in the editor (row id
+    // `<autoSaveId>:<clipId>`) — which getAllClips surfaces as library clips —
+    // would otherwise survive with their media. Drop those rows too.
     await _clipsDao.clearLibraryClips();
+    await _clipsDao.deleteClipsByDraftId(VideoEditorConstants.autoSaveId);
 
     // Delete files only if not referenced by drafts
     await FileCleanupService.deleteSavedClipsFiles(

--- a/mobile/lib/services/clip_library_service.dart
+++ b/mobile/lib/services/clip_library_service.dart
@@ -319,18 +319,26 @@ class ClipLibraryService {
         ownerPubkey: ownerPubkey,
       );
       final documentsPath = await getDocumentsPath();
-      final clips = <DivineVideoClip>[];
+      // A set that went through the editor has both a library row and an
+      // autosave-draft row; softDelete(clearDraftId: true) nulls draft_id on
+      // both, so both match the trashed (draftId IS NULL) query and parse to
+      // the same clip.id. Keep one per clip id — mirroring getAllClips — so a
+      // trashed set shows (and counts) exactly once. Rows arrive newest-deleted
+      // first, so the retained (first) entry keeps that ordering.
+      final byClipId = <String, DivineVideoClip>{};
       for (final row in rows) {
         final clip = _tryParseClipRow(
           row,
           documentsPath,
           label: 'trashed clip',
         );
-        if (clip != null) {
-          clips.add(clip.copyWith(deletedAt: row.deletedAt));
-        }
+        if (clip == null) continue;
+        byClipId.putIfAbsent(
+          clip.id,
+          () => clip.copyWith(deletedAt: row.deletedAt),
+        );
       }
-      return clips;
+      return byClipId.values.toList();
     } catch (e) {
       Log.error(
         '❌ Failed to load trashed clips: $e',

--- a/mobile/lib/services/clip_library_service.dart
+++ b/mobile/lib/services/clip_library_service.dart
@@ -4,6 +4,7 @@
 import 'dart:convert';
 
 import 'package:db_client/db_client.dart';
+import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/services/file_cleanup_service.dart';
 import 'package:openvine/services/video_thumbnail_service.dart';
@@ -61,8 +62,8 @@ class ClipLibraryService {
           durationMs: clip.duration.inMilliseconds,
           recordedAt: clip.recordedAt,
           data: json.encode(clip.toJson()),
-          filePath: clip.video.file?.path != null
-              ? p.basename(clip.video.file!.path)
+          filePath: clip.video?.file?.path != null
+              ? p.basename(clip.video!.file!.path)
               : null,
           thumbnailPath: clip.thumbnailPath != null
               ? p.basename(clip.thumbnailPath!)
@@ -112,8 +113,8 @@ class ClipLibraryService {
       durationMs: clip.duration.inMilliseconds,
       recordedAt: clip.recordedAt,
       data: json.encode(clip.toJson()),
-      filePath: clip.video.file?.path != null
-          ? p.basename(clip.video.file!.path)
+      filePath: clip.video?.file?.path != null
+          ? p.basename(clip.video!.file!.path)
           : null,
       thumbnailPath: clip.thumbnailPath != null
           ? p.basename(clip.thumbnailPath!)
@@ -129,12 +130,34 @@ class ClipLibraryService {
   /// row must never hide every other clip.
   Future<List<DivineVideoClip>> getAllClips() async {
     try {
-      final rows = await _clipsDao.getLibraryClips(ownerPubkey: ownerPubkey);
+      // Include the autosave draft so a just-recorded clip (which the editor
+      // immediately holds in its autosave draft) stays visible in the library.
+      // Clips saved into a named project keep their own draftId and stay hidden.
+      final rows = await _clipsDao.getLibraryClips(
+        ownerPubkey: ownerPubkey,
+        includeAutosaveDraftId: VideoEditorConstants.autoSaveId,
+      );
+
       final documentsPath = await getDocumentsPath();
-      return rows
-          .map((row) => _tryParseClipRow(row, documentsPath, label: 'clip'))
-          .whereType<DivineVideoClip>()
-          .toList();
+
+      // The clips table keys draft clips by `<draftId>:<clipId>` (composite row
+      // id) but library clips by the plain clip id, so the same clip can have a
+      // library row (draftId == null) and an autosave-draft row. Both parse to
+      // the same `clip.id`; keep one per clip id — preferring the library row —
+      // so a just-recorded clip shows exactly once.
+      final byClipId = <String, ({String? draftId, DivineVideoClip clip})>{};
+      for (final row in rows) {
+        final clip = _tryParseClipRow(row, documentsPath, label: 'clip');
+        if (clip == null) continue;
+        final existing = byClipId[clip.id];
+        if (existing == null ||
+            (existing.draftId != null && row.draftId == null)) {
+          byClipId[clip.id] = (draftId: row.draftId, clip: clip);
+        }
+      }
+
+      return byClipId.values.map((e) => e.clip).toList()
+        ..sort((a, b) => b.recordedAt.compareTo(a.recordedAt));
     } catch (e) {
       Log.error(
         '❌ Failed to load clips: $e',
@@ -190,11 +213,22 @@ class ClipLibraryService {
   ///
   /// Returns true if the clip was found and trashed.
   Future<bool> softDelete(String id, {bool clearDraftId = false}) async {
-    final ok = await _clipsDao.softDeleteClip(
+    final now = DateTime.now();
+    final deletedLibraryRow = await _clipsDao.softDeleteClip(
       id: id,
-      deletedAt: DateTime.now(),
+      deletedAt: now,
       clearDraftId: clearDraftId,
     );
+    // A set that has been through the editor also has an autosave-draft copy
+    // (row id `<autoSaveId>:<clipId>`) which the library surfaces via
+    // getLibraryClips(includeAutosaveDraftId:). Trash that row too, or the clip
+    // reappears from it the moment the library reloads after deletion.
+    final deletedAutosaveRow = await _clipsDao.softDeleteClip(
+      id: _autosaveDraftRowId(id),
+      deletedAt: now,
+      clearDraftId: clearDraftId,
+    );
+    final ok = deletedLibraryRow || deletedAutosaveRow;
     if (ok) {
       Log.debug(
         '🗑️ Soft-deleted clip: $id',
@@ -205,12 +239,23 @@ class ClipLibraryService {
     return ok;
   }
 
+  /// Row id of the autosave-draft copy of the clip [clipId], mirroring the
+  /// `<draftId>:<clipId>` scheme [DraftsDao.saveDraftWithClips] writes.
+  String _autosaveDraftRowId(String clipId) =>
+      '${VideoEditorConstants.autoSaveId}:$clipId';
+
   /// Restore a trashed clip. The clip becomes visible to active queries
   /// again with its previous `draft_id` (library if `draft_id` is NULL).
   ///
   /// Returns true if a trashed clip with [id] was restored.
   Future<bool> restore(String id) async {
-    final ok = await _clipsDao.restoreClip(id);
+    final restoredLibraryRow = await _clipsDao.restoreClip(id);
+    // Mirror softDelete: restore the autosave-draft copy too, so an undo brings
+    // the set back exactly as it was.
+    final restoredAutosaveRow = await _clipsDao.restoreClip(
+      _autosaveDraftRowId(id),
+    );
+    final ok = restoredLibraryRow || restoredAutosaveRow;
     if (ok) {
       Log.debug(
         '♻️ Restored clip: $id',
@@ -220,6 +265,14 @@ class ClipLibraryService {
     }
     return ok;
   }
+
+  /// Permanently removes a single clip's library row, leaving its on-disk
+  /// files untouched.
+  ///
+  /// Used to drop an abandoned in-progress stop-motion session (all frames
+  /// undone): the recorder owns and cleans up the frame files, so — unlike
+  /// [hardDelete] — this must not delete them.
+  Future<void> deleteClipRow(String id) => _clipsDao.deleteClip(id);
 
   /// Permanently delete a clip and its files. Skips the trash; use
   /// [softDelete] for the standard delete flow.
@@ -368,7 +421,10 @@ class ClipLibraryService {
 
     for (final clip in incomplete) {
       try {
-        final videoPath = await clip.video.safeFilePath();
+        // Stop-motion clips have no rendered video to recover assets from;
+        // their thumbnail is the first captured frame.
+        if (clip.isStopMotion) continue;
+        final videoPath = await clip.video!.safeFilePath();
         var updatedClip = clip;
 
         if (clip.thumbnailPath == null) {

--- a/mobile/lib/services/draft_storage_service.dart
+++ b/mobile/lib/services/draft_storage_service.dart
@@ -555,7 +555,9 @@ class DraftStorageService {
     final draft = await getDraftById(id);
     if (draft == null) return;
 
-    // Delete from DB first (clips cascade via FK), then delete files
+    // Delete the draft and its clip rows first, then delete files — so the
+    // reference scan in FileCleanupService no longer sees this draft's clips
+    // and can reclaim their media (DraftsDao.deleteDraft removes both rows).
     await _draftsDao.deleteDraft(id);
 
     // Ghost frames live only in the clip `data` blob, so — like draft-local
@@ -710,7 +712,9 @@ class DraftStorageService {
         .expand((draft) => draft.localAudioFilePaths)
         .toSet();
 
-    // Clear DB first (clips cascade via FK), then delete files
+    // Clear drafts and their clip rows first, then delete files — so the
+    // reference scan can reclaim the media (DraftsDao.clearAll removes both;
+    // library clips with a NULL draftId are preserved).
     await _draftsDao.clearAll();
 
     // Every draft and its clips are gone; the clips that survive are library

--- a/mobile/lib/services/draft_storage_service.dart
+++ b/mobile/lib/services/draft_storage_service.dart
@@ -2,8 +2,6 @@
 // ABOUTME: Handles save, load, delete, clear, and migration from SharedPreferences
 
 import 'dart:convert';
-import 'dart:io';
-
 import 'package:db_client/db_client.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/extensions/draft_local_audio_extensions.dart';
@@ -81,8 +79,8 @@ class DraftStorageService {
               durationMs: clip.duration.inMilliseconds,
               recordedAt: clip.recordedAt,
               data: json.encode(clip.toJson()),
-              filePath: clip.video.file?.path != null
-                  ? p.basename(clip.video.file!.path)
+              filePath: clip.video?.file?.path != null
+                  ? p.basename(clip.video!.file!.path)
                   : null,
               thumbnailPath: clip.thumbnailPath != null
                   ? p.basename(clip.thumbnailPath!)
@@ -101,8 +99,8 @@ class DraftStorageService {
           publishAttempts: draft.publishAttempts,
           publishError: draft.publishError,
           data: json.encode(draftJson),
-          renderedFilePath: draft.finalRenderedClip?.video.file?.path != null
-              ? p.basename(draft.finalRenderedClip!.video.file!.path)
+          renderedFilePath: draft.finalRenderedClip?.video?.file?.path != null
+              ? p.basename(draft.finalRenderedClip!.video!.file!.path)
               : null,
           renderedThumbnailPath: draft.finalRenderedClip?.thumbnailPath != null
               ? p.basename(draft.finalRenderedClip!.thumbnailPath!)
@@ -178,25 +176,25 @@ class DraftStorageService {
     if (existingDraft != null) {
       final newFilePaths = <String?>{
         for (final clip in draft.clips) ...[
-          clip.video.file?.path,
+          clip.video?.file?.path,
           clip.thumbnailPath,
         ],
-        draft.finalRenderedClip?.video.file?.path,
+        draft.finalRenderedClip?.video?.file?.path,
         draft.finalRenderedClip?.thumbnailPath,
         draft.customThumbnailPath,
       };
 
       orphanedFiles = <String?>[
         for (final clip in existingDraft.clips) ...[
-          if (!newFilePaths.contains(clip.video.file?.path))
-            clip.video.file?.path,
+          if (!newFilePaths.contains(clip.video?.file?.path))
+            clip.video?.file?.path,
           if (!newFilePaths.contains(clip.thumbnailPath)) clip.thumbnailPath,
         ],
         if (existingDraft.finalRenderedClip != null) ...[
           if (!newFilePaths.contains(
-            existingDraft.finalRenderedClip?.video.file?.path,
+            existingDraft.finalRenderedClip?.video?.file?.path,
           ))
-            existingDraft.finalRenderedClip?.video.file?.path,
+            existingDraft.finalRenderedClip?.video?.file?.path,
           if (!newFilePaths.contains(
             existingDraft.finalRenderedClip?.thumbnailPath,
           ))
@@ -222,8 +220,8 @@ class DraftStorageService {
           durationMs: clip.duration.inMilliseconds,
           recordedAt: clip.recordedAt,
           data: json.encode(clip.toJson()),
-          filePath: clip.video.file?.path != null
-              ? p.basename(clip.video.file!.path)
+          filePath: clip.video?.file?.path != null
+              ? p.basename(clip.video!.file!.path)
               : null,
           thumbnailPath: clip.thumbnailPath != null
               ? p.basename(clip.thumbnailPath!)
@@ -242,8 +240,8 @@ class DraftStorageService {
       publishAttempts: draft.publishAttempts,
       publishError: draft.publishError,
       data: json.encode(draftJson),
-      renderedFilePath: draft.finalRenderedClip?.video.file?.path != null
-          ? p.basename(draft.finalRenderedClip!.video.file!.path)
+      renderedFilePath: draft.finalRenderedClip?.video?.file?.path != null
+          ? p.basename(draft.finalRenderedClip!.video!.file!.path)
           : null,
       renderedThumbnailPath: draft.finalRenderedClip?.thumbnailPath != null
           ? p.basename(draft.finalRenderedClip!.thumbnailPath!)
@@ -447,21 +445,16 @@ class DraftStorageService {
     return _clearMissingFinalRenderedClip(draft.copyWith(clips: validClips));
   }
 
-  /// Filter clips to only include those with existing video files.
+  /// Filter clips to only include those whose source media still exists.
   List<DivineVideoClip> _filterValidClips(List<DivineVideoClip> clips) {
-    return clips.where((clip) {
-      final videoPath = clip.video.file?.path;
-      if (videoPath == null) return false;
-      return File(videoPath).existsSync();
-    }).toList();
+    return clips.where((clip) => clip.hasResolvableVideoFile).toList();
   }
 
   DivineVideoDraft _clearMissingFinalRenderedClip(DivineVideoDraft draft) {
     final finalClip = draft.finalRenderedClip;
     if (finalClip == null) return draft;
 
-    final videoPath = finalClip.video.file?.path;
-    if (videoPath != null && File(videoPath).existsSync()) return draft;
+    if (finalClip.hasResolvableVideoFile) return draft;
 
     Log.info(
       '📝 Draft ${draft.id}: final rendered clip missing, clearing reference',

--- a/mobile/lib/services/draft_storage_service.dart
+++ b/mobile/lib/services/draft_storage_service.dart
@@ -7,6 +7,7 @@ import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/extensions/draft_local_audio_extensions.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/divine_video_draft.dart';
+import 'package:openvine/models/stop_motion/stop_motion_frame_ops.dart';
 import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/services/file_cleanup_service.dart';
 import 'package:openvine/utils/path_resolver.dart';
@@ -177,6 +178,10 @@ class DraftStorageService {
       final newFilePaths = <String?>{
         for (final clip in draft.clips) ...[
           clip.video?.file?.path,
+          // Stop-motion stills are clip-owned source files just like the video;
+          // include them so a still that survives the edit isn't queued for
+          // deletion below.
+          ...?clip.stopMotionFrames?.map((frame) => frame.path),
           clip.thumbnailPath,
         ],
         draft.finalRenderedClip?.video?.file?.path,
@@ -188,6 +193,11 @@ class DraftStorageService {
         for (final clip in existingDraft.clips) ...[
           if (!newFilePaths.contains(clip.video?.file?.path))
             clip.video?.file?.path,
+          // A still captured into this session and then removed no longer
+          // appears in the new frame list, so queue it for deferred cleanup.
+          ...?clip.stopMotionFrames
+              ?.map((frame) => frame.path)
+              .where((path) => !newFilePaths.contains(path)),
           if (!newFilePaths.contains(clip.thumbnailPath)) clip.thumbnailPath,
         ],
         if (existingDraft.finalRenderedClip != null) ...[
@@ -445,9 +455,22 @@ class DraftStorageService {
     return _clearMissingFinalRenderedClip(draft.copyWith(clips: validClips));
   }
 
-  /// Filter clips to only include those whose source media still exists.
+  /// Filter clips to only those whose source media still exists.
+  ///
+  /// Normal video clips are kept only when their file resolves. Frames-only
+  /// stop-motion clips are *sanitized* rather than dropped wholesale: unreadable
+  /// stills are removed and the clip survives while at least one readable still
+  /// remains (it drops out only when none do). This mirrors the per-frame
+  /// salvage in `VideoEditorNotifier.restoreDraft`, so list/autosave validation
+  /// can't hide a stop-motion draft before restore gets a chance to recover it.
   List<DivineVideoClip> _filterValidClips(List<DivineVideoClip> clips) {
-    return clips.where((clip) => clip.hasResolvableVideoFile).toList();
+    return [
+      for (final clip in clips)
+        if (clip.isStopMotion)
+          ?StopMotionFrameOps.sanitizedClip(clip)
+        else if (clip.hasResolvableVideoFile)
+          clip,
+    ];
   }
 
   DivineVideoDraft _clearMissingFinalRenderedClip(DivineVideoDraft draft) {

--- a/mobile/lib/services/file_cleanup_service.dart
+++ b/mobile/lib/services/file_cleanup_service.dart
@@ -72,13 +72,30 @@ class FileCleanupService {
         .where((path) => path != null && path.isNotEmpty)
         .cast<String>()
         .toList();
+    if (validPaths.isEmpty) return;
+
+    // Resolved as one set: a stop-motion clip hands every one of its stills to
+    // this call, and the clip references that hold them are in an unindexed
+    // JSON blob — asking per file would scan the table once per still.
+    final referencedByClips = await clipsDao.referencedFilenames(
+      validPaths.map(p.basename).toSet(),
+    );
 
     for (final path in validPaths) {
-      await deleteFileIfUnreferenced(
-        path,
-        draftsDao: draftsDao,
-        clipsDao: clipsDao,
-      );
+      if (!File(path).existsSync()) continue;
+
+      final filename = p.basename(path);
+      if (referencedByClips.contains(filename) ||
+          await draftsDao.isDraftFileReferenced(filename)) {
+        Log.info(
+          '🔗 File still referenced, skipping delete: $path',
+          name: 'FileCleanupService',
+          category: LogCategory.video,
+        );
+        continue;
+      }
+
+      await _deleteFile(path);
     }
   }
 

--- a/mobile/lib/services/file_cleanup_service.dart
+++ b/mobile/lib/services/file_cleanup_service.dart
@@ -173,7 +173,11 @@ class FileCleanupService {
     Set<String> referencedGhostFrameFilenames = const {},
   }) async {
     await deleteFilesIfUnreferenced(
-      [clip.video.file?.path, clip.thumbnailPath],
+      [
+        clip.video?.file?.path,
+        ...?clip.stopMotionFrames?.map((frame) => frame.path),
+        clip.thumbnailPath,
+      ],
       draftsDao: draftsDao,
       clipsDao: clipsDao,
     );
@@ -197,7 +201,13 @@ class FileCleanupService {
     Set<String> referencedGhostFrameFilenames = const {},
   }) async {
     final indexedPaths = clips
-        .expand((clip) => [clip.video.file?.path, clip.thumbnailPath])
+        .expand(
+          (clip) => [
+            clip.video?.file?.path,
+            ...?clip.stopMotionFrames?.map((frame) => frame.path),
+            clip.thumbnailPath,
+          ],
+        )
         .toList();
 
     await deleteFilesIfUnreferenced(
@@ -221,7 +231,8 @@ class FileCleanupService {
   }) async {
     final paths = <String?>[
       for (final clip in clips) ...[
-        await clip.video.safeFilePath(),
+        if (clip.video != null) await clip.video!.safeFilePath(),
+        ...?clip.stopMotionFrames?.map((frame) => frame.path),
         clip.thumbnailPath,
         clip.ghostFramePath,
       ],

--- a/mobile/lib/services/storage_management_service.dart
+++ b/mobile/lib/services/storage_management_service.dart
@@ -8,6 +8,7 @@ import 'package:flutter/foundation.dart';
 import 'package:media_cache/media_cache.dart';
 import 'package:openvine/constants/storage_cache_constants.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/stop_motion/stop_motion_frame_ops.dart';
 import 'package:openvine/services/clip_library_service.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
@@ -102,11 +103,26 @@ class StorageManagementService {
     await _deleteDirContents(Directory(p.join(docs.path, _seamDir)));
   }
 
-  /// Library clips whose backing video file is gone — broken entries that can
+  /// Library clips whose backing media is gone — broken entries that can
   /// no longer play and should be cleaned up.
   Future<List<DivineVideoClip>> findBrokenClips() async {
     final clips = await _clipLibrary.getAllClips();
-    return clips.where((clip) => !clip.hasResolvableVideoFile).toList();
+    return clips.where(_isUnrecoverable).toList();
+  }
+
+  /// Whether nothing playable remains for [clip]: a video clip whose file is
+  /// gone, or a frames-only stop-motion set with no readable still left.
+  ///
+  /// A stop-motion set that still has at least one readable still is
+  /// salvageable (see [StopMotionFrameOps.sanitizedClip], the same per-still
+  /// policy the restore/editor paths use). Treating it as broken here would let
+  /// [removeBrokenClips] hard-delete the row and destroy the surviving frames
+  /// just because one still went missing.
+  bool _isUnrecoverable(DivineVideoClip clip) {
+    if (clip.isStopMotion) {
+      return StopMotionFrameOps.sanitizedClip(clip) == null;
+    }
+    return !clip.hasResolvableVideoFile;
   }
 
   /// Permanently removes the given broken [clips] from the library.

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -183,6 +183,7 @@ class UploadManager implements BackgroundAwareService {
   // Extracted concerns
   late final UploadRetryPolicy _retryPolicy;
   late final UploadProgressReporter _reporter;
+  final Map<String, Set<String>> _transientRenderPathsByUploadId = {};
 
   // Processing-completion polls keyed by upload id, so dispose() can
   // cancel them — an untracked periodic timer would keep firing against
@@ -481,15 +482,12 @@ class UploadManager implements BackgroundAwareService {
       thumbnailTimestamp: draft.thumbnailTimestamp,
     );
 
-    // _startUploadInternal awaits upload completion and throws on failure, so
-    // reaching here means the input was fully consumed. Delete the transient
-    // fallback renders; a failed upload throws above and keeps its render so a
-    // retry can reuse it.
-    for (final render in transientRenders) {
-      await StopMotionRenderService.cleanupMaterializedOutput(
-        sourceClip: render.source,
-        materializedClip: render.materialized,
-      );
+    if (transientRenders.isNotEmpty) {
+      _transientRenderPathsByUploadId[upload.id] = {
+        for (final render in transientRenders)
+          if (render.source.video == null && render.source.isStopMotion)
+            ?render.materialized.video?.file?.path,
+      };
     }
     return upload;
   }
@@ -1567,7 +1565,10 @@ class UploadManager implements BackgroundAwareService {
   }
 
   /// Remove completed, published, or unrecoverable failed uploads.
-  Future<void> cleanupCompletedUploads() => _store.cleanupCompletedUploads();
+  Future<void> cleanupCompletedUploads() async {
+    await _cleanupTransientRendersForDiscardedUploads();
+    await _store.cleanupCompletedUploads();
+  }
 
   /// Update upload status (public method for VideoEventPublisher)
   Future<void> updateUploadStatus(
@@ -1594,11 +1595,48 @@ class UploadManager implements BackgroundAwareService {
     );
 
     await _store.update(updatedUpload);
+    if (status == UploadStatus.published) {
+      await _cleanupTransientRendersForUpload(uploadId);
+    }
     Log.info(
       'Updated upload status: $uploadId -> $status',
       name: 'UploadManager',
       category: LogCategory.video,
     );
+  }
+
+  Future<void> _cleanupTransientRendersForUpload(String uploadId) async {
+    final paths = _transientRenderPathsByUploadId.remove(uploadId);
+    if (paths == null) {
+      final upload = getUpload(uploadId);
+      if (upload != null &&
+          StopMotionRenderService.isMaterializedOutputPath(
+            upload.localVideoPath,
+          )) {
+        await StopMotionRenderService.cleanupMaterializedOutputPath(
+          upload.localVideoPath,
+        );
+      }
+      return;
+    }
+    for (final path in paths) {
+      await StopMotionRenderService.cleanupMaterializedOutputPath(path);
+    }
+  }
+
+  Future<void> _cleanupTransientRendersForDiscardedUploads() async {
+    for (final upload in pendingUploads) {
+      if (upload.status != UploadStatus.failed ||
+          upload.resumableSession != null ||
+          !StopMotionRenderService.isMaterializedOutputPath(
+            upload.localVideoPath,
+          )) {
+        continue;
+      }
+      await StopMotionRenderService.cleanupMaterializedOutputPath(
+        upload.localVideoPath,
+      );
+    }
   }
 
   /// Get upload statistics

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -361,7 +361,7 @@ class UploadManager implements BackgroundAwareService {
 
     Future<String> prepareUploadFromSourceClips() async {
       if (draft.clips.length == 1) {
-        return draft.clips.first.video.safeFilePath();
+        return draft.clips.first.requireVideo.safeFilePath();
       }
 
       final tempDir = await getTemporaryDirectory();
@@ -379,7 +379,7 @@ class UploadManager implements BackgroundAwareService {
         mergedPath,
         VideoRenderData(
           videoSegments: draft.clips
-              .map((clip) => VideoSegment(video: clip.video))
+              .map((clip) => VideoSegment(video: clip.requireVideo))
               .toList(),
           endTime: VideoEditorConstants.maxDuration,
           shouldOptimizeForNetworkUse: true,
@@ -398,7 +398,7 @@ class UploadManager implements BackgroundAwareService {
     String videoFilePath;
     final renderedClip = draft.finalRenderedClip;
     if (renderedClip != null) {
-      final renderedPath = await renderedClip.video.safeFilePath();
+      final renderedPath = await renderedClip.requireVideo.safeFilePath();
       if (File(renderedPath).existsSync()) {
         videoFilePath = renderedPath;
         videoDuration ??= renderedClip.duration;

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -366,6 +366,13 @@ class UploadManager implements BackgroundAwareService {
     // hands the upload the rendered clip; this fallback path only runs when
     // that render has gone missing, so it has to re-render rather than
     // dereference a video that was never there.
+    //
+    // Each fallback render is a transient mp4 in the app documents dir that no
+    // draft row references. Track the (source, materialized) pairs so they can
+    // be reaped once the upload has consumed them — otherwise every fallback
+    // leaks a full-resolution mp4 that reference cleanup can never discover.
+    final transientRenders =
+        <({DivineVideoClip source, DivineVideoClip materialized})>[];
     Future<DivineVideoClip> materializedSource(DivineVideoClip clip) async {
       if (!clip.isStopMotion) return clip;
       final materialized = await StopMotionRenderService.materialize(clip);
@@ -374,6 +381,7 @@ class UploadManager implements BackgroundAwareService {
           'Stop-motion assembly failed for clip ${clip.id} — nothing to upload',
         );
       }
+      transientRenders.add((source: clip, materialized: materialized));
       return materialized;
     }
 
@@ -459,7 +467,7 @@ class UploadManager implements BackgroundAwareService {
       );
     }
 
-    return _startUploadInternal(
+    final upload = await _startUploadInternal(
       videoFile: File(videoFilePath),
       nostrPubkey: nostrPubkey,
       title: draft.title,
@@ -472,6 +480,18 @@ class UploadManager implements BackgroundAwareService {
       onProgress: onProgress,
       thumbnailTimestamp: draft.thumbnailTimestamp,
     );
+
+    // _startUploadInternal awaits upload completion and throws on failure, so
+    // reaching here means the input was fully consumed. Delete the transient
+    // fallback renders; a failed upload throws above and keeps its render so a
+    // retry can reuse it.
+    for (final render in transientRenders) {
+      await StopMotionRenderService.cleanupMaterializedOutput(
+        sourceClip: render.source,
+        materializedClip: render.materialized,
+      );
+    }
+    return upload;
   }
 
   /// Start a new video upload (legacy method - prefer startUploadFromDraft)

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -11,6 +11,7 @@ import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:models/models.dart' show NativeProofData;
 import 'package:openvine/constants/video_editor_constants.dart';
+import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/divine_video_draft.dart';
 import 'package:openvine/models/pending_upload.dart';
 import 'package:openvine/services/background_activity_manager.dart';
@@ -22,6 +23,7 @@ import 'package:openvine/services/upload/upload_progress_reporter.dart';
 import 'package:openvine/services/upload/upload_retry_policy.dart';
 import 'package:openvine/services/upload/upload_session_errors.dart';
 import 'package:openvine/services/upload_initialization_helper.dart';
+import 'package:openvine/services/video_editor/stop_motion_render_service.dart';
 import 'package:openvine/services/video_editor/video_editor_render_service.dart';
 import 'package:openvine/services/video_thumbnail_service.dart';
 import 'package:path/path.dart' as path;
@@ -359,9 +361,26 @@ class UploadManager implements BackgroundAwareService {
       );
     }
 
+    // A stop-motion clip's source of truth is its stills, not an mp4, so
+    // requireVideo throws on one. Publish normally materializes it up front and
+    // hands the upload the rendered clip; this fallback path only runs when
+    // that render has gone missing, so it has to re-render rather than
+    // dereference a video that was never there.
+    Future<DivineVideoClip> materializedSource(DivineVideoClip clip) async {
+      if (!clip.isStopMotion) return clip;
+      final materialized = await StopMotionRenderService.materialize(clip);
+      if (materialized == null) {
+        throw StateError(
+          'Stop-motion assembly failed for clip ${clip.id} — nothing to upload',
+        );
+      }
+      return materialized;
+    }
+
     Future<String> prepareUploadFromSourceClips() async {
       if (draft.clips.length == 1) {
-        return draft.clips.first.requireVideo.safeFilePath();
+        final source = await materializedSource(draft.clips.first);
+        return source.requireVideo.safeFilePath();
       }
 
       final tempDir = await getTemporaryDirectory();
@@ -375,12 +394,14 @@ class UploadManager implements BackgroundAwareService {
         name: 'UploadManager',
         category: .video,
       );
+      final videoSegments = <VideoSegment>[
+        for (final clip in draft.clips)
+          VideoSegment(video: (await materializedSource(clip)).requireVideo),
+      ];
       await VideoEditorRenderService.renderNativeVideoToFile(
         mergedPath,
         VideoRenderData(
-          videoSegments: draft.clips
-              .map((clip) => VideoSegment(video: clip.requireVideo))
-              .toList(),
+          videoSegments: videoSegments,
           endTime: VideoEditorConstants.maxDuration,
           shouldOptimizeForNetworkUse: true,
         ),

--- a/mobile/lib/services/video_editor/clip_speed_render_service.dart
+++ b/mobile/lib/services/video_editor/clip_speed_render_service.dart
@@ -81,10 +81,14 @@ class ClipSpeedRenderService {
 
   bool _needsRender(DivineVideoClip clip) {
     final speed = clip.playbackSpeed ?? 1.0;
-    return speed > 0 && speed != 1.0 && clip.video.file != null;
+    return speed > 0 && speed != 1.0 && clip.video?.file != null;
   }
 
   Future<RenderedSpeedClip?> _render(DivineVideoClip clip, String key) async {
+    // Reachable only via [render], which gates on [_needsRender] (video
+    // non-null). Re-checked here so the type is provably non-null below.
+    final video = clip.video;
+    if (video == null) return null;
     final renderGeneration = _clearGeneration;
     String? tempOutput;
     String? tempPath;
@@ -124,7 +128,7 @@ class ClipSpeedRenderService {
           id: 'speed_$hash',
           videoSegments: [
             VideoSegment(
-              video: clip.video,
+              video: video,
               startTime: clip.trimStart == Duration.zero
                   ? null
                   : clip.trimStart,
@@ -299,7 +303,7 @@ class ClipSpeedRenderService {
   static const _cacheVersion = 1;
 
   String _key(DivineVideoClip clip) =>
-      'v$_cacheVersion|${clip.id}:${clip.video.file?.path}:'
+      'v$_cacheVersion|${clip.id}:${clip.video?.file?.path}:'
       '${clip.duration.inMicroseconds}:${clip.trimStart.inMicroseconds}:'
       '${clip.trimEnd.inMicroseconds}:${clip.playbackSpeed ?? 1.0}';
 

--- a/mobile/lib/services/video_editor/clip_thumbnail_manager.dart
+++ b/mobile/lib/services/video_editor/clip_thumbnail_manager.dart
@@ -120,7 +120,7 @@ class ClipThumbnailManager {
         clip.id,
         () => ValueNotifier(const []),
       );
-      final newPath = clip.video.file?.path;
+      final newPath = clip.video?.file?.path;
       final hasSubscription = _subscriptions.containsKey(clip.id);
       final isSeeded = _seeded.contains(clip.id);
 
@@ -245,7 +245,7 @@ class ClipThumbnailManager {
     double devicePixelRatio, {
     List<Duration>? priorityTimestamps,
   }) {
-    final videoPath = clip.video.file?.path;
+    final videoPath = clip.video?.file?.path;
     if (videoPath == null) return;
 
     _videoPaths[clip.id] = videoPath;

--- a/mobile/lib/services/video_editor/clip_waveform_manager.dart
+++ b/mobile/lib/services/video_editor/clip_waveform_manager.dart
@@ -100,7 +100,7 @@ class ClipWaveformManager {
         () => ValueNotifier(null),
       );
 
-      final path = clip.video.file?.path;
+      final path = clip.video?.file?.path;
       if (path == null) {
         // A clip whose source file isn't resolved yet (e.g. still rendering).
         _paths.remove(clip.id);

--- a/mobile/lib/services/video_editor/native_render_task_registry.dart
+++ b/mobile/lib/services/video_editor/native_render_task_registry.dart
@@ -1,0 +1,41 @@
+// ABOUTME: Tracks in-flight native pro_video_editor tasks started by this app
+// ABOUTME: Shared registry so teardown cancellation sees every native render
+
+/// Registry of in-flight native `pro_video_editor` tasks started by this app.
+///
+/// Teardown cancellation (`AppLifecycleState.detached`) can only cancel native
+/// work it knows about, so every app-owned native render entry point must run
+/// inside [track]. Lives apart from the render services themselves because both
+/// the composite render service and the stop-motion assembler register here,
+/// and the former already imports the latter.
+class NativeRenderTaskRegistry {
+  NativeRenderTaskRegistry._();
+
+  static final Map<String, Object> _tokens = <String, Object>{};
+
+  /// Ids of the native tasks currently in flight.
+  static Set<String> get activeTaskIds => Set.unmodifiable(_tokens.keys);
+
+  /// Runs [operation], tracking it as active under [id] until it settles.
+  ///
+  /// A task re-registering the same [id] takes ownership of the entry; the
+  /// displaced call's cleanup then leaves the newer registration alone (the
+  /// token identity check), so it stays cancellable.
+  static Future<T> track<T>(String id, Future<T> Function() operation) async {
+    final token = Object();
+    _tokens[id] = token;
+    try {
+      return await operation();
+    } finally {
+      if (identical(_tokens[id], token)) {
+        _tokens.remove(id);
+      }
+    }
+  }
+
+  /// Drops all tracking without cancelling anything.
+  ///
+  /// Test teardown only — the registry has no production reason to forget a
+  /// task that is still running natively.
+  static void reset() => _tokens.clear();
+}

--- a/mobile/lib/services/video_editor/stop_motion_audio_preview.dart
+++ b/mobile/lib/services/video_editor/stop_motion_audio_preview.dart
@@ -146,8 +146,13 @@ class StopMotionAudioPreview {
         scheduled.active = true;
         await scheduled.player.seek(position - track.windowStart);
         if (_disposed) return;
-        // play() resolves when playback finishes; don't block the sync on it.
-        unawaited(scheduled.player.play());
+        // play() resolves when playback finishes, so awaiting it here would
+        // stall the queue for the length of the sound. Left outside the queue
+        // deliberately — which also puts it outside the queue's teardown
+        // ordering, so a setTracks/dispose landing while it resolves can make
+        // it throw. Swallow that the same way syncTo does; there is nothing to
+        // recover once the player it targeted is gone.
+        unawaited(scheduled.player.play().catchError((Object _) {}));
       } else if (!shouldPlay && scheduled.active) {
         scheduled.active = false;
         await scheduled.player.pause();

--- a/mobile/lib/services/video_editor/stop_motion_audio_preview.dart
+++ b/mobile/lib/services/video_editor/stop_motion_audio_preview.dart
@@ -58,9 +58,37 @@ class StopMotionAudioPreview {
   Duration _lastPosition = Duration.zero;
   bool _disposed = false;
 
+  /// Serializes every player-touching operation. [setTracks], [pauseAll],
+  /// [dispose] and each admitted [syncTo] chain onto this tail so they never
+  /// interleave at an `await`: without it, a [setTracks]/[dispose] that clears
+  /// `_tracks` while a suspended [syncTo] is mid-iteration would throw a
+  /// `ConcurrentModificationError` (or call `play()` on a just-disposed
+  /// player). The stop-motion ticker fires [syncTo] every frame while overlay
+  /// edits fire [setTracks], so that interleaving is a normal-usage race.
+  Future<void> _queue = Future<void>.value();
+
+  /// Drops per-frame [syncTo] calls that arrive while one is already queued or
+  /// running, so a slow seek can't let ticker calls pile up unbounded (and so
+  /// two overlapping calls can't race on the shared `active` / `_lastPosition`
+  /// state and leave a track playing past its window).
+  bool _syncInFlight = false;
+
+  Future<T> _enqueue<T>(Future<T> Function() op) {
+    final next = _queue.then((_) => op());
+    // Keep the chain alive even if an op throws; callers still observe the
+    // error through the returned future.
+    _queue = next.then((_) {}, onError: (Object _) {});
+    return next;
+  }
+
   /// Replaces the scheduled sounds. Existing players are disposed; the next
   /// [syncTo] starts whichever new sounds the playhead sits inside.
-  Future<void> setTracks(List<StopMotionAudioPreviewTrack> tracks) async {
+  Future<void> setTracks(List<StopMotionAudioPreviewTrack> tracks) {
+    if (_disposed) return Future<void>.value();
+    return _enqueue(() => _setTracks(tracks));
+  }
+
+  Future<void> _setTracks(List<StopMotionAudioPreviewTrack> tracks) async {
     await _disposeAllPlayers();
     if (_disposed) return;
 
@@ -86,15 +114,29 @@ class StopMotionAudioPreview {
   /// While [isPlaying], a sound whose window contains [position] plays from
   /// the matching offset; sounds outside their window are paused. When not
   /// playing, everything pauses. Cheap when nothing changed — steady playback
-  /// inside a window is a no-op.
-  Future<void> syncTo(Duration position, {required bool isPlaying}) async {
+  /// inside a window is a no-op. Fire-and-forget: dispatched `unawaited` from
+  /// the ticker, so a call that arrives while another is in flight is dropped
+  /// (the next frame re-syncs).
+  Future<void> syncTo(Duration position, {required bool isPlaying}) {
+    if (_disposed || _syncInFlight) return Future<void>.value();
+    _syncInFlight = true;
+    return _enqueue(() => _syncTo(position, isPlaying: isPlaying))
+        // Fire-and-forget from the ticker: never surface as an unhandled
+        // async error.
+        .catchError((Object _) {})
+        .whenComplete(() => _syncInFlight = false);
+  }
+
+  Future<void> _syncTo(Duration position, {required bool isPlaying}) async {
     if (_disposed) return;
     final jumped =
         position < _lastPosition ||
         position - _lastPosition > seekJumpThreshold;
     _lastPosition = position;
 
-    for (final scheduled in _tracks.values) {
+    // Snapshot: the queue already prevents concurrent mutation, but iterating a
+    // copy keeps this loop safe against any future non-queued edit too.
+    for (final scheduled in _tracks.values.toList()) {
       final track = scheduled.track;
       final inWindow =
           position >= track.windowStart && position < track.windowEnd;
@@ -116,8 +158,13 @@ class StopMotionAudioPreview {
 
   /// Pauses every sound (preview paused). Positions re-sync on the next
   /// [syncTo].
-  Future<void> pauseAll() async {
-    for (final scheduled in _tracks.values) {
+  Future<void> pauseAll() {
+    if (_disposed) return Future<void>.value();
+    return _enqueue(_pauseAll);
+  }
+
+  Future<void> _pauseAll() async {
+    for (final scheduled in _tracks.values.toList()) {
       if (!scheduled.active) continue;
       scheduled.active = false;
       await scheduled.player.pause();
@@ -126,9 +173,9 @@ class StopMotionAudioPreview {
   }
 
   /// Releases every player. The instance cannot be reused afterwards.
-  Future<void> dispose() async {
+  Future<void> dispose() {
     _disposed = true;
-    await _disposeAllPlayers();
+    return _enqueue(_disposeAllPlayers);
   }
 
   Future<void> _disposeAllPlayers() async {

--- a/mobile/lib/services/video_editor/stop_motion_audio_preview.dart
+++ b/mobile/lib/services/video_editor/stop_motion_audio_preview.dart
@@ -1,0 +1,151 @@
+// ABOUTME: Plays timeline audio tracks in sync with the stop-motion preview
+// ABOUTME: clock — frames-only clips have no native video player to do it.
+
+import 'dart:async';
+
+import 'package:sound_service/sound_service.dart';
+
+/// One timeline sound scheduled against the stop-motion preview clock.
+class StopMotionAudioPreviewTrack {
+  const StopMotionAudioPreviewTrack({
+    required this.id,
+    required this.source,
+    required this.windowStart,
+    required this.windowEnd,
+    this.volume = 1,
+  });
+
+  /// Timeline item id of the sound.
+  final String id;
+
+  /// Audio source already clipped to this window's slice of the track
+  /// (clip start = the sound's own start offset into the source).
+  final AudioSourceConfig source;
+
+  /// Playback volume, `0.0..1.0`.
+  final double volume;
+
+  /// Editor-timeline position where this sound becomes audible.
+  final Duration windowStart;
+
+  /// Editor-timeline position where this sound stops.
+  final Duration windowEnd;
+}
+
+/// Creates the per-track player; injectable for tests.
+typedef AudioClipPlayerFactory = AudioClipPlayer Function();
+
+/// Audio engine for the frames-only stop-motion preview.
+///
+/// A normal composition plays its overlay sounds through the native video
+/// player (`setAudioTracks`), which follows native playback. A stop-motion
+/// clip has no mp4 and therefore no native player — its playhead is a widget
+/// [Ticker] — so this class schedules one [AudioClipPlayer] per sound and
+/// follows that clock instead: [syncTo] starts a sound when the playhead
+/// enters its window, stops it when the playhead leaves, and re-seeks on
+/// scrubs and loop wraps.
+class StopMotionAudioPreview {
+  StopMotionAudioPreview({AudioClipPlayerFactory? playerFactory})
+    : _playerFactory = playerFactory ?? AudioClipPlayer.new;
+
+  /// A backwards jump, or a forward jump larger than this, is a scrub / loop
+  /// wrap and forces active tracks to re-seek. Normal ticks advance by a
+  /// frame (~17 ms), far below this.
+  static const Duration seekJumpThreshold = Duration(milliseconds: 500);
+
+  final AudioClipPlayerFactory _playerFactory;
+  final Map<String, _ScheduledTrack> _tracks = {};
+  Duration _lastPosition = Duration.zero;
+  bool _disposed = false;
+
+  /// Replaces the scheduled sounds. Existing players are disposed; the next
+  /// [syncTo] starts whichever new sounds the playhead sits inside.
+  Future<void> setTracks(List<StopMotionAudioPreviewTrack> tracks) async {
+    await _disposeAllPlayers();
+    if (_disposed) return;
+
+    for (final track in tracks) {
+      final player = _playerFactory();
+      try {
+        await player.setClip(track.source);
+        await player.setVolume(track.volume);
+      } on Exception {
+        await player.dispose();
+        continue;
+      }
+      if (_disposed) {
+        await player.dispose();
+        return;
+      }
+      _tracks[track.id] = _ScheduledTrack(track: track, player: player);
+    }
+  }
+
+  /// Aligns every sound with the preview clock at [position].
+  ///
+  /// While [isPlaying], a sound whose window contains [position] plays from
+  /// the matching offset; sounds outside their window are paused. When not
+  /// playing, everything pauses. Cheap when nothing changed — steady playback
+  /// inside a window is a no-op.
+  Future<void> syncTo(Duration position, {required bool isPlaying}) async {
+    if (_disposed) return;
+    final jumped =
+        position < _lastPosition ||
+        position - _lastPosition > seekJumpThreshold;
+    _lastPosition = position;
+
+    for (final scheduled in _tracks.values) {
+      final track = scheduled.track;
+      final inWindow =
+          position >= track.windowStart && position < track.windowEnd;
+      final shouldPlay = isPlaying && inWindow;
+
+      if (shouldPlay && (!scheduled.active || jumped)) {
+        scheduled.active = true;
+        await scheduled.player.seek(position - track.windowStart);
+        if (_disposed) return;
+        // play() resolves when playback finishes; don't block the sync on it.
+        unawaited(scheduled.player.play());
+      } else if (!shouldPlay && scheduled.active) {
+        scheduled.active = false;
+        await scheduled.player.pause();
+        if (_disposed) return;
+      }
+    }
+  }
+
+  /// Pauses every sound (preview paused). Positions re-sync on the next
+  /// [syncTo].
+  Future<void> pauseAll() async {
+    for (final scheduled in _tracks.values) {
+      if (!scheduled.active) continue;
+      scheduled.active = false;
+      await scheduled.player.pause();
+      if (_disposed) return;
+    }
+  }
+
+  /// Releases every player. The instance cannot be reused afterwards.
+  Future<void> dispose() async {
+    _disposed = true;
+    await _disposeAllPlayers();
+  }
+
+  Future<void> _disposeAllPlayers() async {
+    final players = _tracks.values.map((s) => s.player).toList();
+    _tracks.clear();
+    for (final player in players) {
+      await player.dispose();
+    }
+  }
+}
+
+class _ScheduledTrack {
+  _ScheduledTrack({required this.track, required this.player});
+
+  final StopMotionAudioPreviewTrack track;
+  final AudioClipPlayer player;
+
+  /// Whether the playhead currently has this sound playing.
+  bool active = false;
+}

--- a/mobile/lib/services/video_editor/stop_motion_audio_preview.dart
+++ b/mobile/lib/services/video_editor/stop_motion_audio_preview.dart
@@ -117,19 +117,37 @@ class StopMotionAudioPreview {
   /// inside a window is a no-op. Fire-and-forget: dispatched `unawaited` from
   /// the ticker, so a call that arrives while another is in flight is dropped
   /// (the next frame re-syncs).
-  Future<void> syncTo(Duration position, {required bool isPlaying}) {
+  ///
+  /// Set [isSeek] when [position] comes from a scrub rather than the ticker.
+  /// The playhead moved discontinuously, so active sounds re-seek even when the
+  /// delta is small enough to pass for a normal tick.
+  Future<void> syncTo(
+    Duration position, {
+    required bool isPlaying,
+    bool isSeek = false,
+  }) {
     if (_disposed || _syncInFlight) return Future<void>.value();
     _syncInFlight = true;
-    return _enqueue(() => _syncTo(position, isPlaying: isPlaying))
+    return _enqueue(
+          () => _syncTo(position, isPlaying: isPlaying, isSeek: isSeek),
+        )
         // Fire-and-forget from the ticker: never surface as an unhandled
         // async error.
         .catchError((Object _) {})
         .whenComplete(() => _syncInFlight = false);
   }
 
-  Future<void> _syncTo(Duration position, {required bool isPlaying}) async {
+  Future<void> _syncTo(
+    Duration position, {
+    required bool isPlaying,
+    required bool isSeek,
+  }) async {
     if (_disposed) return;
+    // The threshold still covers the ticker's own discontinuity — a loop wrap
+    // arrives as a backward move — while [isSeek] catches the scrub the ticker
+    // can't be distinguished from: a small forward hop.
     final jumped =
+        isSeek ||
         position < _lastPosition ||
         position - _lastPosition > seekJumpThreshold;
     _lastPosition = position;

--- a/mobile/lib/services/video_editor/stop_motion_audio_preview.dart
+++ b/mobile/lib/services/video_editor/stop_motion_audio_preview.dart
@@ -73,6 +73,15 @@ class StopMotionAudioPreview {
   /// state and leave a track playing past its window).
   bool _syncInFlight = false;
 
+  /// A scrub ([syncTo] with `isSeek`) that arrived while a sync was in flight
+  /// and got dropped. The dropped call changed nothing, but its re-seek intent
+  /// must survive: an in-flight transition sync (loop wrap / window seek)
+  /// already advanced `_lastPosition`, so the scrub's small forward hop would
+  /// then read as a normal tick and never re-seek, leaving a sound playing from
+  /// the pre-scrub offset. The next admitted sync ORs this in to force a
+  /// re-seek. User scrubs can't pile up at ticker rate, so this can't starve.
+  bool _pendingSeek = false;
+
   Future<T> _enqueue<T>(Future<T> Function() op) {
     final next = _queue.then((_) => op());
     // Keep the chain alive even if an op throws; callers still observe the
@@ -126,7 +135,13 @@ class StopMotionAudioPreview {
     required bool isPlaying,
     bool isSeek = false,
   }) {
-    if (_disposed || _syncInFlight) return Future<void>.value();
+    if (_disposed) return Future<void>.value();
+    if (_syncInFlight) {
+      // Drop the piled-up ticker call, but keep a scrub's re-seek intent so it
+      // isn't lost against the in-flight sync's advanced `_lastPosition`.
+      if (isSeek) _pendingSeek = true;
+      return Future<void>.value();
+    }
     _syncInFlight = true;
     return _enqueue(
           () => _syncTo(position, isPlaying: isPlaying, isSeek: isSeek),
@@ -148,8 +163,10 @@ class StopMotionAudioPreview {
     // can't be distinguished from: a small forward hop.
     final jumped =
         isSeek ||
+        _pendingSeek ||
         position < _lastPosition ||
         position - _lastPosition > seekJumpThreshold;
+    _pendingSeek = false;
     _lastPosition = position;
 
     // Snapshot: the queue already prevents concurrent mutation, but iterating a

--- a/mobile/lib/services/video_editor/stop_motion_render_service.dart
+++ b/mobile/lib/services/video_editor/stop_motion_render_service.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Assembles captured stop-motion frames into a single silent video
 // ABOUTME: Thin wrapper over pro_video_editor's renderStopMotionToFile
 
+import 'dart:io';
+
 import 'package:flutter/foundation.dart';
 import 'package:models/models.dart' as model show AspectRatio;
 import 'package:openvine/constants/video_editor_constants.dart';
@@ -38,6 +40,14 @@ class StopMotionRenderService {
     String? taskId,
   })?
   assembleOverride;
+
+  /// Test-only override for the encoded-duration probe in [materialize].
+  ///
+  /// When set, [materialize] uses this instead of reading the assembled mp4's
+  /// real duration via the native metadata reader. Reset to `null` in
+  /// `tearDown`.
+  @visibleForTesting
+  static Future<Duration?> Function(String outputPath)? probeDurationOverride;
 
   /// Assembles [frames] (captured stills with their hold times, in order)
   /// into a single silent mp4 using pro_video_editor's stop-motion encoder.
@@ -83,11 +93,14 @@ class StopMotionRenderService {
   ///
   /// The returned clip is a genuine video clip: its stills are cleared (they
   /// are now transient and may be cleaned up) and its [DivineVideoClip.duration]
-  /// is set to the assembled mp4's length — which loops short captures up to the
-  /// minimum output duration (see [framesForMinOutputDuration]). Keeping the
-  /// old single-pass duration would let the composite render trim the segment
-  /// back below the file length, dropping the loop and leaving the video track
-  /// shorter than any muxed audio.
+  /// is set to the assembled mp4's real (probed) length. Short captures are
+  /// looped up to the minimum output duration (see [framesForMinOutputDuration]),
+  /// whose summed holds are only the fallback estimate if the probe fails.
+  /// Using the encoded length matters twice: keeping the old single-pass
+  /// duration would let the composite render trim the segment below the file
+  /// length (dropping the loop, leaving the video shorter than muxed audio),
+  /// and an *over*-estimate lets muxed audio outlive the video — which freezes
+  /// the last frame on iOS.
   ///
   /// Returns `null` only when the render fails, so callers (publish, gallery
   /// save) can surface a failure instead of proceeding with a clip that has no
@@ -111,16 +124,39 @@ class StopMotionRenderService {
     );
     if (outputPath == null) return null;
 
-    final renderedFrames = framesForMinOutputDuration(frames);
-    final materializedDuration = renderedFrames.fold(
-      Duration.zero,
-      (sum, frame) => sum + frame.duration,
-    );
+    final estimatedDuration = framesForMinOutputDuration(
+      frames,
+    ).fold(Duration.zero, (sum, frame) => sum + frame.duration);
+    final probedDuration = await _probeEncodedDuration(outputPath);
+    final materializedDuration =
+        probedDuration != null && probedDuration > Duration.zero
+        ? probedDuration
+        : estimatedDuration;
     return clip.copyWith(
       video: EditorVideo.file(outputPath),
       duration: materializedDuration,
       clearStopMotionFrames: true,
     );
+  }
+
+  /// The real encoded duration of the assembled mp4 at [outputPath], or `null`
+  /// when it can't be probed (caller falls back to the frame-hold estimate).
+  static Future<Duration?> _probeEncodedDuration(String outputPath) async {
+    final override = probeDurationOverride;
+    if (override != null) return override(outputPath);
+    try {
+      final metadata = await ProVideoEditor.instance.getMetadata(
+        EditorVideo.file(outputPath),
+      );
+      return metadata.duration;
+    } catch (e) {
+      Log.warning(
+        '⚠️ Failed to probe assembled stop-motion duration; using estimate: $e',
+        name: _logName,
+        category: LogCategory.video,
+      );
+      return null;
+    }
   }
 
   /// Repeats [frames] an integer number of times until the sequence's total
@@ -200,6 +236,7 @@ class StopMotionRenderService {
         name: _logName,
         category: LogCategory.video,
       );
+      await _deletePartialOutput(outputPath);
       return null;
     } catch (e, stack) {
       Log.error(
@@ -218,7 +255,23 @@ class StopMotionRenderService {
           reason: 'StopMotionRenderService.assemble failed',
         );
       }
+      await _deletePartialOutput(outputPath);
       return null;
     }
+  }
+
+  /// Best-effort deletes a partial output file left behind by a failed or
+  /// cancelled render.
+  ///
+  /// The native encoder writes to [outputPath] and only self-deletes when no
+  /// output path is supplied; the app always passes one, so on failure the app
+  /// owns cleanup. The success path is cleaned up by the caller (tracked in
+  /// `intermediateStopMotionPaths`); without this, every failed/cancelled
+  /// export would leak a full-size mp4 in the persistent documents dir.
+  static Future<void> _deletePartialOutput(String outputPath) async {
+    try {
+      final file = File(outputPath);
+      if (file.existsSync()) await file.delete();
+    } catch (_) {}
   }
 }

--- a/mobile/lib/services/video_editor/stop_motion_render_service.dart
+++ b/mobile/lib/services/video_editor/stop_motion_render_service.dart
@@ -10,6 +10,7 @@ import 'package:openvine/extensions/aspect_ratio_extensions.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/services/crash_reporting_service.dart';
+import 'package:openvine/services/video_editor/native_render_task_registry.dart';
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
@@ -219,11 +220,17 @@ class StopMotionRenderService {
         name: _logName,
         category: LogCategory.video,
       );
-      final result = await ProVideoEditor.instance.renderStopMotionToFile(
-        outputPath,
-        data,
-        nativeLogLevel: NativeLogLevel.warning,
-      );
+      // Tracked so a lifecycle-detach cancelActiveNativeTasks() also cancels an
+      // in-flight assembly. Keyed on data.id rather than taskId: most callers
+      // pass no taskId, and StopMotionRenderData then generates its own — which
+      // is the id the native side knows this task by.
+      final result = await NativeRenderTaskRegistry.track(data.id, () {
+        return ProVideoEditor.instance.renderStopMotionToFile(
+          outputPath,
+          data,
+          nativeLogLevel: NativeLogLevel.warning,
+        );
+      });
       Log.info(
         '✅ Stop-motion video assembled to: $result',
         name: _logName,

--- a/mobile/lib/services/video_editor/stop_motion_render_service.dart
+++ b/mobile/lib/services/video_editor/stop_motion_render_service.dart
@@ -7,6 +7,7 @@ import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/extensions/aspect_ratio_extensions.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/stop_motion_clip_frame.dart';
+import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
@@ -75,9 +76,18 @@ class StopMotionRenderService {
     );
   }
 
-  /// Renders [clip]'s stop-motion frames into an mp4 and returns a video-backed
-  /// copy of the clip. Returns [clip] unchanged when it is already a normal
-  /// video clip. [taskId] is forwarded to [assemble] for progress reporting.
+  /// Renders [clip]'s stop-motion frames into an mp4 and returns a plain
+  /// video-backed copy of the clip. Returns [clip] unchanged when it is already
+  /// a normal video clip. [taskId] is forwarded to [assemble] for progress
+  /// reporting.
+  ///
+  /// The returned clip is a genuine video clip: its stills are cleared (they
+  /// are now transient and may be cleaned up) and its [DivineVideoClip.duration]
+  /// is set to the assembled mp4's length — which loops short captures up to the
+  /// minimum output duration (see [framesForMinOutputDuration]). Keeping the
+  /// old single-pass duration would let the composite render trim the segment
+  /// back below the file length, dropping the loop and leaving the video track
+  /// shorter than any muxed audio.
   ///
   /// Returns `null` only when the render fails, so callers (publish, gallery
   /// save) can surface a failure instead of proceeding with a clip that has no
@@ -100,7 +110,17 @@ class StopMotionRenderService {
       taskId: taskId,
     );
     if (outputPath == null) return null;
-    return clip.copyWith(video: EditorVideo.file(outputPath));
+
+    final renderedFrames = framesForMinOutputDuration(frames);
+    final materializedDuration = renderedFrames.fold(
+      Duration.zero,
+      (sum, frame) => sum + frame.duration,
+    );
+    return clip.copyWith(
+      video: EditorVideo.file(outputPath),
+      duration: materializedDuration,
+      clearStopMotionFrames: true,
+    );
   }
 
   /// Repeats [frames] an integer number of times until the sequence's total
@@ -181,12 +201,23 @@ class StopMotionRenderService {
         category: LogCategory.video,
       );
       return null;
-    } catch (e) {
+    } catch (e, stack) {
       Log.error(
         '❌ Stop-motion assembly failed: $e',
         name: _logName,
         category: LogCategory.video,
       );
+      // Native/IO render failures are expected (return null so callers can
+      // surface a friendly failure); only programming-invariant violations
+      // (StateError/TypeError/RangeError — all `Error` subtypes) are worth
+      // surfacing to Crashlytics.
+      if (e is Error) {
+        CrashReportingService.instance.recordError(
+          e,
+          stack,
+          reason: 'StopMotionRenderService.assemble failed',
+        );
+      }
       return null;
     }
   }

--- a/mobile/lib/services/video_editor/stop_motion_render_service.dart
+++ b/mobile/lib/services/video_editor/stop_motion_render_service.dart
@@ -140,6 +140,36 @@ class StopMotionRenderService {
     );
   }
 
+  /// Deletes the mp4 [materialize] created when [sourceClip] was frames-only.
+  ///
+  /// Normal video clips and already-materialized stop-motion clips pass through
+  /// [materialize] unchanged, so their video files remain caller-owned. Gallery
+  /// saves use this after copying the transient render to the camera roll.
+  static Future<void> cleanupMaterializedOutput({
+    required DivineVideoClip sourceClip,
+    required DivineVideoClip? materializedClip,
+  }) async {
+    if (materializedClip == null ||
+        sourceClip.video != null ||
+        !sourceClip.isStopMotion) {
+      return;
+    }
+
+    final outputPath = materializedClip.video?.file?.path;
+    if (outputPath == null) return;
+
+    try {
+      final file = File(outputPath);
+      if (file.existsSync()) await file.delete();
+    } catch (e) {
+      Log.debug(
+        '⚠️ Failed to delete transient stop-motion render $outputPath: $e',
+        name: _logName,
+        category: LogCategory.video,
+      );
+    }
+  }
+
   /// The real encoded duration of the assembled mp4 at [outputPath], or `null`
   /// when it can't be probed (caller falls back to the frame-hold estimate).
   static Future<Duration?> _probeEncodedDuration(String outputPath) async {

--- a/mobile/lib/services/video_editor/stop_motion_render_service.dart
+++ b/mobile/lib/services/video_editor/stop_motion_render_service.dart
@@ -272,6 +272,14 @@ class StopMotionRenderService {
     try {
       final file = File(outputPath);
       if (file.existsSync()) await file.delete();
-    } catch (_) {}
+    } catch (e) {
+      // Best-effort: a failed delete only leaves a temp file behind, never
+      // aborts the caller.
+      Log.debug(
+        '⚠️ Failed to delete partial stop-motion render $outputPath: $e',
+        name: _logName,
+        category: LogCategory.video,
+      );
+    }
   }
 }

--- a/mobile/lib/services/video_editor/stop_motion_render_service.dart
+++ b/mobile/lib/services/video_editor/stop_motion_render_service.dart
@@ -21,6 +21,9 @@ class StopMotionRenderService {
   StopMotionRenderService._();
 
   static const _logName = 'StopMotionRenderService';
+  static final RegExp _materializedOutputName = RegExp(
+    r'^stop_motion_\d+\.mp4$',
+  );
 
   /// Output frame rate of the assembled video.
   ///
@@ -158,6 +161,21 @@ class StopMotionRenderService {
     final outputPath = materializedClip.video?.file?.path;
     if (outputPath == null) return;
 
+    await _deleteOutputPath(outputPath);
+  }
+
+  /// True for mp4 files created by this service's on-demand materializer.
+  static bool isMaterializedOutputPath(String filePath) {
+    return _materializedOutputName.hasMatch(path.basename(filePath));
+  }
+
+  /// Deletes a materialized stop-motion mp4 by path.
+  static Future<void> cleanupMaterializedOutputPath(String outputPath) async {
+    if (!isMaterializedOutputPath(outputPath)) return;
+    await _deleteOutputPath(outputPath);
+  }
+
+  static Future<void> _deleteOutputPath(String outputPath) async {
     try {
       final file = File(outputPath);
       if (file.existsSync()) await file.delete();

--- a/mobile/lib/services/video_editor/stop_motion_render_service.dart
+++ b/mobile/lib/services/video_editor/stop_motion_render_service.dart
@@ -1,0 +1,193 @@
+// ABOUTME: Assembles captured stop-motion frames into a single silent video
+// ABOUTME: Thin wrapper over pro_video_editor's renderStopMotionToFile
+
+import 'package:flutter/foundation.dart';
+import 'package:models/models.dart' as model show AspectRatio;
+import 'package:openvine/constants/video_editor_constants.dart';
+import 'package:openvine/extensions/aspect_ratio_extensions.dart';
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
+import 'package:path/path.dart' as path;
+import 'package:path_provider/path_provider.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// Encodes a sequence of captured stop-motion stills into one silent video.
+class StopMotionRenderService {
+  StopMotionRenderService._();
+
+  static const _logName = 'StopMotionRenderService';
+
+  /// Output frame rate of the assembled video.
+  ///
+  /// 24fps is the classic stop-motion base: "frames per image" counts film
+  /// frames, so a hold of 2 ("on twos") shows 12 images per second — N stills
+  /// at the default hold play as N/12 s.
+  static const double defaultFrameRate = 24;
+
+  /// Test-only override for [assemble].
+  ///
+  /// When set, [assemble] delegates to this callback instead of running the
+  /// real native render. Reset to `null` in `tearDown`.
+  @visibleForTesting
+  static Future<String?> Function({
+    required List<StopMotionClipFrame> frames,
+    required model.AspectRatio aspectRatio,
+    double frameRate,
+    String? taskId,
+  })?
+  assembleOverride;
+
+  /// Assembles [frames] (captured stills with their hold times, in order)
+  /// into a single silent mp4 using pro_video_editor's stop-motion encoder.
+  ///
+  /// Each still is held for its own [StopMotionClipFrame.duration], so
+  /// per-frame edits from the editor survive into the output. [aspectRatio]
+  /// sets the output resolution and a centered crop ([StopMotionFit.cover]).
+  /// When [taskId] is set, the native encoder emits its progress under that
+  /// id via [ProVideoEditor.progressStreamById].
+  ///
+  /// Returns the output file path, or null if rendering failed or was
+  /// cancelled. The native render path needs a device build to exercise.
+  static Future<String?> assemble({
+    required List<StopMotionClipFrame> frames,
+    required model.AspectRatio aspectRatio,
+    double frameRate = defaultFrameRate,
+    String? taskId,
+  }) async {
+    final override = assembleOverride;
+    if (override != null) {
+      return override(
+        frames: frames,
+        aspectRatio: aspectRatio,
+        frameRate: frameRate,
+        taskId: taskId,
+      );
+    }
+
+    if (frames.isEmpty) return null;
+
+    return _renderToFile(
+      frames: frames,
+      aspectRatio: aspectRatio,
+      frameRate: frameRate,
+      taskId: taskId,
+    );
+  }
+
+  /// Renders [clip]'s stop-motion frames into an mp4 and returns a video-backed
+  /// copy of the clip. Returns [clip] unchanged when it is already a normal
+  /// video clip. [taskId] is forwarded to [assemble] for progress reporting.
+  ///
+  /// Returns `null` only when the render fails, so callers (publish, gallery
+  /// save) can surface a failure instead of proceeding with a clip that has no
+  /// playable video.
+  static Future<DivineVideoClip?> materialize(
+    DivineVideoClip clip, {
+    String? taskId,
+  }) async {
+    // A normal video clip (or a stop-motion clip already materialized once)
+    // has its mp4; nothing to do. A frames-only clip (no video) is rendered on
+    // demand below.
+    if (clip.video != null) return clip;
+
+    final frames = clip.stopMotionFrames;
+    if (frames == null) return clip;
+
+    final outputPath = await assemble(
+      frames: frames,
+      aspectRatio: clip.targetAspectRatio,
+      taskId: taskId,
+    );
+    if (outputPath == null) return null;
+    return clip.copyWith(video: EditorVideo.file(outputPath));
+  }
+
+  /// Repeats [frames] an integer number of times until the sequence's total
+  /// duration (each frame held for its own hold time) reaches
+  /// [VideoEditorConstants.stopMotionMinOutputDuration].
+  ///
+  /// Ultra-short clips (a single still ≈ 83ms) make looping players
+  /// stutter/oscillate; repeating preserves the per-frame timing and keeps the
+  /// loop seam clean (last frame → first frame). A sequence already at or above
+  /// the minimum is returned unchanged.
+  static List<StopMotionClipFrame> framesForMinOutputDuration(
+    List<StopMotionClipFrame> frames,
+  ) {
+    if (frames.isEmpty) return frames;
+    final singlePass = frames.fold(
+      Duration.zero,
+      (sum, frame) => sum + frame.duration,
+    );
+    const minDuration = VideoEditorConstants.stopMotionMinOutputDuration;
+    final loops = singlePass >= minDuration || singlePass == Duration.zero
+        ? 1
+        : (minDuration.inMicroseconds / singlePass.inMicroseconds).ceil();
+    return [for (var i = 0; i < loops; i++) ...frames];
+  }
+
+  static Future<String?> _renderToFile({
+    required List<StopMotionClipFrame> frames,
+    required model.AspectRatio aspectRatio,
+    required double frameRate,
+    String? taskId,
+  }) async {
+    final outputDir = await getApplicationDocumentsDirectory();
+    final outputPath = path.join(
+      outputDir.path,
+      'stop_motion_${DateTime.now().microsecondsSinceEpoch}.mp4',
+    );
+
+    final renderedFrames = framesForMinOutputDuration(frames);
+
+    final data = StopMotionRenderData(
+      id: taskId,
+      frames: [
+        for (final frame in renderedFrames)
+          StopMotionFrame(
+            image: EditorLayerImage.file(frame.path),
+            duration: frame.duration,
+          ),
+      ],
+      frameRate: frameRate,
+      resolution: VideoEditorConstants.quality.resolutionForAspectRatio(
+        aspectRatio,
+      ),
+      fit: StopMotionFit.cover,
+    );
+
+    try {
+      Log.debug(
+        '🎞️ Assembling ${frames.length} stop-motion frame(s) '
+        '(rendered: ${renderedFrames.length}, fps: $frameRate)',
+        name: _logName,
+        category: LogCategory.video,
+      );
+      final result = await ProVideoEditor.instance.renderStopMotionToFile(
+        outputPath,
+        data,
+        nativeLogLevel: NativeLogLevel.warning,
+      );
+      Log.info(
+        '✅ Stop-motion video assembled to: $result',
+        name: _logName,
+        category: LogCategory.video,
+      );
+      return result;
+    } on RenderCanceledException {
+      Log.info(
+        '🚫 Stop-motion assembly cancelled',
+        name: _logName,
+        category: LogCategory.video,
+      );
+      return null;
+    } catch (e) {
+      Log.error(
+        '❌ Stop-motion assembly failed: $e',
+        name: _logName,
+        category: LogCategory.video,
+      );
+      return null;
+    }
+  }
+}

--- a/mobile/lib/services/video_editor/transition_seam_render_service.dart
+++ b/mobile/lib/services/video_editor/transition_seam_render_service.dart
@@ -358,7 +358,7 @@ class TransitionSeamRenderService {
     // included because `_tailClip`/`_headClip` read it and it can be trimmed
     // independently of the file (clip_manager caps a clip on add).
     String clipKey(DivineVideoClip c) =>
-        '${c.id}:${c.video.file?.path}:${c.duration.inMicroseconds}:'
+        '${c.id}:${c.requireVideo.file?.path}:${c.duration.inMicroseconds}:'
         '${c.trimStart.inMicroseconds}:${c.trimEnd.inMicroseconds}:'
         '${c.playbackSpeed ?? 1.0}:${c.volume}:${c.targetAspectRatio.name}';
     final t =

--- a/mobile/lib/services/video_editor/video_editor_audio_render.dart
+++ b/mobile/lib/services/video_editor/video_editor_audio_render.dart
@@ -103,7 +103,9 @@ AudioTrack? audioTrackFromMetaForRender(AudioEvent track) {
   );
 }
 
-/// Clamps an audio composition window so it cannot extend past [videoDuration].
+/// Clamps an audio composition window so it cannot extend past [videoDuration],
+/// or returns `null` when the window lies entirely past the video and the track
+/// should be dropped.
 ///
 /// A stop-motion export is only as long as its (looped) stills — often under a
 /// second — while a selected song's window spans the whole track. Muxing a
@@ -112,16 +114,20 @@ AudioTrack? audioTrackFromMetaForRender(AudioEvent track) {
 /// keeps playing. Clamping the window to the video length keeps the two tracks
 /// the same length. A `null` [videoDuration] (or a `null` `endTime`, which
 /// already means "play to the end of the video") is left untouched.
-({Duration? startTime, Duration? endTime}) clampAudioWindowToVideo({
+///
+/// A window that starts at or after [videoDuration] has nothing left to play —
+/// clamping both ends would collapse it to a zero-length `[videoDuration,
+/// videoDuration]`, which violates [VideoAudioTrack]'s `startTime < endTime`
+/// assert. Such a track is reported as `null` so the caller drops it.
+({Duration? startTime, Duration? endTime})? clampAudioWindowToVideo({
   required Duration? startTime,
   required Duration? endTime,
   required Duration? videoDuration,
 }) {
   if (videoDuration == null) return (startTime: startTime, endTime: endTime);
+  if (startTime != null && startTime >= videoDuration) return null;
   return (
-    startTime: startTime != null && startTime > videoDuration
-        ? videoDuration
-        : startTime,
+    startTime: startTime,
     endTime: endTime != null && endTime > videoDuration
         ? videoDuration
         : endTime,
@@ -147,11 +153,21 @@ Future<List<VideoAudioTrack>> resolveRenderAudioTracks(
   for (final track in customTracks) {
     try {
       final audioPath = await track.audio.safeFilePath();
-      final (:startTime, :endTime) = clampAudioWindowToVideo(
+      final window = clampAudioWindowToVideo(
         startTime: track.startTime,
         endTime: track.endTime,
         videoDuration: videoDuration,
       );
+      if (window == null) {
+        Log.warning(
+          'Audio track ${track.id} starts at or after the end of the video '
+          '— skipping it',
+          name: logName,
+          category: LogCategory.video,
+        );
+        continue;
+      }
+      final (:startTime, :endTime) = window;
       audioTracks.add(
         VideoAudioTrack(
           path: audioPath,

--- a/mobile/lib/services/video_editor/video_editor_audio_render.dart
+++ b/mobile/lib/services/video_editor/video_editor_audio_render.dart
@@ -103,6 +103,31 @@ AudioTrack? audioTrackFromMetaForRender(AudioEvent track) {
   );
 }
 
+/// Clamps an audio composition window so it cannot extend past [videoDuration].
+///
+/// A stop-motion export is only as long as its (looped) stills — often under a
+/// second — while a selected song's window spans the whole track. Muxing a
+/// full-length song onto a short video produces an mp4 whose audio track
+/// outlives its video track; on iOS the last frame freezes while the audio
+/// keeps playing. Clamping the window to the video length keeps the two tracks
+/// the same length. A `null` [videoDuration] (or a `null` `endTime`, which
+/// already means "play to the end of the video") is left untouched.
+({Duration? startTime, Duration? endTime}) clampAudioWindowToVideo({
+  required Duration? startTime,
+  required Duration? endTime,
+  required Duration? videoDuration,
+}) {
+  if (videoDuration == null) return (startTime: startTime, endTime: endTime);
+  return (
+    startTime: startTime != null && startTime > videoDuration
+        ? videoDuration
+        : startTime,
+    endTime: endTime != null && endTime > videoDuration
+        ? videoDuration
+        : endTime,
+  );
+}
+
 /// Resolves each render [AudioTrack] to a [VideoAudioTrack] with a local file
 /// path, downloading network sources on demand.
 ///
@@ -110,19 +135,28 @@ AudioTrack? audioTrackFromMetaForRender(AudioEvent track) {
 /// and logged rather than aborting the whole render. A warning is logged when
 /// audio was requested but none could be resolved, so a silent (audio-less)
 /// export is diagnosable from logs.
+///
+/// When [videoDuration] is set, each track's composition window is clamped to
+/// it (see [clampAudioWindowToVideo]) so audio cannot outlast the video track.
 Future<List<VideoAudioTrack>> resolveRenderAudioTracks(
   List<AudioTrack> customTracks, {
   required String logName,
+  Duration? videoDuration,
 }) async {
   final audioTracks = <VideoAudioTrack>[];
   for (final track in customTracks) {
     try {
       final audioPath = await track.audio.safeFilePath();
+      final (:startTime, :endTime) = clampAudioWindowToVideo(
+        startTime: track.startTime,
+        endTime: track.endTime,
+        videoDuration: videoDuration,
+      );
       audioTracks.add(
         VideoAudioTrack(
           path: audioPath,
-          startTime: track.startTime,
-          endTime: track.endTime,
+          startTime: startTime,
+          endTime: endTime,
           audioStartTime: track.audioStartTime,
           audioEndTime: track.audioEndTime,
           loop: track.loop,

--- a/mobile/lib/services/video_editor/video_editor_clip_library_save_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_clip_library_save_service.dart
@@ -110,7 +110,7 @@ class VideoEditorClipLibrarySaveService {
     DivineVideoClip flattened, {
     String? keepThumbnailPath,
   }) async {
-    await _deleteQuietly(flattened.video.file?.path);
+    await _deleteQuietly(flattened.video?.file?.path);
 
     final thumbnailPath = flattened.thumbnailPath;
     if (thumbnailPath != null && thumbnailPath != keepThumbnailPath) {

--- a/mobile/lib/services/video_editor/video_editor_render_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_render_service.dart
@@ -15,6 +15,7 @@ import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/video_editor/transition_geometry.dart';
 import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/services/native_proofmode_service.dart';
+import 'package:openvine/services/video_editor/stop_motion_render_service.dart';
 import 'package:openvine/services/video_editor/video_editor_audio_render.dart';
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
@@ -169,20 +170,34 @@ class _CropParameters {
 }
 
 class _RenderProgressTracker {
-  _RenderProgressTracker({required this.taskId, required int clipCount})
-    : _proofBudget =
-          VideoEditorRenderService.proofModeProgressBudgetForClipCount(
-            clipCount,
-          ),
-      _proofSteps = clipCount + 1;
+  _RenderProgressTracker({
+    required this.taskId,
+    required int clipCount,
+    bool hasAssemblyPhase = false,
+  }) : _proofBudget =
+           VideoEditorRenderService.proofModeProgressBudgetForClipCount(
+             clipCount,
+           ),
+       _proofSteps = clipCount + 1,
+       _hasAssemblyPhase = hasAssemblyPhase;
+
+  /// Share of the non-proof budget reserved for the stop-motion assembly
+  /// pass. Assembly (stills → base mp4) and the composite render are both
+  /// full encode passes over the same output duration, so they get equal
+  /// halves.
+  static const double _assemblyShare = 0.5;
 
   final String taskId;
   final double _proofBudget;
   final int _proofSteps;
+  final bool _hasAssemblyPhase;
   StreamSubscription<ProgressModel>? _renderSubscription;
+  StreamSubscription<ProgressModel>? _assemblySubscription;
   double _lastProgress = 0;
 
-  double get _renderBudget => 1 - _proofBudget;
+  double get _assemblyBudget =>
+      _hasAssemblyPhase ? (1 - _proofBudget) * _assemblyShare : 0;
+  double get _renderBudget => 1 - _proofBudget - _assemblyBudget;
 
   void start() {
     // Emit an explicit reset so a reused broadcast stream does not keep showing
@@ -195,8 +210,32 @@ class _RenderProgressTracker {
     _renderSubscription = ProVideoEditor.instance
         .progressStreamById(taskId)
         .listen((progressModel) {
-          _emit(progressModel.progress * _renderBudget);
+          _emit(_assemblyBudget + progressModel.progress * _renderBudget);
         });
+  }
+
+  /// Routes the native progress of the stop-motion assembly running under
+  /// [assemblyTaskId] (step [step] of [stepCount]) into the assembly slice
+  /// of the composite progress.
+  void startAssemblyStep({
+    required String assemblyTaskId,
+    required int step,
+    required int stepCount,
+  }) {
+    _assemblySubscription?.cancel();
+    _assemblySubscription = ProVideoEditor.instance
+        .progressStreamById(assemblyTaskId)
+        .listen((progressModel) {
+          _emit(_assemblyBudget * (step + progressModel.progress) / stepCount);
+        });
+  }
+
+  Future<void> markAssemblyComplete() async {
+    // Stop listening so late assembly events cannot regress the composite
+    // progress during the render phase.
+    await _assemblySubscription?.cancel();
+    _assemblySubscription = null;
+    _emit(_assemblyBudget);
   }
 
   Future<void> markRenderComplete() async {
@@ -204,17 +243,19 @@ class _RenderProgressTracker {
     // cannot regress the composite progress during the proof phase.
     await _renderSubscription?.cancel();
     _renderSubscription = null;
-    _emit(_renderBudget);
+    _emit(1 - _proofBudget);
   }
 
   void markProofStepComplete(int completedSteps) {
     final normalizedSteps = completedSteps.clamp(0, _proofSteps);
-    _emit(_renderBudget + (_proofBudget * normalizedSteps / _proofSteps));
+    _emit(1 - _proofBudget + (_proofBudget * normalizedSteps / _proofSteps));
   }
 
   Future<void> dispose() async {
     await _renderSubscription?.cancel();
     _renderSubscription = null;
+    await _assemblySubscription?.cancel();
+    _assemblySubscription = null;
   }
 
   /// Emits a monotonically increasing composite progress value, guarding
@@ -342,12 +383,44 @@ class VideoEditorRenderService {
     if (clips.isEmpty) return null;
 
     final effectiveTaskId = taskId ?? clips.first.id;
+    // Frames-only stop-motion clips need an assembly pass (stills → base mp4)
+    // before the composite render. That pass gets its own slice of the
+    // progress budget — without it the bar sits at 0% for the whole (slow)
+    // assembly and then jumps once the (fast) composite render starts.
+    final assemblyStepCount = clips
+        .where((clip) => clip.video == null && clip.isStopMotion)
+        .length;
     final progressTracker = _RenderProgressTracker(
       taskId: effectiveTaskId,
       clipCount: clips.length,
+      hasAssemblyPhase: assemblyStepCount > 0,
     )..start();
 
     try {
+      final renderClips = <DivineVideoClip>[];
+      var assemblyStep = 0;
+      for (final clip in clips) {
+        if (clip.video == null && clip.isStopMotion) {
+          final assemblyTaskId = '$effectiveTaskId-stop-motion-$assemblyStep';
+          progressTracker.startAssemblyStep(
+            assemblyTaskId: assemblyTaskId,
+            step: assemblyStep,
+            stepCount: assemblyStepCount,
+          );
+          assemblyStep++;
+          final materialized = await StopMotionRenderService.materialize(
+            clip,
+            taskId: assemblyTaskId,
+          );
+          if (materialized == null) return null;
+          renderClips.add(materialized);
+        } else {
+          renderClips.add(clip);
+        }
+      }
+      await progressTracker.markAssemblyComplete();
+      clips = renderClips;
+
       Log.debug(
         '🎬 renderVideoToClip: clips=${clips.length}, '
         'parameters=${parameters?.toLogString()}',
@@ -442,7 +515,7 @@ class VideoEditorRenderService {
     required List<DivineVideoClip> clips,
     required Map<String, dynamic> editorStateHistory,
   }) async {
-    final path = clip.video.file?.path;
+    final path = clip.video?.file?.path;
     if (path == null) return null;
 
     final attestedClips = await _ensureClipProofs(clips);
@@ -471,7 +544,7 @@ class VideoEditorRenderService {
         continue;
       }
 
-      final videoFile = clip.video.file;
+      final videoFile = clip.requireVideo.file;
       if (videoFile == null) {
         result.add(clip);
         onClipProcessed?.call();
@@ -617,7 +690,7 @@ class VideoEditorRenderService {
     required ValueChanged<bool> onComplete,
   }) async {
     try {
-      final inputPath = await clip.video.safeFilePath();
+      final inputPath = await clip.requireVideo.safeFilePath();
 
       // Write to a new temporary file to avoid file locking issues
       final tempDir = await getTemporaryDirectory();
@@ -631,7 +704,7 @@ class VideoEditorRenderService {
         outputPath,
         VideoRenderData(
           id: taskId,
-          videoSegments: [VideoSegment(video: clip.video)],
+          videoSegments: [VideoSegment(video: clip.requireVideo)],
           endTime: duration,
         ),
       );
@@ -767,7 +840,7 @@ class VideoEditorRenderService {
         segments: clips
             .map(
               (c) => VideoSegment(
-                video: c.video,
+                video: c.requireVideo,
                 startTime: c.trimStart == .zero ? null : c.trimStart,
                 endTime: c.trimStart + c.trimmedDuration,
                 volume: c.volume,
@@ -810,7 +883,7 @@ class VideoEditorRenderService {
       if (!needsCrop) {
         segments.add(
           VideoSegment(
-            video: entry.clip.video,
+            video: entry.clip.requireVideo,
             startTime: entry.clip.trimStart == .zero
                 ? null
                 : entry.clip.trimStart,
@@ -852,7 +925,9 @@ class VideoEditorRenderService {
     final entries = <_ClipAnalysisEntry>[];
 
     for (final clip in clips) {
-      final metaData = await ProVideoEditor.instance.getMetadata(clip.video);
+      final metaData = await ProVideoEditor.instance.getMetadata(
+        clip.requireVideo,
+      );
       final resolution = metaData.resolution;
       final cropParams = _CropParameters.forAspectRatio(
         resolution: resolution,
@@ -887,7 +962,7 @@ class VideoEditorRenderService {
       id: '${clip.id}_normalized',
       videoSegments: [
         VideoSegment(
-          video: clip.video,
+          video: clip.requireVideo,
           startTime: clip.trimStart == .zero ? null : clip.trimStart,
           endTime: clip.trimStart + clip.trimmedDuration,
           volume: clip.volume,

--- a/mobile/lib/services/video_editor/video_editor_render_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_render_service.dart
@@ -15,6 +15,7 @@ import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/video_editor/transition_geometry.dart';
 import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/services/native_proofmode_service.dart';
+import 'package:openvine/services/video_editor/native_render_task_registry.dart';
 import 'package:openvine/services/video_editor/stop_motion_render_service.dart';
 import 'package:openvine/services/video_editor/video_editor_audio_render.dart';
 import 'package:path/path.dart' as path;
@@ -281,8 +282,6 @@ class VideoEditorRenderService {
 
   static final _compositeProgressController =
       StreamController<ProgressModel>.broadcast();
-  static final Map<String, Object> _activeNativeRenderTokens =
-      <String, Object>{};
 
   @visibleForTesting
   static double proofModeProgressBudgetForClipCount(int clipCount) {
@@ -307,11 +306,11 @@ class VideoEditorRenderService {
 
   @visibleForTesting
   static Set<String> get activeNativeTaskIdsForTesting =>
-      Set.unmodifiable(_activeNativeRenderTokens.keys);
+      NativeRenderTaskRegistry.activeTaskIds;
 
   @visibleForTesting
   static void resetActiveNativeTaskIdsForTesting() {
-    _activeNativeRenderTokens.clear();
+    NativeRenderTaskRegistry.reset();
   }
 
   @visibleForTesting
@@ -1267,19 +1266,13 @@ class VideoEditorRenderService {
     NativeLogLevel? nativeLogLevel = NativeLogLevel.warning,
   }) async {
     await cancelTask(task.id);
-    final token = Object();
-    _activeNativeRenderTokens[task.id] = token;
-    try {
-      return await ProVideoEditor.instance.renderVideoToFile(
+    return NativeRenderTaskRegistry.track(task.id, () {
+      return ProVideoEditor.instance.renderVideoToFile(
         outputPath,
         task,
         nativeLogLevel: nativeLogLevel,
       );
-    } finally {
-      if (identical(_activeNativeRenderTokens[task.id], token)) {
-        _activeNativeRenderTokens.remove(task.id);
-      }
-    }
+    });
   }
 
   /// Cancels native `pro_video_editor` render tasks started by this app.
@@ -1288,7 +1281,7 @@ class VideoEditorRenderService {
   /// Transient background states must not call this: exports may legitimately
   /// continue while the user briefly switches apps or locks the device.
   static Future<void> cancelActiveNativeTasks() async {
-    final taskIds = List<String>.of(_activeNativeRenderTokens.keys);
+    final taskIds = List<String>.of(NativeRenderTaskRegistry.activeTaskIds);
     if (taskIds.isEmpty) return;
 
     Log.info(

--- a/mobile/lib/services/video_editor/video_editor_render_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_render_service.dart
@@ -554,7 +554,7 @@ class VideoEditorRenderService {
         continue;
       }
 
-      final videoFile = clip.requireVideo.file;
+      final videoFile = clip.video?.file;
       if (videoFile == null) {
         result.add(clip);
         onClipProcessed?.call();

--- a/mobile/lib/services/video_editor/video_editor_render_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_render_service.dart
@@ -396,6 +396,12 @@ class VideoEditorRenderService {
       hasAssemblyPhase: assemblyStepCount > 0,
     )..start();
 
+    // Base mp4s assembled from stop-motion stills for this render only. They
+    // are muxed into the composite output below, then deleted in `finally` so
+    // they don't accumulate in the documents directory (each is a full extra
+    // video per export).
+    final intermediateStopMotionPaths = <String>[];
+
     try {
       final renderClips = <DivineVideoClip>[];
       var assemblyStep = 0;
@@ -413,6 +419,10 @@ class VideoEditorRenderService {
             taskId: assemblyTaskId,
           );
           if (materialized == null) return null;
+          final intermediatePath = materialized.video?.file?.path;
+          if (intermediatePath != null) {
+            intermediateStopMotionPaths.add(intermediatePath);
+          }
           renderClips.add(materialized);
         } else {
           renderClips.add(clip);
@@ -500,6 +510,7 @@ class VideoEditorRenderService {
       return (clip, proofManifestJson);
     } finally {
       await progressTracker.dispose();
+      await _cleanupTempFiles(intermediateStopMotionPaths);
     }
   }
 
@@ -676,9 +687,19 @@ class VideoEditorRenderService {
       );
       unawaited(_cleanupTempFiles(tempFilePaths));
       return null;
-    } catch (e) {
+    } catch (e, stack) {
       Log.error('❌ Video render failed: $e', name: _logName, category: .video);
       unawaited(_cleanupTempFiles(tempFilePaths));
+      // Native/IO render failures are expected; only programming-invariant
+      // violations (StateError/TypeError/RangeError — all `Error` subtypes)
+      // are worth surfacing to Crashlytics.
+      if (e is Error) {
+        CrashReportingService.instance.recordError(
+          e,
+          stack,
+          reason: 'renderVideo failed',
+        );
+      }
       return null;
     }
   }
@@ -1016,10 +1037,23 @@ class VideoEditorRenderService {
       'divine_${DateTime.now().microsecondsSinceEpoch}.mp4',
     );
 
+    // Overlap transitions shorten the rendered output, so the true video
+    // length is the transition-mapped output duration, capped by
+    // [maxOutputDuration]. Audio windows are clamped to it below so a short
+    // stop-motion export muxed with a full-length song can't produce an mp4
+    // whose audio outlives its video (which freezes the last frame on iOS).
+    final timelineMap = TransitionTimelineMap.fromClips(clips);
+    final videoContentDuration =
+        maxOutputDuration != null &&
+            maxOutputDuration < timelineMap.outputDuration
+        ? maxOutputDuration
+        : timelineMap.outputDuration;
+
     final customTracks = parameters?.audioTracks ?? const <AudioTrack>[];
     final audioTracks = await resolveRenderAudioTracks(
       customTracks,
       logName: _logName,
+      videoDuration: videoContentDuration,
     );
 
     final volumeSegments = segments
@@ -1037,11 +1071,11 @@ class VideoEditorRenderService {
 
     // Overlay/effect time windows are authored on the editor timeline (clips at
     // full length). Overlap transitions (dissolve/slide/push/wipe) shorten the
-    // rendered output, so every time anchor is mapped onto the output axis;
-    // otherwise anything near the end — a layer's leave animation especially —
-    // lands past the real video end and is clipped ("animation missing at the
-    // end"). Identity when no overlap transition is present.
-    final timelineMap = TransitionTimelineMap.fromClips(clips);
+    // rendered output, so every time anchor is mapped onto the output axis via
+    // [timelineMap] (computed above); otherwise anything near the end — a
+    // layer's leave animation especially — lands past the real video end and is
+    // clipped ("animation missing at the end"). Identity when no overlap
+    // transition is present.
     final videoSize =
         renderResolution ??
         VideoEditorConstants.quality.resolutionForAspectRatio(aspectRatio);

--- a/mobile/lib/services/video_editor/video_editor_reverse_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_reverse_service.dart
@@ -24,7 +24,7 @@ class VideoEditorReverseService {
     required String renderId,
   }) async {
     final documentsPath = await getDocumentsPath();
-    final inputPath = await sourceClip.video.safeFilePath();
+    final inputPath = await sourceClip.requireVideo.safeFilePath();
     final outputPath = p.join(documentsPath, '${sourceClip.id}_reversed.mp4');
 
     // Defensive: refuse to render when the input path collides with the

--- a/mobile/lib/services/video_editor/video_editor_split_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_split_service.dart
@@ -135,7 +135,7 @@ class VideoEditorSplitService {
         category: .video,
       );
       final thumbnailResult = await VideoThumbnailService.extractThumbnail(
-        videoPath: await sourceClip.video.safeFilePath(),
+        videoPath: await sourceClip.requireVideo.safeFilePath(),
         targetTimestamp: timestamp,
       );
       if (thumbnailResult != null) {

--- a/mobile/lib/services/video_editor/video_editor_transform_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_transform_service.dart
@@ -24,7 +24,7 @@ class VideoEditorTransformService {
     required String renderId,
   }) async {
     final documentsPath = await getDocumentsPath();
-    final inputPath = await sourceClip.video.safeFilePath();
+    final inputPath = await sourceClip.requireVideo.safeFilePath();
     // Unique per render so transforming the same clip twice never targets the
     // previous output (which is the new input). The prior file is intentionally
     // left on disk — undo history points back to it.

--- a/mobile/lib/services/video_publish/video_publish_service.dart
+++ b/mobile/lib/services/video_publish/video_publish_service.dart
@@ -196,7 +196,7 @@ class VideoPublishService {
       final publishing = draft.copyWith(publishStatus: .publishing);
       await draftService.saveDraft(publishing);
 
-      final videoPath = await draft.clips.first.video.safeFilePath();
+      final videoPath = await draft.clips.first.requireVideo.safeFilePath();
       Log.info('📝 Publishing video: $videoPath', category: .video);
 
       // Verify user is fully authenticated
@@ -471,11 +471,11 @@ class VideoPublishService {
     try {
       final rendered = draft.finalRenderedClip;
       if (rendered != null) {
-        final path = await rendered.video.safeFilePath();
+        final path = await rendered.requireVideo.safeFilePath();
         if (File(path).existsSync()) return path;
       }
       if (draft.clips.isNotEmpty) {
-        return draft.clips.first.video.safeFilePath();
+        return draft.clips.first.requireVideo.safeFilePath();
       }
     } catch (e) {
       Log.warning('⚠️ Could not resolve video path: $e', category: .video);

--- a/mobile/lib/services/video_publish/video_publish_service.dart
+++ b/mobile/lib/services/video_publish/video_publish_service.dart
@@ -196,8 +196,14 @@ class VideoPublishService {
       final publishing = draft.copyWith(publishStatus: .publishing);
       await draftService.saveDraft(publishing);
 
-      final videoPath = await draft.clips.first.requireVideo.safeFilePath();
-      Log.info('📝 Publishing video: $videoPath', category: .video);
+      // Log-only: prefer the rendered clip (a stop-motion draft's clips.first
+      // is a frames-only clip whose mp4 lives in finalRenderedClip). The real
+      // upload-path resolution happens in _getOrCreateUpload.
+      final videoPath = await _resolveVideoPath(draft);
+      Log.info(
+        '📝 Publishing video: ${videoPath ?? '<pending>'}',
+        category: .video,
+      );
 
       // Verify user is fully authenticated
       if (!authService.isAuthenticated) {

--- a/mobile/lib/utils/gallery_save_utils.dart
+++ b/mobile/lib/utils/gallery_save_utils.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/services/gallery_save_service.dart';
@@ -21,30 +22,38 @@ Future<void> saveToGallery(BuildContext context, WidgetRef ref) async {
   final finalRenderedClip = ref.read(videoEditorProvider).finalRenderedClip;
   if (finalRenderedClip == null) return;
 
-  // Stop-motion clips render their mp4 on demand; a normal clip passes through.
-  final materialized = await StopMotionRenderService.materialize(
-    finalRenderedClip,
-  );
-  if (materialized == null || !context.mounted) return;
-  final video = materialized.requireVideo;
+  DivineVideoClip? materialized;
+  try {
+    // Stop-motion clips render their mp4 on demand; a normal clip passes through.
+    materialized = await StopMotionRenderService.materialize(
+      finalRenderedClip,
+    );
+    if (materialized == null || !context.mounted) return;
+    final video = materialized.requireVideo;
 
-  final gallerySaveService = ref.read(gallerySaveServiceProvider);
-  final result = await gallerySaveService.saveVideoToGallery(video);
+    final gallerySaveService = ref.read(gallerySaveServiceProvider);
+    final result = await gallerySaveService.saveVideoToGallery(video);
 
-  if (result is! GallerySavePermissionDenied || !context.mounted) {
-    return;
-  }
+    if (result is! GallerySavePermissionDenied || !context.mounted) {
+      return;
+    }
 
-  // Permission denied — show an actionable sheet instead of a snackbar.
-  final permissionsService = ref.read(permissionsServiceProvider);
-  final choice = await showGalleryPermissionSheet(
-    context,
-    permissionsService: permissionsService,
-  );
+    // Permission denied — show an actionable sheet instead of a snackbar.
+    final permissionsService = ref.read(permissionsServiceProvider);
+    final choice = await showGalleryPermissionSheet(
+      context,
+      permissionsService: permissionsService,
+    );
 
-  if (choice == GalleryPermissionChoice.openedSettings ||
-      choice == GalleryPermissionChoice.granted) {
-    // Retry once — the user may have just granted access.
-    await gallerySaveService.saveVideoToGallery(video);
+    if (choice == GalleryPermissionChoice.openedSettings ||
+        choice == GalleryPermissionChoice.granted) {
+      // Retry once — the user may have just granted access.
+      await gallerySaveService.saveVideoToGallery(video);
+    }
+  } finally {
+    await StopMotionRenderService.cleanupMaterializedOutput(
+      sourceClip: finalRenderedClip,
+      materializedClip: materialized,
+    );
   }
 }

--- a/mobile/lib/utils/gallery_save_utils.dart
+++ b/mobile/lib/utils/gallery_save_utils.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/services/gallery_save_service.dart';
+import 'package:openvine/services/video_editor/stop_motion_render_service.dart';
 import 'package:openvine/widgets/gallery_permission_sheet.dart';
 
 /// Saves the final rendered video to the device gallery.
@@ -20,10 +21,15 @@ Future<void> saveToGallery(BuildContext context, WidgetRef ref) async {
   final finalRenderedClip = ref.read(videoEditorProvider).finalRenderedClip;
   if (finalRenderedClip == null) return;
 
-  final gallerySaveService = ref.read(gallerySaveServiceProvider);
-  final result = await gallerySaveService.saveVideoToGallery(
-    finalRenderedClip.video,
+  // Stop-motion clips render their mp4 on demand; a normal clip passes through.
+  final materialized = await StopMotionRenderService.materialize(
+    finalRenderedClip,
   );
+  if (materialized == null || !context.mounted) return;
+  final video = materialized.requireVideo;
+
+  final gallerySaveService = ref.read(gallerySaveServiceProvider);
+  final result = await gallerySaveService.saveVideoToGallery(video);
 
   if (result is! GallerySavePermissionDenied || !context.mounted) {
     return;
@@ -39,6 +45,6 @@ Future<void> saveToGallery(BuildContext context, WidgetRef ref) async {
   if (choice == GalleryPermissionChoice.openedSettings ||
       choice == GalleryPermissionChoice.granted) {
     // Retry once — the user may have just granted access.
-    await gallerySaveService.saveVideoToGallery(finalRenderedClip.video);
+    await gallerySaveService.saveVideoToGallery(video);
   }
 }

--- a/mobile/lib/widgets/library/clips_tab.dart
+++ b/mobile/lib/widgets/library/clips_tab.dart
@@ -111,6 +111,7 @@ class ClipsTab extends StatelessWidget {
           selectedClipIds: state.selectedClipIds,
           showSelectionIndicator: selectionEnabled,
           disabledClipIds: state.disabledClipIds,
+          selectedIsStopMotion: state.selectedIsStopMotion,
           scrollController: scrollController,
           targetAspectRatio: targetAspectRatio,
           onTapClip: (clip) {
@@ -246,6 +247,7 @@ class _MasonryLayout extends StatelessWidget {
     this.disabledClipIds = const {},
     this.scrollController,
     this.targetAspectRatio,
+    this.selectedIsStopMotion,
   });
 
   final List<DivineVideoClip> clips;
@@ -256,6 +258,11 @@ class _MasonryLayout extends StatelessWidget {
   final ValueChanged<DivineVideoClip> onTapClip;
   final ValueChanged<DivineVideoClip> onLongPressClip;
   final double? targetAspectRatio;
+
+  /// Type of the current selection (`true` = stop-motion). When set, clips of
+  /// the other type are disabled so a selection can't mix stop-motion stills
+  /// with normal video clips.
+  final bool? selectedIsStopMotion;
 
   static const _columnCount = 3;
 
@@ -284,7 +291,9 @@ class _MasonryLayout extends StatelessWidget {
           disabled:
               disabledClipIds.contains(clip.id) ||
               (targetAspectRatio != null &&
-                  targetAspectRatio != clip.targetAspectRatio.value),
+                  targetAspectRatio != clip.targetAspectRatio.value) ||
+              (selectedIsStopMotion != null &&
+                  clip.isStopMotion != selectedIsStopMotion),
           onTap: () => onTapClip(clip),
           onLongPress: () => onLongPressClip(clip),
         );

--- a/mobile/lib/widgets/stop_motion/stop_motion_player.dart
+++ b/mobile/lib/widgets/stop_motion/stop_motion_player.dart
@@ -1,0 +1,210 @@
+// ABOUTME: Lightweight looping player for a stop-motion clip's captured stills
+// ABOUTME: Renders frames directly, avoiding the short-mp4 loop oscillation
+
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
+
+/// Plays a stop-motion clip by looping through its captured stills, holding
+/// each for its own [StopMotionClipFrame.duration].
+///
+/// Used wherever a frames-based clip would otherwise be handed to the video
+/// player. Rendering the frames directly avoids the stutter/oscillation a
+/// looping video player exhibits on ultra-short (≈83ms) clips.
+///
+/// Two modes:
+///
+/// * **Autonomous** ([position] is `null`): runs its own [Ticker] and loops
+///   continuously. Honors the platform reduce-motion setting — when animations
+///   are disabled it holds the first frame statically. Used by standalone
+///   previews (metadata / clip preview) that have no external timeline.
+/// * **Controlled** ([position] is non-null): renders the frame at the supplied
+///   composition [position] and never runs its own clock. The caller (the video
+///   editor) drives the frame from its play/pause + timeline state, so playback
+///   respects the playhead instead of free-running.
+class StopMotionPlayer extends StatefulWidget {
+  const StopMotionPlayer({
+    required this.frames,
+    this.fit = BoxFit.cover,
+    this.position,
+    this.cacheHeight,
+    super.key,
+  });
+
+  /// The captured stills, in playback order.
+  final List<StopMotionClipFrame> frames;
+
+  /// How each frame is inscribed into the player's box.
+  final BoxFit fit;
+
+  /// When non-null, the player is *controlled*: it renders the frame at this
+  /// composition position (looping past the sequence length) and does not run
+  /// its own ticker. When `null` the player self-drives a continuous loop.
+  final Duration? position;
+
+  /// Optional decode height (physical pixels) for the stills. Captured frames
+  /// are full camera resolution (multiple MB each decoded); decoding a whole
+  /// sequence at that size thrashes the image cache and stutters playback.
+  /// Callers displaying the player at a known size pass the target height so
+  /// precache and display share one bounded decode.
+  final int? cacheHeight;
+
+  @override
+  State<StopMotionPlayer> createState() => _StopMotionPlayerState();
+}
+
+class _StopMotionPlayerState extends State<StopMotionPlayer>
+    with SingleTickerProviderStateMixin {
+  Ticker? _ticker;
+  final ValueNotifier<int> _frameIndex = ValueNotifier<int>(0);
+
+  /// Cumulative end offset (microseconds) per frame, so the active frame for a
+  /// given elapsed time is found with a single forward scan.
+  late List<int> _cumulativeEndUs;
+  late int _totalUs;
+  bool _precached = false;
+
+  bool get _isControlled => widget.position != null;
+
+  @override
+  void initState() {
+    super.initState();
+    _computeTimeline();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _precacheFrames();
+    _syncTicker();
+  }
+
+  @override
+  void didUpdateWidget(StopMotionPlayer oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.frames != widget.frames) {
+      _computeTimeline();
+      _frameIndex.value = 0;
+      _precached = false;
+      _precacheFrames();
+    }
+    if (oldWidget.frames != widget.frames ||
+        oldWidget.position != widget.position) {
+      _syncTicker();
+    }
+  }
+
+  void _computeTimeline() {
+    var acc = 0;
+    _cumulativeEndUs = [
+      for (final frame in widget.frames) acc += frame.duration.inMicroseconds,
+    ];
+    _totalUs = acc;
+  }
+
+  void _precacheFrames() {
+    if (_precached) return;
+    _precached = true;
+    for (final frame in widget.frames) {
+      precacheImage(
+        ResizeImage.resizeIfNeeded(
+          null,
+          widget.cacheHeight,
+          FileImage(File(frame.path)),
+        ),
+        context,
+      );
+    }
+  }
+
+  void _syncTicker() {
+    // Controlled mode renders the frame for the external position; the caller
+    // owns the clock, so the internal ticker must stay off.
+    final reduceMotion = MediaQuery.of(context).disableAnimations;
+    final shouldAnimate =
+        !_isControlled &&
+        !reduceMotion &&
+        widget.frames.length > 1 &&
+        _totalUs > 0;
+
+    if (shouldAnimate && _ticker == null) {
+      _ticker = createTicker(_onTick)..start();
+    } else if (!shouldAnimate && _ticker != null) {
+      _ticker!.dispose();
+      _ticker = null;
+      _frameIndex.value = 0;
+    }
+  }
+
+  void _onTick(Duration elapsed) {
+    final index = _frameIndexForMicros(elapsed.inMicroseconds);
+    if (index != _frameIndex.value) _frameIndex.value = index;
+  }
+
+  /// Maps an absolute microsecond offset (looping past [_totalUs]) to the index
+  /// of the frame that is showing at that time.
+  int _frameIndexForMicros(int micros) {
+    if (_totalUs <= 0) return 0;
+    final t = micros % _totalUs;
+    var index = 0;
+    while (index < _cumulativeEndUs.length - 1 &&
+        t >= _cumulativeEndUs[index]) {
+      index++;
+    }
+    return index;
+  }
+
+  @override
+  void dispose() {
+    _ticker?.dispose();
+    _frameIndex.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.frames.isEmpty) return const SizedBox.shrink();
+
+    final position = widget.position;
+    if (position != null) {
+      return _StopMotionFrame(
+        frame: widget.frames[_frameIndexForMicros(position.inMicroseconds)],
+        fit: widget.fit,
+        cacheHeight: widget.cacheHeight,
+      );
+    }
+
+    return ValueListenableBuilder<int>(
+      valueListenable: _frameIndex,
+      builder: (context, index, _) => _StopMotionFrame(
+        frame: widget.frames[index],
+        fit: widget.fit,
+        cacheHeight: widget.cacheHeight,
+      ),
+    );
+  }
+}
+
+class _StopMotionFrame extends StatelessWidget {
+  const _StopMotionFrame({
+    required this.frame,
+    required this.fit,
+    this.cacheHeight,
+  });
+
+  final StopMotionClipFrame frame;
+  final BoxFit fit;
+  final int? cacheHeight;
+
+  @override
+  Widget build(BuildContext context) {
+    return Image.file(
+      File(frame.path),
+      fit: fit,
+      gaplessPlayback: true,
+      cacheHeight: cacheHeight,
+    );
+  }
+}

--- a/mobile/lib/widgets/stop_motion/stop_motion_player.dart
+++ b/mobile/lib/widgets/stop_motion/stop_motion_player.dart
@@ -87,6 +87,12 @@ class _StopMotionPlayerState extends State<StopMotionPlayer>
     if (oldWidget.frames != widget.frames) {
       _computeTimeline();
       _frameIndex.value = 0;
+    }
+    // Re-run precache when the frames change or when only the decode height
+    // changes — a cacheHeight-only change would otherwise leave the precache
+    // at the previous decode size.
+    if (oldWidget.frames != widget.frames ||
+        oldWidget.cacheHeight != widget.cacheHeight) {
       _precached = false;
       _precacheFrames();
     }

--- a/mobile/lib/widgets/stop_motion/stop_motion_player.dart
+++ b/mobile/lib/widgets/stop_motion/stop_motion_player.dart
@@ -40,8 +40,12 @@ class StopMotionPlayer extends StatefulWidget {
   final BoxFit fit;
 
   /// When non-null, the player is *controlled*: it renders the frame at this
-  /// composition position (looping past the sequence length) and does not run
-  /// its own ticker. When `null` the player self-drives a continuous loop.
+  /// composition position and does not run its own ticker. When `null` the
+  /// player self-drives a continuous loop.
+  ///
+  /// The end of the sequence holds the last still rather than wrapping — the
+  /// editor's playhead clamps to the composition total inclusive, so the total
+  /// means "the end", not "the start of the next loop".
   final Duration? position;
 
   /// Optional decode height (physical pixels) for the stills. Captured frames
@@ -162,6 +166,18 @@ class _StopMotionPlayerState extends State<StopMotionPlayer>
     return index;
   }
 
+  /// Maps an externally driven [micros] to the frame showing at that time,
+  /// holding the last still at the end rather than wrapping to the first.
+  ///
+  /// The controlled clock clamps to the composition total *inclusive*, and at
+  /// exactly the total the loop modulo would land back on frame 0 — showing the
+  /// first still while the timed layers sit at the end.
+  int _controlledFrameIndexForMicros(int micros) {
+    if (_totalUs <= 0) return 0;
+    if (micros >= _totalUs) return widget.frames.length - 1;
+    return _frameIndexForMicros(micros);
+  }
+
   @override
   void dispose() {
     _ticker?.dispose();
@@ -176,7 +192,10 @@ class _StopMotionPlayerState extends State<StopMotionPlayer>
     final position = widget.position;
     if (position != null) {
       return _StopMotionFrame(
-        frame: widget.frames[_frameIndexForMicros(position.inMicroseconds)],
+        frame:
+            widget.frames[_controlledFrameIndexForMicros(
+              position.inMicroseconds,
+            )],
         fit: widget.fit,
         cacheHeight: widget.cacheHeight,
       );

--- a/mobile/lib/widgets/video_clip/video_clip_preview.dart
+++ b/mobile/lib/widgets/video_clip/video_clip_preview.dart
@@ -104,11 +104,12 @@ class _VideoClipPreviewSheetState extends ConsumerState<VideoClipPreview> {
 
     setState(() => _isSaving = true);
 
+    DivineVideoClip? materialized;
     try {
       final gallerySaveService = ref.read(gallerySaveServiceProvider);
       // Stop-motion clips render their mp4 on demand; a normal clip passes
       // through unchanged.
-      final materialized = await StopMotionRenderService.materialize(
+      materialized = await StopMotionRenderService.materialize(
         widget.clip,
       );
       if (!mounted) return;
@@ -166,6 +167,10 @@ class _VideoClipPreviewSheetState extends ConsumerState<VideoClipPreview> {
         );
       }
     } finally {
+      await StopMotionRenderService.cleanupMaterializedOutput(
+        sourceClip: widget.clip,
+        materializedClip: materialized,
+      );
       if (mounted) setState(() => _isSaving = false);
     }
   }

--- a/mobile/lib/widgets/video_clip/video_clip_preview.dart
+++ b/mobile/lib/widgets/video_clip/video_clip_preview.dart
@@ -14,6 +14,8 @@ import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/services/gallery_save_service.dart';
+import 'package:openvine/services/video_editor/stop_motion_render_service.dart';
+import 'package:openvine/widgets/stop_motion/stop_motion_player.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 class VideoClipPreview extends ConsumerStatefulWidget {
@@ -53,7 +55,16 @@ class _VideoClipPreviewSheetState extends ConsumerState<VideoClipPreview> {
   /// [DivineVideoPlayerController], initializes it, enables looping,
   /// and starts playback automatically.
   Future<void> _initializePlayer() async {
-    final file = File(await widget.clip.video.safeFilePath());
+    // Stop-motion clips are rendered frame-by-frame by [StopMotionPlayer];
+    // there is no video file to load into the native player.
+    if (widget.clip.isStopMotion) return;
+
+    final video = widget.clip.video;
+    if (video == null) {
+      if (mounted) context.pop();
+      return;
+    }
+    final file = File(await video.safeFilePath());
     if (!file.existsSync()) {
       if (mounted) context.pop();
       return;
@@ -95,8 +106,29 @@ class _VideoClipPreviewSheetState extends ConsumerState<VideoClipPreview> {
 
     try {
       final gallerySaveService = ref.read(gallerySaveServiceProvider);
-      final video = widget.clip.video;
-      final result = await gallerySaveService.saveVideoToGallery(video);
+      // Stop-motion clips render their mp4 on demand; a normal clip passes
+      // through unchanged.
+      final materialized = await StopMotionRenderService.materialize(
+        widget.clip,
+      );
+      if (!mounted) return;
+      if (materialized == null) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            backgroundColor: VineTheme.transparent,
+            elevation: 0,
+            behavior: SnackBarBehavior.floating,
+            content: DivineSnackbarContainer(
+              label: context.l10n.videoClipSaveFailed,
+              error: true,
+            ),
+          ),
+        );
+        return;
+      }
+      final result = await gallerySaveService.saveVideoToGallery(
+        materialized.requireVideo,
+      );
 
       if (!mounted) return;
 
@@ -161,6 +193,19 @@ class _VideoClipPreviewSheetState extends ConsumerState<VideoClipPreview> {
                         borderRadius: .circular(16),
                         child: Builder(
                           builder: (context) {
+                            if (widget.clip.stopMotionFrames
+                                case final frames?) {
+                              return StopMotionPlayer(
+                                frames: frames,
+                                cacheHeight:
+                                    (MediaQuery.sizeOf(context).height *
+                                            MediaQuery.devicePixelRatioOf(
+                                              context,
+                                            ))
+                                        .round(),
+                              );
+                            }
+
                             final vw = _controller?.state.videoWidth ?? 0;
                             final vh = _controller?.state.videoHeight ?? 0;
 

--- a/mobile/lib/widgets/video_clip/video_clip_thumbnail_card.dart
+++ b/mobile/lib/widgets/video_clip/video_clip_thumbnail_card.dart
@@ -106,8 +106,17 @@ class _VideoClipThumbnailCardState extends State<VideoClipThumbnailCard> {
                     /// Thumbnail or placeholder
                     _Thumbnail(clip: widget.clip),
 
-                    /// Duration badge - bottom left
-                    if (widget.showDurationBadge)
+                    /// Stop-motion marker + still count - top left
+                    if (widget.clip.isStopMotion)
+                      _StopMotionBadge(
+                        frameCount: widget.clip.stopMotionFrames?.length ?? 0,
+                      ),
+
+                    /// Duration badge - bottom left. Hidden for stop-motion
+                    /// recordings: their playback length (frame count / 12fps)
+                    /// is a tiny, misleading value, so they read as a still
+                    /// image marked only by the stop-motion badge.
+                    if (widget.showDurationBadge && !widget.clip.isStopMotion)
                       _DurationBadge(clip: widget.clip),
 
                     if (widget.clip.libraryTitle case final title?)
@@ -173,7 +182,17 @@ class _ThumbnailState extends State<_Thumbnail> {
     if (_thumbnailExists && widget.clip.thumbnailPath != null) {
       return Hero(
         tag: 'Video-Clip-Preview-${widget.clip.id}',
-        child: Image.file(File(widget.clip.thumbnailPath!), fit: .cover),
+        // Stop-motion clips use a full-resolution still as their thumbnail;
+        // bound the decode to the grid cell so it doesn't cost tens of MB.
+        child: Image.file(
+          File(widget.clip.thumbnailPath!),
+          fit: .cover,
+          cacheHeight:
+              (MediaQuery.sizeOf(context).width *
+                      MediaQuery.devicePixelRatioOf(context) /
+                      2)
+                  .round(),
+        ),
       );
     }
 
@@ -209,6 +228,51 @@ class _TitleBadge extends StatelessWidget {
             maxLines: 2,
             overflow: TextOverflow.ellipsis,
             style: VineTheme.labelSmallFont(),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Marks a clip in the library as a stop-motion recording and shows how many
+/// stills it holds (top-left corner).
+class _StopMotionBadge extends StatelessWidget {
+  const _StopMotionBadge({required this.frameCount});
+
+  /// Number of captured stills in the set.
+  final int frameCount;
+
+  @override
+  Widget build(BuildContext context) {
+    return PositionedDirectional(
+      start: 6,
+      top: 6,
+      child: Semantics(
+        label: context.l10n.libraryStopMotionClipLabel,
+        value: context.l10n.videoEditorStopMotionFramesCount(frameCount),
+        // The icon + count are decorative here; the count is already announced
+        // via the badge's semantics value, so exclude the visual content to
+        // keep a single, clean semantics node.
+        child: ExcludeSemantics(
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
+            decoration: BoxDecoration(
+              color: VineTheme.scrim65,
+              borderRadius: BorderRadius.circular(4),
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              spacing: 3,
+              children: [
+                const DivineIcon(
+                  icon: .imagesSquare,
+                  color: VineTheme.lightText,
+                  size: 14,
+                ),
+                Text('$frameCount', style: VineTheme.labelSmallFont()),
+              ],
+            ),
           ),
         ),
       ),

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -1867,7 +1867,12 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
       name: 'VideoEditorCanvas',
       category: LogCategory.video,
     );
-    final wasPlaying = _videoPlayer?.state.isPlaying ?? false;
+    // A stop-motion composition has no native player — its playback is the
+    // widget-driven ticker, whose playing state lives in the bloc. Read before
+    // _pauseStopMotion() below clears it.
+    final wasPlaying = _isStopMotionComposition
+        ? context.read<VideoEditorMainBloc>().state.isPlaying
+        : (_videoPlayer?.state.isPlaying ?? false);
     final resumePosition = context
         .read<VideoEditorMainBloc>()
         .state
@@ -1905,7 +1910,15 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     } finally {
       _isMetadataRouteActive = false;
     }
-    if (!mounted || _clipPaths.isEmpty) return;
+    if (!mounted) return;
+    // Stop-motion has no player to rebuild (_clipPaths is empty, which the
+    // guard below would take as "nothing to resume"); restarting its ticker is
+    // the whole resume.
+    if (_isStopMotionComposition) {
+      if (wasPlaying) _playStopMotion(from: resumePosition);
+      return;
+    }
+    if (_clipPaths.isEmpty) return;
     await ref.read(videoEditorProvider.notifier).waitForRenderIdle();
     if (!mounted || _clipPaths.isEmpty) return;
     await _initializePlayer(_clipPaths, startPosition: resumePosition);

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -969,7 +969,11 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     _proVideoController.setPlayTime(_stopMotionAnchor);
     final audio = _stopMotionAudio;
     if (audio != null) {
-      unawaited(audio.syncTo(_stopMotionAnchor, isPlaying: true));
+      // Re-anchoring is a clock set, not a tick: a resume that lands mid-window
+      // must re-seek even when it re-anchors only slightly ahead.
+      unawaited(
+        audio.syncTo(_stopMotionAnchor, isPlaying: true, isSeek: true),
+      );
     }
 
     context.read<VideoEditorMainBloc>()
@@ -1012,7 +1016,11 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     final audio = _stopMotionAudio;
     if (audio != null) {
       unawaited(
-        audio.syncTo(clamped, isPlaying: _stopMotionStopwatch.isRunning),
+        audio.syncTo(
+          clamped,
+          isPlaying: _stopMotionStopwatch.isRunning,
+          isSeek: true,
+        ),
       );
     }
     context.read<VideoEditorMainBloc>().add(

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -26,6 +26,8 @@ import 'package:openvine/extensions/tune_adjustment_matrix_extensions.dart';
 import 'package:openvine/extensions/video_editor_extensions.dart';
 import 'package:openvine/extensions/video_editor_history_extensions.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/stop_motion/stop_motion_frame_ops.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/models/timeline_overlay_item.dart';
 import 'package:openvine/models/video_editor/transition_geometry.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
@@ -33,6 +35,7 @@ import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/screens/video_metadata/video_metadata_screen.dart';
 import 'package:openvine/services/haptic_service.dart';
 import 'package:openvine/services/video_editor/clip_speed_render_service.dart';
+import 'package:openvine/services/video_editor/stop_motion_audio_preview.dart';
 import 'package:openvine/services/video_editor/transition_seam_render_service.dart';
 import 'package:openvine/utils/await_push_transition.dart';
 import 'package:openvine/utils/mounted_post_frame.dart';
@@ -48,6 +51,7 @@ import 'package:openvine/widgets/video_editor/tune_editor/tune_set_timeline_ops.
 import 'package:pro_image_editor/pro_image_editor.dart'
     hide AudioTrack, VideoClip;
 import 'package:pro_video_editor/pro_video_editor.dart' show ClipTransition;
+import 'package:sound_service/sound_service.dart' show AudioSourceConfig;
 import 'package:unified_logger/unified_logger.dart';
 
 /// Direction an undo/redo navigation moved, used to bias which way
@@ -319,6 +323,35 @@ class VideoEditorCanvas extends StatelessWidget {
     );
   }
 
+  /// Compares two clip lists by their editable properties, deciding whether a
+  /// history snapshot needs mirroring back into the app clip state.
+  @visibleForTesting
+  static bool clipsChanged(
+    List<DivineVideoClip> current,
+    List<DivineVideoClip> next,
+  ) {
+    if (current.length != next.length) return true;
+    for (var i = 0; i < current.length; i++) {
+      final a = current[i];
+      final b = next[i];
+      if (a.id != b.id ||
+          a.video != b.video ||
+          a.trimStart != b.trimStart ||
+          a.trimEnd != b.trimEnd ||
+          a.volume != b.volume ||
+          a.playbackSpeed != b.playbackSpeed ||
+          a.transition != b.transition ||
+          // Frame edits (hold changes, delete, reorder) are the whole edit
+          // surface of a stop-motion clip — without this the clip manager
+          // (publish render, autosave, metadata preview) and undo/redo never
+          // see them.
+          !listEquals(a.stopMotionFrames, b.stopMotionFrames)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   @override
   Widget build(BuildContext context) {
     final isSubEditorOpen = context.select(
@@ -369,7 +402,7 @@ class _VideoEditor extends ConsumerStatefulWidget {
 }
 
 class _VideoEditorState extends ConsumerState<_VideoEditor>
-    with SingleTickerProviderStateMixin {
+    with TickerProviderStateMixin {
   late final ProVideoController _proVideoController;
   final _isPlayerReadyNotifier = ValueNotifier<bool>(false);
   DivineVideoPlayerController? _videoPlayer;
@@ -418,6 +451,28 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
 
   /// Composite (player-space) duration, kept fresh to clamp interpolation.
   Duration _lastPlayerDuration = Duration.zero;
+
+  /// Drives playback of a frames-only stop-motion clip, which has no native
+  /// player (`_videoPlayer` stays null). Advances the bloc's currentPosition —
+  /// and, through it, the timeline playhead — while playing, so the same
+  /// play/pause + scrub controls that drive video also drive stop-motion.
+  Ticker? _stopMotionTicker;
+
+  /// Position the stop-motion clock resumes from; re-anchored on play / seek.
+  Duration _stopMotionAnchor = Duration.zero;
+
+  /// Wall-clock elapsed since [_stopMotionAnchor] was captured.
+  final _stopMotionStopwatch = Stopwatch();
+
+  /// Last position the stop-motion clock pushed to the bloc, used to throttle
+  /// emits to [VideoEditorConstants.stopMotionPlayheadEmitInterval].
+  Duration _lastStopMotionEmit = Duration.zero;
+
+  /// Plays timeline sounds against the stop-motion clock. A frames-only
+  /// composition has no native video player, so `setAudioTracks` (the normal
+  /// audio path) has nothing to attach to — this engine follows
+  /// [_stopMotionTicker] instead. Created lazily by [_syncStopMotionAudio].
+  StopMotionAudioPreview? _stopMotionAudio;
 
   /// Last position dispatched to BLoC — avoids flooding with duplicates.
   Duration _lastReportedPosition = Duration.zero;
@@ -516,6 +571,14 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     if (_clipPaths.isNotEmpty) {
       _initializePlayer(_clipPaths);
     }
+
+    // A stop-motion composition never runs _initializePlayer (no mp4), so its
+    // audio engine needs its own initial sync for sounds restored from a
+    // draft. Post-frame: _isStopMotionComposition reads providers/blocs.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || !_isStopMotionComposition) return;
+      unawaited(_syncAudioTracks());
+    });
   }
 
   /// Renders and caches transition seams so the preview can splice them in
@@ -548,6 +611,9 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
       category: LogCategory.video,
     );
     _playheadTicker?.dispose();
+    _stopMotionTicker?.dispose();
+    _stopMotionAudio?.dispose();
+    _stopMotionAudio = null;
     _videoPlayerSubscription?.cancel();
     _videoPlayer?.dispose();
     // Null it so a release/init still awaiting bails instead of double-disposing
@@ -786,12 +852,16 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
   List<String> get _clipPaths => ref
       .read(clipManagerProvider)
       .clips
-      .map((c) => c.video.file?.path)
+      .map((c) => c.video?.file?.path)
       .whereType<String>()
       .toList();
 
   /// Handles playback restart requests from BLoC.
   void _onPlaybackRestartRequested() {
+    if (_isStopMotionComposition) {
+      _playStopMotion(from: Duration.zero);
+      return;
+    }
     if (!_isPlayerReadyNotifier.value || !_isPlayerInitialized) return;
 
     // Stop the interpolator on the user action so it can't advance the play
@@ -809,6 +879,10 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
 
   /// Handles playback toggle requests from BLoC.
   void _onPlaybackToggleRequested() {
+    if (_isStopMotionComposition) {
+      _toggleStopMotionPlayback();
+      return;
+    }
     if (!_isPlayerReadyNotifier.value || !_isPlayerInitialized) return;
 
     final isPlaying = _videoPlayer?.state.isPlaying ?? false;
@@ -828,6 +902,16 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
 
   /// Handles external pause requests from BLoC.
   void _onExternalPauseChanged({required bool isPaused}) {
+    if (_isStopMotionComposition) {
+      if (isPaused) {
+        _pauseStopMotion();
+      } else {
+        _playStopMotion(
+          from: context.read<VideoEditorMainBloc>().state.currentPosition,
+        );
+      }
+      return;
+    }
     if (!_isPlayerReadyNotifier.value || !_isPlayerInitialized) return;
 
     if (isPaused) {
@@ -841,6 +925,133 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
       // delayed-reset-report window.
       _videoPlayer?.play();
     }
+  }
+
+  // -- Frames-only stop-motion playhead --------------------------------------
+
+  /// Whether the current composition is a frames-only stop-motion clip. Such a
+  /// clip has no mp4, so [_clipPaths] is empty and the native [_videoPlayer] is
+  /// never created — playback is driven by [_stopMotionTicker] against the bloc
+  /// instead.
+  bool get _isStopMotionComposition =>
+      isStopMotionComposition(ref.read(clipManagerProvider).clips);
+
+  /// Wall-clock length of the stop-motion loop (sum of clip playback
+  /// durations), read from the [ClipEditorBloc] the timeline also scales to.
+  Duration get _stopMotionTotalDuration =>
+      context.read<ClipEditorBloc>().state.totalDuration;
+
+  void _toggleStopMotionPlayback() {
+    if (context.read<VideoEditorMainBloc>().state.isPlaying) {
+      _pauseStopMotion();
+    } else {
+      _playStopMotion(
+        from: context.read<VideoEditorMainBloc>().state.currentPosition,
+      );
+    }
+  }
+
+  void _playStopMotion({required Duration from}) {
+    final total = _stopMotionTotalDuration;
+    if (total <= Duration.zero) return;
+
+    _stopMotionAnchor = from >= total ? Duration.zero : from;
+    _lastStopMotionEmit = _stopMotionAnchor;
+    _stopMotionStopwatch
+      ..reset()
+      ..start();
+    // Ticker.start() asserts the ticker is idle; re-anchoring while already
+    // playing (e.g. external unpause) must not double-start it.
+    final ticker = _stopMotionTicker ??= createTicker(_onStopMotionTick);
+    if (!ticker.isActive) ticker.start();
+
+    // Timed layers follow the overlay play time, not the bloc position.
+    _proVideoController.setPlayTime(_stopMotionAnchor);
+    final audio = _stopMotionAudio;
+    if (audio != null) {
+      unawaited(audio.syncTo(_stopMotionAnchor, isPlaying: true));
+    }
+
+    context.read<VideoEditorMainBloc>()
+      ..add(VideoEditorPositionChanged(_stopMotionAnchor))
+      ..add(const VideoEditorPlaybackChanged(isPlaying: true));
+  }
+
+  void _pauseStopMotion() {
+    _stopMotionStopwatch.stop();
+    if (_stopMotionTicker?.isActive ?? false) _stopMotionTicker!.stop();
+    final audio = _stopMotionAudio;
+    if (audio != null) unawaited(audio.pauseAll());
+    if (!context.read<VideoEditorMainBloc>().state.isPlaying) return;
+    context.read<VideoEditorMainBloc>().add(
+      const VideoEditorPlaybackChanged(isPlaying: false),
+    );
+  }
+
+  /// Jumps the stop-motion playhead to [position] (timeline scrubbing),
+  /// re-anchoring the clock so playback continues from there if it was running.
+  void _seekStopMotion(Duration position) {
+    final total = _stopMotionTotalDuration;
+    final clamped = total <= Duration.zero
+        ? Duration.zero
+        : Duration(
+            microseconds: position.inMicroseconds.clamp(
+              0,
+              total.inMicroseconds,
+            ),
+          );
+
+    _stopMotionAnchor = clamped;
+    _lastStopMotionEmit = clamped;
+    if (_stopMotionStopwatch.isRunning) {
+      _stopMotionStopwatch
+        ..reset()
+        ..start();
+    }
+    _proVideoController.setPlayTime(clamped);
+    final audio = _stopMotionAudio;
+    if (audio != null) {
+      unawaited(
+        audio.syncTo(clamped, isPlaying: _stopMotionStopwatch.isRunning),
+      );
+    }
+    context.read<VideoEditorMainBloc>().add(
+      VideoEditorPositionChanged(clamped),
+    );
+  }
+
+  void _onStopMotionTick(Duration _) {
+    if (!mounted) return;
+    final total = _stopMotionTotalDuration;
+    if (total <= Duration.zero) {
+      _pauseStopMotion();
+      return;
+    }
+
+    final looped = stopMotionLoopPosition(
+      anchor: _stopMotionAnchor,
+      elapsed: _stopMotionStopwatch.elapsed,
+      total: total,
+    );
+
+    // Frame-rate consumers first: timed layers follow the overlay play time
+    // (the normal path drives it per frame from the playhead interpolator),
+    // and the audio engine needs the wrap/window transitions the throttled
+    // bloc emit below would swallow.
+    _proVideoController.setPlayTime(looped);
+    final audio = _stopMotionAudio;
+    if (audio != null) unawaited(audio.syncTo(looped, isPlaying: true));
+
+    // Throttle emits: the timeline animates between updates, so a frame-rate
+    // stream would only flood the bloc. A wrap back to the start (looped <
+    // last) always passes so the loop reset isn't swallowed.
+    final advanced = looped - _lastStopMotionEmit;
+    if (advanced >= Duration.zero &&
+        advanced < VideoEditorConstants.stopMotionPlayheadEmitInterval) {
+      return;
+    }
+    _lastStopMotionEmit = looped;
+    context.read<VideoEditorMainBloc>().add(VideoEditorPositionChanged(looped));
   }
 
   /// Coalesces volume-history writes from clip and audio revision changes.
@@ -900,6 +1111,10 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     Duration position, {
     Duration? playTimePosition,
   }) async {
+    if (_isStopMotionComposition) {
+      _seekStopMotion(position);
+      return;
+    }
     if (!_isPlayerReadyNotifier.value || !_isPlayerInitialized) return;
 
     // A scrub owns the play time now; stop the playback interpolator so it
@@ -1100,10 +1315,9 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
                   return Stack(
                     fit: StackFit.passthrough,
                     children: [
-                      VideoEditorPlayer(
+                      _ClipPreview(
+                        clip: clip,
                         controller: _videoPlayer,
-                        targetAspectRatio: clip.targetAspectRatio,
-                        originalAspectRatio: clip.originalAspectRatio,
                         bodySize: widget.bodySize,
                         renderSize: widget.renderSize,
                       ),
@@ -1253,7 +1467,72 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
   /// Reads timeline positions (`startTime` / `endTime`) from the BLoC
   /// state and combines them with the source [AudioEvent] from the
   /// Riverpod provider (URL, asset path, start offset).
+  /// Schedules the timeline sounds on the stop-motion audio engine, mirroring
+  /// the native `setAudioTracks` mapping: each sound's window comes from its
+  /// timeline item, and the source is clipped to the sound's own start offset
+  /// plus the window length.
+  Future<void> _syncStopMotionAudio() async {
+    final overlayState = context.read<TimelineOverlayBloc>().state;
+    final audioById = {for (final e in overlayState.audioTracks) e.id: e};
+
+    final tracks = <StopMotionAudioPreviewTrack>[];
+    for (final item in overlayState.items) {
+      if (item.type != TimelineOverlayType.sound) continue;
+      final sound = audioById[item.id];
+      if (sound == null) continue;
+
+      final trackStart = sound.startOffset;
+      final trackEnd = trackStart + (item.endTime - item.startTime);
+      final AudioSourceConfig source;
+      if (sound.isBundled && sound.assetPath != null) {
+        source = AudioSourceConfig.asset(
+          sound.assetPath!,
+          start: trackStart,
+          end: trackEnd,
+        );
+      } else if (sound.isLocalImport && sound.localFilePath != null) {
+        source = AudioSourceConfig.file(
+          sound.localFilePath!,
+          start: trackStart,
+          end: trackEnd,
+        );
+      } else if (sound.url != null) {
+        source = AudioSourceConfig.network(
+          sound.url!,
+          start: trackStart,
+          end: trackEnd,
+        );
+      } else {
+        continue;
+      }
+
+      tracks.add(
+        StopMotionAudioPreviewTrack(
+          id: item.id,
+          source: source,
+          volume: sound.volume,
+          windowStart: item.startTime,
+          windowEnd: item.endTime,
+        ),
+      );
+    }
+
+    final preview = _stopMotionAudio ??= StopMotionAudioPreview();
+    await preview.setTracks(tracks);
+    Log.info(
+      '🎵 Stop-motion audio synced: ${tracks.length} track(s)',
+      name: 'VideoEditorCanvas',
+      category: LogCategory.video,
+    );
+  }
+
   Future<void> _syncAudioTracks() async {
+    // Frames-only composition: no native player exists to carry the tracks —
+    // schedule them on the stop-motion audio engine instead.
+    if (_isStopMotionComposition) {
+      await _syncStopMotionAudio();
+      return;
+    }
     if (!_isPlayerInitialized) return;
 
     final overlayState = context.read<TimelineOverlayBloc>().state;
@@ -1474,35 +1753,16 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
       // and autosave triggers. DivineVideoClip uses reference equality, so
       // we compare the editable properties explicitly.
       final currentClips = ref.read(clipManagerProvider).clips;
-      if (_clipsChanged(currentClips, clips)) {
+      if (VideoEditorCanvas.clipsChanged(currentClips, clips)) {
         ref.read(clipManagerProvider.notifier).replaceClips(clips);
       }
-      if (_clipsChanged(context.read<ClipEditorBloc>().state.clips, clips)) {
+      if (VideoEditorCanvas.clipsChanged(
+        context.read<ClipEditorBloc>().state.clips,
+        clips,
+      )) {
         context.read<ClipEditorBloc>().add(ClipEditorInitialized(clips));
       }
     });
-  }
-
-  /// Compares two clip lists by their editable properties.
-  bool _clipsChanged(
-    List<DivineVideoClip> current,
-    List<DivineVideoClip> next,
-  ) {
-    if (current.length != next.length) return true;
-    for (var i = 0; i < current.length; i++) {
-      final a = current[i];
-      final b = next[i];
-      if (a.id != b.id ||
-          a.video != b.video ||
-          a.trimStart != b.trimStart ||
-          a.trimEnd != b.trimEnd ||
-          a.volume != b.volume ||
-          a.playbackSpeed != b.playbackSpeed ||
-          a.transition != b.transition) {
-        return true;
-      }
-    }
-    return false;
   }
 
   /// Syncs the draw capabilities from the paint editor to the bloc.
@@ -1612,6 +1872,10 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
         .read<VideoEditorMainBloc>()
         .state
         .currentPosition;
+    // The stop-motion clock (and its audio engine) is widget-driven, not part
+    // of the native player teardown below — without this the sounds keep
+    // playing under the metadata screen.
+    if (_isStopMotionComposition) _pauseStopMotion();
     ref.read(videoEditorProvider.notifier).setProcessing(true);
 
     // Delegate the cover-transition wait to the screen: its context sits above
@@ -1675,8 +1939,10 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     // rebuild even when the paths haven't actually changed.
     ref.listen<List<String>>(
       clipManagerProvider.select(
-        (s) =>
-            s.clips.map((c) => c.video.file?.path).whereType<String>().toList(),
+        (s) => s.clips
+            .map((c) => c.video?.file?.path)
+            .whereType<String>()
+            .toList(),
       ),
       (previous, clipPaths) {
         if (listEquals(previous, clipPaths)) return;
@@ -1850,7 +2116,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
             final clip = state.clips.firstWhere(
               (c) => c.id == state.trimmingClipId,
             );
-            final path = clip.video.file?.path;
+            final path = clip.video?.file?.path;
             if (path == null) return;
             // Composition swap: invalidate in-flight seeks and release _isSeeking.
             _seekEpoch++;
@@ -2891,6 +3157,76 @@ class _RenderHitTestExpander extends RenderProxyBox {
   }
 }
 
+/// The preview surface for the current clip: a [DivineVideoPlayer] for a normal
+/// clip, or a controlled [StopMotionPlayer] for a frames-only stop-motion clip.
+///
+/// The stop-motion branch subscribes to the editor's `currentPosition` so the
+/// shown frame follows play/pause and timeline scrubbing. That subscription is
+/// scoped here — a normal clip never rebuilds on position ticks.
+class _ClipPreview extends StatelessWidget {
+  const _ClipPreview({
+    required this.clip,
+    required this.controller,
+    required this.bodySize,
+    required this.renderSize,
+  });
+
+  final DivineVideoClip clip;
+  final DivineVideoPlayerController? controller;
+  final Size bodySize;
+  final Size renderSize;
+
+  @override
+  Widget build(BuildContext context) {
+    final clipManagerFrames = clip.stopMotionFrames;
+    if (clipManagerFrames == null) {
+      return VideoEditorPlayer(
+        controller: controller,
+        targetAspectRatio: clip.targetAspectRatio,
+        originalAspectRatio: clip.originalAspectRatio,
+        bodySize: bodySize,
+        renderSize: renderSize,
+      );
+    }
+
+    // Read the live frame list from the clip editor, not the clip-manager copy:
+    // frame edits (delete / reorder / frames-per-image) land in ClipEditorBloc
+    // immediately, whereas the clip-manager copy syncs one post-frame later
+    // through the history path.
+    return BlocSelector<
+      ClipEditorBloc,
+      ClipEditorState,
+      List<StopMotionClipFrame>?
+    >(
+      selector: (state) {
+        for (final c in state.clips) {
+          if (c.id == clip.id) return c.stopMotionFrames;
+        }
+        return null;
+      },
+      builder: (context, liveFrames) {
+        final frames = liveFrames ?? clipManagerFrames;
+        return BlocSelector<
+          VideoEditorMainBloc,
+          VideoEditorMainState,
+          Duration
+        >(
+          selector: (state) => state.currentPosition,
+          builder: (context, position) => VideoEditorPlayer(
+            controller: controller,
+            targetAspectRatio: clip.targetAspectRatio,
+            originalAspectRatio: clip.originalAspectRatio,
+            bodySize: bodySize,
+            renderSize: renderSize,
+            stopMotionFrames: frames,
+            stopMotionPosition: position,
+          ),
+        );
+      },
+    );
+  }
+}
+
 /// Interpolates a composite playback position forward from [anchor] by the
 /// wall-clock [elapsed] since the anchor was captured, scaled by playback
 /// [speed], and clamped to `[Duration.zero, maxDuration]`.
@@ -2909,4 +3245,22 @@ Duration interpolatePlayheadPosition({
   if (raw < Duration.zero) return Duration.zero;
   if (raw > maxDuration) return maxDuration;
   return raw;
+}
+
+/// Advances the frames-only stop-motion playhead forward from [anchor] by the
+/// wall-clock [elapsed], wrapping around [total] so playback loops seamlessly.
+///
+/// A frames-only stop-motion clip has no native player to report position, so
+/// this drives the editor timeline directly (see
+/// `_VideoEditorState._onStopMotionTick`). Returns [Duration.zero] when [total]
+/// is non-positive.
+@visibleForTesting
+Duration stopMotionLoopPosition({
+  required Duration anchor,
+  required Duration elapsed,
+  required Duration total,
+}) {
+  if (total <= Duration.zero) return Duration.zero;
+  final raw = (anchor + elapsed).inMicroseconds;
+  return Duration(microseconds: raw % total.inMicroseconds);
 }

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_main_actions_sheet.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_main_actions_sheet.dart
@@ -8,6 +8,7 @@ import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
 import 'package:openvine/blocs/video_editor/main_editor/video_editor_main_bloc.dart';
 import 'package:openvine/blocs/video_editor/tune_editor/video_editor_tune_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/models/stop_motion/stop_motion_frame_ops.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
 import 'package:openvine/widgets/video_editor/tune_editor/open_tune_editor.dart';
 
@@ -61,6 +62,9 @@ class VideoEditorMainActionsSheet extends StatelessWidget {
   Widget build(BuildContext context) {
     final totalDuration = context.select(
       (ClipEditorBloc b) => b.state.totalDuration,
+    );
+    final isStopMotion = context.select(
+      (ClipEditorBloc b) => isStopMotionComposition(b.state.clips),
     );
     return Padding(
       padding: const .all(16),
@@ -161,23 +165,27 @@ class VideoEditorMainActionsSheet extends StatelessWidget {
                   scope.onAddStickers();
                 },
               ),
-              _ItemButton(
-                icon: .bookmarkPlus,
-                label: context.l10n.videoEditorMarkerLabel,
-                semanticLabel:
-                    context.l10n.videoEditorAddTimelineMarkerSemanticLabel,
-                onTap: () {
-                  Navigator.pop(context);
-                  if (totalDuration <= Duration.zero) return;
+              // Timeline markers anchor to video playback positions; on a
+              // frames-first stop-motion composition the stills themselves
+              // are the granularity, so the option is hidden.
+              if (!isStopMotion)
+                _ItemButton(
+                  icon: .bookmarkPlus,
+                  label: context.l10n.videoEditorMarkerLabel,
+                  semanticLabel:
+                      context.l10n.videoEditorAddTimelineMarkerSemanticLabel,
+                  onTap: () {
+                    Navigator.pop(context);
+                    if (totalDuration <= Duration.zero) return;
 
-                  // Enter marker mode instead of dropping a single marker, so
-                  // the bottom bar exposes add/delete-marker controls and the
-                  // user can keep marking beats while playback runs.
-                  context.read<VideoEditorMainBloc>().add(
-                    const VideoEditorMarkerModeChanged(isActive: true),
-                  );
-                },
-              ),
+                    // Enter marker mode instead of dropping a single marker, so
+                    // the bottom bar exposes add/delete-marker controls and the
+                    // user can keep marking beats while playback runs.
+                    context.read<VideoEditorMainBloc>().add(
+                      const VideoEditorMarkerModeChanged(isActive: true),
+                    );
+                  },
+                ),
             ],
           ),
         ],

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_main_overlay_actions.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_main_overlay_actions.dart
@@ -266,25 +266,42 @@ class _StopMotionFramesChip extends StatelessWidget {
         value,
       ),
       child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
         onTap: () => editStopMotionGlobalHold(context, clipId: clipId),
-        child: DecoratedBox(
-          decoration: BoxDecoration(
-            color: VineTheme.surfaceBackground.withValues(alpha: 0.85),
-            borderRadius: BorderRadius.circular(20),
-          ),
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              spacing: 6,
-              children: [
-                const DivineIcon(
-                  icon: .imagesSquare,
-                  color: VineTheme.lightText,
-                  size: 16,
+        // Expand the hit area to the 48dp minimum touch target while the
+        // visible pill keeps its natural size, centred inside it. The
+        // width/height factors are essential: the toolbar row is laid out with
+        // loose (near-full-height) constraints, so a plain Center would grow to
+        // fill them and stretch the whole toolbar down the editor. Sizing to
+        // the child means the ConstrainedBox only enforces the 48dp minimum.
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(minWidth: 48, minHeight: 48),
+          child: Center(
+            widthFactor: 1,
+            heightFactor: 1,
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: VineTheme.surfaceBackground.withValues(alpha: 0.85),
+                borderRadius: BorderRadius.circular(20),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 6,
                 ),
-                Text(label, style: VineTheme.labelLargeFont()),
-              ],
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  spacing: 6,
+                  children: [
+                    const DivineIcon(
+                      icon: .imagesSquare,
+                      color: VineTheme.lightText,
+                      size: 16,
+                    ),
+                    Text(label, style: VineTheme.labelLargeFont()),
+                  ],
+                ),
+              ),
             ),
           ),
         ),

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_main_overlay_actions.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_main_overlay_actions.dart
@@ -6,11 +6,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
 import 'package:openvine/blocs/video_editor/main_editor/video_editor_main_bloc.dart';
+import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/models/stop_motion/stop_motion_frame_ops.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/providers/video_publish_provider.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
+import 'package:openvine/widgets/video_editor/stop_motion/stop_motion_frame_commands.dart';
 import 'package:openvine/widgets/video_editor/video_editor_toolbar.dart';
 
 /// Top action bar for the video editor.
@@ -56,6 +60,23 @@ class _TopActions extends ConsumerWidget {
       videoEditorProvider.select((s) => s.isAutosavedDraft),
     );
 
+    // Frames-per-image control lives in the toolbar's center slot — top
+    // centre, inline between the back and done buttons — only for a
+    // stop-motion composition.
+    final ({String clipId, int value})? stopMotionData = context.select((
+      ClipEditorBloc b,
+    ) {
+      final clips = b.state.clips;
+      if (!isStopMotionComposition(clips)) return null;
+      final clip = clips.first;
+      final frames = clip.stopMotionFrames ?? const [];
+      if (frames.isEmpty) return null;
+      return (
+        clipId: clip.id,
+        value: StopMotionFrameOps.globalDefaultFramesPerImage(frames),
+      );
+    });
+
     return PopScope(
       canPop: !isAutosavedDraft,
       onPopInvokedWithResult: (didPop, result) {
@@ -70,6 +91,12 @@ class _TopActions extends ConsumerWidget {
       child: VideoEditorToolbar(
         closeIcon: .caretLeft,
         doneIcon: .arrowRight,
+        center: stopMotionData == null
+            ? null
+            : _StopMotionFramesChip(
+                clipId: stopMotionData.clipId,
+                value: stopMotionData.value,
+              ),
         onClose: () {
           if (isAutosavedDraft) {
             _onClosePressed(
@@ -81,9 +108,31 @@ class _TopActions extends ConsumerWidget {
             context.pop();
           }
         },
-        onDone: () => scope.editor?.doneEditing(),
+        onDone: () => _onDonePressed(context, scope),
       ),
     );
+  }
+
+  /// Gates Done on the stop-motion minimum length: a composition shorter
+  /// than [VideoEditorConstants.stopMotionMinOutputDuration] would only reach
+  /// that length by silently looping at render, so instead the tap surfaces a
+  /// "capture more frames" snackbar and stays in the editor.
+  void _onDonePressed(BuildContext context, VideoEditorScope scope) {
+    final clipState = context.read<ClipEditorBloc>().state;
+    const minDuration = VideoEditorConstants.stopMotionMinOutputDuration;
+    if (isStopMotionComposition(clipState.clips) &&
+        clipState.totalDuration < minDuration) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        DivineSnackbarContainer.snackBar(
+          context.l10n.videoEditorStopMotionTooShortSnackbar(
+            minDuration.inSeconds,
+          ),
+          error: true,
+        ),
+      );
+      return;
+    }
+    scope.editor?.doneEditing();
   }
 
   void _onClosePressed({
@@ -188,6 +237,56 @@ class _BottomActions extends StatelessWidget {
           ),
           size: .small,
           type: .ghostSecondary,
+        ),
+      ),
+    );
+  }
+}
+
+/// A tappable "N frames" chip shown in the editor toolbar's centre slot (top
+/// centre, between the back and done buttons) while editing a frames-only
+/// stop-motion clip. Opens the frames-per-image wheel sheet and applies the
+/// chosen hold as the global default (per-frame overrides are preserved).
+class _StopMotionFramesChip extends StatelessWidget {
+  const _StopMotionFramesChip({required this.clipId, required this.value});
+
+  final String clipId;
+
+  /// The global-default frames-per-image (see
+  /// [StopMotionFrameOps.globalDefaultFramesPerImage]).
+  final int value;
+
+  @override
+  Widget build(BuildContext context) {
+    final label = context.l10n.videoEditorStopMotionFramesCount(value);
+
+    return Semantics(
+      button: true,
+      value: context.l10n.videoEditorStopMotionFramesPerImageValueSemanticLabel(
+        value,
+      ),
+      child: GestureDetector(
+        onTap: () => editStopMotionGlobalHold(context, clipId: clipId),
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: VineTheme.surfaceBackground.withValues(alpha: 0.85),
+            borderRadius: BorderRadius.circular(20),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              spacing: 6,
+              children: [
+                const DivineIcon(
+                  icon: .imagesSquare,
+                  color: VineTheme.lightText,
+                  size: 16,
+                ),
+                Text(label, style: VineTheme.labelLargeFont()),
+              ],
+            ),
+          ),
         ),
       ),
     );

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_player.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_player.dart
@@ -2,6 +2,8 @@ import 'package:divine_video_player/divine_video_player.dart';
 import 'package:flutter/material.dart';
 import 'package:models/models.dart' as model show AspectRatio;
 import 'package:openvine/constants/video_editor_constants.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
+import 'package:openvine/widgets/stop_motion/stop_motion_player.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_thumbnail.dart';
 
 class VideoEditorPlayer extends StatelessWidget {
@@ -11,6 +13,8 @@ class VideoEditorPlayer extends StatelessWidget {
     required this.originalAspectRatio,
     required this.bodySize,
     required this.renderSize,
+    this.stopMotionFrames,
+    this.stopMotionPosition,
     super.key,
   });
 
@@ -20,9 +24,20 @@ class VideoEditorPlayer extends StatelessWidget {
   final Size bodySize;
   final Size renderSize;
 
+  /// Captured stills when editing a stop-motion clip. When non-null the preview
+  /// plays the frame sequence via [StopMotionPlayer] instead of a video — the
+  /// clip has no mp4 (it is rendered only at publish).
+  final List<StopMotionClipFrame>? stopMotionFrames;
+
+  /// Current editor-timeline position, forwarded to the controlled
+  /// [StopMotionPlayer] so the shown frame follows play/pause and scrubbing
+  /// instead of free-running. Only meaningful when [stopMotionFrames] is set.
+  final Duration? stopMotionPosition;
+
   @override
   Widget build(BuildContext context) {
     final aspectRatio = targetAspectRatio.value;
+    final frames = stopMotionFrames;
 
     return ClipPath(
       clipper: _RoundedRectClipper(
@@ -32,15 +47,23 @@ class VideoEditorPlayer extends StatelessWidget {
       ),
       child: AspectRatio(
         aspectRatio: aspectRatio,
-        child: DivineVideoPlayer(
-          controller: controller,
-          placeholder: VideoEditorThumbnail(contentSize: renderSize),
-          // The editor swaps an external thumbnail spinner straight to the
-          // player once the frame is decoded, so the first frame is already
-          // rendered when this mounts. Cross-fade the thumbnail out instead of
-          // hard-cutting (which read as a flicker on editor open).
-          crossFadePlaceholder: true,
-        ),
+        child: frames != null
+            ? StopMotionPlayer(
+                frames: frames,
+                position: stopMotionPosition,
+                cacheHeight:
+                    (renderSize.height * MediaQuery.devicePixelRatioOf(context))
+                        .round(),
+              )
+            : DivineVideoPlayer(
+                controller: controller,
+                placeholder: VideoEditorThumbnail(contentSize: renderSize),
+                // The editor swaps an external thumbnail spinner straight to
+                // the player once the frame is decoded, so the first frame is
+                // already rendered when this mounts. Cross-fade the thumbnail
+                // out instead of hard-cutting (which read as a flicker).
+                crossFadePlaceholder: true,
+              ),
       ),
     );
   }

--- a/mobile/lib/widgets/video_editor/stop_motion/stop_motion_frame_commands.dart
+++ b/mobile/lib/widgets/video_editor/stop_motion/stop_motion_frame_commands.dart
@@ -1,0 +1,148 @@
+// ABOUTME: Commits stop-motion frame-list edits to the clip editor + history
+// ABOUTME: Shared by the frame strip, the action bar, and the toolbar control
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
+import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
+import 'package:openvine/extensions/video_editor_extensions.dart';
+import 'package:openvine/models/stop_motion/stop_motion_frame_ops.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
+import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
+import 'package:openvine/widgets/video_editor/stop_motion/stop_motion_frames_per_image_sheet.dart';
+import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart';
+
+/// Commits a new stop-motion frame list for the single stop-motion clip
+/// [clipId].
+///
+/// Updates the [ClipEditorBloc], rebases timeline markers, and writes the change
+/// to editor history (undo/redo) — mirroring the clip-level edit commit in
+/// `TimelineClipControls` (`_deleteClip` / `_setPlaybackSpeed`). A no-op edit
+/// (the frame-ops helpers return the source list unchanged) is skipped so it
+/// never records an empty history entry.
+void commitStopMotionFrames(
+  BuildContext context, {
+  required String clipId,
+  required List<StopMotionClipFrame> frames,
+}) {
+  final bloc = context.read<ClipEditorBloc>();
+  final overlayBloc = context.read<TimelineOverlayBloc>();
+  final state = bloc.state;
+  final index = state.clips.indexWhere((clip) => clip.id == clipId);
+  if (index == -1) return;
+
+  final clip = state.clips[index];
+  if (identical(frames, clip.stopMotionFrames)) return;
+
+  final updated = StopMotionFrameOps.clipWithFrames(clip, frames);
+  final newClips = [
+    for (final c in state.clips) c.id == clipId ? updated : c,
+  ];
+  final rebasedMarkers = rebaseTimelineMarkersForClipState(
+    oldClips: state.clips,
+    newClips: newClips,
+    markers: overlayBloc.state.timelineMarkers,
+  );
+
+  bloc.add(ClipEditorClipUpdated(clipId: clipId, clip: updated));
+  overlayBloc.add(TimelineMarkersRebased(rebasedMarkers));
+  VideoEditorScope.of(
+    context,
+  ).requireEditor.setClipState(newClips, timelineMarkers: rebasedMarkers);
+}
+
+List<StopMotionClipFrame>? _stopMotionFrames(
+  BuildContext context,
+  String clipId,
+) {
+  for (final clip in context.read<ClipEditorBloc>().state.clips) {
+    if (clip.id == clipId) return clip.stopMotionFrames;
+  }
+  return null;
+}
+
+/// Opens the frames-per-image wheel sheet and applies the chosen hold to every
+/// still in the stop-motion clip [clipId].
+Future<void> editStopMotionGlobalHold(
+  BuildContext context, {
+  required String clipId,
+}) async {
+  final frames = _stopMotionFrames(context, clipId);
+  if (frames == null || frames.isEmpty) return;
+  final current = StopMotionFrameOps.globalDefaultFramesPerImage(frames);
+
+  final result = await _showFramesPerImageSheet(context, current);
+  if (result == null || !context.mounted) return;
+
+  final latest = _stopMotionFrames(context, clipId);
+  if (latest == null) return;
+  commitStopMotionFrames(
+    context,
+    clipId: clipId,
+    frames: StopMotionFrameOps.setGlobalHold(latest, result),
+  );
+}
+
+/// Opens the frames-per-image wheel sheet and applies the chosen hold to every
+/// still at [frameIndexes] of the stop-motion clip [clipId] (frame
+/// multi-select). The sheet opens on the first selected still's current hold.
+Future<void> editStopMotionFramesHold(
+  BuildContext context, {
+  required String clipId,
+  required Set<int> frameIndexes,
+}) async {
+  final frames = _stopMotionFrames(context, clipId);
+  if (frames == null || frameIndexes.isEmpty) return;
+  final firstIndex = frameIndexes.reduce((a, b) => a < b ? a : b);
+  if (firstIndex < 0 || firstIndex >= frames.length) return;
+  final current = StopMotionFrameOps.durationToFramesPerImage(
+    frames[firstIndex].duration,
+  );
+
+  final result = await _showFramesPerImageSheet(context, current);
+  if (result == null || !context.mounted) return;
+
+  final latest = _stopMotionFrames(context, clipId);
+  if (latest == null) return;
+  commitStopMotionFrames(
+    context,
+    clipId: clipId,
+    frames: StopMotionFrameOps.setFramesHold(latest, frameIndexes, result),
+  );
+}
+
+/// Opens the frames-per-image wheel sheet and applies the chosen hold to the
+/// still at [frameIndex] of the stop-motion clip [clipId].
+Future<void> editStopMotionFrameHold(
+  BuildContext context, {
+  required String clipId,
+  required int frameIndex,
+}) async {
+  final frames = _stopMotionFrames(context, clipId);
+  if (frames == null || frameIndex < 0 || frameIndex >= frames.length) return;
+  final current = StopMotionFrameOps.durationToFramesPerImage(
+    frames[frameIndex].duration,
+  );
+
+  final result = await _showFramesPerImageSheet(context, current);
+  if (result == null || !context.mounted) return;
+
+  final latest = _stopMotionFrames(context, clipId);
+  if (latest == null || frameIndex >= latest.length) return;
+  commitStopMotionFrames(
+    context,
+    clipId: clipId,
+    frames: StopMotionFrameOps.setFrameHold(latest, frameIndex, result),
+  );
+}
+
+Future<int?> _showFramesPerImageSheet(BuildContext context, int initialValue) {
+  return VineBottomSheet.show<int>(
+    context: context,
+    expanded: false,
+    scrollable: false,
+    isScrollControlled: true,
+    body: StopMotionFramesPerImageSheet(initialValue: initialValue),
+  );
+}

--- a/mobile/lib/widgets/video_editor/stop_motion/stop_motion_frame_commands.dart
+++ b/mobile/lib/widgets/video_editor/stop_motion/stop_motion_frame_commands.dart
@@ -21,6 +21,11 @@ import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timel
 /// `TimelineClipControls` (`_deleteClip` / `_setPlaybackSpeed`). A no-op edit
 /// (the frame-ops helpers return the source list unchanged) is skipped so it
 /// never records an empty history entry.
+///
+/// Bails when the [ProImageEditorState] is gone — a tap can resolve after the
+/// editor route is popped, and force-unwrapping it there is a release-mode
+/// crash (#5799). Bailing before the bloc dispatch keeps the frame list and
+/// the editor history from diverging.
 void commitStopMotionFrames(
   BuildContext context, {
   required String clipId,
@@ -28,6 +33,9 @@ void commitStopMotionFrames(
 }) {
   final bloc = context.read<ClipEditorBloc>();
   final overlayBloc = context.read<TimelineOverlayBloc>();
+  final editor = VideoEditorScope.of(context).editor;
+  if (editor == null) return;
+
   final state = bloc.state;
   final index = state.clips.indexWhere((clip) => clip.id == clipId);
   if (index == -1) return;
@@ -47,9 +55,7 @@ void commitStopMotionFrames(
 
   bloc.add(ClipEditorClipUpdated(clipId: clipId, clip: updated));
   overlayBloc.add(TimelineMarkersRebased(rebasedMarkers));
-  VideoEditorScope.of(
-    context,
-  ).requireEditor.setClipState(newClips, timelineMarkers: rebasedMarkers);
+  editor.setClipState(newClips, timelineMarkers: rebasedMarkers);
 }
 
 List<StopMotionClipFrame>? _stopMotionFrames(

--- a/mobile/lib/widgets/video_editor/stop_motion/stop_motion_frames_per_image_sheet.dart
+++ b/mobile/lib/widgets/video_editor/stop_motion/stop_motion_frames_per_image_sheet.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Bottom sheet with a wheel picker for stop-motion frames-per-image
-// ABOUTME: Returns the chosen frames-per-image (1-10) as an int via context.pop
+// ABOUTME: Returns the chosen frames-per-image as an int via context.pop
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/cupertino.dart' show CupertinoPicker;
@@ -10,8 +10,9 @@ import 'package:openvine/models/stop_motion/stop_motion_frame_ops.dart';
 
 /// Wheel picker for how many output frames each stop-motion still is held for.
 ///
-/// Shown in a [VineBottomSheet]; pops the chosen value (1-10) on confirm, or
-/// `null` on cancel.
+/// Shown in a [VineBottomSheet]; pops the chosen value — in
+/// [StopMotionFrameOps.minFramesPerImage]..[StopMotionFrameOps.maxFramesPerImage]
+/// — on confirm, or `null` on cancel.
 class StopMotionFramesPerImageSheet extends StatefulWidget {
   const StopMotionFramesPerImageSheet({required this.initialValue, super.key});
 
@@ -82,20 +83,20 @@ class _StopMotionFramesPerImageSheetState
         ),
         SizedBox(
           height: 200,
-          child: CupertinoPicker(
+          // Lazy builder: the range can be hundreds of items, so build only
+          // the visible rows instead of eagerly constructing every one.
+          child: CupertinoPicker.builder(
             scrollController: _controller,
             itemExtent: 44,
             backgroundColor: VineTheme.surfaceBackground,
             onSelectedItemChanged: (index) => _value = _min + index,
-            children: [
-              for (var n = _min; n <= _max; n++)
-                Center(
-                  child: Text(
-                    context.l10n.videoEditorStopMotionFramesCount(n),
-                    style: VineTheme.titleMediumFont(),
-                  ),
-                ),
-            ],
+            childCount: _max - _min + 1,
+            itemBuilder: (context, index) => Center(
+              child: Text(
+                context.l10n.videoEditorStopMotionFramesCount(_min + index),
+                style: VineTheme.titleMediumFont(),
+              ),
+            ),
           ),
         ),
         SizedBox(height: MediaQuery.paddingOf(context).bottom + 8),

--- a/mobile/lib/widgets/video_editor/stop_motion/stop_motion_frames_per_image_sheet.dart
+++ b/mobile/lib/widgets/video_editor/stop_motion/stop_motion_frames_per_image_sheet.dart
@@ -1,0 +1,105 @@
+// ABOUTME: Bottom sheet with a wheel picker for stop-motion frames-per-image
+// ABOUTME: Returns the chosen frames-per-image (1-10) as an int via context.pop
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/cupertino.dart' show CupertinoPicker;
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/models/stop_motion/stop_motion_frame_ops.dart';
+
+/// Wheel picker for how many output frames each stop-motion still is held for.
+///
+/// Shown in a [VineBottomSheet]; pops the chosen value (1-10) on confirm, or
+/// `null` on cancel.
+class StopMotionFramesPerImageSheet extends StatefulWidget {
+  const StopMotionFramesPerImageSheet({required this.initialValue, super.key});
+
+  /// Current frames-per-image; the wheel opens centered on this value.
+  final int initialValue;
+
+  @override
+  State<StopMotionFramesPerImageSheet> createState() =>
+      _StopMotionFramesPerImageSheetState();
+}
+
+class _StopMotionFramesPerImageSheetState
+    extends State<StopMotionFramesPerImageSheet> {
+  static const int _min = StopMotionFrameOps.minFramesPerImage;
+  static const int _max = StopMotionFrameOps.maxFramesPerImage;
+
+  late final FixedExtentScrollController _controller;
+  late int _value;
+
+  @override
+  void initState() {
+    super.initState();
+    _value = widget.initialValue.clamp(_min, _max);
+    _controller = FixedExtentScrollController(initialItem: _value - _min);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(16),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            spacing: 8,
+            children: [
+              DivineIconButton(
+                icon: DivineIconName.x,
+                type: DivineIconButtonType.secondary,
+                size: DivineIconButtonSize.small,
+                onPressed: () => context.pop<int>(),
+              ),
+              Flexible(
+                child: Text(
+                  context.l10n.videoEditorStopMotionFramesPerImageLabel,
+                  style: VineTheme.titleMediumFont(),
+                ),
+              ),
+              DivineIconButton(
+                icon: DivineIconName.check,
+                size: DivineIconButtonSize.small,
+                onPressed: () => context.pop<int>(_value),
+              ),
+            ],
+          ),
+        ),
+        const Divider(
+          height: 2,
+          thickness: 2,
+          color: VineTheme.outlinedDisabled,
+        ),
+        SizedBox(
+          height: 200,
+          child: CupertinoPicker(
+            scrollController: _controller,
+            itemExtent: 44,
+            backgroundColor: VineTheme.surfaceBackground,
+            onSelectedItemChanged: (index) => _value = _min + index,
+            children: [
+              for (var n = _min; n <= _max; n++)
+                Center(
+                  child: Text(
+                    context.l10n.videoEditorStopMotionFramesCount(n),
+                    style: VineTheme.titleMediumFont(),
+                  ),
+                ),
+            ],
+          ),
+        ),
+        SizedBox(height: MediaQuery.paddingOf(context).bottom + 8),
+      ],
+    );
+  }
+}

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart
@@ -5,9 +5,12 @@ import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
 import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
 import 'package:openvine/extensions/video_editor_extensions.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/models/stop_motion/stop_motion_frame_ops.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/screens/video_editor/video_clip_transform_screen.dart';
 import 'package:openvine/services/video_editor/video_editor_split_service.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
+import 'package:openvine/widgets/video_editor/stop_motion/stop_motion_frame_commands.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_clip_speed_sheet.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_timeline_controls.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart';
@@ -28,6 +31,19 @@ class TimelineClipControls extends StatefulWidget {
 class _TimelineClipControlsState extends State<TimelineClipControls> {
   @override
   Widget build(BuildContext context) {
+    // Frames-only stop-motion clips get a frame-first action set: delete /
+    // duplicate / multi-select stills and adjust their hold. Clip-only
+    // actions (split, speed, reverse, extract audio, transform) don't apply
+    // to a still sequence and are hidden.
+    final isStopMotion = context.select((ClipEditorBloc b) {
+      final state = b.state;
+      final index = state.currentClipIndex;
+      return index >= 0 &&
+          index < state.clips.length &&
+          state.clips[index].isStopMotion;
+    });
+    if (isStopMotion) return const _StopMotionClipControls();
+
     final (
       clipCount,
       isExtractingAudioCurrentClip,
@@ -384,5 +400,110 @@ class _TimelineClipControlsState extends State<TimelineClipControls> {
           splitPosition: localPosition,
         ),
       );
+  }
+}
+
+/// Action bar for a selected still in a frames-only stop-motion clip: delete or
+/// duplicate the still and set how many output frames it is held for. Falls back
+/// to just Done when no still is selected.
+class _StopMotionClipControls extends StatelessWidget {
+  const _StopMotionClipControls();
+
+  @override
+  Widget build(BuildContext context) {
+    final ({
+      String clipId,
+      List<StopMotionClipFrame> frames,
+      int? selected,
+    })?
+    data = context.select((ClipEditorBloc b) {
+      final state = b.state;
+      final index = state.currentClipIndex;
+      if (index < 0 || index >= state.clips.length) return null;
+      final clip = state.clips[index];
+      final frames = clip.stopMotionFrames;
+      if (frames == null) return null;
+      return (
+        clipId: clip.id,
+        frames: frames,
+        selected: state.selectedFrameIndex,
+      );
+    });
+
+    if (data == null) return const SizedBox.shrink();
+
+    final frames = data.frames;
+    final selected = data.selected;
+    final hasSelection =
+        selected != null && selected >= 0 && selected < frames.length;
+
+    return VideoEditorTimelineControls(
+      onDelete: hasSelection && frames.length > 1
+          ? () => commitStopMotionFrames(
+              context,
+              clipId: data.clipId,
+              frames: StopMotionFrameOps.removeFrame(frames, selected),
+            )
+          : null,
+      onDuplicated: hasSelection
+          ? () => commitStopMotionFrames(
+              context,
+              clipId: data.clipId,
+              frames: [
+                ...frames.sublist(0, selected + 1),
+                frames[selected],
+                ...frames.sublist(selected + 1),
+              ],
+            )
+          : null,
+      // Frame multi-select: batch delete / hold on several stills. Needs a
+      // second still to be meaningful.
+      onMultiSelect: frames.length > 1
+          ? () => context.read<ClipEditorBloc>().add(
+              ClipEditorFrameMultiSelectStarted(selected),
+            )
+          : null,
+      onDone: () =>
+          context.read<ClipEditorBloc>().add(const ClipEditorEditingStopped()),
+      extraControls: hasSelection
+          ? [
+              _StopMotionFramesButton(
+                onPressed: () => editStopMotionFrameHold(
+                  context,
+                  clipId: data.clipId,
+                  frameIndex: selected,
+                ),
+              ),
+            ]
+          : const [],
+    );
+  }
+}
+
+/// Action-bar button (icon + label, matching the other controls) that opens the
+/// frames-per-image wheel sheet for the selected still.
+class _StopMotionFramesButton extends StatelessWidget {
+  const _StopMotionFramesButton({required this.onPressed});
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      spacing: 8,
+      children: [
+        DivineIconButton(
+          icon: .imagesSquare,
+          semanticLabel: context.l10n.videoEditorStopMotionFramesPerImageLabel,
+          onPressed: onPressed,
+          type: .secondary,
+          size: .small,
+        ),
+        Text(
+          context.l10n.videoEditorStopMotionFramesPerImageButtonLabel,
+          style: VineTheme.bodySmallFont(),
+        ),
+      ],
+    );
   }
 }

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_control_bar.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_control_bar.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
 import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
+import 'package:openvine/models/stop_motion/stop_motion_frame_ops.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_timeline_layer_multi_select_controls.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_timeline_marker_controls.dart';
@@ -27,8 +28,11 @@ class TimelineControlsBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isMultiSelectMode = context.select(
-      (ClipEditorBloc b) => b.state.isMultiSelectMode,
+    final (isMultiSelectMode, isStopMotion) = context.select(
+      (ClipEditorBloc b) => (
+        b.state.isMultiSelectMode,
+        isStopMotionComposition(b.state.clips),
+      ),
     );
     final isLayerMultiSelectMode = context.select(
       (TimelineOverlayBloc b) => b.state.isLayerMultiSelectMode,
@@ -57,6 +61,12 @@ class TimelineControlsBar extends StatelessWidget {
         key: const ValueKey('timeline_controls_marker'),
         playheadPosition: playheadPosition,
       ),
+      // Frame multi-select on a stop-motion composition; clip multi-select
+      // everywhere else.
+      (false, true, _, _, _) when isStopMotion =>
+        const TimelineFrameMultiSelectControls(
+          key: ValueKey('timeline_controls_frame_multi_select'),
+        ),
       (false, true, _, _, _) => const TimelineMultiSelectControls(
         key: ValueKey('timeline_controls_multi_select'),
       ),

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_controls.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_controls.dart
@@ -23,8 +23,13 @@ class VideoEditorTimelineControls extends StatelessWidget {
     this.isSaveToLibraryDisabled = false,
     this.onMultiSelect,
     this.multiSelectSemanticLabel,
+    this.extraControls = const [],
     super.key,
   });
+
+  /// Extra controls inserted before the Done button — used by the stop-motion
+  /// action bar to add the per-frame "frames per image" stepper.
+  final List<Widget> extraControls;
 
   final VoidCallback? onDelete;
   final VoidCallback? onEdit;
@@ -191,6 +196,7 @@ class VideoEditorTimelineControls extends StatelessWidget {
                           context.l10n.videoEditorMultiSelectSemanticLabel,
                       onPressed: onMultiSelect,
                     ),
+                  ...extraControls,
                   _ControlButton(
                     icon: .check,
                     label: context.l10n.videoEditorDoneLabel,

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_multi_select_controls.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_multi_select_controls.dart
@@ -1,7 +1,10 @@
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/models/stop_motion/stop_motion_frame_ops.dart';
+import 'package:openvine/widgets/video_editor/stop_motion/stop_motion_frame_commands.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_timeline_action_bar.dart';
 
 /// Action bar shown while the timeline is in multi-select mode.
@@ -68,6 +71,192 @@ class TimelineMultiSelectControls extends StatelessWidget {
     // listener rebases markers and commits the new list to editor history.
     context.read<ClipEditorBloc>().add(
       const ClipEditorSelectedClipsRemoved(),
+    );
+  }
+}
+
+/// Action bar shown while a stop-motion composition is in frame multi-select
+/// mode: selection count plus hold / Delete / Done actions on the selected
+/// stills. Delete is gated so at least one still always remains.
+class TimelineFrameMultiSelectControls extends StatelessWidget {
+  const TimelineFrameMultiSelectControls({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final ({String clipId, int frameCount, Set<int> selected})? data = context
+        .select((ClipEditorBloc b) {
+          final state = b.state;
+          if (!isStopMotionComposition(state.clips)) return null;
+          final clip = state.clips.first;
+          return (
+            clipId: clip.id,
+            frameCount: clip.stopMotionFrames?.length ?? 0,
+            selected: state.selectedFrameIndexes,
+          );
+        });
+
+    if (data == null) return const SizedBox.shrink();
+
+    final selectedCount = data.selected.length;
+    final canDelete = selectedCount >= 1 && selectedCount < data.frameCount;
+    final canSetHold = selectedCount >= 1;
+    final canReverse = selectedCount >= 2;
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: VineTheme.backgroundCamera,
+        boxShadow: [
+          BoxShadow(
+            color: VineTheme.backgroundColor.withValues(alpha: 0.4),
+            blurRadius: 8,
+            offset: const Offset(0, -4),
+          ),
+        ],
+      ),
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.fromLTRB(0, 16, 0, 8),
+        child: SafeArea(
+          top: false,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            spacing: 8,
+            children: [
+              Text(
+                context.l10n.videoEditorMultiSelectCountLabel(selectedCount),
+                style: VineTheme.bodySmallFont(color: VineTheme.secondaryText),
+              ),
+              Center(
+                child: SingleChildScrollView(
+                  scrollDirection: Axis.horizontal,
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: Row(
+                    spacing: 16,
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      _ControlButton(
+                        icon: .imagesSquare,
+                        label: context
+                            .l10n
+                            .videoEditorStopMotionFramesPerImageButtonLabel,
+                        semanticLabel: context
+                            .l10n
+                            .videoEditorStopMotionFramesPerImageLabel,
+                        onPressed: canSetHold
+                            ? () => editStopMotionFramesHold(
+                                context,
+                                clipId: data.clipId,
+                                frameIndexes: data.selected,
+                              )
+                            : null,
+                        type: .primary,
+                      ),
+                      _ControlButton(
+                        icon: .arrowCounterClockwise,
+                        label: context.l10n.videoEditorReverseLabel,
+                        semanticLabel: context
+                            .l10n
+                            .videoEditorReverseSelectedFramesSemanticLabel,
+                        onPressed: canReverse ? () => _reverse(context) : null,
+                      ),
+                      _ControlButton(
+                        icon: .trash,
+                        label: context.l10n.videoEditorDeleteLabel,
+                        semanticLabel: context
+                            .l10n
+                            .videoEditorDeleteSelectedFramesSemanticLabel,
+                        onPressed: canDelete ? () => _delete(context) : null,
+                        type: .error,
+                      ),
+                      _ControlButton(
+                        icon: .check,
+                        label: context.l10n.videoEditorDoneLabel,
+                        semanticLabel: context
+                            .l10n
+                            .videoEditorMultiSelectDoneSemanticLabel,
+                        onPressed: () => context.read<ClipEditorBloc>().add(
+                          const ClipEditorMultiSelectCancelled(),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Reverses the selected stills among their own slots. The selection keeps
+  /// pointing at the same positions (now holding the reversed stills), so the
+  /// mode stays active for follow-up actions like a block move.
+  void _reverse(BuildContext context) {
+    final bloc = context.read<ClipEditorBloc>();
+    final state = bloc.state;
+    if (!isStopMotionComposition(state.clips)) return;
+    final clip = state.clips.first;
+    final frames = clip.stopMotionFrames ?? const [];
+
+    commitStopMotionFrames(
+      context,
+      clipId: clip.id,
+      frames: StopMotionFrameOps.reverseFrames(
+        frames,
+        state.selectedFrameIndexes,
+      ),
+    );
+  }
+
+  void _delete(BuildContext context) {
+    final bloc = context.read<ClipEditorBloc>();
+    final state = bloc.state;
+    if (!isStopMotionComposition(state.clips)) return;
+    final clip = state.clips.first;
+    final frames = clip.stopMotionFrames ?? const [];
+
+    commitStopMotionFrames(
+      context,
+      clipId: clip.id,
+      frames: StopMotionFrameOps.removeFrames(
+        frames,
+        state.selectedFrameIndexes,
+      ),
+    );
+    bloc.add(const ClipEditorMultiSelectCancelled());
+  }
+}
+
+class _ControlButton extends StatelessWidget {
+  const _ControlButton({
+    required this.icon,
+    required this.label,
+    required this.semanticLabel,
+    required this.onPressed,
+    this.type = .secondary,
+  });
+
+  final DivineIconName icon;
+  final String label;
+  final String semanticLabel;
+  final VoidCallback? onPressed;
+  final DivineIconButtonType type;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      spacing: 8,
+      children: [
+        DivineIconButton(
+          icon: icon,
+          semanticLabel: semanticLabel,
+          onPressed: onPressed,
+          type: type,
+          size: .small,
+        ),
+        Text(label, style: VineTheme.bodySmallFont()),
+      ],
     );
   }
 }

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_stop_motion_frame_strip.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_stop_motion_frame_strip.dart
@@ -112,6 +112,7 @@ class _VideoEditorStopMotionFrameStripState
   /// releasing without dragging would silently reorder. See
   /// [_onBlockDragStart].
   double _blockDragOffsetX = 0;
+  double _dragTargetOffsetX = 0;
 
   // Finger tracking (global X is the source of truth so auto-scroll and the
   // gesture callbacks never fight over the position).
@@ -231,6 +232,7 @@ class _VideoEditorStopMotionFrameStripState
       _dragStartScrollOffset = widget.scrollController?.offset ?? 0;
       _dragTileWidth = tileWidth;
       _dragFingerRatio = fingerRatio;
+      _dragTargetOffsetX = fingerX - (tileLeft + tileWidth / 2);
     });
   }
 
@@ -312,7 +314,7 @@ class _VideoEditorStopMotionFrameStripState
       }
       return;
     }
-    final target = _indexAtX(_effectiveLocalX, widths);
+    final target = _indexAtX(_effectiveLocalX - _dragTargetOffsetX, widths);
     if (target != _dragIndex) {
       HapticFeedback.selectionClick();
       final frame = _orderedFrames.removeAt(_dragIndex!);
@@ -375,13 +377,14 @@ class _VideoEditorStopMotionFrameStripState
 
     if (_isBlockDrag) {
       final slot = _blockSlot;
+      final moved = (_effectiveLocalX - _dragStartLocalX).abs() > 0.5;
       setState(() {
         _isReordering = false;
         _isBlockDrag = false;
         _blockFrames = const [];
         _orderedFrames = List.of(widget.frames);
       });
-      widget.onBlockMove?.call(slot);
+      if (moved) widget.onBlockMove?.call(slot);
       return;
     }
 
@@ -391,6 +394,7 @@ class _VideoEditorStopMotionFrameStripState
     setState(() {
       _isReordering = false;
       _dragIndex = null;
+      _dragTargetOffsetX = 0;
     });
 
     if (from != to) widget.onReorder(from, to);

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_stop_motion_frame_strip.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_stop_motion_frame_strip.dart
@@ -106,6 +106,13 @@ class _VideoEditorStopMotionFrameStripState
   /// (`0.._orderedFrames.length`).
   int _blockSlot = 0;
 
+  /// Maps the pickup finger x (measured in the full N-tile layout) into the
+  /// post-removal (N-1 tile) layout. Without it, a zero-distance block drag
+  /// resolves the finger against the shifted widths and jumps by one tile —
+  /// releasing without dragging would silently reorder. See
+  /// [_onBlockDragStart].
+  double _blockDragOffsetX = 0;
+
   // Finger tracking (global X is the source of truth so auto-scroll and the
   // gesture callbacks never fight over the position).
   double _dragGlobalX = 0;
@@ -255,6 +262,19 @@ class _VideoEditorStopMotionFrameStripState
       (selection.contains(i) ? blockFrames : remaining).add(widget.frames[i]);
     }
 
+    // Home slot = the block's leftmost original position among the remaining
+    // stills (all frames before it are unselected, so their count is exactly
+    // the smallest selected index). Anchoring the pickup here — instead of
+    // mapping the raw finger x against the shifted post-removal widths — keeps
+    // a no-drag release a no-op for a contiguous block and drives the offset
+    // that makes dragging land on the right slot.
+    final remainingWidths = [for (final frame in remaining) _tileWidth(frame)];
+    final homeSlot = selection.reduce((a, b) => a < b ? a : b);
+    var homeX = 0.0;
+    for (var i = 0; i < homeSlot; i++) {
+      homeX += remainingWidths[i];
+    }
+
     HapticFeedback.mediumImpact();
     widget.onReorderChanged?.call(true);
     setState(() {
@@ -262,10 +282,8 @@ class _VideoEditorStopMotionFrameStripState
       _isBlockDrag = true;
       _blockFrames = blockFrames;
       _orderedFrames = remaining;
-      _blockSlot = _slotAtX(
-        fingerX,
-        [for (final frame in remaining) _tileWidth(frame)],
-      );
+      _blockSlot = homeSlot;
+      _blockDragOffsetX = fingerX - homeX;
       _dragGlobalX = details.globalPosition.dx;
       _dragStartGlobalX = details.globalPosition.dx;
       _dragStartLocalX = fingerX;
@@ -287,7 +305,7 @@ class _VideoEditorStopMotionFrameStripState
   void _applyDragTarget() {
     final widths = _computeLayout().widths;
     if (_isBlockDrag) {
-      final slot = _slotAtX(_effectiveLocalX, widths);
+      final slot = _slotAtX(_effectiveLocalX - _blockDragOffsetX, widths);
       if (slot != _blockSlot) {
         HapticFeedback.selectionClick();
         _blockSlot = slot;

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_stop_motion_frame_strip.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_stop_motion_frame_strip.dart
@@ -1,0 +1,586 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:openvine/constants/video_editor_timeline_constants.dart';
+import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
+
+/// Timeline strip for a frames-only stop-motion clip: one tile per captured
+/// still, laid out by each still's hold duration so the strip stays aligned
+/// with the timeline playhead.
+///
+/// Tapping a tile selects it (via [onFrameTapped]); long-pressing and dragging
+/// reorders the stills (via [onReorder]). In multi-select mode, long-pressing
+/// a *selected* tile drags the whole selection as one block (via
+/// [onBlockMove]). This widget is presentational — it owns only the drag
+/// gesture state; the actual selection and reorder commit live in the caller.
+class VideoEditorStopMotionFrameStrip extends StatefulWidget {
+  const VideoEditorStopMotionFrameStrip({
+    required this.frames,
+    required this.pixelsPerSecond,
+    required this.onFrameTapped,
+    required this.onReorder,
+    this.selectedFrameIndex,
+    this.isMultiSelectMode = false,
+    this.selectedFrameIndexes = const {},
+    this.onBlockMove,
+    this.scrollController,
+    this.onReorderChanged,
+    super.key,
+  });
+
+  /// The clip's captured stills, in playback order.
+  final List<StopMotionClipFrame> frames;
+
+  /// Horizontal pixels per second — the strip's tiles are sized by their hold
+  /// duration times this, matching the rest of the timeline geometry.
+  final double pixelsPerSecond;
+
+  /// Index of the currently selected still, highlighted with a border.
+  final int? selectedFrameIndex;
+
+  /// Whether taps toggle membership in [selectedFrameIndexes] instead of
+  /// selecting a single still. Single-tile drag reorder is disabled while
+  /// active; long-pressing a selected tile block-drags the selection instead.
+  final bool isMultiSelectMode;
+
+  /// Indexes of the stills selected in multi-select mode, each highlighted
+  /// like the single selection.
+  final Set<int> selectedFrameIndexes;
+
+  /// Called with the tapped still's index.
+  final ValueChanged<int> onFrameTapped;
+
+  /// Called when a drag reorder settles, with the still's original and final
+  /// indices. A single-item move — [StopMotionFrameOps.reorderFrame] reproduces
+  /// it on the source list.
+  final void Function(int from, int to) onReorder;
+
+  /// Called when a multi-select block drag settles, with the insertion slot
+  /// within the list of *remaining* (unselected) stills —
+  /// [StopMotionFrameOps.moveFrames] reproduces the move on the source list.
+  final ValueChanged<int>? onBlockMove;
+
+  /// Timeline scroll controller, used to auto-scroll while dragging near an
+  /// edge.
+  final ScrollController? scrollController;
+
+  /// Reports the start (`true`) and end (`false`) of a reorder drag so the
+  /// timeline can fade sibling rows out, matching the clip strip.
+  final ValueChanged<bool>? onReorderChanged;
+
+  @override
+  State<VideoEditorStopMotionFrameStrip> createState() =>
+      _VideoEditorStopMotionFrameStripState();
+}
+
+class _VideoEditorStopMotionFrameStripState
+    extends State<VideoEditorStopMotionFrameStrip> {
+  static const _animDuration = Duration(milliseconds: 200);
+  static const _autoScrollEdgeZone = 40.0;
+  static const _maxAutoScrollPxPerFrame = 8.0;
+
+  /// Local, live-reordered copy of the stills while a drag is in progress.
+  late List<StopMotionClipFrame> _orderedFrames;
+
+  bool _isReordering = false;
+
+  /// Current visual slot of the dragged tile within [_orderedFrames].
+  int? _dragIndex;
+
+  /// The dragged still's index in [widget.frames] when the drag began.
+  int _dragStartIndex = 0;
+
+  /// Whether the active drag moves the multi-select block instead of a single
+  /// tile. While set, [_orderedFrames] holds only the *unselected* stills and
+  /// [_blockSlot] is the insertion slot among them.
+  bool _isBlockDrag = false;
+
+  /// The selected stills being block-dragged, in their current order.
+  List<StopMotionClipFrame> _blockFrames = const [];
+
+  /// Insertion slot of the dragged block within [_orderedFrames]
+  /// (`0.._orderedFrames.length`).
+  int _blockSlot = 0;
+
+  // Finger tracking (global X is the source of truth so auto-scroll and the
+  // gesture callbacks never fight over the position).
+  double _dragGlobalX = 0;
+  double _dragStartGlobalX = 0;
+  double _dragStartLocalX = 0;
+  double _dragStartScrollOffset = 0;
+  double _dragTileWidth = 0;
+  double _dragFingerRatio = 0.5;
+
+  Timer? _autoScrollTimer;
+  double _autoScrollSpeed = 0;
+
+  double get _effectiveLocalX {
+    final scrollDelta =
+        (widget.scrollController?.offset ?? 0) - _dragStartScrollOffset;
+    return _dragGlobalX - _dragStartGlobalX + _dragStartLocalX + scrollDelta;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _orderedFrames = List.of(widget.frames);
+  }
+
+  @override
+  void didUpdateWidget(VideoEditorStopMotionFrameStrip oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!_isReordering) _orderedFrames = List.of(widget.frames);
+  }
+
+  @override
+  void dispose() {
+    _stopAutoScroll();
+    super.dispose();
+  }
+
+  double _tileWidth(StopMotionClipFrame frame) =>
+      frame.duration.inMicroseconds /
+      Duration.microsecondsPerSecond *
+      widget.pixelsPerSecond;
+
+  ({List<double> widths, List<double> offsets, double total}) _computeLayout() {
+    final widths = <double>[];
+    final offsets = <double>[];
+    var x = 0.0;
+    for (final frame in _orderedFrames) {
+      final w = _tileWidth(frame);
+      widths.add(w);
+      offsets.add(x);
+      x += w;
+    }
+    return (widths: widths, offsets: offsets, total: x);
+  }
+
+  /// Drag-target index for [x]: nearest slot by tile midpoints. Only for
+  /// retargeting during a drag — for pickup use [_tileIndexAtX], which is
+  /// containment-based (midpoints would pick the neighbour when pressing the
+  /// right half of a tile).
+  int _indexAtX(double x, List<double> widths) {
+    var acc = 0.0;
+    for (var i = 0; i < widths.length; i++) {
+      if (x < acc + widths[i] / 2) return i;
+      acc += widths[i];
+    }
+    return widths.length - 1;
+  }
+
+  /// Index of the tile whose horizontal extent contains [x].
+  int _tileIndexAtX(double x, List<double> widths) {
+    var acc = 0.0;
+    for (var i = 0; i < widths.length; i++) {
+      acc += widths[i];
+      if (x < acc) return i;
+    }
+    return widths.length - 1;
+  }
+
+  /// Insertion slot for [x]: the number of tiles whose midpoint lies left of
+  /// it (`0..widths.length`).
+  int _slotAtX(double x, List<double> widths) {
+    var acc = 0.0;
+    var slot = 0;
+    for (final width in widths) {
+      if (x < acc + width / 2) break;
+      acc += width;
+      slot++;
+    }
+    return slot;
+  }
+
+  void _onLongPressStart(LongPressStartDetails details) {
+    if (widget.frames.length <= 1) return;
+    if (widget.isMultiSelectMode) {
+      _onBlockDragStart(details);
+      return;
+    }
+
+    final layout = _computeLayout();
+    final fingerX = details.localPosition.dx;
+    final pressedIndex = _tileIndexAtX(fingerX, layout.widths);
+    final tileWidth = layout.widths[pressedIndex];
+    final tileLeft = layout.offsets[pressedIndex];
+    final fingerRatio = tileWidth > 0
+        ? ((fingerX - tileLeft) / tileWidth).clamp(0.0, 1.0)
+        : 0.5;
+
+    HapticFeedback.mediumImpact();
+    widget.onReorderChanged?.call(true);
+    setState(() {
+      _isReordering = true;
+      _dragIndex = pressedIndex;
+      _dragStartIndex = pressedIndex;
+      _dragGlobalX = details.globalPosition.dx;
+      _dragStartGlobalX = details.globalPosition.dx;
+      _dragStartLocalX = fingerX;
+      _dragStartScrollOffset = widget.scrollController?.offset ?? 0;
+      _dragTileWidth = tileWidth;
+      _dragFingerRatio = fingerRatio;
+    });
+  }
+
+  /// Starts dragging the whole multi-select block. Only a long-press on a
+  /// *selected* tile picks the block up; there must be at least one
+  /// unselected still left to move past.
+  void _onBlockDragStart(LongPressStartDetails details) {
+    final selection = widget.selectedFrameIndexes;
+    if (widget.onBlockMove == null ||
+        selection.isEmpty ||
+        selection.length >= widget.frames.length) {
+      return;
+    }
+
+    final layout = _computeLayout();
+    final fingerX = details.localPosition.dx;
+    final pressedIndex = _tileIndexAtX(fingerX, layout.widths);
+    if (!selection.contains(pressedIndex)) return;
+
+    final tileWidth = layout.widths[pressedIndex];
+    final tileLeft = layout.offsets[pressedIndex];
+    final fingerRatio = tileWidth > 0
+        ? ((fingerX - tileLeft) / tileWidth).clamp(0.0, 1.0)
+        : 0.5;
+
+    final blockFrames = <StopMotionClipFrame>[];
+    final remaining = <StopMotionClipFrame>[];
+    for (var i = 0; i < widget.frames.length; i++) {
+      (selection.contains(i) ? blockFrames : remaining).add(widget.frames[i]);
+    }
+
+    HapticFeedback.mediumImpact();
+    widget.onReorderChanged?.call(true);
+    setState(() {
+      _isReordering = true;
+      _isBlockDrag = true;
+      _blockFrames = blockFrames;
+      _orderedFrames = remaining;
+      _blockSlot = _slotAtX(
+        fingerX,
+        [for (final frame in remaining) _tileWidth(frame)],
+      );
+      _dragGlobalX = details.globalPosition.dx;
+      _dragStartGlobalX = details.globalPosition.dx;
+      _dragStartLocalX = fingerX;
+      _dragStartScrollOffset = widget.scrollController?.offset ?? 0;
+      _dragTileWidth = tileWidth;
+      _dragFingerRatio = fingerRatio;
+    });
+  }
+
+  void _onLongPressMoveUpdate(LongPressMoveUpdateDetails details) {
+    if (!_isReordering || (!_isBlockDrag && _dragIndex == null)) return;
+    setState(() {
+      _dragGlobalX = details.globalPosition.dx;
+      _applyDragTarget();
+    });
+    _updateAutoScroll(details.globalPosition.dx);
+  }
+
+  void _applyDragTarget() {
+    final widths = _computeLayout().widths;
+    if (_isBlockDrag) {
+      final slot = _slotAtX(_effectiveLocalX, widths);
+      if (slot != _blockSlot) {
+        HapticFeedback.selectionClick();
+        _blockSlot = slot;
+      }
+      return;
+    }
+    final target = _indexAtX(_effectiveLocalX, widths);
+    if (target != _dragIndex) {
+      HapticFeedback.selectionClick();
+      final frame = _orderedFrames.removeAt(_dragIndex!);
+      _orderedFrames.insert(target, frame);
+      _dragIndex = target;
+    }
+  }
+
+  void _updateAutoScroll(double globalX) {
+    if (widget.scrollController == null) return;
+    final screenWidth = MediaQuery.sizeOf(context).width;
+
+    if (globalX < _autoScrollEdgeZone) {
+      _autoScrollSpeed =
+          -(1 - globalX / _autoScrollEdgeZone) * _maxAutoScrollPxPerFrame;
+    } else if (globalX > screenWidth - _autoScrollEdgeZone) {
+      _autoScrollSpeed =
+          (1 - (screenWidth - globalX) / _autoScrollEdgeZone) *
+          _maxAutoScrollPxPerFrame;
+    } else {
+      _autoScrollSpeed = 0;
+    }
+
+    if (_autoScrollSpeed != 0 && _autoScrollTimer == null) {
+      _autoScrollTimer = Timer.periodic(
+        const Duration(milliseconds: 16),
+        (_) => _tickAutoScroll(),
+      );
+    } else if (_autoScrollSpeed == 0) {
+      _stopAutoScroll();
+    }
+  }
+
+  void _tickAutoScroll() {
+    final sc = widget.scrollController;
+    if (sc == null || !_isReordering) {
+      _stopAutoScroll();
+      return;
+    }
+    final pos = sc.position;
+    final newOffset = (pos.pixels + _autoScrollSpeed).clamp(
+      pos.minScrollExtent,
+      pos.maxScrollExtent,
+    );
+    if (newOffset == pos.pixels) return;
+    sc.jumpTo(newOffset);
+    setState(_applyDragTarget);
+  }
+
+  void _stopAutoScroll() {
+    _autoScrollTimer?.cancel();
+    _autoScrollTimer = null;
+    _autoScrollSpeed = 0;
+  }
+
+  void _endReorder() {
+    if (!_isReordering) return;
+    _stopAutoScroll();
+    widget.onReorderChanged?.call(false);
+
+    if (_isBlockDrag) {
+      final slot = _blockSlot;
+      setState(() {
+        _isReordering = false;
+        _isBlockDrag = false;
+        _blockFrames = const [];
+        _orderedFrames = List.of(widget.frames);
+      });
+      widget.onBlockMove?.call(slot);
+      return;
+    }
+
+    final from = _dragStartIndex;
+    final to = _dragIndex ?? from;
+
+    setState(() {
+      _isReordering = false;
+      _dragIndex = null;
+    });
+
+    if (from != to) widget.onReorder(from, to);
+  }
+
+  /// Unique per-tile keys. Duplicated stills share a file path, so keying by
+  /// path alone collides (Flutter requires unique sibling keys). Disambiguate
+  /// by occurrence — duplicates are identical images, so the exact key→tile
+  /// mapping among them is visually indistinguishable during reorder.
+  List<Key> _tileKeys() {
+    final seen = <String, int>{};
+    return [
+      for (final frame in _orderedFrames)
+        ValueKey(
+          '${frame.path}#${seen[frame.path] = (seen[frame.path] ?? 0) + 1}',
+        ),
+    ];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final layout = _computeLayout();
+    final tileKeys = _tileKeys();
+
+    return GestureDetector(
+      onLongPressStart: _onLongPressStart,
+      onLongPressMoveUpdate: _isReordering ? _onLongPressMoveUpdate : null,
+      onLongPressEnd: _isReordering ? (_) => _endReorder() : null,
+      onLongPressCancel: _isReordering ? _endReorder : null,
+      child: SizedBox(
+        width: layout.total,
+        height: TimelineConstants.thumbnailStripHeight,
+        child: Stack(
+          clipBehavior: .none,
+          children: [
+            for (var i = 0; i < _orderedFrames.length; i++)
+              if (i != _dragIndex)
+                AnimatedPositioned(
+                  key: tileKeys[i],
+                  duration: _isReordering ? _animDuration : Duration.zero,
+                  curve: Curves.easeInOut,
+                  left: layout.offsets[i],
+                  top: 0,
+                  width: layout.widths[i],
+                  height: TimelineConstants.thumbnailStripHeight,
+                  child: _FrameTile(
+                    frame: _orderedFrames[i],
+                    index: i,
+                    total: _orderedFrames.length,
+                    isSelected:
+                        !_isReordering &&
+                        (widget.isMultiSelectMode
+                            ? widget.selectedFrameIndexes.contains(i)
+                            : i == widget.selectedFrameIndex),
+                    onTap: _isReordering ? null : () => widget.onFrameTapped(i),
+                  ),
+                ),
+            if (_dragIndex != null)
+              Positioned(
+                left: _effectiveLocalX - _dragTileWidth * _dragFingerRatio,
+                top: 0,
+                width: _dragTileWidth,
+                height: TimelineConstants.thumbnailStripHeight,
+                child: _FrameTile(
+                  frame: _orderedFrames[_dragIndex!],
+                  index: _dragIndex!,
+                  total: _orderedFrames.length,
+                  isSelected: true,
+                  isDragging: true,
+                ),
+              ),
+
+            // Block drag: an insertion marker at the target slot plus a ghost
+            // of the block (its first still with a count badge) at the finger.
+            if (_isBlockDrag) ...[
+              Positioned(
+                left:
+                    (_blockSlot < layout.offsets.length
+                        ? layout.offsets[_blockSlot]
+                        : layout.total) -
+                    1,
+                top: 0,
+                width: 2,
+                height: TimelineConstants.thumbnailStripHeight,
+                child: const ColoredBox(color: VineTheme.accentYellow),
+              ),
+              Positioned(
+                left: _effectiveLocalX - _dragTileWidth * _dragFingerRatio,
+                top: 0,
+                width: _dragTileWidth,
+                height: TimelineConstants.thumbnailStripHeight,
+                child: Stack(
+                  clipBehavior: .none,
+                  fit: StackFit.expand,
+                  children: [
+                    _FrameTile(
+                      frame: _blockFrames.first,
+                      index: 0,
+                      total: _blockFrames.length,
+                      isSelected: true,
+                      isDragging: true,
+                    ),
+                    if (_blockFrames.length > 1)
+                      PositionedDirectional(
+                        top: -6,
+                        end: -6,
+                        child: _BlockCountBadge(count: _blockFrames.length),
+                      ),
+                  ],
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Count badge on the block-drag ghost showing how many stills move together.
+class _BlockCountBadge extends StatelessWidget {
+  const _BlockCountBadge({required this.count});
+
+  final int count;
+
+  @override
+  Widget build(BuildContext context) {
+    return MediaQuery.withNoTextScaling(
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+        decoration: const BoxDecoration(
+          color: VineTheme.accentYellow,
+          borderRadius: BorderRadius.all(Radius.circular(999)),
+        ),
+        child: Text(
+          count.toString(),
+          style: VineTheme.labelSmallFont(color: VineTheme.backgroundCamera),
+        ),
+      ),
+    );
+  }
+}
+
+class _FrameTile extends StatelessWidget {
+  const _FrameTile({
+    required this.frame,
+    required this.index,
+    required this.total,
+    required this.isSelected,
+    this.onTap,
+    this.isDragging = false,
+  });
+
+  final StopMotionClipFrame frame;
+  final int index;
+  final int total;
+  final bool isSelected;
+  final VoidCallback? onTap;
+  final bool isDragging;
+
+  @override
+  Widget build(BuildContext context) {
+    final radius = BorderRadius.circular(TimelineConstants.thumbnailRadius);
+    // Decode the still at strip height, not full camera resolution — a 4000px
+    // portrait decoded into a 64px tile otherwise wastes ~45 MB per tile.
+    final cacheHeight =
+        (TimelineConstants.thumbnailStripHeight *
+                MediaQuery.devicePixelRatioOf(context))
+            .round();
+    return Semantics(
+      button: true,
+      selected: isSelected,
+      label: context.l10n.videoEditorStopMotionFrameSemanticLabel(
+        index + 1,
+        total,
+      ),
+      child: GestureDetector(
+        onTap: onTap,
+        behavior: HitTestBehavior.opaque,
+        child: Opacity(
+          opacity: isDragging ? 0.85 : 1,
+          child: DecoratedBox(
+            // Foreground: the image fills the same box, so a background
+            // decoration would be painted underneath it and never show.
+            position: DecorationPosition.foreground,
+            decoration: BoxDecoration(
+              borderRadius: radius,
+              // Selected stills use the same accent-yellow highlight as the
+              // trim handles on a video clip — just the highlight, no handles.
+              border: Border.all(
+                color: isSelected
+                    ? VineTheme.accentYellow
+                    : VineTheme.surfaceBackground,
+                width: isSelected ? 2 : 0.5,
+              ),
+            ),
+            child: ClipRRect(
+              borderRadius: radius,
+              child: Image.file(
+                File(frame.path),
+                fit: BoxFit.cover,
+                gaplessPlayback: true,
+                cacheHeight: cacheHeight,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
@@ -254,7 +254,7 @@ class _VideoEditorTimelineClipStripState
     if (startClipIdx == -1 || endClipIdx == -1) return;
     final startClip = widget.clips[startClipIdx];
     final endClip = widget.clips[endClipIdx];
-    final sourcePath = startClip.video.file?.path;
+    final sourcePath = startClip.video?.file?.path;
     if (sourcePath == null) return;
 
     // Mark consumed only once seeding can actually run. Committing before
@@ -284,7 +284,7 @@ class _VideoEditorTimelineClipStripState
         end: split.sourceDuration - split.sourceTrimEnd,
       ),
       timestampOffset: Duration.zero,
-      currentSourcePath: endClip.video.file?.path ?? sourcePath,
+      currentSourcePath: endClip.video?.file?.path ?? sourcePath,
     );
   }
 

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart
@@ -9,6 +9,7 @@ import 'package:openvine/extensions/video_editor_extensions.dart';
 import 'package:openvine/extensions/video_editor_history_extensions.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/stop_motion/stop_motion_frame_ops.dart';
 import 'package:openvine/models/timeline_overlay_item.dart';
 import 'package:openvine/models/video_editor/transition_geometry.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
@@ -48,6 +49,12 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
   bool _isUserScrolling = false;
 
   double _pixelsPerSecond = TimelineConstants.pixelsPerSecond;
+
+  /// One-shot: the first time a stop-motion composition lands, the zoom is
+  /// bumped so its tens-of-ms stills are actually visible (the video default
+  /// renders them a couple of pixels wide). Never re-fires, so a user pinch
+  /// is not overridden.
+  bool _didAutoZoomStopMotion = false;
 
   /// Cached total duration from clip editor — used by scroll listeners
   /// that fire outside the build phase.
@@ -127,6 +134,13 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
       ),
     );
     if (clips.isEmpty) return const SizedBox.shrink();
+
+    if (!_didAutoZoomStopMotion && isStopMotionComposition(clips)) {
+      _didAutoZoomStopMotion = true;
+      _pixelsPerSecond = stopMotionInitialPixelsPerSecond(
+        clips.first.stopMotionFrames ?? const [],
+      );
+    }
 
     final trimmingClipId =
         isEditing && currentClipIndex >= 0 && currentClipIndex < clips.length
@@ -930,9 +944,17 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
     final currentDistance = _currentPointerDistance();
     final scale = currentDistance / _pinchBaseDistance;
 
+    // Stop-motion stills need a far higher ceiling than second-long video
+    // clips to be workable.
+    final maxPps =
+        isStopMotionComposition(
+          context.read<ClipEditorBloc>().state.clips,
+        )
+        ? TimelineConstants.stopMotionMaxPixelsPerSecond
+        : TimelineConstants.maxPixelsPerSecond;
     final newPps = (_pinchBasePps * scale).clamp(
       TimelineConstants.minPixelsPerSecond,
-      TimelineConstants.maxPixelsPerSecond,
+      maxPps,
     );
     if (newPps == _pixelsPerSecond) return;
 

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart
@@ -133,12 +133,16 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
         selectedClipIds: b.state.selectedClipIds,
       ),
     );
-    if (clips.isEmpty) return const SizedBox.shrink();
-
-    if (!_didAutoZoomStopMotion && isStopMotionComposition(clips)) {
-      _didAutoZoomStopMotion = true;
-      _pixelsPerSecond = stopMotionInitialPixelsPerSecond(
-        clips.first.stopMotionFrames ?? const [],
+    // Kept mounted even while [clips] is empty so it catches the transition
+    // into the first (async-loaded) stop-motion composition — see
+    // [_autoZoomForFirstStopMotion]. The root of both the empty and non-empty
+    // branches is this same [BlocListener] type, so its subscription survives
+    // the empty→populated rebuild.
+    if (clips.isEmpty) {
+      return BlocListener<ClipEditorBloc, ClipEditorState>(
+        listenWhen: _shouldAutoZoomForStopMotion,
+        listener: _autoZoomForFirstStopMotion,
+        child: const SizedBox.shrink(),
       );
     }
 
@@ -173,7 +177,7 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
     );
     // Sync layers from main editor to timeline overlay bloc, and
     // sync scroll to playback position while not user-scrolling.
-    return MultiBlocListener(
+    final Widget body = MultiBlocListener(
       listeners: [
         BlocListener<ClipEditorBloc, ClipEditorState>(
           listenWhen: (prev, curr) => prev.totalDuration != curr.totalDuration,
@@ -385,6 +389,37 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
         ),
       ),
     );
+
+    return BlocListener<ClipEditorBloc, ClipEditorState>(
+      listenWhen: _shouldAutoZoomForStopMotion,
+      listener: _autoZoomForFirstStopMotion,
+      child: body,
+    );
+  }
+
+  /// One-shot: the first time a stop-motion composition lands, the zoom is
+  /// bumped so its tens-of-ms stills are actually visible (the video default
+  /// renders them a couple of pixels wide). Guarded by
+  /// [_didAutoZoomStopMotion] so it never re-fires — a user pinch is not
+  /// overridden.
+  bool _shouldAutoZoomForStopMotion(
+    ClipEditorState prev,
+    ClipEditorState curr,
+  ) =>
+      !_didAutoZoomStopMotion &&
+      !isStopMotionComposition(prev.clips) &&
+      isStopMotionComposition(curr.clips);
+
+  void _autoZoomForFirstStopMotion(
+    BuildContext context,
+    ClipEditorState state,
+  ) {
+    setState(() {
+      _didAutoZoomStopMotion = true;
+      _pixelsPerSecond = stopMotionInitialPixelsPerSecond(
+        state.clips.first.stopMotionFrames ?? const [],
+      );
+    });
   }
 
   bool _handleScrollNotification(ScrollNotification notification) {

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_body.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_body.dart
@@ -4,12 +4,16 @@ import 'dart:typed_data';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
 import 'package:openvine/blocs/video_editor/main_editor/video_editor_main_bloc.dart';
 import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/constants/video_editor_timeline_constants.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/stop_motion/stop_motion_frame_ops.dart';
 import 'package:openvine/models/timeline_overlay_item.dart';
+import 'package:openvine/widgets/video_editor/stop_motion/stop_motion_frame_commands.dart';
+import 'package:openvine/widgets/video_editor/timeline_editor/strips/video_editor_stop_motion_frame_strip.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/strips/video_editor_timeline_overlay_strip.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/strips/video_editor_timeline_overlay_strips.dart';
@@ -140,23 +144,30 @@ class VideoEditorTimelineBody extends StatelessWidget {
               ),
               const SizedBox(height: TimelineConstants.rulerToBodyGap),
 
-              /// Video-Clips
+              /// Video clips, or per-frame stills for a stop-motion clip.
               RepaintBoundary(
-                child: VideoEditorTimelineClipStrip(
-                  clips: clips,
-                  totalWidth: totalWidth,
-                  pixelsPerSecond: pixelsPerSecond,
-                  scrollController: scrollController,
-                  isInteracting: isInteracting,
-                  onReorder: onReorder,
-                  onReorderChanged: onReorderChanged,
-                  trimmingClipId: trimmingClipId,
-                  onTrimChanged: onTrimChanged,
-                  onTrimDragChanged: onTrimDragChanged,
-                  onClipTapped: onClipTapped,
-                  isMultiSelectMode: isMultiSelectMode,
-                  selectedClipIds: selectedClipIds,
-                ),
+                child: isStopMotionComposition(clips)
+                    ? _StopMotionFrameStrip(
+                        clip: clips.first,
+                        pixelsPerSecond: pixelsPerSecond,
+                        scrollController: scrollController,
+                        onReorderChanged: onReorderChanged,
+                      )
+                    : VideoEditorTimelineClipStrip(
+                        clips: clips,
+                        totalWidth: totalWidth,
+                        pixelsPerSecond: pixelsPerSecond,
+                        scrollController: scrollController,
+                        isInteracting: isInteracting,
+                        onReorder: onReorder,
+                        onReorderChanged: onReorderChanged,
+                        trimmingClipId: trimmingClipId,
+                        onTrimChanged: onTrimChanged,
+                        onTrimDragChanged: onTrimDragChanged,
+                        onClipTapped: onClipTapped,
+                        isMultiSelectMode: isMultiSelectMode,
+                        selectedClipIds: selectedClipIds,
+                      ),
               ),
 
               /// Layers, Filters and Audio-Tracks
@@ -210,6 +221,74 @@ class VideoEditorTimelineBody extends StatelessWidget {
           ),
         ],
       ),
+    );
+  }
+}
+
+/// Bridges the presentational [VideoEditorStopMotionFrameStrip] to the clip
+/// editor: reads the selected frame from the bloc and commits frame selection
+/// and drag reorders (via [commitStopMotionFrames]).
+class _StopMotionFrameStrip extends StatelessWidget {
+  const _StopMotionFrameStrip({
+    required this.clip,
+    required this.pixelsPerSecond,
+    required this.scrollController,
+    this.onReorderChanged,
+  });
+
+  final DivineVideoClip clip;
+  final double pixelsPerSecond;
+  final ScrollController scrollController;
+  final ValueChanged<bool>? onReorderChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final frames = clip.stopMotionFrames ?? const [];
+    final (
+      selectedFrameIndex,
+      isMultiSelectMode,
+      selectedFrameIndexes,
+    ) = context.select(
+      (ClipEditorBloc b) => (
+        b.state.selectedFrameIndex,
+        b.state.isMultiSelectMode,
+        b.state.selectedFrameIndexes,
+      ),
+    );
+
+    return VideoEditorStopMotionFrameStrip(
+      frames: frames,
+      pixelsPerSecond: pixelsPerSecond,
+      selectedFrameIndex: selectedFrameIndex,
+      isMultiSelectMode: isMultiSelectMode,
+      selectedFrameIndexes: selectedFrameIndexes,
+      scrollController: scrollController,
+      onReorderChanged: onReorderChanged,
+      onFrameTapped: (index) => context.read<ClipEditorBloc>().add(
+        isMultiSelectMode
+            ? ClipEditorFrameMultiSelectToggled(index)
+            : ClipEditorFrameSelected(index),
+      ),
+      onReorder: (from, to) => commitStopMotionFrames(
+        context,
+        clipId: clip.id,
+        frames: StopMotionFrameOps.reorderFrame(frames, from, to),
+      ),
+      onBlockMove: (slot) {
+        final bloc = context.read<ClipEditorBloc>();
+        final selection = bloc.state.selectedFrameIndexes;
+        final moved = StopMotionFrameOps.moveFrames(frames, selection, slot);
+        // No-op moves return the same instance; skip commit and selection
+        // shuffle so the history stays clean.
+        if (identical(moved, frames)) return;
+        commitStopMotionFrames(context, clipId: clip.id, frames: moved);
+        // The block now occupies slot..slot+n-1 — keep it selected.
+        bloc.add(
+          ClipEditorFrameMultiSelectionSet({
+            for (var i = 0; i < selection.length; i++) slot + i,
+          }),
+        );
+      },
     );
   }
 }

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart
@@ -5,6 +5,7 @@
 import 'package:models/models.dart' show AudioEvent;
 import 'package:openvine/constants/video_editor_timeline_constants.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/models/video_editor/transition_geometry.dart';
 
 /// Converts a [sourcePosition] inside one untrimmed clip to the matching
@@ -431,4 +432,26 @@ int timelineOverlayOffsetToMs(
   }
   final ms = ((offset - gapPixels) / pixelsPerSecond * 1000).round();
   return ms.clamp(0, totalDurationMs);
+}
+
+/// Initial timeline zoom for a frames-first stop-motion session.
+///
+/// Stop-motion stills are held for a handful of output frames (tens of ms),
+/// so the video default of [TimelineConstants.pixelsPerSecond] renders them a
+/// couple of pixels wide. This scales the zoom so the *average* still gets
+/// [TimelineConstants.stopMotionTargetTileWidth] of tappable width, clamped
+/// between the video default and the stop-motion zoom ceiling.
+double stopMotionInitialPixelsPerSecond(List<StopMotionClipFrame> frames) {
+  if (frames.isEmpty) return TimelineConstants.pixelsPerSecond;
+  final total = frames.fold(
+    Duration.zero,
+    (sum, frame) => sum + frame.duration,
+  );
+  if (total <= Duration.zero) return TimelineConstants.pixelsPerSecond;
+  final averageSeconds =
+      total.inMicroseconds / frames.length / Duration.microsecondsPerSecond;
+  return (TimelineConstants.stopMotionTargetTileWidth / averageSeconds).clamp(
+    TimelineConstants.pixelsPerSecond,
+    TimelineConstants.stopMotionMaxPixelsPerSecond,
+  );
 }

--- a/mobile/lib/widgets/video_metadata/modes/classic/video_metadata_classic_preview_thumbnail.dart
+++ b/mobile/lib/widgets/video_metadata/modes/classic/video_metadata_classic_preview_thumbnail.dart
@@ -38,7 +38,7 @@ class _VideoMetadataClassicPreviewThumbnailState
       clip,
     ) {
       if (clip != null && _controller == null) {
-        clip.video.safeFilePath().then((path) {
+        clip.requireVideo.safeFilePath().then((path) {
           if (mounted) _initPlayer(path);
         });
       }

--- a/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_capture_actions.dart
+++ b/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_capture_actions.dart
@@ -21,6 +21,9 @@ class VideoRecorderCaptureActions extends ConsumerWidget {
         canSwitchCamera: b.state.canSwitchCamera,
         hasFlash: b.state.hasFlash,
         isRecording: b.state.isRecording,
+        supportsTimer: b.state.recorderMode.supportsCountdownTimer,
+        capturesStills: b.state.recorderMode.capturesStills,
+        supportsStabilization: b.state.recorderMode.supportsVideoStabilization,
       ),
     );
     final hasClips = ref.watch(clipManagerProvider.select((p) => p.hasClips));
@@ -54,13 +57,23 @@ class VideoRecorderCaptureActions extends ConsumerWidget {
                         )
                       : null,
                 ),
-                _IconButton(
-                  icon: state.timer.icon,
-                  label: context.l10n.videoRecorderCycleTimerLabel,
-                  onTap: () => context.read<VideoRecorderBloc>().add(
-                    const VideoRecorderTimerCycled(),
+                if (state.supportsTimer)
+                  _IconButton(
+                    icon: state.timer.icon,
+                    label: context.l10n.videoRecorderCycleTimerLabel,
+                    onTap: () => context.read<VideoRecorderBloc>().add(
+                      const VideoRecorderTimerCycled(),
+                    ),
                   ),
-                ),
+                if (state.capturesStills) const _GhostFrameButton(),
+                if (state.capturesStills)
+                  _IconButton(
+                    icon: .gridNine,
+                    label: context.l10n.videoRecorderToggleGridLabel,
+                    onTap: () => context.read<VideoRecorderBloc>().add(
+                      const VideoRecorderGridLinesToggled(),
+                    ),
+                  ),
                 _IconButton(
                   icon: state.aspectRatio == .square
                       ? .cropSquare
@@ -81,12 +94,40 @@ class VideoRecorderCaptureActions extends ConsumerWidget {
                         )
                       : null,
                 ),
-                const _StabilizationButton(),
+                if (state.supportsStabilization) const _StabilizationButton(),
               ],
             ),
           ),
         ),
       ),
+    );
+  }
+}
+
+/// Toggles the ghost-frame (onion-skin) overlay in stop-motion mode, mirroring
+/// the classic-mode ghost toggle.
+class _GhostFrameButton extends StatelessWidget {
+  const _GhostFrameButton();
+
+  @override
+  Widget build(BuildContext context) {
+    return _IconButton(
+      icon: .ghost,
+      label: context.l10n.videoRecorderToggleGhostFrameLabel,
+      onTap: () {
+        final bloc = context.read<VideoRecorderBloc>();
+        final willEnable = !bloc.state.showLastClipOverlay;
+        bloc.add(const VideoRecorderShowLastClipOverlayToggled());
+        ScaffoldMessenger.of(context)
+          ..clearSnackBars()
+          ..showSnackBar(
+            DivineSnackbarContainer.snackBar(
+              willEnable
+                  ? context.l10n.videoRecorderGhostFrameEnabled
+                  : context.l10n.videoRecorderGhostFrameDisabled,
+            ),
+          );
+      },
     );
   }
 }

--- a/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_capture_stack.dart
+++ b/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_capture_stack.dart
@@ -73,6 +73,11 @@ class VideoRecorderCaptureStack extends ConsumerWidget {
     final canUndo = recorderMode.capturesStills
         ? stopMotionFrameCount > 0
         : hasClips;
+    // Fades out (opacity 0) while recording or in the editor-hosted recorder.
+    // Opacity alone does not stop hit testing, so the button is also gated
+    // with IgnorePointer below — otherwise an invisible tap would silently
+    // delete the last still/clip.
+    final undoButtonVisible = canUndo && !isRecording && !fromEditor;
 
     return SafeArea(
       bottom: false,
@@ -125,18 +130,21 @@ class VideoRecorderCaptureStack extends ConsumerWidget {
                 children: [
                   AnimatedOpacity(
                     duration: const Duration(milliseconds: 220),
-                    opacity: canUndo && !isRecording && !fromEditor ? 1 : 0,
-                    child: DivineIconButton(
-                      icon: .trash,
-                      semanticLabel:
-                          context.l10n.videoRecorderDeleteLastClipLabel,
-                      type: .ghostSecondary,
-                      size: .small,
-                      onPressed: recorderMode.capturesStills
-                          ? () => context.read<VideoRecorderBloc>().add(
-                              const VideoRecorderStopMotionFrameUndone(),
-                            )
-                          : () => _deleteLastClip(context, ref),
+                    opacity: undoButtonVisible ? 1 : 0,
+                    child: IgnorePointer(
+                      ignoring: !undoButtonVisible,
+                      child: DivineIconButton(
+                        icon: .trash,
+                        semanticLabel:
+                            context.l10n.videoRecorderDeleteLastClipLabel,
+                        type: .ghostSecondary,
+                        size: .small,
+                        onPressed: recorderMode.capturesStills
+                            ? () => context.read<VideoRecorderBloc>().add(
+                                const VideoRecorderStopMotionFrameUndone(),
+                              )
+                            : () => _deleteLastClip(context, ref),
+                      ),
                     ),
                   ),
 

--- a/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_capture_stack.dart
+++ b/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_capture_stack.dart
@@ -206,10 +206,9 @@ class _StopMotionAssembleOverlay extends ConsumerWidget {
             }
           case StopMotionStatus.failure:
             ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(
-                content: Text(
-                  context.l10n.videoRecorderStopMotionAssembleFailed,
-                ),
+              DivineSnackbarContainer.snackBar(
+                context.l10n.videoRecorderStopMotionAssembleFailed,
+                error: true,
               ),
             );
           case StopMotionStatus.idle:

--- a/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_capture_stack.dart
+++ b/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_capture_stack.dart
@@ -4,14 +4,17 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/widgets/video_recorder/clip_delete_snackbar.dart';
 import 'package:openvine/widgets/video_recorder/modes/capture/video_recorder_capture_actions.dart';
 import 'package:openvine/widgets/video_recorder/modes/capture/video_recorder_capture_top_bar.dart';
+import 'package:openvine/widgets/video_recorder/modes/capture/video_recorder_shutter_flash.dart';
 import 'package:openvine/widgets/video_recorder/preview/video_recorder_camera_preview.dart';
 import 'package:openvine/widgets/video_recorder/video_recorder_countdown_overlay.dart';
+import 'package:openvine/widgets/video_recorder/video_recorder_navigation.dart';
 import 'package:openvine/widgets/video_recorder/video_recorder_record_button.dart';
 import 'package:openvine/widgets/video_recorder/video_recorder_zoom_indicator.dart';
 
@@ -53,9 +56,23 @@ class VideoRecorderCaptureStack extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final hasClips = ref.watch(clipManagerProvider.select((p) => p.hasClips));
-    final isRecording = context.select(
-      (VideoRecorderBloc b) => b.state.isRecording,
+    final (
+      isRecording,
+      recorderMode,
+      stopMotionFrameCount,
+      stopMotionShutterTick,
+    ) = context.select(
+      (VideoRecorderBloc b) => (
+        b.state.isRecording,
+        b.state.recorderMode,
+        b.state.stopMotionFrameCount,
+        b.state.stopMotionShutterTick,
+      ),
     );
+    // Stop-motion has no clips during capture; undo removes the last still.
+    final canUndo = recorderMode.capturesStills
+        ? stopMotionFrameCount > 0
+        : hasClips;
 
     return SafeArea(
       bottom: false,
@@ -68,6 +85,19 @@ class VideoRecorderCaptureStack extends ConsumerWidget {
             borderRadius: .vertical(bottom: .circular(32)),
             child: VideoRecorderCameraPreview(),
           ),
+
+          // Shutter blink over the preview so each stop-motion capture is
+          // visibly confirmed (the haptic alone is easy to miss).
+          if (recorderMode == .stopMotion)
+            Positioned.fill(
+              child: ClipRRect(
+                clipBehavior: .hardEdge,
+                borderRadius: const .vertical(bottom: .circular(32)),
+                child: VideoRecorderShutterFlash(
+                  shutterTick: stopMotionShutterTick,
+                ),
+              ),
+            ),
 
           // Action buttons
           const Align(
@@ -95,14 +125,18 @@ class VideoRecorderCaptureStack extends ConsumerWidget {
                 children: [
                   AnimatedOpacity(
                     duration: const Duration(milliseconds: 220),
-                    opacity: hasClips && !isRecording && !fromEditor ? 1 : 0,
+                    opacity: canUndo && !isRecording && !fromEditor ? 1 : 0,
                     child: DivineIconButton(
                       icon: .trash,
                       semanticLabel:
                           context.l10n.videoRecorderDeleteLastClipLabel,
                       type: .ghostSecondary,
                       size: .small,
-                      onPressed: () => _deleteLastClip(context, ref),
+                      onPressed: recorderMode.capturesStills
+                          ? () => context.read<VideoRecorderBloc>().add(
+                              const VideoRecorderStopMotionFrameUndone(),
+                            )
+                          : () => _deleteLastClip(context, ref),
                     ),
                   ),
 
@@ -140,8 +174,74 @@ class VideoRecorderCaptureStack extends ConsumerWidget {
 
           // Countdown overlay
           const VideoRecorderCountdownOverlay(),
+
+          // Stop-motion: encodes captured frames into one clip, then opens the
+          // editor; shows a blocking overlay while assembling.
+          _StopMotionAssembleOverlay(fromEditor: fromEditor),
         ],
       ),
+    );
+  }
+}
+
+/// Drives the stop-motion assemble step: a blocking progress overlay while
+/// encoding, navigation to the editor on success, and a snackbar on failure.
+class _StopMotionAssembleOverlay extends ConsumerWidget {
+  const _StopMotionAssembleOverlay({required this.fromEditor});
+
+  final bool fromEditor;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return BlocConsumer<VideoRecorderBloc, VideoRecorderBlocState>(
+      listenWhen: (previous, current) =>
+          previous.stopMotionStatus != current.stopMotionStatus,
+      listener: (context, state) {
+        switch (state.stopMotionStatus) {
+          case StopMotionStatus.ready:
+            if (fromEditor) {
+              context.pop(true);
+            } else {
+              unawaited(openVideoEditorFromRecorder(context, ref));
+            }
+          case StopMotionStatus.failure:
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text(
+                  context.l10n.videoRecorderStopMotionAssembleFailed,
+                ),
+              ),
+            );
+          case StopMotionStatus.idle:
+          case StopMotionStatus.assembling:
+            break;
+        }
+      },
+      buildWhen: (previous, current) =>
+          previous.stopMotionStatus != current.stopMotionStatus,
+      builder: (context, state) {
+        // The spinner animates continuously, so only mount it while assembling
+        // (a permanently-animating child never lets `pumpAndSettle` settle).
+        if (state.stopMotionStatus != StopMotionStatus.assembling) {
+          return const SizedBox.shrink();
+        }
+        return ColoredBox(
+          color: VineTheme.surfaceBackground.withValues(alpha: 0.7),
+          child: Center(
+            child: Column(
+              mainAxisSize: .min,
+              spacing: 16,
+              children: [
+                const CircularProgressIndicator(color: VineTheme.primary),
+                Text(
+                  context.l10n.videoRecorderStopMotionAssembling,
+                  style: VineTheme.bodyMediumFont(),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
     );
   }
 }

--- a/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_capture_top_bar.dart
+++ b/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_capture_top_bar.dart
@@ -36,10 +36,17 @@ class VideoRecorderCaptureTopBar extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final isRecording = context.select(
-      (VideoRecorderBloc b) => b.state.isRecording,
+    final (isRecording, capturesStills, stopMotionFrameCount) = context.select(
+      (VideoRecorderBloc b) => (
+        b.state.isRecording,
+        b.state.recorderMode.capturesStills,
+        b.state.stopMotionFrameCount,
+      ),
     );
     final hasClips = ref.watch(clipManagerProvider.select((p) => p.hasClips));
+    // Stop-motion assembles its frames into a clip on "next" rather than
+    // navigating straight to the editor.
+    final showNext = capturesStills ? stopMotionFrameCount > 0 : hasClips;
 
     return SafeArea(
       left: false,
@@ -68,16 +75,20 @@ class VideoRecorderCaptureTopBar extends ConsumerWidget {
                     ?center,
                     AnimatedOpacity(
                       duration: _animationDuration,
-                      opacity: hasClips ? 1 : 0,
+                      opacity: showNext ? 1 : 0,
                       child: DivineIconButton(
                         icon: .caretRight,
                         semanticLabel:
                             context.l10n.videoRecorderCaptureNextLabel,
                         size: .small,
                         type: .ghostSecondary,
-                        onPressed: () => fromEditor
-                            ? context.pop(true)
-                            : openVideoEditorFromRecorder(context, ref),
+                        onPressed: capturesStills
+                            ? () => context.read<VideoRecorderBloc>().add(
+                                const VideoRecorderStopMotionAssembleRequested(),
+                              )
+                            : () => fromEditor
+                                  ? context.pop(true)
+                                  : openVideoEditorFromRecorder(context, ref),
                       ),
                     ),
                   ],

--- a/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_shutter_flash.dart
+++ b/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_shutter_flash.dart
@@ -1,0 +1,67 @@
+// ABOUTME: Shutter-blink overlay confirming a stop-motion still was captured
+// ABOUTME: Flashes dark briefly whenever the capture count increases
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+
+/// A brief dark blink over the camera preview, fired whenever [shutterTick]
+/// increases.
+///
+/// Stop-motion captures stills without any recording UI change, so without
+/// this the only shutter feedback is haptic — easy to miss. A dark blink
+/// (rather than white) mirrors hardware camera shutters and is safer for
+/// photosensitive users.
+class VideoRecorderShutterFlash extends StatefulWidget {
+  const VideoRecorderShutterFlash({required this.shutterTick, super.key});
+
+  /// Monotonic shutter counter, bumped the instant the shutter fires (before
+  /// the native capture resolves); every increase triggers one blink.
+  final int shutterTick;
+
+  @override
+  State<VideoRecorderShutterFlash> createState() =>
+      _VideoRecorderShutterFlashState();
+}
+
+class _VideoRecorderShutterFlashState extends State<VideoRecorderShutterFlash>
+    with SingleTickerProviderStateMixin {
+  static const _blinkDuration = Duration(milliseconds: 160);
+  static const _peakOpacity = 0.85;
+
+  late final AnimationController _controller = AnimationController(
+    vsync: this,
+    duration: _blinkDuration,
+  );
+
+  @override
+  void didUpdateWidget(VideoRecorderShutterFlash oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.shutterTick > oldWidget.shutterTick) {
+      _controller
+        ..value = 1
+        ..reverse();
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return IgnorePointer(
+      child: AnimatedBuilder(
+        animation: _controller,
+        builder: (context, _) => _controller.value == 0
+            ? const SizedBox.shrink()
+            : ColoredBox(
+                color: VineTheme.backgroundCamera.withValues(
+                  alpha: _peakOpacity * _controller.value,
+                ),
+              ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/widgets/video_recorder/video_recorder_bottom_bar.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_bottom_bar.dart
@@ -18,30 +18,39 @@ class VideoRecorderBottomBar extends StatelessWidget {
       (VideoRecorderBloc b) => (
         isRecording: b.state.isRecording,
         recorderMode: b.state.recorderMode,
+        isAssembling: b.state.stopMotionStatus == StopMotionStatus.assembling,
       ),
     );
+    // The bar fades out while recording, and an assemble is mid-flight over the
+    // captured stills — a mode switch during either would discard work the user
+    // can't get back. Opacity alone still hit-tests, so the gate has to ignore
+    // pointers rather than just fade.
+    final isLocked = state.isRecording || state.isAssembling;
 
     return SafeArea(
       top: false,
-      child: AnimatedOpacity(
-        duration: const Duration(milliseconds: 220),
-        opacity: state.isRecording ? 0 : 1,
-        child: Padding(
-          padding: const EdgeInsets.only(bottom: 4),
-          child: Stack(
-            alignment: .center,
-            children: [
-              VideoRecorderModeSelectorWheel(
-                selectedMode: state.recorderMode,
-                onModeChanged: (mode) => context.read<VideoRecorderBloc>().add(
-                  VideoRecorderRecorderModeSet(mode),
+      child: IgnorePointer(
+        ignoring: isLocked,
+        child: AnimatedOpacity(
+          duration: const Duration(milliseconds: 220),
+          opacity: state.isRecording ? 0 : 1,
+          child: Padding(
+            padding: const EdgeInsets.only(bottom: 4),
+            child: Stack(
+              alignment: .center,
+              children: [
+                VideoRecorderModeSelectorWheel(
+                  selectedMode: state.recorderMode,
+                  onModeChanged: (mode) => context
+                      .read<VideoRecorderBloc>()
+                      .add(VideoRecorderRecorderModeSet(mode)),
                 ),
-              ),
-              const Align(
-                alignment: .centerLeft,
-                child: VideoRecorderLibraryButton(),
-              ),
-            ],
+                const Align(
+                  alignment: .centerLeft,
+                  child: VideoRecorderLibraryButton(),
+                ),
+              ],
+            ),
           ),
         ),
       ),

--- a/mobile/lib/widgets/video_recorder/video_recorder_ghost_frame.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_ghost_frame.dart
@@ -17,11 +17,17 @@ class VideoRecorderGhostFrame extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final (showOverlay, capturesStills, stopMotionLastFrame) = context.select(
+    final (
+      showOverlay,
+      capturesStills,
+      stopMotionLastFrame,
+      isFrontCamera,
+    ) = context.select(
       (VideoRecorderBloc b) => (
         b.state.showLastClipOverlay,
         b.state.recorderMode.capturesStills,
         b.state.stopMotionLastFrame,
+        b.state.isFrontCamera,
       ),
     );
 
@@ -44,13 +50,12 @@ class VideoRecorderGhostFrame extends ConsumerWidget {
     );
 
     // Stop-motion assembles at the end, so there are no clips during capture —
-    // align the next pose against the last captured still instead. The capture
-    // lens of each still is not tracked in recorder state (stopMotionFrames
-    // holds only file paths), so the ghost is shown un-mirrored; the clip
-    // branch above mirrors via clip.isFrontCameraLens.
+    // align the next pose against the last captured still instead. The overlay
+    // sits on top of the live preview, which is mirrored for the front camera,
+    // so mirror the ghost to match whenever the active lens is front-facing.
     final ghostData = capturesStills
         ? (stopMotionLastFrame != null
-              ? (path: stopMotionLastFrame, isFrontCamera: false)
+              ? (path: stopMotionLastFrame, isFrontCamera: isFrontCamera)
               : null)
         : clipGhost;
 

--- a/mobile/lib/widgets/video_recorder/video_recorder_ghost_frame.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_ghost_frame.dart
@@ -17,14 +17,18 @@ class VideoRecorderGhostFrame extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final showOverlay = context.select(
-      (VideoRecorderBloc b) => b.state.showLastClipOverlay,
+    final (showOverlay, capturesStills, stopMotionLastFrame) = context.select(
+      (VideoRecorderBloc b) => (
+        b.state.showLastClipOverlay,
+        b.state.recorderMode.capturesStills,
+        b.state.stopMotionLastFrame,
+      ),
     );
 
     // Use the last clip that has a ghost frame, not just the last clip.
     // This prevents the overlay from disappearing while recording a new
     // clip that doesn't have a ghost frame yet.
-    final ghostData = ref.watch(
+    final clipGhost = ref.watch(
       clipManagerProvider.select((s) {
         for (var i = s.clips.length - 1; i >= 0; i--) {
           final clip = s.clips[i];
@@ -38,6 +42,14 @@ class VideoRecorderGhostFrame extends ConsumerWidget {
         return null;
       }),
     );
+
+    // Stop-motion assembles at the end, so there are no clips during capture —
+    // align the next pose against the last captured still instead.
+    final ghostData = capturesStills
+        ? (stopMotionLastFrame != null
+              ? (path: stopMotionLastFrame, isFrontCamera: false)
+              : null)
+        : clipGhost;
 
     final showGhost = showOverlay && ghostData != null;
 

--- a/mobile/lib/widgets/video_recorder/video_recorder_ghost_frame.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_ghost_frame.dart
@@ -44,7 +44,10 @@ class VideoRecorderGhostFrame extends ConsumerWidget {
     );
 
     // Stop-motion assembles at the end, so there are no clips during capture —
-    // align the next pose against the last captured still instead.
+    // align the next pose against the last captured still instead. The capture
+    // lens of each still is not tracked in recorder state (stopMotionFrames
+    // holds only file paths), so the ghost is shown un-mirrored; the clip
+    // branch above mirrors via clip.isFrontCameraLens.
     final ghostData = capturesStills
         ? (stopMotionLastFrame != null
               ? (path: stopMotionLastFrame, isFrontCamera: false)
@@ -67,6 +70,13 @@ class VideoRecorderGhostFrame extends ConsumerWidget {
                     fit: .cover,
                     width: .infinity,
                     height: .infinity,
+                    // Captured stills are full camera resolution (~12MP);
+                    // bound the decode to the screen height so a full-screen
+                    // live overlay doesn't decode at full resolution.
+                    cacheHeight:
+                        (MediaQuery.sizeOf(context).height *
+                                MediaQuery.devicePixelRatioOf(context))
+                            .round(),
                   ),
                 ),
               ),

--- a/mobile/lib/widgets/video_recorder/video_recorder_library_button.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_library_button.dart
@@ -2,14 +2,21 @@ import 'dart:io';
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/widgets/video_recorder/video_recorder_navigation.dart';
 
 class VideoRecorderLibraryButton extends ConsumerStatefulWidget {
-  const VideoRecorderLibraryButton({super.key});
+  const VideoRecorderLibraryButton({this.interactive = true, super.key});
+
+  /// Whether tapping opens the library. The editor-hosted recorder shows the
+  /// button purely as a capture-count indicator — navigating to the library
+  /// mid editor session is not supported there.
+  final bool interactive;
 
   @override
   ConsumerState<VideoRecorderLibraryButton> createState() =>
@@ -22,8 +29,15 @@ class _VideoRecorderLibraryButtonState
   /// thumbnail is still being generated (~1 s delay).
   String? _lastKnownThumbnailPath;
 
-  /// Thumbnail path from the persisted clip library, loaded on demand.
-  String? _libraryThumbnailPath;
+  /// Newest video-clip thumbnail from the persisted clip library.
+  ///
+  /// Kept separate from [_libraryStopMotionThumbnailPath] because each
+  /// recorder mode opens a type-filtered library — the button must preview
+  /// the newest entry of the current mode's type, not of the whole library.
+  String? _libraryVideoThumbnailPath;
+
+  /// Newest stop-motion-set thumbnail from the persisted clip library.
+  String? _libraryStopMotionThumbnailPath;
 
   @override
   void initState() {
@@ -36,15 +50,30 @@ class _VideoRecorderLibraryButtonState
     final libraryClips = await service.getAllClips();
     if (!mounted) return;
     setState(() {
-      _libraryThumbnailPath = libraryClips.isNotEmpty
-          ? libraryClips.first.thumbnailPath
-          : null;
+      _libraryVideoThumbnailPath = libraryClips
+          .where((clip) => !clip.isStopMotion)
+          .firstOrNull
+          ?.thumbnailPath;
+      _libraryStopMotionThumbnailPath = libraryClips
+          .where((clip) => clip.isStopMotion)
+          .firstOrNull
+          ?.thumbnailPath;
     });
   }
 
   @override
   Widget build(BuildContext context) {
     final clips = ref.watch(clipManagerProvider.select((p) => p.clips));
+
+    // Stop-motion captures accumulate frames in the recorder bloc (not the
+    // clip manager) until assembled, so mirror the latest still and the
+    // captured-frame count directly for a live preview during capture.
+    final (capturesStills, stopMotionFrames) = context.select(
+      (VideoRecorderBloc b) => (
+        b.state.recorderMode.capturesStills,
+        b.state.stopMotionFrames,
+      ),
+    );
 
     // Re-query library thumbnail whenever session clips change to empty
     // (e.g. user reset or deleted clips).
@@ -64,20 +93,35 @@ class _VideoRecorderLibraryButtonState
       _lastKnownThumbnailPath = null;
     }
 
-    final thumbnailPath = _lastKnownThumbnailPath ?? _libraryThumbnailPath;
-    final hasClips = clips.isNotEmpty || _libraryThumbnailPath != null;
+    final String? thumbnailPath;
+    final int count;
+    final bool hasClips;
+    if (capturesStills) {
+      // Newest still first, falling back to a prior library stop-motion set
+      // so the button still opens the library before the first frame is shot.
+      thumbnailPath =
+          stopMotionFrames.lastOrNull ?? _libraryStopMotionThumbnailPath;
+      count = stopMotionFrames.length;
+      hasClips =
+          stopMotionFrames.isNotEmpty ||
+          _libraryStopMotionThumbnailPath != null;
+    } else {
+      thumbnailPath = _lastKnownThumbnailPath ?? _libraryVideoThumbnailPath;
+      count = clips.length;
+      hasClips = clips.isNotEmpty || _libraryVideoThumbnailPath != null;
+    }
 
     return Padding(
       padding: const .only(left: 16),
       child: Semantics(
-        button: true,
+        button: widget.interactive,
         label: hasClips
-            ? context.l10n.videoRecorderLibraryOpenLabel(clips.length)
+            ? context.l10n.videoRecorderLibraryOpenLabel(count)
             : context.l10n.videoRecorderLibraryEmptyLabel,
-        enabled: hasClips,
+        enabled: hasClips && widget.interactive,
         child: GestureDetector(
           behavior: HitTestBehavior.opaque,
-          onTap: hasClips
+          onTap: hasClips && widget.interactive
               ? () async {
                   await openRecorderLibrary(context, ref);
 
@@ -116,11 +160,16 @@ class _VideoRecorderLibraryButtonState
                             File(thumbnailPath),
                             key: ValueKey(thumbnailPath),
                             fit: BoxFit.cover,
+                            // Stop-motion stills are full-resolution photos;
+                            // bound the decode to the 40px button.
+                            cacheHeight:
+                                (40 * MediaQuery.devicePixelRatioOf(context))
+                                    .round(),
                           )
                         : const SizedBox.shrink(),
                   ),
                 ),
-                _SelectionCountBadge(count: clips.length),
+                _SelectionCountBadge(count: count),
               ],
             ),
           ),

--- a/mobile/lib/widgets/video_recorder/video_recorder_library_button.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_library_button.dart
@@ -115,8 +115,14 @@ class _VideoRecorderLibraryButtonState
       padding: const .only(left: 16),
       child: Semantics(
         button: widget.interactive,
+        // A stop-motion session counts captured stills, not clips — the clip
+        // label would announce 12 stills as "12 clips". Its own label also
+        // covers the zero case, which is reachable here: the button opens a
+        // previous session's library before this one's first still is shot.
         label: hasClips
-            ? context.l10n.videoRecorderLibraryOpenLabel(count)
+            ? (capturesStills
+                  ? context.l10n.videoRecorderLibraryOpenStopMotionLabel(count)
+                  : context.l10n.videoRecorderLibraryOpenLabel(count))
             : context.l10n.videoRecorderLibraryEmptyLabel,
         enabled: hasClips && widget.interactive,
         child: GestureDetector(

--- a/mobile/lib/widgets/video_recorder/video_recorder_mode_selector.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_mode_selector.dart
@@ -138,7 +138,9 @@ class _VideoRecorderModeSelectorWheelState
       textDirection: TextDirection.ltr,
       textScaler: textScaler,
     )..layout();
-    return painter.width;
+    final width = painter.width;
+    painter.dispose();
+    return width;
   }
 
   /// Width of each item — its label plus a constant [_labelGap] — so the

--- a/mobile/lib/widgets/video_recorder/video_recorder_mode_selector.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_mode_selector.dart
@@ -53,6 +53,17 @@ class _VideoRecorderModeSelectorWheelState
     _scrollController = ScrollController(
       initialScrollOffset: _snapOffsets[_selectedIndex],
     );
+    // The initial offset is measured at noScaling; the first build recomputes
+    // _snapOffsets from the actual (clamped) text scaler. Under a larger system
+    // font those widths differ, leaving the pre-selected mode off-centre until
+    // the user scrolls — recenter once the scaled offsets are known.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || !_scrollController.hasClients) return;
+      final target = _snapOffsets[_selectedIndex];
+      if ((_scrollController.offset - target).abs() > 0.5) {
+        _scrollController.jumpTo(target);
+      }
+    });
   }
 
   @override

--- a/mobile/lib/widgets/video_recorder/video_recorder_mode_selector.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_mode_selector.dart
@@ -30,18 +30,28 @@ class _VideoRecorderModeSelectorWheelState
   late final ScrollController _scrollController;
   late int _selectedIndex;
   bool _isSnapping = false;
+  bool _userScrolling = false;
   double _lastScrollDelta = 0.0;
 
-  static const double _itemExtent = 96.0;
+  /// Scroll offset that centers each item, indexed by mode. Recomputed on
+  /// every build from the measured label widths.
+  List<double> _snapOffsets = const [];
+
   static const double _pillHeight = 34.0;
   static const double _pillHPadding = 16.0;
+
+  /// Constant gap kept between adjacent labels. Half sits on each side of a
+  /// label, so consecutive labels stay [_labelGap] apart no matter how much
+  /// their text widths differ.
+  static const double _labelGap = 44.0;
 
   @override
   void initState() {
     super.initState();
     _selectedIndex = VideoRecorderMode.values.indexOf(widget.selectedMode);
+    _snapOffsets = _snapOffsetsFor(_itemWidths(TextScaler.noScaling));
     _scrollController = ScrollController(
-      initialScrollOffset: _selectedIndex * _itemExtent,
+      initialScrollOffset: _snapOffsets[_selectedIndex],
     );
   }
 
@@ -50,8 +60,13 @@ class _VideoRecorderModeSelectorWheelState
     super.didUpdateWidget(oldWidget);
     if (oldWidget.selectedMode != widget.selectedMode) {
       final index = VideoRecorderMode.values.indexOf(widget.selectedMode);
+      // Self-originated changes (tap/snap) already animated to this index.
+      if (index == _selectedIndex) return;
       setState(() => _selectedIndex = index);
-      _animateTo(index);
+      // External changes (persisted-mode restore right after open,
+      // editor-driven switches) reposition instantly — a visible scroll
+      // animation on a screen the user just opened feels broken.
+      _jumpTo(index);
     }
   }
 
@@ -61,12 +76,17 @@ class _VideoRecorderModeSelectorWheelState
     super.dispose();
   }
 
+  void _jumpTo(int index) {
+    if (!_scrollController.hasClients) return;
+    _scrollController.jumpTo(_snapOffsets[index]);
+  }
+
   Future<void> _animateTo(int index) async {
     if (!_scrollController.hasClients) return;
     _isSnapping = true;
 
     await _scrollController.animateTo(
-      index * _itemExtent,
+      _snapOffsets[index],
       duration: const Duration(milliseconds: 200),
       curve: Curves.easeInOut,
     );
@@ -75,16 +95,25 @@ class _VideoRecorderModeSelectorWheelState
 
   void _snapToNearest() {
     if (_isSnapping || !_scrollController.hasClients) return;
-    final fractional = _scrollController.offset / _itemExtent;
+    final offset = _scrollController.offset;
+    var floorIndex = 0;
+    var ceilIndex = _snapOffsets.length - 1;
+    for (var i = 0; i < _snapOffsets.length; i++) {
+      if (_snapOffsets[i] <= offset) floorIndex = i;
+    }
+    for (var i = _snapOffsets.length - 1; i >= 0; i--) {
+      if (_snapOffsets[i] >= offset) ceilIndex = i;
+    }
     int targetIndex;
     if (_lastScrollDelta > 0.5) {
-      targetIndex = fractional.ceil();
+      targetIndex = ceilIndex;
     } else if (_lastScrollDelta < -0.5) {
-      targetIndex = fractional.floor();
+      targetIndex = floorIndex;
     } else {
-      targetIndex = fractional.round();
+      final floorDist = (offset - _snapOffsets[floorIndex]).abs();
+      final ceilDist = (offset - _snapOffsets[ceilIndex]).abs();
+      targetIndex = floorDist <= ceilDist ? floorIndex : ceilIndex;
     }
-    targetIndex = targetIndex.clamp(0, VideoRecorderMode.values.length - 1);
     _lastScrollDelta = 0;
     // Defer to the next frame — animateTo called directly inside a scroll
     // notification callback is silently ignored by Flutter's scroll system.
@@ -102,15 +131,40 @@ class _VideoRecorderModeSelectorWheelState
     widget.onModeChanged(VideoRecorderMode.values[index]);
   }
 
-  /// Measures the width the pill needs for the given label text.
-  double _pillWidth(String label, TextScaler textScaler) {
+  /// Rendered width of [label] at [textScaler].
+  double _textWidth(String label, TextScaler textScaler) {
     final painter = TextPainter(
       text: TextSpan(text: label, style: VineTheme.titleSmallFont()),
       textDirection: TextDirection.ltr,
       textScaler: textScaler,
     )..layout();
-    return painter.width + _pillHPadding * 2;
+    return painter.width;
   }
+
+  /// Width of each item — its label plus a constant [_labelGap] — so the
+  /// spacing between adjacent labels stays uniform regardless of text width.
+  List<double> _itemWidths(TextScaler textScaler) => [
+    for (final mode in VideoRecorderMode.values)
+      _textWidth(mode.label, textScaler) + _labelGap,
+  ];
+
+  /// Scroll offset that centers each item, derived from [itemWidths]. The
+  /// result is viewport-independent; the leading/trailing scroll padding in
+  /// [build] takes care of centering the first and last items.
+  List<double> _snapOffsetsFor(List<double> itemWidths) {
+    final firstHalf = itemWidths.first / 2;
+    final offsets = <double>[];
+    var acc = 0.0;
+    for (final width in itemWidths) {
+      offsets.add(acc + width / 2 - firstHalf);
+      acc += width;
+    }
+    return offsets;
+  }
+
+  /// Width the centered pill needs to wrap [label].
+  double _pillWidth(String label, TextScaler textScaler) =>
+      _textWidth(label, textScaler) + _pillHPadding * 2;
 
   @override
   Widget build(BuildContext context) {
@@ -118,9 +172,12 @@ class _VideoRecorderModeSelectorWheelState
     final textScaler = MediaQuery.textScalerOf(
       context,
     ).clamp(maxScaleFactor: 1.3);
+    final itemWidths = _itemWidths(textScaler);
+    _snapOffsets = _snapOffsetsFor(itemWidths);
     return LayoutBuilder(
       builder: (context, constraints) {
-        final sidePadding = (constraints.maxWidth - _itemExtent) / 2;
+        final leadingPadding = (constraints.maxWidth - itemWidths.first) / 2;
+        final trailingPadding = (constraints.maxWidth - itemWidths.last) / 2;
         return SizedBox(
           height: kMinInteractiveDimension,
           child: Stack(
@@ -153,9 +210,17 @@ class _VideoRecorderModeSelectorWheelState
                 blendMode: .dstIn,
                 child: NotificationListener<ScrollNotification>(
                   onNotification: (notification) {
-                    if (notification is ScrollUpdateNotification) {
+                    if (notification is ScrollStartNotification) {
+                      // Only user drags/flings should snap. A programmatic
+                      // animateTo scroll has null drag details; letting its
+                      // end re-trigger snapping made the wheel keep advancing
+                      // to the last item.
+                      _userScrolling = notification.dragDetails != null;
+                    } else if (notification is ScrollUpdateNotification) {
                       _lastScrollDelta = notification.scrollDelta ?? 0;
-                    } else if (notification is ScrollEndNotification) {
+                    } else if (notification is ScrollEndNotification &&
+                        _userScrolling) {
+                      _userScrolling = false;
                       _snapToNearest();
                     }
                     return false;
@@ -163,35 +228,40 @@ class _VideoRecorderModeSelectorWheelState
                   child: ListView.builder(
                     scrollDirection: Axis.horizontal,
                     controller: _scrollController,
-                    padding: .symmetric(horizontal: sidePadding),
+                    padding: EdgeInsets.only(
+                      left: leadingPadding,
+                      right: trailingPadding,
+                    ),
                     itemCount: modes.length,
-                    itemExtent: _itemExtent,
                     itemBuilder: (context, i) {
                       final isSelected = i == _selectedIndex;
-                      return Semantics(
-                        label: modes[i].label,
-                        selected: isSelected,
-                        button: true,
-                        child: GestureDetector(
-                          behavior: HitTestBehavior.opaque,
-                          onTap: () {
-                            _selectIndex(i, animate: true);
-                            if (!_isSnapping) _animateTo(i);
-                          },
-                          child: Center(
-                            child: AnimatedDefaultTextStyle(
-                              duration: const Duration(milliseconds: 200),
-                              style: VineTheme.titleSmallFont(
-                                color: isSelected
-                                    ? VineTheme.primary
-                                    : VineTheme.whiteText,
-                              ),
-                              child: Text(
-                                modes[i].label,
-                                maxLines: 1,
-                                overflow: TextOverflow.visible,
-                                softWrap: false,
-                                textScaler: textScaler,
+                      return SizedBox(
+                        width: itemWidths[i],
+                        child: Semantics(
+                          label: modes[i].label,
+                          selected: isSelected,
+                          button: true,
+                          child: GestureDetector(
+                            behavior: HitTestBehavior.opaque,
+                            onTap: () {
+                              _selectIndex(i, animate: true);
+                              if (!_isSnapping) _animateTo(i);
+                            },
+                            child: Center(
+                              child: AnimatedDefaultTextStyle(
+                                duration: const Duration(milliseconds: 200),
+                                style: VineTheme.titleSmallFont(
+                                  color: isSelected
+                                      ? VineTheme.primary
+                                      : VineTheme.whiteText,
+                                ),
+                                child: Text(
+                                  modes[i].label,
+                                  maxLines: 1,
+                                  overflow: TextOverflow.visible,
+                                  softWrap: false,
+                                  textScaler: textScaler,
+                                ),
                               ),
                             ),
                           ),

--- a/mobile/lib/widgets/video_recorder/video_recorder_navigation.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_navigation.dart
@@ -9,6 +9,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:openvine/blocs/clips_library/clips_library_bloc.dart';
 import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/video_recorder/video_recorder_mode.dart';
@@ -103,13 +104,23 @@ Future<void> openRecorderLibrary(BuildContext context, WidgetRef ref) async {
 
   final bloc = context.read<VideoRecorderBloc>();
 
+  // Scope the library to the current mode's clip type: stop-motion stills and
+  // normal video clips can't share one editor timeline, so each mode only sees
+  // (and can add) its own kind.
+  final clipTypeFilter = bloc.state.recorderMode.capturesStills
+      ? LibraryClipTypeFilter.stopMotion
+      : LibraryClipTypeFilter.video;
+
   // Lock recording before the push so a volume / Bluetooth trigger that races
   // the navigation can't start (or leave) a recording on the camera we are
   // about to release. The camera is still live here, so the lock can reset any
   // in-flight recording cleanly — without racing the deferred dispose below.
   bloc.add(const VideoRecorderRecordingLockedForNavigation());
 
-  final navigation = context.pushNamed(LibraryScreen.clipsOnlyRouteName);
+  final navigation = context.pushNamed(
+    LibraryScreen.clipsOnlyRouteName,
+    queryParameters: {'type': ?clipTypeFilter.queryValue},
+  );
 
   await awaitPushTransition(context);
   await _pauseCameraForNavigation(bloc);

--- a/mobile/lib/widgets/video_recorder/video_recorder_record_button.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_record_button.dart
@@ -45,7 +45,10 @@ class RecordButton extends ConsumerWidget {
       ),
     );
 
-    final isLongPressSupported = state.timerDuration == .off;
+    // Stop-motion captures a still per tap; long-press / hold-to-record would
+    // (wrongly) try to start a video recording, so it is disabled.
+    final isLongPressSupported =
+        state.timerDuration == .off && !state.recorderMode.capturesStills;
     final canStartRecordingOnPressDown =
         isLongPressSupported && startsRecordingOnPressDown;
     final isEnabled =

--- a/mobile/packages/db_client/lib/src/database/daos/clips_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/clips_dao.dart
@@ -368,7 +368,7 @@ class ClipsDao extends DatabaseAccessor<AppDatabase> with _$ClipsDaoMixin {
     if (unresolved.isEmpty) return referenced;
 
     // One full JSON scan for every remaining filename. The data column is
-    // unindexed, so an OR-chain of LIKE predicates still scans the table and
+    // unindexed; an OR-chain of LIKE predicates still scans the table and
     // can exceed SQLite's expression-depth limit for large stop-motion sets.
     final candidateRows = await customSelect(
       'SELECT data FROM clips',

--- a/mobile/packages/db_client/lib/src/database/daos/clips_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/clips_dao.dart
@@ -367,20 +367,11 @@ class ClipsDao extends DatabaseAccessor<AppDatabase> with _$ClipsDaoMixin {
     final unresolved = filenames.difference(referenced).toList();
     if (unresolved.isEmpty) return referenced;
 
-    // One scan for every remaining filename. The LIKE only narrows which rows
-    // are worth decoding — a match is not a reference on its own (the filename
-    // could sit in any string field), so every hit is confirmed against the
-    // decoded JSON below.
-    final likeClauses = List.filled(
-      unresolved.length,
-      r"data LIKE ? ESCAPE '\'",
-    ).join(' OR ');
+    // One full JSON scan for every remaining filename. The data column is
+    // unindexed, so an OR-chain of LIKE predicates still scans the table and
+    // can exceed SQLite's expression-depth limit for large stop-motion sets.
     final candidateRows = await customSelect(
-      'SELECT data FROM clips WHERE $likeClauses',
-      variables: [
-        for (final filename in unresolved)
-          Variable.withString('%${_escapeSqlLike(filename)}%'),
-      ],
+      'SELECT data FROM clips',
       readsFrom: {clips},
     ).get();
 
@@ -438,12 +429,5 @@ class ClipsDao extends DatabaseAccessor<AppDatabase> with _$ClipsDaoMixin {
     }
 
     return false;
-  }
-
-  static String _escapeSqlLike(String value) {
-    return value
-        .replaceAll(r'\', r'\\')
-        .replaceAll('%', r'\%')
-        .replaceAll('_', r'\_');
   }
 }

--- a/mobile/packages/db_client/lib/src/database/daos/clips_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/clips_dao.dart
@@ -2,8 +2,11 @@
 // ABOUTME: Provides CRUD with draft-scoped queries, ordering, and
 // ABOUTME: per-account isolation via ownerPubkey.
 
+import 'dart:convert';
+
 import 'package:db_client/db_client.dart';
 import 'package:drift/drift.dart';
+import 'package:path/path.dart' as p;
 
 part 'clips_dao.g.dart';
 
@@ -46,6 +49,18 @@ class ClipsDao extends DatabaseAccessor<AppDatabase> with _$ClipsDaoMixin {
   ) {
     if (ownerPubkey == null) return const Constant(true);
     return column.equals(ownerPubkey) | column.isNull();
+  }
+
+  /// Whether a clip is a *library* clip: it has no draft association, or (when
+  /// [includeAutosaveDraftId] is given) it belongs to the throwaway autosave /
+  /// recording-scratch draft. Clips saved into a named project are excluded.
+  Expression<bool> _isLibraryClip(
+    GeneratedColumn<String> draftIdColumn,
+    String? includeAutosaveDraftId,
+  ) {
+    if (includeAutosaveDraftId == null) return draftIdColumn.isNull();
+    return draftIdColumn.isNull() |
+        draftIdColumn.equals(includeAutosaveDraftId);
   }
 
   /// Get all clips for a draft. Excludes trashed clips.
@@ -134,15 +149,22 @@ class ClipsDao extends DatabaseAccessor<AppDatabase> with _$ClipsDaoMixin {
 
   // -- Library clip methods (draftId IS NULL) --
 
-  /// Get all library clips (no draft association), newest first.
-  /// Excludes trashed clips. When [ownerPubkey] is provided, returns
-  /// only clips owned by that account **plus** legacy clips with no
-  /// owner.
-  Future<List<ClipRow>> getLibraryClips({int? limit, String? ownerPubkey}) {
+  /// Get all library clips, newest first. Excludes trashed clips. When
+  /// [ownerPubkey] is provided, returns only clips owned by that account
+  /// **plus** legacy clips with no owner.
+  ///
+  /// Clips in a named draft are excluded; when [includeAutosaveDraftId] is
+  /// given, clips in that throwaway autosave draft are included so a
+  /// just-recorded clip stays visible while the editor holds it in autosave.
+  Future<List<ClipRow>> getLibraryClips({
+    int? limit,
+    String? ownerPubkey,
+    String? includeAutosaveDraftId,
+  }) {
     final query = select(clips)
       ..where(
         (t) =>
-            t.draftId.isNull() &
+            _isLibraryClip(t.draftId, includeAutosaveDraftId) &
             _ownedOrLegacy(t.ownerPubkey, ownerPubkey) &
             t.deletedAt.isNull(),
       )
@@ -158,11 +180,14 @@ class ClipsDao extends DatabaseAccessor<AppDatabase> with _$ClipsDaoMixin {
   /// Watch all library clips (reactive stream). Excludes trashed clips.
   /// When [ownerPubkey] is provided, returns only clips owned by that
   /// account **plus** legacy clips with no owner.
-  Stream<List<ClipRow>> watchLibraryClips({String? ownerPubkey}) {
+  Stream<List<ClipRow>> watchLibraryClips({
+    String? ownerPubkey,
+    String? includeAutosaveDraftId,
+  }) {
     final query = select(clips)
       ..where(
         (t) =>
-            t.draftId.isNull() &
+            _isLibraryClip(t.draftId, includeAutosaveDraftId) &
             _ownedOrLegacy(t.ownerPubkey, ownerPubkey) &
             t.deletedAt.isNull(),
       )
@@ -296,15 +321,84 @@ class ClipsDao extends DatabaseAccessor<AppDatabase> with _$ClipsDaoMixin {
         .write(ClipsCompanion(ownerPubkey: Value(newOwnerPubkey)));
   }
 
-  /// Check if a filename is referenced by any clip's file_path
-  /// or thumbnail_path.
+  /// Check if a filename is referenced by any clip-owned file reference.
+  ///
+  /// The indexed `file_path` / `thumbnail_path` columns cover normal clips and
+  /// thumbnail assets. Frames-only stop-motion clips have no `file_path`; their
+  /// source stills live inside the JSON `data` blob as
+  /// `stopMotionFrames[].path`, so candidate JSON rows are decoded and checked
+  /// before cleanup deletes a shared frame file.
   Future<bool> isFileReferenced(String filename) async {
-    final query = selectOnly(clips)
+    final indexedQuery = selectOnly(clips)
       ..addColumns([clips.id.count()])
       ..where(
-        clips.filePath.equals(filename) | clips.thumbnailPath.equals(filename),
+        clips.filePath.equals(filename) |
+            clips.thumbnailPath.equals(filename) |
+            clips.data.like('%"$filename"%'),
       );
-    final result = await query.getSingle();
-    return (result.read(clips.id.count()) ?? 0) > 0;
+    final indexedResult = await indexedQuery.getSingle();
+    if ((indexedResult.read(clips.id.count()) ?? 0) > 0) return true;
+
+    final candidateRows = await customSelect(
+      r"SELECT data FROM clips WHERE data LIKE ? ESCAPE '\'",
+      variables: [Variable.withString('%${_escapeSqlLike(filename)}%')],
+      readsFrom: {clips},
+    ).get();
+
+    return candidateRows.any((row) {
+      try {
+        final data = json.decode(row.read<String>('data'));
+        return _jsonReferencesFilename(data, filename);
+      } on FormatException {
+        return false;
+      }
+    });
+  }
+
+  static const _jsonFilePathKeys = {
+    'filePath',
+    'thumbnailPath',
+    'ghostFramePath',
+    'forwardVideoPath',
+    'reversedVideoPath',
+    'path',
+  };
+
+  static bool _jsonReferencesFilename(
+    Object? value,
+    String filename, {
+    String? key,
+  }) {
+    if (value is String) {
+      return key != null &&
+          _jsonFilePathKeys.contains(key) &&
+          p.basename(value) == filename;
+    }
+
+    if (value is Map) {
+      for (final entry in value.entries) {
+        if (_jsonReferencesFilename(
+          entry.value,
+          filename,
+          key: entry.key.toString(),
+        )) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    if (value is Iterable) {
+      return value.any((item) => _jsonReferencesFilename(item, filename));
+    }
+
+    return false;
+  }
+
+  static String _escapeSqlLike(String value) {
+    return value
+        .replaceAll(r'\', r'\\')
+        .replaceAll('%', r'\%')
+        .replaceAll('_', r'\_');
   }
 }

--- a/mobile/packages/db_client/lib/src/database/daos/clips_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/clips_dao.dart
@@ -323,36 +323,81 @@ class ClipsDao extends DatabaseAccessor<AppDatabase> with _$ClipsDaoMixin {
 
   /// Check if a filename is referenced by any clip-owned file reference.
   ///
+  /// Prefer [referencedFilenames] when checking more than one file — the JSON
+  /// scan below is unindexed, so a per-file loop pays for a full scan each.
+  Future<bool> isFileReferenced(String filename) async {
+    final referenced = await referencedFilenames({filename});
+    return referenced.isNotEmpty;
+  }
+
+  /// The subset of [filenames] referenced by any clip-owned file reference.
+  ///
   /// The indexed `file_path` / `thumbnail_path` columns cover normal clips and
   /// thumbnail assets. Frames-only stop-motion clips have no `file_path`; their
   /// source stills live inside the JSON `data` blob as
   /// `stopMotionFrames[].path`, so candidate JSON rows are decoded and checked
   /// before cleanup deletes a shared frame file.
-  Future<bool> isFileReferenced(String filename) async {
-    final indexedQuery = selectOnly(clips)
-      ..addColumns([clips.id.count()])
-      ..where(
-        clips.filePath.equals(filename) |
-            clips.thumbnailPath.equals(filename) |
-            clips.data.like('%"$filename"%'),
-      );
-    final indexedResult = await indexedQuery.getSingle();
-    if ((indexedResult.read(clips.id.count()) ?? 0) > 0) return true;
+  ///
+  /// Resolves the whole set in a single scan rather than one per filename:
+  /// `data` is unindexed, and deleting one stop-motion session asks about every
+  /// still in it at once.
+  Future<Set<String>> referencedFilenames(Set<String> filenames) async {
+    if (filenames.isEmpty) return const <String>{};
 
+    final referenced = <String>{};
+    final indexedRows =
+        await (selectOnly(clips)
+              ..addColumns([clips.filePath, clips.thumbnailPath])
+              ..where(
+                clips.filePath.isIn(filenames) |
+                    clips.thumbnailPath.isIn(filenames),
+              ))
+            .get();
+    for (final row in indexedRows) {
+      final filePath = row.read(clips.filePath);
+      final thumbnailPath = row.read(clips.thumbnailPath);
+      if (filePath != null && filenames.contains(filePath)) {
+        referenced.add(filePath);
+      }
+      if (thumbnailPath != null && filenames.contains(thumbnailPath)) {
+        referenced.add(thumbnailPath);
+      }
+    }
+
+    final unresolved = filenames.difference(referenced).toList();
+    if (unresolved.isEmpty) return referenced;
+
+    // One scan for every remaining filename. The LIKE only narrows which rows
+    // are worth decoding — a match is not a reference on its own (the filename
+    // could sit in any string field), so every hit is confirmed against the
+    // decoded JSON below.
+    final likeClauses = List.filled(
+      unresolved.length,
+      r"data LIKE ? ESCAPE '\'",
+    ).join(' OR ');
     final candidateRows = await customSelect(
-      r"SELECT data FROM clips WHERE data LIKE ? ESCAPE '\'",
-      variables: [Variable.withString('%${_escapeSqlLike(filename)}%')],
+      'SELECT data FROM clips WHERE $likeClauses',
+      variables: [
+        for (final filename in unresolved)
+          Variable.withString('%${_escapeSqlLike(filename)}%'),
+      ],
       readsFrom: {clips},
     ).get();
 
-    return candidateRows.any((row) {
+    for (final row in candidateRows) {
+      final Object? data;
       try {
-        final data = json.decode(row.read<String>('data'));
-        return _jsonReferencesFilename(data, filename);
+        data = json.decode(row.read<String>('data'));
       } on FormatException {
-        return false;
+        continue;
       }
-    });
+      for (final filename in unresolved) {
+        if (referenced.contains(filename)) continue;
+        if (_jsonReferencesFilename(data, filename)) referenced.add(filename);
+      }
+    }
+
+    return referenced;
   }
 
   static const _jsonFilePathKeys = {

--- a/mobile/packages/db_client/lib/src/database/daos/drafts_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/drafts_dao.dart
@@ -143,9 +143,19 @@ class DraftsDao extends DatabaseAccessor<AppDatabase> with _$DraftsDaoMixin {
     return rowsAffected > 0;
   }
 
-  /// Delete a draft by ID
+  /// Delete a draft by ID, along with its clip rows.
+  ///
+  /// The clips table declares an `ON DELETE CASCADE` FK on `draft_id`, but
+  /// `foreign_keys` enforcement is not enabled on this connection, so the
+  /// cascade never fires. Deleting the clip rows explicitly (mirroring
+  /// [saveDraftWithClips]) keeps orphaned clip rows from surviving and keeping
+  /// the draft's media referenced — which blocks file cleanup and leaks the
+  /// clip/frame files. Returns the number of draft rows deleted.
   Future<int> deleteDraft(String id) {
-    return (delete(drafts)..where((t) => t.id.equals(id))).go();
+    return transaction(() async {
+      await (delete(clips)..where((t) => t.draftId.equals(id))).go();
+      return (delete(drafts)..where((t) => t.id.equals(id))).go();
+    });
   }
 
   /// Delete drafts older than a given date
@@ -225,9 +235,16 @@ class DraftsDao extends DatabaseAccessor<AppDatabase> with _$DraftsDaoMixin {
     return result.read(drafts.id.count()) ?? 0;
   }
 
-  /// Clear all drafts
+  /// Clear all drafts, along with every draft-owned clip row.
+  ///
+  /// Deletes clip rows with a non-null `draft_id` too (the FK cascade does not
+  /// fire — see [deleteDraft]); library clips have a NULL `draft_id` and are
+  /// preserved. Returns the number of draft rows deleted.
   Future<int> clearAll() {
-    return delete(drafts).go();
+    return transaction(() async {
+      await (delete(clips)..where((t) => t.draftId.isNotNull())).go();
+      return delete(drafts).go();
+    });
   }
 
   /// Delete all drafts owned by [userPubkey].

--- a/mobile/packages/db_client/test/src/database/daos/clips_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/clips_dao_test.dart
@@ -736,6 +736,57 @@ void main() {
         expect(libraryClips[1].id, equals('lib_clip_1'));
       });
 
+      test(
+        'getLibraryClips includes the autosave draft when requested',
+        () async {
+          await dao.upsertClip(
+            id: 'lib_clip',
+            orderIndex: 0,
+            durationMs: 3000,
+            recordedAt: DateTime(2023, 11, 14, 10),
+            filePath: 'test.mp4',
+            thumbnailPath: 'thumbnail.jpeg',
+            data: '{}',
+          );
+          await dao.upsertClip(
+            id: 'autosave_clip',
+            draftId: 'draft_autosave',
+            orderIndex: 0,
+            durationMs: 4000,
+            recordedAt: DateTime(2023, 11, 14, 12),
+            filePath: 'test.mp4',
+            thumbnailPath: 'thumbnail.jpeg',
+            data: '{}',
+          );
+          await dao.upsertClip(
+            id: 'named_draft_clip',
+            draftId: 'draft_real',
+            orderIndex: 0,
+            durationMs: 5000,
+            recordedAt: DateTime(2023, 11, 14, 11),
+            filePath: 'test.mp4',
+            thumbnailPath: 'thumbnail.jpeg',
+            data: '{}',
+          );
+
+          // Default: only draftId IS NULL.
+          expect(
+            (await dao.getLibraryClips()).map((c) => c.id),
+            equals(['lib_clip']),
+          );
+
+          // With the autosave draft included: loose + autosave clips, but
+          // not the named-project clip.
+          final withAutosave = await dao.getLibraryClips(
+            includeAutosaveDraftId: 'draft_autosave',
+          );
+          expect(
+            withAutosave.map((c) => c.id),
+            equals(['autosave_clip', 'lib_clip']),
+          );
+        },
+      );
+
       test('getLibraryClips respects limit', () async {
         await dao.upsertClip(
           id: 'lib_1',
@@ -954,6 +1005,34 @@ void main() {
         final result = await dao.isFileReferenced('something.mp4');
         expect(result, isFalse);
       });
+
+      test(
+        'returns true for a stop-motion still referenced only inside data',
+        () async {
+          // A stop-motion clip keeps its stills in the `data` JSON blob; only
+          // the first frame is mirrored into thumbnail_path. Every other still
+          // must still count as referenced, or file cleanup would delete it.
+          await dao.upsertClip(
+            id: 'sm_clip',
+            orderIndex: 0,
+            durationMs: 2000,
+            recordedAt: DateTime(2023, 11, 14, 10),
+            filePath: null,
+            thumbnailPath: 'sm_frame_0.jpg',
+            data:
+                '{"id":"sm_clip","stopMotionFrames":['
+                '{"path":"sm_frame_0.jpg","durationUs":41667},'
+                '{"path":"sm_frame_1.jpg","durationUs":41667},'
+                '{"path":"sm_frame_2.jpg","durationUs":41667}]}',
+          );
+
+          // The thumbnail (indexed) and a non-thumbnail still (data-only) are
+          // both referenced; an unrelated basename is not.
+          expect(await dao.isFileReferenced('sm_frame_0.jpg'), isTrue);
+          expect(await dao.isFileReferenced('sm_frame_1.jpg'), isTrue);
+          expect(await dao.isFileReferenced('sm_frame_9.jpg'), isFalse);
+        },
+      );
     });
 
     group('ownerPubkey isolation', () {

--- a/mobile/packages/db_client/test/src/database/daos/clips_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/clips_dao_test.dart
@@ -147,6 +147,30 @@ void main() {
       });
     });
 
+    group('referencedFilenames', () {
+      test(
+        'scans large unresolved filename sets without SQL expression blowup',
+        () async {
+          await dao.upsertClip(
+            id: 'clip_frames',
+            draftId: testDraftId,
+            orderIndex: 0,
+            durationMs: 3000,
+            recordedAt: DateTime(2023, 11, 14, 10),
+            filePath: null,
+            thumbnailPath: null,
+            data: '{"stopMotionFrames":[{"path":"frame_1001.jpg"}]}',
+          );
+
+          final filenames = {for (var i = 0; i < 1200; i++) 'frame_$i.jpg'};
+
+          final referenced = await dao.referencedFilenames(filenames);
+
+          expect(referenced, {'frame_1001.jpg'});
+        },
+      );
+    });
+
     group('getClipsByDraftId', () {
       test('returns clips sorted by orderIndex ascending', () async {
         await dao.upsertClip(

--- a/mobile/packages/db_client/test/src/database/daos/clips_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/clips_dao_test.dart
@@ -1033,6 +1033,45 @@ void main() {
           expect(await dao.isFileReferenced('sm_frame_9.jpg'), isFalse);
         },
       );
+
+      test(
+        'returns true for a still stored as a legacy absolute path in data',
+        () async {
+          // A legacy row can store the full path rather than a basename. The
+          // quoted-basename phase-1 LIKE misses it, so the JSON matcher
+          // (decode + basename compare) is the branch that catches it.
+          await dao.upsertClip(
+            id: 'sm_legacy',
+            orderIndex: 0,
+            durationMs: 1000,
+            recordedAt: DateTime(2023, 11, 14, 10),
+            filePath: null,
+            thumbnailPath: null,
+            data:
+                '{"id":"sm_legacy","stopMotionFrames":['
+                '{"path":"/docs/clips/keyframe99.jpg","durationUs":41667}]}',
+          );
+
+          expect(await dao.isFileReferenced('keyframe99.jpg'), isTrue);
+          expect(await dao.isFileReferenced('keyframe98.jpg'), isFalse);
+        },
+      );
+
+      test('tolerates a malformed data blob without throwing', () async {
+        // A corrupt row whose data mentions the name but is not valid JSON must
+        // be skipped by the FormatException guard, not crash the cleanup query.
+        await dao.upsertClip(
+          id: 'corrupt',
+          orderIndex: 0,
+          durationMs: 1000,
+          recordedAt: DateTime(2023, 11, 14, 10),
+          filePath: null,
+          thumbnailPath: null,
+          data: 'not-json-but-mentions badfile.jpg here',
+        );
+
+        expect(await dao.isFileReferenced('badfile.jpg'), isFalse);
+      });
     });
 
     group('ownerPubkey isolation', () {

--- a/mobile/packages/db_client/test/src/database/daos/drafts_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/drafts_dao_test.dart
@@ -346,6 +346,67 @@ void main() {
       });
     });
 
+    group('deleteDraft / clearAll remove draft clip rows', () {
+      Future<void> saveDraftWithOneClip(String draftId) {
+        return dao.saveDraftWithClips(
+          id: draftId,
+          title: 'D',
+          description: '',
+          publishStatus: 'draft',
+          createdAt: DateTime(2026),
+          lastModified: DateTime(2026),
+          renderedFilePath: null,
+          renderedThumbnailPath: null,
+          customThumbnailPath: null,
+          data: '{}',
+          clipDataList: [
+            DraftClipData(
+              id: 'c0',
+              orderIndex: 0,
+              durationMs: 1000,
+              recordedAt: DateTime(2026),
+              data: '{}',
+              filePath: 'clip.mp4',
+            ),
+          ],
+        );
+      }
+
+      test('deleteDraft also deletes the draft clip rows', () async {
+        await saveDraftWithOneClip('d1');
+        expect(await database.clipsDao.getClipsByDraftId('d1'), isNotEmpty);
+
+        await dao.deleteDraft('d1');
+
+        // The FK cascade never fires (foreign_keys is off), so the rows must be
+        // deleted explicitly — otherwise they keep the media referenced.
+        expect(await database.clipsDao.getClipsByDraftId('d1'), isEmpty);
+        expect(await dao.getDraftById('d1'), isNull);
+      });
+
+      test(
+        'clearAll deletes draft clip rows but keeps library clips',
+        () async {
+          await saveDraftWithOneClip('d2');
+          // A library clip has a NULL draftId and must survive clearAll.
+          await database.clipsDao.upsertClip(
+            id: 'lib_clip',
+            orderIndex: 0,
+            durationMs: 1000,
+            recordedAt: DateTime(2026),
+            data: '{}',
+            filePath: 'lib.mp4',
+            thumbnailPath: null,
+          );
+
+          await dao.clearAll();
+
+          expect(await database.clipsDao.getClipsByDraftId('d2'), isEmpty);
+          expect(await database.clipsDao.getClipById('lib_clip'), isNotNull);
+        },
+      );
+    });
+
     group('deleteAllForUser', () {
       const pubkeyA =
           'aaaa1111aaaa1111aaaa1111aaaa1111'

--- a/mobile/packages/sound_service/lib/src/audio_clip_player.dart
+++ b/mobile/packages/sound_service/lib/src/audio_clip_player.dart
@@ -108,6 +108,11 @@ class AudioClipPlayer {
     await _audioPlayer.seek(position);
   }
 
+  /// Sets the playback volume, clamped to `0.0..1.0`.
+  Future<void> setVolume(double volume) async {
+    await _audioPlayer.setVolume(volume.clamp(0.0, 1.0));
+  }
+
   /// Releases all resources held by the underlying player.
   Future<void> dispose() async {
     try {

--- a/mobile/packages/sound_service/test/src/audio_clip_player_test.dart
+++ b/mobile/packages/sound_service/test/src/audio_clip_player_test.dart
@@ -641,6 +641,28 @@ void main() {
       });
     });
 
+    group('setVolume', () {
+      setUp(() {
+        when(() => mockAudioPlayer.setVolume(any())).thenAnswer((_) async {});
+      });
+
+      test('delegates to audio player', () async {
+        await player.setVolume(0.5);
+
+        verify(() => mockAudioPlayer.setVolume(0.5)).called(1);
+      });
+
+      test('clamps out-of-range volumes to 0..1', () async {
+        await player.setVolume(1.7);
+        await player.setVolume(-0.3);
+
+        verifyInOrder([
+          () => mockAudioPlayer.setVolume(1),
+          () => mockAudioPlayer.setVolume(0),
+        ]);
+      });
+    });
+
     group('dispose', () {
       test('disposes the audio player', () async {
         await player.dispose();

--- a/mobile/test/blocs/clips_library/clips_library_bloc_test.dart
+++ b/mobile/test/blocs/clips_library/clips_library_bloc_test.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Tests loading, selection, deletion, and gallery export
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:bloc/bloc.dart';
 import 'package:bloc_test/bloc_test.dart';
@@ -12,6 +13,7 @@ import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/services/clip_library_service.dart';
 import 'package:openvine/services/gallery_save_service.dart';
+import 'package:openvine/services/video_editor/stop_motion_render_service.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -72,6 +74,11 @@ void main() {
       when(() => mockClipLibraryService.recoverMissingAssets(any())).thenAnswer(
         (inv) async => inv.positionalArguments.first as List<DivineVideoClip>,
       );
+    });
+
+    tearDown(() {
+      StopMotionRenderService.assembleOverride = null;
+      StopMotionRenderService.probeDurationOverride = null;
     });
 
     DivineVideoClip createStopMotionClip({
@@ -963,6 +970,48 @@ void main() {
                     .having((r) => r.failureCount, 'failureCount', 0),
               ),
         ],
+      );
+
+      blocTest<ClipsLibraryBloc, ClipsLibraryState>(
+        'cleans up the transient mp4 after saving a stop-motion clip',
+        setUp: () {
+          final tempDir = Directory.systemTemp.createTempSync(
+            'clips_library_stop_motion_gallery_test',
+          );
+          addTearDown(() async {
+            if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+          });
+          final output = File('${tempDir.path}/rendered.mp4')
+            ..writeAsStringSync('rendered');
+          StopMotionRenderService.assembleOverride =
+              ({
+                required frames,
+                required aspectRatio,
+                frameRate = StopMotionRenderService.defaultFrameRate,
+                String? taskId,
+              }) async => output.path;
+          StopMotionRenderService.probeDurationOverride = (_) async => null;
+          when(
+            () => mockGallerySaveService.saveVideoToGallery(any()),
+          ).thenAnswer((_) async => const GallerySaveSuccess());
+        },
+        seed: () => ClipsLibraryState(
+          status: ClipsLibraryStatus.loaded,
+          clips: [createStopMotionClip(id: 'sm1')],
+          selectedClipIds: const {'sm1'},
+          selectedDuration: const Duration(seconds: 1),
+        ),
+        build: createBloc,
+        act: (bloc) => bloc.add(const ClipsLibrarySaveToGallery()),
+        verify: (_) {
+          final captured =
+              verify(
+                    () =>
+                        mockGallerySaveService.saveVideoToGallery(captureAny()),
+                  ).captured.single
+                  as EditorVideo;
+          expect(File(captured.file!.path).existsSync(), isFalse);
+        },
       );
 
       blocTest<ClipsLibraryBloc, ClipsLibraryState>(

--- a/mobile/test/blocs/clips_library/clips_library_bloc_test.dart
+++ b/mobile/test/blocs/clips_library/clips_library_bloc_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/clips_library/clips_library_bloc.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/services/clip_library_service.dart';
 import 'package:openvine/services/gallery_save_service.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
@@ -64,17 +65,42 @@ void main() {
       SharedPreferences.setMockInitialValues({});
       sharedPreferences = await SharedPreferences.getInstance();
 
-      // Stub recoverMissingAssets so the unawaited background recovery
-      // triggered by clips with null ghostFramePath doesn't throw.
-      when(
-        () => mockClipLibraryService.recoverMissingAssets(any()),
-      ).thenAnswer((_) async => []);
+      // Stub recoverMissingAssets to mirror the real no-op: return the SAME
+      // list instance when nothing is recovered. Returning a fresh list would
+      // fail the `identical` check in `_recoverAndReload` and re-dispatch load
+      // forever for clips with a null ghostFramePath (e.g. stop-motion stills).
+      when(() => mockClipLibraryService.recoverMissingAssets(any())).thenAnswer(
+        (inv) async => inv.positionalArguments.first as List<DivineVideoClip>,
+      );
     });
 
-    ClipsLibraryBloc createBloc() => ClipsLibraryBloc(
+    DivineVideoClip createStopMotionClip({
+      String? id,
+      Duration duration = const Duration(seconds: 1),
+    }) {
+      return DivineVideoClip(
+        id: id ?? 'sm-${DateTime.now().millisecondsSinceEpoch}',
+        stopMotionFrames: const [
+          StopMotionClipFrame(
+            path: '/frames/f0.jpg',
+            duration: Duration(milliseconds: 83),
+          ),
+        ],
+        thumbnailPath: '/frames/f0.jpg',
+        duration: duration,
+        recordedAt: DateTime.now(),
+        targetAspectRatio: .vertical,
+        originalAspectRatio: 9 / 16,
+      );
+    }
+
+    ClipsLibraryBloc createBloc({
+      LibraryClipTypeFilter clipTypeFilter = LibraryClipTypeFilter.all,
+    }) => ClipsLibraryBloc(
       clipLibraryService: mockClipLibraryService,
       gallerySaveService: mockGallerySaveService,
       sharedPreferences: sharedPreferences,
+      clipTypeFilter: clipTypeFilter,
     );
 
     test('initial state is correct', () {
@@ -312,6 +338,120 @@ void main() {
             clips: [clip1, clip2],
             selectedClipIds: const {'clip1', 'clip2'},
             selectedDuration: const Duration(seconds: 8),
+          ),
+        ],
+      );
+
+      blocTest<ClipsLibraryBloc, ClipsLibraryState>(
+        'ignores a clip of a different type than the current selection',
+        seed: () => ClipsLibraryState(
+          status: ClipsLibraryStatus.loaded,
+          clips: [
+            clip1,
+            createStopMotionClip(id: 'sm1'),
+          ],
+          selectedClipIds: const {'clip1'},
+          selectedDuration: const Duration(seconds: 5),
+        ),
+        build: createBloc,
+        act: (bloc) => bloc.add(
+          ClipsLibraryToggleSelection(createStopMotionClip(id: 'sm1')),
+        ),
+        expect: () => <ClipsLibraryState>[],
+      );
+
+      blocTest<ClipsLibraryBloc, ClipsLibraryState>(
+        'allows selecting a second clip of the same type',
+        seed: () => ClipsLibraryState(
+          status: ClipsLibraryStatus.loaded,
+          clips: [
+            createStopMotionClip(id: 'sm1'),
+            createStopMotionClip(id: 'sm2'),
+          ],
+          selectedClipIds: const {'sm1'},
+          selectedDuration: const Duration(seconds: 1),
+        ),
+        build: createBloc,
+        act: (bloc) => bloc.add(
+          ClipsLibraryToggleSelection(createStopMotionClip(id: 'sm2')),
+        ),
+        expect: () => [
+          isA<ClipsLibraryState>().having(
+            (s) => s.selectedClipIds,
+            'selectedClipIds',
+            equals({'sm1', 'sm2'}),
+          ),
+        ],
+      );
+    });
+
+    group('clipTypeFilter', () {
+      blocTest<ClipsLibraryBloc, ClipsLibraryState>(
+        'stopMotion filter loads only stop-motion clips',
+        setUp: () {
+          when(() => mockClipLibraryService.getAllClips()).thenAnswer(
+            (_) async => [
+              createClip(id: 'video1'),
+              createStopMotionClip(id: 'sm1'),
+              createClip(id: 'video2'),
+            ],
+          );
+        },
+        build: () =>
+            createBloc(clipTypeFilter: LibraryClipTypeFilter.stopMotion),
+        act: (bloc) => bloc.add(const ClipsLibraryLoadRequested()),
+        expect: () => [
+          const ClipsLibraryState(status: ClipsLibraryStatus.loading),
+          isA<ClipsLibraryState>()
+              .having((s) => s.status, 'status', ClipsLibraryStatus.loaded)
+              .having(
+                (s) => s.clips.map((c) => c.id).toList(),
+                'clip ids',
+                ['sm1'],
+              ),
+        ],
+      );
+
+      blocTest<ClipsLibraryBloc, ClipsLibraryState>(
+        'video filter loads only normal video clips',
+        setUp: () {
+          when(() => mockClipLibraryService.getAllClips()).thenAnswer(
+            (_) async => [
+              createClip(id: 'video1'),
+              createStopMotionClip(id: 'sm1'),
+            ],
+          );
+        },
+        build: () => createBloc(clipTypeFilter: LibraryClipTypeFilter.video),
+        act: (bloc) => bloc.add(const ClipsLibraryLoadRequested()),
+        expect: () => [
+          const ClipsLibraryState(status: ClipsLibraryStatus.loading),
+          isA<ClipsLibraryState>().having(
+            (s) => s.clips.map((c) => c.id).toList(),
+            'clip ids',
+            ['video1'],
+          ),
+        ],
+      );
+
+      blocTest<ClipsLibraryBloc, ClipsLibraryState>(
+        'all filter loads both types',
+        setUp: () {
+          when(() => mockClipLibraryService.getAllClips()).thenAnswer(
+            (_) async => [
+              createClip(id: 'video1'),
+              createStopMotionClip(id: 'sm1'),
+            ],
+          );
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(const ClipsLibraryLoadRequested()),
+        expect: () => [
+          const ClipsLibraryState(status: ClipsLibraryStatus.loading),
+          isA<ClipsLibraryState>().having(
+            (s) => s.clips.length,
+            'clips.length',
+            2,
           ),
         ],
       );

--- a/mobile/test/blocs/clips_library/clips_library_bloc_test.dart
+++ b/mobile/test/blocs/clips_library/clips_library_bloc_test.dart
@@ -84,6 +84,7 @@ void main() {
     DivineVideoClip createStopMotionClip({
       String? id,
       Duration duration = const Duration(seconds: 1),
+      DateTime? deletedAt,
     }) {
       return DivineVideoClip(
         id: id ?? 'sm-${DateTime.now().millisecondsSinceEpoch}',
@@ -98,6 +99,7 @@ void main() {
         recordedAt: DateTime.now(),
         targetAspectRatio: .vertical,
         originalAspectRatio: 9 / 16,
+        deletedAt: deletedAt,
       );
     }
 
@@ -717,6 +719,11 @@ void main() {
         deletedAt: DateTime(2026, 5),
       );
 
+      final trashedStopMotionClip = createStopMotionClip(
+        id: 'trashed-sm',
+        deletedAt: DateTime(2026, 5),
+      );
+
       blocTest<ClipsLibraryBloc, ClipsLibraryState>(
         'loads trashed clips',
         setUp: () {
@@ -731,6 +738,28 @@ void main() {
           isA<ClipsLibraryState>()
               .having((s) => s.status, 'status', ClipsLibraryStatus.trashLoaded)
               .having((s) => s.trashedClips, 'trashedClips', [trashedClip]),
+        ],
+      );
+
+      blocTest<ClipsLibraryBloc, ClipsLibraryState>(
+        'applies the type filter when loading trashed clips',
+        setUp: () {
+          when(() => mockClipLibraryService.getTrashedClips()).thenAnswer(
+            (_) async => [trashedClip, trashedStopMotionClip],
+          );
+        },
+        build: () =>
+            createBloc(clipTypeFilter: LibraryClipTypeFilter.stopMotion),
+        act: (bloc) => bloc.add(const ClipsLibraryTrashLoadRequested()),
+        expect: () => [
+          const ClipsLibraryState(status: ClipsLibraryStatus.trashLoading),
+          isA<ClipsLibraryState>()
+              .having((s) => s.status, 'status', ClipsLibraryStatus.trashLoaded)
+              .having(
+                (s) => s.trashedClips.map((c) => c.id).toList(),
+                'trashed clip ids',
+                ['trashed-sm'],
+              ),
         ],
       );
 
@@ -790,6 +819,41 @@ void main() {
           verify(() => mockClipLibraryService.getAllClips()).called(1);
           verify(() => mockClipLibraryService.getTrashedClips()).called(1);
         },
+      );
+
+      blocTest<ClipsLibraryBloc, ClipsLibraryState>(
+        'applies the type filter after restoring from trash',
+        setUp: () {
+          when(
+            () => mockClipLibraryService.restore('trashed-sm'),
+          ).thenAnswer((_) async => true);
+          when(
+            () => mockClipLibraryService.getAllClips(),
+          ).thenAnswer((_) async => [activeClip, trashedStopMotionClip]);
+          when(() => mockClipLibraryService.getTrashedClips()).thenAnswer(
+            (_) async => [trashedClip, trashedStopMotionClip],
+          );
+        },
+        seed: () => ClipsLibraryState(
+          status: ClipsLibraryStatus.trashLoaded,
+          trashedClips: [trashedStopMotionClip],
+        ),
+        build: () =>
+            createBloc(clipTypeFilter: LibraryClipTypeFilter.stopMotion),
+        act: (bloc) => bloc.add(const ClipsLibraryRestoreClips({'trashed-sm'})),
+        expect: () => [
+          isA<ClipsLibraryState>()
+              .having(
+                (s) => s.clips.map((c) => c.id).toList(),
+                'active clip ids',
+                ['trashed-sm'],
+              )
+              .having(
+                (s) => s.trashedClips.map((c) => c.id).toList(),
+                'trashed clip ids',
+                ['trashed-sm'],
+              ),
+        ],
       );
 
       blocTest<ClipsLibraryBloc, ClipsLibraryState>(
@@ -889,6 +953,36 @@ void main() {
         verify: (_) {
           verify(() => mockClipLibraryService.getTrashedClips()).called(1);
           verify(() => mockClipLibraryService.hardDelete('trashed')).called(1);
+        },
+      );
+
+      blocTest<ClipsLibraryBloc, ClipsLibraryState>(
+        'empty trash only purges clips matching the type filter',
+        setUp: () {
+          when(() => mockClipLibraryService.getTrashedClips()).thenAnswer(
+            (_) async => [trashedClip, trashedStopMotionClip],
+          );
+          when(
+            () => mockClipLibraryService.hardDelete('trashed-sm'),
+          ).thenAnswer((_) async {});
+        },
+        seed: () => ClipsLibraryState(
+          status: ClipsLibraryStatus.trashLoaded,
+          trashedClips: [trashedStopMotionClip],
+        ),
+        build: () =>
+            createBloc(clipTypeFilter: LibraryClipTypeFilter.stopMotion),
+        act: (bloc) => bloc.add(const ClipsLibraryEmptyTrash()),
+        expect: () => [
+          isA<ClipsLibraryState>()
+              .having((s) => s.status, 'status', ClipsLibraryStatus.trashLoaded)
+              .having((s) => s.trashedClips, 'trashedClips', isEmpty),
+        ],
+        verify: (_) {
+          verifyNever(() => mockClipLibraryService.hardDelete('trashed'));
+          verify(
+            () => mockClipLibraryService.hardDelete('trashed-sm'),
+          ).called(1);
         },
       );
 

--- a/mobile/test/blocs/clips_library/clips_library_state_test.dart
+++ b/mobile/test/blocs/clips_library/clips_library_state_test.dart
@@ -4,6 +4,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/blocs/clips_library/clips_library_bloc.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 
 void main() {
@@ -155,6 +156,49 @@ void main() {
       });
     });
 
+    group('selectedIsStopMotion', () {
+      final smClip = DivineVideoClip(
+        id: 'sm1',
+        stopMotionFrames: const [
+          StopMotionClipFrame(
+            path: '/frames/f0.jpg',
+            duration: Duration(milliseconds: 83),
+          ),
+        ],
+        thumbnailPath: '/frames/f0.jpg',
+        duration: const Duration(seconds: 1),
+        recordedAt: DateTime(2026),
+        targetAspectRatio: .vertical,
+        originalAspectRatio: 9 / 16,
+      );
+
+      test('is null when nothing is selected', () {
+        final state = ClipsLibraryState(
+          status: ClipsLibraryStatus.loaded,
+          clips: [clip1, smClip],
+        );
+        expect(state.selectedIsStopMotion, isNull);
+      });
+
+      test('is false when a normal video clip is selected', () {
+        final state = ClipsLibraryState(
+          status: ClipsLibraryStatus.loaded,
+          clips: [clip1, smClip],
+          selectedClipIds: const {'clip1'},
+        );
+        expect(state.selectedIsStopMotion, isFalse);
+      });
+
+      test('is true when a stop-motion clip is selected', () {
+        final state = ClipsLibraryState(
+          status: ClipsLibraryStatus.loaded,
+          clips: [clip1, smClip],
+          selectedClipIds: const {'sm1'},
+        );
+        expect(state.selectedIsStopMotion, isTrue);
+      });
+    });
+
     test('props are correct', () {
       final state = ClipsLibraryState(
         status: ClipsLibraryStatus.loaded,
@@ -254,6 +298,64 @@ void main() {
           ClipsLibraryStatus.error,
         ]),
       );
+    });
+  });
+
+  group(LibraryClipTypeFilter, () {
+    final videoClip = DivineVideoClip(
+      id: 'v',
+      video: EditorVideo.file('/v.mp4'),
+      duration: const Duration(seconds: 2),
+      recordedAt: DateTime(2026),
+      targetAspectRatio: .vertical,
+      originalAspectRatio: 9 / 16,
+    );
+    final stopMotionClip = DivineVideoClip(
+      id: 'sm',
+      stopMotionFrames: const [
+        StopMotionClipFrame(
+          path: '/frames/f0.jpg',
+          duration: Duration(milliseconds: 83),
+        ),
+      ],
+      duration: const Duration(seconds: 1),
+      recordedAt: DateTime(2026),
+      targetAspectRatio: .vertical,
+      originalAspectRatio: 9 / 16,
+    );
+
+    test('fromQuery round-trips the non-default values', () {
+      expect(
+        LibraryClipTypeFilter.fromQuery(
+          LibraryClipTypeFilter.stopMotion.queryValue,
+        ),
+        LibraryClipTypeFilter.stopMotion,
+      );
+      expect(
+        LibraryClipTypeFilter.fromQuery(LibraryClipTypeFilter.video.queryValue),
+        LibraryClipTypeFilter.video,
+      );
+    });
+
+    test('fromQuery defaults to all for null or unknown', () {
+      expect(LibraryClipTypeFilter.fromQuery(null), LibraryClipTypeFilter.all);
+      expect(
+        LibraryClipTypeFilter.fromQuery('bogus'),
+        LibraryClipTypeFilter.all,
+      );
+    });
+
+    test('all has no query value', () {
+      expect(LibraryClipTypeFilter.all.queryValue, isNull);
+    });
+
+    test('matches respects clip type', () {
+      expect(LibraryClipTypeFilter.all.matches(videoClip), isTrue);
+      expect(LibraryClipTypeFilter.all.matches(stopMotionClip), isTrue);
+      expect(LibraryClipTypeFilter.stopMotion.matches(stopMotionClip), isTrue);
+      expect(LibraryClipTypeFilter.stopMotion.matches(videoClip), isFalse);
+      expect(LibraryClipTypeFilter.video.matches(videoClip), isTrue);
+      expect(LibraryClipTypeFilter.video.matches(stopMotionClip), isFalse);
     });
   });
 }

--- a/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
@@ -91,10 +91,7 @@ DivineVideoClip _createClipNoFile({String id = 'clip-no-file'}) {
   );
 }
 
-DivineVideoClip _createStopMotionClip({
-  String id = 'sm',
-  int frameCount = 3,
-}) {
+DivineVideoClip _createStopMotionClip({String id = 'sm', int frameCount = 3}) {
   final frames = [
     for (var i = 0; i < frameCount; i++)
       StopMotionClipFrame(
@@ -573,6 +570,35 @@ void main() {
           ),
         ],
       );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'clears the selection when a frame update leaves the clip empty',
+        build: buildBloc,
+        seed: () => ClipEditorState(
+          clips: [_createStopMotionClip()],
+          selectedFrameIndex: 0,
+          isEditing: true,
+        ),
+        act: (bloc) {
+          final clip = bloc.state.clips.first;
+          final empty = DivineVideoClip(
+            id: clip.id,
+            stopMotionFrames: const [],
+            duration: Duration.zero,
+            recordedAt: clip.recordedAt,
+            targetAspectRatio: clip.targetAspectRatio,
+            originalAspectRatio: clip.originalAspectRatio,
+          );
+          bloc.add(ClipEditorClipUpdated(clipId: clip.id, clip: empty));
+        },
+        expect: () => [
+          isA<ClipEditorState>().having(
+            (s) => s.selectedFrameIndex,
+            'selectedFrameIndex',
+            isNull,
+          ),
+        ],
+      );
     });
 
     group('frame multi-select', () {
@@ -589,11 +615,7 @@ void main() {
           isA<ClipEditorState>()
               .having((s) => s.isMultiSelectMode, 'isMultiSelectMode', isTrue)
               .having((s) => s.isEditing, 'isEditing', isFalse)
-              .having(
-                (s) => s.selectedFrameIndex,
-                'selectedFrameIndex',
-                isNull,
-              )
+              .having((s) => s.selectedFrameIndex, 'selectedFrameIndex', isNull)
               .having((s) => s.selectedFrameIndexes, 'selectedFrameIndexes', {
                 1,
               }),
@@ -972,10 +994,7 @@ void main() {
           expect(state.clips, hasLength(4));
           expect(state.clips.last.id, equals('c'));
           // The selection still points at 'c', not the clip now at index 2.
-          expect(
-            state.clips[state.currentClipIndex].id,
-            equals('c'),
-          );
+          expect(state.clips[state.currentClipIndex].id, equals('c'));
         },
       );
 
@@ -1874,11 +1893,7 @@ void main() {
                 'trimStart',
                 Duration.zero,
               )
-              .having(
-                (s) => s.clips.first.trimEnd,
-                'trimEnd',
-                Duration.zero,
-              )
+              .having((s) => s.clips.first.trimEnd, 'trimEnd', Duration.zero)
               .having(
                 (s) => s.clips.first.minTrimStart,
                 'minTrimStart',
@@ -2292,11 +2307,7 @@ void main() {
               ),
           isA<ClipEditorState>()
               .having((s) => s.isTransforming, 'isTransforming', isFalse)
-              .having(
-                (s) => s.transformingClipId,
-                'transformingClipId',
-                isNull,
-              )
+              .having((s) => s.transformingClipId, 'transformingClipId', isNull)
               .having(
                 (s) => s.clips.first.forwardVideoPath,
                 'forwardVideoPath',
@@ -2346,11 +2357,7 @@ void main() {
           ),
           isA<ClipEditorState>()
               .having((s) => s.isTransforming, 'isTransforming', isFalse)
-              .having(
-                (s) => s.transformingClipId,
-                'transformingClipId',
-                isNull,
-              )
+              .having((s) => s.transformingClipId, 'transformingClipId', isNull)
               .having(
                 (s) => s.lastTransformResult,
                 'lastTransformResult',
@@ -2360,11 +2367,7 @@ void main() {
         errors: () => [
           isA<Reportable<Object>>()
               .having((r) => r.unwrap(), 'unwrap', isA<StateError>())
-              .having(
-                (r) => r.context,
-                'context',
-                '_onClipTransformRequested',
-              ),
+              .having((r) => r.context, 'context', '_onClipTransformRequested'),
         ],
       );
 
@@ -2404,10 +2407,7 @@ void main() {
           expect(bloc.state.isTransforming, isFalse);
           expect(bloc.state.transformingClipId, isNull);
           expect(bloc.state.clips, isEmpty);
-          expect(
-            bloc.state.lastTransformResult,
-            isA<ClipTransformDiscarded>(),
-          );
+          expect(bloc.state.lastTransformResult, isA<ClipTransformDiscarded>());
 
           await bloc.close();
         },
@@ -3369,9 +3369,8 @@ void main() {
             saveClipToLibrary: recordSave,
           ),
           seed: () => ClipEditorState(clips: twoClips),
-          act: (bloc) => bloc.add(
-            const ClipEditorSaveClipToLibraryRequested(clipId: 'a'),
-          ),
+          act: (bloc) =>
+              bloc.add(const ClipEditorSaveClipToLibraryRequested(clipId: 'a')),
           verify: (bloc) {
             expect(forwardedOverlays, isNull);
           },
@@ -3385,9 +3384,8 @@ void main() {
           saveClipToLibrary: recordSave,
         ),
         seed: () => ClipEditorState(clips: twoClips),
-        act: (bloc) => bloc.add(
-          const ClipEditorSaveClipToLibraryRequested(clipId: 'a'),
-        ),
+        act: (bloc) =>
+            bloc.add(const ClipEditorSaveClipToLibraryRequested(clipId: 'a')),
         verify: (bloc) {
           expect(savedToLibrary.map((c) => c.id), equals(['flattened-a']));
           expect(bloc.state.lastClipLibrarySave, isA<ClipLibrarySaveSuccess>());
@@ -3403,9 +3401,8 @@ void main() {
           saveClipToLibrary: recordSave,
         ),
         seed: () => ClipEditorState(clips: twoClips, currentClipIndex: 1),
-        act: (bloc) => bloc.add(
-          const ClipEditorSaveClipToLibraryRequested(clipId: 'b'),
-        ),
+        act: (bloc) =>
+            bloc.add(const ClipEditorSaveClipToLibraryRequested(clipId: 'b')),
         verify: (bloc) {
           expect(bloc.state.clips.map((c) => c.id), equals(['a', 'b']));
           expect(bloc.state.currentClipIndex, equals(1));
@@ -3419,9 +3416,8 @@ void main() {
           saveClipToLibrary: recordSave,
         ),
         seed: () => ClipEditorState(clips: twoClips, currentClipIndex: 1),
-        act: (bloc) => bloc.add(
-          const ClipEditorSaveClipToLibraryRequested(clipId: 'a'),
-        ),
+        act: (bloc) =>
+            bloc.add(const ClipEditorSaveClipToLibraryRequested(clipId: 'a')),
         verify: (bloc) {
           expect(savedToLibrary.map((c) => c.id), equals(['flattened-a']));
         },
@@ -3451,9 +3447,8 @@ void main() {
           saveClipToLibrary: recordSave,
         ),
         seed: () => ClipEditorState(clips: twoClips),
-        act: (bloc) => bloc.add(
-          const ClipEditorSaveClipToLibraryRequested(clipId: 'a'),
-        ),
+        act: (bloc) =>
+            bloc.add(const ClipEditorSaveClipToLibraryRequested(clipId: 'a')),
         verify: (bloc) {
           expect(savedToLibrary, isEmpty);
           expect(bloc.state.lastClipLibrarySave, isA<ClipLibrarySaveFailure>());
@@ -3468,9 +3463,8 @@ void main() {
           saveClipToLibrary: ({required clip}) async => false,
         ),
         seed: () => ClipEditorState(clips: twoClips),
-        act: (bloc) => bloc.add(
-          const ClipEditorSaveClipToLibraryRequested(clipId: 'a'),
-        ),
+        act: (bloc) =>
+            bloc.add(const ClipEditorSaveClipToLibraryRequested(clipId: 'a')),
         verify: (bloc) {
           expect(bloc.state.lastClipLibrarySave, isA<ClipLibrarySaveFailure>());
         },
@@ -3483,9 +3477,8 @@ void main() {
           saveClipToLibrary: recordSave,
         ),
         seed: () => ClipEditorState(clips: twoClips),
-        act: (bloc) => bloc.add(
-          const ClipEditorSaveClipToLibraryRequested(clipId: 'a'),
-        ),
+        act: (bloc) =>
+            bloc.add(const ClipEditorSaveClipToLibraryRequested(clipId: 'a')),
         errors: () => [
           isA<Reportable<Object>>().having(
             (r) => r.unwrap(),
@@ -3516,9 +3509,7 @@ void main() {
           await Future<void>.delayed(Duration.zero);
           bloc.add(const ClipEditorClipRemoved('a'));
           await Future<void>.delayed(Duration.zero);
-          flattenCompleter.complete(
-            _createClip(id: 'flattened-a'),
-          );
+          flattenCompleter.complete(_createClip(id: 'flattened-a'));
         },
         verify: (bloc) {
           // The user deleted the clip they asked to save — storing it anyway
@@ -3548,9 +3539,7 @@ void main() {
           // A double-tap while the first render is still running.
           bloc.add(const ClipEditorSaveClipToLibraryRequested(clipId: 'a'));
           await Future<void>.delayed(Duration.zero);
-          flattenCompleter.complete(
-            _createClip(id: 'flattened-a'),
-          );
+          flattenCompleter.complete(_createClip(id: 'flattened-a'));
           await Future<void>.delayed(Duration.zero);
         },
         verify: (bloc) {

--- a/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
@@ -10,6 +10,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/stop_motion/stop_motion_frame_ops.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/models/video_editor/editor_overlay_snapshot.dart';
 import 'package:openvine/observability/reportable_error.dart';
 import 'package:openvine/services/audio_extraction_service.dart';
@@ -83,6 +85,27 @@ DivineVideoClip _createClipNoFile({String id = 'clip-no-file'}) {
     id: id,
     video: EditorVideo.network('https://example.com/vid.mp4'),
     duration: const Duration(seconds: 3),
+    recordedAt: DateTime(2025),
+    targetAspectRatio: .vertical,
+    originalAspectRatio: 9 / 16,
+  );
+}
+
+DivineVideoClip _createStopMotionClip({
+  String id = 'sm',
+  int frameCount = 3,
+}) {
+  final frames = [
+    for (var i = 0; i < frameCount; i++)
+      StopMotionClipFrame(
+        path: '$id-$i.jpg',
+        duration: StopMotionFrameOps.framesPerImageToDuration(1),
+      ),
+  ];
+  return DivineVideoClip(
+    id: id,
+    stopMotionFrames: frames,
+    duration: StopMotionFrameOps.totalDuration(frames),
     recordedAt: DateTime(2025),
     targetAspectRatio: .vertical,
     originalAspectRatio: 9 / 16,
@@ -476,6 +499,224 @@ void main() {
         seed: () => ClipEditorState(clips: twoClips),
         act: (bloc) => bloc.add(const ClipEditorClipSelected(5)),
         expect: () => <ClipEditorState>[],
+      );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'clears a stop-motion frame selection',
+        build: buildBloc,
+        seed: () => ClipEditorState(
+          clips: [_createStopMotionClip()],
+          selectedFrameIndex: 2,
+        ),
+        act: (bloc) => bloc.add(const ClipEditorClipSelected(0)),
+        expect: () => [
+          isA<ClipEditorState>().having(
+            (s) => s.selectedFrameIndex,
+            'selectedFrameIndex',
+            isNull,
+          ),
+        ],
+      );
+    });
+
+    group('ClipEditorFrameSelected', () {
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'selects the frame and enters editing on a stop-motion clip',
+        build: buildBloc,
+        seed: () => ClipEditorState(clips: [_createStopMotionClip()]),
+        act: (bloc) => bloc.add(const ClipEditorFrameSelected(1)),
+        expect: () => [
+          isA<ClipEditorState>()
+              .having((s) => s.selectedFrameIndex, 'selectedFrameIndex', 1)
+              .having((s) => s.isEditing, 'isEditing', isTrue)
+              .having((s) => s.currentClipIndex, 'currentClipIndex', 0),
+        ],
+      );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'is a no-op for a normal video composition',
+        build: buildBloc,
+        seed: () => ClipEditorState(clips: twoClips),
+        act: (bloc) => bloc.add(const ClipEditorFrameSelected(0)),
+        expect: () => <ClipEditorState>[],
+      );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'is a no-op for an out-of-range frame index',
+        build: buildBloc,
+        seed: () => ClipEditorState(clips: [_createStopMotionClip()]),
+        act: (bloc) => bloc.add(const ClipEditorFrameSelected(9)),
+        expect: () => <ClipEditorState>[],
+      );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'clamps the selection when a frame delete shrinks the clip',
+        build: buildBloc,
+        seed: () => ClipEditorState(
+          clips: [_createStopMotionClip()],
+          selectedFrameIndex: 2,
+          isEditing: true,
+        ),
+        act: (bloc) {
+          final clip = bloc.state.clips.first;
+          final shorter = StopMotionFrameOps.clipWithFrames(
+            clip,
+            StopMotionFrameOps.removeFrame(clip.stopMotionFrames!, 2),
+          );
+          bloc.add(ClipEditorClipUpdated(clipId: clip.id, clip: shorter));
+        },
+        expect: () => [
+          isA<ClipEditorState>().having(
+            (s) => s.selectedFrameIndex,
+            'selectedFrameIndex',
+            1,
+          ),
+        ],
+      );
+    });
+
+    group('frame multi-select', () {
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'starts with the current frame pre-selected and exits editing',
+        build: buildBloc,
+        seed: () => ClipEditorState(
+          clips: [_createStopMotionClip()],
+          selectedFrameIndex: 1,
+          isEditing: true,
+        ),
+        act: (bloc) => bloc.add(const ClipEditorFrameMultiSelectStarted(1)),
+        expect: () => [
+          isA<ClipEditorState>()
+              .having((s) => s.isMultiSelectMode, 'isMultiSelectMode', isTrue)
+              .having((s) => s.isEditing, 'isEditing', isFalse)
+              .having(
+                (s) => s.selectedFrameIndex,
+                'selectedFrameIndex',
+                isNull,
+              )
+              .having((s) => s.selectedFrameIndexes, 'selectedFrameIndexes', {
+                1,
+              }),
+        ],
+      );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'is a no-op for a normal video composition',
+        build: buildBloc,
+        seed: () => ClipEditorState(clips: twoClips),
+        act: (bloc) => bloc.add(const ClipEditorFrameMultiSelectStarted(0)),
+        expect: () => <ClipEditorState>[],
+      );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'toggling adds and removes stills from the selection',
+        build: buildBloc,
+        seed: () => ClipEditorState(
+          clips: [_createStopMotionClip()],
+          isMultiSelectMode: true,
+          selectedFrameIndexes: const {0},
+        ),
+        act: (bloc) => bloc
+          ..add(const ClipEditorFrameMultiSelectToggled(2))
+          ..add(const ClipEditorFrameMultiSelectToggled(0)),
+        expect: () => [
+          isA<ClipEditorState>().having(
+            (s) => s.selectedFrameIndexes,
+            'selectedFrameIndexes',
+            {0, 2},
+          ),
+          isA<ClipEditorState>().having(
+            (s) => s.selectedFrameIndexes,
+            'selectedFrameIndexes',
+            {2},
+          ),
+        ],
+      );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'ignores an out-of-range toggle',
+        build: buildBloc,
+        seed: () => ClipEditorState(
+          clips: [_createStopMotionClip()],
+          isMultiSelectMode: true,
+        ),
+        act: (bloc) => bloc.add(const ClipEditorFrameMultiSelectToggled(9)),
+        expect: () => <ClipEditorState>[],
+      );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'cancelling clears the frame selection and exits the mode',
+        build: buildBloc,
+        seed: () => ClipEditorState(
+          clips: [_createStopMotionClip()],
+          isMultiSelectMode: true,
+          selectedFrameIndexes: const {0, 1},
+        ),
+        act: (bloc) => bloc.add(const ClipEditorMultiSelectCancelled()),
+        expect: () => [
+          isA<ClipEditorState>()
+              .having((s) => s.isMultiSelectMode, 'isMultiSelectMode', isFalse)
+              .having(
+                (s) => s.selectedFrameIndexes,
+                'selectedFrameIndexes',
+                isEmpty,
+              ),
+        ],
+      );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'replaces the selection wholesale after a block move',
+        build: buildBloc,
+        seed: () => ClipEditorState(
+          clips: [_createStopMotionClip()],
+          isMultiSelectMode: true,
+          selectedFrameIndexes: const {0, 1},
+        ),
+        act: (bloc) => bloc.add(const ClipEditorFrameMultiSelectionSet({1, 2})),
+        expect: () => [
+          isA<ClipEditorState>().having(
+            (s) => s.selectedFrameIndexes,
+            'selectedFrameIndexes',
+            {1, 2},
+          ),
+        ],
+      );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'ignores a selection-set with out-of-range indexes',
+        build: buildBloc,
+        seed: () => ClipEditorState(
+          clips: [_createStopMotionClip()],
+          isMultiSelectMode: true,
+          selectedFrameIndexes: const {0},
+        ),
+        act: (bloc) => bloc.add(const ClipEditorFrameMultiSelectionSet({0, 9})),
+        expect: () => <ClipEditorState>[],
+      );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'prunes out-of-range indexes when a frame delete shrinks the clip',
+        build: buildBloc,
+        seed: () => ClipEditorState(
+          clips: [_createStopMotionClip()],
+          isMultiSelectMode: true,
+          selectedFrameIndexes: const {0, 2},
+        ),
+        act: (bloc) {
+          final clip = bloc.state.clips.first;
+          final shorter = StopMotionFrameOps.clipWithFrames(
+            clip,
+            StopMotionFrameOps.removeFrame(clip.stopMotionFrames!, 2),
+          );
+          bloc.add(ClipEditorClipUpdated(clipId: clip.id, clip: shorter));
+        },
+        expect: () => [
+          isA<ClipEditorState>().having(
+            (s) => s.selectedFrameIndexes,
+            'selectedFrameIndexes',
+            {0},
+          ),
+        ],
       );
     });
 
@@ -1666,7 +1907,7 @@ void main() {
         ],
         verify: (bloc) {
           expect(
-            bloc.state.clips.first.video.file?.path,
+            bloc.state.clips.first.requireVideo.file?.path,
             equals('/reversed/clip-local_clip-local.mp4'),
           );
         },
@@ -1748,7 +1989,7 @@ void main() {
           isA<ClipEditorState>()
               .having((s) => s.clips.first.reversed, 'reversed', isFalse)
               .having(
-                (s) => s.clips.first.video.file?.path,
+                (s) => s.clips.first.requireVideo.file?.path,
                 'videoPath',
                 '/path/clip-local.mp4',
               )
@@ -1787,7 +2028,7 @@ void main() {
           isA<ClipEditorState>()
               .having((s) => s.clips.first.reversed, 'reversed', isTrue)
               .having(
-                (s) => s.clips.first.video.file?.path,
+                (s) => s.clips.first.requireVideo.file?.path,
                 'videoPath',
                 '/reversed/clip-local_clip-local.mp4',
               )
@@ -1860,7 +2101,7 @@ void main() {
         ],
         verify: (bloc) {
           expect(
-            bloc.state.clips.first.video.file?.path,
+            bloc.state.clips.first.requireVideo.file?.path,
             equals('/reversed/clip-local_clip-local.mp4'),
           );
         },
@@ -2074,7 +2315,7 @@ void main() {
         ],
         verify: (bloc) {
           expect(
-            bloc.state.clips.first.video.file?.path,
+            bloc.state.clips.first.requireVideo.file?.path,
             equals('/transformed/clip-local_clip-local_transform.mp4'),
           );
         },

--- a/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
+++ b/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
@@ -2661,6 +2661,43 @@ void main() {
       );
 
       blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'switching modes discards the session and drops its library row',
+        build: buildBloc,
+        seed: () => VideoRecorderBlocState(
+          recorderMode: VideoRecorderMode.stopMotion,
+          stopMotionFrames: [frameAPath, frameBPath],
+        ),
+        act: (bloc) => bloc.add(
+          const VideoRecorderRecorderModeSet(VideoRecorderMode.classic),
+        ),
+        wait: const Duration(milliseconds: 20),
+        verify: (bloc) {
+          expect(bloc.state.stopMotionFrames, isEmpty);
+          // Files deleted AND the eager-saved row removed — no orphan.
+          verify(
+            () => clipManager.removeStopMotionSessionFromLibrary('clip_sm_a'),
+          ).called(1);
+        },
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'reset discards the session and drops its library row',
+        build: buildBloc,
+        seed: () => VideoRecorderBlocState(
+          recorderMode: VideoRecorderMode.stopMotion,
+          stopMotionFrames: [frameAPath, frameBPath],
+        ),
+        act: (bloc) => bloc.add(const VideoRecorderResetRequested()),
+        wait: const Duration(milliseconds: 20),
+        verify: (bloc) {
+          expect(bloc.state.stopMotionFrames, isEmpty);
+          verify(
+            () => clipManager.removeStopMotionSessionFromLibrary('clip_sm_a'),
+          ).called(1);
+        },
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
         'ingest saves the captured frames as a clip and signals ready',
         setUp: stubClipIngest,
         build: buildBloc,

--- a/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
+++ b/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
@@ -84,6 +84,8 @@ class _MockSharedPreferences extends Mock implements SharedPreferences {}
 
 class _MockEditorVideo extends Mock implements EditorVideo {}
 
+class _MockFile extends Mock implements File {}
+
 /// A fake wakelock platform —
 /// production code calls `WakelockPlus.enable/disable` around every
 /// recording session, which hits a platform channel that isn't bound
@@ -2790,36 +2792,66 @@ void main() {
         verify: (bloc) => expect(bloc.state.stopMotionFrames, isEmpty),
       );
 
-      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
-        'deletes an unreadable captured frame instead of leaking it',
-        setUp: () {
-          final unreadablePath = '${frameDir.path}/unreadable.jpg';
-          File(unreadablePath).writeAsBytesSync(const []);
-          framePath = unreadablePath;
-          when(() => cameraService.capturePhoto()).thenAnswer(
-            (_) async => PhotoCaptureResult(filePath: unreadablePath),
-          );
-        },
-        build: buildBloc,
-        seed: () => const VideoRecorderBlocState(
-          recorderMode: VideoRecorderMode.stopMotion,
-        ),
-        act: (bloc) => bloc.add(const VideoRecorderStopMotionFrameCaptured()),
-        wait: const Duration(milliseconds: 20),
-        verify: (bloc) {
-          expect(bloc.state.stopMotionFrames, isEmpty);
-          expect(File(framePath).existsSync(), isFalse);
-          verifyNever(
-            () => clipManager.saveStopMotionSessionToLibrary(
-              id: any(named: 'id'),
-              frames: any(named: 'frames'),
-              originalAspectRatio: any(named: 'originalAspectRatio'),
-              targetAspectRatio: any(named: 'targetAspectRatio'),
-              duration: any(named: 'duration'),
-              thumbnailPath: any(named: 'thumbnailPath'),
-              lensMetadata: any(named: 'lensMetadata'),
-            ),
-          );
+      test(
+        'waits for unreadable frame deletion before accepting another capture',
+        () {
+          fakeAsync((async) {
+            const unreadablePath = '/unreadable.jpg';
+            final unreadableFile = _MockFile();
+            final deleteGate = Completer<File>();
+            when(unreadableFile.existsSync).thenReturn(true);
+            when(unreadableFile.lengthSync).thenReturn(0);
+            when(unreadableFile.delete).thenAnswer(
+              (_) => deleteGate.future,
+            );
+            when(() => cameraService.capturePhoto()).thenAnswer(
+              (_) async => const PhotoCaptureResult(filePath: unreadablePath),
+            );
+
+            IOOverrides.runZoned(
+              () {
+                final bloc = buildBloc();
+                bloc.emit(
+                  const VideoRecorderBlocState(
+                    recorderMode: VideoRecorderMode.stopMotion,
+                  ),
+                );
+
+                bloc.add(
+                  const VideoRecorderStopMotionFrameCaptured(),
+                );
+                async.flushMicrotasks();
+                verify(() => cameraService.capturePhoto()).called(1);
+
+                // The droppable handler must still own the invalid capture
+                // until its file is deleted, so a second shutter event cannot
+                // start another native capture in the cleanup window.
+                bloc.add(
+                  const VideoRecorderStopMotionFrameCaptured(),
+                );
+                async.flushMicrotasks();
+                verifyNever(() => cameraService.capturePhoto());
+
+                deleteGate.complete(unreadableFile);
+                async.flushMicrotasks();
+                unawaited(bloc.close());
+                async.flushMicrotasks();
+
+                verifyNever(
+                  () => clipManager.saveStopMotionSessionToLibrary(
+                    id: any(named: 'id'),
+                    frames: any(named: 'frames'),
+                    originalAspectRatio: any(named: 'originalAspectRatio'),
+                    targetAspectRatio: any(named: 'targetAspectRatio'),
+                    duration: any(named: 'duration'),
+                    thumbnailPath: any(named: 'thumbnailPath'),
+                    lensMetadata: any(named: 'lensMetadata'),
+                  ),
+                );
+              },
+              createFile: (_) => unreadableFile,
+            );
+          });
         },
       );
 

--- a/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
+++ b/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
@@ -2534,6 +2534,24 @@ void main() {
       );
 
       blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'a frame captured while ready (assemble done, navigation pending) '
+        'skips the wasted native capture',
+        build: buildBloc,
+        seed: () => const VideoRecorderBlocState(
+          recorderMode: VideoRecorderMode.stopMotion,
+          stopMotionStatus: StopMotionStatus.ready,
+        ),
+        act: (bloc) => bloc.add(const VideoRecorderStopMotionFrameCaptured()),
+        wait: const Duration(milliseconds: 20),
+        verify: (bloc) {
+          // The after-await guard deletes such a still anyway; the top guard
+          // short-circuits the native capture in the ~1-frame ready window.
+          verifyNever(() => cameraService.capturePhoto());
+          expect(bloc.state.stopMotionStatus, StopMotionStatus.ready);
+        },
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
         'a frame that lands after an assemble started is dropped, not '
         're-persisted as a new session',
         setUp: () {
@@ -2563,6 +2581,54 @@ void main() {
           // mode wheel mid-save and re-writes a phantom one-frame library row.
           expect(bloc.state.stopMotionFrames, isEmpty);
           expect(bloc.state.stopMotionStatus, StopMotionStatus.ready);
+          verifyNever(
+            () => clipManager.saveStopMotionSessionToLibrary(
+              id: any(named: 'id'),
+              frames: any(named: 'frames'),
+              originalAspectRatio: any(named: 'originalAspectRatio'),
+              targetAspectRatio: any(named: 'targetAspectRatio'),
+              duration: any(named: 'duration'),
+              thumbnailPath: any(named: 'thumbnailPath'),
+              lensMetadata: any(named: 'lensMetadata'),
+            ),
+          );
+        },
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'a frame that lands after a mode switch is dropped, not re-persisted '
+        'on the new mode',
+        setUp: () {
+          stubClipIngest();
+          // The mode wheel stays live during an idle capture, so a swipe can
+          // land the switch while this still is in flight.
+          when(() => cameraService.capturePhoto()).thenAnswer((_) async {
+            await Future<void>.delayed(const Duration(milliseconds: 10));
+            return PhotoCaptureResult(filePath: framePath);
+          });
+        },
+        build: buildBloc,
+        seed: () => VideoRecorderBlocState(
+          recorderMode: VideoRecorderMode.stopMotion,
+          stopMotionFrames: [frameAPath],
+        ),
+        act: (bloc) async {
+          bloc.add(const VideoRecorderStopMotionFrameCaptured());
+          // Swipe the wheel off stop-motion while the capture is in flight.
+          await Future<void>.delayed(const Duration(milliseconds: 1));
+          bloc.add(
+            const VideoRecorderRecorderModeSet(VideoRecorderMode.upload),
+          );
+        },
+        wait: const Duration(milliseconds: 60),
+        verify: (bloc) {
+          // The switch discarded the session and moved the recorder off
+          // stop-motion; appending the resumed still would write a phantom
+          // one-frame library row on the new mode, so it is dropped with its
+          // file.
+          expect(bloc.state.recorderMode, VideoRecorderMode.upload);
+          expect(bloc.state.stopMotionFrames, isEmpty);
+          expect(File(framePath).existsSync(), isFalse);
           verifyNever(
             () => clipManager.saveStopMotionSessionToLibrary(
               id: any(named: 'id'),

--- a/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
+++ b/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
@@ -2516,6 +2516,68 @@ void main() {
       );
 
       blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'a frame captured while assembling is dropped',
+        build: buildBloc,
+        seed: () => const VideoRecorderBlocState(
+          recorderMode: VideoRecorderMode.stopMotion,
+          stopMotionStatus: StopMotionStatus.assembling,
+        ),
+        act: (bloc) => bloc.add(const VideoRecorderStopMotionFrameCaptured()),
+        wait: const Duration(milliseconds: 20),
+        verify: (bloc) {
+          // The assemble owns the session: it reads the frame list, saves it,
+          // then clears it. A still appended here races that save.
+          verifyNever(() => cameraService.capturePhoto());
+          expect(bloc.state.stopMotionFrames, isEmpty);
+          expect(bloc.state.stopMotionStatus, StopMotionStatus.assembling);
+        },
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'a frame that lands after an assemble started is dropped, not '
+        're-persisted as a new session',
+        setUp: () {
+          stubClipIngest();
+          // "Next" stays tappable across the slow native capture, so the
+          // assemble claims the session while this still is in flight.
+          when(() => cameraService.capturePhoto()).thenAnswer((_) async {
+            await Future<void>.delayed(const Duration(milliseconds: 10));
+            return PhotoCaptureResult(filePath: framePath);
+          });
+        },
+        build: buildBloc,
+        seed: () => VideoRecorderBlocState(
+          recorderMode: VideoRecorderMode.stopMotion,
+          stopMotionFrames: [frameAPath],
+        ),
+        act: (bloc) async {
+          bloc.add(const VideoRecorderStopMotionFrameCaptured());
+          // Tap "Next" while the capture is still in flight.
+          await Future<void>.delayed(const Duration(milliseconds: 1));
+          bloc.add(const VideoRecorderStopMotionAssembleRequested());
+        },
+        wait: const Duration(milliseconds: 60),
+        verify: (bloc) {
+          // A late still must not reopen the session the assemble just closed,
+          // nor clobber the terminal status back to `idle` — that reopens the
+          // mode wheel mid-save and re-writes a phantom one-frame library row.
+          expect(bloc.state.stopMotionFrames, isEmpty);
+          expect(bloc.state.stopMotionStatus, StopMotionStatus.ready);
+          verifyNever(
+            () => clipManager.saveStopMotionSessionToLibrary(
+              id: any(named: 'id'),
+              frames: any(named: 'frames'),
+              originalAspectRatio: any(named: 'originalAspectRatio'),
+              targetAspectRatio: any(named: 'targetAspectRatio'),
+              duration: any(named: 'duration'),
+              thumbnailPath: any(named: 'thumbnailPath'),
+              lensMetadata: any(named: 'lensMetadata'),
+            ),
+          );
+        },
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
         'the shutter tick fires before the captured frame lands',
         setUp: () {
           // Simulate the slow native capture: the blink must not wait for it.

--- a/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
+++ b/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
@@ -2791,6 +2791,39 @@ void main() {
       );
 
       blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'deletes an unreadable captured frame instead of leaking it',
+        setUp: () {
+          final unreadablePath = '${frameDir.path}/unreadable.jpg';
+          File(unreadablePath).writeAsBytesSync(const []);
+          framePath = unreadablePath;
+          when(() => cameraService.capturePhoto()).thenAnswer(
+            (_) async => PhotoCaptureResult(filePath: unreadablePath),
+          );
+        },
+        build: buildBloc,
+        seed: () => const VideoRecorderBlocState(
+          recorderMode: VideoRecorderMode.stopMotion,
+        ),
+        act: (bloc) => bloc.add(const VideoRecorderStopMotionFrameCaptured()),
+        wait: const Duration(milliseconds: 20),
+        verify: (bloc) {
+          expect(bloc.state.stopMotionFrames, isEmpty);
+          expect(File(framePath).existsSync(), isFalse);
+          verifyNever(
+            () => clipManager.saveStopMotionSessionToLibrary(
+              id: any(named: 'id'),
+              frames: any(named: 'frames'),
+              originalAspectRatio: any(named: 'originalAspectRatio'),
+              targetAspectRatio: any(named: 'targetAspectRatio'),
+              duration: any(named: 'duration'),
+              thumbnailPath: any(named: 'thumbnailPath'),
+              lensMetadata: any(named: 'lensMetadata'),
+            ),
+          );
+        },
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
         'undo removes the last captured frame and re-syncs the library',
         build: buildBloc,
         seed: () => VideoRecorderBlocState(

--- a/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
+++ b/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
@@ -2552,6 +2552,48 @@ void main() {
       );
 
       blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'clears a leftover ready on re-init so the shutter works after '
+        'backing out of the editor',
+        setUp: () {
+          when(
+            () => cameraService.initialize(
+              videoQuality: any(named: 'videoQuality'),
+              initialLens: any(named: 'initialLens'),
+              enableAutoLensSwitch: any(named: 'enableAutoLensSwitch'),
+            ),
+          ).thenAnswer((_) async {});
+          when(
+            () => cameraService.setRemoteRecordControlEnabled(
+              enabled: any(named: 'enabled'),
+            ),
+          ).thenAnswer((_) async => true);
+          // Same mode persisted, so init's mode branch is skipped and nothing
+          // else would move a leftover `ready` back to `idle`.
+          when(
+            () => prefs.getString(VideoRecorderMode.persistenceKey),
+          ).thenReturn(VideoRecorderMode.stopMotion.name);
+        },
+        build: buildBloc,
+        seed: () => const VideoRecorderBlocState(
+          recorderMode: VideoRecorderMode.stopMotion,
+          stopMotionStatus: StopMotionStatus.ready,
+        ),
+        act: (bloc) async {
+          bloc.add(const VideoRecorderInitializeRequested());
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+          bloc.add(const VideoRecorderStopMotionFrameCaptured());
+        },
+        wait: const Duration(milliseconds: 40),
+        verify: (bloc) {
+          // Without the reset the top guard would swallow this tap (leftover
+          // `ready`): no capture, empty frames. With it, a fresh session
+          // starts.
+          verify(() => cameraService.capturePhoto()).called(1);
+          expect(bloc.state.stopMotionFrames, [framePath]);
+        },
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
         'a frame that lands after an assemble started is dropped, not '
         're-persisted as a new session',
         setUp: () {

--- a/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
+++ b/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
@@ -2410,6 +2410,9 @@ void main() {
       late String framePath;
       late String frameAPath;
       late String frameBPath;
+      // Releases a gated capturePhoto() in the tests that force a still to
+      // land after a session-claiming event.
+      late Completer<void> captureGate;
 
       DivineVideoClip fakeClip() => DivineVideoClip(
         id: 'clip_sm_1',
@@ -2599,9 +2602,12 @@ void main() {
         setUp: () {
           stubClipIngest();
           // "Next" stays tappable across the slow native capture, so the
-          // assemble claims the session while this still is in flight.
+          // assemble claims the session while this still is in flight. The
+          // gate holds the capture open until the act has run the assemble,
+          // so the interleave is forced rather than timed.
+          captureGate = Completer<void>();
           when(() => cameraService.capturePhoto()).thenAnswer((_) async {
-            await Future<void>.delayed(const Duration(milliseconds: 10));
+            await captureGate.future;
             return PhotoCaptureResult(filePath: framePath);
           });
         },
@@ -2612,11 +2618,15 @@ void main() {
         ),
         act: (bloc) async {
           bloc.add(const VideoRecorderStopMotionFrameCaptured());
+          // Let the handler reach the gated capturePhoto().
+          await pumpEventQueue();
           // Tap "Next" while the capture is still in flight.
-          await Future<void>.delayed(const Duration(milliseconds: 1));
           bloc.add(const VideoRecorderStopMotionAssembleRequested());
+          await pumpEventQueue();
+          // Only now does the still land — strictly after the assemble.
+          captureGate.complete();
+          await pumpEventQueue();
         },
-        wait: const Duration(milliseconds: 60),
         verify: (bloc) {
           // A late still must not reopen the session the assemble just closed,
           // nor clobber the terminal status back to `idle` — that reopens the
@@ -2643,9 +2653,12 @@ void main() {
         setUp: () {
           stubClipIngest();
           // The mode wheel stays live during an idle capture, so a swipe can
-          // land the switch while this still is in flight.
+          // land the switch while this still is in flight. The gate holds the
+          // capture open until the act has run the switch, so the interleave
+          // is forced rather than timed.
+          captureGate = Completer<void>();
           when(() => cameraService.capturePhoto()).thenAnswer((_) async {
-            await Future<void>.delayed(const Duration(milliseconds: 10));
+            await captureGate.future;
             return PhotoCaptureResult(filePath: framePath);
           });
         },
@@ -2656,13 +2669,17 @@ void main() {
         ),
         act: (bloc) async {
           bloc.add(const VideoRecorderStopMotionFrameCaptured());
+          // Let the handler reach the gated capturePhoto().
+          await pumpEventQueue();
           // Swipe the wheel off stop-motion while the capture is in flight.
-          await Future<void>.delayed(const Duration(milliseconds: 1));
           bloc.add(
             const VideoRecorderRecorderModeSet(VideoRecorderMode.upload),
           );
+          await pumpEventQueue();
+          // Only now does the still land — strictly after the switch.
+          captureGate.complete();
+          await pumpEventQueue();
         },
-        wait: const Duration(milliseconds: 60),
         verify: (bloc) {
           // The switch discarded the session and moved the recorder off
           // stop-motion; appending the resumed still would write a phantom

--- a/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
+++ b/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
@@ -12,6 +12,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart' as model show AspectRatio, AudioEvent;
 import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
 import 'package:openvine/models/video_recorder/video_recorder_flash_mode.dart';
 import 'package:openvine/models/video_recorder/video_recorder_mode.dart';
@@ -171,6 +172,8 @@ void main() {
         originalAspectRatio: 1,
       ),
     );
+    registerFallbackValue(<StopMotionClipFrame>[]);
+    registerFallbackValue(Duration.zero);
   });
 
   setUp(() {
@@ -229,6 +232,8 @@ void main() {
 
     when(() => prefs.getString(any())).thenReturn(null);
     when(() => prefs.setString(any(), any())).thenAnswer((_) async => true);
+    when(() => prefs.getBool(any())).thenReturn(null);
+    when(() => prefs.setBool(any(), any())).thenAnswer((_) async => true);
   });
 
   /// Builds a bloc with all dependencies wired to the mocks.
@@ -892,6 +897,41 @@ void main() {
           const VideoRecorderBlocState(showGridLines: true),
           const VideoRecorderBlocState(),
         ],
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'persists each choice',
+        build: buildBloc,
+        act: (bloc) async {
+          bloc.add(const VideoRecorderGridLinesToggled());
+          await Future<void>.delayed(Duration.zero);
+          bloc.add(const VideoRecorderGridLinesToggled());
+        },
+        verify: (_) {
+          verify(
+            () => prefs.setBool('camera_grid_lines_enabled', true),
+          ).called(1);
+          verify(
+            () => prefs.setBool('camera_grid_lines_enabled', false),
+          ).called(1);
+        },
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'a persisted off choice keeps the grid hidden on mode switch',
+        setUp: () {
+          when(
+            () => prefs.getBool('camera_grid_lines_enabled'),
+          ).thenReturn(false);
+        },
+        build: buildBloc,
+        act: (bloc) => bloc.add(
+          const VideoRecorderRecorderModeSet(VideoRecorderMode.classic),
+        ),
+        verify: (bloc) {
+          expect(bloc.state.recorderMode, VideoRecorderMode.classic);
+          expect(bloc.state.showGridLines, isFalse);
+        },
       );
     });
 
@@ -2194,6 +2234,41 @@ void main() {
       );
 
       blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'switches to stop-motion mode when opened from a stop-motion editor',
+        setUp: () {
+          when(() => clipManager.clips).thenReturn([
+            DivineVideoClip(
+              id: 'clip_sm_1',
+              stopMotionFrames: const [
+                StopMotionClipFrame(
+                  path: '/f0.jpg',
+                  duration: Duration(milliseconds: 42),
+                ),
+              ],
+              duration: const Duration(milliseconds: 42),
+              recordedAt: DateTime(2024),
+              targetAspectRatio: model.AspectRatio.vertical,
+              originalAspectRatio: 9 / 16,
+            ),
+          ]);
+        },
+        build: buildBloc,
+        act: (bloc) =>
+            bloc.add(const VideoRecorderInitializeRequested(fromEditor: true)),
+        verify: (bloc) {
+          expect(bloc.state.recorderMode, VideoRecorderMode.stopMotion);
+          // The mode's grid default applies even on this direct switch.
+          expect(bloc.state.showGridLines, isTrue);
+          // Setting the mode directly must not clear the composition.
+          verifyNever(
+            () => clipManager.clearAll(
+              keepAutosavedDraft: any(named: 'keepAutosavedDraft'),
+            ),
+          );
+        },
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
         'restores persisted mode when NOT opened from the editor',
         setUp: () {
           when(
@@ -2326,6 +2401,328 @@ void main() {
         await bloc.close();
         verify(() => cameraService.dispose()).called(1);
       });
+    });
+
+    group('stop-motion', () {
+      // Ingest and eager-persist filter unreadable stills via existsSync, so
+      // the frame paths used here must be real, non-empty files.
+      late Directory frameDir;
+      late String framePath;
+      late String frameAPath;
+      late String frameBPath;
+
+      DivineVideoClip fakeClip() => DivineVideoClip(
+        id: 'clip_sm_1',
+        video: EditorVideo.file('/out.mp4'),
+        duration: const Duration(milliseconds: 250),
+        recordedAt: DateTime(2024),
+        targetAspectRatio: model.AspectRatio.vertical,
+        originalAspectRatio: 9 / 16,
+      );
+
+      void stubClipIngest() {
+        when(
+          () => clipManager.addStopMotionClip(
+            id: any(named: 'id'),
+            frames: any(named: 'frames'),
+            originalAspectRatio: any(named: 'originalAspectRatio'),
+            targetAspectRatio: any(named: 'targetAspectRatio'),
+            duration: any(named: 'duration'),
+            thumbnailPath: any(named: 'thumbnailPath'),
+            lensMetadata: any(named: 'lensMetadata'),
+          ),
+        ).thenReturn(fakeClip());
+        when(() => clipManager.clips).thenReturn([fakeClip()]);
+        when(
+          () => clipManager.saveClipToLibrary(any()),
+        ).thenAnswer((_) async => true);
+      }
+
+      setUp(() {
+        frameDir = Directory.systemTemp.createTempSync('sm_frames');
+        framePath = '${frameDir.path}/frame.jpg';
+        frameAPath = '${frameDir.path}/a.jpg';
+        frameBPath = '${frameDir.path}/b.jpg';
+        for (final path in [framePath, frameAPath, frameBPath]) {
+          File(path).writeAsBytesSync(const [0]);
+        }
+
+        when(() => cameraService.capturePhoto()).thenAnswer(
+          (_) async => PhotoCaptureResult(filePath: framePath),
+        );
+        // Capture and undo eagerly mirror the session into the library.
+        when(
+          () => clipManager.saveStopMotionSessionToLibrary(
+            id: any(named: 'id'),
+            frames: any(named: 'frames'),
+            originalAspectRatio: any(named: 'originalAspectRatio'),
+            targetAspectRatio: any(named: 'targetAspectRatio'),
+            duration: any(named: 'duration'),
+            thumbnailPath: any(named: 'thumbnailPath'),
+            lensMetadata: any(named: 'lensMetadata'),
+          ),
+        ).thenAnswer((_) async => true);
+        when(
+          () => clipManager.removeStopMotionSessionFromLibrary(any()),
+        ).thenAnswer((_) async {});
+      });
+
+      tearDown(() {
+        if (frameDir.existsSync()) frameDir.deleteSync(recursive: true);
+      });
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'a camera re-sync keeps the captured frames (session not split)',
+        setUp: () {
+          when(
+            () => cameraService.switchCamera(),
+          ).thenAnswer((_) async => true);
+        },
+        build: buildBloc,
+        seed: () => VideoRecorderBlocState(
+          recorderMode: VideoRecorderMode.stopMotion,
+          stopMotionFrames: [frameAPath, frameBPath],
+        ),
+        act: (bloc) => bloc.add(const VideoRecorderCameraSwitched()),
+        verify: (bloc) => expect(
+          bloc.state.stopMotionFrames,
+          [frameAPath, frameBPath],
+        ),
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'a captured frame is appended without rendering a clip',
+        build: buildBloc,
+        seed: () => const VideoRecorderBlocState(
+          recorderMode: VideoRecorderMode.stopMotion,
+        ),
+        act: (bloc) => bloc.add(const VideoRecorderStopMotionFrameCaptured()),
+        wait: const Duration(milliseconds: 20),
+        verify: (bloc) {
+          verify(() => cameraService.capturePhoto()).called(1);
+          expect(bloc.state.stopMotionFrames, [framePath]);
+          verifyNever(
+            () => clipManager.addClip(
+              video: any(named: 'video'),
+              originalAspectRatio: any(named: 'originalAspectRatio'),
+              targetAspectRatio: any(named: 'targetAspectRatio'),
+              limitClipDuration: any(named: 'limitClipDuration'),
+              duration: any(named: 'duration'),
+              thumbnailPath: any(named: 'thumbnailPath'),
+              lensMetadata: any(named: 'lensMetadata'),
+            ),
+          );
+        },
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'the shutter tick fires before the captured frame lands',
+        setUp: () {
+          // Simulate the slow native capture: the blink must not wait for it.
+          when(() => cameraService.capturePhoto()).thenAnswer((_) async {
+            await Future<void>.delayed(const Duration(milliseconds: 10));
+            return PhotoCaptureResult(filePath: framePath);
+          });
+        },
+        build: buildBloc,
+        seed: () => const VideoRecorderBlocState(
+          recorderMode: VideoRecorderMode.stopMotion,
+        ),
+        act: (bloc) => bloc.add(const VideoRecorderStopMotionFrameCaptured()),
+        wait: const Duration(milliseconds: 50),
+        expect: () => [
+          isA<VideoRecorderBlocState>()
+              .having(
+                (s) => s.stopMotionShutterTick,
+                'stopMotionShutterTick',
+                1,
+              )
+              .having((s) => s.stopMotionFrames, 'stopMotionFrames', isEmpty),
+          isA<VideoRecorderBlocState>().having(
+            (s) => s.stopMotionFrames,
+            'stopMotionFrames',
+            hasLength(1),
+          ),
+        ],
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'a captured frame is persisted to the library immediately',
+        build: buildBloc,
+        seed: () => const VideoRecorderBlocState(
+          recorderMode: VideoRecorderMode.stopMotion,
+        ),
+        act: (bloc) => bloc.add(const VideoRecorderStopMotionFrameCaptured()),
+        wait: const Duration(milliseconds: 20),
+        verify: (bloc) {
+          final captured = verify(
+            () => clipManager.saveStopMotionSessionToLibrary(
+              id: captureAny(named: 'id'),
+              frames: captureAny(named: 'frames'),
+              originalAspectRatio: any(named: 'originalAspectRatio'),
+              targetAspectRatio: any(named: 'targetAspectRatio'),
+              duration: any(named: 'duration'),
+              thumbnailPath: any(named: 'thumbnailPath'),
+              lensMetadata: any(named: 'lensMetadata'),
+            ),
+          )..called(1);
+          // Session id is derived from the first frame's filename so it stays
+          // stable as the session grows.
+          expect(captured.captured[0], 'clip_sm_frame');
+          final frames = captured.captured[1] as List<StopMotionClipFrame>;
+          expect(frames.map((f) => f.path), [framePath]);
+        },
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'the shutter toggle captures a frame in stop-motion mode',
+        build: buildBloc,
+        seed: () => const VideoRecorderBlocState(
+          recorderMode: VideoRecorderMode.stopMotion,
+        ),
+        act: (bloc) => bloc.add(const VideoRecorderRecordingToggleRequested()),
+        wait: const Duration(milliseconds: 20),
+        verify: (bloc) {
+          verify(() => cameraService.capturePhoto()).called(1);
+          expect(bloc.state.stopMotionFrames, hasLength(1));
+        },
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'no frame is appended when the camera returns no photo',
+        setUp: () {
+          when(
+            () => cameraService.capturePhoto(),
+          ).thenAnswer((_) async => null);
+        },
+        build: buildBloc,
+        seed: () => const VideoRecorderBlocState(
+          recorderMode: VideoRecorderMode.stopMotion,
+        ),
+        act: (bloc) => bloc.add(const VideoRecorderStopMotionFrameCaptured()),
+        verify: (bloc) => expect(bloc.state.stopMotionFrames, isEmpty),
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'undo removes the last captured frame and re-syncs the library',
+        build: buildBloc,
+        seed: () => VideoRecorderBlocState(
+          recorderMode: VideoRecorderMode.stopMotion,
+          stopMotionFrames: [frameAPath, frameBPath],
+        ),
+        act: (bloc) => bloc.add(const VideoRecorderStopMotionFrameUndone()),
+        wait: const Duration(milliseconds: 20),
+        verify: (bloc) {
+          expect(bloc.state.stopMotionFrames, [frameAPath]);
+          final captured = verify(
+            () => clipManager.saveStopMotionSessionToLibrary(
+              id: captureAny(named: 'id'),
+              frames: captureAny(named: 'frames'),
+              originalAspectRatio: any(named: 'originalAspectRatio'),
+              targetAspectRatio: any(named: 'targetAspectRatio'),
+              duration: any(named: 'duration'),
+              thumbnailPath: any(named: 'thumbnailPath'),
+              lensMetadata: any(named: 'lensMetadata'),
+            ),
+          )..called(1);
+          // Same session id — the first frame is unchanged.
+          expect(captured.captured[0], 'clip_sm_a');
+          final frames = captured.captured[1] as List<StopMotionClipFrame>;
+          expect(frames.map((f) => f.path), [frameAPath]);
+        },
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'undoing the final frame drops the session library row',
+        build: buildBloc,
+        seed: () => VideoRecorderBlocState(
+          recorderMode: VideoRecorderMode.stopMotion,
+          stopMotionFrames: [frameAPath],
+        ),
+        act: (bloc) => bloc.add(const VideoRecorderStopMotionFrameUndone()),
+        wait: const Duration(milliseconds: 20),
+        verify: (bloc) {
+          expect(bloc.state.stopMotionFrames, isEmpty);
+          verify(
+            () => clipManager.removeStopMotionSessionFromLibrary('clip_sm_a'),
+          ).called(1);
+          verifyNever(
+            () => clipManager.saveStopMotionSessionToLibrary(
+              id: any(named: 'id'),
+              frames: any(named: 'frames'),
+              originalAspectRatio: any(named: 'originalAspectRatio'),
+              targetAspectRatio: any(named: 'targetAspectRatio'),
+              duration: any(named: 'duration'),
+              thumbnailPath: any(named: 'thumbnailPath'),
+              lensMetadata: any(named: 'lensMetadata'),
+            ),
+          );
+        },
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'ingest saves the captured frames as a clip and signals ready',
+        setUp: stubClipIngest,
+        build: buildBloc,
+        seed: () => VideoRecorderBlocState(
+          recorderMode: VideoRecorderMode.stopMotion,
+          stopMotionFrames: [frameAPath, frameBPath],
+        ),
+        act: (bloc) =>
+            bloc.add(const VideoRecorderStopMotionAssembleRequested()),
+        verify: (bloc) {
+          final captured = verify(
+            () => clipManager.addStopMotionClip(
+              id: captureAny(named: 'id'),
+              frames: captureAny(named: 'frames'),
+              originalAspectRatio: any(named: 'originalAspectRatio'),
+              targetAspectRatio: any(named: 'targetAspectRatio'),
+              duration: any(named: 'duration'),
+              thumbnailPath: any(named: 'thumbnailPath'),
+              lensMetadata: any(named: 'lensMetadata'),
+            ),
+          )..called(1);
+          // Captured values follow the method's parameter declaration order:
+          // frames is declared before id.
+          final frames = captured.captured[0] as List<StopMotionClipFrame>;
+          expect(frames.map((f) => f.path), [frameAPath, frameBPath]);
+          // Assemble reuses the capture session's library id so the row
+          // written during capture is updated, not duplicated.
+          expect(captured.captured[1], 'clip_sm_a');
+          verify(() => clipManager.saveClipToLibrary(any())).called(1);
+          expect(bloc.state.stopMotionStatus, StopMotionStatus.ready);
+          expect(bloc.state.stopMotionFrames, isEmpty);
+        },
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'emits failure when ingest throws',
+        setUp: () {
+          when(
+            () => clipManager.addStopMotionClip(
+              id: any(named: 'id'),
+              frames: any(named: 'frames'),
+              originalAspectRatio: any(named: 'originalAspectRatio'),
+              targetAspectRatio: any(named: 'targetAspectRatio'),
+              duration: any(named: 'duration'),
+              thumbnailPath: any(named: 'thumbnailPath'),
+              lensMetadata: any(named: 'lensMetadata'),
+            ),
+          ).thenThrow(Exception('ingest failed'));
+        },
+        build: buildBloc,
+        seed: () => VideoRecorderBlocState(
+          recorderMode: VideoRecorderMode.stopMotion,
+          stopMotionFrames: [frameAPath],
+        ),
+        act: (bloc) =>
+            bloc.add(const VideoRecorderStopMotionAssembleRequested()),
+        errors: () => [isA<Exception>()],
+        verify: (bloc) {
+          expect(bloc.state.stopMotionStatus, StopMotionStatus.failure);
+          verifyNever(() => clipManager.saveClipToLibrary(any()));
+        },
+      );
     });
   });
 }

--- a/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
+++ b/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
@@ -205,9 +205,7 @@ void main() {
     when(
       () => cameraService.availableVideoStabilizationModes,
     ).thenReturn(const [DivineVideoStabilizationMode.off]);
-    when(
-      () => cameraService.isVideoStabilizationSupported,
-    ).thenReturn(false);
+    when(() => cameraService.isVideoStabilizationSupported).thenReturn(false);
     when(() => cameraService.initializationError).thenReturn(null);
     when(() => cameraService.dispose()).thenAnswer((_) async {});
     when(
@@ -215,9 +213,9 @@ void main() {
     ).thenAnswer((_) async {});
 
     when(() => clipManager.clips).thenReturn(const []);
-    when(() => clipManager.remainingDuration).thenReturn(
-      const Duration(seconds: 6),
-    );
+    when(
+      () => clipManager.remainingDuration,
+    ).thenReturn(const Duration(seconds: 6));
     when(() => clipManager.totalDuration).thenReturn(Duration.zero);
     when(
       () => clipManager.clearAll(
@@ -601,9 +599,7 @@ void main() {
           ).thenAnswer((_) async => true);
         },
         build: () => buildBloc()
-          ..emit(
-            const VideoRecorderBlocState(flashMode: DivineFlashMode.off),
-          ),
+          ..emit(const VideoRecorderBlocState(flashMode: DivineFlashMode.off)),
         act: (bloc) async {
           bloc.add(const VideoRecorderFlashToggled());
           await Future<void>.delayed(Duration.zero);
@@ -772,10 +768,8 @@ void main() {
             ),
           ).called(1);
           verify(
-            () => prefs.setString(
-              'camera_last_used_stabilization',
-              'cinematic',
-            ),
+            () =>
+                prefs.setString('camera_last_used_stabilization', 'cinematic'),
           ).called(1);
         },
       );
@@ -806,9 +800,7 @@ void main() {
         ),
         expect: () => const <VideoRecorderBlocState>[],
         verify: (_) {
-          verifyNever(
-            () => cameraService.setVideoStabilizationMode(any()),
-          );
+          verifyNever(() => cameraService.setVideoStabilizationMode(any()));
         },
       );
 
@@ -827,9 +819,7 @@ void main() {
         ),
         expect: () => const <VideoRecorderBlocState>[],
         verify: (_) {
-          verifyNever(
-            () => cameraService.setVideoStabilizationMode(any()),
-          );
+          verifyNever(() => cameraService.setVideoStabilizationMode(any()));
           verifyNever(
             () => prefs.setString('camera_last_used_stabilization', any()),
           );
@@ -941,12 +931,9 @@ void main() {
       blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
         'toggles showLastClipOverlay',
         build: buildBloc,
-        act: (bloc) => bloc.add(
-          const VideoRecorderShowLastClipOverlayToggled(),
-        ),
-        expect: () => const [
-          VideoRecorderBlocState(showLastClipOverlay: true),
-        ],
+        act: (bloc) =>
+            bloc.add(const VideoRecorderShowLastClipOverlayToggled()),
+        expect: () => const [VideoRecorderBlocState(showLastClipOverlay: true)],
       );
     });
 
@@ -956,9 +943,7 @@ void main() {
         setUp: () {
           when(
             () => cameraService.setZoomLevel(any()),
-          ).thenAnswer(
-            (inv) async => inv.positionalArguments.first as double,
-          );
+          ).thenAnswer((inv) async => inv.positionalArguments.first as double);
         },
         build: buildBloc,
         act: (bloc) => bloc.add(const VideoRecorderZoomLevelSet(2)),
@@ -982,9 +967,7 @@ void main() {
           // until the first set refreshes them to the live range (2.5) —
           // mirroring how the real service learns of the restriction.
           var restricted = false;
-          when(() => cameraService.setZoomLevel(any())).thenAnswer((
-            inv,
-          ) async {
+          when(() => cameraService.setZoomLevel(any())).thenAnswer((inv) async {
             final requested = inv.positionalArguments.first as double;
             if (requested <= 2.5) return requested;
             restricted = true;
@@ -1006,44 +989,39 @@ void main() {
         ],
       );
 
-      test(
-        'heals a stale shrunk ceiling on pinch-out even when the clamp '
-        'pins the zoom to the current level',
-        () async {
-          // The live max was restricted to 2.5 and the user is pinned there.
-          // The restriction has since lifted (live max back to 5.0) but the
-          // service still advertises the stale 2.5 until the next set's
-          // read-back refreshes it. A pinch-out clamps back to 2.5 (== the
-          // current zoom), so the applied zoom doesn't move — the dispatch
-          // must still fire so the ceiling heals on this gesture rather than
-          // staying capped until the user first pinches back in.
-          var healed = false;
-          when(() => cameraService.setZoomLevel(any())).thenAnswer((inv) async {
-            healed = true;
-            return inv.positionalArguments.first as double;
-          });
-          when(
-            () => cameraService.maxZoomLevel,
-          ).thenAnswer((_) => healed ? 5.0 : 2.5);
+      test('heals a stale shrunk ceiling on pinch-out even when the clamp '
+          'pins the zoom to the current level', () async {
+        // The live max was restricted to 2.5 and the user is pinned there.
+        // The restriction has since lifted (live max back to 5.0) but the
+        // service still advertises the stale 2.5 until the next set's
+        // read-back refreshes it. A pinch-out clamps back to 2.5 (== the
+        // current zoom), so the applied zoom doesn't move — the dispatch
+        // must still fire so the ceiling heals on this gesture rather than
+        // staying capped until the user first pinches back in.
+        var healed = false;
+        when(() => cameraService.setZoomLevel(any())).thenAnswer((inv) async {
+          healed = true;
+          return inv.positionalArguments.first as double;
+        });
+        when(
+          () => cameraService.maxZoomLevel,
+        ).thenAnswer((_) => healed ? 5.0 : 2.5);
 
-          final bloc = buildBloc()
-            ..emit(
-              const VideoRecorderBlocState(zoomLevel: 2.5, maxZoomLevel: 2.5),
-            );
-          addTearDown(bloc.close);
-
-          bloc.add(
-            VideoRecorderScaleStarted(ScaleStartDetails(pointerCount: 2)),
+        final bloc = buildBloc()
+          ..emit(
+            const VideoRecorderBlocState(zoomLevel: 2.5, maxZoomLevel: 2.5),
           );
-          await pumpEventQueue();
-          // 2.5 × 1.6 = 4.0 > stale max 2.5, so clampedZoom pins back to 2.5.
-          bloc.add(VideoRecorderScaleUpdated(ScaleUpdateDetails(scale: 1.6)));
-          await pumpEventQueue();
+        addTearDown(bloc.close);
 
-          verify(() => cameraService.setZoomLevel(2.5)).called(1);
-          expect(bloc.state.maxZoomLevel, 5.0);
-        },
-      );
+        bloc.add(VideoRecorderScaleStarted(ScaleStartDetails(pointerCount: 2)));
+        await pumpEventQueue();
+        // 2.5 × 1.6 = 4.0 > stale max 2.5, so clampedZoom pins back to 2.5.
+        bloc.add(VideoRecorderScaleUpdated(ScaleUpdateDetails(scale: 1.6)));
+        await pumpEventQueue();
+
+        verify(() => cameraService.setZoomLevel(2.5)).called(1);
+        expect(bloc.state.maxZoomLevel, 5.0);
+      });
 
       blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
         'no-op when zoom value out of bounds',
@@ -1100,9 +1078,7 @@ void main() {
           ).thenAnswer((_) async => true);
         },
         build: buildBloc,
-        act: (bloc) => bloc.add(
-          const VideoRecorderRecordingToggleRequested(),
-        ),
+        act: (bloc) => bloc.add(const VideoRecorderRecordingToggleRequested()),
         // start emits: isStartingRecording=true → recording → isStartingRecording=false
         verify: (bloc) {
           expect(bloc.state.isStartingRecording, isFalse);
@@ -1115,9 +1091,7 @@ void main() {
           when(() => cameraService.isSwitchingCamera).thenReturn(true);
         },
         build: buildBloc,
-        act: (bloc) => bloc.add(
-          const VideoRecorderRecordingToggleRequested(),
-        ),
+        act: (bloc) => bloc.add(const VideoRecorderRecordingToggleRequested()),
         expect: () => const <VideoRecorderBlocState>[],
         verify: (_) {
           verifyNever(
@@ -1204,143 +1178,137 @@ void main() {
       );
     });
 
-    group(
-      'RecordingStartRequested → flags-in-state migration',
-      () {
-        blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
-          'sets isStartingRecording true before the camera call and false '
-          'after, with recordingState transitioning to recording',
-          setUp: () {
-            when(
-              () => cameraService.startRecording(
-                maxDuration: any(named: 'maxDuration'),
-              ),
-            ).thenAnswer((_) async => true);
-          },
-          build: buildBloc,
-          act: (bloc) => bloc.add(const VideoRecorderRecordingStartRequested()),
-          // Expected sequence:
-          //   1. isStartingRecording=true, baseZoomLevel=1.0
-          //   2. recordingState=recording (no countdown path)
-          //   3. isStartingRecording=false (success)
-          verify: (bloc) {
-            expect(bloc.state.recordingState, VideoRecorderState.recording);
-            expect(bloc.state.isStartingRecording, isFalse);
-          },
-        );
-
-        blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
-          'on camera-rejected start, recordingState returns to idle and '
-          'isStartingRecording resets to false',
-          setUp: () {
-            when(
-              () => cameraService.startRecording(
-                maxDuration: any(named: 'maxDuration'),
-              ),
-            ).thenAnswer((_) async => false);
-          },
-          build: buildBloc,
-          act: (bloc) => bloc.add(const VideoRecorderRecordingStartRequested()),
-          verify: (bloc) {
-            expect(bloc.state.recordingState, VideoRecorderState.idle);
-            expect(bloc.state.isStartingRecording, isFalse);
-          },
-        );
-
-        blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
-          'guards against re-entry when isStartingRecording is already true',
-          build: () => buildBloc()
-            ..emit(
-              const VideoRecorderBlocState(isStartingRecording: true),
+    group('RecordingStartRequested → flags-in-state migration', () {
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'sets isStartingRecording true before the camera call and false '
+        'after, with recordingState transitioning to recording',
+        setUp: () {
+          when(
+            () => cameraService.startRecording(
+              maxDuration: any(named: 'maxDuration'),
             ),
-          act: (bloc) => bloc.add(const VideoRecorderRecordingStartRequested()),
-          expect: () => const <VideoRecorderBlocState>[],
-          verify: (_) {
-            verifyNever(
-              () => cameraService.startRecording(
-                maxDuration: any(named: 'maxDuration'),
-              ),
-            );
-          },
-        );
+          ).thenAnswer((_) async => true);
+        },
+        build: buildBloc,
+        act: (bloc) => bloc.add(const VideoRecorderRecordingStartRequested()),
+        // Expected sequence:
+        //   1. isStartingRecording=true, baseZoomLevel=1.0
+        //   2. recordingState=recording (no countdown path)
+        //   3. isStartingRecording=false (success)
+        verify: (bloc) {
+          expect(bloc.state.recordingState, VideoRecorderState.recording);
+          expect(bloc.state.isStartingRecording, isFalse);
+        },
+      );
 
-        blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
-          'guards against start when isStoppingRecording is true',
-          build: () => buildBloc()
-            ..emit(
-              const VideoRecorderBlocState(isStoppingRecording: true),
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'on camera-rejected start, recordingState returns to idle and '
+        'isStartingRecording resets to false',
+        setUp: () {
+          when(
+            () => cameraService.startRecording(
+              maxDuration: any(named: 'maxDuration'),
             ),
-          act: (bloc) => bloc.add(const VideoRecorderRecordingStartRequested()),
-          expect: () => const <VideoRecorderBlocState>[],
-        );
+          ).thenAnswer((_) async => false);
+        },
+        build: buildBloc,
+        act: (bloc) => bloc.add(const VideoRecorderRecordingStartRequested()),
+        verify: (bloc) {
+          expect(bloc.state.recordingState, VideoRecorderState.idle);
+          expect(bloc.state.isStartingRecording, isFalse);
+        },
+      );
 
-        blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
-          'starts classic recording immediately when capture timer was set',
-          setUp: () {
-            when(
-              () => cameraService.startRecording(
-                maxDuration: any(named: 'maxDuration'),
-              ),
-            ).thenAnswer((_) async => true);
-          },
-          build: () => buildBloc()
-            ..emit(
-              const VideoRecorderBlocState(
-                recorderMode: VideoRecorderMode.classic,
-                aspectRatio: model.AspectRatio.square,
-                showGridLines: true,
-                timerDuration: TimerDuration.three,
-              ),
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'guards against re-entry when isStartingRecording is already true',
+        build: () =>
+            buildBloc()
+              ..emit(const VideoRecorderBlocState(isStartingRecording: true)),
+        act: (bloc) => bloc.add(const VideoRecorderRecordingStartRequested()),
+        expect: () => const <VideoRecorderBlocState>[],
+        verify: (_) {
+          verifyNever(
+            () => cameraService.startRecording(
+              maxDuration: any(named: 'maxDuration'),
             ),
-          act: (bloc) => bloc.add(const VideoRecorderRecordingStartRequested()),
-          expect: () => const [
-            VideoRecorderBlocState(
+          );
+        },
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'guards against start when isStoppingRecording is true',
+        build: () =>
+            buildBloc()
+              ..emit(const VideoRecorderBlocState(isStoppingRecording: true)),
+        act: (bloc) => bloc.add(const VideoRecorderRecordingStartRequested()),
+        expect: () => const <VideoRecorderBlocState>[],
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'starts classic recording immediately when capture timer was set',
+        setUp: () {
+          when(
+            () => cameraService.startRecording(
+              maxDuration: any(named: 'maxDuration'),
+            ),
+          ).thenAnswer((_) async => true);
+        },
+        build: () => buildBloc()
+          ..emit(
+            const VideoRecorderBlocState(
               recorderMode: VideoRecorderMode.classic,
               aspectRatio: model.AspectRatio.square,
               showGridLines: true,
               timerDuration: TimerDuration.three,
-              isStartingRecording: true,
             ),
-            VideoRecorderBlocState(
-              recorderMode: VideoRecorderMode.classic,
-              recordingState: VideoRecorderState.recording,
-              aspectRatio: model.AspectRatio.square,
-              showGridLines: true,
-              timerDuration: TimerDuration.three,
-              isStartingRecording: true,
+          ),
+        act: (bloc) => bloc.add(const VideoRecorderRecordingStartRequested()),
+        expect: () => const [
+          VideoRecorderBlocState(
+            recorderMode: VideoRecorderMode.classic,
+            aspectRatio: model.AspectRatio.square,
+            showGridLines: true,
+            timerDuration: TimerDuration.three,
+            isStartingRecording: true,
+          ),
+          VideoRecorderBlocState(
+            recorderMode: VideoRecorderMode.classic,
+            recordingState: VideoRecorderState.recording,
+            aspectRatio: model.AspectRatio.square,
+            showGridLines: true,
+            timerDuration: TimerDuration.three,
+            isStartingRecording: true,
+          ),
+          VideoRecorderBlocState(
+            recorderMode: VideoRecorderMode.classic,
+            recordingState: VideoRecorderState.recording,
+            aspectRatio: model.AspectRatio.square,
+            showGridLines: true,
+            timerDuration: TimerDuration.three,
+          ),
+        ],
+        verify: (_) {
+          verifyNever(
+            () => cameraService.setVolumeKeysEnabled(
+              enabled: any(named: 'enabled'),
             ),
-            VideoRecorderBlocState(
-              recorderMode: VideoRecorderMode.classic,
-              recordingState: VideoRecorderState.recording,
-              aspectRatio: model.AspectRatio.square,
-              showGridLines: true,
-              timerDuration: TimerDuration.three,
+          );
+          verify(
+            () => cameraService.startRecording(
+              maxDuration: const Duration(seconds: 6),
             ),
-          ],
-          verify: (_) {
-            verifyNever(
-              () => cameraService.setVolumeKeysEnabled(
-                enabled: any(named: 'enabled'),
-              ),
-            );
-            verify(
-              () => cameraService.startRecording(
-                maxDuration: const Duration(seconds: 6),
-              ),
-            ).called(1);
-          },
-        );
-      },
-    );
+          ).called(1);
+        },
+      );
+    });
 
     group('RecordingStopRequested → start-cancel fast path', () {
       blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
         'when called during startRecording, sets pendingStopAfterStart '
         'without touching the camera service',
-        build: () => buildBloc()
-          ..emit(
-            const VideoRecorderBlocState(isStartingRecording: true),
-          ),
+        build: () =>
+            buildBloc()
+              ..emit(const VideoRecorderBlocState(isStartingRecording: true)),
         act: (bloc) => bloc.add(const VideoRecorderRecordingStopRequested()),
         expect: () => const [
           VideoRecorderBlocState(
@@ -1357,10 +1325,9 @@ void main() {
 
       blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
         'when isStoppingRecording is already true, is fully ignored',
-        build: () => buildBloc()
-          ..emit(
-            const VideoRecorderBlocState(isStoppingRecording: true),
-          ),
+        build: () =>
+            buildBloc()
+              ..emit(const VideoRecorderBlocState(isStoppingRecording: true)),
         act: (bloc) => bloc.add(const VideoRecorderRecordingStopRequested()),
         expect: () => const <VideoRecorderBlocState>[],
         verify: (_) {
@@ -1535,14 +1502,12 @@ void main() {
             () => cameraService.startRecording(
               maxDuration: any(named: 'maxDuration'),
             ),
-          ).thenAnswer(
-            (_) async {
-              // Simulate a slow native start so the second event would
-              // otherwise overlap if the transformer were concurrent.
-              await Future<void>.delayed(const Duration(milliseconds: 50));
-              return true;
-            },
-          );
+          ).thenAnswer((_) async {
+            // Simulate a slow native start so the second event would
+            // otherwise overlap if the transformer were concurrent.
+            await Future<void>.delayed(const Duration(milliseconds: 50));
+            return true;
+          });
         },
         build: buildBloc,
         act: (bloc) async {
@@ -1652,9 +1617,7 @@ void main() {
           when(() => editor.getMetadata(any())).thenAnswer(
             (_) async => VideoMetadata.fromMap(const {'duration': 2000}, 'mp4'),
           );
-          when(
-            () => editor.getThumbnails(any()),
-          ).thenAnswer(
+          when(() => editor.getThumbnails(any())).thenAnswer(
             (_) async => [
               Uint8List.fromList(const [1, 2, 3]),
             ],
@@ -2193,9 +2156,7 @@ void main() {
         'failed camera return must not leave the recorder permanently locked',
         setUp: () {
           when(() => cameraService.isInitialized).thenReturn(false);
-          when(
-            () => cameraService.initializationError,
-          ).thenReturn('boom');
+          when(() => cameraService.initializationError).thenReturn('boom');
         },
         build: () => buildBloc()
           ..emit(
@@ -2331,9 +2292,7 @@ void main() {
         build: buildBloc,
         act: (bloc) => bloc.add(const VideoRecorderInitializeRequested()),
         verify: (_) {
-          verifyNever(
-            () => cameraService.setVideoStabilizationMode(any()),
-          );
+          verifyNever(() => cameraService.setVideoStabilizationMode(any()));
         },
       );
 
@@ -2343,9 +2302,7 @@ void main() {
         build: buildBloc,
         act: (bloc) => bloc.add(const VideoRecorderInitializeRequested()),
         verify: (_) {
-          verifyNever(
-            () => cameraService.setVideoStabilizationMode(any()),
-          );
+          verifyNever(() => cameraService.setVideoStabilizationMode(any()));
         },
       );
 
@@ -2359,9 +2316,7 @@ void main() {
         build: buildBloc,
         act: (bloc) => bloc.add(const VideoRecorderInitializeRequested()),
         verify: (_) {
-          verifyNever(
-            () => cameraService.setVideoStabilizationMode(any()),
-          );
+          verifyNever(() => cameraService.setVideoStabilizationMode(any()));
         },
       );
 
@@ -2452,9 +2407,9 @@ void main() {
           File(path).writeAsBytesSync(const [0]);
         }
 
-        when(() => cameraService.capturePhoto()).thenAnswer(
-          (_) async => PhotoCaptureResult(filePath: framePath),
-        );
+        when(
+          () => cameraService.capturePhoto(),
+        ).thenAnswer((_) async => PhotoCaptureResult(filePath: framePath));
         // Capture and undo eagerly mirror the session into the library.
         when(
           () => clipManager.saveStopMotionSessionToLibrary(
@@ -2489,10 +2444,8 @@ void main() {
           stopMotionFrames: [frameAPath, frameBPath],
         ),
         act: (bloc) => bloc.add(const VideoRecorderCameraSwitched()),
-        verify: (bloc) => expect(
-          bloc.state.stopMotionFrames,
-          [frameAPath, frameBPath],
-        ),
+        verify: (bloc) =>
+            expect(bloc.state.stopMotionFrames, [frameAPath, frameBPath]),
       );
 
       blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
@@ -2801,56 +2754,47 @@ void main() {
             final deleteGate = Completer<File>();
             when(unreadableFile.existsSync).thenReturn(true);
             when(unreadableFile.lengthSync).thenReturn(0);
-            when(unreadableFile.delete).thenAnswer(
-              (_) => deleteGate.future,
-            );
+            when(unreadableFile.delete).thenAnswer((_) => deleteGate.future);
             when(() => cameraService.capturePhoto()).thenAnswer(
               (_) async => const PhotoCaptureResult(filePath: unreadablePath),
             );
 
-            IOOverrides.runZoned(
-              () {
-                final bloc = buildBloc();
-                bloc.emit(
-                  const VideoRecorderBlocState(
-                    recorderMode: VideoRecorderMode.stopMotion,
-                  ),
-                );
+            IOOverrides.runZoned(() {
+              final bloc = buildBloc();
+              bloc.emit(
+                const VideoRecorderBlocState(
+                  recorderMode: VideoRecorderMode.stopMotion,
+                ),
+              );
 
-                bloc.add(
-                  const VideoRecorderStopMotionFrameCaptured(),
-                );
-                async.flushMicrotasks();
-                verify(() => cameraService.capturePhoto()).called(1);
+              bloc.add(const VideoRecorderStopMotionFrameCaptured());
+              async.flushMicrotasks();
+              verify(() => cameraService.capturePhoto()).called(1);
 
-                // The droppable handler must still own the invalid capture
-                // until its file is deleted, so a second shutter event cannot
-                // start another native capture in the cleanup window.
-                bloc.add(
-                  const VideoRecorderStopMotionFrameCaptured(),
-                );
-                async.flushMicrotasks();
-                verifyNever(() => cameraService.capturePhoto());
+              // The droppable handler must still own the invalid capture
+              // until its file is deleted, so a second shutter event cannot
+              // start another native capture in the cleanup window.
+              bloc.add(const VideoRecorderStopMotionFrameCaptured());
+              async.flushMicrotasks();
+              verifyNever(() => cameraService.capturePhoto());
 
-                deleteGate.complete(unreadableFile);
-                async.flushMicrotasks();
-                unawaited(bloc.close());
-                async.flushMicrotasks();
+              deleteGate.complete(unreadableFile);
+              async.flushMicrotasks();
+              unawaited(bloc.close());
+              async.flushMicrotasks();
 
-                verifyNever(
-                  () => clipManager.saveStopMotionSessionToLibrary(
-                    id: any(named: 'id'),
-                    frames: any(named: 'frames'),
-                    originalAspectRatio: any(named: 'originalAspectRatio'),
-                    targetAspectRatio: any(named: 'targetAspectRatio'),
-                    duration: any(named: 'duration'),
-                    thumbnailPath: any(named: 'thumbnailPath'),
-                    lensMetadata: any(named: 'lensMetadata'),
-                  ),
-                );
-              },
-              createFile: (_) => unreadableFile,
-            );
+              verifyNever(
+                () => clipManager.saveStopMotionSessionToLibrary(
+                  id: any(named: 'id'),
+                  frames: any(named: 'frames'),
+                  originalAspectRatio: any(named: 'originalAspectRatio'),
+                  targetAspectRatio: any(named: 'targetAspectRatio'),
+                  duration: any(named: 'duration'),
+                  thumbnailPath: any(named: 'thumbnailPath'),
+                  lensMetadata: any(named: 'lensMetadata'),
+                ),
+              );
+            }, createFile: (_) => unreadableFile);
           });
         },
       );
@@ -2911,6 +2855,58 @@ void main() {
           );
         },
       );
+
+      test('undo removal waits for the in-flight eager save', () async {
+        final calls = <String>[];
+        when(
+          () => clipManager.saveStopMotionSessionToLibrary(
+            id: any(named: 'id'),
+            frames: any(named: 'frames'),
+            originalAspectRatio: any(named: 'originalAspectRatio'),
+            targetAspectRatio: any(named: 'targetAspectRatio'),
+            duration: any(named: 'duration'),
+            thumbnailPath: any(named: 'thumbnailPath'),
+            lensMetadata: any(named: 'lensMetadata'),
+          ),
+        ).thenAnswer((_) async {
+          calls.add('save-start');
+          await Future<void>.delayed(const Duration(milliseconds: 20));
+          calls.add('save-end');
+          return true;
+        });
+        when(
+          () => clipManager.removeStopMotionSessionFromLibrary(any()),
+        ).thenAnswer((_) async {
+          calls.add('remove');
+        });
+
+        final bloc = buildBloc();
+        final stopMotionMode = bloc.stream.firstWhere(
+          (state) => state.recorderMode == VideoRecorderMode.stopMotion,
+        );
+        bloc.add(
+          const VideoRecorderRecorderModeSet(VideoRecorderMode.stopMotion),
+        );
+        await stopMotionMode;
+
+        final captured = bloc.stream.firstWhere(
+          (state) => state.stopMotionFrames.isNotEmpty,
+        );
+        bloc.add(const VideoRecorderStopMotionFrameCaptured());
+        await captured;
+        await Future<void>.delayed(Duration.zero);
+        expect(calls, ['save-start']);
+
+        bloc.add(const VideoRecorderStopMotionFrameUndone());
+        await Future<void>.delayed(Duration.zero);
+
+        expect(calls, ['save-start']);
+
+        await Future<void>.delayed(const Duration(milliseconds: 40));
+        await bloc.close();
+
+        expect(calls, ['save-start', 'save-end', 'remove']);
+      });
 
       blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
         'switching modes discards the session and drops its library row',

--- a/mobile/test/models/divine_video_clip_stop_motion_test.dart
+++ b/mobile/test/models/divine_video_clip_stop_motion_test.dart
@@ -1,0 +1,117 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart' as model show AspectRatio;
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
+
+void main() {
+  group(StopMotionClipFrame, () {
+    test('JSON round-trips the basename and duration exactly', () {
+      // 2 frames @ 24fps — not a whole number of milliseconds; a millisecond
+      // round-trip would shift the hold off the output frame grid.
+      const frame = StopMotionClipFrame(
+        path: '/some/dir/frame_1.jpg',
+        duration: Duration(microseconds: 83333),
+      );
+
+      final json = frame.toJson();
+      expect(json['path'], 'frame_1.jpg');
+      expect(json['durationUs'], 83333);
+
+      final restored = StopMotionClipFrame.fromJson(json, '/docs');
+      expect(restored.path, '/docs/frame_1.jpg');
+      expect(restored.duration, const Duration(microseconds: 83333));
+    });
+
+    test('falls back to legacy durationMs when durationUs is absent', () {
+      final restored = StopMotionClipFrame.fromJson(
+        const {'path': 'frame_1.jpg', 'durationMs': 83},
+        '/docs',
+      );
+      expect(restored.duration, const Duration(milliseconds: 83));
+    });
+
+    test('uses value equality', () {
+      const a = StopMotionClipFrame(
+        path: '/a.jpg',
+        duration: Duration(milliseconds: 83),
+      );
+      const b = StopMotionClipFrame(
+        path: '/a.jpg',
+        duration: Duration(milliseconds: 83),
+      );
+      const c = StopMotionClipFrame(
+        path: '/b.jpg',
+        duration: Duration(milliseconds: 83),
+      );
+
+      expect(a, b);
+      expect(a, isNot(c));
+    });
+  });
+
+  group('$DivineVideoClip stop-motion', () {
+    DivineVideoClip framesClip() => DivineVideoClip(
+      id: 'sm1',
+      stopMotionFrames: const [
+        StopMotionClipFrame(
+          path: '/d/a.jpg',
+          duration: Duration(milliseconds: 83),
+        ),
+        StopMotionClipFrame(
+          path: '/d/b.jpg',
+          duration: Duration(milliseconds: 83),
+        ),
+      ],
+      duration: const Duration(milliseconds: 166),
+      recordedAt: DateTime(2024),
+      thumbnailPath: '/d/a.jpg',
+      targetAspectRatio: model.AspectRatio.vertical,
+      originalAspectRatio: 9 / 16,
+    );
+
+    test('isStopMotion is true and video is null', () {
+      final clip = framesClip();
+      expect(clip.isStopMotion, isTrue);
+      expect(clip.video, isNull);
+    });
+
+    test('requireVideo throws for a frames clip', () {
+      expect(() => framesClip().requireVideo, throwsStateError);
+    });
+
+    test('JSON round-trips frames with a null filePath', () {
+      final json = framesClip().toJson();
+
+      expect(json['filePath'], isNull);
+      expect(json['stopMotionFrames'], hasLength(2));
+
+      final restored = DivineVideoClip.fromJson(json, '/docs');
+      expect(restored.isStopMotion, isTrue);
+      expect(restored.video, isNull);
+      expect(restored.stopMotionFrames!.map((f) => f.path), [
+        '/docs/a.jpg',
+        '/docs/b.jpg',
+      ]);
+      expect(
+        restored.stopMotionFrames!.map((f) => f.duration),
+        everyElement(const Duration(milliseconds: 83)),
+      );
+    });
+
+    test('a video clip is not stop-motion and exposes requireVideo', () {
+      final clip = DivineVideoClip(
+        id: 'v1',
+        video: EditorVideo.file('/v.mp4'),
+        duration: const Duration(seconds: 1),
+        recordedAt: DateTime(2024),
+        targetAspectRatio: model.AspectRatio.vertical,
+        originalAspectRatio: 9 / 16,
+      );
+
+      expect(clip.isStopMotion, isFalse);
+      expect(clip.stopMotionFrames, isNull);
+      expect(clip.requireVideo.file?.path, '/v.mp4');
+    });
+  });
+}

--- a/mobile/test/models/divine_video_clip_stop_motion_test.dart
+++ b/mobile/test/models/divine_video_clip_stop_motion_test.dart
@@ -99,6 +99,36 @@ void main() {
       );
     });
 
+    test('fromJson derives clip duration from the microsecond frame holds', () {
+      final clip = DivineVideoClip(
+        id: 'sm-us',
+        stopMotionFrames: const [
+          StopMotionClipFrame(
+            path: '/d/a.jpg',
+            duration: Duration(microseconds: 83333),
+          ),
+          StopMotionClipFrame(
+            path: '/d/b.jpg',
+            duration: Duration(microseconds: 83333),
+          ),
+        ],
+        duration: const Duration(microseconds: 166666),
+        recordedAt: DateTime(2024),
+        targetAspectRatio: model.AspectRatio.vertical,
+        originalAspectRatio: 9 / 16,
+      );
+
+      final json = clip.toJson();
+      // The aggregate is persisted ms-truncated; the frames keep microseconds.
+      expect(json['durationMs'], 166);
+
+      final restored = DivineVideoClip.fromJson(json, '/docs');
+      // Duration is recomputed from the frames' µs holds, not the truncated ms
+      // value, so it stays on the frame grid after a reload.
+      expect(restored.duration, const Duration(microseconds: 166666));
+      expect(restored.duration, isNot(const Duration(milliseconds: 166)));
+    });
+
     test('a video clip is not stop-motion and exposes requireVideo', () {
       final clip = DivineVideoClip(
         id: 'v1',

--- a/mobile/test/models/divine_video_clip_test.dart
+++ b/mobile/test/models/divine_video_clip_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart' as model;
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:pro_video_editor/pro_video_editor.dart' as editor;
 
 void main() {
@@ -13,6 +14,21 @@ void main() {
     recordedAt: DateTime(2024),
     targetAspectRatio: model.AspectRatio.square,
     originalAspectRatio: 1,
+  );
+
+  DivineVideoClip stopMotionClip(List<String> framePaths) => DivineVideoClip(
+    id: 'sm1',
+    stopMotionFrames: [
+      for (final path in framePaths)
+        StopMotionClipFrame(
+          path: path,
+          duration: const Duration(milliseconds: 83),
+        ),
+    ],
+    duration: Duration(milliseconds: 83 * framePaths.length),
+    recordedAt: DateTime(2024),
+    targetAspectRatio: model.AspectRatio.vertical,
+    originalAspectRatio: 9 / 16,
   );
 
   group('DivineVideoClip.hasResolvableVideoFile', () {
@@ -36,6 +52,25 @@ void main() {
     test('is false when the source video file is missing', () {
       expect(
         clip('${tempDir.path}/deleted.mp4').hasResolvableVideoFile,
+        isFalse,
+      );
+    });
+
+    test('is true for a stop-motion clip whose stills all exist', () async {
+      final a = '${tempDir.path}/f0.jpg';
+      final b = '${tempDir.path}/f1.jpg';
+      await File(a).writeAsBytes(const [0]);
+      await File(b).writeAsBytes(const [0]);
+
+      expect(stopMotionClip([a, b]).hasResolvableVideoFile, isTrue);
+    });
+
+    test('is false for a stop-motion clip with a missing still', () async {
+      final a = '${tempDir.path}/f0.jpg';
+      await File(a).writeAsBytes(const [0]);
+
+      expect(
+        stopMotionClip([a, '${tempDir.path}/gone.jpg']).hasResolvableVideoFile,
         isFalse,
       );
     });

--- a/mobile/test/models/divine_video_clip_test.dart
+++ b/mobile/test/models/divine_video_clip_test.dart
@@ -74,6 +74,61 @@ void main() {
         isFalse,
       );
     });
+
+    test(
+      'resolves a materialized clip against its mp4, not its cleaned stills',
+      () async {
+        final path = '${tempDir.path}/rendered.mp4';
+        await File(path).writeAsBytes(const [0]);
+
+        // A materialized clip carries a rendered mp4 and may still carry its
+        // now-deleted stills. It must resolve against the mp4 that exists, not
+        // be dropped as orphaned for the missing stills.
+        final materialized = stopMotionClip([
+          '${tempDir.path}/gone.jpg',
+        ]).copyWith(video: editor.EditorVideo.file(File(path)));
+
+        expect(materialized.hasResolvableVideoFile, isTrue);
+      },
+    );
+  });
+
+  group('DivineVideoClip.isStopMotion (video-first)', () {
+    test('is true for a frames-only clip', () {
+      expect(stopMotionClip(['/a.jpg']).isStopMotion, isTrue);
+    });
+
+    test('is false once a video is present, even if stills remain', () {
+      final materialized = stopMotionClip([
+        '/a.jpg',
+      ]).copyWith(video: editor.EditorVideo.file(File('/rendered.mp4')));
+
+      expect(materialized.isStopMotion, isFalse);
+    });
+
+    test('is false for a normal video clip', () {
+      expect(clip('/v.mp4').isStopMotion, isFalse);
+    });
+  });
+
+  group('DivineVideoClip.copyWith clearStopMotionFrames', () {
+    test('drops the stills so the result is a plain video clip', () {
+      final materialized = stopMotionClip(['/a.jpg', '/b.jpg']).copyWith(
+        video: editor.EditorVideo.file(File('/rendered.mp4')),
+        clearStopMotionFrames: true,
+      );
+
+      expect(materialized.stopMotionFrames, isNull);
+      expect(materialized.isStopMotion, isFalse);
+    });
+
+    test('keeps the stills when the flag is not set', () {
+      final copy = stopMotionClip(['/a.jpg']).copyWith(
+        video: editor.EditorVideo.file(File('/rendered.mp4')),
+      );
+
+      expect(copy.stopMotionFrames, hasLength(1));
+    });
   });
 
   group('DivineVideoClip.sourceStartOffset', () {

--- a/mobile/test/models/proofmode_flow_test.dart
+++ b/mobile/test/models/proofmode_flow_test.dart
@@ -73,7 +73,7 @@ void main() {
 
       // Step 4: Convert draft to PendingUpload (as done in UploadManager:startUpload)
       final upload = PendingUpload.create(
-        localVideoPath: draft.clips.first.video.file!.path,
+        localVideoPath: draft.clips.first.requireVideo.file!.path,
         nostrPubkey: 'pubkey123',
         title: draft.title,
         description: draft.description,
@@ -146,7 +146,7 @@ void main() {
 
       // Upload should also not have ProofMode
       final upload = PendingUpload.create(
-        localVideoPath: draft.clips.first.video.file!.path,
+        localVideoPath: draft.clips.first.requireVideo.file!.path,
         nostrPubkey: 'pubkey123',
       );
 

--- a/mobile/test/models/recording_clip_test.dart
+++ b/mobile/test/models/recording_clip_test.dart
@@ -20,7 +20,10 @@ void main() {
       );
 
       expect(clip.id, equals('clip_001'));
-      expect(await clip.video.safeFilePath(), equals('/path/to/video.mp4'));
+      expect(
+        await clip.requireVideo.safeFilePath(),
+        equals('/path/to/video.mp4'),
+      );
       expect(clip.duration.inSeconds, equals(2));
       expect(clip.thumbnailPath, isNull);
       expect(clip.targetAspectRatio, equals(model.AspectRatio.vertical));
@@ -288,7 +291,10 @@ void main() {
 
       expect(updated.duration, equals(const Duration(seconds: 3)));
       expect(updated.id, equals(clip.id));
-      expect(await updated.video.safeFilePath(), equals('/path/to/video.mp4'));
+      expect(
+        await updated.requireVideo.safeFilePath(),
+        equals('/path/to/video.mp4'),
+      );
     });
 
     test('copyWith creates new instance with updated thumbnailPath', () {
@@ -381,7 +387,7 @@ void main() {
 
       expect(clip.id, equals('clip_001'));
       // Path resolution uses platform separator, so check it ends with the filename
-      final filePath = await clip.video.safeFilePath();
+      final filePath = await clip.requireVideo.safeFilePath();
       expect(filePath, endsWith('video.mp4'));
       expect(filePath, contains('path'));
       expect(clip.duration, equals(const Duration(milliseconds: 2500)));
@@ -421,8 +427,8 @@ void main() {
 
       expect(restored.id, equals(clip.id));
       // Both should end with same filename
-      final originalPath = await clip.video.safeFilePath();
-      final restoredPath = await restored.video.safeFilePath();
+      final originalPath = await clip.requireVideo.safeFilePath();
+      final restoredPath = await restored.requireVideo.safeFilePath();
       expect(restoredPath, endsWith('video.mp4'));
       expect(originalPath, endsWith('video.mp4'));
       expect(restored.duration, equals(clip.duration));
@@ -764,8 +770,8 @@ void main() {
         final json = clip.toJson();
         final restored = DivineVideoClip.fromJson(json, documentsPath);
 
-        final originalPath = await clip.video.safeFilePath();
-        final restoredPath = await restored.video.safeFilePath();
+        final originalPath = await clip.requireVideo.safeFilePath();
+        final restoredPath = await restored.requireVideo.safeFilePath();
         expect(restoredPath, equals(originalPath));
         expect(restored.thumbnailPath, equals(clip.thumbnailPath));
       });
@@ -790,8 +796,8 @@ void main() {
         // fromJson resolves against documentsPath, not tempPath
         final restored = DivineVideoClip.fromJson(json, documentsPath);
 
-        final originalPath = await clip.video.safeFilePath();
-        final restoredPath = await restored.video.safeFilePath();
+        final originalPath = await clip.requireVideo.safeFilePath();
+        final restoredPath = await restored.requireVideo.safeFilePath();
         // The paths will differ because the file was in /tmp
         // but fromJson resolves to /var/mobile/Documents
         expect(restoredPath, isNot(equals(originalPath)));

--- a/mobile/test/models/stop_motion/stop_motion_frame_ops_test.dart
+++ b/mobile/test/models/stop_motion/stop_motion_frame_ops_test.dart
@@ -9,7 +9,7 @@ import 'package:openvine/services/video_editor/stop_motion_render_service.dart';
 import 'package:pro_video_editor/pro_video_editor.dart' show EditorVideo;
 
 void main() {
-  // At the default 12fps base, one output frame is 1/12s.
+  // At the default 24fps base, one output frame is 1/24s.
   Duration hold(int framesPerImage) => Duration(
     microseconds:
         (framesPerImage *
@@ -492,6 +492,23 @@ void main() {
         id: 'v',
         video: EditorVideo.file('/v.mp4'),
         duration: const Duration(seconds: 2),
+        recordedAt: DateTime(2024),
+        targetAspectRatio: model.AspectRatio.vertical,
+        originalAspectRatio: 9 / 16,
+      );
+
+      expect(StopMotionFrameOps.sanitizedClip(clip), same(clip));
+    });
+
+    test('sanitizedClip passes a materialized clip through even with a '
+        'missing still', () {
+      // A materialized clip has a rendered mp4; its stills are transient and
+      // may already be cleaned. It must not be dropped for a missing still.
+      final clip = DivineVideoClip(
+        id: 'sm-materialized',
+        video: EditorVideo.file('/rendered.mp4'),
+        stopMotionFrames: [frameAt('gone.jpg')],
+        duration: const Duration(seconds: 1),
         recordedAt: DateTime(2024),
         targetAspectRatio: model.AspectRatio.vertical,
         originalAspectRatio: 9 / 16,

--- a/mobile/test/models/stop_motion/stop_motion_frame_ops_test.dart
+++ b/mobile/test/models/stop_motion/stop_motion_frame_ops_test.dart
@@ -1,0 +1,619 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart' as model show AspectRatio;
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/stop_motion/stop_motion_frame_ops.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
+import 'package:openvine/services/video_editor/stop_motion_render_service.dart';
+import 'package:pro_video_editor/pro_video_editor.dart' show EditorVideo;
+
+void main() {
+  // At the default 12fps base, one output frame is 1/12s.
+  Duration hold(int framesPerImage) => Duration(
+    microseconds:
+        (framesPerImage *
+                Duration.microsecondsPerSecond /
+                StopMotionRenderService.defaultFrameRate)
+            .round(),
+  );
+
+  List<StopMotionClipFrame> framesOf(List<int> holds) => [
+    for (var i = 0; i < holds.length; i++)
+      StopMotionClipFrame(path: 'f$i.jpg', duration: hold(holds[i])),
+  ];
+
+  group('framesPerImageToDuration / durationToFramesPerImage', () {
+    test('round-trips every valid frames-per-image value', () {
+      for (var n = 1; n <= 10; n++) {
+        expect(
+          StopMotionFrameOps.durationToFramesPerImage(
+            StopMotionFrameOps.framesPerImageToDuration(n),
+          ),
+          n,
+        );
+      }
+    });
+
+    test('clamps out-of-range frames-per-image to the valid bounds', () {
+      expect(
+        StopMotionFrameOps.framesPerImageToDuration(0),
+        StopMotionFrameOps.framesPerImageToDuration(1),
+      );
+      expect(
+        StopMotionFrameOps.framesPerImageToDuration(
+          StopMotionFrameOps.maxFramesPerImage + 1,
+        ),
+        StopMotionFrameOps.framesPerImageToDuration(
+          StopMotionFrameOps.maxFramesPerImage,
+        ),
+      );
+    });
+  });
+
+  group('removeFrame', () {
+    test('removes the frame at the index', () {
+      final result = StopMotionFrameOps.removeFrame(framesOf([1, 1, 1]), 1);
+      expect(result.map((f) => f.path), ['f0.jpg', 'f2.jpg']);
+    });
+
+    test('keeps at least one frame (a clip cannot be emptied)', () {
+      final single = framesOf([1]);
+      expect(StopMotionFrameOps.removeFrame(single, 0), same(single));
+    });
+
+    test('returns the list unchanged for an out-of-range index', () {
+      final frames = framesOf([1, 1]);
+      expect(StopMotionFrameOps.removeFrame(frames, 5), same(frames));
+    });
+  });
+
+  group('reorderFrame', () {
+    test('moves a frame forward', () {
+      final result = StopMotionFrameOps.reorderFrame(framesOf([1, 1, 1]), 0, 2);
+      expect(result.map((f) => f.path), ['f1.jpg', 'f2.jpg', 'f0.jpg']);
+    });
+
+    test('returns the list unchanged when from == to', () {
+      final frames = framesOf([1, 1, 1]);
+      expect(StopMotionFrameOps.reorderFrame(frames, 1, 1), same(frames));
+    });
+  });
+
+  group('removeFrames', () {
+    test('removes every still at the given indexes', () {
+      final result = StopMotionFrameOps.removeFrames(framesOf([1, 1, 1, 1]), {
+        1,
+        3,
+      });
+      expect(result.map((f) => f.path), ['f0.jpg', 'f2.jpg']);
+    });
+
+    test('keeps at least one still (cannot empty the clip)', () {
+      final frames = framesOf([1, 1]);
+      expect(StopMotionFrameOps.removeFrames(frames, {0, 1}), same(frames));
+    });
+
+    test('returns the list unchanged for out-of-range indexes', () {
+      final frames = framesOf([1, 1]);
+      expect(StopMotionFrameOps.removeFrames(frames, {0, 5}), same(frames));
+    });
+
+    test('returns the list unchanged for an empty selection', () {
+      final frames = framesOf([1, 1]);
+      expect(StopMotionFrameOps.removeFrames(frames, const {}), same(frames));
+    });
+  });
+
+  group('reverseFrames', () {
+    test('reverses the selected stills among their own slots', () {
+      // Select 0, 2, 3 of [f0, f1, f2, f3]: the selected slots keep their
+      // positions but receive the selected stills in reverse order.
+      final result = StopMotionFrameOps.reverseFrames(
+        framesOf([
+          1,
+          1,
+          1,
+          1,
+        ]),
+        {0, 2, 3},
+      );
+      expect(result.map((f) => f.path), [
+        'f3.jpg',
+        'f1.jpg',
+        'f2.jpg',
+        'f0.jpg',
+      ]);
+    });
+
+    test('returns the list unchanged for fewer than two selected', () {
+      final frames = framesOf([1, 1]);
+      expect(StopMotionFrameOps.reverseFrames(frames, {0}), same(frames));
+    });
+
+    test('returns the list unchanged for out-of-range indexes', () {
+      final frames = framesOf([1, 1]);
+      expect(StopMotionFrameOps.reverseFrames(frames, {0, 5}), same(frames));
+    });
+  });
+
+  group('moveFrames', () {
+    test('moves the selected stills as one block to the slot', () {
+      // Select f0 + f1, insert at slot 2 of the remaining [f2, f3].
+      final result = StopMotionFrameOps.moveFrames(
+        framesOf([
+          1,
+          1,
+          1,
+          1,
+        ]),
+        {0, 1},
+        2,
+      );
+      expect(result.map((f) => f.path), [
+        'f2.jpg',
+        'f3.jpg',
+        'f0.jpg',
+        'f1.jpg',
+      ]);
+    });
+
+    test(
+      "keeps the block's relative order for a non-contiguous selection",
+      () {
+        // Select f0 + f2, insert at slot 1 of the remaining [f1, f3].
+        final result = StopMotionFrameOps.moveFrames(
+          framesOf([
+            1,
+            1,
+            1,
+            1,
+          ]),
+          {0, 2},
+          1,
+        );
+        expect(result.map((f) => f.path), [
+          'f1.jpg',
+          'f0.jpg',
+          'f2.jpg',
+          'f3.jpg',
+        ]);
+      },
+    );
+
+    test('clamps the slot to the remaining list bounds', () {
+      final result = StopMotionFrameOps.moveFrames(framesOf([1, 1, 1]), {
+        0,
+      }, 99);
+      expect(result.map((f) => f.path), ['f1.jpg', 'f2.jpg', 'f0.jpg']);
+    });
+
+    test('returns the same instance for a no-op move', () {
+      final frames = framesOf([1, 1, 1]);
+      expect(StopMotionFrameOps.moveFrames(frames, {0}, 0), same(frames));
+    });
+
+    test('returns the list unchanged for an empty or invalid selection', () {
+      final frames = framesOf([1, 1]);
+      expect(StopMotionFrameOps.moveFrames(frames, const {}, 1), same(frames));
+      expect(StopMotionFrameOps.moveFrames(frames, {5}, 1), same(frames));
+    });
+  });
+
+  group('setFramesHold', () {
+    test('sets the hold on every selected still and marks it overridden', () {
+      final result = StopMotionFrameOps.setFramesHold(
+        framesOf([1, 1, 1]),
+        {0, 2},
+        4,
+      );
+
+      expect(
+        result.map(
+          (f) => StopMotionFrameOps.durationToFramesPerImage(f.duration),
+        ),
+        [4, 1, 4],
+      );
+      expect(result.map((f) => f.holdOverridden), [true, false, true]);
+    });
+
+    test('returns the list unchanged for an empty selection', () {
+      final frames = framesOf([1, 1]);
+      expect(
+        StopMotionFrameOps.setFramesHold(frames, const {}, 4),
+        same(frames),
+      );
+    });
+  });
+
+  group('insertIndexAtPosition', () {
+    final frames = framesOf([1, 1, 1]); // three 1/24s stills
+
+    test('prepends at (or before) the start', () {
+      expect(
+        StopMotionFrameOps.insertIndexAtPosition(frames, Duration.zero),
+        0,
+      );
+      expect(
+        StopMotionFrameOps.insertIndexAtPosition(
+          frames,
+          const Duration(seconds: -1),
+        ),
+        0,
+      );
+    });
+
+    test('inserts after the still under the playhead', () {
+      // Inside frame 0 → after it.
+      expect(
+        StopMotionFrameOps.insertIndexAtPosition(frames, hold(1) ~/ 2),
+        1,
+      );
+      // Inside frame 1 → after it.
+      expect(
+        StopMotionFrameOps.insertIndexAtPosition(
+          frames,
+          hold(1) + hold(1) ~/ 2,
+        ),
+        2,
+      );
+    });
+
+    test('appends at or past the end', () {
+      expect(
+        StopMotionFrameOps.insertIndexAtPosition(frames, hold(3)),
+        3,
+      );
+      expect(
+        StopMotionFrameOps.insertIndexAtPosition(frames, hold(10)),
+        3,
+      );
+    });
+  });
+
+  group('insertFramesAt', () {
+    test('splices frames in at the index', () {
+      final result = StopMotionFrameOps.insertFramesAt(
+        framesOf([1, 1]),
+        1,
+        framesOf([2, 2]),
+      );
+      expect(result.map((f) => f.path), [
+        'f0.jpg',
+        'f0.jpg',
+        'f1.jpg',
+        'f1.jpg',
+      ]);
+    });
+
+    test('clamps an out-of-range index to the end', () {
+      final result = StopMotionFrameOps.insertFramesAt(
+        framesOf([1, 1]),
+        99,
+        framesOf([2]),
+      );
+      expect(result, hasLength(3));
+      expect(result.last.duration, hold(2));
+    });
+
+    test('returns the list unchanged for an empty insert', () {
+      final frames = framesOf([1, 1]);
+      expect(
+        StopMotionFrameOps.insertFramesAt(frames, 1, const []),
+        same(frames),
+      );
+    });
+  });
+
+  group('setFrameHold / setGlobalHold', () {
+    test('sets only the targeted frame hold and marks it overridden', () {
+      final result = StopMotionFrameOps.setFrameHold(framesOf([1, 1, 1]), 1, 4);
+      expect(
+        StopMotionFrameOps.durationToFramesPerImage(result[0].duration),
+        1,
+      );
+      expect(
+        StopMotionFrameOps.durationToFramesPerImage(result[1].duration),
+        4,
+      );
+      expect(
+        StopMotionFrameOps.durationToFramesPerImage(result[2].duration),
+        1,
+      );
+      expect(result[1].holdOverridden, isTrue);
+      expect(result[0].holdOverridden, isFalse);
+    });
+
+    test('sets every non-overridden frame hold', () {
+      final result = StopMotionFrameOps.setGlobalHold(framesOf([1, 2, 3]), 5);
+      expect(
+        result.every(
+          (f) => StopMotionFrameOps.durationToFramesPerImage(f.duration) == 5,
+        ),
+        isTrue,
+      );
+    });
+
+    test('global hold leaves individually overridden frames untouched', () {
+      // Override the middle frame to 8, then apply a global default of 2.
+      final overridden = StopMotionFrameOps.setFrameHold(
+        framesOf([1, 1, 1]),
+        1,
+        8,
+      );
+      final result = StopMotionFrameOps.setGlobalHold(overridden, 2);
+
+      expect(
+        StopMotionFrameOps.durationToFramesPerImage(result[0].duration),
+        2,
+      );
+      expect(
+        StopMotionFrameOps.durationToFramesPerImage(result[1].duration),
+        8,
+      );
+      expect(
+        StopMotionFrameOps.durationToFramesPerImage(result[2].duration),
+        2,
+      );
+      // The override flag survives a global change.
+      expect(result[1].holdOverridden, isTrue);
+    });
+  });
+
+  group('globalDefaultFramesPerImage', () {
+    test('returns the shared value of non-overridden frames', () {
+      expect(
+        StopMotionFrameOps.globalDefaultFramesPerImage(framesOf([3, 3, 3])),
+        3,
+      );
+    });
+
+    test('ignores overridden frames', () {
+      final frames = StopMotionFrameOps.setFrameHold(framesOf([2, 2, 2]), 1, 9);
+      // Frame 1 is overridden to 9; the default of the rest is still 2.
+      expect(StopMotionFrameOps.globalDefaultFramesPerImage(frames), 2);
+    });
+
+    test(
+      'falls back to the most common hold when non-overridden frames '
+      'disagree',
+      () {
+        expect(
+          StopMotionFrameOps.globalDefaultFramesPerImage(
+            framesOf([2, 2, 1, 2]),
+          ),
+          2,
+        );
+      },
+    );
+
+    test('breaks a tie by first occurrence', () {
+      expect(
+        StopMotionFrameOps.globalDefaultFramesPerImage(framesOf([3, 1, 3, 1])),
+        3,
+      );
+    });
+
+    test(
+      'falls back to the most common hold when every frame is overridden',
+      () {
+        var frames = framesOf([2, 2, 2]);
+        frames = StopMotionFrameOps.setFrameHold(frames, 0, 4);
+        frames = StopMotionFrameOps.setFrameHold(frames, 1, 4);
+        frames = StopMotionFrameOps.setFrameHold(frames, 2, 6);
+        expect(StopMotionFrameOps.globalDefaultFramesPerImage(frames), 4);
+      },
+    );
+
+    test('returns the capture default for an empty list', () {
+      expect(
+        StopMotionFrameOps.globalDefaultFramesPerImage(const []),
+        StopMotionFrameOps.defaultFramesPerImage,
+      );
+    });
+  });
+
+  group('existingFrames / sanitizedClip', () {
+    late Directory tempDir;
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('frame_ops_sanitize');
+    });
+
+    tearDown(() {
+      if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+    });
+
+    StopMotionClipFrame frameAt(String name, {List<int>? bytes}) {
+      final path = '${tempDir.path}/$name';
+      if (bytes != null) File(path).writeAsBytesSync(bytes);
+      return StopMotionClipFrame(path: path, duration: hold(1));
+    }
+
+    test('drops missing and zero-byte stills, keeps readable ones', () {
+      final readable = frameAt('ok.jpg', bytes: const [0]);
+      final empty = frameAt('empty.jpg', bytes: const []);
+      final missing = frameAt('missing.jpg');
+
+      expect(
+        StopMotionFrameOps.existingFrames([readable, empty, missing]),
+        [readable],
+      );
+    });
+
+    test('sanitizedClip returns the same clip when all stills read', () {
+      final clip = DivineVideoClip(
+        id: 'sm',
+        stopMotionFrames: [
+          frameAt('a.jpg', bytes: const [0]),
+        ],
+        duration: hold(1),
+        recordedAt: DateTime(2024),
+        targetAspectRatio: model.AspectRatio.vertical,
+        originalAspectRatio: 9 / 16,
+      );
+
+      expect(StopMotionFrameOps.sanitizedClip(clip), same(clip));
+    });
+
+    test('sanitizedClip filters broken stills and recomputes duration', () {
+      final clip = DivineVideoClip(
+        id: 'sm',
+        stopMotionFrames: [
+          frameAt('a.jpg', bytes: const [0]),
+          frameAt('gone.jpg'),
+        ],
+        duration: hold(1) * 2,
+        recordedAt: DateTime(2024),
+        targetAspectRatio: model.AspectRatio.vertical,
+        originalAspectRatio: 9 / 16,
+      );
+
+      final sanitized = StopMotionFrameOps.sanitizedClip(clip);
+      expect(sanitized!.stopMotionFrames, hasLength(1));
+      expect(sanitized.duration, hold(1));
+    });
+
+    test('sanitizedClip returns null when no readable still remains', () {
+      final clip = DivineVideoClip(
+        id: 'sm',
+        stopMotionFrames: [frameAt('gone.jpg')],
+        duration: hold(1),
+        recordedAt: DateTime(2024),
+        targetAspectRatio: model.AspectRatio.vertical,
+        originalAspectRatio: 9 / 16,
+      );
+
+      expect(StopMotionFrameOps.sanitizedClip(clip), isNull);
+    });
+
+    test('sanitizedClip passes a normal video clip through unchanged', () {
+      final clip = DivineVideoClip(
+        id: 'v',
+        video: EditorVideo.file('/v.mp4'),
+        duration: const Duration(seconds: 2),
+        recordedAt: DateTime(2024),
+        targetAspectRatio: model.AspectRatio.vertical,
+        originalAspectRatio: 9 / 16,
+      );
+
+      expect(StopMotionFrameOps.sanitizedClip(clip), same(clip));
+    });
+  });
+
+  group('mergeClips', () {
+    DivineVideoClip stopMotionClip(String id, List<int> holds) =>
+        DivineVideoClip(
+          id: id,
+          stopMotionFrames: [
+            for (var i = 0; i < holds.length; i++)
+              StopMotionClipFrame(
+                path: '$id-f$i.jpg',
+                duration: hold(holds[i]),
+              ),
+          ],
+          duration: holds.fold(Duration.zero, (sum, n) => sum + hold(n)),
+          recordedAt: DateTime(2024),
+          targetAspectRatio: model.AspectRatio.vertical,
+          originalAspectRatio: 9 / 16,
+        );
+
+    test('concatenates the sets in order onto the first clip', () {
+      final merged = StopMotionFrameOps.mergeClips([
+        stopMotionClip('a', [2, 2]),
+        stopMotionClip('b', [4]),
+      ]);
+
+      expect(merged, isNotNull);
+      expect(merged!.id, 'a');
+      expect(merged.stopMotionFrames!.map((f) => f.path), [
+        'a-f0.jpg',
+        'a-f1.jpg',
+        'b-f0.jpg',
+      ]);
+      // Per-frame holds survive the merge; duration is recomputed.
+      expect(merged.stopMotionFrames![2].duration, hold(4));
+      expect(merged.duration, hold(2) + hold(2) + hold(4));
+    });
+
+    test('returns null for fewer than two clips', () {
+      expect(
+        StopMotionFrameOps.mergeClips([
+          stopMotionClip('a', [2]),
+        ]),
+        isNull,
+      );
+      expect(StopMotionFrameOps.mergeClips(const []), isNull);
+    });
+
+    test('returns null when any clip is a normal video clip', () {
+      final videoClip = DivineVideoClip(
+        id: 'v',
+        video: EditorVideo.file('/v.mp4'),
+        duration: const Duration(seconds: 2),
+        recordedAt: DateTime(2024),
+        targetAspectRatio: model.AspectRatio.vertical,
+        originalAspectRatio: 9 / 16,
+      );
+
+      expect(
+        StopMotionFrameOps.mergeClips([
+          stopMotionClip('a', [2]),
+          videoClip,
+        ]),
+        isNull,
+      );
+    });
+  });
+
+  group('clipWithFrames', () {
+    DivineVideoClip stopMotionClip(List<int> holds) => DivineVideoClip(
+      id: 'clip',
+      stopMotionFrames: framesOf(holds),
+      duration: StopMotionFrameOps.totalDuration(framesOf(holds)),
+      recordedAt: DateTime(2024),
+      targetAspectRatio: model.AspectRatio.vertical,
+      originalAspectRatio: 1,
+    );
+
+    test('recomputes the clip duration from the new frame holds', () {
+      final clip = stopMotionClip([1, 1, 1]);
+      final newFrames = StopMotionFrameOps.removeFrame(
+        clip.stopMotionFrames!,
+        0,
+      );
+      final updated = StopMotionFrameOps.clipWithFrames(clip, newFrames);
+
+      expect(updated.stopMotionFrames, hasLength(2));
+      expect(updated.duration, StopMotionFrameOps.totalDuration(newFrames));
+      expect(updated.duration, hold(1) * 2);
+    });
+  });
+
+  group('isStopMotionComposition', () {
+    DivineVideoClip stopMotion() => DivineVideoClip(
+      id: 's',
+      stopMotionFrames: framesOf([1]),
+      duration: hold(1),
+      recordedAt: DateTime(2024),
+      targetAspectRatio: model.AspectRatio.vertical,
+      originalAspectRatio: 1,
+    );
+
+    DivineVideoClip video() => DivineVideoClip(
+      id: 'v',
+      video: EditorVideo.file('/v.mp4'),
+      duration: const Duration(seconds: 1),
+      recordedAt: DateTime(2024),
+      targetAspectRatio: model.AspectRatio.vertical,
+      originalAspectRatio: 1,
+    );
+
+    test('true only when every clip is stop-motion', () {
+      expect(isStopMotionComposition([stopMotion(), stopMotion()]), isTrue);
+      expect(isStopMotionComposition([stopMotion(), video()]), isFalse);
+      expect(isStopMotionComposition([video()]), isFalse);
+      expect(isStopMotionComposition(const []), isFalse);
+    });
+  });
+}

--- a/mobile/test/models/stop_motion/stop_motion_frame_ops_test.dart
+++ b/mobile/test/models/stop_motion/stop_motion_frame_ops_test.dart
@@ -224,6 +224,21 @@ void main() {
         same(frames),
       );
     });
+
+    test('returns the source list when no selected hold actually changes', () {
+      final frames = [
+        const StopMotionClipFrame(
+          path: 'f0.jpg',
+          duration: Duration(microseconds: 166667), // 4 frames @ 24fps
+          holdOverridden: true,
+        ),
+        StopMotionClipFrame(path: 'f1.jpg', duration: hold(1)),
+      ];
+      // Re-selecting the same hold on the already-overridden still is a no-op,
+      // so the source instance is returned and the commit's identical guard
+      // skips a redundant history entry.
+      expect(StopMotionFrameOps.setFramesHold(frames, {0}, 4), same(frames));
+    });
   });
 
   group('insertIndexAtPosition', () {
@@ -357,6 +372,18 @@ void main() {
       );
       // The override flag survives a global change.
       expect(result[1].holdOverridden, isTrue);
+    });
+
+    test('setFrameHold returns the source list when nothing changes', () {
+      // Already overridden to 4; re-applying 4 is a no-op.
+      final frames = StopMotionFrameOps.setFrameHold(framesOf([1, 1, 1]), 1, 4);
+      expect(StopMotionFrameOps.setFrameHold(frames, 1, 4), same(frames));
+    });
+
+    test('setGlobalHold returns the source list when nothing changes', () {
+      // Every still already holds 2 and none is overridden.
+      final frames = framesOf([2, 2, 2]);
+      expect(StopMotionFrameOps.setGlobalHold(frames, 2), same(frames));
     });
   });
 

--- a/mobile/test/models/stop_motion_clip_frame_test.dart
+++ b/mobile/test/models/stop_motion_clip_frame_test.dart
@@ -48,5 +48,27 @@ void main() {
         expect(restored.holdOverridden, isFalse);
       },
     );
+
+    test('throws a FormatException (not a TypeError) for a missing path', () {
+      expect(
+        () => StopMotionClipFrame.fromJson(
+          const {'durationUs': 83000},
+          '/docs',
+          useOriginalPath: true,
+        ),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('throws a FormatException when both duration keys are absent', () {
+      expect(
+        () => StopMotionClipFrame.fromJson(
+          const {'path': 'f0.jpg'},
+          '/docs',
+          useOriginalPath: true,
+        ),
+        throwsA(isA<FormatException>()),
+      );
+    });
   });
 }

--- a/mobile/test/models/stop_motion_clip_frame_test.dart
+++ b/mobile/test/models/stop_motion_clip_frame_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
+
+void main() {
+  group(StopMotionClipFrame, () {
+    const frame = StopMotionClipFrame(
+      path: '/frames/f0.jpg',
+      duration: Duration(milliseconds: 83),
+    );
+
+    test('holdOverridden defaults to false', () {
+      expect(frame.holdOverridden, isFalse);
+    });
+
+    test('copyWith updates holdOverridden', () {
+      final overridden = frame.copyWith(holdOverridden: true);
+      expect(overridden.holdOverridden, isTrue);
+      expect(overridden.path, frame.path);
+      expect(overridden.duration, frame.duration);
+    });
+
+    test('equality and hashCode include holdOverridden', () {
+      final overridden = frame.copyWith(holdOverridden: true);
+      expect(frame == overridden, isFalse);
+      expect(frame.hashCode == overridden.hashCode, isFalse);
+      expect(overridden, equals(frame.copyWith(holdOverridden: true)));
+    });
+
+    test('JSON round-trips holdOverridden', () {
+      final overridden = frame.copyWith(holdOverridden: true);
+      final restored = StopMotionClipFrame.fromJson(
+        overridden.toJson(),
+        '/docs',
+        useOriginalPath: true,
+      );
+      expect(restored.holdOverridden, isTrue);
+      expect(restored.duration, overridden.duration);
+    });
+
+    test(
+      'holdOverridden defaults to false for legacy JSON without the key',
+      () {
+        final restored = StopMotionClipFrame.fromJson(
+          const {'path': 'f0.jpg', 'durationMs': 83},
+          '/docs',
+          useOriginalPath: true,
+        );
+        expect(restored.holdOverridden, isFalse);
+      },
+    );
+  });
+}

--- a/mobile/test/models/video_recorder/video_recorder_mode_test.dart
+++ b/mobile/test/models/video_recorder/video_recorder_mode_test.dart
@@ -105,5 +105,46 @@ void main() {
         );
       });
     });
+
+    group('stopMotion', () {
+      test('has label "Stop Motion"', () {
+        expect(VideoRecorderMode.stopMotion.label, equals('Stop Motion'));
+      });
+
+      test('has no recording limit', () {
+        expect(VideoRecorderMode.stopMotion.hasRecordingLimit, isFalse);
+      });
+
+      test(
+        'has a video editor (previews frames via the stop-motion player)',
+        () {
+          expect(VideoRecorderMode.stopMotion.hasVideoEditor, isTrue);
+        },
+      );
+
+      test('supports grid lines (shot-to-shot alignment)', () {
+        expect(VideoRecorderMode.stopMotion.supportGridLines, isTrue);
+      });
+
+      test('does not support a countdown timer', () {
+        expect(VideoRecorderMode.stopMotion.supportsCountdownTimer, isFalse);
+      });
+
+      test('defaults to vertical aspect ratio', () {
+        expect(
+          VideoRecorderMode.stopMotion.defaultAspectRatio,
+          equals(model.AspectRatio.vertical),
+        );
+      });
+    });
+
+    group('capturesStills', () {
+      test('is true only for stop-motion', () {
+        expect(VideoRecorderMode.stopMotion.capturesStills, isTrue);
+        expect(VideoRecorderMode.capture.capturesStills, isFalse);
+        expect(VideoRecorderMode.classic.capturesStills, isFalse);
+        expect(VideoRecorderMode.upload.capturesStills, isFalse);
+      });
+    });
   });
 }

--- a/mobile/test/providers/clip_manager_provider_test.dart
+++ b/mobile/test/providers/clip_manager_provider_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
@@ -23,6 +24,19 @@ void main() {
     late ProviderContainer container;
     late _MockDraftStorageService mockDraftStorageService;
     late _MockClipLibraryService mockClipLibraryService;
+
+    setUpAll(() {
+      registerFallbackValue(
+        DivineVideoClip(
+          id: 'fallback',
+          video: EditorVideo.file('/fallback.mp4'),
+          duration: Duration.zero,
+          recordedAt: DateTime(2024),
+          targetAspectRatio: .vertical,
+          originalAspectRatio: 9 / 16,
+        ),
+      );
+    });
 
     setUp(() async {
       SharedPreferences.setMockInitialValues({});
@@ -845,6 +859,90 @@ void main() {
         expect(clip.thumbnailPath, equals('/path/to/thumb.jpg'));
         expect(clip.duration, equals(const Duration(seconds: 2)));
         expect(clip.ghostFramePath, equals('/path/to/ghost.jpg'));
+      });
+    });
+
+    group('stop-motion session library persistence', () {
+      const frame = StopMotionClipFrame(
+        path: '/tmp/frame_0.jpg',
+        duration: Duration(milliseconds: 83),
+      );
+
+      test('addStopMotionClip reuses a caller-supplied id', () {
+        final notifier = container.read(clipManagerProvider.notifier);
+
+        final clip = notifier.addStopMotionClip(
+          id: 'clip_sm_frame_0',
+          frames: const [frame],
+          originalAspectRatio: 9 / 16,
+          targetAspectRatio: .vertical,
+          duration: const Duration(milliseconds: 83),
+          thumbnailPath: frame.path,
+        );
+
+        expect(clip.id, equals('clip_sm_frame_0'));
+        expect(
+          container.read(clipManagerProvider).clips.single.id,
+          equals('clip_sm_frame_0'),
+        );
+      });
+
+      test('addStopMotionClip generates an id when none is supplied', () {
+        final notifier = container.read(clipManagerProvider.notifier);
+
+        final clip = notifier.addStopMotionClip(
+          frames: const [frame],
+          originalAspectRatio: 9 / 16,
+          targetAspectRatio: .vertical,
+          duration: const Duration(milliseconds: 83),
+        );
+
+        expect(clip.id, startsWith('clip_'));
+        expect(clip.id, isNot(equals('clip_sm_frame_0')));
+      });
+
+      test(
+        'saveStopMotionSessionToLibrary upserts a frames-only clip by id',
+        () async {
+          when(
+            () => mockClipLibraryService.saveClip(any()),
+          ).thenAnswer((_) async {});
+          final notifier = container.read(clipManagerProvider.notifier);
+
+          final saved = await notifier.saveStopMotionSessionToLibrary(
+            id: 'clip_sm_frame_0',
+            frames: const [frame],
+            originalAspectRatio: 9 / 16,
+            targetAspectRatio: .vertical,
+            duration: const Duration(milliseconds: 83),
+            thumbnailPath: frame.path,
+          );
+
+          expect(saved, isTrue);
+          final captured =
+              verify(
+                    () => mockClipLibraryService.saveClip(captureAny()),
+                  ).captured.single
+                  as DivineVideoClip;
+          expect(captured.id, equals('clip_sm_frame_0'));
+          expect(captured.isStopMotion, isTrue);
+          expect(captured.stopMotionFrames, equals(const [frame]));
+          // A frames-only session clip is not added to the working set.
+          expect(container.read(clipManagerProvider).clips, isEmpty);
+        },
+      );
+
+      test('removeStopMotionSessionFromLibrary deletes the row only', () async {
+        when(
+          () => mockClipLibraryService.deleteClipRow(any()),
+        ).thenAnswer((_) async {});
+        final notifier = container.read(clipManagerProvider.notifier);
+
+        await notifier.removeStopMotionSessionFromLibrary('clip_sm_frame_0');
+
+        verify(
+          () => mockClipLibraryService.deleteClipRow('clip_sm_frame_0'),
+        ).called(1);
       });
     });
   });

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -18,6 +18,7 @@ import 'package:models/models.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/divine_video_draft.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
@@ -1973,6 +1974,51 @@ void main() {
                 'the clip with a missing source file must be dropped, '
                 'leaving only the clip whose media still exists',
           );
+        },
+      );
+
+      test(
+        'repairs a frames-only stop-motion clip thumbnail from its first still',
+        () async {
+          // A frames-only stop-motion draft with no rendered video and a
+          // missing thumbnail must repair from its first still, not reach for
+          // requireVideo (which throws on a video-less clip) and abort restore.
+          final framePath = '${tempDir.path}/frame_a.jpg';
+          await File(framePath).writeAsBytes(const [0]);
+          final draft = DivineVideoDraft.create(
+            id: 'sm-draft',
+            clips: [
+              DivineVideoClip(
+                id: 'sm',
+                stopMotionFrames: [
+                  StopMotionClipFrame(
+                    path: framePath,
+                    duration: const Duration(milliseconds: 83),
+                  ),
+                ],
+                duration: const Duration(milliseconds: 83),
+                recordedAt: DateTime.now(),
+                targetAspectRatio: .vertical,
+                originalAspectRatio: 9 / 16,
+              ),
+            ],
+            title: 'Title',
+            description: '',
+            hashtags: const {},
+            selectedApproach: 'video',
+          );
+          when(
+            () => mockDraftStorage.getDraftById('sm-draft'),
+          ).thenAnswer((_) async => draft);
+
+          final result = await container
+              .read(videoEditorProvider.notifier)
+              .restoreDraft('sm-draft');
+
+          expect(result, isTrue);
+          final clips = container.read(clipManagerProvider).clips;
+          expect(clips, hasLength(1));
+          expect(clips.single.thumbnailPath, framePath);
         },
       );
 

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -1043,6 +1043,66 @@ void main() {
       });
 
       test(
+        're-signs rendered stop-motion output without requiring a source mp4',
+        () async {
+          final notifier = container.read(videoEditorProvider.notifier);
+          container
+              .read(clipManagerProvider.notifier)
+              .addStopMotionClip(
+                id: 'frames-only',
+                frames: [
+                  const StopMotionClipFrame(
+                    path: '/docs/frame.jpg',
+                    duration: Duration(milliseconds: 83),
+                  ),
+                ],
+                duration: const Duration(milliseconds: 83),
+                targetAspectRatio: .vertical,
+                originalAspectRatio: 9 / 16,
+              );
+          final rendered = DivineVideoClip(
+            id: 'rendered',
+            video: EditorVideo.file('/docs/rendered.mp4'),
+            duration: const Duration(seconds: 3),
+            recordedAt: DateTime.now(),
+            targetAspectRatio: .vertical,
+            originalAspectRatio: 9 / 16,
+          );
+          notifier.state = notifier.state.copyWith(
+            finalRenderedClip: rendered,
+            c2paSigningFailed: true,
+          );
+
+          String? proofedPath;
+          NativeProofModeService.proofFileOverride =
+              (
+                file, {
+                required enableAdvancedCawgEmbedding,
+                creatorBindingAssertion,
+                cawgIdentityAssertion,
+                verifiedIdentityBundle,
+                clips,
+                editorStateHistory,
+              }) async {
+                proofedPath = file.path;
+                return const NativeProofData(
+                  videoHash: 'h',
+                  c2paManifestId: 'urn:c2pa:stop-motion',
+                );
+              };
+
+          await notifier.retryC2paSigning();
+
+          final state = container.read(videoEditorProvider);
+          expect(proofedPath, '/docs/rendered.mp4');
+          expect(state.c2paSigningFailed, isFalse);
+          expect(state.proofManifestJson, contains('urn:c2pa:stop-motion'));
+          expect(state.finalRenderedClip, equals(rendered));
+          expect(state.isProcessing, isFalse);
+        },
+      );
+
+      test(
         're-raises the prompt when the re-sign fails again (#6058)',
         () async {
           final notifier = container.read(videoEditorProvider.notifier);

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -33,10 +33,13 @@ import 'package:openvine/services/video_editor/video_editor_audio_render.dart';
 import 'package:openvine/services/video_editor/video_editor_render_service.dart';
 import 'package:openvine/widgets/video_editor/sticker_editor/video_editor_sticker.dart';
 import 'package:path/path.dart' as p;
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:pro_image_editor/pro_image_editor.dart'
     show CompleteParameters, WidgetLayer, WidgetLayerExportConfigs;
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
+import '../mocks/mock_path_provider_platform.dart';
 
 class _MockDraftStorageService extends Mock implements DraftStorageService {}
 
@@ -2943,24 +2946,24 @@ void main() {
     });
 
     test('container teardown reaps a replaced final rendered file', () async {
-      final suffix = DateTime.now().microsecondsSinceEpoch;
-      final documentsDir = Directory('/tmp/documents')
-        ..createSync(recursive: true);
-      final source = File(p.join(documentsDir.path, 'source-$suffix.mp4'))
+      // Point the documents dir at this group's unique per-test temp dir
+      // instead of the shared global `/tmp/documents`: the draft_storage suite
+      // recursively wipes that path, and races these files away when
+      // `flutter test` runs the suites concurrently.
+      final documentsDir = tempDir;
+      final originalPathProvider = PathProviderPlatform.instance;
+      PathProviderPlatform.instance = MockPathProviderPlatform()
+        ..setApplicationDocumentsPath(documentsDir.path);
+      addTearDown(() => PathProviderPlatform.instance = originalPathProvider);
+
+      final source = File(p.join(documentsDir.path, 'source.mp4'))
         ..writeAsBytesSync(const [1, 2, 3]);
       final oldRendered = File(
-        p.join(documentsDir.path, 'old-rendered-$suffix.mp4'),
+        p.join(documentsDir.path, 'old-rendered.mp4'),
       )..writeAsBytesSync(const [4, 5, 6]);
       final newRendered = File(
-        p.join(documentsDir.path, 'new-rendered-$suffix.mp4'),
+        p.join(documentsDir.path, 'new-rendered.mp4'),
       )..writeAsBytesSync(const [7, 8, 9]);
-      addTearDown(() async {
-        for (final file in [source, oldRendered, newRendered]) {
-          if (file.existsSync()) {
-            await file.delete();
-          }
-        }
-      });
       final realDraftStorage = DraftStorageService(
         draftsDao: database.draftsDao,
         clipsDao: database.clipsDao,

--- a/mobile/test/router/route_coverage_test.dart
+++ b/mobile/test/router/route_coverage_test.dart
@@ -725,5 +725,30 @@ void main() {
         expect(buildRoute(parseRoute(path)), path);
       });
     });
+
+    group('query parameters do not break route parsing', () {
+      // Regression: parseRoute segments the raw location string, so a query
+      // parameter used to glue itself onto the last segment
+      // ("clips-only?type=video" matched nothing → RouteType.home fallback),
+      // and the route normalizer then yanked the user to /home/0 whenever the
+      // recorder opened the scoped library.
+      test('parseRoute(/clips-only?type=video) parses to clipsOnly', () {
+        final context = parseRoute('/clips-only?type=video');
+        expect(context.type, RouteType.clipsOnly);
+      });
+
+      test('the canonical path of a query-carrying location is stable', () {
+        // buildRoute(parseRoute(path)) is the normalizer's canonical form;
+        // it must match the path portion so no normalization redirect fires.
+        final context = parseRoute('/clips-only?type=stop_motion');
+        expect(buildRoute(context), '/clips-only');
+      });
+
+      test('parseRoute keeps path indices with a query present', () {
+        final context = parseRoute('/home/2?foo=bar');
+        expect(context.type, RouteType.home);
+        expect(context.videoIndex, 2);
+      });
+    });
   });
 }

--- a/mobile/test/services/clip_library_service_test.dart
+++ b/mobile/test/services/clip_library_service_test.dart
@@ -7,8 +7,12 @@ import 'package:db_client/db_client.dart';
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart' as models show AspectRatio;
+import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/divine_video_draft.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/services/clip_library_service.dart';
+import 'package:openvine/services/draft_storage_service.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 
 void main() {
@@ -47,10 +51,90 @@ void main() {
         expect(clips.first.id, 'clip_123');
         // Path uses platform separator, so check filename
         expect(
-          await clips.first.video.safeFilePath(),
+          await clips.first.requireVideo.safeFilePath(),
           endsWith('test_video.mp4'),
         );
       });
+
+      test(
+        'saves a frames-only stop-motion clip and reloads its frames',
+        () async {
+          final clip = DivineVideoClip(
+            id: 'sm_clip',
+            stopMotionFrames: const [
+              StopMotionClipFrame(
+                path: '/tmp/frame0.jpg',
+                duration: Duration(milliseconds: 167),
+              ),
+              StopMotionClipFrame(
+                path: '/tmp/frame1.jpg',
+                duration: Duration(milliseconds: 167),
+              ),
+            ],
+            thumbnailPath: '/tmp/frame0.jpg',
+            duration: const Duration(milliseconds: 334),
+            recordedAt: DateTime(2026),
+            targetAspectRatio: .vertical,
+            originalAspectRatio: 9 / 16,
+          );
+
+          await service.saveClip(clip);
+          final clips = await service.getAllClips();
+
+          expect(clips, hasLength(1));
+          expect(clips.first.id, 'sm_clip');
+          expect(clips.first.isStopMotion, isTrue);
+          expect(clips.first.stopMotionFrames, hasLength(2));
+          expect(clips.first.video, isNull);
+        },
+      );
+
+      DivineVideoClip stopMotionClip() => DivineVideoClip(
+        id: 'sm_clip',
+        stopMotionFrames: const [
+          StopMotionClipFrame(
+            path: '/tmp/frame0.jpg',
+            duration: Duration(milliseconds: 167),
+          ),
+        ],
+        thumbnailPath: '/tmp/frame0.jpg',
+        duration: const Duration(milliseconds: 167),
+        recordedAt: DateTime(2026),
+        targetAspectRatio: .vertical,
+        originalAspectRatio: 9 / 16,
+      );
+
+      test(
+        'stays in the library exactly once through the editor autosave flow',
+        () async {
+          final draftService = DraftStorageService(
+            draftsDao: database.draftsDao,
+            clipsDao: database.clipsDao,
+          );
+          final clip = stopMotionClip();
+
+          // 1. Recorder saves the clip to the library.
+          await service.saveClip(clip);
+          expect(await service.getAllClips(), hasLength(1));
+
+          // 2. Editor autosave persists the clip into the autosave draft
+          // (exactly what happens after navigating from the recorder).
+          await draftService.saveDraft(
+            DivineVideoDraft.create(
+              id: VideoEditorConstants.autoSaveId,
+              clips: [clip],
+              title: '',
+              description: '',
+              hashtags: const {},
+              selectedApproach: '',
+            ),
+          );
+
+          // 3. It must still be visible in the library.
+          final clips = await service.getAllClips();
+          expect(clips.map((c) => c.id), equals(['sm_clip']));
+        },
+      );
 
       test('updates existing clip with same ID', () async {
         final clip1 = DivineVideoClip(
@@ -109,6 +193,58 @@ void main() {
         final result = await service.softDelete('nonexistent_clip');
         expect(result, isFalse);
       });
+
+      test(
+        'also trashes the autosave-draft copy so the set does not reappear',
+        () async {
+          final draftService = DraftStorageService(
+            draftsDao: database.draftsDao,
+            clipsDao: database.clipsDao,
+          );
+          final clip = DivineVideoClip(
+            id: 'sm_set',
+            stopMotionFrames: const [
+              StopMotionClipFrame(
+                path: '/tmp/f0.jpg',
+                duration: Duration(milliseconds: 167),
+              ),
+            ],
+            thumbnailPath: '/tmp/f0.jpg',
+            duration: const Duration(milliseconds: 167),
+            recordedAt: DateTime(2026),
+            targetAspectRatio: .vertical,
+            originalAspectRatio: 9 / 16,
+          );
+
+          // The two rows a set that went through the editor ends up with:
+          // a library row (recorder) and an autosave-draft row (editor).
+          await service.saveClip(clip);
+          await draftService.saveDraft(
+            DivineVideoDraft.create(
+              id: VideoEditorConstants.autoSaveId,
+              clips: [clip],
+              title: '',
+              description: '',
+              hashtags: const {},
+              selectedApproach: '',
+            ),
+          );
+          expect((await service.getAllClips()).length, 1);
+
+          final trashed = await service.softDelete('sm_set');
+          expect(trashed, isTrue);
+          // Gone for good: the autosave-draft copy is trashed too, so the
+          // library reload can't resurrect it.
+          expect(await service.getAllClips(), isEmpty);
+
+          // Undo restores both rows.
+          await service.restore('sm_set');
+          expect(
+            (await service.getAllClips()).map((c) => c.id),
+            equals(['sm_set']),
+          );
+        },
+      );
 
       test(
         'getTrashedClips skips a corrupt clip and returns valid ones',
@@ -206,6 +342,32 @@ void main() {
         await service.hardDelete('nonexistent_clip');
 
         expect((await service.getAllClips()).length, 1);
+      });
+    });
+
+    group('deleteClipRow', () {
+      test('removes the library row for the given id', () async {
+        final clip = DivineVideoClip(
+          id: 'sm_session',
+          stopMotionFrames: const [
+            StopMotionClipFrame(
+              path: '/tmp/frame0.jpg',
+              duration: Duration(milliseconds: 83),
+            ),
+          ],
+          duration: const Duration(milliseconds: 83),
+          recordedAt: DateTime.now(),
+          targetAspectRatio: .vertical,
+          originalAspectRatio: 9 / 16,
+        );
+
+        await service.saveClip(clip);
+        expect((await service.getAllClips()).length, 1);
+
+        await service.deleteClipRow('sm_session');
+
+        expect(await service.getAllClips(), isEmpty);
+        expect(await service.getTrashedClips(), isEmpty);
       });
     });
 
@@ -536,7 +698,7 @@ void main() {
       expect(restored.id, original.id);
       expect(restored.libraryTitle, original.libraryTitle);
       // Path uses platform separator, check it ends with filename
-      expect(await restored.video.safeFilePath(), endsWith('video.mp4'));
+      expect(await restored.requireVideo.safeFilePath(), endsWith('video.mp4'));
       expect(restored.thumbnailPath, endsWith('thumb.jpg'));
       expect(restored.duration, original.duration);
       expect(restored.recordedAt, original.recordedAt);

--- a/mobile/test/services/clip_library_service_test.dart
+++ b/mobile/test/services/clip_library_service_test.dart
@@ -15,7 +15,10 @@ import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/services/clip_library_service.dart';
 import 'package:openvine/services/draft_storage_service.dart';
 import 'package:path/path.dart' as p;
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
+
+import '../mocks/mock_path_provider_platform.dart';
 
 void main() {
   group('ClipLibraryService', () {
@@ -675,12 +678,21 @@ void main() {
     });
 
     group('stop-motion autosave-row cleanup', () {
-      // The global test config mocks the documents directory to this path, and
-      // stop-motion frame paths are persisted as basenames resolved against it.
-      const documentsPath = '/tmp/documents';
+      // Stop-motion frame paths are persisted as basenames resolved against the
+      // documents directory. Use a UNIQUE temp dir per test and mock the path
+      // provider to point at it, so this group never touches the shared
+      // `/tmp/documents` — otherwise its recursive cleanup races the
+      // draft_storage suite's use of the same path when `flutter test` runs the
+      // files concurrently.
+      late Directory documentsDir;
+      late PathProviderPlatform originalPathProvider;
       late DraftStorageService draftService;
 
       setUp(() {
+        documentsDir = Directory.systemTemp.createTempSync('clip_library_sm');
+        originalPathProvider = PathProviderPlatform.instance;
+        PathProviderPlatform.instance = MockPathProviderPlatform()
+          ..setApplicationDocumentsPath(documentsDir.path);
         draftService = DraftStorageService(
           draftsDao: database.draftsDao,
           clipsDao: database.clipsDao,
@@ -688,12 +700,14 @@ void main() {
       });
 
       tearDown(() {
-        final dir = Directory(documentsPath);
-        if (dir.existsSync()) dir.deleteSync(recursive: true);
+        PathProviderPlatform.instance = originalPathProvider;
+        if (documentsDir.existsSync()) {
+          documentsDir.deleteSync(recursive: true);
+        }
       });
 
       File writeFrame(String name) {
-        final file = File(p.join(documentsPath, name));
+        final file = File(p.join(documentsDir.path, name));
         file.parent.createSync(recursive: true);
         file.writeAsBytesSync(const [0, 1, 2, 3]);
         return file;

--- a/mobile/test/services/clip_library_service_test.dart
+++ b/mobile/test/services/clip_library_service_test.dart
@@ -252,6 +252,50 @@ void main() {
       );
 
       test(
+        'trashing a dual-row set with clearDraftId shows once in trash',
+        () async {
+          final draftService = DraftStorageService(
+            draftsDao: database.draftsDao,
+            clipsDao: database.clipsDao,
+          );
+          final clip = DivineVideoClip(
+            id: 'sm_dup',
+            stopMotionFrames: const [
+              StopMotionClipFrame(
+                path: '/tmp/f0.jpg',
+                duration: Duration(milliseconds: 167),
+              ),
+            ],
+            thumbnailPath: '/tmp/f0.jpg',
+            duration: const Duration(milliseconds: 167),
+            recordedAt: DateTime(2026),
+            targetAspectRatio: .vertical,
+            originalAspectRatio: 9 / 16,
+          );
+
+          // Library row (recorder) + autosave-draft row (editor).
+          await service.saveClip(clip);
+          await draftService.saveDraft(
+            DivineVideoDraft.create(
+              id: VideoEditorConstants.autoSaveId,
+              clips: [clip],
+              title: '',
+              description: '',
+              hashtags: const {},
+              selectedApproach: '',
+            ),
+          );
+
+          // The recorder path nulls draft_id on both rows, so both match the
+          // trashed (draftId IS NULL) query — the set must still surface once.
+          await service.softDelete('sm_dup', clearDraftId: true);
+
+          final trashed = await service.getTrashedClips();
+          expect(trashed.map((c) => c.id), ['sm_dup']);
+        },
+      );
+
+      test(
         'getTrashedClips skips a corrupt clip and returns valid ones',
         () async {
           final validClip = DivineVideoClip(

--- a/mobile/test/services/clip_library_service_test.dart
+++ b/mobile/test/services/clip_library_service_test.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Covers save, load, delete, and thumbnail generation for clips
 
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:db_client/db_client.dart';
 import 'package:drift/native.dart';
@@ -13,6 +14,7 @@ import 'package:openvine/models/divine_video_draft.dart';
 import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/services/clip_library_service.dart';
 import 'package:openvine/services/draft_storage_service.dart';
+import 'package:path/path.dart' as p;
 import 'package:pro_video_editor/pro_video_editor.dart';
 
 void main() {
@@ -670,6 +672,137 @@ void main() {
         expect((await service.getAllClips()).length, 0);
         expect((await service.getTrashedClips()).length, 0);
       });
+    });
+
+    group('stop-motion autosave-row cleanup', () {
+      // The global test config mocks the documents directory to this path, and
+      // stop-motion frame paths are persisted as basenames resolved against it.
+      const documentsPath = '/tmp/documents';
+      late DraftStorageService draftService;
+
+      setUp(() {
+        draftService = DraftStorageService(
+          draftsDao: database.draftsDao,
+          clipsDao: database.clipsDao,
+        );
+      });
+
+      tearDown(() {
+        final dir = Directory(documentsPath);
+        if (dir.existsSync()) dir.deleteSync(recursive: true);
+      });
+
+      File writeFrame(String name) {
+        final file = File(p.join(documentsPath, name));
+        file.parent.createSync(recursive: true);
+        file.writeAsBytesSync(const [0, 1, 2, 3]);
+        return file;
+      }
+
+      DivineVideoClip stopMotionSet(
+        List<File> frames, {
+        String id = 'sm_set',
+      }) => DivineVideoClip(
+        id: id,
+        stopMotionFrames: [
+          for (final frame in frames)
+            StopMotionClipFrame(
+              path: frame.path,
+              duration: const Duration(milliseconds: 167),
+            ),
+        ],
+        thumbnailPath: frames.first.path,
+        duration: Duration(milliseconds: frames.length * 167),
+        recordedAt: DateTime(2026),
+        targetAspectRatio: .vertical,
+        originalAspectRatio: 9 / 16,
+      );
+
+      // Recreate the two rows a set ends up with after going through the
+      // editor: a library row (recorder) and a `<autoSaveId>:<clipId>` row
+      // (editor autosave draft).
+      Future<void> saveThroughEditor(DivineVideoClip clip) async {
+        await service.saveClip(clip);
+        await draftService.saveDraft(
+          DivineVideoDraft.create(
+            id: VideoEditorConstants.autoSaveId,
+            clips: [clip],
+            title: '',
+            description: '',
+            hashtags: const {},
+            selectedApproach: 'stop_motion',
+          ),
+        );
+      }
+
+      test(
+        'hardDelete removes the autosave-draft row and its frame files',
+        () async {
+          final frame0 = writeFrame('hard_f0.jpg');
+          final frame1 = writeFrame('hard_f1.jpg');
+          final clip = stopMotionSet([frame0, frame1], id: 'sm_hard');
+          final autosaveRowId = '${VideoEditorConstants.autoSaveId}:${clip.id}';
+
+          await saveThroughEditor(clip);
+          expect((await service.getAllClips()).length, 1);
+          expect(
+            await database.clipsDao.getClipById(autosaveRowId),
+            isNotNull,
+          );
+
+          await service.hardDelete(clip.id);
+
+          expect(await service.getAllClips(), isEmpty);
+          expect(await database.clipsDao.getClipById(clip.id), isNull);
+          expect(
+            await database.clipsDao.getClipById(autosaveRowId),
+            isNull,
+            reason:
+                'the mirrored autosave-draft row must not survive '
+                'hardDelete',
+          );
+          expect(
+            frame0.existsSync(),
+            isFalse,
+            reason:
+                'with no row left referencing them, the frame files must '
+                'be reaped',
+          );
+          expect(frame1.existsSync(), isFalse);
+        },
+      );
+
+      test(
+        'clearAllClips removes autosave-draft rows and their frame files',
+        () async {
+          final frame0 = writeFrame('clear_f0.jpg');
+          final frame1 = writeFrame('clear_f1.jpg');
+          final clip = stopMotionSet([frame0, frame1], id: 'sm_clear');
+          final autosaveRowId = '${VideoEditorConstants.autoSaveId}:${clip.id}';
+
+          await saveThroughEditor(clip);
+          expect((await service.getAllClips()).length, 1);
+          expect(
+            await database.clipsDao.getClipById(autosaveRowId),
+            isNotNull,
+          );
+
+          await service.clearAllClips();
+
+          expect(await service.getAllClips(), isEmpty);
+          expect(
+            await database.clipsDao.getClipById(autosaveRowId),
+            isNull,
+            reason: 'clearing the library must also drop autosave-backed rows',
+          );
+          expect(
+            frame0.existsSync(),
+            isFalse,
+            reason: 'clearing the library must not leak the frame files',
+          );
+          expect(frame1.existsSync(), isFalse);
+        },
+      );
     });
   });
 

--- a/mobile/test/services/draft_storage_service_test.dart
+++ b/mobile/test/services/draft_storage_service_test.dart
@@ -11,6 +11,8 @@ import 'package:models/models.dart' show AspectRatio, AudioEvent;
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/divine_video_draft.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
+import 'package:openvine/services/clip_library_service.dart';
 import 'package:openvine/services/draft_storage_service.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
@@ -556,6 +558,105 @@ void main() {
 
         final drafts = await service.getAllDrafts();
         expect(drafts.length, 1);
+      });
+    });
+
+    group('stop-motion frame-only drafts', () {
+      late Directory docsDir;
+
+      setUp(() {
+        docsDir = Directory(documentsPath)..createSync(recursive: true);
+      });
+
+      tearDown(() {
+        if (docsDir.existsSync()) docsDir.deleteSync(recursive: true);
+      });
+
+      File writeFrame(String name) {
+        final file = File(p.join(documentsPath, name));
+        file.writeAsBytesSync(const [0, 1, 2, 3]);
+        return file;
+      }
+
+      DivineVideoClip framesOnlyClip({
+        required List<File> frames,
+        String id = 'stop_motion_clip',
+      }) {
+        return DivineVideoClip(
+          id: id,
+          stopMotionFrames: [
+            for (final frame in frames)
+              StopMotionClipFrame(
+                path: frame.path,
+                duration: const Duration(milliseconds: 167),
+              ),
+          ],
+          thumbnailPath: frames.first.path,
+          duration: Duration(milliseconds: frames.length * 167),
+          recordedAt: DateTime(2026),
+          targetAspectRatio: AspectRatio.vertical,
+          originalAspectRatio: 9 / 16,
+        );
+      }
+
+      test(
+        'deleting a draft keeps frame files referenced by a library clip',
+        () async {
+          final frame0 = writeFrame('draft_shared_frame0.jpg');
+          final frame1 = writeFrame('draft_shared_frame1.jpg');
+          final clip = framesOnlyClip(frames: [frame0, frame1]);
+          final libraryService = ClipLibraryService(
+            clipsDao: database.clipsDao,
+            draftsDao: database.draftsDao,
+          );
+
+          await libraryService.saveClip(clip);
+          await service.saveDraft(
+            DivineVideoDraft.create(
+              id: 'draft_stop_motion',
+              clips: [clip],
+              title: 'Stop motion',
+              description: '',
+              hashtags: const {},
+              selectedApproach: 'stop_motion',
+            ),
+          );
+
+          await service.deleteDraft('draft_stop_motion');
+
+          expect(frame0.existsSync(), isTrue);
+          expect(
+            frame1.existsSync(),
+            isTrue,
+            reason:
+                'all library stop-motion frame paths live in JSON, not only '
+                'indexed thumbnail/file columns',
+          );
+        },
+      );
+
+      test('validated autosave keeps frame-only stop-motion clips', () async {
+        final frame0 = writeFrame('autosave_frame0.jpg');
+        final frame1 = writeFrame('autosave_frame1.jpg');
+        final clip = framesOnlyClip(frames: [frame0, frame1]);
+
+        await service.saveDraft(
+          DivineVideoDraft.create(
+            id: VideoEditorConstants.autoSaveId,
+            clips: [clip],
+            title: 'Autosave',
+            description: '',
+            hashtags: const {},
+            selectedApproach: 'stop_motion',
+          ),
+        );
+
+        final autosave = await service.getAutosaveDraft();
+
+        expect(autosave, isNotNull);
+        expect(autosave!.clips, hasLength(1));
+        expect(autosave.clips.single.isStopMotion, isTrue);
+        expect(await service.hasValidAutosave(), isTrue);
       });
     });
 

--- a/mobile/test/services/draft_storage_service_test.dart
+++ b/mobile/test/services/draft_storage_service_test.dart
@@ -658,6 +658,80 @@ void main() {
         expect(autosave.clips.single.isStopMotion, isTrue);
         expect(await service.hasValidAutosave(), isTrue);
       });
+
+      test(
+        'keeps a stop-motion draft, dropping only the unreadable still',
+        () async {
+          final frame0 = writeFrame('salvage_frame0.jpg');
+          final frame1 = writeFrame('salvage_frame1.jpg');
+          final clip = framesOnlyClip(
+            frames: [frame0, frame1],
+            id: 'sm_salvage',
+          );
+
+          await service.saveDraft(
+            DivineVideoDraft.create(
+              id: 'draft_salvage',
+              clips: [clip],
+              title: 'Stop motion',
+              description: '',
+              hashtags: const {},
+              selectedApproach: 'stop_motion',
+            ),
+          );
+
+          // One still goes missing after the draft was persisted (file cleanup
+          // reaped it). getAllDrafts validation must salvage the clip per-frame
+          // instead of hiding the whole draft before restore can recover it.
+          frame1.deleteSync();
+
+          final drafts = await service.getAllDrafts();
+          expect(drafts.map((draft) => draft.id), ['draft_salvage']);
+          final restored = drafts.single.clips.single;
+          expect(restored.isStopMotion, isTrue);
+          expect(restored.stopMotionFrames, hasLength(1));
+          expect(
+            restored.stopMotionFrames!.single.path,
+            endsWith('salvage_frame0.jpg'),
+          );
+        },
+      );
+
+      test(
+        'reaps a still removed from an existing session on the next save',
+        () async {
+          final frame0 = writeFrame('resave_frame0.jpg');
+          final frame1 = writeFrame('resave_frame1.jpg');
+          final frame2 = writeFrame('resave_frame2.jpg');
+
+          DivineVideoDraft draftWithFrames(List<File> frames) =>
+              DivineVideoDraft.create(
+                id: 'draft_resave',
+                clips: [framesOnlyClip(frames: frames, id: 'sm_resave')],
+                title: 'Stop motion',
+                description: '',
+                hashtags: const {},
+                selectedApproach: 'stop_motion',
+              );
+
+          await service.saveDraft(draftWithFrames([frame0, frame1, frame2]));
+
+          // The user deletes the middle still in the editor; the session
+          // autosaves. The removed still is no longer referenced by the draft
+          // and must be queued for cleanup (and reaped when no sink defers it).
+          await service.saveDraft(draftWithFrames([frame0, frame2]));
+
+          expect(
+            frame1.existsSync(),
+            isFalse,
+            reason:
+                'a still removed from the clip is orphaned and must be cleaned '
+                'up on the next save',
+          );
+          expect(frame0.existsSync(), isTrue);
+          expect(frame2.existsSync(), isTrue);
+        },
+      );
     });
 
     group('clearAllDrafts', () {

--- a/mobile/test/services/draft_storage_service_test.dart
+++ b/mobile/test/services/draft_storage_service_test.dart
@@ -635,6 +635,62 @@ void main() {
         },
       );
 
+      test(
+        'deleting a draft removes its unreferenced frame files',
+        () async {
+          final frame0 = writeFrame('draft_only_frame0.jpg');
+          final frame1 = writeFrame('draft_only_frame1.jpg');
+          final clip = framesOnlyClip(frames: [frame0, frame1]);
+
+          await service.saveDraft(
+            DivineVideoDraft.create(
+              id: 'draft_only_stop_motion',
+              clips: [clip],
+              title: 'Stop motion',
+              description: '',
+              hashtags: const {},
+              selectedApproach: 'stop_motion',
+            ),
+          );
+
+          await service.deleteDraft('draft_only_stop_motion');
+
+          // No surviving row references the stills, so the frames are reaped.
+          // Before deleteDraft removed the draft's clip rows, they lingered
+          // (the FK cascade never fires) and kept the frames pinned on disk.
+          expect(frame0.existsSync(), isFalse);
+          expect(frame1.existsSync(), isFalse);
+        },
+      );
+
+      test(
+        'clearing all drafts removes unreferenced frame files',
+        () async {
+          final frame0 = writeFrame('clear_frame0.jpg');
+          final frame1 = writeFrame('clear_frame1.jpg');
+          final clip = framesOnlyClip(
+            frames: [frame0, frame1],
+            id: 'clear_clip',
+          );
+
+          await service.saveDraft(
+            DivineVideoDraft.create(
+              id: 'draft_clear_stop_motion',
+              clips: [clip],
+              title: 'Stop motion',
+              description: '',
+              hashtags: const {},
+              selectedApproach: 'stop_motion',
+            ),
+          );
+
+          await service.clearAllDrafts();
+
+          expect(frame0.existsSync(), isFalse);
+          expect(frame1.existsSync(), isFalse);
+        },
+      );
+
       test('validated autosave keeps frame-only stop-motion clips', () async {
         final frame0 = writeFrame('autosave_frame0.jpg');
         final frame1 = writeFrame('autosave_frame1.jpg');

--- a/mobile/test/services/file_cleanup_service_test.dart
+++ b/mobile/test/services/file_cleanup_service_test.dart
@@ -4,8 +4,13 @@
 import 'dart:io';
 
 import 'package:db_client/db_client.dart';
+import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart' as model show AspectRatio;
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
+import 'package:openvine/services/clip_library_service.dart';
 import 'package:openvine/services/file_cleanup_service.dart';
 import 'package:path/path.dart' as p;
 
@@ -130,6 +135,95 @@ void main() {
         verifyNever(() => clipsDao.isFileReferenced(any()));
         verifyNever(() => draftsDao.isDraftFileReferenced(any()));
       });
+    });
+
+    // Regression for the multi-set stop-motion frame loss: a stop-motion clip
+    // keeps its stills in the row's `data` JSON, not in an indexed file column
+    // (only the first still is mirrored into thumbnail_path). Deleting the
+    // autosave draft that also held the clip must NOT delete the stills the
+    // surviving library row still references — otherwise a saved set silently
+    // shrinks to its thumbnail and two sets merge to two frames.
+    group('stop-motion frames referenced only in data', () {
+      late AppDatabase database;
+      late ClipLibraryService libraryService;
+      late Directory tempDir;
+
+      setUp(() {
+        database = AppDatabase.test(NativeDatabase.memory());
+        libraryService = ClipLibraryService(
+          clipsDao: database.clipsDao,
+          draftsDao: database.draftsDao,
+        );
+        tempDir = Directory.systemTemp.createTempSync('divine_sm_cleanup');
+      });
+
+      tearDown(() async {
+        await database.close();
+        if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+      });
+
+      DivineVideoClip writeStopMotionSet(String id, int frameCount) {
+        final frames = [
+          for (var i = 0; i < frameCount; i++)
+            StopMotionClipFrame(
+              path: (File(
+                p.join(tempDir.path, '${id}_frame_$i.jpg'),
+              )..writeAsBytesSync(const [1, 2, 3])).path,
+              duration: const Duration(microseconds: 41667),
+            ),
+        ];
+        return DivineVideoClip(
+          id: id,
+          stopMotionFrames: frames,
+          duration: const Duration(milliseconds: 125),
+          recordedAt: DateTime(2024),
+          targetAspectRatio: model.AspectRatio.vertical,
+          originalAspectRatio: 9 / 16,
+          // The recorder uses the first still as the library thumbnail.
+          thumbnailPath: frames.first.path,
+        );
+      }
+
+      test(
+        'keeps every still while the library row still references them',
+        () async {
+          final set = writeStopMotionSet('clip_sm_a', 3);
+          await libraryService.saveClip(set);
+
+          // Simulate the autosave-draft delete cleanup running on the same
+          // clip while its library row (draftId == null) survives.
+          await FileCleanupService.deleteRecordingClipFiles(
+            set,
+            draftsDao: database.draftsDao,
+            clipsDao: database.clipsDao,
+          );
+
+          for (final frame in set.stopMotionFrames!) {
+            expect(
+              File(frame.path).existsSync(),
+              isTrue,
+              reason: 'still ${frame.path} is referenced by the library row',
+            );
+          }
+        },
+      );
+
+      test(
+        'deletes stills once no row references them',
+        () async {
+          final set = writeStopMotionSet('clip_sm_b', 3);
+          // No row saved — nothing references the stills.
+          await FileCleanupService.deleteRecordingClipFiles(
+            set,
+            draftsDao: database.draftsDao,
+            clipsDao: database.clipsDao,
+          );
+
+          for (final frame in set.stopMotionFrames!) {
+            expect(File(frame.path).existsSync(), isFalse);
+          }
+        },
+      );
     });
   });
 }

--- a/mobile/test/services/native_proofmode_service_test.dart
+++ b/mobile/test/services/native_proofmode_service_test.dart
@@ -167,10 +167,10 @@ void main() {
     });
   });
 
-  group('proofFile C2PA manifest id propagation', () {
-    test('fresh proof generation carries the C2PA manifest id', () async {
+  group('proofFile C2PA manifest handling', () {
+    test('preserves the active manifest ID from an existing proof', () async {
       final directory = await Directory.systemTemp.createTemp(
-        'native-proofmode-test-',
+        'native-proofmode-existing-test-',
       );
       addTearDown(() async {
         if (directory.existsSync()) {
@@ -180,16 +180,60 @@ void main() {
 
       final video = File('${directory.path}/video.mp4');
       await video.writeAsBytes(const [1, 2, 3, 4]);
+      final videoHash = await NativeProofModeService.generateSha256FileHash(
+        video.path,
+      );
+      final proofDir = Directory('${directory.path}/$videoHash');
+      await proofDir.create();
+      await File(
+        '${proofDir.path}/$videoHash.asc',
+      ).writeAsString('signature');
 
+      final c2paService = _ExistingProofC2paSigningService();
+      NativeProofModeService.c2paSigningServiceFactoryOverride = () =>
+          c2paService;
+
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(proofModeChannel, (call) async {
+            switch (call.method) {
+              case 'isAvailable':
+                return true;
+              case 'getProofDir':
+                return proofDir.path;
+              default:
+                fail('Unexpected proof mode method call: ${call.method}');
+            }
+          });
+
+      final proofData = await NativeProofModeService.proofFile(video);
+
+      expect(proofData, isNotNull);
+      expect(proofData!.c2paManifestId, 'urn:c2pa:existing');
+      expect(c2paService.readManifestCallCount, 1);
+      expect(c2paService.signVideoCallCount, 0);
+    });
+
+    test('preserves the active manifest ID after generating a proof', () async {
+      final directory = await Directory.systemTemp.createTemp(
+        'native-proofmode-generated-test-',
+      );
+      addTearDown(() async {
+        if (directory.existsSync()) {
+          await directory.delete(recursive: true);
+        }
+      });
+
+      final video = File('${directory.path}/video.mp4');
+      await video.writeAsBytes(const [1, 2, 3, 4]);
       const generatedProofHash =
-          'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
       final proofDir = Directory('${directory.path}/$generatedProofHash');
       await proofDir.create();
       await File(
         '${proofDir.path}/$generatedProofHash.asc',
       ).writeAsString('signature');
 
-      final c2paService = _SigningC2paSigningService(video.path);
+      final c2paService = _SuccessfulC2paSigningService(video.path);
       NativeProofModeService.c2paSigningServiceFactoryOverride = () =>
           c2paService;
 
@@ -213,56 +257,9 @@ void main() {
       final proofData = await NativeProofModeService.proofFile(video);
 
       expect(proofData, isNotNull);
-      expect(proofData!.videoHash, generatedProofHash);
-      expect(proofData.c2paManifestId, _SigningC2paSigningService.manifestId);
-    });
-
-    test('existing proof metadata carries the C2PA manifest id', () async {
-      final directory = await Directory.systemTemp.createTemp(
-        'native-proofmode-test-',
-      );
-      addTearDown(() async {
-        if (directory.existsSync()) {
-          await directory.delete(recursive: true);
-        }
-      });
-
-      final video = File('${directory.path}/video.mp4');
-      await video.writeAsBytes(const [1, 2, 3, 4]);
-      final videoHash = await NativeProofModeService.generateSha256FileHash(
-        video.path,
-      );
-
-      final proofDir = Directory('${directory.path}/$videoHash');
-      await proofDir.create();
-      await File('${proofDir.path}/$videoHash.asc').writeAsString('signature');
-
-      final c2paService = _SigningC2paSigningService(
-        video.path,
-        allowSign: false,
-      );
-      NativeProofModeService.c2paSigningServiceFactoryOverride = () =>
-          c2paService;
-
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(proofModeChannel, (call) async {
-            switch (call.method) {
-              case 'isAvailable':
-                return true;
-              case 'getProofDir':
-                final args = call.arguments as Map<Object?, Object?>;
-                return args['proofHash'] == videoHash ? proofDir.path : null;
-              default:
-                fail('Unexpected proof mode method call: ${call.method}');
-            }
-          });
-
-      final proofData = await NativeProofModeService.proofFile(video);
-
-      expect(proofData, isNotNull);
-      expect(proofData!.videoHash, videoHash);
-      expect(proofData.c2paManifestId, _SigningC2paSigningService.manifestId);
-      expect(c2paService.signVideoCallCount, 0);
+      expect(proofData!.c2paManifestId, 'urn:c2pa:generated');
+      expect(c2paService.signVideoCallCount, 1);
+      expect(c2paService.readManifestCallCount, 1);
     });
   });
 }
@@ -307,13 +304,8 @@ class _FailingC2paSigningService extends C2paSigningService {
   }
 }
 
-class _SigningC2paSigningService extends C2paSigningService {
-  _SigningC2paSigningService(this.videoPath, {this.allowSign = true});
-
-  static const manifestId = 'urn:c2pa:test-manifest';
-
-  final String videoPath;
-  final bool allowSign;
+class _ExistingProofC2paSigningService extends C2paSigningService {
+  int readManifestCallCount = 0;
   int signVideoCallCount = 0;
 
   @override
@@ -324,14 +316,37 @@ class _SigningC2paSigningService extends C2paSigningService {
     bool enableAdvancedCawgEmbedding = false,
   }) async {
     signVideoCallCount += 1;
-    if (!allowSign) {
-      fail('signVideo should not be called when proof metadata exists');
-    }
+    throw StateError('Existing proof must not be signed again');
+  }
+
+  @override
+  Future<ManifestStoreInfo?> readManifest(String filePath) async {
+    readManifestCallCount += 1;
+    return const ManifestStoreInfo(activeManifest: 'urn:c2pa:existing');
+  }
+}
+
+class _SuccessfulC2paSigningService extends C2paSigningService {
+  _SuccessfulC2paSigningService(this.videoPath);
+
+  final String videoPath;
+  int readManifestCallCount = 0;
+  int signVideoCallCount = 0;
+
+  @override
+  Future<C2paSigningResult> signVideo({
+    required String videoPath,
+    NostrCreatorBindingAssertion? creatorBindingAssertion,
+    Map<String, dynamic>? cawgIdentityAssertion,
+    bool enableAdvancedCawgEmbedding = false,
+  }) async {
+    signVideoCallCount += 1;
     return C2paSigningResult(signedFilePath: this.videoPath, success: true);
   }
 
   @override
   Future<ManifestStoreInfo?> readManifest(String filePath) async {
-    return const ManifestStoreInfo(activeManifest: manifestId);
+    readManifestCallCount += 1;
+    return const ManifestStoreInfo(activeManifest: 'urn:c2pa:generated');
   }
 }

--- a/mobile/test/services/storage_management_service_test.dart
+++ b/mobile/test/services/storage_management_service_test.dart
@@ -6,6 +6,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart' as model;
 import 'package:openvine/constants/storage_cache_constants.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/services/clip_library_service.dart';
 import 'package:openvine/services/storage_management_service.dart';
 import 'package:pro_video_editor/pro_video_editor.dart' as editor;
@@ -63,6 +64,22 @@ void main() {
       targetAspectRatio: model.AspectRatio.square,
       originalAspectRatio: 1,
     );
+
+    DivineVideoClip stopMotionClip(String id, List<String> framePaths) =>
+        DivineVideoClip(
+          id: id,
+          stopMotionFrames: [
+            for (final path in framePaths)
+              StopMotionClipFrame(
+                path: path,
+                duration: const Duration(milliseconds: 167),
+              ),
+          ],
+          duration: const Duration(milliseconds: 167),
+          recordedAt: DateTime(2024),
+          targetAspectRatio: model.AspectRatio.vertical,
+          originalAspectRatio: 9 / 16,
+        );
 
     group('cacheSizeBytes', () {
       test('sums cache dirs, seams and temp renders, ignoring other '
@@ -161,6 +178,39 @@ void main() {
         final result = await service.findBrokenClips();
 
         expect(result.map((c) => c.id), equals(['broken']));
+      });
+
+      test(
+        'keeps a stop-motion set with at least one surviving still',
+        () async {
+          final present = writeFile('${docs.path}/frame_present.png', 10);
+          final salvageable = stopMotionClip('salvageable', [
+            present.path,
+            '${docs.path}/frame_gone.png',
+          ]);
+          final brokenVideo = clip('broken', '${docs.path}/gone.mp4');
+          when(
+            clipLibrary.getAllClips,
+          ).thenAnswer((_) async => [salvageable, brokenVideo]);
+
+          final result = await service.findBrokenClips();
+
+          // One still is missing but another survives, so the set is
+          // salvageable — only the video clip with a gone file is broken.
+          expect(result.map((c) => c.id), equals(['broken']));
+        },
+      );
+
+      test('flags a stop-motion set whose stills are all gone', () async {
+        final dead = stopMotionClip('dead', [
+          '${docs.path}/gone_a.png',
+          '${docs.path}/gone_b.png',
+        ]);
+        when(clipLibrary.getAllClips).thenAnswer((_) async => [dead]);
+
+        final result = await service.findBrokenClips();
+
+        expect(result.map((c) => c.id), equals(['dead']));
       });
     });
 

--- a/mobile/test/services/upload_manager_from_draft_test.dart
+++ b/mobile/test/services/upload_manager_from_draft_test.dart
@@ -277,11 +277,11 @@ void main() {
     });
 
     test(
-      'deletes the transient stop-motion render after a successful upload',
+      'keeps transient stop-motion render until the upload is published',
       () async {
         // No finalRenderedClip, so startUploadFromDraft hits the fallback that
         // re-renders the frames-only clip into a documents-dir mp4.
-        final renderPath = '${tempDir.path}/documents/stop_motion_fallback.mp4';
+        final renderPath = '${tempDir.path}/documents/stop_motion_123.mp4';
         StopMotionRenderService.assembleOverride =
             ({
               required frames,
@@ -328,12 +328,107 @@ void main() {
           nostrPubkey: 'test-pubkey',
         );
 
-        // The fallback render was the upload input, and it is reaped once the
-        // upload has consumed it — no orphaned mp4 left in documents.
         expect(upload.localVideoPath, equals(renderPath));
+        expect(File(renderPath).existsSync(), isTrue);
+
+        await uploadManager.updateUploadStatus(
+          upload.id,
+          UploadStatus.published,
+          nostrEventId: 'event-id',
+        );
+
         expect(File(renderPath).existsSync(), isFalse);
       },
     );
+
+    test('cleans failed non-resumable transient stop-motion renders', () async {
+      final renderPath = '${tempDir.path}/documents/stop_motion_456.mp4';
+      StopMotionRenderService.assembleOverride =
+          ({
+            required frames,
+            required aspectRatio,
+            frameRate = StopMotionRenderService.defaultFrameRate,
+            taskId,
+          }) async {
+            File(renderPath)
+              ..parent.createSync(recursive: true)
+              ..writeAsBytesSync([0, 1, 2, 3]);
+            return renderPath;
+          };
+      StopMotionRenderService.probeDurationOverride = (_) async =>
+          const Duration(seconds: 2);
+      addTearDown(() {
+        StopMotionRenderService.assembleOverride = null;
+        StopMotionRenderService.probeDurationOverride = null;
+      });
+
+      when(
+        () => mockBlossomService.uploadVideoWithResume(
+          videoFile: any(named: 'videoFile'),
+          nostrPubkey: any(named: 'nostrPubkey'),
+          taskId: any(named: 'taskId'),
+          title: any(named: 'title'),
+          description: any(named: 'description'),
+          hashtags: any(named: 'hashtags'),
+          proofManifestJson: any(named: 'proofManifestJson'),
+          useBackgroundFirst: any(named: 'useBackgroundFirst'),
+          resumableTimeout: any(named: 'resumableTimeout'),
+          resumableSession: any(named: 'resumableSession'),
+          onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
+          onProgress: any(named: 'onProgress'),
+        ),
+      ).thenAnswer(
+        (_) async => const BlossomUploadResult(
+          success: false,
+          errorMessage: 'upload failed',
+        ),
+      );
+
+      final draft = DivineVideoDraft.create(
+        clips: [
+          DivineVideoClip(
+            id: 'sm_clip',
+            stopMotionFrames: const [
+              StopMotionClipFrame(
+                path: '/tmp/f0.jpg',
+                duration: Duration(milliseconds: 167),
+              ),
+            ],
+            duration: const Duration(milliseconds: 167),
+            recordedAt: DateTime.now(),
+            targetAspectRatio: AspectRatio.vertical,
+            originalAspectRatio: 9 / 16,
+          ),
+        ],
+        title: 'Stop Motion',
+        description: 'Fallback render',
+        hashtags: {'sm'},
+        selectedApproach: 'native',
+      );
+
+      await expectLater(
+        () => uploadManager.startUploadFromDraft(
+          draft: draft,
+          nostrPubkey: 'test-pubkey',
+        ),
+        throwsA(isA<Exception>()),
+      );
+      expect(File(renderPath).existsSync(), isTrue);
+      final failedUpload = uploadManager.pendingUploads.firstWhere(
+        (upload) => upload.localVideoPath == renderPath,
+      );
+      expect(failedUpload.status, UploadStatus.failed);
+
+      await uploadManager.cleanupCompletedUploads();
+
+      expect(File(renderPath).existsSync(), isFalse);
+      expect(
+        uploadManager.pendingUploads.where(
+          (upload) => upload.localVideoPath == renderPath,
+        ),
+        isEmpty,
+      );
+    });
 
     test(
       'throws when upload finishes in failed state instead of returning a completed upload',

--- a/mobile/test/services/upload_manager_from_draft_test.dart
+++ b/mobile/test/services/upload_manager_from_draft_test.dart
@@ -10,7 +10,9 @@ import 'package:models/models.dart' show AspectRatio;
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/divine_video_draft.dart';
 import 'package:openvine/models/pending_upload.dart' show UploadStatus;
+import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/services/upload_manager.dart';
+import 'package:openvine/services/video_editor/stop_motion_render_service.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 
@@ -273,6 +275,65 @@ void main() {
       expect(upload.hasProofMode, isFalse);
       expect(upload.proofManifestJson, isNull);
     });
+
+    test(
+      'deletes the transient stop-motion render after a successful upload',
+      () async {
+        // No finalRenderedClip, so startUploadFromDraft hits the fallback that
+        // re-renders the frames-only clip into a documents-dir mp4.
+        final renderPath = '${tempDir.path}/documents/stop_motion_fallback.mp4';
+        StopMotionRenderService.assembleOverride =
+            ({
+              required frames,
+              required aspectRatio,
+              frameRate = StopMotionRenderService.defaultFrameRate,
+              taskId,
+            }) async {
+              File(renderPath)
+                ..parent.createSync(recursive: true)
+                ..writeAsBytesSync([0, 1, 2, 3]);
+              return renderPath;
+            };
+        StopMotionRenderService.probeDurationOverride = (_) async =>
+            const Duration(seconds: 2);
+        addTearDown(() {
+          StopMotionRenderService.assembleOverride = null;
+          StopMotionRenderService.probeDurationOverride = null;
+        });
+
+        final draft = DivineVideoDraft.create(
+          clips: [
+            DivineVideoClip(
+              id: 'sm_clip',
+              stopMotionFrames: const [
+                StopMotionClipFrame(
+                  path: '/tmp/f0.jpg',
+                  duration: Duration(milliseconds: 167),
+                ),
+              ],
+              duration: const Duration(milliseconds: 167),
+              recordedAt: DateTime.now(),
+              targetAspectRatio: AspectRatio.vertical,
+              originalAspectRatio: 9 / 16,
+            ),
+          ],
+          title: 'Stop Motion',
+          description: 'Fallback render',
+          hashtags: {'sm'},
+          selectedApproach: 'native',
+        );
+
+        final upload = await uploadManager.startUploadFromDraft(
+          draft: draft,
+          nostrPubkey: 'test-pubkey',
+        );
+
+        // The fallback render was the upload input, and it is reaped once the
+        // upload has consumed it — no orphaned mp4 left in documents.
+        expect(upload.localVideoPath, equals(renderPath));
+        expect(File(renderPath).existsSync(), isFalse);
+      },
+    );
 
     test(
       'throws when upload finishes in failed state instead of returning a completed upload',

--- a/mobile/test/services/video_clip_import_service_test.dart
+++ b/mobile/test/services/video_clip_import_service_test.dart
@@ -149,10 +149,10 @@ void main() {
     expect(success.clip.originalAspectRatio, 1);
     expect(success.clip.thumbnailPath, endsWith('thumb.jpg'));
     expect(success.clip.ghostFramePath, endsWith('ghost.jpg'));
-    expect(success.clip.video.file!.path, startsWith(docsDir.path));
+    expect(success.clip.requireVideo.file!.path, startsWith(docsDir.path));
     expect(success.clip.libraryTitle, 'classic vine');
     expect(
-      File(success.clip.video.file!.path).readAsBytesSync(),
+      File(success.clip.requireVideo.file!.path).readAsBytesSync(),
       sourceVideo.readAsBytesSync(),
     );
 

--- a/mobile/test/services/video_editor/clip_speed_render_service_test.dart
+++ b/mobile/test/services/video_editor/clip_speed_render_service_test.dart
@@ -230,7 +230,7 @@ void main() {
             playbackSpeed: 2,
             path: p.join(tempDir.path, 'source.mp4'),
           );
-          File(c.video.file!.path).writeAsStringSync('source');
+          File(c.video!.file!.path).writeAsStringSync('source');
           final fakeEditor = _FakeProVideoEditor();
           editor.ProVideoEditor.instance = fakeEditor;
           final service = ClipSpeedRenderService();
@@ -285,7 +285,7 @@ void main() {
             playbackSpeed: 2,
             path: p.join(tempDir.path, 'source.mp4'),
           );
-          File(c.video.file!.path).writeAsStringSync('source');
+          File(c.video!.file!.path).writeAsStringSync('source');
           final fakeEditor = _FakeProVideoEditor();
           editor.ProVideoEditor.instance = fakeEditor;
           final service = ClipSpeedRenderService();
@@ -314,7 +314,7 @@ void main() {
             playbackSpeed: 2,
             path: p.join(tempDir.path, 'source.mp4'),
           );
-          File(c.video.file!.path).writeAsStringSync('source');
+          File(c.video!.file!.path).writeAsStringSync('source');
           final fakeEditor = _FakeProVideoEditor();
           editor.ProVideoEditor.instance = fakeEditor;
           final service = ClipSpeedRenderService();

--- a/mobile/test/services/video_editor/ensure_clip_proofs_test.dart
+++ b/mobile/test/services/video_editor/ensure_clip_proofs_test.dart
@@ -26,7 +26,7 @@ List<DivineVideoClip> ensureClipProofsSimulated(
       continue;
     }
 
-    final videoFile = clip.video.file;
+    final videoFile = clip.requireVideo.file;
     if (videoFile == null) {
       result.add(clip);
       continue;

--- a/mobile/test/services/video_editor/native_render_task_registry_test.dart
+++ b/mobile/test/services/video_editor/native_render_task_registry_test.dart
@@ -1,0 +1,99 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/video_editor/native_render_task_registry.dart';
+
+void main() {
+  group(NativeRenderTaskRegistry, () {
+    tearDown(NativeRenderTaskRegistry.reset);
+
+    group('track', () {
+      test('exposes the task as active while it is in flight', () async {
+        final gate = Completer<String>();
+
+        final tracked = NativeRenderTaskRegistry.track(
+          'task-1',
+          () => gate.future,
+        );
+
+        expect(NativeRenderTaskRegistry.activeTaskIds, contains('task-1'));
+
+        gate.complete('done');
+        await tracked;
+
+        expect(NativeRenderTaskRegistry.activeTaskIds, isEmpty);
+      });
+
+      test('returns the operation result', () async {
+        final result = await NativeRenderTaskRegistry.track(
+          'task-1',
+          () async => '/tmp/out.mp4',
+        );
+
+        expect(result, equals('/tmp/out.mp4'));
+      });
+
+      test('stops tracking a task that throws, and rethrows', () async {
+        await expectLater(
+          NativeRenderTaskRegistry.track<void>(
+            'task-1',
+            () async => throw StateError('render failed'),
+          ),
+          throwsStateError,
+        );
+
+        expect(NativeRenderTaskRegistry.activeTaskIds, isEmpty);
+      });
+
+      test('tracks concurrent tasks independently', () async {
+        final first = Completer<void>();
+        final second = Completer<void>();
+
+        final tracked = [
+          NativeRenderTaskRegistry.track('task-1', () => first.future),
+          NativeRenderTaskRegistry.track('task-2', () => second.future),
+        ];
+
+        expect(
+          NativeRenderTaskRegistry.activeTaskIds,
+          containsAll(<String>['task-1', 'task-2']),
+        );
+
+        first.complete();
+        await tracked.first;
+
+        expect(NativeRenderTaskRegistry.activeTaskIds, equals({'task-2'}));
+
+        second.complete();
+        await Future.wait(tracked);
+      });
+
+      // A re-registered id belongs to the newer call, so the displaced one
+      // must not remove it on the way out — otherwise the live task silently
+      // stops being cancellable at teardown.
+      test('keeps the newer registration when an id is reused', () async {
+        final first = Completer<void>();
+        final second = Completer<void>();
+
+        final firstTracked = NativeRenderTaskRegistry.track(
+          'task-1',
+          () => first.future,
+        );
+        final secondTracked = NativeRenderTaskRegistry.track(
+          'task-1',
+          () => second.future,
+        );
+
+        first.complete();
+        await firstTracked;
+
+        expect(NativeRenderTaskRegistry.activeTaskIds, contains('task-1'));
+
+        second.complete();
+        await secondTracked;
+
+        expect(NativeRenderTaskRegistry.activeTaskIds, isEmpty);
+      });
+    });
+  });
+}

--- a/mobile/test/services/video_editor/stop_motion_audio_preview_test.dart
+++ b/mobile/test/services/video_editor/stop_motion_audio_preview_test.dart
@@ -131,6 +131,24 @@ void main() {
       verify(() => players.single.seek(const Duration(seconds: 3))).called(1);
     });
 
+    test('a short forward scrub re-seeks the sound', () async {
+      await preview.setTracks([track(windowEnd: const Duration(seconds: 5))]);
+
+      await preview.syncTo(const Duration(milliseconds: 100), isPlaying: true);
+      // A 300ms forward scrub is under the jump threshold, so it is
+      // indistinguishable from a run of normal ticks — only the explicit seek
+      // flag separates them. Without it the sound plays on from 100ms.
+      await preview.syncTo(
+        const Duration(milliseconds: 400),
+        isPlaying: true,
+        isSeek: true,
+      );
+
+      verify(
+        () => players.single.seek(const Duration(milliseconds: 400)),
+      ).called(1);
+    });
+
     test('syncTo with isPlaying false pauses an active sound', () async {
       await preview.setTracks([track()]);
 

--- a/mobile/test/services/video_editor/stop_motion_audio_preview_test.dart
+++ b/mobile/test/services/video_editor/stop_motion_audio_preview_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Tests for StopMotionAudioPreview - stop-motion preview audio engine
 // ABOUTME: Verifies window scheduling, scrub re-seek, pause, and disposal
 
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/services/video_editor/stop_motion_audio_preview.dart';
@@ -186,6 +188,82 @@ void main() {
 
       await preview.syncTo(const Duration(milliseconds: 500), isPlaying: true);
       verifyNever(players.single.play);
+    });
+
+    // Regression: syncTo used to iterate the live _tracks map across its
+    // seek/pause awaits, so a setTracks() that cleared the map mid-iteration
+    // (a sound edit during playback) threw ConcurrentModificationError. The
+    // operations are now serialized, so setTracks waits for the in-flight sync.
+    test(
+      'setTracks during an in-flight syncTo does not throw '
+      'ConcurrentModificationError',
+      () async {
+        final seekGate = Completer<void>();
+        final gated = _MockAudioClipPlayer();
+        when(() => gated.setClip(any())).thenAnswer((_) async {});
+        when(() => gated.setVolume(any())).thenAnswer((_) async {});
+        when(() => gated.seek(any())).thenAnswer((_) => seekGate.future);
+        when(gated.play).thenAnswer((_) async {});
+        when(gated.pause).thenAnswer((_) async {});
+        when(gated.dispose).thenAnswer((_) async {});
+
+        var served = false;
+        preview = StopMotionAudioPreview(
+          playerFactory: () {
+            if (!served) {
+              served = true;
+              return gated;
+            }
+            return newPlayer();
+          },
+        );
+        await preview.setTracks([track()]);
+
+        // Suspends inside the gated seek.
+        final syncing = preview.syncTo(
+          const Duration(milliseconds: 100),
+          isPlaying: true,
+        );
+        // Replaces the tracks while the sync is suspended — must not throw.
+        final replacing = preview.setTracks([track(id: 'b')]);
+
+        seekGate.complete();
+        await syncing;
+        await replacing;
+
+        // The replacement generation disposed the gated player; no CME.
+        verify(gated.dispose).called(1);
+      },
+    );
+
+    // Regression: overlapping unawaited syncTo calls used to race on the shared
+    // active/_lastPosition state. A call issued while another is in flight is
+    // now dropped (the next frame re-syncs).
+    test('drops a syncTo issued while another is in flight', () async {
+      final seekGate = Completer<void>();
+      final gated = _MockAudioClipPlayer();
+      when(() => gated.setClip(any())).thenAnswer((_) async {});
+      when(() => gated.setVolume(any())).thenAnswer((_) async {});
+      when(() => gated.seek(any())).thenAnswer((_) => seekGate.future);
+      when(gated.play).thenAnswer((_) async {});
+      when(gated.pause).thenAnswer((_) async {});
+      when(gated.dispose).thenAnswer((_) async {});
+
+      preview = StopMotionAudioPreview(playerFactory: () => gated);
+      await preview.setTracks([track()]);
+
+      final first = preview.syncTo(
+        const Duration(milliseconds: 100),
+        isPlaying: true,
+      );
+      // Dropped: the first sync is still suspended in seek.
+      await preview.syncTo(const Duration(milliseconds: 117), isPlaying: true);
+
+      seekGate.complete();
+      await first;
+
+      verify(() => gated.seek(const Duration(milliseconds: 100))).called(1);
+      verifyNever(() => gated.seek(const Duration(milliseconds: 117)));
     });
   });
 }

--- a/mobile/test/services/video_editor/stop_motion_audio_preview_test.dart
+++ b/mobile/test/services/video_editor/stop_motion_audio_preview_test.dart
@@ -1,0 +1,191 @@
+// ABOUTME: Tests for StopMotionAudioPreview - stop-motion preview audio engine
+// ABOUTME: Verifies window scheduling, scrub re-seek, pause, and disposal
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/services/video_editor/stop_motion_audio_preview.dart';
+import 'package:sound_service/sound_service.dart';
+
+class _MockAudioClipPlayer extends Mock implements AudioClipPlayer {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(const AudioSourceConfig.file('/fallback.mp3'));
+    registerFallbackValue(Duration.zero);
+  });
+
+  group(StopMotionAudioPreview, () {
+    late List<_MockAudioClipPlayer> players;
+    late StopMotionAudioPreview preview;
+
+    _MockAudioClipPlayer newPlayer() {
+      final player = _MockAudioClipPlayer();
+      when(() => player.setClip(any())).thenAnswer((_) async {});
+      when(() => player.setVolume(any())).thenAnswer((_) async {});
+      when(() => player.seek(any())).thenAnswer((_) async {});
+      when(player.play).thenAnswer((_) async {});
+      when(player.pause).thenAnswer((_) async {});
+      when(player.dispose).thenAnswer((_) async {});
+      players.add(player);
+      return player;
+    }
+
+    StopMotionAudioPreviewTrack track({
+      String id = 'sound-1',
+      Duration windowStart = Duration.zero,
+      Duration windowEnd = const Duration(seconds: 2),
+      double volume = 1,
+    }) {
+      return StopMotionAudioPreviewTrack(
+        id: id,
+        source: const AudioSourceConfig.file('/music.mp3'),
+        windowStart: windowStart,
+        windowEnd: windowEnd,
+        volume: volume,
+      );
+    }
+
+    setUp(() {
+      players = [];
+      preview = StopMotionAudioPreview(playerFactory: newPlayer);
+    });
+
+    tearDown(() async {
+      await preview.dispose();
+    });
+
+    test('setTracks loads the clip and applies the track volume', () async {
+      await preview.setTracks([track(volume: 0.4)]);
+
+      expect(players, hasLength(1));
+      verify(
+        () =>
+            players.single.setClip(const AudioSourceConfig.file('/music.mp3')),
+      ).called(1);
+      verify(() => players.single.setVolume(0.4)).called(1);
+    });
+
+    test('starts a sound when the playhead enters its window', () async {
+      await preview.setTracks([
+        track(
+          windowStart: const Duration(seconds: 1),
+          windowEnd: const Duration(seconds: 3),
+        ),
+      ]);
+
+      await preview.syncTo(const Duration(milliseconds: 500), isPlaying: true);
+      verifyNever(players.single.play);
+
+      await preview.syncTo(const Duration(milliseconds: 1500), isPlaying: true);
+      verify(
+        () => players.single.seek(const Duration(milliseconds: 500)),
+      ).called(1);
+      verify(players.single.play).called(1);
+    });
+
+    test('steady playback inside the window does not re-seek', () async {
+      await preview.setTracks([track()]);
+
+      await preview.syncTo(const Duration(milliseconds: 100), isPlaying: true);
+      await preview.syncTo(const Duration(milliseconds: 117), isPlaying: true);
+      await preview.syncTo(const Duration(milliseconds: 134), isPlaying: true);
+
+      verify(() => players.single.seek(any())).called(1);
+      verify(players.single.play).called(1);
+    });
+
+    test('pauses a sound when the playhead leaves its window', () async {
+      await preview.setTracks([
+        track(windowEnd: const Duration(seconds: 1)),
+      ]);
+
+      await preview.syncTo(const Duration(milliseconds: 500), isPlaying: true);
+      await preview.syncTo(const Duration(milliseconds: 900), isPlaying: true);
+      // 1.2s is past the 1s window end but within the jump threshold.
+      await preview.syncTo(const Duration(milliseconds: 1200), isPlaying: true);
+
+      verify(players.single.pause).called(1);
+    });
+
+    test('a backwards jump (loop wrap / scrub) re-seeks the sound', () async {
+      await preview.setTracks([track()]);
+
+      await preview.syncTo(const Duration(milliseconds: 1500), isPlaying: true);
+      await preview.syncTo(const Duration(milliseconds: 100), isPlaying: true);
+
+      verifyInOrder([
+        () => players.single.seek(const Duration(milliseconds: 1500)),
+        () => players.single.seek(const Duration(milliseconds: 100)),
+      ]);
+      verify(players.single.play).called(2);
+    });
+
+    test('a forward jump past the threshold re-seeks the sound', () async {
+      await preview.setTracks([track(windowEnd: const Duration(seconds: 5))]);
+
+      await preview.syncTo(const Duration(milliseconds: 100), isPlaying: true);
+      await preview.syncTo(const Duration(seconds: 3), isPlaying: true);
+
+      verify(() => players.single.seek(const Duration(seconds: 3))).called(1);
+    });
+
+    test('syncTo with isPlaying false pauses an active sound', () async {
+      await preview.setTracks([track()]);
+
+      await preview.syncTo(const Duration(milliseconds: 500), isPlaying: true);
+      await preview.syncTo(const Duration(milliseconds: 600), isPlaying: false);
+
+      verify(players.single.pause).called(1);
+    });
+
+    test('pauseAll pauses only active sounds', () async {
+      await preview.setTracks([
+        track(id: 'a'),
+        track(
+          id: 'b',
+          windowStart: const Duration(seconds: 5),
+          windowEnd: const Duration(seconds: 6),
+        ),
+      ]);
+
+      await preview.syncTo(const Duration(seconds: 1), isPlaying: true);
+      await preview.pauseAll();
+
+      verify(players[0].pause).called(1);
+      verifyNever(players[1].pause);
+    });
+
+    test('setTracks disposes the previous generation of players', () async {
+      await preview.setTracks([track(id: 'a')]);
+      await preview.setTracks([track(id: 'b')]);
+
+      expect(players, hasLength(2));
+      verify(players[0].dispose).called(1);
+      verifyNever(players[1].dispose);
+    });
+
+    test('a track whose clip fails to load is skipped and disposed', () async {
+      final failing = _MockAudioClipPlayer();
+      when(() => failing.setClip(any())).thenThrow(Exception('bad file'));
+      when(failing.dispose).thenAnswer((_) async {});
+
+      preview = StopMotionAudioPreview(playerFactory: () => failing);
+      await preview.setTracks([track()]);
+
+      verify(failing.dispose).called(1);
+      // No crash on sync with the failed track skipped.
+      await preview.syncTo(Duration.zero, isPlaying: true);
+      verifyNever(failing.play);
+    });
+
+    test('dispose releases every player and ignores later syncs', () async {
+      await preview.setTracks([track()]);
+      await preview.dispose();
+
+      verify(players.single.dispose).called(1);
+
+      await preview.syncTo(const Duration(milliseconds: 500), isPlaying: true);
+      verifyNever(players.single.play);
+    });
+  });
+}

--- a/mobile/test/services/video_editor/stop_motion_audio_preview_test.dart
+++ b/mobile/test/services/video_editor/stop_motion_audio_preview_test.dart
@@ -283,5 +283,51 @@ void main() {
       verify(() => gated.seek(const Duration(milliseconds: 100))).called(1);
       verifyNever(() => gated.seek(const Duration(milliseconds: 117)));
     });
+
+    // Regression: a scrub dropped because a sync was already in flight used to
+    // lose its re-seek intent. The in-flight sync had already advanced
+    // _lastPosition, so the next normal tick read as a sub-threshold forward
+    // hop (steady playback) and never re-seeked — the sound played on from the
+    // pre-scrub offset until the next window/loop boundary. The dropped scrub
+    // is now remembered and forces the next admitted sync to re-seek.
+    test('a scrub dropped mid-sync forces the next tick to re-seek', () async {
+      final seekGate = Completer<void>();
+      final gated = _MockAudioClipPlayer();
+      when(() => gated.setClip(any())).thenAnswer((_) async {});
+      when(() => gated.setVolume(any())).thenAnswer((_) async {});
+      when(() => gated.seek(any())).thenAnswer((_) => seekGate.future);
+      when(gated.play).thenAnswer((_) async {});
+      when(gated.pause).thenAnswer((_) async {});
+      when(gated.dispose).thenAnswer((_) async {});
+
+      preview = StopMotionAudioPreview(playerFactory: () => gated);
+      await preview.setTracks([track(windowEnd: const Duration(seconds: 5))]);
+
+      // A sync suspends inside the gated seek, holding _syncInFlight and having
+      // already advanced _lastPosition to 100ms.
+      final first = preview.syncTo(
+        const Duration(milliseconds: 100),
+        isPlaying: true,
+      );
+      // Let that sync run up to (and suspend in) the seek await, so it is past
+      // the point where it reads the pending-seek flag.
+      await Future<void>.delayed(Duration.zero);
+
+      // A scrub lands while the sync is in flight: dropped, but remembered.
+      await preview.syncTo(
+        const Duration(milliseconds: 400),
+        isPlaying: true,
+        isSeek: true,
+      );
+
+      seekGate.complete();
+      await first;
+
+      // A 317ms forward hop from _lastPosition is under the 500ms threshold, so
+      // without the remembered scrub this tick would not re-seek.
+      await preview.syncTo(const Duration(milliseconds: 417), isPlaying: true);
+
+      verify(() => gated.seek(const Duration(milliseconds: 417))).called(1);
+    });
   });
 }

--- a/mobile/test/services/video_editor/stop_motion_render_service_test.dart
+++ b/mobile/test/services/video_editor/stop_motion_render_service_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart' as model show AspectRatio;
 import 'package:openvine/constants/video_editor_constants.dart';
@@ -310,6 +312,71 @@ void main() {
         );
 
         expect(result, isNull);
+      });
+    });
+
+    group('cleanupMaterializedOutput', () {
+      test('deletes the rendered mp4 for a frames-only source clip', () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'stop_motion_cleanup_test',
+        );
+        addTearDown(() async {
+          if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+        });
+        final output = File('${tempDir.path}/rendered.mp4')
+          ..writeAsStringSync('rendered');
+
+        final source = DivineVideoClip(
+          id: 'sm-cleanup',
+          stopMotionFrames: const [
+            StopMotionClipFrame(
+              path: '/a.jpg',
+              duration: Duration(milliseconds: 83),
+            ),
+          ],
+          duration: const Duration(milliseconds: 83),
+          recordedAt: DateTime(2024),
+          targetAspectRatio: model.AspectRatio.vertical,
+          originalAspectRatio: 9 / 16,
+        );
+        final materialized = source.copyWith(
+          video: EditorVideo.file(output.path),
+          clearStopMotionFrames: true,
+        );
+
+        await StopMotionRenderService.cleanupMaterializedOutput(
+          sourceClip: source,
+          materializedClip: materialized,
+        );
+
+        expect(output.existsSync(), isFalse);
+      });
+
+      test('does not delete an already video-backed source clip', () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'stop_motion_cleanup_video_test',
+        );
+        addTearDown(() async {
+          if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+        });
+        final output = File('${tempDir.path}/source.mp4')
+          ..writeAsStringSync('video');
+
+        final source = DivineVideoClip(
+          id: 'video-cleanup',
+          video: EditorVideo.file(output.path),
+          duration: const Duration(seconds: 1),
+          recordedAt: DateTime(2024),
+          targetAspectRatio: model.AspectRatio.vertical,
+          originalAspectRatio: 9 / 16,
+        );
+
+        await StopMotionRenderService.cleanupMaterializedOutput(
+          sourceClip: source,
+          materializedClip: source,
+        );
+
+        expect(output.existsSync(), isTrue);
       });
     });
   });

--- a/mobile/test/services/video_editor/stop_motion_render_service_test.dart
+++ b/mobile/test/services/video_editor/stop_motion_render_service_test.dart
@@ -202,9 +202,46 @@ void main() {
         // The progress task id is forwarded to the assembly.
         expect(capturedTaskId, 'render-task');
         expect(result?.video?.file?.path, '/rendered.mp4');
-        // Frames are kept as the source of truth.
-        expect(result?.stopMotionFrames, clip.stopMotionFrames);
+        // The materialized clip is now a plain video clip: its transient stills
+        // are cleared and it no longer classifies as stop-motion.
+        expect(result?.stopMotionFrames, isNull);
+        expect(result?.isStopMotion, isFalse);
+        // Duration matches the looped mp4: 333ms single pass loops x4 to clear
+        // the 1s minimum output duration (ceil(1000/333) = 4 → 1332ms).
+        expect(result?.duration, const Duration(milliseconds: 1332));
       });
+
+      test(
+        'keeps the single-pass duration when already >= min output',
+        () async {
+          StopMotionRenderService.assembleOverride =
+              ({
+                required frames,
+                required aspectRatio,
+                frameRate = StopMotionRenderService.defaultFrameRate,
+                String? taskId,
+              }) async => '/rendered.mp4';
+
+          final clip = DivineVideoClip(
+            id: 'sm-long',
+            stopMotionFrames: const [
+              StopMotionClipFrame(
+                path: '/a.jpg',
+                duration: Duration(milliseconds: 1200),
+              ),
+            ],
+            duration: const Duration(milliseconds: 1200),
+            recordedAt: DateTime(2024),
+            targetAspectRatio: model.AspectRatio.vertical,
+            originalAspectRatio: 9 / 16,
+          );
+
+          final result = await StopMotionRenderService.materialize(clip);
+
+          expect(result?.duration, const Duration(milliseconds: 1200));
+          expect(result?.stopMotionFrames, isNull);
+        },
+      );
 
       test('returns null when the render fails', () async {
         StopMotionRenderService.assembleOverride =

--- a/mobile/test/services/video_editor/stop_motion_render_service_test.dart
+++ b/mobile/test/services/video_editor/stop_motion_render_service_test.dart
@@ -16,7 +16,10 @@ void main() {
   ];
 
   group(StopMotionRenderService, () {
-    tearDown(() => StopMotionRenderService.assembleOverride = null);
+    tearDown(() {
+      StopMotionRenderService.assembleOverride = null;
+      StopMotionRenderService.probeDurationOverride = null;
+    });
 
     test('returns null for an empty frame list', () async {
       final result = await StopMotionRenderService.assemble(
@@ -143,6 +146,13 @@ void main() {
     });
 
     group('materialize', () {
+      setUp(() {
+        // Default: the assembled path is a stub with no probe-able mp4, so fall
+        // back to the frame-hold estimate for a deterministic duration. Tests
+        // that assert the probe path override this.
+        StopMotionRenderService.probeDurationOverride = (_) async => null;
+      });
+
       DivineVideoClip stopMotionClip() => DivineVideoClip(
         id: 'sm1',
         stopMotionFrames: const [
@@ -242,6 +252,49 @@ void main() {
           expect(result?.stopMotionFrames, isNull);
         },
       );
+
+      test(
+        'uses the probed encoded mp4 duration over the frame-hold estimate',
+        () async {
+          StopMotionRenderService.assembleOverride =
+              ({
+                required frames,
+                required aspectRatio,
+                frameRate = StopMotionRenderService.defaultFrameRate,
+                String? taskId,
+              }) async => '/rendered.mp4';
+          // The real encoder lands a hair short of the 1332ms hold estimate;
+          // the muxed-audio clamp keys off the clip duration, so the probed
+          // length must win or audio outlives the video (the iOS freeze).
+          StopMotionRenderService.probeDurationOverride = (_) async =>
+              const Duration(milliseconds: 1300);
+
+          final result = await StopMotionRenderService.materialize(
+            stopMotionClip(),
+          );
+
+          expect(result?.duration, const Duration(milliseconds: 1300));
+          expect(result?.stopMotionFrames, isNull);
+        },
+      );
+
+      test('falls back to the estimate when the probe returns null', () async {
+        StopMotionRenderService.assembleOverride =
+            ({
+              required frames,
+              required aspectRatio,
+              frameRate = StopMotionRenderService.defaultFrameRate,
+              String? taskId,
+            }) async => '/rendered.mp4';
+        StopMotionRenderService.probeDurationOverride = (_) async => null;
+
+        final result = await StopMotionRenderService.materialize(
+          stopMotionClip(),
+        );
+
+        // 333ms single pass loops x4 to clear the 1s minimum (ceil(1000/333)).
+        expect(result?.duration, const Duration(milliseconds: 1332));
+      });
 
       test('returns null when the render fails', () async {
         StopMotionRenderService.assembleOverride =

--- a/mobile/test/services/video_editor/stop_motion_render_service_test.dart
+++ b/mobile/test/services/video_editor/stop_motion_render_service_test.dart
@@ -1,0 +1,226 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart' as model show AspectRatio;
+import 'package:openvine/constants/video_editor_constants.dart';
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
+import 'package:openvine/services/video_editor/stop_motion_render_service.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
+
+void main() {
+  List<StopMotionClipFrame> framesOf(
+    List<String> paths, {
+    Duration duration = const Duration(milliseconds: 83),
+  }) => [
+    for (final path in paths)
+      StopMotionClipFrame(path: path, duration: duration),
+  ];
+
+  group(StopMotionRenderService, () {
+    tearDown(() => StopMotionRenderService.assembleOverride = null);
+
+    test('returns null for an empty frame list', () async {
+      final result = await StopMotionRenderService.assemble(
+        frames: const [],
+        aspectRatio: model.AspectRatio.vertical,
+      );
+
+      expect(result, isNull);
+    });
+
+    test('delegates to assembleOverride with the given arguments', () async {
+      List<StopMotionClipFrame>? capturedFrames;
+      model.AspectRatio? capturedRatio;
+      double? capturedFrameRate;
+      String? capturedTaskId;
+
+      StopMotionRenderService.assembleOverride =
+          ({
+            required frames,
+            required aspectRatio,
+            frameRate = StopMotionRenderService.defaultFrameRate,
+            String? taskId,
+          }) async {
+            capturedFrames = frames;
+            capturedRatio = aspectRatio;
+            capturedFrameRate = frameRate;
+            capturedTaskId = taskId;
+            return '/tmp/out.mp4';
+          };
+
+      final frames = framesOf(const ['/a.jpg', '/b.jpg']);
+      final result = await StopMotionRenderService.assemble(
+        frames: frames,
+        aspectRatio: model.AspectRatio.square,
+        taskId: 'assembly-task',
+      );
+
+      expect(result, '/tmp/out.mp4');
+      expect(capturedFrames, frames);
+      expect(capturedRatio, model.AspectRatio.square);
+      expect(capturedFrameRate, StopMotionRenderService.defaultFrameRate);
+      expect(capturedTaskId, 'assembly-task');
+    });
+
+    group('framesForMinOutputDuration', () {
+      const min = VideoEditorConstants.stopMotionMinOutputDuration;
+
+      Duration total(List<StopMotionClipFrame> frames) =>
+          frames.fold(Duration.zero, (sum, frame) => sum + frame.duration);
+
+      test('returns an empty list unchanged', () {
+        expect(
+          StopMotionRenderService.framesForMinOutputDuration(const []),
+          isEmpty,
+        );
+      });
+
+      test('repeats a single still until it reaches the minimum', () {
+        final frames = framesOf(const ['/a.jpg']);
+        final result = StopMotionRenderService.framesForMinOutputDuration(
+          frames,
+        );
+
+        expect(result.map((f) => f.path).toSet(), {'/a.jpg'});
+        expect(total(result), greaterThanOrEqualTo(min));
+        // Minimal: one fewer copy would fall short of the floor.
+        expect(
+          total(result.sublist(0, result.length - 1)),
+          lessThan(min),
+        );
+      });
+
+      test('loops a short sequence a whole number of times', () {
+        final frames = framesOf(
+          const ['/a.jpg', '/b.jpg', '/c.jpg'],
+          duration: const Duration(milliseconds: 100),
+        ); // 300ms < 1s
+        final result = StopMotionRenderService.framesForMinOutputDuration(
+          frames,
+        );
+
+        expect(result.length % frames.length, 0);
+        expect(total(result), greaterThanOrEqualTo(min));
+        expect(
+          total(result.sublist(0, result.length - frames.length)),
+          lessThan(min),
+        );
+        // Order preserved across the repeats (seamless loop).
+        expect(result.sublist(0, frames.length), frames);
+      });
+
+      test('preserves per-frame holds when looping', () {
+        final frames = [
+          const StopMotionClipFrame(
+            path: '/a.jpg',
+            duration: Duration(milliseconds: 83),
+          ),
+          const StopMotionClipFrame(
+            path: '/b.jpg',
+            duration: Duration(milliseconds: 250),
+          ),
+        ];
+        final result = StopMotionRenderService.framesForMinOutputDuration(
+          frames,
+        );
+
+        for (var i = 0; i < result.length; i += 2) {
+          expect(result[i].duration, const Duration(milliseconds: 83));
+          expect(result[i + 1].duration, const Duration(milliseconds: 250));
+        }
+      });
+
+      test('leaves a sequence already at the minimum unchanged', () {
+        final frames = framesOf(
+          const ['/a.jpg', '/b.jpg', '/c.jpg', '/d.jpg'],
+          duration: const Duration(milliseconds: 250),
+        ); // 1s
+        final result = StopMotionRenderService.framesForMinOutputDuration(
+          frames,
+        );
+
+        expect(result, frames);
+      });
+    });
+
+    group('materialize', () {
+      DivineVideoClip stopMotionClip() => DivineVideoClip(
+        id: 'sm1',
+        stopMotionFrames: const [
+          StopMotionClipFrame(
+            path: '/a.jpg',
+            duration: Duration(milliseconds: 83),
+          ),
+          StopMotionClipFrame(
+            path: '/b.jpg',
+            duration: Duration(milliseconds: 250),
+          ),
+        ],
+        duration: const Duration(milliseconds: 333),
+        recordedAt: DateTime(2024),
+        targetAspectRatio: model.AspectRatio.vertical,
+        originalAspectRatio: 9 / 16,
+      );
+
+      test('returns a non-stop-motion clip unchanged', () async {
+        final clip = DivineVideoClip(
+          id: 'v1',
+          video: EditorVideo.file('/v.mp4'),
+          duration: const Duration(seconds: 2),
+          recordedAt: DateTime(2024),
+          targetAspectRatio: model.AspectRatio.vertical,
+          originalAspectRatio: 9 / 16,
+        );
+
+        final result = await StopMotionRenderService.materialize(clip);
+
+        expect(identical(result, clip), isTrue);
+      });
+
+      test('renders the clip frames — per-frame holds included', () async {
+        List<StopMotionClipFrame>? capturedFrames;
+        String? capturedTaskId;
+        StopMotionRenderService.assembleOverride =
+            ({
+              required frames,
+              required aspectRatio,
+              frameRate = StopMotionRenderService.defaultFrameRate,
+              String? taskId,
+            }) async {
+              capturedFrames = frames;
+              capturedTaskId = taskId;
+              return '/rendered.mp4';
+            };
+
+        final clip = stopMotionClip();
+        final result = await StopMotionRenderService.materialize(
+          clip,
+          taskId: 'render-task',
+        );
+
+        // The clip's own frames (with individual hold times) reach the render.
+        expect(capturedFrames, clip.stopMotionFrames);
+        // The progress task id is forwarded to the assembly.
+        expect(capturedTaskId, 'render-task');
+        expect(result?.video?.file?.path, '/rendered.mp4');
+        // Frames are kept as the source of truth.
+        expect(result?.stopMotionFrames, clip.stopMotionFrames);
+      });
+
+      test('returns null when the render fails', () async {
+        StopMotionRenderService.assembleOverride =
+            ({
+              required frames,
+              required aspectRatio,
+              frameRate = StopMotionRenderService.defaultFrameRate,
+              String? taskId,
+            }) async => null;
+
+        final result = await StopMotionRenderService.materialize(
+          stopMotionClip(),
+        );
+
+        expect(result, isNull);
+      });
+    });
+  });
+}

--- a/mobile/test/services/video_editor/video_editor_audio_render_test.dart
+++ b/mobile/test/services/video_editor/video_editor_audio_render_test.dart
@@ -112,5 +112,78 @@ void main() {
 
       expect(result, isEmpty);
     });
+
+    test(
+      'clamps a track window that outlasts the video to the video duration',
+      () async {
+        // A full-length song (endTime 4s) muxed onto a ~1s stop-motion video
+        // must not outlast the video track, or iOS freezes the last frame.
+        final result = await resolveRenderAudioTracks(
+          [
+            _fileTrack(
+              id: 'song',
+              path: '/tmp/song.mp3',
+              startTime: Duration.zero,
+            ),
+          ],
+          logName: 'test',
+          videoDuration: const Duration(seconds: 1),
+        );
+
+        expect(result.single.startTime, equals(Duration.zero));
+        expect(result.single.endTime, equals(const Duration(seconds: 1)));
+      },
+    );
+
+    test('leaves a track shorter than the video untouched', () async {
+      final result = await resolveRenderAudioTracks(
+        [
+          _fileTrack(
+            id: 'short',
+            path: '/tmp/short.mp3',
+            endTime: const Duration(seconds: 2),
+          ),
+        ],
+        logName: 'test',
+        videoDuration: const Duration(seconds: 6),
+      );
+
+      expect(result.single.startTime, equals(const Duration(seconds: 1)));
+      expect(result.single.endTime, equals(const Duration(seconds: 2)));
+    });
+  });
+
+  group('clampAudioWindowToVideo', () {
+    test('returns the window unchanged when videoDuration is null', () {
+      final result = clampAudioWindowToVideo(
+        startTime: const Duration(seconds: 1),
+        endTime: const Duration(seconds: 9),
+        videoDuration: null,
+      );
+
+      expect(result.startTime, equals(const Duration(seconds: 1)));
+      expect(result.endTime, equals(const Duration(seconds: 9)));
+    });
+
+    test('leaves a null endTime null (means "play to end of video")', () {
+      final result = clampAudioWindowToVideo(
+        startTime: Duration.zero,
+        endTime: null,
+        videoDuration: const Duration(seconds: 1),
+      );
+
+      expect(result.endTime, isNull);
+    });
+
+    test('clamps both start and end past the video to the video end', () {
+      final result = clampAudioWindowToVideo(
+        startTime: const Duration(seconds: 5),
+        endTime: const Duration(seconds: 9),
+        videoDuration: const Duration(seconds: 1),
+      );
+
+      expect(result.startTime, equals(const Duration(seconds: 1)));
+      expect(result.endTime, equals(const Duration(seconds: 1)));
+    });
   });
 }

--- a/mobile/test/services/video_editor/video_editor_audio_render_test.dart
+++ b/mobile/test/services/video_editor/video_editor_audio_render_test.dart
@@ -161,8 +161,8 @@ void main() {
         videoDuration: null,
       );
 
-      expect(result.startTime, equals(const Duration(seconds: 1)));
-      expect(result.endTime, equals(const Duration(seconds: 9)));
+      expect(result?.startTime, equals(const Duration(seconds: 1)));
+      expect(result?.endTime, equals(const Duration(seconds: 9)));
     });
 
     test('leaves a null endTime null (means "play to end of video")', () {
@@ -172,18 +172,41 @@ void main() {
         videoDuration: const Duration(seconds: 1),
       );
 
-      expect(result.endTime, isNull);
+      expect(result, isNotNull);
+      expect(result?.endTime, isNull);
     });
 
-    test('clamps both start and end past the video to the video end', () {
+    test('drops a track whose whole window starts past the video', () {
+      // Clamping both ends would collapse this to a zero-length
+      // [1s, 1s] window, which VideoAudioTrack asserts against.
       final result = clampAudioWindowToVideo(
         startTime: const Duration(seconds: 5),
         endTime: const Duration(seconds: 9),
         videoDuration: const Duration(seconds: 1),
       );
 
-      expect(result.startTime, equals(const Duration(seconds: 1)));
-      expect(result.endTime, equals(const Duration(seconds: 1)));
+      expect(result, isNull);
+    });
+
+    test('drops a track starting exactly at the video end', () {
+      final result = clampAudioWindowToVideo(
+        startTime: const Duration(seconds: 1),
+        endTime: const Duration(seconds: 9),
+        videoDuration: const Duration(seconds: 1),
+      );
+
+      expect(result, isNull);
+    });
+
+    test('keeps a window that still has video left to play over', () {
+      final result = clampAudioWindowToVideo(
+        startTime: const Duration(milliseconds: 500),
+        endTime: const Duration(seconds: 9),
+        videoDuration: const Duration(seconds: 1),
+      );
+
+      expect(result?.startTime, equals(const Duration(milliseconds: 500)));
+      expect(result?.endTime, equals(const Duration(seconds: 1)));
     });
   });
 }

--- a/mobile/test/services/video_editor/video_editor_clip_library_save_service_test.dart
+++ b/mobile/test/services/video_editor/video_editor_clip_library_save_service_test.dart
@@ -83,7 +83,7 @@ void main() {
         );
         expect(forwardedTaskId, equals('save-1'));
         expect(result, isNotNull);
-        expect(result!.video.file?.path, equals('/documents/divine_1.mp4'));
+        expect(result!.video?.file?.path, equals('/documents/divine_1.mp4'));
         expect(result.id, isNot(equals(clip.id)));
         expect(result.targetAspectRatio, equals(model.AspectRatio.vertical));
         expect(

--- a/mobile/test/services/video_editor/video_editor_merge_service_test.dart
+++ b/mobile/test/services/video_editor/video_editor_merge_service_test.dart
@@ -89,7 +89,10 @@ void main() {
         expect(forwardedTaskId, equals('merge-1'));
         expect(forwardedPersistent, isTrue);
         expect(result, isNotNull);
-        expect(result!.video.file?.path, equals('/documents/merged.mp4'));
+        expect(
+          result!.requireVideo.file?.path,
+          equals('/documents/merged.mp4'),
+        );
         expect(result.duration, equals(const Duration(seconds: 5)));
         expect(result.trimStart, equals(Duration.zero));
         expect(result.trimEnd, equals(Duration.zero));

--- a/mobile/test/services/video_editor/video_editor_render_service_progress_test.dart
+++ b/mobile/test/services/video_editor/video_editor_render_service_progress_test.dart
@@ -178,6 +178,10 @@ void main() {
       originalProVideoEditor = ProVideoEditor.instance;
       proVideoEditor = _ProgressProVideoEditor();
       ProVideoEditor.instance = proVideoEditor;
+      // materialize probes the assembled mp4's real duration; the assembled
+      // path here is a stub, so force the frame-hold estimate fallback for a
+      // deterministic materialized duration.
+      StopMotionRenderService.probeDurationOverride = (_) async => null;
       VideoEditorRenderService.resetActiveNativeTaskIdsForTesting();
     });
 
@@ -185,6 +189,7 @@ void main() {
       VideoEditorRenderService.renderVideoOverride = null;
       NativeProofModeService.proofFileOverride = null;
       StopMotionRenderService.assembleOverride = null;
+      StopMotionRenderService.probeDurationOverride = null;
       VideoEditorRenderService.resetActiveNativeTaskIdsForTesting();
       await proVideoEditor.dispose();
       ProVideoEditor.instance = originalProVideoEditor;

--- a/mobile/test/services/video_editor/video_editor_render_service_progress_test.dart
+++ b/mobile/test/services/video_editor/video_editor_render_service_progress_test.dart
@@ -8,7 +8,9 @@ import 'dart:ui';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart' as model;
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/services/native_proofmode_service.dart';
+import 'package:openvine/services/video_editor/stop_motion_render_service.dart';
 import 'package:openvine/services/video_editor/video_editor_render_service.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
@@ -182,6 +184,7 @@ void main() {
     tearDown(() async {
       VideoEditorRenderService.renderVideoOverride = null;
       NativeProofModeService.proofFileOverride = null;
+      StopMotionRenderService.assembleOverride = null;
       VideoEditorRenderService.resetActiveNativeTaskIdsForTesting();
       await proVideoEditor.dispose();
       ProVideoEditor.instance = originalProVideoEditor;
@@ -287,6 +290,104 @@ void main() {
           );
         }
         expect(progressValues.last, equals(1.0));
+      },
+    );
+
+    test(
+      'gives the stop-motion assembly its own progress slice before the '
+      'composite render',
+      () async {
+        const taskId = 'stop-motion-progress-test';
+        final progressValues = <double>[];
+
+        final progressSubscription =
+            VideoEditorRenderService.compositeProgressStreamById(
+              taskId,
+            ).listen((progress) => progressValues.add(progress.progress));
+        addTearDown(progressSubscription.cancel);
+
+        StopMotionRenderService.assembleOverride =
+            ({
+              required frames,
+              required aspectRatio,
+              frameRate = StopMotionRenderService.defaultFrameRate,
+              String? taskId,
+            }) async {
+              expect(taskId, equals('stop-motion-progress-test-stop-motion-0'));
+              proVideoEditor.emitProgress(taskId!, 0.5);
+              await _flushStreamEvents();
+              return '${Directory.systemTemp.path}/assembled.mp4';
+            };
+
+        VideoEditorRenderService.renderVideoOverride =
+            ({
+              required clips,
+              required usePersistentStorage,
+              aspectRatio,
+              parameters,
+              taskId,
+            }) async {
+              // The composite render receives the materialized (video-backed)
+              // clip, not the frames-only one.
+              expect(clips.single.video, isNotNull);
+              proVideoEditor.emitProgress(taskId!, 0.5);
+              await _flushStreamEvents();
+              return '${Directory.systemTemp.path}/rendered-sm.mp4';
+            };
+
+        NativeProofModeService.proofFileOverride =
+            (
+              File videoFile, {
+              required bool enableAdvancedCawgEmbedding,
+              creatorBindingAssertion,
+              cawgIdentityAssertion,
+              verifiedIdentityBundle,
+              clips,
+              editorStateHistory,
+            }) async => const model.NativeProofData(videoHash: 'proof');
+
+        final stopMotionClip = DivineVideoClip(
+          id: 'sm-clip',
+          stopMotionFrames: const [
+            StopMotionClipFrame(
+              path: '/frames/f0.jpg',
+              duration: Duration(milliseconds: 83),
+            ),
+          ],
+          duration: const Duration(milliseconds: 83),
+          recordedAt: DateTime(2026),
+          targetAspectRatio: model.AspectRatio.vertical,
+          originalAspectRatio: 9 / 16,
+        );
+
+        final result = await VideoEditorRenderService.renderVideoToClip(
+          clips: [stopMotionClip],
+          editorStateHistory: const {},
+          taskId: taskId,
+        );
+        await _flushStreamEvents();
+
+        expect(result, isNotNull);
+
+        // One clip → 5% proof budget; the remaining 95% splits evenly
+        // between the assembly pass and the composite render.
+        const proofBudget = 0.05;
+        const assemblyBudget = (1 - proofBudget) * 0.5;
+        const renderBudget = 1 - proofBudget - assemblyBudget;
+        final expectedProgressValues = [
+          0.0,
+          assemblyBudget * 0.5,
+          assemblyBudget,
+          assemblyBudget + renderBudget * 0.5,
+          1 - proofBudget,
+          1 - proofBudget + proofBudget / 2,
+          1.0,
+        ];
+
+        expect(progressValues, hasLength(expectedProgressValues.length));
+        for (var i = 0; i < expectedProgressValues.length; i++) {
+          expect(progressValues[i], closeTo(expectedProgressValues[i], 1e-9));
+        }
       },
     );
 

--- a/mobile/test/services/video_editor/video_editor_render_service_progress_test.dart
+++ b/mobile/test/services/video_editor/video_editor_render_service_progress_test.dart
@@ -331,6 +331,7 @@ void main() {
               aspectRatio,
               parameters,
               taskId,
+              maxOutputDuration,
             }) async {
               // The composite render receives the materialized (video-backed)
               // clip, not the frames-only one.

--- a/mobile/test/services/video_editor/video_editor_split_service_test.dart
+++ b/mobile/test/services/video_editor/video_editor_split_service_test.dart
@@ -242,8 +242,8 @@ void main() {
 
           // Nothing is re-encoded; both halves keep the source file.
           expect(mockProVideoEditor.splitRequests, isEmpty);
-          expect(start!.video.file?.path, clip.video.file?.path);
-          expect(end!.video.file?.path, clip.video.file?.path);
+          expect(start!.video?.file?.path, clip.video?.file?.path);
+          expect(end!.video?.file?.path, clip.video?.file?.path);
         },
       );
 

--- a/mobile/test/services/video_publish/video_publish_service_test.dart
+++ b/mobile/test/services/video_publish/video_publish_service_test.dart
@@ -8,6 +8,7 @@ import 'package:models/models.dart' show AspectRatio;
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/divine_video_draft.dart';
 import 'package:openvine/models/pending_upload.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/collaborator_invite_service.dart';
 import 'package:openvine/services/draft_storage_service.dart';
@@ -129,6 +130,37 @@ void main() {
         expect(result, isA<PublishSuccess>());
         verify(() => mockDraftService.deleteDraft(draft.id)).called(1);
       });
+
+      test(
+        'publishes a stop-motion draft whose clips.first has no rendered mp4',
+        () async {
+          // Regression: the publish flow used to read clips.first.requireVideo
+          // for a log line, which threw StateError for a frames-only
+          // stop-motion clip and aborted the whole publish. The rendered mp4
+          // lives in finalRenderedClip, and the upload path already prefers it.
+          _setupSuccessfulPublish(
+            mockAuthService: mockAuthService,
+            mockUploadManager: mockUploadManager,
+            mockDraftService: mockDraftService,
+            mockVideoEventPublisher: mockVideoEventPublisher,
+          );
+
+          final draft = DivineVideoDraft.create(
+            clips: [_createStopMotionClip()],
+            title: 'Stop Motion',
+            description: 'Test',
+            hashtags: {'test'},
+            selectedApproach: 'test',
+            id: 'stop_motion_draft_id',
+            finalRenderedClip: _createTestClip(),
+          );
+
+          final result = await service.publishVideo(draft: draft);
+
+          expect(result, isA<PublishSuccess>());
+          verify(() => mockDraftService.deleteDraft(draft.id)).called(1);
+        },
+      );
 
       test(
         'returns error and does not publish when upload has no CDN thumbnail',
@@ -1607,6 +1639,24 @@ DivineVideoClip _createTestClip() {
     id: 'test_clip',
     video: EditorVideo.file('/test/video.mp4'),
     duration: const Duration(seconds: 10),
+    recordedAt: DateTime.now(),
+    targetAspectRatio: AspectRatio.square,
+    originalAspectRatio: 9 / 16,
+  );
+}
+
+/// A frames-only stop-motion clip whose mp4 is not rendered yet — its rendered
+/// video lives in the draft's [DivineVideoDraft.finalRenderedClip].
+DivineVideoClip _createStopMotionClip() {
+  return DivineVideoClip(
+    id: 'clip_sm_test',
+    stopMotionFrames: const [
+      StopMotionClipFrame(
+        path: '/test/frame_0.jpg',
+        duration: Duration(microseconds: 83333),
+      ),
+    ],
+    duration: const Duration(seconds: 1),
     recordedAt: DateTime.now(),
     targetAspectRatio: AspectRatio.square,
     originalAspectRatio: 9 / 16,

--- a/mobile/test/utils/gallery_save_utils_test.dart
+++ b/mobile/test/utils/gallery_save_utils_test.dart
@@ -103,7 +103,7 @@ void main() {
     ) async {
       final clip = _createClip();
       when(
-        () => mockGallerySaveService.saveVideoToGallery(clip.video),
+        () => mockGallerySaveService.saveVideoToGallery(clip.requireVideo),
       ).thenAnswer((_) async => const GallerySaveSuccess());
 
       await tester.pumpWidget(buildSubject(clip: clip));
@@ -111,7 +111,7 @@ void main() {
       await tester.pumpAndSettle();
 
       verify(
-        () => mockGallerySaveService.saveVideoToGallery(clip.video),
+        () => mockGallerySaveService.saveVideoToGallery(clip.requireVideo),
       ).called(1);
     });
 
@@ -120,7 +120,7 @@ void main() {
     ) async {
       final clip = _createClip();
       when(
-        () => mockGallerySaveService.saveVideoToGallery(clip.video),
+        () => mockGallerySaveService.saveVideoToGallery(clip.requireVideo),
       ).thenAnswer((_) async => const GallerySaveSuccess());
 
       await tester.pumpWidget(buildSubject(clip: clip));
@@ -129,7 +129,7 @@ void main() {
 
       // Only one call — no retry.
       verify(
-        () => mockGallerySaveService.saveVideoToGallery(clip.video),
+        () => mockGallerySaveService.saveVideoToGallery(clip.requireVideo),
       ).called(1);
     });
 
@@ -138,7 +138,7 @@ void main() {
     ) async {
       final clip = _createClip();
       when(
-        () => mockGallerySaveService.saveVideoToGallery(clip.video),
+        () => mockGallerySaveService.saveVideoToGallery(clip.requireVideo),
       ).thenAnswer((_) async => const GallerySaveFailure('disk full'));
 
       await tester.pumpWidget(buildSubject(clip: clip));
@@ -147,7 +147,7 @@ void main() {
 
       // Only one call — no retry for generic failures.
       verify(
-        () => mockGallerySaveService.saveVideoToGallery(clip.video),
+        () => mockGallerySaveService.saveVideoToGallery(clip.requireVideo),
       ).called(1);
     });
   });

--- a/mobile/test/widgets/stop_motion/stop_motion_player_test.dart
+++ b/mobile/test/widgets/stop_motion/stop_motion_player_test.dart
@@ -114,20 +114,22 @@ void main() {
       expect(currentPath(tester), frames[2].path);
     });
 
-    testWidgets('loops the frame index past the sequence length', (
+    testWidgets('holds the last frame at the end of the sequence', (
       tester,
     ) async {
-      // 350ms % 300ms total = 50ms → back to the first frame.
+      // The editor clamps the playhead to the composition total *inclusive*, so
+      // scrubbing to the end hands over exactly the 300ms total. Wrapping that
+      // to 0 would show the first still while the timed layers sit at the end.
       await tester.pumpWidget(
         wrap(
           StopMotionPlayer(
             frames: frames,
-            position: const Duration(milliseconds: 350),
+            position: const Duration(milliseconds: 300),
           ),
         ),
       );
       await tester.pump();
-      expect(currentPath(tester), frames[0].path);
+      expect(currentPath(tester), frames[2].path);
     });
 
     testWidgets('does not self-advance — the frame is frozen for a fixed '

--- a/mobile/test/widgets/stop_motion/stop_motion_player_test.dart
+++ b/mobile/test/widgets/stop_motion/stop_motion_player_test.dart
@@ -1,0 +1,152 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
+import 'package:openvine/widgets/stop_motion/stop_motion_player.dart';
+
+void main() {
+  // 1x1 transparent PNG.
+  final pngBytes = base64Decode(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk'
+    '+M8AAAMBAQDJ/IY1AAAAAElFTkSuQmCC',
+  );
+
+  late Directory tempDir;
+  late List<StopMotionClipFrame> frames;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('stop_motion_player_test');
+    frames = [
+      for (final name in ['a', 'b', 'c'])
+        StopMotionClipFrame(
+          path: (File(
+            '${tempDir.path}/$name.png',
+          )..writeAsBytesSync(pngBytes)).path,
+          duration: const Duration(milliseconds: 100),
+        ),
+    ];
+  });
+
+  tearDown(() => tempDir.deleteSync(recursive: true));
+
+  String currentPath(WidgetTester tester) {
+    final image = tester.widget<Image>(find.byType(Image));
+    return (image.image as FileImage).file.path;
+  }
+
+  Widget wrap(Widget child, {bool reduceMotion = false}) {
+    return MediaQuery(
+      data: MediaQueryData(disableAnimations: reduceMotion),
+      child: Directionality(
+        textDirection: TextDirection.ltr,
+        child: child,
+      ),
+    );
+  }
+
+  testWidgets('advances through frames over time and loops', (tester) async {
+    await tester.pumpWidget(wrap(StopMotionPlayer(frames: frames)));
+
+    await tester.pump();
+    expect(currentPath(tester), frames[0].path);
+
+    await tester.pump(const Duration(milliseconds: 110));
+    expect(currentPath(tester), frames[1].path);
+
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(currentPath(tester), frames[2].path);
+
+    // Wraps back to the first frame after the last (seamless loop).
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(currentPath(tester), frames[0].path);
+  });
+
+  testWidgets('holds the first frame when animations are disabled', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      wrap(StopMotionPlayer(frames: frames), reduceMotion: true),
+    );
+
+    await tester.pump();
+    expect(currentPath(tester), frames[0].path);
+
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(currentPath(tester), frames[0].path);
+  });
+
+  group('controlled mode (position provided)', () {
+    testWidgets('renders the frame for the supplied position', (tester) async {
+      // Frames are 3 × 100ms → windows [0,100)=0, [100,200)=1, [200,300)=2.
+      await tester.pumpWidget(
+        wrap(
+          StopMotionPlayer(
+            frames: frames,
+            position: const Duration(milliseconds: 50),
+          ),
+        ),
+      );
+      await tester.pump();
+      expect(currentPath(tester), frames[0].path);
+
+      await tester.pumpWidget(
+        wrap(
+          StopMotionPlayer(
+            frames: frames,
+            position: const Duration(milliseconds: 150),
+          ),
+        ),
+      );
+      await tester.pump();
+      expect(currentPath(tester), frames[1].path);
+
+      await tester.pumpWidget(
+        wrap(
+          StopMotionPlayer(
+            frames: frames,
+            position: const Duration(milliseconds: 250),
+          ),
+        ),
+      );
+      await tester.pump();
+      expect(currentPath(tester), frames[2].path);
+    });
+
+    testWidgets('loops the frame index past the sequence length', (
+      tester,
+    ) async {
+      // 350ms % 300ms total = 50ms → back to the first frame.
+      await tester.pumpWidget(
+        wrap(
+          StopMotionPlayer(
+            frames: frames,
+            position: const Duration(milliseconds: 350),
+          ),
+        ),
+      );
+      await tester.pump();
+      expect(currentPath(tester), frames[0].path);
+    });
+
+    testWidgets('does not self-advance — the frame is frozen for a fixed '
+        'position', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          StopMotionPlayer(
+            frames: frames,
+            position: const Duration(milliseconds: 50),
+          ),
+        ),
+      );
+      await tester.pump();
+      expect(currentPath(tester), frames[0].path);
+
+      // Pumping wall-clock time must not change the frame: the caller owns the
+      // clock, so play/pause is respected (a paused editor holds the frame).
+      await tester.pump(const Duration(milliseconds: 500));
+      expect(currentPath(tester), frames[0].path);
+    });
+  });
+}

--- a/mobile/test/widgets/video_clip/video_clip_thumbnail_card_test.dart
+++ b/mobile/test/widgets/video_clip/video_clip_thumbnail_card_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/widgets/video_clip/video_clip_thumbnail_card.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 
@@ -15,10 +16,21 @@ void main() {
       String id = 'clip-1',
       Duration duration = const Duration(seconds: 5),
       String? libraryTitle,
+      bool stopMotion = false,
+      int stopMotionFrameCount = 1,
     }) {
       return DivineVideoClip(
         id: id,
-        video: EditorVideo.file('/path/to/clip.mp4'),
+        video: stopMotion ? null : EditorVideo.file('/path/to/clip.mp4'),
+        stopMotionFrames: stopMotion
+            ? [
+                for (var i = 0; i < stopMotionFrameCount; i++)
+                  StopMotionClipFrame(
+                    path: '/frames/f$i.jpg',
+                    duration: const Duration(milliseconds: 83),
+                  ),
+              ]
+            : null,
         libraryTitle: libraryTitle,
         duration: duration,
         recordedAt: DateTime(2026),
@@ -65,6 +77,54 @@ void main() {
         );
 
         expect(find.text('Rooftop loop'), findsOneWidget);
+      });
+
+      testWidgets('stop-motion badge for a stop-motion clip', (tester) async {
+        await tester.pumpWidget(
+          buildWidget(clip: createClip(stopMotion: true)),
+        );
+        final l10n = lookupAppLocalizations(const Locale('en'));
+
+        expect(
+          find.bySemanticsLabel(l10n.libraryStopMotionClipLabel),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('stop-motion badge shows the still count', (tester) async {
+        await tester.pumpWidget(
+          buildWidget(
+            clip: createClip(stopMotion: true, stopMotionFrameCount: 10),
+          ),
+        );
+
+        expect(find.text('10'), findsOneWidget);
+      });
+
+      testWidgets('no duration badge for a stop-motion clip', (tester) async {
+        await tester.pumpWidget(
+          buildWidget(
+            clip: createClip(
+              stopMotion: true,
+              duration: const Duration(seconds: 3),
+            ),
+          ),
+        );
+
+        // A stop-motion recording reads as an image: no seconds badge.
+        expect(find.text('3.00'), findsNothing);
+      });
+
+      testWidgets('no stop-motion badge for a normal video clip', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildWidget());
+        final l10n = lookupAppLocalizations(const Locale('en'));
+
+        expect(
+          find.bySemanticsLabel(l10n.libraryStopMotionClipLabel),
+          findsNothing,
+        );
       });
 
       testWidgets('selection index when selected', (tester) async {

--- a/mobile/test/widgets/video_editor/main_editor/video_editor_canvas_test.dart
+++ b/mobile/test/widgets/video_editor/main_editor/video_editor_canvas_test.dart
@@ -12,6 +12,7 @@ import 'package:openvine/blocs/video_editor/filter_editor/video_editor_filter_bl
 import 'package:openvine/blocs/video_editor/main_editor/video_editor_main_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_canvas.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
 import 'package:pro_image_editor/pro_image_editor.dart' show ProVideoController;
@@ -436,6 +437,55 @@ void main() {
     });
   });
 
+  group('stopMotionLoopPosition', () {
+    const total = Duration(milliseconds: 300);
+
+    test('advances from the anchor by the elapsed wall-clock', () {
+      expect(
+        stopMotionLoopPosition(
+          anchor: const Duration(milliseconds: 100),
+          elapsed: const Duration(milliseconds: 50),
+          total: total,
+        ),
+        const Duration(milliseconds: 150),
+      );
+    });
+
+    test('wraps around the total so playback loops', () {
+      // 250 + 100 = 350, 350 % 300 = 50.
+      expect(
+        stopMotionLoopPosition(
+          anchor: const Duration(milliseconds: 250),
+          elapsed: const Duration(milliseconds: 100),
+          total: total,
+        ),
+        const Duration(milliseconds: 50),
+      );
+    });
+
+    test('returns zero exactly at a full loop boundary', () {
+      expect(
+        stopMotionLoopPosition(
+          anchor: Duration.zero,
+          elapsed: total,
+          total: total,
+        ),
+        Duration.zero,
+      );
+    });
+
+    test('returns zero when total is non-positive', () {
+      expect(
+        stopMotionLoopPosition(
+          anchor: const Duration(milliseconds: 100),
+          elapsed: const Duration(milliseconds: 50),
+          total: Duration.zero,
+        ),
+        Duration.zero,
+      );
+    });
+  });
+
   group('VideoEditorCanvas.resolveClipSnapshotSync', () {
     late Directory tempDir;
 
@@ -566,6 +616,74 @@ void main() {
 
       expect(decision.op, ClipSnapshotSyncOp.skip);
     });
+
+    test(
+      'treats a stop-motion clip whose stills exist as resolvable',
+      () async {
+        // Frames-only clips have no video by design; without the stop-motion
+        // branch in hasResolvableVideoFile every history sync would classify
+        // them as orphaned and step the history backwards, silently undoing
+        // frame edits.
+        final framePath = '${tempDir.path}/frame0.jpg';
+        File(framePath).writeAsBytesSync(const [0]);
+        final clip = DivineVideoClip(
+          id: 'sm',
+          stopMotionFrames: [
+            StopMotionClipFrame(
+              path: framePath,
+              duration: const Duration(milliseconds: 83),
+            ),
+          ],
+          duration: const Duration(milliseconds: 83),
+          recordedAt: DateTime(2024),
+          targetAspectRatio: model.AspectRatio.vertical,
+          originalAspectRatio: 9 / 16,
+        );
+
+        final decision = VideoEditorCanvas.resolveClipSnapshotSync(
+          snapshot: [clip],
+          direction: ClipHistoryDirection.none,
+          canUndo: true,
+          canRedo: false,
+          didReverse: false,
+        );
+
+        expect(decision.op, ClipSnapshotSyncOp.sync);
+        expect(decision.resolvableClips, [clip]);
+      },
+    );
+  });
+
+  group('VideoEditorCanvas.clipsChanged', () {
+    const hold2 = Duration(milliseconds: 83);
+    const hold4 = Duration(milliseconds: 167);
+
+    test('is false for equal-content lists (different instances)', () {
+      final a = _createStopMotionClip(id: 'sm', holds: [hold2, hold2]);
+      final b = _createStopMotionClip(id: 'sm', holds: [hold2, hold2]);
+
+      expect(VideoEditorCanvas.clipsChanged([a], [b]), isFalse);
+    });
+
+    test('detects a frame-hold change', () {
+      final a = _createStopMotionClip(id: 'sm', holds: [hold2, hold2]);
+      final b = _createStopMotionClip(id: 'sm', holds: [hold4, hold4]);
+
+      expect(VideoEditorCanvas.clipsChanged([a], [b]), isTrue);
+    });
+
+    test('detects a deleted frame', () {
+      final a = _createStopMotionClip(id: 'sm', holds: [hold2, hold2]);
+      final b = _createStopMotionClip(id: 'sm', holds: [hold2]);
+
+      expect(VideoEditorCanvas.clipsChanged([a], [b]), isTrue);
+    });
+
+    test('detects a clip-count change', () {
+      final a = _createStopMotionClip(id: 'sm', holds: [hold2]);
+
+      expect(VideoEditorCanvas.clipsChanged([a], []), isTrue);
+    });
   });
 }
 
@@ -574,6 +692,23 @@ DivineVideoClip _createClip({required String id, String? videoPath}) {
     id: id,
     video: EditorVideo.file(videoPath ?? '/test/$id.mp4'),
     duration: const Duration(seconds: 2),
+    recordedAt: DateTime(2024),
+    targetAspectRatio: model.AspectRatio.vertical,
+    originalAspectRatio: 9 / 16,
+  );
+}
+
+DivineVideoClip _createStopMotionClip({
+  required String id,
+  required List<Duration> holds,
+}) {
+  return DivineVideoClip(
+    id: id,
+    stopMotionFrames: [
+      for (var i = 0; i < holds.length; i++)
+        StopMotionClipFrame(path: '/frames/$id-$i.jpg', duration: holds[i]),
+    ],
+    duration: holds.fold(Duration.zero, (sum, hold) => sum + hold),
     recordedAt: DateTime(2024),
     targetAspectRatio: model.AspectRatio.vertical,
     originalAspectRatio: 9 / 16,

--- a/mobile/test/widgets/video_editor/main_editor/video_editor_main_actions_sheet_test.dart
+++ b/mobile/test/widgets/video_editor/main_editor/video_editor_main_actions_sheet_test.dart
@@ -6,12 +6,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart' as model show AspectRatio;
 import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
 import 'package:openvine/blocs/video_editor/main_editor/video_editor_main_bloc.dart';
 import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
 import 'package:openvine/blocs/video_editor/tune_editor/video_editor_tune_bloc.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_main_actions_sheet.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
@@ -91,6 +94,43 @@ void main() {
       expect(find.text(l10n.videoEditorDrawLabel), findsOneWidget);
       expect(find.text(l10n.videoEditorFilterLabel), findsOneWidget);
       expect(find.text(l10n.videoEditorStickers), findsOneWidget);
+      expect(find.text(l10n.videoEditorMarkerLabel), findsOneWidget);
+    });
+
+    testWidgets('hides the marker action for a stop-motion composition', (
+      tester,
+    ) async {
+      when(() => clipBloc.state).thenReturn(
+        ClipEditorState(
+          clips: [
+            DivineVideoClip(
+              id: 'sm1',
+              stopMotionFrames: const [
+                StopMotionClipFrame(
+                  path: '/frames/f0.jpg',
+                  duration: Duration(milliseconds: 83),
+                ),
+              ],
+              duration: const Duration(milliseconds: 83),
+              recordedAt: DateTime(2024),
+              targetAspectRatio: model.AspectRatio.vertical,
+              originalAspectRatio: 9 / 16,
+            ),
+          ],
+        ),
+      );
+
+      await tester.pumpWidget(
+        _buildWidget(
+          mainBloc: mainBloc,
+          clipBloc: clipBloc,
+          timelineOverlayBloc: timelineOverlayBloc,
+        ),
+      );
+
+      expect(find.text(l10n.videoEditorMarkerLabel), findsNothing);
+      // The rest of the actions stay available.
+      expect(find.text(l10n.videoEditorCameraLabel), findsOneWidget);
     });
 
     testWidgets('tap on Clips triggers onOpenClipsEditor', (tester) async {

--- a/mobile/test/widgets/video_editor/main_editor/video_editor_main_overlay_actions_test.dart
+++ b/mobile/test/widgets/video_editor/main_editor/video_editor_main_overlay_actions_test.dart
@@ -8,9 +8,14 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart' as model show AspectRatio;
+import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
 import 'package:openvine/blocs/video_editor/main_editor/video_editor_main_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/divine_video_draft.dart';
+import 'package:openvine/models/stop_motion/stop_motion_frame_ops.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
 import 'package:openvine/models/video_publish/video_publish_provider_state.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
@@ -73,12 +78,17 @@ void main() {
 
   group(VideoEditorMainOverlayActions, () {
     late _MockVideoEditorMainBloc mockBloc;
+    late ClipEditorBloc clipEditorBloc;
     late MockGoRouter mockGoRouter;
     late _FakeVideoEditorNotifier fakeVideoEditorNotifier;
     late _FakeVideoPublishNotifier fakeVideoPublishNotifier;
 
     setUp(() {
       mockBloc = _MockVideoEditorMainBloc();
+      clipEditorBloc = ClipEditorBloc(
+        onFinalClipInvalidated: () {},
+        saveClipToLibrary: ({required clip}) async => false,
+      );
       mockGoRouter = MockGoRouter();
 
       when(() => mockBloc.state).thenReturn(const VideoEditorMainState());
@@ -87,6 +97,8 @@ void main() {
       ).thenAnswer((_) => const Stream<VideoEditorMainState>.empty());
       when(() => mockGoRouter.pop<Object?>(any())).thenAnswer((_) async {});
     });
+
+    tearDown(() => clipEditorBloc.close());
 
     Widget buildWidget({
       VideoEditorMainState? state,
@@ -134,8 +146,11 @@ void main() {
                 onOpenMusicLibrary: () {},
                 onOpenVoiceOver: () {},
                 onAddEditTextLayer: ([layer]) async => null,
-                child: BlocProvider<VideoEditorMainBloc>.value(
-                  value: mockBloc,
+                child: MultiBlocProvider(
+                  providers: [
+                    BlocProvider<VideoEditorMainBloc>.value(value: mockBloc),
+                    BlocProvider<ClipEditorBloc>.value(value: clipEditorBloc),
+                  ],
                   child: const VideoEditorMainOverlayActions(),
                 ),
               ),
@@ -361,6 +376,126 @@ void main() {
           expect(find.text('Failed to save'), findsNothing);
           // The prompt stays open so the in-flight save can land.
           expect(find.text('Save your draft?'), findsOneWidget);
+        },
+      );
+    });
+
+    group('stop-motion minimum length gate', () {
+      DivineVideoClip stopMotionClip(Duration total) => DivineVideoClip(
+        id: 'sm1',
+        stopMotionFrames: [
+          StopMotionClipFrame(path: '/frames/f0.jpg', duration: total),
+        ],
+        duration: total,
+        recordedAt: DateTime(2024),
+        targetAspectRatio: model.AspectRatio.vertical,
+        originalAspectRatio: 9 / 16,
+      );
+
+      Finder doneButton() => find.ancestor(
+        of: find.byWidgetPredicate(
+          (w) => w is DivineIcon && w.icon == DivineIconName.arrowRight,
+        ),
+        matching: find.byType(DivineIconButton),
+      );
+
+      testWidgets('a too-short composition shows the snackbar and stays', (
+        tester,
+      ) async {
+        clipEditorBloc.add(
+          ClipEditorInitialized([
+            stopMotionClip(const Duration(milliseconds: 500)),
+          ]),
+        );
+        await tester.pumpWidget(buildWidget());
+        await tester.pump();
+
+        await tester.tap(doneButton());
+        await tester.pump();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(
+          find.text(l10n.videoEditorStopMotionTooShortSnackbar(1)),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('a long-enough composition passes without a snackbar', (
+        tester,
+      ) async {
+        clipEditorBloc.add(
+          ClipEditorInitialized([stopMotionClip(const Duration(seconds: 2))]),
+        );
+        await tester.pumpWidget(buildWidget());
+        await tester.pump();
+
+        await tester.tap(doneButton());
+        await tester.pump();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(
+          find.text(l10n.videoEditorStopMotionTooShortSnackbar(1)),
+          findsNothing,
+        );
+      });
+    });
+
+    group('stop-motion frames chip', () {
+      DivineVideoClip clipWithHolds(List<int> holds) {
+        final frames = [
+          for (final (i, hold) in holds.indexed)
+            StopMotionClipFrame(
+              path: '/frames/f$i.jpg',
+              duration: StopMotionFrameOps.framesPerImageToDuration(hold),
+            ),
+        ];
+        return DivineVideoClip(
+          id: 'sm1',
+          stopMotionFrames: frames,
+          duration: StopMotionFrameOps.totalDuration(frames),
+          recordedAt: DateTime(2024),
+          targetAspectRatio: model.AspectRatio.vertical,
+          originalAspectRatio: 9 / 16,
+        );
+      }
+
+      testWidgets('shows the shared global hold', (tester) async {
+        clipEditorBloc.add(
+          ClipEditorInitialized([
+            clipWithHolds([3, 3, 3]),
+          ]),
+        );
+        await tester.pumpWidget(buildWidget());
+        await tester.pump();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(
+          find.text(l10n.videoEditorStopMotionFramesCount(3)),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets(
+        'shows the most common hold instead of the bare label when '
+        'frames disagree',
+        (tester) async {
+          clipEditorBloc.add(
+            ClipEditorInitialized([
+              clipWithHolds([2, 2, 1, 2]),
+            ]),
+          );
+          await tester.pumpWidget(buildWidget());
+          await tester.pump();
+
+          final l10n = lookupAppLocalizations(const Locale('en'));
+          expect(
+            find.text(l10n.videoEditorStopMotionFramesCount(2)),
+            findsOneWidget,
+          );
+          expect(
+            find.text(l10n.videoEditorStopMotionFramesPerImageLabel),
+            findsNothing,
+          );
         },
       );
     });

--- a/mobile/test/widgets/video_editor/main_editor/video_editor_main_overlay_actions_test.dart
+++ b/mobile/test/widgets/video_editor/main_editor/video_editor_main_overlay_actions_test.dart
@@ -475,6 +475,32 @@ void main() {
         );
       });
 
+      testWidgets('exposes at least a 48dp square tap target', (tester) async {
+        clipEditorBloc.add(
+          ClipEditorInitialized([
+            clipWithHolds([3, 3, 3]),
+          ]),
+        );
+        await tester.pumpWidget(buildWidget());
+        await tester.pump();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        final chipLabel = find.text(l10n.videoEditorStopMotionFramesCount(3));
+        expect(chipLabel, findsOneWidget);
+
+        // The visible pill is ~28dp tall; the tap target must still reach the
+        // 48dp minimum touch size.
+        final tapTarget = find
+            .ancestor(of: chipLabel, matching: find.byType(GestureDetector))
+            .first;
+        final size = tester.getSize(tapTarget);
+        expect(size.width, greaterThanOrEqualTo(48));
+        expect(size.height, greaterThanOrEqualTo(48));
+        // ...but it must NOT stretch to fill the toolbar's loose height (a
+        // plain Center did, dragging the whole back/done row down the editor).
+        expect(size.height, lessThan(80));
+      });
+
       testWidgets(
         'shows the most common hold instead of the bare label when '
         'frames disagree',

--- a/mobile/test/widgets/video_editor/main_editor/video_editor_player_test.dart
+++ b/mobile/test/widgets/video_editor/main_editor/video_editor_player_test.dart
@@ -1,9 +1,76 @@
-import 'dart:ui';
+import 'dart:convert';
+import 'dart:io';
 
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart' as model show AspectRatio;
+import 'package:openvine/models/stop_motion_clip_frame.dart';
+import 'package:openvine/widgets/stop_motion/stop_motion_player.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_player.dart';
 
 void main() {
+  group('stop-motion preview', () {
+    // 1x1 transparent PNG.
+    final pngBytes = base64Decode(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk'
+      '+M8AAAMBAQDJ/IY1AAAAAElFTkSuQmCC',
+    );
+
+    late Directory tempDir;
+    late List<StopMotionClipFrame> frames;
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('video_editor_player_test');
+      frames = [
+        for (final name in ['a', 'b', 'c'])
+          StopMotionClipFrame(
+            path: (File(
+              '${tempDir.path}/$name.png',
+            )..writeAsBytesSync(pngBytes)).path,
+            duration: const Duration(milliseconds: 100),
+          ),
+      ];
+    });
+
+    tearDown(() => tempDir.deleteSync(recursive: true));
+
+    testWidgets('drives the StopMotionPlayer from stopMotionPosition', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Center(
+            child: SizedBox(
+              width: 200,
+              height: 400,
+              child: VideoEditorPlayer(
+                controller: null,
+                targetAspectRatio: model.AspectRatio.vertical,
+                originalAspectRatio: 9 / 16,
+                bodySize: const Size(200, 400),
+                renderSize: const Size(200, 400),
+                stopMotionFrames: frames,
+                // 150ms → the second frame's window [100,200).
+                stopMotionPosition: const Duration(milliseconds: 150),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byType(StopMotionPlayer), findsOneWidget);
+      final image = tester.widget<Image>(find.byType(Image));
+      // The editor bounds the decode size, so the provider is a ResizeImage
+      // wrapping the FileImage.
+      final provider = image.image;
+      final fileImage = provider is ResizeImage
+          ? provider.imageProvider as FileImage
+          : provider as FileImage;
+      expect(fileImage.file.path, frames[1].path);
+    });
+  });
+
   group(computeClipSize, () {
     group('square (1:1) target', () {
       test('clips tall widget to square using width as shortest side', () {

--- a/mobile/test/widgets/video_editor/stop_motion/stop_motion_frames_per_image_sheet_test.dart
+++ b/mobile/test/widgets/video_editor/stop_motion/stop_motion_frames_per_image_sheet_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/widgets/video_editor/stop_motion/stop_motion_frames_per_image_sheet.dart';
+
+void main() {
+  Future<void> pump(WidgetTester tester, {required int initialValue}) {
+    return tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: StopMotionFramesPerImageSheet(initialValue: initialValue),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('renders the title and the value it opens on', (tester) async {
+    await pump(tester, initialValue: 5);
+    final l10n = lookupAppLocalizations(const Locale('en'));
+
+    expect(
+      find.text(l10n.videoEditorStopMotionFramesPerImageLabel),
+      findsOneWidget,
+    );
+    // The wheel opens centered on the initial value.
+    expect(find.text(l10n.videoEditorStopMotionFramesCount(5)), findsWidgets);
+  });
+
+  testWidgets('uses the singular form for a hold of one frame', (tester) async {
+    await pump(tester, initialValue: 1);
+    final l10n = lookupAppLocalizations(const Locale('en'));
+    expect(l10n.videoEditorStopMotionFramesCount(1), '1 frame');
+    expect(find.text('1 frame'), findsWidgets);
+  });
+}

--- a/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls_test.dart
@@ -2,7 +2,6 @@
 // ABOUTME: Verifies visible actions and done-event dispatch.
 
 import 'package:bloc_test/bloc_test.dart';
-import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -172,7 +171,10 @@ void main() {
     ) async {
       await tester.pumpWidget(build());
 
-      await tester.tap(find.byType(DivineIconButton).last);
+      final controls = tester.widget<VideoEditorTimelineControls>(
+        find.byType(VideoEditorTimelineControls),
+      );
+      controls.onDone!();
       await tester.pump();
 
       verify(() => bloc.add(const ClipEditorEditingStopped())).called(1);
@@ -230,7 +232,7 @@ void main() {
       );
       expect(controls.onDone, isNotNull);
 
-      await tester.tap(find.byType(DivineIconButton).last);
+      controls.onDone!();
       await tester.pump();
 
       verify(() => bloc.add(const ClipEditorEditingStopped())).called(1);

--- a/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls_test.dart
@@ -13,6 +13,7 @@ import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
 import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_timeline_controls.dart';
@@ -82,12 +83,31 @@ void main() {
       originalAspectRatio: 9 / 16,
     );
 
+    DivineVideoClip stopMotionClip(String id) => DivineVideoClip(
+      id: id,
+      duration: const Duration(milliseconds: 200),
+      recordedAt: DateTime(2025),
+      targetAspectRatio: model.AspectRatio.vertical,
+      originalAspectRatio: 9 / 16,
+      stopMotionFrames: const [
+        StopMotionClipFrame(
+          path: '/tmp/frame-0.jpg',
+          duration: Duration(milliseconds: 100),
+        ),
+        StopMotionClipFrame(
+          path: '/tmp/frame-1.jpg',
+          duration: Duration(milliseconds: 100),
+        ),
+      ],
+    );
+
     Future<VideoEditorTimelineControls> pumpWithMissingEditorScope(
-      WidgetTester tester,
-    ) async {
-      when(
-        () => bloc.state,
-      ).thenReturn(ClipEditorState(clips: [clip('clip-1'), clip('clip-2')]));
+      WidgetTester tester, {
+      ClipEditorState? state,
+    }) async {
+      when(() => bloc.state).thenReturn(
+        state ?? ClipEditorState(clips: [clip('clip-1'), clip('clip-2')]),
+      );
       final overlayBloc = _MockTimelineOverlayBloc();
       when(() => overlayBloc.state).thenReturn(const TimelineOverlayState());
       when(
@@ -349,6 +369,50 @@ void main() {
         '${action.actionLabel} is a no-op when the editor scope is gone',
         (tester) async {
           final controls = await pumpWithMissingEditorScope(tester);
+
+          final callback = action.callback(controls);
+          expect(callback, isNotNull);
+          callback!.call();
+          await tester.pump();
+
+          expect(tester.takeException(), isNull);
+          verifyNever(() => bloc.add(any()));
+        },
+      );
+    }
+
+    // The frames path reaches the same commit through _StopMotionClipControls,
+    // and its clip id always resolves — so the index guard never short-circuits
+    // it before the editor is dereferenced.
+    final staleEditorFrameActions =
+        <
+          ({
+            String actionLabel,
+            VoidCallback? Function(VideoEditorTimelineControls controls)
+            callback,
+          })
+        >[
+          (
+            actionLabel: 'frame delete',
+            callback: (controls) => controls.onDelete,
+          ),
+          (
+            actionLabel: 'frame duplicate',
+            callback: (controls) => controls.onDuplicated,
+          ),
+        ];
+
+    for (final action in staleEditorFrameActions) {
+      testWidgets(
+        '${action.actionLabel} is a no-op when the editor scope is gone',
+        (tester) async {
+          final controls = await pumpWithMissingEditorScope(
+            tester,
+            state: ClipEditorState(
+              clips: [stopMotionClip('clip-1')],
+              selectedFrameIndex: 0,
+            ),
+          );
 
           final callback = action.callback(controls);
           expect(callback, isNotNull);

--- a/mobile/test/widgets/video_editor/timeline_editor/strips/video_editor_stop_motion_frame_strip_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/strips/video_editor_stop_motion_frame_strip_test.dart
@@ -202,6 +202,33 @@ void main() {
     expect(movedToSlot, 2);
   });
 
+  testWidgets(
+    'right-half block pickup released without dragging is a no-op',
+    (tester) async {
+      int? movedToSlot;
+      await pump(
+        tester,
+        onFrameTapped: (_) {},
+        isMultiSelectMode: true,
+        selectedFrameIndexes: {1},
+        onBlockMove: (slot) => movedToSlot = slot,
+      );
+
+      // Long-press the RIGHT half of the selected middle tile (each 50px wide),
+      // then release without any drag. The block's home slot is 1 (its original
+      // position), so it must stay put — not phantom-shift to slot 2.
+      final gesture = await tester.startGesture(
+        tester.getCenter(find.byType(Image).at(1)) + const Offset(15, 0),
+      );
+      await tester.pump(kLongPressTimeout + const Duration(milliseconds: 50));
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      expect(movedToSlot, 1);
+    },
+  );
+
   testWidgets('block drag does not start on an unselected tile', (
     tester,
   ) async {

--- a/mobile/test/widgets/video_editor/timeline_editor/strips/video_editor_stop_motion_frame_strip_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/strips/video_editor_stop_motion_frame_strip_test.dart
@@ -41,6 +41,7 @@ void main() {
     int? selectedFrameIndex,
     bool isMultiSelectMode = false,
     Set<int> selectedFrameIndexes = const {},
+    void Function(int from, int to)? onReorder,
     ValueChanged<int>? onBlockMove,
   }) {
     return tester.pumpWidget(
@@ -58,7 +59,7 @@ void main() {
               selectedFrameIndexes: selectedFrameIndexes,
               onBlockMove: onBlockMove,
               onFrameTapped: onFrameTapped,
-              onReorder: (_, _) {},
+              onReorder: onReorder ?? (_, _) {},
             ),
           ),
         ),
@@ -202,21 +203,42 @@ void main() {
     expect(movedToSlot, 2);
   });
 
+  testWidgets('right-half block pickup released without dragging is a no-op', (
+    tester,
+  ) async {
+    int? movedToSlot;
+    await pump(
+      tester,
+      onFrameTapped: (_) {},
+      isMultiSelectMode: true,
+      selectedFrameIndexes: {1},
+      onBlockMove: (slot) => movedToSlot = slot,
+    );
+
+    // Long-press the RIGHT half of the selected middle tile (each 50px wide),
+    // then release without any drag. The block's home slot is 1 (its original
+    // position), so it must stay put — not phantom-shift to slot 2.
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.byType(Image).at(1)) + const Offset(15, 0),
+    );
+    await tester.pump(kLongPressTimeout + const Duration(milliseconds: 50));
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(movedToSlot, isNull);
+  });
+
   testWidgets(
-    'right-half block pickup released without dragging is a no-op',
+    'right-half single-frame pickup released without dragging is a no-op',
     (tester) async {
-      int? movedToSlot;
+      ({int from, int to})? reorder;
       await pump(
         tester,
         onFrameTapped: (_) {},
-        isMultiSelectMode: true,
-        selectedFrameIndexes: {1},
-        onBlockMove: (slot) => movedToSlot = slot,
+        onReorder: (from, to) => reorder = (from: from, to: to),
       );
 
-      // Long-press the RIGHT half of the selected middle tile (each 50px wide),
-      // then release without any drag. The block's home slot is 1 (its original
-      // position), so it must stay put — not phantom-shift to slot 2.
       final gesture = await tester.startGesture(
         tester.getCenter(find.byType(Image).at(1)) + const Offset(15, 0),
       );
@@ -225,7 +247,31 @@ void main() {
       await gesture.up();
       await tester.pumpAndSettle();
 
-      expect(movedToSlot, 1);
+      expect(reorder, isNull);
+    },
+  );
+
+  testWidgets(
+    'non-contiguous block pickup released without dragging is a no-op',
+    (tester) async {
+      int? movedToSlot;
+      await pump(
+        tester,
+        onFrameTapped: (_) {},
+        isMultiSelectMode: true,
+        selectedFrameIndexes: {0, 2},
+        onBlockMove: (slot) => movedToSlot = slot,
+      );
+
+      final gesture = await tester.startGesture(
+        tester.getCenter(find.byType(Image).at(0)),
+      );
+      await tester.pump(kLongPressTimeout + const Duration(milliseconds: 50));
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      expect(movedToSlot, isNull);
     },
   );
 

--- a/mobile/test/widgets/video_editor/timeline_editor/strips/video_editor_stop_motion_frame_strip_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/strips/video_editor_stop_motion_frame_strip_test.dart
@@ -1,0 +1,228 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/gestures.dart' show kLongPressTimeout;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
+import 'package:openvine/widgets/video_editor/timeline_editor/strips/video_editor_stop_motion_frame_strip.dart';
+
+void main() {
+  // 1x1 transparent PNG.
+  final pngBytes = base64Decode(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk'
+    '+M8AAAMBAQDJ/IY1AAAAAElFTkSuQmCC',
+  );
+
+  late Directory tempDir;
+  late List<StopMotionClipFrame> frames;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('frame_strip_test');
+    frames = [
+      for (final name in ['a', 'b', 'c'])
+        StopMotionClipFrame(
+          path: (File(
+            '${tempDir.path}/$name.png',
+          )..writeAsBytesSync(pngBytes)).path,
+          // 0.5s each → wide, easily tappable tiles at the test pps.
+          duration: const Duration(milliseconds: 500),
+        ),
+    ];
+  });
+
+  tearDown(() => tempDir.deleteSync(recursive: true));
+
+  Future<void> pump(
+    WidgetTester tester, {
+    required ValueChanged<int> onFrameTapped,
+    int? selectedFrameIndex,
+    bool isMultiSelectMode = false,
+    Set<int> selectedFrameIndexes = const {},
+    ValueChanged<int>? onBlockMove,
+  }) {
+    return tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: Align(
+            alignment: Alignment.topLeft,
+            child: VideoEditorStopMotionFrameStrip(
+              frames: frames,
+              pixelsPerSecond: 100,
+              selectedFrameIndex: selectedFrameIndex,
+              isMultiSelectMode: isMultiSelectMode,
+              selectedFrameIndexes: selectedFrameIndexes,
+              onBlockMove: onBlockMove,
+              onFrameTapped: onFrameTapped,
+              onReorder: (_, _) {},
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('renders one tile per captured still', (tester) async {
+    await pump(tester, onFrameTapped: (_) {});
+    expect(find.byType(Image), findsNWidgets(3));
+  });
+
+  testWidgets('renders duplicated stills without a key collision', (
+    tester,
+  ) async {
+    // Duplicating a still reuses its file path; sibling tile keys must stay
+    // unique or the Stack throws "duplicate keys found".
+    frames = [...frames, frames[1]];
+    await pump(tester, onFrameTapped: (_) {});
+
+    expect(tester.takeException(), isNull);
+    expect(find.byType(Image), findsNWidgets(4));
+  });
+
+  testWidgets('tapping a tile reports its index', (tester) async {
+    int? tapped;
+    await pump(tester, onFrameTapped: (index) => tapped = index);
+
+    await tester.tap(find.byType(Image).at(1));
+    expect(tapped, 1);
+  });
+
+  testWidgets('marks the selected tile via semantics', (tester) async {
+    await pump(tester, onFrameTapped: (_) {}, selectedFrameIndex: 2);
+
+    final l10n = lookupAppLocalizations(const Locale('en'));
+    expect(
+      tester.getSemantics(
+        find.bySemanticsLabel(
+          l10n.videoEditorStopMotionFrameSemanticLabel(3, 3),
+        ),
+      ),
+      isSemantics(isSelected: true),
+    );
+  });
+
+  testWidgets('selected tile paints a visible accent-yellow border', (
+    tester,
+  ) async {
+    await pump(tester, onFrameTapped: (_) {}, selectedFrameIndex: 1);
+
+    final selectedBoxes = tester
+        .widgetList<DecoratedBox>(find.byType(DecoratedBox))
+        .where((box) {
+          final decoration = box.decoration;
+          return decoration is BoxDecoration &&
+              decoration.border is Border &&
+              (decoration.border! as Border).top.color ==
+                  VineTheme.accentYellow;
+        })
+        .toList();
+
+    expect(selectedBoxes, hasLength(1));
+    // Foreground position — a background border would be painted underneath
+    // the image that fills the same box and never be visible.
+    expect(selectedBoxes.single.position, DecorationPosition.foreground);
+    expect(
+      ((selectedBoxes.single.decoration as BoxDecoration).border! as Border)
+          .top
+          .width,
+      2,
+    );
+  });
+
+  testWidgets('multi-select highlights every selected tile', (tester) async {
+    await pump(
+      tester,
+      onFrameTapped: (_) {},
+      isMultiSelectMode: true,
+      selectedFrameIndexes: {0, 2},
+    );
+
+    final selectedBoxes = tester
+        .widgetList<DecoratedBox>(find.byType(DecoratedBox))
+        .where((box) {
+          final decoration = box.decoration;
+          return decoration is BoxDecoration &&
+              decoration.border is Border &&
+              (decoration.border! as Border).top.color ==
+                  VineTheme.accentYellow;
+        });
+
+    expect(selectedBoxes, hasLength(2));
+  });
+
+  testWidgets('multi-select taps still report the tile index', (tester) async {
+    int? tapped;
+    await pump(
+      tester,
+      onFrameTapped: (index) => tapped = index,
+      isMultiSelectMode: true,
+    );
+
+    await tester.tap(find.byType(Image).at(2));
+    expect(tapped, 2);
+  });
+
+  testWidgets('block drag reports the drop slot among remaining stills', (
+    tester,
+  ) async {
+    int? movedToSlot;
+    await pump(
+      tester,
+      onFrameTapped: (_) {},
+      isMultiSelectMode: true,
+      selectedFrameIndexes: {0},
+      onBlockMove: (slot) => movedToSlot = slot,
+    );
+
+    // Long-press the selected first tile, drag past the other two (each 50px
+    // wide at 100 pps x 0.5s), release: the block lands at the end (slot 2).
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.byType(Image).at(0)),
+    );
+    await tester.pump(kLongPressTimeout + const Duration(milliseconds: 50));
+    // Rebuild so the drag-in-progress move/end handlers are wired.
+    await tester.pump();
+    // The block pickup shows the accent-yellow insertion marker.
+    expect(
+      find.byWidgetPredicate(
+        (w) => w is ColoredBox && w.color == VineTheme.accentYellow,
+      ),
+      findsOneWidget,
+      reason: 'insertion marker',
+    );
+    await gesture.moveBy(const Offset(120, 0));
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(movedToSlot, 2);
+  });
+
+  testWidgets('block drag does not start on an unselected tile', (
+    tester,
+  ) async {
+    int? movedToSlot;
+    await pump(
+      tester,
+      onFrameTapped: (_) {},
+      isMultiSelectMode: true,
+      selectedFrameIndexes: {2},
+      onBlockMove: (slot) => movedToSlot = slot,
+    );
+
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.byType(Image).at(0)),
+    );
+    await tester.pump(kLongPressTimeout + const Duration(milliseconds: 50));
+    await gesture.moveBy(const Offset(120, 0));
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(movedToSlot, isNull);
+  });
+}

--- a/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
@@ -4,7 +4,9 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart' show AudioEvent;
+import 'package:openvine/constants/video_editor_timeline_constants.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/models/video_editor/transition_geometry.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
@@ -1230,6 +1232,43 @@ void main() {
       expect(
         identical(rebaseAnchoredAudioForClipState(baseClips(), tracks), tracks),
         isTrue,
+      );
+    });
+  });
+
+  group(stopMotionInitialPixelsPerSecond, () {
+    List<StopMotionClipFrame> framesOf(int count, Duration hold) => [
+      for (var i = 0; i < count; i++)
+        StopMotionClipFrame(path: 'f$i.jpg', duration: hold),
+    ];
+
+    test('scales so the average still gets the target tile width', () {
+      // 100ms stills → pps = targetTileWidth / 0.1s.
+      final pps = stopMotionInitialPixelsPerSecond(
+        framesOf(10, const Duration(milliseconds: 100)),
+      );
+      expect(pps, TimelineConstants.stopMotionTargetTileWidth / 0.1);
+    });
+
+    test('clamps to the stop-motion zoom ceiling for tiny holds', () {
+      // 1ms stills would need an absurd zoom; the ceiling caps it.
+      final pps = stopMotionInitialPixelsPerSecond(
+        framesOf(5, const Duration(milliseconds: 1)),
+      );
+      expect(pps, TimelineConstants.stopMotionMaxPixelsPerSecond);
+    });
+
+    test('never zooms below the video default for long holds', () {
+      final pps = stopMotionInitialPixelsPerSecond(
+        framesOf(3, const Duration(seconds: 5)),
+      );
+      expect(pps, TimelineConstants.pixelsPerSecond);
+    });
+
+    test('falls back to the video default for an empty frame list', () {
+      expect(
+        stopMotionInitialPixelsPerSecond(const []),
+        TimelineConstants.pixelsPerSecond,
       );
     });
   });

--- a/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_test.dart
@@ -2,6 +2,8 @@
 // ABOUTME: Validates timeline rendering, scroll content, playhead, and empty state.
 
 import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:bloc_test/bloc_test.dart';
@@ -14,13 +16,17 @@ import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
 import 'package:openvine/blocs/video_editor/filter_editor/video_editor_filter_bloc.dart';
 import 'package:openvine/blocs/video_editor/main_editor/video_editor_main_bloc.dart';
 import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
+import 'package:openvine/constants/video_editor_timeline_constants.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timeline.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timeline_body.dart';
+import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timeline_header.dart';
+import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timeline_interactive_body.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timeline_playhead.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timeline_rules_indicator.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
@@ -574,7 +580,111 @@ void main() {
         ).called(1);
       });
     });
+
+    group('stop-motion auto-zoom', () {
+      late Directory tempDir;
+
+      setUp(() {
+        tempDir = Directory.systemTemp.createTempSync('tl_auto_zoom');
+      });
+      tearDown(() => tempDir.deleteSync(recursive: true));
+
+      // Drives the empty→populated transition through the mock: the state stub
+      // is flipped to [populated] before the stream emit, so `context.select`
+      // (which reads `bloc.state`) reads the fresh value when the always-mounted
+      // BlocListener catches the transition. Mirrors production, where the
+      // composition is dispatched after the (empty) first build.
+      Future<void> transitionTo(
+        WidgetTester tester,
+        StreamController<ClipEditorState> clipStates,
+        ClipEditorState populated,
+      ) async {
+        when(() => mockClipBloc.state).thenReturn(populated);
+        clipStates.add(populated);
+        // Two pumps: the broadcast emit is delivered on a microtask after the
+        // first frame, then the second frame builds the rebuilt tree.
+        await tester.pump();
+        await tester.pump();
+      }
+
+      testWidgets('zooms in when the first stop-motion composition loads', (
+        tester,
+      ) async {
+        final clipStates = StreamController<ClipEditorState>.broadcast();
+        addTearDown(clipStates.close);
+        when(() => mockClipBloc.stream).thenAnswer((_) => clipStates.stream);
+        when(() => mockClipBloc.state).thenReturn(const ClipEditorState());
+
+        await tester.pumpWidget(buildWidget());
+        await tester.pump();
+        // The empty first build renders nothing but keeps the listener mounted.
+        expect(find.byType(VideoEditorTimelineInteractiveBody), findsNothing);
+
+        final clip = _stopMotionClip(tempDir);
+        await transitionTo(tester, clipStates, ClipEditorState(clips: [clip]));
+
+        final body = tester.widget<VideoEditorTimelineInteractiveBody>(
+          find.byType(VideoEditorTimelineInteractiveBody),
+        );
+        // Zoomed to the computed stop-motion default, above the video default
+        // that would render the tens-of-ms stills a couple of pixels wide.
+        expect(
+          body.pixelsPerSecond,
+          stopMotionInitialPixelsPerSecond(clip.stopMotionFrames!),
+        );
+        expect(
+          body.pixelsPerSecond,
+          greaterThan(TimelineConstants.pixelsPerSecond),
+        );
+      });
+
+      testWidgets('leaves the zoom at the video default for a regular '
+          'composition', (tester) async {
+        final clipStates = StreamController<ClipEditorState>.broadcast();
+        addTearDown(clipStates.close);
+        when(() => mockClipBloc.stream).thenAnswer((_) => clipStates.stream);
+        when(() => mockClipBloc.state).thenReturn(const ClipEditorState());
+
+        await tester.pumpWidget(buildWidget());
+        await tester.pump();
+
+        await transitionTo(
+          tester,
+          clipStates,
+          ClipEditorState(clips: [_createTestClip(id: 'a')]),
+        );
+
+        final body = tester.widget<VideoEditorTimelineInteractiveBody>(
+          find.byType(VideoEditorTimelineInteractiveBody),
+        );
+        expect(body.pixelsPerSecond, TimelineConstants.pixelsPerSecond);
+      });
+    });
   });
+}
+
+/// A frames-only stop-motion clip backed by real 1×1 PNG files under [dir] so
+/// the timeline frame strip's `Image.file` decode does not raise a load error.
+DivineVideoClip _stopMotionClip(Directory dir) {
+  final pngBytes = base64Decode(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk'
+    '+M8AAAMBAQDJ/IY1AAAAAElFTkSuQmCC',
+  );
+  final frames = [
+    for (var i = 0; i < 4; i++)
+      StopMotionClipFrame(
+        path: (File('${dir.path}/f$i.png')..writeAsBytesSync(pngBytes)).path,
+        duration: const Duration(milliseconds: 83),
+      ),
+  ];
+  return DivineVideoClip(
+    id: 'stop_motion',
+    stopMotionFrames: frames,
+    duration: const Duration(milliseconds: 332),
+    recordedAt: DateTime(2025),
+    originalAspectRatio: 9 / 16,
+    targetAspectRatio: .vertical,
+  );
 }
 
 DivineVideoClip _createTestClip({required String id, int seconds = 2}) {

--- a/mobile/test/widgets/video_recorder/modes/capture/video_recorder_capture_actions_test.dart
+++ b/mobile/test/widgets/video_recorder/modes/capture/video_recorder_capture_actions_test.dart
@@ -12,6 +12,7 @@ import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/clip_manager_state.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/video_recorder/video_recorder_flash_mode.dart';
+import 'package:openvine/models/video_recorder/video_recorder_mode.dart';
 import 'package:openvine/models/video_recorder/video_recorder_state.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/widgets/video_recorder/modes/capture/video_recorder_capture_actions.dart';
@@ -35,6 +36,7 @@ void main() {
 
     Widget buildWidget({
       VideoRecorderState recordingState = VideoRecorderState.idle,
+      VideoRecorderMode recorderMode = VideoRecorderMode.capture,
       DivineFlashMode flashMode = DivineFlashMode.auto,
       bool canSwitchCamera = true,
       bool hasFlash = true,
@@ -48,6 +50,7 @@ void main() {
       when(() => recorderBloc.state).thenReturn(
         VideoRecorderBlocState(
           recordingState: recordingState,
+          recorderMode: recorderMode,
           flashMode: flashMode,
           canSwitchCamera: canSwitchCamera,
           hasFlash: hasFlash,
@@ -327,6 +330,46 @@ void main() {
             ),
           ),
         );
+      });
+    });
+
+    group('grid lines button', () {
+      testWidgets('is hidden in capture mode', (tester) async {
+        await tester.pumpWidget(buildWidget());
+        await tester.pumpAndSettle();
+
+        expect(
+          find.byTooltip(l10n.videoRecorderToggleGridLabel),
+          findsNothing,
+        );
+      });
+
+      testWidgets('is shown in stop-motion mode', (tester) async {
+        await tester.pumpWidget(
+          buildWidget(recorderMode: VideoRecorderMode.stopMotion),
+        );
+        await tester.pumpAndSettle();
+
+        expect(
+          find.byTooltip(l10n.videoRecorderToggleGridLabel),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('tap dispatches $VideoRecorderGridLinesToggled', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildWidget(recorderMode: VideoRecorderMode.stopMotion),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byTooltip(l10n.videoRecorderToggleGridLabel));
+        await tester.pumpAndSettle();
+
+        verify(
+          () => recorderBloc.add(const VideoRecorderGridLinesToggled()),
+        ).called(1);
       });
     });
 

--- a/mobile/test/widgets/video_recorder/modes/capture/video_recorder_capture_stack_test.dart
+++ b/mobile/test/widgets/video_recorder/modes/capture/video_recorder_capture_stack_test.dart
@@ -1,4 +1,7 @@
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -193,6 +196,53 @@ void main() {
 
         expect(recordButtonRect.center.dx, closeTo(stackRect.center.dx, 2.0));
       });
+    });
+
+    group('stop-motion assemble', () {
+      testWidgets(
+        'shows a DivineSnackbarContainer error when assembly fails',
+        (tester) async {
+          final states = StreamController<VideoRecorderBlocState>.broadcast();
+          addTearDown(states.close);
+
+          final widget = buildWidget();
+          // whenListen overrides the state stub from buildWidget so the
+          // BlocConsumer reacts to the emitted status transition.
+          whenListen(
+            recorderBloc,
+            states.stream,
+            initialState: const VideoRecorderBlocState(
+              isCameraInitialized: true,
+              canRecord: true,
+            ),
+          );
+          await tester.pumpWidget(widget);
+          await tester.pump();
+
+          states.add(
+            const VideoRecorderBlocState(
+              isCameraInitialized: true,
+              canRecord: true,
+              stopMotionStatus: StopMotionStatus.failure,
+            ),
+          );
+          await tester.pump();
+          await tester.pump();
+
+          final l10n = lookupAppLocalizations(const Locale('en'));
+          expect(
+            find.widgetWithText(
+              DivineSnackbarContainer,
+              l10n.videoRecorderStopMotionAssembleFailed,
+            ),
+            findsOneWidget,
+          );
+          final container = tester.widget<DivineSnackbarContainer>(
+            find.byType(DivineSnackbarContainer),
+          );
+          expect(container.error, isTrue);
+        },
+      );
     });
   });
 }

--- a/mobile/test/widgets/video_recorder/modes/capture/video_recorder_capture_stack_test.dart
+++ b/mobile/test/widgets/video_recorder/modes/capture/video_recorder_capture_stack_test.dart
@@ -11,6 +11,7 @@ import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/clip_manager_state.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/video_recorder/video_recorder_mode.dart';
 import 'package:openvine/models/video_recorder/video_recorder_state.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
@@ -47,12 +48,17 @@ void main() {
     Widget buildWidget({
       VideoRecorderState recordingState = VideoRecorderState.idle,
       List<DivineVideoClip>? clips,
+      bool fromEditor = false,
+      VideoRecorderMode recorderMode = VideoRecorderMode.capture,
+      List<String> stopMotionFrames = const [],
     }) {
       when(() => recorderBloc.state).thenReturn(
         VideoRecorderBlocState(
           recordingState: recordingState,
           isCameraInitialized: true,
           canRecord: true,
+          recorderMode: recorderMode,
+          stopMotionFrames: stopMotionFrames,
         ),
       );
 
@@ -65,14 +71,25 @@ void main() {
         ],
         child: BlocProvider<VideoRecorderBloc>.value(
           value: recorderBloc,
-          child: const MaterialApp(
+          child: MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
-            home: Scaffold(body: VideoRecorderCaptureStack(fromEditor: false)),
+            home: Scaffold(
+              body: VideoRecorderCaptureStack(fromEditor: fromEditor),
+            ),
           ),
         ),
       );
     }
+
+    // The real (non-dummy) undo button is the trash icon button with a live
+    // onPressed; the sibling placeholder passes onPressed: null.
+    final undoButtonFinder = find.byWidgetPredicate(
+      (w) =>
+          w is DivineIconButton &&
+          w.icon == DivineIconName.trash &&
+          w.onPressed != null,
+    );
 
     group('renders', () {
       testWidgets('renders $VideoRecorderCaptureStack', (tester) async {
@@ -168,6 +185,48 @@ void main() {
             .toList();
         expect(opacities.any((o) => o.opacity == 0), isTrue);
       });
+
+      testWidgets(
+        'invisible undo button ignores taps in editor-hosted recorder',
+        (tester) async {
+          await tester.pumpWidget(
+            buildWidget(
+              fromEditor: true,
+              recorderMode: VideoRecorderMode.stopMotion,
+              stopMotionFrames: const ['/test/frame1.jpg'],
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          // Hidden (opacity 0) but present; tap must not reach onPressed.
+          await tester.tap(undoButtonFinder, warnIfMissed: false);
+          await tester.pump();
+
+          verifyNever(
+            () => recorderBloc.add(const VideoRecorderStopMotionFrameUndone()),
+          );
+        },
+      );
+
+      testWidgets(
+        'visible undo button deletes the last still when tapped',
+        (tester) async {
+          await tester.pumpWidget(
+            buildWidget(
+              recorderMode: VideoRecorderMode.stopMotion,
+              stopMotionFrames: const ['/test/frame1.jpg'],
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          await tester.tap(undoButtonFinder);
+          await tester.pump();
+
+          verify(
+            () => recorderBloc.add(const VideoRecorderStopMotionFrameUndone()),
+          ).called(1);
+        },
+      );
     });
 
     group('layout', () {

--- a/mobile/test/widgets/video_recorder/modes/capture/video_recorder_shutter_flash_test.dart
+++ b/mobile/test/widgets/video_recorder/modes/capture/video_recorder_shutter_flash_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/widgets/video_recorder/modes/capture/video_recorder_shutter_flash.dart';
+
+void main() {
+  Widget build(int shutterTick) => MaterialApp(
+    home: Scaffold(
+      body: VideoRecorderShutterFlash(shutterTick: shutterTick),
+    ),
+  );
+
+  double flashAlpha(WidgetTester tester) {
+    final boxes = tester.widgetList<ColoredBox>(
+      find.descendant(
+        of: find.byType(VideoRecorderShutterFlash),
+        matching: find.byType(ColoredBox),
+      ),
+    );
+    return boxes.isEmpty ? 0 : boxes.single.color.a;
+  }
+
+  testWidgets('is invisible until a capture happens', (tester) async {
+    await tester.pumpWidget(build(0));
+
+    expect(flashAlpha(tester), 0);
+  });
+
+  testWidgets('blinks when the capture count increases, then fades out', (
+    tester,
+  ) async {
+    await tester.pumpWidget(build(0));
+    await tester.pumpWidget(build(1));
+    await tester.pump();
+
+    expect(flashAlpha(tester), greaterThan(0.5));
+
+    await tester.pumpAndSettle();
+    expect(flashAlpha(tester), 0);
+  });
+
+  testWidgets('does not blink when the count stays the same', (tester) async {
+    await tester.pumpWidget(build(2));
+    await tester.pumpWidget(build(2));
+    await tester.pump();
+
+    expect(flashAlpha(tester), 0);
+  });
+}

--- a/mobile/test/widgets/video_recorder/video_recorder_ghost_frame_test.dart
+++ b/mobile/test/widgets/video_recorder/video_recorder_ghost_frame_test.dart
@@ -14,6 +14,7 @@ import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/clip_manager_state.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/video_recorder/video_recorder_mode.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/widgets/video_recorder/video_recorder_ghost_frame.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
@@ -233,6 +234,65 @@ void main() {
         );
         expect(transformFinder, findsOneWidget);
       });
+    });
+
+    group('stop-motion ghost', () {
+      Widget buildStopMotionWidget({required bool isFrontCamera}) {
+        when(() => recorderBloc.state).thenReturn(
+          VideoRecorderBlocState(
+            recorderMode: VideoRecorderMode.stopMotion,
+            showLastClipOverlay: true,
+            stopMotionFrames: [tempFile.path],
+            isFrontCamera: isFrontCamera,
+          ),
+        );
+        return ProviderScope(
+          overrides: [
+            clipManagerProvider.overrideWith(
+              () => _TestClipManagerNotifier(const []),
+            ),
+          ],
+          child: BlocProvider<VideoRecorderBloc>.value(
+            value: recorderBloc,
+            child: const MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(body: VideoRecorderGhostFrame()),
+            ),
+          ),
+        );
+      }
+
+      testWidgets('flips the last still while the front lens is active', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildStopMotionWidget(isFrontCamera: true));
+
+        // The live preview is mirrored for the front camera, so the ghost of
+        // the last still must be flipped (matrix[0][0] == -1) to line up.
+        expect(
+          find.byWidgetPredicate(
+            (w) => w is Transform && w.transform.getColumn(0)[0] == -1.0,
+          ),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets(
+        'does not flip the last still while the back lens is active',
+        (
+          tester,
+        ) async {
+          await tester.pumpWidget(buildStopMotionWidget(isFrontCamera: false));
+
+          expect(
+            find.byWidgetPredicate(
+              (w) => w is Transform && w.transform.getColumn(0)[0] == 1.0,
+            ),
+            findsOneWidget,
+          );
+        },
+      );
     });
 
     group('decode bounds', () {

--- a/mobile/test/widgets/video_recorder/video_recorder_ghost_frame_test.dart
+++ b/mobile/test/widgets/video_recorder/video_recorder_ghost_frame_test.dart
@@ -234,6 +234,31 @@ void main() {
         expect(transformFinder, findsOneWidget);
       });
     });
+
+    group('decode bounds', () {
+      testWidgets('bounds the ghost frame decode with cacheHeight', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildTestWidget(
+            showLastClipOverlay: true,
+            clips: [createClip(ghostFramePath: tempFile.path)],
+          ),
+        );
+
+        // A cacheHeight wraps the FileImage in a ResizeImage; without it the
+        // full-resolution still is decoded onto the full-screen live overlay.
+        final image = tester.widget<Image>(find.byType(Image));
+        expect(image.image, isA<ResizeImage>());
+
+        final context = tester.element(find.byType(VideoRecorderGhostFrame));
+        final expected =
+            (MediaQuery.sizeOf(context).height *
+                    MediaQuery.devicePixelRatioOf(context))
+                .round();
+        expect((image.image as ResizeImage).height, expected);
+      });
+    });
   });
 }
 

--- a/mobile/test/widgets/video_recorder/video_recorder_library_button_test.dart
+++ b/mobile/test/widgets/video_recorder/video_recorder_library_button_test.dart
@@ -391,7 +391,7 @@ void main() {
         expect(find.byKey(const ValueKey('/frames/c.jpg')), findsOneWidget);
       });
 
-      testWidgets('semantic label reflects the captured-frame count', (
+      testWidgets('semantic label counts captured frames, not clips', (
         tester,
       ) async {
         await tester.pumpWidget(buildWidget(recorderState: stopMotionState));
@@ -405,9 +405,15 @@ void main() {
               )
               .first,
         );
+        final l10n = lookupAppLocalizations(const Locale('en'));
         expect(
           semantics.properties.label,
-          equals('Open clip library, 3 clips'),
+          equals(l10n.videoRecorderLibraryOpenStopMotionLabel(3)),
+        );
+        // The stills must not be announced as clips.
+        expect(
+          semantics.properties.label,
+          isNot(equals(l10n.videoRecorderLibraryOpenLabel(3))),
         );
       });
 

--- a/mobile/test/widgets/video_recorder/video_recorder_library_button_test.dart
+++ b/mobile/test/widgets/video_recorder/video_recorder_library_button_test.dart
@@ -517,8 +517,10 @@ void main() {
           await tester.pumpAndSettle();
 
           expect(find.byType(Image), findsNothing);
-          final inkWell = tester.widget<InkWell>(find.byType(InkWell));
-          expect(inkWell.onTap, isNull);
+          final detector = tester.widget<GestureDetector>(
+            find.byType(GestureDetector),
+          );
+          expect(detector.onTap, isNull);
         },
       );
     });
@@ -539,8 +541,10 @@ void main() {
         await tester.pump();
 
         expect(find.text('2'), findsOneWidget);
-        final inkWell = tester.widget<InkWell>(find.byType(InkWell));
-        expect(inkWell.onTap, isNull);
+        final detector = tester.widget<GestureDetector>(
+          find.byType(GestureDetector),
+        );
+        expect(detector.onTap, isNull);
 
         final semantics = tester.widget<Semantics>(
           find

--- a/mobile/test/widgets/video_recorder/video_recorder_library_button_test.dart
+++ b/mobile/test/widgets/video_recorder/video_recorder_library_button_test.dart
@@ -1,10 +1,15 @@
+import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/clip_manager_state.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
+import 'package:openvine/models/video_recorder/video_recorder_mode.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/services/clip_library_service.dart';
@@ -13,21 +18,36 @@ import 'package:pro_video_editor/core/models/video/editor_video_model.dart';
 
 class _MockClipLibraryService extends Mock implements ClipLibraryService {}
 
+class _MockVideoRecorderBloc
+    extends MockBloc<VideoRecorderEvent, VideoRecorderBlocState>
+    implements VideoRecorderBloc {}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group(VideoRecorderLibraryButton, () {
     late _MockClipLibraryService mockClipLibraryService;
+    late _MockVideoRecorderBloc recorderBloc;
 
     setUp(() {
       mockClipLibraryService = _MockClipLibraryService();
+      recorderBloc = _MockVideoRecorderBloc();
 
       when(
         () => mockClipLibraryService.getAllClips(),
       ).thenAnswer((_) async => []);
     });
 
-    Widget buildWidget({List<DivineVideoClip>? clips}) {
+    Widget buildWidget({
+      List<DivineVideoClip>? clips,
+      VideoRecorderBlocState recorderState = const VideoRecorderBlocState(),
+      bool interactive = true,
+    }) {
+      whenListen(
+        recorderBloc,
+        const Stream<VideoRecorderBlocState>.empty(),
+        initialState: recorderState,
+      );
       return ProviderScope(
         overrides: [
           clipManagerProvider.overrideWith(
@@ -35,10 +55,15 @@ void main() {
           ),
           clipLibraryServiceProvider.overrideWithValue(mockClipLibraryService),
         ],
-        child: const MaterialApp(
+        child: MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
-          home: Scaffold(body: VideoRecorderLibraryButton()),
+          home: Scaffold(
+            body: BlocProvider<VideoRecorderBloc>.value(
+              value: recorderBloc,
+              child: VideoRecorderLibraryButton(interactive: interactive),
+            ),
+          ),
         ),
       );
     }
@@ -341,6 +366,186 @@ void main() {
         await tester.pumpAndSettle();
 
         verify(() => mockClipLibraryService.getAllClips()).called(1);
+      });
+    });
+
+    group('stop-motion capture', () {
+      const stopMotionState = VideoRecorderBlocState(
+        recorderMode: VideoRecorderMode.stopMotion,
+        stopMotionFrames: ['/frames/a.jpg', '/frames/b.jpg', '/frames/c.jpg'],
+      );
+
+      testWidgets('badge shows the captured-frame count, not clip count', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildWidget(recorderState: stopMotionState));
+        await tester.pump();
+
+        expect(find.text('3'), findsOneWidget);
+      });
+
+      testWidgets('thumbnail is the last captured frame', (tester) async {
+        await tester.pumpWidget(buildWidget(recorderState: stopMotionState));
+        await tester.pump();
+
+        expect(find.byKey(const ValueKey('/frames/c.jpg')), findsOneWidget);
+      });
+
+      testWidgets('semantic label reflects the captured-frame count', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildWidget(recorderState: stopMotionState));
+        await tester.pump();
+
+        final semantics = tester.widget<Semantics>(
+          find
+              .descendant(
+                of: find.byType(VideoRecorderLibraryButton),
+                matching: find.byType(Semantics),
+              )
+              .first,
+        );
+        expect(
+          semantics.properties.label,
+          equals('Open clip library, 3 clips'),
+        );
+      });
+
+      testWidgets('no badge before the first frame is captured', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildWidget(
+            recorderState: const VideoRecorderBlocState(
+              recorderMode: VideoRecorderMode.stopMotion,
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('0'), findsNothing);
+      });
+    });
+
+    group('library fallback per mode', () {
+      final videoClip = DivineVideoClip(
+        id: 'lib-video',
+        video: EditorVideo.file('/lib/video.mp4'),
+        duration: const Duration(seconds: 5),
+        recordedAt: DateTime(2024),
+        targetAspectRatio: .vertical,
+        originalAspectRatio: 9 / 16,
+        thumbnailPath: '/lib/video_thumb.jpg',
+      );
+      final stopMotionClip = DivineVideoClip(
+        id: 'lib-sm',
+        stopMotionFrames: const [
+          StopMotionClipFrame(
+            path: '/lib/sm_thumb.jpg',
+            duration: Duration(milliseconds: 42),
+          ),
+        ],
+        duration: const Duration(milliseconds: 42),
+        recordedAt: DateTime(2024),
+        targetAspectRatio: .vertical,
+        originalAspectRatio: 9 / 16,
+        thumbnailPath: '/lib/sm_thumb.jpg',
+      );
+
+      testWidgets(
+        'stop-motion mode previews the newest stop-motion set, not the '
+        'newest video clip',
+        (tester) async {
+          when(
+            () => mockClipLibraryService.getAllClips(),
+          ).thenAnswer((_) async => [videoClip, stopMotionClip]);
+
+          await tester.pumpWidget(
+            buildWidget(
+              recorderState: const VideoRecorderBlocState(
+                recorderMode: VideoRecorderMode.stopMotion,
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          expect(find.byKey(const ValueKey('/lib/sm_thumb.jpg')), findsOne);
+          expect(
+            find.byKey(const ValueKey('/lib/video_thumb.jpg')),
+            findsNothing,
+          );
+        },
+      );
+
+      testWidgets(
+        'capture mode previews the newest video clip, not the newest '
+        'stop-motion set',
+        (tester) async {
+          when(
+            () => mockClipLibraryService.getAllClips(),
+          ).thenAnswer((_) async => [stopMotionClip, videoClip]);
+
+          await tester.pumpWidget(buildWidget());
+          await tester.pumpAndSettle();
+
+          expect(find.byKey(const ValueKey('/lib/video_thumb.jpg')), findsOne);
+          expect(find.byKey(const ValueKey('/lib/sm_thumb.jpg')), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'stop-motion mode stays empty when the library only holds video '
+        'clips',
+        (tester) async {
+          when(
+            () => mockClipLibraryService.getAllClips(),
+          ).thenAnswer((_) async => [videoClip]);
+
+          await tester.pumpWidget(
+            buildWidget(
+              recorderState: const VideoRecorderBlocState(
+                recorderMode: VideoRecorderMode.stopMotion,
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          expect(find.byType(Image), findsNothing);
+          final inkWell = tester.widget<InkWell>(find.byType(InkWell));
+          expect(inkWell.onTap, isNull);
+        },
+      );
+    });
+
+    group('non-interactive (editor-hosted recorder)', () {
+      testWidgets('still shows the capture count but cannot be pressed', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildWidget(
+            interactive: false,
+            recorderState: const VideoRecorderBlocState(
+              recorderMode: VideoRecorderMode.stopMotion,
+              stopMotionFrames: ['/frames/a.jpg', '/frames/b.jpg'],
+            ),
+          ),
+        );
+        await tester.pump();
+
+        expect(find.text('2'), findsOneWidget);
+        final inkWell = tester.widget<InkWell>(find.byType(InkWell));
+        expect(inkWell.onTap, isNull);
+
+        final semantics = tester.widget<Semantics>(
+          find
+              .descendant(
+                of: find.byType(VideoRecorderLibraryButton),
+                matching: find.byType(Semantics),
+              )
+              .first,
+        );
+        expect(semantics.properties.enabled, isFalse);
+        expect(semantics.properties.button, isFalse);
       });
     });
   });

--- a/mobile/test/widgets/video_recorder/video_recorder_mode_selector_test.dart
+++ b/mobile/test/widgets/video_recorder/video_recorder_mode_selector_test.dart
@@ -7,6 +7,13 @@ import 'package:openvine/widgets/video_recorder/video_recorder_mode_selector.dar
 
 void main() {
   group(VideoRecorderModeSelectorWheel, () {
+    // Item widths follow each label's measured (wide, extra-bold) text, and
+    // the wheel lazily builds only the items inside its viewport. The tests
+    // below assert on every mode at once, so both the surface and the host
+    // box are sized wide enough to lay out all modes on screen — otherwise
+    // the outer labels scroll off and are never built or hit-testable.
+    const surfaceWidth = 1500.0;
+
     late VideoRecorderMode selectedMode;
     late List<VideoRecorderMode> modeChanges;
 
@@ -22,7 +29,7 @@ void main() {
         home: Scaffold(
           body: Center(
             child: SizedBox(
-              width: 400,
+              width: surfaceWidth,
               child: VideoRecorderModeSelectorWheel(
                 selectedMode: mode ?? selectedMode,
                 onModeChanged: (m) => modeChanges.add(m),
@@ -33,10 +40,21 @@ void main() {
       );
     }
 
+    Future<void> pumpSelector(
+      WidgetTester tester, {
+      VideoRecorderMode? mode,
+    }) async {
+      tester.view.physicalSize = const Size(surfaceWidth, 400);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      await tester.pumpWidget(buildWidget(mode: mode));
+      await tester.pumpAndSettle();
+    }
+
     group('renders', () {
       testWidgets('renders all mode labels', (tester) async {
-        await tester.pumpWidget(buildWidget());
-        await tester.pumpAndSettle();
+        await pumpSelector(tester);
 
         for (final mode in VideoRecorderMode.values) {
           expect(find.text(mode.label), findsOneWidget);
@@ -44,22 +62,19 @@ void main() {
       });
 
       testWidgets('renders with capture mode selected', (tester) async {
-        await tester.pumpWidget(buildWidget(mode: VideoRecorderMode.capture));
-        await tester.pumpAndSettle();
+        await pumpSelector(tester, mode: VideoRecorderMode.capture);
 
         expect(find.byType(VideoRecorderModeSelectorWheel), findsOneWidget);
       });
 
       testWidgets('renders with classic mode selected', (tester) async {
-        await tester.pumpWidget(buildWidget(mode: VideoRecorderMode.classic));
-        await tester.pumpAndSettle();
+        await pumpSelector(tester, mode: VideoRecorderMode.classic);
 
         expect(find.byType(VideoRecorderModeSelectorWheel), findsOneWidget);
       });
 
       testWidgets('renders pill background', (tester) async {
-        await tester.pumpWidget(buildWidget());
-        await tester.pumpAndSettle();
+        await pumpSelector(tester);
 
         expect(find.byType(AnimatedContainer), findsOneWidget);
       });
@@ -79,8 +94,7 @@ void main() {
               .setMockMethodCallHandler(SystemChannels.platform, null);
         });
 
-        await tester.pumpWidget(buildWidget(mode: VideoRecorderMode.capture));
-        await tester.pumpAndSettle();
+        await pumpSelector(tester, mode: VideoRecorderMode.capture);
 
         await tester.tap(find.text('Classic'));
         await tester.pumpAndSettle();
@@ -88,16 +102,39 @@ void main() {
         expect(modeChanges, contains(VideoRecorderMode.classic));
       });
 
-      testWidgets('uses ShaderMask for fade-out edges', (tester) async {
-        await tester.pumpWidget(buildWidget());
+      testWidgets('a forward drag settles on one item, not the last', (
+        tester,
+      ) async {
+        // Suppress haptic feedback method channel calls in test
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+              return null;
+            });
+        addTearDown(() {
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+              .setMockMethodCallHandler(SystemChannels.platform, null);
+        });
+
+        await pumpSelector(tester, mode: VideoRecorderMode.capture);
+
+        // A single user drag must produce a single snap. Regression guard:
+        // the programmatic snap animation used to re-trigger snapping and run
+        // the wheel all the way to the final ("Classic") item.
+        await tester.drag(find.byType(ListView), const Offset(-60, 0));
         await tester.pumpAndSettle();
+
+        expect(modeChanges, isNotEmpty);
+        expect(modeChanges, isNot(contains(VideoRecorderMode.classic)));
+      });
+
+      testWidgets('uses ShaderMask for fade-out edges', (tester) async {
+        await pumpSelector(tester);
 
         expect(find.byType(ShaderMask), findsOneWidget);
       });
 
       testWidgets('renders horizontal ListView', (tester) async {
-        await tester.pumpWidget(buildWidget());
-        await tester.pumpAndSettle();
+        await pumpSelector(tester);
 
         final listView = tester.widget<ListView>(find.byType(ListView));
         expect(listView.scrollDirection, equals(Axis.horizontal));
@@ -108,8 +145,7 @@ void main() {
       testWidgets('each mode is exposed as a selectable Semantics button', (
         tester,
       ) async {
-        await tester.pumpWidget(buildWidget(mode: VideoRecorderMode.capture));
-        await tester.pumpAndSettle();
+        await pumpSelector(tester, mode: VideoRecorderMode.capture);
 
         for (final mode in VideoRecorderMode.values) {
           final semantics = tester
@@ -126,8 +162,7 @@ void main() {
       testWidgets('each mode tap target meets the 48dp minimum', (
         tester,
       ) async {
-        await tester.pumpWidget(buildWidget());
-        await tester.pumpAndSettle();
+        await pumpSelector(tester);
 
         final targets = find.descendant(
           of: find.byType(ListView),
@@ -147,14 +182,33 @@ void main() {
       testWidgets('updates selection when mode changes externally', (
         tester,
       ) async {
-        await tester.pumpWidget(buildWidget(mode: VideoRecorderMode.capture));
-        await tester.pumpAndSettle();
+        await pumpSelector(tester, mode: VideoRecorderMode.capture);
 
-        await tester.pumpWidget(buildWidget(mode: VideoRecorderMode.classic));
-        await tester.pumpAndSettle();
+        await pumpSelector(tester, mode: VideoRecorderMode.classic);
 
         expect(find.byType(VideoRecorderModeSelectorWheel), findsOneWidget);
       });
+
+      testWidgets(
+        'an external mode change repositions instantly without a scroll '
+        'animation (persisted-mode restore on open)',
+        (tester) async {
+          await pumpSelector(tester, mode: VideoRecorderMode.capture);
+          final scrollable = tester.state<ScrollableState>(
+            find.byType(Scrollable).first,
+          );
+          final offsetBefore = scrollable.position.pixels;
+
+          await tester.pumpWidget(buildWidget(mode: VideoRecorderMode.classic));
+
+          // The wheel is already on the new mode after the rebuild frame —
+          // no in-flight animation left for pumpAndSettle to advance.
+          final offsetAfterRebuild = scrollable.position.pixels;
+          expect(offsetAfterRebuild, isNot(equals(offsetBefore)));
+          await tester.pumpAndSettle();
+          expect(scrollable.position.pixels, equals(offsetAfterRebuild));
+        },
+      );
     });
   });
 }


### PR DESCRIPTION
Closes #5764
Closes #6241

## What

Builds out the stop-motion feature (recorder mode landed in the branch's first commit) into a complete frames-first pipeline: editing, library, persistence, preview, and publish render.

### Editor: frame-first editing
- Each captured still is its own timeline tile: tap to select (accent-yellow trim-handle-style highlight, no trim handles — stills have no trim), long-press drag to reorder, delete via the action bar. Split/speed/reverse/extract-audio are hidden for stop-motion since they are clip-boundary concepts that don't apply to a frames list.
- Frames-per-image control as a toolbar chip (top centre) opening a wheel sheet; the global value acts as a *default* — stills whose hold was set individually are marked `holdOverridden` and survive later global changes. Base semantics are classic 24fps film frames; capture default is 1 frame.
- Timed layers and timeline audio now follow the stop-motion clock: the widget-driven ticker feeds `ProVideoController.setPlayTime` (layers) and a new `StopMotionAudioPreview` engine (one `AudioClipPlayer` per sound, window scheduling, scrub/loop re-seek) — frames-only clips have no native player to do either. Audio pauses when the editor is covered (Done → metadata).
- Undo/redo and clip-manager mirroring work for frame edits: `hasResolvableVideoFile` now understands frames-only clips (they were classified as orphaned, silently stepping history backwards) and the history diff compares `stopMotionFrames` (frame edits never reached publish/autosave/metadata preview before). Frame holds serialize in microseconds so history snapshots compare exactly (2 frames @ 24fps = 83333µs; a millisecond round-trip drifted off the frame grid).

### Recorder & library
- Captures persist to the library eagerly per frame under a stable session id (derived from the first still), so a recording exists the moment it is shot — previously the only save was the assemble tap. Undo removes/re-syncs; assemble updates the same row (no duplicates). The recorder's library button mirrors the live session (last still + frame count).
- Library scopes to the recorder mode (`?type=` query param → bloc-level filter): stop-motion mode sees only stop-motion sets, other modes only video clips. The standalone library shows both but blocks mixing types in one selection — they can't share a timeline.
- Selecting multiple stop-motion sets merges them into one frames clip on editor entry (the frame-first editor edits exactly one frames list, the shape a recorder session produces).
- Unreadable stills (deleted or zero-byte captures) are filtered at every session entry point: recorder ingest, library→editor, and draft restore (which now salvages a stop-motion clip per still instead of dropping it for one missing frame).
- Stop-motion clips render as an image in the library (stop-motion badge, no misleading seconds badge); grid/preview/editor decode stills at display size (`cacheHeight`) — full-resolution decodes previously thrashed the image cache and stuttered playback.

### Render & routing
- `materialize` (publish / gallery export) now renders each still with its own hold duration — it previously ignored the editor's frame settings entirely, producing videos shorter than the timeline.
- C2PA signing is stop-motion-safe (closes #6241): the proof paths resolve `clip.video?.file` instead of `requireVideo`, so a frames-only clip is skipped/rendered-first rather than throwing `requireVideo … without a rendered video` mid-save. Initial signing runs on the materialized mp4; the re-sign retry and per-clip attestation skip frames-only sources.
- Route fix: `parseRoute` misparsed query-carrying locations (`/clips-only?type=video` fell through to the home fallback and the route normalizer yanked the user to `/home/0`). The normalizer now compares only the path and preserves query params.

## Why frames-only until publish

Encoding an mp4 per shutter tap is seconds-slow and looping players stutter on sub-second clips; keeping the stills as the source of truth makes capture instant, editing lossless (holds are metadata), and defers the single encode to publish.

## Testing
- `flutter analyze lib test` clean; pre-push hook ran 1158 tests green.
- New/updated coverage: frame ops (merge, sanitize, hold semantics), recorder bloc (eager persist, session id reuse, camera-resync preservation — with real temp files), clips-library bloc/state (type filter, no-mix guard), canvas (`clipsChanged`, stop-motion snapshot resolvability), render service (per-frame holds reach the render), `StopMotionAudioPreview` (11 cases), route parsing with query params, frame strip (selection border), library button (session mirroring).
- Manual: record → library → editor → frame edit → publish flows on device; macOS library-open regression verified via router logs.
