### PR TITLE
fix(push): encrypt FCM token in kind-3080 deregistration events

### DIFF
--- a/mobile/lib/services/push_notification_service.dart
+++ b/mobile/lib/services/push_notification_service.dart
@@ -133,9 +133,11 @@ class PushNotificationService {
 
   /// Deregisters this device from the divine push service.
   ///
-  /// Publishes a kind [pushDeregistrationKind] Nostr event to the push
-  /// service pubkey, signalling that notifications should no longer be
-  /// delivered to this device.
+  /// NIP-44 encrypts the current FCM token and publishes a kind
+  /// [pushDeregistrationKind] Nostr event to the push service pubkey so the
+  /// service can identify and remove exactly this device's token. The push
+  /// service rejects plaintext/empty content, so the token must be encrypted
+  /// the same way as registration.
   ///
   /// If [signingIdentity] is provided, deregistration signs with that captured
   /// outgoing identity instead of the live auth session. This is used by
@@ -160,11 +162,7 @@ class PushNotificationService {
     }
 
     final event = signingIdentity == null
-        ? await _authService.createAndSignEvent(
-            kind: pushDeregistrationKind,
-            content: '',
-            tags: _deregistrationTags(pushServicePubkey),
-          )
+        ? await _createLiveDeregistrationEvent(pushServicePubkey)
         : await createSignedDeregistrationEvent(
             userPubkey,
             signingIdentity: signingIdentity,
@@ -209,10 +207,19 @@ class PushNotificationService {
       return null;
     }
 
+    final content = await _encryptedDeregistrationContent(
+      pushServicePubkey,
+      signingIdentity.nip44Encrypt,
+    );
+    if (content == null) return null;
+    if (!await _isPublishCurrent(isCurrent, checkServiceCurrent: false)) {
+      return null;
+    }
+
     final event = await _createAndSignEventWithIdentity(
       signingIdentity,
       kind: pushDeregistrationKind,
-      content: '',
+      content: content,
       tags: _deregistrationTags(pushServicePubkey),
     );
     if (!await _isPublishCurrent(isCurrent, checkServiceCurrent: false)) {
@@ -411,6 +418,59 @@ class PushNotificationService {
       );
     }
     return outcome.confirmed;
+  }
+
+  /// Builds the live-session deregistration event: NIP-44 encrypts the current
+  /// FCM token for [pushServicePubkey] and signs a kind [pushDeregistrationKind]
+  /// event with the live signer. Returns null when the token is unavailable or
+  /// encryption fails (both already logged).
+  Future<Event?> _createLiveDeregistrationEvent(
+    String pushServicePubkey,
+  ) async {
+    final content = await _encryptedDeregistrationContent(
+      pushServicePubkey,
+      _nostrClient.signer.nip44Encrypt,
+    );
+    if (content == null) return null;
+
+    return _authService.createAndSignEvent(
+      kind: pushDeregistrationKind,
+      content: content,
+      tags: _deregistrationTags(pushServicePubkey),
+    );
+  }
+
+  /// Fetches the current FCM token and NIP-44 encrypts `{"token": <token>}` for
+  /// [pushServicePubkey] using [nip44Encrypt], so a deregistration event tells
+  /// the push service which token to remove (it rejects empty/plaintext
+  /// content). Returns null (and logs) when the token is unavailable or
+  /// encryption fails.
+  Future<String?> _encryptedDeregistrationContent(
+    String pushServicePubkey,
+    Future<String?> Function(String pubkey, String plaintext) nip44Encrypt,
+  ) async {
+    final token = await _getToken();
+    if (token == null) {
+      Log.warning(
+        'FCM token is null — skipping push notification deregistration',
+        name: 'PushNotificationService',
+        category: LogCategory.system,
+      );
+      return null;
+    }
+
+    final encrypted = await nip44Encrypt(
+      pushServicePubkey,
+      jsonEncode({'token': token}),
+    );
+    if (encrypted == null) {
+      Log.error(
+        'NIP-44 encryption failed for token deregistration',
+        name: 'PushNotificationService',
+        category: LogCategory.system,
+      );
+    }
+    return encrypted;
   }
 
   Future<Event?> _createAndSignEventWithIdentity(

--- a/mobile/lib/services/push_notification_service.dart
+++ b/mobile/lib/services/push_notification_service.dart
@@ -176,11 +176,6 @@ class PushNotificationService {
     }
 
     if (event == null) {
-      Log.error(
-        'Failed to sign deregistration event',
-        name: 'PushNotificationService',
-        category: LogCategory.system,
-      );
       return;
     }
     if (!await _isPublishCurrent(
@@ -433,11 +428,19 @@ class PushNotificationService {
     );
     if (content == null) return null;
 
-    return _authService.createAndSignEvent(
+    final event = await _authService.createAndSignEvent(
       kind: pushDeregistrationKind,
       content: content,
       tags: _deregistrationTags(pushServicePubkey),
     );
+    if (event == null) {
+      Log.error(
+        'Failed to sign deregistration event',
+        name: 'PushNotificationService',
+        category: LogCategory.system,
+      );
+    }
+    return event;
   }
 
   /// Fetches the current FCM token and NIP-44 encrypts `{"token": <token>}` for

--- a/mobile/test/providers/push_notification_sync_test.dart
+++ b/mobile/test/providers/push_notification_sync_test.dart
@@ -1379,6 +1379,10 @@ void main() {
         when(() => event.isValid).thenReturn(true);
         when(() => signer.signEvent(any())).thenAnswer((_) async => event);
         when(
+          () => signer.nip44Encrypt(any(), any()),
+        ).thenAnswer((_) async => 'encrypted-dereg-token');
+        when(() => messaging.getToken()).thenAnswer((_) async => 'fcm-token');
+        when(
           () => defaultCleanupClient.publishEventAwaitOk(
             event,
             targetRelays: [pushEnvironment.relayUrl],
@@ -1468,6 +1472,10 @@ void main() {
         when(() => event.isValid).thenReturn(true);
         when(() => signer.signEvent(any())).thenAnswer((_) async => event);
         when(
+          () => signer.nip44Encrypt(any(), any()),
+        ).thenAnswer((_) async => 'encrypted-dereg-token');
+        when(() => messaging.getToken()).thenAnswer((_) async => 'fcm-token');
+        when(
           () => defaultCleanupClient.publishEventAwaitOk(
             event,
             targetRelays: [pushEnvironment.relayUrl],
@@ -1555,6 +1563,10 @@ void main() {
         when(() => event.isSigned).thenReturn(true);
         when(() => event.isValid).thenReturn(true);
         when(() => signer.signEvent(any())).thenAnswer((_) async => event);
+        when(
+          () => signer.nip44Encrypt(any(), any()),
+        ).thenAnswer((_) async => 'encrypted-dereg-token');
+        when(() => messaging.getToken()).thenAnswer((_) async => 'fcm-token');
         when(
           () => cleanupClient.publishEventAwaitOk(
             event,
@@ -1775,7 +1787,13 @@ void main() {
         when(
           () => messaging.getNotificationSettings(),
         ).thenAnswer((_) async => _settings(AuthorizationStatus.authorized));
-        when(() => messaging.getToken()).thenAnswer((_) async => null);
+        // getToken() is null at startup (initial register skips and waits for a
+        // refresh); once the refresh arrives the device has a token, so
+        // deregistration can encrypt it for the push service.
+        String? sessionToken;
+        when(
+          () => messaging.getToken(),
+        ).thenAnswer((_) async => sessionToken);
         when(
           () => messaging.onTokenRefresh,
         ).thenAnswer((_) => tokenRefreshController.stream);
@@ -1871,6 +1889,10 @@ void main() {
         await Future<void>.delayed(Duration.zero);
         await Future<void>.delayed(Duration.zero);
         expect(events, ['registration publish started']);
+
+        // The refresh delivered a token, so getToken() now returns it and the
+        // pending deregistration can encrypt it.
+        sessionToken = 'refreshed-token-during-session';
 
         final teardownFuture = beforeSessionTeardownCallback!();
         await Future<void>.delayed(Duration.zero);

--- a/mobile/test/services/push_notification_service_test.dart
+++ b/mobile/test/services/push_notification_service_test.dart
@@ -78,6 +78,9 @@ void main() {
     mockNostrSigner = _MockNostrSigner();
 
     when(() => mockNostrClient.signer).thenReturn(mockNostrSigner);
+    when(
+      () => mockNostrSigner.nip44Encrypt(any(), any()),
+    ).thenAnswer((_) async => encryptedPayload);
 
     registerFallbackValue(_FakeEvent());
     registerFallbackValue(<String>[]);
@@ -398,13 +401,87 @@ void main() {
 
     group('deregister', () {
       test(
+        'encrypts the FCM token into the deregistration event content',
+        () async {
+          final fakeEvent = _FakeEvent();
+          when(
+            () => mockAuthService.createAndSignEvent(
+              kind: PushNotificationService.pushDeregistrationKind,
+              content: encryptedPayload,
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer((_) async => fakeEvent);
+          when(
+            () => mockNostrClient.publishEventAwaitOk(
+              fakeEvent,
+              targetRelays: [testEnvironment.relayUrl],
+              timeout: pushPublishTimeout,
+              diagnosticTag: 'push-control',
+            ),
+          ).thenAnswer(
+            (_) async => PublishOutcome(
+              eventId: fakeEvent.id,
+              acceptedBy: [testEnvironment.relayUrl],
+              rejectedBy: const {},
+              noResponseFrom: const [],
+            ),
+          );
+
+          final service = buildService();
+          await service.deregister(testPubkey);
+
+          verify(
+            () => mockNostrSigner.nip44Encrypt(
+              testEnvironment.pushServicePubkey,
+              '{"token":"$testToken"}',
+            ),
+          ).called(1);
+          verify(
+            () => mockAuthService.createAndSignEvent(
+              kind: PushNotificationService.pushDeregistrationKind,
+              content: encryptedPayload,
+              tags: any(named: 'tags'),
+            ),
+          ).called(1);
+          service.dispose();
+        },
+      );
+
+      test(
+        'does not publish deregistration when the FCM token is unavailable',
+        () async {
+          final service = buildService(token: null);
+
+          await service.deregister(testPubkey);
+
+          verifyNever(() => mockNostrSigner.nip44Encrypt(any(), any()));
+          verifyNever(
+            () => mockAuthService.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          );
+          verifyNever(
+            () => mockNostrClient.publishEventAwaitOk(
+              any(),
+              targetRelays: any(named: 'targetRelays'),
+              timeout: any(named: 'timeout'),
+              diagnosticTag: any(named: 'diagnosticTag'),
+            ),
+          );
+          service.dispose();
+        },
+      );
+
+      test(
         'publishes kind 3080 event to environment relay with OK timeout',
         () async {
           final fakeEvent = _FakeEvent();
           when(
             () => mockAuthService.createAndSignEvent(
               kind: PushNotificationService.pushDeregistrationKind,
-              content: '',
+              content: encryptedPayload,
               tags: any(named: 'tags'),
             ),
           ).thenAnswer((_) async => fakeEvent);
@@ -431,7 +508,7 @@ void main() {
           verify(
             () => mockAuthService.createAndSignEvent(
               kind: PushNotificationService.pushDeregistrationKind,
-              content: '',
+              content: encryptedPayload,
               tags: any(named: 'tags'),
             ),
           ).called(1);
@@ -570,7 +647,7 @@ void main() {
           when(
             () => mockAuthService.createAndSignEvent(
               kind: PushNotificationService.pushDeregistrationKind,
-              content: '',
+              content: encryptedPayload,
               tags: any(named: 'tags'),
             ),
           ).thenAnswer((_) async {
@@ -585,7 +662,7 @@ void main() {
           verify(
             () => mockAuthService.createAndSignEvent(
               kind: PushNotificationService.pushDeregistrationKind,
-              content: '',
+              content: encryptedPayload,
               tags: any(named: 'tags'),
             ),
           ).called(1);
@@ -608,6 +685,9 @@ void main() {
           ).thenReturn('captured-deregistration-event-id');
           when(() => fakeEvent.isSigned).thenReturn(true);
           when(() => fakeEvent.isValid).thenReturn(true);
+          when(
+            () => capturedSigner.nip44Encrypt(any(), any()),
+          ).thenAnswer((_) async => encryptedPayload);
           when(
             () => capturedSigner.signEvent(any()),
           ).thenAnswer((_) async => fakeEvent);
@@ -668,6 +748,9 @@ void main() {
           ).thenReturn('cleanup-deregistration-event-id');
           when(() => fakeEvent.isSigned).thenReturn(true);
           when(() => fakeEvent.isValid).thenReturn(true);
+          when(
+            () => capturedSigner.nip44Encrypt(any(), any()),
+          ).thenAnswer((_) async => encryptedPayload);
           when(
             () => capturedSigner.signEvent(any()),
           ).thenAnswer((_) async => fakeEvent);

--- a/mobile/test/services/push_notification_service_test.dart
+++ b/mobile/test/services/push_notification_service_test.dart
@@ -18,6 +18,7 @@ import 'package:openvine/services/notification_helpers.dart'
     show localNotificationTapPayload;
 import 'package:openvine/services/notification_service.dart';
 import 'package:openvine/services/push_notification_service.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 class _MockAuthService extends Mock implements AuthService {}
 
@@ -450,6 +451,7 @@ void main() {
       test(
         'does not publish deregistration when the FCM token is unavailable',
         () async {
+          await LogCaptureService().clearAllLogs();
           final service = buildService(token: null);
 
           await service.deregister(testPubkey);
@@ -469,6 +471,19 @@ void main() {
               timeout: any(named: 'timeout'),
               diagnosticTag: any(named: 'diagnosticTag'),
             ),
+          );
+          final messages = LogCaptureService().getRecentLogs().map(
+            (entry) => entry.message,
+          );
+          expect(
+            messages,
+            contains(
+              'FCM token is null — skipping push notification deregistration',
+            ),
+          );
+          expect(
+            messages,
+            isNot(contains('Failed to sign deregistration event')),
           );
           service.dispose();
         },


### PR DESCRIPTION
## What

Kind-3080 push-token **deregistration** events now carry NIP-44-encrypted `{"token": <fcm>}` content instead of empty content, on both the live-session and captured-identity (teardown) deregistration paths — symmetric with registration (3079).

Fixes #5827.

## Why

`divine-push-service` `handle_deregistration` rejects empty/plaintext content and needs the encrypted token to know which token to remove (`event_handler.rs` → `validate_encrypted_content` → early return, no removal). With empty content, **every deregistration was a silent no-op**: a signed-out or account-switched device kept its FCM token registered until the 90-day NIP-40 expiration lapsed (or FCM later reported it invalid and the service auto-pruned it). The prod relay stores many empty-content 3080 events — evidence of the silently-dropped deregistrations.

## How

- `deregister` (live path) and `createSignedDeregistrationEvent` (captured-identity teardown path) fetch the current FCM token via `_getToken()` and NIP-44-encrypt `{"token": token}` for the push-service pubkey, mirroring `_publishRegistration`.
- New `_encryptedDeregistrationContent` helper; the live path is factored into `_createLiveDeregistrationEvent`.
- Skips (and logs) when the token is unavailable — no more empty-content publishes.
- Per-device removal is preserved (a single device's sign-out must not clobber other devices' tokens), so the fix stays mobile-side rather than a push-service "remove all tokens for pubkey".

## Testing

- `flutter test test/services/push_notification_service_test.dart test/providers/push_notification_sync_test.dart` — green.
- New regression test: 3080 content is the encrypted token (not empty). New guard test: no publish when the FCM token is unavailable.
- `flutter analyze lib test integration_test` — clean.

## Notes

Found while verifying the push-control rollout for #4437. The `#4437` relay-OK diagnostics cannot detect this bug — the relay accepts a 3080 on kind + p-tag and never inspects content, so the publish looks healthy while the service drops it.
