### PR TITLE
fix(video-editor): pause playback when a scrub grabs the timeline mid follow-animation

### DIFF
--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart
@@ -315,20 +315,29 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
   }
 
   bool _handleScrollNotification(ScrollNotification notification) {
-    if (notification is ScrollStartNotification &&
-        notification.dragDetails != null) {
+    // A drag that grabs the timeline during playback can start without a
+    // ScrollStartNotification: when a playback-sync animateTo restarts
+    // between touch-down and drag-start, the framework sees a
+    // scrolling→scrolling activity transition and skips didStartScroll.
+    // Drag-driven updates always carry dragDetails, so they detect the
+    // scrub too.
+    final isUserDrag = switch (notification) {
+      ScrollStartNotification(:final dragDetails) => dragDetails != null,
+      ScrollUpdateNotification(:final dragDetails) => dragDetails != null,
+      _ => false,
+    };
+    if (isUserDrag && !_isUserScrolling) {
       _isUserScrolling = true;
       // Explicitly pause video while scrubbing so seekTo shows each frame.
       context.read<VideoEditorMainBloc>().add(
         const VideoEditorExternalPauseRequested(isPaused: true),
       );
-    } else if (notification is ScrollUpdateNotification && _isUserScrolling) {
+    }
+    if (notification is ScrollUpdateNotification && _isUserScrolling) {
       _syncPositionFromScroll();
-    } else if (notification is ScrollEndNotification) {
-      if (_isUserScrolling) {
-        _isUserScrolling = false;
-        _syncPositionFromScroll(force: true);
-      }
+    } else if (notification is ScrollEndNotification && _isUserScrolling) {
+      _isUserScrolling = false;
+      _syncPositionFromScroll(force: true);
     }
     return false;
   }

--- a/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_test.dart
@@ -80,6 +80,10 @@ void main() {
     late _MockVideoEditorFilterBloc mockFilterBloc;
     late ProVideoEditor originalProVideoEditor;
 
+    setUpAll(() {
+      registerFallbackValue(const VideoEditorSeekRequested(Duration.zero));
+    });
+
     setUp(() {
       originalProVideoEditor = ProVideoEditor.instance;
       ProVideoEditor.instance = _MockProVideoEditor();
@@ -378,6 +382,12 @@ void main() {
             const VideoEditorExternalPauseRequested(isPaused: true),
           ),
         ).called(1);
+
+        // The scrub also seeks — the user-visible payload the pause enables.
+        // Throttled on real wall-clock, so assert at-least-once.
+        verify(
+          () => mockMainBloc.add(any(that: isA<VideoEditorSeekRequested>())),
+        ).called(isPositive);
       });
 
       testWidgets(
@@ -415,6 +425,15 @@ void main() {
           await tester.pump(const Duration(milliseconds: 250));
           await tester.pump(const Duration(milliseconds: 50));
 
+          // The follow animation scrolls via a DrivenScrollActivity
+          // (dragDetails == null); it must never be misread as a user scrub.
+          // This negative case is the exact discriminator the fix relies on.
+          verifyNever(
+            () => mockMainBloc.add(
+              const VideoEditorExternalPauseRequested(isPaused: true),
+            ),
+          );
+
           // Touch down on the clip strip while idle. The clip's tap /
           // long-press recognizers join the gesture arena, so the scroll
           // drag only wins after touch slop — as with a real finger on a
@@ -451,8 +470,36 @@ void main() {
             ),
           ).called(1);
 
+          // The scrub also seeks — the user-visible payload the pause enables.
+          // Throttled on real wall-clock, so assert at-least-once.
+          verify(
+            () => mockMainBloc.add(any(that: isA<VideoEditorSeekRequested>())),
+          ).called(isPositive);
+
           await gesture.up();
           await tester.pumpAndSettle();
+
+          // ScrollEnd cleared _isUserScrolling, re-enabling follow-sync: a new
+          // position update now drives a fresh follow animation. The scrub left
+          // the timeline scrolled forward, so a jump back near the start scrolls
+          // it toward zero — proving the follow ran, not that the flag stayed
+          // stuck.
+          final scrollView = tester.widget<SingleChildScrollView>(
+            timelineScrollView(),
+          );
+          final offsetBeforeFollow = scrollView.controller!.offset;
+          expect(offsetBeforeFollow, greaterThan(0));
+          states.add(
+            const VideoEditorMainState(
+              currentPosition: Duration(milliseconds: 500),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          expect(
+            scrollView.controller!.offset,
+            lessThan(offsetBeforeFollow),
+          );
         },
       );
     });

--- a/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Widget tests for VideoEditorTimeline.
 // ABOUTME: Validates timeline rendering, scroll content, playhead, and empty state.
 
+import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:bloc_test/bloc_test.dart';
@@ -18,6 +19,7 @@ import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timeline.dart';
+import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timeline_body.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timeline_header.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timeline_playhead.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timeline_rules_indicator.dart';
@@ -344,6 +346,115 @@ void main() {
 
         expect(find.byType(SingleChildScrollView), findsWidgets);
       });
+    });
+
+    group('scrub pause', () {
+      Finder timelineScrollView() => find.ancestor(
+        of: find.byType(VideoEditorTimelineBody),
+        matching: find.byWidgetPredicate(
+          (widget) =>
+              widget is SingleChildScrollView &&
+              widget.scrollDirection == Axis.horizontal,
+        ),
+      );
+
+      testWidgets('pauses playback when the user drags the timeline', (
+        tester,
+      ) async {
+        final clips = [_createTestClip(id: 'a', seconds: 20)];
+
+        await tester.pumpWidget(
+          buildWidget(clipState: ClipEditorState(clips: clips)),
+        );
+
+        await tester.drag(
+          timelineScrollView(),
+          const Offset(-100, 0),
+        );
+        await tester.pumpAndSettle();
+
+        verify(
+          () => mockMainBloc.add(
+            const VideoEditorExternalPauseRequested(isPaused: true),
+          ),
+        ).called(1);
+      });
+
+      testWidgets(
+        'pauses playback when a drag grabs the timeline while a '
+        'playback-sync animation restarts mid touch-down',
+        (tester) async {
+          // Regression: while playing, every position update animates the
+          // timeline to follow the playhead. When the finger lands in the
+          // idle gap between two follow animations and the next animateTo
+          // restarts during the touch-down hold, the drag then begins from
+          // an already-scrolling activity, so Flutter emits no
+          // ScrollStartNotification — the scrub used to go undetected and
+          // the video kept playing, fighting the user's drag.
+          final clips = [_createTestClip(id: 'a', seconds: 20)];
+          final states = StreamController<VideoEditorMainState>.broadcast();
+          addTearDown(states.close);
+          whenListen(
+            mockMainBloc,
+            states.stream,
+            initialState: const VideoEditorMainState(),
+          );
+
+          await tester.pumpWidget(
+            buildWidget(clipState: ClipEditorState(clips: clips)),
+          );
+
+          // Playback position update → follow animation runs to completion,
+          // leaving the scroll position idle.
+          states.add(
+            const VideoEditorMainState(
+              currentPosition: Duration(seconds: 2),
+            ),
+          );
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 250));
+          await tester.pump(const Duration(milliseconds: 50));
+
+          // Touch down on the clip strip while idle. The clip's tap /
+          // long-press recognizers join the gesture arena, so the scroll
+          // drag only wins after touch slop — as with a real finger on a
+          // clip. (Mid animation the viewport ignores pointers, so the
+          // scroll drag would win the arena instantly at touch-down, which
+          // sidesteps the race.)
+          final strip = find.byType(VideoEditorTimelineClipStrip);
+          final touchPoint =
+              tester.getTopLeft(strip) +
+              Offset(60, tester.getSize(strip).height / 2);
+          final gesture = await tester.startGesture(touchPoint);
+
+          // The next position update restarts the follow animation while
+          // the finger is down, swallowing the upcoming
+          // ScrollStartNotification.
+          states.add(
+            const VideoEditorMainState(
+              currentPosition: Duration(milliseconds: 2200),
+            ),
+          );
+          await tester.pump();
+
+          // First move wins the arena and starts the drag mid animation
+          // (no start notification); the second move emits the first
+          // drag-driven ScrollUpdateNotification.
+          await gesture.moveBy(const Offset(-40, 0));
+          await tester.pump();
+          await gesture.moveBy(const Offset(-40, 0));
+          await tester.pump();
+
+          verify(
+            () => mockMainBloc.add(
+              const VideoEditorExternalPauseRequested(isPaused: true),
+            ),
+          ).called(1);
+
+          await gesture.up();
+          await tester.pumpAndSettle();
+        },
+      );
     });
   });
 }


### PR DESCRIPTION
Closes #5811

## Description

While the editor preview is playing, manually scrubbing the timeline is supposed to pause playback — but it intermittently didn't, and the timeline then fought the user's drag by snapping back to the playhead.

Root cause: the scrub detection relied solely on `ScrollStartNotification.dragDetails != null`. During playback, every position update (~5×/s) drives a 200 ms `animateTo` that makes the timeline follow the playhead. When a touch lands in the idle gap between two follow animations, the clip's tap/long-press recognizers join the gesture arena, so the scroll drag only wins after touch slop. If the next position update restarts the follow animation during that touch-down hold, the drag then begins from an already-scrolling activity — Flutter only dispatches `ScrollStartNotification` on a not-scrolling → scrolling transition, so it never fires and the scrub went undetected: no pause, and each subsequent position update kept yanking the timeline away from the finger. Whether the bug hit depended on a position update landing in that hold window, hence "doesn't always pause".

Fix: also detect the scrub from drag-driven `ScrollUpdateNotification`s, which always carry `dragDetails` regardless of how the drag activity started. Once detected, the existing `_isUserScrolling` guard pauses playback and stops the follow animations, exactly as in the normal path.

The regression test reproduces the race faithfully (follow animation runs to idle → touch down on the clip strip → position update restarts the animation during the hold → drag past slop) and fails without the fix.

**Related Issue:** 

## Out of Scope

None.

## Verification

- `flutter test test/widgets/video_editor/timeline_editor/video_editor_timeline_test.dart` — all 15 pass; the new regression test was verified to fail against the unfixed code
- `flutter analyze lib test integration_test` — clean
- Re-ran both after rebasing onto `origin/main`

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore