### PR TITLE
build(android): re-enable R8 minification

### DIFF
--- a/docs/CRASH_REPORTING_SETUP.md
+++ b/docs/CRASH_REPORTING_SETUP.md
@@ -15,7 +15,7 @@ reporting. The active Firebase project is **`openvine-co`** (bundle id
 |----------|-----------------|---------------|--------|
 | iOS | `openvine-co` — `firebase_options.dart`, `ios/Runner/GoogleService-Info.plist` | ✅ dSYMs via Codemagic | Production |
 | macOS | `openvine-co` — `macos/Runner/GoogleService-Info.plist` | — | Production (reuses the iOS appId — see note below) |
-| Android | `openvine-co` — `android/app/google-services.json` | ⚠️ wired, but no mapping file is produced while R8 is disabled | `firebase_options.dart` Android options are still being reconciled in #3343 |
+| Android | `openvine-co` — `android/app/google-services.json` | ✅ release mapping/native symbol upload via Gradle | `firebase_options.dart` Android options are still being reconciled in #3343 |
 | Web / Windows / Linux | none | — | Not supported; init is gated off |
 
 `isFirebaseSupported` (`mobile/lib/utils/platform_support.dart`) is a
@@ -31,9 +31,8 @@ currently initialized only when startup passes both `isFirebaseSupported` and
 > `DefaultFirebaseOptions.android` is still a placeholder, so
 > `Firebase.initializeApp` does not yet initialise Android against the real
 > project. The Crashlytics Gradle plugin is already applied and release builds
-> already enable mapping/native symbol upload, but R8 is currently disabled, so
-> no obfuscation mapping file is produced. Reconciling the Android options (and
-> re-enabling R8 when ready) is tracked in #3343.
+> enable R8 plus mapping/native symbol upload. Reconciling the Android options is
+> tracked in #3343.
 
 ## Configuration files
 
@@ -76,10 +75,9 @@ Release builds upload Crashlytics debug symbols automatically. See
 
 Without this, iOS crash stacks arrive in Crashlytics unsymbolicated.
 
-> **Android note:** Crashlytics upload wiring is already present in Gradle, but
-> Android release symbolication is still incomplete in practice because R8 is
-> currently disabled, so no mapping file is generated to upload. That cleanup
-> remains tracked in #3343.
+> **Android note:** Crashlytics upload wiring is present in Gradle and release
+> builds generate an R8 mapping file for symbolication. Android Firebase options
+> still need reconciliation under #3343.
 
 ## Custom keys on every report
 

--- a/docs/CRASH_REPORTING_SETUP.md
+++ b/docs/CRASH_REPORTING_SETUP.md
@@ -15,7 +15,7 @@ reporting. The active Firebase project is **`openvine-co`** (bundle id
 |----------|-----------------|---------------|--------|
 | iOS | `openvine-co` — `firebase_options.dart`, `ios/Runner/GoogleService-Info.plist` | ✅ dSYMs via Codemagic | Production |
 | macOS | `openvine-co` — `macos/Runner/GoogleService-Info.plist` | — | Production (reuses the iOS appId — see note below) |
-| Android | `openvine-co` — `android/app/google-services.json` | ✅ release mapping/native symbol upload via Gradle | `firebase_options.dart` Android options are still being reconciled in #3343 |
+| Android | `openvine-co` — `android/app/google-services.json` | ⚠️ R8 mapping upload wired via Gradle; native-symbol upload configured but unverified | `firebase_options.dart` Android options are still being reconciled in #3343 |
 | Web / Windows / Linux | none | — | Not supported; init is gated off |
 
 `isFirebaseSupported` (`mobile/lib/utils/platform_support.dart`) is a
@@ -31,8 +31,9 @@ currently initialized only when startup passes both `isFirebaseSupported` and
 > `DefaultFirebaseOptions.android` is still a placeholder, so
 > `Firebase.initializeApp` does not yet initialise Android against the real
 > project. The Crashlytics Gradle plugin is already applied and release builds
-> enable R8 plus mapping/native symbol upload. Reconciling the Android options is
-> tracked in #3343.
+> now enable R8, so an obfuscation mapping file is produced and uploaded;
+> native-symbol upload is configured but not yet verified end-to-end.
+> Reconciling the Android options is tracked in #3343.
 
 ## Configuration files
 

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -77,15 +77,13 @@ android {
         }
         release {
             signingConfig = signingConfigs.getByName("release")
-            // TEMPORARILY DISABLE R8 minification for debugging
-            isMinifyEnabled = false
-            isShrinkResources = false
-            // Apply ProGuard rules to prevent stripping Flutter/platform channel classes
+            isMinifyEnabled = true
+            isShrinkResources = true
+            // Apply ProGuard rules to preserve Flutter/platform channel classes used from native code.
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
-            // Enable Crashlytics mapping file upload (for when R8 is re-enabled)
             configure<com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsExtension> {
                 mappingFileUploadEnabled = true
                 nativeSymbolUploadEnabled = true

--- a/mobile/android/app/proguard-rules.pro
+++ b/mobile/android/app/proguard-rules.pro
@@ -15,6 +15,11 @@
 -keep class org.witness.proofmode.** { *; }
 -keep class com.eternitywall.** { *; }
 
+# BouncyCastle JCA provider (ProofMode PGP signing, CSR/cert generation) loads algorithm
+# classes by name via reflection; without this R8 strips them -> runtime crypto failures.
+-keep class org.bouncycastle.** { *; }
+-dontwarn org.bouncycastle.**
+
 # Keep Kotlin metadata and reflection (required for platform channels)
 -keep class kotlin.Metadata { *; }
 -keepclassmembers class * {
@@ -50,9 +55,11 @@
 -keep class io.flutter.plugins.** { *; }
 
 # GeneratedPluginRegistrant (auto-registration of Flutter plugins)
+# Keep: R8 previously stripped this, breaking plugin registration in release builds.
 -keep class io.flutter.plugins.GeneratedPluginRegistrant { *; }
 
 # SharedPreferences (used in router redirect for TOS check on app startup)
+# Keep: R8 previously stripped this, hanging the startup router redirect forever.
 -keepclassmembers class * implements android.content.SharedPreferences {
     *;
 }

--- a/mobile/android/app/proguard-rules.pro
+++ b/mobile/android/app/proguard-rules.pro
@@ -1,5 +1,5 @@
-# ABOUTME: ProGuard/R8 keep rules to prevent release APK loading screen hang caused by bytecode stripping
-# ABOUTME: Preserves Flutter engine, platform channels, SharedPreferences, and reflection-based Android classes
+# ABOUTME: ProGuard/R8 keep rules for release APK code shrinking.
+# ABOUTME: Preserves Flutter engine, platform channels, SharedPreferences, and reflection-based Android classes.
 
 # Allow duplicate classes from java-opentimestamps fat JAR
 # This library bundles Guava, Protobuf, JSR305, and Okio internally
@@ -50,11 +50,9 @@
 -keep class io.flutter.plugins.** { *; }
 
 # GeneratedPluginRegistrant (auto-registration of Flutter plugins)
-# R8 was stripping this class, preventing plugins from being registered
 -keep class io.flutter.plugins.GeneratedPluginRegistrant { *; }
 
 # SharedPreferences (used in router redirect for TOS check on app startup)
-# R8 was stripping this, causing router redirect to hang forever waiting for response
 -keepclassmembers class * implements android.content.SharedPreferences {
     *;
 }

--- a/mobile/android/gradle.properties
+++ b/mobile/android/gradle.properties
@@ -3,6 +3,7 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Allow duplicate classes from java-opentimestamps fat JAR
 android.suppressUnsupportedOptionWarnings=true
+# Keep R8 in compatibility mode; full mode is more aggressive and needs a separate release smoke pass.
 android.enableR8.fullMode=false
 # Keep using the explicit org.jetbrains.kotlin.android plugin with AGP 8.11.
 android.builtInKotlin=false


### PR DESCRIPTION
## Summary
- Re-enable R8 minification and Android resource shrinking for release builds.
- Keep the existing ProGuard rules wired for Flutter/platform channel/native integration paths.
- Remove stale comments that claimed R8 was temporarily disabled and update Crashlytics docs now that release builds generate mapping files.
- Document that `android.enableR8.fullMode=false` remains intentional compatibility mode pending a separate full-mode release smoke pass.

## Root cause
Issue #3601 found that Android release builds still had `isMinifyEnabled = false` and `isShrinkResources = false` after earlier release debugging. That left unused release code/resources unshrunk and prevented R8 mapping generation for Android Crashlytics symbolication.

## Verification
- `flutter analyze`
- `flutter build apk --release --split-per-abi --build-number=3601 --dart-define=DEFAULT_ENV=production` with a disposable temp keystore
- `flutter build appbundle --release --build-number=3601 --dart-define=DEFAULT_ENV=production` reached bundle output/mapping generation locally, then failed local Flutter native symbol stripping because this machine's Android SDK reports missing cmdline-tools; Codemagic has the release Android toolchain and remains the authoritative AAB check
- Release startup smoke on `Medium_Phone_API_36.1`: installed the temp-signed arm64 APK, launched `co.openvine.app`, confirmed `MainActivity` foregrounded and process stayed alive, and scanned logcat for fatal/class/linkage/plugin startup errors
- Size comparison against `origin/main` with the same build number/temp key:
  - armeabi-v7a: 150,596,227 -> 125,806,560 bytes (-24,789,667, 16.5%)
  - arm64-v8a: 158,609,415 -> 133,819,748 bytes (-24,789,667, 15.6%)
  - x86_64: 166,473,715 -> 141,684,048 bytes (-24,789,667, 14.9%)
- R8 mapping produced locally at `build/app/outputs/mapping/release/mapping.txt`

Closes #3601
