### PR TITLE
fix(profile): don't re-claim owned usernames + classify claim network errors (#4199)

### DIFF
--- a/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
+++ b/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
@@ -973,10 +973,20 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
     // If the claim fails for any reason — taken, reserved, network error,
     // server unreachable — we abort *before* publishing kind 0. This keeps
     // the user's metadata in sync with the registry by construction.
+    // Only claim when the requested username is NOT already owned by this
+    // account. Ownership is recognized either from editor state
+    // (`initialUsername`, seeded when the profile loaded) or from the loaded
+    // profile's current NIP-05 (`divineUsername`). Relying on `initialUsername`
+    // alone re-claimed an already-owned name whenever the profile hadn't seeded
+    // it (e.g. a cold web load) — which, before the name-server CORS fix, failed
+    // on web. See #4199.
+    final requestedLower = username?.toLowerCase();
+    final ownedLower = <String?>[
+      state.initialUsername,
+      currentProfile?.divineUsername,
+    ].whereType<String>().map((u) => u.toLowerCase()).toSet();
     final shouldClaimUsername =
-        username != null &&
-        (state.initialUsername == null ||
-            username.toLowerCase() != state.initialUsername!.toLowerCase());
+        username != null && !ownedLower.contains(requestedLower);
     if (shouldClaimUsername) {
       Log.info(
         '📝 Attempting to claim username: $username',
@@ -991,6 +1001,7 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
         UsernameClaimSuccess() => null,
         UsernameClaimTaken() => ProfileEditorError.usernameTaken,
         UsernameClaimReserved() => ProfileEditorError.usernameReserved,
+        UsernameClaimNetworkError() => ProfileEditorError.claimNetworkError,
         UsernameClaimError() => ProfileEditorError.claimFailed,
       };
 

--- a/mobile/lib/blocs/profile_editor/profile_editor_state.dart
+++ b/mobile/lib/blocs/profile_editor/profile_editor_state.dart
@@ -41,8 +41,14 @@ enum ProfileEditorError {
   /// The UI should show a connectivity-specific message and offer a retry.
   noRelaysConnected,
 
-  /// Failed to claim username (network error or other issue).
+  /// The server rejected the username claim (invalid format or an unexpected
+  /// server response). Network failures use [claimNetworkError] instead.
   claimFailed,
+
+  /// Could not reach the name server to claim the username (network failure,
+  /// timeout, or a browser CORS block on web). The UI offers a connectivity
+  /// retry rather than treating it as a rejected claim.
+  claimNetworkError,
 
   /// Username was already taken by another user.
   usernameTaken,

--- a/mobile/lib/screens/profile_setup/widgets/profile_setup_listeners.dart
+++ b/mobile/lib/screens/profile_setup/widgets/profile_setup_listeners.dart
@@ -196,7 +196,12 @@ class ProfileSetupListeners extends ConsumerWidget {
                     context: context,
                     builder: (context) => UsernameReservedDialog(username),
                   );
+                // claimFailed (server rejected) and claimNetworkError
+                // (couldn't reach the server) currently share this copy; the
+                // types stay distinct for telemetry and to allow a
+                // connectivity-specific message later.
                 case ProfileEditorError.claimFailed:
+                case ProfileEditorError.claimNetworkError:
                   ScaffoldMessenger.of(context).showSnackBar(
                     SnackBar(
                       content: Text(context.l10n.profileSetupClaimFailed),

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -773,7 +773,7 @@ class ProfileRepository {
         error: e,
         stackTrace: st,
       );
-      return UsernameClaimError('Network error: $e');
+      return const UsernameClaimNetworkError();
     }
   }
 

--- a/mobile/packages/profile_repository/lib/src/username_claim_result.dart
+++ b/mobile/packages/profile_repository/lib/src/username_claim_result.dart
@@ -22,7 +22,16 @@ class UsernameClaimReserved extends UsernameClaimResult {
   const UsernameClaimReserved();
 }
 
-/// An error occurred during username claiming.
+/// The server could not be reached (network failure, timeout, or a browser
+/// CORS block on web). Distinct from [UsernameClaimError] so the UI can offer a
+/// connectivity-specific retry rather than treating it like a rejected claim.
+class UsernameClaimNetworkError extends UsernameClaimResult {
+  /// Creates a network-error result.
+  const UsernameClaimNetworkError();
+}
+
+/// An error occurred during username claiming (server rejected the claim or the
+/// request could not be authenticated).
 class UsernameClaimError extends UsernameClaimResult {
   /// Creates an error result with the given [message].
   const UsernameClaimError(this.message);

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -4064,7 +4064,7 @@ void main() {
         );
       });
 
-      test('returns UsernameClaimError on network exception ', () async {
+      test('returns UsernameClaimNetworkError on network exception', () async {
         when(
           () => mockNostrClient.createNip98AuthHeader(
             url: any(named: 'url'),
@@ -4078,19 +4078,12 @@ void main() {
             headers: any(named: 'headers'),
             body: any(named: 'body'),
           ),
-        ).thenThrow(Exception('network exception'));
+        ).thenThrow(ClientException('network exception'));
 
         final usernameClaimResult = await profileRepository.claimUsername(
           username: 'username',
         );
-        expect(
-          usernameClaimResult,
-          isA<UsernameClaimError>().having(
-            (e) => e.message,
-            'message',
-            'Network error: Exception: network exception',
-          ),
-        );
+        expect(usernameClaimResult, isA<UsernameClaimNetworkError>());
       });
 
       test(
@@ -4250,55 +4243,51 @@ void main() {
         );
       });
 
-      test('returns UsernameClaimError when the POST exceeds the timeout', () {
-        fakeAsync((async) {
-          when(
-            () => mockNostrClient.createNip98AuthHeader(
-              url: any(named: 'url'),
-              method: any(named: 'method'),
-              payload: any(named: 'payload'),
-            ),
-          ).thenAnswer((_) => Future.value('authHeader'));
-          when(
-            () => mockHttpClient.post(
-              any(),
-              headers: any(named: 'headers'),
-              body: any(named: 'body'),
-            ),
-          ).thenAnswer((_) async {
-            // Simulates an unresponsive name server: never resolves within
-            // the repository's _nameServerHttpTimeout (10s).
-            await Future<void>.delayed(const Duration(minutes: 5));
-            return Response('unused', 200);
+      test(
+        'returns UsernameClaimNetworkError when the POST exceeds the timeout',
+        () {
+          fakeAsync((async) {
+            when(
+              () => mockNostrClient.createNip98AuthHeader(
+                url: any(named: 'url'),
+                method: any(named: 'method'),
+                payload: any(named: 'payload'),
+              ),
+            ).thenAnswer((_) => Future.value('authHeader'));
+            when(
+              () => mockHttpClient.post(
+                any(),
+                headers: any(named: 'headers'),
+                body: any(named: 'body'),
+              ),
+            ).thenAnswer((_) async {
+              // Simulates an unresponsive name server: never resolves within
+              // the repository's _nameServerHttpTimeout (10s).
+              await Future<void>.delayed(const Duration(minutes: 5));
+              return Response('unused', 200);
+            });
+
+            UsernameClaimResult? result;
+            unawaited(
+              profileRepository
+                  .claimUsername(username: 'username')
+                  .then((r) => result = r),
+            );
+
+            // Below the 10s repository timeout — call still pending.
+            async
+              ..elapse(const Duration(seconds: 9))
+              ..flushMicrotasks();
+            expect(result, isNull);
+
+            // Crosses the 10s repository timeout.
+            async
+              ..elapse(const Duration(seconds: 2))
+              ..flushMicrotasks();
+            expect(result, isA<UsernameClaimNetworkError>());
           });
-
-          UsernameClaimResult? result;
-          unawaited(
-            profileRepository
-                .claimUsername(username: 'username')
-                .then((r) => result = r),
-          );
-
-          // Below the 10s repository timeout — call still pending.
-          async
-            ..elapse(const Duration(seconds: 9))
-            ..flushMicrotasks();
-          expect(result, isNull);
-
-          // Crosses the 10s repository timeout.
-          async
-            ..elapse(const Duration(seconds: 2))
-            ..flushMicrotasks();
-          expect(
-            result,
-            isA<UsernameClaimError>().having(
-              (e) => e.message,
-              'message',
-              contains('TimeoutException'),
-            ),
-          );
-        });
-      });
+        },
+      );
     });
 
     group('UsernameClaimResult', () {

--- a/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
+++ b/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
@@ -568,6 +568,70 @@ void main() {
         );
 
         blocTest<ProfileEditorBloc, ProfileEditorState>(
+          'publishes without claiming when the username is already owned via '
+          'the loaded profile NIP-05 and initialUsername is unset (#4199)',
+          setUp: () {
+            // Cold web load: the editor never seeded initialUsername, but the
+            // loaded profile already carries this divine.video username, so the
+            // claim must be skipped (and, before the CORS fix, would have failed
+            // on web).
+            final owned = createTestProfile(
+              nip05: '_@$testUsername.divine.video',
+            );
+            when(
+              () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
+            ).thenAnswer((_) async => owned);
+            when(
+              () => mockProfileRepository.saveProfileEvent(
+                displayName: testDisplayName,
+                about: testAbout,
+                username: testUsername,
+                picture: testPicture,
+                currentProfile: owned,
+              ),
+            ).thenAnswer((_) async => createTestProfile());
+          },
+          build: createBloc,
+          act: (bloc) => bloc.add(
+            const ProfileSaved(
+              pubkey: testPubkey,
+              displayName: testDisplayName,
+              about: testAbout,
+              picture: testPicture,
+              username: testUsername,
+            ),
+          ),
+          expect: () => [
+            isA<ProfileEditorState>().having(
+              (s) => s.status,
+              'status',
+              ProfileEditorStatus.loading,
+            ),
+            isA<ProfileEditorState>().having(
+              (s) => s.status,
+              'status',
+              ProfileEditorStatus.success,
+            ),
+          ],
+          verify: (_) {
+            verifyNever(
+              () => mockProfileRepository.claimUsername(
+                username: any(named: 'username'),
+              ),
+            );
+            verify(
+              () => mockProfileRepository.saveProfileEvent(
+                displayName: testDisplayName,
+                about: testAbout,
+                username: testUsername,
+                picture: testPicture,
+                currentProfile: any(named: 'currentProfile'),
+              ),
+            ).called(1);
+          },
+        );
+
+        blocTest<ProfileEditorBloc, ProfileEditorState>(
           'supports admin-assigned username for current user through '
           'availability check then save/claim success',
           setUp: () {
@@ -867,6 +931,12 @@ void main() {
             label: 'name server error',
             result: const UsernameClaimError('Server unavailable'),
             expectedError: ProfileEditorError.claimFailed,
+            expectedUsernameStatus: null,
+          ),
+          (
+            label: 'name server unreachable',
+            result: const UsernameClaimNetworkError(),
+            expectedError: ProfileEditorError.claimNetworkError,
             expectedUsernameStatus: null,
           ),
         ]) {


### PR DESCRIPTION
## Summary

Hardening for the web username-claim flow. Companion to the name-server CORS fix in **divinevideo/divine-name-server#61**, which is the actual root-cause fix for #4199 (browsers could not `POST /api/username/claim` cross-origin because the service had no CORS preflight support).

Refs #4199.

## Changes

### 1. Don't re-claim an already-owned username (guard hole)
The save guard only recognized ownership from the editor's `initialUsername`, which is seeded from the loaded profile. On a cold web load where the profile hadn't seeded it, saving an unchanged/already-owned username triggered a redundant re-claim — which, before the CORS fix, failed on web with "Failed to claim username."

The guard now also recognizes ownership from the loaded profile's current NIP-05 (`UserProfile.divineUsername`), so an already-owned username is never re-claimed regardless of whether `initialUsername` was seeded.

### 2. Classify claim network errors
Replaced the stringly-typed `UsernameClaimError('Network error: $e')` with a typed `UsernameClaimNetworkError`, mapped to a new `ProfileEditorError.claimNetworkError`. This distinguishes "couldn't reach the server" (network / timeout / browser CORS block) from a rejected claim, for telemetry and future connectivity-specific messaging.

The profile-setup UI currently shares the existing `profileSetupClaimFailed` copy for both (a compiler-verified switch fall-through), so there is no new l10n key and no locale churn. The types stay distinct so a connectivity-specific message can be added later without re-plumbing.

## Testing

- `profile_editor_bloc`: skips the claim when the username is owned via the loaded profile NIP-05 with `initialUsername` unset; the claim-result → error mapping table gains a `UsernameClaimNetworkError → claimNetworkError` case.
- `profile_repository`: network exception and timeout paths now return `UsernameClaimNetworkError`.
- Full suites green: profile_repository (220), profile_editor bloc (94), profile_setup screen (49). `flutter analyze lib test integration_test` clean; format clean.

## Notes

- The UI mapping for `claimNetworkError` is a switch fall-through sharing `claimFailed`'s snackbar; its state emission is covered by the bloc test and the switch is compiler-verified, so no separate widget test was added for the shared-copy case.
- Independent of #61 (name-server): this PR is safe to merge in either order; after #61 lands, a same-owner re-claim also succeeds idempotently, so this guard is defense-in-depth plus a cleaner error contract.