### PR TITLE
fix(upload): keep the picked cover thumbnail on publish

### DIFF
--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -138,10 +138,7 @@ class UploadManager {
          scopeUploadsToCurrentUser: scopeUploadsToCurrentUser,
          currentNostrPubkey: currentNostrPubkey,
        ) {
-    _retryPolicy = UploadRetryPolicy(
-      store: _store,
-      retryConfig: _retryConfig,
-    );
+    _retryPolicy = UploadRetryPolicy(store: _store, retryConfig: _retryConfig);
     _reporter = UploadProgressReporter(
       store: _store,
       circuitBreaker: _circuitBreaker,
@@ -779,28 +776,24 @@ class UploadManager {
     File videoFile,
     ValueChanged<double>? onProgress,
   ) async {
-    await _retryPolicy.performWithRetry(
-      upload,
-      () async {
-        final currentUpload = _store.getUpload(upload.id) ?? upload;
+    await _retryPolicy.performWithRetry(upload, () async {
+      final currentUpload = _store.getUpload(upload.id) ?? upload;
 
-        // Validate file still exists
-        if (!videoFile.existsSync()) {
-          throw Exception('Video file not found: ${upload.localVideoPath}');
-        }
+      // Validate file still exists
+      if (!videoFile.existsSync()) {
+        throw Exception('Video file not found: ${upload.localVideoPath}');
+      }
 
-        // Execute upload with timeout
-        final result = await _executeUploadWithTimeout(
-          currentUpload,
-          videoFile,
-          onProgress,
-        );
+      // Execute upload with timeout
+      final result = await _executeUploadWithTimeout(
+        currentUpload,
+        videoFile,
+        onProgress,
+      );
 
-        // Success - record metrics and complete
-        await _handleUploadSuccess(currentUpload, result);
-      },
-      isRetriable: _retryPolicy.isRetriableError,
-    );
+      // Success - record metrics and complete
+      await _handleUploadSuccess(currentUpload, result);
+    }, isRetriable: _retryPolicy.isRetriableError);
   }
 
   /// Execute upload with timeout and progress tracking
@@ -924,9 +917,7 @@ class UploadManager {
                 // Send timeout crash report asynchronously
                 _reporter
                     .sendTimeoutCrashReport(upload, timeoutError)
-                    .catchError((
-                      e,
-                    ) {
+                    .catchError((e) {
                       Log.error(
                         'Failed to send timeout crash report: $e',
                         name: 'UploadManager',
@@ -1018,7 +1009,7 @@ class UploadManager {
       final latestUpload = getUpload(upload.id) ?? upload;
 
       // Create updated upload with success metadata
-      final updatedUpload = _createSuccessfulUpload(latestUpload, result);
+      final updatedUpload = createSuccessfulUpload(latestUpload, result);
       await _store.update(updatedUpload);
 
       // Record successful metrics
@@ -1255,10 +1246,7 @@ class UploadManager {
 
   /// Retry a failed upload. Delegates to [UploadRetryPolicy.retryUpload].
   Future<void> retryUpload(String uploadId) async {
-    await _retryPolicy.retryUpload(
-      uploadId,
-      performUpload: _performUpload,
-    );
+    await _retryPolicy.retryUpload(uploadId, performUpload: _performUpload);
   }
 
   /// Resumes a single interrupted upload.
@@ -1376,16 +1364,24 @@ class UploadManager {
     );
   }
 
-  /// Create successful upload with metadata
-  PendingUpload _createSuccessfulUpload(PendingUpload upload, dynamic result) {
+  /// Create successful upload with metadata.
+  ///
+  /// Visible for testing so the thumbnail-precedence contract — a custom
+  /// cover already uploaded onto [upload] wins over the server-derived
+  /// poster carried by [result] — can be exercised directly.
+  @visibleForTesting
+  PendingUpload createSuccessfulUpload(PendingUpload upload, dynamic result) {
     final resultThumbnailUrl = _resultThumbnailUrl(result);
 
     final existingThumbnailUrl = upload.thumbnailPath;
+    // Prefer the custom cover we uploaded from the user's chosen frame
+    // (already stored on the upload) over the server's derived poster —
+    // otherwise a picked cover is silently replaced by {videoHash}.jpg.
     String? thumbnailUrl;
-    if (_isHttpUrl(resultThumbnailUrl)) {
-      thumbnailUrl = resultThumbnailUrl;
-    } else if (_isHttpUrl(existingThumbnailUrl)) {
+    if (_isHttpUrl(existingThumbnailUrl)) {
       thumbnailUrl = existingThumbnailUrl;
+    } else if (_isHttpUrl(resultThumbnailUrl)) {
+      thumbnailUrl = resultThumbnailUrl;
     }
 
     if (resultThumbnailUrl != null && !_isHttpUrl(resultThumbnailUrl)) {

--- a/mobile/test/services/upload_manager_thumbnail_test.dart
+++ b/mobile/test/services/upload_manager_thumbnail_test.dart
@@ -5,7 +5,9 @@ import 'dart:io';
 import 'package:blossom_upload_service/blossom_upload_service.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:openvine/models/pending_upload.dart';
 import 'package:openvine/services/circuit_breaker_service.dart';
+import 'package:openvine/services/upload_manager.dart';
 
 class _MockBlossomUploadService extends Mock implements BlossomUploadService {}
 
@@ -246,6 +248,71 @@ void main() {
       // If thumbnail generation fails, video upload should still succeed
       // This is verified by the try-catch in the implementation
       expect(true, isTrue);
+    });
+  });
+
+  group('UploadManager.createSuccessfulUpload thumbnail precedence', () {
+    // The server derives a poster at {videoHash}.jpg and returns it as the
+    // video upload's thumbnailUrl. When the user picked a cover, we extract
+    // and upload it separately and store it on the upload's thumbnailPath —
+    // that custom cover must survive, not be replaced by the server poster.
+    const serverPoster = 'https://media.divine.video/videohash.jpg';
+    const customCover = 'https://media.divine.video/customcoverhash';
+
+    late _MockBlossomUploadService mockBlossomService;
+    late UploadManager uploadManager;
+
+    setUp(() {
+      mockBlossomService = _MockBlossomUploadService();
+      uploadManager = UploadManager(blossomService: mockBlossomService);
+    });
+
+    tearDown(() {
+      uploadManager.dispose();
+    });
+
+    PendingUpload uploadWith(String? thumbnailPath) => PendingUpload.create(
+      localVideoPath: '/tmp/video.mp4',
+      nostrPubkey: 'test-pubkey',
+      thumbnailPath: thumbnailPath,
+    );
+
+    BlossomUploadResult resultWithPoster() => const BlossomUploadResult(
+      success: true,
+      videoId: 'videohash',
+      url: 'https://media.divine.video/videohash',
+      fallbackUrl: 'https://media.divine.video/videohash',
+      thumbnailUrl: serverPoster,
+    );
+
+    test('keeps the custom uploaded cover over the server poster', () {
+      final updated = uploadManager.createSuccessfulUpload(
+        uploadWith(customCover),
+        resultWithPoster(),
+      );
+
+      expect(updated.thumbnailPath, equals(customCover));
+    });
+
+    test(
+      'falls back to the server poster when no custom cover was uploaded',
+      () {
+        final updated = uploadManager.createSuccessfulUpload(
+          uploadWith(null),
+          resultWithPoster(),
+        );
+
+        expect(updated.thumbnailPath, equals(serverPoster));
+      },
+    );
+
+    test('ignores a non-http local cover path and uses the server poster', () {
+      final updated = uploadManager.createSuccessfulUpload(
+        uploadWith('/data/app/thumbnail_local.jpg'),
+        resultWithPoster(),
+      );
+
+      expect(updated.thumbnailPath, equals(serverPoster));
     });
   });
 }


### PR DESCRIPTION
Closes #5833

## What

Custom cover thumbnails picked in the editor were silently dropped at publish time — the published video used the server's default poster instead of the frame the user chose.

## Root cause

At publish, `UploadManager` correctly re-extracts the user's chosen frame (at `upload.thumbnailTimestamp`) and uploads it as a custom cover, storing the resulting CDN URL on `upload.thumbnailPath`. But `createSuccessfulUpload` then rebuilt the upload record preferring the *video* upload response's `thumbnailUrl` — which the server derives as `{videoHash}.jpg` — over that custom cover. So the picked cover was overwritten by the server's default poster before `VideoEventPublisher` emitted the `image` field in the kind 34236 event's imeta.

Confirmed from a user log: the custom cover uploaded to `…/718c2342…`, yet the published event carried `…/8ea637d5….jpg`, which is `{videoHash}.jpg` (the server poster).

## Fix

Swap the precedence in `createSuccessfulUpload` so a valid HTTP custom cover wins, falling back to the server poster only when no uploaded cover is present. `_isHttpUrl` still filters out stale local paths, so the fallback stays correct when custom thumbnail generation fails.

Scope note: every publish uploads a CDN thumbnail (the relay requires one), so this makes the client-uploaded thumbnail win over the server poster for all uploads — not only user-picked covers. The server poster is now used only as a fallback when the thumbnail upload itself failed.

## Tests

Exposed `createSuccessfulUpload` as `@visibleForTesting` (matching the existing `startProcessingPoll` precedent) and added three regression cases in `upload_manager_thumbnail_test.dart`: the custom cover wins over the poster, it falls back to the poster when there is no cover, and it ignores a non-http local path. `flutter analyze` and the touched test suite are green.

## Manual test plan

Pick a custom cover in the editor, publish, and verify the published video's thumbnail matches the chosen frame (not the server's default poster).
