### PR TITLE
fix(camera): freeze preview on lens switch via SurfaceProducer

### DIFF
--- a/mobile/lib/widgets/video_recorder/video_recorder_focus_point.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_focus_point.dart
@@ -32,11 +32,15 @@ class _VideoRecorderFocusPointState extends State<VideoRecorderFocusPoint> {
     final camera = DivineCamera.instance;
     if (!camera.lens.isFrontFacing) return false;
 
-    // On iOS, mirror preview only when native isn't mirroring
-    if (!kIsWeb && defaultTargetPlatform == TargetPlatform.iOS) {
+    // Must mirror the indicator the same way CameraPreviewWidget mirrors the
+    // preview, so the indicator stays under the user's finger.
+    if (defaultTargetPlatform == TargetPlatform.iOS ||
+        defaultTargetPlatform == TargetPlatform.macOS) {
       return !camera.mirrorFrontCameraOutput;
     }
-    return false;
+    // Android: mirrored unless the native producer applies its own transform
+    // (the API<29 SurfaceTexture path).
+    return !camera.state.previewHandlesTransform;
   }
   // coverage:ignore-end
 

--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/CameraController.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/CameraController.kt
@@ -1133,13 +1133,16 @@ class CameraController(
             // first frame. Until then the SurfaceProducer keeps showing the old
             // frame (frozen) and the state (lens/rotation) stays on the old
             // camera, so the frozen frame never flips to the new rotation early.
-            var switchResolved = false
-            val finishSwitch = Runnable {
-                if (switchResolved) return@Runnable
-                switchResolved = true
-                onFirstFrameAfterSwitch = null
-                DivineCameraLog.d(TAG, "Camera switched successfully")
-                callback(getCameraState(), null)
+            // Whichever path runs first (first frame or the timeout) cancels the
+            // other queued copy via removeCallbacks, so this runs exactly once
+            // and no stale timeout lingers on the main looper afterwards.
+            val finishSwitch = object : Runnable {
+                override fun run() {
+                    mainHandler.removeCallbacks(this)
+                    onFirstFrameAfterSwitch = null
+                    DivineCameraLog.d(TAG, "Camera switched successfully")
+                    callback(getCameraState(), null)
+                }
             }
             onFirstFrameAfterSwitch = { mainHandler.post(finishSwitch) }
             mainHandler.postDelayed(finishSwitch, SWITCH_FIRST_FRAME_TIMEOUT_MS)
@@ -2340,6 +2343,10 @@ class CameraController(
         }
     }
 
+    // SENSOR_ORIENTATION is immutable per camera id, so cache it and avoid a
+    // fresh getCameraCharacteristics() lookup on every getCameraState() call.
+    private val sensorOrientationByCameraId = mutableMapOf<String, Int>()
+
     /**
      * Reads the clockwise sensor orientation (degrees) of the current lens.
      * The recorder is portrait-locked, so this doubles as the rotation the UI
@@ -2349,11 +2356,13 @@ class CameraController(
     private fun currentSensorOrientation(): Int {
         return try {
             val cameraId = getCameraIdForLens(currentLensType) ?: return 0
-            val cameraManager =
-                context.getSystemService(Context.CAMERA_SERVICE) as CameraManager
-            cameraManager
-                .getCameraCharacteristics(cameraId)
-                .get(CameraCharacteristics.SENSOR_ORIENTATION) ?: 0
+            sensorOrientationByCameraId.getOrPut(cameraId) {
+                val cameraManager =
+                    context.getSystemService(Context.CAMERA_SERVICE) as CameraManager
+                cameraManager
+                    .getCameraCharacteristics(cameraId)
+                    .get(CameraCharacteristics.SENSOR_ORIENTATION) ?: 0
+            }
         } catch (e: Exception) {
             DivineCameraLog.w(TAG, "Failed to read sensor orientation: ${e.message}")
             0

--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/CameraController.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/CameraController.kt
@@ -40,7 +40,7 @@ private const val TAG = "DivineCameraController"
 private const val LENS_SWITCH_HYSTERESIS = 0.03f
 
 /** How a preview [Surface] should be supplied to a CameraX surface request. */
-internal enum class SurfaceProvision { REUSE, CREATE, DECLINE }
+internal enum class SurfaceProvision { CREATE, DECLINE }
 
 /**
  * Controller for CameraX-based camera operations.
@@ -67,7 +67,6 @@ class CameraController(
     // rebinds during a lens switch, so the preview freezes instead of flashing
     // black — issue #5865.
     private var surfaceProducer: TextureRegistry.SurfaceProducer? = null
-    private var previewSurface: Surface? = null
 
     private var cameraExecutor: ExecutorService =
         RejectionTolerantExecutorService(Executors.newSingleThreadExecutor())
@@ -252,17 +251,18 @@ class CameraController(
          * surface provider and CameraX actually dispatching the request. When
          * no producer is available the caller must [DECLINE] the request via
          * `willNotProvideSurface()` rather than provide a null surface;
-         * [REUSE] the cached surface while it is still valid, otherwise
-         * [CREATE] a fresh one from the producer.
+         * otherwise [CREATE] fetches the current surface from the producer.
+         *
+         * The surface is always re-fetched from the producer rather than
+         * cached: a cross-lens resolution change applied via `setSize()` is
+         * materialised lazily by `ImageReaderSurfaceProducer` inside
+         * `getSurface()`, so reusing a cached surface would strand the preview
+         * on the previous lens's reader for the session.
          */
         internal fun decideSurfaceProvision(
             hasTexture: Boolean,
-            existingSurfaceValid: Boolean,
-        ): SurfaceProvision = when {
-            existingSurfaceValid -> SurfaceProvision.REUSE
-            hasTexture -> SurfaceProvision.CREATE
-            else -> SurfaceProvision.DECLINE
-        }
+        ): SurfaceProvision =
+            if (hasTexture) SurfaceProvision.CREATE else SurfaceProvision.DECLINE
 
         /** Returns the next lower quality, or null if already at minimum. */
         fun lowerQuality(current: Quality): Quality? = when (current) {
@@ -820,22 +820,14 @@ class CameraController(
 
     /**
      * Returns a preview [Surface] to hand to a CameraX surface request,
-     * reusing the cached one when still valid and otherwise fetching a fresh
-     * one from the Flutter [TextureRegistry.SurfaceProducer]. Returns null when
-     * no surface can be supplied (the producer was released), so the caller
+     * fetching the current one from the Flutter [TextureRegistry.SurfaceProducer]
+     * each time so a `setSize()` resolution change is picked up. Returns null
+     * when no surface can be supplied (the producer was released), so the caller
      * declines the request via `willNotProvideSurface()`.
      */
     private fun resolvePreviewSurface(): Surface? {
-        val existing = previewSurface
-        return when (
-            decideSurfaceProvision(
-                hasTexture = surfaceProducer != null,
-                existingSurfaceValid = existing != null && existing.isValid,
-            )
-        ) {
-            SurfaceProvision.REUSE -> existing
-            SurfaceProvision.CREATE ->
-                surfaceProducer?.getSurface()?.also { previewSurface = it }
+        return when (decideSurfaceProvision(hasTexture = surfaceProducer != null)) {
+            SurfaceProvision.CREATE -> surfaceProducer?.getSurface()
             SurfaceProvision.DECLINE -> null
         }
     }
@@ -864,9 +856,8 @@ class CameraController(
 
             // Release previous resources only if not already handled (e.g., by switchCamera)
             if (surfaceProducer != null) {
-                // The SurfaceProducer owns the Surface, so drop the cached
-                // reference and let release() tear it down.
-                previewSurface = null
+                // The SurfaceProducer owns the Surface, so release() tears it
+                // down.
                 surfaceProducer?.release()
                 surfaceProducer = null
             }
@@ -1005,9 +996,16 @@ class CameraController(
     /**
      * Switches to a different camera lens.
      * Reuses the same texture to avoid black screen during switch.
+     *
+     * [onBound] runs synchronously once the new camera is bound, before the
+     * switch is gated on the first frame and while the preview is still frozen
+     * on the old frame. Use it for adjustments (e.g. restoring zoom) that must
+     * already be in effect when the incoming frame becomes visible, so the
+     * preview doesn't visibly unfreeze at the default and then jump.
      */
     fun switchCamera(
         lens: String,
+        onBound: (() -> Unit)? = null,
         callback: (Map<String, Any?>?, String?) -> Unit
     ) {
         DivineCameraLog.d(TAG, "Switching camera to: $lens")
@@ -1128,6 +1126,11 @@ class CameraController(
 
             // Compute virtual zoom ranges for auto lens switching
             computeVirtualZoomRanges()
+
+            // Apply post-bind adjustments (e.g. zoom restore) while the preview
+            // is still frozen, so the incoming frame is already correct when it
+            // becomes visible instead of unfreezing at the reset default.
+            onBound?.invoke()
 
             // Resolve the switch only once the incoming camera has produced its
             // first frame. Until then the SurfaceProducer keeps showing the old
@@ -1817,17 +1820,22 @@ class CameraController(
         // Rebind the current lens so CameraX reconfigures the session with the
         // new stabilization setting. The switch path resets zoom to 1.0x like a
         // lens switch, but a stabilization toggle should not move the framing —
-        // capture the current (reported) zoom and restore it once rebound. This
-        // also keeps the Dart-side zoom (which is not re-fetched after this
-        // call) consistent with the native zoom.
+        // capture the current (reported) zoom and restore it in onBound (right
+        // after the rebind, before the frozen preview releases) so the preview
+        // never unfreezes at 1.0x and then jumps back. This also keeps the
+        // Dart-side zoom (not re-fetched after this call) consistent with the
+        // native zoom.
         val zoomToRestore =
             if (autoLensSwitchEnabled) virtualCurrentZoom else currentZoom
         DivineCameraLog.d(TAG, "Rebinding to apply stabilization mode: $mode")
-        switchCamera(currentLensType) { _, error ->
-            if (error == null && zoomToRestore != 1.0f) {
-                setZoomLevel(zoomToRestore)
+        switchCamera(
+            currentLensType,
+            onBound = {
+                if (zoomToRestore != 1.0f) {
+                    setZoomLevel(zoomToRestore)
+                }
             }
-        }
+        ) { _, _ -> }
         return true
     }
 
@@ -2374,12 +2382,14 @@ class CameraController(
      */
     fun getCameraState(): MutableMap<String, Any?> {
         val textureId = surfaceProducer?.id() ?: -1L
-        // When the surface producer handles crop/rotation itself, Flutter
-        // rotates the preview; otherwise the frames arrive in sensor
-        // orientation and the UI must rotate them (issue #5865).
+        // When the surface producer applies its transform matrix itself (the
+        // API<29 SurfaceTexture path), that matrix already carries both the
+        // preview rotation and the front-camera mirror, so Flutter must apply
+        // neither. Otherwise (API 29+ ImageReader path) frames arrive raw and
+        // the UI reconstructs both (issue #5865).
+        val handlesTransform = surfaceProducer?.handlesCropAndRotation() == true
         val previewRotation =
-            if (surfaceProducer?.handlesCropAndRotation() == true) 0
-            else currentSensorOrientation()
+            if (handlesTransform) 0 else currentSensorOrientation()
         val stabilizationModes = availableVideoStabilizationModesForCurrentLens()
         return mutableMapOf(
             "isInitialized" to (camera != null),
@@ -2399,6 +2409,7 @@ class CameraController(
             "isExposurePointSupported" to isExposurePointSupported,
             "textureId" to textureId,
             "previewRotationDegrees" to previewRotation,
+            "previewHandlesTransform" to handlesTransform,
             "availableLenses" to getAvailableLenses(),
             "currentLensMetadata" to getCurrentLensMetadata(),
             "videoStabilizationMode" to requestedStabilizationMode,
@@ -2440,10 +2451,7 @@ class CameraController(
             preview = null
             videoCapture = null
 
-            // The SurfaceProducer owns the Surface; drop the cached reference
-            // and let release() tear it down.
-            previewSurface = null
-
+            // The SurfaceProducer owns the Surface; release() tears it down.
             surfaceProducer?.release()
             surfaceProducer = null
 

--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/CameraController.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/CameraController.kt
@@ -9,7 +9,6 @@ import android.app.Activity
 import android.content.Context
 import android.content.pm.PackageManager
 import android.graphics.BitmapFactory
-import android.graphics.SurfaceTexture
 import android.hardware.camera2.CameraCaptureSession
 import android.hardware.camera2.CameraCharacteristics
 import android.hardware.camera2.CameraManager
@@ -63,8 +62,11 @@ class CameraController(
     // case photo capture is unavailable but video keeps working.
     private var imageCapture: ImageCapture? = null
 
-    private var textureEntry: TextureRegistry.SurfaceTextureEntry? = null
-    private var flutterSurfaceTexture: SurfaceTexture? = null
+    // Flutter's SurfaceProducer (not the deprecated SurfaceTexture API): under
+    // Impeller it retains the last rendered frame while CameraX detaches and
+    // rebinds during a lens switch, so the preview freezes instead of flashing
+    // black — issue #5865.
+    private var surfaceProducer: TextureRegistry.SurfaceProducer? = null
     private var previewSurface: Surface? = null
 
     private var cameraExecutor: ExecutorService =
@@ -129,6 +131,13 @@ class CameraController(
             result.get(CaptureResult.SENSOR_EXPOSURE_TIME)?.let { exposureTime ->
                 currentExposureTime = exposureTime
             }
+
+            // First frame after a lens switch: let the switch completion run so
+            // the UI flips lens/rotation only now that the new frame is ready.
+            onFirstFrameAfterSwitch?.let { completion ->
+                onFirstFrameAfterSwitch = null
+                completion()
+            }
         }
     }
 
@@ -188,6 +197,14 @@ class CameraController(
     private var maxDurationRunnable: Runnable? = null
     private var autoStopCallback: ((Map<String, Any?>?, String?) -> Unit)? = null
 
+    // Fires once, on the first frame the incoming camera produces after a lens
+    // switch, so the switch completes (and the UI flips lens/rotation) only when
+    // the new frame is ready — otherwise the frozen preview briefly flips upside
+    // down at the old→new rotation boundary (#5865). Written on the main thread,
+    // read on the Camera2 capture thread, so it must be @Volatile.
+    @Volatile
+    private var onFirstFrameAfterSwitch: (() -> Unit)? = null
+
     // Quality fallback: when the hardware encoder rejects the requested quality
     // (e.g. device falsely reports FHD support), retry with lower quality.
     private var encoderRetryCount: Int = 0
@@ -202,6 +219,11 @@ class CameraController(
 
     companion object {
         private const val MAX_ENCODER_RETRIES = 2
+
+        // Safety net: resolve a lens switch even if the incoming camera never
+        // reports a frame (rare device quirk), so `await switchCamera` on the
+        // Dart side can't hang forever.
+        private const val SWITCH_FIRST_FRAME_TIMEOUT_MS = 1200L
 
         // Canonical cross-platform stabilization mode strings, shared with the
         // iOS/macOS implementations so the Dart layer speaks one vocabulary.
@@ -226,12 +248,12 @@ class CameraController(
         /**
          * Decides how a preview surface request should be fulfilled.
          *
-         * The Flutter [SurfaceTexture] can be torn down (released and the
-         * field nulled by `release()`) between registering a surface provider
-         * and CameraX actually dispatching the request. Reading it then
-         * passing it straight to `Surface(...)` crashes with
-         * `surfaceTexture must not be null`, so callers must [DECLINE] when no
-         * texture is available rather than build a surface from null.
+         * The Flutter surface producer can be released between registering a
+         * surface provider and CameraX actually dispatching the request. When
+         * no producer is available the caller must [DECLINE] the request via
+         * `willNotProvideSurface()` rather than provide a null surface;
+         * [REUSE] the cached surface while it is still valid, otherwise
+         * [CREATE] a fresh one from the producer.
          */
         internal fun decideSurfaceProvision(
             hasTexture: Boolean,
@@ -798,22 +820,22 @@ class CameraController(
 
     /**
      * Returns a preview [Surface] to hand to a CameraX surface request,
-     * reusing the existing one when still valid and otherwise creating a new
-     * one from [surfaceTexture]. Returns null when no surface can be supplied
-     * (the Flutter texture was released), so the caller declines the request
-     * via `willNotProvideSurface()` instead of constructing `Surface(null)`.
+     * reusing the cached one when still valid and otherwise fetching a fresh
+     * one from the Flutter [TextureRegistry.SurfaceProducer]. Returns null when
+     * no surface can be supplied (the producer was released), so the caller
+     * declines the request via `willNotProvideSurface()`.
      */
-    private fun resolvePreviewSurface(surfaceTexture: SurfaceTexture?): Surface? {
+    private fun resolvePreviewSurface(): Surface? {
         val existing = previewSurface
         return when (
             decideSurfaceProvision(
-                hasTexture = surfaceTexture != null,
+                hasTexture = surfaceProducer != null,
                 existingSurfaceValid = existing != null && existing.isValid,
             )
         ) {
             SurfaceProvision.REUSE -> existing
             SurfaceProvision.CREATE ->
-                surfaceTexture?.let { Surface(it).also { s -> previewSurface = s } }
+                surfaceProducer?.getSurface()?.also { previewSurface = it }
             SurfaceProvision.DECLINE -> null
         }
     }
@@ -841,19 +863,18 @@ class CameraController(
             DivineCameraLog.d(TAG, "Unbound all previous use cases")
 
             // Release previous resources only if not already handled (e.g., by switchCamera)
-            if (textureEntry != null) {
-                previewSurface?.release()
+            if (surfaceProducer != null) {
+                // The SurfaceProducer owns the Surface, so drop the cached
+                // reference and let release() tear it down.
                 previewSurface = null
-                textureEntry?.release()
-                textureEntry = null
-                flutterSurfaceTexture = null
+                surfaceProducer?.release()
+                surfaceProducer = null
             }
 
-            // Create texture entry for Flutter
-            textureEntry = textureRegistry.createSurfaceTexture()
-            flutterSurfaceTexture = textureEntry?.surfaceTexture()
+            // Create the Flutter surface producer for the preview.
+            surfaceProducer = textureRegistry.createSurfaceProducer()
 
-            val textureId = textureEntry?.id() ?: run {
+            val textureId = surfaceProducer?.id() ?: run {
                 DivineCameraLog.e(TAG, "Failed to create texture entry")
                 callback(null, "Failed to create texture")
                 return
@@ -894,12 +915,9 @@ class CameraController(
                 aspectRatio = videoHeight.toFloat() / videoWidth.toFloat()
                 DivineCameraLog.d(TAG, "Aspect ratio set to: $aspectRatio (portrait), video dimensions: ${videoWidth}x${videoHeight}")
 
-                // Capture the texture locally: the request fires asynchronously
-                // and release() may have nulled the field in the meantime.
-                val surfaceTexture = flutterSurfaceTexture
-                surfaceTexture?.setDefaultBufferSize(videoWidth, videoHeight)
+                surfaceProducer?.setSize(videoWidth, videoHeight)
 
-                val surface = resolvePreviewSurface(surfaceTexture)
+                val surface = resolvePreviewSurface()
 
                 // Provide the surface
                 if (surface != null && surface.isValid) {
@@ -1053,12 +1071,9 @@ class CameraController(
                 // Update aspect ratio for portrait mode (height/width gives 9:16 ratio)
                 aspectRatio = videoHeight.toFloat() / videoWidth.toFloat()
 
-                // Capture the texture locally: release() may have nulled the
-                // field between registering the provider and this request.
-                val surfaceTexture = flutterSurfaceTexture
-                surfaceTexture?.setDefaultBufferSize(videoWidth, videoHeight)
+                surfaceProducer?.setSize(videoWidth, videoHeight)
 
-                val surface = resolvePreviewSurface(surfaceTexture)
+                val surface = resolvePreviewSurface()
                 if (surface != null && surface.isValid) {
                     request.provideSurface(
                         surface,
@@ -1114,11 +1129,20 @@ class CameraController(
             // Compute virtual zoom ranges for auto lens switching
             computeVirtualZoomRanges()
 
-            DivineCameraLog.d(TAG, "Camera switched successfully")
-
-            mainHandler.post {
+            // Resolve the switch only once the incoming camera has produced its
+            // first frame. Until then the SurfaceProducer keeps showing the old
+            // frame (frozen) and the state (lens/rotation) stays on the old
+            // camera, so the frozen frame never flips to the new rotation early.
+            var switchResolved = false
+            val finishSwitch = Runnable {
+                if (switchResolved) return@Runnable
+                switchResolved = true
+                onFirstFrameAfterSwitch = null
+                DivineCameraLog.d(TAG, "Camera switched successfully")
                 callback(getCameraState(), null)
             }
+            onFirstFrameAfterSwitch = { mainHandler.post(finishSwitch) }
+            mainHandler.postDelayed(finishSwitch, SWITCH_FIRST_FRAME_TIMEOUT_MS)
 
         } catch (e: Exception) {
             DivineCameraLog.e(TAG, "Failed to switch camera", e)
@@ -1605,7 +1629,7 @@ class CameraController(
                 videoHeight = resolution.height
                 aspectRatio =
                     videoHeight.toFloat() / videoWidth.toFloat()
-                flutterSurfaceTexture?.setDefaultBufferSize(
+                surfaceProducer?.setSize(
                     videoWidth,
                     videoHeight
                 )
@@ -1613,10 +1637,8 @@ class CameraController(
                 // Post surface provision to let setZoomRatio settle
                 // in the camera pipeline before any frames flow.
                 mainHandler.postDelayed({
-                    // Re-read the texture: release() can null it during the
-                    // delay, which would crash Surface(null).
                     val surface =
-                        resolvePreviewSurface(flutterSurfaceTexture)
+                        resolvePreviewSurface()
                     if (surface != null && surface.isValid) {
                         request.provideSurface(
                             surface,
@@ -2319,10 +2341,36 @@ class CameraController(
     }
 
     /**
+     * Reads the clockwise sensor orientation (degrees) of the current lens.
+     * The recorder is portrait-locked, so this doubles as the rotation the UI
+     * must apply to the preview when the surface producer does not rotate it.
+     * Returns 0 if the characteristic is unavailable.
+     */
+    private fun currentSensorOrientation(): Int {
+        return try {
+            val cameraId = getCameraIdForLens(currentLensType) ?: return 0
+            val cameraManager =
+                context.getSystemService(Context.CAMERA_SERVICE) as CameraManager
+            cameraManager
+                .getCameraCharacteristics(cameraId)
+                .get(CameraCharacteristics.SENSOR_ORIENTATION) ?: 0
+        } catch (e: Exception) {
+            DivineCameraLog.w(TAG, "Failed to read sensor orientation: ${e.message}")
+            0
+        }
+    }
+
+    /**
      * Gets the current camera state as a map.
      */
     fun getCameraState(): MutableMap<String, Any?> {
-        val textureId = textureEntry?.id() ?: -1L
+        val textureId = surfaceProducer?.id() ?: -1L
+        // When the surface producer handles crop/rotation itself, Flutter
+        // rotates the preview; otherwise the frames arrive in sensor
+        // orientation and the UI must rotate them (issue #5865).
+        val previewRotation =
+            if (surfaceProducer?.handlesCropAndRotation() == true) 0
+            else currentSensorOrientation()
         val stabilizationModes = availableVideoStabilizationModesForCurrentLens()
         return mutableMapOf(
             "isInitialized" to (camera != null),
@@ -2341,6 +2389,7 @@ class CameraController(
             "isFocusPointSupported" to isFocusPointSupported,
             "isExposurePointSupported" to isExposurePointSupported,
             "textureId" to textureId,
+            "previewRotationDegrees" to previewRotation,
             "availableLenses" to getAvailableLenses(),
             "currentLensMetadata" to getCurrentLensMetadata(),
             "videoStabilizationMode" to requestedStabilizationMode,
@@ -2382,12 +2431,12 @@ class CameraController(
             preview = null
             videoCapture = null
 
-            previewSurface?.release()
+            // The SurfaceProducer owns the Surface; drop the cached reference
+            // and let release() tear it down.
             previewSurface = null
 
-            textureEntry?.release()
-            textureEntry = null
-            flutterSurfaceTexture = null
+            surfaceProducer?.release()
+            surfaceProducer = null
 
             // Delay shutdown so CameraX can drain in-flight encoder/muxer
             // tasks. cameraExecutor is rejection-tolerant, so any callback

--- a/mobile/packages/divine_camera/android/src/test/kotlin/co/openvine/divine_camera/DivineCameraPluginTest.kt
+++ b/mobile/packages/divine_camera/android/src/test/kotlin/co/openvine/divine_camera/DivineCameraPluginTest.kt
@@ -416,31 +416,13 @@ internal class VideoStabilizationTest {
 // the plain JUnit runner rather than Robolectric.
 internal class SurfaceProvisionTest {
     @Test
-    fun existingSurfaceValid_reusesRegardlessOfTexture() {
-        assertEquals(
-            SurfaceProvision.REUSE,
-            CameraController.decideSurfaceProvision(
-                hasTexture = true,
-                existingSurfaceValid = true,
-            ),
-        )
-        assertEquals(
-            SurfaceProvision.REUSE,
-            CameraController.decideSurfaceProvision(
-                hasTexture = false,
-                existingSurfaceValid = true,
-            ),
-        )
-    }
-
-    @Test
-    fun noExistingSurfaceButTexturePresent_createsNew() {
+    fun texturePresent_createsFromProducer() {
+        // The surface is always re-fetched from the producer so a cross-lens
+        // setSize() resolution change is picked up instead of stranding the
+        // preview on the previous lens's reader.
         assertEquals(
             SurfaceProvision.CREATE,
-            CameraController.decideSurfaceProvision(
-                hasTexture = true,
-                existingSurfaceValid = false,
-            ),
+            CameraController.decideSurfaceProvision(hasTexture = true),
         )
     }
 
@@ -451,10 +433,7 @@ internal class SurfaceProvisionTest {
         // request must be declined, never turned into Surface(null).
         assertEquals(
             SurfaceProvision.DECLINE,
-            CameraController.decideSurfaceProvision(
-                hasTexture = false,
-                existingSurfaceValid = false,
-            ),
+            CameraController.decideSurfaceProvision(hasTexture = false),
         )
     }
 }

--- a/mobile/packages/divine_camera/lib/divine_camera.dart
+++ b/mobile/packages/divine_camera/lib/divine_camera.dart
@@ -163,22 +163,44 @@ class DivineCamera {
     return success;
   }
 
-  /// Sets the focus point in normalized coordinates (0.0-1.0).
+  /// Sets the focus point.
   ///
-  /// [offset] the focus point coordinates.
+  /// [offset] is a point in the displayed (upright) preview's normalized
+  /// coordinates (0.0-1.0), i.e. where the user tapped. It is mapped onto the
+  /// raw sensor axes here so a rotated preview focuses the right spot; see
+  /// [_sensorOrientedPoint].
   /// Returns true if successful.
   Future<bool> setFocusPoint(Offset offset) async {
     if (!_state.isFocusPointSupported) return false;
-    return _platform.setFocusPoint(offset);
+    return _platform.setFocusPoint(_sensorOrientedPoint(offset));
   }
 
-  /// Sets the exposure point in normalized coordinates (0.0-1.0).
+  /// Sets the exposure point.
   ///
-  /// [offset] the exposure point coordinates.
+  /// [offset] is a point in the displayed (upright) preview's normalized
+  /// coordinates (0.0-1.0); it is mapped onto the raw sensor axes here the same
+  /// way as [setFocusPoint].
   /// Returns true if successful.
   Future<bool> setExposurePoint(Offset offset) async {
     if (!_state.isExposurePointSupported) return false;
-    return _platform.setExposurePoint(offset);
+    return _platform.setExposurePoint(_sensorOrientedPoint(offset));
+  }
+
+  /// Maps a point normalized against the displayed (upright) preview back into
+  /// the raw sensor texture's coordinate space by undoing the clockwise
+  /// [CameraState.previewRotationDegrees] the UI applies to render the preview
+  /// upright (the Android ImageReader path). Native metering maps normalized
+  /// coords onto the un-rotated sensor, so without this a non-center tap on a
+  /// 90/270 preview would meter the wrong point. Returns the point unchanged
+  /// when no rotation applies (the common 0° / SurfaceTexture cases).
+  Offset _sensorOrientedPoint(Offset point) {
+    final quarterTurns = (_state.previewRotationDegrees ~/ 90) % 4;
+    return switch (quarterTurns) {
+      1 => Offset(point.dy, 1.0 - point.dx),
+      2 => Offset(1.0 - point.dx, 1.0 - point.dy),
+      3 => Offset(1.0 - point.dy, point.dx),
+      _ => point,
+    };
   }
 
   /// Cancels any active focus/metering lock and returns to continuous

--- a/mobile/packages/divine_camera/lib/divine_camera.dart
+++ b/mobile/packages/divine_camera/lib/divine_camera.dart
@@ -207,9 +207,12 @@ class DivineCamera {
 
   /// Switches between front and back camera.
   ///
-  /// Returns true if successful.
+  /// Returns true if successful. Returns false while a switch is already in
+  /// flight: the native side now completes a switch on the incoming camera's
+  /// first frame, so a re-entrant call would clobber that pending completion
+  /// and target the wrong lens.
   Future<bool> switchCamera() async {
-    if (!_state.canSwitchCamera) return false;
+    if (!_state.canSwitchCamera || _state.isSwitchingCamera) return false;
     final newLens = _state.lens.opposite;
 
     // Set switching state to keep last frame visible
@@ -246,10 +249,13 @@ class DivineCamera {
   /// Switches to a specific camera lens.
   ///
   /// [lens] the lens to switch to.
-  /// Returns true if successful.
+  /// Returns true if successful. Returns false while a switch is already in
+  /// flight, for the same reason as [switchCamera].
   Future<bool> setLens(DivineCameraLens lens) async {
     if (lens == _state.lens) return true;
-    if (!_state.availableLenses.contains(lens)) return false;
+    if (!_state.availableLenses.contains(lens) || _state.isSwitchingCamera) {
+      return false;
+    }
 
     // Set switching state to keep last frame visible
     _state = _state.copyWith(isSwitchingCamera: true);

--- a/mobile/packages/divine_camera/lib/divine_camera.dart
+++ b/mobile/packages/divine_camera/lib/divine_camera.dart
@@ -219,10 +219,17 @@ class DivineCamera {
     _state = _state.copyWith(isSwitchingCamera: true);
     _notifyStateChanged();
 
-    _state = await _platform.switchCamera(newLens);
-    _state = _state.copyWith(isSwitchingCamera: false);
-    _notifyStateChanged();
-    return true;
+    // Reset the flag in `finally` so a thrown platform switch (e.g. a CameraX
+    // bind failure) doesn't leave `isSwitchingCamera` stuck true — which would
+    // both freeze the preview and, via the re-entrancy guard above, block every
+    // later switch for the session.
+    try {
+      _state = await _platform.switchCamera(newLens);
+      return true;
+    } finally {
+      _state = _state.copyWith(isSwitchingCamera: false);
+      _notifyStateChanged();
+    }
   }
 
   /// Sets the video stabilization mode.
@@ -261,10 +268,15 @@ class DivineCamera {
     _state = _state.copyWith(isSwitchingCamera: true);
     _notifyStateChanged();
 
-    _state = await _platform.switchCamera(lens);
-    _state = _state.copyWith(isSwitchingCamera: false);
-    _notifyStateChanged();
-    return true;
+    // Reset the flag in `finally` for the same reason as [switchCamera]: a
+    // thrown switch must not strand `isSwitchingCamera` true.
+    try {
+      _state = await _platform.switchCamera(lens);
+      return true;
+    } finally {
+      _state = _state.copyWith(isSwitchingCamera: false);
+      _notifyStateChanged();
+    }
   }
 
   /// Starts video recording.

--- a/mobile/packages/divine_camera/lib/src/models/camera_state.dart
+++ b/mobile/packages/divine_camera/lib/src/models/camera_state.dart
@@ -27,6 +27,7 @@ class CameraState extends Equatable {
     this.isExposurePointSupported = false,
     this.textureId,
     this.previewRotationDegrees = 0,
+    this.previewHandlesTransform = false,
     this.availableLenses = const [DivineCameraLens.back],
     this.currentLensMetadata,
     this.videoStabilizationMode = DivineVideoStabilizationMode.off,
@@ -58,6 +59,7 @@ class CameraState extends Equatable {
           map['isExposurePointSupported'] as bool? ?? false,
       textureId: map['textureId'] as int?,
       previewRotationDegrees: map['previewRotationDegrees'] as int? ?? 0,
+      previewHandlesTransform: map['previewHandlesTransform'] as bool? ?? false,
       availableLenses: map['availableLenses'] != null
           ? DivineCameraLens.fromNativeStringList(
               map['availableLenses'] as List<dynamic>,
@@ -133,6 +135,13 @@ class CameraState extends Equatable {
   /// sensor orientation and the UI must rotate them.
   final int previewRotationDegrees;
 
+  /// Whether the native surface producer already applies its transform matrix
+  /// to the preview (the Android API<29 SurfaceTexture path). When `true`, that
+  /// matrix carries both the rotation and the front-camera mirror, so the UI
+  /// must apply neither; when `false` (API 29+ ImageReader path) the UI
+  /// reconstructs both. Always `false` on non-Android platforms.
+  final bool previewHandlesTransform;
+
   /// List of all available camera lenses on this device.
   /// Includes front, back, ultraWide, telephoto, and macro if supported.
   final List<DivineCameraLens> availableLenses;
@@ -199,6 +208,7 @@ class CameraState extends Equatable {
     bool? isExposurePointSupported,
     int? textureId,
     int? previewRotationDegrees,
+    bool? previewHandlesTransform,
     List<DivineCameraLens>? availableLenses,
     CameraLensMetadata? currentLensMetadata,
     DivineVideoStabilizationMode? videoStabilizationMode,
@@ -225,6 +235,8 @@ class CameraState extends Equatable {
       textureId: textureId ?? this.textureId,
       previewRotationDegrees:
           previewRotationDegrees ?? this.previewRotationDegrees,
+      previewHandlesTransform:
+          previewHandlesTransform ?? this.previewHandlesTransform,
       availableLenses: availableLenses ?? this.availableLenses,
       currentLensMetadata: currentLensMetadata ?? this.currentLensMetadata,
       videoStabilizationMode:
@@ -256,6 +268,7 @@ class CameraState extends Equatable {
       'isExposurePointSupported': isExposurePointSupported,
       'textureId': textureId,
       'previewRotationDegrees': previewRotationDegrees,
+      'previewHandlesTransform': previewHandlesTransform,
       'availableLenses': availableLenses
           .map((l) => l.toNativeString())
           .toList(),
@@ -286,6 +299,7 @@ class CameraState extends Equatable {
         'isExposurePointSupported: $isExposurePointSupported, '
         'textureId: $textureId, '
         'previewRotationDegrees: $previewRotationDegrees, '
+        'previewHandlesTransform: $previewHandlesTransform, '
         'availableLenses: $availableLenses, '
         'currentLensMetadata: $currentLensMetadata, '
         'videoStabilizationMode: $videoStabilizationMode, '
@@ -312,6 +326,7 @@ class CameraState extends Equatable {
     isExposurePointSupported,
     textureId,
     previewRotationDegrees,
+    previewHandlesTransform,
     availableLenses,
     currentLensMetadata,
     videoStabilizationMode,

--- a/mobile/packages/divine_camera/lib/src/models/camera_state.dart
+++ b/mobile/packages/divine_camera/lib/src/models/camera_state.dart
@@ -26,6 +26,7 @@ class CameraState extends Equatable {
     this.isFocusPointSupported = false,
     this.isExposurePointSupported = false,
     this.textureId,
+    this.previewRotationDegrees = 0,
     this.availableLenses = const [DivineCameraLens.back],
     this.currentLensMetadata,
     this.videoStabilizationMode = DivineVideoStabilizationMode.off,
@@ -56,6 +57,7 @@ class CameraState extends Equatable {
       isExposurePointSupported:
           map['isExposurePointSupported'] as bool? ?? false,
       textureId: map['textureId'] as int?,
+      previewRotationDegrees: map['previewRotationDegrees'] as int? ?? 0,
       availableLenses: map['availableLenses'] != null
           ? DivineCameraLens.fromNativeStringList(
               map['availableLenses'] as List<dynamic>,
@@ -125,6 +127,12 @@ class CameraState extends Equatable {
   /// The texture ID for the camera preview (Android).
   final int? textureId;
 
+  /// Clockwise rotation (degrees) to apply to the preview texture so it renders
+  /// upright. Non-zero on Android when the Flutter surface producer does not
+  /// handle crop/rotation itself, in which case the raw camera frames arrive in
+  /// sensor orientation and the UI must rotate them.
+  final int previewRotationDegrees;
+
   /// List of all available camera lenses on this device.
   /// Includes front, back, ultraWide, telephoto, and macro if supported.
   final List<DivineCameraLens> availableLenses;
@@ -190,6 +198,7 @@ class CameraState extends Equatable {
     bool? isFocusPointSupported,
     bool? isExposurePointSupported,
     int? textureId,
+    int? previewRotationDegrees,
     List<DivineCameraLens>? availableLenses,
     CameraLensMetadata? currentLensMetadata,
     DivineVideoStabilizationMode? videoStabilizationMode,
@@ -214,6 +223,8 @@ class CameraState extends Equatable {
       isExposurePointSupported:
           isExposurePointSupported ?? this.isExposurePointSupported,
       textureId: textureId ?? this.textureId,
+      previewRotationDegrees:
+          previewRotationDegrees ?? this.previewRotationDegrees,
       availableLenses: availableLenses ?? this.availableLenses,
       currentLensMetadata: currentLensMetadata ?? this.currentLensMetadata,
       videoStabilizationMode:
@@ -244,6 +255,7 @@ class CameraState extends Equatable {
       'isFocusPointSupported': isFocusPointSupported,
       'isExposurePointSupported': isExposurePointSupported,
       'textureId': textureId,
+      'previewRotationDegrees': previewRotationDegrees,
       'availableLenses': availableLenses
           .map((l) => l.toNativeString())
           .toList(),
@@ -273,6 +285,7 @@ class CameraState extends Equatable {
         'isFocusPointSupported: $isFocusPointSupported, '
         'isExposurePointSupported: $isExposurePointSupported, '
         'textureId: $textureId, '
+        'previewRotationDegrees: $previewRotationDegrees, '
         'availableLenses: $availableLenses, '
         'currentLensMetadata: $currentLensMetadata, '
         'videoStabilizationMode: $videoStabilizationMode, '
@@ -298,6 +311,7 @@ class CameraState extends Equatable {
     isFocusPointSupported,
     isExposurePointSupported,
     textureId,
+    previewRotationDegrees,
     availableLenses,
     currentLensMetadata,
     videoStabilizationMode,

--- a/mobile/packages/divine_camera/lib/src/widgets/camera_preview_widget.dart
+++ b/mobile/packages/divine_camera/lib/src/widgets/camera_preview_widget.dart
@@ -128,16 +128,12 @@ class _CameraPreviewWidgetState extends State<CameraPreviewWidget> {
     }
     // coverage:ignore-end
 
-    // Undo the display rotation so the point lands in the raw texture's
-    // coordinate space. The Android SurfaceProducer path rotates the preview
-    // in Flutter ([RotatedBox]) and hands frames to native un-rotated, so
-    // native maps normalized focus/exposure coords onto the sensor axes. On a
-    // 90/270 preview a tap in the upright widget would otherwise focus the
-    // wrong point.
-    final normalizedPosition = _unrotateNormalized(
-      Offset(normalizedX, normalizedY),
-      _camera.state.previewRotationDegrees,
-    );
+    // This point stays in the displayed (upright) preview's coordinate space:
+    // it drives both the native focus call and the visual focus indicator. The
+    // display-rotation undo needed to map it onto the raw sensor axes happens
+    // at the native boundary (DivineCamera.setFocusPoint/setExposurePoint), so
+    // the indicator can keep positioning itself where the user tapped.
+    final normalizedPosition = Offset(normalizedX, normalizedY);
 
     // Update focus point for indicator
     if (widget.focusIndicatorBuilder != null) {
@@ -146,19 +142,6 @@ class _CameraPreviewWidgetState extends State<CameraPreviewWidget> {
 
     // Call external callback - user decides what to do with the position
     widget.onTap?.call(localPosition, normalizedPosition);
-  }
-
-  /// Maps a point normalized against the displayed (upright) preview back into
-  /// the raw texture's coordinate space by undoing the [RotatedBox]'s clockwise
-  /// [rotationDegrees]. Returns the point unchanged when no rotation applies.
-  Offset _unrotateNormalized(Offset point, int rotationDegrees) {
-    final quarterTurns = (rotationDegrees ~/ 90) % 4;
-    return switch (quarterTurns) {
-      1 => Offset(point.dy, 1.0 - point.dx),
-      2 => Offset(1.0 - point.dx, 1.0 - point.dy),
-      3 => Offset(1.0 - point.dy, point.dx),
-      _ => point,
-    };
   }
 
   /// Calculate the actual preview size based on constraints and aspect ratio

--- a/mobile/packages/divine_camera/lib/src/widgets/camera_preview_widget.dart
+++ b/mobile/packages/divine_camera/lib/src/widgets/camera_preview_widget.dart
@@ -65,15 +65,23 @@ class _CameraPreviewWidgetState extends State<CameraPreviewWidget> {
     if (kIsWeb) return false;
     if (!_camera.lens.isFrontFacing) return false;
 
-    // On iOS/macOS, mirror preview only when native isn't mirroring
+    // Platform-specific mirror handling. These branches depend on the host OS
+    // via `dart:io` Platform, so they resolve differently under a widget test
+    // than on device (a macOS test host takes the Apple branch; Linux CI falls
+    // through to Android). They're verified on device, not in host tests, and
+    // excluded from coverage the same way across both arms.
     // coverage:ignore-start
+    // On iOS/macOS, mirror preview only when native isn't mirroring.
     if (Platform.isIOS || Platform.isMacOS) {
       return !_camera.mirrorFrontCameraOutput;
     }
+    // Android: mirror the selfie preview in Flutter only when the native
+    // producer doesn't apply its own transform matrix. On the API<29
+    // SurfaceTexture path (previewHandlesTransform == true) that matrix already
+    // carries the front-camera mirror, so mirroring again would double-flip it.
+    // On the API 29+ ImageReader path the matrix is dropped, so mirror here.
+    return !_camera.state.previewHandlesTransform;
     // coverage:ignore-end
-    // Android: the SurfaceProducer preview path drops the native front-camera
-    // mirror transform, so mirror the selfie preview in Flutter instead.
-    return true;
   }
 
   @override
@@ -120,7 +128,16 @@ class _CameraPreviewWidgetState extends State<CameraPreviewWidget> {
     }
     // coverage:ignore-end
 
-    final normalizedPosition = Offset(normalizedX, normalizedY);
+    // Undo the display rotation so the point lands in the raw texture's
+    // coordinate space. The Android SurfaceProducer path rotates the preview
+    // in Flutter ([RotatedBox]) and hands frames to native un-rotated, so
+    // native maps normalized focus/exposure coords onto the sensor axes. On a
+    // 90/270 preview a tap in the upright widget would otherwise focus the
+    // wrong point.
+    final normalizedPosition = _unrotateNormalized(
+      Offset(normalizedX, normalizedY),
+      _camera.state.previewRotationDegrees,
+    );
 
     // Update focus point for indicator
     if (widget.focusIndicatorBuilder != null) {
@@ -129,6 +146,19 @@ class _CameraPreviewWidgetState extends State<CameraPreviewWidget> {
 
     // Call external callback - user decides what to do with the position
     widget.onTap?.call(localPosition, normalizedPosition);
+  }
+
+  /// Maps a point normalized against the displayed (upright) preview back into
+  /// the raw texture's coordinate space by undoing the [RotatedBox]'s clockwise
+  /// [rotationDegrees]. Returns the point unchanged when no rotation applies.
+  Offset _unrotateNormalized(Offset point, int rotationDegrees) {
+    final quarterTurns = (rotationDegrees ~/ 90) % 4;
+    return switch (quarterTurns) {
+      1 => Offset(point.dy, 1.0 - point.dx),
+      2 => Offset(1.0 - point.dx, 1.0 - point.dy),
+      3 => Offset(1.0 - point.dy, point.dx),
+      _ => point,
+    };
   }
 
   /// Calculate the actual preview size based on constraints and aspect ratio

--- a/mobile/packages/divine_camera/lib/src/widgets/camera_preview_widget.dart
+++ b/mobile/packages/divine_camera/lib/src/widgets/camera_preview_widget.dart
@@ -71,7 +71,9 @@ class _CameraPreviewWidgetState extends State<CameraPreviewWidget> {
       return !_camera.mirrorFrontCameraOutput;
     }
     // coverage:ignore-end
-    return false;
+    // Android: the SurfaceProducer preview path drops the native front-camera
+    // mirror transform, so mirror the selfie preview in Flutter instead.
+    return true;
   }
 
   @override
@@ -205,6 +207,7 @@ class _CameraPreviewWidgetState extends State<CameraPreviewWidget> {
                 aspectRatio: aspectRatio,
                 fit: widget.fit,
                 shouldMirror: _isPreviewMirrored,
+                rotationDegrees: _camera.state.previewRotationDegrees,
               ),
             ),
             ValueListenableBuilder<Offset?>(
@@ -233,12 +236,17 @@ class _CameraPreview extends StatelessWidget {
     required this.aspectRatio,
     required this.fit,
     required this.shouldMirror,
+    required this.rotationDegrees,
   });
 
   final BoxConstraints constraints;
   final int textureId;
   final double aspectRatio;
   final BoxFit fit;
+
+  /// Clockwise rotation to apply to the raw preview texture so it renders
+  /// upright. Zero when the platform already delivers an oriented frame.
+  final int rotationDegrees;
 
   /// Whether to apply a horizontal flip transform to the preview.
   /// This is determined by the parent widget based on platform and settings.
@@ -247,6 +255,14 @@ class _CameraPreview extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     Widget preview = Texture(textureId: textureId);
+
+    // Rotate the raw sensor-oriented frame upright when the platform doesn't
+    // orient it itself (Android SurfaceProducer path). Applied before mirror so
+    // the horizontal flip stays horizontal on the upright image.
+    final quarterTurns = (rotationDegrees ~/ 90) % 4;
+    if (quarterTurns != 0) {
+      preview = RotatedBox(quarterTurns: quarterTurns, child: preview);
+    }
 
     // Mirror front camera preview (selfie mode)
     // This is a visual-only transform, the actual pixels remain "real-world"

--- a/mobile/packages/divine_camera/test/divine_camera_test.dart
+++ b/mobile/packages/divine_camera/test/divine_camera_test.dart
@@ -1048,13 +1048,14 @@ void main() {
 
       final props = state.props;
 
-      expect(props.length, 20);
+      expect(props.length, 21);
       expect(props[0], isTrue); // isInitialized
       expect(props[1], isFalse); // isRecording
       expect(props[4], DivineCameraLens.back); // lens
       expect(props[14], 1); // textureId
+      expect(props[15], 0); // previewRotationDegrees
       expect(
-        props[17],
+        props[18],
         DivineVideoStabilizationMode.off,
       ); // videoStabilizationMode
     });

--- a/mobile/packages/divine_camera/test/divine_camera_test.dart
+++ b/mobile/packages/divine_camera/test/divine_camera_test.dart
@@ -98,13 +98,22 @@ class MockDivineCameraPlatform
     return true;
   }
 
+  /// The last point handed to [setFocusPoint], for asserting the sensor-space
+  /// mapping DivineCamera applies before the native call.
+  Offset? capturedFocusPoint;
+
+  /// The last point handed to [setExposurePoint].
+  Offset? capturedExposurePoint;
+
   @override
   Future<bool> setFocusPoint(Offset offset) async {
+    capturedFocusPoint = offset;
     return true;
   }
 
   @override
   Future<bool> setExposurePoint(Offset offset) async {
+    capturedExposurePoint = offset;
     return true;
   }
 
@@ -418,6 +427,8 @@ void main() {
         );
 
         expect(success, isTrue);
+        // No preview rotation (default): the point passes through unchanged.
+        expect(mockPlatform.capturedFocusPoint, const Offset(0.5, 0.5));
       });
 
       test('sets exposure point successfully', () async {
@@ -428,7 +439,51 @@ void main() {
         );
 
         expect(success, isTrue);
+        expect(mockPlatform.capturedExposurePoint, const Offset(0.3, 0.7));
       });
+
+      test(
+        'maps focus/exposure onto sensor axes for a rotated preview',
+        () async {
+          // The tap is in the displayed (upright) preview's space; DivineCamera
+          // undoes the clockwise RotatedBox so native meters the right point.
+          const tap = Offset(0.3, 0.25);
+          final cases = <(int, Offset)>[
+            (90, const Offset(0.25, 0.7)), // (y, 1 - x)
+            (180, const Offset(0.7, 0.75)), // (1 - x, 1 - y)
+            (270, const Offset(0.75, 0.3)), // (1 - y, x)
+          ];
+          for (final (degrees, expected) in cases) {
+            final mock = _RotatedFocusMock(degrees);
+            DivineCameraPlatform.instance = mock;
+            await DivineCamera.instance.initialize();
+
+            await DivineCamera.instance.setFocusPoint(tap);
+            await DivineCamera.instance.setExposurePoint(tap);
+
+            expect(
+              mock.capturedFocusPoint!.dx,
+              closeTo(expected.dx, 0.0001),
+              reason: 'focus dx @ $degrees',
+            );
+            expect(
+              mock.capturedFocusPoint!.dy,
+              closeTo(expected.dy, 0.0001),
+              reason: 'focus dy @ $degrees',
+            );
+            expect(
+              mock.capturedExposurePoint!.dx,
+              closeTo(expected.dx, 0.0001),
+              reason: 'exposure dx @ $degrees',
+            );
+            expect(
+              mock.capturedExposurePoint!.dy,
+              closeTo(expected.dy, 0.0001),
+              reason: 'exposure dy @ $degrees',
+            );
+          }
+        },
+      );
 
       test('cancels focus and metering successfully', () async {
         await DivineCamera.instance.initialize();
@@ -1805,6 +1860,31 @@ void main() {
 
   // MethodChannelDivineCamera Tests
   _runMethodChannelTests();
+}
+
+/// Mock reporting a non-zero preview rotation with focus/exposure supported,
+/// to verify DivineCamera maps tap coords onto the sensor axes before the
+/// native focus/exposure call.
+class _RotatedFocusMock extends MockDivineCameraPlatform {
+  _RotatedFocusMock(this.degrees);
+
+  final int degrees;
+
+  @override
+  Future<CameraState> initializeCamera({
+    DivineCameraLens lens = DivineCameraLens.back,
+    DivineVideoQuality videoQuality = DivineVideoQuality.fhd,
+    bool enableScreenFlash = true,
+    bool mirrorFrontCameraOutput = false,
+    bool enableAutoLensSwitch = false,
+  }) async {
+    return CameraState(
+      isInitialized: true,
+      isFocusPointSupported: true,
+      isExposurePointSupported: true,
+      previewRotationDegrees: degrees,
+    );
+  }
 }
 
 /// Mock that doesn't support focus point

--- a/mobile/packages/divine_camera/test/divine_camera_test.dart
+++ b/mobile/packages/divine_camera/test/divine_camera_test.dart
@@ -122,9 +122,16 @@ class MockDivineCameraPlatform
   /// hold a switch in flight and probe re-entrant calls.
   Completer<void>? switchGate;
 
+  /// When true, [switchCamera] throws to exercise the native failure path
+  /// (e.g. a CameraX bind error surfaced as a [PlatformException]).
+  bool throwOnSwitch = false;
+
   @override
   Future<CameraState> switchCamera(DivineCameraLens lens) async {
     await switchGate?.future;
+    if (throwOnSwitch) {
+      throw PlatformException(code: 'SWITCH_FAILED');
+    }
     return _state = _state.copyWith(lens: lens);
   }
 
@@ -490,6 +497,28 @@ void main() {
         expect(await first, isTrue);
         expect(DivineCamera.instance.state.lens, DivineCameraLens.front);
       });
+
+      test(
+        'resets isSwitchingCamera and stays switchable after a thrown switch',
+        () async {
+          await DivineCamera.instance.initialize();
+
+          mockPlatform.throwOnSwitch = true;
+          await expectLater(
+            DivineCamera.instance.switchCamera(),
+            throwsA(isA<PlatformException>()),
+          );
+
+          // A stuck flag would freeze the preview and, via the re-entrancy
+          // guard, block every later switch for the session.
+          expect(DivineCamera.instance.isSwitchingCamera, isFalse);
+
+          mockPlatform.throwOnSwitch = false;
+          final recovered = await DivineCamera.instance.switchCamera();
+          expect(recovered, isTrue);
+          expect(DivineCamera.instance.state.lens, DivineCameraLens.front);
+        },
+      );
     });
 
     group('setLens', () {
@@ -540,6 +569,25 @@ void main() {
           DivineCamera.instance.state.lens,
           DivineCameraLens.frontUltraWide,
         );
+      });
+
+      test('resets isSwitchingCamera after a thrown setLens', () async {
+        await DivineCamera.instance.initialize();
+
+        mockPlatform.throwOnSwitch = true;
+        await expectLater(
+          DivineCamera.instance.setLens(DivineCameraLens.ultraWide),
+          throwsA(isA<PlatformException>()),
+        );
+
+        expect(DivineCamera.instance.isSwitchingCamera, isFalse);
+
+        mockPlatform.throwOnSwitch = false;
+        final recovered = await DivineCamera.instance.setLens(
+          DivineCameraLens.ultraWide,
+        );
+        expect(recovered, isTrue);
+        expect(DivineCamera.instance.state.lens, DivineCameraLens.ultraWide);
       });
     });
 
@@ -1071,14 +1119,15 @@ void main() {
 
       final props = state.props;
 
-      expect(props.length, 21);
+      expect(props.length, 22);
       expect(props[0], isTrue); // isInitialized
       expect(props[1], isFalse); // isRecording
       expect(props[4], DivineCameraLens.back); // lens
       expect(props[14], 1); // textureId
       expect(props[15], 0); // previewRotationDegrees
+      expect(props[16], isFalse); // previewHandlesTransform
       expect(
-        props[18],
+        props[19],
         DivineVideoStabilizationMode.off,
       ); // videoStabilizationMode
     });

--- a/mobile/packages/divine_camera/test/divine_camera_test.dart
+++ b/mobile/packages/divine_camera/test/divine_camera_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:divine_camera/divine_camera.dart';
 import 'package:divine_camera/divine_camera_method_channel.dart';
 import 'package:divine_camera/divine_camera_platform_interface.dart';
@@ -116,8 +118,13 @@ class MockDivineCameraPlatform
     return level >= 1.0 && level <= 10.0;
   }
 
+  /// When set, [switchCamera] awaits this before completing, so a test can
+  /// hold a switch in flight and probe re-entrant calls.
+  Completer<void>? switchGate;
+
   @override
   Future<CameraState> switchCamera(DivineCameraLens lens) async {
+    await switchGate?.future;
     return _state = _state.copyWith(lens: lens);
   }
 
@@ -467,6 +474,22 @@ void main() {
           expect(DivineCamera.instance.canSwitchCamera, isTrue);
         },
       );
+
+      test('ignores a re-entrant switch while one is in flight', () async {
+        await DivineCamera.instance.initialize();
+
+        final gate = Completer<void>();
+        mockPlatform.switchGate = gate;
+
+        final first = DivineCamera.instance.switchCamera();
+        // Second call arrives before the first resolves.
+        final second = await DivineCamera.instance.switchCamera();
+        expect(second, isFalse);
+
+        gate.complete();
+        expect(await first, isTrue);
+        expect(DivineCamera.instance.state.lens, DivineCameraLens.front);
+      });
     });
 
     group('setLens', () {

--- a/mobile/packages/divine_camera/test/widgets/camera_preview_widget_test.dart
+++ b/mobile/packages/divine_camera/test/widgets/camera_preview_widget_test.dart
@@ -148,6 +148,25 @@ class _WideAspectRatioMock extends MockDivineCameraPlatform {
   }
 }
 
+/// Mock that reports a non-zero preview rotation, as the Android
+/// SurfaceProducer path does when the producer does not orient frames itself.
+class _RotatedPreviewMock extends MockDivineCameraPlatform {
+  @override
+  Future<CameraState> initializeCamera({
+    DivineCameraLens lens = DivineCameraLens.back,
+    DivineVideoQuality videoQuality = DivineVideoQuality.fhd,
+    bool enableScreenFlash = true,
+    bool mirrorFrontCameraOutput = false,
+    bool enableAutoLensSwitch = false,
+  }) async {
+    return const CameraState(
+      isInitialized: true,
+      textureId: 1,
+      previewRotationDegrees: 90,
+    );
+  }
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -230,6 +249,27 @@ void main() {
       await tester.pumpWidget(buildTestWidget(fit: BoxFit.cover));
 
       expect(find.byType(FittedBox), findsOneWidget);
+    });
+
+    testWidgets('rotates preview when previewRotationDegrees is non-zero', (
+      tester,
+    ) async {
+      DivineCameraPlatform.instance = _RotatedPreviewMock();
+      await camera.initialize();
+      await tester.pumpWidget(buildTestWidget());
+
+      final rotatedBox = tester.widget<RotatedBox>(find.byType(RotatedBox));
+      // 90 degrees clockwise = one quarter turn.
+      expect(rotatedBox.quarterTurns, 1);
+    });
+
+    testWidgets('does not rotate preview when previewRotationDegrees is zero', (
+      tester,
+    ) async {
+      await camera.initialize();
+      await tester.pumpWidget(buildTestWidget());
+
+      expect(find.byType(RotatedBox), findsNothing);
     });
 
     testWidgets('calls onTap callback with correct positions', (tester) async {

--- a/mobile/packages/divine_camera/test/widgets/camera_preview_widget_test.dart
+++ b/mobile/packages/divine_camera/test/widgets/camera_preview_widget_test.dart
@@ -151,6 +151,10 @@ class _WideAspectRatioMock extends MockDivineCameraPlatform {
 /// Mock that reports a non-zero preview rotation, as the Android
 /// SurfaceProducer path does when the producer does not orient frames itself.
 class _RotatedPreviewMock extends MockDivineCameraPlatform {
+  _RotatedPreviewMock({this.degrees = 90});
+
+  final int degrees;
+
   @override
   Future<CameraState> initializeCamera({
     DivineCameraLens lens = DivineCameraLens.back,
@@ -159,10 +163,10 @@ class _RotatedPreviewMock extends MockDivineCameraPlatform {
     bool mirrorFrontCameraOutput = false,
     bool enableAutoLensSwitch = false,
   }) async {
-    return const CameraState(
+    return CameraState(
       isInitialized: true,
       textureId: 1,
-      previewRotationDegrees: 90,
+      previewRotationDegrees: degrees,
     );
   }
 }
@@ -271,6 +275,49 @@ void main() {
 
       expect(find.byType(RotatedBox), findsNothing);
     });
+
+    // Same tap point, once on an un-rotated preview and once on a rotated one.
+    // Both share the layout, so the rotated result must be the un-rotated
+    // point mapped back into the raw texture's coordinate space (undoing the
+    // clockwise RotatedBox). Without the inverse rotation a non-center tap
+    // would focus the wrong point on the sensor.
+    final rotationCases = <(int, Offset Function(Offset))>[
+      (90, (n) => Offset(n.dy, 1.0 - n.dx)),
+      (180, (n) => Offset(1.0 - n.dx, 1.0 - n.dy)),
+      (270, (n) => Offset(1.0 - n.dy, n.dx)),
+    ];
+    for (final (degrees, expectedMapping) in rotationCases) {
+      testWidgets(
+        'inverse-rotates tap coordinates on a $degrees degree preview',
+        (tester) async {
+          Offset? unrotated;
+          await camera.initialize();
+          await tester.pumpWidget(
+            buildTestWidget(onTap: (_, normalized) => unrotated = normalized),
+          );
+          final rect = tester.getRect(find.byType(GestureDetector));
+          final tapPoint =
+              rect.topLeft + Offset(rect.width * 0.3, rect.height * 0.25);
+          await tester.tapAt(tapPoint);
+          await tester.pump();
+
+          Offset? rotated;
+          DivineCameraPlatform.instance = _RotatedPreviewMock(degrees: degrees);
+          await camera.initialize();
+          await tester.pumpWidget(
+            buildTestWidget(onTap: (_, normalized) => rotated = normalized),
+          );
+          await tester.tapAt(tapPoint);
+          await tester.pump();
+
+          expect(unrotated, isNotNull);
+          expect(rotated, isNotNull);
+          final expected = expectedMapping(unrotated!);
+          expect(rotated!.dx, closeTo(expected.dx, 0.0001));
+          expect(rotated!.dy, closeTo(expected.dy, 0.0001));
+        },
+      );
+    }
 
     testWidgets('calls onTap callback with correct positions', (tester) async {
       await camera.initialize();

--- a/mobile/packages/divine_camera/test/widgets/camera_preview_widget_test.dart
+++ b/mobile/packages/divine_camera/test/widgets/camera_preview_widget_test.dart
@@ -151,10 +151,6 @@ class _WideAspectRatioMock extends MockDivineCameraPlatform {
 /// Mock that reports a non-zero preview rotation, as the Android
 /// SurfaceProducer path does when the producer does not orient frames itself.
 class _RotatedPreviewMock extends MockDivineCameraPlatform {
-  _RotatedPreviewMock({this.degrees = 90});
-
-  final int degrees;
-
   @override
   Future<CameraState> initializeCamera({
     DivineCameraLens lens = DivineCameraLens.back,
@@ -163,10 +159,10 @@ class _RotatedPreviewMock extends MockDivineCameraPlatform {
     bool mirrorFrontCameraOutput = false,
     bool enableAutoLensSwitch = false,
   }) async {
-    return CameraState(
+    return const CameraState(
       isInitialized: true,
       textureId: 1,
-      previewRotationDegrees: degrees,
+      previewRotationDegrees: 90,
     );
   }
 }
@@ -276,48 +272,41 @@ void main() {
       expect(find.byType(RotatedBox), findsNothing);
     });
 
-    // Same tap point, once on an un-rotated preview and once on a rotated one.
-    // Both share the layout, so the rotated result must be the un-rotated
-    // point mapped back into the raw texture's coordinate space (undoing the
-    // clockwise RotatedBox). Without the inverse rotation a non-center tap
-    // would focus the wrong point on the sensor.
-    final rotationCases = <(int, Offset Function(Offset))>[
-      (90, (n) => Offset(n.dy, 1.0 - n.dx)),
-      (180, (n) => Offset(1.0 - n.dx, 1.0 - n.dy)),
-      (270, (n) => Offset(1.0 - n.dy, n.dx)),
-    ];
-    for (final (degrees, expectedMapping) in rotationCases) {
-      testWidgets(
-        'inverse-rotates tap coordinates on a $degrees degree preview',
-        (tester) async {
-          Offset? unrotated;
-          await camera.initialize();
-          await tester.pumpWidget(
-            buildTestWidget(onTap: (_, normalized) => unrotated = normalized),
-          );
-          final rect = tester.getRect(find.byType(GestureDetector));
-          final tapPoint =
-              rect.topLeft + Offset(rect.width * 0.3, rect.height * 0.25);
-          await tester.tapAt(tapPoint);
-          await tester.pump();
+    testWidgets(
+      'onTap coordinates stay in display space regardless of preview rotation',
+      (tester) async {
+        // The onTap point drives both the native focus call and the visual
+        // focus indicator, so it must stay in the displayed preview's space.
+        // The rotation-to-sensor mapping happens at the native boundary
+        // (DivineCamera.setFocusPoint), not here — a rotated preview must not
+        // shift the emitted point, or the indicator would jump away from the
+        // tap.
+        Offset? unrotated;
+        await camera.initialize();
+        await tester.pumpWidget(
+          buildTestWidget(onTap: (_, normalized) => unrotated = normalized),
+        );
+        final rect = tester.getRect(find.byType(GestureDetector));
+        final tapPoint =
+            rect.topLeft + Offset(rect.width * 0.3, rect.height * 0.25);
+        await tester.tapAt(tapPoint);
+        await tester.pump();
 
-          Offset? rotated;
-          DivineCameraPlatform.instance = _RotatedPreviewMock(degrees: degrees);
-          await camera.initialize();
-          await tester.pumpWidget(
-            buildTestWidget(onTap: (_, normalized) => rotated = normalized),
-          );
-          await tester.tapAt(tapPoint);
-          await tester.pump();
+        Offset? rotated;
+        DivineCameraPlatform.instance = _RotatedPreviewMock();
+        await camera.initialize();
+        await tester.pumpWidget(
+          buildTestWidget(onTap: (_, normalized) => rotated = normalized),
+        );
+        await tester.tapAt(tapPoint);
+        await tester.pump();
 
-          expect(unrotated, isNotNull);
-          expect(rotated, isNotNull);
-          final expected = expectedMapping(unrotated!);
-          expect(rotated!.dx, closeTo(expected.dx, 0.0001));
-          expect(rotated!.dy, closeTo(expected.dy, 0.0001));
-        },
-      );
-    }
+        expect(unrotated, isNotNull);
+        expect(rotated, isNotNull);
+        expect(rotated!.dx, closeTo(unrotated!.dx, 0.0001));
+        expect(rotated!.dy, closeTo(unrotated!.dy, 0.0001));
+      },
+    );
 
     testWidgets('calls onTap callback with correct positions', (tester) async {
       await camera.initialize();


### PR DESCRIPTION
## Description

The Android camera preview flashed **black** during a front↔back lens switch in **release** builds. Debug builds froze the last frame correctly, so this only reproduced on shipped (release/Impeller) builds — including production `1.0.16`.

**Root cause:** the camera plugin used Flutter's deprecated `SurfaceTexture` texture API. Under Impeller/Vulkan, that texture does **not** retain its last frame across the CameraX `unbindAll()` → rebind that a lens switch performs, so the reused texture went black in the switch gap. Debug's slower JIT timing happened to mask it. (Confirmed with a differential test: the black also reproduces on a non-minified release build, so it is unrelated to the R8 re-enable PR.)

**Fix:** migrate the preview to Flutter's `SurfaceProducer` API, which retains the last frame during the gap — and which Flutter now explicitly recommends over `SurfaceTexture` (the old API is slated to become a build error).

Because `SurfaceProducer` reports `handlesCropAndRotation() == false` on this path, it no longer applies the native transform matrix that previously carried **preview rotation** and the **front-camera mirror**. Both are therefore reconstructed in the widget:
- rotate the preview by the current lens' sensor orientation (`RotatedBox`), and
- mirror the front-camera preview on Android (previously handled natively via that matrix).

The switch completion is gated on the incoming camera's **first frame** (via the existing Camera2 capture callback) so the lens/rotation state flips only once the new frame is ready, rather than while the old frame is still on screen.

**Why not a two-texture switch:** a two-producer approach (old texture frozen at old rotation, new texture at new rotation, atomic flip) would remove the residual blip below, but in on-device testing it regressed the freeze and the front mirror, so it was reverted in favour of the simpler single-producer path.

**Known minor limitation:** a 1-2 frame rotation blip can still briefly appear during a front↔back switch because the old and new frames share one texture. This is a large improvement over the previous full black flash and was accepted for this PR.

**Performance:** neutral-to-slightly-better. `SurfaceProducer` is the Impeller-native path (the old `SurfaceTexture`-under-Impeller path used a compatibility bridge); the reconstructed rotation/mirror add two GPU-cheap compositor transform layers on the preview. The recording path (`VideoCapture`) is unchanged.

## Out of Scope

- The residual 1-2 frame rotation blip on front↔back switch (documented above).
- iOS/macOS are unaffected: the migration is Android-only Kotlin, `previewRotationDegrees` is 0 on iOS (no `RotatedBox`), and the mirror still routes through the existing iOS branch.

**Related Issue:** Closes #5865

## Verification

- On-device manual test on a real Samsung SM-S942B (Android 16), release build: preview orientation correct on both lenses, front preview mirrored, lens switch freezes (no black), recording + playback correct on both lenses, tap-to-focus / zoom / flash, and background→resume all verified.
- `flutter analyze packages/divine_camera` — clean.
- `flutter test` for `divine_camera` (state + preview widget + method channel) — all pass; updated the `CameraState.props` test for the new `previewRotationDegrees` field.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 🧹 Code refactor
