### PR TITLE
fix(media_cache): stop reporting scroll-away image cancellations as fatal

### DIFF
--- a/mobile/packages/media_cache/lib/src/media_cache_image_provider.dart
+++ b/mobile/packages/media_cache/lib/src/media_cache_image_provider.dart
@@ -77,13 +77,13 @@ class MediaCacheImageProvider extends ImageProvider<MediaCacheImageProvider> {
       final existing = await cacheManager.getFileFromCache(_resolvedCacheKey);
       if (existing != null && existing.file.existsSync()) {
         if (loadHandle.isCancelled) {
-          throw const _ImageLoadCancelledException();
+          return _abortCancelledLoad(key);
         }
         return _decodeFile(existing.file, decode: decode);
       }
 
       if (loadHandle.isCancelled) {
-        throw const _ImageLoadCancelledException();
+        return _abortCancelledLoad(key);
       }
 
       final operation = cacheManager.cacheFileCancellable(
@@ -94,7 +94,10 @@ class MediaCacheImageProvider extends ImageProvider<MediaCacheImageProvider> {
       loadHandle.attach(operation);
 
       final file = await operation.file;
-      if (file == null || loadHandle.isCancelled) {
+      if (loadHandle.isCancelled) {
+        return _abortCancelledLoad(key);
+      }
+      if (file == null) {
         throw const _ImageLoadCancelledException();
       }
 
@@ -105,6 +108,21 @@ class MediaCacheImageProvider extends ImageProvider<MediaCacheImageProvider> {
       });
       rethrow;
     }
+  }
+
+  /// Stops a load whose last listener was removed before it finished.
+  ///
+  /// Cancellation is expected during fast scrolling. Throwing here would let
+  /// [MultiFrameImageStreamCompleter] forward the error to
+  /// `FlutterError.onError` (and therefore Crashlytics) once no listener
+  /// remains, turning a benign scroll-away into a fatal report. Instead we
+  /// evict the stale cache entry and return a future that never completes, so
+  /// the cancelled load simply stops.
+  Future<ui.Codec> _abortCancelledLoad(MediaCacheImageProvider key) {
+    scheduleMicrotask(() {
+      PaintingBinding.instance.imageCache.evict(key);
+    });
+    return Completer<ui.Codec>().future;
   }
 
   Future<ui.Codec> _decodeFile(

--- a/mobile/packages/media_cache/test/src/media_cache_image_provider_test.dart
+++ b/mobile/packages/media_cache/test/src/media_cache_image_provider_test.dart
@@ -1,9 +1,9 @@
 import 'dart:async';
 import 'dart:io';
-import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:file/local.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:media_cache/media_cache.dart';
@@ -398,6 +398,54 @@ void main() {
       );
 
       completer.removeListener(listener);
+    });
+
+    test('does not report a FlutterError when the last listener leaves '
+        'before an in-flight download resolves', () async {
+      const url = 'https://example.com/scrolled-away.png';
+      final cacheManager = _MockMediaCacheManager();
+      final download = FakeCancellableDownload(
+        url: url,
+        targetFile: File('$testTempPath/scrolled-away.png'),
+        headers: null,
+      );
+      final operation = CancellableCacheOperation.fromDownload(download);
+
+      when(
+        () => cacheManager.getFileFromCache(url),
+      ).thenAnswer((_) async => null);
+      when(
+        () => cacheManager.cacheFileCancellable(url, key: url),
+      ).thenReturn(operation);
+
+      final flutterErrors = <FlutterErrorDetails>[];
+      final previousOnError = FlutterError.onError;
+      FlutterError.onError = flutterErrors.add;
+      addTearDown(() => FlutterError.onError = previousOnError);
+
+      final provider = MediaCacheImageProvider(url, cacheManager: cacheManager);
+      final completer = provider.loadImage(
+        provider,
+        (buffer, {getTargetSize}) => Completer<ui.Codec>().future,
+      );
+      final listener = ImageStreamListener((image, synchronousCall) {
+        image.dispose();
+      });
+
+      completer.addListener(listener);
+      await Future<void>.delayed(Duration.zero);
+
+      completer.removeListener(listener);
+      expect(download.isCancelled, isTrue);
+
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(flutterErrors, isEmpty);
+      expect(
+        PaintingBinding.instance.imageCache.containsKey(provider),
+        isFalse,
+      );
     });
 
     test('throws for an empty cached file', () async {

--- a/mobile/packages/media_cache/test/src/media_cache_image_provider_test.dart
+++ b/mobile/packages/media_cache/test/src/media_cache_image_provider_test.dart
@@ -485,5 +485,137 @@ void main() {
 
       completer.removeListener(listener);
     });
+
+    test('skips the download and reports nothing when cancelled before the '
+        'cache miss resolves', () async {
+      const url = 'https://example.com/cancel-before-download.png';
+      final cacheManager = _MockMediaCacheManager();
+      final release = Completer<void>();
+      when(() => cacheManager.getFileFromCache(url)).thenAnswer((_) async {
+        await release.future;
+        return null;
+      });
+
+      final flutterErrors = <FlutterErrorDetails>[];
+      final previousOnError = FlutterError.onError;
+      FlutterError.onError = flutterErrors.add;
+      addTearDown(() => FlutterError.onError = previousOnError);
+
+      final provider = MediaCacheImageProvider(url, cacheManager: cacheManager);
+      final completer = provider.loadImage(
+        provider,
+        (buffer, {getTargetSize}) => Completer<ui.Codec>().future,
+      );
+      final listener = ImageStreamListener((image, synchronousCall) {
+        image.dispose();
+      });
+
+      completer.addListener(listener);
+      await Future<void>.delayed(Duration.zero);
+
+      completer.removeListener(listener);
+      release.complete();
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(flutterErrors, isEmpty);
+      verifyNever(
+        () => cacheManager.cacheFileCancellable(any(), key: any(named: 'key')),
+      );
+      expect(
+        PaintingBinding.instance.imageCache.containsKey(provider),
+        isFalse,
+      );
+    });
+
+    test('does not decode or report when cancelled while an existing cache '
+        'entry resolves', () async {
+      const url = 'https://example.com/cancel-existing.png';
+      final cacheManager = _MockMediaCacheManager();
+      final imageFile = const LocalFileSystem().file(
+        '$testTempPath/cancel-existing.png',
+      )..writeAsBytesSync(Uint8List.fromList(_transparentPng));
+      final fileInfo = MockFileInfo();
+      when(() => fileInfo.file).thenReturn(imageFile);
+      final release = Completer<void>();
+      when(() => cacheManager.getFileFromCache(url)).thenAnswer((_) async {
+        await release.future;
+        return fileInfo;
+      });
+
+      final flutterErrors = <FlutterErrorDetails>[];
+      final previousOnError = FlutterError.onError;
+      FlutterError.onError = flutterErrors.add;
+      addTearDown(() => FlutterError.onError = previousOnError);
+
+      final provider = MediaCacheImageProvider(url, cacheManager: cacheManager);
+      var decodeCalled = false;
+      final completer = provider.loadImage(provider, (buffer, {getTargetSize}) {
+        decodeCalled = true;
+        return Completer<ui.Codec>().future;
+      });
+      final listener = ImageStreamListener((image, synchronousCall) {
+        image.dispose();
+      });
+
+      completer.addListener(listener);
+      await Future<void>.delayed(Duration.zero);
+
+      completer.removeListener(listener);
+      release.complete();
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(decodeCalled, isFalse);
+      expect(flutterErrors, isEmpty);
+      expect(
+        PaintingBinding.instance.imageCache.containsKey(provider),
+        isFalse,
+      );
+    });
+
+    test('still surfaces a genuine null-result download failure through '
+        'FlutterError when a listener without onError remains', () async {
+      const url = 'https://example.com/null-download.png';
+      final cacheManager = _MockMediaCacheManager();
+      final download = FakeCancellableDownload(
+        url: url,
+        targetFile: File('$testTempPath/null-download.png'),
+        headers: null,
+      );
+      final operation = CancellableCacheOperation.fromDownload(download);
+
+      when(
+        () => cacheManager.getFileFromCache(url),
+      ).thenAnswer((_) async => null);
+      when(
+        () => cacheManager.cacheFileCancellable(url, key: url),
+      ).thenReturn(operation);
+
+      final flutterErrors = <FlutterErrorDetails>[];
+      final previousOnError = FlutterError.onError;
+      FlutterError.onError = flutterErrors.add;
+      addTearDown(() => FlutterError.onError = previousOnError);
+
+      final provider = MediaCacheImageProvider(url, cacheManager: cacheManager);
+      final completer = provider.loadImage(
+        provider,
+        (buffer, {getTargetSize}) => Completer<ui.Codec>().future,
+      );
+      final listener = ImageStreamListener((image, synchronousCall) {
+        image.dispose();
+      });
+
+      completer.addListener(listener);
+      await Future<void>.delayed(Duration.zero);
+      download.completeNull();
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(flutterErrors, hasLength(1));
+      expect(flutterErrors.single.toString(), contains(url));
+
+      completer.removeListener(listener);
+    });
   });
 }


### PR DESCRIPTION
Closes #5783

## What

`MediaCacheImageProvider._loadAsync` threw `_ImageLoadCancelledException` whenever an image load was cancelled — the common case being the last stream listener getting removed while a download was still in flight (the user scrolled the thumbnail off-screen). By the time the cancelled operation resolved, `MultiFrameImageStreamCompleter` had **no listener left**, so it forwarded the error to `FlutterError.onError`, which this app routes to Crashlytics as a **fatal**.

The result: a completely benign, expected scroll-away was being recorded as a crash — and it was the **#1 iOS fatal by impacted users** on the current release.

## Crash

- Crashlytics issue `975327951e70a1acb98303a1285ca34b` (iOS)
- `FlutterError - MediaCacheImageProvider load cancelled`
- 54 events / 40 impacted users over 7 days, `firstSeenVersion 1.0.15`, `lastSeenVersion 1.0.16` (current)
- Sample events fire mid-scroll (`pooled_video_feed → search_results → profile_view`), one with `processState: BACKGROUND` — confirming benign cancellation, not a real decode failure.

## Fix

Distinguish the two paths that previously shared one exception:

- **Genuine cancellation** (`loadHandle.isCancelled`): evict the stale cache entry and return a future that never completes, so the load stops silently and nothing reaches `FlutterError.onError`.
- **Real null-result download failure** (`file == null` while *not* cancelled): unchanged — still thrown and surfaced to a present listener's `onError`, since a widget still cares about the result.

## Test

Adds a regression test that reproduces the exact fatal: add a listener, remove it while the download is in-flight (cancelling it), let the operation resolve, and assert the load reaches **neither** `FlutterError.onError` **nor** the image cache. Verified it fails on the pre-fix source (throws "EXCEPTION CAUGHT BY IMAGE RESOURCE SERVICE") and passes after. Full `media_cache` suite green (171 pass), `flutter analyze` clean.

Found and triaged by the hourly Crashlytics agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)