### PR TITLE
fix(profile): scroll profile badges horizontally instead of wrapping

### DIFF
--- a/mobile/lib/widgets/profile/profile_header_identity.dart
+++ b/mobile/lib/widgets/profile/profile_header_identity.dart
@@ -23,38 +23,64 @@ class _ProfileNameAndBio extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Every child except the badge row carries the horizontal inset. The
+    // badge block spans the full width so its row can scroll edge-to-edge.
+    const inset = EdgeInsets.symmetric(
+      horizontal: _profileIdentityHorizontalInset,
+    );
     return Column(
       children: [
-        if (profile != null)
-          UserName.fromUserProfile(profile!, style: VineTheme.titleLargeFont())
-        else
-          UserName.fromPubKey(
-            userIdHex,
-            style: VineTheme.titleLargeFont(),
-            anonymousName: displayNameHint,
-          ),
-        Skeleton.keep(
-          child: _UniqueIdentifier(
-            userIdHex: userIdHex,
-            nip05: nip05,
-            isOwnProfile: isOwnProfile,
-            accentColor: accentColor,
+        Padding(
+          padding: inset,
+          child: Column(
+            children: [
+              if (profile != null)
+                UserName.fromUserProfile(
+                  profile!,
+                  style: VineTheme.titleLargeFont(),
+                )
+              else
+                UserName.fromPubKey(
+                  userIdHex,
+                  style: VineTheme.titleLargeFont(),
+                  anonymousName: displayNameHint,
+                ),
+              Skeleton.keep(
+                child: _UniqueIdentifier(
+                  userIdHex: userIdHex,
+                  nip05: nip05,
+                  isOwnProfile: isOwnProfile,
+                  accentColor: accentColor,
+                ),
+              ),
+            ],
           ),
         ),
         Skeleton.keep(child: _ProfileBadgesBlock(userIdHex: userIdHex)),
-        if (about != null && about!.isNotEmpty) ...[
-          const SizedBox(height: 16),
-          Skeleton.keep(child: _AboutText(about: about!)),
-        ],
-        if (profile?.website?.isNotEmpty == true) ...[
-          const SizedBox(height: 8),
-          Skeleton.keep(child: ProfileWebsiteRow(url: profile!.website!)),
-        ],
-        _VerifiedAccountsBlock(isOwnProfile: isOwnProfile),
+        Padding(
+          padding: inset,
+          child: Column(
+            children: [
+              if (about != null && about!.isNotEmpty) ...[
+                const SizedBox(height: 16),
+                Skeleton.keep(child: _AboutText(about: about!)),
+              ],
+              if (profile?.website?.isNotEmpty == true) ...[
+                const SizedBox(height: 8),
+                Skeleton.keep(child: ProfileWebsiteRow(url: profile!.website!)),
+              ],
+              _VerifiedAccountsBlock(isOwnProfile: isOwnProfile),
+            ],
+          ),
+        ),
       ],
     );
   }
 }
+
+/// Horizontal inset applied to the name/bio identity block. Shared so the
+/// badge row can break out of it and scroll edge-to-edge.
+const double _profileIdentityHorizontalInset = 16;
 
 class _ProfileBadgesBlock extends ConsumerWidget {
   const _ProfileBadgesBlock({required this.userIdHex});
@@ -69,13 +95,31 @@ class _ProfileBadgesBlock extends ConsumerWidget {
         if (items.isEmpty) return const SizedBox.shrink();
         return Padding(
           padding: const EdgeInsets.only(top: 12),
-          child: Wrap(
-            alignment: WrapAlignment.center,
-            spacing: 8,
-            runSpacing: 8,
-            children: [
-              for (final item in items) _ProfileBadgeChip(badge: item),
-            ],
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              // The block spans the full width (its siblings carry the
+              // horizontal inset instead), so the row scrolls edge-to-edge.
+              // A resting lead keeps chips aligned with the text above while
+              // letting them peek past the screen edge once they overflow.
+              const inset = _profileIdentityHorizontalInset;
+              return SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                padding: const EdgeInsets.symmetric(horizontal: inset),
+                // Centered when the badges fit; scrollable once they overflow.
+                child: ConstrainedBox(
+                  constraints: BoxConstraints(
+                    minWidth: constraints.maxWidth - inset * 2,
+                  ),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    spacing: 8,
+                    children: [
+                      for (final item in items) _ProfileBadgeChip(badge: item),
+                    ],
+                  ),
+                ),
+              );
+            },
           ),
         );
       },

--- a/mobile/lib/widgets/profile/profile_header_widget.dart
+++ b/mobile/lib/widgets/profile/profile_header_widget.dart
@@ -339,9 +339,10 @@ class _ProfileHeaderWidgetState extends ConsumerState<ProfileHeaderWidget> {
                   ),
                 ),
 
-                // Name, NIP-05, and bio
+                // Name, NIP-05, and bio. Horizontal inset lives on the
+                // children so the badge row can scroll edge-to-edge.
                 Padding(
-                  padding: const EdgeInsets.fromLTRB(16, 32, 16, 16),
+                  padding: const EdgeInsets.only(top: 32, bottom: 16),
                   child: _ProfileNameAndBio(
                     profile: effectiveProfile,
                     userIdHex: widget.userIdHex,

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -526,6 +526,66 @@ void main() {
       expect(find.text('+2 more'), findsOneWidget);
     });
 
+    testWidgets('lays accepted badges out in a single horizontal scroll row', (
+      tester,
+    ) async {
+      final testProfile = createTestProfile(displayName: 'Badged User');
+      ProfileBadgeViewData acceptedBadge(String name, String dTag) {
+        final coordinate = '30009:$issuerUserHex:$dTag';
+        return ProfileBadgeViewData(
+          badge: Nip58ProfileBadgeRef(
+            definitionCoordinate: coordinate,
+            awardEventId:
+                '00000000000000000000000000000000000000000000000000000000000000aa',
+          ),
+          award: Nip58BadgeAward(
+            event: _badgeAwardEvent(),
+            definitionCoordinate: coordinate,
+            recipientPubkeys: const [testUserHex],
+          ),
+          definition: Nip58BadgeDefinition(
+            event: _badgeDefinitionEvent(),
+            coordinate: coordinate,
+            dTag: dTag,
+            name: name,
+          ),
+        );
+      }
+
+      await tester.pumpWidget(
+        buildTestWidget(
+          userIdHex: testUserHex,
+          isOwnProfile: false,
+          suppliedProfile: testProfile,
+          acceptedProfileBadges: [
+            acceptedBadge('Badge One', 'badge-one'),
+            acceptedBadge('Badge Two', 'badge-two'),
+            acceptedBadge('Badge Three', 'badge-three'),
+          ],
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      // All badges render — they are not truncated to a single row.
+      expect(find.text('Badge One'), findsOneWidget);
+      expect(find.text('Badge Two'), findsOneWidget);
+      expect(find.text('Badge Three'), findsOneWidget);
+
+      // The row scrolls horizontally instead of wrapping, so each chip lives
+      // inside a horizontal SingleChildScrollView rather than a Wrap.
+      Finder horizontalScrollAbove(String badgeName) => find.ancestor(
+        of: find.text(badgeName),
+        matching: find.byWidgetPredicate(
+          (widget) =>
+              widget is SingleChildScrollView &&
+              widget.scrollDirection == Axis.horizontal,
+        ),
+      );
+      expect(horizontalScrollAbove('Badge One'), findsOneWidget);
+      expect(horizontalScrollAbove('Badge Three'), findsOneWidget);
+    });
+
     testWidgets('displays user avatar when profile is loaded', (tester) async {
       final testProfile = createTestProfile(
         displayName: 'Test User',


### PR DESCRIPTION
Closes #5856

## Description

Profiles with many accepted badges filled the header with several wrapped rows, pushing the bio far down the screen. This replaces the wrapping badge layout with a single horizontal row: centered while the badges fit, horizontally scrollable once they overflow.

To let the row scroll edge-to-edge, the name/bio block's 16px horizontal inset now lives on its children instead of on the wrapping block, so the badge row spans the full width. A resting 16px lead keeps the first chip aligned with the text above while chips peek past the screen edge on scroll. The inset is shared via a single constant so the resting lead and the block padding cannot drift apart.

The badge chip widget and its tap→`VineBottomSheet` detail sheet are unchanged; only the container layout changed.

**Related Issue:** 

## Out of Scope

None.

## Verification

- `flutter analyze lib/widgets/profile/profile_header_identity.dart lib/widgets/profile/profile_header_widget.dart` — no issues
- `flutter test test/widgets/profile/profile_header_widget_test.dart` — 55 passed
- Screen recording pending before marking ready for review (draft).

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)