### PR TITLE
fix(library): guard clip-delete Undo against a closed bloc

### DIFF
--- a/mobile/lib/screens/library_screen.dart
+++ b/mobile/lib/screens/library_screen.dart
@@ -433,6 +433,11 @@ class _LibraryViewState extends ConsumerState<_LibraryView>
                   ? null
                   : () {
                       messenger.hideCurrentSnackBar();
+                      // The delete snackbar is shown on the app-level
+                      // ScaffoldMessenger, so it can outlive this screen. If
+                      // the user navigated away the bloc is already closed —
+                      // adding to it would throw. Undo is a no-op then.
+                      if (clipsBloc.isClosed) return;
                       clipsBloc.add(ClipsLibraryRestoreClips(deletedIds));
                     },
             );

--- a/mobile/test/screens/library_screen_test.dart
+++ b/mobile/test/screens/library_screen_test.dart
@@ -4,10 +4,12 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart' as models;
+import 'package:openvine/blocs/clips_library/clips_library_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/l10n/generated/app_localizations_en.dart';
 import 'package:openvine/models/divine_video_clip.dart';
@@ -387,6 +389,89 @@ void main() {
         },
       );
     });
+    group('delete undo snackbar', () {
+      testWidgets('tapping Undo after the screen is gone does not add to the '
+          'closed bloc', (tester) async {
+        final clip = DivineVideoClip(
+          id: 'undo-clip-1',
+          video: EditorVideo.file('/test/undo.mp4'),
+          duration: const Duration(seconds: 2),
+          recordedAt: DateTime.now(),
+          targetAspectRatio: models.AspectRatio.vertical,
+          originalAspectRatio: 9 / 16,
+          thumbnailPath: '/test/undo.jpg',
+          ghostFramePath: '/test/undo_ghost.jpg',
+        );
+
+        when(
+          () => mockClipLibraryService.getAllClips(),
+        ).thenAnswer((_) async => [clip]);
+        when(
+          () => mockClipLibraryService.recoverMissingAssets(any()),
+        ).thenAnswer((_) async => [clip]);
+        when(
+          () => mockClipLibraryService.softDelete(any()),
+        ).thenAnswer((_) async => true);
+
+        final showLibrary = ValueNotifier<bool>(true);
+        addTearDown(showLibrary.dispose);
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              sharedPreferencesProvider.overrideWithValue(sharedPreferences),
+              gallerySaveServiceProvider.overrideWithValue(
+                mockGallerySaveService,
+              ),
+              clipLibraryServiceProvider.overrideWithValue(
+                mockClipLibraryService,
+              ),
+              draftStorageServiceProvider.overrideWithValue(
+                mockDraftStorageService,
+              ),
+              clipManagerProvider.overrideWith(ClipManagerNotifier.new),
+            ],
+            child: MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              theme: VineTheme.theme,
+              home: Scaffold(
+                body: ValueListenableBuilder<bool>(
+                  valueListenable: showLibrary,
+                  builder: (context, show, _) => show
+                      ? const LibraryScreen(
+                          initialTabIndex: 1,
+                          tabsMode: LibraryTabsMode.clipsOnly,
+                        )
+                      : const SizedBox.shrink(),
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Trigger the delete → the app-level "Undo" snackbar appears.
+        final clipsBloc = BlocProvider.of<ClipsLibraryBloc>(
+          tester.element(find.byType(ClipsTab)),
+        )..add(ClipsLibraryDeleteClip(clip));
+        await tester.pumpAndSettle();
+
+        expect(find.text(en.libraryClipsDeletedUndoLabel), findsOneWidget);
+
+        // Navigate away: unmount the screen, closing its bloc, while the
+        // app-level snackbar stays on screen.
+        showLibrary.value = false;
+        await tester.pump();
+        expect(clipsBloc.isClosed, isTrue);
+
+        await tester.tap(find.text(en.libraryClipsDeletedUndoLabel));
+        await tester.pump();
+
+        expect(tester.takeException(), isNull);
+      });
+    });
+
     group('web', () {
       testWidgets('shows mobile-app intercept instead of tabs', (tester) async {
         await tester.pumpWidget(buildWidget());


### PR DESCRIPTION
Closes #5795

## What

The Library screen's clip-delete flow shows an **"Undo" snackbar** via the app-level `ScaffoldMessenger`, so the snackbar outlives the screen. If the user navigates away before tapping Undo, the screen's `ClipsLibraryBloc` has already been closed, and the Undo action's `clipsBloc.add(ClipsLibraryRestoreClips(...))` throws `Bad state: Cannot add new events after calling close` — an uncaught fatal.

## Crash

- Crashlytics issue `a454fc7bcda88d465a51b758951d26b5` (iOS)
- `FlutterError - Bad state: Cannot add new events after calling close`
- 12 impacted users; `firstSeenVersion 1.0.14`, still firing on 1.0.14/1.0.15 (sample event today)
- Blame frame: `_LibraryViewState.build.<fn>.<fn>` → `library_screen.dart` Undo action. Breadcrumbs confirm the user had navigated away (clips → video-recorder) before the crash.

## Fix

Guard the Undo callback with `clipsBloc.isClosed` before adding the restore event — once the screen is gone, Undo is a no-op (the clip is soft-deleted and recoverable from Trash regardless). This matches the existing `if (!bloc.isClosed)` precedent in `pooled_age_restricted_retry.dart`.

## Test

Adds a regression test that deletes a clip (raising the app-level Undo snackbar), unmounts the Library screen to close its bloc, then taps Undo and asserts no exception. Verified it fails on the pre-fix source with the exact `StateError: Cannot add new events after calling close`, and passes after. Full `library_screen_test.dart` suite green (15 pass), `flutter analyze` clean.

Found and triaged by the hourly Crashlytics agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)