### PR TITLE
fix(editor): layer animation reliability (timeline drop + export axis)

### DIFF
--- a/mobile/lib/models/video_editor/transition_geometry.dart
+++ b/mobile/lib/models/video_editor/transition_geometry.dart
@@ -199,6 +199,12 @@ class TransitionTimelineMap {
 
   final List<_Blend> _blends;
 
+  /// Null-safe [editorToOutput]: maps [position] onto the output axis, or
+  /// returns `null` when [position] is `null` (a layer/effect with no explicit
+  /// time anchor — e.g. one that spans the whole video).
+  Duration? editorToOutputOrNull(Duration? position) =>
+      position == null ? null : editorToOutput(position);
+
   /// Maps an editor-axis [position] onto the output axis.
   Duration editorToOutput(Duration position) {
     var removed = Duration.zero;

--- a/mobile/lib/services/video_editor/video_editor_render_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_render_service.dart
@@ -964,24 +964,11 @@ class VideoEditorRenderService {
         timelineMap: timelineMap,
       ),
       blur: parameters?.blur,
-      colorFilters: [
-        ...?parameters?.tuneAdjustments.map(
-          (t) => ColorFilter(
-            matrix: t.matrix,
-            startTime: timelineMap.editorToOutputOrNull(t.startTime),
-            endTime: timelineMap.editorToOutputOrNull(t.endTime),
-          ),
-        ),
-        ...?parameters?.filterStates.expand(
-          (f) => f.matrices.map(
-            (matrix) => ColorFilter(
-              matrix: matrix,
-              startTime: timelineMap.editorToOutputOrNull(f.startTime),
-              endTime: timelineMap.editorToOutputOrNull(f.endTime),
-            ),
-          ),
-        ),
-      ],
+      colorFilters: buildColorFilters(
+        tuneAdjustments: parameters?.tuneAdjustments ?? const [],
+        filterStates: parameters?.filterStates ?? const [],
+        timelineMap: timelineMap,
+      ),
       imageBytesWithCropping: true,
       qualityConfig: VideoQualityConfig.custom(
         bitrate: VideoEditorConstants.quality.bitrate,
@@ -1046,6 +1033,37 @@ class VideoEditorRenderService {
           ),
           animations: item.layer.divineAnimations,
         ),
+    ];
+  }
+
+  /// Builds the [ColorFilter]s applied to the exported video from the tune
+  /// adjustments and filter states.
+  ///
+  /// Each filter's editor-timeline window is mapped onto the output axis via
+  /// [timelineMap] — the same mapping [buildImageLayers] applies — so an
+  /// overlap transition can't push a filter (or its leave animation) past the
+  /// real video end. A `null` start/end stays un-anchored (spans the whole
+  /// video). One [ColorFilter] is emitted per filter matrix.
+  @visibleForTesting
+  static List<ColorFilter> buildColorFilters({
+    required List<TuneAdjustmentMatrix> tuneAdjustments,
+    required List<FilterState> filterStates,
+    required TransitionTimelineMap timelineMap,
+  }) {
+    return [
+      for (final tune in tuneAdjustments)
+        ColorFilter(
+          matrix: tune.matrix,
+          startTime: timelineMap.editorToOutputOrNull(tune.startTime),
+          endTime: timelineMap.editorToOutputOrNull(tune.endTime),
+        ),
+      for (final filter in filterStates)
+        for (final matrix in filter.matrices)
+          ColorFilter(
+            matrix: matrix,
+            startTime: timelineMap.editorToOutputOrNull(filter.startTime),
+            endTime: timelineMap.editorToOutputOrNull(filter.endTime),
+          ),
     ];
   }
 

--- a/mobile/lib/services/video_editor/video_editor_render_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_render_service.dart
@@ -554,6 +554,7 @@ class VideoEditorRenderService {
       tempFilePaths = result.tempFilePaths;
 
       final outputPath = await _concatenateSegments(
+        clips: clips,
         segments: result.segments,
         taskId: taskId ?? clips.first.id,
         outputDir: outputDir,
@@ -906,6 +907,7 @@ class VideoEditorRenderService {
   /// If [globalTransform] is provided, applies it to all segments in a single
   /// pass.
   static Future<String> _concatenateSegments({
+    required List<DivineVideoClip> clips,
     required List<VideoSegment> segments,
     required String taskId,
     required Directory outputDir,
@@ -938,62 +940,44 @@ class VideoEditorRenderService {
       renderResolution = metadata.resolution;
     }
 
+    // Overlay/effect time windows are authored on the editor timeline (clips at
+    // full length). Overlap transitions (dissolve/slide/push/wipe) shorten the
+    // rendered output, so every time anchor is mapped onto the output axis;
+    // otherwise anything near the end — a layer's leave animation especially —
+    // lands past the real video end and is clipped ("animation missing at the
+    // end"). Identity when no overlap transition is present.
+    final timelineMap = TransitionTimelineMap.fromClips(clips);
+    final videoSize =
+        renderResolution ??
+        VideoEditorConstants.quality.resolutionForAspectRatio(aspectRatio);
+
     final task = VideoRenderData(
       id: taskId,
       videoSegments: volumeSegments,
       endTime: maxOutputDuration,
       shouldOptimizeForNetworkUse: true,
       audioTracks: audioTracks,
-      imageLayers: parameters?.capturedLayers.isNotEmpty == true
-          ? () {
-              final bodySize = parameters!.bodySize;
-              if (bodySize == null) return null;
-              final videoSize =
-                  renderResolution ??
-                  VideoEditorConstants.quality.resolutionForAspectRatio(
-                    aspectRatio,
-                  );
-              final scale = videoSize.width / bodySize.width;
-              return [
-                for (final item in parameters.capturedLayers)
-                  ImageLayer(
-                    image: EditorLayerImage.memory(item.bytes),
-                    startTime: item.layer.startTime,
-                    endTime: item.layer.endTime,
-                    offset: Offset(
-                      (bodySize.width / 2 +
-                              item.layer.offset.dx -
-                              item.logicalSize.width / 2) *
-                          scale,
-                      (bodySize.height / 2 +
-                              item.layer.offset.dy -
-                              item.logicalSize.height / 2) *
-                          scale,
-                    ),
-                    size: Size(
-                      item.logicalSize.width * scale,
-                      item.logicalSize.height * scale,
-                    ),
-                    animations: item.layer.divineAnimations,
-                  ),
-              ];
-            }()
-          : null,
+      imageLayers: buildImageLayers(
+        capturedLayers: parameters?.capturedLayers ?? const [],
+        bodySize: parameters?.bodySize,
+        videoSize: videoSize,
+        timelineMap: timelineMap,
+      ),
       blur: parameters?.blur,
       colorFilters: [
         ...?parameters?.tuneAdjustments.map(
           (t) => ColorFilter(
             matrix: t.matrix,
-            startTime: t.startTime,
-            endTime: t.endTime,
+            startTime: timelineMap.editorToOutputOrNull(t.startTime),
+            endTime: timelineMap.editorToOutputOrNull(t.endTime),
           ),
         ),
         ...?parameters?.filterStates.expand(
           (f) => f.matrices.map(
             (matrix) => ColorFilter(
               matrix: matrix,
-              startTime: f.startTime,
-              endTime: f.endTime,
+              startTime: timelineMap.editorToOutputOrNull(f.startTime),
+              endTime: timelineMap.editorToOutputOrNull(f.endTime),
             ),
           ),
         ),
@@ -1021,6 +1005,48 @@ class VideoEditorRenderService {
     await _cancelAndRender(outputPath, task);
 
     return outputPath;
+  }
+
+  /// Builds the [ImageLayer]s composited over the exported video from the
+  /// captured overlay layers.
+  ///
+  /// Each layer is scaled from editor body space ([bodySize]) into the rendered
+  /// video's pixel space ([videoSize]), and its time window is mapped from the
+  /// editor timeline onto the output axis via [timelineMap] — so an overlap
+  /// transition can't push a layer (or its leave animation) past the real video
+  /// end. Returns `null` when there is nothing to overlay.
+  @visibleForTesting
+  static List<ImageLayer>? buildImageLayers({
+    required List<ExportedLayer> capturedLayers,
+    required Size? bodySize,
+    required Size videoSize,
+    required TransitionTimelineMap timelineMap,
+  }) {
+    if (capturedLayers.isEmpty || bodySize == null) return null;
+    final scale = videoSize.width / bodySize.width;
+    return [
+      for (final item in capturedLayers)
+        ImageLayer(
+          image: EditorLayerImage.memory(item.bytes),
+          startTime: timelineMap.editorToOutputOrNull(item.layer.startTime),
+          endTime: timelineMap.editorToOutputOrNull(item.layer.endTime),
+          offset: Offset(
+            (bodySize.width / 2 +
+                    item.layer.offset.dx -
+                    item.logicalSize.width / 2) *
+                scale,
+            (bodySize.height / 2 +
+                    item.layer.offset.dy -
+                    item.logicalSize.height / 2) *
+                scale,
+          ),
+          size: Size(
+            item.logicalSize.width * scale,
+            item.logicalSize.height * scale,
+          ),
+          animations: item.layer.divineAnimations,
+        ),
+    ];
   }
 
   // ─────────────────────────────────────────────────────────────────────────

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_layer_animation_sheet.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_layer_animation_sheet.dart
@@ -101,6 +101,7 @@ Future<void> editLayerAnimation(
 
   final endTime = resolveLayerEndTime(
     currentEndTime: layer.endTime,
+    startTime: layer.startTime ?? Duration.zero,
     totalDuration: totalDuration,
     hasLeaveAnimation: result.leave.isNotEmpty,
   );
@@ -142,21 +143,36 @@ Future<void> editLayerAnimation(
 /// equals its [Layer.endTime]) would make `currentEndTime < totalDuration` false
 /// for every trim, so genuine trims would read as full-length and be dropped.
 ///
+/// [startTime] is the layer's own start. The returned end is never at or before
+/// it: a stale or transient-zero [totalDuration] (e.g. read before the player
+/// has reported its length) must not anchor the leave window at `<= startTime`,
+/// which would collapse the layer to a zero-length window and drop it from the
+/// timeline entirely. In that degenerate case the layer's existing end is kept
+/// (when still valid) or the end is left un-anchored — the layer stays visible
+/// either way.
+///
 /// With [hasLeaveAnimation] true the end is anchored to that trim, or to
-/// [totalDuration] when there is no real trim — never beyond the video. Without
-/// a leave animation a real trim is preserved and everything else collapses to
-/// `null`.
+/// [totalDuration] when there is no real trim — never beyond the video, never
+/// at or before [startTime]. Without a leave animation a real trim is preserved
+/// and everything else collapses to `null`.
 @visibleForTesting
 Duration? resolveLayerEndTime({
   required Duration? currentEndTime,
+  required Duration startTime,
   required Duration totalDuration,
   required bool hasLeaveAnimation,
 }) {
   final trim = currentEndTime != null && currentEndTime < totalDuration
       ? currentEndTime
       : null;
-  if (hasLeaveAnimation) return trim ?? totalDuration;
-  return trim;
+  if (!hasLeaveAnimation) return trim;
+
+  final anchor = trim ?? totalDuration;
+  if (anchor > startTime) return anchor;
+  if (currentEndTime != null && currentEndTime > startTime) {
+    return currentEndTime;
+  }
+  return null;
 }
 
 /// The picker's result: the chosen enter and leave animations. A phase can

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_overlay_controls.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_overlay_controls.dart
@@ -1,6 +1,7 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
 import 'package:openvine/blocs/video_editor/main_editor/video_editor_main_bloc.dart';
 import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
@@ -66,13 +67,13 @@ class _LayerOverlayControls extends StatelessWidget {
           : () => editLayerAnimation(
               context,
               layer,
-              // The true total video duration, not item.endTime (which is the
-              // layer's own clamped end) — resolveLayerEndTime needs an
-              // independent signal to tell a genuine trim from a stale anchor.
-              totalDuration: context
-                  .read<VideoEditorMainBloc>()
-                  .state
-                  .totalDuration,
+              // The stable editor-timeline total (sum of clip playback
+              // lengths), not item.endTime (the layer's own clamped end) and
+              // not VideoEditorMainBloc.totalDuration — the latter is derived
+              // from player duration reports and can be a transient zero right
+              // after a clip change. A too-small total here would collapse the
+              // layer's leave-animation window and drop it from the timeline.
+              totalDuration: context.read<ClipEditorBloc>().state.totalDuration,
             ),
       onDone: () => TimelineOverlayControls._deselect(context),
     );

--- a/mobile/test/models/video_editor/transition_geometry_test.dart
+++ b/mobile/test/models/video_editor/transition_geometry_test.dart
@@ -486,6 +486,46 @@ void main() {
 
         expect(map.editorDuration, equals(map.outputDuration));
       });
+
+      group('editorToOutputOrNull', () {
+        test('returns null for a null position', () {
+          final map = TransitionTimelineMap.fromClips([
+            clip('a', const Duration(seconds: 1), transition: overlap500),
+            clip('b', const Duration(seconds: 1)),
+          ]);
+
+          expect(map.editorToOutputOrNull(null), isNull);
+        });
+
+        test('maps a non-null position like editorToOutput', () {
+          final map = TransitionTimelineMap.fromClips([
+            clip('a', const Duration(seconds: 1), transition: overlap500),
+            clip('b', const Duration(seconds: 1)),
+          ]);
+
+          // The editor end (2s) lands on the shorter output end (1.5s).
+          expect(
+            map.editorToOutputOrNull(const Duration(seconds: 2)),
+            equals(map.editorToOutput(const Duration(seconds: 2))),
+          );
+          expect(
+            map.editorToOutputOrNull(const Duration(seconds: 2)),
+            equals(const Duration(milliseconds: 1500)),
+          );
+        });
+
+        test('is the identity when no transition shortens the timeline', () {
+          final map = TransitionTimelineMap.fromClips([
+            clip('a', const Duration(seconds: 1)),
+            clip('b', const Duration(seconds: 1)),
+          ]);
+
+          expect(
+            map.editorToOutputOrNull(const Duration(milliseconds: 1500)),
+            equals(const Duration(milliseconds: 1500)),
+          );
+        });
+      });
     });
   });
 }

--- a/mobile/test/services/video_editor/video_editor_render_service_test.dart
+++ b/mobile/test/services/video_editor/video_editor_render_service_test.dart
@@ -1,5 +1,7 @@
-// ABOUTME: Tests VideoEditorRenderService.buildImageLayers — the overlay-layer
-// ABOUTME: scaling and editor→output timeline mapping applied at export.
+// ABOUTME: Tests VideoEditorRenderService.buildImageLayers and
+// ABOUTME: buildColorFilters — the overlay-layer scaling and editor→output
+// ABOUTME: timeline mapping applied to layers, tune adjustments and filters at
+// ABOUTME: export.
 
 import 'dart:io';
 import 'dart:typed_data';
@@ -35,35 +37,31 @@ void main() {
     Offset offset = Offset.zero,
     Size logicalSize = const Size(10, 20),
   }) => pie.ExportedLayer(
-    layer: pie.Layer(
-      startTime: startTime,
-      endTime: endTime,
-      offset: offset,
-    ),
+    layer: pie.Layer(startTime: startTime, endTime: endTime, offset: offset),
     bytes: Uint8List.fromList(const [1, 2, 3]),
     logicalSize: logicalSize,
   );
 
-  group('buildImageLayers', () {
-    // Two 2s clips joined by a 400ms dissolve: an overlap removes its 400ms
-    // blend, so the 4s editor timeline renders to a 3.6s output. The transition
-    // is the outgoing transition of clip A (the a→b boundary).
-    final overlapClips = [
-      clip(
-        'a',
-        const Duration(seconds: 2),
-        transition: const ClipTransition(
-          type: ClipTransitionType.dissolve,
-          duration: Duration(milliseconds: 400),
-        ),
+  // Two 2s clips joined by a 400ms dissolve: an overlap removes its 400ms
+  // blend, so the 4s editor timeline renders to a 3.6s output. The transition
+  // is the outgoing transition of clip A (the a→b boundary).
+  final overlapClips = [
+    clip(
+      'a',
+      const Duration(seconds: 2),
+      transition: const ClipTransition(
+        type: ClipTransitionType.dissolve,
+        duration: Duration(milliseconds: 400),
       ),
-      clip('b', const Duration(seconds: 2)),
-    ];
-    final noTransitionClips = [
-      clip('a', const Duration(seconds: 2)),
-      clip('b', const Duration(seconds: 2)),
-    ];
+    ),
+    clip('b', const Duration(seconds: 2)),
+  ];
+  final noTransitionClips = [
+    clip('a', const Duration(seconds: 2)),
+    clip('b', const Duration(seconds: 2)),
+  ];
 
+  group('buildImageLayers', () {
     test('returns null when there are no captured layers', () {
       expect(
         VideoEditorRenderService.buildImageLayers(
@@ -150,6 +148,97 @@ void main() {
 
       expect(layers.single.startTime, isNull);
       expect(layers.single.endTime, isNull);
+    });
+  });
+
+  group('buildColorFilters', () {
+    pie.TuneAdjustmentMatrix tune({Duration? startTime, Duration? endTime}) =>
+        pie.TuneAdjustmentMatrix(
+          id: 'brightness',
+          value: 0.5,
+          matrix: const [1, 0, 0],
+          startTime: startTime,
+          endTime: endTime,
+        );
+
+    test('returns an empty list when there are no adjustments or filters', () {
+      expect(
+        VideoEditorRenderService.buildColorFilters(
+          tuneAdjustments: const [],
+          filterStates: const [],
+          timelineMap: TransitionTimelineMap.fromClips(noTransitionClips),
+        ),
+        isEmpty,
+      );
+    });
+
+    test('passes tune times through unchanged when there is no overlap '
+        'transition', () {
+      final filters = VideoEditorRenderService.buildColorFilters(
+        tuneAdjustments: [
+          tune(startTime: Duration.zero, endTime: const Duration(seconds: 4)),
+        ],
+        filterStates: const [],
+        timelineMap: TransitionTimelineMap.fromClips(noTransitionClips),
+      );
+
+      expect(filters.single.matrix, const [1, 0, 0]);
+      expect(filters.single.startTime, Duration.zero);
+      expect(filters.single.endTime, const Duration(seconds: 4));
+    });
+
+    test('maps a full-length tune window onto the shorter output axis when an '
+        'overlap transition compresses the timeline', () {
+      final filters = VideoEditorRenderService.buildColorFilters(
+        tuneAdjustments: [
+          tune(startTime: Duration.zero, endTime: const Duration(seconds: 4)),
+        ],
+        filterStates: const [],
+        timelineMap: TransitionTimelineMap.fromClips(overlapClips),
+      );
+
+      expect(filters.single.startTime, Duration.zero);
+      expect(filters.single.endTime, const Duration(milliseconds: 3600));
+    });
+
+    test('emits one filter per matrix and maps each window onto the output '
+        'axis', () {
+      final filters = VideoEditorRenderService.buildColorFilters(
+        tuneAdjustments: const [],
+        filterStates: [
+          pie.FilterState(
+            name: 'sepia',
+            matrices: const [
+              [1, 0, 0],
+              [0, 1, 0],
+            ],
+            startTime: Duration.zero,
+            endTime: const Duration(seconds: 4),
+          ),
+        ],
+        timelineMap: TransitionTimelineMap.fromClips(overlapClips),
+      );
+
+      expect(filters, hasLength(2));
+      expect(filters.map((f) => f.matrix), [
+        const [1, 0, 0],
+        const [0, 1, 0],
+      ]);
+      for (final filter in filters) {
+        expect(filter.startTime, Duration.zero);
+        expect(filter.endTime, const Duration(milliseconds: 3600));
+      }
+    });
+
+    test('leaves null tune times un-anchored', () {
+      final filters = VideoEditorRenderService.buildColorFilters(
+        tuneAdjustments: [tune()],
+        filterStates: const [],
+        timelineMap: TransitionTimelineMap.fromClips(overlapClips),
+      );
+
+      expect(filters.single.startTime, isNull);
+      expect(filters.single.endTime, isNull);
     });
   });
 }

--- a/mobile/test/services/video_editor/video_editor_render_service_test.dart
+++ b/mobile/test/services/video_editor/video_editor_render_service_test.dart
@@ -1,0 +1,155 @@
+// ABOUTME: Tests VideoEditorRenderService.buildImageLayers — the overlay-layer
+// ABOUTME: scaling and editor→output timeline mapping applied at export.
+
+import 'dart:io';
+import 'dart:typed_data';
+import 'dart:ui' show Offset, Size;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart' as model;
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/video_editor/transition_geometry.dart';
+import 'package:openvine/services/video_editor/video_editor_render_service.dart';
+import 'package:pro_image_editor/pro_image_editor.dart' as pie;
+import 'package:pro_video_editor/pro_video_editor.dart'
+    show ClipTransition, ClipTransitionType, EditorVideo;
+
+void main() {
+  DivineVideoClip clip(
+    String id,
+    Duration duration, {
+    ClipTransition? transition,
+  }) => DivineVideoClip(
+    id: id,
+    video: EditorVideo.file('${Directory.systemTemp.path}/$id.mp4'),
+    duration: duration,
+    recordedAt: DateTime(2026),
+    targetAspectRatio: model.AspectRatio.vertical,
+    originalAspectRatio: 9 / 16,
+    transition: transition,
+  );
+
+  pie.ExportedLayer layer({
+    Duration? startTime,
+    Duration? endTime,
+    Offset offset = Offset.zero,
+    Size logicalSize = const Size(10, 20),
+  }) => pie.ExportedLayer(
+    layer: pie.Layer(
+      startTime: startTime,
+      endTime: endTime,
+      offset: offset,
+    ),
+    bytes: Uint8List.fromList(const [1, 2, 3]),
+    logicalSize: logicalSize,
+  );
+
+  group('buildImageLayers', () {
+    // Two 2s clips joined by a 400ms dissolve: an overlap removes its 400ms
+    // blend, so the 4s editor timeline renders to a 3.6s output. The transition
+    // is the outgoing transition of clip A (the a→b boundary).
+    final overlapClips = [
+      clip(
+        'a',
+        const Duration(seconds: 2),
+        transition: const ClipTransition(
+          type: ClipTransitionType.dissolve,
+          duration: Duration(milliseconds: 400),
+        ),
+      ),
+      clip('b', const Duration(seconds: 2)),
+    ];
+    final noTransitionClips = [
+      clip('a', const Duration(seconds: 2)),
+      clip('b', const Duration(seconds: 2)),
+    ];
+
+    test('returns null when there are no captured layers', () {
+      expect(
+        VideoEditorRenderService.buildImageLayers(
+          capturedLayers: const [],
+          bodySize: const Size(100, 200),
+          videoSize: const Size(300, 600),
+          timelineMap: TransitionTimelineMap.fromClips(noTransitionClips),
+        ),
+        isNull,
+      );
+    });
+
+    test('returns null when bodySize is null', () {
+      expect(
+        VideoEditorRenderService.buildImageLayers(
+          capturedLayers: [layer()],
+          bodySize: null,
+          videoSize: const Size(300, 600),
+          timelineMap: TransitionTimelineMap.fromClips(noTransitionClips),
+        ),
+        isNull,
+      );
+    });
+
+    test('scales offset and size from body space into video pixel space', () {
+      // scale = videoWidth / bodyWidth = 300 / 100 = 3.
+      final layers = VideoEditorRenderService.buildImageLayers(
+        capturedLayers: [layer()],
+        bodySize: const Size(100, 200),
+        videoSize: const Size(300, 600),
+        timelineMap: TransitionTimelineMap.fromClips(noTransitionClips),
+      )!;
+
+      final built = layers.single;
+      // (bodyW/2 + dx - logicalW/2) * scale = (50 + 0 - 5) * 3 = 135.
+      expect(built.offset, const Offset(135, 270));
+      expect(built.size, const Size(30, 60));
+    });
+
+    test('passes layer times through unchanged when there is no overlap '
+        'transition', () {
+      final layers = VideoEditorRenderService.buildImageLayers(
+        capturedLayers: [
+          layer(startTime: Duration.zero, endTime: const Duration(seconds: 4)),
+        ],
+        bodySize: const Size(100, 200),
+        videoSize: const Size(300, 600),
+        timelineMap: TransitionTimelineMap.fromClips(noTransitionClips),
+      )!;
+
+      expect(layers.single.startTime, Duration.zero);
+      expect(layers.single.endTime, const Duration(seconds: 4));
+    });
+
+    test('maps a full-length layer end onto the shorter output axis when an '
+        'overlap transition compresses the timeline', () {
+      final map = TransitionTimelineMap.fromClips(overlapClips);
+      // Sanity: the overlap removes its 400ms blend from the 4s editor total.
+      expect(map.outputDuration, const Duration(milliseconds: 3600));
+
+      final layers = VideoEditorRenderService.buildImageLayers(
+        capturedLayers: [
+          // A full-length layer whose leave animation is anchored to the
+          // editor-timeline end (4s).
+          layer(startTime: Duration.zero, endTime: const Duration(seconds: 4)),
+        ],
+        bodySize: const Size(100, 200),
+        videoSize: const Size(300, 600),
+        timelineMap: map,
+      )!;
+
+      // The end must land on the real (shorter) video end, not 4s past it.
+      expect(layers.single.startTime, Duration.zero);
+      expect(layers.single.endTime, const Duration(milliseconds: 3600));
+    });
+
+    test('leaves null start/end times un-anchored', () {
+      final layers = VideoEditorRenderService.buildImageLayers(
+        capturedLayers: [layer()],
+        bodySize: const Size(100, 200),
+        videoSize: const Size(300, 600),
+        timelineMap: TransitionTimelineMap.fromClips(overlapClips),
+      )!;
+
+      expect(layers.single.startTime, isNull);
+      expect(layers.single.endTime, isNull);
+    });
+  });
+}

--- a/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_layer_animation_sheet_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_layer_animation_sheet_test.dart
@@ -304,6 +304,7 @@ void main() {
       expect(
         resolveLayerEndTime(
           currentEndTime: null,
+          startTime: Duration.zero,
           totalDuration: total,
           hasLeaveAnimation: true,
         ),
@@ -316,6 +317,7 @@ void main() {
       expect(
         resolveLayerEndTime(
           currentEndTime: trimEnd,
+          startTime: Duration.zero,
           totalDuration: total,
           hasLeaveAnimation: true,
         ),
@@ -327,6 +329,7 @@ void main() {
       expect(
         resolveLayerEndTime(
           currentEndTime: null,
+          startTime: Duration.zero,
           totalDuration: total,
           hasLeaveAnimation: false,
         ),
@@ -339,6 +342,7 @@ void main() {
       expect(
         resolveLayerEndTime(
           currentEndTime: trimEnd,
+          startTime: Duration.zero,
           totalDuration: total,
           hasLeaveAnimation: false,
         ),
@@ -352,6 +356,7 @@ void main() {
       expect(
         resolveLayerEndTime(
           currentEndTime: total,
+          startTime: Duration.zero,
           totalDuration: total,
           hasLeaveAnimation: false,
         ),
@@ -364,6 +369,7 @@ void main() {
       expect(
         resolveLayerEndTime(
           currentEndTime: const Duration(seconds: 8),
+          startTime: Duration.zero,
           totalDuration: total,
           hasLeaveAnimation: false,
         ),
@@ -375,10 +381,58 @@ void main() {
       expect(
         resolveLayerEndTime(
           currentEndTime: const Duration(seconds: 8),
+          startTime: Duration.zero,
           totalDuration: total,
           hasLeaveAnimation: true,
         ),
         total,
+      );
+    });
+
+    test('does not collapse the layer when totalDuration is a transient '
+        'zero', () {
+      // A leave set before the player has reported its length: a zero total
+      // must not anchor endTime at zero (== startTime), which would collapse
+      // the layer to a zero-length window and drop it from the timeline.
+      // Un-anchored (null) keeps it spanning the whole video instead.
+      expect(
+        resolveLayerEndTime(
+          currentEndTime: null,
+          startTime: Duration.zero,
+          totalDuration: Duration.zero,
+          hasLeaveAnimation: true,
+        ),
+        isNull,
+      );
+    });
+
+    test('never anchors a late layer at or before its start on a stale '
+        'small total', () {
+      // A layer starting at 4s with a stale total of 3s must not anchor its
+      // end at 3s (<= start). With no valid existing end it stays un-anchored
+      // rather than vanish from the timeline.
+      expect(
+        resolveLayerEndTime(
+          currentEndTime: null,
+          startTime: const Duration(seconds: 4),
+          totalDuration: const Duration(seconds: 3),
+          hasLeaveAnimation: true,
+        ),
+        isNull,
+      );
+    });
+
+    test('keeps the existing valid end when the total is stale small', () {
+      // total (1s) is stale below the layer window; rather than collapse, keep
+      // the real end (4s) that is still after the 2s start.
+      expect(
+        resolveLayerEndTime(
+          currentEndTime: const Duration(seconds: 4),
+          startTime: const Duration(seconds: 2),
+          totalDuration: const Duration(seconds: 1),
+          hasLeaveAnimation: true,
+        ),
+        const Duration(seconds: 4),
       );
     });
   });

--- a/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_overlay_controls_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_overlay_controls_test.dart
@@ -9,12 +9,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
+import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
 import 'package:openvine/blocs/video_editor/main_editor/video_editor_main_bloc.dart';
 import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/timeline_overlay_item.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
+import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_layer_animation_sheet.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_timeline_controls.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_timeline_overlay_controls.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
@@ -26,6 +28,9 @@ class _MockTimelineOverlayBloc
 class _MockVideoEditorMainBloc
     extends MockBloc<VideoEditorMainEvent, VideoEditorMainState>
     implements VideoEditorMainBloc {}
+
+class _MockClipEditorBloc extends MockBloc<ClipEditorEvent, ClipEditorState>
+    implements ClipEditorBloc {}
 
 class _MockProImageEditorState extends Mock implements ProImageEditorState {
   @override
@@ -55,8 +60,9 @@ void main() {
     Widget buildWithEditor(
       TimelineOverlayItem item,
       _MockProImageEditorState mockEditor,
-      _MockVideoEditorMainBloc mainBloc,
-    ) {
+      _MockVideoEditorMainBloc mainBloc, {
+      _MockClipEditorBloc? clipBloc,
+    }) {
       return ProviderScope(
         child: MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -66,6 +72,8 @@ void main() {
               providers: [
                 BlocProvider<VideoEditorMainBloc>.value(value: mainBloc),
                 BlocProvider<TimelineOverlayBloc>.value(value: overlayBloc),
+                if (clipBloc != null)
+                  BlocProvider<ClipEditorBloc>.value(value: clipBloc),
               ],
               child: VideoEditorScope(
                 editorKey: GlobalKey(),
@@ -601,6 +609,57 @@ void main() {
           // second.startOffset = originalStartOffset + (splitAt - item.startTime)
           //                     = 2s + (5s - 3s) = 4s
           expect(second.startOffset, equals(const Duration(seconds: 4)));
+        },
+      );
+
+      testWidgets(
+        'animate sources the total duration from ClipEditorBloc, not '
+        'VideoEditorMainBloc',
+        (tester) async {
+          final layer = TextLayer(
+            text: 'Layer A',
+            id: 'layer-a',
+            startTime: Duration.zero,
+            endTime: const Duration(seconds: 3),
+          );
+          when(() => mockEditor.activeLayers).thenReturn([layer]);
+          when(() => mainBloc.state).thenReturn(const VideoEditorMainState());
+
+          final clipBloc = _MockClipEditorBloc();
+          when(
+            () => clipBloc.stream,
+          ).thenAnswer((_) => const Stream<ClipEditorState>.empty());
+          when(() => clipBloc.state).thenReturn(const ClipEditorState());
+
+          const item = TimelineOverlayItem(
+            id: 'layer-a',
+            type: TimelineOverlayType.layer,
+            startTime: Duration.zero,
+            endTime: Duration(seconds: 3),
+          );
+          await tester.pumpWidget(
+            buildWithEditor(item, mockEditor, mainBloc, clipBloc: clipBloc),
+          );
+
+          // The total is only consulted when animate is tapped.
+          verifyNever(() => clipBloc.state);
+
+          await tester.tap(
+            find.bySemanticsLabel(
+              l10n.videoEditorLayerAnimationButtonSemanticLabel,
+            ),
+          );
+          // Bounded pumps rather than pumpAndSettle: the picker preview loops
+          // continuously so the tree never settles.
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 400));
+
+          // The animation sheet opens with the total taken from
+          // ClipEditorBloc.totalDuration. If the source were reverted to
+          // VideoEditorMainBloc (the transient-zero bug this PR fixes),
+          // clipBloc.state would never be read.
+          verify(() => clipBloc.state).called(greaterThanOrEqualTo(1));
+          expect(find.byType(LayerAnimationPickerView), findsOneWidget);
         },
       );
     });


### PR DESCRIPTION
Closes #5816

## Description

Fixes three related layer-animation defects in the video editor.

**1. Layer disappears from the timeline when adding a leave animation.** Setting a leave (animateOut) animation anchored the layer's `endTime` to `VideoEditorMainBloc.totalDuration`, which is derived from player duration reports and can be a transient zero right after a clip change. A zero (or stale-small) total produced an `endTime <= startTime`, so the timeline bloc dropped the layer out of the strip entirely. Now the anchor comes from the stable `ClipEditorBloc.totalDuration` (summed clip playback lengths), and `resolveLayerEndTime` is hardened to never return an end at or before the layer's start — it falls back to the layer's existing valid end, or leaves it un-anchored, rather than collapsing the layer.

**2 & 3. Layer animation missing at the end when an overlap transition (dissolve) is used, and animations generally misplaced at render.** Overlap transitions (dissolve/slide/push/wipe) shorten the rendered output, but overlay layer and color-filter time windows were passed to the export on the *editor* timeline (clips at full length). Anything anchored near the end — a layer's leave animation especially — landed past the real video end and was clipped, even though the in-editor preview (playhead mapped composite→editor) looked correct. Every time anchor is now mapped through `TransitionTimelineMap.editorToOutput` onto the shorter output axis (identity when no overlap transition is present). The layer composition math was extracted into a testable `buildImageLayers`.

**Related Issue:** 

## Out of Scope

- The export-axis fix was extended to color-filter / tune time windows too, since they share the identical bug on the same code path (harmless — identity without an overlap transition).
- Intermittent render-animation failures that occur *without* any transition are not addressed here; that would be a separate root cause and needs a concrete repro.

## Verification

- `flutter analyze lib test` — clean.
- `flutter test` on: `video_editor_render_service_test.dart` (new), `layer_animation_storage_test.dart`, `video_editor_layer_animation_sheet_test.dart`, `transition_geometry_test.dart`, `transition_seam_render_service_test.dart`, `timeline_overlay/`, `video_editor_timeline_overlay_controls_test.dart` — all green.
- Manually verified in the editor: leave animation keeps the layer on the timeline; dissolve + leave animation now plays at the real video end.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)