### PR TITLE
fix(editor): restore playback after voice-over

### DIFF
--- a/mobile/lib/blocs/video_editor/voice_over/voice_over_cubit.dart
+++ b/mobile/lib/blocs/video_editor/voice_over/voice_over_cubit.dart
@@ -12,6 +12,7 @@ import 'package:openvine/services/video_editor/voice_over_recorder_service.dart'
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:permissions_service/permissions_service.dart';
+import 'package:sound_service/sound_service.dart';
 
 part 'voice_over_state.dart';
 
@@ -39,10 +40,12 @@ class VoiceOverCubit extends Cubit<VoiceOverState> {
     required PermissionsService permissionsService,
     required String Function(int takeNumber) takeTitleBuilder,
     VoiceOverRecorderService? recorder,
+    AudioSessionService? audioSessionService,
     Duration availableDuration = Duration.zero,
     int priorTakeCount = 0,
     Future<Directory> Function()? storageDirectoryProvider,
   }) : _recorder = recorder ?? RecordVoiceOverRecorderService(),
+       _audioSessionService = audioSessionService ?? AudioSessionService(),
        _permissionsService = permissionsService,
        _takeTitleBuilder = takeTitleBuilder,
        _storageDirectoryProvider =
@@ -66,6 +69,7 @@ class VoiceOverCubit extends Cubit<VoiceOverState> {
       VoiceOverRecorderService.amplitudeInterval;
 
   final VoiceOverRecorderService _recorder;
+  final AudioSessionService _audioSessionService;
   final PermissionsService _permissionsService;
   final String Function(int takeNumber) _takeTitleBuilder;
   final Future<Directory> Function() _storageDirectoryProvider;
@@ -155,6 +159,7 @@ class VoiceOverCubit extends Cubit<VoiceOverState> {
     try {
       await _recorder.start(path);
     } catch (_) {
+      await _restoreMixedPlayback();
       // start() may have created a partial file before throwing; delete it and
       // clear the field so the failed take can't strand an orphan or be
       // overwritten (and leaked) by the next successful start.
@@ -216,6 +221,7 @@ class VoiceOverCubit extends Cubit<VoiceOverState> {
 
     try {
       final path = await _recorder.stop() ?? _currentPath;
+      await _restoreMixedPlayback();
       final duration = state.currentDuration;
       _currentPath = null;
 
@@ -264,6 +270,7 @@ class VoiceOverCubit extends Cubit<VoiceOverState> {
         ),
       );
     } catch (e, stackTrace) {
+      await _restoreMixedPlayback();
       addError(e, stackTrace);
       if (!isClosed) emit(state.copyWith(status: VoiceOverStatus.error));
     } finally {
@@ -294,6 +301,7 @@ class VoiceOverCubit extends Cubit<VoiceOverState> {
     if (state.isRecording) {
       await _stopMetering();
       await _safeStopRecorder();
+      await _restoreMixedPlayback();
     }
     await _deleteTakeFiles(state.takes);
     if (_currentPath != null) {
@@ -320,6 +328,9 @@ class VoiceOverCubit extends Cubit<VoiceOverState> {
     }
   }
 
+  Future<void> _restoreMixedPlayback() =>
+      _audioSessionService.configureForMixedPlayback();
+
   Future<void> _deleteTakeFiles(List<AudioEvent> takes) async {
     for (final take in takes) {
       await _deleteFile(take.localFilePath);
@@ -344,7 +355,11 @@ class VoiceOverCubit extends Cubit<VoiceOverState> {
     // system-back / swipe-close exit (which never runs discardAll) doesn't
     // leave orphaned recordings behind.
     if (!_committed) {
+      final wasRecording = state.isRecording;
       await _safeStopRecorder();
+      if (wasRecording) {
+        await _restoreMixedPlayback();
+      }
       await _deleteTakeFiles(state.takes);
       await _deleteFile(_currentPath);
       _currentPath = null;

--- a/mobile/lib/screens/video_editor/voice_over_recorder_screen.dart
+++ b/mobile/lib/screens/video_editor/voice_over_recorder_screen.dart
@@ -5,9 +5,11 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:models/models.dart' show AudioEvent;
 import 'package:openvine/blocs/video_editor/voice_over/voice_over_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/upload_media_providers.dart';
 import 'package:openvine/widgets/video_editor/video_editor_toolbar.dart';
 import 'package:permissions_service/permissions_service.dart';
 
@@ -17,7 +19,7 @@ import 'package:permissions_service/permissions_service.dart';
 /// Returns the recorded takes (as draft-local [AudioEvent]s) via
 /// [Navigator.pop] when the user taps Done, or `null` when they close the
 /// screen (in which case the recordings are discarded).
-class VoiceOverRecorderScreen extends StatelessWidget {
+class VoiceOverRecorderScreen extends ConsumerWidget {
   /// Creates the voice-over recorder screen.
   const VoiceOverRecorderScreen({
     required this.availableDuration,
@@ -38,7 +40,7 @@ class VoiceOverRecorderScreen extends StatelessWidget {
   static const routeName = 'voice-over-recorder';
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     // Resolve l10n here (a valid place) and capture the AppLocalizations
     // instance — `create` runs in a one-time lifecycle that cannot listen to
     // the AppLocalizations InheritedWidget, but the captured object can be
@@ -47,6 +49,7 @@ class VoiceOverRecorderScreen extends StatelessWidget {
     return BlocProvider<VoiceOverCubit>(
       create: (_) => VoiceOverCubit(
         permissionsService: const PermissionHandlerPermissionsService(),
+        audioSessionService: ref.read(audioSessionServiceProvider),
         takeTitleBuilder: l10n.videoEditorVoiceOverTakeName,
         availableDuration: availableDuration,
         priorTakeCount: priorTakeCount,
@@ -93,10 +96,8 @@ class VoiceOverRecorderView extends StatelessWidget {
           BlocListener<VoiceOverCubit, VoiceOverState>(
             listenWhen: (previous, current) =>
                 !previous.isOverAvailable && current.isOverAvailable,
-            listener: (context, _) => _announce(
-              context,
-              context.l10n.videoEditorVoiceOverTooLong,
-            ),
+            listener: (context, _) =>
+                _announce(context, context.l10n.videoEditorVoiceOverTooLong),
           ),
         ],
         child: const Column(

--- a/mobile/test/blocs/video_editor/voice_over/voice_over_cubit_test.dart
+++ b/mobile/test/blocs/video_editor/voice_over/voice_over_cubit_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/blocs/video_editor/voice_over/voice_over_cubit.dart';
 import 'package:openvine/services/video_editor/voice_over_recorder_service.dart';
 import 'package:permissions_service/permissions_service.dart';
+import 'package:sound_service/sound_service.dart';
 
 class _FakeRecorder implements VoiceOverRecorderService {
   final StreamController<double> _controller =
@@ -17,6 +18,7 @@ class _FakeRecorder implements VoiceOverRecorderService {
   int stopCount = 0;
   bool disposed = false;
   bool throwOnStart = false;
+  bool throwOnStop = false;
   String? lastPath;
 
   @override
@@ -35,6 +37,7 @@ class _FakeRecorder implements VoiceOverRecorderService {
   @override
   Future<String?> stop() async {
     stopCount++;
+    if (throwOnStop) throw StateError('stop failed');
     return lastPath;
   }
 
@@ -45,6 +48,15 @@ class _FakeRecorder implements VoiceOverRecorderService {
   }
 
   void emitAmplitude(double value) => _controller.add(value);
+}
+
+class _FakeAudioSessionService extends AudioSessionService {
+  int configureForMixedPlaybackCount = 0;
+
+  @override
+  Future<void> configureForMixedPlayback() async {
+    configureForMixedPlaybackCount++;
+  }
 }
 
 class _FakePermissions implements PermissionsService {
@@ -120,12 +132,14 @@ void main() {
 
   group(VoiceOverCubit, () {
     late _FakeRecorder recorder;
+    late _FakeAudioSessionService audioSessionService;
     late Directory tempDir;
 
     String takeTitle(int number) => 'Recording $number';
 
     setUp(() {
       recorder = _FakeRecorder();
+      audioSessionService = _FakeAudioSessionService();
       tempDir = Directory.systemTemp.createTempSync('voice_over_test');
     });
 
@@ -136,6 +150,7 @@ void main() {
     VoiceOverCubit buildCubit(PermissionsService permissions) {
       return VoiceOverCubit(
         recorder: recorder,
+        audioSessionService: audioSessionService,
         permissionsService: permissions,
         takeTitleBuilder: takeTitle,
         storageDirectoryProvider: () async => tempDir,
@@ -269,6 +284,7 @@ void main() {
         expect(take.duration, closeTo(0.3, 0.0001));
         expect(cubit.state.currentDuration, equals(Duration.zero));
         expect(cubit.state.waveformBars, isEmpty);
+        expect(audioSessionService.configureForMixedPlaybackCount, equals(1));
 
         await cubit.close();
       });
@@ -281,6 +297,22 @@ void main() {
 
         expect(cubit.state.takes, isEmpty);
         expect(cubit.state.status, equals(VoiceOverStatus.idle));
+        expect(audioSessionService.configureForMixedPlaybackCount, equals(1));
+
+        await cubit.close();
+      });
+
+      test('restores mixed playback when recorder stop fails', () async {
+        recorder.throwOnStop = true;
+        final cubit = buildCubit(_FakePermissions(PermissionStatus.granted));
+        await cubit.requestPermissionAndStart();
+        recorder.emitAmplitude(0.5);
+        await flush();
+
+        await cubit.stop();
+
+        expect(cubit.state.status, equals(VoiceOverStatus.error));
+        expect(audioSessionService.configureForMixedPlaybackCount, equals(1));
 
         await cubit.close();
       });
@@ -405,6 +437,7 @@ void main() {
         () async {
           final cubit = VoiceOverCubit(
             recorder: recorder,
+            audioSessionService: audioSessionService,
             permissionsService: _FakePermissions(PermissionStatus.granted),
             takeTitleBuilder: takeTitle,
             priorTakeCount: 2,
@@ -447,6 +480,7 @@ void main() {
 
         expect(cubit.state.takes, isEmpty);
         expect(cubit.state.status, equals(VoiceOverStatus.idle));
+        expect(audioSessionService.configureForMixedPlaybackCount, equals(1));
 
         await cubit.close();
       });
@@ -501,6 +535,7 @@ void main() {
         () async {
           final cubit = VoiceOverCubit(
             recorder: recorder,
+            audioSessionService: audioSessionService,
             permissionsService: _FakePermissions(PermissionStatus.granted),
             takeTitleBuilder: takeTitle,
             availableDuration: const Duration(milliseconds: 150),
@@ -555,6 +590,15 @@ void main() {
     });
 
     group('close', () {
+      test('restores mixed playback when closed during recording', () async {
+        final cubit = buildCubit(_FakePermissions(PermissionStatus.granted));
+        await cubit.requestPermissionAndStart();
+
+        await cubit.close();
+
+        expect(audioSessionService.configureForMixedPlaybackCount, equals(1));
+      });
+
       test('discards uncommitted take files', () async {
         final cubit = buildCubit(_FakePermissions(PermissionStatus.granted));
         await cubit.requestPermissionAndStart();
@@ -590,9 +634,7 @@ void main() {
 
     group('openSettings', () {
       test('delegates to the permissions service', () async {
-        final permissions = _FakePermissions(
-          PermissionStatus.requiresSettings,
-        );
+        final permissions = _FakePermissions(PermissionStatus.requiresSettings);
         final cubit = buildCubit(permissions);
 
         await cubit.openSettings();
@@ -609,6 +651,18 @@ void main() {
       await cubit.close();
 
       expect(recorder.disposed, isTrue);
+    });
+
+    test('restores mixed playback when recorder start fails', () async {
+      recorder.throwOnStart = true;
+      final cubit = buildCubit(_FakePermissions(PermissionStatus.granted));
+
+      await cubit.requestPermissionAndStart();
+
+      expect(cubit.state.status, equals(VoiceOverStatus.error));
+      expect(audioSessionService.configureForMixedPlaybackCount, equals(1));
+
+      await cubit.close();
     });
   });
 }

--- a/mobile/test/screens/video_editor/voice_over_recorder_screen_test.dart
+++ b/mobile/test/screens/video_editor/voice_over_recorder_screen_test.dart
@@ -8,6 +8,7 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart' show AudioEvent;
@@ -551,8 +552,10 @@ void main() {
         const MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
-          home: VoiceOverRecorderScreen(
-            availableDuration: Duration(seconds: 6),
+          home: ProviderScope(
+            child: VoiceOverRecorderScreen(
+              availableDuration: Duration(seconds: 6),
+            ),
           ),
         ),
       );


### PR DESCRIPTION
Closes #5777

## Summary
- Inject the existing AudioSessionService into the in-editor voice-over recorder cubit.
- Restore mixed playback after voice-over recorder stop paths, including failed stop, failed start cleanup, discard while recording, and close while recording.
- Wire VoiceOverRecorderScreen to the existing audioSessionServiceProvider so session policy stays centralized in sound_service.
- Add focused regression coverage for the voice-over recorder lifecycle and update the screen construction test for the provider-backed dependency.

## Root Cause
The in-editor voice-over recorder uses package:record, which can leave the shared iOS AVAudioSession in a record-tuned category after recording stops. PR #5766 restored playback only for the camera recorder-to-editor navigation path, so editor preview playback could still inherit the record session after using voice-over.

## Risk / Scope
This intentionally does not add global audio-session side effects to divine_video_player. That player is used in feed, metadata, clip transform, and editor surfaces; restoring only from the voice-over recorder path fixes the reported editor bug without changing feed playback semantics.

## Validation
- flutter analyze (mobile)
- flutter test test/blocs/video_editor/voice_over/voice_over_cubit_test.dart test/screens/video_editor/voice_over_recorder_screen_test.dart (mobile)
- flutter test test/src/audio_session_service_test.dart test/src/audio_playback_service_test.dart (mobile/packages/sound_service)
- Pre-push hook: merge-conflict check, changed-file analyzer, changed-file tests

## Manual QA
Physical iPhone QA is still required for the hardware-specific AVAudioSession behavior: record a voice-over inside the editor, stop recording, return to preview, and confirm preview audio remains audible with and without the silent switch.