### PR TITLE
fix(editor): stop split clip thumbnails flashing black

### DIFF
--- a/mobile/lib/services/video_editor/clip_thumbnail_manager.dart
+++ b/mobile/lib/services/video_editor/clip_thumbnail_manager.dart
@@ -120,14 +120,17 @@ class ClipThumbnailManager {
           priorityTimestamps: priorityTimestamps[clip.id],
         );
       } else if (newPath != null && newPath != currentPath) {
-        // Source file changed (e.g. clip was rendered to a trimmed
-        // file after a split). Restart against the new file, but keep
-        // the current frames on screen — clearing them here would
-        // flash black until the first fresh batch arrives. The old
+        // Source file of an already-subscribed clip changed (e.g. it was
+        // re-rendered to a trimmed file). Restart against the new file
+        // but keep the current frames on screen — clearing them here
+        // would flash black until the first fresh batch arrives. The old
         // files are deleted once the new subscription replaces them.
+        //
+        // Seeded split halves never reach this branch: they carry no
+        // subscription until their rendered path arrives via the
+        // !hasSubscription branch above, which is where _seeded and any
+        // pending rebase are consumed.
         _subscriptions.remove(clip.id)?.cancel();
-        _seeded.remove(clip.id);
-        _rebaseThumbnails(clip.id);
         _loadThumbnails(
           clip,
           devicePixelRatio,
@@ -250,12 +253,19 @@ class ClipThumbnailManager {
           if (notifier == null) return;
           final replaced = notifier.value;
           notifier.value = thumbnails;
+          if (replaced.isEmpty) return;
           // Frames carried over across a restart (seeded split frames,
           // pre-render frames) are superseded now — delete their files
-          // unless another clip still shows them. During normal
-          // accumulation each batch contains the previous paths, so
-          // nothing is deleted.
-          _deleteUnreferencedFiles(replaced);
+          // unless another clip still shows them. Each batch is a
+          // superset of the previous (the generator accumulates), so in
+          // steady state every replaced path is still in [thumbnails];
+          // filtering to the genuinely dropped paths first skips the
+          // cross-notifier scan on every normal accumulation batch.
+          final currentPaths = {for (final thumb in thumbnails) thumb.path};
+          _deleteUnreferencedFiles([
+            for (final thumb in replaced)
+              if (!currentPaths.contains(thumb.path)) thumb,
+          ]);
         });
     // If the owner paused while this clip was (re)synced, keep the new
     // subscription paused too so it doesn't start extracting off-screen.

--- a/mobile/lib/services/video_editor/clip_thumbnail_manager.dart
+++ b/mobile/lib/services/video_editor/clip_thumbnail_manager.dart
@@ -5,7 +5,6 @@ import 'package:flutter/widgets.dart';
 import 'package:openvine/constants/video_editor_timeline_constants.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/services/video_thumbnail_service.dart';
-import 'package:path/path.dart' as p;
 
 /// Signature of [VideoThumbnailService.generateStripThumbnails], injectable
 /// so tests can assert pause/resume behaviour on the produced subscriptions
@@ -47,6 +46,13 @@ class ClipThumbnailManager {
   // be immediately overwritten by a fresh subscription against the
   // (still un-trimmed) source video.
   final Set<String> _seeded = {};
+  // Timestamp shift to apply to a seeded clip's thumbnails when its
+  // rendered file path arrives. Seeded frames are kept in the *current*
+  // clip's timebase so they display immediately; when the rendered file
+  // rebases the clip's timeline (split end half: source-time →
+  // zero-based), the same shift is applied here so the frames stay
+  // aligned until fresh thumbnails replace them.
+  final Map<String, Duration> _pendingRebase = {};
 
   /// When true, newly started subscriptions begin paused and existing ones are
   /// held. See [pauseAll].
@@ -78,9 +84,12 @@ class ClipThumbnailManager {
       _subscriptions.remove(id)?.cancel();
       _videoPaths.remove(id);
       _seeded.remove(id);
+      _pendingRebase.remove(id);
       final notifier = _notifiers.remove(id);
       if (notifier != null) {
-        _deleteFiles(notifier.value);
+        // Files borrowed by seeded clips (split halves) stay alive; only
+        // files no other notifier references are deleted.
+        _deleteUnreferencedFiles(notifier.value);
         notifier.dispose();
       }
     }
@@ -94,11 +103,17 @@ class ClipThumbnailManager {
       final isSeeded = _seeded.contains(clip.id);
 
       if (!hasSubscription) {
-        // Skip auto-loading for seeded clips — their notifier already
-        // shows the right frames borrowed from the source clip. The
-        // real subscription kicks in once the rendered (trimmed) file
-        // path arrives via the path-change branch below.
-        if (isSeeded && newPath == currentPath) continue;
+        if (isSeeded) {
+          // Skip auto-loading for seeded clips — their notifier already
+          // shows the right frames borrowed from the source clip.
+          if (newPath == null || newPath == currentPath) continue;
+          // The rendered (trimmed) file path arrived — start the real
+          // subscription. The seeded frames stay visible (rebased into
+          // the rendered file's timebase where needed) until the first
+          // fresh batch replaces them; their files are deleted then.
+          _seeded.remove(clip.id);
+          _rebaseThumbnails(clip.id);
+        }
         _loadThumbnails(
           clip,
           devicePixelRatio,
@@ -106,24 +121,18 @@ class ClipThumbnailManager {
         );
       } else if (newPath != null && newPath != currentPath) {
         // Source file changed (e.g. clip was rendered to a trimmed
-        // file after a split). Restart against the new file so the
-        // thumbnails reflect the actual segment content.
+        // file after a split). Restart against the new file, but keep
+        // the current frames on screen — clearing them here would
+        // flash black until the first fresh batch arrives. The old
+        // files are deleted once the new subscription replaces them.
         _subscriptions.remove(clip.id)?.cancel();
         _seeded.remove(clip.id);
-        final notifier = _notifiers[clip.id];
-        if (notifier != null) {
-          _deleteFiles(notifier.value);
-          notifier.value = const [];
-        }
+        _rebaseThumbnails(clip.id);
         _loadThumbnails(
           clip,
           devicePixelRatio,
           priorityTimestamps: priorityTimestamps[clip.id],
         );
-      } else if (isSeeded && newPath != null && newPath == currentPath) {
-        // Seeded clip is still pointing at the source video (render
-        // hasn't finished yet) — keep the seeded frames visible.
-        continue;
       }
     }
   }
@@ -134,11 +143,23 @@ class ClipThumbnailManager {
   /// `-sourceRange.start` so they map to the new clip's local timeline.
   /// Pass [timestampOffset] to use a different source-to-target mapping.
   ///
+  /// The seeded entries reference the source clip's thumbnail *files*
+  /// directly (no copy) so the image cache entries decoded for the
+  /// source tile repaint instantly — a copied file would be a cold
+  /// decode that flashes black. Cleanup protects borrowed files: they
+  /// are only deleted once no notifier references them anymore.
+  ///
   /// The clip is marked as "seeded" so [sync] will not auto-load a
   /// fresh subscription against the still-un-trimmed source video
   /// — that would overwrite these correct frames with the wrong
   /// range. The real subscription starts once the rendered file
-  /// path arrives via the path-change branch in [sync].
+  /// path arrives via the path-change branch in [sync]; the seeded
+  /// frames stay visible until its first batch lands.
+  ///
+  /// [rebaseOnPathChange] is subtracted from every seeded timestamp
+  /// when the rendered file path arrives. Use it when the rendered
+  /// file rebases the clip's timeline (split end half: the preview
+  /// clip is source-timed, the rendered file starts at zero).
   ///
   /// [currentSourcePath] is the video path the target clip currently
   /// points at (typically the source video). Recording it lets
@@ -150,24 +171,20 @@ class ClipThumbnailManager {
     required DurationRange sourceRange,
     required String currentSourcePath,
     Duration? timestampOffset,
+    Duration rebaseOnPathChange = Duration.zero,
   }) {
     final source = _notifiers[sourceClipId];
     if (source == null) return;
     final shift = timestampOffset ?? sourceRange.start;
-    final seeded = <StripThumbnail>[];
-    for (var i = 0; i < source.value.length; i++) {
-      final thumbnail = source.value[i];
-      if (thumbnail.timestamp < sourceRange.start ||
-          thumbnail.timestamp >= sourceRange.end) {
-        continue;
-      }
-      seeded.add(
-        StripThumbnail(
-          path: _copySeededThumbnailFile(thumbnail.path, targetClipId, i),
-          timestamp: thumbnail.timestamp - shift,
-        ),
-      );
-    }
+    final seeded = <StripThumbnail>[
+      for (final thumbnail in source.value)
+        if (thumbnail.timestamp >= sourceRange.start &&
+            thumbnail.timestamp < sourceRange.end)
+          StripThumbnail(
+            path: thumbnail.path,
+            timestamp: thumbnail.timestamp - shift,
+          ),
+    ];
     final notifier = _notifiers.putIfAbsent(
       targetClipId,
       () => ValueNotifier(const []),
@@ -175,28 +192,27 @@ class ClipThumbnailManager {
     notifier.value = seeded;
     _videoPaths[targetClipId] = currentSourcePath;
     _seeded.add(targetClipId);
+    if (rebaseOnPathChange == Duration.zero) {
+      _pendingRebase.remove(targetClipId);
+    } else {
+      _pendingRebase[targetClipId] = rebaseOnPathChange;
+    }
   }
 
-  static String _copySeededThumbnailFile(
-    String sourcePath,
-    String targetClipId,
-    int index,
-  ) {
-    final sourceFile = File(sourcePath);
-    if (!sourceFile.existsSync()) return sourcePath;
-
-    final extension = p.extension(sourcePath);
-    final destinationPath = p.join(
-      p.dirname(sourcePath),
-      'seed_${targetClipId}_${DateTime.now().microsecondsSinceEpoch}_'
-      '$index$extension',
-    );
-
-    try {
-      return sourceFile.copySync(destinationPath).path;
-    } catch (_) {
-      return sourcePath;
-    }
+  /// Applies the pending timestamp rebase recorded by [seedFromSource]
+  /// when the clip's rendered file path arrives.
+  void _rebaseThumbnails(String clipId) {
+    final shift = _pendingRebase.remove(clipId);
+    if (shift == null || shift == Duration.zero) return;
+    final notifier = _notifiers[clipId];
+    if (notifier == null) return;
+    notifier.value = List.unmodifiable([
+      for (final thumbnail in notifier.value)
+        StripThumbnail(
+          path: thumbnail.path,
+          timestamp: thumbnail.timestamp - shift,
+        ),
+    ]);
   }
 
   void _loadThumbnails(
@@ -230,7 +246,16 @@ class ClipThumbnailManager {
           thumbsPerSecond: thumbsPerSecond,
           priorityTimestamps: priorityTimestamps,
         ).listen((thumbnails) {
-          _notifiers[clip.id]?.value = thumbnails;
+          final notifier = _notifiers[clip.id];
+          if (notifier == null) return;
+          final replaced = notifier.value;
+          notifier.value = thumbnails;
+          // Frames carried over across a restart (seeded split frames,
+          // pre-render frames) are superseded now — delete their files
+          // unless another clip still shows them. During normal
+          // accumulation each batch contains the previous paths, so
+          // nothing is deleted.
+          _deleteUnreferencedFiles(replaced);
         });
     // If the owner paused while this clip was (re)synced, keep the new
     // subscription paused too so it doesn't start extracting off-screen.
@@ -257,6 +282,24 @@ class ClipThumbnailManager {
     }
   }
 
+  /// Deletes the files of [thumbnails] that no current notifier value
+  /// references anymore. Seeded clips borrow the source clip's files,
+  /// so a plain delete would pull decoded frames out from under a
+  /// live tile.
+  void _deleteUnreferencedFiles(List<StripThumbnail> thumbnails) {
+    if (thumbnails.isEmpty) return;
+    final live = <String>{
+      for (final notifier in _notifiers.values)
+        for (final thumbnail in notifier.value) thumbnail.path,
+    };
+    for (final thumb in thumbnails) {
+      if (live.contains(thumb.path)) continue;
+      try {
+        File(thumb.path).deleteSync();
+      } catch (_) {}
+    }
+  }
+
   static void _deleteFiles(List<StripThumbnail> thumbnails) {
     for (final thumb in thumbnails) {
       try {
@@ -278,6 +321,7 @@ class ClipThumbnailManager {
     _notifiers.clear();
     _videoPaths.clear();
     _seeded.clear();
+    _pendingRebase.clear();
   }
 }
 

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
@@ -251,6 +251,9 @@ class _VideoEditorTimelineClipStripState
       timestampOffset: Duration.zero,
       currentSourcePath: sourcePath,
     );
+    // The end half previews the un-trimmed source video (trimStart at the
+    // split point), so its seeds stay source-timed for now. The rendered
+    // file starts at zero, so the same shift is applied on path change.
     _thumbnails.seedFromSource(
       sourceClipId: split.sourceClipId,
       targetClipId: split.endClipId,
@@ -258,6 +261,8 @@ class _VideoEditorTimelineClipStripState
         start: split.absoluteSplitPosition,
         end: split.sourceDuration - split.sourceTrimEnd,
       ),
+      timestampOffset: Duration.zero,
+      rebaseOnPathChange: split.absoluteSplitPosition,
       currentSourcePath: endClip.video.file?.path ?? sourcePath,
     );
   }

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
@@ -229,7 +229,6 @@ class _VideoEditorTimelineClipStripState
     if (bloc == null) return;
     final split = bloc.state.lastSplit;
     if (split == null || identical(split, _lastSeededSplit)) return;
-    _lastSeededSplit = split;
 
     final startClipIdx = widget.clips.indexWhere(
       (c) => c.id == split.startClipId,
@@ -240,6 +239,12 @@ class _VideoEditorTimelineClipStripState
     final endClip = widget.clips[endClipIdx];
     final sourcePath = startClip.video.file?.path;
     if (sourcePath == null) return;
+
+    // Mark consumed only once seeding can actually run. Committing before
+    // the guards above would permanently drop the seed if a transient
+    // bail hit (clips not yet rebuilt / momentarily-null source path),
+    // reintroducing the black flash for that split.
+    _lastSeededSplit = split;
 
     _thumbnails.seedFromSource(
       sourceClipId: split.sourceClipId,

--- a/mobile/test/services/video_editor/clip_thumbnail_manager_test.dart
+++ b/mobile/test/services/video_editor/clip_thumbnail_manager_test.dart
@@ -574,6 +574,133 @@ void main() {
           expect(freshA.existsSync(), isTrue);
         },
       );
+
+      test(
+        'keeps START-half seeds as-is on rendered path arrival (no rebase), '
+        'then the first fresh batch supersedes and deletes them',
+        () async {
+          final borrowed = File('${tempDir.path}/start_borrowed.jpg')
+            ..writeAsStringSync('borrowed');
+          final sourceVideoPath = '${tempDir.path}/source.mp4';
+          final renderedVideoPath = '${tempDir.path}/rendered_start.mp4';
+
+          final sourceClip = _createFileClip(
+            id: 'src',
+            videoPath: sourceVideoPath,
+            seconds: 10,
+          );
+          fakeStreamManager.sync(clips: [sourceClip], devicePixelRatio: 1);
+          fakeStreamManager['src'].value = [
+            StripThumbnail(
+              path: borrowed.path,
+              timestamp: const Duration(seconds: 1),
+            ),
+          ];
+
+          // Split at 3 s: the start half already begins at zero, so the
+          // rendered file needs no rebase (rebaseOnPathChange stays zero)
+          // and the seed keeps its source-timed timestamp verbatim.
+          fakeStreamManager.seedFromSource(
+            sourceClipId: 'src',
+            targetClipId: 'start',
+            sourceRange: const DurationRange(
+              start: Duration.zero,
+              end: Duration(seconds: 3),
+            ),
+            timestampOffset: Duration.zero,
+            currentSourcePath: sourceVideoPath,
+          );
+          expect(
+            fakeStreamManager['start'].value.single.timestamp,
+            equals(const Duration(seconds: 1)),
+          );
+
+          // Rendered file arrives: a real subscription starts and the seed
+          // is held unchanged (no rebase branch runs for the start half).
+          final renderedStartClip = _createFileClip(
+            id: 'start',
+            videoPath: renderedVideoPath,
+          );
+          fakeStreamManager.sync(
+            clips: [renderedStartClip],
+            devicePixelRatio: 1,
+          );
+          expect(controllers, hasLength(2));
+          final held = fakeStreamManager['start'].value.single;
+          expect(held.path, equals(borrowed.path));
+          expect(held.timestamp, equals(const Duration(seconds: 1)));
+          expect(borrowed.existsSync(), isTrue);
+
+          final fresh = File('${tempDir.path}/fresh_start.jpg')
+            ..writeAsStringSync('fresh');
+          controllers[1].add([
+            StripThumbnail(
+              path: fresh.path,
+              timestamp: const Duration(seconds: 1),
+            ),
+          ]);
+          await pumpEventQueue();
+
+          expect(
+            fakeStreamManager['start'].value.single.path,
+            equals(fresh.path),
+          );
+          expect(borrowed.existsSync(), isFalse);
+          expect(fresh.existsSync(), isTrue);
+        },
+      );
+
+      test(
+        'marks the target seeded and suppresses the source-video load when '
+        'the source has no thumbnails yet, then loads on rendered path arrival',
+        () async {
+          final sourceVideoPath = '${tempDir.path}/empty_source.mp4';
+          final renderedVideoPath = '${tempDir.path}/empty_rendered.mp4';
+
+          final sourceClip = _createFileClip(
+            id: 'src',
+            videoPath: sourceVideoPath,
+            seconds: 10,
+          );
+          fakeStreamManager.sync(clips: [sourceClip], devicePixelRatio: 1);
+          expect(controllers, hasLength(1));
+
+          // Source frames haven't been extracted yet — seeding is
+          // best-effort: the target is created empty but still marked
+          // seeded so [sync] does not spin up a subscription against the
+          // un-trimmed source video.
+          fakeStreamManager.seedFromSource(
+            sourceClipId: 'src',
+            targetClipId: 'end',
+            sourceRange: const DurationRange(
+              start: Duration(seconds: 3),
+              end: Duration(seconds: 10),
+            ),
+            timestampOffset: Duration.zero,
+            rebaseOnPathChange: const Duration(seconds: 3),
+            currentSourcePath: sourceVideoPath,
+          );
+          expect(fakeStreamManager['end'].value, isEmpty);
+
+          final previewEndClip = _createFileClip(
+            id: 'end',
+            videoPath: sourceVideoPath,
+            seconds: 10,
+          );
+          fakeStreamManager.sync(clips: [previewEndClip], devicePixelRatio: 1);
+          // No new subscription while the clip still points at the source.
+          expect(controllers, hasLength(1));
+
+          // Rendered file arrives — now the real subscription starts.
+          final renderedEndClip = _createFileClip(
+            id: 'end',
+            videoPath: renderedVideoPath,
+            seconds: 7,
+          );
+          fakeStreamManager.sync(clips: [renderedEndClip], devicePixelRatio: 1);
+          expect(controllers, hasLength(2));
+        },
+      );
     });
 
     group('pauseAll / resumeAll', () {
@@ -688,6 +815,50 @@ void main() {
         // Should not throw.
         localManager.dispose();
       });
+
+      test(
+        'deletes a borrowed seed file once when two notifiers share it',
+        () {
+          final tempDir = Directory.systemTemp.createTempSync(
+            'clip_thumbnail_dispose_test_',
+          );
+          addTearDown(() {
+            if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+          });
+          final borrowed = File('${tempDir.path}/borrowed.jpg')
+            ..writeAsStringSync('borrowed');
+
+          final localManager = ClipThumbnailManager();
+          localManager.sync(
+            clips: [
+              _createFileClip(id: 'src', videoPath: '${tempDir.path}/src.mp4'),
+            ],
+            devicePixelRatio: 1,
+          );
+          localManager['src'].value = [
+            StripThumbnail(path: borrowed.path, timestamp: Duration.zero),
+          ];
+          // The start half borrows the same source frame file, so both
+          // notifiers reference it — dispose must delete it once and
+          // swallow the second (already-gone) deleteSync.
+          localManager.seedFromSource(
+            sourceClipId: 'src',
+            targetClipId: 'start',
+            sourceRange: const DurationRange(
+              start: Duration.zero,
+              end: Duration(seconds: 1),
+            ),
+            currentSourcePath: '${tempDir.path}/src.mp4',
+          );
+          expect(
+            localManager['start'].value.single.path,
+            equals(borrowed.path),
+          );
+
+          expect(localManager.dispose, returnsNormally);
+          expect(borrowed.existsSync(), isFalse);
+        },
+      );
     });
   });
 

--- a/mobile/test/services/video_editor/clip_thumbnail_manager_test.dart
+++ b/mobile/test/services/video_editor/clip_thumbnail_manager_test.dart
@@ -532,6 +532,48 @@ void main() {
           expect(second.existsSync(), isTrue);
         },
       );
+
+      test(
+        'restart keeps a dropped frame whose file a sibling clip still shows',
+        () async {
+          final shared = File('${tempDir.path}/shared.jpg')
+            ..writeAsStringSync('shared');
+          final freshA = File('${tempDir.path}/fresh_a.jpg')
+            ..writeAsStringSync('fresh-a');
+
+          fakeStreamManager.sync(
+            clips: [
+              _createFileClip(id: 'a', videoPath: '${tempDir.path}/a.mp4'),
+              _createFileClip(id: 'b', videoPath: '${tempDir.path}/b.mp4'),
+            ],
+            devicePixelRatio: 1,
+          );
+          expect(controllers, hasLength(2));
+
+          // Both clips end up showing the same file (an overlapping
+          // borrow). A fresh batch on 'a' that drops the shared path must
+          // not delete the file while 'b' still references it.
+          controllers[0].add([
+            StripThumbnail(path: shared.path, timestamp: Duration.zero),
+          ]);
+          controllers[1].add([
+            StripThumbnail(path: shared.path, timestamp: Duration.zero),
+          ]);
+          await pumpEventQueue();
+
+          controllers[0].add([
+            StripThumbnail(path: freshA.path, timestamp: Duration.zero),
+          ]);
+          await pumpEventQueue();
+
+          expect(
+            fakeStreamManager['a'].value.single.path,
+            equals(freshA.path),
+          );
+          expect(shared.existsSync(), isTrue);
+          expect(freshA.existsSync(), isTrue);
+        },
+      );
     });
 
     group('pauseAll / resumeAll', () {

--- a/mobile/test/services/video_editor/clip_thumbnail_manager_test.dart
+++ b/mobile/test/services/video_editor/clip_thumbnail_manager_test.dart
@@ -260,7 +260,8 @@ void main() {
       });
 
       test(
-        'copies seeded files before source cleanup deletes originals',
+        'borrows source files without copying and protects them from '
+        'source cleanup',
         () async {
           final tempDir = Directory.systemTemp.createTempSync(
             'clip_thumbnail_seed_test_',
@@ -271,11 +272,13 @@ void main() {
             }
           });
 
-          final sourceThumbnail = File('${tempDir.path}/source.jpg')
-            ..writeAsStringSync('source-thumbnail');
+          final borrowedThumbnail = File('${tempDir.path}/borrowed.jpg')
+            ..writeAsStringSync('borrowed-thumbnail');
+          final unborrowedThumbnail = File('${tempDir.path}/unborrowed.jpg')
+            ..writeAsStringSync('unborrowed-thumbnail');
           final sourceVideoPath = '${tempDir.path}/source.mp4';
 
-          final sourceClip = _createTestClip(id: 'src', seconds: 2);
+          final sourceClip = _createTestClip(id: 'src', seconds: 4);
           final targetClip = _createFileClip(
             id: 'tgt',
             videoPath: sourceVideoPath,
@@ -284,8 +287,12 @@ void main() {
           manager.sync(clips: [sourceClip], devicePixelRatio: 1);
           manager['src'].value = [
             StripThumbnail(
-              path: sourceThumbnail.path,
+              path: borrowedThumbnail.path,
               timestamp: const Duration(seconds: 1),
+            ),
+            StripThumbnail(
+              path: unborrowedThumbnail.path,
+              timestamp: const Duration(seconds: 3),
             ),
           ];
 
@@ -299,17 +306,21 @@ void main() {
             currentSourcePath: sourceVideoPath,
           );
 
+          // Borrowed, not copied — the image cache entry decoded for the
+          // source tile stays valid, so the new tile paints instantly
+          // instead of flashing black on a cold decode.
           final seededPath = manager['tgt'].value.single.path;
-          expect(seededPath, isNot(equals(sourceThumbnail.path)));
+          expect(seededPath, equals(borrowedThumbnail.path));
 
           // Simulate the split lifecycle: the source clip is removed, but
           // the seeded target still points at the source video until render
-          // completes. Target thumbnails must survive stale source cleanup.
+          // completes. Borrowed files must survive stale source cleanup;
+          // files nobody borrowed are deleted.
           manager.sync(clips: [targetClip], devicePixelRatio: 1);
           await Future<void>.delayed(Duration.zero);
 
-          expect(sourceThumbnail.existsSync(), isFalse);
-          expect(File(seededPath).existsSync(), isTrue);
+          expect(borrowedThumbnail.existsSync(), isTrue);
+          expect(unborrowedThumbnail.existsSync(), isFalse);
         },
       );
 
@@ -353,6 +364,174 @@ void main() {
         expect(thumbnails[1].path, equals('/t/4.jpg'));
         expect(thumbnails[1].timestamp, equals(const Duration(seconds: 4)));
       });
+    });
+
+    group('rendered path arrival', () {
+      late List<StreamController<List<StripThumbnail>>> controllers;
+      late ClipThumbnailManager fakeStreamManager;
+      late Directory tempDir;
+
+      setUp(() {
+        controllers = [];
+        fakeStreamManager = ClipThumbnailManager(
+          stripThumbnailStreamFactory:
+              ({
+                required String videoPath,
+                required String clipId,
+                required Duration duration,
+                required Size outputSize,
+                required int thumbsPerSecond,
+                List<Duration>? priorityTimestamps,
+              }) {
+                final controller = StreamController<List<StripThumbnail>>();
+                controllers.add(controller);
+                return controller.stream;
+              },
+        );
+        tempDir = Directory.systemTemp.createTempSync(
+          'clip_thumbnail_path_change_test_',
+        );
+      });
+
+      tearDown(() {
+        fakeStreamManager.dispose();
+        for (final controller in controllers) {
+          unawaited(controller.close());
+        }
+        if (tempDir.existsSync()) {
+          tempDir.deleteSync(recursive: true);
+        }
+      });
+
+      test(
+        'keeps seeded frames rebased into the rendered timebase until the '
+        'first fresh batch replaces them, then deletes the borrowed files',
+        () async {
+          final borrowed = File('${tempDir.path}/borrowed.jpg')
+            ..writeAsStringSync('borrowed');
+          final sourceVideoPath = '${tempDir.path}/source.mp4';
+          final renderedVideoPath = '${tempDir.path}/rendered_end.mp4';
+
+          final sourceClip = _createFileClip(
+            id: 'src',
+            videoPath: sourceVideoPath,
+            seconds: 10,
+          );
+          fakeStreamManager.sync(clips: [sourceClip], devicePixelRatio: 1);
+          fakeStreamManager['src'].value = [
+            StripThumbnail(
+              path: borrowed.path,
+              timestamp: const Duration(seconds: 4),
+            ),
+          ];
+
+          // Split at 3 s: the end half previews the source video, so its
+          // seeds stay source-timed; the rendered file starts at zero.
+          fakeStreamManager.seedFromSource(
+            sourceClipId: 'src',
+            targetClipId: 'end',
+            sourceRange: const DurationRange(
+              start: Duration(seconds: 3),
+              end: Duration(seconds: 10),
+            ),
+            timestampOffset: Duration.zero,
+            rebaseOnPathChange: const Duration(seconds: 3),
+            currentSourcePath: sourceVideoPath,
+          );
+          expect(
+            fakeStreamManager['end'].value.single.timestamp,
+            equals(const Duration(seconds: 4)),
+          );
+
+          // Source replaced by the preview end half — no new subscription
+          // while the clip still points at the source video.
+          final previewEndClip = _createFileClip(
+            id: 'end',
+            videoPath: sourceVideoPath,
+            seconds: 10,
+          );
+          fakeStreamManager.sync(
+            clips: [previewEndClip],
+            devicePixelRatio: 1,
+          );
+          expect(controllers, hasLength(1));
+          expect(
+            fakeStreamManager['end'].value.single.timestamp,
+            equals(const Duration(seconds: 4)),
+          );
+
+          // Rendered file arrives: the real subscription starts, the
+          // seeded frame stays visible and is rebased to the rendered
+          // file's zero-based timeline.
+          final renderedEndClip = _createFileClip(
+            id: 'end',
+            videoPath: renderedVideoPath,
+            seconds: 7,
+          );
+          fakeStreamManager.sync(
+            clips: [renderedEndClip],
+            devicePixelRatio: 1,
+          );
+          expect(controllers, hasLength(2));
+          final held = fakeStreamManager['end'].value.single;
+          expect(held.path, equals(borrowed.path));
+          expect(held.timestamp, equals(const Duration(seconds: 1)));
+          expect(borrowed.existsSync(), isTrue);
+
+          // First fresh batch replaces the seeds and deletes the borrowed
+          // file, which no notifier references anymore.
+          final fresh = File('${tempDir.path}/fresh.jpg')
+            ..writeAsStringSync('fresh');
+          controllers[1].add([
+            StripThumbnail(
+              path: fresh.path,
+              timestamp: const Duration(seconds: 1),
+            ),
+          ]);
+          await pumpEventQueue();
+
+          expect(
+            fakeStreamManager['end'].value.single.path,
+            equals(fresh.path),
+          );
+          expect(borrowed.existsSync(), isFalse);
+          expect(fresh.existsSync(), isTrue);
+        },
+      );
+
+      test(
+        'accumulating batches never delete still-referenced files',
+        () async {
+          final first = File('${tempDir.path}/first.jpg')
+            ..writeAsStringSync('first');
+          final second = File('${tempDir.path}/second.jpg')
+            ..writeAsStringSync('second');
+
+          fakeStreamManager.sync(
+            clips: [
+              _createFileClip(id: 'a', videoPath: '${tempDir.path}/a.mp4'),
+            ],
+            devicePixelRatio: 1,
+          );
+
+          controllers.single.add([
+            StripThumbnail(path: first.path, timestamp: Duration.zero),
+          ]);
+          await pumpEventQueue();
+          controllers.single.add([
+            StripThumbnail(path: first.path, timestamp: Duration.zero),
+            StripThumbnail(
+              path: second.path,
+              timestamp: const Duration(seconds: 1),
+            ),
+          ]);
+          await pumpEventQueue();
+
+          expect(fakeStreamManager['a'].value, hasLength(2));
+          expect(first.existsSync(), isTrue);
+          expect(second.existsSync(), isTrue);
+        },
+      );
     });
 
     group('pauseAll / resumeAll', () {

--- a/mobile/test/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_test.dart
@@ -1,19 +1,26 @@
 // ABOUTME: Widget tests for VideoEditorTimelineClipStrip.
 // ABOUTME: Validates clip rendering, layout, reorder gesture, and accessibility.
 
+import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
 import 'package:openvine/blocs/video_editor/main_editor/video_editor_main_bloc.dart';
 import 'package:openvine/constants/video_editor_timeline_constants.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/router/app_router.dart';
 import 'package:openvine/services/video_editor/clip_thumbnail_manager.dart';
+import 'package:openvine/services/video_thumbnail_service.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/strips/timeline_trim_handles.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
+
+class _MockClipEditorBloc extends MockBloc<ClipEditorEvent, ClipEditorState>
+    implements ClipEditorBloc {}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -256,38 +263,37 @@ void main() {
       // Regression: the fallback must be a plain FileImage (not a
       // cacheHeight-keyed ResizeImage) so it hits the warm poster cache entry
       // instead of a cold decode that flashes black on first open.
-      testWidgets(
-        'poster fallback reuses the plain FileImage key (no resize)',
-        (tester) async {
-          final clips = [
-            _createTestClip(
-              id: 'a',
-              thumbnailPath: '/tmp/nonexistent_thumb_a.jpg',
+      testWidgets('poster fallback reuses the plain FileImage key (no resize)', (
+        tester,
+      ) async {
+        final clips = [
+          _createTestClip(
+            id: 'a',
+            thumbnailPath: '/tmp/nonexistent_thumb_a.jpg',
+          ),
+        ];
+
+        await tester.pumpWidget(buildWidget(clips: clips, totalWidth: 400));
+
+        // Before strip thumbnails stream in, every slot renders the poster
+        // fallback. Each must be a plain FileImage on the thumbnail path.
+        final images = tester.widgetList<Image>(find.byType(Image)).toList();
+        expect(images, isNotEmpty);
+        for (final image in images) {
+          expect(
+            image.image,
+            isA<FileImage>().having(
+              (provider) => provider.file.path,
+              'file.path',
+              '/tmp/nonexistent_thumb_a.jpg',
             ),
-          ];
-
-          await tester.pumpWidget(buildWidget(clips: clips, totalWidth: 400));
-
-          // Before strip thumbnails stream in, every slot renders the poster
-          // fallback. Each must be a plain FileImage on the thumbnail path.
-          final images = tester.widgetList<Image>(find.byType(Image)).toList();
-          expect(images, isNotEmpty);
-          for (final image in images) {
-            expect(
-              image.image,
-              isA<FileImage>().having(
-                (provider) => provider.file.path,
-                'file.path',
-                '/tmp/nonexistent_thumb_a.jpg',
-              ),
-              reason:
-                  'Fallback must use a plain FileImage (not a cacheHeight-keyed '
-                  'ResizeImage) so it hits the warm poster cache entry and '
-                  'paints instantly instead of flashing black.',
-            );
-          }
-        },
-      );
+            reason:
+                'Fallback must use a plain FileImage (not a cacheHeight-keyed '
+                'ResizeImage) so it hits the warm poster cache entry and '
+                'paints instantly instead of flashing black.',
+          );
+        }
+      });
     });
 
     group('empty state', () {
@@ -315,30 +321,25 @@ void main() {
         expect(tester.takeException(), isNull);
       });
 
-      testWidgets(
-        'multi-clip strip with trimmed clips renders both tiles',
-        (tester) async {
-          final clips = [
-            // trimmedDuration = 5s - 2s - 1s = 2s
-            _createTestClip(
-              id: 'a',
-              seconds: 5,
-              trimStartMs: 2000,
-              trimEndMs: 1000,
-            ),
-            _createTestClip(id: 'b', seconds: 3),
-          ];
+      testWidgets('multi-clip strip with trimmed clips renders both tiles', (
+        tester,
+      ) async {
+        final clips = [
+          // trimmedDuration = 5s - 2s - 1s = 2s
+          _createTestClip(
+            id: 'a',
+            seconds: 5,
+            trimStartMs: 2000,
+            trimEndMs: 1000,
+          ),
+          _createTestClip(id: 'b', seconds: 3),
+        ];
 
-          await tester.pumpWidget(
-            buildWidget(
-              clips: clips,
-            ),
-          );
+        await tester.pumpWidget(buildWidget(clips: clips));
 
-          expect(find.byType(ClipRRect), findsNWidgets(2));
-          expect(tester.takeException(), isNull);
-        },
-      );
+        expect(find.byType(ClipRRect), findsNWidgets(2));
+        expect(tester.takeException(), isNull);
+      });
 
       testWidgets('fully trimmed clip does not crash the strip', (
         tester,
@@ -559,58 +560,149 @@ void main() {
       // Without the fix `contentWidth < displayWidth`, so the renderer
       // falls back to stretched slots (`displayWidth / count`) wider than
       // `thumbnailWidth`, producing zero slot boxes at the natural width.
+      testWidgets('slow clip renders thumbnail slots at the natural width', (
+        tester,
+      ) async {
+        const pps = 50.0;
+        // source duration 4s, speed 0.5 → playback duration 8s.
+        // Playback-scaled width = 4 / 0.5 * 50 = 400 px.
+        // Expected natural-width slot count for the slow clip:
+        //   ceil(400 / TimelineConstants.thumbnailWidth (= 48)) = 9.
+        final slow = _createTestClip(
+          id: 'slow',
+          seconds: 4,
+        ).copyWith(playbackSpeed: 0.5);
+        // Normal clip kept tiny so its slot count is small and stable
+        // (ceil(2 * 50 / 48) = 3) — used only to keep the strip on its
+        // multi-clip branch (single-clip branch overrides _clipWidth with
+        // totalWidth).
+        final clips = [slow, _createTestClip(id: 'normal')];
+
+        await tester.pumpWidget(
+          buildWidget(clips: clips, pixelsPerSecond: pps, totalWidth: 1000),
+        );
+
+        final naturalSlotCount = tester
+            .widgetList<SizedBox>(find.byType(SizedBox))
+            .where(
+              (s) =>
+                  s.height == TimelineConstants.thumbnailStripHeight &&
+                  s.width == TimelineConstants.thumbnailWidth,
+            )
+            .length;
+
+        // 9 (slow clip) + 3 (normal clip) = 12. Without the 1/speed
+        // scaling the slow clip falls back to stretched slots wider than
+        // thumbnailWidth and contributes 0, leaving only the 3 from the
+        // normal clip.
+        expect(
+          naturalSlotCount,
+          equals(12),
+          reason:
+              'Slow clip must render ceil(playbackWidth / thumbnailWidth) '
+              'natural-width slots. Without the 1/playbackSpeed scaling '
+              'of _ClipTile.fullWidth the slow clip falls back to '
+              'stretched slots (width > thumbnailWidth), producing 3 '
+              'instead of 12 natural-width slots.',
+        );
+      });
+    });
+
+    group('split seeding', () {
+      late _MockClipEditorBloc clipBloc;
+      late ClipThumbnailManager manager;
+
+      setUp(() {
+        clipBloc = _MockClipEditorBloc();
+        manager = ClipThumbnailManager(
+          stripThumbnailStreamFactory:
+              ({
+                required String videoPath,
+                required String clipId,
+                required Duration duration,
+                required Size outputSize,
+                required int thumbsPerSecond,
+                List<Duration>? priorityTimestamps,
+              }) => const Stream<List<StripThumbnail>>.empty(),
+        );
+      });
+
+      tearDown(() {
+        manager.dispose();
+      });
+
+      Widget buildStrip(List<DivineVideoClip> clips) {
+        return MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: MultiBlocProvider(
+              providers: [
+                BlocProvider<VideoEditorMainBloc>.value(value: mainBloc),
+                BlocProvider<ClipEditorBloc>.value(value: clipBloc),
+              ],
+              child: SingleChildScrollView(
+                controller: scrollController,
+                scrollDirection: Axis.horizontal,
+                child: VideoEditorTimelineClipStrip(
+                  clips: clips,
+                  totalWidth: 500,
+                  pixelsPerSecond: TimelineConstants.pixelsPerSecond,
+                  scrollController: scrollController,
+                  thumbnailManager: manager,
+                ),
+              ),
+            ),
+          ),
+        );
+      }
+
       testWidgets(
-        'slow clip renders thumbnail slots at the natural width',
+        'seeds the split halves even when the first build bails before the '
+        'halves exist (transient bail must not consume the split)',
         (tester) async {
-          const pps = 50.0;
-          // source duration 4s, speed 0.5 → playback duration 8s.
-          // Playback-scaled width = 4 / 0.5 * 50 = 400 px.
-          // Expected natural-width slot count for the slow clip:
-          //   ceil(400 / TimelineConstants.thumbnailWidth (= 48)) = 9.
-          final slow = _createTestClip(
-            id: 'slow',
-            seconds: 4,
-          ).copyWith(playbackSpeed: 0.5);
-          // Normal clip kept tiny so its slot count is small and stable
-          // (ceil(2 * 50 / 48) = 3) — used only to keep the strip on its
-          // multi-clip branch (single-clip branch overrides _clipWidth with
-          // totalWidth).
-          final clips = [
-            slow,
-            _createTestClip(id: 'normal'),
+          final split = ClipSplitEvent(
+            sourceClipId: 'src',
+            startClipId: 'start',
+            endClipId: 'end',
+            absoluteSplitPosition: const Duration(seconds: 3),
+            sourceDuration: const Duration(seconds: 10),
+          );
+          when(
+            () => clipBloc.state,
+          ).thenReturn(ClipEditorState(lastSplit: split));
+
+          // Seed the source clip's thumbnails so each split half (the
+          // start range [0, 3s) and the end range [3s, 10s)) has a warm
+          // frame to borrow.
+          final sourceClip = _createTestClip(id: 'src', seconds: 10);
+          manager.sync(clips: [sourceClip], devicePixelRatio: 1);
+          manager['src'].value = [
+            const StripThumbnail(
+              path: '/tmp/frame_start.jpg',
+              timestamp: Duration(seconds: 1),
+            ),
+            const StripThumbnail(
+              path: '/tmp/frame_end.jpg',
+              timestamp: Duration(seconds: 5),
+            ),
           ];
 
-          await tester.pumpWidget(
-            buildWidget(
-              clips: clips,
-              pixelsPerSecond: pps,
-              totalWidth: 1000,
-            ),
-          );
+          // First build still only contains the source clip — the split
+          // halves don't exist yet, so seeding must bail without marking
+          // the split consumed. No 'start' notifier is created by the bail.
+          await tester.pumpWidget(buildStrip([sourceClip]));
+          expect(() => manager['start'], throwsA(anything));
 
-          final naturalSlotCount = tester
-              .widgetList<SizedBox>(find.byType(SizedBox))
-              .where(
-                (s) =>
-                    s.height == TimelineConstants.thumbnailStripHeight &&
-                    s.width == TimelineConstants.thumbnailWidth,
-              )
-              .length;
+          // The halves arrive on the next build. If the transient bail had
+          // permanently consumed the split, seeding would be skipped here
+          // and the black flash would return.
+          final startClip = _createTestClip(id: 'start', seconds: 3);
+          final endClip = _createTestClip(id: 'end', seconds: 7);
+          await tester.pumpWidget(buildStrip([startClip, endClip]));
 
-          // 9 (slow clip) + 3 (normal clip) = 12. Without the 1/speed
-          // scaling the slow clip falls back to stretched slots wider than
-          // thumbnailWidth and contributes 0, leaving only the 3 from the
-          // normal clip.
-          expect(
-            naturalSlotCount,
-            equals(12),
-            reason:
-                'Slow clip must render ceil(playbackWidth / thumbnailWidth) '
-                'natural-width slots. Without the 1/playbackSpeed scaling '
-                'of _ClipTile.fullWidth the slow clip falls back to '
-                'stretched slots (width > thumbnailWidth), producing 3 '
-                'instead of 12 natural-width slots.',
-          );
+          expect(manager['start'].value, isNotEmpty);
+          expect(manager['end'].value, isNotEmpty);
         },
       );
     });


### PR DESCRIPTION
Closes #5813

## Description

Splitting a clip briefly showed the timeline thumbnails of the new halves as black before the correct frames appeared.

Root cause: `ClipThumbnailManager.seedFromSource` copied the source clip's thumbnail files to new paths when seeding the two split halves. Flutter's image cache is keyed by file path, so the copies were cache-cold and had to be decoded asynchronously — for the first frames every slot rendered empty (black). The end half had a second defect: its seeds were shifted to the rendered file's zero-based timebase while the preview clip still points at the un-trimmed source video (source-timed), so the seeded frames fell outside the visible window and never displayed at all.

Fix, in three parts:

- **Borrow instead of copy.** Seeds now reference the source clip's thumbnail files directly, so the already-decoded image cache entries repaint instantly. Copying was only there to survive the source clip's file cleanup, so deletion is now reference-protected instead: `_deleteUnreferencedFiles` only deletes files no other notifier still shows.
- **End-half seeds stay source-timed, with a rebase on path change.** New `rebaseOnPathChange` parameter on `seedFromSource`: the seeds align with the preview clip immediately after the split, and when the rendered (zero-based) file arrives the same shift is applied so they stay aligned until fresh thumbnails replace them.
- **Keep frames across subscription restarts.** The path-change restart branch used to clear the notifier to `[]` and delete the files up front, flashing the fallback until the first fresh batch. Old frames now stay visible and their files are deleted only once the new subscription's first batch replaces them (`gaplessPlayback` covers the swap). This also fixes a disk leak: seeded files were previously never deleted after being superseded.

**Related Issue:** 

## Out of Scope

None.

## Verification

- `flutter test test/services/video_editor/clip_thumbnail_manager_test.dart` — 23/23, including new regression tests for borrow protection, timestamp rebase on rendered-path arrival, and deferred deletion
- `flutter test test/widgets/video_editor/timeline_editor/strips/` — 60/60
- `flutter analyze` on changed areas — clean
- Manual: split a clip in the editor and confirm the strip no longer flashes black at the split moment or when the rendered segments arrive

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore