### PR TITLE
fix(feed): stop the home overlay sliding on keyboard close

### DIFF
--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -353,55 +353,63 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
               // [PageView]. The default predicate (depth == 0) restricts the
               // gesture to the outermost scrollable, so inner overlay
               // scrollables can't trigger a refresh.
+              // The video overlay positions its author block and action
+              // column against `viewPadding.bottom`.
+              // [_KeyboardStableBottomInset] holds that inset steady while the
+              // share sheet's keyboard is open, so the overlay does not slide
+              // when the keyboard closes (#5758 follow-up).
               return RefreshIndicator(
                 onRefresh: () => _refreshFeed(context),
-                child: Stack(
-                  children: [
-                    FeedVideos(
-                      videos: state.videos,
-                      contextTitle: state.feedContextTitle,
-                      currentIndex: clampedIndex,
-                      isActive: _isNewFeedActive,
-                      // The home feed stays mounted across tab switches and
-                      // pushed routes (StatefulShellRoute keep-alive), so
-                      // release the off-screen neighbour players and pause
-                      // disk prefetch while it is backgrounded. Bottom sheets
-                      // (comments/share) only pause the current player — they
-                      // keep neighbours and prefetch warm via shouldRetainPlayer.
-                      releaseNeighboursWhenInactive: !shouldRetainPlayer,
-                      hasMore: state.hasMore,
-                      isLoadingMore: state.isLoadingMore,
-                      trafficSource: ViewTrafficSource.home,
-                      onActiveVideoChanged: (video, index) {
-                        ref
-                            .read(foregroundFeedActivityGateProvider)
-                            .markActive();
-                        _currentIndex = index;
-                        context.read<VideoFeedBloc>().add(
-                          VideoFeedActiveIndexChanged(index),
-                        );
-                        ref
-                            .read(lastTabPositionProvider.notifier)
-                            .recordPosition(RouteType.home, index);
-                        _resumeAutoAdvanceAfterSwipe();
-                        FeedPerformanceTracker().startVideoSwipeTracking(
-                          video.id,
-                        );
-                        if (!_hasMarkedVideoReady && index == 0) {
-                          _hasMarkedVideoReady = true;
-                          StartupPerformanceService.instance.markVideoReady();
-                        }
-                      },
-                      onNearEnd: () {
-                        if (state.hasMore) {
+                child: _KeyboardStableBottomInset(
+                  child: Stack(
+                    children: [
+                      FeedVideos(
+                        videos: state.videos,
+                        contextTitle: state.feedContextTitle,
+                        currentIndex: clampedIndex,
+                        isActive: _isNewFeedActive,
+                        // The home feed stays mounted across tab switches and
+                        // pushed routes (StatefulShellRoute keep-alive), so
+                        // release the off-screen neighbour players and pause
+                        // disk prefetch while it is backgrounded. Bottom sheets
+                        // (comments/share) only pause the current player — they
+                        // keep neighbours and prefetch warm via
+                        // shouldRetainPlayer.
+                        releaseNeighboursWhenInactive: !shouldRetainPlayer,
+                        hasMore: state.hasMore,
+                        isLoadingMore: state.isLoadingMore,
+                        trafficSource: ViewTrafficSource.home,
+                        onActiveVideoChanged: (video, index) {
+                          ref
+                              .read(foregroundFeedActivityGateProvider)
+                              .markActive();
+                          _currentIndex = index;
                           context.read<VideoFeedBloc>().add(
-                            const VideoFeedLoadMoreRequested(),
+                            VideoFeedActiveIndexChanged(index),
                           );
-                        }
-                      },
-                    ),
-                    const FeedModeSwitch(),
-                  ],
+                          ref
+                              .read(lastTabPositionProvider.notifier)
+                              .recordPosition(RouteType.home, index);
+                          _resumeAutoAdvanceAfterSwipe();
+                          FeedPerformanceTracker().startVideoSwipeTracking(
+                            video.id,
+                          );
+                          if (!_hasMarkedVideoReady && index == 0) {
+                            _hasMarkedVideoReady = true;
+                            StartupPerformanceService.instance.markVideoReady();
+                          }
+                        },
+                        onNearEnd: () {
+                          if (state.hasMore) {
+                            context.read<VideoFeedBloc>().add(
+                              const VideoFeedLoadMoreRequested(),
+                            );
+                          }
+                        },
+                      ),
+                      const FeedModeSwitch(),
+                    ],
+                  ),
                 ),
               );
             },
@@ -432,6 +440,57 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
           s.status == VideoFeedStatus.success ||
           s.status == VideoFeedStatus.failure,
       orElse: () => bloc.state,
+    );
+  }
+}
+
+/// Holds the child subtree's bottom safe-area inset steady while a modal
+/// keyboard is open over the home feed.
+///
+/// The shell [Scaffold] has a `bottomNavigationBar`, so it strips the body's
+/// bottom padding: at rest the feed subtree reads `viewPadding.bottom == 0`.
+/// While the share sheet's keyboard is up, the shell keeps its layout (it does
+/// not resize for a modal route), so the window's keyboard inset zeroes the
+/// shell's own `padding.bottom` — the strip then subtracts nothing and
+/// `viewPadding.bottom` springs back up to the raw safe-area value, sliding the
+/// overlay's action column up and then back down on keyboard close.
+///
+/// Latch the at-rest inset whenever the keyboard is down and hold it while the
+/// keyboard is up, so the overlay positions against a stable inset. Holding the
+/// real at-rest value (rather than a recomputed one) keeps the resting layout
+/// pixel-identical. Scoped to the home feed; the fullscreen feed removes the
+/// bottom padding outright and never springs.
+class _KeyboardStableBottomInset extends StatefulWidget {
+  const _KeyboardStableBottomInset({required this.child});
+
+  final Widget child;
+
+  @override
+  State<_KeyboardStableBottomInset> createState() =>
+      _KeyboardStableBottomInsetState();
+}
+
+class _KeyboardStableBottomInsetState
+    extends State<_KeyboardStableBottomInset> {
+  double? _restingBottom;
+
+  @override
+  Widget build(BuildContext context) {
+    final mediaQuery = MediaQuery.of(context);
+    final keyboardIsUp = mediaQuery.viewInsets.bottom > 0;
+
+    // Track the at-rest inset whenever nothing is consuming the safe area, and
+    // hold the last tracked value while a keyboard is up.
+    if (!keyboardIsUp) {
+      _restingBottom = mediaQuery.viewPadding.bottom;
+    }
+    final stableBottom = _restingBottom ?? mediaQuery.viewPadding.bottom;
+
+    return MediaQuery(
+      data: mediaQuery.copyWith(
+        viewPadding: mediaQuery.viewPadding.copyWith(bottom: stableBottom),
+      ),
+      child: widget.child,
     );
   }
 }

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -475,15 +475,20 @@ class _KeyboardStableBottomInsetState
   double? _restingBottom;
 
   @override
-  Widget build(BuildContext context) {
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // Latch the at-rest inset whenever nothing is consuming the safe area, and
+    // hold the last latched value while a keyboard is up. This fires on every
+    // MediaQuery change, so `build` stays free of the caching side effect.
     final mediaQuery = MediaQuery.of(context);
-    final keyboardIsUp = mediaQuery.viewInsets.bottom > 0;
-
-    // Track the at-rest inset whenever nothing is consuming the safe area, and
-    // hold the last tracked value while a keyboard is up.
-    if (!keyboardIsUp) {
+    if (mediaQuery.viewInsets.bottom == 0) {
       _restingBottom = mediaQuery.viewPadding.bottom;
     }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final mediaQuery = MediaQuery.of(context);
     final stableBottom = _restingBottom ?? mediaQuery.viewPadding.bottom;
 
     return MediaQuery(

--- a/mobile/test/screens/feed/video_feed_page_test.dart
+++ b/mobile/test/screens/feed/video_feed_page_test.dart
@@ -257,6 +257,82 @@ void main() {
       await tester.pump();
     });
 
+    testWidgets(
+      'holds the overlay bottom inset steady while a modal keyboard is open '
+      '(no slide on keyboard close, #5758 follow-up)',
+      (tester) async {
+        // Model the shell Scaffold: its bottomNavigationBar strips the body's
+        // bottom padding, so `removeBottom: true` recomputes the feed subtree's
+        // viewPadding.bottom as max(0, safeArea - padding.bottom). At rest
+        // padding.bottom == safeArea, collapsing the inset to 0; while the
+        // keyboard is up the window inset zeroes padding.bottom, so the strip
+        // springs the inset back to the full safe area. The latch must hold it.
+        tester.view.devicePixelRatio = 1;
+        tester.view.viewPadding = const FakeViewPadding(bottom: 34);
+        tester.view.padding = const FakeViewPadding(bottom: 34);
+        addTearDown(tester.view.reset);
+
+        final video = createTestVideoEvent();
+        final state = VideoFeedBlocState(
+          status: VideoFeedStatus.success,
+          videos: [video],
+        );
+        when(() => videoFeedBloc.state).thenReturn(state);
+        whenListen(
+          videoFeedBloc,
+          const Stream<VideoFeedBlocState>.empty(),
+          initialState: state,
+        );
+
+        await tester.pumpWidget(
+          testMaterialApp(
+            home: MultiBlocProvider(
+              providers: [
+                BlocProvider<VideoFeedBloc>.value(value: videoFeedBloc),
+                BlocProvider<VideoPlaybackStatusCubit>(
+                  create: (_) => VideoPlaybackStatusCubit(),
+                ),
+                BlocProvider<VideoVolumeCubit>.value(value: videoVolumeCubit),
+              ],
+              child: Builder(
+                builder: (context) => MediaQuery.removePadding(
+                  context: context,
+                  removeBottom: true,
+                  child: const VideoFeedView(),
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        double feedBottomInset() => MediaQuery.viewPaddingOf(
+          tester.element(find.byType(FeedVideos)),
+        ).bottom;
+
+        // At rest the padding strip collapses the inset to 0.
+        expect(feedBottomInset(), 0);
+
+        // Keyboard opens: without the latch the strip would spring the inset
+        // back to 34 (the overlay slides up); the latch holds it at 0.
+        tester.view.viewInsets = const FakeViewPadding(bottom: 300);
+        tester.view.padding = const FakeViewPadding();
+        await tester.pump();
+        expect(feedBottomInset(), 0);
+
+        // Keyboard closes: the inset returns to rest, still 0 — no downward
+        // slide of the overlay.
+        tester.view.viewInsets = const FakeViewPadding();
+        tester.view.padding = const FakeViewPadding(bottom: 34);
+        await tester.pump();
+        expect(feedBottomInset(), 0);
+
+        await tester.pump(const Duration(seconds: 3));
+        await tester.pumpWidget(const SizedBox());
+        await tester.pump();
+      },
+    );
+
     testWidgets('requests auto-refresh when app returns from background', (
       tester,
     ) async {


### PR DESCRIPTION
## Description

Follow-up to #5758. On the **home feed**, opening the share sheet and then closing its keyboard made the overlay action column (Like / Share / …) do a small vertical "jump" — it slid up while the keyboard was up and dropped back on close (spotted on device by @hm21).

**Root cause.** The home overlay positions its author block and action column against `MediaQuery.viewPadding.bottom`. The shell `Scaffold` has a `bottomNavigationBar`, so Flutter strips the feed body's bottom padding — at rest the feed subtree reads `viewPadding.bottom == 0`. When the share sheet's keyboard opens, the shell keeps its layout (it deliberately does **not** resize for a modal route, to avoid relaying-out the feed every keyboard frame, #5758), so the window's keyboard inset zeroes the shell's own `padding.bottom`. The strip then subtracts nothing and `viewPadding.bottom` springs back to the full safe-area value — sliding the overlay up, then back down on keyboard close. The fullscreen feed removes the bottom padding outright, so it never springs.

**Fix.** Wrap the home feed in `_KeyboardStableBottomInset`, which latches the at-rest `viewPadding.bottom` while the keyboard is down and holds that exact value while it is up. It positions the overlay against a stable inset without touching the fullscreen path.

Holding the *real* resting value (rather than recomputing one) is deliberate: the reverted in-PR attempt on #5758 forced the raw **window** inset instead, which shifted the whole overlay up and left a gap at the bottom. Latching the value the feed actually reads at rest keeps the resting layout pixel-identical — it can only remove the transient slide, never move the steady state.

## Related Issue

Closes #5817

## Verification

- `flutter analyze lib test integration_test` — clean
- `flutter test test/screens/feed/ test/widgets/video_feed_item/` — 395 passed
- New regression test (`test/screens/feed/video_feed_page_test.dart`) models the shell Scaffold's padding strip and drives the keyboard open → close, asserting the feed's bottom inset never leaves its resting value. Without the latch, the keyboard-up phase springs the inset back and the assertion fails.

## Testing on a real device

The bug is a transient CI can't observe, so an on-device check is the real gate — ideally @hm21, who caught it:

1. Home feed → share arrow → tap a contact to bring up the composer keyboard.
2. Type a note, then dismiss the keyboard (send, or tap away).
3. **Expect:** the Like/Share action column and author block stay put — no upward slide while the keyboard is up, no downward drop on close.
4. **Resting state unchanged:** with no keyboard, the overlay sits exactly where it does on `main` (no gap at the bottom — the failure mode of the reverted attempt).
5. Repeat from the fullscreen feed — unchanged, still no jump.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
