### PR TITLE
fix(playback): prefer raw direct upload sources

### DIFF
--- a/mobile/lib/extensions/video_event_extensions.dart
+++ b/mobile/lib/extensions/video_event_extensions.dart
@@ -22,6 +22,27 @@ String _getBandwidthBasedQuality() {
   }
 }
 
+bool _isVideoUrlKey(String key) {
+  return switch (key) {
+    'url' ||
+    'hls' ||
+    'dash' ||
+    'stream' ||
+    'streaming' ||
+    'fallback' ||
+    'mp4' ||
+    'video' => true,
+    _ => false,
+  };
+}
+
+bool _isHttpVideoUrl(String value) {
+  final uri = Uri.tryParse(value);
+  return uri != null &&
+      (uri.scheme == 'http' || uri.scheme == 'https') &&
+      uri.host.isNotEmpty;
+}
+
 /// Extension methods for VideoEvent that require app-level dependencies.
 ///
 /// These methods are separated from the core VideoEvent model because they
@@ -101,6 +122,22 @@ extension VideoEventAppExtensions on VideoEvent {
     } catch (_) {
       return false;
     }
+  }
+
+  /// Whether the event explicitly advertises only the raw Blossom blob URL.
+  ///
+  /// Fresh direct uploads can publish before `/720p.mp4` or HLS derivatives
+  /// exist. When the event's `imeta` contains a single raw
+  /// `https://media.divine.video/{sha256}` URL, prefer that proven source for
+  /// initial playback instead of speculatively probing derived variants.
+  bool get hasRawOnlyDivineImetaUrl {
+    final url = videoUrl;
+    if (url == null || url.isEmpty || !hasBareDivineHashPath) {
+      return false;
+    }
+
+    final imetaUrls = _imetaVideoUrls();
+    return imetaUrls.length == 1 && imetaUrls.single == url;
   }
 
   /// Check if we should show the "Not Divine" badge.
@@ -218,6 +255,11 @@ extension VideoEventAppExtensions on VideoEvent {
     // Transcoded 720p variants are pointless upscales and may not exist.
     if (isOriginalVine) return '$_divineMediaBase/$hash';
 
+    // Direct Blossom uploads that only advertise the raw blob should start
+    // from that actual published URL. Derived MP4/HLS variants may not exist
+    // yet and can generate avoidable parser errors before falling back.
+    if (hasRawOnlyDivineImetaUrl) return videoUrl;
+
     // Developer format override takes priority
     final override = videoFormatPreference.format;
     if (override != null) {
@@ -313,6 +355,44 @@ extension VideoEventAppExtensions on VideoEvent {
   /// Use this when preparing to play a video.
   Future<String?> getPlayableUrl() async {
     return resolvePlayableUrl(videoUrl);
+  }
+
+  List<String> _imetaVideoUrls() {
+    final urls = <String>[];
+    for (final tag in nostrEventTags) {
+      if (tag.isEmpty || tag[0] != 'imeta') continue;
+      var i = 1;
+      while (i < tag.length) {
+        final component = tag[i].trim();
+        if (component.isEmpty) {
+          i++;
+          continue;
+        }
+
+        final splitIndex = component.indexOf(' ');
+        if (splitIndex > 0) {
+          final key = component.substring(0, splitIndex);
+          final value = component.substring(splitIndex + 1).trim();
+          if (_isVideoUrlKey(key) && _isHttpVideoUrl(value)) {
+            urls.add(value);
+          }
+          i++;
+          continue;
+        }
+
+        if (_isVideoUrlKey(component) && i + 1 < tag.length) {
+          final value = tag[i + 1].trim();
+          if (_isHttpVideoUrl(value)) {
+            urls.add(value);
+          }
+          i += 2;
+          continue;
+        }
+
+        i++;
+      }
+    }
+    return urls.toSet().toList(growable: false);
   }
 
   /// Resolve a video URL to its best playable format.

--- a/mobile/lib/extensions/video_event_extensions.dart
+++ b/mobile/lib/extensions/video_event_extensions.dart
@@ -22,27 +22,6 @@ String _getBandwidthBasedQuality() {
   }
 }
 
-bool _isVideoUrlKey(String key) {
-  return switch (key) {
-    'url' ||
-    'hls' ||
-    'dash' ||
-    'stream' ||
-    'streaming' ||
-    'fallback' ||
-    'mp4' ||
-    'video' => true,
-    _ => false,
-  };
-}
-
-bool _isHttpVideoUrl(String value) {
-  final uri = Uri.tryParse(value);
-  return uri != null &&
-      (uri.scheme == 'http' || uri.scheme == 'https') &&
-      uri.host.isNotEmpty;
-}
-
 /// Extension methods for VideoEvent that require app-level dependencies.
 ///
 /// These methods are separated from the core VideoEvent model because they
@@ -136,7 +115,7 @@ extension VideoEventAppExtensions on VideoEvent {
       return false;
     }
 
-    final imetaUrls = _imetaVideoUrls();
+    final imetaUrls = imetaVideoUrls;
     return imetaUrls.length == 1 && imetaUrls.single == url;
   }
 
@@ -257,7 +236,9 @@ extension VideoEventAppExtensions on VideoEvent {
 
     // Direct Blossom uploads that only advertise the raw blob should start
     // from that actual published URL. Derived MP4/HLS variants may not exist
-    // yet and can generate avoidable parser errors before falling back.
+    // yet and can generate avoidable parser errors before falling back. This
+    // intentionally precedes the developer format override below: forcing a
+    // derived variant on a raw-only upload would just 404.
     if (hasRawOnlyDivineImetaUrl) return videoUrl;
 
     // Developer format override takes priority
@@ -355,44 +336,6 @@ extension VideoEventAppExtensions on VideoEvent {
   /// Use this when preparing to play a video.
   Future<String?> getPlayableUrl() async {
     return resolvePlayableUrl(videoUrl);
-  }
-
-  List<String> _imetaVideoUrls() {
-    final urls = <String>[];
-    for (final tag in nostrEventTags) {
-      if (tag.isEmpty || tag[0] != 'imeta') continue;
-      var i = 1;
-      while (i < tag.length) {
-        final component = tag[i].trim();
-        if (component.isEmpty) {
-          i++;
-          continue;
-        }
-
-        final splitIndex = component.indexOf(' ');
-        if (splitIndex > 0) {
-          final key = component.substring(0, splitIndex);
-          final value = component.substring(splitIndex + 1).trim();
-          if (_isVideoUrlKey(key) && _isHttpVideoUrl(value)) {
-            urls.add(value);
-          }
-          i++;
-          continue;
-        }
-
-        if (_isVideoUrlKey(component) && i + 1 < tag.length) {
-          final value = tag[i + 1].trim();
-          if (_isHttpVideoUrl(value)) {
-            urls.add(value);
-          }
-          i += 2;
-          continue;
-        }
-
-        i++;
-      }
-    }
-    return urls.toSet().toList(growable: false);
   }
 
   /// Resolve a video URL to its best playable format.

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -1382,6 +1382,43 @@ class VideoEvent {
     }
   }
 
+  /// Whether [key] names a video URL inside an `imeta` tag.
+  ///
+  /// Mirrors the `url`-plus-POSTEL'S-LAW-alternates set that
+  /// `fromNostrEvent` collects as video URL candidates.
+  static bool _isImetaVideoUrlKey(String key) => switch (key) {
+    'url' ||
+    'hls' ||
+    'dash' ||
+    'stream' ||
+    'streaming' ||
+    'fallback' ||
+    'mp4' ||
+    'video' => true,
+    _ => false,
+  };
+
+  /// Video URLs advertised in this event's `imeta` tags, deduplicated.
+  ///
+  /// Uses the same key set ([_isImetaVideoUrlKey]) and
+  /// [VideoUrlResolver.isValidVideoUrl] validation as `fromNostrEvent`'s
+  /// candidate collection, so imeta URL extraction can't drift from the URL
+  /// actually selected into [videoUrl]. Handles both the space-separated
+  /// (`"url https://…"`) and positional (`"url", "https://…"`) encodings.
+  List<String> get imetaVideoUrls {
+    final urls = <String>[];
+    for (final tag in nostrEventTags) {
+      if (tag.isEmpty || tag.first != 'imeta') continue;
+      _parseImetaTag(tag, (key, value) {
+        final url = value.trim();
+        if (_isImetaVideoUrlKey(key) && VideoUrlResolver.isValidVideoUrl(url)) {
+          urls.add(url);
+        }
+      });
+    }
+    return urls.toSet().toList(growable: false);
+  }
+
   /// Extract width from dimensions string
   int? get width {
     if (dimensions == null) return null;

--- a/mobile/packages/models/test/src/video_event_parsing_test.dart
+++ b/mobile/packages/models/test/src/video_event_parsing_test.dart
@@ -803,4 +803,82 @@ void main() {
       expect(info1, isNot(equals(info3)));
     });
   });
+
+  group('VideoEvent.imetaVideoUrls', () {
+    const hash =
+        'e770667c1a62cc394602fc07462fa0d7ba83441002d9aac662fb88d0cc575338';
+
+    VideoEvent eventWithTags(List<List<String>> tags) {
+      final event = Event(
+        'e2fef811cf3a5e0ff69f645d8207ee7cff36d64c81a7f2a8d0c8ff8ceecd6b0f',
+        34236,
+        tags,
+        '',
+        createdAt: 1234567890,
+      );
+      return VideoEvent.fromNostrEvent(event);
+    }
+
+    test('extracts the single url from space-separated imeta', () {
+      final video = eventWithTags([
+        [
+          'imeta',
+          'url https://media.divine.video/$hash',
+          'm video/mp4',
+          'x $hash',
+        ],
+      ]);
+
+      expect(
+        video.imetaVideoUrls,
+        equals(['https://media.divine.video/$hash']),
+      );
+    });
+
+    test('extracts and dedups urls from positional imeta', () {
+      final video = eventWithTags([
+        [
+          'imeta',
+          'url',
+          'https://media.divine.video/$hash/720p.mp4',
+          'url',
+          'https://media.divine.video/$hash',
+          'm',
+          'video/mp4',
+        ],
+      ]);
+
+      expect(
+        video.imetaVideoUrls,
+        equals([
+          'https://media.divine.video/$hash/720p.mp4',
+          'https://media.divine.video/$hash',
+        ]),
+      );
+    });
+
+    test('ignores thumbnail and non-url imeta keys', () {
+      final video = eventWithTags([
+        [
+          'imeta',
+          'url https://media.divine.video/$hash',
+          'image https://media.divine.video/$hash/thumb.jpg',
+          'thumb https://media.divine.video/$hash/thumb.jpg',
+        ],
+      ]);
+
+      expect(
+        video.imetaVideoUrls,
+        equals(['https://media.divine.video/$hash']),
+      );
+    });
+
+    test('returns empty list when there is no imeta tag', () {
+      final video = eventWithTags([
+        ['url', 'https://media.divine.video/$hash'],
+      ]);
+
+      expect(video.imetaVideoUrls, isEmpty);
+    });
+  });
 }

--- a/mobile/test/extensions/video_event_divine_server_test.dart
+++ b/mobile/test/extensions/video_event_divine_server_test.dart
@@ -8,12 +8,18 @@ import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/services/bandwidth_tracker_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-VideoEvent _createVideoWithUrl(String url, {Map<String, String>? rawTags}) {
-  final tags = <List<String>>[
-    ['url', url],
-    for (final entry in (rawTags ?? const <String, String>{}).entries)
-      [entry.key, entry.value],
-  ];
+VideoEvent _createVideoWithUrl(
+  String url, {
+  Map<String, String>? rawTags,
+  List<List<String>>? tags,
+}) {
+  final eventTags =
+      tags ??
+      <List<String>>[
+        ['url', url],
+        for (final entry in (rawTags ?? const <String, String>{}).entries)
+          [entry.key, entry.value],
+      ];
   final event = Event.fromJson({
     'id': 'aaaa1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab',
     'pubkey':
@@ -21,7 +27,7 @@ VideoEvent _createVideoWithUrl(String url, {Map<String, String>? rawTags}) {
     'created_at': 1234567890,
     'kind': 34236,
     'content': '',
-    'tags': tags,
+    'tags': eventTags,
     'sig': 'cccc1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab',
   });
   return VideoEvent.fromNostrEvent(event);
@@ -163,6 +169,60 @@ void main() {
       );
     });
 
+    test('uses raw URL when imeta only advertises a direct Blossom blob', () {
+      const hash =
+          'e770667c1a62cc394602fc07462fa0d7ba83441002d9aac662fb88d0cc575338';
+      final video = _createVideoWithUrl(
+        'https://media.divine.video/$hash',
+        tags: const [
+          [
+            'imeta',
+            'url https://media.divine.video/$hash',
+            'm video/mp4',
+            'x $hash',
+          ],
+        ],
+      );
+
+      expect(video.hasBareDivineHashPath, isTrue);
+      expect(video.hasRawOnlyDivineImetaUrl, isTrue);
+      expect(
+        video.getOptimalVideoUrlForPlatform(),
+        equals('https://media.divine.video/$hash'),
+      );
+      expect(
+        video.getCacheableVideoUrlForPlatform(),
+        equals('https://media.divine.video/$hash'),
+      );
+    });
+
+    test('keeps MP4 720p when imeta advertises processed variants', () {
+      const hash =
+          'e770667c1a62cc394602fc07462fa0d7ba83441002d9aac662fb88d0cc575338';
+      final video = _createVideoWithUrl(
+        'https://media.divine.video/$hash',
+        tags: const [
+          [
+            'imeta',
+            'url',
+            'https://media.divine.video/$hash/720p.mp4',
+            'url',
+            'https://media.divine.video/$hash',
+            'm',
+            'video/mp4',
+            'x',
+            hash,
+          ],
+        ],
+      );
+
+      expect(video.hasRawOnlyDivineImetaUrl, isFalse);
+      expect(
+        video.getOptimalVideoUrlForPlatform(),
+        equals('https://media.divine.video/$hash/720p.mp4'),
+      );
+    });
+
     test('returns original URL for non-Divine videos', () {
       final video = _createVideoWithUrl(
         'https://blossom.primal.net/test/video.mp4',
@@ -198,9 +258,7 @@ void main() {
       expect(video.isOriginalVine, isTrue);
       expect(
         video.getOptimalVideoUrlForPlatform(),
-        equals(
-          'https://media.divine.video/$hash',
-        ),
+        equals('https://media.divine.video/$hash'),
       );
       expect(video.getCacheableVideoUrlForPlatform(), isNull);
     });


### PR DESCRIPTION
Closes #5847

## Summary
- detects direct Blossom publishes whose imeta advertises only the raw media.divine.video blob
- uses that actual published raw URL for initial playback and single-file cache selection
- keeps the existing optimized 720p behavior for generic Divine hash URLs and events with processed variants

## Root Cause
Playback source selection treated every Divine hash URL as eligible for synthesized /720p.mp4 and HLS variants. The 2026-07-04 Android logs showed a fresh direct upload whose event only advertised the raw URL, but feed playback tried two derived sources first and logged parser errors before falling back to the raw URL.

## Validation
- flutter test test/extensions/video_event_divine_server_test.dart
- flutter test packages/infinite_video_feed/test/src/utils/playback_sources_test.dart
- flutter analyze
- pre-push analyzer and targeted tests