### PR TITLE
refactor(auth): extract KnownAccountsRegistry — known-accounts CRUD + migration (#4741)

### DIFF
--- a/mobile/lib/models/authentication_source.dart
+++ b/mobile/lib/models/authentication_source.dart
@@ -1,3 +1,8 @@
+/// SharedPreferences key under which the current session's
+/// [AuthenticationSource] `code` is persisted, so the correct sign-in method
+/// can be restored at startup.
+const kAuthenticationSourceKey = 'authentication_source';
+
 /// Source of authentication used to restore session at startup
 enum AuthenticationSource {
   none('none'),

--- a/mobile/lib/services/auth/known_accounts_registry.dart
+++ b/mobile/lib/services/auth/known_accounts_registry.dart
@@ -15,12 +15,6 @@ import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:unified_logger/unified_logger.dart';
 
-// Mirrors the facade's `authentication_source` SharedPreferences key; the
-// legacy migration reads it to recover the pre-multi-account session. Kept in
-// sync with `_kAuthSourceKey` in auth_service.dart — both pin the same literal,
-// which the multi_account suite asserts.
-const _kAuthSourceKey = 'authentication_source';
-
 /// Owns the persisted "known accounts" registry that backs the multi-account
 /// welcome-screen picker: reading/writing [kKnownAccountsKey], the one-time
 /// legacy migration, add/update/remove, and the restorable-account filter.
@@ -102,7 +96,7 @@ class KnownAccountsRegistry {
       category: LogCategory.auth,
     );
 
-    final rawAuthSource = prefs.getString(_kAuthSourceKey);
+    final rawAuthSource = prefs.getString(kAuthenticationSourceKey);
     final source = AuthenticationSource.fromCode(rawAuthSource);
     Log.info(
       'Legacy migration: rawAuthSource=$rawAuthSource, '

--- a/mobile/lib/services/auth/known_accounts_registry.dart
+++ b/mobile/lib/services/auth/known_accounts_registry.dart
@@ -1,0 +1,411 @@
+// ABOUTME: Persistent registry of previously used accounts — the multi-account
+// ABOUTME: welcome-screen picker source. Owns known-accounts CRUD, the one-time
+// ABOUTME: legacy migration, and the restorable-account filter. Extracted from
+// ABOUTME: AuthService (#4741, repository tier).
+
+import 'dart:convert';
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:keycast_flutter/keycast_flutter.dart';
+import 'package:nostr_key_manager/nostr_key_manager.dart' show SecureKeyStorage;
+import 'package:openvine/models/authentication_source.dart';
+import 'package:openvine/models/known_account.dart';
+import 'package:openvine/services/auth/signer_secure_store.dart';
+import 'package:openvine/utils/nostr_key_utils.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+// Mirrors the facade's `authentication_source` SharedPreferences key; the
+// legacy migration reads it to recover the pre-multi-account session. Kept in
+// sync with `_kAuthSourceKey` in auth_service.dart — both pin the same literal,
+// which the multi_account suite asserts.
+const _kAuthSourceKey = 'authentication_source';
+
+/// Owns the persisted "known accounts" registry that backs the multi-account
+/// welcome-screen picker: reading/writing [kKnownAccountsKey], the one-time
+/// legacy migration, add/update/remove, and the restorable-account filter.
+///
+/// Extracted from `AuthService` (#4741, repository tier). Unlike
+/// [OAuthSessionCoordinator] this collaborator is STATELESS — every method
+/// reads [SharedPreferences] fresh, so there is no cached state to detach on
+/// sign-out. The facade retains all session state (`_authSource`, auth-state
+/// guards, restore orchestration) and calls into this registry for the pure
+/// storage rules, so `multi_account` behavior is preserved exactly.
+class KnownAccountsRegistry {
+  KnownAccountsRegistry({
+    required SecureKeyStorage keyStorage,
+    required SignerSecureStore signerStore,
+    required FlutterSecureStorage? flutterSecureStorage,
+  }) : _keyStorage = keyStorage,
+       _signerStore = signerStore,
+       _flutterSecureStorage = flutterSecureStorage;
+
+  final SecureKeyStorage _keyStorage;
+  final SignerSecureStore _signerStore;
+  final FlutterSecureStorage? _flutterSecureStorage;
+
+  /// Returns all previously used accounts, most-recently-used first.
+  ///
+  /// On first read (the `known_accounts` key has never been written) runs a
+  /// one-time migration that checks for a legacy session and persists the
+  /// result so the migration never runs again.
+  Future<List<KnownAccount>> getKnownAccounts() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final raw = prefs.getString(kKnownAccountsKey);
+      Log.info(
+        'getKnownAccounts: raw=${raw == null ? 'null' : '${raw.length} chars'}',
+        name: 'KnownAccountsRegistry',
+        category: LogCategory.auth,
+      );
+
+      // null  → key never written → run one-time migration
+      // empty → key was written but all accounts removed → no migration
+      if (raw == null) {
+        return _migrateLegacyAccount(prefs);
+      }
+      if (raw.isEmpty) return [];
+
+      final decoded = (jsonDecode(raw) as List<dynamic>)
+          .cast<Map<String, dynamic>>();
+      final accounts = decoded.map(KnownAccount.fromJson).toList()
+        ..sort((a, b) => b.lastUsedAt.compareTo(a.lastUsedAt));
+      return accounts;
+    } catch (e) {
+      Log.warning(
+        'Failed to load known accounts: $e',
+        name: 'KnownAccountsRegistry',
+        category: LogCategory.auth,
+      );
+      return [];
+    }
+  }
+
+  /// One-time migration from the old single-account auth system.
+  ///
+  /// Checks for a legacy session stored under the old `authentication_source`
+  /// key and, if found, creates a [KnownAccount] entry for it.
+  ///
+  /// Additionally, always checks [SecureKeyStorage] for an automatic/anonymous
+  /// identity. A user may have started with an automatic account and later
+  /// switched to bunker/OAuth — the old automatic keys are still in storage
+  /// even though `authentication_source` was overwritten.
+  ///
+  /// The result is persisted to [kKnownAccountsKey] so this migration never
+  /// runs again.
+  Future<List<KnownAccount>> _migrateLegacyAccount(
+    SharedPreferences prefs,
+  ) async {
+    Log.info(
+      'known_accounts key absent — running one-time legacy migration',
+      name: 'KnownAccountsRegistry',
+      category: LogCategory.auth,
+    );
+
+    final rawAuthSource = prefs.getString(_kAuthSourceKey);
+    final source = AuthenticationSource.fromCode(rawAuthSource);
+    Log.info(
+      'Legacy migration: rawAuthSource=$rawAuthSource, '
+      'resolved=${source.name}',
+      name: 'KnownAccountsRegistry',
+      category: LogCategory.auth,
+    );
+
+    if (source == AuthenticationSource.none) {
+      // Fresh install or explicit logout — still check for automatic keys.
+      Log.info(
+        'Legacy migration: source=none, checking automatic keys...',
+        name: 'KnownAccountsRegistry',
+        category: LogCategory.auth,
+      );
+      final accounts = await _migrateAutomaticKeys([]);
+      Log.info(
+        'Legacy migration: source=none, automatic keys check '
+        'returned ${accounts.length} account(s)',
+        name: 'KnownAccountsRegistry',
+        category: LogCategory.auth,
+      );
+      await _persistMigrationResult(prefs, accounts);
+      return accounts;
+    }
+
+    final accounts = <KnownAccount>[];
+
+    // 1. Recover the account matching the persisted auth source.
+    String? pubkeyHex;
+    try {
+      switch (source) {
+        case AuthenticationSource.automatic:
+        case AuthenticationSource.importedKeys:
+          final keyContainer = await _keyStorage.getKeyContainer();
+          pubkeyHex = keyContainer?.publicKeyHex;
+
+        case AuthenticationSource.amber:
+          final amberInfo = await _signerStore.loadAmber();
+          pubkeyHex = amberInfo?.pubkey;
+
+        case AuthenticationSource.bunker:
+          final bunkerInfo = await _signerStore.loadBunker();
+          pubkeyHex = bunkerInfo?.userPubkey;
+
+        case AuthenticationSource.divineOAuth:
+          final session = await KeycastSession.load(_flutterSecureStorage);
+          pubkeyHex = session?.userPubkey;
+
+        case AuthenticationSource.nip07:
+          // NIP-07 was introduced after the legacy migration; no archived
+          // hint to recover. Leave pubkeyHex null so this path is skipped.
+          break;
+
+        case AuthenticationSource.none:
+          break;
+      }
+    } catch (e) {
+      Log.warning(
+        'Legacy migration failed to read old session: $e',
+        name: 'KnownAccountsRegistry',
+        category: LogCategory.auth,
+      );
+    }
+
+    if (pubkeyHex != null && pubkeyHex.length == 64) {
+      final now = DateTime.now();
+      accounts.add(
+        KnownAccount(
+          pubkeyHex: pubkeyHex,
+          authSource: source,
+          addedAt: now,
+          lastUsedAt: now,
+        ),
+      );
+      Log.info(
+        'Legacy migration: created entry for '
+        'pubkey=$pubkeyHex, source=${source.name}',
+        name: 'KnownAccountsRegistry',
+        category: LogCategory.auth,
+      );
+    }
+
+    // 2. Always check for automatic keys that may belong to a different
+    //    identity than the current auth source (e.g. user started with an
+    //    anonymous account, then later logged in via bunker/OAuth).
+    if (source != AuthenticationSource.automatic &&
+        source != AuthenticationSource.importedKeys) {
+      await _migrateAutomaticKeys(accounts);
+    }
+
+    if (accounts.isEmpty) {
+      Log.info(
+        'Legacy migration: no recoverable session found',
+        name: 'KnownAccountsRegistry',
+        category: LogCategory.auth,
+      );
+    }
+
+    await _persistMigrationResult(prefs, accounts);
+    return accounts;
+  }
+
+  /// Checks [SecureKeyStorage] for automatic/anonymous keys and adds a
+  /// [KnownAccount] entry if found and not already in [accounts].
+  ///
+  /// Returns [accounts] for convenience (mutates in place).
+  Future<List<KnownAccount>> _migrateAutomaticKeys(
+    List<KnownAccount> accounts,
+  ) async {
+    try {
+      Log.info(
+        'Legacy migration: _migrateAutomaticKeys — '
+        'calling _keyStorage.getKeyContainer()...',
+        name: 'KnownAccountsRegistry',
+        category: LogCategory.auth,
+      );
+      final keyContainer = await _keyStorage.getKeyContainer();
+      final hex = keyContainer?.publicKeyHex;
+      Log.info(
+        'Legacy migration: _migrateAutomaticKeys — '
+        'keyContainer=${keyContainer != null}, '
+        'hex=${hex != null ? '${hex.length} chars' : 'null'}',
+        name: 'KnownAccountsRegistry',
+        category: LogCategory.auth,
+      );
+      if (hex != null &&
+          hex.length == 64 &&
+          !accounts.any((a) => a.pubkeyHex == hex)) {
+        final now = DateTime.now();
+        accounts.add(
+          KnownAccount(
+            pubkeyHex: hex,
+            authSource: AuthenticationSource.automatic,
+            addedAt: now,
+            lastUsedAt: now,
+          ),
+        );
+        Log.info(
+          'Legacy migration: recovered automatic keys — pubkey=$hex',
+          name: 'KnownAccountsRegistry',
+          category: LogCategory.auth,
+        );
+      }
+    } catch (e) {
+      Log.warning(
+        'Legacy migration: failed to check automatic keys: $e',
+        name: 'KnownAccountsRegistry',
+        category: LogCategory.auth,
+      );
+    }
+    return accounts;
+  }
+
+  /// Persists the migration result to seal it permanently.
+  Future<void> _persistMigrationResult(
+    SharedPreferences prefs,
+    List<KnownAccount> accounts,
+  ) async {
+    await prefs.setString(
+      kKnownAccountsKey,
+      jsonEncode(accounts.map((a) => a.toJson()).toList()),
+    );
+  }
+
+  /// Adds or updates an account in the known accounts registry.
+  ///
+  /// Called after successful authentication to record which pubkey was used
+  /// and which [AuthenticationSource] authenticated it.
+  Future<void> upsert(
+    String pubkeyHex,
+    AuthenticationSource source,
+  ) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final accounts = await getKnownAccounts();
+      final now = DateTime.now();
+
+      final index = accounts.indexWhere((a) => a.pubkeyHex == pubkeyHex);
+      if (index >= 0) {
+        accounts[index] = accounts[index].copyWith(
+          authSource: source,
+          lastUsedAt: now,
+        );
+      } else {
+        accounts.add(
+          KnownAccount(
+            pubkeyHex: pubkeyHex,
+            authSource: source,
+            addedAt: now,
+            lastUsedAt: now,
+          ),
+        );
+      }
+
+      final json = jsonEncode(accounts.map((a) => a.toJson()).toList());
+      await prefs.setString(kKnownAccountsKey, json);
+
+      Log.info(
+        'Updated known accounts registry '
+        '(total=${accounts.length}, pubkey=$pubkeyHex, source=${source.name})',
+        name: 'KnownAccountsRegistry',
+        category: LogCategory.auth,
+      );
+    } catch (e) {
+      Log.warning(
+        'Failed to update known accounts: $e',
+        name: 'KnownAccountsRegistry',
+        category: LogCategory.auth,
+      );
+    }
+  }
+
+  /// Removes an account from the known accounts registry.
+  Future<void> remove(String pubkeyHex) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final accounts = await getKnownAccounts();
+      accounts.removeWhere((a) => a.pubkeyHex == pubkeyHex);
+
+      final json = jsonEncode(accounts.map((a) => a.toJson()).toList());
+      await prefs.setString(kKnownAccountsKey, json);
+
+      Log.info(
+        'Removed $pubkeyHex from known accounts '
+        '(remaining=${accounts.length})',
+        name: 'KnownAccountsRegistry',
+        category: LogCategory.auth,
+      );
+    } catch (e) {
+      Log.warning(
+        'Failed to remove from known accounts: $e',
+        name: 'KnownAccountsRegistry',
+        category: LogCategory.auth,
+      );
+    }
+  }
+
+  /// Overwrites the persisted registry with [accounts] verbatim (in the order
+  /// given — callers that need MRU order sort first).
+  ///
+  /// Used by sign-out recovery to prune the registry to the restorable set.
+  Future<void> persist(List<KnownAccount> accounts) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      kKnownAccountsKey,
+      jsonEncode(accounts.map((a) => a.toJson()).toList()),
+    );
+  }
+
+  /// Filters [accounts] to those that still have restorable local login
+  /// material on this device (a local nsec, or an archived remote-signer
+  /// session). Non-restorable sources ([AuthenticationSource.none]/`nip07`)
+  /// are always dropped.
+  Future<List<KnownAccount>> restorableAccounts(
+    List<KnownAccount> accounts,
+  ) async {
+    final restorable = <KnownAccount>[];
+    for (final account in accounts) {
+      switch (account.authSource) {
+        case AuthenticationSource.automatic:
+        case AuthenticationSource.importedKeys:
+          if (await _hasRestorableLocalKey(account)) {
+            restorable.add(account);
+          }
+        case AuthenticationSource.amber:
+        case AuthenticationSource.bunker:
+        case AuthenticationSource.divineOAuth:
+          if (await _hasRestorableSignerArchive(account)) {
+            restorable.add(account);
+          }
+        case AuthenticationSource.none:
+        case AuthenticationSource.nip07:
+          break;
+      }
+    }
+    return restorable;
+  }
+
+  Future<bool> _hasRestorableLocalKey(KnownAccount account) async {
+    final npub = NostrKeyUtils.encodePubKey(account.pubkeyHex);
+    try {
+      final identityContainer = await _keyStorage.getIdentityKeyContainer(npub);
+      if (identityContainer?.publicKeyHex == account.pubkeyHex) {
+        return true;
+      }
+
+      if (await _keyStorage.hasKeys()) {
+        final primaryContainer = await _keyStorage.getKeyContainer();
+        if (primaryContainer?.publicKeyHex == account.pubkeyHex) {
+          return true;
+        }
+      }
+    } catch (e) {
+      Log.warning(
+        'signOut: failed to verify local nsec for ${account.pubkeyHex}: $e',
+        name: 'KnownAccountsRegistry',
+        category: LogCategory.auth,
+      );
+    }
+    return false;
+  }
+
+  Future<bool> _hasRestorableSignerArchive(KnownAccount account) =>
+      _signerStore.hasArchive(account.pubkeyHex, account.authSource);
+}

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -4,7 +4,6 @@
 // with secure storage
 
 import 'dart:async';
-import 'dart:convert';
 
 import 'package:cache_sync/cache_sync.dart';
 import 'package:flutter/foundation.dart';
@@ -18,6 +17,7 @@ import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/models/auth_rpc_capability.dart';
 import 'package:openvine/models/authentication_source.dart';
 import 'package:openvine/models/known_account.dart';
+import 'package:openvine/services/auth/known_accounts_registry.dart';
 import 'package:openvine/services/auth/nostr_identity.dart';
 import 'package:openvine/services/auth/oauth_session_coordinator.dart';
 import 'package:openvine/services/auth/relay_discovery_orchestrator.dart';
@@ -243,6 +243,14 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   final FlutterSecureStorage? _flutterSecureStorage;
   late final SignerSecureStore _signerStore = SignerSecureStore(
     _flutterSecureStorage,
+  );
+  // Owns the persisted known-accounts registry (CRUD, one-time legacy
+  // migration, restorable-account filter); the facade keeps all session state
+  // and restore orchestration, calling in for the pure storage rules.
+  late final KnownAccountsRegistry _knownAccounts = KnownAccountsRegistry(
+    keyStorage: _keyStorage,
+    signerStore: _signerStore,
+    flutterSecureStorage: _flutterSecureStorage,
   );
   // Tear-off keeps the Crashlytics `auth_source` custom key reading live
   // state at report time (see _reportAuthError).
@@ -1382,303 +1390,14 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   /// the `known_accounts` key will be absent (`null`). In that case we run a
   /// one-time migration that checks for a legacy session and persists the
   /// result so the migration never runs again.
-  Future<List<KnownAccount>> getKnownAccounts() async {
-    try {
-      final prefs = await SharedPreferences.getInstance();
-      final raw = prefs.getString(kKnownAccountsKey);
-      Log.info(
-        'getKnownAccounts: raw=${raw == null ? 'null' : '${raw.length} chars'}',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-
-      // null  → key never written → run one-time migration
-      // empty → key was written but all accounts removed → no migration
-      if (raw == null) {
-        return _migrateLegacyAccount(prefs);
-      }
-      if (raw.isEmpty) return [];
-
-      final decoded = (jsonDecode(raw) as List<dynamic>)
-          .cast<Map<String, dynamic>>();
-      final accounts = decoded.map(KnownAccount.fromJson).toList()
-        ..sort((a, b) => b.lastUsedAt.compareTo(a.lastUsedAt));
-      return accounts;
-    } catch (e) {
-      Log.warning(
-        'Failed to load known accounts: $e',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-      return [];
-    }
-  }
-
-  /// One-time migration from the old single-account auth system.
-  ///
-  /// Checks for a legacy session stored under the old `authentication_source`
-  /// key and, if found, creates a [KnownAccount] entry for it.
-  ///
-  /// Additionally, always checks [SecureKeyStorage] for an automatic/anonymous
-  /// identity. A user may have started with an automatic account and later
-  /// switched to bunker/OAuth — the old automatic keys are still in storage
-  /// even though `authentication_source` was overwritten.
-  ///
-  /// The result is persisted to [kKnownAccountsKey] so this migration never
-  /// runs again.
-  Future<List<KnownAccount>> _migrateLegacyAccount(
-    SharedPreferences prefs,
-  ) async {
-    Log.info(
-      'known_accounts key absent — running one-time legacy migration',
-      name: 'AuthService',
-      category: LogCategory.auth,
-    );
-
-    final rawAuthSource = prefs.getString(_kAuthSourceKey);
-    final source = AuthenticationSource.fromCode(rawAuthSource);
-    Log.info(
-      'Legacy migration: rawAuthSource=$rawAuthSource, '
-      'resolved=${source.name}',
-      name: 'AuthService',
-      category: LogCategory.auth,
-    );
-
-    if (source == AuthenticationSource.none) {
-      // Fresh install or explicit logout — still check for automatic keys.
-      Log.info(
-        'Legacy migration: source=none, checking automatic keys...',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-      final accounts = await _migrateAutomaticKeys([]);
-      Log.info(
-        'Legacy migration: source=none, automatic keys check '
-        'returned ${accounts.length} account(s)',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-      await _persistMigrationResult(prefs, accounts);
-      return accounts;
-    }
-
-    final accounts = <KnownAccount>[];
-
-    // 1. Recover the account matching the persisted auth source.
-    String? pubkeyHex;
-    try {
-      switch (source) {
-        case AuthenticationSource.automatic:
-        case AuthenticationSource.importedKeys:
-          final keyContainer = await _keyStorage.getKeyContainer();
-          pubkeyHex = keyContainer?.publicKeyHex;
-
-        case AuthenticationSource.amber:
-          final amberInfo = await _loadAmberInfo();
-          pubkeyHex = amberInfo?.pubkey;
-
-        case AuthenticationSource.bunker:
-          final bunkerInfo = await _loadBunkerInfo();
-          pubkeyHex = bunkerInfo?.userPubkey;
-
-        case AuthenticationSource.divineOAuth:
-          final session = await KeycastSession.load(_flutterSecureStorage);
-          pubkeyHex = session?.userPubkey;
-
-        case AuthenticationSource.nip07:
-          // NIP-07 was introduced after the legacy migration; no archived
-          // hint to recover. Leave pubkeyHex null so this path is skipped.
-          break;
-
-        case AuthenticationSource.none:
-          break;
-      }
-    } catch (e) {
-      Log.warning(
-        'Legacy migration failed to read old session: $e',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-    }
-
-    if (pubkeyHex != null && pubkeyHex.length == 64) {
-      final now = DateTime.now();
-      accounts.add(
-        KnownAccount(
-          pubkeyHex: pubkeyHex,
-          authSource: source,
-          addedAt: now,
-          lastUsedAt: now,
-        ),
-      );
-      Log.info(
-        'Legacy migration: created entry for '
-        'pubkey=$pubkeyHex, source=${source.name}',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-    }
-
-    // 2. Always check for automatic keys that may belong to a different
-    //    identity than the current auth source (e.g. user started with an
-    //    anonymous account, then later logged in via bunker/OAuth).
-    if (source != AuthenticationSource.automatic &&
-        source != AuthenticationSource.importedKeys) {
-      await _migrateAutomaticKeys(accounts);
-    }
-
-    if (accounts.isEmpty) {
-      Log.info(
-        'Legacy migration: no recoverable session found',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-    }
-
-    await _persistMigrationResult(prefs, accounts);
-    return accounts;
-  }
-
-  /// Checks [SecureKeyStorage] for automatic/anonymous keys and adds a
-  /// [KnownAccount] entry if found and not already in [accounts].
-  ///
-  /// Returns [accounts] for convenience (mutates in place).
-  Future<List<KnownAccount>> _migrateAutomaticKeys(
-    List<KnownAccount> accounts,
-  ) async {
-    try {
-      Log.info(
-        'Legacy migration: _migrateAutomaticKeys — '
-        'calling _keyStorage.getKeyContainer()...',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-      final keyContainer = await _keyStorage.getKeyContainer();
-      final hex = keyContainer?.publicKeyHex;
-      Log.info(
-        'Legacy migration: _migrateAutomaticKeys — '
-        'keyContainer=${keyContainer != null}, '
-        'hex=${hex != null ? '${hex.length} chars' : 'null'}',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-      if (hex != null &&
-          hex.length == 64 &&
-          !accounts.any((a) => a.pubkeyHex == hex)) {
-        final now = DateTime.now();
-        accounts.add(
-          KnownAccount(
-            pubkeyHex: hex,
-            authSource: AuthenticationSource.automatic,
-            addedAt: now,
-            lastUsedAt: now,
-          ),
-        );
-        Log.info(
-          'Legacy migration: recovered automatic keys — pubkey=$hex',
-          name: 'AuthService',
-          category: LogCategory.auth,
-        );
-      }
-    } catch (e) {
-      Log.warning(
-        'Legacy migration: failed to check automatic keys: $e',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-    }
-    return accounts;
-  }
-
-  /// Persists the migration result to seal it permanently.
-  Future<void> _persistMigrationResult(
-    SharedPreferences prefs,
-    List<KnownAccount> accounts,
-  ) async {
-    await prefs.setString(
-      kKnownAccountsKey,
-      jsonEncode(accounts.map((a) => a.toJson()).toList()),
-    );
-  }
-
-  /// Adds or updates an account in the known accounts registry.
-  ///
-  /// Called after successful authentication to record which pubkey was used
-  /// and which [AuthenticationSource] authenticated it.
-  Future<void> _addToKnownAccounts(
-    String pubkeyHex,
-    AuthenticationSource source,
-  ) async {
-    try {
-      final prefs = await SharedPreferences.getInstance();
-      final accounts = await getKnownAccounts();
-      final now = DateTime.now();
-
-      final index = accounts.indexWhere((a) => a.pubkeyHex == pubkeyHex);
-      if (index >= 0) {
-        accounts[index] = accounts[index].copyWith(
-          authSource: source,
-          lastUsedAt: now,
-        );
-      } else {
-        accounts.add(
-          KnownAccount(
-            pubkeyHex: pubkeyHex,
-            authSource: source,
-            addedAt: now,
-            lastUsedAt: now,
-          ),
-        );
-      }
-
-      final json = jsonEncode(accounts.map((a) => a.toJson()).toList());
-      await prefs.setString(kKnownAccountsKey, json);
-
-      Log.info(
-        'Updated known accounts registry '
-        '(total=${accounts.length}, pubkey=$pubkeyHex, source=${source.name})',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-    } catch (e) {
-      Log.warning(
-        'Failed to update known accounts: $e',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-    }
-  }
-
-  /// Removes an account from the known accounts registry.
-  Future<void> _removeFromKnownAccounts(String pubkeyHex) async {
-    try {
-      final prefs = await SharedPreferences.getInstance();
-      final accounts = await getKnownAccounts();
-      accounts.removeWhere((a) => a.pubkeyHex == pubkeyHex);
-
-      final json = jsonEncode(accounts.map((a) => a.toJson()).toList());
-      await prefs.setString(kKnownAccountsKey, json);
-
-      Log.info(
-        'Removed $pubkeyHex from known accounts '
-        '(remaining=${accounts.length})',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-    } catch (e) {
-      Log.warning(
-        'Failed to remove from known accounts: $e',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-    }
-  }
+  Future<List<KnownAccount>> getKnownAccounts() =>
+      _knownAccounts.getKnownAccounts();
 
   /// Removes an account from the known accounts list and cleans up its
   /// archived signer info. Called from the welcome screen when the user
   /// long-presses to remove an account.
   Future<void> removeKnownAccount(String pubkeyHex) async {
-    await _removeFromKnownAccounts(pubkeyHex);
+    await _knownAccounts.remove(pubkeyHex);
     await _clearArchivedSignerInfo(pubkeyHex);
   }
 
@@ -2155,7 +1874,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       _profileController.add(_currentProfile);
 
       // Register in known accounts
-      await _addToKnownAccounts(userPubkey, AuthenticationSource.bunker);
+      await _knownAccounts.upsert(userPubkey, AuthenticationSource.bunker);
 
       // Run discovery in background - not needed for home feed
       unawaited(_performDiscovery());
@@ -2437,7 +2156,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       _profileController.add(_currentProfile);
 
       // Register in known accounts
-      await _addToKnownAccounts(pubkey, AuthenticationSource.amber);
+      await _knownAccounts.upsert(pubkey, AuthenticationSource.amber);
 
       // Run discovery in background - not needed for home feed
       unawaited(_performDiscovery());
@@ -3358,7 +3077,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
 
       // On destructive sign-out, remove this device's local login for the
       // current account and then return to the welcome/account-picker surface.
-      // Deferred: remaining-account cleanup runs after _removeFromKnownAccounts
+      // Deferred: remaining-account cleanup runs after _knownAccounts.remove
       // so the deleted account is excluded from the remaining list.
       // Non-destructive sign-out (switch account) preserves these so that
       // initialize() can reconnect to the same external signer.
@@ -3422,7 +3141,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       if (deleteKeys) {
         // Destructive sign-out: remove from known accounts and clean up
         if (currentPubkey != null) {
-          await _removeFromKnownAccounts(currentPubkey);
+          await _knownAccounts.remove(currentPubkey);
           await _clearArchivedSignerInfo(currentPubkey);
         }
 
@@ -3677,7 +3396,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
 
     if (removedPubkey != null) {
       try {
-        await _removeFromKnownAccounts(removedPubkey);
+        await _knownAccounts.remove(removedPubkey);
         await _clearArchivedSignerInfo(removedPubkey);
       } catch (e) {
         Log.warning(
@@ -3732,14 +3451,16 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   ) async {
     try {
       final remaining = await getKnownAccounts();
-      final restorableAccounts = await _restorableAccounts(remaining);
+      final restorableAccounts = await _knownAccounts.restorableAccounts(
+        remaining,
+      );
 
       _authSource = AuthenticationSource.none;
       await prefs.setString(_kAuthSourceKey, AuthenticationSource.none.code);
       await prefs.remove(_kLastUsedNpubKey);
 
       if (restorableAccounts.isEmpty) {
-        await prefs.setString(kKnownAccountsKey, jsonEncode(<Object>[]));
+        await _knownAccounts.persist(const <KnownAccount>[]);
         Log.info(
           'signOut: no restorable local accounts — reset to fresh welcome',
           name: 'AuthService',
@@ -3749,10 +3470,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       }
 
       restorableAccounts.sort((a, b) => b.lastUsedAt.compareTo(a.lastUsedAt));
-      await prefs.setString(
-        kKnownAccountsKey,
-        jsonEncode(restorableAccounts.map((a) => a.toJson()).toList()),
-      );
+      await _knownAccounts.persist(restorableAccounts);
 
       Log.info(
         'signOut: kept ${restorableAccounts.length} restorable local '
@@ -3771,61 +3489,9 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       _authSource = AuthenticationSource.none;
       await prefs.setString(_kAuthSourceKey, AuthenticationSource.none.code);
       await prefs.remove(_kLastUsedNpubKey);
-      await prefs.setString(kKnownAccountsKey, jsonEncode(<Object>[]));
+      await _knownAccounts.persist(const <KnownAccount>[]);
     }
   }
-
-  Future<List<KnownAccount>> _restorableAccounts(
-    List<KnownAccount> accounts,
-  ) async {
-    final restorable = <KnownAccount>[];
-    for (final account in accounts) {
-      switch (account.authSource) {
-        case AuthenticationSource.automatic:
-        case AuthenticationSource.importedKeys:
-          if (await _hasRestorableLocalKey(account)) {
-            restorable.add(account);
-          }
-        case AuthenticationSource.amber:
-        case AuthenticationSource.bunker:
-        case AuthenticationSource.divineOAuth:
-          if (await _hasRestorableSignerArchive(account)) {
-            restorable.add(account);
-          }
-        case AuthenticationSource.none:
-        case AuthenticationSource.nip07:
-          break;
-      }
-    }
-    return restorable;
-  }
-
-  Future<bool> _hasRestorableLocalKey(KnownAccount account) async {
-    final npub = NostrKeyUtils.encodePubKey(account.pubkeyHex);
-    try {
-      final identityContainer = await _keyStorage.getIdentityKeyContainer(npub);
-      if (identityContainer?.publicKeyHex == account.pubkeyHex) {
-        return true;
-      }
-
-      if (await _keyStorage.hasKeys()) {
-        final primaryContainer = await _keyStorage.getKeyContainer();
-        if (primaryContainer?.publicKeyHex == account.pubkeyHex) {
-          return true;
-        }
-      }
-    } catch (e) {
-      Log.warning(
-        'signOut: failed to verify local nsec for ${account.pubkeyHex}: $e',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-    }
-    return false;
-  }
-
-  Future<bool> _hasRestorableSignerArchive(KnownAccount account) =>
-      _signerStore.hasArchive(account.pubkeyHex, account.authSource);
 
   /// Export nsec for backup purposes
   Future<String?> exportNsec({String? biometricPrompt}) async {
@@ -4443,7 +4109,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       _setAuthState(AuthState.authenticated);
 
       // Register this account in the known accounts list
-      await _addToKnownAccounts(keyContainer.publicKeyHex, source);
+      await _knownAccounts.upsert(keyContainer.publicKeyHex, source);
 
       // Store identity keys for multi-account switching
       try {

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -39,9 +39,6 @@ export 'package:openvine/models/authentication_source.dart';
 export 'package:openvine/services/auth/relay_discovery_orchestrator.dart'
     show BootstrapRelayListCallback, UserRelaysDiscoveredCallback;
 
-// Key for persisted authentication source
-const _kAuthSourceKey = 'authentication_source';
-
 // Key for the last-used account npub (used to restore the correct identity on restart)
 const _kLastUsedNpubKey = 'last_used_npub';
 
@@ -1367,10 +1364,10 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   Future<AuthenticationSource> _loadAuthSource() async {
     try {
       final prefs = await SharedPreferences.getInstance();
-      final raw = prefs.getString(_kAuthSourceKey);
+      final raw = prefs.getString(kAuthenticationSourceKey);
       final authSource = AuthenticationSource.fromCode(raw);
       Log.info(
-        'Loaded $_kAuthSourceKey as $authSource',
+        'Loaded $kAuthenticationSourceKey as $authSource',
         name: 'AuthService',
         category: LogCategory.auth,
       );
@@ -1434,7 +1431,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
 
       // Set the auth source so initialize() picks the right path
       final prefs = await SharedPreferences.getInstance();
-      await prefs.setString(_kAuthSourceKey, source.code);
+      await prefs.setString(kAuthenticationSourceKey, source.code);
 
       Log.info(
         'Restored signer info for $pubkeyHex (source=${source.name})',
@@ -3456,7 +3453,10 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       );
 
       _authSource = AuthenticationSource.none;
-      await prefs.setString(_kAuthSourceKey, AuthenticationSource.none.code);
+      await prefs.setString(
+        kAuthenticationSourceKey,
+        AuthenticationSource.none.code,
+      );
       await prefs.remove(_kLastUsedNpubKey);
 
       if (restorableAccounts.isEmpty) {
@@ -3487,7 +3487,10 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
         category: LogCategory.auth,
       );
       _authSource = AuthenticationSource.none;
-      await prefs.setString(_kAuthSourceKey, AuthenticationSource.none.code);
+      await prefs.setString(
+        kAuthenticationSourceKey,
+        AuthenticationSource.none.code,
+      );
       await prefs.remove(_kLastUsedNpubKey);
       await _knownAccounts.persist(const <KnownAccount>[]);
     }
@@ -4053,7 +4056,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       // visible to other accounts.
       await _userDataCleanupService.claimLegacyRows(keyContainer.publicKeyHex);
 
-      await prefs.setString(_kAuthSourceKey, source.code);
+      await prefs.setString(kAuthenticationSourceKey, source.code);
 
       await prefs.setString(_kLastUsedNpubKey, keyContainer.npub);
 

--- a/mobile/test/services/auth/known_accounts_registry_test.dart
+++ b/mobile/test/services/auth/known_accounts_registry_test.dart
@@ -1,0 +1,480 @@
+// ABOUTME: Tests for KnownAccountsRegistry — known-accounts CRUD, the one-time
+// ABOUTME: legacy migration, persist, and the restorable-account filter.
+
+import 'dart:convert';
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_key_manager/nostr_key_manager.dart'
+    show SecureKeyContainer, SecureKeyStorage;
+import 'package:nostr_sdk/nostr_sdk.dart' show NostrRemoteSignerInfo;
+import 'package:openvine/models/authentication_source.dart';
+import 'package:openvine/models/known_account.dart';
+import 'package:openvine/services/auth/known_accounts_registry.dart';
+import 'package:openvine/services/auth/signer_secure_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockSecureKeyStorage extends Mock implements SecureKeyStorage {}
+
+class _MockSignerSecureStore extends Mock implements SignerSecureStore {}
+
+class _MockFlutterSecureStorage extends Mock implements FlutterSecureStorage {}
+
+// Test nsec from a known keypair (same one used in other auth_service tests).
+const _testNsec =
+    'nsec1vl029mgpspedva04g90vltkh6fvh240zqtv9k0t9af8935ke9laqsnlfe5';
+
+String _accountsJson(List<KnownAccount> accounts) =>
+    jsonEncode(accounts.map((a) => a.toJson()).toList());
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group(KnownAccountsRegistry, () {
+    late _MockSecureKeyStorage keyStorage;
+    late _MockSignerSecureStore signerStore;
+    late _MockFlutterSecureStorage secureStorage;
+    late SecureKeyContainer testKeyContainer;
+
+    setUpAll(() {
+      registerFallbackValue(AuthenticationSource.automatic);
+    });
+
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+      keyStorage = _MockSecureKeyStorage();
+      signerStore = _MockSignerSecureStore();
+      secureStorage = _MockFlutterSecureStorage();
+      testKeyContainer = SecureKeyContainer.fromNsec(_testNsec);
+
+      when(() => keyStorage.hasKeys()).thenAnswer((_) async => false);
+      when(() => keyStorage.getKeyContainer()).thenAnswer((_) async => null);
+      when(
+        () => keyStorage.getIdentityKeyContainer(any()),
+      ).thenAnswer((_) async => null);
+      when(() => signerStore.loadAmber()).thenAnswer((_) async => null);
+      when(() => signerStore.loadBunker()).thenAnswer((_) async => null);
+      when(
+        () => signerStore.hasArchive(any(), any()),
+      ).thenAnswer((_) async => false);
+      when(
+        () => secureStorage.read(key: any(named: 'key')),
+      ).thenAnswer((_) async => null);
+    });
+
+    KnownAccountsRegistry build() => KnownAccountsRegistry(
+      keyStorage: keyStorage,
+      signerStore: signerStore,
+      flutterSecureStorage: secureStorage,
+    );
+
+    KnownAccount account(
+      String pubkeyHex,
+      AuthenticationSource source, {
+      DateTime? addedAt,
+      DateTime? lastUsedAt,
+    }) {
+      final now = addedAt ?? DateTime(2024);
+      return KnownAccount(
+        pubkeyHex: pubkeyHex,
+        authSource: source,
+        addedAt: now,
+        lastUsedAt: lastUsedAt ?? now,
+      );
+    }
+
+    group('getKnownAccounts', () {
+      test(
+        'returns empty list for a sealed-empty key (no migration)',
+        () async {
+          SharedPreferences.setMockInitialValues({kKnownAccountsKey: ''});
+
+          final accounts = await build().getKnownAccounts();
+
+          expect(accounts, isEmpty);
+          // The empty (not null) key must NOT re-trigger legacy migration.
+          verifyNever(() => keyStorage.getKeyContainer());
+        },
+      );
+
+      test('returns stored accounts sorted by lastUsedAt descending', () async {
+        final older = account(
+          'a' * 64,
+          AuthenticationSource.automatic,
+          lastUsedAt: DateTime(2024),
+        );
+        final newer = account(
+          'b' * 64,
+          AuthenticationSource.bunker,
+          lastUsedAt: DateTime(2024, 6),
+        );
+        SharedPreferences.setMockInitialValues({
+          kKnownAccountsKey: _accountsJson([older, newer]),
+        });
+
+        final accounts = await build().getKnownAccounts();
+
+        expect(accounts.map((a) => a.pubkeyHex), ['b' * 64, 'a' * 64]);
+      });
+
+      test('returns empty list on malformed JSON', () async {
+        SharedPreferences.setMockInitialValues({
+          kKnownAccountsKey: 'not-valid-json',
+        });
+
+        final accounts = await build().getKnownAccounts();
+
+        expect(accounts, isEmpty);
+      });
+    });
+
+    group('legacy migration (via null key)', () {
+      test(
+        'source=none with no keys returns empty and seals the key',
+        () async {
+          SharedPreferences.setMockInitialValues({
+            'authentication_source': 'none',
+          });
+
+          final accounts = await build().getKnownAccounts();
+
+          expect(accounts, isEmpty);
+          final prefs = await SharedPreferences.getInstance();
+          expect(prefs.getString(kKnownAccountsKey), '[]');
+        },
+      );
+
+      test('recovers automatic keys even when source=none', () async {
+        SharedPreferences.setMockInitialValues({
+          'authentication_source': 'none',
+        });
+        when(
+          () => keyStorage.getKeyContainer(),
+        ).thenAnswer((_) async => testKeyContainer);
+
+        final accounts = await build().getKnownAccounts();
+
+        expect(accounts, hasLength(1));
+        expect(accounts[0].pubkeyHex, testKeyContainer.publicKeyHex);
+        expect(accounts[0].authSource, AuthenticationSource.automatic);
+      });
+
+      test('migrates an automatic account from the legacy source', () async {
+        SharedPreferences.setMockInitialValues({
+          'authentication_source': 'automatic',
+        });
+        when(
+          () => keyStorage.getKeyContainer(),
+        ).thenAnswer((_) async => testKeyContainer);
+
+        final accounts = await build().getKnownAccounts();
+
+        expect(accounts, hasLength(1));
+        expect(accounts[0].authSource, AuthenticationSource.automatic);
+      });
+
+      test('migrates an amber account from the legacy source', () async {
+        final amberPubkey = 'd' * 64;
+        SharedPreferences.setMockInitialValues({
+          'authentication_source': 'amber',
+        });
+        when(
+          () => signerStore.loadAmber(),
+        ).thenAnswer((_) async => (pubkey: amberPubkey, package: null));
+
+        final accounts = await build().getKnownAccounts();
+
+        expect(accounts, hasLength(1));
+        expect(accounts[0].pubkeyHex, amberPubkey);
+        expect(accounts[0].authSource, AuthenticationSource.amber);
+      });
+
+      test('migrates a bunker account from the legacy source', () async {
+        final userPubkey = 'e' * 64;
+        SharedPreferences.setMockInitialValues({
+          'authentication_source': 'bunker',
+        });
+        when(() => signerStore.loadBunker()).thenAnswer(
+          (_) async => NostrRemoteSignerInfo(
+            remoteSignerPubkey: 'a' * 64,
+            relays: const ['wss://relay.example.com'],
+            userPubkey: userPubkey,
+          ),
+        );
+
+        final accounts = await build().getKnownAccounts();
+
+        expect(accounts, hasLength(1));
+        expect(accounts[0].pubkeyHex, userPubkey);
+        expect(accounts[0].authSource, AuthenticationSource.bunker);
+      });
+
+      test('migrates a divineOAuth account from the legacy source', () async {
+        final oauthPubkey = 'f' * 64;
+        SharedPreferences.setMockInitialValues({
+          'authentication_source': 'divineOAuth',
+        });
+        when(() => secureStorage.read(key: 'keycast_session')).thenAnswer(
+          (_) async => jsonEncode({
+            'bunker_url': 'wss://keycast.example.com',
+            'access_token': 'test_token',
+            'scope': 'policy:full',
+            'user_pubkey': oauthPubkey,
+          }),
+        );
+
+        final accounts = await build().getKnownAccounts();
+
+        expect(accounts, hasLength(1));
+        expect(accounts[0].pubkeyHex, oauthPubkey);
+        expect(accounts[0].authSource, AuthenticationSource.divineOAuth);
+      });
+
+      test('recovers both the source account and automatic keys', () async {
+        final oauthPubkey = 'f' * 64;
+        SharedPreferences.setMockInitialValues({
+          'authentication_source': 'divineOAuth',
+        });
+        when(() => secureStorage.read(key: 'keycast_session')).thenAnswer(
+          (_) async => jsonEncode({
+            'bunker_url': 'wss://keycast.example.com',
+            'access_token': 'test_token',
+            'scope': 'policy:full',
+            'user_pubkey': oauthPubkey,
+          }),
+        );
+        when(
+          () => keyStorage.getKeyContainer(),
+        ).thenAnswer((_) async => testKeyContainer);
+
+        final accounts = await build().getKnownAccounts();
+
+        expect(accounts, hasLength(2));
+        expect(accounts.any((a) => a.pubkeyHex == oauthPubkey), isTrue);
+        expect(
+          accounts.any((a) => a.pubkeyHex == testKeyContainer.publicKeyHex),
+          isTrue,
+        );
+      });
+
+      test(
+        'does not duplicate when source keys match automatic keys',
+        () async {
+          SharedPreferences.setMockInitialValues({
+            'authentication_source': 'automatic',
+          });
+          when(
+            () => keyStorage.getKeyContainer(),
+          ).thenAnswer((_) async => testKeyContainer);
+
+          final accounts = await build().getKnownAccounts();
+
+          expect(accounts, hasLength(1));
+        },
+      );
+
+      test('persists the result so migration only runs once', () async {
+        SharedPreferences.setMockInitialValues({
+          'authentication_source': 'automatic',
+        });
+        when(
+          () => keyStorage.getKeyContainer(),
+        ).thenAnswer((_) async => testKeyContainer);
+        final registry = build();
+
+        await registry.getKnownAccounts();
+        await registry.getKnownAccounts();
+
+        // getKeyContainer is only reached inside the migration; the sealed key
+        // means the second read never re-migrates.
+        verify(() => keyStorage.getKeyContainer()).called(1);
+      });
+
+      test('swallows key-loading errors and still seals the key', () async {
+        SharedPreferences.setMockInitialValues({
+          'authentication_source': 'automatic',
+        });
+        when(
+          () => keyStorage.getKeyContainer(),
+        ).thenThrow(Exception('storage corrupted'));
+
+        final accounts = await build().getKnownAccounts();
+
+        expect(accounts, isEmpty);
+        final prefs = await SharedPreferences.getInstance();
+        expect(prefs.getString(kKnownAccountsKey), isNotNull);
+      });
+    });
+
+    group('upsert', () {
+      test('inserts a new account', () async {
+        SharedPreferences.setMockInitialValues({kKnownAccountsKey: '[]'});
+        final registry = build();
+
+        await registry.upsert('a' * 64, AuthenticationSource.bunker);
+
+        final accounts = await registry.getKnownAccounts();
+        expect(accounts, hasLength(1));
+        expect(accounts[0].pubkeyHex, 'a' * 64);
+        expect(accounts[0].authSource, AuthenticationSource.bunker);
+      });
+
+      test('updates an existing account, preserving addedAt', () async {
+        final existing = account(
+          'a' * 64,
+          AuthenticationSource.automatic,
+          addedAt: DateTime(2023),
+          lastUsedAt: DateTime(2023),
+        );
+        SharedPreferences.setMockInitialValues({
+          kKnownAccountsKey: _accountsJson([existing]),
+        });
+        final registry = build();
+
+        await registry.upsert('a' * 64, AuthenticationSource.bunker);
+
+        final accounts = await registry.getKnownAccounts();
+        expect(accounts, hasLength(1));
+        expect(accounts[0].addedAt, DateTime(2023));
+        expect(accounts[0].authSource, AuthenticationSource.bunker);
+        expect(accounts[0].lastUsedAt.isAfter(DateTime(2023)), isTrue);
+      });
+    });
+
+    group('remove', () {
+      test('removes the matching account', () async {
+        final keep = account('a' * 64, AuthenticationSource.automatic);
+        final drop = account('b' * 64, AuthenticationSource.bunker);
+        SharedPreferences.setMockInitialValues({
+          kKnownAccountsKey: _accountsJson([keep, drop]),
+        });
+        final registry = build();
+
+        await registry.remove('b' * 64);
+
+        final accounts = await registry.getKnownAccounts();
+        expect(accounts.map((a) => a.pubkeyHex), ['a' * 64]);
+      });
+
+      test('is a no-op for an unknown pubkey', () async {
+        final keep = account('a' * 64, AuthenticationSource.automatic);
+        SharedPreferences.setMockInitialValues({
+          kKnownAccountsKey: _accountsJson([keep]),
+        });
+        final registry = build();
+
+        await registry.remove('c' * 64);
+
+        final accounts = await registry.getKnownAccounts();
+        expect(accounts.map((a) => a.pubkeyHex), ['a' * 64]);
+      });
+    });
+
+    group('persist', () {
+      test('overwrites the stored registry with the given list', () async {
+        final a = account('a' * 64, AuthenticationSource.automatic);
+        final b = account('b' * 64, AuthenticationSource.bunker);
+        SharedPreferences.setMockInitialValues({
+          kKnownAccountsKey: _accountsJson([a, b]),
+        });
+        final registry = build();
+
+        await registry.persist([a]);
+
+        final accounts = await registry.getKnownAccounts();
+        expect(accounts.map((a) => a.pubkeyHex), ['a' * 64]);
+      });
+
+      test('persisting an empty list writes "[]"', () async {
+        final a = account('a' * 64, AuthenticationSource.automatic);
+        SharedPreferences.setMockInitialValues({
+          kKnownAccountsKey: _accountsJson([a]),
+        });
+
+        await build().persist(const <KnownAccount>[]);
+
+        final prefs = await SharedPreferences.getInstance();
+        expect(prefs.getString(kKnownAccountsKey), '[]');
+      });
+    });
+
+    group('restorableAccounts', () {
+      test('keeps an automatic account with a matching identity key', () async {
+        final acc = account(
+          testKeyContainer.publicKeyHex,
+          AuthenticationSource.automatic,
+        );
+        when(
+          () => keyStorage.getIdentityKeyContainer(any()),
+        ).thenAnswer((_) async => testKeyContainer);
+
+        final restorable = await build().restorableAccounts([acc]);
+
+        expect(restorable, [acc]);
+      });
+
+      test('keeps an automatic account with a matching primary key', () async {
+        final acc = account(
+          testKeyContainer.publicKeyHex,
+          AuthenticationSource.importedKeys,
+        );
+        when(() => keyStorage.hasKeys()).thenAnswer((_) async => true);
+        when(
+          () => keyStorage.getKeyContainer(),
+        ).thenAnswer((_) async => testKeyContainer);
+
+        final restorable = await build().restorableAccounts([acc]);
+
+        expect(restorable, [acc]);
+      });
+
+      test('drops an automatic account with no local key material', () async {
+        final acc = account('a' * 64, AuthenticationSource.automatic);
+
+        final restorable = await build().restorableAccounts([acc]);
+
+        expect(restorable, isEmpty);
+      });
+
+      test('keeps a remote-signer account when an archive exists', () async {
+        final acc = account('a' * 64, AuthenticationSource.bunker);
+        when(
+          () => signerStore.hasArchive('a' * 64, AuthenticationSource.bunker),
+        ).thenAnswer((_) async => true);
+
+        final restorable = await build().restorableAccounts([acc]);
+
+        expect(restorable, [acc]);
+      });
+
+      test('drops a remote-signer account with no archive', () async {
+        final acc = account('a' * 64, AuthenticationSource.divineOAuth);
+
+        final restorable = await build().restorableAccounts([acc]);
+
+        expect(restorable, isEmpty);
+      });
+
+      test('always drops none and nip07 accounts', () async {
+        final none = account('a' * 64, AuthenticationSource.none);
+        final nip07 = account('b' * 64, AuthenticationSource.nip07);
+
+        final restorable = await build().restorableAccounts([none, nip07]);
+
+        expect(restorable, isEmpty);
+      });
+
+      test('treats a local-key verification error as not restorable', () async {
+        final acc = account('a' * 64, AuthenticationSource.automatic);
+        when(
+          () => keyStorage.getIdentityKeyContainer(any()),
+        ).thenThrow(Exception('keychain unavailable'));
+
+        final restorable = await build().restorableAccounts([acc]);
+
+        expect(restorable, isEmpty);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## What & why

Third **repository-tier** slice of #4741 (after R1 #5757, R2 #5805). The known-accounts registry — the multi-account welcome-screen picker source — moves out of `auth_service.dart` behind the stable facade. auth_service.dart **4,776 → 4,442**.

## The stateless collaborator

New `lib/services/auth/known_accounts_registry.dart` (`KnownAccountsRegistry`). Unlike R2's `OAuthSessionCoordinator` this one is **STATELESS** — every method reads `SharedPreferences` fresh, so there's no cached state and no `detach()`/sign-out hook. It needs **no tear-off ports** either: just three injected deps (`SecureKeyStorage`, `SignerSecureStore`, `FlutterSecureStorage?`), and it imports `keycast_flutter` directly for the one `KeycastSession.load` in the migration path (the R2 precedent — the `auth/` collaborators already depend on keycast_flutter).

Moved verbatim into the collaborator:
- `getKnownAccounts()` — read + MRU sort + the `null → one-time migration` vs `empty → []` branch
- the one-time legacy migration (`_migrateLegacyAccount` + `_migrateAutomaticKeys` + `_persistMigrationResult`)
- `upsert` (was `_addToKnownAccounts`) and `remove` (was `_removeFromKnownAccounts`)
- the restorable-account filter (`restorableAccounts` + `_hasRestorableLocalKey` + `_hasRestorableSignerArchive`)
- **new** `persist(List<KnownAccount>)` so the registry owns **every** `kKnownAccountsKey` write (including the ones the facade's sign-out recovery used to do inline)

## Seam (what stays on the facade)

The facade keeps all session state and restore orchestration — nothing that reads `_authState`/`_authSource`/`currentPublicKeyHex` moves:
- `signInForAccount`, `_restoreLastUsedAccountOrFallback`, `_tryRestoreFromKnownAccounts` (the live `AccountRestoreFailedException` guard is facade-owned)
- `signOut` ordering invariants unchanged (anchor-write, archive/remove-before-teardown, reset-recovery-after-signer-cleanup)
- `_resetRecoveryAfterLocalAccountRemoval` keeps its `_authSource = none` / `authentication_source` / `last_used_npub` resets and its facade-layer logs; it now calls `_knownAccounts.restorableAccounts(...)` + `_knownAccounts.persist(...)` instead of the inline filter + `prefs.setString(kKnownAccountsKey, ...)`.

Public surface is preserved: `getKnownAccounts()` and `removeKnownAccount()` stay as thin delegators, so all 108 consumers are untouched.

## Log `name:` retag (not drift)

Every moved log line keeps its **message content byte-identical** vs `origin/main`; only the structured `name:` tag is retagged `AuthService` → `KnownAccountsRegistry` at the moved sites — the same R1/R2 own-class-tag convention. The only thing this affects is an external log filter keyed on `name:'AuthService'` for these specific lines (nothing in-repo keys on that tag). The facade-layer logs (in `signOut` / the reset method) stay `name:'AuthService'`.

## Verification

- **Adversarial drift-hunter (3 independent lenses vs `origin/main`): zero behavior drift.** Confirmed all five moved clusters are token-for-token identical (control flow, await ordering, the null-vs-empty branch, `length == 64` guards, the `!accounts.any` dedup, the `copyWith` upsert preserving `addedAt`, the `removeWhere`, the restorable switch arms). Confirmed the two wiring substitutions are transparent: `origin/main`'s `_loadAmberInfo()`/`_loadBunkerInfo()` were exact one-line delegators to `_signerStore.loadAmber()`/`loadBunker()`; and `persist(const <KnownAccount>[])` emits `"[]"`, byte-identical to the old `jsonEncode(<Object>[])`. All 12 call sites rewired with identical args; `dart:convert` import removal from the facade verified safe.
- **New `known_accounts_registry_test.dart` — 26 tests** covering getKnownAccounts (sort / sealed-empty / parse-failure), every migration arm (automatic / amber / bunker / divineOAuth / source=none, dedup, seal-once, error-swallow), upsert (insert + update-preserving-addedAt), remove, persist (overwrite + empty→`"[]"`), and restorableAccounts (local-key match, primary-key match, no-material drop, archive keep/drop, none/nip07 always dropped, verification-error → not restorable).
- **`multi_account` (91 tests) stays byte-identical** — zero edits. (Its group-name strings still say `_migrateLegacyAccount` / `_addToKnownAccounts`; those are pre-extraction labels left untouched on purpose, since editing the pinned suite would itself signal drift.) Pinned suites green: identity_change_preservation, destructive_signout, signout_cleanup, oauth_recovery, expired_session_downgrade.
- **375-test auth sweep green; `flutter analyze` clean; `dart format` clean.** CI ratchets pass: untested-services floor (new file ships its same-named test), empty-catch ceiling (no bare catch moved), service-sentinel (43→20, decreases are free).

No user-facing change. Part of #4741. Next: PR5–6 in-place split completion, then the `packages/auth_repository` scaffold.
