### PR TITLE
fix(account): scope local creator data maintenance

### DIFF
--- a/mobile/lib/services/clip_library_service.dart
+++ b/mobile/lib/services/clip_library_service.dart
@@ -284,7 +284,10 @@ class ClipLibraryService {
   /// Returns the number of clips purged.
   Future<int> purgeExpiredTrash({Duration retention = trashRetention}) async {
     final cutoff = DateTime.now().subtract(retention);
-    final expired = await _clipsDao.getTrashedClipsOlderThan(cutoff);
+    final expired = await _clipsDao.getTrashedClipsOlderThan(
+      cutoff,
+      ownerPubkey: ownerPubkey,
+    );
     if (expired.isEmpty) return 0;
 
     final documentsPath = await getDocumentsPath();

--- a/mobile/packages/db_client/lib/src/database/daos/clips_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/clips_dao.dart
@@ -231,11 +231,19 @@ class ClipsDao extends DatabaseAccessor<AppDatabase> with _$ClipsDaoMixin {
   }
 
   /// Get trashed clips whose `deletedAt` is older than [cutoff], ready
-  /// to be hard-deleted by the purge sweep.
-  Future<List<ClipRow>> getTrashedClipsOlderThan(DateTime cutoff) {
+  /// to be hard-deleted by the purge sweep. When [ownerPubkey] is provided,
+  /// returns only clips owned by that account **plus** legacy clips with no
+  /// owner.
+  Future<List<ClipRow>> getTrashedClipsOlderThan(
+    DateTime cutoff, {
+    String? ownerPubkey,
+  }) {
     final query = select(clips)
       ..where(
-        (t) => t.deletedAt.isNotNull() & t.deletedAt.isSmallerThanValue(cutoff),
+        (t) =>
+            _ownedOrLegacy(t.ownerPubkey, ownerPubkey) &
+            t.deletedAt.isNotNull() &
+            t.deletedAt.isSmallerThanValue(cutoff),
       );
     return query.get();
   }

--- a/mobile/packages/db_client/lib/src/database/daos/pending_uploads_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/pending_uploads_dao.dart
@@ -90,17 +90,60 @@ class PendingUploadsDao extends DatabaseAccessor<AppDatabase>
     return row != null ? _rowToModel(row) : null;
   }
 
-  /// Get all pending uploads (not completed/failed)
-  Future<List<PendingUpload>> getPendingUploads() async {
+  Expression<bool> _ownedBy(
+    GeneratedColumn<String> column,
+    String ownerPubkey,
+  ) {
+    return column.equals(ownerPubkey);
+  }
+
+  /// Get all pending uploads for [ownerPubkey] (not completed/failed).
+  Future<List<PendingUpload>> getPendingUploads({
+    required String ownerPubkey,
+  }) async {
     final query = select(pendingUploads)
-      ..where((t) => t.status.isNotIn(['published', 'failed']))
+      ..where(
+        (t) =>
+            _ownedBy(t.nostrPubkey, ownerPubkey) &
+            t.status.isNotIn(['published', 'failed']),
+      )
       ..orderBy([(t) => OrderingTerm(expression: t.createdAt)]);
     final rows = await query.get();
     return rows.map(_rowToModel).toList();
   }
 
-  /// Get all uploads sorted by creation time
-  Future<List<PendingUpload>> getAllUploads() async {
+  /// Get all uploads for [ownerPubkey] sorted by creation time.
+  Future<List<PendingUpload>> getAllUploads({
+    required String ownerPubkey,
+  }) async {
+    final query = select(pendingUploads)
+      ..where((t) => _ownedBy(t.nostrPubkey, ownerPubkey))
+      ..orderBy([
+        (t) => OrderingTerm(expression: t.createdAt, mode: OrderingMode.desc),
+      ]);
+    final rows = await query.get();
+    return rows.map(_rowToModel).toList();
+  }
+
+  /// Get uploads for [ownerPubkey] by status.
+  Future<List<PendingUpload>> getUploadsByStatus(
+    UploadStatus status, {
+    required String ownerPubkey,
+  }) async {
+    final query = select(pendingUploads)
+      ..where(
+        (t) =>
+            _ownedBy(t.nostrPubkey, ownerPubkey) & t.status.equals(status.name),
+      )
+      ..orderBy([
+        (t) => OrderingTerm(expression: t.createdAt, mode: OrderingMode.desc),
+      ]);
+    final rows = await query.get();
+    return rows.map(_rowToModel).toList();
+  }
+
+  /// Get all uploads across every owner for maintenance tasks.
+  Future<List<PendingUpload>> getAllUploadsForMaintenance() async {
     final query = select(pendingUploads)
       ..orderBy([
         (t) => OrderingTerm(expression: t.createdAt, mode: OrderingMode.desc),
@@ -109,8 +152,19 @@ class PendingUploadsDao extends DatabaseAccessor<AppDatabase>
     return rows.map(_rowToModel).toList();
   }
 
-  /// Get uploads by status
-  Future<List<PendingUpload>> getUploadsByStatus(UploadStatus status) async {
+  /// Get all non-terminal uploads across every owner for maintenance tasks.
+  Future<List<PendingUpload>> getPendingUploadsForMaintenance() async {
+    final query = select(pendingUploads)
+      ..where((t) => t.status.isNotIn(['published', 'failed']))
+      ..orderBy([(t) => OrderingTerm(expression: t.createdAt)]);
+    final rows = await query.get();
+    return rows.map(_rowToModel).toList();
+  }
+
+  /// Get uploads with [status] across every owner for maintenance tasks.
+  Future<List<PendingUpload>> getUploadsByStatusForMaintenance(
+    UploadStatus status,
+  ) async {
     final query = select(pendingUploads)
       ..where((t) => t.status.equals(status.name))
       ..orderBy([
@@ -154,8 +208,32 @@ class PendingUploadsDao extends DatabaseAccessor<AppDatabase>
     )..where((t) => t.status.isIn(['published', 'failed']))).go();
   }
 
-  /// Watch all uploads (reactive stream)
-  Stream<List<PendingUpload>> watchAllUploads() {
+  /// Watch all uploads for [ownerPubkey] (reactive stream).
+  Stream<List<PendingUpload>> watchAllUploads({required String ownerPubkey}) {
+    final query = select(pendingUploads)
+      ..where((t) => _ownedBy(t.nostrPubkey, ownerPubkey))
+      ..orderBy([
+        (t) => OrderingTerm(expression: t.createdAt, mode: OrderingMode.desc),
+      ]);
+    return query.watch().map((rows) => rows.map(_rowToModel).toList());
+  }
+
+  /// Watch pending uploads for [ownerPubkey] (reactive stream).
+  Stream<List<PendingUpload>> watchPendingUploads({
+    required String ownerPubkey,
+  }) {
+    final query = select(pendingUploads)
+      ..where(
+        (t) =>
+            _ownedBy(t.nostrPubkey, ownerPubkey) &
+            t.status.isNotIn(['published', 'failed']),
+      )
+      ..orderBy([(t) => OrderingTerm(expression: t.createdAt)]);
+    return query.watch().map((rows) => rows.map(_rowToModel).toList());
+  }
+
+  /// Watch all uploads across every owner for maintenance tasks.
+  Stream<List<PendingUpload>> watchAllUploadsForMaintenance() {
     final query = select(pendingUploads)
       ..orderBy([
         (t) => OrderingTerm(expression: t.createdAt, mode: OrderingMode.desc),
@@ -163,8 +241,8 @@ class PendingUploadsDao extends DatabaseAccessor<AppDatabase>
     return query.watch().map((rows) => rows.map(_rowToModel).toList());
   }
 
-  /// Watch pending uploads (reactive stream)
-  Stream<List<PendingUpload>> watchPendingUploads() {
+  /// Watch pending uploads across every owner for maintenance tasks.
+  Stream<List<PendingUpload>> watchPendingUploadsForMaintenance() {
     final query = select(pendingUploads)
       ..where((t) => t.status.isNotIn(['published', 'failed']))
       ..orderBy([(t) => OrderingTerm(expression: t.createdAt)]);

--- a/mobile/packages/db_client/test/src/database/daos/clips_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/clips_dao_test.dart
@@ -1070,6 +1070,73 @@ void main() {
         final clipsB = await dao.getLibraryClips(ownerPubkey: pubkeyB);
         expect(clipsB, isEmpty);
       });
+
+      test(
+        'getTrashedClipsOlderThan returns owner and legacy trash only',
+        () async {
+          final now = DateTime(2024, 1, 31);
+          final oldDeletedAt = DateTime(2023, 12);
+          final cutoff = DateTime(2024);
+
+          await dao.upsertClip(
+            id: 'clip_a_old',
+            orderIndex: 0,
+            durationMs: 1000,
+            recordedAt: now,
+            filePath: 'a.mp4',
+            thumbnailPath: 'a.jpeg',
+            data: '{}',
+            ownerPubkey: pubkeyA,
+          );
+          await dao.upsertClip(
+            id: 'clip_b_old',
+            orderIndex: 0,
+            durationMs: 1000,
+            recordedAt: now,
+            filePath: 'b.mp4',
+            thumbnailPath: 'b.jpeg',
+            data: '{}',
+            ownerPubkey: pubkeyB,
+          );
+          await dao.upsertClip(
+            id: 'clip_legacy_old',
+            orderIndex: 0,
+            durationMs: 1000,
+            recordedAt: now,
+            filePath: 'legacy.mp4',
+            thumbnailPath: 'legacy.jpeg',
+            data: '{}',
+          );
+          await dao.upsertClip(
+            id: 'clip_a_recent',
+            orderIndex: 0,
+            durationMs: 1000,
+            recordedAt: now,
+            filePath: 'recent.mp4',
+            thumbnailPath: 'recent.jpeg',
+            data: '{}',
+            ownerPubkey: pubkeyA,
+          );
+
+          await dao.softDeleteClip(id: 'clip_a_old', deletedAt: oldDeletedAt);
+          await dao.softDeleteClip(id: 'clip_b_old', deletedAt: oldDeletedAt);
+          await dao.softDeleteClip(
+            id: 'clip_legacy_old',
+            deletedAt: oldDeletedAt,
+          );
+          await dao.softDeleteClip(id: 'clip_a_recent', deletedAt: now);
+
+          final scoped = await dao.getTrashedClipsOlderThan(
+            cutoff,
+            ownerPubkey: pubkeyA,
+          );
+
+          expect(scoped.map((clip) => clip.id).toSet(), {
+            'clip_a_old',
+            'clip_legacy_old',
+          });
+        },
+      );
     });
 
     group('deleteAllForUser', () {

--- a/mobile/packages/db_client/test/src/database/daos/pending_uploads_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/pending_uploads_dao_test.dart
@@ -18,6 +18,10 @@ void main() {
   const testPubkey =
       '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
 
+  const testPubkey2 =
+      'fedcba9876543210fedcba9876543210'
+      'fedcba9876543210fedcba9876543210';
+
   /// Valid 64-char hex event ID for testing
   const testEventId =
       'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
@@ -107,7 +111,7 @@ void main() {
         expect(result.uploadProgress, equals(0.5));
 
         // Verify only one entry exists
-        final all = await dao.getAllUploads();
+        final all = await dao.getAllUploads(ownerPubkey: testPubkey);
         expect(all, hasLength(1));
       });
 
@@ -197,7 +201,7 @@ void main() {
           createTestUpload(id: 'failed', status: UploadStatus.failed),
         );
 
-        final results = await dao.getPendingUploads();
+        final results = await dao.getPendingUploads(ownerPubkey: testPubkey);
 
         expect(results, hasLength(3));
         expect(
@@ -219,7 +223,7 @@ void main() {
           createTestUpload(id: 'second', createdAt: DateTime(2024, 1, 2)),
         );
 
-        final results = await dao.getPendingUploads();
+        final results = await dao.getPendingUploads(ownerPubkey: testPubkey);
 
         expect(results[0].id, equals('first'));
         expect(results[1].id, equals('second'));
@@ -231,7 +235,7 @@ void main() {
           createTestUpload(id: 'published', status: UploadStatus.published),
         );
 
-        final results = await dao.getPendingUploads();
+        final results = await dao.getPendingUploads(ownerPubkey: testPubkey);
         expect(results, isEmpty);
       });
     });
@@ -248,7 +252,7 @@ void main() {
           createTestUpload(id: 'second', createdAt: DateTime(2024, 1, 2)),
         );
 
-        final results = await dao.getAllUploads();
+        final results = await dao.getAllUploads(ownerPubkey: testPubkey);
 
         expect(results, hasLength(3));
         expect(results[0].id, equals('third'));
@@ -257,7 +261,7 @@ void main() {
       });
 
       test('returns empty list when no uploads exist', () async {
-        final results = await dao.getAllUploads();
+        final results = await dao.getAllUploads(ownerPubkey: testPubkey);
         expect(results, isEmpty);
       });
     });
@@ -270,7 +274,10 @@ void main() {
           createTestUpload(id: 'uploading', status: UploadStatus.uploading),
         );
 
-        final results = await dao.getUploadsByStatus(UploadStatus.pending);
+        final results = await dao.getUploadsByStatus(
+          UploadStatus.pending,
+          ownerPubkey: testPubkey,
+        );
 
         expect(results, hasLength(2));
         expect(results.every((r) => r.status == UploadStatus.pending), isTrue);
@@ -279,7 +286,10 @@ void main() {
       test('returns empty list when no uploads match status', () async {
         await dao.upsertUpload(createTestUpload(id: 'pending'));
 
-        final results = await dao.getUploadsByStatus(UploadStatus.failed);
+        final results = await dao.getUploadsByStatus(
+          UploadStatus.failed,
+          ownerPubkey: testPubkey,
+        );
         expect(results, isEmpty);
       });
     });
@@ -333,7 +343,7 @@ void main() {
         final deleted = await dao.deleteUpload('upload_1');
 
         expect(deleted, equals(1));
-        final remaining = await dao.getAllUploads();
+        final remaining = await dao.getAllUploads(ownerPubkey: testPubkey);
         expect(remaining, hasLength(1));
         expect(remaining.first.id, equals('upload_2'));
       });
@@ -357,7 +367,7 @@ void main() {
         final deleted = await dao.deleteCompleted();
 
         expect(deleted, equals(2));
-        final remaining = await dao.getAllUploads();
+        final remaining = await dao.getAllUploads(ownerPubkey: testPubkey);
         expect(remaining, hasLength(1));
         expect(remaining.first.id, equals('pending'));
       });
@@ -375,7 +385,7 @@ void main() {
         await dao.upsertUpload(createTestUpload());
         await dao.upsertUpload(createTestUpload(id: 'upload_2'));
 
-        final stream = dao.watchAllUploads();
+        final stream = dao.watchAllUploads(ownerPubkey: testPubkey);
         final results = await stream.first;
 
         expect(results, hasLength(2));
@@ -389,7 +399,7 @@ void main() {
           createTestUpload(id: 'new', createdAt: DateTime(2024, 1, 2)),
         );
 
-        final stream = dao.watchAllUploads();
+        final stream = dao.watchAllUploads(ownerPubkey: testPubkey);
         final results = await stream.first;
 
         expect(results[0].id, equals('new'));
@@ -404,7 +414,7 @@ void main() {
           createTestUpload(id: 'published', status: UploadStatus.published),
         );
 
-        final stream = dao.watchPendingUploads();
+        final stream = dao.watchPendingUploads(ownerPubkey: testPubkey);
         final results = await stream.first;
 
         expect(results, hasLength(1));
@@ -419,12 +429,178 @@ void main() {
           createTestUpload(id: 'first', createdAt: DateTime(2024)),
         );
 
-        final stream = dao.watchPendingUploads();
+        final stream = dao.watchPendingUploads(ownerPubkey: testPubkey);
         final results = await stream.first;
 
         expect(results[0].id, equals('first'));
         expect(results[1].id, equals('second'));
       });
+    });
+
+    group('owner-scoped reads', () {
+      test(
+        'getPendingUploads returns only non-terminal uploads for owner',
+        () async {
+          await dao.upsertUpload(createTestUpload(id: 'a_pending'));
+          await dao.upsertUpload(
+            createTestUpload(id: 'a_published', status: UploadStatus.published),
+          );
+          await dao.upsertUpload(
+            createTestUpload(id: 'b_pending', nostrPubkey: testPubkey2),
+          );
+
+          final results = await dao.getPendingUploads(ownerPubkey: testPubkey);
+
+          expect(results.map((r) => r.id), ['a_pending']);
+        },
+      );
+
+      test('getAllUploads returns only uploads for owner', () async {
+        await dao.upsertUpload(createTestUpload(id: 'a_upload'));
+        await dao.upsertUpload(
+          createTestUpload(id: 'b_upload', nostrPubkey: testPubkey2),
+        );
+
+        final results = await dao.getAllUploads(ownerPubkey: testPubkey);
+
+        expect(results.map((r) => r.id), ['a_upload']);
+      });
+
+      test(
+        'getUploadsByStatus returns only matching status for owner',
+        () async {
+          await dao.upsertUpload(createTestUpload(id: 'a_pending'));
+          await dao.upsertUpload(
+            createTestUpload(id: 'a_uploading', status: UploadStatus.uploading),
+          );
+          await dao.upsertUpload(
+            createTestUpload(id: 'b_pending', nostrPubkey: testPubkey2),
+          );
+
+          final results = await dao.getUploadsByStatus(
+            UploadStatus.pending,
+            ownerPubkey: testPubkey,
+          );
+
+          expect(results.map((r) => r.id), ['a_pending']);
+        },
+      );
+
+      test('watchAllUploads emits only uploads for owner', () async {
+        await dao.upsertUpload(createTestUpload(id: 'a_upload'));
+        await dao.upsertUpload(
+          createTestUpload(id: 'b_upload', nostrPubkey: testPubkey2),
+        );
+
+        final results = await dao
+            .watchAllUploads(ownerPubkey: testPubkey)
+            .first;
+
+        expect(results.map((r) => r.id), ['a_upload']);
+      });
+
+      test(
+        'watchPendingUploads emits only non-terminal uploads for owner',
+        () async {
+          await dao.upsertUpload(createTestUpload(id: 'a_pending'));
+          await dao.upsertUpload(
+            createTestUpload(id: 'a_failed', status: UploadStatus.failed),
+          );
+          await dao.upsertUpload(
+            createTestUpload(id: 'b_pending', nostrPubkey: testPubkey2),
+          );
+
+          final results = await dao
+              .watchPendingUploads(ownerPubkey: testPubkey)
+              .first;
+
+          expect(results.map((r) => r.id), ['a_pending']);
+        },
+      );
+    });
+
+    group('maintenance reads', () {
+      test(
+        'getAllUploadsForMaintenance returns uploads for every owner',
+        () async {
+          await dao.upsertUpload(createTestUpload(id: 'a_upload'));
+          await dao.upsertUpload(
+            createTestUpload(id: 'b_upload', nostrPubkey: testPubkey2),
+          );
+
+          final results = await dao.getAllUploadsForMaintenance();
+
+          expect(results.map((r) => r.id).toSet(), {'a_upload', 'b_upload'});
+        },
+      );
+
+      test(
+        'getPendingUploadsForMaintenance returns non-terminal uploads '
+        'for every owner',
+        () async {
+          await dao.upsertUpload(createTestUpload(id: 'a_pending'));
+          await dao.upsertUpload(
+            createTestUpload(id: 'b_pending', nostrPubkey: testPubkey2),
+          );
+          await dao.upsertUpload(
+            createTestUpload(
+              id: 'b_failed',
+              nostrPubkey: testPubkey2,
+              status: UploadStatus.failed,
+            ),
+          );
+
+          final results = await dao.getPendingUploadsForMaintenance();
+
+          expect(results.map((r) => r.id).toSet(), {'a_pending', 'b_pending'});
+        },
+      );
+
+      test('getUploadsByStatusForMaintenance returns every owner', () async {
+        await dao.upsertUpload(createTestUpload(id: 'a_pending'));
+        await dao.upsertUpload(
+          createTestUpload(id: 'b_pending', nostrPubkey: testPubkey2),
+        );
+        await dao.upsertUpload(
+          createTestUpload(
+            id: 'b_failed',
+            nostrPubkey: testPubkey2,
+            status: UploadStatus.failed,
+          ),
+        );
+
+        final results = await dao.getUploadsByStatusForMaintenance(
+          UploadStatus.pending,
+        );
+
+        expect(results.map((r) => r.id).toSet(), {'a_pending', 'b_pending'});
+      });
+
+      test('watchAllUploadsForMaintenance emits every owner', () async {
+        await dao.upsertUpload(createTestUpload(id: 'a_upload'));
+        await dao.upsertUpload(
+          createTestUpload(id: 'b_upload', nostrPubkey: testPubkey2),
+        );
+
+        final results = await dao.watchAllUploadsForMaintenance().first;
+
+        expect(results.map((r) => r.id).toSet(), {'a_upload', 'b_upload'});
+      });
+
+      test(
+        'watchPendingUploadsForMaintenance emits non-terminal uploads '
+        'for every owner',
+        () async {
+          await dao.upsertUpload(createTestUpload(id: 'a_pending'));
+          await dao.upsertUpload(
+            createTestUpload(id: 'b_pending', nostrPubkey: testPubkey2),
+          );
+
+          final results = await dao.watchPendingUploadsForMaintenance().first;
+
+          expect(results.map((r) => r.id).toSet(), {'a_pending', 'b_pending'});
+        },
+      );
     });
 
     group('clearAll', () {
@@ -435,7 +611,7 @@ void main() {
         final deleted = await dao.clearAll();
 
         expect(deleted, equals(2));
-        final results = await dao.getAllUploads();
+        final results = await dao.getAllUploads(ownerPubkey: testPubkey);
         expect(results, isEmpty);
       });
 
@@ -446,10 +622,6 @@ void main() {
     });
 
     group('deleteAllForUser', () {
-      const testPubkey2 =
-          'fedcba9876543210fedcba9876543210'
-          'fedcba9876543210fedcba9876543210';
-
       test('deletes all uploads for user', () async {
         await dao.upsertUpload(createTestUpload(id: 'u1'));
         await dao.upsertUpload(createTestUpload(id: 'u2'));
@@ -457,7 +629,7 @@ void main() {
         final deleted = await dao.deleteAllForUser(testPubkey);
 
         expect(deleted, equals(2));
-        final remaining = await dao.getAllUploads();
+        final remaining = await dao.getAllUploadsForMaintenance();
         expect(remaining, isEmpty);
       });
 
@@ -469,7 +641,7 @@ void main() {
 
         await dao.deleteAllForUser(testPubkey);
 
-        final remaining = await dao.getAllUploads();
+        final remaining = await dao.getAllUploadsForMaintenance();
         expect(remaining, hasLength(1));
         expect(remaining.first.id, equals('u_b'));
       });

--- a/mobile/test/services/clip_library_service_test.dart
+++ b/mobile/test/services/clip_library_service_test.dart
@@ -210,6 +210,13 @@ void main() {
     });
 
     group('purgeExpiredTrash', () {
+      const pubkeyA =
+          'aaaa1111aaaa1111aaaa1111aaaa1111'
+          'aaaa1111aaaa1111aaaa1111aaaa1111';
+      const pubkeyB =
+          'bbbb2222bbbb2222bbbb2222bbbb2222'
+          'bbbb2222bbbb2222bbbb2222bbbb2222';
+
       test('hard-deletes trashed clips older than retention', () async {
         final clip = DivineVideoClip(
           id: 'old_trashed',
@@ -258,6 +265,89 @@ void main() {
         expect(purged, 0);
         expect((await service.getTrashedClips()).length, 1);
       });
+
+      test(
+        'purges current owner and legacy trash without deleting other owners',
+        () async {
+          final serviceA = ClipLibraryService(
+            clipsDao: database.clipsDao,
+            draftsDao: database.draftsDao,
+            ownerPubkey: pubkeyA,
+          );
+          final serviceB = ClipLibraryService(
+            clipsDao: database.clipsDao,
+            draftsDao: database.draftsDao,
+            ownerPubkey: pubkeyB,
+          );
+
+          final clipA = DivineVideoClip(
+            id: 'a_expired',
+            video: EditorVideo.file('/tmp/a_expired.mp4'),
+            duration: const Duration(seconds: 2),
+            recordedAt: DateTime.now(),
+            targetAspectRatio: .square,
+            originalAspectRatio: 9 / 16,
+          );
+          final clipB = DivineVideoClip(
+            id: 'b_expired',
+            video: EditorVideo.file('/tmp/b_expired.mp4'),
+            duration: const Duration(seconds: 2),
+            recordedAt: DateTime.now(),
+            targetAspectRatio: .square,
+            originalAspectRatio: 9 / 16,
+          );
+          final legacyClip = DivineVideoClip(
+            id: 'legacy_expired',
+            video: EditorVideo.file('/tmp/legacy_expired.mp4'),
+            duration: const Duration(seconds: 2),
+            recordedAt: DateTime.now(),
+            targetAspectRatio: .square,
+            originalAspectRatio: 9 / 16,
+          );
+
+          await serviceA.saveClip(clipA);
+          await serviceB.saveClip(clipB);
+          await database.clipsDao.upsertClip(
+            id: legacyClip.id,
+            orderIndex: 0,
+            durationMs: legacyClip.duration.inMilliseconds,
+            recordedAt: legacyClip.recordedAt,
+            data: jsonEncode(legacyClip.toJson()),
+            filePath: 'legacy_expired.mp4',
+            thumbnailPath: null,
+          );
+
+          await serviceA.softDelete(clipA.id);
+          await serviceB.softDelete(clipB.id);
+          await database.clipsDao.softDeleteClip(
+            id: legacyClip.id,
+            deletedAt: DateTime.now(),
+          );
+
+          await database.customStatement(
+            'UPDATE clips SET deleted_at = ? WHERE id IN (?, ?, ?)',
+            [
+              DateTime.now()
+                      .subtract(const Duration(days: 31))
+                      .millisecondsSinceEpoch ~/
+                  1000,
+              clipA.id,
+              clipB.id,
+              legacyClip.id,
+            ],
+          );
+
+          final purged = await serviceA.purgeExpiredTrash();
+
+          expect(purged, 2);
+          expect(await database.clipsDao.getClipById(clipA.id), isNull);
+          expect(await database.clipsDao.getClipById(legacyClip.id), isNull);
+          expect(await database.clipsDao.getClipById(clipB.id), isNotNull);
+          expect((await serviceB.getTrashedClips()).map((c) => c.id), [
+            clipB.id,
+          ]);
+        },
+      );
     });
 
     group('getAllClips', () {


### PR DESCRIPTION
## Summary

Closes #5788.

Scopes the remaining local creator-data maintenance paths by account owner:

- Makes PendingUploadsDao current-account read/watch APIs require an owner pubkey.
- Adds explicitly named unscoped pending-upload maintenance APIs so cross-account reads are deliberate.
- Scopes expired clip trash purging by ClipLibraryService.ownerPubkey while preserving legacy NULL-owner rows.
- Adds account A/account B regression coverage for pending uploads, clip DAO trash queries, and the service-level purge path.

## Root Cause

PR #4858 stopped destructive account-switch cleanup, but two smaller owner-scope gaps remained:

- PendingUploadsDao read/watch methods exposed all non-terminal uploads at the DAO layer.
- ClipLibraryService.purgeExpiredTrash called ClipsDao.getTrashedClipsOlderThan without owner scope, so the active account startup sweep could hard-delete another account’s expired trash.

## Behavior Notes

Expired trash for another account is no longer purged while the current account is active. Those rows are swept when that owner’s scoped ClipLibraryService runs, which preserves per-account local data isolation.

## Validation

- flutter analyze
- flutter test packages/db_client/test/src/database/daos/pending_uploads_dao_test.dart packages/db_client/test/src/database/daos/clips_dao_test.dart test/services/clip_library_service_test.dart
- Pre-push hook: analyzer, generated-file verification, and changed-file tests all passed.