### PR TITLE
fix(video-editor): guard timeline clip controls against a torn-down editor

### DIFF
--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart
@@ -11,6 +11,8 @@ import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dar
 import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_clip_speed_sheet.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_timeline_controls.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart';
+import 'package:pro_image_editor/pro_image_editor.dart'
+    show ProImageEditorState;
 import 'package:pro_video_editor/pro_video_editor.dart' show ExportTransform;
 
 /// Controls shown when a clip is in editing mode: Delete, Copy, Split, Done.
@@ -66,6 +68,15 @@ class _TimelineClipControlsState extends State<TimelineClipControls> {
     );
   }
 
+  /// The editor backing these controls, or `null` if it has been torn down.
+  ///
+  /// A gesture can resolve after the editor route is popped (e.g. rapid
+  /// editor <-> clips navigation), leaving the [ProImageEditorState]
+  /// unmounted. Handlers must bail on `null` rather than force-unwrapping,
+  /// which is a release-mode crash.
+  ProImageEditorState? _editorOrNull(BuildContext context) =>
+      VideoEditorScope.of(context).editor;
+
   Future<void> _transformClip(BuildContext context) async {
     final bloc = context.read<ClipEditorBloc>();
     final state = bloc.state;
@@ -115,7 +126,8 @@ class _TimelineClipControlsState extends State<TimelineClipControls> {
       return;
     }
     final clip = state.clips[state.currentClipIndex];
-    final editor = VideoEditorScope.of(context).requireEditor;
+    final editor = _editorOrNull(context);
+    if (editor == null) return;
 
     final result = await VineBottomSheet.show<double>(
       context: context,
@@ -170,7 +182,8 @@ class _TimelineClipControlsState extends State<TimelineClipControls> {
     final overlayBloc = context.read<TimelineOverlayBloc>();
     final state = bloc.state;
     final clipId = state.clips[state.currentClipIndex].id;
-    final editor = VideoEditorScope.of(context).requireEditor;
+    final editor = _editorOrNull(context);
+    if (editor == null) return;
 
     final newClips = state.clips.where((clip) => clip.id != clipId).toList();
     // Markers on the removed clip are dropped; markers on later clips shift
@@ -197,7 +210,8 @@ class _TimelineClipControlsState extends State<TimelineClipControls> {
     final overlayBloc = context.read<TimelineOverlayBloc>();
     final state = bloc.state;
     final clip = state.clips[state.currentClipIndex];
-    final editor = VideoEditorScope.of(context).requireEditor;
+    final editor = _editorOrNull(context);
+    if (editor == null) return;
 
     final copy = clip.copyWith(
       id:

--- a/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls_test.dart
@@ -10,14 +10,22 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart' as model;
 import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
+import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_timeline_controls.dart';
+import 'package:pro_image_editor/pro_image_editor.dart'
+    show ProImageEditorState;
 import 'package:pro_video_editor/pro_video_editor.dart';
 
 class _MockClipEditorBloc extends MockBloc<ClipEditorEvent, ClipEditorState>
     implements ClipEditorBloc {}
+
+class _MockTimelineOverlayBloc
+    extends MockBloc<TimelineOverlayEvent, TimelineOverlayState>
+    implements TimelineOverlayBloc {}
 
 void main() {
   group(TimelineClipControls, () {
@@ -72,9 +80,7 @@ void main() {
 
     testWidgets(
       'dispatches ClipEditorClipReverseRequested when reverse pressed',
-      (
-        tester,
-      ) async {
+      (tester) async {
         final state = ClipEditorState(
           clips: [
             DivineVideoClip(
@@ -128,20 +134,19 @@ void main() {
       },
     );
 
-    testWidgets(
-      'Speed button is hidden while isExtractingAudio',
-      (tester) async {
-        when(
-          () => bloc.state,
-        ).thenReturn(const ClipEditorState(isExtractingAudio: true));
-        await tester.pumpWidget(build());
+    testWidgets('Speed button is hidden while isExtractingAudio', (
+      tester,
+    ) async {
+      when(
+        () => bloc.state,
+      ).thenReturn(const ClipEditorState(isExtractingAudio: true));
+      await tester.pumpWidget(build());
 
-        final controls = tester.widget<VideoEditorTimelineControls>(
-          find.byType(VideoEditorTimelineControls),
-        );
-        expect(controls.onSpeed, isNull);
-      },
-    );
+      final controls = tester.widget<VideoEditorTimelineControls>(
+        find.byType(VideoEditorTimelineControls),
+      );
+      expect(controls.onSpeed, isNull);
+    });
 
     testWidgets('Select button is hidden for a single clip', (tester) async {
       when(() => bloc.state).thenReturn(
@@ -166,6 +171,76 @@ void main() {
       expect(controls.onMultiSelect, isNull);
     });
 
+    testWidgets(
+      'deleting a clip is a no-op (no crash) when the editor scope is gone',
+      (tester) async {
+        DivineVideoClip clip(String id) => DivineVideoClip(
+          id: id,
+          video: EditorVideo.file('/tmp/$id.mp4'),
+          duration: const Duration(seconds: 3),
+          recordedAt: DateTime(2025),
+          targetAspectRatio: model.AspectRatio.vertical,
+          originalAspectRatio: 9 / 16,
+        );
+        when(
+          () => bloc.state,
+        ).thenReturn(ClipEditorState(clips: [clip('clip-1'), clip('clip-2')]));
+        final overlayBloc = _MockTimelineOverlayBloc();
+        when(() => overlayBloc.state).thenReturn(const TimelineOverlayState());
+        when(
+          () => overlayBloc.stream,
+        ).thenAnswer((_) => const Stream<TimelineOverlayState>.empty());
+
+        await tester.pumpWidget(
+          ProviderScope(
+            child: MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(
+                // An unattached editorKey => VideoEditorScope.editor is null,
+                // reproducing a gesture that resolves after the editor route
+                // was popped.
+                body: VideoEditorScope(
+                  editorKey: GlobalKey<ProImageEditorState>(),
+                  removeAreaKey: GlobalKey(),
+                  originalClipAspectRatio: 9 / 16,
+                  bodySizeNotifier: ValueNotifier(const Size(400, 600)),
+                  zoomMatrixNotifier: ValueNotifier(Matrix4.identity()),
+                  fromLibrary: false,
+                  onOpenCamera: () {},
+                  onOpenClipsEditor: () {},
+                  onAddStickers: () {},
+                  onOpenMusicLibrary: () {},
+                  onOpenVoiceOver: () {},
+                  onAddEditTextLayer: ([layer]) async => null,
+                  child: MultiBlocProvider(
+                    providers: [
+                      BlocProvider<ClipEditorBloc>.value(value: bloc),
+                      BlocProvider<TimelineOverlayBloc>.value(
+                        value: overlayBloc,
+                      ),
+                    ],
+                    child: TimelineClipControls(
+                      playheadPosition: ValueNotifier(Duration.zero),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        final controls = tester.widget<VideoEditorTimelineControls>(
+          find.byType(VideoEditorTimelineControls),
+        );
+        expect(controls.onDelete, isNotNull);
+        controls.onDelete!.call();
+        await tester.pump();
+
+        expect(tester.takeException(), isNull);
+      },
+    );
+
     testWidgets('Select button starts multi-select with multiple clips', (
       tester,
     ) async {
@@ -177,9 +252,9 @@ void main() {
         targetAspectRatio: model.AspectRatio.vertical,
         originalAspectRatio: 9 / 16,
       );
-      when(() => bloc.state).thenReturn(
-        ClipEditorState(clips: [clip('clip-1'), clip('clip-2')]),
-      );
+      when(
+        () => bloc.state,
+      ).thenReturn(ClipEditorState(clips: [clip('clip-1'), clip('clip-2')]));
 
       await tester.pumpWidget(build());
 

--- a/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls_test.dart
@@ -31,6 +31,10 @@ void main() {
   group(TimelineClipControls, () {
     late _MockClipEditorBloc bloc;
 
+    setUpAll(() {
+      registerFallbackValue(const ClipEditorEditingStopped());
+    });
+
     setUp(() {
       bloc = _MockClipEditorBloc();
       when(() => bloc.state).thenReturn(const ClipEditorState());
@@ -53,6 +57,69 @@ void main() {
             ),
           ),
         ),
+      );
+    }
+
+    DivineVideoClip clip(String id) => DivineVideoClip(
+      id: id,
+      video: EditorVideo.file('/tmp/$id.mp4'),
+      duration: const Duration(seconds: 3),
+      recordedAt: DateTime(2025),
+      targetAspectRatio: model.AspectRatio.vertical,
+      originalAspectRatio: 9 / 16,
+    );
+
+    Future<VideoEditorTimelineControls> pumpWithMissingEditorScope(
+      WidgetTester tester,
+    ) async {
+      when(
+        () => bloc.state,
+      ).thenReturn(ClipEditorState(clips: [clip('clip-1'), clip('clip-2')]));
+      final overlayBloc = _MockTimelineOverlayBloc();
+      when(() => overlayBloc.state).thenReturn(const TimelineOverlayState());
+      when(
+        () => overlayBloc.stream,
+      ).thenAnswer((_) => const Stream<TimelineOverlayState>.empty());
+
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              // An unattached editorKey => VideoEditorScope.editor is null,
+              // reproducing a gesture that resolves after the editor route
+              // was popped.
+              body: VideoEditorScope(
+                editorKey: GlobalKey<ProImageEditorState>(),
+                removeAreaKey: GlobalKey(),
+                originalClipAspectRatio: 9 / 16,
+                bodySizeNotifier: ValueNotifier(const Size(400, 600)),
+                zoomMatrixNotifier: ValueNotifier(Matrix4.identity()),
+                fromLibrary: false,
+                onOpenCamera: () {},
+                onOpenClipsEditor: () {},
+                onAddStickers: () {},
+                onOpenMusicLibrary: () {},
+                onOpenVoiceOver: () {},
+                onAddEditTextLayer: ([layer]) async => null,
+                child: MultiBlocProvider(
+                  providers: [
+                    BlocProvider<ClipEditorBloc>.value(value: bloc),
+                    BlocProvider<TimelineOverlayBloc>.value(value: overlayBloc),
+                  ],
+                  child: TimelineClipControls(
+                    playheadPosition: ValueNotifier(Duration.zero),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      return tester.widget<VideoEditorTimelineControls>(
+        find.byType(VideoEditorTimelineControls),
       );
     }
 
@@ -171,87 +238,45 @@ void main() {
       expect(controls.onMultiSelect, isNull);
     });
 
-    testWidgets(
-      'deleting a clip is a no-op (no crash) when the editor scope is gone',
-      (tester) async {
-        DivineVideoClip clip(String id) => DivineVideoClip(
-          id: id,
-          video: EditorVideo.file('/tmp/$id.mp4'),
-          duration: const Duration(seconds: 3),
-          recordedAt: DateTime(2025),
-          targetAspectRatio: model.AspectRatio.vertical,
-          originalAspectRatio: 9 / 16,
-        );
-        when(
-          () => bloc.state,
-        ).thenReturn(ClipEditorState(clips: [clip('clip-1'), clip('clip-2')]));
-        final overlayBloc = _MockTimelineOverlayBloc();
-        when(() => overlayBloc.state).thenReturn(const TimelineOverlayState());
-        when(
-          () => overlayBloc.stream,
-        ).thenAnswer((_) => const Stream<TimelineOverlayState>.empty());
-
-        await tester.pumpWidget(
-          ProviderScope(
-            child: MaterialApp(
-              localizationsDelegates: AppLocalizations.localizationsDelegates,
-              supportedLocales: AppLocalizations.supportedLocales,
-              home: Scaffold(
-                // An unattached editorKey => VideoEditorScope.editor is null,
-                // reproducing a gesture that resolves after the editor route
-                // was popped.
-                body: VideoEditorScope(
-                  editorKey: GlobalKey<ProImageEditorState>(),
-                  removeAreaKey: GlobalKey(),
-                  originalClipAspectRatio: 9 / 16,
-                  bodySizeNotifier: ValueNotifier(const Size(400, 600)),
-                  zoomMatrixNotifier: ValueNotifier(Matrix4.identity()),
-                  fromLibrary: false,
-                  onOpenCamera: () {},
-                  onOpenClipsEditor: () {},
-                  onAddStickers: () {},
-                  onOpenMusicLibrary: () {},
-                  onOpenVoiceOver: () {},
-                  onAddEditTextLayer: ([layer]) async => null,
-                  child: MultiBlocProvider(
-                    providers: [
-                      BlocProvider<ClipEditorBloc>.value(value: bloc),
-                      BlocProvider<TimelineOverlayBloc>.value(
-                        value: overlayBloc,
-                      ),
-                    ],
-                    child: TimelineClipControls(
-                      playheadPosition: ValueNotifier(Duration.zero),
-                    ),
-                  ),
-                ),
-              ),
-            ),
+    final staleEditorActions =
+        <
+          ({
+            String actionLabel,
+            VoidCallback? Function(VideoEditorTimelineControls controls)
+            callback,
+          })
+        >[
+          (actionLabel: 'delete', callback: (controls) => controls.onDelete),
+          (
+            actionLabel: 'duplicate',
+            callback: (controls) => controls.onDuplicated,
           ),
-        );
+          (
+            actionLabel: 'speed change',
+            callback: (controls) => controls.onSpeed,
+          ),
+        ];
 
-        final controls = tester.widget<VideoEditorTimelineControls>(
-          find.byType(VideoEditorTimelineControls),
-        );
-        expect(controls.onDelete, isNotNull);
-        controls.onDelete!.call();
-        await tester.pump();
+    for (final action in staleEditorActions) {
+      testWidgets(
+        '${action.actionLabel} is a no-op when the editor scope is gone',
+        (tester) async {
+          final controls = await pumpWithMissingEditorScope(tester);
 
-        expect(tester.takeException(), isNull);
-      },
-    );
+          final callback = action.callback(controls);
+          expect(callback, isNotNull);
+          callback!.call();
+          await tester.pump();
+
+          expect(tester.takeException(), isNull);
+          verifyNever(() => bloc.add(any()));
+        },
+      );
+    }
 
     testWidgets('Select button starts multi-select with multiple clips', (
       tester,
     ) async {
-      DivineVideoClip clip(String id) => DivineVideoClip(
-        id: id,
-        video: EditorVideo.file('/tmp/$id.mp4'),
-        duration: const Duration(seconds: 3),
-        recordedAt: DateTime(2025),
-        targetAspectRatio: model.AspectRatio.vertical,
-        originalAspectRatio: 9 / 16,
-      );
       when(
         () => bloc.state,
       ).thenReturn(ClipEditorState(clips: [clip('clip-1'), clip('clip-2')]));


### PR DESCRIPTION
Closes #5800

## What

`TimelineClipControls` gesture handlers (`_deleteClip`, `_duplicateClip`, `_setPlaybackSpeed`) read `VideoEditorScope.requireEditor`, which asserts non-null in debug and **force-unwraps `state!` in release**. When a tap resolves after the editor route has been popped — e.g. rapid `video_editor` ↔ `clips_only` navigation — the `ProImageEditorState` is unmounted and the unwrap throws `Null check operator used on a null value`, an uncaught fatal.

`requireEditor`'s own doc already admits *"This can happen if a gesture resolves after a route pop"* — but it still crashes.

## Crash

- Crashlytics issue `543913871a7dbe466a08b7646af40cc1` (iOS), **SIGNAL_FRESH**
- `FlutterError - Null check operator used on a null value` at `VideoEditorScope.requireEditor` ← `_TimelineClipControlsState._deleteClip`
- 24 events / 4 impacted users, first & last seen 1.0.15
- Breadcrumbs show rapid `video_editor → clips_only → video_editor` transitions (screen_time 0s) right before the crash — the editor was mid-teardown when the delete tap landed.

## Fix

Add a small `_editorOrNull(context)` helper that returns the nullable editor, and have the three affected handlers bail when it's `null` — a gesture that resolves after the editor is gone is stale and should be ignored. Scoped to this widget (the three callsites that crash); the other `requireEditor` users live in different editor surfaces not implicated here.

## Test

Adds a regression test that pumps `TimelineClipControls` under a `VideoEditorScope` whose `editorKey` is unattached (so `editor` is null), invokes the delete action, and asserts no exception. Verified it fails on the pre-fix source (`requireEditor` assert `state != null`) and passes after. Full widget suite green (8 pass), `flutter analyze` clean.

Found and triaged by the hourly Crashlytics agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)