### PR TITLE
fix(keycast): cache unsupported canonical signing

### DIFF
--- a/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
+++ b/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
@@ -29,6 +29,7 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
   String _accessToken;
   final http.Client _client;
   final TokenRefreshCallback? _onTokenRefresh;
+  bool _signCanonicalUnsupported = false;
 
   /// Maximum time to wait for any single RPC request before failing
   /// with a [TimeoutException].
@@ -64,8 +65,9 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
   Future<T> _call<T>(
     String method,
     List<dynamic> params,
-    T Function(dynamic) fromResult,
-  ) async {
+    T Function(dynamic) fromResult, {
+    bool logHttpErrors = true,
+  }) async {
     var response = await _sendRequest(method, params);
 
     if (response.statusCode == 401 && _onTokenRefresh != null) {
@@ -82,11 +84,13 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
     }
 
     if (response.statusCode != 200) {
-      Log.error(
-        '[Keycast RPC] Error response: ${response.body}',
-        name: 'KeycastRpc',
-        category: LogCategory.auth,
-      );
+      if (logHttpErrors) {
+        Log.error(
+          '[Keycast RPC] Error response: ${response.body}',
+          name: 'KeycastRpc',
+          category: LogCategory.auth,
+        );
+      }
       throw RpcException(
         'HTTP ${response.statusCode}: ${response.body}',
         method: method,
@@ -203,19 +207,55 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
   /// Callers (e.g. [KeycastNostrIdentity]) treat null as "canonical signing
   /// unsupported by this identity" and skip the assertion gracefully.
   Future<String?> signCanonicalPayload(Uint8List payload) async {
+    if (_signCanonicalUnsupported) {
+      return null;
+    }
+
     try {
       return await _call(
         'sign_canonical',
         [base64Encode(payload)],
         (result) => result as String,
+        logHttpErrors: false,
       );
-    } on RpcException {
-      // Backend doesn't expose sign_canonical yet, or returned an error.
+    } on RpcException catch (error) {
+      if (_isUnsupportedSignCanonical(error)) {
+        _signCanonicalUnsupported = true;
+        Log.info(
+          '[Keycast RPC] sign_canonical unsupported by backend; '
+          'canonical creator-binding will be skipped for this session',
+          name: 'KeycastRpc',
+          category: LogCategory.auth,
+        );
+      } else {
+        Log.warning(
+          '[Keycast RPC] sign_canonical failed; '
+          'canonical creator-binding will be skipped: ${error.message}',
+          name: 'KeycastRpc',
+          category: LogCategory.auth,
+        );
+      }
       return null;
-    } catch (_) {
+    } catch (error) {
       // Network/parse error: degrade gracefully.
+      Log.warning(
+        '[Keycast RPC] sign_canonical request failed; '
+        'canonical creator-binding will be skipped: $error',
+        name: 'KeycastRpc',
+        category: LogCategory.auth,
+      );
       return null;
     }
+  }
+
+  bool _isUnsupportedSignCanonical(RpcException error) {
+    if (error.method != 'sign_canonical') {
+      return false;
+    }
+    final lower = error.message.toLowerCase();
+    return lower.contains('unsupported method') ||
+        lower.contains('method_not_found') ||
+        lower.contains('method not found');
   }
 
   /// Server-side NIP-59 gift-wrap unwrap for the remote-signer DM history

--- a/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
+++ b/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
@@ -248,10 +248,18 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
     }
   }
 
+  /// Whether [error] is the backend signalling that `sign_canonical` is not
+  /// implemented, as opposed to a transient or auth failure that must stay
+  /// retryable.
+  ///
+  /// Matched against the exact wordings the login backend returns today: the
+  /// HTTP `Unsupported method: sign_canonical` body and the JSON-RPC
+  /// `method_not_found` error field. The match is deliberately narrow — a
+  /// broader signal (e.g. caching on any 4xx) would risk permanently disabling
+  /// a supported capability after a transient blip. If the backend ever rewords
+  /// this, update the substrings here, otherwise canonical binding silently
+  /// re-requests on every publish.
   bool _isUnsupportedSignCanonical(RpcException error) {
-    if (error.method != 'sign_canonical') {
-      return false;
-    }
     final lower = error.message.toLowerCase();
     return lower.contains('unsupported method') ||
         lower.contains('method_not_found') ||

--- a/mobile/packages/keycast_flutter/test/rpc_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/rpc_client_test.dart
@@ -65,9 +65,7 @@ void main() {
           clientId: 'test',
           redirectUri: 'divine://callback',
         );
-        const session = KeycastSession(
-          bunkerUrl: 'bunker://test',
-        );
+        const session = KeycastSession(bunkerUrl: 'bunker://test');
 
         expect(
           () => KeycastRpc.fromSession(config, session),
@@ -280,16 +278,10 @@ void main() {
         mockClient = MockClient((request) async {
           callCount++;
           if (callCount == 1) {
-            expect(
-              request.headers['Authorization'],
-              'Bearer expired_token',
-            );
+            expect(request.headers['Authorization'], 'Bearer expired_token');
             return http.Response('Unauthorized', 401);
           }
-          expect(
-            request.headers['Authorization'],
-            'Bearer fresh_token',
-          );
+          expect(request.headers['Authorization'], 'Bearer fresh_token');
           return http.Response(
             jsonEncode({
               'result':
@@ -406,9 +398,7 @@ void main() {
       test('throws TimeoutException when the request hangs', () async {
         // Simulates a dead socket (e.g. Android Doze killing the
         // connection) — the request future never completes.
-        mockClient = MockClient(
-          (request) => Completer<http.Response>().future,
-        );
+        mockClient = MockClient((request) => Completer<http.Response>().future);
 
         final rpc = KeycastRpc(
           nostrApi: 'https://login.divine.video/api/nostr',
@@ -417,10 +407,7 @@ void main() {
           requestTimeout: const Duration(milliseconds: 50),
         );
 
-        await expectLater(
-          rpc.getPublicKey(),
-          throwsA(isA<TimeoutException>()),
-        );
+        await expectLater(rpc.getPublicKey(), throwsA(isA<TimeoutException>()));
       });
     });
 
@@ -441,10 +428,7 @@ void main() {
             expect(body['method'], 'sign_canonical');
             expect(body['params'], [base64Encode(payload)]);
 
-            return http.Response(
-              jsonEncode({'result': expectedSig}),
-              200,
-            );
+            return http.Response(jsonEncode({'result': expectedSig}), 200);
           });
 
           final rpc = KeycastRpc(
@@ -461,7 +445,9 @@ void main() {
       test(
         'returns null (not throw) when backend reports method-not-found',
         () async {
+          var callCount = 0;
           mockClient = MockClient((request) async {
+            callCount++;
             return http.Response(
               jsonEncode({'error': 'method_not_found'}),
               200,
@@ -478,8 +464,73 @@ void main() {
             Uint8List.fromList([1, 2, 3]),
           );
           expect(result, isNull);
+
+          final secondResult = await rpc.signCanonicalPayload(
+            Uint8List.fromList([4, 5, 6]),
+          );
+          expect(secondResult, isNull);
+          expect(callCount, equals(1));
         },
       );
+
+      test(
+        'caches unsupported HTTP response and skips later requests',
+        () async {
+          var callCount = 0;
+          mockClient = MockClient((request) async {
+            callCount++;
+            return http.Response(
+              jsonEncode({'error': 'Unsupported method: sign_canonical'}),
+              400,
+            );
+          });
+
+          final rpc = KeycastRpc(
+            nostrApi: 'https://login.divine.video/api/nostr',
+            accessToken: 'test_token',
+            httpClient: mockClient,
+          );
+
+          final result = await rpc.signCanonicalPayload(
+            Uint8List.fromList([1, 2, 3]),
+          );
+          expect(result, isNull);
+
+          final secondResult = await rpc.signCanonicalPayload(
+            Uint8List.fromList([4, 5, 6]),
+          );
+          expect(secondResult, isNull);
+          expect(callCount, equals(1));
+        },
+      );
+
+      test('does not cache transient HTTP failures', () async {
+        var callCount = 0;
+        mockClient = MockClient((request) async {
+          callCount++;
+          if (callCount == 1) {
+            return http.Response('Server error', 500);
+          }
+          return http.Response(jsonEncode({'result': 'a' * 128}), 200);
+        });
+
+        final rpc = KeycastRpc(
+          nostrApi: 'https://login.divine.video/api/nostr',
+          accessToken: 'test_token',
+          httpClient: mockClient,
+        );
+
+        final firstResult = await rpc.signCanonicalPayload(
+          Uint8List.fromList([1, 2, 3]),
+        );
+        expect(firstResult, isNull);
+
+        final secondResult = await rpc.signCanonicalPayload(
+          Uint8List.fromList([4, 5, 6]),
+        );
+        expect(secondResult, equals('a' * 128));
+        expect(callCount, equals(2));
+      });
 
       test('returns null on HTTP 500 error response', () async {
         mockClient = MockClient((request) async {
@@ -602,9 +653,7 @@ void main() {
         // A timed-out page must be retryable by the caller, never mistaken
         // for "no messages" — so unlike signCanonicalPayload, the batch verb
         // does not catch TimeoutException.
-        mockClient = MockClient(
-          (request) => Completer<http.Response>().future,
-        );
+        mockClient = MockClient((request) => Completer<http.Response>().future);
         final rpc = KeycastRpc(
           nostrApi: 'https://login.divine.video/api/nostr',
           accessToken: 'test_token',


### PR DESCRIPTION
Closes #5849

## Summary
- caches sign_canonical unsupported responses per KeycastRpc instance
- avoids generic RPC error logging for expected unsupported canonical signing
- keeps transient failures retryable and preserves normal generic error behavior for other RPC methods

## Root Cause
The sign_canonical optional capability used the generic RPC helper, which logged every non-200 response as an error before signCanonicalPayload could gracefully return null. OAuth publishes then repeated a known unsupported request on each publish.

## Validation
- flutter test, from mobile/packages/keycast_flutter
- flutter analyze, from mobile
- pre-push analyzer and targeted packages/keycast_flutter/test/rpc_client_test.dart
