### PR TITLE
revert(reel): restore the pre-#5704 center reaction pop

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -3889,7 +3889,6 @@
     "dmReelReplyViewChatA11yLabel": "ውይይት ይክፈቱ",
     "dmReelReplySentAnnouncement": "መልስ ተልኳል",
     "dmReelReactionSentAnnouncement": "በ{emoji} ምላሽ ሰጥተዋል",
-    "dmReelReactionSentPill": "ምላሽ ተልኳል",
     "dmReelReplyFailed": "መላክ አልተቻለም",
     "emojiPickerSearchHint": "ፍለጋ",
     "emojiCategoryRecent": "የቅርብ ጊዜ",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -3757,7 +3757,6 @@
     "dmReelReplyViewChatA11yLabel": "فتح المحادثة",
     "dmReelReplySentAnnouncement": "تم إرسال الرد",
     "dmReelReactionSentAnnouncement": "تفاعلت بـ {emoji}",
-    "dmReelReactionSentPill": "تم إرسال التفاعل",
     "dmReelReplyFailed": "تعذّر الإرسال",
     "emojiPickerSearchHint": "بحث",
     "emojiCategoryRecent": "الأخيرة",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -3895,7 +3895,6 @@
     "dmReelReplyViewChatA11yLabel": "Отвори чата",
     "dmReelReplySentAnnouncement": "Отговорът е изпратен",
     "dmReelReactionSentAnnouncement": "Реагирахте с {emoji}",
-    "dmReelReactionSentPill": "Реакцията е изпратена",
     "dmReelReplyFailed": "Изпращането е неуспешно",
     "emojiPickerSearchHint": "Търсене",
     "emojiCategoryRecent": "Скорошни",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -3757,7 +3757,6 @@
     "dmReelReplyViewChatA11yLabel": "Chat öffnen",
     "dmReelReplySentAnnouncement": "Antwort gesendet",
     "dmReelReactionSentAnnouncement": "Mit {emoji} reagiert",
-    "dmReelReactionSentPill": "Reaktion gesendet",
     "dmReelReplyFailed": "Senden fehlgeschlagen",
     "emojiPickerSearchHint": "Suchen",
     "emojiCategoryRecent": "Zuletzt verwendet",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -3189,10 +3189,6 @@
       }
     }
   },
-  "dmReelReactionSentPill": "Reaction sent",
-  "@dmReelReactionSentPill": {
-    "description": "Centered confirmation pill shown over the reel for ~1s after a quick reaction is sent, alongside the emoji float animation."
-  },
   "dmReelReplyFailed": "Couldn't send",
   "@dmReelReplyFailed": {
     "description": "Transient toast shown in the reel player when a reply or reaction fails to send."

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -3757,7 +3757,6 @@
     "dmReelReplyViewChatA11yLabel": "Abrir chat",
     "dmReelReplySentAnnouncement": "Respuesta enviada",
     "dmReelReactionSentAnnouncement": "Reaccionaste {emoji}",
-    "dmReelReactionSentPill": "Reacción enviada",
     "dmReelReplyFailed": "No se pudo enviar",
     "emojiPickerSearchHint": "Buscar",
     "emojiCategoryRecent": "Recientes",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -2340,7 +2340,6 @@
     "dmReelReplyViewChatA11yLabel": "Buksan ang chat",
     "dmReelReplySentAnnouncement": "Naipadala ang tugon",
     "dmReelReactionSentAnnouncement": "Nag-react ng {emoji}",
-    "dmReelReactionSentPill": "Naipadala ang reaksyon",
     "dmReelReplyFailed": "Hindi maipadala",
     "emojiPickerSearchHint": "Maghanap",
     "emojiCategoryRecent": "Kamakailan",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -3757,7 +3757,6 @@
     "dmReelReplyViewChatA11yLabel": "Ouvrir la discussion",
     "dmReelReplySentAnnouncement": "Réponse envoyée",
     "dmReelReactionSentAnnouncement": "Réaction {emoji} envoyée",
-    "dmReelReactionSentPill": "Réaction envoyée",
     "dmReelReplyFailed": "Échec de l'envoi",
     "emojiPickerSearchHint": "Rechercher",
     "emojiCategoryRecent": "Récents",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -3757,7 +3757,6 @@
     "dmReelReplyViewChatA11yLabel": "Buka obrolan",
     "dmReelReplySentAnnouncement": "Balasan terkirim",
     "dmReelReactionSentAnnouncement": "Bereaksi {emoji}",
-    "dmReelReactionSentPill": "Reaksi terkirim",
     "dmReelReplyFailed": "Tidak dapat mengirim",
     "emojiPickerSearchHint": "Cari",
     "emojiCategoryRecent": "Terbaru",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -3757,7 +3757,6 @@
     "dmReelReplyViewChatA11yLabel": "Apri chat",
     "dmReelReplySentAnnouncement": "Risposta inviata",
     "dmReelReactionSentAnnouncement": "Hai reagito {emoji}",
-    "dmReelReactionSentPill": "Reazione inviata",
     "dmReelReplyFailed": "Invio non riuscito",
     "emojiPickerSearchHint": "Cerca",
     "emojiCategoryRecent": "Recenti",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -3757,7 +3757,6 @@
     "dmReelReplyViewChatA11yLabel": "チャットを開く",
     "dmReelReplySentAnnouncement": "返信を送信しました",
     "dmReelReactionSentAnnouncement": "{emoji}でリアクションしました",
-    "dmReelReactionSentPill": "リアクションを送信しました",
     "dmReelReplyFailed": "送信できませんでした",
     "emojiPickerSearchHint": "検索",
     "emojiCategoryRecent": "最近使った絵文字",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -3088,7 +3088,6 @@
     "dmReelReplyViewChatA11yLabel": "채팅 열기",
     "dmReelReplySentAnnouncement": "답장을 보냈습니다",
     "dmReelReactionSentAnnouncement": "{emoji} 반응함",
-    "dmReelReactionSentPill": "반응을 보냈어요",
     "dmReelReplyFailed": "보내지 못했습니다",
     "emojiPickerSearchHint": "검색",
     "emojiCategoryRecent": "최근 사용",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -3757,7 +3757,6 @@
     "dmReelReplyViewChatA11yLabel": "Chat openen",
     "dmReelReplySentAnnouncement": "Antwoord verzonden",
     "dmReelReactionSentAnnouncement": "Gereageerd met {emoji}",
-    "dmReelReactionSentPill": "Reactie verzonden",
     "dmReelReplyFailed": "Verzenden mislukt",
     "emojiPickerSearchHint": "Zoeken",
     "emojiCategoryRecent": "Recent",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -3757,7 +3757,6 @@
     "dmReelReplyViewChatA11yLabel": "Otwórz czat",
     "dmReelReplySentAnnouncement": "Odpowiedź wysłana",
     "dmReelReactionSentAnnouncement": "Zareagowano {emoji}",
-    "dmReelReactionSentPill": "Wysłano reakcję",
     "dmReelReplyFailed": "Nie udało się wysłać",
     "emojiPickerSearchHint": "Szukaj",
     "emojiCategoryRecent": "Ostatnie",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -3757,7 +3757,6 @@
     "dmReelReplyViewChatA11yLabel": "Abrir conversa",
     "dmReelReplySentAnnouncement": "Resposta enviada",
     "dmReelReactionSentAnnouncement": "Você reagiu {emoji}",
-    "dmReelReactionSentPill": "Reação enviada",
     "dmReelReplyFailed": "Não foi possível enviar",
     "emojiPickerSearchHint": "Pesquisar",
     "emojiCategoryRecent": "Recentes",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -3757,7 +3757,6 @@
     "dmReelReplyViewChatA11yLabel": "Deschide conversația",
     "dmReelReplySentAnnouncement": "Răspuns trimis",
     "dmReelReactionSentAnnouncement": "Ai reacționat {emoji}",
-    "dmReelReactionSentPill": "Reacție trimisă",
     "dmReelReplyFailed": "Trimiterea a eșuat",
     "emojiPickerSearchHint": "Căutare",
     "emojiCategoryRecent": "Recente",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -3757,7 +3757,6 @@
     "dmReelReplyViewChatA11yLabel": "Öppna chatt",
     "dmReelReplySentAnnouncement": "Svar skickat",
     "dmReelReactionSentAnnouncement": "Reagerade {emoji}",
-    "dmReelReactionSentPill": "Reaktion skickad",
     "dmReelReplyFailed": "Det gick inte att skicka",
     "emojiPickerSearchHint": "Sök",
     "emojiCategoryRecent": "Senaste",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -3757,7 +3757,6 @@
     "dmReelReplyViewChatA11yLabel": "Sohbeti aç",
     "dmReelReplySentAnnouncement": "Yanıt gönderildi",
     "dmReelReactionSentAnnouncement": "{emoji} ile tepki verildi",
-    "dmReelReactionSentPill": "Tepki gönderildi",
     "dmReelReplyFailed": "Gönderilemedi",
     "emojiPickerSearchHint": "Ara",
     "emojiCategoryRecent": "Son Kullanılanlar",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -9768,12 +9768,6 @@ abstract class AppLocalizations {
   /// **'Reacted {emoji}'**
   String dmReelReactionSentAnnouncement(String emoji);
 
-  /// Centered confirmation pill shown over the reel for ~1s after a quick reaction is sent, alongside the emoji float animation.
-  ///
-  /// In en, this message translates to:
-  /// **'Reaction sent'**
-  String get dmReelReactionSentPill;
-
   /// Transient toast shown in the reel player when a reply or reaction fails to send.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -5451,9 +5451,6 @@ class AppLocalizationsAm extends AppLocalizations {
   }
 
   @override
-  String get dmReelReactionSentPill => 'ምላሽ ተልኳል';
-
-  @override
   String get dmReelReplyFailed => 'መላክ አልተቻለም';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -5527,9 +5527,6 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
-  String get dmReelReactionSentPill => 'تم إرسال التفاعل';
-
-  @override
   String get dmReelReplyFailed => 'تعذّر الإرسال';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -5614,9 +5614,6 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
-  String get dmReelReactionSentPill => 'Реакцията е изпратена';
-
-  @override
   String get dmReelReplyFailed => 'Изпращането е неуспешно';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -5630,9 +5630,6 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get dmReelReactionSentPill => 'Reaktion gesendet';
-
-  @override
   String get dmReelReplyFailed => 'Senden fehlgeschlagen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -5561,9 +5561,6 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get dmReelReactionSentPill => 'Reaction sent';
-
-  @override
   String get dmReelReplyFailed => 'Couldn\'t send';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -5605,9 +5605,6 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get dmReelReactionSentPill => 'Reacción enviada';
-
-  @override
   String get dmReelReplyFailed => 'No se pudo enviar';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -5629,9 +5629,6 @@ class AppLocalizationsFil extends AppLocalizations {
   }
 
   @override
-  String get dmReelReactionSentPill => 'Naipadala ang reaksyon';
-
-  @override
   String get dmReelReplyFailed => 'Hindi maipadala';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -5634,9 +5634,6 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get dmReelReactionSentPill => 'Réaction envoyée';
-
-  @override
   String get dmReelReplyFailed => 'Échec de l\'envoi';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -5536,9 +5536,6 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
-  String get dmReelReactionSentPill => 'Reaksi terkirim';
-
-  @override
   String get dmReelReplyFailed => 'Tidak dapat mengirim';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -5611,9 +5611,6 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get dmReelReactionSentPill => 'Reazione inviata';
-
-  @override
   String get dmReelReplyFailed => 'Invio non riuscito';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -5334,9 +5334,6 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get dmReelReactionSentPill => 'リアクションを送信しました';
-
-  @override
   String get dmReelReplyFailed => '送信できませんでした';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -5354,9 +5354,6 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
-  String get dmReelReactionSentPill => '반응을 보냈어요';
-
-  @override
   String get dmReelReplyFailed => '보내지 못했습니다';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -5587,9 +5587,6 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
-  String get dmReelReactionSentPill => 'Reactie verzonden';
-
-  @override
   String get dmReelReplyFailed => 'Verzenden mislukt';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -5706,9 +5706,6 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String get dmReelReactionSentPill => 'Wysłano reakcję';
-
-  @override
   String get dmReelReplyFailed => 'Nie udało się wysłać';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -5597,9 +5597,6 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get dmReelReactionSentPill => 'Reação enviada';
-
-  @override
   String get dmReelReplyFailed => 'Não foi possível enviar';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -5714,9 +5714,6 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get dmReelReactionSentPill => 'Reacție trimisă';
-
-  @override
   String get dmReelReplyFailed => 'Trimiterea a eșuat';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -5562,9 +5562,6 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
-  String get dmReelReactionSentPill => 'Reaktion skickad';
-
-  @override
   String get dmReelReplyFailed => 'Det gick inte att skicka';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -5542,9 +5542,6 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
-  String get dmReelReactionSentPill => 'Tepki gönderildi';
-
-  @override
   String get dmReelReplyFailed => 'Gönderilemedi';
 
   @override

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -896,8 +896,8 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                           ),
                       ],
                     ),
-                    // Full-screen Instagram-style reaction float over the
-                    // reel.
+                    // Full-screen TikTok/IG-style reaction pop, centered over
+                    // the reel.
                     if (_reactionEmoji != null)
                       Positioned.fill(
                         child: ReactionOverlay(

--- a/mobile/lib/widgets/video_feed_item/reaction_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/reaction_overlay.dart
@@ -1,137 +1,32 @@
-// ABOUTME: Full-screen Instagram-style reaction "float" over the reel.
-// ABOUTME: Tapping a reaction emits a stream of emoji that drift gently up from a
-// ABOUTME: lower-center anchor, wiggle side-to-side, and fade near the top,
-// ABOUTME: alongside a centered "Reaction sent" pill.
+// ABOUTME: Full-screen TikTok/Instagram-style reaction animation over the reel.
+// ABOUTME: A big emoji springs in at screen center (overshoot), holds, floats
+// ABOUTME: up and fades, garnished by a few floating-particle copies.
 //
-// Motion model (matches Instagram/TikTok DM reactions): a calm upward float —
-// NOT a ballistic burst. Each emoji rises with a gentle ease-out, sways
-// sinusoidally (bigger emoji wiggle wider), pops in, and fades out across the
-// back half of its life. No gravity arc.
-//
-// Rendering: every particle is drawn in ONE batched `Canvas.drawRawAtlas` call
-// from a single rasterized glyph image, with the transform/color buffers
-// pre-allocated once and refilled in place each frame (zero per-frame
-// allocation). Driven by one `AnimationController` as the `repaint:` Listenable
-// inside a `RepaintBoundary`; it is one-shot and stops on completion, so the
-// overlay never burns CPU/battery while idle (#5389).
+// Rendered on a SINGLE GPU layer: the emoji is rasterized once to a
+// `ui.Image`, then the hero + particles are drawn by one `CustomPainter` via
+// `drawImageRect` (alpha modulated through `paint.color`, transforms through
+// the canvas). This avoids the per-frame `Opacity` save-layers and per-frame
+// widget rebuilds that made the previous `Stack`-of-`Text` version stutter on
+// low-end devices (#5389).
 
 import 'dart:math';
-import 'dart:typed_data';
 import 'dart:ui' as ui;
 
-import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
-import 'package:openvine/l10n/l10n.dart';
 
-/// Tunable parameters for the reaction float. Grouped here so the motion can be
-/// adjusted in one place rather than scattered as magic numbers.
-abstract class _FloatConfig {
-  /// Number of emoji emitted per tap.
-  static const int count = 18;
+/// Font size the hero emoji is rasterized at; particles draw the same image
+/// scaled down.
+const double _heroFontSize = 120;
 
-  /// Total animation duration. Every particle has faded out by the end, after
-  /// which the host removes the overlay.
-  static const Duration duration = Duration(milliseconds: 2700);
-
-  static double get durationSeconds =>
-      duration.inMicroseconds / Duration.microsecondsPerSecond;
-
-  /// Font size the emoji is rasterized at; particles only ever downscale this.
-  static const double glyphFontSize = 120;
-
-  /// Vertical anchor for the emission origin, as a fraction of overlay height.
-  static const double originYFraction = 0.72;
-
-  /// Spawn spread around the origin, as a fraction of overlay width/height.
-  /// A near-full-width horizontal band keeps emoji from bunching up — the
-  /// Instagram reference spans ~80% of the screen width.
-  static const double spawnSpreadXFraction = 0.40;
-  static const double spawnSpreadYFraction = 0.05;
-
-  /// How far up an emoji travels, as a fraction of overlay height (randomized).
-  static const double riseFractionMin = 0.52;
-  static const double riseFractionMax = 0.66;
-
-  /// Target on-screen draw size range for an emoji (logical px).
-  static const double sizeMin = 24;
-  static const double sizeMax = 48;
-
-  /// Window over which emissions are staggered (seconds), so the burst reads as
-  /// a stream rather than a single instantaneous batch.
-  static const double staggerWindow = 0.40;
-
-  /// Sine-wiggle amplitude as a multiple of the emoji's size (bigger emoji
-  /// wiggle wider) and the number of sway cycles over a lifetime.
-  static const double wiggleAmpMultMin = 0.8;
-  static const double wiggleAmpMultMax = 1.3;
-  static const double wiggleFreqMin = 0.7;
-  static const double wiggleFreqMax = 1.5;
-
-  /// Subtle tilt half-extent (radians) synced to the wiggle.
-  static const double tiltMax = 0.12;
-
-  /// Normalized-life envelope breakpoints (per particle).
-  static const double fadeInFraction = 0.08;
-  static const double holdUntilFraction = 0.5;
-  static const double scaleInFraction = 0.12;
-}
-
-/// Opacity envelope for a floating emoji over its normalized life [lp] (0 at
-/// birth, 1 at death): quick fade in, hold, then a long fade out across the back
-/// half so it dims as it nears the top. Always within `[0, 1]`.
-@visibleForTesting
-double reactionFloatOpacity(double lp) {
-  if (lp <= 0 || lp >= 1) return 0;
-  if (lp < _FloatConfig.fadeInFraction) {
-    return lp / _FloatConfig.fadeInFraction;
-  }
-  if (lp < _FloatConfig.holdUntilFraction) return 1;
-  final fade =
-      (lp - _FloatConfig.holdUntilFraction) /
-      (1 - _FloatConfig.holdUntilFraction);
-  return (1 - fade).clamp(0.0, 1.0);
-}
-
-/// Scale-in (pop) multiplier over normalized life [lp]: eases 0→1 over the first
-/// [_FloatConfig.scaleInFraction], then holds at 1. Emoji never shrink out —
-/// opacity carries the disappearance.
-@visibleForTesting
-double reactionFloatScaleIn(double lp) {
-  if (lp <= 0) return 0;
-  if (lp >= _FloatConfig.scaleInFraction) return 1;
-  return Curves.easeOut.transform(lp / _FloatConfig.scaleInFraction);
-}
-
-/// Eased vertical-rise fraction (0→1) over normalized life [lp]. A gentle
-/// ease-out so the emoji drifts up at a near-constant pace and settles near the
-/// top rather than launching — the opposite of a ballistic burst.
-@visibleForTesting
-double reactionFloatRise(double lp) =>
-    Curves.easeOutSine.transform(lp.clamp(0.0, 1.0));
-
-/// Horizontal sine-wiggle offset (logical px) at normalized life [lp].
-@visibleForTesting
-double reactionFloatWiggle(
-  double amplitude,
-  double frequency,
-  double phase,
-  double lp,
-) => amplitude * sin(frequency * 2 * pi * lp + phase);
-
-/// One-shot full-screen reaction float over the player. [_FloatConfig.count]
-/// emoji drift up from a lower-center anchor while a centered "Reaction sent"
-/// pill fades in and out.
+/// One-shot reaction animation centered over the player. The hero emoji springs
+/// in with an overshoot (`easeOutBack`), holds, then floats up ~70px while
+/// fading; a light layer of floating copies sways upward alongside it.
 ///
 /// Rebuild with a fresh `key` (e.g. `ValueKey(nonce)`) to replay on each tap.
 class ReactionOverlay extends StatefulWidget {
   /// Creates a reaction overlay for [emoji]. [onComplete] fires when the
   /// animation ends so the host can remove the overlay.
-  const ReactionOverlay({
-    required this.emoji,
-    this.onComplete,
-    this.randomSeed,
-    super.key,
-  });
+  const ReactionOverlay({required this.emoji, this.onComplete, super.key});
 
   /// The emoji to animate.
   final String emoji;
@@ -139,73 +34,78 @@ class ReactionOverlay extends StatefulWidget {
   /// Called once the animation completes.
   final VoidCallback? onComplete;
 
-  /// Optional seed for deterministic particle generation in tests.
-  @visibleForTesting
-  final int? randomSeed;
-
   @override
   State<ReactionOverlay> createState() => _ReactionOverlayState();
 }
 
 class _ReactionOverlayState extends State<ReactionOverlay>
     with SingleTickerProviderStateMixin {
-  late final AnimationController _controller;
-  late final Animation<double> _pillOpacity;
-  late final List<_FloatParticle> _particles;
+  static const Duration _duration = Duration(milliseconds: 1100);
+  static const int _particleCount = 5;
 
-  /// Pre-allocated, reused-every-frame buffers for the batched draw call.
-  /// `_rstTransforms` (scale/rotation/translate) and `_colors` (per-sprite
-  /// alpha) are refilled in place each paint; `_rects` is constant (every
-  /// particle samples the whole glyph) and filled once.
-  late final Float32List _rstTransforms;
-  late final Int32List _colors;
-  Float32List? _rects;
+  /// Extra resolution headroom so the hero's `easeOutBack` overshoot
+  /// (peak scale ~1.28) never upsamples the rasterized glyph past device
+  /// pixels.
+  static const double _supersample = 1.3;
+
+  late final AnimationController _controller;
+  late final Animation<double> _heroScale;
+  late final Animation<double> _heroGrow;
+  late final Animation<double> _heroOpacity;
+  late final Animation<double> _heroY;
+  late final List<_Particle> _particles;
 
   /// The emoji rasterized once to a GPU image; null until prepared.
   ui.Image? _emojiImage;
-  double _devicePixelRatio = 1;
+
+  /// Logical size of the rasterized glyph at [_heroFontSize] (the draw size
+  /// before any animated scale).
+  Size _baseSize = Size.zero;
   bool _prepared = false;
 
   @override
   void initState() {
     super.initState();
-    _controller =
-        AnimationController(vsync: this, duration: _FloatConfig.duration)
-          ..addStatusListener((status) {
-            if (status == AnimationStatus.completed) widget.onComplete?.call();
-          })
-          ..forward();
+    _controller = AnimationController(vsync: this, duration: _duration)
+      ..addStatusListener((status) {
+        if (status == AnimationStatus.completed) widget.onComplete?.call();
+      })
+      ..forward();
 
-    // The "Reaction sent" pill: fade in, hold, fade out within the first ~1.5s
-    // (it need not linger for the full float).
-    _pillOpacity = TweenSequence<double>([
-      TweenSequenceItem(
-        tween: Tween(
-          begin: 0.0,
-          end: 1.0,
-        ).chain(CurveTween(curve: Curves.easeOut)),
-        weight: 7,
+    // Spring in with a single ~27.5% overshoot, settle to 1.0.
+    _heroScale = Tween<double>(begin: 0, end: 1).animate(
+      CurvedAnimation(
+        parent: _controller,
+        curve: const Interval(0, 0.35, curve: Curves.easeOutBack),
       ),
-      TweenSequenceItem(tween: ConstantTween(1), weight: 48),
+    );
+    // Gentle extra grow as it floats away.
+    _heroGrow = Tween<double>(begin: 1, end: 1.08).animate(
+      CurvedAnimation(parent: _controller, curve: const Interval(0.65, 1)),
+    );
+    _heroOpacity = TweenSequence<double>([
+      TweenSequenceItem(tween: Tween(begin: 0, end: 1), weight: 15),
+      TweenSequenceItem(tween: ConstantTween(1), weight: 50),
       TweenSequenceItem(
         tween: Tween(
           begin: 1.0,
           end: 0.0,
         ).chain(CurveTween(curve: Curves.easeIn)),
-        weight: 12,
+        weight: 35,
       ),
-      TweenSequenceItem(tween: ConstantTween(0), weight: 33),
     ]).animate(_controller);
-
-    final random = widget.randomSeed != null
-        ? Random(widget.randomSeed)
-        : Random();
-    _particles = List.generate(
-      _FloatConfig.count,
-      (_) => _FloatParticle.random(random),
+    _heroY = Tween<double>(begin: 0, end: -70).animate(
+      CurvedAnimation(
+        parent: _controller,
+        curve: const Interval(0.65, 1, curve: Curves.easeOut),
+      ),
     );
-    _rstTransforms = Float32List(_FloatConfig.count * 4);
-    _colors = Int32List(_FloatConfig.count);
+
+    final random = Random();
+    _particles = List.generate(
+      _particleCount,
+      (_) => _Particle.random(random),
+    );
   }
 
   @override
@@ -215,40 +115,32 @@ class _ReactionOverlayState extends State<ReactionOverlay>
     // Runs before the first build, so the first frame paints the image.
     if (_prepared) return;
     _prepared = true;
-    _devicePixelRatio = MediaQuery.devicePixelRatioOf(context);
     _prepareEmojiImage();
   }
 
   void _prepareEmojiImage() {
+    final devicePixelRatio = MediaQuery.devicePixelRatioOf(context);
     final textPainter = TextPainter(
       text: TextSpan(
         text: widget.emoji,
-        style: const TextStyle(fontSize: _FloatConfig.glyphFontSize),
+        style: const TextStyle(fontSize: _heroFontSize),
       ),
       textDirection: TextDirection.ltr,
     )..layout();
 
     final logicalSize = textPainter.size;
-    // Particles only downscale the glyph, so device-pixel resolution is enough
-    // headroom — no supersampling needed.
-    final pixelWidth = (logicalSize.width * _devicePixelRatio).ceil();
-    final pixelHeight = (logicalSize.height * _devicePixelRatio).ceil();
+    final pixelScale = devicePixelRatio * _supersample;
+    final pixelWidth = (logicalSize.width * pixelScale).ceil();
+    final pixelHeight = (logicalSize.height * pixelScale).ceil();
     if (pixelWidth <= 0 || pixelHeight <= 0) return;
 
     final recorder = ui.PictureRecorder();
-    final canvas = Canvas(recorder)..scale(_devicePixelRatio);
+    final canvas = Canvas(recorder)..scale(pixelScale);
     textPainter.paint(canvas, Offset.zero);
     final picture = recorder.endRecording();
     _emojiImage = picture.toImageSync(pixelWidth, pixelHeight);
+    _baseSize = logicalSize;
     picture.dispose();
-
-    // Every particle samples the whole glyph, so the source rects are constant.
-    final rects = Float32List(_FloatConfig.count * 4);
-    for (var i = 0; i < _FloatConfig.count; i++) {
-      rects[i * 4 + 2] = pixelWidth.toDouble();
-      rects[i * 4 + 3] = pixelHeight.toDouble();
-    }
-    _rects = rects;
   }
 
   @override
@@ -262,233 +154,167 @@ class _ReactionOverlayState extends State<ReactionOverlay>
   Widget build(BuildContext context) {
     return IgnorePointer(
       child: RepaintBoundary(
-        child: Stack(
-          children: [
-            Positioned.fill(
-              child: CustomPaint(
-                painter: _FloatPainter(
-                  image: _emojiImage,
-                  devicePixelRatio: _devicePixelRatio,
-                  progress: _controller,
-                  particles: _particles,
-                  rstTransforms: _rstTransforms,
-                  rects: _rects,
-                  colors: _colors,
-                ),
-              ),
-            ),
-            Positioned.fill(
-              child: FadeTransition(
-                opacity: _pillOpacity,
-                child: const Align(
-                  alignment: Alignment(0, -0.1),
-                  child: _ReactionSentPill(),
-                ),
-              ),
-            ),
-          ],
+        child: CustomPaint(
+          size: Size.infinite,
+          painter: _ReactionPainter(
+            image: _emojiImage,
+            baseSize: _baseSize,
+            progress: _controller,
+            heroScale: _heroScale,
+            heroGrow: _heroGrow,
+            heroOpacity: _heroOpacity,
+            heroY: _heroY,
+            particles: _particles,
+          ),
         ),
       ),
     );
   }
 }
 
-/// Paints every floating emoji from a single rasterized [image] in ONE batched
-/// `drawRawAtlas` call. Repaints on every [progress] tick without rebuilding any
-/// widget; the transform/color buffers are refilled in place (no allocation).
-class _FloatPainter extends CustomPainter {
-  _FloatPainter({
+/// Paints the hero + particle emoji from a single rasterized [image] on one
+/// canvas. Repaints on every [progress] tick without rebuilding any widget;
+/// opacity is applied via `paint.color` (no save-layer) and position/scale/
+/// rotation via canvas transforms.
+class _ReactionPainter extends CustomPainter {
+  _ReactionPainter({
     required this.image,
-    required this.devicePixelRatio,
+    required this.baseSize,
     required this.progress,
+    required this.heroScale,
+    required this.heroGrow,
+    required this.heroOpacity,
+    required this.heroY,
     required this.particles,
-    required this.rstTransforms,
-    required this.rects,
-    required this.colors,
   }) : super(repaint: progress);
 
   final ui.Image? image;
-  final double devicePixelRatio;
+  final Size baseSize;
   final Animation<double> progress;
-  final List<_FloatParticle> particles;
-  final Float32List rstTransforms;
-  final Float32List? rects;
-  final Int32List colors;
-
-  static final Paint _paint = Paint()
-    ..filterQuality = FilterQuality.medium
-    ..isAntiAlias = true;
+  final Animation<double> heroScale;
+  final Animation<double> heroGrow;
+  final Animation<double> heroOpacity;
+  final Animation<double> heroY;
+  final List<_Particle> particles;
 
   @override
   void paint(Canvas canvas, Size size) {
     final glyph = image;
-    final rectBuffer = rects;
-    if (glyph == null || rectBuffer == null) return;
+    if (glyph == null) return;
 
-    final elapsed = progress.value * _FloatConfig.durationSeconds;
-    final origin = Offset(
-      size.width / 2,
-      size.height * _FloatConfig.originYFraction,
+    final t = progress.value;
+    final centerX = size.width / 2;
+    final centerY = size.height / 2;
+    final source = Rect.fromLTWH(
+      0,
+      0,
+      glyph.width.toDouble(),
+      glyph.height.toDouble(),
     );
-    final halfW = glyph.width / 2;
-    final halfH = glyph.height / 2;
 
-    for (var i = 0; i < particles.length; i++) {
-      final p = particles[i];
-      final base = i * 4;
-      final localT = elapsed - p.birthTime;
-      final life = _FloatConfig.durationSeconds - p.birthTime;
-      final lp = life <= 0 ? 1.0 : (localT / life).clamp(0.0, 1.0);
-      final opacity = localT < 0 ? 0.0 : reactionFloatOpacity(lp);
-
-      if (opacity <= 0) {
-        // Not born yet or already gone: contribute an invisible sprite.
-        colors[i] = 0;
-        rstTransforms[base] = 0;
-        rstTransforms[base + 1] = 0;
-        rstTransforms[base + 2] = 0;
-        rstTransforms[base + 3] = 0;
-        continue;
-      }
-
-      final cx =
-          origin.dx +
-          p.spawnFracX * _FloatConfig.spawnSpreadXFraction * size.width +
-          reactionFloatWiggle(
-            p.wiggleAmplitude,
-            p.wiggleFrequency,
-            p.wigglePhase,
-            lp,
-          );
-      final cy =
-          origin.dy +
-          p.spawnFracY * _FloatConfig.spawnSpreadYFraction * size.height -
-          p.riseFraction * size.height * reactionFloatRise(lp);
-
-      // Atlas scale maps glyph pixels → logical canvas; dividing by the device
-      // pixel ratio undoes the raster oversampling.
-      final s =
-          (p.sizePx / _FloatConfig.glyphFontSize) /
-          devicePixelRatio *
-          reactionFloatScaleIn(lp);
-      final rot =
-          p.tiltAmplitude *
-          sin(p.wiggleFrequency * 2 * pi * lp + p.wigglePhase);
-      final scos = s * cos(rot);
-      final ssin = s * sin(rot);
-
-      rstTransforms[base] = scos;
-      rstTransforms[base + 1] = ssin;
-      rstTransforms[base + 2] = cx - (scos * halfW - ssin * halfH);
-      rstTransforms[base + 3] = cy - (ssin * halfW + scos * halfH);
-
-      // Pack alpha into all four channels so `modulate` scales the premultiplied
-      // glyph uniformly — a clean fade with no edge halo.
-      final a = (opacity * 255).round().clamp(0, 255);
-      colors[i] = (a << 24) | (a << 16) | (a << 8) | a;
+    // Secondary floating-particle layer (garnish). All particles share the
+    // same opacity curve, varying only in position, scale and tilt.
+    final particleOpacity = sin(t * pi).clamp(0.0, 1.0);
+    for (final p in particles) {
+      final dx =
+          centerX +
+          p.startX +
+          p.amplitude * sin(p.frequency * t * 2 * pi + p.phase);
+      final dy = centerY - p.riseHeight * t;
+      final scale = (p.size * 0.85 / _heroFontSize) * p.scaleAt(t);
+      final rotation = 0.035 * sin(p.frequency * t * 2 * pi);
+      _paintEmoji(
+        canvas,
+        glyph,
+        source,
+        Offset(dx, dy),
+        scale,
+        rotation,
+        particleOpacity,
+      );
     }
 
-    canvas.drawRawAtlas(
+    // Primary hero pop at screen center.
+    _paintEmoji(
+      canvas,
       glyph,
-      rstTransforms,
-      rectBuffer,
-      colors,
-      BlendMode.modulate,
-      Offset.zero & size,
-      _paint,
+      source,
+      Offset(centerX, centerY + heroY.value),
+      heroScale.value * heroGrow.value,
+      0,
+      heroOpacity.value.clamp(0.0, 1.0),
     );
   }
 
+  void _paintEmoji(
+    Canvas canvas,
+    ui.Image glyph,
+    Rect source,
+    Offset center,
+    double scale,
+    double rotation,
+    double opacity,
+  ) {
+    if (opacity <= 0 || scale <= 0) return;
+    final paint = Paint()
+      ..filterQuality = FilterQuality.medium
+      ..isAntiAlias = true
+      ..color = Color.fromRGBO(255, 255, 255, opacity);
+    canvas.save();
+    canvas.translate(center.dx, center.dy);
+    if (rotation != 0) canvas.rotate(rotation);
+    canvas.scale(scale);
+    canvas.drawImageRect(
+      glyph,
+      source,
+      Rect.fromCenter(
+        center: Offset.zero,
+        width: baseSize.width,
+        height: baseSize.height,
+      ),
+      paint,
+    );
+    canvas.restore();
+  }
+
   @override
-  bool shouldRepaint(_FloatPainter oldDelegate) =>
-      image != oldDelegate.image ||
-      rects != oldDelegate.rects ||
-      devicePixelRatio != oldDelegate.devicePixelRatio;
+  bool shouldRepaint(_ReactionPainter oldDelegate) =>
+      image != oldDelegate.image || baseSize != oldDelegate.baseSize;
 }
 
-/// One floating emoji: an upward drift with a sinusoidal wiggle. Immutable after
-/// spawn; all motion is a pure function of elapsed time.
-class _FloatParticle {
-  _FloatParticle({
-    required this.birthTime,
-    required this.spawnFracX,
-    required this.spawnFracY,
-    required this.riseFraction,
-    required this.sizePx,
-    required this.wiggleAmplitude,
-    required this.wiggleFrequency,
-    required this.wigglePhase,
-    required this.tiltAmplitude,
+class _Particle {
+  _Particle({
+    required this.startX,
+    required this.size,
+    required this.scale,
+    required this.riseHeight,
+    required this.amplitude,
+    required this.frequency,
+    required this.phase,
   });
 
-  factory _FloatParticle.random(Random r) {
-    final sizePx =
-        _FloatConfig.sizeMin +
-        r.nextDouble() * (_FloatConfig.sizeMax - _FloatConfig.sizeMin);
-    return _FloatParticle(
-      birthTime: r.nextDouble() * _FloatConfig.staggerWindow,
-      spawnFracX: r.nextDouble() * 2 - 1,
-      spawnFracY: r.nextDouble() * 2 - 1,
-      riseFraction:
-          _FloatConfig.riseFractionMin +
-          r.nextDouble() *
-              (_FloatConfig.riseFractionMax - _FloatConfig.riseFractionMin),
-      sizePx: sizePx,
-      // Bigger emoji wiggle wider.
-      wiggleAmplitude:
-          sizePx *
-          (_FloatConfig.wiggleAmpMultMin +
-              r.nextDouble() *
-                  (_FloatConfig.wiggleAmpMultMax -
-                      _FloatConfig.wiggleAmpMultMin)),
-      wiggleFrequency:
-          _FloatConfig.wiggleFreqMin +
-          r.nextDouble() *
-              (_FloatConfig.wiggleFreqMax - _FloatConfig.wiggleFreqMin),
-      wigglePhase: r.nextDouble() * 2 * pi,
-      tiltAmplitude: (r.nextDouble() * 2 - 1) * _FloatConfig.tiltMax,
-    );
-  }
+  factory _Particle.random(Random r) => _Particle(
+    startX: (r.nextDouble() - 0.5) * 60, // ±30px
+    size: 44,
+    scale: 0.6 + r.nextDouble() * 0.4, // 0.6–1.0
+    riseHeight: 180 + r.nextDouble() * 140, // 180–320
+    amplitude: 12 + r.nextDouble() * 22, // 12–34
+    frequency: 1.0 + r.nextDouble() * 1.5, // 1.0–2.5
+    phase: r.nextDouble() * 2 * pi,
+  );
 
-  final double birthTime;
-  final double spawnFracX;
-  final double spawnFracY;
-  final double riseFraction;
-  final double sizePx;
-  final double wiggleAmplitude;
-  final double wiggleFrequency;
-  final double wigglePhase;
-  final double tiltAmplitude;
-}
+  final double startX;
+  final double size;
+  final double scale;
+  final double riseHeight;
+  final double amplitude;
+  final double frequency;
+  final double phase;
 
-/// The centered, translucent "Reaction sent" confirmation pill, styled from the
-/// design system (mirrors `FeedPlaybackTogglesPill`).
-class _ReactionSentPill extends StatelessWidget {
-  const _ReactionSentPill();
-
-  @override
-  Widget build(BuildContext context) {
-    return ClipRRect(
-      borderRadius: const BorderRadius.all(Radius.circular(22)),
-      child: BackdropFilter(
-        filter: ui.ImageFilter.blur(sigmaX: 4, sigmaY: 4),
-        child: DecoratedBox(
-          decoration: const BoxDecoration(
-            color: VineTheme.scrim70,
-            borderRadius: BorderRadius.all(Radius.circular(22)),
-            boxShadow: [
-              BoxShadow(color: VineTheme.shadow25, blurRadius: 4),
-            ],
-          ),
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
-            child: Text(
-              context.l10n.dmReelReactionSentPill,
-              style: VineTheme.labelLargeFont(),
-            ),
-          ),
-        ),
-      ),
-    );
+  /// Pop in (easeOutBack, first 20%), hold, then shrink out (last 25%).
+  double scaleAt(double t) {
+    if (t < 0.20) return scale * Curves.easeOutBack.transform(t / 0.20);
+    if (t > 0.75) return scale * (1 - (t - 0.75) / 0.25);
+    return scale;
   }
 }

--- a/mobile/lib/widgets/video_feed_item/reel_dm_reply_bar.dart
+++ b/mobile/lib/widgets/video_feed_item/reel_dm_reply_bar.dart
@@ -591,7 +591,7 @@ class _QuickReactionRow extends StatelessWidget {
   }
 }
 
-class _ReactionEmojiButton extends StatelessWidget {
+class _ReactionEmojiButton extends StatefulWidget {
   const _ReactionEmojiButton({
     required this.emoji,
     required this.isActive,
@@ -603,18 +603,73 @@ class _ReactionEmojiButton extends StatelessWidget {
   final VoidCallback onTap;
 
   @override
+  State<_ReactionEmojiButton> createState() => _ReactionEmojiButtonState();
+}
+
+class _ReactionEmojiButtonState extends State<_ReactionEmojiButton>
+    with SingleTickerProviderStateMixin {
+  static const Duration _bounceDuration = Duration(milliseconds: 550);
+
+  late final AnimationController _controller = AnimationController(
+    vsync: this,
+    duration: _bounceDuration,
+  );
+
+  /// Soft bounce: an unhurried lift, a gentle dip just below rest, then a
+  /// smooth settle. All-sine curves keep it springy without any snap.
+  late final Animation<double> _scale = TweenSequence<double>([
+    TweenSequenceItem(
+      tween: Tween(
+        begin: 1.0,
+        end: 1.25,
+      ).chain(CurveTween(curve: Curves.easeOutSine)),
+      weight: 35,
+    ),
+    TweenSequenceItem(
+      tween: Tween(
+        begin: 1.25,
+        end: 0.97,
+      ).chain(CurveTween(curve: Curves.easeInOutSine)),
+      weight: 35,
+    ),
+    TweenSequenceItem(
+      tween: Tween(
+        begin: 0.97,
+        end: 1.0,
+      ).chain(CurveTween(curve: Curves.easeOutSine)),
+      weight: 30,
+    ),
+  ]).animate(_controller);
+
+  void _handleTap() {
+    if (!MediaQuery.of(context).disableAnimations) {
+      _controller.forward(from: 0);
+    }
+    widget.onTap();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Semantics(
       button: true,
-      selected: isActive,
-      label: emoji,
+      selected: widget.isActive,
+      label: widget.emoji,
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
-        onTap: onTap,
+        onTap: _handleTap,
         child: ConstrainedBox(
           constraints: const BoxConstraints(minWidth: 48, minHeight: 48),
           child: Center(
-            child: Text(emoji, style: const TextStyle(fontSize: 28)),
+            child: ScaleTransition(
+              scale: _scale,
+              child: Text(widget.emoji, style: const TextStyle(fontSize: 28)),
+            ),
           ),
         ),
       ),

--- a/mobile/test/widgets/video_feed_item/reaction_overlay_test.dart
+++ b/mobile/test/widgets/video_feed_item/reaction_overlay_test.dart
@@ -1,141 +1,69 @@
-// ABOUTME: Widget + physics tests for the full-screen reaction float overlay.
+// ABOUTME: Widget test for the full-screen reaction overlay animation.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/widgets/video_feed_item/reaction_overlay.dart';
 
 void main() {
-  group('ReactionOverlay', () {
-    testWidgets(
-      'paints the float on a CustomPaint, shows the localized pill, '
-      'then fires onComplete',
-      (tester) async {
-        var completed = false;
-        await tester.pumpWidget(
-          MaterialApp(
-            localizationsDelegates: AppLocalizations.localizationsDelegates,
-            supportedLocales: AppLocalizations.supportedLocales,
-            home: Scaffold(
-              body: ReactionOverlay(
-                emoji: '❤️',
-                randomSeed: 1,
-                onComplete: () => completed = true,
-              ),
-            ),
-          ),
-        );
-        await tester.pump();
-
-        // Every particle is drawn by one CustomPainter (a batched drawRawAtlas),
-        // not a Stack of Text.
-        expect(
-          find.descendant(
-            of: find.byType(ReactionOverlay),
-            matching: find.byType(CustomPaint),
-          ),
-          findsWidgets,
-        );
-        expect(completed, isFalse);
-
-        // Mid-animation: the confirmation pill reads its label from l10n, not a
-        // hardcoded literal (the German value must NOT appear in an `en` tree).
-        await tester.pump(const Duration(milliseconds: 250));
-        final en = lookupAppLocalizations(const Locale('en'));
-        expect(find.text(en.dmReelReactionSentPill), findsOneWidget);
-        expect(
-          find.text(
-            lookupAppLocalizations(const Locale('de')).dmReelReactionSentPill,
-          ),
-          findsNothing,
-        );
-        expect(completed, isFalse);
-
-        // Drain the animation → completes and notifies the host.
-        await tester.pumpAndSettle();
-        expect(completed, isTrue);
-      },
-    );
-
-    testWidgets('does not absorb pointer events (IgnorePointer)', (
-      tester,
-    ) async {
-      var tappedBehind = false;
-      await tester.pumpWidget(
-        MaterialApp(
-          localizationsDelegates: AppLocalizations.localizationsDelegates,
-          supportedLocales: AppLocalizations.supportedLocales,
-          home: Scaffold(
-            body: Stack(
-              children: [
-                GestureDetector(
-                  behavior: HitTestBehavior.opaque,
-                  onTap: () => tappedBehind = true,
-                  child: const SizedBox.expand(),
-                ),
-                const ReactionOverlay(emoji: '🔥', randomSeed: 2),
-              ],
-            ),
+  testWidgets('paints on a single CustomPaint then fires onComplete', (
+    tester,
+  ) async {
+    var completed = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ReactionOverlay(
+            emoji: '❤️',
+            onComplete: () => completed = true,
           ),
         ),
-      );
-      await tester.pump();
-      await tester.tapAt(const Offset(10, 10));
-      expect(tappedBehind, isTrue);
-      // Let the animation finish so no ticker leaks into teardown.
-      await tester.pump(const Duration(milliseconds: 2400));
-    });
+      ),
+    );
+    await tester.pump();
+
+    // The 6 emoji are now drawn by one CustomPainter, not a Stack of Text.
+    expect(
+      find.descendant(
+        of: find.byType(ReactionOverlay),
+        matching: find.byType(CustomPaint),
+      ),
+      findsWidgets,
+    );
+    expect(completed, isFalse);
+
+    // Mid-animation: opacity/scale are non-zero here, so the painter actually
+    // draws the glyph (at t≈0 and t≈1 they are 0). Still animating.
+    await tester.pump(const Duration(milliseconds: 450));
+    expect(completed, isFalse);
+
+    // Past the 1100ms animation → completes and notifies.
+    await tester.pump(const Duration(milliseconds: 800));
+    await tester.pumpAndSettle();
+    expect(completed, isTrue);
   });
 
-  group('float physics', () {
-    test('reactionFloatOpacity: 0 at the ends, holds at 1, stays in [0,1]', () {
-      expect(reactionFloatOpacity(0), 0);
-      expect(reactionFloatOpacity(1), 0);
-      expect(reactionFloatOpacity(0.3), 1); // inside the hold band
-      for (var i = 0; i <= 100; i++) {
-        expect(reactionFloatOpacity(i / 100), inInclusiveRange(0.0, 1.0));
-      }
-      // Fades out across the back half but is still visible at 0.75.
-      final late = reactionFloatOpacity(0.75);
-      expect(late, greaterThan(0));
-      expect(late, lessThan(1));
-    });
-
-    test('reactionFloatScaleIn pops 0→1 then holds at 1', () {
-      expect(reactionFloatScaleIn(0), 0);
-      expect(reactionFloatScaleIn(0.2), 1); // past the scale-in fraction
-      expect(reactionFloatScaleIn(0.99), 1);
-      final mid = reactionFloatScaleIn(0.06);
-      expect(mid, greaterThan(0));
-      expect(mid, lessThan(1));
-    });
-
-    test('reactionFloatRise is a monotonic ease-out from 0 to 1', () {
-      expect(reactionFloatRise(0), 0);
-      expect(reactionFloatRise(1), closeTo(1, 1e-9));
-      // Ease-out: more than half the distance is covered by the halfway point.
-      expect(reactionFloatRise(0.5), greaterThan(0.5));
-      var prev = -1.0;
-      for (var i = 0; i <= 100; i++) {
-        final v = reactionFloatRise(i / 100);
-        expect(v, greaterThanOrEqualTo(prev));
-        prev = v;
-      }
-    });
-
-    test('reactionFloatWiggle is a bounded sine sway', () {
-      const amp = 40.0;
-      // Zero at phase 0, lp 0.
-      expect(reactionFloatWiggle(amp, 1, 0, 0), closeTo(0, 1e-9));
-      // Peaks at +amplitude a quarter-cycle in.
-      expect(reactionFloatWiggle(amp, 1, 0, 0.25), closeTo(amp, 1e-9));
-      // Never exceeds the amplitude.
-      for (var i = 0; i <= 100; i++) {
-        expect(
-          reactionFloatWiggle(amp, 1.7, 1.2, i / 100).abs(),
-          lessThanOrEqualTo(amp + 1e-9),
-        );
-      }
-    });
+  testWidgets('does not absorb pointer events (IgnorePointer)', (tester) async {
+    var tappedBehind = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Stack(
+            children: [
+              GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: () => tappedBehind = true,
+                child: const SizedBox.expand(),
+              ),
+              const ReactionOverlay(emoji: '🔥'),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.tapAt(const Offset(10, 10));
+    expect(tappedBehind, isTrue);
+    // Let the animation finish so no timer leaks into teardown.
+    await tester.pump(const Duration(milliseconds: 1200));
   });
 }

--- a/mobile/test/widgets/video_feed_item/reel_dm_reply_bar_test.dart
+++ b/mobile/test/widgets/video_feed_item/reel_dm_reply_bar_test.dart
@@ -387,4 +387,54 @@ void main() {
 
     expect(reacted, '❤️');
   });
+
+  testWidgets('reduced motion suppresses the player reaction overlay', (
+    tester,
+  ) async {
+    String? reacted;
+    final dmContext = context();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          dmRepositoryProvider.overrideWithValue(dmRepo),
+          dmReactionsRepositoryProvider.overrideWithValue(reactionsRepo),
+          authServiceProvider.overrideWithValue(auth),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => MediaQuery(
+                data: MediaQuery.of(context).copyWith(disableAnimations: true),
+                child: Align(
+                  alignment: Alignment.bottomCenter,
+                  child: ReelReplyBridge(
+                    setComposerFocused: (_) {},
+                    playReaction: (emoji) => reacted = emoji,
+                    child: ReelDmReplyBarHost(dmReplyContext: dmContext),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    await tester.tap(find.text('❤️'));
+    await tester.pump();
+
+    verify(
+      () => reactionsRepo.publish(
+        conversationId: 'convo-id',
+        targetMessageId: _reelId,
+        targetMessageAuthor: _peer,
+        emoji: '❤️',
+      ),
+    ).called(1);
+    expect(reacted, isNull);
+  });
 }

--- a/mobile/test/widgets/video_feed_item/reel_dm_reply_bar_test.dart
+++ b/mobile/test/widgets/video_feed_item/reel_dm_reply_bar_test.dart
@@ -141,6 +141,75 @@ void main() {
     ).called(1);
   });
 
+  testWidgets('tapped emoji bounces softly, then settles back to rest', (
+    tester,
+  ) async {
+    // Same host as [wrap], but without the disableAnimations override so the
+    // pulse actually runs. No ReelReplyBridge is wired, so the tap still
+    // never triggers a player overlay.
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          dmRepositoryProvider.overrideWithValue(dmRepo),
+          dmReactionsRepositoryProvider.overrideWithValue(reactionsRepo),
+          authServiceProvider.overrideWithValue(auth),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: Align(
+              alignment: Alignment.bottomCenter,
+              child: ReelDmReplyBarHost(dmReplyContext: context()),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final scaleFinder = find.ancestor(
+      of: find.text('❤️'),
+      matching: find.byType(ScaleTransition),
+    );
+    expect(
+      tester.widget<ScaleTransition>(scaleFinder).scale.value,
+      moreOrLessEquals(1),
+    );
+
+    await tester.tap(find.text('❤️'));
+    await tester.pump(); // start the bounce ticker
+    await tester.pump(const Duration(milliseconds: 190));
+    expect(
+      tester.widget<ScaleTransition>(scaleFinder).scale.value,
+      greaterThan(1.1),
+    );
+
+    await tester.pump(const Duration(milliseconds: 650));
+    expect(
+      tester.widget<ScaleTransition>(scaleFinder).scale.value,
+      moreOrLessEquals(1),
+    );
+  });
+
+  testWidgets('reduced motion suppresses the tap pulse', (tester) async {
+    await tester.pumpWidget(wrap(context()));
+    await tester.pump();
+
+    final scaleFinder = find.ancestor(
+      of: find.text('❤️'),
+      matching: find.byType(ScaleTransition),
+    );
+
+    await tester.tap(find.text('❤️'));
+    await tester.pump(); // would start the ticker if one were scheduled
+    await tester.pump(const Duration(milliseconds: 80));
+    expect(
+      tester.widget<ScaleTransition>(scaleFinder).scale.value,
+      moreOrLessEquals(1),
+    );
+  });
+
   testWidgets('re-tapping the active emoji is a no-op', (tester) async {
     await tester.pumpWidget(wrap(context()));
     await tester.pump();


### PR DESCRIPTION
## Description

Restores the reel reaction animation that users voted for on Discord — the pre-#5704 TikTok/IG-style center pop — and replaces the reaction bar's persistent "last chosen" ring with a soft bounce on tap.

**Animation revert (exact pre-#5704 code):**
- `reaction_overlay.dart` and its test are restored byte-identical to their state before #5704: a big emoji springs in at screen center with an overshoot (`easeOutBack`), holds, floats up ~70px while fading, garnished by five sine-swaying floating copies. Single rasterized glyph drawn by one `CustomPainter` on one GPU layer (#5389 perf model preserved).
- Drops the `dmReelReactionSentPill` l10n key across all 18 locales + regenerated files (exact revert of the key #5704 added — the pill does not exist in the restored animation).
- Restores the feed-screen mount comment wording.

**Reaction bar:**
- The persistent active-emoji ring is not brought back; the semantic selected state for screen readers and the re-tap no-op logic are unchanged.
- Instead, the tapped emoji plays a soft bounce: lift to 1.25x, gentle dip below rest, settle — 550ms, all-sine curves. Suppressed when the platform reports reduced motion.

**Related Issue:** Closes #5867. Relates to #5704.

## Out of Scope

Any further animation variants (e.g. the extended hero+fountain treatment) — per team decision, those can be proposed on Discord after this ships.

## Verification

- `flutter analyze lib test integration_test` — no issues
- `flutter test test/widgets/video_feed_item/reaction_overlay_test.dart test/widgets/video_feed_item/reel_dm_reply_bar_test.dart` — 14 tests pass (includes bounce plays and settles; reduced motion suppresses the button pulse and the player overlay bridge)
- `flutter test test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart` — 32 tests pass
- `dart format` clean; verified restored files are byte-identical to their pre-#5704 state via `git diff c938f7c579~1`
- Manually verified on device: center pop matches the reference recording users voted on

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
