### PR TITLE
fix(editor): restore playback session after recording

### DIFF
--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -1292,16 +1292,23 @@ class VideoRecorderBloc
     VideoRecorderCameraPausedForNavigation event,
     Emitter<VideoRecorderBlocState> emit,
   ) async {
-    Log.info(
-      '📹 Camera paused for navigation - disposing',
-      name: 'VideoRecorderBloc',
-      category: LogCategory.video,
-    );
-    // Idempotent with VideoRecorderRecordingLockedForNavigation (which the View
-    // dispatches first, before the push transition). Re-asserting here keeps
-    // the recorder safe even if only the pause event is dispatched.
-    _lockRecordingForNavigation(emit);
-    await _cameraService.dispose();
+    try {
+      Log.info(
+        '📹 Camera paused for navigation - disposing',
+        name: 'VideoRecorderBloc',
+        category: LogCategory.video,
+      );
+      // Idempotent with VideoRecorderRecordingLockedForNavigation (which the
+      // View dispatches first, before the push transition). Re-asserting here
+      // keeps the recorder safe even if only the pause event is dispatched.
+      _lockRecordingForNavigation(emit);
+      await _cameraService.dispose();
+    } finally {
+      final completion = event.completion;
+      if (completion != null && !completion.isCompleted) {
+        completion.complete();
+      }
+    }
   }
 
   /// Locks recording for a navigation push: sets the lock, detaches the remote

--- a/mobile/lib/blocs/video_recorder/video_recorder_event.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_event.dart
@@ -209,7 +209,10 @@ final class VideoRecorderScaleUpdated extends VideoRecorderEvent {
 /// transition is past the visible frame. Pair with
 /// [VideoRecorderInitializeRequested] on return.
 final class VideoRecorderCameraPausedForNavigation extends VideoRecorderEvent {
-  const VideoRecorderCameraPausedForNavigation();
+  const VideoRecorderCameraPausedForNavigation({this.completion});
+
+  /// Optional completion signal for callers that must run after camera dispose.
+  final Completer<void>? completion;
 }
 
 /// Locks recording and detaches the remote (volume / Bluetooth) trigger the

--- a/mobile/lib/blocs/video_recorder/video_recorder_event.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_event.dart
@@ -213,6 +213,9 @@ final class VideoRecorderCameraPausedForNavigation extends VideoRecorderEvent {
 
   /// Optional completion signal for callers that must run after camera dispose.
   final Completer<void>? completion;
+
+  @override
+  List<Object?> get props => [completion];
 }
 
 /// Locks recording and detaches the remote (volume / Bluetooth) trigger the

--- a/mobile/lib/providers/upload_media_providers.dart
+++ b/mobile/lib/providers/upload_media_providers.dart
@@ -314,3 +314,12 @@ AudioPlaybackService audioPlaybackService(Ref ref) {
 
   return service;
 }
+
+/// Audio-session-only configuration used by recorder/editor route handoffs.
+///
+/// Kept separate from [audioPlaybackServiceProvider] so playback routes can
+/// restore `AVAudioSession` without constructing a player or starting headphone
+/// detection.
+final audioSessionServiceProvider = Provider<AudioSessionService>((ref) {
+  return AudioSessionService();
+});

--- a/mobile/lib/widgets/video_recorder/video_recorder_navigation.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_navigation.dart
@@ -111,6 +111,9 @@ Future<void> openRecorderLibrary(BuildContext context, WidgetRef ref) async {
 }
 
 Future<void> _pauseCameraForNavigation(VideoRecorderBloc bloc) {
+  // A closed bloc drops the event, so the completion would never resolve and
+  // the awaiting caller would hang. Skip the handoff instead.
+  if (bloc.isClosed) return Future<void>.value();
   final completion = Completer<void>();
   bloc.add(VideoRecorderCameraPausedForNavigation(completion: completion));
   return completion.future;

--- a/mobile/lib/widgets/video_recorder/video_recorder_navigation.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_navigation.dart
@@ -73,7 +73,12 @@ Future<void> openVideoEditorFromRecorder(
       : context.push(VideoMetadataScreen.path);
 
   await awaitPushTransition(context);
-  bloc.add(const VideoRecorderCameraPausedForNavigation());
+  await _pauseCameraForNavigation(bloc);
+  if (recorderMode.hasVideoEditor) {
+    await ref.read(audioSessionServiceProvider).configureForMixedPlayback();
+  } else {
+    await ref.read(audioSessionServiceProvider).resetAudioSession();
+  }
 
   await navigation;
   if (!context.mounted) return;
@@ -97,11 +102,18 @@ Future<void> openRecorderLibrary(BuildContext context, WidgetRef ref) async {
   final navigation = context.pushNamed(LibraryScreen.clipsOnlyRouteName);
 
   await awaitPushTransition(context);
-  bloc.add(const VideoRecorderCameraPausedForNavigation());
+  await _pauseCameraForNavigation(bloc);
+  await ref.read(audioSessionServiceProvider).resetAudioSession();
 
   await navigation;
   if (!context.mounted) return;
   bloc.add(const VideoRecorderInitializeRequested());
+}
+
+Future<void> _pauseCameraForNavigation(VideoRecorderBloc bloc) {
+  final completion = Completer<void>();
+  bloc.add(VideoRecorderCameraPausedForNavigation(completion: completion));
+  return completion.future;
 }
 
 Future<bool> _ensureAuthenticatedForRecorderExit(

--- a/mobile/packages/sound_service/lib/sound_service.dart
+++ b/mobile/packages/sound_service/lib/sound_service.dart
@@ -3,6 +3,7 @@ library;
 
 export 'src/audio_clip_player.dart';
 export 'src/audio_playback_service.dart';
+export 'src/audio_session_service.dart';
 export 'src/audio_session_wrapper.dart';
 export 'src/audio_source_config.dart';
 export 'src/countdown_sound_service.dart';

--- a/mobile/packages/sound_service/lib/src/audio_playback_service.dart
+++ b/mobile/packages/sound_service/lib/src/audio_playback_service.dart
@@ -12,6 +12,7 @@ import 'package:audio_session/audio_session.dart' as audio_session;
 import 'package:flutter/foundation.dart';
 import 'package:just_audio/just_audio.dart';
 import 'package:rxdart/rxdart.dart';
+import 'package:sound_service/src/audio_session_service.dart';
 import 'package:sound_service/src/audio_session_wrapper.dart';
 import 'package:sound_service/src/audio_source_config.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -39,12 +40,16 @@ class AudioPlaybackService {
            ),
        _audioSessionWrapper =
            audioSessionWrapper ?? DefaultAudioSessionWrapper() {
+    _audioSessionService = AudioSessionService(
+      audioSessionWrapper: _audioSessionWrapper,
+    );
     unawaited(_initializeHeadphoneDetection());
   }
   // coverage:ignore-end
 
   final AudioPlayer _audioPlayer;
   final AudioSessionWrapper _audioSessionWrapper;
+  late final AudioSessionService _audioSessionService;
 
   /// BehaviorSubject for headphone connection state.
   /// Starts with false (no headphones) until actual state is determined.
@@ -445,42 +450,7 @@ class AudioPlaybackService {
   /// "call started/ended" sounds on Bluetooth headsets.
   Future<void> configureForRecording() async {
     if (_isDisposed) return;
-    try {
-      await _audioSessionWrapper.configure(
-        audio_session.AudioSessionConfiguration(
-          avAudioSessionCategory:
-              audio_session.AVAudioSessionCategory.playAndRecord,
-          avAudioSessionCategoryOptions:
-              audio_session.AVAudioSessionCategoryOptions.defaultToSpeaker |
-              audio_session.AVAudioSessionCategoryOptions.allowBluetoothA2dp,
-          avAudioSessionMode: audio_session.AVAudioSessionMode.defaultMode,
-          avAudioSessionRouteSharingPolicy:
-              audio_session.AVAudioSessionRouteSharingPolicy.defaultPolicy,
-          avAudioSessionSetActiveOptions:
-              audio_session.AVAudioSessionSetActiveOptions.none,
-          androidAudioAttributes: const audio_session.AndroidAudioAttributes(
-            contentType: audio_session.AndroidAudioContentType.music,
-            usage: audio_session.AndroidAudioUsage.media,
-          ),
-          androidAudioFocusGainType:
-              audio_session.AndroidAudioFocusGainType.gainTransientMayDuck,
-          androidWillPauseWhenDucked: false,
-        ),
-      );
-
-      Log.debug(
-        'Configured audio session for recording mode',
-        name: 'AudioPlaybackService',
-        category: LogCategory.video,
-      );
-    } on Exception catch (e) {
-      Log.warning(
-        'Failed to configure audio session for recording: $e',
-        name: 'AudioPlaybackService',
-        category: LogCategory.video,
-      );
-      // Don't rethrow - allow playback to continue even if session config fails
-    }
+    await _audioSessionService.configureForRecording();
   }
 
   /// Configures the audio session for mixed playback.
@@ -490,40 +460,7 @@ class AudioPlaybackService {
   /// the audio from pausing the video.
   Future<void> configureForMixedPlayback() async {
     if (_isDisposed) return;
-    try {
-      await _audioSessionWrapper.configure(
-        const audio_session.AudioSessionConfiguration(
-          avAudioSessionCategory: audio_session.AVAudioSessionCategory.playback,
-          avAudioSessionCategoryOptions:
-              audio_session.AVAudioSessionCategoryOptions.mixWithOthers,
-          avAudioSessionMode: audio_session.AVAudioSessionMode.defaultMode,
-          avAudioSessionRouteSharingPolicy:
-              audio_session.AVAudioSessionRouteSharingPolicy.defaultPolicy,
-          avAudioSessionSetActiveOptions:
-              audio_session.AVAudioSessionSetActiveOptions.none,
-          androidAudioAttributes: audio_session.AndroidAudioAttributes(
-            contentType: audio_session.AndroidAudioContentType.music,
-            usage: audio_session.AndroidAudioUsage.media,
-          ),
-          androidAudioFocusGainType:
-              audio_session.AndroidAudioFocusGainType.gainTransientMayDuck,
-          androidWillPauseWhenDucked: false,
-        ),
-      );
-
-      Log.debug(
-        'Configured audio session for mixed playback',
-        name: 'AudioPlaybackService',
-        category: LogCategory.video,
-      );
-    } on Exception catch (e) {
-      Log.warning(
-        'Failed to configure audio session for mixed playback: $e',
-        name: 'AudioPlaybackService',
-        category: LogCategory.video,
-      );
-      // Don't rethrow - allow playback to continue even if session config fails
-    }
+    await _audioSessionService.configureForMixedPlayback();
   }
 
   /// Resets the audio session to default configuration.
@@ -531,36 +468,7 @@ class AudioPlaybackService {
   /// Call this when exiting recording mode.
   Future<void> resetAudioSession() async {
     if (_isDisposed) return;
-    try {
-      await _audioSessionWrapper.configure(
-        const audio_session.AudioSessionConfiguration(
-          avAudioSessionCategory: audio_session.AVAudioSessionCategory.playback,
-          avAudioSessionCategoryOptions:
-              audio_session.AVAudioSessionCategoryOptions.none,
-          avAudioSessionMode: audio_session.AVAudioSessionMode.defaultMode,
-          avAudioSessionRouteSharingPolicy:
-              audio_session.AVAudioSessionRouteSharingPolicy.defaultPolicy,
-          androidAudioFocusGainType:
-              audio_session.AndroidAudioFocusGainType.gainTransientMayDuck,
-          avAudioSessionSetActiveOptions:
-              audio_session.AVAudioSessionSetActiveOptions.none,
-          androidAudioAttributes: audio_session.AndroidAudioAttributes(
-            contentType: audio_session.AndroidAudioContentType.music,
-            usage: audio_session.AndroidAudioUsage.media,
-          ),
-          androidWillPauseWhenDucked: true,
-        ),
-      );
-
-      Log.debug('Reset audio session to default', name: 'AudioPlaybackService');
-    } on Exception catch (e) {
-      Log.warning(
-        'Failed to reset audio session: $e',
-        name: 'AudioPlaybackService',
-        category: LogCategory.video,
-      );
-      // Don't rethrow - allow continued operation even if reset fails
-    }
+    await _audioSessionService.resetAudioSession();
   }
 
   /// Disposes of all resources used by this service.

--- a/mobile/packages/sound_service/lib/src/audio_session_service.dart
+++ b/mobile/packages/sound_service/lib/src/audio_session_service.dart
@@ -1,0 +1,143 @@
+// ABOUTME: Audio-session-only configuration helpers shared by playback flows.
+// ABOUTME: Keeps AVAudioSession policy out of player lifecycle code.
+
+import 'package:audio_session/audio_session.dart' as audio_session;
+import 'package:sound_service/src/audio_session_wrapper.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// Configures the platform audio session for recorder and editor handoffs.
+class AudioSessionService {
+  /// Creates an [AudioSessionService].
+  AudioSessionService({AudioSessionWrapper? audioSessionWrapper})
+    : _audioSessionWrapper =
+          audioSessionWrapper ?? DefaultAudioSessionWrapper();
+
+  final AudioSessionWrapper _audioSessionWrapper;
+
+  /// Configures the audio session for recording mode.
+  ///
+  /// This sets up the audio session to:
+  /// - Allow audio playback during recording via A2DP to Bluetooth headphones
+  /// - Use built-in microphone for recording (NOT Bluetooth mic)
+  /// - Route to speaker when no headphones connected
+  ///
+  /// IMPORTANT: Only uses allowBluetoothA2dp, NOT allowBluetooth.
+  /// allowBluetooth enables HFP (phone call mode) which causes
+  /// "call started/ended" sounds on Bluetooth headsets.
+  Future<void> configureForRecording() async {
+    try {
+      await _audioSessionWrapper.configure(
+        audio_session.AudioSessionConfiguration(
+          avAudioSessionCategory:
+              audio_session.AVAudioSessionCategory.playAndRecord,
+          avAudioSessionCategoryOptions:
+              audio_session.AVAudioSessionCategoryOptions.defaultToSpeaker |
+              audio_session.AVAudioSessionCategoryOptions.allowBluetoothA2dp,
+          avAudioSessionMode: audio_session.AVAudioSessionMode.defaultMode,
+          avAudioSessionRouteSharingPolicy:
+              audio_session.AVAudioSessionRouteSharingPolicy.defaultPolicy,
+          avAudioSessionSetActiveOptions:
+              audio_session.AVAudioSessionSetActiveOptions.none,
+          androidAudioAttributes: const audio_session.AndroidAudioAttributes(
+            contentType: audio_session.AndroidAudioContentType.music,
+            usage: audio_session.AndroidAudioUsage.media,
+          ),
+          androidAudioFocusGainType:
+              audio_session.AndroidAudioFocusGainType.gainTransientMayDuck,
+          androidWillPauseWhenDucked: false,
+        ),
+      );
+
+      Log.debug(
+        'Configured audio session for recording mode',
+        name: 'AudioSessionService',
+        category: LogCategory.video,
+      );
+    } on Exception catch (e) {
+      Log.warning(
+        'Failed to configure audio session for recording: $e',
+        name: 'AudioSessionService',
+        category: LogCategory.video,
+      );
+      // Keep playback usable if the platform rejects configuration.
+    }
+  }
+
+  /// Configures the audio session for mixed playback.
+  ///
+  /// This allows audio to play simultaneously with other audio sources
+  /// (e.g., video player). Use this in the video editor to prevent
+  /// the audio from pausing the video.
+  Future<void> configureForMixedPlayback() async {
+    try {
+      await _audioSessionWrapper.configure(
+        const audio_session.AudioSessionConfiguration(
+          avAudioSessionCategory: audio_session.AVAudioSessionCategory.playback,
+          avAudioSessionCategoryOptions:
+              audio_session.AVAudioSessionCategoryOptions.mixWithOthers,
+          avAudioSessionMode: audio_session.AVAudioSessionMode.defaultMode,
+          avAudioSessionRouteSharingPolicy:
+              audio_session.AVAudioSessionRouteSharingPolicy.defaultPolicy,
+          avAudioSessionSetActiveOptions:
+              audio_session.AVAudioSessionSetActiveOptions.none,
+          androidAudioAttributes: audio_session.AndroidAudioAttributes(
+            contentType: audio_session.AndroidAudioContentType.music,
+            usage: audio_session.AndroidAudioUsage.media,
+          ),
+          androidAudioFocusGainType:
+              audio_session.AndroidAudioFocusGainType.gainTransientMayDuck,
+          androidWillPauseWhenDucked: false,
+        ),
+      );
+
+      Log.debug(
+        'Configured audio session for mixed playback',
+        name: 'AudioSessionService',
+        category: LogCategory.video,
+      );
+    } on Exception catch (e) {
+      Log.warning(
+        'Failed to configure audio session for mixed playback: $e',
+        name: 'AudioSessionService',
+        category: LogCategory.video,
+      );
+      // Keep playback usable if the platform rejects configuration.
+    }
+  }
+
+  /// Resets the audio session to default playback configuration.
+  ///
+  /// Call this when exiting recording mode.
+  Future<void> resetAudioSession() async {
+    try {
+      await _audioSessionWrapper.configure(
+        const audio_session.AudioSessionConfiguration(
+          avAudioSessionCategory: audio_session.AVAudioSessionCategory.playback,
+          avAudioSessionCategoryOptions:
+              audio_session.AVAudioSessionCategoryOptions.none,
+          avAudioSessionMode: audio_session.AVAudioSessionMode.defaultMode,
+          avAudioSessionRouteSharingPolicy:
+              audio_session.AVAudioSessionRouteSharingPolicy.defaultPolicy,
+          androidAudioFocusGainType:
+              audio_session.AndroidAudioFocusGainType.gainTransientMayDuck,
+          avAudioSessionSetActiveOptions:
+              audio_session.AVAudioSessionSetActiveOptions.none,
+          androidAudioAttributes: audio_session.AndroidAudioAttributes(
+            contentType: audio_session.AndroidAudioContentType.music,
+            usage: audio_session.AndroidAudioUsage.media,
+          ),
+          androidWillPauseWhenDucked: true,
+        ),
+      );
+
+      Log.debug('Reset audio session to default', name: 'AudioSessionService');
+    } on Exception catch (e) {
+      Log.warning(
+        'Failed to reset audio session: $e',
+        name: 'AudioSessionService',
+        category: LogCategory.video,
+      );
+      // Don't rethrow - allow continued operation even if reset fails.
+    }
+  }
+}

--- a/mobile/packages/sound_service/test/src/audio_session_service_test.dart
+++ b/mobile/packages/sound_service/test/src/audio_session_service_test.dart
@@ -1,0 +1,102 @@
+// ABOUTME: Tests for AudioSessionService AVAudioSession policy.
+// ABOUTME: Covers recorder/editor playback configuration without an audio player.
+
+import 'package:audio_session/audio_session.dart' as audio_session;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:sound_service/sound_service.dart';
+
+class _MockAudioSessionWrapper extends Mock implements AudioSessionWrapper {}
+
+class _FakeAudioSessionConfig extends Fake
+    implements audio_session.AudioSessionConfiguration {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(_FakeAudioSessionConfig());
+  });
+
+  group(AudioSessionService, () {
+    late _MockAudioSessionWrapper wrapper;
+    late AudioSessionService service;
+
+    setUp(() {
+      wrapper = _MockAudioSessionWrapper();
+      service = AudioSessionService(audioSessionWrapper: wrapper);
+
+      when(() => wrapper.configure(any())).thenAnswer((_) async {});
+    });
+
+    test('can create with default audio session wrapper', () {
+      expect(AudioSessionService(), isA<AudioSessionService>());
+    });
+
+    test('configureForRecording uses playAndRecord with A2DP', () async {
+      await service.configureForRecording();
+
+      final captured =
+          verify(() => wrapper.configure(captureAny())).captured.single
+              as audio_session.AudioSessionConfiguration;
+      expect(
+        captured.avAudioSessionCategory,
+        audio_session.AVAudioSessionCategory.playAndRecord,
+      );
+      expect(
+        captured.avAudioSessionCategoryOptions,
+        audio_session.AVAudioSessionCategoryOptions.defaultToSpeaker |
+            audio_session.AVAudioSessionCategoryOptions.allowBluetoothA2dp,
+      );
+      expect(
+        captured.avAudioSessionCategoryOptions! &
+            audio_session.AVAudioSessionCategoryOptions.allowBluetooth,
+        audio_session.AVAudioSessionCategoryOptions.none,
+      );
+      expect(captured.androidWillPauseWhenDucked, isFalse);
+    });
+
+    test(
+      'configureForMixedPlayback uses playback with mixWithOthers',
+      () async {
+        await service.configureForMixedPlayback();
+
+        final captured =
+            verify(() => wrapper.configure(captureAny())).captured.single
+                as audio_session.AudioSessionConfiguration;
+        expect(
+          captured.avAudioSessionCategory,
+          audio_session.AVAudioSessionCategory.playback,
+        );
+        expect(
+          captured.avAudioSessionCategoryOptions,
+          audio_session.AVAudioSessionCategoryOptions.mixWithOthers,
+        );
+        expect(captured.androidWillPauseWhenDucked, isFalse);
+      },
+    );
+
+    test('resetAudioSession uses playback without mixing', () async {
+      await service.resetAudioSession();
+
+      final captured =
+          verify(() => wrapper.configure(captureAny())).captured.single
+              as audio_session.AudioSessionConfiguration;
+      expect(
+        captured.avAudioSessionCategory,
+        audio_session.AVAudioSessionCategory.playback,
+      );
+      expect(
+        captured.avAudioSessionCategoryOptions,
+        audio_session.AVAudioSessionCategoryOptions.none,
+      );
+      expect(captured.androidWillPauseWhenDucked, isTrue);
+    });
+
+    test('configuration errors are swallowed', () async {
+      when(() => wrapper.configure(any())).thenThrow(Exception('boom'));
+
+      await expectLater(service.configureForRecording(), completes);
+      await expectLater(service.configureForMixedPlayback(), completes);
+      await expectLater(service.resetAudioSession(), completes);
+    });
+  });
+}

--- a/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
+++ b/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
@@ -1411,6 +1411,44 @@ void main() {
           verify(() => cameraService.dispose());
         },
       );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'completes the navigation completer after the camera is disposed — the '
+        'audio-session handoff must run strictly after dispose',
+        build: buildBloc,
+        act: (bloc) {
+          // act awaits the returned future, so a completer that never resolves
+          // fails the test by timing out.
+          final completion = Completer<void>();
+          bloc.add(
+            VideoRecorderCameraPausedForNavigation(completion: completion),
+          );
+          return completion.future;
+        },
+        verify: (_) {
+          // Disposed by the pause handler (the bloc also disposes on close()).
+          verify(() => cameraService.dispose());
+        },
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'still completes the navigation completer when camera dispose throws — '
+        'the finally must unblock the caller even on failure',
+        setUp: () {
+          when(
+            () => cameraService.dispose(),
+          ).thenThrow(Exception('dispose failed'));
+        },
+        build: buildBloc,
+        act: (bloc) {
+          final completion = Completer<void>();
+          bloc.add(
+            VideoRecorderCameraPausedForNavigation(completion: completion),
+          );
+          return completion.future;
+        },
+        errors: () => [isA<Exception>()],
+      );
     });
 
     group('VideoRecorderRecordingLockedForNavigation → recording lock', () {

--- a/mobile/test/widgets/video_recorder/video_recorder_navigation_test.dart
+++ b/mobile/test/widgets/video_recorder/video_recorder_navigation_test.dart
@@ -22,6 +22,7 @@ import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/screens/auth/welcome_screen.dart';
 import 'package:openvine/screens/library_screen.dart';
 import 'package:openvine/screens/video_editor/video_editor_screen.dart';
+import 'package:openvine/screens/video_metadata/video_metadata_screen.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/widgets/video_recorder/video_recorder_navigation.dart';
 import 'package:sound_service/sound_service.dart';
@@ -77,6 +78,7 @@ void main() {
     fakeClipManager = _FakeClipManagerNotifier();
 
     when(() => recorderBloc.state).thenReturn(const VideoRecorderBlocState());
+    when(() => recorderBloc.isClosed).thenReturn(false);
     when(() => recorderBloc.add(any())).thenAnswer((invocation) {
       final event = invocation.positionalArguments.single as VideoRecorderEvent;
       if (event is VideoRecorderCameraPausedForNavigation) {
@@ -108,6 +110,10 @@ void main() {
         GoRoute(
           path: VideoEditorScreen.path,
           builder: (_, _) => const _StubScreen(label: 'editor'),
+        ),
+        GoRoute(
+          path: VideoMetadataScreen.path,
+          builder: (_, _) => const _StubScreen(label: 'metadata'),
         ),
         GoRoute(
           path: '/library-clips',
@@ -217,6 +223,23 @@ void main() {
         expect(fakeClipManager.muteAllClipsCalled, isFalse);
         expect(find.text('editor'), findsOneWidget);
         verify(() => audioSessionService.configureForMixedPlayback()).called(1);
+      });
+
+      testWidgets('openVideoEditorFromRecorder resets the session for a mode '
+          'without a video editor (routes to metadata)', (tester) async {
+        when(() => recorderBloc.state).thenReturn(
+          const VideoRecorderBlocState(recorderMode: VideoRecorderMode.classic),
+        );
+
+        await tester.pumpWidget(buildHarness());
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byKey(const Key('open-editor')));
+        await tester.pumpAndSettle();
+
+        expect(find.text('metadata'), findsOneWidget);
+        verify(() => audioSessionService.resetAudioSession()).called(1);
+        verifyNever(() => audioSessionService.configureForMixedPlayback());
       });
     });
 

--- a/mobile/test/widgets/video_recorder/video_recorder_navigation_test.dart
+++ b/mobile/test/widgets/video_recorder/video_recorder_navigation_test.dart
@@ -24,12 +24,15 @@ import 'package:openvine/screens/library_screen.dart';
 import 'package:openvine/screens/video_editor/video_editor_screen.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/widgets/video_recorder/video_recorder_navigation.dart';
+import 'package:sound_service/sound_service.dart';
 
 class _MockAuthService extends Mock implements AuthService {}
 
 class _MockVideoRecorderBloc
     extends MockBloc<VideoRecorderEvent, VideoRecorderBlocState>
     implements VideoRecorderBloc {}
+
+class _MockAudioSessionService extends Mock implements AudioSessionService {}
 
 class _FakeVideoEditorNotifier extends VideoEditorNotifier {
   bool saveAsDraftCalled = false;
@@ -58,16 +61,34 @@ void main() {
 
   late _MockAuthService mockAuthService;
   late _MockVideoRecorderBloc recorderBloc;
+  late _MockAudioSessionService audioSessionService;
   late _FakeVideoEditorNotifier fakeEditor;
   late _FakeClipManagerNotifier fakeClipManager;
+
+  setUpAll(() {
+    registerFallbackValue(const VideoRecorderCameraPausedForNavigation());
+  });
 
   setUp(() {
     mockAuthService = _MockAuthService();
     recorderBloc = _MockVideoRecorderBloc();
+    audioSessionService = _MockAudioSessionService();
     fakeEditor = _FakeVideoEditorNotifier();
     fakeClipManager = _FakeClipManagerNotifier();
 
     when(() => recorderBloc.state).thenReturn(const VideoRecorderBlocState());
+    when(() => recorderBloc.add(any())).thenAnswer((invocation) {
+      final event = invocation.positionalArguments.single as VideoRecorderEvent;
+      if (event is VideoRecorderCameraPausedForNavigation) {
+        event.completion?.complete();
+      }
+    });
+    when(
+      () => audioSessionService.configureForMixedPlayback(),
+    ).thenAnswer((_) async {});
+    when(
+      () => audioSessionService.resetAudioSession(),
+    ).thenAnswer((_) async {});
     when(
       () => mockAuthService.authStateStream,
     ).thenAnswer((_) => const Stream<AuthState>.empty());
@@ -105,6 +126,7 @@ void main() {
         authServiceProvider.overrideWithValue(mockAuthService),
         videoEditorProvider.overrideWith(() => fakeEditor),
         clipManagerProvider.overrideWith(() => fakeClipManager),
+        audioSessionServiceProvider.overrideWithValue(audioSessionService),
       ],
       child: MaterialApp.router(
         localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -132,6 +154,8 @@ void main() {
 
         expect(find.text('editor'), findsOneWidget);
         expect(fakeEditor.saveAsDraftCalled, isFalse);
+        verify(() => audioSessionService.configureForMixedPlayback()).called(1);
+        verifyNever(() => audioSessionService.resetAudioSession());
         // The lock guards the camera against a volume / BLE trigger racing the
         // push — it is the feature's only production trigger, so assert it
         // fired (deleting it would silently disable the lock).
@@ -152,6 +176,8 @@ void main() {
 
         expect(find.text('library'), findsOneWidget);
         expect(fakeEditor.saveAsDraftCalled, isFalse);
+        verify(() => audioSessionService.resetAudioSession()).called(1);
+        verifyNever(() => audioSessionService.configureForMixedPlayback());
         // The lock guards the camera against a volume / BLE trigger racing the
         // push — it is the feature's only production trigger, so assert it
         // fired (deleting it would silently disable the lock).
@@ -177,6 +203,7 @@ void main() {
 
         expect(fakeClipManager.muteAllClipsCalled, isTrue);
         expect(find.text('editor'), findsOneWidget);
+        verify(() => audioSessionService.configureForMixedPlayback()).called(1);
       });
 
       testWidgets('openVideoEditorFromRecorder does not mute clips in '
@@ -189,6 +216,7 @@ void main() {
 
         expect(fakeClipManager.muteAllClipsCalled, isFalse);
         expect(find.text('editor'), findsOneWidget);
+        verify(() => audioSessionService.configureForMixedPlayback()).called(1);
       });
     });
 


### PR DESCRIPTION
Closes #5761

## Summary
- Add an audio-session-only service for recorder and editor handoffs, then delegate the existing playback-service session methods to it.
- Wait for the recorder camera pause/dispose handoff to complete before restoring playback audio for editor and library routes.
- Restore mixed playback for editor entry and default playback for metadata/library exits so the editor player does not inherit the camera recording session.

## Root Cause
On iOS, camera capture configures the shared AVAudioSession for recording. Normal capture paths that do not use a selected sound can navigate into the editor without resetting that session, so the editor video player inherits a record-tuned audio route and previews silently.

## Validation
- flutter analyze (mobile)
- flutter analyze (mobile/packages/sound_service)
- flutter test test/widgets/video_recorder/video_recorder_navigation_test.dart test/blocs/video_recorder/video_recorder_bloc_test.dart (mobile)
- flutter test test/src/audio_session_service_test.dart test/src/audio_playback_service_test.dart (mobile/packages/sound_service)
- flutter test (mobile/packages/sound_service)
- flutter test (mobile): 11336 passing, 347 skipped
- Pre-push hook: analyzer, generated-file verification, changed-file tests

## Manual QA
This should still be verified on a physical iPhone because AVAudioSession routing is hardware and iOS behavior: capture a video, enter the editor, and confirm preview audio is audible with and without the silent switch.