### PR TITLE
feat(dm): double-tap a message to like it

### DIFF
--- a/mobile/lib/blocs/dm/reactions/conversation_reactions_cubit.dart
+++ b/mobile/lib/blocs/dm/reactions/conversation_reactions_cubit.dart
@@ -135,8 +135,18 @@ class ConversationReactionsCubit
     Emitter<ConversationReactionsState> emit,
   ) async {
     // Set-not-toggle: re-selecting the active emoji is a no-op (keep it);
-    // a different emoji supersedes the prior one in the repository.
-    if (_ownLiveReaction(event.messageId, event.emoji) != null) return;
+    // a different emoji supersedes the prior one in the repository. The
+    // optimistic-inclusive check also covers the pre-persist window, so a
+    // rapid double-tap burst can't fan out duplicate gift-wrapped reactions
+    // before the first row lands — the whole publish decision lives here, and
+    // callers (double-tap-to-like, the reel reply bar) just dispatch.
+    if (state.ownReactionPendingOrLive(
+      messageId: event.messageId,
+      emoji: event.emoji,
+      ownerPubkey: _ownerPubkey,
+    )) {
+      return;
+    }
 
     await _publishReaction(
       conversationId: event.conversationId,

--- a/mobile/lib/blocs/dm/reactions/conversation_reactions_state.dart
+++ b/mobile/lib/blocs/dm/reactions/conversation_reactions_state.dart
@@ -140,6 +140,24 @@ class ConversationReactionsState extends Equatable {
     return false;
   }
 
+  /// Like [ownReactionMatches] but also honours the synchronous [optimistic]
+  /// overlay via [reactionsFor], so a reaction that is added-but-not-yet-
+  /// persisted counts as present. The double-tap-to-like guard uses this to
+  /// avoid publishing a duplicate ❤️ when the user re-double-taps during the
+  /// pre-persist window (the Drift round-trip crosses an isolate + SQLCipher).
+  bool ownReactionPendingOrLive({
+    required String messageId,
+    required String emoji,
+    required String ownerPubkey,
+  }) {
+    for (final r in reactionsFor(messageId)) {
+      if (r.reactorPubkey == ownerPubkey && r.emoji == emoji) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   /// Copy with overrides. `null` is "no change" semantics; explicit
   /// empties are passed by the caller.
   ConversationReactionsState copyWith({

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -4,6 +4,7 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart' show SemanticsService;
+import 'package:flutter/services.dart' show HapticFeedback;
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -393,6 +394,12 @@ DmSharedVideoRef? resolveQuotedVideoRef(
 DmSharedVideoRef? resolveOwnShareVideoRef(DmMessage message) =>
     message.replyToId == null ? message.sharedVideoRef : null;
 
+/// The emoji a double-tap-to-like publishes: the ❤️ that heads the DM quick
+/// reaction row ([kDefaultDmReactionEmojis]), reused verbatim so a double-tap
+/// and a picker ❤️ collapse to one reaction instead of two distinct rows
+/// (there is no emoji normalization on the reaction path).
+final String _doubleTapLikeEmoji = kDefaultDmReactionEmojis.first;
+
 class _MessageList extends StatelessWidget {
   const _MessageList({
     required this.messages,
@@ -468,6 +475,34 @@ class _MessageList extends StatelessWidget {
         messageId: message.id,
         messageAuthorPubkey: message.senderPubkey,
         emoji: emoji,
+      ),
+    );
+  }
+
+  /// Double-tap-to-like (Instagram-style). Fires a light haptic and adds a ❤️
+  /// via [ConversationReactionSet] (add-only: a repeat double-tap never
+  /// un-likes — removal stays on the long-press picker). The chip itself
+  /// animates in via [ReactionsRow]. The pending-or-live guard skips
+  /// re-publishing when the account already has ❤️ on this message, including
+  /// the pre-persist optimistic window, so rapid double-taps don't fan out
+  /// duplicate gift-wrapped reactions.
+  void _likeOnDoubleTap(BuildContext context, DmMessage message) {
+    HapticFeedback.lightImpact();
+
+    final reactions = context.read<ConversationReactionsCubit>().state;
+    final alreadyLiked = reactions.ownReactionPendingOrLive(
+      messageId: message.id,
+      emoji: _doubleTapLikeEmoji,
+      ownerPubkey: currentPubkey,
+    );
+    if (alreadyLiked) return;
+
+    context.read<ConversationReactionsCubit>().add(
+      ConversationReactionSet(
+        conversationId: message.conversationId,
+        messageId: message.id,
+        messageAuthorPubkey: message.senderPubkey,
+        emoji: _doubleTapLikeEmoji,
       ),
     );
   }
@@ -554,6 +589,12 @@ class _MessageList extends StatelessWidget {
             isLastInGroup: isLastInGroup,
             onLongPress: () =>
                 _onMessageLongPress(context, message, isSent, status),
+            // Double-tap-to-like, hidden on failed own sends to mirror the
+            // long-press picker guard (reacting to a message the recipient
+            // never received is meaningless).
+            onDoubleTap: isSent && status == DmDeliveryStatus.failed
+                ? null
+                : () => _likeOnDoubleTap(context, message),
             deliveryStatus: status,
             dmReplyContext: dmReplyContext,
             sharedVideoRef: ownShareVideoRef,

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -482,21 +482,12 @@ class _MessageList extends StatelessWidget {
   /// Double-tap-to-like (Instagram-style). Fires a light haptic and adds a ❤️
   /// via [ConversationReactionSet] (add-only: a repeat double-tap never
   /// un-likes — removal stays on the long-press picker). The chip itself
-  /// animates in via [ReactionsRow]. The pending-or-live guard skips
-  /// re-publishing when the account already has ❤️ on this message, including
-  /// the pre-persist optimistic window, so rapid double-taps don't fan out
-  /// duplicate gift-wrapped reactions.
+  /// animates in via [ReactionsRow]. Dedup lives in the cubit's
+  /// [ConversationReactionSet] handler — including the pre-persist optimistic
+  /// window — so a rapid double-tap burst can't fan out duplicate gift-wrapped
+  /// reactions; the UI just dispatches.
   void _likeOnDoubleTap(BuildContext context, DmMessage message) {
     HapticFeedback.lightImpact();
-
-    final reactions = context.read<ConversationReactionsCubit>().state;
-    final alreadyLiked = reactions.ownReactionPendingOrLive(
-      messageId: message.id,
-      emoji: _doubleTapLikeEmoji,
-      ownerPubkey: currentPubkey,
-    );
-    if (alreadyLiked) return;
-
     context.read<ConversationReactionsCubit>().add(
       ConversationReactionSet(
         conversationId: message.conversationId,

--- a/mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart
@@ -111,7 +111,10 @@ class MessageBubble extends StatelessWidget {
 
   /// Called when the user double-taps the bubble. Wired to double-tap-to-like,
   /// which adds a ❤️ reaction to the message. Null disables double-tap on the
-  /// bubble (e.g. failed own sends). Screen readers never reach this —
+  /// bubble (e.g. failed own sends). It is also suppressed internally on
+  /// bubbles whose dominant content is itself a tap target (shared-video card,
+  /// quoted-video reply) so the ancestor double-tap recognizer can't delay
+  /// tap-to-open — see the wiring below. Screen readers never reach this —
   /// double-tap is the AT activation gesture — so the long-press picker stays
   /// the a11y path.
   final VoidCallback? onDoubleTap;
@@ -246,7 +249,14 @@ class MessageBubble extends StatelessWidget {
               : null,
           child: GestureDetector(
             onLongPress: onLongPress,
-            onDoubleTap: onDoubleTap,
+            // Suppress double-tap-to-like on bubbles whose dominant content is
+            // itself a tap target — the shared-video card and the quoted-video
+            // reply both open the reel on tap. An ancestor onDoubleTap makes
+            // its DoubleTapGestureRecognizer hold the gesture arena for
+            // ~kDoubleTapTimeout after the first tap, so the inner onTap only
+            // fires once that window elapses (~300 ms delay to tap-to-open).
+            // Text bubbles keep double-tap-to-like.
+            onDoubleTap: hasVideo || hasQuotedVideo ? null : onDoubleTap,
             child: Container(
               // Video bubbles cap their max width at the thumbnail's
               // own width (248) plus the symmetric 16 px padding so the

--- a/mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart
@@ -86,6 +86,7 @@ class MessageBubble extends StatelessWidget {
     this.isFirstInGroup = true,
     this.isLastInGroup = true,
     this.onLongPress,
+    this.onDoubleTap,
     this.deliveryStatus = DmDeliveryStatus.delivered,
     this.dmReplyContext,
     this.sharedVideoRef,
@@ -107,6 +108,13 @@ class MessageBubble extends StatelessWidget {
 
   /// Called when the user long-presses the bubble.
   final VoidCallback? onLongPress;
+
+  /// Called when the user double-taps the bubble. Wired to double-tap-to-like,
+  /// which adds a ❤️ reaction to the message. Null disables double-tap on the
+  /// bubble (e.g. failed own sends). Screen readers never reach this —
+  /// double-tap is the AT activation gesture — so the long-press picker stays
+  /// the a11y path.
+  final VoidCallback? onDoubleTap;
 
   /// Per-bubble delivery state. Only rendered for sent messages; received
   /// bubbles ignore it. Defaults to [DmDeliveryStatus.delivered] so test
@@ -238,6 +246,7 @@ class MessageBubble extends StatelessWidget {
               : null,
           child: GestureDetector(
             onLongPress: onLongPress,
+            onDoubleTap: onDoubleTap,
             child: Container(
               // Video bubbles cap their max width at the thumbnail's
               // own width (248) plus the symmetric 16 px padding so the

--- a/mobile/lib/screens/inbox/conversation/widgets/reactions_row.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/reactions_row.dart
@@ -19,7 +19,7 @@ import 'package:openvine/widgets/user_avatar.dart';
 /// [ConversationReactionsCubit] via `BlocBuilder` with a per-message
 /// `buildWhen` so only this row rebuilds when its reactions (or in-flight
 /// pending state) change.
-class ReactionsRow extends StatelessWidget {
+class ReactionsRow extends StatefulWidget {
   /// Construct a reactions row.
   const ReactionsRow({
     required this.conversationId,
@@ -50,6 +50,33 @@ class ReactionsRow extends StatelessWidget {
   final Set<String> blockedPubkeys;
 
   @override
+  State<ReactionsRow> createState() => _ReactionsRowState();
+}
+
+class _ReactionsRowState extends State<ReactionsRow> {
+  /// Emojis already on the message when this row first built — a conversation
+  /// opening, or a reacted row scrolling back into view. A glyph whose emoji is
+  /// absent here is a post-mount addition (a live incoming reaction, or the
+  /// user's own double-tap ❤️) and grows in via [_PoppingEmoji]; emojis in the
+  /// baseline render settled. Captured on the first build even when the message
+  /// starts with zero reactions, so the first like on a never-reacted message —
+  /// which mounts the pill for the first time — still pops. This lives on the
+  /// row (always mounted for a visible message) rather than the pill (absent
+  /// until the first reaction), so the empty → first-reaction transition reads
+  /// as an addition, not an initial mount.
+  Set<String>? _baselineEmojis;
+
+  @override
+  void didUpdateWidget(ReactionsRow oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // A ListView can rebind this element to a different message; drop the
+    // baseline so it recaptures for the new message on the next build.
+    if (oldWidget.messageId != widget.messageId) {
+      _baselineEmojis = null;
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     // Rebuild when EITHER the persisted reactions for this message change OR
     // the in-flight pending entries for this message change — so the own
@@ -57,24 +84,31 @@ class ReactionsRow extends StatelessWidget {
     return BlocBuilder<ConversationReactionsCubit, ConversationReactionsState>(
       buildWhen: (prev, curr) {
         if (!_listEquals(
-          prev.reactionsFor(messageId),
-          curr.reactionsFor(messageId),
+          prev.reactionsFor(widget.messageId),
+          curr.reactionsFor(widget.messageId),
         )) {
           return true;
         }
-        return !_pendingForMessageEquals(prev.pending, curr.pending, messageId);
+        return !_pendingForMessageEquals(
+          prev.pending,
+          curr.pending,
+          widget.messageId,
+        );
       },
       builder: (context, state) {
         final reactions = state
-            .reactionsFor(messageId)
-            .where((r) => !blockedPubkeys.contains(r.reactorPubkey))
+            .reactionsFor(widget.messageId)
+            .where((r) => !widget.blockedPubkeys.contains(r.reactorPubkey))
             .toList(growable: false);
+        // Capture the baseline on the first build (even when empty) so the very
+        // first reaction added afterwards — the double-tap ❤️ — reads as new.
+        _baselineEmojis ??= reactions.map((r) => r.emoji).toSet();
         if (reactions.isEmpty) return const SizedBox.shrink();
 
         return Padding(
           padding: const EdgeInsets.fromLTRB(20, 0, 20, 4),
           child: Align(
-            alignment: isSentByMe
+            alignment: widget.isSentByMe
                 ? Alignment.centerRight
                 : Alignment.centerLeft,
             // Pull the pill up ~14 px so it overlaps the bubble's bottom edge,
@@ -83,15 +117,16 @@ class ReactionsRow extends StatelessWidget {
               offset: const Offset(0, -14),
               child: _ReactionPill(
                 reactions: reactions,
-                ownerPubkey: ownerPubkey,
+                ownerPubkey: widget.ownerPubkey,
+                baselineEmojis: _baselineEmojis!,
                 onTap: () => ReactionsDetailSheet.show(
                   context: context,
                   cubit: context.read<ConversationReactionsCubit>(),
-                  conversationId: conversationId,
-                  messageId: messageId,
-                  messageAuthorPubkey: messageAuthorPubkey,
-                  ownerPubkey: ownerPubkey,
-                  blockedPubkeys: blockedPubkeys,
+                  conversationId: widget.conversationId,
+                  messageId: widget.messageId,
+                  messageAuthorPubkey: widget.messageAuthorPubkey,
+                  ownerPubkey: widget.ownerPubkey,
+                  blockedPubkeys: widget.blockedPubkeys,
                 ),
               ),
             ),
@@ -107,12 +142,18 @@ class _ReactionPill extends StatelessWidget {
   const _ReactionPill({
     required this.reactions,
     required this.ownerPubkey,
+    required this.baselineEmojis,
     required this.onTap,
   });
 
   /// Live reactions for the message (blocklist-filtered, ascending createdAt).
   final List<DmReaction> reactions;
   final String ownerPubkey;
+
+  /// Emojis already present when the enclosing row first built. A shown glyph
+  /// whose emoji is absent here is a post-mount addition and grows in; emojis
+  /// in the baseline render settled (see [_PoppingEmoji.animateIn]).
+  final Set<String> baselineEmojis;
   final VoidCallback onTap;
 
   static const int _maxEmojis = 3;
@@ -165,9 +206,16 @@ class _ReactionPill extends StatelessWidget {
     final rowChildren = <Widget>[
       for (var i = 0; i < shownEmojis.length; i++) ...[
         if (i > 0) const SizedBox(width: 1),
-        // Keyed by emoji so only a newly-added glyph (e.g. a double-tap ❤️)
-        // grows in — existing glyphs keep their settled scale across rebuilds.
-        _PoppingEmoji(shownEmojis[i], key: ValueKey(shownEmojis[i])),
+        // Keyed by emoji so a newly-added glyph (e.g. a double-tap ❤️) spins up
+        // a fresh element that grows in, while existing glyphs keep their
+        // element — and settled scale — across rebuilds. animateIn gates the
+        // pop to emojis absent from the row's mount-time baseline, so the
+        // initial set (open / scroll-in) settles silently.
+        _PoppingEmoji(
+          shownEmojis[i],
+          key: ValueKey(shownEmojis[i]),
+          animateIn: !baselineEmojis.contains(shownEmojis[i]),
+        ),
       ],
       if (extraEmojis > 0) ...[
         const SizedBox(width: 2),
@@ -231,15 +279,21 @@ const _emojiTextStyle = TextStyle(fontSize: 15);
 /// Duration of the reaction glyph grow-in.
 const _emojiPopDuration = Duration(milliseconds: 180);
 
-/// A reaction emoji glyph that gently grows in (no bounce) the first time it
-/// mounts, then stays. [_ReactionPill] keys each glyph by its emoji, so only a
-/// newly-added reaction (e.g. a double-tap ❤️) animates — existing glyphs keep
-/// their settled scale across rebuilds. Scale-only (paint transform), so it
-/// never reflows the fixed-height pill.
+/// A reaction emoji glyph that gently grows in (no bounce) when [animateIn] is
+/// set, otherwise mounts already at its settled scale. [_ReactionPill] keys
+/// each glyph by its emoji and only passes `animateIn: true` for a glyph added
+/// *after* the row mounted (a live incoming reaction or the user's own
+/// double-tap ❤️) — so the initial set (conversation open, scroll-in) settles
+/// silently and existing glyphs never re-pop. Scale-only (paint transform), so
+/// it never reflows the fixed-height pill.
 class _PoppingEmoji extends StatefulWidget {
-  const _PoppingEmoji(this.emoji, {super.key});
+  const _PoppingEmoji(this.emoji, {required this.animateIn, super.key});
 
   final String emoji;
+
+  /// Whether this glyph grows in on mount. False for glyphs already present at
+  /// the row's first build; true for a glyph that appears once mounted.
+  final bool animateIn;
 
   @override
   State<_PoppingEmoji> createState() => _PoppingEmojiState();
@@ -260,7 +314,11 @@ class _PoppingEmojiState extends State<_PoppingEmoji>
   @override
   void initState() {
     super.initState();
-    _controller.forward();
+    if (widget.animateIn) {
+      _controller.forward();
+    } else {
+      _controller.value = 1;
+    }
   }
 
   @override

--- a/mobile/lib/screens/inbox/conversation/widgets/reactions_row.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/reactions_row.dart
@@ -158,10 +158,6 @@ class _ReactionPill extends StatelessWidget {
         : VineTheme.outlineVariant;
     final borderRadius = BorderRadius.circular(_height / 2);
 
-    // 🔥 is painted by the platform colour-emoji font (Inter ships no emoji),
-    // so a forced line-height drops the glyph low on Android. Natural leading
-    // lets the Row centre the glyph box — mirrors reaction_picker_overlay.
-    const emojiStyle = TextStyle(fontSize: 15);
     final overflowStyle = VineTheme.labelSmallFont(
       color: VineTheme.onSurface,
     ).copyWith(fontSize: 11, height: 1);
@@ -169,7 +165,9 @@ class _ReactionPill extends StatelessWidget {
     final rowChildren = <Widget>[
       for (var i = 0; i < shownEmojis.length; i++) ...[
         if (i > 0) const SizedBox(width: 1),
-        Text(shownEmojis[i], style: emojiStyle),
+        // Keyed by emoji so only a newly-added glyph (e.g. a double-tap ❤️)
+        // grows in — existing glyphs keep their settled scale across rebuilds.
+        _PoppingEmoji(shownEmojis[i], key: ValueKey(shownEmojis[i])),
       ],
       if (extraEmojis > 0) ...[
         const SizedBox(width: 2),
@@ -219,6 +217,63 @@ class _ReactionPill extends StatelessWidget {
           ),
         ),
       ),
+    );
+  }
+}
+
+/// Text style for a reaction glyph.
+///
+/// 🔥 is painted by the platform colour-emoji font (Inter ships no emoji), so a
+/// forced line-height drops the glyph low on Android. Natural leading lets the
+/// Row centre the glyph box — mirrors reaction_picker_overlay.
+const _emojiTextStyle = TextStyle(fontSize: 15);
+
+/// Duration of the reaction glyph grow-in.
+const _emojiPopDuration = Duration(milliseconds: 180);
+
+/// A reaction emoji glyph that gently grows in (no bounce) the first time it
+/// mounts, then stays. [_ReactionPill] keys each glyph by its emoji, so only a
+/// newly-added reaction (e.g. a double-tap ❤️) animates — existing glyphs keep
+/// their settled scale across rebuilds. Scale-only (paint transform), so it
+/// never reflows the fixed-height pill.
+class _PoppingEmoji extends StatefulWidget {
+  const _PoppingEmoji(this.emoji, {super.key});
+
+  final String emoji;
+
+  @override
+  State<_PoppingEmoji> createState() => _PoppingEmojiState();
+}
+
+class _PoppingEmojiState extends State<_PoppingEmoji>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller = AnimationController(
+    vsync: this,
+    duration: _emojiPopDuration,
+  );
+
+  late final Animation<double> _scale = Tween<double>(begin: 0.6, end: 1)
+      .animate(
+        CurvedAnimation(parent: _controller, curve: Curves.easeOutCubic),
+      );
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.forward();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ScaleTransition(
+      scale: _scale,
+      child: Text(widget.emoji, style: _emojiTextStyle),
     );
   }
 }

--- a/mobile/test/blocs/dm/reactions/conversation_reactions_cubit_test.dart
+++ b/mobile/test/blocs/dm/reactions/conversation_reactions_cubit_test.dart
@@ -576,4 +576,125 @@ void main() {
       );
     });
   });
+
+  group('ConversationReactionsState.ownReactionPendingOrLive', () {
+    const heart = '❤️';
+
+    DmReaction reaction({
+      required String id,
+      required String reactor,
+      required String emoji,
+      DmReactionPublishStatus status = DmReactionPublishStatus.sent,
+    }) => DmReaction(
+      id: id,
+      conversationId: _convo,
+      targetMessageId: _msgId,
+      targetMessageAuthor: _peer,
+      reactorPubkey: reactor,
+      emoji: emoji,
+      createdAt: 1700000000,
+      ownerPubkey: _owner,
+      publishStatus: status,
+    );
+
+    test('true when the owner has a persisted matching reaction', () {
+      final state = ConversationReactionsState(
+        reactionsByMessageId: {
+          _msgId: [reaction(id: 'own', reactor: _owner, emoji: heart)],
+        },
+      );
+      expect(
+        state.ownReactionPendingOrLive(
+          messageId: _msgId,
+          emoji: heart,
+          ownerPubkey: _owner,
+        ),
+        isTrue,
+      );
+    });
+
+    test('false when the message has no reactions', () {
+      const state = ConversationReactionsState();
+      expect(
+        state.ownReactionPendingOrLive(
+          messageId: _msgId,
+          emoji: heart,
+          ownerPubkey: _owner,
+        ),
+        isFalse,
+      );
+    });
+
+    test('false when only another reactor has the emoji', () {
+      final state = ConversationReactionsState(
+        reactionsByMessageId: {
+          _msgId: [reaction(id: 'peer', reactor: _peer, emoji: heart)],
+        },
+      );
+      expect(
+        state.ownReactionPendingOrLive(
+          messageId: _msgId,
+          emoji: heart,
+          ownerPubkey: _owner,
+        ),
+        isFalse,
+      );
+    });
+
+    test('true from an optimistic add before the row persists', () {
+      final state = ConversationReactionsState(
+        optimistic: {
+          const ReactionPublishKey(
+            messageId: _msgId,
+            emoji: heart,
+          ): OptimisticReactionAdded(
+            reaction(
+              id: 'optimistic:$_msgId:$heart',
+              reactor: _owner,
+              emoji: heart,
+              status: DmReactionPublishStatus.pending,
+            ),
+          ),
+        },
+      );
+      expect(
+        state.ownReactionPendingOrLive(
+          messageId: _msgId,
+          emoji: heart,
+          ownerPubkey: _owner,
+        ),
+        isTrue,
+      );
+      // The persisted-only getter does NOT see the optimistic overlay — this
+      // is exactly the pre-persist window the double-tap guard must cover.
+      expect(
+        state.ownReactionMatches(
+          messageId: _msgId,
+          emoji: heart,
+          ownerPubkey: _owner,
+        ),
+        isFalse,
+      );
+    });
+
+    test('false when an optimistic remove hides the persisted reaction', () {
+      final state = ConversationReactionsState(
+        reactionsByMessageId: {
+          _msgId: [reaction(id: 'own', reactor: _owner, emoji: heart)],
+        },
+        optimistic: {
+          const ReactionPublishKey(messageId: _msgId, emoji: heart):
+              const OptimisticReactionRemoved(),
+        },
+      );
+      expect(
+        state.ownReactionPendingOrLive(
+          messageId: _msgId,
+          emoji: heart,
+          ownerPubkey: _owner,
+        ),
+        isFalse,
+      );
+    });
+  });
 }

--- a/mobile/test/blocs/dm/reactions/conversation_reactions_cubit_test.dart
+++ b/mobile/test/blocs/dm/reactions/conversation_reactions_cubit_test.dart
@@ -260,6 +260,62 @@ void main() {
     );
 
     blocTest<ConversationReactionsCubit, ConversationReactionsState>(
+      'rapid double-tap set is a no-op during the pre-persist optimistic '
+      'window (publishes once)',
+      build: () {
+        when(
+          () => repo.publish(
+            conversationId: any(named: 'conversationId'),
+            targetMessageId: any(named: 'targetMessageId'),
+            targetMessageAuthor: any(named: 'targetMessageAuthor'),
+            emoji: any(named: 'emoji'),
+          ),
+        ).thenAnswer(
+          (_) async =>
+              const DmReactionPublishResult(success: true, rumorId: 'r-set'),
+        );
+        return ConversationReactionsCubit(
+          reactionsRepository: repo,
+          ownerPubkey: _owner,
+        );
+      },
+      act: (cubit) async {
+        // Two sets in a burst, before any persisted row (or stream tick) lands.
+        // The first paints the optimistic ❤️; the second must see it via the
+        // optimistic-inclusive guard and no-op — so only one gift-wrap is sent
+        // and the pre-persist window can't fan out duplicates.
+        cubit
+          ..add(
+            const ConversationReactionSet(
+              conversationId: _convo,
+              messageId: _msgId,
+              messageAuthorPubkey: _peer,
+              emoji: '❤️',
+            ),
+          )
+          ..add(
+            const ConversationReactionSet(
+              conversationId: _convo,
+              messageId: _msgId,
+              messageAuthorPubkey: _peer,
+              emoji: '❤️',
+            ),
+          );
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      },
+      verify: (_) {
+        verify(
+          () => repo.publish(
+            conversationId: _convo,
+            targetMessageId: _msgId,
+            targetMessageAuthor: _peer,
+            emoji: '❤️',
+          ),
+        ).called(1);
+      },
+    );
+
+    blocTest<ConversationReactionsCubit, ConversationReactionsState>(
       'set with a different emoji publishes (supersede handled by repo)',
       build: () {
         when(

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -95,6 +95,14 @@ void main() {
       registerFallbackValue(
         const ConversationSelfWrapRecoveryRequested(rumorIds: <String>[]),
       );
+      registerFallbackValue(
+        const ConversationReactionSet(
+          conversationId: '',
+          messageId: '',
+          messageAuthorPubkey: '',
+          emoji: '',
+        ),
+      );
     });
 
     setUp(() {
@@ -178,6 +186,111 @@ void main() {
           ? app
           : MockGoRouterProvider(goRouter: goRouter, child: app);
     }
+
+    group('double-tap to like', () {
+      DmMessage reactableMessage({required bool sent}) => DmMessage(
+        id: 'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
+        conversationId:
+            'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+        senderPubkey: sent ? currentPubkey : otherPubkey,
+        content: 'React to me',
+        createdAt: now.millisecondsSinceEpoch ~/ 1000,
+        giftWrapId:
+            'aaaaaaaabbbbbbbbccccccccddddddddaaaaaaaabbbbbbbbccccccccdddddddd',
+      );
+
+      // WidgetTester has no built-in double tap: synthesize two taps at the
+      // same point with a gap inside the double-tap window (> 40 ms min,
+      // < 300 ms timeout). pumpAndSettle only AFTER the second tap so the
+      // gap doesn't overrun the window and register as two single taps.
+      Future<void> doubleTapBubble(WidgetTester tester) async {
+        final center = tester.getCenter(find.text('React to me'));
+        await tester.tapAt(center);
+        await tester.pump(const Duration(milliseconds: 50));
+        await tester.tapAt(center);
+        await tester.pumpAndSettle();
+      }
+
+      List<ConversationReactionSet> capturedReactionSets() => verify(
+        () => mockReactionsCubit.add(captureAny()),
+      ).captured.whereType<ConversationReactionSet>().toList();
+
+      testWidgets('received bubble adds a ❤️ reaction to the message', (
+        tester,
+      ) async {
+        final message = reactableMessage(sent: false);
+        await tester.pumpWidget(
+          buildSubject(
+            state: ConversationState(
+              status: ConversationStatus.loaded,
+              messages: [message],
+            ),
+          ),
+        );
+        await tester.pump();
+
+        await doubleTapBubble(tester);
+
+        final sets = capturedReactionSets();
+        expect(sets, hasLength(1));
+        expect(sets.single.emoji, kDefaultDmReactionEmojis.first);
+        expect(sets.single.messageId, message.id);
+        expect(sets.single.messageAuthorPubkey, otherPubkey);
+      });
+
+      testWidgets('own delivered bubble also adds a ❤️ reaction', (
+        tester,
+      ) async {
+        final message = reactableMessage(sent: true);
+        await tester.pumpWidget(
+          buildSubject(
+            state: ConversationState(
+              status: ConversationStatus.loaded,
+              messages: [message],
+            ),
+          ),
+        );
+        await tester.pump();
+
+        await doubleTapBubble(tester);
+
+        final sets = capturedReactionSets();
+        expect(sets, hasLength(1));
+        expect(sets.single.emoji, kDefaultDmReactionEmojis.first);
+      });
+
+      testWidgets('failed own send does not dispatch a reaction', (
+        tester,
+      ) async {
+        final failedRow = OutgoingDm(
+          id: 'rumor-failed-id',
+          conversationId:
+              'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+          recipientPubkey: otherPubkey,
+          content: 'React to me',
+          createdAt: now.millisecondsSinceEpoch ~/ 1000,
+          rumorEventJson: '{}',
+          recipientWrapStatus: OutgoingWrapStatus.failed,
+          selfWrapStatus: OutgoingWrapStatus.failed,
+          queuedAt: now,
+          ownerPubkey: currentPubkey,
+        );
+
+        await tester.pumpWidget(
+          buildSubject(
+            state: ConversationState(
+              status: ConversationStatus.loaded,
+              pendingOutgoing: [failedRow],
+            ),
+          ),
+        );
+        await tester.pump();
+
+        await doubleTapBubble(tester);
+
+        verifyNever(() => mockReactionsCubit.add(any()));
+      });
+    });
 
     group('renders', () {
       testWidgets('renders $ConversationAppBar', (tester) async {

--- a/mobile/test/screens/inbox/conversation/widgets/message_bubble_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/message_bubble_test.dart
@@ -776,6 +776,7 @@ void main() {
       Widget buildWithVideoMessage({
         required String message,
         DmSharedVideoRef? sharedVideoRef,
+        VoidCallback? onDoubleTap,
       }) => testMaterialApp(
         home: Scaffold(
           body: MessageBubble(
@@ -783,6 +784,7 @@ void main() {
             timestamp: '2:30 PM',
             isSent: true,
             sharedVideoRef: sharedVideoRef,
+            onDoubleTap: onDoubleTap,
           ),
         ),
         mockNostrService: mockNostrClient,
@@ -791,6 +793,37 @@ void main() {
             mockVideoEventService,
           ),
         ],
+      );
+
+      testWidgets(
+        'suppresses double-tap-to-like on a shared-video bubble '
+        '(gesture-arena guard)',
+        (tester) async {
+          var doubleTapped = false;
+
+          // Default stubs resolve the preview to "unavailable" — a static card
+          // with no inner tap target and no pending timer.
+          await tester.pumpWidget(
+            buildWithVideoMessage(
+              message: 'https://divine.video/video/abc123',
+              onDoubleTap: () => doubleTapped = true,
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          final center = tester.getCenter(find.byType(MessageBubble));
+          await tester.tapAt(center);
+          await tester.pump(kDoubleTapMinTime);
+          await tester.tapAt(center);
+          await tester.pumpAndSettle();
+
+          // Double-tap is not wired on video bubbles: an ancestor onDoubleTap
+          // would hold the gesture arena for ~kDoubleTapTimeout and delay
+          // tap-to-open the reel. The text-bubble 'calls onDoubleTap' test is
+          // the positive control.
+          expect(doubleTapped, isFalse);
+          expect(find.byType(MessageBubble), findsOneWidget);
+        },
       );
 
       testWidgets('shows loading spinner before video resolves', (
@@ -1168,6 +1201,7 @@ void main() {
       Widget buildWithQuotedReply({
         required String message,
         DmSharedVideoRef? quotedVideoRef,
+        VoidCallback? onDoubleTap,
       }) => testMaterialApp(
         home: Scaffold(
           body: MessageBubble(
@@ -1175,6 +1209,7 @@ void main() {
             timestamp: '2:30 PM',
             isSent: true,
             quotedVideoRef: quotedVideoRef,
+            onDoubleTap: onDoubleTap,
           ),
         ),
         mockNostrService: mockNostrClient,
@@ -1183,6 +1218,36 @@ void main() {
             mockVideoEventService,
           ),
         ],
+      );
+
+      testWidgets(
+        'suppresses double-tap-to-like on a quoted-video reply bubble '
+        '(gesture-arena guard)',
+        (tester) async {
+          var doubleTapped = false;
+
+          // Default stubs resolve the quoted preview to "unavailable" — a
+          // static frame with no pending timer.
+          await tester.pumpWidget(
+            buildWithQuotedReply(
+              message: 'love this one',
+              quotedVideoRef: quotedRef,
+              onDoubleTap: () => doubleTapped = true,
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          final center = tester.getCenter(find.byType(MessageBubble));
+          await tester.tapAt(center);
+          await tester.pump(kDoubleTapMinTime);
+          await tester.tapAt(center);
+          await tester.pumpAndSettle();
+
+          // The quoted preview is itself a tap target (opens the cited reel),
+          // so double-tap-to-like is suppressed to keep tap-to-open instant.
+          expect(doubleTapped, isFalse);
+          expect(find.byType(MessageBubble), findsOneWidget);
+        },
       );
 
       testWidgets(

--- a/mobile/test/screens/inbox/conversation/widgets/message_bubble_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/message_bubble_test.dart
@@ -1417,6 +1417,60 @@ void main() {
       });
     });
 
+    group('double-tap', () {
+      testWidgets('calls onDoubleTap', (tester) async {
+        var doubleTapped = false;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: MessageBubble(
+                message: 'Double tap me',
+                timestamp: '2:30 PM',
+                isSent: true,
+                onDoubleTap: () => doubleTapped = true,
+              ),
+            ),
+          ),
+        );
+
+        final target = tester.getCenter(find.text('Double tap me'));
+        await tester.tapAt(target);
+        // Second tap within the double-tap window (>= min gap, < timeout).
+        await tester.pump(kDoubleTapMinTime);
+        await tester.tapAt(target);
+        await tester.pumpAndSettle();
+
+        expect(doubleTapped, isTrue);
+      });
+
+      testWidgets('does not crash when onDoubleTap is null', (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: MessageBubble(
+                message: 'No double tap',
+                timestamp: '2:30 PM',
+                isSent: true,
+              ),
+            ),
+          ),
+        );
+
+        final target = tester.getCenter(find.text('No double tap'));
+        await tester.tapAt(target);
+        await tester.pump(kDoubleTapMinTime);
+        await tester.tapAt(target);
+        await tester.pumpAndSettle();
+
+        expect(find.text('No double tap'), findsOneWidget);
+      });
+    });
+
     group('markdown rendering', () {
       /// Walks the rendered span tree and collects every TextSpan that
       /// satisfies [predicate]. Used to assert on the inline-style

--- a/mobile/test/screens/inbox/conversation/widgets/reactions_row_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/reactions_row_test.dart
@@ -242,7 +242,8 @@ void main() {
       );
 
       await tester.pumpWidget(buildSubject(cubit));
-      await tester.pump();
+      // Settle the glyph pop-in so the emoji is at full scale and hittable.
+      await tester.pumpAndSettle();
 
       // Sheet not open yet.
       expect(find.text(l10n.dmReactionsSheetTitle), findsNothing);
@@ -288,5 +289,35 @@ void main() {
         );
       },
     );
+
+    testWidgets('a reaction glyph grows in and settles at full scale', (
+      tester,
+    ) async {
+      primeState(
+        stateWith([
+          makeReaction(id: '1', reactorPubkey: ownerPubkey, emoji: '❤️'),
+        ]),
+      );
+
+      await tester.pumpWidget(buildSubject(cubit));
+
+      // The glyph starts below full scale and grows in (the gentle "small heart
+      // appearing" the double-tap flow shows in the pill).
+      expect(_emojiScale(tester, '❤️'), lessThan(1));
+
+      // …and settles at full scale, where it stays.
+      await tester.pumpAndSettle();
+      expect(_emojiScale(tester, '❤️'), closeTo(1, 0.01));
+      expect(find.text('❤️'), findsOneWidget);
+    });
   });
+}
+
+/// Current scale of the `_PoppingEmoji` [ScaleTransition] wrapping the [emoji]
+/// glyph, read straight off the animation value.
+double _emojiScale(WidgetTester tester, String emoji) {
+  final scaleTransition = tester.widget<ScaleTransition>(
+    find.ancestor(of: find.text(emoji), matching: find.byType(ScaleTransition)),
+  );
+  return scaleTransition.scale.value;
 }

--- a/mobile/test/screens/inbox/conversation/widgets/reactions_row_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/reactions_row_test.dart
@@ -2,6 +2,8 @@
 // ABOUTME: Covers distinct-glyph rendering, reactor avatars, the
 // ABOUTME: "see who reacted" semantic label, and tap-opens-sheet.
 
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -30,6 +32,8 @@ void main() {
       'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
   const messageId =
       'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+  const messageIdB =
+      'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
 
   DmReaction makeReaction({
     required String id,
@@ -290,26 +294,184 @@ void main() {
       },
     );
 
-    testWidgets('a reaction glyph grows in and settles at full scale', (
-      tester,
-    ) async {
-      primeState(
-        stateWith([
+    testWidgets(
+      'a reaction present at mount renders settled (no pop on open / scroll-in)',
+      (tester) async {
+        primeState(
+          stateWith([
+            makeReaction(id: '1', reactorPubkey: ownerPubkey, emoji: '❤️'),
+          ]),
+        );
+
+        await tester.pumpWidget(buildSubject(cubit));
+        await tester.pump();
+
+        // A reaction that already exists when the pill first builds must not
+        // grow in — otherwise every reacted message pops on conversation open
+        // and each time it scrolls back into view.
+        expect(_emojiScale(tester, '❤️'), closeTo(1, 0.01));
+        expect(find.text('❤️'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'a reaction added while the pill is mounted grows in and settles',
+      (tester) async {
+        final controller =
+            StreamController<ConversationReactionsState>.broadcast();
+        addTearDown(controller.close);
+
+        final initial = stateWith([
           makeReaction(id: '1', reactorPubkey: ownerPubkey, emoji: '❤️'),
-        ]),
-      );
+        ]);
+        when(() => cubit.state).thenReturn(initial);
+        whenListen(cubit, controller.stream, initialState: initial);
 
-      await tester.pumpWidget(buildSubject(cubit));
+        await tester.pumpWidget(buildSubject(cubit));
+        await tester.pump();
 
-      // The glyph starts below full scale and grows in (the gentle "small heart
-      // appearing" the double-tap flow shows in the pill).
-      expect(_emojiScale(tester, '❤️'), lessThan(1));
+        // The pre-existing glyph is settled — the mount is silent.
+        expect(_emojiScale(tester, '❤️'), closeTo(1, 0.01));
 
-      // …and settles at full scale, where it stays.
-      await tester.pumpAndSettle();
-      expect(_emojiScale(tester, '❤️'), closeTo(1, 0.01));
-      expect(find.text('❤️'), findsOneWidget);
-    });
+        // A new reactor's glyph arrives on the live stream while the pill stays
+        // mounted → it grows in (the gentle "small heart appearing" feel).
+        controller.add(
+          stateWith([
+            makeReaction(id: '1', reactorPubkey: ownerPubkey, emoji: '❤️'),
+            makeReaction(
+              id: '2',
+              reactorPubkey: otherPubkey,
+              emoji: '🔥',
+              createdAt: 1_700_000_001,
+              publishStatus: DmReactionPublishStatus.received,
+            ),
+          ]),
+        );
+        // Two pumps: one flushes the stream event, one builds the frame that
+        // mounts the new glyph (its controller starts at 0 → below full scale).
+        await tester.pump();
+        await tester.pump();
+
+        expect(_emojiScale(tester, '🔥'), lessThan(1));
+        // The existing ❤️ keeps its element and does NOT re-pop.
+        expect(_emojiScale(tester, '❤️'), closeTo(1, 0.01));
+
+        await tester.pumpAndSettle();
+        expect(_emojiScale(tester, '🔥'), closeTo(1, 0.01));
+        expect(find.text('🔥'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'the first like on a never-reacted message grows in (double-tap flagship)',
+      (tester) async {
+        final controller =
+            StreamController<ConversationReactionsState>.broadcast();
+        addTearDown(controller.close);
+
+        // The message starts with zero reactions: the row is mounted (and
+        // captures an empty baseline) but no pill is shown yet.
+        const empty = ConversationReactionsState();
+        when(() => cubit.state).thenReturn(empty);
+        whenListen(cubit, controller.stream, initialState: empty);
+
+        await tester.pumpWidget(buildSubject(cubit));
+        await tester.pump();
+        expect(find.text('❤️'), findsNothing);
+
+        // The user double-taps → the cubit paints the optimistic own ❤️. It is
+        // absent from the mount-time baseline, so it must grow in — this is the
+        // whole point of the double-tap-to-like animation, and it must survive
+        // the "no prior reactions" path that mounts the pill for the first time.
+        controller.add(
+          ConversationReactionsState(
+            optimistic: {
+              const ReactionPublishKey(
+                messageId: messageId,
+                emoji: '❤️',
+              ): OptimisticReactionAdded(
+                makeReaction(
+                  id: 'optimistic:$messageId:❤️',
+                  reactorPubkey: ownerPubkey,
+                  emoji: '❤️',
+                  publishStatus: DmReactionPublishStatus.pending,
+                ),
+              ),
+            },
+          ),
+        );
+        // Two pumps: one flushes the stream event, one builds the frame that
+        // mounts the heart (its controller starts at 0 → below full scale).
+        await tester.pump();
+        await tester.pump();
+
+        expect(_emojiScale(tester, '❤️'), lessThan(1));
+
+        await tester.pumpAndSettle();
+        expect(_emojiScale(tester, '❤️'), closeTo(1, 0.01));
+        expect(find.text('❤️'), findsOneWidget);
+
+        // The optimistic pending ❤️ reconciles to a persisted `sent` row — same
+        // emoji, same keyed glyph — so it must NOT re-pop on the swap.
+        controller.add(
+          stateWith([
+            makeReaction(id: '1', reactorPubkey: ownerPubkey, emoji: '❤️'),
+          ]),
+        );
+        await tester.pump();
+        await tester.pump();
+        expect(_emojiScale(tester, '❤️'), closeTo(1, 0.01));
+      },
+    );
+
+    testWidgets(
+      'recaptures the baseline when the row is rebound to another message '
+      '(list recycling)',
+      (tester) async {
+        // Both messages already have a reaction; neither should pop at mount.
+        primeState(
+          ConversationReactionsState(
+            reactionsByMessageId: {
+              messageId: [
+                makeReaction(id: 'a', reactorPubkey: otherPubkey, emoji: '❤️'),
+              ],
+              messageIdB: [
+                makeReaction(id: 'b', reactorPubkey: otherPubkey, emoji: '🔥'),
+              ],
+            },
+          ),
+        );
+
+        Widget rowFor(String id) => testMaterialApp(
+          home: Scaffold(
+            body: BlocProvider<ConversationReactionsCubit>.value(
+              value: cubit,
+              child: ReactionsRow(
+                conversationId: conversationId,
+                messageId: id,
+                messageAuthorPubkey: otherPubkey,
+                ownerPubkey: ownerPubkey,
+                isSentByMe: false,
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpWidget(rowFor(messageId));
+        await tester.pump();
+        expect(_emojiScale(tester, '❤️'), closeTo(1, 0.01));
+
+        // Re-pump the SAME element position with a different messageId — the
+        // shape a ListView takes when it recycles a row onto another message.
+        // didUpdateWidget must drop the stale baseline so message B's reaction,
+        // present at rebind, does NOT spuriously pop. Without the reset the
+        // {❤️} baseline lingers and 🔥 (absent from it) grows in.
+        await tester.pumpWidget(rowFor(messageIdB));
+        await tester.pump();
+        expect(find.text('❤️'), findsNothing);
+        expect(_emojiScale(tester, '🔥'), closeTo(1, 0.01));
+      },
+    );
   });
 }
 


### PR DESCRIPTION
## Description

Adds Instagram-style double-tap-to-like on DM message bubbles, done the Nostr way.

- Double-tap a message bubble → fires a light haptic and adds a ❤️ **NIP-25 kind-7** reaction through the existing **NIP-17** gift-wrap pipeline (reusing the add-only `ConversationReactionSet` event). No new event kind or protocol shape.
- The ❤️ lands in the message's reaction pill and gently **grows in** (scale 0.6 → 1.0, ease-out, 180ms) via a keyed `_PoppingEmoji` — only the newly-added glyph animates; existing ones stay put. No full-screen burst.
- **Add-only:** a repeat double-tap never un-likes. Removal stays on the long-press reaction picker, which also remains the **screen-reader path** (double-tap is the AT activation gesture, so this is a sighted-user accelerator only).
- **Hidden on failed own sends,** mirroring the long-press picker guard (reacting to a message the recipient never received is meaningless).
- The like emoji reuses `kDefaultDmReactionEmojis.first`, so a double-tap and a picker ❤️ collapse to one reaction (there is no emoji normalization on the reaction path).
- A pending-or-live guard on the reactions state skips re-publishing during the pre-persist optimistic window, so rapid double-taps don't fan out duplicate gift-wrapped reactions.

**Related Issue:** Closes #5803

## Out of Scope

None.

## Verification

- `flutter analyze lib test integration_test` — clean.
- Targeted tests (all green):
  - `message_bubble_test.dart` — double-tap invokes the callback.
  - `conversation_view_test.dart` — double-tap dispatches a ❤️ `ConversationReactionSet` on received + own-delivered bubbles; no dispatch on a failed own send.
  - `reactions_row_test.dart` — the reaction glyph grows in and settles at full scale.
  - `conversation_reactions_cubit_test.dart` — the pending-or-live guard (persisted / optimistic-add / optimistic-remove / other-reactor).
- On-device pass of the grow-in feel still recommended before merge.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)