### PR TITLE
refactor(auth): extract NostrConnectCoordinator — nostrconnect:// flow (#4741)

### DIFF
--- a/mobile/lib/models/auth_result.dart
+++ b/mobile/lib/models/auth_result.dart
@@ -1,0 +1,38 @@
+// ABOUTME: Result of an authentication operation — success plus an optional key
+// ABOUTME: container, error message, or nostrconnect:// failure reason. Lifted
+// ABOUTME: out of auth_service.dart (#4741) so auth/ collaborators can return it
+// ABOUTME: without importing the facade (which would be a cycle); re-exported by
+// ABOUTME: auth_service.dart so existing consumers keep their import.
+
+import 'package:nostr_key_manager/nostr_key_manager.dart'
+    show SecureKeyContainer;
+import 'package:nostr_sdk/nostr_sdk.dart' show NostrConnectFailureReason;
+
+/// Result of authentication operations
+class AuthResult {
+  const AuthResult({
+    required this.success,
+    this.errorMessage,
+    this.keyContainer,
+    this.nostrConnectFailureReason,
+  });
+
+  factory AuthResult.success(SecureKeyContainer keyContainer) =>
+      AuthResult(success: true, keyContainer: keyContainer);
+
+  factory AuthResult.failure(String errorMessage) =>
+      AuthResult(success: false, errorMessage: errorMessage);
+
+  /// Failure result for the nostrconnect:// flow, carrying a localizable
+  /// reason code instead of a raw English string. The UI maps the reason to a
+  /// `context.l10n.*` string.
+  factory AuthResult.nostrConnectFailure(NostrConnectFailureReason reason) =>
+      AuthResult(success: false, nostrConnectFailureReason: reason);
+
+  final bool success;
+  final String? errorMessage;
+  final SecureKeyContainer? keyContainer;
+
+  /// Set only by the nostrconnect:// failure path; `null` for every other flow.
+  final NostrConnectFailureReason? nostrConnectFailureReason;
+}

--- a/mobile/lib/services/auth/nostr_connect_coordinator.dart
+++ b/mobile/lib/services/auth/nostr_connect_coordinator.dart
@@ -1,0 +1,361 @@
+// ABOUTME: Stateful coordinator for the client-initiated nostrconnect:// flow —
+// ABOUTME: owns the NIP-46 connect session, the single-flight wait future, and
+// ABOUTME: the deep-link callback-handoff timers. Extracted from AuthService
+// ABOUTME: (#4741, repository tier). The facade keeps all auth-session state and
+// ABOUTME: applies a successful connection through the injected ports.
+
+import 'dart:async';
+
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:openvine/models/auth_result.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// Builds a [NostrConnectSession] for a set of [relays]. Injectable so tests
+/// can supply a fake session that completes `waitForConnection` without opening
+/// real relay sockets (closes the deferred nostrconnect happy-path gap #5713).
+typedef NostrConnectSessionFactory =
+    NostrConnectSession Function(List<String> relays);
+
+/// Applies a successful nostrconnect connection on the facade: builds the
+/// bunker signer from [result], persists its info, and sets up the user
+/// session. Returns the [AuthResult] to surface to the caller.
+typedef NostrConnectApply =
+    Future<AuthResult> Function(NostrConnectResult result);
+
+/// Reports an error to Crashlytics — mirrors `AuthService._reportAuthError`.
+typedef NostrConnectErrorReporter =
+    void Function(
+      Object error,
+      StackTrace stack, {
+      required String reason,
+      required String logMessage,
+    });
+
+/// Coordinates the client-initiated `nostrconnect://` connection flow.
+///
+/// Extracted from `AuthService` (#4741, repository tier). Like
+/// [OAuthSessionCoordinator] this collaborator is STATEFUL: it owns the connect
+/// [NostrConnectSession], the single-flight wait future, and the two
+/// deep-link callback-handoff [Timer]s. The facade keeps the *auth* session
+/// state (`_bunkerSigner`, `_currentIdentity`, auth-state, `_lastError`) and
+/// applies a successful connection through [_onConnected]/[_onConnectFailed],
+/// so behavior is preserved exactly.
+class NostrConnectCoordinator {
+  NostrConnectCoordinator({
+    required NostrConnectApply onConnected,
+    required void Function(Object error) onConnectFailed,
+    required void Function() onWaitStarted,
+    required void Function() onWaitFailed,
+    required NostrConnectErrorReporter reportError,
+    NostrConnectSessionFactory? sessionFactory,
+  }) : _onConnected = onConnected,
+       _onConnectFailed = onConnectFailed,
+       _onWaitStarted = onWaitStarted,
+       _onWaitFailed = onWaitFailed,
+       _reportError = reportError,
+       _sessionFactory = sessionFactory ?? _defaultSessionFactory;
+
+  final NostrConnectApply _onConnected;
+  final void Function(Object error) _onConnectFailed;
+  final void Function() _onWaitStarted;
+  final void Function() _onWaitFailed;
+  final NostrConnectErrorReporter _reportError;
+  final NostrConnectSessionFactory _sessionFactory;
+
+  NostrConnectSession? _session;
+  Future<AuthResult>? _waitFuture;
+  Timer? _callbackHandoffTimer;
+  Timer? _callbackHandoffCancelTimer;
+  bool _isCallbackHandoffActive = false;
+
+  static NostrConnectSession _defaultSessionFactory(List<String> relays) =>
+      NostrConnectSession(
+        relays: relays,
+        appName: 'Divine',
+        appUrl: 'https://divine.video',
+        appIcon: 'https://divine.video/icon.png',
+        callback: 'divine://nostrconnect',
+      );
+
+  /// The active nostrconnect:// URL, or null if no session is active.
+  String? get connectUrl => _session?.connectUrl;
+
+  /// The current nostrconnect session state, or null if no session is active.
+  NostrConnectState? get state => _session?.state;
+
+  /// Stream of nostrconnect session state changes, or null if no session.
+  Stream<NostrConnectState>? get stateStream => _session?.stateStream;
+
+  /// True while Android/iOS custom-scheme routing is handing control back
+  /// from a NIP-46 signer app to Divine.
+  bool get isCallbackHandoffActive => _isCallbackHandoffActive;
+
+  /// Starts a new nostrconnect:// session (generates the keypair + URL and
+  /// connects to [customRelays] or the default NIP-46 relays). Cancels any
+  /// existing session first.
+  Future<NostrConnectSession> initiate({List<String>? customRelays}) async {
+    Log.info(
+      'Initiating nostrconnect:// session...',
+      name: 'NostrConnectCoordinator',
+      category: LogCategory.auth,
+    );
+
+    // Cancel any existing session
+    cancel();
+
+    // Default relays for nostrconnect:// connections.
+    // Use NIP-46 compatible relays (relay.divine.video rejects Kind 24133).
+    // These are public Nostr infrastructure relays — same URLs regardless of
+    // app environment (dev/staging/prod).
+    final relays =
+        customRelays ??
+        [
+          'wss://relay.nsec.app',
+          'wss://relay.damus.io',
+          'wss://nos.lol',
+          'wss://relay.primal.net',
+        ];
+
+    // Create the session
+    _session = _sessionFactory(relays);
+
+    // Start the session (generates keypair and URL, connects to relays)
+    await _session!.start();
+
+    Log.info(
+      'NostrConnect session started, URL: ${_session!.connectUrl}',
+      name: 'NostrConnectCoordinator',
+      category: LogCategory.auth,
+    );
+
+    return _session!;
+  }
+
+  /// Wait for the bunker to respond to a nostrconnect:// URL.
+  ///
+  /// Must be called after [initiate].
+  ///
+  /// Returns [AuthResult.success] if the bunker connects and we can
+  /// authenticate, or [AuthResult.failure] on timeout/error. Concurrent callers
+  /// share the single in-flight wait.
+  Future<AuthResult> waitForResponse({
+    Duration timeout = const Duration(minutes: 2),
+  }) {
+    if (_session == null) {
+      return Future.value(
+        AuthResult.failure(
+          'No active nostrconnect session. Call initiateNostrConnect first.',
+        ),
+      );
+    }
+
+    final activeWait = _waitFuture;
+    if (activeWait != null) return activeWait;
+
+    final waitFuture = _waitForResponse(timeout: timeout);
+    _waitFuture = waitFuture;
+    waitFuture.whenComplete(() {
+      if (identical(_waitFuture, waitFuture)) {
+        _waitFuture = null;
+      }
+    });
+    return waitFuture;
+  }
+
+  Future<AuthResult> _waitForResponse({required Duration timeout}) async {
+    Log.info(
+      'Waiting for nostrconnect response (timeout: ${timeout.inSeconds}s)...',
+      name: 'NostrConnectCoordinator',
+      category: LogCategory.auth,
+    );
+
+    _onWaitStarted();
+
+    try {
+      // Keep a local reference in case session is cancelled during await
+      final session = _session!;
+
+      // Wait for the bunker to connect
+      final result = await session.waitForConnection(timeout: timeout);
+
+      // Check if session was cancelled while we were waiting
+      if (_session == null) {
+        _onWaitFailed();
+        return AuthResult.nostrConnectFailure(
+          NostrConnectFailureReason.cancelled,
+        );
+      }
+
+      if (result == null) {
+        // Timeout, cancellation, or a terminal session error.
+        final state = session.state;
+        _onWaitFailed();
+        final reason = switch (state) {
+          NostrConnectState.cancelled => NostrConnectFailureReason.cancelled,
+          NostrConnectState.timeout => NostrConnectFailureReason.timedOut,
+          NostrConnectState.error =>
+            session.failureReason ??
+                NostrConnectFailureReason.postConnectFailed,
+          _ => NostrConnectFailureReason.postConnectFailed,
+        };
+        // `noExpectedSecret` is a programmer-invariant violation that "should
+        // never happen": the response handler was reached with no secret to
+        // validate against. Surface it to Crashlytics so a real break is
+        // visible instead of reading as a routine "link expired" to the user.
+        if (reason == NostrConnectFailureReason.noExpectedSecret) {
+          _reportError(
+            StateError(
+              'nostrconnect response handling reached with no expected secret',
+            ),
+            StackTrace.current,
+            reason: 'NostrConnect.noExpectedSecret',
+            logMessage:
+                'nostrconnect invariant violated: no expected secret to validate',
+          );
+        }
+        return AuthResult.nostrConnectFailure(reason);
+      }
+
+      // Success! Apply the connection on the facade (build signer + session).
+      Log.info(
+        'NostrConnect succeeded! Bunker pubkey: ${result.remoteSignerPubkey}',
+        name: 'NostrConnectCoordinator',
+        category: LogCategory.auth,
+      );
+
+      final authResult = await _onConnected(result);
+
+      // Clean up session (signer is now managing connections)
+      _session?.dispose();
+      _session = null;
+
+      return authResult;
+    } catch (e) {
+      Log.error(
+        'NostrConnect failed: $e',
+        name: 'NostrConnectCoordinator',
+        category: LogCategory.auth,
+      );
+      _onConnectFailed(e);
+
+      return AuthResult.nostrConnectFailure(
+        NostrConnectFailureReason.postConnectFailed,
+      );
+    }
+  }
+
+  /// Cancel an active nostrconnect:// session.
+  ///
+  /// Safe to call even if no session is active.
+  void cancel() {
+    _waitFuture = null;
+    _isCallbackHandoffActive = false;
+    _callbackHandoffTimer?.cancel();
+    _callbackHandoffTimer = null;
+    _callbackHandoffCancelTimer?.cancel();
+    _callbackHandoffCancelTimer = null;
+
+    if (_session != null) {
+      Log.info(
+        'Cancelling nostrconnect session',
+        name: 'NostrConnectCoordinator',
+        category: LogCategory.auth,
+      );
+      _session!.cancel();
+      _session!.dispose();
+      _session = null;
+    }
+  }
+
+  /// Preserve the active session for the replacement NostrConnect screen.
+  ///
+  /// If no replacement screen claims the handoff quickly, cancel the session so
+  /// backing out during the callback route handoff cannot orphan relay sockets.
+  void preserveForCallbackHandoff() {
+    if (!_isCallbackHandoffActive ||
+        _session?.state != NostrConnectState.listening) {
+      return;
+    }
+
+    _callbackHandoffCancelTimer?.cancel();
+    _callbackHandoffCancelTimer = Timer(const Duration(seconds: 5), () {
+      _callbackHandoffCancelTimer = null;
+      if (_isCallbackHandoffActive &&
+          _session?.state == NostrConnectState.listening) {
+        Log.info(
+          'NostrConnect callback handoff was not resumed - cancelling',
+          name: 'NostrConnectCoordinator',
+          category: LogCategory.auth,
+        );
+        cancel();
+      }
+    });
+  }
+
+  /// Marks the callback handoff as claimed by a mounted NostrConnect screen.
+  ///
+  /// The short handoff flag is left to expire on its own so an old route that
+  /// disposes after the replacement screen mounts still preserves the session.
+  void claimCallbackHandoff() {
+    _callbackHandoffCancelTimer?.cancel();
+    _callbackHandoffCancelTimer = null;
+  }
+
+  /// Called when a divine:// signer callback deep link is received.
+  ///
+  /// Ensures the nostrconnect session relay connections are alive so we
+  /// don't miss the bunker's response event after being brought back
+  /// from background.
+  void onSignerCallbackReceived({String? relayUrl}) {
+    if (_session?.state != NostrConnectState.listening) {
+      return;
+    }
+
+    _isCallbackHandoffActive = true;
+    _callbackHandoffTimer?.cancel();
+    _callbackHandoffTimer = Timer(const Duration(seconds: 5), () {
+      _isCallbackHandoffActive = false;
+    });
+
+    if (relayUrl != null) {
+      Log.info(
+        'Signer callback supplied relay $relayUrl - connecting',
+        name: 'NostrConnectCoordinator',
+        category: LogCategory.auth,
+      );
+      unawaited(_session!.addRelay(relayUrl));
+    }
+    Log.info(
+      'Signer callback received - ensuring nostrconnect relays are connected',
+      name: 'NostrConnectCoordinator',
+      category: LogCategory.auth,
+    );
+    unawaited(_session!.ensureConnected());
+  }
+
+  /// Reconnect nostrconnect:// session relays that may have dropped while the
+  /// app was backgrounded (e.g. the user switched to a signer app to approve
+  /// the connection). No-op unless a session is actively listening.
+  void reconnectListeningRelays() {
+    if (_session != null && _session!.state == NostrConnectState.listening) {
+      Log.info(
+        '📱 App resumed - reconnecting nostrconnect session relays',
+        name: 'NostrConnectCoordinator',
+        category: LogCategory.auth,
+      );
+      _session!.ensureConnected();
+    }
+  }
+
+  /// Cancels the callback-handoff timers on service teardown.
+  ///
+  /// Mirrors the facade's prior `dispose()` behavior exactly: it cancels the
+  /// two handoff timers and deliberately leaves any live session untouched
+  /// (the pre-existing behavior — see #4741 PR-R4).
+  void dispose() {
+    _callbackHandoffTimer?.cancel();
+    _callbackHandoffTimer = null;
+    _callbackHandoffCancelTimer?.cancel();
+    _callbackHandoffCancelTimer = null;
+  }
+}

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -14,10 +14,12 @@ import 'package:nostr_key_manager/nostr_key_manager.dart'
     show SecureKeyContainer, SecureKeyStorage, SecureKeyStorageException;
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:openvine/constants/app_constants.dart';
+import 'package:openvine/models/auth_result.dart';
 import 'package:openvine/models/auth_rpc_capability.dart';
 import 'package:openvine/models/authentication_source.dart';
 import 'package:openvine/models/known_account.dart';
 import 'package:openvine/services/auth/known_accounts_registry.dart';
+import 'package:openvine/services/auth/nostr_connect_coordinator.dart';
 import 'package:openvine/services/auth/nostr_identity.dart';
 import 'package:openvine/services/auth/oauth_session_coordinator.dart';
 import 'package:openvine/services/auth/relay_discovery_orchestrator.dart';
@@ -33,6 +35,9 @@ import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:unified_logger/unified_logger.dart';
 
+// AuthResult moved to its own file (#4741) so auth/ collaborators can return it
+// without a facade import cycle; external consumers keep importing it here.
+export 'package:openvine/models/auth_result.dart';
 export 'package:openvine/models/authentication_source.dart';
 // Discovery callback contracts moved with the orchestrator (#4741); external
 // consumers (NostrService wiring) keep importing them from this facade.
@@ -100,35 +105,6 @@ class AccountRestoreFailedException implements Exception {
       '$resolvedState'
       '${resolvedPubkeyHex == null ? '' : ' as $resolvedPubkeyHex'} '
       'instead of the requested account';
-}
-
-/// Result of authentication operations
-class AuthResult {
-  const AuthResult({
-    required this.success,
-    this.errorMessage,
-    this.keyContainer,
-    this.nostrConnectFailureReason,
-  });
-
-  factory AuthResult.success(SecureKeyContainer keyContainer) =>
-      AuthResult(success: true, keyContainer: keyContainer);
-
-  factory AuthResult.failure(String errorMessage) =>
-      AuthResult(success: false, errorMessage: errorMessage);
-
-  /// Failure result for the nostrconnect:// flow, carrying a localizable
-  /// reason code instead of a raw English string. The UI maps the reason to a
-  /// `context.l10n.*` string.
-  factory AuthResult.nostrConnectFailure(NostrConnectFailureReason reason) =>
-      AuthResult(success: false, nostrConnectFailureReason: reason);
-
-  final bool success;
-  final String? errorMessage;
-  final SecureKeyContainer? keyContainer;
-
-  /// Set only by the nostrconnect:// failure path; `null` for every other flow.
-  final NostrConnectFailureReason? nostrConnectFailureReason;
 }
 
 /// User profile information
@@ -280,6 +256,21 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
         hasExpiredSession: () => _hasExpiredOAuthSession,
         onRefreshSucceeded: () => _hasExpiredOAuthSession = false,
       );
+  // Owns the client-initiated nostrconnect:// session + wait future + callback
+  // handoff timers; the facade keeps _bunkerSigner and applies a successful
+  // connection through the ports so behavior stays byte-identical.
+  late final NostrConnectCoordinator _nostrConnect = NostrConnectCoordinator(
+    onConnected: _applyNostrConnectSuccess,
+    onConnectFailed: (e) {
+      _bunkerSigner?.close();
+      _bunkerSigner = null;
+      _lastError = 'NostrConnect failed: $e';
+      _setAuthState(AuthState.unauthenticated);
+    },
+    onWaitStarted: () => _setAuthState(AuthState.authenticating),
+    onWaitFailed: () => _setAuthState(AuthState.unauthenticated),
+    reportError: _reportAuthError,
+  );
   final PreFetchFollowingCallback? _preFetchFollowing;
   final AuthUrlLauncher? _launchAuthUrl;
   final BackgroundActivityManager _backgroundActivityManager;
@@ -329,12 +320,8 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   // NIP-07 browser extension signer state (nullable; null when no session active)
   Nip07Service? _nip07Service;
 
-  // NIP-46 nostrconnect:// session state (for client-initiated connections)
-  NostrConnectSession? _nostrConnectSession;
-  Future<AuthResult>? _nostrConnectWaitFuture;
-  Timer? _nostrConnectCallbackHandoffTimer;
-  Timer? _nostrConnectCallbackHandoffCancelTimer;
-  bool _isNostrConnectCallbackHandoffActive = false;
+  // NIP-46 nostrconnect:// session state is owned by [_nostrConnect]
+  // (NostrConnectCoordinator); the facade delegates to it (#4741).
 
   // Atomic signing identity — couples pubkey with signing mechanism
   NostrIdentity? _currentIdentity;
@@ -2471,49 +2458,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   /// The session will listen on relays for the bunker's response.
   Future<NostrConnectSession> initiateNostrConnect({
     List<String>? customRelays,
-  }) async {
-    Log.info(
-      'Initiating nostrconnect:// session...',
-      name: 'AuthService',
-      category: LogCategory.auth,
-    );
-
-    // Cancel any existing session
-    cancelNostrConnect();
-
-    // Default relays for nostrconnect:// connections.
-    // Use NIP-46 compatible relays (relay.divine.video rejects Kind 24133).
-    // These are public Nostr infrastructure relays — same URLs regardless of
-    // app environment (dev/staging/prod).
-    final relays =
-        customRelays ??
-        [
-          'wss://relay.nsec.app',
-          'wss://relay.damus.io',
-          'wss://nos.lol',
-          'wss://relay.primal.net',
-        ];
-
-    // Create the session
-    _nostrConnectSession = NostrConnectSession(
-      relays: relays,
-      appName: 'Divine',
-      appUrl: 'https://divine.video',
-      appIcon: 'https://divine.video/icon.png',
-      callback: 'divine://nostrconnect',
-    );
-
-    // Start the session (generates keypair and URL, connects to relays)
-    await _nostrConnectSession!.start();
-
-    Log.info(
-      'NostrConnect session started, URL: ${_nostrConnectSession!.connectUrl}',
-      name: 'AuthService',
-      category: LogCategory.auth,
-    );
-
-    return _nostrConnectSession!;
-  }
+  }) => _nostrConnect.initiate(customRelays: customRelays);
 
   /// Wait for the bunker to respond to a nostrconnect:// URL.
   ///
@@ -2523,260 +2468,100 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   /// authenticate, or [AuthResult.failure] on timeout/error.
   Future<AuthResult> waitForNostrConnectResponse({
     Duration timeout = const Duration(minutes: 2),
-  }) {
-    if (_nostrConnectSession == null) {
-      return Future.value(
-        AuthResult.failure(
-          'No active nostrconnect session. Call initiateNostrConnect first.',
-        ),
-      );
+  }) => _nostrConnect.waitForResponse(timeout: timeout);
+
+  /// Applies a successful nostrconnect connection: builds and connects the
+  /// bunker signer, persists its info, and sets up the user session. Wired into
+  /// [NostrConnectCoordinator] as its `onConnected` port — it stays on the
+  /// facade because it mutates [_bunkerSigner] and drives the user session.
+  Future<AuthResult> _applyNostrConnectSuccess(
+    NostrConnectResult result,
+  ) async {
+    // Create and connect the NostrRemoteSigner
+    // Note: Don't send connect request since we're already connected via
+    // nostrconnect://
+    _bunkerSigner = _remoteSignerFactory(RelayMode.baseMode, result.info);
+    _setupBunkerAuthCallback();
+    await _bunkerSigner!.connect(sendConnectRequest: false);
+
+    // Get user's public key from the bunker
+    final userPubkey = await _bunkerSigner!.pullPubkey();
+    if (userPubkey == null || userPubkey.isEmpty) {
+      throw Exception('Failed to get public key from bunker');
     }
 
-    final activeWait = _nostrConnectWaitFuture;
-    if (activeWait != null) return activeWait;
+    // Update info with user pubkey for persistence
+    final updatedInfo = NostrRemoteSignerInfo(
+      remoteSignerPubkey: result.remoteSignerPubkey,
+      relays: result.info.relays,
+      optionalSecret: result.info.optionalSecret,
+      nsec: result.info.nsec,
+      userPubkey: userPubkey,
+      isClientInitiated: true,
+      clientPubkey: result.info.clientPubkey,
+    );
 
-    final waitFuture = _waitForNostrConnectResponse(timeout: timeout);
-    _nostrConnectWaitFuture = waitFuture;
-    waitFuture.whenComplete(() {
-      if (identical(_nostrConnectWaitFuture, waitFuture)) {
-        _nostrConnectWaitFuture = null;
-      }
-    });
-    return waitFuture;
-  }
+    // Save bunker info for reconnection
+    await _saveBunkerInfo(updatedInfo);
 
-  Future<AuthResult> _waitForNostrConnectResponse({
-    required Duration timeout,
-  }) async {
+    // Set up user session
+    await _setupUserSession(
+      SecureKeyContainer.fromPublicKey(userPubkey),
+      AuthenticationSource.bunker,
+    );
+
     Log.info(
-      'Waiting for nostrconnect response (timeout: ${timeout.inSeconds}s)...',
+      'NostrConnect authentication complete for user: $userPubkey',
       name: 'AuthService',
       category: LogCategory.auth,
     );
 
-    _setAuthState(AuthState.authenticating);
-
-    try {
-      // Keep a local reference in case session is cancelled during await
-      final session = _nostrConnectSession!;
-
-      // Wait for the bunker to connect
-      final result = await session.waitForConnection(timeout: timeout);
-
-      // Check if session was cancelled while we were waiting
-      if (_nostrConnectSession == null) {
-        _setAuthState(AuthState.unauthenticated);
-        return AuthResult.nostrConnectFailure(
-          NostrConnectFailureReason.cancelled,
-        );
-      }
-
-      if (result == null) {
-        // Timeout, cancellation, or a terminal session error.
-        final state = session.state;
-        _setAuthState(AuthState.unauthenticated);
-        final reason = switch (state) {
-          NostrConnectState.cancelled => NostrConnectFailureReason.cancelled,
-          NostrConnectState.timeout => NostrConnectFailureReason.timedOut,
-          NostrConnectState.error =>
-            session.failureReason ??
-                NostrConnectFailureReason.postConnectFailed,
-          _ => NostrConnectFailureReason.postConnectFailed,
-        };
-        // `noExpectedSecret` is a programmer-invariant violation that "should
-        // never happen": the response handler was reached with no secret to
-        // validate against. Surface it to Crashlytics so a real break is
-        // visible instead of reading as a routine "link expired" to the user.
-        if (reason == NostrConnectFailureReason.noExpectedSecret) {
-          _reportAuthError(
-            StateError(
-              'nostrconnect response handling reached with no expected secret',
-            ),
-            StackTrace.current,
-            reason: 'NostrConnect.noExpectedSecret',
-            logMessage:
-                'nostrconnect invariant violated: no expected secret to validate',
-          );
-        }
-        return AuthResult.nostrConnectFailure(reason);
-      }
-
-      // Success! Create the bunker signer from the result
-      Log.info(
-        'NostrConnect succeeded! Bunker pubkey: ${result.remoteSignerPubkey}',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-
-      // Create and connect the NostrRemoteSigner
-      // Note: Don't send connect request since we're already connected via
-      // nostrconnect://
-      _bunkerSigner = _remoteSignerFactory(RelayMode.baseMode, result.info);
-      _setupBunkerAuthCallback();
-      await _bunkerSigner!.connect(sendConnectRequest: false);
-
-      // Get user's public key from the bunker
-      final userPubkey = await _bunkerSigner!.pullPubkey();
-      if (userPubkey == null || userPubkey.isEmpty) {
-        throw Exception('Failed to get public key from bunker');
-      }
-
-      // Update info with user pubkey for persistence
-      final updatedInfo = NostrRemoteSignerInfo(
-        remoteSignerPubkey: result.remoteSignerPubkey,
-        relays: result.info.relays,
-        optionalSecret: result.info.optionalSecret,
-        nsec: result.info.nsec,
-        userPubkey: userPubkey,
-        isClientInitiated: true,
-        clientPubkey: result.info.clientPubkey,
-      );
-
-      // Save bunker info for reconnection
-      await _saveBunkerInfo(updatedInfo);
-
-      // Set up user session
-      await _setupUserSession(
-        SecureKeyContainer.fromPublicKey(userPubkey),
-        AuthenticationSource.bunker,
-      );
-
-      Log.info(
-        'NostrConnect authentication complete for user: $userPubkey',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-
-      // Clean up session (signer is now managing connections)
-      _nostrConnectSession?.dispose();
-      _nostrConnectSession = null;
-
-      return const AuthResult(success: true);
-    } catch (e) {
-      Log.error(
-        'NostrConnect failed: $e',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-      _bunkerSigner?.close();
-      _bunkerSigner = null;
-      _lastError = 'NostrConnect failed: $e';
-      _setAuthState(AuthState.unauthenticated);
-
-      return AuthResult.nostrConnectFailure(
-        NostrConnectFailureReason.postConnectFailed,
-      );
-    }
+    return const AuthResult(success: true);
   }
 
   /// Cancel an active nostrconnect:// session.
   ///
   /// Safe to call even if no session is active.
-  void cancelNostrConnect() {
-    _nostrConnectWaitFuture = null;
-    _isNostrConnectCallbackHandoffActive = false;
-    _nostrConnectCallbackHandoffTimer?.cancel();
-    _nostrConnectCallbackHandoffTimer = null;
-    _nostrConnectCallbackHandoffCancelTimer?.cancel();
-    _nostrConnectCallbackHandoffCancelTimer = null;
-
-    if (_nostrConnectSession != null) {
-      Log.info(
-        'Cancelling nostrconnect session',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-      _nostrConnectSession!.cancel();
-      _nostrConnectSession!.dispose();
-      _nostrConnectSession = null;
-    }
-  }
+  void cancelNostrConnect() => _nostrConnect.cancel();
 
   /// Get the current nostrconnect:// URL if a session is active.
   ///
   /// Returns null if no session is active.
-  String? get nostrConnectUrl => _nostrConnectSession?.connectUrl;
+  String? get nostrConnectUrl => _nostrConnect.connectUrl;
 
   /// Get the current nostrconnect session state.
-  NostrConnectState? get nostrConnectState => _nostrConnectSession?.state;
+  NostrConnectState? get nostrConnectState => _nostrConnect.state;
 
   /// Stream of nostrconnect session state changes.
   Stream<NostrConnectState>? get nostrConnectStateStream =>
-      _nostrConnectSession?.stateStream;
+      _nostrConnect.stateStream;
 
   /// True while Android/iOS custom-scheme routing is handing control back
   /// from a NIP-46 signer app to Divine.
   bool get isNostrConnectCallbackHandoffActive =>
-      _isNostrConnectCallbackHandoffActive;
+      _nostrConnect.isCallbackHandoffActive;
 
   /// Preserve the active session for the replacement NostrConnect screen.
   ///
   /// If no replacement screen claims the handoff quickly, cancel the session so
   /// backing out during the callback route handoff cannot orphan relay sockets.
-  void preserveNostrConnectForCallbackHandoff() {
-    if (!_isNostrConnectCallbackHandoffActive ||
-        _nostrConnectSession?.state != NostrConnectState.listening) {
-      return;
-    }
-
-    _nostrConnectCallbackHandoffCancelTimer?.cancel();
-    _nostrConnectCallbackHandoffCancelTimer = Timer(
-      const Duration(seconds: 5),
-      () {
-        _nostrConnectCallbackHandoffCancelTimer = null;
-        if (_isNostrConnectCallbackHandoffActive &&
-            _nostrConnectSession?.state == NostrConnectState.listening) {
-          Log.info(
-            'NostrConnect callback handoff was not resumed - cancelling',
-            name: 'AuthService',
-            category: LogCategory.auth,
-          );
-          cancelNostrConnect();
-        }
-      },
-    );
-  }
+  void preserveNostrConnectForCallbackHandoff() =>
+      _nostrConnect.preserveForCallbackHandoff();
 
   /// Marks the callback handoff as claimed by a mounted NostrConnect screen.
   ///
   /// The short handoff flag is left to expire on its own so an old route that
   /// disposes after the replacement screen mounts still preserves the session.
-  void claimNostrConnectCallbackHandoff() {
-    _nostrConnectCallbackHandoffCancelTimer?.cancel();
-    _nostrConnectCallbackHandoffCancelTimer = null;
-  }
+  void claimNostrConnectCallbackHandoff() =>
+      _nostrConnect.claimCallbackHandoff();
 
   /// Called when a divine:// signer callback deep link is received.
   ///
   /// Ensures the nostrconnect session relay connections are alive so we
   /// don't miss the bunker's response event after being brought back
   /// from background.
-  void onSignerCallbackReceived({String? relayUrl}) {
-    if (_nostrConnectSession?.state != NostrConnectState.listening) {
-      return;
-    }
-
-    _isNostrConnectCallbackHandoffActive = true;
-    _nostrConnectCallbackHandoffTimer?.cancel();
-    _nostrConnectCallbackHandoffTimer = Timer(const Duration(seconds: 5), () {
-      _isNostrConnectCallbackHandoffActive = false;
-    });
-
-    if (relayUrl != null) {
-      Log.info(
-        'Signer callback supplied relay $relayUrl - connecting',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-      unawaited(_nostrConnectSession!.addRelay(relayUrl));
-    }
-    Log.info(
-      'Signer callback received - ensuring nostrconnect relays are connected',
-      name: 'AuthService',
-      category: LogCategory.auth,
-    );
-    unawaited(_nostrConnectSession!.ensureConnected());
-  }
+  void onSignerCallbackReceived({String? relayUrl}) =>
+      _nostrConnect.onSignerCallbackReceived(relayUrl: relayUrl);
 
   /// Sign in using OAuth 2.0 flow
   Future<void> signInWithDivineOAuth(KeycastSession session) async {
@@ -4333,15 +4118,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     // Reconnect nostrconnect:// session relays that may have dropped
     // while the app was in the background (e.g. user switched to Primal
     // to approve the connection on Android).
-    if (_nostrConnectSession != null &&
-        _nostrConnectSession!.state == NostrConnectState.listening) {
-      Log.info(
-        '📱 App resumed - reconnecting nostrconnect session relays',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-      _nostrConnectSession!.ensureConnected();
-    }
+    _nostrConnect.reconnectListeningRelays();
 
     unawaited(_refreshOAuthTokenOnResume());
   }
@@ -4428,10 +4205,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     _amberSigner?.close();
     _amberSigner = null;
 
-    _nostrConnectCallbackHandoffTimer?.cancel();
-    _nostrConnectCallbackHandoffTimer = null;
-    _nostrConnectCallbackHandoffCancelTimer?.cancel();
-    _nostrConnectCallbackHandoffCancelTimer = null;
+    _nostrConnect.dispose();
 
     // Securely dispose of key container
     _currentKeyContainer?.dispose();

--- a/mobile/test/services/auth/nostr_connect_coordinator_test.dart
+++ b/mobile/test/services/auth/nostr_connect_coordinator_test.dart
@@ -1,0 +1,349 @@
+// ABOUTME: Tests for NostrConnectCoordinator — session lifecycle, the
+// ABOUTME: single-flight wait, failure-reason mapping, the connection ports,
+// ABOUTME: and the deep-link callback-handoff timers.
+
+import 'dart:async';
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:openvine/models/auth_result.dart';
+import 'package:openvine/services/auth/nostr_connect_coordinator.dart';
+
+class _MockNostrConnectSession extends Mock implements NostrConnectSession {}
+
+void main() {
+  group(NostrConnectCoordinator, () {
+    late _MockNostrConnectSession session;
+    late List<String> createdRelays;
+    late int waitStartedCalls;
+    late int waitFailedCalls;
+    late List<NostrConnectResult> connectedResults;
+    late List<Object> connectFailedErrors;
+    late List<String> reportedReasons;
+    late Future<AuthResult> Function(NostrConnectResult) onConnectedImpl;
+
+    setUpAll(() {
+      registerFallbackValue(Duration.zero);
+    });
+
+    setUp(() {
+      session = _MockNostrConnectSession();
+      createdRelays = [];
+      waitStartedCalls = 0;
+      waitFailedCalls = 0;
+      connectedResults = [];
+      connectFailedErrors = [];
+      reportedReasons = [];
+      onConnectedImpl = (_) async => const AuthResult(success: true);
+
+      when(() => session.start()).thenAnswer((_) async {});
+      when(session.cancel).thenReturn(null);
+      when(session.dispose).thenReturn(null);
+      when(session.ensureConnected).thenAnswer((_) async {});
+      when(() => session.addRelay(any())).thenAnswer((_) async {});
+      when(() => session.connectUrl).thenReturn('nostrconnect://abc');
+      when(() => session.state).thenReturn(NostrConnectState.listening);
+      when(() => session.failureReason).thenReturn(null);
+    });
+
+    NostrConnectCoordinator build() => NostrConnectCoordinator(
+      onConnected: (result) {
+        connectedResults.add(result);
+        return onConnectedImpl(result);
+      },
+      onConnectFailed: connectFailedErrors.add,
+      onWaitStarted: () => waitStartedCalls++,
+      onWaitFailed: () => waitFailedCalls++,
+      reportError:
+          (
+            error,
+            stack, {
+            required String reason,
+            required String logMessage,
+          }) => reportedReasons.add(reason),
+      sessionFactory: (relays) {
+        createdRelays = relays;
+        return session;
+      },
+    );
+
+    NostrConnectResult resultFor(String pubkey) => NostrConnectResult(
+      remoteSignerPubkey: pubkey,
+      userPubkey: pubkey,
+      info: NostrRemoteSignerInfo(remoteSignerPubkey: pubkey, relays: const []),
+    );
+
+    group('initiate', () {
+      test('creates a session via the factory and starts it', () async {
+        final coordinator = build();
+        final s = await coordinator.initiate();
+        expect(s, session);
+        verify(() => session.start()).called(1);
+        expect(createdRelays, isNotEmpty);
+      });
+
+      test('uses custom relays when provided', () async {
+        final coordinator = build();
+        await coordinator.initiate(customRelays: const ['wss://custom']);
+        expect(createdRelays, ['wss://custom']);
+      });
+
+      test('exposes connectUrl + state from the session', () async {
+        final coordinator = build();
+        expect(coordinator.connectUrl, isNull);
+        expect(coordinator.state, isNull);
+        await coordinator.initiate();
+        expect(coordinator.connectUrl, 'nostrconnect://abc');
+        expect(coordinator.state, NostrConnectState.listening);
+      });
+    });
+
+    group('waitForResponse', () {
+      test('returns failure when no session is active', () async {
+        final result = await build().waitForResponse();
+        expect(result.success, isFalse);
+        expect(result.errorMessage, contains('No active nostrconnect session'));
+        expect(waitStartedCalls, 0);
+      });
+
+      test(
+        'applies the connection and disposes the session on success',
+        () async {
+          when(
+            () => session.waitForConnection(timeout: any(named: 'timeout')),
+          ).thenAnswer((_) async => resultFor('a' * 64));
+          final coordinator = build();
+          await coordinator.initiate();
+
+          final result = await coordinator.waitForResponse();
+
+          expect(result.success, isTrue);
+          expect(waitStartedCalls, 1);
+          expect(connectedResults.single.remoteSignerPubkey, 'a' * 64);
+          verify(() => session.dispose()).called(1);
+        },
+      );
+
+      test('shares a single in-flight wait', () async {
+        final completer = Completer<NostrConnectResult?>();
+        when(
+          () => session.waitForConnection(timeout: any(named: 'timeout')),
+        ).thenAnswer((_) => completer.future);
+        final coordinator = build();
+        await coordinator.initiate();
+
+        final a = coordinator.waitForResponse();
+        final b = coordinator.waitForResponse();
+        expect(identical(a, b), isTrue);
+
+        completer.complete(null);
+        await a;
+        await b;
+        verify(
+          () => session.waitForConnection(timeout: any(named: 'timeout')),
+        ).called(1);
+      });
+
+      test('maps timeout state to timedOut', () async {
+        when(
+          () => session.waitForConnection(timeout: any(named: 'timeout')),
+        ).thenAnswer((_) async => null);
+        when(() => session.state).thenReturn(NostrConnectState.timeout);
+        final coordinator = build();
+        await coordinator.initiate();
+
+        final result = await coordinator.waitForResponse();
+
+        expect(
+          result.nostrConnectFailureReason,
+          NostrConnectFailureReason.timedOut,
+        );
+        expect(waitFailedCalls, 1);
+      });
+
+      test('maps an error state to the session failure reason', () async {
+        when(
+          () => session.waitForConnection(timeout: any(named: 'timeout')),
+        ).thenAnswer((_) async => null);
+        when(() => session.state).thenReturn(NostrConnectState.error);
+        when(
+          () => session.failureReason,
+        ).thenReturn(NostrConnectFailureReason.bunkerRejected);
+        final coordinator = build();
+        await coordinator.initiate();
+
+        final result = await coordinator.waitForResponse();
+
+        expect(
+          result.nostrConnectFailureReason,
+          NostrConnectFailureReason.bunkerRejected,
+        );
+      });
+
+      test('reports the noExpectedSecret invariant to Crashlytics', () async {
+        when(
+          () => session.waitForConnection(timeout: any(named: 'timeout')),
+        ).thenAnswer((_) async => null);
+        when(() => session.state).thenReturn(NostrConnectState.error);
+        when(
+          () => session.failureReason,
+        ).thenReturn(NostrConnectFailureReason.noExpectedSecret);
+        final coordinator = build();
+        await coordinator.initiate();
+
+        final result = await coordinator.waitForResponse();
+
+        expect(
+          result.nostrConnectFailureReason,
+          NostrConnectFailureReason.noExpectedSecret,
+        );
+        expect(reportedReasons, ['NostrConnect.noExpectedSecret']);
+      });
+
+      test('treats cancellation during the wait as cancelled', () async {
+        final completer = Completer<NostrConnectResult?>();
+        when(
+          () => session.waitForConnection(timeout: any(named: 'timeout')),
+        ).thenAnswer((_) => completer.future);
+        final coordinator = build();
+        await coordinator.initiate();
+
+        final future = coordinator.waitForResponse();
+        coordinator.cancel();
+        completer.complete(resultFor('a' * 64));
+
+        final result = await future;
+        expect(
+          result.nostrConnectFailureReason,
+          NostrConnectFailureReason.cancelled,
+        );
+        expect(waitFailedCalls, 1);
+      });
+
+      test('routes application errors through onConnectFailed', () async {
+        when(
+          () => session.waitForConnection(timeout: any(named: 'timeout')),
+        ).thenAnswer((_) async => resultFor('a' * 64));
+        onConnectedImpl = (_) async => throw Exception('boom');
+        final coordinator = build();
+        await coordinator.initiate();
+
+        final result = await coordinator.waitForResponse();
+
+        expect(
+          result.nostrConnectFailureReason,
+          NostrConnectFailureReason.postConnectFailed,
+        );
+        expect(connectFailedErrors, hasLength(1));
+      });
+    });
+
+    group('cancel', () {
+      test('cancels and disposes the active session', () async {
+        final coordinator = build();
+        await coordinator.initiate();
+        coordinator.cancel();
+        verify(() => session.cancel()).called(1);
+        verify(() => session.dispose()).called(1);
+      });
+
+      test('is safe with no active session', () {
+        expect(build().cancel, returnsNormally);
+      });
+    });
+
+    group('callback handoff', () {
+      test(
+        'onSignerCallbackReceived activates handoff + ensures connected',
+        () async {
+          final coordinator = build();
+          await coordinator.initiate();
+
+          coordinator.onSignerCallbackReceived(relayUrl: 'wss://r');
+
+          expect(coordinator.isCallbackHandoffActive, isTrue);
+          verify(() => session.addRelay('wss://r')).called(1);
+          verify(() => session.ensureConnected()).called(1);
+        },
+      );
+
+      test('onSignerCallbackReceived no-ops when not listening', () async {
+        when(() => session.state).thenReturn(NostrConnectState.idle);
+        final coordinator = build();
+        await coordinator.initiate();
+
+        coordinator.onSignerCallbackReceived();
+
+        expect(coordinator.isCallbackHandoffActive, isFalse);
+        verifyNever(() => session.ensureConnected());
+      });
+
+      test('the handoff-active flag expires after 5s', () {
+        fakeAsync((async) {
+          final coordinator = build();
+          unawaited(coordinator.initiate());
+          async.flushMicrotasks();
+
+          coordinator.onSignerCallbackReceived();
+          expect(coordinator.isCallbackHandoffActive, isTrue);
+
+          async.elapse(const Duration(seconds: 5));
+          expect(coordinator.isCallbackHandoffActive, isFalse);
+        });
+      });
+
+      test('preserveForCallbackHandoff no-ops when handoff is inactive', () {
+        fakeAsync((async) {
+          final coordinator = build();
+          unawaited(coordinator.initiate());
+          async.flushMicrotasks();
+
+          coordinator.preserveForCallbackHandoff();
+          async.elapse(const Duration(seconds: 5));
+
+          verifyNever(() => session.cancel());
+        });
+      });
+
+      test('claimCallbackHandoff is safe to call', () {
+        expect(build().claimCallbackHandoff, returnsNormally);
+      });
+
+      test('dispose cancels the handoff timers', () {
+        fakeAsync((async) {
+          final coordinator = build();
+          unawaited(coordinator.initiate());
+          async.flushMicrotasks();
+
+          coordinator.onSignerCallbackReceived();
+          expect(coordinator.isCallbackHandoffActive, isTrue);
+
+          coordinator.dispose();
+          async.elapse(const Duration(seconds: 5));
+
+          // The expiry timer was cancelled by dispose, so the flag never reset.
+          expect(coordinator.isCallbackHandoffActive, isTrue);
+        });
+      });
+    });
+
+    group('reconnectListeningRelays', () {
+      test('ensures connected when listening', () async {
+        final coordinator = build();
+        await coordinator.initiate();
+        coordinator.reconnectListeningRelays();
+        verify(() => session.ensureConnected()).called(1);
+      });
+
+      test('no-ops when not listening', () async {
+        when(() => session.state).thenReturn(NostrConnectState.idle);
+        final coordinator = build();
+        await coordinator.initiate();
+        coordinator.reconnectListeningRelays();
+        verifyNever(() => session.ensureConnected());
+      });
+    });
+  });
+}


### PR DESCRIPTION
## What & why

Fourth **repository-tier** slice of #4741 (after R1 #5757, R2 #5805, R3 #5807). The client-initiated **`nostrconnect://` flow** moves out of `auth_service.dart` behind the stable facade. auth_service.dart **4,445 → 4,219**.

## The stateful coordinator

New `lib/services/auth/nostr_connect_coordinator.dart` (`NostrConnectCoordinator`). Like R2's `OAuthSessionCoordinator` it is **stateful** — it owns the 5 nostrconnect fields (the connect `NostrConnectSession`, the single-flight wait future, and the two deep-link callback-handoff `Timer`s + active flag). Moved (log `name:` retagged, message content verbatim): `initiate`, `waitForResponse` (single-flight), `cancel`, `preserveForCallbackHandoff`, `claimCallbackHandoff`, `onSignerCallbackReceived`, the 4 getters, plus `reconnectListeningRelays()` (was the `onAppResumed` block) and `dispose()` (was the `dispose` timer-cancel block).

The seam is **cleaner than R2** — the connect flow reads *nothing* live from the facade; every coupling is a terminal completion callback. Five ports:
- `onConnected(result)` → `_applyNostrConnectSuccess` — builds `_bunkerSigner`, persists its info, sets up the user session (stays on the facade because it mutates `_bunkerSigner`)
- `onConnectFailed(e)` — the catch cleanup (close `_bunkerSigner`, `_lastError`, unauthenticated)
- `onWaitStarted` / `onWaitFailed` → `_setAuthState(authenticating / unauthenticated)`
- `reportError` → `_reportAuthError` (the `noExpectedSecret` invariant)

## AuthResult lifted

`AuthResult` moved from `auth_service.dart` to **`lib/models/auth_result.dart`** (mirroring the existing `ViewerAuthResult`) so the coordinator can return it without a facade import cycle. `auth_service.dart` re-exports it, so **every existing importer keeps its import unchanged** — no consumer churn.

## Closes the deferred nostrconnect test gap (#5713)

The coordinator takes an injectable **`NostrConnectSessionFactory`** (default = the real session with the same app-metadata literals). This is the injection seam that #5713 called out as missing: tests inject a fake session that completes `waitForConnection` without opening real relay sockets — so the nostrconnect **happy path is now unit-tested** for the first time.

## Log `name:` retag (not drift)

Moved log lines keep their message content byte-identical; only the structured `name:` tag is retagged `AuthService` → `NostrConnectCoordinator` at the moved sites (the R1/R2 own-class-tag convention). The facade-layer application logs (in `_applyNostrConnectSuccess`) stay `name:'AuthService'`.

## Behavior note (pre-existing, preserved)

The facade's `dispose()` cancelled only the two handoff timers and left a live listening session untouched; `coordinator.dispose()` preserves that exactly (byte-identical) rather than silently fixing the latent leak. Flagging it here rather than smuggling a behavior change into the extraction.

## Verification

- **Adversarial drift verification (3 independent lenses vs `origin/main`): zero behavior drift.** Confirmed the `_waitForResponse` flow (single-flight, failure-reason switch, `noExpectedSecret` report, success/catch ordering) is token-for-token identical; `_applyNostrConnectSuccess` byte-identical to the origin success block; all port closures reproduce the origin's inline facade mutations exactly; `initiate` relay/metadata literals + `cancel`/handoff timer durations + guards identical; the `AuthResult` lift is transparent (no consumer import changes, no cycle).
- **New `nostr_connect_coordinator_test.dart` — 21 tests** covering initiate, the single-flight wait, success application + session dispose, the full failure-reason mapping (timeout / error→failureReason / noExpectedSecret→Crashlytics), cancellation-during-wait, application-error routing, cancel, the callback-handoff timers (activate / 5s expiry / dispose cancels timers), and resume-reconnect — via the injected fake session.
- **Pinned facade suites stay byte-identical (zero edits):** `auth_service_bunker_connect_test.dart` (the nostrconnect guards) and `app_router_test.dart` (the deep-link `onSignerCallbackReceived` redirect). The 5 external consumers (nostr_connect_screen, main.dart deep-link handler, app_router_redirect + 2 tests) are untouched — the facade keeps identical public signatures as delegators.
- **410-test auth + router sweep green; `flutter analyze` clean; `dart format` clean.** CI ratchets pass: untested-services floor (coordinator ships its same-named test; `AuthResult` lives in `lib/models/`, outside the floor's scope), empty-catch, sentinel.

No user-facing change. Part of #4741. Next: PR5–6 (remaining in-facade clusters) → the `packages/auth_repository` scaffold.
