### PR TITLE
fix(video_editor): stop trim handle lagging behind the finger

### DIFF
--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_tiles.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_tiles.dart
@@ -48,26 +48,40 @@ class _TrimmableClipTileState extends State<_TrimmableClipTile> {
   bool _leftAtLimit = false;
   bool _rightAtLimit = false;
 
+  // Trim values accumulated during the active drag. Handles report incremental
+  // pixel deltas; the result round-trips through ClipEditorBloc and only lands
+  // back on widget.clip a frame later. Reading widget.clip mid-drag would use a
+  // stale base and drop deltas whenever pointer updates outpace rebuilds (e.g.
+  // 120Hz touch sampling emitting 2+ moves per frame), making the handle lag
+  // further behind the finger the longer you drag. Accumulating locally keeps
+  // every delta.
+  Duration? _dragTrimStart;
+  Duration? _dragTrimEnd;
+
   Duration _dxToDuration(double dx) {
     final seconds = dx / widget.pixelsPerSecond;
     return Duration(microseconds: (seconds * 1000000).round());
   }
 
   void _onDragStart() {
+    _dragTrimStart = widget.clip.trimStart;
+    _dragTrimEnd = widget.clip.trimEnd;
     widget.onTrimDragChanged?.call(true);
   }
 
   void _onDragEnd() {
+    _dragTrimStart = null;
+    _dragTrimEnd = null;
     widget.onTrimDragChanged?.call(false);
   }
 
   void _onLeftDragUpdate(double dx) {
     final clip = widget.clip;
-    final delta = _dxToDuration(dx);
-    var newTrimStart = clip.trimStart + delta;
+    final trimEnd = _dragTrimEnd ?? clip.trimEnd;
+    var newTrimStart = (_dragTrimStart ?? clip.trimStart) + _dxToDuration(dx);
 
     final maxTrimStart =
-        clip.duration - clip.trimEnd - TimelineConstants.minTrimDuration;
+        clip.duration - trimEnd - TimelineConstants.minTrimDuration;
 
     var atLimit = false;
 
@@ -83,23 +97,24 @@ class _TrimmableClipTileState extends State<_TrimmableClipTile> {
       HapticFeedback.mediumImpact();
     }
     _leftAtLimit = atLimit;
+    _dragTrimStart = newTrimStart;
 
     widget.onTrimChanged?.call(
       clipId: clip.id,
       isStart: true,
       trimStart: newTrimStart,
-      trimEnd: clip.trimEnd,
+      trimEnd: trimEnd,
     );
   }
 
   void _onRightDragUpdate(double dx) {
     final clip = widget.clip;
+    final trimStart = _dragTrimStart ?? clip.trimStart;
     // Dragging right handle left (negative dx) increases trimEnd.
-    final delta = _dxToDuration(-dx);
-    var newTrimEnd = clip.trimEnd + delta;
+    var newTrimEnd = (_dragTrimEnd ?? clip.trimEnd) + _dxToDuration(-dx);
 
     final maxTrimEnd =
-        clip.duration - clip.trimStart - TimelineConstants.minTrimDuration;
+        clip.duration - trimStart - TimelineConstants.minTrimDuration;
 
     var atLimit = false;
 
@@ -115,11 +130,12 @@ class _TrimmableClipTileState extends State<_TrimmableClipTile> {
       HapticFeedback.mediumImpact();
     }
     _rightAtLimit = atLimit;
+    _dragTrimEnd = newTrimEnd;
 
     widget.onTrimChanged?.call(
       clipId: clip.id,
       isStart: false,
-      trimStart: clip.trimStart,
+      trimStart: trimStart,
       trimEnd: newTrimEnd,
     );
   }

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_tiles.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_tiles.dart
@@ -64,6 +64,9 @@ class _TrimmableClipTileState extends State<_TrimmableClipTile> {
   }
 
   void _onDragStart() {
+    // Re-arm the at-limit haptic: a previous drag may have ended at a limit.
+    _leftAtLimit = false;
+    _rightAtLimit = false;
     _dragTrimStart = widget.clip.trimStart;
     _dragTrimEnd = widget.clip.trimEnd;
     widget.onTrimDragChanged?.call(true);

--- a/mobile/test/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_test.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Validates clip rendering, layout, reorder gesture, and accessibility.
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/blocs/video_editor/main_editor/video_editor_main_bloc.dart';
@@ -425,6 +426,122 @@ void main() {
                 'dropped the previous deltas.',
           );
         }
+      });
+
+      testWidgets('left handle accumulates deltas across updates without a '
+          'rebuilt clip', (tester) async {
+        final clip = _createTestClip(id: 'solo', seconds: 30);
+        final reportedTrimStartMs = <int>[];
+
+        await tester.pumpWidget(
+          buildWidget(
+            clips: [clip],
+            trimmingClipId: clip.id,
+            scrollable: false,
+            onTrimChanged:
+                ({
+                  required clipId,
+                  required isStart,
+                  required trimStart,
+                  required trimEnd,
+                }) {
+                  if (isStart) {
+                    reportedTrimStartMs.add(trimStart.inMilliseconds);
+                  }
+                },
+          ),
+        );
+
+        // Start just inside the left edge — the left handle's grab zone
+        // reaches inward from the edge (mirrors the right-handle test above).
+        final box = tester.renderObject<RenderBox>(
+          find.byType(TimelineTrimHandles),
+        );
+        final start = box.localToGlobal(Offset(2, box.size.height / 2));
+
+        final gesture = await tester.startGesture(start);
+        await tester.pump();
+        for (var i = 0; i < 5; i++) {
+          await gesture.moveBy(const Offset(30, 0));
+          await tester.pump();
+        }
+        await gesture.up();
+        await tester.pump();
+
+        expect(reportedTrimStartMs.length, greaterThanOrEqualTo(3));
+        for (var i = 1; i < reportedTrimStartMs.length; i++) {
+          expect(
+            reportedTrimStartMs[i],
+            greaterThan(reportedTrimStartMs[i - 1]),
+            reason:
+                'trimStart must accumulate across drag updates. A constant '
+                'value means each update reused the stale widget.clip base '
+                'and dropped the previous deltas.',
+          );
+        }
+      });
+    });
+
+    group('trim limit haptics', () {
+      testWidgets('re-arms the at-limit haptic on each new drag', (
+        tester,
+      ) async {
+        final hapticCalls = <MethodCall>[];
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+              if (call.method == 'HapticFeedback.vibrate') {
+                hapticCalls.add(call);
+              }
+              return null;
+            });
+        addTearDown(() {
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+              .setMockMethodCallHandler(SystemChannels.platform, null);
+        });
+
+        final clip = _createTestClip(id: 'solo', seconds: 3);
+        await tester.pumpWidget(
+          buildWidget(
+            clips: [clip],
+            trimmingClipId: clip.id,
+            scrollable: false,
+          ),
+        );
+
+        final box = tester.renderObject<RenderBox>(
+          find.byType(TimelineTrimHandles),
+        );
+        final start = box.localToGlobal(
+          Offset(box.size.width - 2, box.size.height / 2),
+        );
+
+        // The first move only triggers gesture acceptance and is consumed by
+        // DragStartBehavior.start without producing an update. Each following
+        // move must already overshoot the 2.94s max-trim limit on its own
+        // (170px / 52pps ≈ 3.27s) so that every delivered update is clamped:
+        // an intermediate non-clamped update would clear the at-limit flag
+        // itself and hide a stale flag carried over from the previous drag.
+        Future<void> dragPastLimit() async {
+          final gesture = await tester.startGesture(start);
+          await tester.pump();
+          for (var i = 0; i < 3; i++) {
+            await gesture.moveBy(const Offset(-170, 0));
+            await tester.pump();
+          }
+          await gesture.up();
+          await tester.pump();
+        }
+
+        // First drag overshoots far past the max-trim limit → one haptic.
+        await dragPastLimit();
+
+        expect(hapticCalls, hasLength(1));
+
+        // A second drag hitting the limit again must haptic again — the
+        // at-limit flag is re-armed on drag start, not kept from last drag.
+        await dragPastLimit();
+
+        expect(hapticCalls, hasLength(2));
       });
     });
 

--- a/mobile/test/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_test.dart
@@ -10,6 +10,7 @@ import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/router/app_router.dart';
 import 'package:openvine/services/video_editor/clip_thumbnail_manager.dart';
+import 'package:openvine/widgets/video_editor/timeline_editor/strips/timeline_trim_handles.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 
@@ -38,6 +39,10 @@ void main() {
       ValueChanged<List<DivineVideoClip>>? onReorder,
       ValueChanged<bool>? onReorderChanged,
       ClipThumbnailManager? thumbnailManager,
+      String? trimmingClipId,
+      ClipTrimCallback? onTrimChanged,
+      ValueChanged<bool>? onTrimDragChanged,
+      bool scrollable = true,
       List<NavigatorObserver> navigatorObservers = const <NavigatorObserver>[],
     }) {
       final testClips =
@@ -47,6 +52,20 @@ void main() {
             _createTestClip(id: 'clip2', seconds: 4),
           ];
 
+      final strip = VideoEditorTimelineClipStrip(
+        clips: testClips,
+        totalWidth: totalWidth,
+        pixelsPerSecond: pixelsPerSecond,
+        scrollController: scrollable ? scrollController : null,
+        isInteracting: isInteracting,
+        onReorder: onReorder,
+        onReorderChanged: onReorderChanged,
+        trimmingClipId: trimmingClipId,
+        onTrimChanged: onTrimChanged,
+        onTrimDragChanged: onTrimDragChanged,
+        thumbnailManager: thumbnailManager,
+      );
+
       return MaterialApp(
         navigatorObservers: navigatorObservers,
         localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -54,20 +73,13 @@ void main() {
         home: Scaffold(
           body: BlocProvider<VideoEditorMainBloc>.value(
             value: mainBloc,
-            child: SingleChildScrollView(
-              controller: scrollController,
-              scrollDirection: Axis.horizontal,
-              child: VideoEditorTimelineClipStrip(
-                clips: testClips,
-                totalWidth: totalWidth,
-                pixelsPerSecond: pixelsPerSecond,
-                scrollController: scrollController,
-                isInteracting: isInteracting,
-                onReorder: onReorder,
-                onReorderChanged: onReorderChanged,
-                thumbnailManager: thumbnailManager,
-              ),
-            ),
+            child: scrollable
+                ? SingleChildScrollView(
+                    controller: scrollController,
+                    scrollDirection: Axis.horizontal,
+                    child: strip,
+                  )
+                : Align(alignment: Alignment.centerLeft, child: strip),
           ),
         ),
       );
@@ -344,6 +356,75 @@ void main() {
         await tester.pumpWidget(buildWidget(clips: clips, totalWidth: 400));
 
         expect(tester.takeException(), isNull);
+      });
+    });
+
+    group('trim drag accumulation', () {
+      // Regression: the trim tile used to compute `newTrim = widget.clip.trim +
+      // incrementalDelta`, reading the base back from widget.clip. That value
+      // only lands on widget.clip a frame after it round-trips through
+      // ClipEditorBloc, so when several drag updates fire before a rebuild
+      // (120Hz touch, or a heavy timeline that can't rebuild every frame) every
+      // update reused the same stale base and dropped the intermediate deltas —
+      // the handle lagged further behind the finger the longer you dragged.
+      //
+      // Here widget.clip is never fed the reported trim back, so the base stays
+      // at zero across the whole drag. With local accumulation the reported
+      // trimEnd grows on every update; without it every update reports the same
+      // single-delta value.
+      testWidgets('right handle accumulates deltas across updates without a '
+          'rebuilt clip', (tester) async {
+        final clip = _createTestClip(id: 'solo', seconds: 30);
+        final reportedTrimEndMs = <int>[];
+
+        await tester.pumpWidget(
+          buildWidget(
+            clips: [clip],
+            trimmingClipId: clip.id,
+            scrollable: false,
+            onTrimChanged:
+                ({
+                  required clipId,
+                  required isStart,
+                  required trimStart,
+                  required trimEnd,
+                }) {
+                  if (!isStart) reportedTrimEndMs.add(trimEnd.inMilliseconds);
+                },
+          ),
+        );
+
+        // Start just inside the right edge: the right handle's grab zone
+        // reaches inward from the edge, and staying in-bounds avoids the
+        // beyond-edge hit area that only the production HitExpandedBox makes
+        // reachable.
+        final box = tester.renderObject<RenderBox>(
+          find.byType(TimelineTrimHandles),
+        );
+        final start = box.localToGlobal(
+          Offset(box.size.width - 2, box.size.height / 2),
+        );
+
+        final gesture = await tester.startGesture(start);
+        await tester.pump();
+        for (var i = 0; i < 5; i++) {
+          await gesture.moveBy(const Offset(-30, 0));
+          await tester.pump();
+        }
+        await gesture.up();
+        await tester.pump();
+
+        expect(reportedTrimEndMs.length, greaterThanOrEqualTo(3));
+        for (var i = 1; i < reportedTrimEndMs.length; i++) {
+          expect(
+            reportedTrimEndMs[i],
+            greaterThan(reportedTrimEndMs[i - 1]),
+            reason:
+                'trimEnd must accumulate across drag updates. A constant value '
+                'means each update reused the stale widget.clip base and '
+                'dropped the previous deltas.',
+          );
+        }
       });
     });
 


### PR DESCRIPTION
Closes #5809

## What

Fixes the timeline trim/resize handle drifting progressively behind the finger while dragging — the further you drag, the wider the gap between finger and handle.



## Why it happened

Each drag update computed the new trim as `widget.clip.trim + incrementalDelta`, reading the *base* back from `widget.clip`. But that value round-trips through `ClipEditorBloc` (`add` → `emit` → rebuild) and only lands back on `widget.clip` a frame later. When pointer updates outpace rebuilds — 120 Hz+ touch sampling firing 2+ moves per frame, or the heavy timeline not rebuilding every frame — several updates reused the **same stale base**, and because `_onTrimUpdated` uses `restartable()`, only the last update's delta survived. The intermediate deltas were silently dropped, so the handle moved slower than the finger and drifted cumulatively.

This is why the drift shows up even for normal clips at `playbackSpeed == 1`, where the pixel↔time conversion is exact and can't account for it.

## The fix

`_TrimmableClipTileState` now accumulates the trim **locally** for the duration of a drag (`_dragTrimStart` / `_dragTrimEnd`, captured from `widget.clip` on drag start) instead of re-reading `widget.clip` mid-gesture. This is immune to rebuild latency and touch-sample rate, and works cleanly with `restartable()` because every event now carries the fully-accumulated absolute value.

## Test

Added a regression test that drags the right handle through several updates **without** feeding the reported trim back into `widget.clip` (reproducing the stale-base condition) and asserts the reported `trimEnd` strictly increases. Verified red/green: it fails against the old stale-base code and passes with the fix.

`flutter analyze` clean; the clip-strip, tiles, and trim-handle test files all pass.

## Not included

At `playbackSpeed != 1` there's a *separate* scaling mismatch — `_dxToDuration` converts finger pixels to source time while the tile width uses playback time, so the handle moves at `dx / speed`. That's a distinct, speed-only bug and out of scope here; happy to follow up if wanted.