### PR TITLE
fix(feed): support desktop feed tuning swipes

### DIFF
--- a/mobile/lib/blocs/video_feed/video_feed_bloc.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_bloc.dart
@@ -110,7 +110,6 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
   final FeedPerformanceTracker? _feedTracker;
   final EnrichVideos? _enrichVideos;
   final FeedTuningRepository? _feedTuningRepository;
-  int _tuningActionSequence = 0;
 
   /// Owns the cross-restart cache serve / splice / resume-persist logic.
   final HomeFeedResumeManager _resumeManager;
@@ -182,13 +181,15 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
       video: target,
       direction: event.direction,
     );
+    final sequence = state.tuningActionSequence + 1;
 
     emit(
       state.copyWith(
+        tuningActionSequence: sequence,
         lastTuningAction: VideoFeedTuningAction(
           videoId: event.videoId,
           direction: event.direction,
-          sequence: ++_tuningActionSequence,
+          sequence: sequence,
           publishedEventId: publishedEventId,
         ),
       ),

--- a/mobile/lib/blocs/video_feed/video_feed_bloc.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_bloc.dart
@@ -9,6 +9,7 @@ import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:curated_list_repository/curated_list_repository.dart';
 import 'package:equatable/equatable.dart';
+import 'package:feed_tuning_repository/feed_tuning_repository.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:follow_repository/follow_repository.dart';
 import 'package:models/models.dart' hide LogCategory;
@@ -55,6 +56,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
     FeedPerformanceTracker? feedTracker,
     HomeFeedCache? homeFeedCache,
     EnrichVideos? enrichVideos,
+    FeedTuningRepository? feedTuningRepository,
   }) : _videosRepository = videosRepository,
        _followRepository = followRepository,
        _curatedListRepository = curatedListRepository,
@@ -66,6 +68,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
        _autoRefreshMinInterval = autoRefreshMinInterval,
        _feedTracker = feedTracker,
        _enrichVideos = enrichVideos,
+       _feedTuningRepository = feedTuningRepository,
        _resumeManager = HomeFeedResumeManager(
          cache: homeFeedCache ?? const HomeFeedCache(),
          videosRepository: videosRepository,
@@ -91,6 +94,8 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
     on<VideoFeedBlocklistChanged>(_onBlocklistChanged);
     on<VideoFeedActiveIndexChanged>(_onActiveIndexChanged);
     on<VideoFeedEnrichmentReady>(_onEnrichmentReady);
+    on<VideoFeedTuningSwipeCommitted>(_onTuningSwipeCommitted);
+    on<VideoFeedTuningUndoRequested>(_onTuningUndoRequested);
   }
 
   final VideosRepository _videosRepository;
@@ -104,6 +109,8 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
   final Duration _autoRefreshMinInterval;
   final FeedPerformanceTracker? _feedTracker;
   final EnrichVideos? _enrichVideos;
+  final FeedTuningRepository? _feedTuningRepository;
+  int _tuningActionSequence = 0;
 
   /// Owns the cross-restart cache serve / splice / resume-persist logic.
   final HomeFeedResumeManager _resumeManager;
@@ -152,6 +159,49 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
       // Subscribed-list rows are loaded from locally held event IDs and are
       // already resolved as full events rather than compact server feed rows.
       source.type != VideoFeedSourceType.subscribedList;
+
+  /// Publish a feed-tuning signal for the swiped home-feed video and record it
+  /// for the UI's Undo snackbar. Does not mutate the video list.
+  Future<void> _onTuningSwipeCommitted(
+    VideoFeedTuningSwipeCommitted event,
+    Emitter<VideoFeedBlocState> emit,
+  ) async {
+    final repository = _feedTuningRepository;
+    if (repository == null) return;
+
+    VideoEvent? target;
+    for (final video in state.videos) {
+      if (video.id == event.videoId) {
+        target = video;
+        break;
+      }
+    }
+    if (target == null) return;
+
+    final publishedEventId = await repository.tune(
+      video: target,
+      direction: event.direction,
+    );
+
+    emit(
+      state.copyWith(
+        lastTuningAction: VideoFeedTuningAction(
+          videoId: event.videoId,
+          direction: event.direction,
+          sequence: ++_tuningActionSequence,
+          publishedEventId: publishedEventId,
+        ),
+      ),
+    );
+  }
+
+  /// Retract a previously-published feed-tuning signal.
+  Future<void> _onTuningUndoRequested(
+    VideoFeedTuningUndoRequested event,
+    Emitter<VideoFeedBlocState> emit,
+  ) async {
+    await _feedTuningRepository?.undo(event.feedTuningEventId);
+  }
 
   /// Handle feed started event.
   ///

--- a/mobile/lib/blocs/video_feed/video_feed_event.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_event.dart
@@ -171,3 +171,32 @@ final class VideoFeedBlocklistChanged extends VideoFeedEvent {
   @override
   List<Object?> get props => [blockedPubkey];
 }
+
+/// Dispatched when the user commits a feed-tuning swipe on [videoId]
+/// ("more"/"less like this").
+final class VideoFeedTuningSwipeCommitted extends VideoFeedEvent {
+  const VideoFeedTuningSwipeCommitted({
+    required this.videoId,
+    required this.direction,
+  });
+
+  /// Event ID of the swiped video.
+  final String videoId;
+
+  /// Swipe direction — more or less like this.
+  final FeedTuningDirection direction;
+
+  @override
+  List<Object?> get props => [videoId, direction];
+}
+
+/// Dispatched when the user taps Undo on a just-published tuning signal.
+final class VideoFeedTuningUndoRequested extends VideoFeedEvent {
+  const VideoFeedTuningUndoRequested(this.feedTuningEventId);
+
+  /// Event ID of the feed-tuning event to retract.
+  final String feedTuningEventId;
+
+  @override
+  List<Object?> get props => [feedTuningEventId];
+}

--- a/mobile/lib/blocs/video_feed/video_feed_state.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_state.dart
@@ -137,6 +137,33 @@ enum VideoFeedError {
   noFollowedUsers,
 }
 
+/// A just-committed home-feed tuning swipe, surfaced for the UI's Undo
+/// snackbar.
+final class VideoFeedTuningAction extends Equatable {
+  const VideoFeedTuningAction({
+    required this.videoId,
+    required this.direction,
+    required this.sequence,
+    this.publishedEventId,
+  });
+
+  /// Event ID of the swiped video.
+  final String videoId;
+
+  /// The direction that was published.
+  final FeedTuningDirection direction;
+
+  /// Monotonic action id so identical consecutive swipes still notify
+  /// listeners.
+  final int sequence;
+
+  /// Published feed-tuning event id, or `null` when nothing was published.
+  final String? publishedEventId;
+
+  @override
+  List<Object?> get props => [videoId, direction, sequence, publishedEventId];
+}
+
 /// State for the VideoFeedBloc.
 ///
 /// Contains:
@@ -162,6 +189,7 @@ final class VideoFeedBlocState extends Equatable {
     this.paginationCursor,
     this.currentIndex = 0,
     this.enrichmentRevision = 0,
+    this.lastTuningAction,
   }) : source =
            source ??
            (mode == FeedMode.following
@@ -229,6 +257,10 @@ final class VideoFeedBlocState extends Equatable {
   /// BLoC can suppress an otherwise valid state emission.
   final int enrichmentRevision;
 
+  /// The most recently committed feed-tuning swipe, for the UI's Undo
+  /// snackbar. `null` until the user tunes a video.
+  final VideoFeedTuningAction? lastTuningAction;
+
   /// Whether data has been successfully loaded.
   bool get isLoaded => status == VideoFeedStatus.success;
 
@@ -266,6 +298,7 @@ final class VideoFeedBlocState extends Equatable {
     bool clearPaginationCursor = false,
     int? currentIndex,
     int? enrichmentRevision,
+    VideoFeedTuningAction? lastTuningAction,
   }) {
     return VideoFeedBlocState(
       status: status ?? this.status,
@@ -285,6 +318,7 @@ final class VideoFeedBlocState extends Equatable {
           : (paginationCursor ?? this.paginationCursor),
       currentIndex: currentIndex ?? this.currentIndex,
       enrichmentRevision: enrichmentRevision ?? this.enrichmentRevision,
+      lastTuningAction: lastTuningAction ?? this.lastTuningAction,
     );
   }
 
@@ -303,5 +337,6 @@ final class VideoFeedBlocState extends Equatable {
     paginationCursor,
     currentIndex,
     enrichmentRevision,
+    lastTuningAction,
   ];
 }

--- a/mobile/lib/blocs/video_feed/video_feed_state.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_state.dart
@@ -189,6 +189,7 @@ final class VideoFeedBlocState extends Equatable {
     this.paginationCursor,
     this.currentIndex = 0,
     this.enrichmentRevision = 0,
+    this.tuningActionSequence = 0,
     this.lastTuningAction,
   }) : source =
            source ??
@@ -261,6 +262,12 @@ final class VideoFeedBlocState extends Equatable {
   /// snackbar. `null` until the user tunes a video.
   final VideoFeedTuningAction? lastTuningAction;
 
+  /// Monotonic counter for feed-tuning actions.
+  ///
+  /// Kept in state so every BLoC mutation remains observable through the state
+  /// stream while still letting identical consecutive swipes notify listeners.
+  final int tuningActionSequence;
+
   /// Whether data has been successfully loaded.
   bool get isLoaded => status == VideoFeedStatus.success;
 
@@ -298,6 +305,7 @@ final class VideoFeedBlocState extends Equatable {
     bool clearPaginationCursor = false,
     int? currentIndex,
     int? enrichmentRevision,
+    int? tuningActionSequence,
     VideoFeedTuningAction? lastTuningAction,
   }) {
     return VideoFeedBlocState(
@@ -318,6 +326,7 @@ final class VideoFeedBlocState extends Equatable {
           : (paginationCursor ?? this.paginationCursor),
       currentIndex: currentIndex ?? this.currentIndex,
       enrichmentRevision: enrichmentRevision ?? this.enrichmentRevision,
+      tuningActionSequence: tuningActionSequence ?? this.tuningActionSequence,
       lastTuningAction: lastTuningAction ?? this.lastTuningAction,
     );
   }
@@ -337,6 +346,7 @@ final class VideoFeedBlocState extends Equatable {
     paginationCursor,
     currentIndex,
     enrichmentRevision,
+    tuningActionSequence,
     lastTuningAction,
   ];
 }

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -152,6 +152,7 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
   late int _currentIndex;
 
   final _feedVideosKey = GlobalKey<FeedVideosState>();
+  int? _pendingTuningAutoAdvanceIndex;
 
   /// Feed-scoped Auto playback state. Owned by this state so tests can drive
   /// the screen without also wiring the cubit externally; exposed to children
@@ -223,6 +224,7 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
 
     final nextIndex = _currentIndex + 1;
     if (nextIndex < videos.length) {
+      _pendingTuningAutoAdvanceIndex = nextIndex;
       _animateToPage(nextIndex);
     }
   }
@@ -468,7 +470,12 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
                           isLoadingMore: state.isLoadingMore,
                           trafficSource: ViewTrafficSource.home,
                           onActiveVideoChanged: (video, index) {
-                            _dismissTuningSnackbar();
+                            final isTuningAutoAdvance =
+                                _pendingTuningAutoAdvanceIndex == index;
+                            _pendingTuningAutoAdvanceIndex = null;
+                            if (!isTuningAutoAdvance) {
+                              _dismissTuningSnackbar();
+                            }
                             ref
                                 .read(foregroundFeedActivityGateProvider)
                                 .markActive();

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -2,11 +2,15 @@ import 'dart:async';
 
 import 'package:analytics/analytics.dart';
 import 'package:divine_ui/divine_ui.dart';
+import 'package:feed_tuning_repository/feed_tuning_repository.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/blocs/video_feed/video_feed_bloc.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
+import 'package:openvine/features/feature_flags/models/feature_flag.dart';
+import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
+import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/foreground_idle_warmup_provider.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
@@ -24,6 +28,7 @@ import 'package:openvine/services/view_event_publisher.dart'
     show ViewTrafficSource;
 import 'package:openvine/utils/video_nostr_enrichment.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
+import 'package:openvine/widgets/feed_tuning/feed_tuning_swipe_overlay.dart';
 import 'package:openvine/widgets/nav_rounded_shell.dart';
 import 'package:openvine/widgets/video_feed_item/feed_videos.dart';
 
@@ -67,6 +72,7 @@ class VideoFeedPage extends ConsumerWidget {
         .showDivineHostedOnly;
 
     final blocklistRepository = ref.watch(contentBlocklistRepositoryProvider);
+    final feedTuningRepository = ref.watch(feedTuningRepositoryProvider);
     final enrichmentAttemptTracker = NostrTagEnrichmentAttemptTracker();
 
     return MultiBlocProvider(
@@ -86,6 +92,7 @@ class VideoFeedPage extends ConsumerWidget {
             // on read and the splice-on-refresh keeps the post-active tail
             // fresh, so the cached serve is never stale to the viewer.
             feedTracker: FeedPerformanceTracker(),
+            feedTuningRepository: feedTuningRepository,
             enrichVideos: (videos) => enrichVideosWithNostrTags(
               videos,
               nostrService: ref.read(nostrServiceProvider),
@@ -144,6 +151,8 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
   /// Tracks the active Home video without forcing route updates while swiping.
   late int _currentIndex;
 
+  final _feedVideosKey = GlobalKey<FeedVideosState>();
+
   /// Feed-scoped Auto playback state. Owned by this state so tests can drive
   /// the screen without also wiring the cubit externally; exposed to children
   /// via `BlocProvider.value` in [build] so the rail control and feed items
@@ -192,6 +201,69 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
   }
 
   void _resumeAutoAdvanceAfterSwipe() => _autoAdvanceCubit.resumeAfterSwipe();
+
+  void _animateToPage(int index) {
+    final feedVideosState = _feedVideosKey.currentState;
+    if (feedVideosState != null) {
+      unawaited(feedVideosState.animateToPage(index));
+    }
+  }
+
+  /// Publish a feed-tuning signal for the active home-feed video and page
+  /// forward.
+  void _onTuned(FeedTuningDirection direction) {
+    final bloc = context.read<VideoFeedBloc>();
+    final videos = bloc.state.videos;
+    if (_currentIndex < 0 || _currentIndex >= videos.length) return;
+    final video = videos[_currentIndex];
+
+    bloc.add(
+      VideoFeedTuningSwipeCommitted(videoId: video.id, direction: direction),
+    );
+
+    final nextIndex = _currentIndex + 1;
+    if (nextIndex < videos.length) {
+      _animateToPage(nextIndex);
+    }
+  }
+
+  void _showTuningSnackbar(VideoFeedTuningAction action) {
+    final l10n = context.l10n;
+    final label = action.direction == FeedTuningDirection.more
+        ? l10n.feedTuningMoreLabel
+        : l10n.feedTuningLessLabel;
+    final eventId = action.publishedEventId;
+    ScaffoldMessenger.of(context)
+      ..clearSnackBars()
+      ..showSnackBar(
+        SnackBar(
+          behavior: SnackBarBehavior.floating,
+          content: Text(label),
+          action: eventId == null
+              ? null
+              : SnackBarAction(
+                  label: l10n.feedTuningUndo,
+                  onPressed: () => _undoTuning(eventId, action.videoId),
+                ),
+        ),
+      );
+  }
+
+  void _dismissTuningSnackbar() {
+    ScaffoldMessenger.maybeOf(context)?.removeCurrentSnackBar();
+  }
+
+  void _undoTuning(String feedTuningEventId, String videoId) {
+    final bloc = context.read<VideoFeedBloc>()
+      ..add(VideoFeedTuningUndoRequested(feedTuningEventId));
+    final videos = bloc.state.videos;
+    for (var i = 0; i < videos.length; i++) {
+      if (videos[i].id == videoId) {
+        _animateToPage(i);
+        return;
+      }
+    }
+  }
 
   /// Recomputes whether the home feed should be playing and updates
   /// [_isNewFeedActive] if it changed. The feed is active only when the home
@@ -250,6 +322,9 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
     final shouldRetainPlayer = ref
         .watch(overlayVisibilityProvider)
         .shouldRetainPlayer;
+    final feedTuningEnabled = ref.watch(
+      isFeatureEnabledProvider(FeatureFlag.feedTuning),
+    );
 
     return BlocProvider.value(
       value: _autoAdvanceCubit,
@@ -292,6 +367,15 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
                   _hasMarkedUIReady = true;
                   StartupPerformanceService.instance.markUIReady();
                 }
+              },
+            ),
+            BlocListener<VideoFeedBloc, VideoFeedBlocState>(
+              listenWhen: (previous, current) =>
+                  previous.lastTuningAction != current.lastTuningAction &&
+                  current.lastTuningAction != null,
+              listener: (context, state) {
+                final action = state.lastTuningAction;
+                if (action != null) _showTuningSnackbar(action);
               },
             ),
           ],
@@ -363,49 +447,56 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
                 child: _KeyboardStableBottomInset(
                   child: Stack(
                     children: [
-                      FeedVideos(
-                        videos: state.videos,
-                        contextTitle: state.feedContextTitle,
-                        currentIndex: clampedIndex,
-                        isActive: _isNewFeedActive,
-                        // The home feed stays mounted across tab switches and
-                        // pushed routes (StatefulShellRoute keep-alive), so
-                        // release the off-screen neighbour players and pause
-                        // disk prefetch while it is backgrounded. Bottom sheets
-                        // (comments/share) only pause the current player — they
-                        // keep neighbours and prefetch warm via
-                        // shouldRetainPlayer.
-                        releaseNeighboursWhenInactive: !shouldRetainPlayer,
-                        hasMore: state.hasMore,
-                        isLoadingMore: state.isLoadingMore,
-                        trafficSource: ViewTrafficSource.home,
-                        onActiveVideoChanged: (video, index) {
-                          ref
-                              .read(foregroundFeedActivityGateProvider)
-                              .markActive();
-                          _currentIndex = index;
-                          context.read<VideoFeedBloc>().add(
-                            VideoFeedActiveIndexChanged(index),
-                          );
-                          ref
-                              .read(lastTabPositionProvider.notifier)
-                              .recordPosition(RouteType.home, index);
-                          _resumeAutoAdvanceAfterSwipe();
-                          FeedPerformanceTracker().startVideoSwipeTracking(
-                            video.id,
-                          );
-                          if (!_hasMarkedVideoReady && index == 0) {
-                            _hasMarkedVideoReady = true;
-                            StartupPerformanceService.instance.markVideoReady();
-                          }
-                        },
-                        onNearEnd: () {
-                          if (state.hasMore) {
+                      FeedTuningSwipeGate(
+                        enabled: feedTuningEnabled,
+                        onTuned: _onTuned,
+                        child: FeedVideos(
+                          key: _feedVideosKey,
+                          videos: state.videos,
+                          contextTitle: state.feedContextTitle,
+                          currentIndex: clampedIndex,
+                          isActive: _isNewFeedActive,
+                          // The home feed stays mounted across tab switches and
+                          // pushed routes (StatefulShellRoute keep-alive), so
+                          // release the off-screen neighbour players and pause
+                          // disk prefetch while it is backgrounded. Bottom sheets
+                          // (comments/share) only pause the current player — they
+                          // keep neighbours and prefetch warm via
+                          // shouldRetainPlayer.
+                          releaseNeighboursWhenInactive: !shouldRetainPlayer,
+                          hasMore: state.hasMore,
+                          isLoadingMore: state.isLoadingMore,
+                          trafficSource: ViewTrafficSource.home,
+                          onActiveVideoChanged: (video, index) {
+                            _dismissTuningSnackbar();
+                            ref
+                                .read(foregroundFeedActivityGateProvider)
+                                .markActive();
+                            _currentIndex = index;
                             context.read<VideoFeedBloc>().add(
-                              const VideoFeedLoadMoreRequested(),
+                              VideoFeedActiveIndexChanged(index),
                             );
-                          }
-                        },
+                            ref
+                                .read(lastTabPositionProvider.notifier)
+                                .recordPosition(RouteType.home, index);
+                            _resumeAutoAdvanceAfterSwipe();
+                            FeedPerformanceTracker().startVideoSwipeTracking(
+                              video.id,
+                            );
+                            if (!_hasMarkedVideoReady && index == 0) {
+                              _hasMarkedVideoReady = true;
+                              StartupPerformanceService.instance
+                                  .markVideoReady();
+                            }
+                          },
+                          onNearEnd: () {
+                            if (state.hasMore) {
+                              context.read<VideoFeedBloc>().add(
+                                const VideoFeedLoadMoreRequested(),
+                              );
+                            }
+                          },
+                        ),
                       ),
                       const FeedModeSwitch(),
                     ],

--- a/mobile/lib/widgets/feed_tuning/feed_tuning_swipe_overlay.dart
+++ b/mobile/lib/widgets/feed_tuning/feed_tuning_swipe_overlay.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
+
 import 'package:divine_ui/divine_ui.dart';
 import 'package:feed_tuning_repository/feed_tuning_repository.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
 import 'package:flutter/services.dart';
@@ -39,6 +42,10 @@ class FeedTuningSwipeOverlay extends StatefulWidget {
 class _FeedTuningSwipeOverlayState extends State<FeedTuningSwipeOverlay> {
   double _dragExtent = 0;
   bool _passedThreshold = false;
+  Timer? _pointerSignalResetTimer;
+  int? _activeDragPointer;
+  Offset _dragOffset = Offset.zero;
+  _DragIntent _dragIntent = _DragIntent.undecided;
 
   double get _progress =>
       (_dragExtent.abs() / widget.commitThreshold).clamp(0.0, 1.0);
@@ -50,8 +57,8 @@ class _FeedTuningSwipeOverlayState extends State<FeedTuningSwipeOverlay> {
         : FeedTuningDirection.less;
   }
 
-  void _onUpdate(DragUpdateDetails details) {
-    setState(() => _dragExtent += details.delta.dx);
+  void _applyHorizontalDelta(double delta) {
+    setState(() => _dragExtent += delta);
     final passed = _dragExtent.abs() >= widget.commitThreshold;
     if (passed && !_passedThreshold) {
       HapticFeedback.selectionClick();
@@ -59,18 +66,122 @@ class _FeedTuningSwipeOverlayState extends State<FeedTuningSwipeOverlay> {
     _passedThreshold = passed;
   }
 
-  void _onEnd(DragEndDetails details) {
+  void _onPointerDown(PointerDownEvent event) {
+    if (_activeDragPointer != null) return;
+    _activeDragPointer = event.pointer;
+    _dragOffset = Offset.zero;
+    _dragIntent = _DragIntent.undecided;
+  }
+
+  void _onPointerMove(PointerMoveEvent event) {
+    if (event.pointer != _activeDragPointer) return;
+    _onDragDelta(event.delta);
+  }
+
+  void _onPointerUp(PointerUpEvent event) {
+    if (event.pointer != _activeDragPointer) return;
+    _onDragEnd();
+  }
+
+  void _onPointerCancel(PointerCancelEvent event) {
+    if (event.pointer != _activeDragPointer) return;
+    _reset();
+  }
+
+  void _onPointerPanZoomStart(PointerPanZoomStartEvent event) {
+    if (_activeDragPointer != null) return;
+    _activeDragPointer = event.pointer;
+    _dragOffset = Offset.zero;
+    _dragIntent = _DragIntent.undecided;
+  }
+
+  void _onPointerPanZoomUpdate(PointerPanZoomUpdateEvent event) {
+    if (event.pointer != _activeDragPointer) return;
+    _onDragDelta(event.panDelta);
+  }
+
+  void _onPointerPanZoomEnd(PointerPanZoomEndEvent event) {
+    if (event.pointer != _activeDragPointer) return;
+    _onDragEnd();
+  }
+
+  void _onDragDelta(Offset delta) {
+    _dragOffset += delta;
+    final absDx = _dragOffset.dx.abs();
+    final absDy = _dragOffset.dy.abs();
+
+    if (_dragIntent == _DragIntent.vertical) return;
+
+    if (_dragIntent == _DragIntent.undecided) {
+      if (absDx < kTouchSlop && absDy < kTouchSlop) return;
+      if (absDy > absDx) {
+        _dragIntent = _DragIntent.vertical;
+        return;
+      }
+      _dragIntent = _DragIntent.horizontal;
+      _applyHorizontalDelta(_dragOffset.dx);
+      return;
+    }
+
+    if (!_passedThreshold && absDy > absDx * 1.2) {
+      _dragIntent = _DragIntent.vertical;
+      _resetVisualState();
+      return;
+    }
+
+    _applyHorizontalDelta(delta.dx);
+  }
+
+  void _onDragEnd() {
     final direction = _direction;
-    final committed = _passedThreshold && direction != null;
+    final committed =
+        _dragIntent == _DragIntent.horizontal &&
+        _passedThreshold &&
+        direction != null;
     _reset();
     if (committed) widget.onTuned(direction);
   }
 
+  void _onPointerSignal(PointerSignalEvent event) {
+    if (event is! PointerScrollEvent) return;
+    final scrollDelta = event.scrollDelta;
+    if (scrollDelta.dx.abs() <= scrollDelta.dy.abs()) return;
+
+    _pointerSignalResetTimer?.cancel();
+    // Pointer scroll deltas are scroll offsets, not finger movement. Negating
+    // preserves the same left/right meaning as touch and mouse drags.
+    _applyHorizontalDelta(-scrollDelta.dx);
+
+    final direction = _direction;
+    if (_passedThreshold && direction != null) {
+      _reset();
+      widget.onTuned(direction);
+      return;
+    }
+
+    _pointerSignalResetTimer = Timer(const Duration(milliseconds: 140), _reset);
+  }
+
   void _reset() {
+    _pointerSignalResetTimer?.cancel();
+    _pointerSignalResetTimer = null;
+    _activeDragPointer = null;
+    _dragOffset = Offset.zero;
+    _dragIntent = _DragIntent.undecided;
+    _resetVisualState();
+  }
+
+  void _resetVisualState() {
     setState(() {
       _dragExtent = 0;
       _passedThreshold = false;
     });
+  }
+
+  @override
+  void dispose() {
+    _pointerSignalResetTimer?.cancel();
+    super.dispose();
   }
 
   @override
@@ -85,11 +196,16 @@ class _FeedTuningSwipeOverlayState extends State<FeedTuningSwipeOverlay> {
         CustomSemanticsAction(label: l10n.feedTuningLessLabel): () =>
             widget.onTuned(FeedTuningDirection.less),
       },
-      child: GestureDetector(
+      child: Listener(
         behavior: HitTestBehavior.translucent,
-        onHorizontalDragUpdate: _onUpdate,
-        onHorizontalDragEnd: _onEnd,
-        onHorizontalDragCancel: _reset,
+        onPointerDown: _onPointerDown,
+        onPointerMove: _onPointerMove,
+        onPointerUp: _onPointerUp,
+        onPointerCancel: _onPointerCancel,
+        onPointerPanZoomStart: _onPointerPanZoomStart,
+        onPointerPanZoomUpdate: _onPointerPanZoomUpdate,
+        onPointerPanZoomEnd: _onPointerPanZoomEnd,
+        onPointerSignal: _onPointerSignal,
         child: Stack(
           fit: StackFit.passthrough,
           children: [
@@ -112,6 +228,8 @@ class _FeedTuningSwipeOverlayState extends State<FeedTuningSwipeOverlay> {
     );
   }
 }
+
+enum _DragIntent { undecided, horizontal, vertical }
 
 /// Gates [FeedTuningSwipeOverlay] behind a feature flag.
 ///

--- a/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
+++ b/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
@@ -9,6 +9,7 @@ import 'package:analytics/analytics.dart';
 import 'package:bloc_test/bloc_test.dart';
 import 'package:cache_sync/cache_sync.dart';
 import 'package:curated_list_repository/curated_list_repository.dart';
+import 'package:feed_tuning_repository/feed_tuning_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:follow_repository/follow_repository.dart';
 import 'package:mocktail/mocktail.dart';
@@ -34,6 +35,8 @@ class _MockFeedPerformanceTracker extends Mock
 class _MockProfileRepository extends Mock implements ProfileRepository {}
 
 class _MockHomeFeedCache extends Mock implements HomeFeedCache {}
+
+class _MockFeedTuningRepository extends Mock implements FeedTuningRepository {}
 
 /// No-op cache DAO so the bloc tests never touch the shared on-disk
 /// [CacheSync] database. Under CI's parallel test isolates the
@@ -114,10 +117,13 @@ void main() {
       curatedListsController.close();
     });
 
-    VideoFeedBloc createBloc() => VideoFeedBloc(
+    VideoFeedBloc createBloc({
+      FeedTuningRepository? feedTuningRepository,
+    }) => VideoFeedBloc(
       videosRepository: mockVideosRepository,
       followRepository: mockFollowRepository,
       curatedListRepository: mockCuratedListRepository,
+      feedTuningRepository: feedTuningRepository,
     );
 
     VideoEvent createTestVideo(
@@ -185,6 +191,82 @@ void main() {
       expect(bloc.state.isLoadingMore, isFalse);
       expect(bloc.state.error, isNull);
       bloc.close();
+    });
+
+    group('feed tuning', () {
+      late _MockFeedTuningRepository tuningRepository;
+      late VideoEvent tunedVideo;
+
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
+        'publishes a tuning signal for the target video',
+        setUp: () {
+          tuningRepository = _MockFeedTuningRepository();
+          tunedVideo = createTestVideo('tuned-video');
+          when(
+            () => tuningRepository.tune(
+              video: tunedVideo,
+              direction: FeedTuningDirection.more,
+            ),
+          ).thenAnswer((_) async => 'published-tuning-event-id');
+        },
+        build: () => createBloc(feedTuningRepository: tuningRepository),
+        seed: () => VideoFeedBlocState(
+          status: VideoFeedStatus.success,
+          videos: [tunedVideo],
+        ),
+        act: (bloc) => bloc.add(
+          const VideoFeedTuningSwipeCommitted(
+            videoId: 'tuned-video',
+            direction: FeedTuningDirection.more,
+          ),
+        ),
+        expect: () => [
+          isA<VideoFeedBlocState>().having(
+            (state) => state.lastTuningAction,
+            'lastTuningAction',
+            isA<VideoFeedTuningAction>()
+                .having((action) => action.videoId, 'videoId', 'tuned-video')
+                .having(
+                  (action) => action.direction,
+                  'direction',
+                  FeedTuningDirection.more,
+                )
+                .having(
+                  (action) => action.publishedEventId,
+                  'publishedEventId',
+                  'published-tuning-event-id',
+                ),
+          ),
+        ],
+        verify: (_) {
+          verify(
+            () => tuningRepository.tune(
+              video: tunedVideo,
+              direction: FeedTuningDirection.more,
+            ),
+          ).called(1);
+        },
+      );
+
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
+        'undo retracts a published tuning signal',
+        setUp: () {
+          tuningRepository = _MockFeedTuningRepository();
+          when(
+            () => tuningRepository.undo('published-tuning-event-id'),
+          ).thenAnswer((_) async {});
+        },
+        build: () => createBloc(feedTuningRepository: tuningRepository),
+        act: (bloc) => bloc.add(
+          const VideoFeedTuningUndoRequested('published-tuning-event-id'),
+        ),
+        expect: () => <VideoFeedBlocState>[],
+        verify: (_) {
+          verify(
+            () => tuningRepository.undo('published-tuning-event-id'),
+          ).called(1);
+        },
+      );
     });
 
     group('VideoFeedBlocState', () {

--- a/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
+++ b/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
@@ -221,22 +221,29 @@ void main() {
           ),
         ),
         expect: () => [
-          isA<VideoFeedBlocState>().having(
-            (state) => state.lastTuningAction,
-            'lastTuningAction',
-            isA<VideoFeedTuningAction>()
-                .having((action) => action.videoId, 'videoId', 'tuned-video')
-                .having(
-                  (action) => action.direction,
-                  'direction',
-                  FeedTuningDirection.more,
-                )
-                .having(
-                  (action) => action.publishedEventId,
-                  'publishedEventId',
-                  'published-tuning-event-id',
-                ),
-          ),
+          isA<VideoFeedBlocState>()
+              .having((state) => state.tuningActionSequence, 'sequence', 1)
+              .having(
+                (state) => state.lastTuningAction,
+                'lastTuningAction',
+                isA<VideoFeedTuningAction>()
+                    .having(
+                      (action) => action.videoId,
+                      'videoId',
+                      'tuned-video',
+                    )
+                    .having(
+                      (action) => action.direction,
+                      'direction',
+                      FeedTuningDirection.more,
+                    )
+                    .having((action) => action.sequence, 'sequence', 1)
+                    .having(
+                      (action) => action.publishedEventId,
+                      'publishedEventId',
+                      'published-tuning-event-id',
+                    ),
+              ),
         ],
         verify: (_) {
           verify(

--- a/mobile/test/screens/feed/video_feed_page_test.dart
+++ b/mobile/test/screens/feed/video_feed_page_test.dart
@@ -456,6 +456,92 @@ void main() {
       await tester.pump();
     });
 
+    testWidgets(
+      'keeps the tuning receipt after the tuning-driven auto-advance',
+      (tester) async {
+        final videos = [
+          createTestVideoEvent(id: 'video-0'),
+          createTestVideoEvent(id: 'video-1'),
+        ];
+        final initialState = VideoFeedBlocState(
+          status: VideoFeedStatus.success,
+          videos: videos,
+        );
+        final tunedState = initialState.copyWith(
+          tuningActionSequence: 1,
+          lastTuningAction: VideoFeedTuningAction(
+            videoId: videos.first.id,
+            direction: FeedTuningDirection.more,
+            sequence: 1,
+            publishedEventId: 'published-tuning-event-id',
+          ),
+        );
+        final controller = StreamController<VideoFeedBlocState>();
+        addTearDown(controller.close);
+        when(() => videoFeedBloc.state).thenReturn(initialState);
+        whenListen(
+          videoFeedBloc,
+          controller.stream,
+          initialState: initialState,
+        );
+
+        await tester.pumpWidget(
+          testMaterialApp(
+            additionalOverrides: [
+              isFeatureEnabledProvider(
+                FeatureFlag.feedTuning,
+              ).overrideWith((_) => true),
+            ],
+            home: MultiBlocProvider(
+              providers: [
+                BlocProvider<VideoFeedBloc>.value(value: videoFeedBloc),
+                BlocProvider<VideoPlaybackStatusCubit>(
+                  create: (_) => VideoPlaybackStatusCubit(),
+                ),
+                BlocProvider<VideoVolumeCubit>.value(value: videoVolumeCubit),
+              ],
+              child: const Scaffold(body: VideoFeedView()),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        await tester.drag(
+          find.byType(FeedTuningSwipeOverlay),
+          const Offset(200, 0),
+        );
+        await tester.pump();
+
+        verify(
+          () => videoFeedBloc.add(
+            VideoFeedTuningSwipeCommitted(
+              videoId: videos.first.id,
+              direction: FeedTuningDirection.more,
+            ),
+          ),
+        ).called(1);
+
+        final feedVideos = tester.widget<FeedVideos>(find.byType(FeedVideos));
+        feedVideos.onActiveVideoChanged!(videos[1], 1);
+        await tester.pump();
+
+        when(() => videoFeedBloc.state).thenReturn(tunedState);
+        controller.add(tunedState);
+        await tester.pump();
+
+        expect(find.text('More like this'), findsOneWidget);
+
+        feedVideos.onActiveVideoChanged!(videos[1], 1);
+        await tester.pump();
+
+        expect(find.text('More like this'), findsNothing);
+
+        await tester.pump(const Duration(seconds: 3));
+        await tester.pumpWidget(const SizedBox());
+        await tester.pump();
+      },
+    );
+
     testWidgets('requests auto-refresh when app returns from background', (
       tester,
     ) async {

--- a/mobile/test/screens/feed/video_feed_page_test.dart
+++ b/mobile/test/screens/feed/video_feed_page_test.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:bloc_test/bloc_test.dart';
 import 'package:divine_ui/divine_ui.dart';
+import 'package:feed_tuning_repository/feed_tuning_repository.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -16,6 +17,8 @@ import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/video_feed/video_feed_bloc.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
 import 'package:openvine/blocs/video_volume/video_volume_cubit.dart';
+import 'package:openvine/features/feature_flags/models/feature_flag.dart';
+import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/overlay_visibility_provider.dart';
 import 'package:openvine/providers/route_feed_providers.dart';
@@ -25,6 +28,7 @@ import 'package:openvine/screens/explore/explore_screen.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
 import 'package:openvine/screens/feed/video_feed_page/feed_empty_widget.dart';
 import 'package:openvine/services/view_event_publisher.dart';
+import 'package:openvine/widgets/feed_tuning/feed_tuning_swipe_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/feed_videos.dart';
 
 import '../../helpers/test_provider_overrides.dart';
@@ -332,6 +336,125 @@ void main() {
         await tester.pump();
       },
     );
+
+    testWidgets('wraps the home feed with tuning swipes when enabled', (
+      tester,
+    ) async {
+      final video = createTestVideoEvent();
+      final state = VideoFeedBlocState(
+        status: VideoFeedStatus.success,
+        videos: [video],
+      );
+      when(() => videoFeedBloc.state).thenReturn(state);
+      whenListen(
+        videoFeedBloc,
+        const Stream<VideoFeedBlocState>.empty(),
+        initialState: state,
+      );
+
+      await tester.pumpWidget(
+        testMaterialApp(
+          additionalOverrides: [
+            isFeatureEnabledProvider(
+              FeatureFlag.feedTuning,
+            ).overrideWith((_) => true),
+          ],
+          home: MultiBlocProvider(
+            providers: [
+              BlocProvider<VideoFeedBloc>.value(value: videoFeedBloc),
+              BlocProvider<VideoPlaybackStatusCubit>(
+                create: (_) => VideoPlaybackStatusCubit(),
+              ),
+              BlocProvider<VideoVolumeCubit>.value(value: videoVolumeCubit),
+            ],
+            child: const VideoFeedView(),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byType(FeedTuningSwipeOverlay), findsOneWidget);
+
+      await tester.drag(
+        find.byType(FeedTuningSwipeOverlay),
+        const Offset(200, 0),
+      );
+      await tester.pump();
+
+      verify(
+        () => videoFeedBloc.add(
+          VideoFeedTuningSwipeCommitted(
+            videoId: video.id,
+            direction: FeedTuningDirection.more,
+          ),
+        ),
+      ).called(1);
+
+      await tester.pump(const Duration(seconds: 3));
+      await tester.pumpWidget(const SizedBox());
+      await tester.pump();
+    });
+
+    testWidgets('dismisses the tuning receipt when the feed page changes', (
+      tester,
+    ) async {
+      final videos = [
+        createTestVideoEvent(id: 'video-0'),
+        createTestVideoEvent(id: 'video-1'),
+      ];
+      final initialState = VideoFeedBlocState(
+        status: VideoFeedStatus.success,
+        videos: videos,
+      );
+      final tunedState = initialState.copyWith(
+        lastTuningAction: VideoFeedTuningAction(
+          videoId: videos.first.id,
+          direction: FeedTuningDirection.less,
+          sequence: 1,
+          publishedEventId: 'published-tuning-event-id',
+        ),
+      );
+      final controller = StreamController<VideoFeedBlocState>();
+      addTearDown(controller.close);
+      when(() => videoFeedBloc.state).thenReturn(initialState);
+      whenListen(
+        videoFeedBloc,
+        controller.stream,
+        initialState: initialState,
+      );
+
+      await tester.pumpWidget(
+        testMaterialApp(
+          home: MultiBlocProvider(
+            providers: [
+              BlocProvider<VideoFeedBloc>.value(value: videoFeedBloc),
+              BlocProvider<VideoPlaybackStatusCubit>(
+                create: (_) => VideoPlaybackStatusCubit(),
+              ),
+              BlocProvider<VideoVolumeCubit>.value(value: videoVolumeCubit),
+            ],
+            child: const Scaffold(body: VideoFeedView()),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      when(() => videoFeedBloc.state).thenReturn(tunedState);
+      controller.add(tunedState);
+      await tester.pump();
+
+      expect(find.text('Less like this'), findsOneWidget);
+
+      final feedVideos = tester.widget<FeedVideos>(find.byType(FeedVideos));
+      feedVideos.onActiveVideoChanged!(videos[1], 1);
+      await tester.pump();
+
+      expect(find.text('Less like this'), findsNothing);
+
+      await tester.pump(const Duration(seconds: 3));
+      await tester.pumpWidget(const SizedBox());
+      await tester.pump();
+    });
 
     testWidgets('requests auto-refresh when app returns from background', (
       tester,

--- a/mobile/test/widgets/feed_tuning/feed_tuning_swipe_overlay_test.dart
+++ b/mobile/test/widgets/feed_tuning/feed_tuning_swipe_overlay_test.dart
@@ -1,4 +1,5 @@
 import 'package:feed_tuning_repository/feed_tuning_repository.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -66,6 +67,66 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(tuned, isEmpty);
+    });
+
+    testWidgets('trackpad swipe right past the threshold tunes "more"', (
+      tester,
+    ) async {
+      final tuned = await pumpOverlay(tester);
+      final pointer = TestPointer(1, PointerDeviceKind.trackpad);
+      await tester.sendEventToBinding(
+        pointer.hover(tester.getCenter(find.byType(FeedTuningSwipeOverlay))),
+      );
+
+      await tester.sendEventToBinding(pointer.scroll(const Offset(-200, 0)));
+      await tester.pumpAndSettle();
+
+      expect(tuned, [FeedTuningDirection.more]);
+    });
+
+    testWidgets('trackpad swipe left past the threshold tunes "less"', (
+      tester,
+    ) async {
+      final tuned = await pumpOverlay(tester);
+      final pointer = TestPointer(1, PointerDeviceKind.trackpad);
+      await tester.sendEventToBinding(
+        pointer.hover(tester.getCenter(find.byType(FeedTuningSwipeOverlay))),
+      );
+
+      await tester.sendEventToBinding(pointer.scroll(const Offset(200, 0)));
+      await tester.pumpAndSettle();
+
+      expect(tuned, [FeedTuningDirection.less]);
+    });
+
+    testWidgets('trackpad pan right past the threshold tunes "more"', (
+      tester,
+    ) async {
+      final tuned = await pumpOverlay(tester);
+
+      await tester.trackpadFling(
+        find.byType(FeedTuningSwipeOverlay),
+        const Offset(200, 0),
+        1000,
+      );
+      await tester.pumpAndSettle();
+
+      expect(tuned, [FeedTuningDirection.more]);
+    });
+
+    testWidgets('trackpad pan left past the threshold tunes "less"', (
+      tester,
+    ) async {
+      final tuned = await pumpOverlay(tester);
+
+      await tester.trackpadFling(
+        find.byType(FeedTuningSwipeOverlay),
+        const Offset(-200, 0),
+        1000,
+      );
+      await tester.pumpAndSettle();
+
+      expect(tuned, [FeedTuningDirection.less]);
     });
 
     testWidgets('shows the directional indicator during a drag', (
@@ -180,7 +241,48 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(tuned, isEmpty);
-      expect(controller.page, 1); // advanced one page
+      expect(controller.page, greaterThan(0)); // vertical pager advanced
+    });
+
+    testWidgets('vertical swipe with sideways drift still pages', (
+      tester,
+    ) async {
+      final tuned = <FeedTuningDirection>[];
+      final controller = PageController();
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: FeedTuningSwipeOverlay(
+              onTuned: tuned.add,
+              child: PageView(
+                controller: controller,
+                scrollDirection: Axis.vertical,
+                children: const [
+                  SizedBox.expand(child: Center(child: Text('page-0'))),
+                  SizedBox.expand(child: Center(child: Text('page-1'))),
+                  SizedBox.expand(child: Center(child: Text('page-2'))),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final gesture = await tester.startGesture(
+        tester.getCenter(find.byType(FeedTuningSwipeOverlay)),
+      );
+      await gesture.moveBy(const Offset(24, -4));
+      await tester.pump();
+      await gesture.moveBy(const Offset(0, -600));
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      expect(tuned, isEmpty);
+      expect(controller.page, 1);
     });
   });
 


### PR DESCRIPTION
Closes #5787

## Summary
- Handle horizontal desktop trackpad pointer-scroll signals in the feed tuning overlay.
- Wire feed tuning swipes into the home `/home` feed as well as fullscreen, with BLoC-backed publish and undo handling.
- Stop the tuning overlay from claiming the mobile gesture arena, so normal vertical feed swipes keep working even with sideways finger drift.
- Keep the tuning Undo receipt visible across the automatic page advance caused by a tuning swipe, then dismiss it on a later independent page change.
- Keep the home feed tuning action sequence in BLoC state instead of a mutable BLoC field.
- Preserve desktop trackpad, touch, mouse, accessibility, BLoC, and snackbar lifecycle paths with regression coverage.

## Test Plan
- flutter test test/blocs/video_feed/video_feed_bloc_test.dart
- flutter test test/screens/feed/video_feed_page_test.dart
- flutter test test/widgets/feed_tuning/feed_tuning_swipe_overlay_test.dart
- flutter analyze
- git push pre-push checks