### PR TITLE
fix(likes): chunk the Kind 5 deletion REQ so it can't overflow the relay frame

### DIFF
--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -26,6 +26,18 @@ const _likeContent = '+';
 /// NIP-25 reaction content for a downvote.
 const _downvoteContent = '-';
 
+/// Max number of reaction ids per Kind 5 deletion REQ.
+///
+/// The resolver scopes the deletion query to the reaction ids it fetched,
+/// which can approach the relay's per-REQ cap (~5000) on a very
+/// high-engagement video. A single `#e` filter with that many 64-char ids
+/// (~67 bytes each in JSON) would build a REQ frame near/over the relay's
+/// `max_message_length` (512KB); an oversized frame errors the socket and
+/// `queryEvents` fails open, silently counting deleted likes. Chunking keeps
+/// every frame small (500 ids ~= 34KB, well under 512KB and the advertised
+/// `max_event_tags` of 2000). See #5751.
+const _deletionReqEidChunkSize = 500;
+
 /// Callback to check if the device is currently online
 typedef IsOnlineCallback = bool Function();
 
@@ -1225,25 +1237,30 @@ class LikesRepository {
       return {for (final eventId in eventIds) eventId: <String>[]};
     }
 
-    final reactionAuthors = allReactionsById.values
-        .map((event) => event.pubkey)
-        .toSet()
-        .toList();
-    // Scope the deletion query to the reaction ids we actually fetched, in
-    // addition to their authors. The consumer below only honors a Kind 5 whose
-    // `e` tag points at a fetched reaction *and* whose author matches, so
-    // `#e`-scoping is semantics-preserving; without it the query pulls every
-    // deletion these (possibly prolific) authors ever published, inflating the
-    // response and risking crowd-out under the relay's per-REQ cap.
-    final deletionEvents = reactionAuthors.isEmpty
-        ? const <Event>[]
-        : await _nostrClient.queryEvents([
+    // Scope the deletion query to the reaction ids we fetched. The consumer
+    // below only honors a Kind 5 whose `e` tag points at a fetched reaction
+    // AND whose author matches it, so `#e`-scoping is semantics-preserving and
+    // an `authors:` filter is redundant (dropped to halve the frame size).
+    // Chunk the `#e` list so a very high-engagement video can't build a single
+    // REQ frame over the relay's `max_message_length` — an oversized frame
+    // errors the socket and the query fails open, counting deletes (#5751).
+    final reactionIds = allReactionsById.keys.toList();
+    final deletionEvents = <Event>[];
+    if (reactionIds.isNotEmpty) {
+      final chunkedDeletions = await Future.wait([
+        for (var i = 0; i < reactionIds.length; i += _deletionReqEidChunkSize)
+          _nostrClient.queryEvents([
             Filter(
               kinds: const [EventKind.eventDeletion],
-              authors: reactionAuthors,
-              e: allReactionsById.keys.toList(),
+              e: reactionIds.sublist(
+                i,
+                min(i + _deletionReqEidChunkSize, reactionIds.length),
+              ),
             ),
-          ]);
+          ]),
+      ]);
+      chunkedDeletions.forEach(deletionEvents.addAll);
+    }
 
     // Only honor a Kind 5 deletion when its author matches the reaction's
     // author — otherwise anyone could suppress someone else's like by

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -2436,6 +2436,60 @@ void main() {
         expect(likers, [likerB, likerA]);
       });
 
+      test(
+        'chunks the Kind 5 deletion query so no REQ exceeds the frame limit',
+        () async {
+          // 600 reactions from distinct authors => the resolver must split the
+          // deletion `#e` query into 2 chunks (500 + 100) so no single REQ
+          // frame approaches the relay's max_message_length (#5751).
+          final reactions = [
+            for (var i = 0; i < 600; i++)
+              createReaction(
+                id: 'reaction_$i',
+                authorPubkey: 'liker_pubkey_$i',
+              ),
+          ];
+          // call 0: e-tag reaction query; calls 1-2: chunked deletion queries.
+          mockQueryEventsSequence([reactions, <Event>[], <Event>[]]);
+
+          repository = createRepository();
+          final likers = await repository.fetchEventLikers(
+            eventId: targetEventId,
+          );
+          expect(likers, hasLength(600));
+
+          final calls = verify(
+            () => mockNostrClient.queryEvents(captureAny()),
+          ).captured.cast<List<Filter>>();
+          // 1 reaction (e) query + 2 chunked deletion queries.
+          expect(calls, hasLength(3));
+
+          final deletionFilters = calls
+              .map((filters) => filters.single)
+              .where(
+                (f) => f.kinds?.contains(EventKind.eventDeletion) ?? false,
+              )
+              .toList();
+          expect(deletionFilters, hasLength(2));
+          expect(deletionFilters[0].e, hasLength(500));
+          expect(deletionFilters[1].e, hasLength(100));
+          for (final filter in deletionFilters) {
+            expect(
+              filter.authors,
+              isNull,
+              reason: 'authors filter dropped; consumer enforces author match',
+            );
+            expect(filter.e!.length, lessThanOrEqualTo(500));
+          }
+          // The chunks partition every fetched reaction id without overlap.
+          final chunkedIds = <String>{
+            ...deletionFilters[0].e!,
+            ...deletionFilters[1].e!,
+          };
+          expect(chunkedIds, hasLength(600));
+        },
+      );
+
       test('excludes likers hidden by the block filter', () async {
         final blockedReaction = createReaction(
           id: 'reaction_blocked',


### PR DESCRIPTION
## Description

Residual 2 of #5751. The liker resolver (`_fetchResolvedLikersByEvent`, shared by the like-count and
"Liked by" list paths) sent its Kind 5 deletion query as one REQ carrying **every** fetched reaction id
plus their authors. On a very high-engagement video (~5000 reactions near the relay's per-REQ cap, from
thousands of distinct authors) that frame exceeds the relay's 512KB `max_message_length`; the relay
silently closes the socket (no NOTICE), `queryEvents` fails open to `[]`, and deleted likes get counted
and cached as authoritative.

This chunks the deletion `#e` list into sub-REQs well under the frame limit (500 ids ≈ 34KB, also under
the advertised `max_event_tags` of 2000) and **drops the now-redundant `authors:` filter** — the consumer
already enforces `deletion.pubkey == reaction.pubkey`, so `#e`-scoping alone is semantics-preserving. The
fix lives at the single resolver chokepoint, so both the count and the list resolve paths are covered.

Reproduced on the local funnelcake stack: a 272KB REQ returns `EOSE`, while 544KB / 680KB REQs silently
close the socket with no NOTICE. After chunking, the deletion query is split into ≤500-id sub-REQs.

**Related Issue:** Relates to #5751 (Residual 2). This does **not** close #5751 — Residual 1 (seed-vs-
resolved count precedence) is a separate follow-up PR, gated on a product decision. Backend root cause is
tracked in divine-funnelcake#626.

## Out of Scope

- **Residual 1** (seed precedence / count-vs-list divergence) — separate PR after the canonical-count
  product decision.
- **Cache guard for transient mid-query socket drops** — a clean guard needs a `queryEvents`
  error-surfacing change (it is fail-open by contract today); tracked as a follow-up. Chunking removes the
  only reproduced overflow trigger.

## Verification

- `dart format` — clean
- `flutter analyze lib test` — package and mobile-level: **No issues found**
- `flutter test` (likes_repository) — **113/113 pass**, including a new regression test asserting the
  deletion query is chunked into ≤500-id sub-REQs with no `authors:` filter
- Empirically reproduced the >512KB silent socket-close on the local funnelcake relay (272KB → EOSE;
  544KB/680KB → close)

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
