### PR TITLE
fix(divine-camera): recover iOS audio after stale interruption

### DIFF
--- a/mobile/packages/divine_camera/ios/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/ios/Classes/CameraController.swift
@@ -2055,13 +2055,22 @@ class CameraController: NSObject {
         // blocks for ~1.4s on older A9/A10 iPads — accepted as edge case.
         sessionQueue.async { [weak self] in
             guard let self = self else { return }
-            // Note: there is a brief window between this check and the first
-            // audioInput.append() call on videoOutputQueue. An interruption
-            // arriving in that window produces a silent track rather than no
-            // audio track. The captureOutput guard (!audioInterrupted) limits
-            // the damage; full protection would require a writer-level lock
-            // that is not worth the added complexity here.
-            let audioReady = self.attachAudioToSessionIfNeeded() && !self.audioInterrupted
+            // Note: there is a brief window between this recovery and the
+            // first audioInput.append() call on videoOutputQueue. An
+            // interruption arriving in that window produces a silent track
+            // rather than no audio track. The captureOutput guard
+            // (!audioInterrupted) limits the damage; full protection would
+            // require a writer-level lock that is not worth the added
+            // complexity here.
+            let audioAttached = self.attachAudioToSessionIfNeeded()
+            if audioAttached && self.audioInterrupted {
+                self.audioInterrupted = false
+                DivineCameraLog.shared.info(
+                    "Recovered audio session before recording; cleared stale interruption",
+                    name: "DivineCamera.AudioSession"
+                )
+            }
+            let audioReady = audioAttached && !self.audioInterrupted
             if !audioReady {
                 DivineCameraLog.shared.warning(
                     "Audio not ready (attach failed or interrupted) — recording "


### PR DESCRIPTION
Closes #5845

## Summary
- clears stale iOS audio interruption state at record start after the audio session/capture session is successfully reattached
- preserves the existing audio append guard so active interruptions still avoid writing known-silent buffers
- adds a recovery log line for the observed background/foreground case where AVAudioSession never posts .ended

## Root Cause
Release logs showed AVAudioSession interruption .began during backgrounding, but no .ended notification. Later record attempts successfully configured audio, then still skipped the audio track because audioInterrupted remained stuck true.

## Validation
- flutter test, from mobile/packages/divine_camera
- flutter analyze, from mobile
- flutter build ios --no-codesign, from mobile