### PR TITLE
fix(nostr): verify inbound relay event signatures

### DIFF
--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -413,6 +413,15 @@ class RelayPool {
         final eventJson = _mapAt(relay, json, 2, 'EVENT payload');
         if (eventJson == null) return;
 
+        final event = Event.fromJson(eventJson);
+        if (!event.isValid || !event.isSigned) {
+          log(
+            'Dropping relay event with invalid id or signature '
+            'from ${relay.url}: eventId=${event.id}',
+          );
+          return;
+        }
+
         if ((relay.relayStatus.relayType != RelayType.cache)) {
           var event = Map<String, dynamic>.from(eventJson);
           var kind = event["kind"];
@@ -421,8 +430,6 @@ class RelayPool {
             _broadcaseToCache(event);
           }
         }
-
-        final event = Event.fromJson(eventJson);
 
         if (event.kind == EventKind.giftWrap) {
           log(

--- a/mobile/packages/nostr_sdk/test/integration/nip50_search_test.dart
+++ b/mobile/packages/nostr_sdk/test/integration/nip50_search_test.dart
@@ -1,43 +1,25 @@
 // ABOUTME: Tests for NIP-50 full-text search functionality
 // ABOUTME: Tests search queries using mock relays that simulate NIP-50 responses
 
-import 'dart:convert';
-
-import 'package:crypto/crypto.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:nostr_sdk/relay/client_connected.dart';
 
-/// A test pubkey (valid 64-char hex).
-const _testPubkey =
-    'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2';
+const _testPrivateKey =
+    '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12';
 
-/// Creates a fake event JSON map with a deterministic id.
-Map<String, dynamic> _fakeEventJson({
+/// Creates a signed event JSON map that RelayPool will accept.
+Future<Map<String, dynamic>> _fakeEventJson({
   required String content,
   int kind = 1,
   int? createdAt,
-}) {
+}) async {
   final created = createdAt ?? DateTime.now().millisecondsSinceEpoch ~/ 1000;
-  final tags = <List<String>>[];
-  final serialized = json.encode([
-    0,
-    _testPubkey,
-    created,
-    kind,
-    tags,
-    content,
-  ]);
-  final id = sha256.convert(utf8.encode(serialized)).toString();
-  return {
-    'id': id,
-    'pubkey': _testPubkey,
-    'created_at': created,
-    'kind': kind,
-    'tags': tags,
-    'content': content,
-    'sig': '',
-  };
+  final signer = LocalNostrSigner(_testPrivateKey);
+  final pubkey = await signer.getPublicKey();
+  final event = Event(pubkey!, kind, [], content, createdAt: created);
+  await signer.signEvent(event);
+  return event.toJson();
 }
 
 /// Mock relay that captures sent messages and can simulate EVENT responses.
@@ -92,11 +74,8 @@ void main() {
     late LocalNostrSigner signer;
     late _MockRelay mockRelay;
 
-    const testPrivateKey =
-        '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12';
-
     setUp(() async {
-      signer = LocalNostrSigner(testPrivateKey);
+      signer = LocalNostrSigner(_testPrivateKey);
       nostr = Nostr(signer, [], (url) => _MockRelay(url));
       await nostr.refreshPublicKey();
 
@@ -106,8 +85,8 @@ void main() {
     test('Should search for text content in events', () async {
       // Configure mock relay to return events containing 'bitcoin'
       mockRelay.eventsToReturn = [
-        _fakeEventJson(content: 'I love bitcoin and crypto'),
-        _fakeEventJson(content: 'bitcoin is the future'),
+        await _fakeEventJson(content: 'I love bitcoin and crypto'),
+        await _fakeEventJson(content: 'bitcoin is the future'),
       ];
       await nostr.relayPool.add(mockRelay);
 
@@ -153,11 +132,11 @@ void main() {
           1000;
 
       mockRelay.eventsToReturn = [
-        _fakeEventJson(
+        await _fakeEventJson(
           content: 'The nostr protocol is amazing',
           createdAt: sinceTimestamp + 3600,
         ),
-        _fakeEventJson(
+        await _fakeEventJson(
           content: 'Building on nostr protocol today',
           createdAt: sinceTimestamp + 7200,
         ),
@@ -229,8 +208,8 @@ void main() {
 
     test('Search API should provide convenient method', () async {
       mockRelay.eventsToReturn = [
-        _fakeEventJson(content: 'bitcoin price is rising'),
-        _fakeEventJson(content: 'bitcoin fundamentals are strong'),
+        await _fakeEventJson(content: 'bitcoin price is rising'),
+        await _fakeEventJson(content: 'bitcoin fundamentals are strong'),
       ];
       await nostr.relayPool.add(mockRelay);
 

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_event_signature_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_event_signature_test.dart
@@ -1,0 +1,155 @@
+// ABOUTME: Regression tests for RelayPool inbound event signature validation.
+// ABOUTME: Ensures relay-delivered events are verified before app handlers see them.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:nostr_sdk/relay/client_connected.dart';
+
+class _FakeRelay extends Relay {
+  _FakeRelay(String url) : super(url, RelayStatus(url));
+
+  final List<List<dynamic>> sentMessages = [];
+
+  @override
+  Future<bool> doConnect() async {
+    relayStatus.connected = ClientConnected.connected;
+    return true;
+  }
+
+  @override
+  Future<void> disconnect() async {
+    relayStatus.connected = ClientConnected.disconnect;
+  }
+
+  @override
+  Future<bool> send(
+    List<dynamic> message, {
+    bool? forceSend,
+    bool queueIfFailed = true,
+    bool skipReconnect = false,
+    DateTime? deadline,
+  }) async {
+    sentMessages.add(message);
+    return true;
+  }
+
+  Future<void> deliver(List<dynamic> json) async {
+    final handler = onMessage;
+    expect(handler, isNotNull, reason: 'RelayPool did not wire onMessage');
+    final dynamic result = handler!(this, json);
+    if (result is Future) {
+      await result;
+    }
+  }
+}
+
+Future<Event> _signedEvent(String content) async {
+  const privateKey =
+      '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12';
+  final signer = LocalNostrSigner(privateKey);
+  final pubkey = await signer.getPublicKey();
+  final event = Event(
+    pubkey!,
+    EventKind.textNote,
+    [],
+    content,
+    createdAt: 1780000000,
+  );
+  await signer.signEvent(event);
+  return event;
+}
+
+void main() {
+  group('RelayPool inbound event signature validation', () {
+    Relay dummyTempRelay(String url) => RelayBase(url, RelayStatus(url));
+
+    test('delivers signed events with valid ids', () async {
+      final nostr = Nostr(
+        LocalNostrSigner(generatePrivateKey()),
+        [],
+        dummyTempRelay,
+      );
+      final relay = _FakeRelay('wss://relay.example');
+      expect(await nostr.relayPool.add(relay), isTrue);
+
+      final delivered = <Event>[];
+      nostr.subscribe(
+        [
+          {
+            'kinds': [EventKind.textNote],
+          },
+        ],
+        delivered.add,
+        id: 'sub',
+      );
+
+      final event = await _signedEvent('valid relay event');
+      await relay.deliver(['EVENT', 'sub', event.toJson()]);
+
+      expect(delivered, hasLength(1));
+      expect(delivered.single.id, event.id);
+    });
+
+    test(
+      'drops events whose content no longer matches the signed id',
+      () async {
+        final nostr = Nostr(
+          LocalNostrSigner(generatePrivateKey()),
+          [],
+          dummyTempRelay,
+        );
+        final relay = _FakeRelay('wss://relay.example');
+        expect(await nostr.relayPool.add(relay), isTrue);
+
+        final delivered = <Event>[];
+        nostr.subscribe(
+          [
+            {
+              'kinds': [EventKind.textNote],
+            },
+          ],
+          delivered.add,
+          id: 'sub',
+        );
+
+        final event = await _signedEvent('original content');
+        final tampered = event.toJson()..['content'] = 'tampered content';
+        await relay.deliver(['EVENT', 'sub', tampered]);
+
+        expect(delivered, isEmpty);
+      },
+    );
+
+    test('drops unsigned events even when the event id is valid', () async {
+      final nostr = Nostr(
+        LocalNostrSigner(generatePrivateKey()),
+        [],
+        dummyTempRelay,
+      );
+      final relay = _FakeRelay('wss://relay.example');
+      expect(await nostr.relayPool.add(relay), isTrue);
+
+      final delivered = <Event>[];
+      nostr.subscribe(
+        [
+          {
+            'kinds': [EventKind.textNote],
+          },
+        ],
+        delivered.add,
+        id: 'sub',
+      );
+
+      final event = Event(
+        getPublicKey(generatePrivateKey()),
+        EventKind.textNote,
+        [],
+        'unsigned relay event',
+        createdAt: 1780000000,
+      );
+      await relay.deliver(['EVENT', 'sub', event.toJson()]);
+
+      expect(delivered, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
Closes #5773

## Summary

- require inbound relay EVENT payloads to have a valid event id and author signature before RelayPool forwards them to subscriptions or cache relays
- add relay-pool regression coverage for valid signed events, tampered payloads, and unsigned payloads
- update NIP-50 integration fixtures to emit signed relay events so query/search tests exercise the production validation path

## Testing

- flutter test test/unit/relay_pool_event_signature_test.dart
- flutter test test/unit/relay_pool_auth_test.dart test/unit/relay_pool_malformed_frame_test.dart test/unit/relay_pool_event_signature_test.dart
- flutter test test/integration/nip50_search_test.dart
- flutter test
- flutter analyze

🤖 Generated with Codex