### PR TITLE
feat(moderation): hide nudity/sexual content by default until explicit opt-in

### DIFF
--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -677,6 +677,10 @@
   "@videoErrorVerifyAgeSignerUnreachable": {
     "description": "Snackbar shown when tapping Verify age on an age-restricted video and the remote signer didn't respond in time (timeout). Distinct from videoErrorVerifyAgeFailed because the remedy is checking connectivity, not re-verifying age."
   },
+  "videoErrorAdultContentHidden": "Adult content is switched off. You can turn it on in Settings → Content Filters.",
+  "@videoErrorAdultContentHidden": {
+    "description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."
+  },
   "videoFollowButtonFollowing": "Following",
   "videoFollowButtonFollow": "Follow",
   "audioAttributionOriginalSound": "Original sound",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -2524,6 +2524,12 @@ abstract class AppLocalizations {
   /// **'Verification timed out. Check your connection or try again shortly.'**
   String get videoErrorVerifyAgeSignerUnreachable;
 
+  /// Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age.
+  ///
+  /// In en, this message translates to:
+  /// **'Adult content is switched off. You can turn it on in Settings → Content Filters.'**
+  String get videoErrorAdultContentHidden;
+
   /// No description provided for @videoFollowButtonFollowing.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -1369,6 +1369,10 @@ class AppLocalizationsAm extends AppLocalizations {
       'ማረጋገጡ ጊዜው አልፎበታል። ግንኙነትህን አረጋግጥ ወይም ትንሽ ቆይተህ እንደገና ሞክር።';
 
   @override
+  String get videoErrorAdultContentHidden =>
+      'Adult content is switched off. You can turn it on in Settings → Content Filters.';
+
+  @override
   String get videoFollowButtonFollowing => 'በመከተል ላይ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -1386,6 +1386,10 @@ class AppLocalizationsAr extends AppLocalizations {
       'انتهت مهلة التحقق. تحقّق من اتصالك أو حاول مرّة أخرى بعد قليل.';
 
   @override
+  String get videoErrorAdultContentHidden =>
+      'Adult content is switched off. You can turn it on in Settings → Content Filters.';
+
+  @override
   String get videoFollowButtonFollowing => 'متابع';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -1429,6 +1429,10 @@ class AppLocalizationsBg extends AppLocalizations {
       'Потвърждаването изтече. Провери връзката си или опитай пак след малко.';
 
   @override
+  String get videoErrorAdultContentHidden =>
+      'Adult content is switched off. You can turn it on in Settings → Content Filters.';
+
+  @override
   String get videoFollowButtonFollowing => 'Следване';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -1425,6 +1425,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Zeitüberschreitung bei der Überprüfung. Prüf deine Verbindung oder versuch es gleich nochmal.';
 
   @override
+  String get videoErrorAdultContentHidden =>
+      'Adult content is switched off. You can turn it on in Settings → Content Filters.';
+
+  @override
   String get videoFollowButtonFollowing => 'Gefolgt';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -1407,6 +1407,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Verification timed out. Check your connection or try again shortly.';
 
   @override
+  String get videoErrorAdultContentHidden =>
+      'Adult content is switched off. You can turn it on in Settings → Content Filters.';
+
+  @override
   String get videoFollowButtonFollowing => 'Following';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -1427,6 +1427,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'Se agotó el tiempo de verificación. Revisa tu conexión o vuelve a intentarlo en un momento.';
 
   @override
+  String get videoErrorAdultContentHidden =>
+      'Adult content is switched off. You can turn it on in Settings → Content Filters.';
+
+  @override
   String get videoFollowButtonFollowing => 'Siguiendo';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -1434,6 +1434,10 @@ class AppLocalizationsFil extends AppLocalizations {
       'Nag-timeout ang pag-verify. I-check ang koneksyon mo o subukan ulit mamaya.';
 
   @override
+  String get videoErrorAdultContentHidden =>
+      'Adult content is switched off. You can turn it on in Settings → Content Filters.';
+
+  @override
   String get videoFollowButtonFollowing => 'Sinusundan';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -1434,6 +1434,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Délai de vérification dépassé. Vérifie ta connexion ou réessaie dans un instant.';
 
   @override
+  String get videoErrorAdultContentHidden =>
+      'Adult content is switched off. You can turn it on in Settings → Content Filters.';
+
+  @override
   String get videoFollowButtonFollowing => 'Abonné';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -1384,6 +1384,10 @@ class AppLocalizationsId extends AppLocalizations {
       'Waktu verifikasi habis. Periksa koneksi kamu atau coba lagi sebentar lagi.';
 
   @override
+  String get videoErrorAdultContentHidden =>
+      'Adult content is switched off. You can turn it on in Settings → Content Filters.';
+
+  @override
   String get videoFollowButtonFollowing => 'Mengikuti';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -1429,6 +1429,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Verifica scaduta. Controlla la connessione o riprova tra poco.';
 
   @override
+  String get videoErrorAdultContentHidden =>
+      'Adult content is switched off. You can turn it on in Settings → Content Filters.';
+
+  @override
   String get videoFollowButtonFollowing => 'Segui già';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -1317,6 +1317,10 @@ class AppLocalizationsJa extends AppLocalizations {
       '確認がタイムアウトしました。接続を確認するか、少し時間をおいてもう一回試してみて';
 
   @override
+  String get videoErrorAdultContentHidden =>
+      'Adult content is switched off. You can turn it on in Settings → Content Filters.';
+
+  @override
   String get videoFollowButtonFollowing => 'フォロー中';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -1325,6 +1325,10 @@ class AppLocalizationsKo extends AppLocalizations {
       '확인 시간이 초과되었습니다. 연결을 확인하거나 잠시 후 다시 시도해보세요';
 
   @override
+  String get videoErrorAdultContentHidden =>
+      'Adult content is switched off. You can turn it on in Settings → Content Filters.';
+
+  @override
   String get videoFollowButtonFollowing => '팔로잉';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -1415,6 +1415,10 @@ class AppLocalizationsNl extends AppLocalizations {
       'Verificatie duurde te lang. Controleer je verbinding of probeer het straks opnieuw.';
 
   @override
+  String get videoErrorAdultContentHidden =>
+      'Adult content is switched off. You can turn it on in Settings → Content Filters.';
+
+  @override
   String get videoFollowButtonFollowing => 'Volgend';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -1426,6 +1426,10 @@ class AppLocalizationsPl extends AppLocalizations {
       'Przekroczono czas weryfikacji. Sprawdź połączenie lub spróbuj ponownie za chwilę.';
 
   @override
+  String get videoErrorAdultContentHidden =>
+      'Adult content is switched off. You can turn it on in Settings → Content Filters.';
+
+  @override
   String get videoFollowButtonFollowing => 'Obserwujesz';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -1425,6 +1425,10 @@ class AppLocalizationsPt extends AppLocalizations {
       'Tempo de verificação esgotado. Verifique sua conexão ou tente novamente em breve.';
 
   @override
+  String get videoErrorAdultContentHidden =>
+      'Adult content is switched off. You can turn it on in Settings → Content Filters.';
+
+  @override
   String get videoFollowButtonFollowing => 'Seguindo';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -1443,6 +1443,10 @@ class AppLocalizationsRo extends AppLocalizations {
       'Timpul de verificare a expirat. Verifică-ți conexiunea sau încearcă din nou în scurt timp.';
 
   @override
+  String get videoErrorAdultContentHidden =>
+      'Adult content is switched off. You can turn it on in Settings → Content Filters.';
+
+  @override
   String get videoFollowButtonFollowing => 'Urmărit';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -1403,6 +1403,10 @@ class AppLocalizationsSv extends AppLocalizations {
       'Timeout vid verifiering. Kontrollera din anslutning eller försök igen om en stund.';
 
   @override
+  String get videoErrorAdultContentHidden =>
+      'Adult content is switched off. You can turn it on in Settings → Content Filters.';
+
+  @override
   String get videoFollowButtonFollowing => 'Följer';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -1389,6 +1389,10 @@ class AppLocalizationsTr extends AppLocalizations {
       'Doğrulama zaman aşımına uğradı. Bağlantını kontrol et ya da birazdan tekrar dene.';
 
   @override
+  String get videoErrorAdultContentHidden =>
+      'Adult content is switched off. You can turn it on in Settings → Content Filters.';
+
+  @override
   String get videoFollowButtonFollowing => 'Takip ediliyor';
 
   @override

--- a/mobile/lib/models/viewer_auth_result.dart
+++ b/mobile/lib/models/viewer_auth_result.dart
@@ -12,6 +12,7 @@ sealed class ViewerAuthResult {
   Map<String, String>? get headersOrNull => switch (this) {
     ViewerAuthAuthorized(:final headers) => headers,
     ViewerAuthSignerUnreachable() => null,
+    ViewerAuthBlockedByPreference() => null,
     ViewerAuthUnavailable() => null,
   };
 }
@@ -28,6 +29,13 @@ class ViewerAuthAuthorized extends ViewerAuthResult {
 /// re-verifying age — so this surfaces its own user-facing message.
 class ViewerAuthSignerUnreachable extends ViewerAuthResult {
   const ViewerAuthSignerUnreachable();
+}
+
+/// The viewer is age-verified but their Content Filters keep adult content
+/// hidden. The remedy is opting in via Settings → Content Filters, not
+/// re-verifying age — so this surfaces its own user-facing message.
+class ViewerAuthBlockedByPreference extends ViewerAuthResult {
+  const ViewerAuthBlockedByPreference();
 }
 
 /// No viewer-auth headers could be created for any other reason: the user is not

--- a/mobile/lib/screens/feed/pooled_age_restricted_retry.dart
+++ b/mobile/lib/screens/feed/pooled_age_restricted_retry.dart
@@ -97,6 +97,11 @@ Future<void> retryAgeRestrictedPooledVideo({
         // A remote signer timed out — distinct from a verify failure, since the
         // remedy is checking the connection rather than re-verifying.
         _showSignerUnreachable(context);
+      case ViewerAuthBlockedByPreference():
+        // The viewer is verified but adult content is switched off in their
+        // Content Filters (the default). Point them at the setting instead of
+        // implying verification failed.
+        _showAdultContentHidden(context);
       case ViewerAuthUnavailable():
         // Unavailable covers both a deliberate decline (stay silent) and an
         // accept-then-no-header case (surface feedback). Distinguish the two by
@@ -150,6 +155,7 @@ Future<void> autoRetryAgeRestrictedPooledVideo({
         if (!context.mounted || !playbackSucceeded) return;
         playbackStatusCubit.report(video.id, PlaybackStatus.ready);
       case ViewerAuthSignerUnreachable():
+      case ViewerAuthBlockedByPreference():
       case ViewerAuthUnavailable():
         break;
     }
@@ -166,6 +172,15 @@ void _showVerifyAgeFailed(BuildContext context) {
   if (!context.mounted) return;
   ScaffoldMessenger.of(context).showSnackBar(
     DivineSnackbarContainer.snackBar(context.l10n.videoErrorVerifyAgeFailed),
+  );
+}
+
+/// Tells an age-verified viewer that adult content is switched off in their
+/// Content Filters, so they know where to opt in rather than re-verifying.
+void _showAdultContentHidden(BuildContext context) {
+  if (!context.mounted) return;
+  ScaffoldMessenger.of(context).showSnackBar(
+    DivineSnackbarContainer.snackBar(context.l10n.videoErrorAdultContentHidden),
   );
 }
 

--- a/mobile/lib/services/content_filter_service.dart
+++ b/mobile/lib/services/content_filter_service.dart
@@ -48,6 +48,14 @@ class ContentFilterService extends ChangeNotifier {
     ContentLabel.porn,
   };
 
+  /// Adult categories the user can actually opt into for generic protected
+  /// media playback. [ContentLabel.porn] stays in [adultCategories] so label
+  /// filtering always hides it, but it is not a settings toggle.
+  static const Set<ContentLabel> configurableAdultCategories = {
+    ContentLabel.nudity,
+    ContentLabel.sexual,
+  };
+
   /// Visible categories locked to hide unless the user is age-verified.
   static const Set<ContentLabel> ageRestrictedCategories = {
     ...adultCategories,
@@ -256,13 +264,17 @@ class ContentFilterService extends ChangeNotifier {
   /// preference override the current settings UI, derive a single playback
   /// policy from the new per-category source of truth:
   ///
-  /// - all `hide` -> verified users should be blocked
-  /// - all `show` -> verified users can auto-allow
-  /// - any mixed state -> require an explicit retry/confirmation path
+  /// - any configurable adult category at `hide` -> verified users are blocked
+  /// - all configurable adult categories at `show` -> verified users can
+  ///   auto-allow
+  /// - any remaining mixed state -> require an explicit retry/confirmation path
   ContentFilterPreference get adultPlaybackPreference {
-    final preferences = adultCategories.map(getPreference).toSet();
-    if (preferences.length == 1) {
-      return preferences.single;
+    final preferences = configurableAdultCategories.map(getPreference).toSet();
+    if (preferences.contains(ContentFilterPreference.hide)) {
+      return ContentFilterPreference.hide;
+    }
+    if (preferences.every((pref) => pref == ContentFilterPreference.show)) {
+      return ContentFilterPreference.show;
     }
     return ContentFilterPreference.warn;
   }

--- a/mobile/lib/services/content_filter_service.dart
+++ b/mobile/lib/services/content_filter_service.dart
@@ -74,9 +74,10 @@ class ContentFilterService extends ChangeNotifier {
 
   /// Default preferences for each category.
   static const Map<ContentLabel, ContentFilterPreference> _defaults = {
-    // Visible adult content starts at warn when the age gate is unlocked.
-    ContentLabel.nudity: ContentFilterPreference.warn,
-    ContentLabel.sexual: ContentFilterPreference.warn,
+    // Adult content stays hidden even after age verification; the user must
+    // opt in per category via Content Filters.
+    ContentLabel.nudity: ContentFilterPreference.hide,
+    ContentLabel.sexual: ContentFilterPreference.hide,
     // Always-filtered categories are not user-configurable.
     ContentLabel.graphicMedia: ContentFilterPreference.hide,
     ContentLabel.violence: ContentFilterPreference.hide,
@@ -277,19 +278,22 @@ class ContentFilterService extends ChangeNotifier {
     notifyListeners();
   }
 
-  /// Unlock adult categories when the user enables age verification.
+  /// Unlock age-restricted categories when the user enables age verification.
   ///
-  /// Only promotes categories that are still at [ContentFilterPreference.hide]
-  /// to [ContentFilterPreference.warn]. Categories the user has already
+  /// Adult categories ([adultCategories]) are never promoted: age
+  /// verification only unlocks the *ability* to change them, and adult
+  /// content stays hidden until the user opts in per category via Content
+  /// Filters.
+  ///
+  /// Non-adult age-restricted categories (alcohol, tobacco, profanity,
+  /// gambling) still at [ContentFilterPreference.hide] are promoted to
+  /// [ContentFilterPreference.warn]. Categories the user has already
   /// explicitly changed to [warn] or [show] are left untouched, so this
   /// never overwrites a deliberate preference.
-  ///
-  /// Using [warn] as the unlock default means the user sees a confirmation
-  /// prompt the first time they play a given adult video — a safe default
-  /// that can be overridden per-category in Content Filters.
   Future<void> unlockAdultCategories() async {
     for (final label in ageRestrictedCategories) {
       if (alwaysFilteredCategories.contains(label)) continue;
+      if (adultCategories.contains(label)) continue;
       if ((_preferences[label] ?? _defaultFor(label)) ==
           ContentFilterPreference.hide) {
         _preferences[label] = ContentFilterPreference.warn;

--- a/mobile/lib/services/media_auth_interceptor.dart
+++ b/mobile/lib/services/media_auth_interceptor.dart
@@ -165,6 +165,16 @@ class MediaAuthInterceptor {
 
       await _contentFilterService.unlockAdultCategories();
 
+      if (_contentFilterService.adultPlaybackPreference ==
+          ContentFilterPreference.hide) {
+        Log.debug(
+          '🚫 Adult content remains hidden after verification',
+          name: 'MediaAuthInterceptor',
+          category: LogCategory.system,
+        );
+        return const ViewerAuthBlockedByPreference();
+      }
+
       // Create auth header after verification
       return await _mediaViewerAuthService.createAuthHeaders(
         sha256Hash: sha256Hash,

--- a/mobile/lib/services/media_auth_interceptor.dart
+++ b/mobile/lib/services/media_auth_interceptor.dart
@@ -75,8 +75,9 @@ class MediaAuthInterceptor {
   ///
   /// Returns [ViewerAuthAuthorized] with request headers when the viewer can
   /// see adult content, [ViewerAuthSignerUnreachable] when a remote signer
-  /// timed out, or [ViewerAuthUnavailable] when the viewer declined / is
-  /// blocked by preference / no headers could be created.
+  /// timed out, [ViewerAuthBlockedByPreference] when a verified viewer's
+  /// Content Filters keep adult content hidden, or [ViewerAuthUnavailable]
+  /// when the viewer declined / no headers could be created.
   Future<ViewerAuthResult> handleUnauthorizedMedia({
     required BuildContext context,
     String? sha256Hash,
@@ -96,8 +97,9 @@ class MediaAuthInterceptor {
       final isAdultContentVerified =
           _ageVerificationService.isAdultContentVerified;
 
-      // Verified users with all adult categories set to hide should be
-      // blocked immediately. Unverified users still go through the existing
+      // Verified users with all adult categories at hide (the default —
+      // opting in happens per category in Content Filters) are blocked
+      // immediately. Unverified users still go through the existing
       // verify-on-play path below.
       if (isAdultContentVerified &&
           playbackPreference == ContentFilterPreference.hide) {
@@ -106,7 +108,7 @@ class MediaAuthInterceptor {
           name: 'MediaAuthInterceptor',
           category: LogCategory.system,
         );
-        return const ViewerAuthUnavailable();
+        return const ViewerAuthBlockedByPreference();
       }
 
       // Once the viewer has completed adult-content age verification, keep that

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -148,6 +148,9 @@ const _knownUntranslatedDebt = {
   'notificationRepliedToYourComment',
   'notificationAndConnector',
   'notificationOthersCount',
+  // Added by the adult-content opt-in default change. Translators will pick
+  // this up in the next pass; until then it falls back to English.
+  'videoErrorAdultContentHidden',
   // Added while localizing the settings taxonomy and related settings flows
   // for Amharic. Existing locales fall back to English until the next
   // full translation pass.

--- a/mobile/test/models/viewer_auth_result_test.dart
+++ b/mobile/test/models/viewer_auth_result_test.dart
@@ -20,6 +20,12 @@ void main() {
       expect(result.headersOrNull, isNull);
     });
 
+    test('ViewerAuthBlockedByPreference has no headers', () {
+      const result = ViewerAuthBlockedByPreference();
+
+      expect(result.headersOrNull, isNull);
+    });
+
     test('ViewerAuthUnavailable has no headers', () {
       const result = ViewerAuthUnavailable();
 

--- a/mobile/test/screens/feed/pooled_age_restricted_retry_test.dart
+++ b/mobile/test/screens/feed/pooled_age_restricted_retry_test.dart
@@ -40,6 +40,9 @@ String get _signerUnreachableText => lookupAppLocalizations(
   const Locale('en'),
 ).videoErrorVerifyAgeSignerUnreachable;
 
+String get _adultContentHiddenText =>
+    lookupAppLocalizations(const Locale('en')).videoErrorAdultContentHidden;
+
 AgeVerificationService _ageService({required bool verified}) {
   final service = _MockAgeVerificationService();
   when(() => service.isAdultContentVerified).thenReturn(verified);
@@ -344,6 +347,56 @@ void main() {
       );
       expect(find.text(_failureText), findsOneWidget);
     });
+
+    testWidgets(
+      'surfaces the Content Filters message when playback is blocked by '
+      'preference',
+      (tester) async {
+        final mediaAuthInterceptor = _MockMediaAuthInterceptor();
+        final playbackStatusCubit = VideoPlaybackStatusCubit();
+        var retryCount = 0;
+        addTearDown(playbackStatusCubit.close);
+
+        // A verified viewer whose Content Filters keep adult content hidden
+        // (the default) is blocked; the remedy is opting in via settings.
+        when(
+          () => mediaAuthInterceptor.handleUnauthorizedMedia(
+            context: any(named: 'context'),
+            sha256Hash: _sha256,
+            url: _videoUrl,
+            serverUrl: 'https://media.divine.video',
+            category: 'video',
+          ),
+        ).thenAnswer((_) async => const ViewerAuthBlockedByPreference());
+
+        await tester.pumpWidget(
+          _RetryHarness(
+            mediaAuthInterceptor: mediaAuthInterceptor,
+            playbackStatusCubit: playbackStatusCubit,
+            ageVerificationService: _ageService(verified: true),
+            retryPlayback: (_) {
+              retryCount++;
+              return true;
+            },
+          ),
+        );
+
+        playbackStatusCubit.report(_videoId, PlaybackStatus.ageRestricted);
+
+        await tester.tap(find.text('Verify'));
+        await tester.pump();
+        await tester.pump();
+
+        expect(retryCount, 0);
+        expect(
+          playbackStatusCubit.state.statusFor(_videoId),
+          PlaybackStatus.ageRestricted,
+        );
+        // The settings-specific copy, not the generic verify failure.
+        expect(find.text(_adultContentHiddenText), findsOneWidget);
+        expect(find.text(_failureText), findsNothing);
+      },
+    );
 
     testWidgets(
       'surfaces the connectivity message when the remote signer is unreachable',

--- a/mobile/test/services/content_filter_service_test.dart
+++ b/mobile/test/services/content_filter_service_test.dart
@@ -554,6 +554,23 @@ void main() {
           equals(ContentFilterPreference.warn),
         );
       });
+
+      test('adultPlaybackPreference stays hide until every configurable adult '
+          'category is opted in', () async {
+        await ageService.initialize();
+        await ageService.setAdultContentVerified(true);
+        await service.initialize();
+
+        await service.setPreference(
+          ContentLabel.nudity,
+          ContentFilterPreference.warn,
+        );
+
+        expect(
+          service.adultPlaybackPreference,
+          equals(ContentFilterPreference.hide),
+        );
+      });
     });
 
     group('adultPlaybackPreference', () {
@@ -568,7 +585,7 @@ void main() {
       });
 
       test(
-        'returns warn when visible adult categories are set to show',
+        'returns show when configurable adult categories are set to show',
         () async {
           await ageService.initialize();
           await ageService.setAdultContentVerified(true);
@@ -580,13 +597,14 @@ void main() {
 
           expect(
             service.adultPlaybackPreference,
-            equals(ContentFilterPreference.warn),
+            equals(ContentFilterPreference.show),
           );
         },
       );
 
       test(
-        'returns warn when adult categories have mixed preferences',
+        'returns warn when opted-in adult categories have mixed non-hide '
+        'preferences',
         () async {
           await ageService.initialize();
           await ageService.setAdultContentVerified(true);
@@ -608,6 +626,25 @@ void main() {
           expect(
             service.adultPlaybackPreference,
             equals(ContentFilterPreference.warn),
+          );
+        },
+      );
+
+      test(
+        'returns hide when any configurable adult category remains hidden',
+        () async {
+          await ageService.initialize();
+          await ageService.setAdultContentVerified(true);
+          await service.initialize();
+
+          await service.setPreference(
+            ContentLabel.nudity,
+            ContentFilterPreference.show,
+          );
+
+          expect(
+            service.adultPlaybackPreference,
+            equals(ContentFilterPreference.hide),
           );
         },
       );

--- a/mobile/test/services/content_filter_service_test.dart
+++ b/mobile/test/services/content_filter_service_test.dart
@@ -82,8 +82,6 @@ void main() {
         await ageService.setAdultContentVerified(true);
 
         for (final label in [
-          ContentLabel.nudity,
-          ContentLabel.sexual,
           ContentLabel.alcohol,
           ContentLabel.tobacco,
           ContentLabel.gambling,
@@ -96,6 +94,22 @@ void main() {
             service.getPreference(label),
             equals(ContentFilterPreference.warn),
             reason: '${label.displayName} should default to warn',
+          );
+        }
+      });
+
+      test('adult categories default to hide even when age verified', () async {
+        await service.initialize();
+        await ageService.initialize();
+        await ageService.setAdultContentVerified(true);
+
+        for (final label in ContentFilterService.adultCategories) {
+          expect(
+            service.getPreference(label),
+            equals(ContentFilterPreference.hide),
+            reason:
+                '${label.displayName} should stay hidden until the user '
+                'opts in via Content Filters',
           );
         }
       });
@@ -343,35 +357,35 @@ void main() {
     });
 
     group('unlockAdultCategories', () {
-      test(
-        'visible adult categories default to warn after verification',
-        () async {
-          await ageService.initialize();
-          await ageService.setAdultContentVerified(true);
-          await service.initialize();
+      test('non-adult age-restricted categories default to warn after '
+          'verification while adult categories stay hidden', () async {
+        await ageService.initialize();
+        await ageService.setAdultContentVerified(true);
+        await service.initialize();
 
-          for (final label in [
-            ContentLabel.nudity,
-            ContentLabel.sexual,
-            ContentLabel.alcohol,
-            ContentLabel.tobacco,
-            ContentLabel.profanity,
-            ContentLabel.gambling,
-          ]) {
-            expect(
-              service.getPreference(label),
-              equals(ContentFilterPreference.warn),
-              reason: '${label.displayName} should default to warn',
-            );
-          }
+        for (final label in [
+          ContentLabel.alcohol,
+          ContentLabel.tobacco,
+          ContentLabel.profanity,
+          ContentLabel.gambling,
+        ]) {
           expect(
-            service.getPreference(ContentLabel.porn),
-            equals(ContentFilterPreference.hide),
+            service.getPreference(label),
+            equals(ContentFilterPreference.warn),
+            reason: '${label.displayName} should default to warn',
           );
-        },
-      );
+        }
+        for (final label in ContentFilterService.adultCategories) {
+          expect(
+            service.getPreference(label),
+            equals(ContentFilterPreference.hide),
+            reason: '${label.displayName} should stay hidden',
+          );
+        }
+      });
 
-      test('promotes locked visible adult categories back to warn', () async {
+      test('promotes locked non-adult categories back to warn but leaves '
+          'adult categories hidden', () async {
         await ageService.initialize();
         await ageService.setAdultContentVerified(true);
         await service.initialize();
@@ -380,8 +394,6 @@ void main() {
         await service.unlockAdultCategories();
 
         for (final label in [
-          ContentLabel.nudity,
-          ContentLabel.sexual,
           ContentLabel.alcohol,
           ContentLabel.tobacco,
           ContentLabel.profanity,
@@ -393,10 +405,13 @@ void main() {
             reason: '${label.displayName} should be promoted from hide to warn',
           );
         }
-        expect(
-          service.getPreference(ContentLabel.porn),
-          equals(ContentFilterPreference.hide),
-        );
+        for (final label in ContentFilterService.adultCategories) {
+          expect(
+            service.getPreference(label),
+            equals(ContentFilterPreference.hide),
+            reason: '${label.displayName} requires explicit opt-in',
+          );
+        }
       });
 
       test('does not overwrite an existing warn preference', () async {
@@ -455,11 +470,12 @@ void main() {
           service.getPreference(ContentLabel.nudity),
           equals(ContentFilterPreference.show),
         );
-        // sexual was hide, so it is promoted to warn. Pornography remains
-        // locked to hide because it is always filtered out.
+        // sexual is an adult category: unlock never promotes it, so it
+        // stays hidden until the user opts in. Pornography remains locked
+        // to hide because it is always filtered out.
         expect(
           service.getPreference(ContentLabel.sexual),
-          equals(ContentFilterPreference.warn),
+          equals(ContentFilterPreference.hide),
         );
         expect(
           service.getPreference(ContentLabel.porn),
@@ -484,8 +500,6 @@ void main() {
         // age-verified so the gate is lifted; persisted warn should be visible
         await newAgeService.setAdultContentVerified(true);
         for (final label in [
-          ContentLabel.nudity,
-          ContentLabel.sexual,
           ContentLabel.alcohol,
           ContentLabel.tobacco,
           ContentLabel.profanity,
@@ -497,29 +511,49 @@ void main() {
             reason: '${label.displayName} should survive restart',
           );
         }
+        for (final label in ContentFilterService.adultCategories) {
+          expect(
+            newService.getPreference(label),
+            equals(ContentFilterPreference.hide),
+            reason: '${label.displayName} should stay hidden after restart',
+          );
+        }
+      });
+
+      test('adultPlaybackPreference stays hide after unlock until the user '
+          'opts in', () async {
+        await ageService.initialize();
+        await ageService.setAdultContentVerified(true);
+        await service.initialize();
+
+        await service.unlockAdultCategories();
+
         expect(
-          newService.getPreference(ContentLabel.porn),
+          service.adultPlaybackPreference,
           equals(ContentFilterPreference.hide),
         );
       });
 
-      test(
-        'adultPlaybackPreference is warn after unlock from all-hide',
-        () async {
-          await ageService.initialize();
-          await ageService.setAdultContentVerified(true);
-          await service.initialize();
+      test('adultPlaybackPreference is warn after an explicit per-category '
+          'opt-in', () async {
+        await ageService.initialize();
+        await ageService.setAdultContentVerified(true);
+        await service.initialize();
 
-          // Starts as hide (not verified initially wouldn't matter here,
-          // but we need verified to read through the age gate)
-          await service.unlockAdultCategories();
+        await service.setPreference(
+          ContentLabel.nudity,
+          ContentFilterPreference.warn,
+        );
+        await service.setPreference(
+          ContentLabel.sexual,
+          ContentFilterPreference.warn,
+        );
 
-          expect(
-            service.adultPlaybackPreference,
-            equals(ContentFilterPreference.warn),
-          );
-        },
-      );
+        expect(
+          service.adultPlaybackPreference,
+          equals(ContentFilterPreference.warn),
+        );
+      });
     });
 
     group('adultPlaybackPreference', () {
@@ -540,10 +574,7 @@ void main() {
           await ageService.setAdultContentVerified(true);
           await service.initialize();
 
-          for (final label in [
-            ContentLabel.nudity,
-            ContentLabel.sexual,
-          ]) {
+          for (final label in [ContentLabel.nudity, ContentLabel.sexual]) {
             await service.setPreference(label, ContentFilterPreference.show);
           }
 
@@ -693,10 +724,7 @@ void main() {
         );
         await restartedService.initialize();
 
-        for (final label in [
-          ContentLabel.nudity,
-          ContentLabel.sexual,
-        ]) {
+        for (final label in [ContentLabel.nudity, ContentLabel.sexual]) {
           expect(
             restartedService.getPreference(label),
             equals(ContentFilterPreference.show),

--- a/mobile/test/services/media_auth_interceptor_preference_test.dart
+++ b/mobile/test/services/media_auth_interceptor_preference_test.dart
@@ -4,6 +4,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:openvine/models/content_label.dart';
 import 'package:openvine/models/viewer_auth_result.dart';
 import 'package:openvine/services/age_verification_service.dart';
 import 'package:openvine/services/content_filter_service.dart';
@@ -48,7 +49,8 @@ void main() {
 
   group('MediaAuthInterceptor - preference handling', () {
     test(
-      'handleUnauthorizedMedia still creates auth headers after unlock sets verified users to warn',
+      'handleUnauthorizedMedia blocks verified users at default preferences '
+      'even after unlock',
       () async {
         SharedPreferences.setMockInitialValues({});
 
@@ -61,6 +63,65 @@ void main() {
         );
         await realContentFilterService.initialize();
         await realContentFilterService.unlockAdultCategories();
+
+        final interceptor = MediaAuthInterceptor(
+          ageVerificationService: realAgeVerificationService,
+          contentFilterService: realContentFilterService,
+          mediaViewerAuthService: mockMediaViewerAuthService,
+        );
+
+        when(
+          () => mockMediaViewerAuthService.canCreateHeaders,
+        ).thenReturn(true);
+        when(() => mockContext.mounted).thenReturn(true);
+
+        // Adult categories stay hidden after unlock; playback stays blocked
+        // until the user opts in via Content Filters.
+        expect(
+          realContentFilterService.adultPlaybackPreference,
+          ContentFilterPreference.hide,
+        );
+        expect(interceptor.shouldAutoAuthorizeAgeRestrictedMedia, isFalse);
+
+        final result = await interceptor.handleUnauthorizedMedia(
+          context: mockContext,
+          sha256Hash: 'abc123',
+          category: 'nudity',
+        );
+
+        expect(result, isA<ViewerAuthBlockedByPreference>());
+        verifyNever(
+          () => mockMediaViewerAuthService.createAuthHeaders(
+            sha256Hash: any(named: 'sha256Hash'),
+            url: any(named: 'url'),
+            serverUrl: any(named: 'serverUrl'),
+          ),
+        );
+      },
+    );
+
+    test(
+      'handleUnauthorizedMedia creates auth headers after an explicit '
+      'per-category opt-in',
+      () async {
+        SharedPreferences.setMockInitialValues({});
+
+        final realAgeVerificationService = AgeVerificationService();
+        await realAgeVerificationService.initialize();
+        await realAgeVerificationService.setAdultContentVerified(true);
+
+        final realContentFilterService = ContentFilterService(
+          ageVerificationService: realAgeVerificationService,
+        );
+        await realContentFilterService.initialize();
+        await realContentFilterService.setPreference(
+          ContentLabel.nudity,
+          ContentFilterPreference.warn,
+        );
+        await realContentFilterService.setPreference(
+          ContentLabel.sexual,
+          ContentFilterPreference.warn,
+        );
 
         final interceptor = MediaAuthInterceptor(
           ageVerificationService: realAgeVerificationService,
@@ -114,7 +175,8 @@ void main() {
     );
 
     test(
-      'handleUnauthorizedMedia returns null when verified user preference is hide',
+      'handleUnauthorizedMedia reports a preference block when verified user '
+      'preference is hide',
       () async {
         when(
           () => mockContentFilterService.adultPlaybackPreference,
@@ -134,7 +196,7 @@ void main() {
           category: 'nudity',
         );
 
-        expect(result, isA<ViewerAuthUnavailable>());
+        expect(result, isA<ViewerAuthBlockedByPreference>());
         verifyNever(
           () => mockMediaViewerAuthService.createAuthHeaders(
             sha256Hash: any(named: 'sha256Hash'),

--- a/mobile/test/services/media_auth_interceptor_preference_test.dart
+++ b/mobile/test/services/media_auth_interceptor_preference_test.dart
@@ -101,6 +101,58 @@ void main() {
     );
 
     test(
+      'handleUnauthorizedMedia blocks verified users after only a partial '
+      'adult-category opt-in',
+      () async {
+        SharedPreferences.setMockInitialValues({});
+
+        final realAgeVerificationService = AgeVerificationService();
+        await realAgeVerificationService.initialize();
+        await realAgeVerificationService.setAdultContentVerified(true);
+
+        final realContentFilterService = ContentFilterService(
+          ageVerificationService: realAgeVerificationService,
+        );
+        await realContentFilterService.initialize();
+        await realContentFilterService.setPreference(
+          ContentLabel.nudity,
+          ContentFilterPreference.warn,
+        );
+
+        final interceptor = MediaAuthInterceptor(
+          ageVerificationService: realAgeVerificationService,
+          contentFilterService: realContentFilterService,
+          mediaViewerAuthService: mockMediaViewerAuthService,
+        );
+
+        when(
+          () => mockMediaViewerAuthService.canCreateHeaders,
+        ).thenReturn(true);
+
+        expect(
+          realContentFilterService.adultPlaybackPreference,
+          ContentFilterPreference.hide,
+        );
+        expect(interceptor.shouldAutoAuthorizeAgeRestrictedMedia, isFalse);
+
+        final result = await interceptor.handleUnauthorizedMedia(
+          context: mockContext,
+          sha256Hash: 'abc123',
+          category: 'nudity',
+        );
+
+        expect(result, isA<ViewerAuthBlockedByPreference>());
+        verifyNever(
+          () => mockMediaViewerAuthService.createAuthHeaders(
+            sha256Hash: any(named: 'sha256Hash'),
+            url: any(named: 'url'),
+            serverUrl: any(named: 'serverUrl'),
+          ),
+        );
+      },
+    );
+
+    test(
       'handleUnauthorizedMedia creates auth headers after an explicit '
       'per-category opt-in',
       () async {

--- a/mobile/test/services/media_auth_interceptor_preference_test.dart
+++ b/mobile/test/services/media_auth_interceptor_preference_test.dart
@@ -211,7 +211,8 @@ void main() {
     );
 
     test(
-      'handleUnauthorizedMedia prompts when unverified user preference resolves to hide',
+      'handleUnauthorizedMedia keeps adult media blocked after verification '
+      'when preferences still hide it',
       () async {
         when(
           () => mockContentFilterService.adultPlaybackPreference,
@@ -226,17 +227,6 @@ void main() {
         when(
           () => mockContentFilterService.unlockAdultCategories(),
         ).thenAnswer((_) async {});
-        when(
-          () => mockMediaViewerAuthService.createAuthHeaders(
-            sha256Hash: any(named: 'sha256Hash'),
-            url: any(named: 'url'),
-            serverUrl: any(named: 'serverUrl'),
-          ),
-        ).thenAnswer(
-          (_) async => const ViewerAuthAuthorized({
-            'Authorization': 'Nostr dialogToken',
-          }),
-        );
 
         final result = await interceptor.handleUnauthorizedMedia(
           context: mockContext,
@@ -244,17 +234,20 @@ void main() {
           category: 'nudity',
         );
 
-        expect(result, isA<ViewerAuthAuthorized>());
-        expect(
-          result.headersOrNull,
-          equals({'Authorization': 'Nostr dialogToken'}),
-        );
+        expect(result, isA<ViewerAuthBlockedByPreference>());
         verify(
           () => mockAgeVerificationService.verifyAdultContentAccess(any()),
         ).called(1);
         verify(
           () => mockContentFilterService.unlockAdultCategories(),
         ).called(1);
+        verifyNever(
+          () => mockMediaViewerAuthService.createAuthHeaders(
+            sha256Hash: any(named: 'sha256Hash'),
+            url: any(named: 'url'),
+            serverUrl: any(named: 'serverUrl'),
+          ),
+        );
       },
     );
 


### PR DESCRIPTION
Closes #5769

## Description

Makes adult content (`nudity`, `sexual`) opt-in rather than opt-out.

- **Defaults flip**: `ContentFilterService` now defaults `nudity` and `sexual` to `hide` for users without saved preferences.
- **No adult auto-promotion on age verification**: `unlockAdultCategories()` no longer promotes nudity or sexual content from hide to warn. Verifying age unlocks the ability to change those categories; the user still opts in under Settings -> Content Filters. Non-adult age-restricted categories (`alcohol`, `tobacco`, `profanity`, `gambling`) keep the existing hide-to-warn behavior.
- **Accurate feedback**: verified viewers whose Content Filters still hide adult content now get a `ViewerAuthBlockedByPreference` result and a settings-specific snackbar instead of a misleading verification failure.
- **Full configurable adult opt-in required for generic media auth**: generic protected media requests do not tell us whether the asset is nudity or sexual, so playback auth stays blocked until every configurable adult category is opted in. Porn remains always-filtered and is not a settings toggle.

Existing users who previously age-verified keep their behavior: old unlock/migration paths wrote preferences to disk, and explicitly saved preferences are not overwritten.

## Linked Issue

- Closes #5769

## Out of Scope

- Replacing the already-existing "Verify age" CTA text with a Settings deep-link for already-verified viewers.
- Translating the new `videoErrorAdultContentHidden` l10n key before the next translation pass; it is tracked in `_knownUntranslatedDebt`.

## Verification

- `flutter test test/services/content_filter_service_test.dart test/services/media_auth_interceptor_preference_test.dart test/screens/feed/pooled_age_restricted_retry_test.dart test/models/viewer_auth_result_test.dart test/l10n/arb_consistency_test.dart`
- `flutter analyze`
- Pre-push hook: merge-conflict check, analyzer, and changed-file tests including `media_auth_interceptor_test.dart`

## Type of Change

- [x] New feature / behavior change
- [x] Safety-critical moderation default change
- [x] Regression tests
- [x] Generated l10n committed
