### PR TITLE
fix(drafts): guard missing split clip files

### DIFF
--- a/mobile/lib/services/draft_storage_service.dart
+++ b/mobile/lib/services/draft_storage_service.dart
@@ -277,7 +277,8 @@ class DraftStorageService {
   ///
   /// Queries the database directly by `publish_status` column instead of
   /// loading all drafts into memory. Corrupted rows (0 clips) are cleaned
-  /// up automatically.
+  /// up automatically. Drafts whose clip source files are missing are excluded
+  /// from playable lists without mutating their rows.
   Future<List<DivineVideoDraft>> getDraftsByPublishStatuses(
     Set<PublishStatus> statuses,
   ) async {
@@ -304,8 +305,9 @@ class DraftStorageService {
           clipRows: clipRows,
           documentsPath: documentsPath,
         );
-        if (draft != null) {
-          drafts.add(draft);
+        final validatedDraft = draft == null ? null : _validatedDraft(draft);
+        if (validatedDraft != null) {
+          drafts.add(validatedDraft);
         }
       }
     }
@@ -422,6 +424,29 @@ class DraftStorageService {
     return draft != null && draft.clips.isNotEmpty;
   }
 
+  DivineVideoDraft? _validatedDraft(DivineVideoDraft draft) {
+    final validClips = _filterValidClips(draft.clips);
+    if (validClips.isEmpty) {
+      Log.warning(
+        '📝 Draft ${draft.id} hidden because all clip files are missing',
+        name: 'DraftStorageService',
+        category: LogCategory.video,
+      );
+      return null;
+    }
+
+    if (validClips.length < draft.clips.length) {
+      Log.info(
+        '📝 Draft ${draft.id}: ${validClips.length} playable clips '
+        '(${draft.clips.length - validClips.length} missing)',
+        name: 'DraftStorageService',
+        category: LogCategory.video,
+      );
+    }
+
+    return _clearMissingFinalRenderedClip(draft.copyWith(clips: validClips));
+  }
+
   /// Filter clips to only include those with existing video files.
   List<DivineVideoClip> _filterValidClips(List<DivineVideoClip> clips) {
     return clips.where((clip) {
@@ -467,8 +492,9 @@ class DraftStorageService {
           clipRows: clipRows,
           documentsPath: documentsPath,
         );
-        if (draft != null) {
-          drafts.add(_clearMissingFinalRenderedClip(draft));
+        final validatedDraft = draft == null ? null : _validatedDraft(draft);
+        if (validatedDraft != null) {
+          drafts.add(validatedDraft);
         }
       }
 

--- a/mobile/lib/services/video_editor/video_editor_render_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_render_service.dart
@@ -1141,7 +1141,7 @@ class VideoEditorRenderService {
     final token = Object();
     _activeNativeRenderTokens[model.id] = token;
     try {
-      return await ProVideoEditor.instance
+      final outputPaths = await ProVideoEditor.instance
           .splitVideo(model, nativeLogLevel: nativeLogLevel)
           .timeout(
             _splitWatchdogTimeout,
@@ -1153,6 +1153,16 @@ class VideoEditorRenderService {
               throw const RenderCanceledException();
             },
           );
+      final missingOutputPath = outputPaths.where((path) {
+        return path.isEmpty || !File(path).existsSync();
+      }).firstOrNull;
+      if (missingOutputPath != null) {
+        throw StateError(
+          'Native split completed without creating output file: '
+          '$missingOutputPath',
+        );
+      }
+      return outputPaths;
     } finally {
       if (identical(_activeNativeRenderTokens[model.id], token)) {
         _activeNativeRenderTokens.remove(model.id);

--- a/mobile/test/providers/vine_recording_provider_auto_draft_test.dart
+++ b/mobile/test/providers/vine_recording_provider_auto_draft_test.dart
@@ -11,15 +11,36 @@ import 'package:models/models.dart' show AspectRatio;
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/divine_video_draft.dart';
 import 'package:openvine/services/draft_storage_service.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
+
+import '../mocks/mock_path_provider_platform.dart';
 
 void main() {
   group('VineRecordingProvider auto-draft', () {
     late ProviderContainer container;
     late AppDatabase database;
     late DraftStorageService draftStorage;
+    late Directory tempDir;
+    late Directory documentsDir;
+    late Directory supportDir;
+    late PathProviderPlatform originalPathProviderInstance;
 
     setUp(() async {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      tempDir = Directory.systemTemp.createTempSync(
+        'vine_recording_provider_auto_draft_test_',
+      );
+      documentsDir = Directory('${tempDir.path}/documents')..createSync();
+      supportDir = Directory('${tempDir.path}/support')..createSync();
+
+      originalPathProviderInstance = PathProviderPlatform.instance;
+      final mockPathProvider = MockPathProviderPlatform()
+        ..setTemporaryPath(tempDir.path)
+        ..setApplicationDocumentsPath(documentsDir.path)
+        ..setApplicationSupportPath(supportDir.path);
+      PathProviderPlatform.instance = mockPathProvider;
+
       database = AppDatabase.test(NativeDatabase.memory());
       draftStorage = DraftStorageService(
         draftsDao: database.draftsDao,
@@ -34,7 +55,17 @@ void main() {
     tearDown(() async {
       container.dispose();
       await database.close();
+      PathProviderPlatform.instance = originalPathProviderInstance;
+      if (tempDir.existsSync()) {
+        tempDir.deleteSync(recursive: true);
+      }
     });
+
+    File createVideoFile(String name) {
+      final file = File('${documentsDir.path}/$name');
+      file.writeAsBytesSync([0]);
+      return file;
+    }
 
     test('stopRecording should create draft automatically', () async {
       // This test validates the auto-draft creation behavior
@@ -43,7 +74,7 @@ void main() {
 
       // Simulate what stopRecording should do:
       // 1. Create a draft with default metadata
-      final videoFile = File('/tmp/test_video.mp4');
+      final videoFile = createVideoFile('test_video.mp4');
       final draft = DivineVideoDraft.create(
         clips: [
           DivineVideoClip(
@@ -72,7 +103,7 @@ void main() {
 
     test('auto-created draft should have default metadata', () async {
       // Create draft with expected default values
-      final videoFile = File('/tmp/test_video.mp4');
+      final videoFile = createVideoFile('test_video.mp4');
       final draft = DivineVideoDraft.create(
         clips: [
           DivineVideoClip(

--- a/mobile/test/services/auto_draft_complete_flow_test.dart
+++ b/mobile/test/services/auto_draft_complete_flow_test.dart
@@ -1,48 +1,57 @@
 // ABOUTME: Integration test for complete auto-draft flow from recording to publish
 // ABOUTME: Validates end-to-end behavior: record → auto-draft → edit → publish → retry
+import 'dart:io';
+
 import 'package:db_client/db_client.dart';
 import 'package:drift/native.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/divine_video_draft.dart';
 import 'package:openvine/services/draft_storage_service.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
+
+import '../mocks/mock_path_provider_platform.dart';
 
 void main() {
   group('Auto-draft complete flow integration', () {
     late AppDatabase database;
+    late Directory tempDir;
+    late Directory documentsDir;
+    late Directory supportDir;
+    late PathProviderPlatform originalPathProviderInstance;
 
     setUp(() {
       TestWidgetsFlutterBinding.ensureInitialized();
-
-      // Mock path provider for getApplicationDocumentsDirectory
-      const MethodChannel pathProviderChannel = MethodChannel(
-        'plugins.flutter.io/path_provider',
+      tempDir = Directory.systemTemp.createTempSync(
+        'auto_draft_complete_flow_test_',
       );
+      documentsDir = Directory('${tempDir.path}/documents')..createSync();
+      supportDir = Directory('${tempDir.path}/support')..createSync();
 
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(pathProviderChannel, (
-            MethodCall methodCall,
-          ) async {
-            switch (methodCall.method) {
-              case 'getTemporaryDirectory':
-                return '/tmp';
-              case 'getApplicationDocumentsDirectory':
-                return '/tmp/documents';
-              case 'getApplicationSupportDirectory':
-                return '/tmp/support';
-              default:
-                return null;
-            }
-          });
+      originalPathProviderInstance = PathProviderPlatform.instance;
+      final mockPathProvider = MockPathProviderPlatform()
+        ..setTemporaryPath(tempDir.path)
+        ..setApplicationDocumentsPath(documentsDir.path)
+        ..setApplicationSupportPath(supportDir.path);
+      PathProviderPlatform.instance = mockPathProvider;
 
       database = AppDatabase.test(NativeDatabase.memory());
     });
 
     tearDown(() async {
       await database.close();
+      PathProviderPlatform.instance = originalPathProviderInstance;
+      if (tempDir.existsSync()) {
+        tempDir.deleteSync(recursive: true);
+      }
     });
+
+    String createVideoFile(String basename) {
+      final file = File('${documentsDir.path}/$basename');
+      file.writeAsBytesSync([0]);
+      return file.path;
+    }
 
     test('record → auto-draft → edit → publish flow', () async {
       final draftStorage = DraftStorageService(
@@ -61,7 +70,7 @@ void main() {
         clips: [
           DivineVideoClip(
             id: 'id',
-            video: EditorVideo.file('/path/to/video.mp4'),
+            video: EditorVideo.file(createVideoFile('recorded-video.mp4')),
             duration: const Duration(seconds: 4),
             recordedAt: .now(),
             targetAspectRatio: .vertical,
@@ -115,7 +124,7 @@ void main() {
         clips: [
           DivineVideoClip(
             id: 'id',
-            video: EditorVideo.file('/path/to/video.mp4'),
+            video: EditorVideo.file(createVideoFile('retry-video.mp4')),
             duration: const Duration(seconds: 4),
             recordedAt: .now(),
             targetAspectRatio: .vertical,

--- a/mobile/test/services/draft_storage_service_test.dart
+++ b/mobile/test/services/draft_storage_service_test.dart
@@ -26,6 +26,12 @@ void main() {
     late DraftStorageService service;
     late PathProviderPlatform originalPathProviderInstance;
 
+    void createDocumentFile(String basename) {
+      final file = File(p.join(documentsPath, basename));
+      file.parent.createSync(recursive: true);
+      file.writeAsBytesSync([0]);
+    }
+
     setUp(() async {
       TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -40,9 +46,25 @@ void main() {
         draftsDao: database.draftsDao,
         clipsDao: database.clipsDao,
       );
+
+      for (final basename in [
+        'video.mp4',
+        'video1.mp4',
+        'video2.mp4',
+        'clip_valid.mp4',
+        'clip_corrupt.mp4',
+        'a1.mp4',
+        'a2.mp4',
+        'b1.mp4',
+        'old_video.mp4',
+      ]) {
+        createDocumentFile(basename);
+      }
     });
 
     tearDown(() async {
+      final docsDir = Directory(documentsPath);
+      if (docsDir.existsSync()) docsDir.deleteSync(recursive: true);
       PathProviderPlatform.instance = originalPathProviderInstance;
       await database.close();
     });
@@ -312,6 +334,66 @@ void main() {
           expect(drafts.map((d) => d.id), ['draft_valid']);
         },
       );
+
+      test('hides drafts whose clip source files are missing', () async {
+        final now = DateTime(2025);
+        createDocumentFile('present.mp4');
+        final playableDraft = DivineVideoDraft(
+          id: 'draft_playable',
+          clips: [
+            DivineVideoClip(
+              id: 'clip_present',
+              video: EditorVideo.file('/path/to/present.mp4'),
+              duration: const Duration(seconds: 6),
+              recordedAt: now,
+              targetAspectRatio: AspectRatio.square,
+              originalAspectRatio: 9 / 16,
+            ),
+          ],
+          title: 'Playable',
+          description: '',
+          hashtags: {},
+          selectedApproach: 'hybrid',
+          createdAt: now,
+          lastModified: now,
+          publishStatus: PublishStatus.draft,
+          publishAttempts: 0,
+        );
+        final brokenDraft = DivineVideoDraft(
+          id: 'draft_broken',
+          clips: [
+            DivineVideoClip(
+              id: 'clip_missing',
+              video: EditorVideo.file('/path/to/missing-split-output.mp4'),
+              duration: const Duration(seconds: 6),
+              recordedAt: now,
+              targetAspectRatio: AspectRatio.square,
+              originalAspectRatio: 9 / 16,
+            ),
+          ],
+          title: 'Broken',
+          description: '',
+          hashtags: {},
+          selectedApproach: 'hybrid',
+          createdAt: now,
+          lastModified: now,
+          publishStatus: PublishStatus.draft,
+          publishAttempts: 0,
+        );
+
+        await service.saveDraft(playableDraft);
+        await service.saveDraft(brokenDraft);
+
+        final drafts = await service.getAllDrafts();
+        expect(drafts.map((draft) => draft.id), ['draft_playable']);
+
+        // The row is left intact so a future recovery path or support tooling
+        // can still inspect it; the playable library just stops offering it.
+        expect(
+          await database.draftsDao.getDraftById('draft_broken'),
+          isNotNull,
+        );
+      });
 
       test('clears missing final rendered clip references', () async {
         final draft = DivineVideoDraft.create(
@@ -670,6 +752,7 @@ void main() {
     group('getDraftsByPublishStatuses', () {
       DivineVideoDraft createDraftWithStatus(String id, PublishStatus status) {
         final now = DateTime.now();
+        createDocumentFile('$id.mp4');
         return DivineVideoDraft(
           id: id,
           clips: [
@@ -937,6 +1020,9 @@ void main() {
       });
 
       test('preserves clip order after migration', () async {
+        createDocumentFile('first.mp4');
+        createDocumentFile('second.mp4');
+        createDocumentFile('third.mp4');
         final draftJson = buildDraftJson(
           id: 'draft_order',
           clips: [
@@ -1193,12 +1279,12 @@ void main() {
       test('keeps a cover referenced by a saved draft when autosave is '
           'deleted', () async {
         final cover = writeCover('shared_cover.jpg');
-        final autosave = draftWithCover(cover.path).copyWith(
-          id: 'draft_autosave',
-        );
-        final savedDraft = draftWithCover(cover.path).copyWith(
-          id: 'draft_named',
-        );
+        final autosave = draftWithCover(
+          cover.path,
+        ).copyWith(id: 'draft_autosave');
+        final savedDraft = draftWithCover(
+          cover.path,
+        ).copyWith(id: 'draft_named');
 
         await service.saveDraft(autosave);
         await service.saveDraft(savedDraft);

--- a/mobile/test/services/video_editor/video_editor_split_service_test.dart
+++ b/mobile/test/services/video_editor/video_editor_split_service_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart' as model show AspectRatio;
 import 'package:openvine/models/divine_video_clip.dart';
@@ -9,6 +11,10 @@ import 'package:pro_video_editor/pro_video_editor.dart';
 class MockPathProviderPlatform extends Fake
     with MockPlatformInterfaceMixin
     implements PathProviderPlatform {
+  MockPathProviderPlatform({required this.documentsPath});
+
+  final String documentsPath;
+
   @override
   Future<String?> getApplicationCachePath() async {
     return '/cache';
@@ -16,12 +22,13 @@ class MockPathProviderPlatform extends Fake
 
   @override
   Future<String?> getApplicationDocumentsPath() async {
-    return '/documents';
+    return documentsPath;
   }
 }
 
 class MockProVideoEditor extends ProVideoEditor {
   bool shouldThrowError = false;
+  bool createOutputFiles = true;
   final List<SplitVideoModel> splitRequests = [];
 
   @override
@@ -39,6 +46,13 @@ class MockProVideoEditor extends ProVideoEditor {
     }
     splitRequests.add(value);
     // Simulate a frame-accurate split producing two files.
+    if (createOutputFiles) {
+      for (final outputPath in [value.startOutputPath, value.endOutputPath]) {
+        final file = File(outputPath);
+        file.parent.createSync(recursive: true);
+        file.writeAsBytesSync([0]);
+      }
+    }
     await Future<void>.delayed(const Duration(milliseconds: 10));
     return [value.startOutputPath, value.endOutputPath];
   }
@@ -50,11 +64,17 @@ class MockProVideoEditor extends ProVideoEditor {
 void main() {
   late MockProVideoEditor mockProVideoEditor;
   late PathProviderPlatform originalPathProviderInstance;
+  late Directory tempDir;
 
   setUp(() {
     TestWidgetsFlutterBinding.ensureInitialized();
+    tempDir = Directory.systemTemp.createTempSync(
+      'openvine_split_service_test_',
+    );
     originalPathProviderInstance = PathProviderPlatform.instance;
-    PathProviderPlatform.instance = MockPathProviderPlatform();
+    PathProviderPlatform.instance = MockPathProviderPlatform(
+      documentsPath: '${tempDir.path}/documents',
+    );
     mockProVideoEditor = MockProVideoEditor();
     ProVideoEditor.instance = mockProVideoEditor;
     mockProVideoEditor.splitRequests.clear();
@@ -62,6 +82,9 @@ void main() {
 
   tearDown(() {
     PathProviderPlatform.instance = originalPathProviderInstance;
+    if (tempDir.existsSync()) {
+      tempDir.deleteSync(recursive: true);
+    }
   });
 
   group('VideoEditorSplitService', () {
@@ -439,6 +462,39 @@ void main() {
           expect(e, isException);
         }
       });
+
+      test(
+        'does not report rendered clips when output files are missing',
+        () async {
+          mockProVideoEditor.createOutputFiles = false;
+
+          final clip = DivineVideoClip(
+            id: 'test-clip',
+            video: EditorVideo.file('/test/video.mp4'),
+            duration: const Duration(seconds: 5),
+            recordedAt: DateTime.now(),
+            targetAspectRatio: model.AspectRatio.square,
+            originalAspectRatio: 9 / 16,
+          );
+
+          final renderedClips = <DivineVideoClip>[];
+
+          await expectLater(
+            VideoEditorSplitService.splitClip(
+              sourceClip: clip,
+              splitPosition: const Duration(seconds: 2),
+              onClipsCreated: (_, _) {},
+              onThumbnailExtracted: null,
+              onClipRendered: (renderedClip, _) {
+                renderedClips.add(renderedClip);
+              },
+            ),
+            throwsStateError,
+          );
+
+          expect(renderedClips, isEmpty);
+        },
+      );
 
       test('generates unique IDs for split clips', () async {
         final clip = DivineVideoClip(


### PR DESCRIPTION
Closes #5780

## Summary
- Validate native split output files before split render completion is reported, so failed native splits cannot mark missing files as rendered.
- Exclude drafts whose clip source files are missing from playable draft/status lists without deleting the stored rows, preserving support/recovery visibility.
- Tighten draft and auto-draft test fixtures to use real temp document files and add regression coverage for missing split outputs.

## Verification
- dart format lib test integration_test
- flutter analyze
- flutter test test/services/video_editor/video_editor_split_service_test.dart
- flutter test
- Pre-push hook: analyzer plus changed-file tests