### PR TITLE
fix(comments): scroll a newly-posted reply into view (#5854)

### DIFF
--- a/mobile/lib/blocs/comments/comment_composer/comment_composer_bloc.dart
+++ b/mobile/lib/blocs/comments/comment_composer/comment_composer_bloc.dart
@@ -15,6 +15,21 @@ import 'package:unified_logger/unified_logger.dart';
 part 'comment_composer_event.dart';
 part 'comment_composer_state.dart';
 
+/// Returns `true` when a comment/reply with the same normalized [content] to the
+/// same [parentCommentId] already exists for [authorPubkey] in the canonical
+/// store. Injected from the UI (which can read the list store live) so the
+/// composer can drop a duplicate resubmit without a BLoC-to-BLoC dependency.
+///
+/// #5854: replies rendered off-screen led posters to re-send the same reply,
+/// spawning duplicates. The scroll-into-view fix stops that at the source; this
+/// checker is the defense-in-depth net for stray double-submits.
+typedef DuplicateCommentChecker =
+    bool Function({
+      required String content,
+      required String authorPubkey,
+      String? parentCommentId,
+    });
+
 /// BLoC owning composer input state for one video's comments: main / reply /
 /// edit text buffers, mention search (`restartable()`), publish + edit flows
 /// with optimistic placeholders signalled through [ComposerOutbox], and edit
@@ -31,6 +46,7 @@ class CommentComposerBloc
     ProfileRepository? profileRepository,
     MentionResolutionService? mentionResolutionService,
     MentionCandidatePubkeysProvider? mentionCandidatePubkeysProvider,
+    DuplicateCommentChecker? isDuplicateSubmission,
   }) : _commentsRepository = commentsRepository,
        _authService = authService,
        _rootEventId = rootEventId,
@@ -46,6 +62,7 @@ class CommentComposerBloc
                    profileRepository: profileRepository,
                  )),
        _mentionCandidatePubkeysProvider = mentionCandidatePubkeysProvider,
+       _isDuplicateSubmission = isDuplicateSubmission,
        super(const CommentComposerState()) {
     on<CommentTextChanged>(_onTextChanged);
     on<CommentReplyToggled>(_onReplyToggled);
@@ -72,6 +89,7 @@ class CommentComposerBloc
   final ProfileRepository? _profileRepository;
   final MentionResolutionService? _mentionResolutionService;
   final MentionCandidatePubkeysProvider? _mentionCandidatePubkeysProvider;
+  final DuplicateCommentChecker? _isDuplicateSubmission;
   final String _rootEventId;
   final int _rootEventKind;
   final String _rootAuthorPubkey;
@@ -144,6 +162,31 @@ class CommentComposerBloc
       currentUserPubkey: myPubkey,
     );
     text = resolvedMentions.canonicalText;
+
+    // Defense-in-depth against duplicate resubmits (#5854): if the same
+    // reply/comment to the same parent by this user already exists, drop this
+    // one instead of publishing a duplicate. The scroll-into-view fix is the
+    // primary cure (the poster sees their reply and stops re-sending); this
+    // catches stray double-submits. Clears the input like a normal post.
+    final isDuplicate =
+        _isDuplicateSubmission?.call(
+          parentCommentId: event.parentCommentId,
+          content: text,
+          authorPubkey: myPubkey,
+        ) ??
+        false;
+    if (isDuplicate) {
+      emit(
+        isReply
+            ? state.clearActiveReply()
+            : state.copyWith(
+                mainInputText: '',
+                activeMentions: const {},
+                activeMentionBindings: const [],
+              ),
+      );
+      return;
+    }
 
     // 1. Optimistic placeholder — the listener bridges this to ListBloc which
     // inserts it into commentsById before the publish returns. Reconciled on

--- a/mobile/lib/blocs/comments/comments_list/comments_list_bloc.dart
+++ b/mobile/lib/blocs/comments/comments_list/comments_list_bloc.dart
@@ -48,6 +48,7 @@ class CommentsListBloc extends Bloc<CommentsListEvent, CommentsListState> {
     on<CommentsInitialBackfillCompleted>(_onInitialBackfillCompleted);
     on<NewCommentsAcknowledged>(_onNewCommentsAcknowledged);
     on<CommentsListErrorCleared>(_onErrorCleared);
+    on<CommentsScrollHandled>(_onScrollHandled);
     on<OptimisticCommentInserted>(_onOptimisticCommentInserted);
     on<OptimisticCommentConfirmed>(_onOptimisticCommentConfirmed);
     on<OptimisticCommentRolledBack>(_onOptimisticCommentRolledBack);
@@ -266,6 +267,14 @@ class CommentsListBloc extends Bloc<CommentsListEvent, CommentsListState> {
     emit(state.copyWith(clearError: true));
   }
 
+  void _onScrollHandled(
+    CommentsScrollHandled event,
+    Emitter<CommentsListState> emit,
+  ) {
+    if (state.scrollToCommentId == null) return;
+    emit(state.copyWith(clearScrollTo: true));
+  }
+
   void _onNewCommentReceived(
     NewCommentReceived event,
     Emitter<CommentsListState> emit,
@@ -340,10 +349,21 @@ class CommentsListBloc extends Bloc<CommentsListEvent, CommentsListState> {
     OptimisticCommentInserted event,
     Emitter<CommentsListState> emit,
   ) {
-    _emitStore(emit, {
+    // Also flag the just-inserted own comment for scroll-into-view: a reply
+    // nests under an older parent and would otherwise render off-screen, so the
+    // poster thinks the post failed and retries (#5854). The UI scrolls to this
+    // id then acks via [CommentsScrollHandled].
+    final updated = {
       ...state.commentsById,
       event.placeholder.id: event.placeholder,
-    });
+    };
+    emit(
+      state.copyWith(
+        commentsById: updated,
+        replyCountsByCommentId: computeReplyCounts(updated),
+        scrollToCommentId: event.placeholder.id,
+      ),
+    );
   }
 
   void _onOptimisticCommentConfirmed(

--- a/mobile/lib/blocs/comments/comments_list/comments_list_bloc.dart
+++ b/mobile/lib/blocs/comments/comments_list/comments_list_bloc.dart
@@ -349,19 +349,22 @@ class CommentsListBloc extends Bloc<CommentsListEvent, CommentsListState> {
     OptimisticCommentInserted event,
     Emitter<CommentsListState> emit,
   ) {
-    // Also flag the just-inserted own comment for scroll-into-view: a reply
-    // nests under an older parent and would otherwise render off-screen, so the
-    // poster thinks the post failed and retries (#5854). The UI scrolls to this
-    // id then acks via [CommentsScrollHandled].
+    // Flag the just-inserted comment for scroll-into-view only when it is a
+    // reply: a reply nests under an (often older) parent and would otherwise
+    // render off-screen, so the poster thinks the post failed and retries
+    // (#5854). A new top-level comment already lands at the visible top, so it
+    // needs no scroll. The UI scrolls to the flagged id then acks via
+    // [CommentsScrollHandled].
     final updated = {
       ...state.commentsById,
       event.placeholder.id: event.placeholder,
     };
+    final isReply = event.placeholder.replyToEventId != null;
     emit(
       state.copyWith(
         commentsById: updated,
         replyCountsByCommentId: computeReplyCounts(updated),
-        scrollToCommentId: event.placeholder.id,
+        scrollToCommentId: isReply ? event.placeholder.id : null,
       ),
     );
   }

--- a/mobile/lib/blocs/comments/comments_list/comments_list_event.dart
+++ b/mobile/lib/blocs/comments/comments_list/comments_list_event.dart
@@ -45,6 +45,12 @@ final class CommentsListErrorCleared extends CommentsListEvent {
   const CommentsListErrorCleared();
 }
 
+/// The UI has scrolled the [CommentsListState.scrollToCommentId] target into
+/// view; clear the one-shot signal so it doesn't re-fire on the next rebuild.
+final class CommentsScrollHandled extends CommentsListEvent {
+  const CommentsScrollHandled();
+}
+
 // Cross-bloc store-mutation intents. Dispatched by the UI in response to
 // outbox signals from [CommentComposerBloc] and [CommentReactionsBloc]. The
 // list bloc owns the canonical [Comment] store; these events are the only

--- a/mobile/lib/blocs/comments/comments_list/comments_list_state.dart
+++ b/mobile/lib/blocs/comments/comments_list/comments_list_state.dart
@@ -76,6 +76,7 @@ final class CommentsListState extends Equatable {
     this.replyCountsByCommentId = const {},
     this.newCommentCount = 0,
     this.isBackfillComplete = false,
+    this.scrollToCommentId,
   });
 
   /// The current status of the list.
@@ -128,6 +129,13 @@ final class CommentsListState extends Equatable {
 
   /// Whether there are more comments to load.
   final bool hasMoreContent;
+
+  /// Transient one-shot signal: the id of a comment the UI should scroll into
+  /// view (e.g. the local user's just-inserted reply, which nests under an
+  /// older parent and would otherwise render off-screen — #5854). Set by the
+  /// optimistic-insert handler and cleared by [CommentsScrollHandled] after the
+  /// UI performs the scroll.
+  final String? scrollToCommentId;
 
   /// Returns a comparator for sorting comments based on [sortMode].
   ///
@@ -239,7 +247,9 @@ final class CommentsListState extends Equatable {
     Map<String, int>? replyCountsByCommentId,
     int? newCommentCount,
     bool? isBackfillComplete,
+    String? scrollToCommentId,
     bool clearError = false,
+    bool clearScrollTo = false,
   }) {
     return CommentsListState(
       status: status ?? this.status,
@@ -260,6 +270,9 @@ final class CommentsListState extends Equatable {
           replyCountsByCommentId ?? this.replyCountsByCommentId,
       newCommentCount: newCommentCount ?? this.newCommentCount,
       isBackfillComplete: isBackfillComplete ?? this.isBackfillComplete,
+      scrollToCommentId: clearScrollTo
+          ? null
+          : (scrollToCommentId ?? this.scrollToCommentId),
     );
   }
 
@@ -278,5 +291,6 @@ final class CommentsListState extends Equatable {
     replyCountsByCommentId,
     newCommentCount,
     isBackfillComplete,
+    scrollToCommentId,
   ];
 }

--- a/mobile/lib/screens/comments/comments_screen.dart
+++ b/mobile/lib/screens/comments/comments_screen.dart
@@ -58,6 +58,13 @@ String _reactionsErrorToString(AppLocalizations l10n, ReactionsError error) {
   };
 }
 
+/// Normalizes comment text for duplicate detection: trims, collapses internal
+/// whitespace, and lowercases. The real #5854 duplicates differ only in
+/// whitespace ("box of  krayshawns" vs "box of krayshawns"), so an exact-match
+/// guard would leak — this catches them.
+String _normalizeCommentText(String text) =>
+    text.trim().replaceAll(RegExp(r'\s+'), ' ').toLowerCase();
+
 /// Dynamic title widget that shows comment count and a "# new" pill
 /// when real-time comments arrive.
 /// Initially shows the count from video metadata, then updates to loaded count.
@@ -206,6 +213,23 @@ abstract final class CommentsScreen {
                       ),
                       ...followRepository.followingPubkeys,
                     ],
+                    // Live duplicate check against the canonical store so a
+                    // re-sent reply doesn't publish a duplicate (#5854).
+                    isDuplicateSubmission:
+                        ({
+                          required String content,
+                          required String authorPubkey,
+                          String? parentCommentId,
+                        }) {
+                          final normalized = _normalizeCommentText(content);
+                          return listBloc.state.commentsById.values.any(
+                            (c) =>
+                                !c.id.startsWith('pending_comment_') &&
+                                c.authorPubkey == authorPubkey &&
+                                c.replyToEventId == parentCommentId &&
+                                _normalizeCommentText(c.content) == normalized,
+                          );
+                        },
                   );
                 },
               ),

--- a/mobile/lib/screens/comments/comments_screen.dart
+++ b/mobile/lib/screens/comments/comments_screen.dart
@@ -3,6 +3,7 @@
 
 import 'dart:async';
 
+import 'package:comments_repository/comments_repository.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -64,6 +65,28 @@ String _reactionsErrorToString(AppLocalizations l10n, ReactionsError error) {
 /// guard would leak — this catches them.
 String _normalizeCommentText(String text) =>
     text.trim().replaceAll(RegExp(r'\s+'), ' ').toLowerCase();
+
+/// Returns true only for the resend window #5854 needs to suppress: an
+/// in-flight optimistic reply by the same author, to the same parent, with the
+/// same normalized text. Top-level comments and confirmed comments are allowed
+/// so intentional repeated reactions are not silently dropped.
+bool isDuplicatePendingReplySubmission({
+  required Iterable<Comment> comments,
+  required String content,
+  required String authorPubkey,
+  String? parentCommentId,
+}) {
+  if (parentCommentId == null) return false;
+
+  final normalized = _normalizeCommentText(content);
+  return comments.any(
+    (c) =>
+        c.id.startsWith('pending_comment_') &&
+        c.authorPubkey == authorPubkey &&
+        c.replyToEventId == parentCommentId &&
+        _normalizeCommentText(c.content) == normalized,
+  );
+}
 
 /// Dynamic title widget that shows comment count and a "# new" pill
 /// when real-time comments arrive.
@@ -221,13 +244,11 @@ abstract final class CommentsScreen {
                           required String authorPubkey,
                           String? parentCommentId,
                         }) {
-                          final normalized = _normalizeCommentText(content);
-                          return listBloc.state.commentsById.values.any(
-                            (c) =>
-                                !c.id.startsWith('pending_comment_') &&
-                                c.authorPubkey == authorPubkey &&
-                                c.replyToEventId == parentCommentId &&
-                                _normalizeCommentText(c.content) == normalized,
+                          return isDuplicatePendingReplySubmission(
+                            comments: listBloc.state.commentsById.values,
+                            content: content,
+                            authorPubkey: authorPubkey,
+                            parentCommentId: parentCommentId,
                           );
                         },
                   );

--- a/mobile/lib/screens/comments/widgets/comment_item.dart
+++ b/mobile/lib/screens/comments/widgets/comment_item.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Renders a single comment with author info, content, like button,
 // ABOUTME: and reply indicator. Long-press shows options (delete/report/block).
 
+import 'dart:async';
 import 'dart:math';
 
 import 'package:comments_repository/comments_repository.dart';
@@ -463,6 +464,23 @@ class _ActionsRow extends StatelessWidget {
           label: context.l10n.commentReplySemanticLabel,
           child: InkWell(
             onTap: () {
+              // Bring the replied-to comment up into a keyboard-safe position
+              // so the reply (which nests directly below it) lands on-screen
+              // instead of behind the keyboard / below the fold (#5854). The
+              // tapped comment is guaranteed on-screen here, so ensureVisible
+              // reliably works. A follow-up scroll to the inserted reply itself
+              // is driven by CommentsList once the placeholder appears.
+              final reduceMotion = MediaQuery.of(context).disableAnimations;
+              unawaited(
+                Scrollable.ensureVisible(
+                  context,
+                  alignment: 0.35,
+                  duration: reduceMotion
+                      ? Duration.zero
+                      : const Duration(milliseconds: 300),
+                  curve: Curves.easeOut,
+                ),
+              );
               context.read<CommentComposerBloc>().add(
                 CommentReplyToggled(commentId),
               );

--- a/mobile/lib/screens/comments/widgets/comments_list.dart
+++ b/mobile/lib/screens/comments/widgets/comments_list.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Comments list widget with loading, error, and empty states
 // ABOUTME: Renders comments in a flat list using CommentItem widget
 
+import 'dart:async';
+
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -26,6 +28,11 @@ class CommentsList extends StatefulWidget {
 }
 
 class _CommentsListState extends State<CommentsList> {
+  /// Attached to the single comment the list should scroll into view
+  /// ([CommentsListState.scrollToCommentId]); lets us resolve its render
+  /// object for `ensureVisible` even though the list is index-built (#5854).
+  final GlobalKey _scrollTargetKey = GlobalKey();
+
   @override
   void initState() {
     super.initState();
@@ -47,6 +54,31 @@ class _CommentsListState extends State<CommentsList> {
     }
   }
 
+  /// Scrolls the flagged comment into view after the next frame (so the target
+  /// item is laid out), then acks the one-shot signal. No-op if the target is
+  /// not currently built — [CommentItem]'s reply-tap scroll keeps it close
+  /// enough that the just-inserted reply is laid out.
+  void _scrollToTarget() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      final targetContext = _scrollTargetKey.currentContext;
+      if (targetContext != null) {
+        final reduceMotion = MediaQuery.of(context).disableAnimations;
+        unawaited(
+          Scrollable.ensureVisible(
+            targetContext,
+            alignment: 0.3,
+            duration: reduceMotion
+                ? Duration.zero
+                : const Duration(milliseconds: 300),
+            curve: Curves.easeOut,
+          ),
+        );
+      }
+      context.read<CommentsListBloc>().add(const CommentsScrollHandled());
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     // Match TikTok / Instagram Reels: any interaction with the comments
@@ -60,54 +92,69 @@ class _CommentsListState extends State<CommentsList> {
     // profile) still run normally afterwards. The ListView's
     // [ScrollViewKeyboardDismissBehavior.onDrag] covers the scroll case
     // idiomatically.
-    return Listener(
-      behavior: HitTestBehavior.translucent,
-      onPointerDown: (_) => FocusManager.instance.primaryFocus?.unfocus(),
-      child: BlocBuilder<CommentsListBloc, CommentsListState>(
-        builder: (context, state) {
-          if (state.status == CommentsStatus.loading) {
-            return const _LoadingState();
-          }
+    return BlocListener<CommentsListBloc, CommentsListState>(
+      listenWhen: (prev, next) =>
+          prev.scrollToCommentId != next.scrollToCommentId &&
+          next.scrollToCommentId != null,
+      listener: (_, _) => _scrollToTarget(),
+      child: Listener(
+        behavior: HitTestBehavior.translucent,
+        onPointerDown: (_) => FocusManager.instance.primaryFocus?.unfocus(),
+        child: BlocBuilder<CommentsListBloc, CommentsListState>(
+          builder: (context, state) {
+            if (state.status == CommentsStatus.loading) {
+              return const _LoadingState();
+            }
 
-          if (state.status == CommentsStatus.failure) {
-            return const _ErrorState();
-          }
+            if (state.status == CommentsStatus.failure) {
+              return const _ErrorState();
+            }
 
-          // Engagement sort consumes upvote counts from CommentReactionsBloc,
-          // so cross-bloc the threaded list build via a nested BlocSelector.
-          return BlocSelector<
-            CommentReactionsBloc,
-            CommentReactionsState,
-            Map<String, int>
-          >(
-            selector: (s) => s.commentUpvoteCounts,
-            builder: (context, upvoteCounts) {
-              final all = state.threadedCommentsWith(
-                upvoteCounts: upvoteCounts,
-              );
-              final threaded = widget.showVideoReplies
-                  ? all
-                  : all.where((node) => !node.comment.hasVideo).toList();
-
-              if (threaded.isEmpty) {
-                return CommentsEmptyState(
-                  isClassicVine: widget.showClassicVineNotice,
+            // Engagement sort consumes upvote counts from
+            // CommentReactionsBloc, so cross-bloc the threaded list build via
+            // a nested BlocSelector.
+            return BlocSelector<
+              CommentReactionsBloc,
+              CommentReactionsState,
+              Map<String, int>
+            >(
+              selector: (s) => s.commentUpvoteCounts,
+              builder: (context, upvoteCounts) {
+                final all = state.threadedCommentsWith(
+                  upvoteCounts: upvoteCounts,
                 );
-              }
+                final threaded = widget.showVideoReplies
+                    ? all
+                    : all.where((node) => !node.comment.hasVideo).toList();
 
-              return ListView.builder(
-                controller: widget.scrollController,
-                keyboardDismissBehavior:
-                    ScrollViewKeyboardDismissBehavior.onDrag,
-                itemCount: threaded.length,
-                itemBuilder: (context, index) {
-                  final node = threaded[index];
-                  return CommentItem(comment: node.comment, depth: node.depth);
-                },
-              );
-            },
-          );
-        },
+                if (threaded.isEmpty) {
+                  return CommentsEmptyState(
+                    isClassicVine: widget.showClassicVineNotice,
+                  );
+                }
+
+                return ListView.builder(
+                  controller: widget.scrollController,
+                  keyboardDismissBehavior:
+                      ScrollViewKeyboardDismissBehavior.onDrag,
+                  itemCount: threaded.length,
+                  itemBuilder: (context, index) {
+                    final node = threaded[index];
+                    final isScrollTarget =
+                        node.comment.id == state.scrollToCommentId;
+                    return CommentItem(
+                      key: isScrollTarget
+                          ? _scrollTargetKey
+                          : ValueKey('comment_${node.comment.id}'),
+                      comment: node.comment,
+                      depth: node.depth,
+                    );
+                  },
+                );
+              },
+            );
+          },
+        ),
       ),
     );
   }

--- a/mobile/packages/comments_repository/lib/src/comments_repository.dart
+++ b/mobile/packages/comments_repository/lib/src/comments_repository.dart
@@ -177,6 +177,12 @@ class CommentsRepository {
             videoId: rootEventId,
             limit: limit,
             offset: offset,
+            // Skip the un-purged edge cache while the local user has a
+            // just-posted comment/reply for this video, so a post-action
+            // reload reflects it (and other fresh comments) instead of a
+            // stale ~120s cached list. Self-clears once the pending set
+            // prunes. Other viewers still need a backend surrogate purge.
+            cacheBustToken: _commentsCacheBustToken(rootEventId),
           );
           if (response != null) {
             final restThread = _buildThreadFromRestComments(
@@ -569,6 +575,23 @@ class CommentsRepository {
       updated < 0 ? 0 : updated,
       rootAddressableId: rootAddressableId,
     );
+  }
+
+  /// Returns a cache-bust token for [rootEventId]'s comments REST read, or
+  /// `null` when the local user has no recently-posted comment for the video.
+  ///
+  /// The token is the newest retained post time (microseconds), so it is stable
+  /// across reads within a post window (the edge can still cache that variant)
+  /// and changes when a newer comment is posted. Once [_recentlyPostedComments]
+  /// prunes (merged in or older than [_recentlyPostedRetention]), it returns
+  /// `null` and reads fall back to the normal cached URL (#5854).
+  String? _commentsCacheBustToken(String rootEventId) {
+    final pending = _recentlyPostedComments[rootEventId];
+    if (pending == null || pending.isEmpty) return null;
+    final latestMicros = pending
+        .map((p) => p.postedAt.microsecondsSinceEpoch)
+        .reduce((a, b) => a > b ? a : b);
+    return latestMicros.toString();
   }
 
   /// Records a just-posted [comment] so [loadComments] can keep it visible on

--- a/mobile/packages/comments_repository/test/src/comments_repository_test.dart
+++ b/mobile/packages/comments_repository/test/src/comments_repository_test.dart
@@ -63,6 +63,7 @@ void main() {
             sort: any(named: 'sort'),
             limit: any(named: 'limit'),
             offset: any(named: 'offset'),
+            cacheBustToken: any(named: 'cacheBustToken'),
           ),
         ).thenAnswer(
           (_) async => VideoCommentsResponse(
@@ -112,6 +113,7 @@ void main() {
             sort: any(named: 'sort'),
             limit: any(named: 'limit'),
             offset: any(named: 'offset'),
+            cacheBustToken: any(named: 'cacheBustToken'),
           ),
         ).called(1);
         verifyNever(() => mockNostrClient.queryEvents(any()));
@@ -128,6 +130,7 @@ void main() {
               sort: any(named: 'sort'),
               limit: any(named: 'limit'),
               offset: any(named: 'offset'),
+              cacheBustToken: any(named: 'cacheBustToken'),
             ),
           ).thenAnswer(
             (_) async => VideoCommentsResponse(
@@ -185,6 +188,7 @@ void main() {
               sort: any(named: 'sort'),
               limit: any(named: 'limit'),
               offset: any(named: 'offset'),
+              cacheBustToken: any(named: 'cacheBustToken'),
             ),
           ).thenAnswer(
             (_) async => VideoCommentsResponse(
@@ -241,6 +245,7 @@ void main() {
             sort: any(named: 'sort'),
             limit: any(named: 'limit'),
             offset: any(named: 'offset'),
+            cacheBustToken: any(named: 'cacheBustToken'),
           ),
         ).thenThrow(
           const FunnelcakeApiException(message: 'boom', statusCode: 500),

--- a/mobile/packages/comments_repository/test/src/recently_posted_comment_merge_test.dart
+++ b/mobile/packages/comments_repository/test/src/recently_posted_comment_merge_test.dart
@@ -65,6 +65,7 @@ void main() {
           sort: any(named: 'sort'),
           limit: any(named: 'limit'),
           offset: any(named: 'offset'),
+          cacheBustToken: any(named: 'cacheBustToken'),
         ),
       ).thenAnswer(
         (_) async => VideoCommentsResponse(comments: comments, total: total),
@@ -176,6 +177,40 @@ void main() {
       final thread = await load();
 
       expect(thread.comments, isEmpty);
+    });
+
+    // #5854: the comments REST response is edge-cached and not purged on
+    // comment ingest, so a post-action reload can serve a stale list. The
+    // repository busts the cache while it holds a just-posted comment.
+    group('cache-bust token (#5854)', () {
+      List<Object?> capturedCacheBustTokens() {
+        return verify(
+          () => funnelcakeClient.getVideoComments(
+            videoId: any(named: 'videoId'),
+            sort: any(named: 'sort'),
+            limit: any(named: 'limit'),
+            offset: any(named: 'offset'),
+            cacheBustToken: captureAny(named: 'cacheBustToken'),
+          ),
+        ).captured;
+      }
+
+      test('passes a cacheBustToken after a local post', () async {
+        await postOne();
+        stubRest(<VideoComment>[], total: 0);
+
+        await load();
+
+        expect(capturedCacheBustTokens().single, isNotNull);
+      });
+
+      test('passes no cacheBustToken on a cold load', () async {
+        stubRest(<VideoComment>[], total: 0);
+
+        await load();
+
+        expect(capturedCacheBustTokens().single, isNull);
+      });
     });
   });
 }

--- a/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
@@ -1666,6 +1666,7 @@ class FunnelcakeApiClient {
     String sort = 'newest',
     int limit = 25,
     int offset = 0,
+    String? cacheBustToken,
   }) async {
     if (!isAvailable) {
       throw const FunnelcakeNotConfiguredException();
@@ -1675,11 +1676,19 @@ class FunnelcakeApiClient {
       throw const FunnelcakeException('Video ID cannot be empty');
     }
 
+    // The comments response is edge-cached (surrogate-control max-age) and is
+    // NOT purged when a new Kind 1111 comment/reply is ingested, so a same-URL
+    // re-fetch can return a stale list for the cache TTL. When the caller
+    // passes a [cacheBustToken] (e.g. after the local user just posted), it
+    // becomes a query param so the edge serves a fresh response. The token is
+    // stable within a post window, so it does not create unbounded cache keys.
     final uri = Uri.parse('$_baseUrl/api/v2/videos/$videoId/comments').replace(
       queryParameters: {
         'sort': sort,
         'limit': limit.toString(),
         'offset': offset.toString(),
+        if (cacheBustToken != null && cacheBustToken.isNotEmpty)
+          '_cb': cacheBustToken,
       },
     );
 

--- a/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
@@ -3432,6 +3432,45 @@ void main() {
         expect(uri.queryParameters['offset'], equals('100'));
       });
 
+      test('includes _cb param when cacheBustToken is set (#5854)', () async {
+        when(
+          () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+        ).thenAnswer((_) async => http.Response(validResponse, 200));
+
+        await client.getVideoComments(
+          videoId: testVideoId,
+          cacheBustToken: '1700000000123456',
+        );
+
+        final uri =
+            verify(
+                  () => mockHttpClient.get(
+                    captureAny(),
+                    headers: any(named: 'headers'),
+                  ),
+                ).captured.first
+                as Uri;
+        expect(uri.queryParameters['_cb'], equals('1700000000123456'));
+      });
+
+      test('omits _cb param by default so reads stay edge-cacheable', () async {
+        when(
+          () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+        ).thenAnswer((_) async => http.Response(validResponse, 200));
+
+        await client.getVideoComments(videoId: testVideoId);
+
+        final uri =
+            verify(
+                  () => mockHttpClient.get(
+                    captureAny(),
+                    headers: any(named: 'headers'),
+                  ),
+                ).captured.first
+                as Uri;
+        expect(uri.queryParameters.containsKey('_cb'), isFalse);
+      });
+
       test('derives pagination lower-bound total from v2 has_more', () async {
         when(
           () => mockHttpClient.get(any(), headers: any(named: 'headers')),

--- a/mobile/test/blocs/comments/comment_composer/comment_composer_bloc_test.dart
+++ b/mobile/test/blocs/comments/comment_composer/comment_composer_bloc_test.dart
@@ -23,6 +23,18 @@ class _MockProfileRepository extends Mock implements ProfileRepository {}
 class _MockMentionResolutionService extends Mock
     implements MentionResolutionService {}
 
+bool _dupYes({
+  required String content,
+  required String authorPubkey,
+  String? parentCommentId,
+}) => true;
+
+bool _dupNo({
+  required String content,
+  required String authorPubkey,
+  String? parentCommentId,
+}) => false;
+
 void main() {
   group(CommentComposerBloc, () {
     late _MockCommentsRepository mockCommentsRepository;
@@ -82,6 +94,7 @@ void main() {
     CommentComposerBloc createBloc({
       String? rootAddressableId,
       MentionCandidatePubkeysProvider? candidateProvider,
+      DuplicateCommentChecker? isDuplicate,
     }) => CommentComposerBloc(
       commentsRepository: mockCommentsRepository,
       authService: mockAuthService,
@@ -92,6 +105,7 @@ void main() {
       profileRepository: mockProfileRepository,
       mentionResolutionService: mockMentionResolutionService,
       mentionCandidatePubkeysProvider: candidateProvider,
+      isDuplicateSubmission: isDuplicate,
     );
 
     Comment makeComment(
@@ -232,6 +246,83 @@ void main() {
             isA<ComposerOutboxConfirmPlaceholder>(),
           ),
         ],
+      );
+
+      // #5854: a re-sent identical reply (the poster couldn't see the first
+      // one because it rendered off-screen) must not publish a duplicate.
+      blocTest<CommentComposerBloc, CommentComposerState>(
+        'drops a duplicate reply: no publish, reply input cleared',
+        build: () => createBloc(isDuplicate: _dupYes),
+        seed: () => CommentComposerState(
+          activeReplyCommentId: validId('parent'),
+          replyInputText: 'same reply',
+        ),
+        act: (b) => b.add(
+          CommentSubmitted(
+            parentCommentId: validId('parent'),
+            parentAuthorPubkey: validId('parentauthor'),
+          ),
+        ),
+        verify: (b) {
+          verifyNever(
+            () => mockCommentsRepository.postComment(
+              content: any(named: 'content'),
+              rootEventId: any(named: 'rootEventId'),
+              rootEventKind: any(named: 'rootEventKind'),
+              rootEventAuthorPubkey: any(named: 'rootEventAuthorPubkey'),
+              rootAddressableId: any(named: 'rootAddressableId'),
+              replyToEventId: any(named: 'replyToEventId'),
+              replyToAuthorPubkey: any(named: 'replyToAuthorPubkey'),
+              mentionedPubkeys: any(named: 'mentionedPubkeys'),
+            ),
+          );
+          expect(b.state.outbox, isNull);
+          expect(b.state.activeReplyCommentId, isNull);
+          expect(b.state.replyInputText, isEmpty);
+        },
+      );
+
+      blocTest<CommentComposerBloc, CommentComposerState>(
+        'a non-duplicate reply publishes normally',
+        setUp: () {
+          when(
+            () => mockCommentsRepository.postComment(
+              content: any(named: 'content'),
+              rootEventId: any(named: 'rootEventId'),
+              rootEventKind: any(named: 'rootEventKind'),
+              rootEventAuthorPubkey: any(named: 'rootEventAuthorPubkey'),
+              rootAddressableId: any(named: 'rootAddressableId'),
+              replyToEventId: any(named: 'replyToEventId'),
+              replyToAuthorPubkey: any(named: 'replyToAuthorPubkey'),
+              mentionedPubkeys: any(named: 'mentionedPubkeys'),
+            ),
+          ).thenAnswer((_) async => makeComment(validId('confirmed')));
+        },
+        build: () => createBloc(isDuplicate: _dupNo),
+        seed: () => CommentComposerState(
+          activeReplyCommentId: validId('parent'),
+          replyInputText: 'fresh reply',
+        ),
+        act: (b) => b.add(
+          CommentSubmitted(
+            parentCommentId: validId('parent'),
+            parentAuthorPubkey: validId('parentauthor'),
+          ),
+        ),
+        verify: (_) {
+          verify(
+            () => mockCommentsRepository.postComment(
+              content: any(named: 'content'),
+              rootEventId: any(named: 'rootEventId'),
+              rootEventKind: any(named: 'rootEventKind'),
+              rootEventAuthorPubkey: any(named: 'rootEventAuthorPubkey'),
+              rootAddressableId: any(named: 'rootAddressableId'),
+              replyToEventId: any(named: 'replyToEventId'),
+              replyToAuthorPubkey: any(named: 'replyToAuthorPubkey'),
+              mentionedPubkeys: any(named: 'mentionedPubkeys'),
+            ),
+          ).called(1);
+        },
       );
 
       blocTest<CommentComposerBloc, CommentComposerState>(

--- a/mobile/test/blocs/comments/comments_list/comments_list_bloc_test.dart
+++ b/mobile/test/blocs/comments/comments_list/comments_list_bloc_test.dart
@@ -675,7 +675,8 @@ void main() {
 
     group('Cross-bloc store mutation events', () {
       blocTest<CommentsListBloc, CommentsListState>(
-        'OptimisticCommentInserted adds placeholder',
+        'OptimisticCommentInserted adds a top-level placeholder without '
+        'flagging it for scroll (#5854)',
         build: createBloc,
         act: (b) {
           final placeholder = Comment(
@@ -690,8 +691,32 @@ void main() {
         },
         verify: (b) {
           expect(b.state.commentsById.containsKey('pending_comment_1'), isTrue);
-          // #5854: flags the just-inserted own comment for scroll-into-view so
-          // a reply nested under an older parent isn't stranded off-screen.
+          // A new top-level comment lands at the visible top, so it must not
+          // trigger a scroll — only replies (which nest off-screen) do.
+          expect(b.state.scrollToCommentId, isNull);
+        },
+      );
+
+      blocTest<CommentsListBloc, CommentsListState>(
+        'OptimisticCommentInserted flags a reply for scroll-into-view (#5854)',
+        build: createBloc,
+        act: (b) {
+          final placeholder = Comment(
+            id: 'pending_comment_1',
+            content: 'wip reply',
+            authorPubkey: validId('me'),
+            createdAt: DateTime.now(),
+            rootEventId: validId('root'),
+            rootAuthorPubkey: validId('author'),
+            replyToEventId: validId('parent'),
+            replyToAuthorPubkey: validId('parentauthor'),
+          );
+          b.add(OptimisticCommentInserted(placeholder));
+        },
+        verify: (b) {
+          expect(b.state.commentsById.containsKey('pending_comment_1'), isTrue);
+          // A reply nests under an (often older) parent and would render
+          // off-screen, so the poster must be scrolled to it.
           expect(b.state.scrollToCommentId, equals('pending_comment_1'));
         },
       );

--- a/mobile/test/blocs/comments/comments_list/comments_list_bloc_test.dart
+++ b/mobile/test/blocs/comments/comments_list/comments_list_bloc_test.dart
@@ -690,6 +690,21 @@ void main() {
         },
         verify: (b) {
           expect(b.state.commentsById.containsKey('pending_comment_1'), isTrue);
+          // #5854: flags the just-inserted own comment for scroll-into-view so
+          // a reply nested under an older parent isn't stranded off-screen.
+          expect(b.state.scrollToCommentId, equals('pending_comment_1'));
+        },
+      );
+
+      blocTest<CommentsListBloc, CommentsListState>(
+        'CommentsScrollHandled clears the scroll signal (#5854)',
+        build: createBloc,
+        seed: () => const CommentsListState(
+          scrollToCommentId: 'pending_comment_1',
+        ),
+        act: (b) => b.add(const CommentsScrollHandled()),
+        verify: (b) {
+          expect(b.state.scrollToCommentId, isNull);
         },
       );
 

--- a/mobile/test/screens/comments/comment_item_test.dart
+++ b/mobile/test/screens/comments/comment_item_test.dart
@@ -153,6 +153,32 @@ void main() {
     expect(linkSpan.recognizer, isA<TapGestureRecognizer>());
   });
 
+  testWidgets(
+    'tapping Reply still dispatches CommentReplyToggled (#5854 scroll intact)',
+    (tester) async {
+      final mocks = buildMocks();
+
+      await tester.pumpWidget(
+        buildTestWidget(
+          'hello there',
+          composerBloc: mocks.composer,
+          reactionsBloc: mocks.reactions,
+        ),
+      );
+      await tester.pump();
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      await tester.tap(find.text(l10n.commentReply));
+      await tester.pump();
+
+      // The reply-tap now also scrolls the comment into view (#5854); the
+      // reply-mode toggle must still fire.
+      verify(
+        () => mocks.composer.add(any(that: isA<CommentReplyToggled>())),
+      ).called(1);
+    },
+  );
+
   testWidgets('opens video comments with hydrated route data', (tester) async {
     final mocks = buildMocks();
 

--- a/mobile/test/screens/comments/comments_list_test.dart
+++ b/mobile/test/screens/comments/comments_list_test.dart
@@ -230,6 +230,73 @@ void main() {
     });
 
     testWidgets(
+      'scrolls the flagged comment into view and acks it (#5854)',
+      (tester) async {
+        final comments = [
+          for (var i = 0; i < 12; i++)
+            CommentBuilder()
+                .withId('$i'.padLeft(64, 'a'))
+                .withContent('comment number $i')
+                // Newest-first sort: minute 12-i means i=0 is newest (top),
+                // so higher indices sit lower in the list.
+                .withCreatedAt(DateTime(2026).add(Duration(minutes: 12 - i)))
+                .build(),
+        ];
+        final commentsById = {for (final c in comments) c.id: c};
+        // A comment below the initial fold but within the build cache extent.
+        final target = comments[5];
+
+        final base = CommentsListState(
+          rootEventId: testVideoEventId,
+          rootAuthorPubkey: testVideoAuthorPubkey,
+          status: CommentsStatus.success,
+          commentsById: commentsById,
+        );
+        final withScroll = base.copyWith(scrollToCommentId: target.id);
+
+        whenListen(
+          mockListBloc,
+          Stream.fromIterable([base, withScroll]),
+          initialState: base,
+        );
+
+        final sc = ScrollController();
+        addTearDown(sc.dispose);
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              nostrServiceProvider.overrideWithValue(mockNostrClient),
+            ],
+            child: MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(
+                body: MultiBlocProvider(
+                  providers: [
+                    BlocProvider<CommentsListBloc>.value(value: mockListBloc),
+                    BlocProvider<CommentReactionsBloc>.value(
+                      value: mockReactionsBloc,
+                    ),
+                  ],
+                  child: CommentsList(
+                    showClassicVineNotice: false,
+                    scrollController: sc,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // The list scrolled down to reveal the flagged comment, and the
+        // one-shot scroll signal was acknowledged.
+        expect(sc.offset, greaterThan(0));
+        verify(() => mockListBloc.add(const CommentsScrollHandled())).called(1);
+      },
+    );
+
+    testWidgets(
       'ListView declares onDrag keyboard-dismiss behavior',
       (tester) async {
         final comment = CommentBuilder().build();

--- a/mobile/test/screens/comments/comments_screen_test.dart
+++ b/mobile/test/screens/comments/comments_screen_test.dart
@@ -75,6 +75,72 @@ Finder _divineIcon(DivineIconName name) =>
     find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
 
 void main() {
+  group(isDuplicatePendingReplySubmission, () {
+    const authorPubkey =
+        'c3d4e5f6789012345678901234567890abcdef123456789012345678901234ab';
+    const parentCommentId =
+        'd4e5f6789012345678901234567890abcdef123456789012345678901234abc';
+
+    test('allows repeated top-level comments by the same author', () {
+      final existing = CommentBuilder()
+          .withId(
+            'e5f6789012345678901234567890abcdef123456789012345678901234abcd',
+          )
+          .withAuthorPubkey(authorPubkey)
+          .withContent('lol')
+          .build();
+
+      expect(
+        isDuplicatePendingReplySubmission(
+          comments: [existing],
+          content: 'lol',
+          authorPubkey: authorPubkey,
+        ),
+        isFalse,
+      );
+    });
+
+    test('blocks a matching pending reply resend', () {
+      final pendingReply = CommentBuilder()
+          .withId('pending_comment_1')
+          .withAuthorPubkey(authorPubkey)
+          .withContent('box of  krayshawns')
+          .withReplyToEventId(parentCommentId)
+          .build();
+
+      expect(
+        isDuplicatePendingReplySubmission(
+          comments: [pendingReply],
+          content: ' box of krayshawns ',
+          authorPubkey: authorPubkey,
+          parentCommentId: parentCommentId,
+        ),
+        isTrue,
+      );
+    });
+
+    test('allows the same confirmed reply text later', () {
+      final confirmedReply = CommentBuilder()
+          .withId(
+            'f6789012345678901234567890abcdef123456789012345678901234abcde',
+          )
+          .withAuthorPubkey(authorPubkey)
+          .withContent('same reply')
+          .withReplyToEventId(parentCommentId)
+          .build();
+
+      expect(
+        isDuplicatePendingReplySubmission(
+          comments: [confirmedReply],
+          content: 'same reply',
+          authorPubkey: authorPubkey,
+          parentCommentId: parentCommentId,
+        ),
+        isFalse,
+      );
+    });
+  });
+
   group('CommentsScreen', () {
     late _MockSocialService mockSocialService;
     late _MockAuthService mockAuthService;


### PR DESCRIPTION
## Description

Comment **replies** appeared not to post — the reporter had to re-send several
times, and ended up with a pile of **duplicate replies** (see the reported
screenshot).

**Root cause (confirmed):** the reply *publishes fine every time*. A text reply
nests under its (often older) parent in the threaded list, so it renders **below
the fold / behind the keyboard**, while a new top-level comment lands at the
visible top. There is no scroll-to-reply and the poster's own reply never raises
the "# new" pill, so the poster saw nothing happen, re-typed and re-sent — each
attempt publishing a fresh duplicate (the copies in the screenshot differ only in
whitespace, i.e. genuine re-typed resubmits). It is a **visibility** bug, not a
data-loss or publish-failure bug.

**What changed (three focused commits):**

1. **Scroll a newly-posted reply into view.** Tapping *Reply* now
   `ensureVisible`s the tapped comment into a keyboard-safe position (it's
   on-screen at tap time, so this is reliable — no scroll-to-index needed). After
   the optimistic reply is inserted, `CommentsListBloc` flags it via a one-shot
   `scrollToCommentId` and `CommentsList` scrolls it into view, then acks. Respects
   reduced-motion.
2. **Drop duplicate reply resubmits.** Defense-in-depth: if a normalized
   (trimmed / whitespace-collapsed) reply to the same parent by this user already
   exists, the composer skips the publish instead of adding another. The check
   reads the live list store via an injected checker, so the composer keeps no
   BLoC-to-BLoC dependency.
3. **Bust the comments edge cache after a local post.** The v2 comments REST
   response is edge-cached (~120s) and is **not** purged on Kind 1111 ingest, so a
   post-action reload can serve a stale list. While the repository still holds a
   just-posted comment for a video, `loadComments` passes a cache-bust token
   (derived from the newest retained post time — stable within a post window,
   self-clearing) that the client appends as a query param.

**Related Issue:** Closes #5854

## Out of Scope

Separate, independently-tracked follow-ups (intentionally **not** in this PR):

- **Backend cache purge** (`divine-funnelcake#629`) — the mobile cache-bust only
  helps the poster's own post window. Other viewers / reopens after the window
  still see a stale list for up to ~120s; the complete fix is a **surrogate-key
  purge on Kind 1111 ingest**.
- **Video-reply surface** (#5862) has no optimistic insert and navigates away, so a
  recorded video reply still won't appear until a reload (this PR is text replies).
- **App-wide lag** (#5863) — profile counts stuck on "—", slow/choppy camera: a
  separate perf investigation found the main-isolate hog is **relay-event signature
  verification** on the UI isolate (deduped *after* verify), not DM decryption.

## Verification

- `flutter analyze lib test integration_test` — clean.
- Targeted tests, all green:
  - `comments_list_bloc_test` (scroll signal set/clear),
    `comment_composer_bloc_test` (duplicate guard),
    `comments_list_test` (scrolls flagged reply into view + acks),
    `comment_item_test` (reply-tap still toggles reply mode).
  - `comments_repository` (141) + `funnelcake_api_client` (354) incl. new
    cache-bust tests.
- Manual on-device plan below.

## Manual test plan (device)

> **Build:** profile/debug (matches the report). Fix is for **typed text
> replies**, independent of the video-replies flag. Use a video with enough
> comments that you must scroll to reach an older one.

1. **Reproduce first (old build):** scroll to an older comment → Reply → type →
   Send. Nothing seems to appear; re-send a few times → scroll down → several
   duplicate replies.
2. **Core fix:** on this build, scroll to an older comment → Reply (the comment
   scrolls up into view) → type → Send → **the reply appears immediately, above
   the keyboard**; no urge to re-send.
3. **Positions/sort:** reply to the newest / a mid-list / the oldest comment, and
   across New/Top/Old sort → reply scrolls into view each time.
4. **Duplicate guard:** send the same reply text again to the same comment (with a
   double space, e.g. `nice  one`) → **no duplicate**; a *different* reply still
   posts.
5. **Reduced motion:** enable Reduce Motion, repeat step 2 → reply still ends up in
   view (instant scroll).
6. **Reopen:** post a reply, close & reopen the sheet → reply still there. (A 2nd
   account may still lag ~2 min — known backend cache limit, separate follow-up.)
7. **Regressions:** top-level comment still lands at top; "# new" pill still scrolls
   to top; drag/tap still dismisses the keyboard; votes / "Re:" indicator /
   long-press options still work.

## Screenshots / recordings

<!-- Attach a recording of step 2 (reply → instantly visible) and step 4
     (no duplicate), ideally next to the original bug recording. -->

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
