### PR TITLE
fix(dm): guard cubit emits after close during conversation scroll

### DIFF
--- a/mobile/lib/blocs/dm/conversation/collaborator_invite_actions_cubit.dart
+++ b/mobile/lib/blocs/dm/conversation/collaborator_invite_actions_cubit.dart
@@ -125,14 +125,16 @@ class CollaboratorInviteActionsCubit
       state: inviteState,
     );
 
-    emit(
-      state.copyWith(
-        inviteStates: {
-          ...state.inviteStates,
-          CollaboratorInviteActionsState._keyFor(invite): inviteState,
-        },
-      ),
-    );
+    if (!isClosed) {
+      emit(
+        state.copyWith(
+          inviteStates: {
+            ...state.inviteStates,
+            CollaboratorInviteActionsState._keyFor(invite): inviteState,
+          },
+        ),
+      );
+    }
   }
 
   bool _isCurrentUserInviteCreator(CollaboratorInvite invite) =>

--- a/mobile/lib/blocs/dm/conversation_actions/conversation_actions_cubit.dart
+++ b/mobile/lib/blocs/dm/conversation_actions/conversation_actions_cubit.dart
@@ -61,14 +61,18 @@ class ConversationActionsCubit extends Cubit<ConversationActionsState> {
         reason: ContentFilterReason.other,
         details: 'Reported from DM conversation',
       );
-      emit(state.copyWith(status: ConversationActionsStatus.idle));
+      if (!isClosed) {
+        emit(state.copyWith(status: ConversationActionsStatus.idle));
+      }
       return result.success;
     } catch (e, stackTrace) {
       // `ContentReportingService.reportUser` returns `ReportResult.failure`
       // for expected publish/auth problems. Any throw escaping here is
       // unexpected, so surface it as Reportable.
       addError(Reportable(e, context: 'reportUser'), stackTrace);
-      emit(state.copyWith(status: ConversationActionsStatus.idle));
+      if (!isClosed) {
+        emit(state.copyWith(status: ConversationActionsStatus.idle));
+      }
       return false;
     }
   }
@@ -84,12 +88,16 @@ class ConversationActionsCubit extends Cubit<ConversationActionsState> {
         pubkey,
         ourPubkey: _currentUserPubkey,
       );
-      emit(state.copyWith(status: ConversationActionsStatus.success));
+      if (!isClosed) {
+        emit(state.copyWith(status: ConversationActionsStatus.success));
+      }
     } catch (e, stackTrace) {
       // Blocklist IO / publish failures are expected. Per
       // .claude/rules/error_handling.md they are NOT Reportable.
       addError(e, stackTrace);
-      emit(state.copyWith(status: ConversationActionsStatus.failure));
+      if (!isClosed) {
+        emit(state.copyWith(status: ConversationActionsStatus.failure));
+      }
     }
   }
 
@@ -98,12 +106,16 @@ class ConversationActionsCubit extends Cubit<ConversationActionsState> {
     emit(state.copyWith(status: ConversationActionsStatus.processing));
     try {
       await _blocklistRepository.unblockUser(pubkey);
-      emit(state.copyWith(status: ConversationActionsStatus.success));
+      if (!isClosed) {
+        emit(state.copyWith(status: ConversationActionsStatus.success));
+      }
     } catch (e, stackTrace) {
       // Blocklist IO / publish failures are expected. Per
       // .claude/rules/error_handling.md they are NOT Reportable.
       addError(e, stackTrace);
-      emit(state.copyWith(status: ConversationActionsStatus.failure));
+      if (!isClosed) {
+        emit(state.copyWith(status: ConversationActionsStatus.failure));
+      }
     }
   }
 
@@ -114,13 +126,17 @@ class ConversationActionsCubit extends Cubit<ConversationActionsState> {
     emit(state.copyWith(status: ConversationActionsStatus.processing));
     try {
       await _dmRepository.removeConversation(conversationId);
-      emit(state.copyWith(status: ConversationActionsStatus.success));
+      if (!isClosed) {
+        emit(state.copyWith(status: ConversationActionsStatus.success));
+      }
       return true;
     } catch (e, stackTrace) {
       // Drift write failures are expected. Per
       // .claude/rules/error_handling.md they are NOT Reportable.
       addError(e, stackTrace);
-      emit(state.copyWith(status: ConversationActionsStatus.failure));
+      if (!isClosed) {
+        emit(state.copyWith(status: ConversationActionsStatus.failure));
+      }
       return false;
     }
   }

--- a/mobile/lib/blocs/dm/conversation_mute/conversation_mute_cubit.dart
+++ b/mobile/lib/blocs/dm/conversation_mute/conversation_mute_cubit.dart
@@ -76,12 +76,14 @@ class ConversationMuteCubit extends Cubit<ConversationMuteState> {
       // SharedPreferences IO failures are expected. Per
       // .claude/rules/error_handling.md they are NOT Reportable.
       addError(e, stackTrace);
-      emit(
-        state.copyWith(
-          status: ConversationMuteStatus.error,
-          mutedIds: previousIds,
-        ),
-      );
+      if (!isClosed) {
+        emit(
+          state.copyWith(
+            status: ConversationMuteStatus.error,
+            mutedIds: previousIds,
+          ),
+        );
+      }
     }
 
     Log.debug(

--- a/mobile/lib/blocs/dm/inline_reel_reply/inline_reel_reply_cubit.dart
+++ b/mobile/lib/blocs/dm/inline_reel_reply/inline_reel_reply_cubit.dart
@@ -85,13 +85,15 @@ class InlineReelReplyCubit extends Cubit<InlineReelReplyState> {
               );
         ok = result.success;
       }
-      emit(
-        state.copyWith(
-          status: ok
-              ? InlineReelReplyStatus.success
-              : InlineReelReplyStatus.failure,
-        ),
-      );
+      if (!isClosed) {
+        emit(
+          state.copyWith(
+            status: ok
+                ? InlineReelReplyStatus.success
+                : InlineReelReplyStatus.failure,
+          ),
+        );
+      }
     } catch (error, stackTrace) {
       Log.error(
         'Reel reply send failed',
@@ -111,7 +113,9 @@ class InlineReelReplyCubit extends Cubit<InlineReelReplyState> {
       } else {
         addError(error, stackTrace);
       }
-      emit(state.copyWith(status: InlineReelReplyStatus.failure));
+      if (!isClosed) {
+        emit(state.copyWith(status: InlineReelReplyStatus.failure));
+      }
     }
   }
 

--- a/mobile/lib/blocs/dm/message_requests/message_request_actions_cubit.dart
+++ b/mobile/lib/blocs/dm/message_requests/message_request_actions_cubit.dart
@@ -34,12 +34,16 @@ class MessageRequestActionsCubit extends Cubit<MessageRequestActionsState> {
     emit(state.copyWith(status: MessageRequestActionsStatus.processing));
     try {
       await _dmRepository.removeConversation(conversationId);
-      emit(state.copyWith(status: MessageRequestActionsStatus.success));
+      if (!isClosed) {
+        emit(state.copyWith(status: MessageRequestActionsStatus.success));
+      }
     } catch (e, stackTrace) {
       // Drift IO failures are expected. Per
       // .claude/rules/error_handling.md they are NOT Reportable.
       addError(e, stackTrace);
-      emit(state.copyWith(status: MessageRequestActionsStatus.error));
+      if (!isClosed) {
+        emit(state.copyWith(status: MessageRequestActionsStatus.error));
+      }
     }
   }
 
@@ -49,12 +53,16 @@ class MessageRequestActionsCubit extends Cubit<MessageRequestActionsState> {
     emit(state.copyWith(status: MessageRequestActionsStatus.processing));
     try {
       await _dmRepository.markConversationsAsRead(conversationIds);
-      emit(state.copyWith(status: MessageRequestActionsStatus.success));
+      if (!isClosed) {
+        emit(state.copyWith(status: MessageRequestActionsStatus.success));
+      }
     } catch (e, stackTrace) {
       // Drift IO failures are expected. Per
       // .claude/rules/error_handling.md they are NOT Reportable.
       addError(e, stackTrace);
-      emit(state.copyWith(status: MessageRequestActionsStatus.error));
+      if (!isClosed) {
+        emit(state.copyWith(status: MessageRequestActionsStatus.error));
+      }
     }
   }
 
@@ -64,12 +72,16 @@ class MessageRequestActionsCubit extends Cubit<MessageRequestActionsState> {
     emit(state.copyWith(status: MessageRequestActionsStatus.processing));
     try {
       await _dmRepository.removeConversations(conversationIds);
-      emit(state.copyWith(status: MessageRequestActionsStatus.success));
+      if (!isClosed) {
+        emit(state.copyWith(status: MessageRequestActionsStatus.success));
+      }
     } catch (e, stackTrace) {
       // Drift IO failures are expected. Per
       // .claude/rules/error_handling.md they are NOT Reportable.
       addError(e, stackTrace);
-      emit(state.copyWith(status: MessageRequestActionsStatus.error));
+      if (!isClosed) {
+        emit(state.copyWith(status: MessageRequestActionsStatus.error));
+      }
     }
   }
 }

--- a/mobile/lib/blocs/dm/message_requests/request_preview_cubit.dart
+++ b/mobile/lib/blocs/dm/message_requests/request_preview_cubit.dart
@@ -75,19 +75,23 @@ class RequestPreviewCubit extends Cubit<RequestPreviewState> {
           ? _initialParticipantPubkeys
           : await _resolveParticipants();
 
-      emit(
-        state.copyWith(
-          status: RequestPreviewStatus.loaded,
-          messageCount: messageCount,
-          participantPubkeys: pubkeys,
-          messages: messages,
-        ),
-      );
+      if (!isClosed) {
+        emit(
+          state.copyWith(
+            status: RequestPreviewStatus.loaded,
+            messageCount: messageCount,
+            participantPubkeys: pubkeys,
+            messages: messages,
+          ),
+        );
+      }
     } catch (e, stackTrace) {
       // Drift read failures are expected. Per
       // .claude/rules/error_handling.md they are NOT Reportable.
       addError(e, stackTrace);
-      emit(state.copyWith(status: RequestPreviewStatus.error));
+      if (!isClosed) {
+        emit(state.copyWith(status: RequestPreviewStatus.error));
+      }
     }
   }
 

--- a/mobile/lib/screens/inbox/conversation/widgets/video_link_preview_cubit.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/video_link_preview_cubit.dart
@@ -72,7 +72,7 @@ class VideoLinkPreviewCubit extends Cubit<VideoLinkPreviewState> {
         _videoEventService.getVideoById(_videoStableId) ??
         _videoEventService.getVideoEventByVineId(_videoStableId);
     if (cached != null) {
-      emit(VideoLinkPreviewResolved(cached));
+      if (!isClosed) emit(VideoLinkPreviewResolved(cached));
       return;
     }
 
@@ -97,7 +97,9 @@ class VideoLinkPreviewCubit extends Cubit<VideoLinkPreviewState> {
       }
 
       if (event != null) {
-        emit(VideoLinkPreviewResolved(VideoEvent.fromNostrEvent(event)));
+        if (!isClosed) {
+          emit(VideoLinkPreviewResolved(VideoEvent.fromNostrEvent(event)));
+        }
         return;
       }
     } catch (e) {
@@ -108,6 +110,6 @@ class VideoLinkPreviewCubit extends Cubit<VideoLinkPreviewState> {
       );
     }
 
-    emit(const VideoLinkPreviewNotFound());
+    if (!isClosed) emit(const VideoLinkPreviewNotFound());
   }
 }

--- a/mobile/test/blocs/dm/conversation/collaborator_invite_actions_cubit_test.dart
+++ b/mobile/test/blocs/dm/conversation/collaborator_invite_actions_cubit_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Tests collaborator invite accept/ignore UI action state.
 // ABOUTME: Verifies accept publishes while ignore stays local-only.
 
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:collaborator_repository/collaborator_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -70,6 +72,26 @@ void main() {
   }
 
   group(CollaboratorInviteActionsCubit, () {
+    test('does not emit or throw when closed mid-ignore', () async {
+      final completer = Completer<void>();
+      when(
+        () => store.setState(
+          videoAddress: any(named: 'videoAddress'),
+          creatorPubkey: any(named: 'creatorPubkey'),
+          collaboratorPubkey: any(named: 'collaboratorPubkey'),
+          state: any(named: 'state'),
+        ),
+      ).thenAnswer((_) => completer.future);
+
+      final cubit = buildCubit();
+      final future = cubit.ignoreInvite(invite);
+      await cubit.close();
+      completer.complete();
+      await expectLater(future, completes);
+
+      expect(cubit.state.stateFor(invite), CollaboratorInviteState.pending);
+    });
+
     test('loads persisted invite state', () {
       when(
         () => store.getState(

--- a/mobile/test/blocs/dm/conversation_actions/conversation_actions_cubit_test.dart
+++ b/mobile/test/blocs/dm/conversation_actions/conversation_actions_cubit_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Tests for ConversationActionsCubit — report, block, remove.
 // ABOUTME: Verifies service delegation, return values, and error handling.
 
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:dm_repository/dm_repository.dart';
@@ -46,6 +48,25 @@ void main() {
       dmRepository: mockDmRepo,
       currentUserPubkey: currentUserPubkey,
     );
+
+    test('does not emit or throw when closed mid-block', () async {
+      final completer = Completer<void>();
+      when(
+        () => mockBlocklistRepository.blockUser(
+          pubkey,
+          ourPubkey: currentUserPubkey,
+        ),
+      ).thenAnswer((_) => completer.future);
+
+      final cubit = createCubit();
+      final future = cubit.blockUser(pubkey);
+      // processing emitted synchronously; close before the block resolves.
+      await cubit.close();
+      completer.complete();
+      await expectLater(future, completes);
+
+      expect(cubit.state.status, ConversationActionsStatus.processing);
+    });
 
     test('initial state is idle', () {
       final cubit = createCubit();

--- a/mobile/test/blocs/dm/conversation_mute/conversation_mute_cubit_test.dart
+++ b/mobile/test/blocs/dm/conversation_mute/conversation_mute_cubit_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Unit tests for ConversationMuteCubit.
 // ABOUTME: Verifies toggle, persistence load, and state transitions.
 
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:bloc/bloc.dart';
@@ -44,6 +45,22 @@ void main() {
 
     ConversationMuteCubit buildCubit() =>
         ConversationMuteCubit(prefs: mockPrefs);
+
+    test('does not emit or throw when closed mid-save failure', () async {
+      final completer = Completer<bool>();
+      when(
+        () => mockPrefs.setString(any(), any()),
+      ).thenAnswer((_) => completer.future);
+
+      final cubit = buildCubit();
+      final future = cubit.toggleMute(conversationId);
+      // Optimistic mute emitted synchronously; close before the save resolves.
+      await cubit.close();
+      completer.completeError(Exception('disk full'));
+      await expectLater(future, completes);
+
+      expect(cubit.state.status, ConversationMuteStatus.success);
+    });
 
     test('initial state has empty mutedIds and idle status', () {
       final cubit = buildCubit();

--- a/mobile/test/blocs/dm/inline_reel_reply/inline_reel_reply_cubit_test.dart
+++ b/mobile/test/blocs/dm/inline_reel_reply/inline_reel_reply_cubit_test.dart
@@ -1,5 +1,7 @@
 // ABOUTME: Cubit tests for InlineReelReplyCubit (in-player reel text replies).
 
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:dm_repository/dm_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -87,6 +89,35 @@ void main() {
     late _MockDmRepository repo;
 
     setUp(() => repo = _MockDmRepository());
+
+    test('does not emit or throw when closed mid-send', () async {
+      final completer = Completer<NIP17SendResult>();
+      when(
+        () => repo.sendMessage(
+          recipientPubkey: any(named: 'recipientPubkey'),
+          content: any(named: 'content'),
+          replyToId: any(named: 'replyToId'),
+        ),
+      ).thenAnswer((_) => completer.future);
+
+      final cubit = InlineReelReplyCubit(
+        dmRepository: repo,
+        replyContext: oneToOne(),
+      );
+      final future = cubit.submit('hi');
+      // sending emitted synchronously; close before the send resolves.
+      await cubit.close();
+      completer.complete(
+        NIP17SendResult.success(
+          rumorEventId: 'r',
+          messageEventId: 'g',
+          recipientPubkey: _peer,
+        ),
+      );
+      await expectLater(future, completes);
+
+      expect(cubit.state.status, InlineReelReplyStatus.sending);
+    });
 
     void stubSendSuccess() {
       when(

--- a/mobile/test/blocs/dm/message_requests/message_request_actions_cubit_test.dart
+++ b/mobile/test/blocs/dm/message_requests/message_request_actions_cubit_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Tests for MessageRequestActionsCubit - decline, mark-all-read,
 // ABOUTME: and remove-all actions for message requests.
 
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:dm_repository/dm_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -24,6 +26,22 @@ void main() {
 
     MessageRequestActionsCubit createCubit() =>
         MessageRequestActionsCubit(dmRepository: mockDmRepository);
+
+    test('does not emit or throw when closed mid-decline', () async {
+      final completer = Completer<void>();
+      when(
+        () => mockDmRepository.removeConversation(_testConversationId1),
+      ).thenAnswer((_) => completer.future);
+
+      final cubit = createCubit();
+      final future = cubit.declineRequest(_testConversationId1);
+      // processing emitted synchronously; close before the delete resolves.
+      await cubit.close();
+      completer.complete();
+      await expectLater(future, completes);
+
+      expect(cubit.state.status, MessageRequestActionsStatus.processing);
+    });
 
     test('initial state has idle status', () {
       final cubit = createCubit();

--- a/mobile/test/blocs/dm/message_requests/request_preview_cubit_test.dart
+++ b/mobile/test/blocs/dm/message_requests/request_preview_cubit_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Unit tests for RequestPreviewCubit.
 // ABOUTME: Verifies message count loading and participant pubkey resolution.
 
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:dm_repository/dm_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -55,6 +57,24 @@ void main() {
         initialParticipantPubkeys: initialParticipantPubkeys,
       );
     }
+
+    test('does not emit or throw when closed mid-load', () async {
+      final completer = Completer<int>();
+      when(
+        () => mockDmRepository.countMessagesInConversation(any()),
+      ).thenAnswer((_) => completer.future);
+      when(
+        () => mockDmRepository.getMessages(any(), limit: any(named: 'limit')),
+      ).thenAnswer((_) async => const []);
+
+      final cubit = buildCubit(initialParticipantPubkeys: [otherPubkey]);
+      final future = cubit.load();
+      await cubit.close();
+      completer.complete(5);
+      await expectLater(future, completes);
+
+      expect(cubit.state.status, RequestPreviewStatus.loading);
+    });
 
     test('initial state is loading with empty data', () {
       final cubit = buildCubit();

--- a/mobile/test/screens/inbox/conversation/widgets/video_link_preview_cubit_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/video_link_preview_cubit_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Unit tests for VideoLinkPreviewCubit.
 // ABOUTME: Tests cache hit, relay fetch, d-tag fallback, and not-found paths.
 
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -185,6 +187,30 @@ void main() {
         build: createCubit,
         expect: () => [isA<VideoLinkPreviewNotFound>()],
       );
+    });
+
+    group('close during in-flight resolve', () {
+      test('does not emit or throw when closed mid relay fetch', () async {
+        final completer = Completer<Event?>();
+        when(
+          () => mockNostrClient.fetchEventById(any()),
+        ).thenAnswer((_) => completer.future);
+
+        final cubit = createCubit();
+        // Let _resolve run past the cache miss to the awaited fetch.
+        await pumpEventQueue();
+        expect(cubit.state, isA<VideoLinkPreviewLoading>());
+
+        // Close while the relay fetch is still in flight.
+        await cubit.close();
+
+        // Completing drives the post-await not-found path; without the
+        // isClosed guard this emits on the closed cubit and throws StateError.
+        completer.complete(null);
+        await pumpEventQueue();
+
+        expect(cubit.state, isA<VideoLinkPreviewLoading>());
+      });
     });
   });
 }


### PR DESCRIPTION
## Description

`Cubit.emit` throws `StateError('Cannot emit new states after calling close')` when a `BlocProvider`-owned cubit is closed (widget unmount) while an `await` in one of its methods is still in flight — the trailing unguarded `emit()` fires after close.

**#5806** is the high-frequency case: `VideoLinkPreviewCubit._resolve()` awaits up to two relay calls in the scrolling DM message list, so a message bubble scrolling off-screen closes the cubit mid-await and the emit throws. The stack trace matches `bloc_base.dart:100` and `video_link_preview_cubit.dart:111` exactly; it is more likely on slow relays where the await stays in flight longer. Guarding the relay-resolved emit also removes a misleading "relay fetch failed" log in the found-but-closed race (that emit throws inside the `try` and is swallowed by the `catch`).

While here, I swept the six other DM cubits that share the exact class (all `extends Cubit`, zero `isClosed` guards, emit after an `await`). These are reachable on **screen-pop** rather than scroll (lower frequency), but `InlineReelReplyCubit` is worse per-hit — it wraps the `StateError` in `Reportable`, so each occurrence reports to Crashlytics.

The fix is the repo's house idiom `if (!isClosed) emit(...)` on every **post-await** emit (23 sites across 7 files). Synchronous pre-await optimistic / `processing` emits are intentionally left unguarded — they cannot emit-after-close. `addError` after close is safe in bloc (no `isClosed` check), so guarding the trailing `emit` is the complete fix.

Two commits: the #5806 crash (`VideoLinkPreviewCubit`), then the sibling sweep.

**Related Issue:** Closes #5806

## Out of Scope

- Pre-existing architecture debt in `VideoLinkPreviewCubit` (calls `NostrClient` directly instead of via a repository; `ref.read` capture in `BlocProvider.create`) — unrelated to the crash.
- A CI ratchet / shared `SafeEmitCubit` base to prevent this recurring class — deferred; the guard idiom stays review-enforced.
- PR #5794 (`ClipsLibraryBloc` Undo) is the same bug class but an independent instance (different screen/bloc), so it stays a separate PR.

## Verification

- `flutter analyze` (changed dirs) — no issues.
- All 7 affected cubit test suites — 76 tests pass; pre-commit and pre-push hooks green.
- Each new close-mid-await regression test verified **load-bearing**: stashing the guards makes exactly the 7 new tests fail with `StateError`, and only those.
- `dart format` — no changes.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
