### PR TITLE
refactor(router): retire forceExploreTabNameProvider

### DIFF
--- a/docs/superpowers/specs/2026-03-25-apps-explore-tab-directory-bootstrap-design.md
+++ b/docs/superpowers/specs/2026-03-25-apps-explore-tab-directory-bootstrap-design.md
@@ -27,7 +27,7 @@ The sandbox PR made vetted apps reachable from Settings, but that buries the fea
 
 Add `Apps` as the last Explore top tab so the existing saved explore tab indices remain stable. Reuse the current `AppsDirectoryScreen` in two modes: standalone for `/apps`, and embedded inside Explore without its own scaffold or back button.
 
-The Settings `Apps` tile should no longer push `/apps`. It should send the user to Explore with the forced tab name set to `apps`. The direct `/apps` route stays available for fallback navigation, tests, and future deep links.
+The Settings `Apps` tile should no longer push `/apps`. It should send the user to Explore's URL-addressable Apps tab (`/explore/tab/apps`, via `ExploreScreen.pathForTab('apps')`). The direct `/apps` route stays available for fallback navigation, tests, and future deep links.
 
 For catalog data, add repo-owned manifest fixtures under the worker package plus a small import/upsert path for admins. The listed apps are stored as manifests that the worker validates and serves through `GET /v1/apps`, not Flutter constants.
 
@@ -55,5 +55,5 @@ The exact signable kinds should stay conservative in this slice and can widen la
 
 - Widget tests for embedded `AppsDirectoryScreen`.
 - Explore screen tests that assert the `Apps` tab is present and routable.
-- Settings navigation tests that assert `Apps` jumps to Explore with `forceExploreTabNameProvider = 'apps'`.
+- Settings navigation tests that assert `Apps` jumps to `/explore/tab/apps`.
 - Worker tests that validate the seeded manifests parse cleanly and surface through the existing directory APIs/import utilities.

--- a/mobile/lib/providers/route_feed_providers.dart
+++ b/mobile/lib/providers/route_feed_providers.dart
@@ -39,15 +39,9 @@ final exploreTabVideoUpdateListenerProvider = Provider<void>((ref) {
 });
 
 /// Provider to persist the current tab index across widget recreation.
-/// Default to 1. Note: Use forceExploreTabNameProvider for semantic tab
-/// selection that survives tab count changes.
+/// Default to 1. Note: navigate to `ExploreScreen.pathForTab(name)` for
+/// semantic tab selection that survives tab count changes.
 final exploreTabIndexProvider = StateProvider<int>((ref) => 1);
-
-/// Provider to force a specific tab by NAME on next ExploreScreen init.
-/// Uses tab name instead of index because indices shift when Classics/ForYou
-/// tabs become available asynchronously.
-/// Valid values: 'classics', 'new', 'popular', 'for_you', 'lists', 'apps'
-final forceExploreTabNameProvider = StateProvider<String?>((ref) => null);
 
 /// Index of the currently-active bottom-nav branch
 /// (0 = Home, 1 = Explore, 2 = Inbox, 3 = Profile).

--- a/mobile/lib/screens/auth/email_verification_screen.dart
+++ b/mobile/lib/screens/auth/email_verification_screen.dart
@@ -20,7 +20,6 @@ import 'package:openvine/blocs/invite_gate/invite_gate_event.dart';
 import 'package:openvine/l10n/email_verification_error_l10n.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
-import 'package:openvine/providers/route_feed_providers.dart';
 import 'package:openvine/screens/auth/welcome_screen.dart';
 import 'package:openvine/screens/explore/explore_screen.dart';
 import 'package:openvine/services/auth_service.dart';
@@ -107,8 +106,7 @@ class _EmailVerificationScreenState
         _cubit.stopPolling();
         ref.read(pendingVerificationServiceProvider).clear();
         context.read<InviteGateBloc>().add(const InviteGateAccessCleared());
-        ref.read(forceExploreTabNameProvider.notifier).state = 'popular';
-        context.go(ExploreScreen.path);
+        context.go(ExploreScreen.pathForTab('popular'));
       }
     });
   }
@@ -285,16 +283,13 @@ class _EmailVerificationScreenState
     ref.read(pendingVerificationServiceProvider).clear();
 
     if (!_isTokenMode) {
-      // Polling mode: navigate to explore screen (Popular tab) after
-      // verification
+      // Polling mode: the auth-state listener navigates to the explore
+      // Popular tab (by URL) once sign-in completes.
       Log.info(
         'Email verification succeeded, navigating to explore (Popular tab)',
         name: 'EmailVerificationScreen',
         category: LogCategory.auth,
       );
-      // Set tab by NAME (not index) because indices shift when
-      // Classics/ForYou tabs become available asynchronously
-      ref.read(forceExploreTabNameProvider.notifier).state = 'popular';
     } else {
       // Token mode: redirect to login screen
       _handleTokenModeSuccess();

--- a/mobile/lib/screens/explore/explore_screen.dart
+++ b/mobile/lib/screens/explore/explore_screen.dart
@@ -64,7 +64,7 @@ class ExploreScreen extends ConsumerWidget {
   }
 
   /// Optional tab name to select on first build. Takes precedence over
-  /// [forceExploreTabNameProvider] and the saved [exploreTabIndexProvider].
+  /// the saved [exploreTabIndexProvider].
   final String? initialTabName;
 
   @override

--- a/mobile/lib/screens/explore/explore_view.dart
+++ b/mobile/lib/screens/explore/explore_view.dart
@@ -49,14 +49,11 @@ class _ExploreViewState extends ConsumerState<ExploreView>
   /// Build a new [TabController]. [previousTabName] is the name of the tab the
   /// user was on before a rebuild (resolved while the old availability flags
   /// were still in effect). Resolution order:
-  /// [ExploreView.initialTabName] > [forceExploreTabNameProvider] >
-  /// previous tab > default. Falls back to the default tab by name — never by
-  /// raw index, because indices shift when optional tabs appear or disappear.
+  /// [ExploreView.initialTabName] > previous tab > default. Falls back to the
+  /// default tab by name — never by raw index, because indices shift when
+  /// optional tabs appear or disappear.
   void _initTabController({String? previousTabName}) {
-    final forcedTabName = ref.read(forceExploreTabNameProvider);
-
-    final targetTabName =
-        widget.initialTabName ?? forcedTabName ?? previousTabName;
+    final targetTabName = widget.initialTabName ?? previousTabName;
     final initialIndex = _tabsState.indexForName(
       targetTabName ?? exploreDefaultTabName,
     );
@@ -133,19 +130,6 @@ class _ExploreViewState extends ConsumerState<ExploreView>
     final index = _tabController!.index;
     final tabName = _tabsState.nameForIndex(index);
 
-    // Check if there's a forced tab name
-    final forcedName = ref.read(forceExploreTabNameProvider);
-    if (forcedName != null && tabName != forcedName) {
-      // User switched to a different tab than the forced one — clear the force.
-      Log.info(
-        '🎯 ExploreScreen: User changed tab from forced "$forcedName" to '
-        '"$tabName", clearing force',
-        name: 'ExploreScreen',
-        category: LogCategory.ui,
-      );
-      ref.read(forceExploreTabNameProvider.notifier).state = null;
-    }
-
     // Always persist the current index
     ref.read(exploreTabIndexProvider.notifier).state = index;
 
@@ -183,20 +167,6 @@ class _ExploreViewState extends ConsumerState<ExploreView>
   @override
   Widget build(BuildContext context) {
     ref.watch(exploreTabVideoUpdateListenerProvider);
-
-    // Apply a forced tab name set before navigating to this screen.
-    final forcedTabName = ref.watch(forceExploreTabNameProvider);
-    if (forcedTabName != null && _tabController != null) {
-      final targetIndex = _tabsState.indexForName(forcedTabName);
-      if (_tabController!.index != targetIndex) {
-        // Schedule tab change for after build (don't clear provider yet).
-        Future(() {
-          if (mounted && _tabController != null) {
-            _tabController!.animateTo(targetIndex);
-          }
-        });
-      }
-    }
 
     // Watch tab availability and rebuild the controller when it changes.
     final classicsAvailable =

--- a/mobile/test/screens/auth/email_verification_screen_test.dart
+++ b/mobile/test/screens/auth/email_verification_screen_test.dart
@@ -141,6 +141,12 @@ void main() {
                   path: '/explore',
                   builder: (_, _) => const Scaffold(body: Text('Explore')),
                 ),
+                GoRoute(
+                  path: '/explore/tab/:tab',
+                  builder: (_, state) => Scaffold(
+                    body: Text('Explore ${state.pathParameters['tab']}'),
+                  ),
+                ),
               ],
             ),
           ),
@@ -302,6 +308,29 @@ void main() {
         await tester.pump();
 
         expect(_divineIcon(DivineIconName.x), findsNothing);
+      });
+
+      testWidgets('auth success navigates to the Popular explore tab by URL', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          createTestWidget(
+            deviceCode: 'test-device-code',
+            verifier: 'test-verifier',
+            email: 'user@example.com',
+            initialState: const EmailVerificationState(
+              status: EmailVerificationStatus.success,
+            ),
+          ),
+        );
+        await tester.pump();
+
+        authStateController.add(AuthState.authenticated);
+        await tester.pumpAndSettle();
+
+        expect(find.text('Explore popular'), findsOneWidget);
+        verify(() => mockCubit.stopPolling()).called(greaterThan(0));
+        verify(() => mockPendingVerification.clear()).called(greaterThan(0));
       });
     });
 

--- a/mobile/test/screens/auth/email_verification_screen_test.dart
+++ b/mobile/test/screens/auth/email_verification_screen_test.dart
@@ -17,7 +17,6 @@ import 'package:openvine/blocs/email_verification/email_verification_cubit.dart'
 import 'package:openvine/blocs/invite_gate/invite_gate_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
-import 'package:openvine/providers/route_feed_providers.dart';
 import 'package:openvine/screens/auth/email_verification_screen.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/pending_verification_service.dart';
@@ -100,7 +99,6 @@ void main() {
         pendingVerificationServiceProvider.overrideWithValue(
           mockPendingVerification,
         ),
-        forceExploreTabNameProvider.overrideWith((ref) => null),
       ],
       child: RepositoryProvider<InviteApiClient>.value(
         value: mockInviteApiClient,
@@ -617,7 +615,6 @@ void main() {
                 pendingVerificationServiceProvider.overrideWithValue(
                   mockPendingVerification,
                 ),
-                forceExploreTabNameProvider.overrideWith((ref) => null),
               ],
               child: MaterialApp(
                 localizationsDelegates: AppLocalizations.localizationsDelegates,


### PR DESCRIPTION
## Description

Completes the URL-first routing cleanup started in PR #3899. The `/explore/tab/:name` route makes Explore tab selection URL-addressable, so the out-of-band `forceExploreTabNameProvider` override is no longer needed:

- `EmailVerificationScreen` now navigates with `context.go(ExploreScreen.pathForTab('popular'))` (the same pattern `redirect_provider.dart` and `feed_empty_widget.dart` already use) instead of setting the provider and going to bare `/explore`. The redundant provider write in `_handleSuccess` is dropped too — the auth-state listener owns the navigation.
- `ExploreView` drops all three pieces of forced-tab wiring (init-time read, tab-change clearing, and the build-time animate block).
- The provider itself is deleted from `route_feed_providers.dart`, along with stale doc references and the now-unneeded test overrides.

Net −44 lines.

**Related Issue:** Closes #4123

## Out of Scope

None.

## Verification

- `flutter analyze lib test integration_test` → no issues
- `flutter test test/screens/auth/email_verification_screen_test.dart` → 19 pass
- All 11 explore screen test files → 39 pass
- `grep -rn forceExplore mobile` → zero references remain

## Type of Change

- [x] 🧹 Code refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)