### PR TITLE
feat(video_recorder): let lip-sync record past the 6.3s limit

### DIFF
--- a/mobile/lib/models/video_recorder/video_recorder_mode.dart
+++ b/mobile/lib/models/video_recorder/video_recorder_mode.dart
@@ -28,7 +28,7 @@ enum VideoRecorderMode {
   bool get hasRecordingLimit => switch (this) {
     .upload => false,
     .capture => false,
-    .lipSync => true,
+    .lipSync => false,
     .classic => true,
   };
 

--- a/mobile/test/models/video_recorder/video_recorder_mode_test.dart
+++ b/mobile/test/models/video_recorder/video_recorder_mode_test.dart
@@ -27,8 +27,8 @@ void main() {
         expect(VideoRecorderMode.capture.hasRecordingLimit, isFalse);
       });
 
-      test('lipSync has recording limit', () {
-        expect(VideoRecorderMode.lipSync.hasRecordingLimit, isTrue);
+      test('lipSync has no recording limit', () {
+        expect(VideoRecorderMode.lipSync.hasRecordingLimit, isFalse);
       });
 
       test('classic has recording limit', () {


### PR DESCRIPTION
## What

Removes the hard recording cap in **lip-sync** mode by setting `hasRecordingLimit` to `false` in `VideoRecorderMode`. Lip-sync now records freely and routes the full clip into the video editor — the same path `capture` mode already uses.

## Why

From the Zendesk request (#5823): users want to record a longer take in lip-sync, then trim it down to fit the 6.3s window and their chosen audio.

Previously lip-sync stopped the camera at 6.3s and, if a clip somehow exceeded the remaining window, hard-trimmed it from the **front** — the user had no say in which slice was kept. Since lip-sync already has the video editor enabled (`hasVideoEditor == true`), lifting the cap lets the recorded take flow into the editor's timeline where the user picks the portion that fits the sound.

All four `hasRecordingLimit` reads live in `VideoRecorderBloc` (auto-stop guard, start guard, `maxDuration`, and the `limitClipDuration` bool it hands to `ClipManagerNotifier`) and degrade cleanly to the existing `capture`-mode behavior: no auto-stop, no `maxDuration` passed to the camera, and no auto-trim on the clip. (Two further reads sit in UI widgets, one on the lip-sync path.)

## Changes

- `video_recorder_mode.dart` — `lipSync.hasRecordingLimit` → `false`.
- `video_recorder_mode_test.dart` — updated the assertion to match.

## Testing

- `flutter test test/models/video_recorder/video_recorder_mode_test.dart` ✅
- `flutter test test/widgets/video_recorder/modes/lip_sync/video_recorder_lip_sync_stack_test.dart` ✅
- `flutter analyze` on changed files — no issues.

Closes #5823