### PR TITLE
refactor(auth): extract OAuthSessionCoordinator — single-flight refresh (#4741)

### DIFF
--- a/mobile/lib/services/auth/oauth_session_coordinator.dart
+++ b/mobile/lib/services/auth/oauth_session_coordinator.dart
@@ -1,0 +1,190 @@
+// ABOUTME: Single-flight coordinator for Divine/Keycast OAuth session refresh.
+// ABOUTME: Owns the dedup futures + timeouts so concurrent 401s, app-resume,
+// ABOUTME: and expired-session recovery share one refresh-token exchange.
+
+import 'dart:async';
+
+import 'package:keycast_flutter/keycast_flutter.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// Coordinates OAuth session refresh so concurrent callers never race on a
+/// one-time-use refresh token.
+///
+/// Extracted from `AuthService` (#4741, repository tier). Unlike the other
+/// collaborators this one is STATEFUL: it owns the two single-flight futures
+/// ([_pendingOAuthRefresh]/[_pendingRefresh]) — process-lifetime concurrency
+/// state, not per-call snapshots. The facade retains ownership of the
+/// `_hasExpiredOAuthSession` flag (written by restore orchestration) and all
+/// result application (rebuilding the signer, `signInWithDivineOAuth`), reached
+/// here through the injected ports so behavior is preserved exactly.
+class OAuthSessionCoordinator {
+  OAuthSessionCoordinator({
+    required KeycastOAuth? oauthClient,
+    required Duration oauthRefreshTimeout,
+    required Duration expiredSessionRefreshTimeout,
+    required String? Function() currentPubkeyFallback,
+    required bool Function() hasExpiredSession,
+    required void Function() onRefreshSucceeded,
+  }) : _oauthClient = oauthClient,
+       _oauthRefreshTimeout = oauthRefreshTimeout,
+       _expiredSessionRefreshTimeout = expiredSessionRefreshTimeout,
+       _currentPubkeyFallback = currentPubkeyFallback,
+       _hasExpiredSession = hasExpiredSession,
+       _onRefreshSucceeded = onRefreshSucceeded;
+
+  final KeycastOAuth? _oauthClient;
+  final Duration _oauthRefreshTimeout;
+  final Duration _expiredSessionRefreshTimeout;
+  final String? Function() _currentPubkeyFallback;
+  final bool Function() _hasExpiredSession;
+  final void Function() _onRefreshSucceeded;
+
+  Future<bool>? _pendingRefresh;
+  Future<KeycastSession?>? _pendingOAuthRefresh;
+
+  /// Runs [attempt] under an outer single-flight, bounded by
+  /// [expiredSessionRefreshTimeout], to silently refresh an expired OAuth
+  /// session. [attempt] performs the refresh + result application (the caller
+  /// wires it to `_tryRefreshOAuthSession`).
+  ///
+  /// No-ops (returns false) unless [hasExpiredSession] and an OAuth client are
+  /// both present. Concurrent callers share the in-flight attempt; the shared
+  /// future always releases the slot even on a hung request (#4942).
+  Future<bool> refreshExpiredSession({
+    required Future<bool> Function() attempt,
+  }) {
+    if (!_hasExpiredSession() || _oauthClient == null) {
+      return Future.value(false);
+    }
+    final pending = _pendingRefresh;
+    if (pending != null) return pending;
+
+    late final Future<bool> refresh;
+    refresh = attempt()
+        .timeout(
+          _expiredSessionRefreshTimeout,
+          onTimeout: () {
+            Log.warning(
+              'tryRefreshExpiredSession: timed out after '
+              '${_expiredSessionRefreshTimeout.inMilliseconds}ms — '
+              'treating as failed',
+              name: 'OAuthSessionCoordinator',
+              category: LogCategory.auth,
+            );
+            return false;
+          },
+        )
+        .whenComplete(() {
+          // Only release the slot if it still holds this attempt — signOut
+          // may have detached it and a fresh attempt may already be in
+          // flight.
+          if (identical(_pendingRefresh, refresh)) {
+            _pendingRefresh = null;
+          }
+        });
+    return _pendingRefresh = refresh;
+  }
+
+  /// Single-flight OAuth session refresh. Every code path that needs a fresh
+  /// [KeycastSession] MUST call this instead of `KeycastOAuth.refreshSession()`
+  /// directly.
+  ///
+  /// Guarantees:
+  /// - Only one `refreshSession()` call in flight at a time (concurrent
+  ///   callers share the same [Future]).
+  /// - The shared future is bounded by [oauthRefreshTimeout] and ALWAYS
+  ///   releases the single-flight slot, even if the underlying request hangs
+  ///   on a dead socket — so the next attempt gets a fresh refresh instead of
+  ///   joining a poisoned one (#4942).
+  /// - `userPubkey` is bound before the session is persisted, so ownership
+  ///   checks on restore stay valid.
+  /// - [onRefreshSucceeded] runs on success (the facade clears its
+  ///   `_hasExpiredOAuthSession` flag there).
+  ///
+  /// [expectedOwnerPubkey] binds the refreshed session to a specific account.
+  /// Callers that hold a stored session should pass its `userPubkey`;
+  /// mid-session callers (401 retry, app resume) may omit it — the method
+  /// falls back to [currentPubkeyFallback].
+  ///
+  /// Returns the refreshed session on success, or `null` on failure.
+  Future<KeycastSession?> refreshSession({String? expectedOwnerPubkey}) {
+    final pending = _pendingOAuthRefresh;
+    if (pending != null) return pending;
+
+    late final Future<KeycastSession?> refresh;
+    refresh = _doRefreshSession(expectedOwnerPubkey: expectedOwnerPubkey)
+        .timeout(
+          _oauthRefreshTimeout,
+          onTimeout: () {
+            Log.warning(
+              '_refreshOAuthSession: timed out after '
+              '${_oauthRefreshTimeout.inMilliseconds}ms — '
+              'treating as failed',
+              name: 'OAuthSessionCoordinator',
+              category: LogCategory.auth,
+            );
+            return null;
+          },
+        )
+        .whenComplete(() {
+          // Only release the slot if it still holds this attempt — signOut
+          // may have detached it and a fresh attempt may already be in
+          // flight.
+          if (identical(_pendingOAuthRefresh, refresh)) {
+            _pendingOAuthRefresh = null;
+          }
+        });
+    return _pendingOAuthRefresh = refresh;
+  }
+
+  Future<KeycastSession?> _doRefreshSession({
+    String? expectedOwnerPubkey,
+  }) async {
+    final oauthClient = _oauthClient;
+    if (oauthClient == null) return null;
+    try {
+      final pubkey = expectedOwnerPubkey ?? _currentPubkeyFallback();
+      final refreshed = await oauthClient.refreshSession(userPubkey: pubkey);
+      if (refreshed == null || !refreshed.hasRpcAccess) return null;
+
+      _onRefreshSucceeded();
+      Log.info(
+        '_refreshOAuthSession: succeeded '
+        '(userPubkey=${refreshed.userPubkey != null ? "bound" : "unbound"})',
+        name: 'OAuthSessionCoordinator',
+        category: LogCategory.auth,
+      );
+      return refreshed;
+    } catch (e) {
+      Log.error(
+        '_refreshOAuthSession: failed: $e',
+        name: 'OAuthSessionCoordinator',
+        category: LogCategory.auth,
+      );
+      return null;
+    }
+  }
+
+  /// [TokenRefreshCallback] passed to [KeycastRpc] so it can recover from
+  /// mid-session 401s without caller involvement.
+  ///
+  /// Delegates to [refreshSession] which deduplicates concurrent callers —
+  /// multiple in-flight RPC 401s and app-resume refresh all share a single
+  /// refresh token exchange.
+  Future<String?> refreshAccessToken() async {
+    final refreshed = await refreshSession();
+    return refreshed?.accessToken;
+  }
+
+  /// Detaches any in-flight refresh so a post-sign-out login starts a fresh
+  /// attempt instead of joining one issued for the outgoing session.
+  ///
+  /// The futures cannot be cancelled, but their completion handlers only
+  /// release the slot they still own (identical check), so a late completion
+  /// cannot clobber a newer attempt. Deliberately does NOT touch the facade's
+  /// expired-session flag — sign-out clears the futures but not that flag.
+  void detach() {
+    _pendingOAuthRefresh = null;
+    _pendingRefresh = null;
+  }
+}

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -19,6 +19,7 @@ import 'package:openvine/models/auth_rpc_capability.dart';
 import 'package:openvine/models/authentication_source.dart';
 import 'package:openvine/models/known_account.dart';
 import 'package:openvine/services/auth/nostr_identity.dart';
+import 'package:openvine/services/auth/oauth_session_coordinator.dart';
 import 'package:openvine/services/auth/relay_discovery_orchestrator.dart';
 import 'package:openvine/services/auth/signer_factory.dart';
 import 'package:openvine/services/auth/signer_secure_store.dart';
@@ -262,6 +263,18 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
         userRelaysDiscoveredCallback: () => _onUserRelaysDiscovered,
         bootstrapRelayListCallback: () => _onBootstrapRelayListRequested,
       );
+  // Owns the single-flight refresh futures + timeouts; the facade keeps the
+  // _hasExpiredOAuthSession flag and all result application, reached here
+  // through ports so restore orchestration stays byte-identical.
+  late final OAuthSessionCoordinator _oauthCoordinator =
+      OAuthSessionCoordinator(
+        oauthClient: _oauthClient,
+        oauthRefreshTimeout: _oauthRefreshTimeout,
+        expiredSessionRefreshTimeout: _expiredSessionRefreshTimeout,
+        currentPubkeyFallback: () => _currentProfile?.publicKeyHex,
+        hasExpiredSession: () => _hasExpiredOAuthSession,
+        onRefreshSucceeded: () => _hasExpiredOAuthSession = false,
+      );
   final PreFetchFollowingCallback? _preFetchFollowing;
   final AuthUrlLauncher? _launchAuthUrl;
   final BackgroundActivityManager _backgroundActivityManager;
@@ -269,12 +282,12 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   final RemoteSignerFactory _remoteSignerFactory;
   final Duration _startupNetworkOperationTimeout;
 
-  /// Bound applied to the single-flight OAuth token refresh stored in
-  /// [_pendingOAuthRefresh]. Injectable so tests can use a short bound.
+  /// Bound applied to the single-flight OAuth token refresh in
+  /// [OAuthSessionCoordinator]. Injectable so tests can use a short bound.
   final Duration _oauthRefreshTimeout;
 
-  /// Bound applied to the full expired-session refresh flow stored in
-  /// [_pendingRefresh]. Injectable so tests can use a short bound.
+  /// Bound applied to the full expired-session refresh flow in
+  /// [OAuthSessionCoordinator]. Injectable so tests can use a short bound.
   final Duration _expiredSessionRefreshTimeout;
 
   /// Test seam: when supplied, bypasses the [Nip07Service] singleton and the
@@ -296,8 +309,6 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   bool _storageErrorOccurred = false;
   bool _hasExpiredOAuthSession = false;
   bool _isRpcUpgradeInProgress = false;
-  Future<bool>? _pendingRefresh;
-  Future<KeycastSession?>? _pendingOAuthRefresh;
   KeycastRpc? _keycastSigner;
 
   // RPC capability state — separate from AuthState so the router doesn't
@@ -685,9 +696,9 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       }
 
       // The shared refresh future is internally bounded by
-      // [_oauthRefreshTimeout] (see _refreshOAuthSession), so this await
+      // [_oauthRefreshTimeout] (see [OAuthSessionCoordinator]), so this await
       // cannot block startup indefinitely.
-      final refreshed = await _refreshOAuthSession(
+      final refreshed = await _oauthCoordinator.refreshSession(
         expectedOwnerPubkey: expectedOwnerPubkey ?? session?.userPubkey,
       );
 
@@ -787,9 +798,11 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     if (_oauthClient != null) {
       final KeycastSession? refreshed;
       try {
-        refreshed = await _refreshOAuthSession(
-          expectedOwnerPubkey: session?.userPubkey,
-        ).timeout(_startupNetworkOperationTimeout);
+        refreshed = await _oauthCoordinator
+            .refreshSession(
+              expectedOwnerPubkey: session?.userPubkey,
+            )
+            .timeout(_startupNetworkOperationTimeout);
       } on TimeoutException {
         Log.warning(
           'initialize: synchronous refresh timed out '
@@ -877,38 +890,8 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   /// consuming one-time-use refresh tokens in a race. The shared future is
   /// bounded by [_expiredSessionRefreshTimeout] so a hung attempt always
   /// releases the slot and the next call starts a fresh refresh (#4942).
-  Future<bool> tryRefreshExpiredSession() {
-    if (!_hasExpiredOAuthSession || _oauthClient == null) {
-      return Future.value(false);
-    }
-    final pending = _pendingRefresh;
-    if (pending != null) return pending;
-
-    late final Future<bool> refresh;
-    refresh = _doRefreshExpiredSession()
-        .timeout(
-          _expiredSessionRefreshTimeout,
-          onTimeout: () {
-            Log.warning(
-              'tryRefreshExpiredSession: timed out after '
-              '${_expiredSessionRefreshTimeout.inMilliseconds}ms — '
-              'treating as failed',
-              name: 'AuthService',
-              category: LogCategory.auth,
-            );
-            return false;
-          },
-        )
-        .whenComplete(() {
-          // Only release the slot if it still holds this attempt — signOut
-          // may have detached it and a fresh attempt may already be in
-          // flight.
-          if (identical(_pendingRefresh, refresh)) {
-            _pendingRefresh = null;
-          }
-        });
-    return _pendingRefresh = refresh;
-  }
+  Future<bool> tryRefreshExpiredSession() => _oauthCoordinator
+      .refreshExpiredSession(attempt: _doRefreshExpiredSession);
 
   Future<bool> _doRefreshExpiredSession() async {
     Log.info(
@@ -939,7 +922,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     required String caller,
     String? expectedOwnerPubkey,
   }) async {
-    final refreshed = await _refreshOAuthSession(
+    final refreshed = await _oauthCoordinator.refreshSession(
       expectedOwnerPubkey: expectedOwnerPubkey,
     );
     if (refreshed != null) {
@@ -955,94 +938,14 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     return false;
   }
 
-  /// Single-flight OAuth session refresh. Every code path that needs a
-  /// fresh [KeycastSession] MUST call this instead of
-  /// `_oauthClient.refreshSession()` directly.
-  ///
-  /// Guarantees:
-  /// - Only one `refreshSession()` call in flight at a time (concurrent
-  ///   callers share the same [Future]).
-  /// - The shared future is bounded by [_oauthRefreshTimeout] and ALWAYS
-  ///   releases the single-flight slot, even if the underlying request
-  ///   hangs on a dead socket — so the next attempt gets a fresh refresh
-  ///   instead of joining a poisoned one (#4942).
-  /// - `userPubkey` is bound before the session is persisted, so
-  ///   ownership checks on restore stay valid.
-  /// - `_hasExpiredOAuthSession` is cleared on success.
-  ///
-  /// [expectedOwnerPubkey] binds the refreshed session to a specific
-  /// account. Callers that hold a stored session should pass its
-  /// `userPubkey`; mid-session callers (401 retry, app resume) may omit
-  /// it — the method falls back to [_currentProfile].
-  ///
-  /// Returns the refreshed session on success, or `null` on failure.
-  Future<KeycastSession?> _refreshOAuthSession({String? expectedOwnerPubkey}) {
-    final pending = _pendingOAuthRefresh;
-    if (pending != null) return pending;
-
-    late final Future<KeycastSession?> refresh;
-    refresh = _doRefreshOAuthSession(expectedOwnerPubkey: expectedOwnerPubkey)
-        .timeout(
-          _oauthRefreshTimeout,
-          onTimeout: () {
-            Log.warning(
-              '_refreshOAuthSession: timed out after '
-              '${_oauthRefreshTimeout.inMilliseconds}ms — '
-              'treating as failed',
-              name: 'AuthService',
-              category: LogCategory.auth,
-            );
-            return null;
-          },
-        )
-        .whenComplete(() {
-          // Only release the slot if it still holds this attempt —
-          // signOut may have detached it and a fresh attempt may
-          // already be in flight.
-          if (identical(_pendingOAuthRefresh, refresh)) {
-            _pendingOAuthRefresh = null;
-          }
-        });
-    return _pendingOAuthRefresh = refresh;
-  }
-
-  Future<KeycastSession?> _doRefreshOAuthSession({
-    String? expectedOwnerPubkey,
-  }) async {
-    if (_oauthClient == null) return null;
-    try {
-      final pubkey = expectedOwnerPubkey ?? _currentProfile?.publicKeyHex;
-      final refreshed = await _oauthClient.refreshSession(userPubkey: pubkey);
-      if (refreshed == null || !refreshed.hasRpcAccess) return null;
-
-      _hasExpiredOAuthSession = false;
-      Log.info(
-        '_refreshOAuthSession: succeeded '
-        '(userPubkey=${refreshed.userPubkey != null ? "bound" : "unbound"})',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-      return refreshed;
-    } catch (e) {
-      Log.error(
-        '_refreshOAuthSession: failed: $e',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-      return null;
-    }
-  }
-
   /// [TokenRefreshCallback] passed to [KeycastRpc] so it can recover
   /// from mid-session 401s without caller involvement.
   ///
-  /// Delegates to [_refreshOAuthSession] which deduplicates concurrent
-  /// callers — multiple in-flight RPC 401s and app-resume refresh all
-  /// share a single refresh token exchange.
-  Future<String?> _refreshAccessToken() async {
-    final refreshed = await _refreshOAuthSession();
-    return refreshed?.accessToken;
-  }
+  /// Delegates to [OAuthSessionCoordinator.refreshAccessToken] which
+  /// deduplicates concurrent callers — multiple in-flight RPC 401s and
+  /// app-resume refresh all share a single refresh token exchange.
+  Future<String?> _refreshAccessToken() =>
+      _oauthCoordinator.refreshAccessToken();
 
   Future<void> _clearDismissedDivineLoginBannerForCurrentUser([
     String? publicKeyHex,
@@ -3634,12 +3537,9 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       _setRpcCapability(AuthRpcCapability.unavailable);
 
       // Detach any in-flight token refresh so post-signout logins start a
-      // fresh attempt instead of joining one issued for the outgoing
-      // session. The futures cannot be cancelled, but their completion
-      // handlers only release the slot they still own (identical check),
-      // so a late completion cannot clobber a newer attempt.
-      _pendingOAuthRefresh = null;
-      _pendingRefresh = null;
+      // fresh attempt instead of joining one issued for the outgoing session.
+      // Deliberately leaves _hasExpiredOAuthSession untouched.
+      _oauthCoordinator.detach();
 
       await _clearOAuthSessionForSignOut();
 
@@ -4796,7 +4696,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
         name: 'AuthService',
         category: LogCategory.auth,
       );
-      final refreshed = await _refreshOAuthSession(
+      final refreshed = await _oauthCoordinator.refreshSession(
         expectedOwnerPubkey: resumeOwnerPubkey,
       );
       if (!resumeContextStillCurrent()) {

--- a/mobile/test/services/auth/oauth_session_coordinator_test.dart
+++ b/mobile/test/services/auth/oauth_session_coordinator_test.dart
@@ -1,0 +1,428 @@
+// ABOUTME: Tests for OAuthSessionCoordinator — single-flight dedup, timeout
+// ABOUTME: slot release, expired-session guard, and the success/detach ports.
+
+import 'dart:async';
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:keycast_flutter/keycast_flutter.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/services/auth/oauth_session_coordinator.dart';
+
+class _MockKeycastOAuth extends Mock implements KeycastOAuth {}
+
+KeycastSession _session({String? userPubkey, String accessToken = 'token'}) =>
+    KeycastSession(
+      bunkerUrl: 'bunker://test',
+      accessToken: accessToken,
+      expiresAt: DateTime(2999),
+      userPubkey: userPubkey,
+    );
+
+void main() {
+  const oauthTimeout = Duration(milliseconds: 200);
+  const expiredTimeout = Duration(milliseconds: 200);
+
+  group(OAuthSessionCoordinator, () {
+    late _MockKeycastOAuth oauthClient;
+    late bool hasExpired;
+    late int refreshSucceededCalls;
+    late String? pubkeyFallback;
+
+    setUp(() {
+      oauthClient = _MockKeycastOAuth();
+      hasExpired = true;
+      refreshSucceededCalls = 0;
+      pubkeyFallback = 'fallback_pubkey';
+    });
+
+    OAuthSessionCoordinator build({bool nullClient = false}) =>
+        OAuthSessionCoordinator(
+          oauthClient: nullClient ? null : oauthClient,
+          oauthRefreshTimeout: oauthTimeout,
+          expiredSessionRefreshTimeout: expiredTimeout,
+          currentPubkeyFallback: () => pubkeyFallback,
+          hasExpiredSession: () => hasExpired,
+          onRefreshSucceeded: () => refreshSucceededCalls++,
+        );
+
+    group('refreshSession', () {
+      test(
+        'returns the refreshed session and fires onRefreshSucceeded',
+        () async {
+          final session = _session(userPubkey: 'owner');
+          when(
+            () => oauthClient.refreshSession(
+              userPubkey: any(named: 'userPubkey'),
+            ),
+          ).thenAnswer((_) async => session);
+
+          final result = await build().refreshSession(
+            expectedOwnerPubkey: 'owner',
+          );
+
+          expect(result, same(session));
+          expect(refreshSucceededCalls, equals(1));
+          verify(
+            () => oauthClient.refreshSession(userPubkey: 'owner'),
+          ).called(1);
+        },
+      );
+
+      test(
+        'falls back to currentPubkeyFallback when no owner is passed',
+        () async {
+          when(
+            () => oauthClient.refreshSession(
+              userPubkey: any(named: 'userPubkey'),
+            ),
+          ).thenAnswer((_) async => _session());
+
+          await build().refreshSession();
+
+          verify(
+            () => oauthClient.refreshSession(userPubkey: 'fallback_pubkey'),
+          ).called(1);
+        },
+      );
+
+      test('returns null and does not fire the success port when the '
+          'refreshed session has no RPC access', () async {
+        // No accessToken -> hasRpcAccess is false.
+        when(
+          () =>
+              oauthClient.refreshSession(userPubkey: any(named: 'userPubkey')),
+        ).thenAnswer(
+          (_) async => const KeycastSession(bunkerUrl: 'bunker://x'),
+        );
+
+        final result = await build().refreshSession();
+
+        expect(result, isNull);
+        expect(refreshSucceededCalls, isZero);
+      });
+
+      test('returns null (never throws) when the client throws', () async {
+        when(
+          () =>
+              oauthClient.refreshSession(userPubkey: any(named: 'userPubkey')),
+        ).thenThrow(Exception('network down'));
+
+        final result = await build().refreshSession();
+
+        expect(result, isNull);
+        expect(refreshSucceededCalls, isZero);
+      });
+
+      test('returns null when no OAuth client is configured', () async {
+        final result = await build(nullClient: true).refreshSession();
+
+        expect(result, isNull);
+      });
+
+      test(
+        'deduplicates concurrent callers into a single client call',
+        () async {
+          final gate = Completer<KeycastSession?>();
+          when(
+            () => oauthClient.refreshSession(
+              userPubkey: any(named: 'userPubkey'),
+            ),
+          ).thenAnswer((_) => gate.future);
+
+          final coordinator = build();
+          final a = coordinator.refreshSession();
+          final b = coordinator.refreshSession();
+
+          gate.complete(_session());
+          await Future.wait([a, b]);
+
+          verify(
+            () => oauthClient.refreshSession(
+              userPubkey: any(named: 'userPubkey'),
+            ),
+          ).called(1);
+        },
+      );
+
+      test('releases the slot after a hung request times out so the next '
+          'call starts a fresh refresh', () {
+        fakeAsync((async) {
+          var calls = 0;
+          when(
+            () => oauthClient.refreshSession(
+              userPubkey: any(named: 'userPubkey'),
+            ),
+          ).thenAnswer((_) {
+            calls++;
+            return Completer<KeycastSession?>().future; // never completes
+          });
+
+          final coordinator = build();
+
+          KeycastSession? firstResult;
+          var firstDone = false;
+          coordinator.refreshSession().then((r) {
+            firstResult = r;
+            firstDone = true;
+          });
+
+          async.elapse(oauthTimeout + const Duration(milliseconds: 1));
+          expect(firstDone, isTrue);
+          expect(firstResult, isNull);
+          expect(calls, equals(1));
+
+          // Slot released: a fresh call issues a new client request.
+          coordinator.refreshSession();
+          async.flushMicrotasks();
+          expect(calls, equals(2));
+        });
+      });
+    });
+
+    group('refreshExpiredSession', () {
+      test(
+        'returns false without running the attempt when not expired',
+        () async {
+          hasExpired = false;
+          var attemptRan = false;
+          final result = await build().refreshExpiredSession(
+            attempt: () async {
+              attemptRan = true;
+              return true;
+            },
+          );
+
+          expect(result, isFalse);
+          expect(attemptRan, isFalse);
+        },
+      );
+
+      test(
+        'returns false without running the attempt when no client',
+        () async {
+          var attemptRan = false;
+          final result = await build(nullClient: true).refreshExpiredSession(
+            attempt: () async {
+              attemptRan = true;
+              return true;
+            },
+          );
+
+          expect(result, isFalse);
+          expect(attemptRan, isFalse);
+        },
+      );
+
+      test('runs the attempt and returns its result when expired', () async {
+        final result = await build().refreshExpiredSession(
+          attempt: () async => true,
+        );
+
+        expect(result, isTrue);
+      });
+
+      test('deduplicates concurrent expired-session refreshes', () async {
+        final gate = Completer<bool>();
+        var attemptCalls = 0;
+
+        final coordinator = build();
+        final a = coordinator.refreshExpiredSession(
+          attempt: () {
+            attemptCalls++;
+            return gate.future;
+          },
+        );
+        final b = coordinator.refreshExpiredSession(attempt: () async => true);
+
+        gate.complete(true);
+        final results = await Future.wait([a, b]);
+
+        expect(results, equals([true, true]));
+        expect(attemptCalls, equals(1));
+      });
+
+      test('times out a hung attempt as failed and releases the slot', () {
+        fakeAsync((async) {
+          final coordinator = build();
+          var secondAttemptRan = false;
+
+          bool? firstResult;
+          coordinator
+              .refreshExpiredSession(
+                attempt: () => Completer<bool>().future, // hangs
+              )
+              .then((r) => firstResult = r);
+
+          async.elapse(expiredTimeout + const Duration(milliseconds: 1));
+          expect(firstResult, isFalse);
+
+          coordinator.refreshExpiredSession(
+            attempt: () async {
+              secondAttemptRan = true;
+              return true;
+            },
+          );
+          async.flushMicrotasks();
+          expect(secondAttemptRan, isTrue);
+        });
+      });
+    });
+
+    group('refreshAccessToken', () {
+      test('returns the access token of a successful refresh', () async {
+        when(
+          () =>
+              oauthClient.refreshSession(userPubkey: any(named: 'userPubkey')),
+        ).thenAnswer((_) async => _session(accessToken: 'fresh-token'));
+
+        final token = await build().refreshAccessToken();
+
+        expect(token, equals('fresh-token'));
+      });
+
+      test('returns null when the refresh fails', () async {
+        when(
+          () =>
+              oauthClient.refreshSession(userPubkey: any(named: 'userPubkey')),
+        ).thenAnswer((_) async => null);
+
+        final token = await build().refreshAccessToken();
+
+        expect(token, isNull);
+      });
+    });
+
+    group('detach', () {
+      test(
+        'clears the in-flight OAuth refresh so the next call starts fresh',
+        () async {
+          final firstGate = Completer<KeycastSession?>();
+          var calls = 0;
+          when(
+            () => oauthClient.refreshSession(
+              userPubkey: any(named: 'userPubkey'),
+            ),
+          ).thenAnswer((_) {
+            calls++;
+            return calls == 1 ? firstGate.future : Future.value(_session());
+          });
+
+          final coordinator = build();
+          final first = coordinator.refreshSession();
+
+          coordinator.detach();
+
+          // A post-detach call must not join the detached in-flight future.
+          final second = await coordinator.refreshSession();
+          expect(second, isNotNull);
+          expect(calls, equals(2));
+
+          firstGate.complete(null);
+          await first;
+        },
+      );
+
+      test(
+        "a detached future's late completion does not clobber a newer "
+        'in-flight slot',
+        () async {
+          final gates = [
+            Completer<KeycastSession?>(),
+            Completer<KeycastSession?>(),
+          ];
+          var calls = 0;
+          when(
+            () => oauthClient.refreshSession(
+              userPubkey: any(named: 'userPubkey'),
+            ),
+          ).thenAnswer((_) => gates[calls++].future);
+
+          final coordinator = build();
+          final first = coordinator.refreshSession(); // slot = refresh1
+          coordinator.detach(); // slot = null
+          final second = coordinator.refreshSession(); // slot = refresh2 (hung)
+          expect(calls, equals(2));
+
+          // The detached refresh1 completes AFTER refresh2 took the slot.
+          gates[0].complete(null);
+          await first;
+
+          // refresh1's whenComplete must NOT null refresh2's slot (identical
+          // guard is false), so a third call JOINS refresh2 instead of
+          // issuing a new client request.
+          final third = coordinator.refreshSession();
+          expect(calls, equals(2));
+
+          gates[1].complete(_session());
+          await Future.wait([second, third]);
+        },
+      );
+
+      test('clears the in-flight expired-session refresh', () async {
+        final coordinator = build();
+        final attemptGate = Completer<bool>();
+        var attemptCalls = 0;
+
+        final first = coordinator.refreshExpiredSession(
+          attempt: () {
+            attemptCalls++;
+            return attemptGate.future;
+          },
+        );
+
+        coordinator.detach();
+
+        // A post-detach expired-session refresh must start a fresh attempt
+        // rather than joining the detached one — so its attempt runs too.
+        final second = await coordinator.refreshExpiredSession(
+          attempt: () async {
+            attemptCalls++;
+            return true;
+          },
+        );
+        expect(second, isTrue);
+        expect(attemptCalls, equals(2));
+
+        attemptGate.complete(false);
+        await first;
+      });
+    });
+
+    test(
+      'a nested refreshExpiredSession whose attempt re-enters refreshSession '
+      'dedups the two slots independently',
+      () async {
+        when(
+          () =>
+              oauthClient.refreshSession(userPubkey: any(named: 'userPubkey')),
+        ).thenAnswer((_) async => _session());
+
+        final coordinator = build();
+        var innerRefreshResults = 0;
+
+        // Mirrors the facade wiring: the outer attempt re-enters the inner
+        // single-flight (as _tryRefreshOAuthSession does via refreshSession).
+        Future<bool> attempt() async {
+          final session = await coordinator.refreshSession();
+          if (session != null) innerRefreshResults++;
+          return session != null;
+        }
+
+        final results = await Future.wait([
+          coordinator.refreshExpiredSession(attempt: attempt),
+          coordinator.refreshExpiredSession(attempt: attempt),
+        ]);
+
+        // Outer slot dedups both callers into one attempt; that single attempt
+        // acquires the inner slot exactly once.
+        expect(results, equals([true, true]));
+        expect(innerRefreshResults, equals(1));
+        verify(
+          () =>
+              oauthClient.refreshSession(userPubkey: any(named: 'userPubkey')),
+        ).called(1);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## What & why

Second **repository-tier** slice of #4741 (after R1 #5757). The Divine/Keycast OAuth session-refresh cluster moves out of `auth_service.dart` behind the stable facade. auth_service.dart **4,876 → 4,776**.

## The stateful exception

This collaborator is deliberately **stateful** — unlike SignerFactory/RelayDiscoveryOrchestrator (per-call snapshots), `OAuthSessionCoordinator` owns the two single-flight dedup futures (`_pendingRefresh`/`_pendingOAuthRefresh`), the two timeout bounds, and the injected `KeycastOAuth`. Those futures are process-lifetime concurrency state, not per-call session state — the "AuthService keeps all mutable session fields" rule is bent here on purpose, flagged in the class doc.

## Seam (lowest-risk variant)

The facade **keeps** `_hasExpiredOAuthSession` and every restore site that writes it (init fast/slow path, `signInForAccount` downgrade), plus all result application (rebuilding `_keycastSigner`/`_currentIdentity`, `signInWithDivineOAuth`). That means the **multi_account-pinned restore code stays byte-identical** — the extraction only touches the refresh composition. The coordinator reaches shared facade state through three ports:
- `currentPubkeyFallback` — the `_currentProfile` read (evaluated inside the deduped future at execution time, so a joined caller binds the same pubkey as before)
- `hasExpiredSession` — the outer guard
- `onRefreshSucceeded` — clears the facade flag on a successful refresh

`signOut` becomes `_oauthCoordinator.detach()`, which nulls both futures and **deliberately leaves `_hasExpiredOAuthSession` untouched** (preserving the pre-existing asymmetry).

## Public surface

`refreshSession({expectedOwnerPubkey})` (inner single-flight), `refreshExpiredSession({attempt})` (outer, wraps the facade's `_tryRefreshOAuthSession` refresh+apply closure), `refreshAccessToken()` (the `KeycastRpc.onTokenRefresh` tear-off), `detach()`. The `identical()`-guarded slot release and the #4942 hung-request timeout semantics are preserved verbatim.

## Verification

- **Adversarial drift-hunter: zero behavior drift** — line-by-line vs `origin/main` (slot release, timeouts, fallback, flag-clear timing, the 3 redelegated call sites, signOut asymmetry, all log message strings). One deliberate non-behavioural change: the structured `name:` tag at the 4 moved `Log.*` sites is retagged `AuthService` → `OAuthSessionCoordinator` per the R1/R2 own-class-tag convention — the message content is byte-identical; only external log filters keyed on `name:'AuthService'` for these specific lines are affected (nothing in-repo keys on that tag).
- New `oauth_session_coordinator_test.dart` — **18 tests**: hung-request timeout slot-release for both inner *and* outer (#4942), dedup, no-client guards, `onRefreshSucceeded`-only-on-`hasRpcAccess`, and the concurrency-reviewer-requested hardening: the detach `identical()` false-branch (a detached future's late completion cannot clobber a newer slot) + the nested outer/inner two-slot interaction that mirrors the facade wiring.
- Pinned suites unchanged and green: **multi_account (113)**, oauth_recovery, expired_session_downgrade (incl. the hung-refresh slot-release behavior), oauth_local_signing, local_first_startup, delete_keycast_account, invite_session_cleanup, data_cleanup_ordering.
- Full auth sweep: **352 tests**; analyze clean; all CI ratchets green (empty_catch/sentinel/floor/skip/future_delayed).

No user-facing change. Part of #4741. Next: R3 (known-accounts registry rules).
