### PR TITLE
chore(logs): quiet routine foreground-idle warmup passes

### DIFF
--- a/mobile/lib/services/foreground_idle_warmup_coordinator.dart
+++ b/mobile/lib/services/foreground_idle_warmup_coordinator.dart
@@ -82,7 +82,7 @@ class ForegroundIdleWarmupScheduler {
   }
 
   void _requestSafely(ForegroundIdleWarmupTrigger trigger) {
-    Log.info(
+    Log.debug(
       'Foreground idle warmup scheduler fired (${trigger.name})',
       name: 'ForegroundIdleWarmupScheduler',
       category: LogCategory.system,
@@ -214,7 +214,7 @@ class ForegroundIdleWarmupCoordinator {
   bool get _canRun => _isForeground() && _isIdle();
 
   Future<void> _run(ForegroundIdleWarmupTrigger trigger) async {
-    Log.info(
+    Log.debug(
       'Foreground idle warmup started (${trigger.name})',
       name: 'ForegroundIdleWarmupCoordinator',
       category: LogCategory.system,
@@ -257,7 +257,7 @@ class ForegroundIdleWarmupCoordinator {
         switch (outcome) {
           case _ForegroundIdleWarmupTaskOutcome.completed:
             _lastSuccessAt[task.id] = _now();
-            Log.info(
+            Log.debug(
               'Foreground idle warmup completed ${task.id.name}',
               name: 'ForegroundIdleWarmupCoordinator',
               category: LogCategory.system,

--- a/mobile/test/services/foreground_idle_warmup_coordinator_test.dart
+++ b/mobile/test/services/foreground_idle_warmup_coordinator_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/services/foreground_idle_warmup_coordinator.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 void main() {
   group('ForegroundIdleWarmupCoordinator', () {
@@ -34,11 +35,16 @@ void main() {
       );
     }
 
-    setUp(() {
+    setUp(() async {
+      await LogCaptureService().clearAllLogs();
       now = DateTime(2026, 6, 17, 12);
       isForeground = true;
       isIdle = true;
       calls = [];
+    });
+
+    tearDown(() async {
+      await LogCaptureService().clearAllLogs();
     });
 
     test('runs eligible warmups when the app is foreground and idle', () async {
@@ -54,6 +60,32 @@ void main() {
       );
 
       expect(calls, ['forYou', 'newVideos', 'popular', 'notifications']);
+    });
+
+    test('routine successful pass logs stay below info level', () async {
+      final coordinator = coordinatorWith([
+        task(ForegroundIdleWarmupTaskId.forYou),
+      ]);
+
+      await coordinator.requestWarmup(
+        trigger: ForegroundIdleWarmupTrigger.videoPlaybackSettled,
+      );
+
+      final warmupLogs = LogCaptureService().getRecentLogs().where(
+        (entry) => entry.message.startsWith('Foreground idle warmup '),
+      );
+      expect(
+        warmupLogs.where((entry) => entry.level == LogLevel.info),
+        isEmpty,
+      );
+      expect(
+        _latestLogContaining('Foreground idle warmup started')?.level,
+        LogLevel.debug,
+      );
+      expect(
+        _latestLogContaining('Foreground idle warmup completed forYou')?.level,
+        LogLevel.debug,
+      );
     });
 
     test('does not run while the app is backgrounded', () async {
@@ -463,6 +495,14 @@ void main() {
   });
 
   group('ForegroundIdleWarmupScheduler', () {
+    setUp(() async {
+      await LogCaptureService().clearAllLogs();
+    });
+
+    tearDown(() async {
+      await LogCaptureService().clearAllLogs();
+    });
+
     test('runs an initial warmup after the startup delay', () {
       fakeAsync((async) {
         final triggers = <ForegroundIdleWarmupTrigger>[];
@@ -482,6 +522,35 @@ void main() {
 
         expect(triggers, [ForegroundIdleWarmupTrigger.startupSettled]);
         scheduler.stop();
+      });
+    });
+
+    test('keeps lifecycle logs at info and routine ticks at debug', () {
+      fakeAsync((async) {
+        final scheduler = ForegroundIdleWarmupScheduler(
+          requestWarmup: (_) => Future<void>.value(),
+        );
+
+        scheduler.start();
+        async.elapse(const Duration(seconds: 10));
+        scheduler.stop();
+
+        expect(
+          _latestLogContaining(
+            'Foreground idle warmup scheduler started',
+          )?.level,
+          LogLevel.info,
+        );
+        expect(
+          _latestLogContaining('Foreground idle warmup scheduler fired')?.level,
+          LogLevel.debug,
+        );
+        expect(
+          _latestLogContaining(
+            'Foreground idle warmup scheduler stopped',
+          )?.level,
+          LogLevel.info,
+        );
       });
     });
 
@@ -636,4 +705,11 @@ void main() {
       });
     });
   });
+}
+
+LogEntry? _latestLogContaining(String message) {
+  final matches = LogCaptureService().getRecentLogs().where(
+    (entry) => entry.message.contains(message),
+  );
+  return matches.isEmpty ? null : matches.last;
 }


### PR DESCRIPTION
Closes #5260

## Summary
`ForegroundIdleWarmupScheduler` / `ForegroundIdleWarmupCoordinator` emitted `Log.info` on every periodic pass — "scheduler fired", "warmup started", and "warmup completed `<task>`" per task. With a 5-minute interval that's ~288 ticks/day fanning out to multiple per-task lines, roughly 300+ info-level lines/day in steady state even when most tasks are cooling down and doing nothing.

This drops those three routine per-pass / per-task lines to `Log.debug`. Meaningful lifecycle and problem signals are unchanged:
- scheduler `start` / `stop` — stay `Log.info`
- gate-closed stops (before / during a task) — stay `Log.info`
- timeouts and failures — stay `Log.warning`

No behavior change beyond log verbosity.

## Test Plan
- `flutter analyze lib/services/foreground_idle_warmup_coordinator.dart` — no issues
- `flutter test test/services/foreground_idle_warmup_coordinator_test.dart` — all 24 pass
- `dart format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)