### PR TITLE
test(feed): cover bulk-stats hydration fallbacks in videos_repository

### DIFF
--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -1828,6 +1828,152 @@ void main() {
           verify(() => mockNostrClient.queryEvents(any())).called(1);
         });
 
+        test('hydrates Nostr fallback videos with bulk stats', () async {
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.getHomeFeed(
+              pubkey: any(named: 'pubkey'),
+              limit: any(named: 'limit'),
+              before: any(named: 'before'),
+            ),
+          ).thenThrow(const FunnelcakeException('Network error'));
+
+          final nostrEvent = _createVideoEvent(
+            id: 'nostr-video',
+            pubkey: 'followed-user',
+            videoUrl: 'https://example.com/nostr.mp4',
+            createdAt: 1704067200,
+          );
+          when(
+            () => mockNostrClient.queryEvents(any()),
+          ).thenAnswer((_) async => [nostrEvent]);
+          when(
+            () => mockFunnelcakeClient.getBulkVideoStats(['nostr-video']),
+          ).thenAnswer(
+            (_) async => const BulkVideoStatsResponse(
+              stats: {
+                'nostr-video': BulkVideoStatsEntry(
+                  eventId: 'nostr-video',
+                  reactions: 3,
+                  comments: 1,
+                  reposts: 2,
+                  views: 11,
+                ),
+              },
+            ),
+          );
+
+          final repositoryWithApi = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          final result = await repositoryWithApi.getHomeFeedVideos(
+            authors: ['followed-user'],
+            userPubkey: 'my-pubkey',
+          );
+
+          expect(result.videos, hasLength(1));
+          expect(result.videos.first.rawTags['views'], equals('11'));
+          expect(result.videos.first.totalLoops, equals(11));
+          expect(result.videos.first.nostrLikeCount, equals(3));
+          expect(result.videos.first.nostrCommentCount, equals(1));
+          expect(result.videos.first.nostrRepostCount, equals(2));
+          verify(
+            () => mockFunnelcakeClient.getBulkVideoStats(['nostr-video']),
+          ).called(1);
+        });
+
+        test(
+          'returns un-hydrated API videos when bulk stats hydration throws',
+          () async {
+            when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+            when(
+              () => mockFunnelcakeClient.getHomeFeed(
+                pubkey: any(named: 'pubkey'),
+                limit: any(named: 'limit'),
+                before: any(named: 'before'),
+              ),
+            ).thenAnswer(
+              (_) async => HomeFeedResponse(
+                videos: [
+                  _createVideoStats(
+                    id: 'event-1',
+                    pubkey: 'followed-user',
+                    dTag: 'dtag-1',
+                    videoUrl: 'https://example.com/video.mp4',
+                  ),
+                ],
+              ),
+            );
+            when(
+              () => mockFunnelcakeClient.getBulkVideoStats(any()),
+            ).thenThrow(const FunnelcakeException('bulk stats down'));
+
+            final repositoryWithApi = VideosRepository(
+              nostrClient: mockNostrClient,
+              funnelcakeApiClient: mockFunnelcakeClient,
+            );
+
+            final result = await repositoryWithApi.getHomeFeedVideos(
+              authors: ['followed-user'],
+              userPubkey: 'my-pubkey',
+            );
+
+            expect(result.videos, hasLength(1));
+            expect(result.videos.first.id, equals('event-1'));
+            expect(result.videos.first.rawTags['views'], isNull);
+            expect(result.videos.first.totalLoops, equals(0));
+            verify(
+              () => mockFunnelcakeClient.getBulkVideoStats(['event-1']),
+            ).called(1);
+            verifyNever(() => mockNostrClient.queryEvents(any()));
+          },
+        );
+
+        test('returns un-hydrated Nostr fallback videos when bulk stats '
+            'hydration throws', () async {
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.getHomeFeed(
+              pubkey: any(named: 'pubkey'),
+              limit: any(named: 'limit'),
+              before: any(named: 'before'),
+            ),
+          ).thenThrow(const FunnelcakeException('Network error'));
+
+          final nostrEvent = _createVideoEvent(
+            id: 'nostr-video',
+            pubkey: 'followed-user',
+            videoUrl: 'https://example.com/nostr.mp4',
+            createdAt: 1704067200,
+          );
+          when(
+            () => mockNostrClient.queryEvents(any()),
+          ).thenAnswer((_) async => [nostrEvent]);
+          when(
+            () => mockFunnelcakeClient.getBulkVideoStats(any()),
+          ).thenThrow(const FunnelcakeException('bulk stats down'));
+
+          final repositoryWithApi = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          final result = await repositoryWithApi.getHomeFeedVideos(
+            authors: ['followed-user'],
+            userPubkey: 'my-pubkey',
+          );
+
+          expect(result.videos, hasLength(1));
+          expect(result.videos.first.id, equals('nostr-video'));
+          expect(result.videos.first.rawTags['views'], isNull);
+          expect(result.videos.first.nostrLikeCount, isNull);
+          verify(
+            () => mockFunnelcakeClient.getBulkVideoStats(['nostr-video']),
+          ).called(1);
+        });
+
         test(
           'trusts empty Funnelcake home feed without Nostr fallback',
           () async {


### PR DESCRIPTION
## Description

Adds regression coverage for two untested paths of the home-feed bulk-stats hydration helper introduced in PR #3568, closing the two follow-up issues it left:

- **#3711** — when Funnelcake `getHomeFeed` throws and the repository falls back to the Nostr relay, bulk-stats hydration still runs on the relay results (views tag, live like/comment/repost counts, `totalLoops`).
- **#3710** — when `getBulkVideoStats` itself throws, `getHomeFeedVideos` returns the un-hydrated videos unchanged instead of failing the feed load. Covered for both the Funnelcake primary path and the relay fallback path.

Test-only change; no production code touched.

**Related Issue:** Closes #3710, Closes #3711

## Out of Scope

None.

## Verification

- `flutter test test/src/videos_repository_test.dart --plain-name "getHomeFeedVideos"` → 44 tests pass (3 new)
- `flutter test --coverage` from `mobile/packages/videos_repository` → all 433 tests pass
- `flutter analyze lib test` in the package → no issues
- `dart format --set-exit-if-changed` → clean

## Type of Change

- [x] ✅ Build configuration change
- [ ] ✨ New feature

(test-only change — closest checkbox is none; this adds regression tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)