### PR TITLE
fix(profile): scope profile tab cache by viewer

### DIFF
--- a/.claude/rules/state_management.md
+++ b/.claude/rules/state_management.md
@@ -643,23 +643,30 @@ Consequences:
 - The user sees the screen "reset" (e.g. selected tab → Videos, scroll
   position → top) after closing the pushed route.
 
-**Fix:** persist the state externally, keyed by a stable identifier.
-For per-screen state like "active tab index," a simple
-`StateProvider<Map<String, int>>` keyed by `userIdHex` is enough:
+**Fix:** persist the state externally, keyed by stable identifiers.
+For per-screen state like "active tab index," include both the signed-in
+viewer and target profile so account switches cannot restore another
+identity's tab selection for the same profile:
 
 ```dart
 // lib/providers/profile_tab_index_provider.dart
 import 'package:flutter_riverpod/legacy.dart';
 
-final profileTabIndexProvider = StateProvider<Map<String, int>>(
-  (ref) => <String, int>{},
+typedef ProfileTabIndexKey = ({
+  String? viewerPubkeyHex,
+  String targetPubkeyHex,
+});
+
+final profileTabIndexProvider = StateProvider<Map<ProfileTabIndexKey, int>>(
+  (ref) => <ProfileTabIndexKey, int>{},
 );
 ```
 
 Read in `initState` to seed `TabController.initialIndex`; write in the
-tab listener. Lazy-sync side effects (e.g. loading a tab's data on
-first view) must also be re-dispatched when the restored index is not
-zero, since the controller's listener doesn't fire for the initial
+tab listener using `authServiceProvider.currentPublicKeyHex` plus the
+profile pubkey as the key. Lazy-sync side effects (e.g. loading a tab's
+data on first view) must also be re-dispatched when the restored index is
+not zero, since the controller's listener doesn't fire for the initial
 index.
 
 See `profile_grid.dart` + `profile_tab_index_provider.dart` for the

--- a/mobile/lib/providers/profile_tab_index_provider.dart
+++ b/mobile/lib/providers/profile_tab_index_provider.dart
@@ -3,8 +3,24 @@
 
 import 'package:flutter_riverpod/legacy.dart';
 
-/// Remembers the currently selected tab index per profile (keyed by hex
-/// pubkey).
+/// Cache key for the selected profile tab index.
+///
+/// [viewerPubkeyHex] scopes the cache to the signed-in identity so switching
+/// accounts cannot restore another viewer's tab selection for the same target
+/// profile.
+typedef ProfileTabIndexKey = ({
+  String? viewerPubkeyHex,
+  String targetPubkeyHex,
+});
+
+ProfileTabIndexKey profileTabIndexKey({
+  required String? viewerPubkeyHex,
+  required String targetPubkeyHex,
+}) {
+  return (viewerPubkeyHex: viewerPubkeyHex, targetPubkeyHex: targetPubkeyHex);
+}
+
+/// Remembers the currently selected tab index per viewer/profile pair.
 ///
 /// `ProfileGridView`'s [TabController] is recreated whenever the profile
 /// subtree is unmounted and remounted. This happens on any navigation that
@@ -13,8 +29,9 @@ import 'package:flutter_riverpod/legacy.dart';
 /// `routeContext.type == RouteType.profile` and returns an empty widget
 /// otherwise — which throws away `TabController` state.
 ///
-/// Stored as a Map so multiple profiles (own + recently visited others)
-/// each keep their own position without bleeding into each other.
-final profileTabIndexProvider = StateProvider<Map<String, int>>(
-  (ref) => <String, int>{},
+/// Stored as a Map so multiple profiles (own + recently visited others) each
+/// keep their own position without bleeding into each other or across account
+/// switches.
+final profileTabIndexProvider = StateProvider<Map<ProfileTabIndexKey, int>>(
+  (ref) => <ProfileTabIndexKey, int>{},
 );

--- a/mobile/lib/providers/profile_tab_index_provider.dart
+++ b/mobile/lib/providers/profile_tab_index_provider.dart
@@ -13,13 +13,6 @@ typedef ProfileTabIndexKey = ({
   String targetPubkeyHex,
 });
 
-ProfileTabIndexKey profileTabIndexKey({
-  required String? viewerPubkeyHex,
-  required String targetPubkeyHex,
-}) {
-  return (viewerPubkeyHex: viewerPubkeyHex, targetPubkeyHex: targetPubkeyHex);
-}
-
 /// Remembers the currently selected tab index per viewer/profile pair.
 ///
 /// `ProfileGridView`'s [TabController] is recreated whenever the profile

--- a/mobile/lib/widgets/profile/profile_grid.dart
+++ b/mobile/lib/widgets/profile/profile_grid.dart
@@ -190,7 +190,7 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
   List<ProfileTabKind> get _tabKinds =>
       profileTabKinds(isOwnProfile: widget.isOwnProfile);
 
-  ProfileTabIndexKey get _tabIndexKey => profileTabIndexKey(
+  ProfileTabIndexKey get _tabIndexKey => (
     viewerPubkeyHex: ref.read(authServiceProvider).currentPublicKeyHex,
     targetPubkeyHex: widget.userIdHex,
   );

--- a/mobile/lib/widgets/profile/profile_grid.dart
+++ b/mobile/lib/widgets/profile/profile_grid.dart
@@ -190,6 +190,11 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
   List<ProfileTabKind> get _tabKinds =>
       profileTabKinds(isOwnProfile: widget.isOwnProfile);
 
+  ProfileTabIndexKey get _tabIndexKey => profileTabIndexKey(
+    viewerPubkeyHex: ref.read(authServiceProvider).currentPublicKeyHex,
+    targetPubkeyHex: widget.userIdHex,
+  );
+
   /// Key attached to the ProfileHeaderWidget so we can measure its height
   /// and compute the tab bar top inset accordingly.
   final GlobalKey _headerKey = GlobalKey();
@@ -200,11 +205,8 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
     // Restore the previously selected tab index (if any) so navigating back
     // from a fullscreen video doesn't drop the user on the Videos tab.
     final tabCount = _tabKinds.length;
-    final restoredIndex =
-        (ref.read(profileTabIndexProvider)[widget.userIdHex] ?? 0).clamp(
-          0,
-          tabCount - 1,
-        );
+    final restoredIndex = (ref.read(profileTabIndexProvider)[_tabIndexKey] ?? 0)
+        .clamp(0, tabCount - 1);
     _tabController = TabController(
       length: tabCount,
       vsync: this,
@@ -243,10 +245,7 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
     // transitions that briefly take the URL off the profile route) can
     // restore the user to the tab they were on.
     final notifier = ref.read(profileTabIndexProvider.notifier);
-    notifier.state = {
-      ...notifier.state,
-      widget.userIdHex: _tabController.index,
-    };
+    notifier.state = {...notifier.state, _tabIndexKey: _tabController.index};
 
     _syncCurrentTabIfNeeded();
   }

--- a/mobile/test/widgets/profile/profile_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_grid_test.dart
@@ -5,6 +5,7 @@ import 'package:content_policy/content_policy.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:likes_repository/likes_repository.dart';
 import 'package:mocktail/mocktail.dart';
@@ -13,6 +14,7 @@ import 'package:openvine/blocs/my_profile/my_profile_bloc.dart';
 import 'package:openvine/blocs/profile_feed/profile_feed_cubit.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/services/bookmark_service.dart';
 import 'package:openvine/widgets/profile/profile_grid.dart';
@@ -122,6 +124,7 @@ void main() {
     Widget buildSubject({
       required bool isOwnProfile,
       bool isLoadingVideos = false,
+      MockAuthService? mockAuthService,
     }) {
       return testMaterialApp(
         theme: VineTheme.theme,
@@ -141,6 +144,7 @@ void main() {
           ),
         ),
         mockNostrService: nostrClient,
+        mockAuthService: mockAuthService,
         additionalOverrides: [
           likesRepositoryProvider.overrideWithValue(likesRepository),
           repostsRepositoryProvider.overrideWithValue(repostsRepository),
@@ -157,6 +161,31 @@ void main() {
             FeatureFlag.curatedLists,
           ).overrideWith((_) => false),
         ],
+      );
+    }
+
+    Widget buildSubjectWithContainer(ProviderContainer container) {
+      return UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          theme: VineTheme.theme,
+          home: Scaffold(
+            body: MultiBlocProvider(
+              providers: [
+                BlocProvider<MyProfileBloc>.value(value: myProfileBloc),
+                BlocProvider<ProfileFeedCubit>.value(value: profileFeedCubit),
+              ],
+              child: const ProfileGridView(
+                key: ValueKey('profile-grid'),
+                userIdHex: userIdHex,
+                isOwnProfile: false,
+                videos: [],
+              ),
+            ),
+          ),
+        ),
       );
     }
 
@@ -181,6 +210,67 @@ void main() {
         expect(find.bySemanticsLabel('reposted_tab'), findsOneWidget);
         expect(find.bySemanticsLabel('saved_tab'), findsOneWidget);
         expect(find.bySemanticsLabel('comments_tab'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'does not restore another viewer identity tab index after auth change',
+      (tester) async {
+        const viewerA =
+            '1111111111111111111111111111111111111111111111111111111111111111';
+        const viewerB =
+            '2222222222222222222222222222222222222222222222222222222222222222';
+        var currentViewer = viewerA;
+        final authService = createMockAuthService();
+        when(
+          () => authService.currentPublicKeyHex,
+        ).thenAnswer((_) => currentViewer);
+        when(() => authService.isAuthenticated).thenReturn(true);
+        when(() => authService.isAnonymous).thenReturn(false);
+        when(() => authService.hasExpiredOAuthSession).thenReturn(false);
+        when(() => authService.isRpcUpgradeInProgress).thenReturn(false);
+
+        final container = ProviderContainer(
+          overrides: [
+            ...getStandardTestOverrides(
+              mockAuthService: authService,
+              mockNostrService: nostrClient,
+            ),
+            likesRepositoryProvider.overrideWithValue(likesRepository),
+            repostsRepositoryProvider.overrideWithValue(repostsRepository),
+            videosRepositoryProvider.overrideWithValue(videosRepository),
+            commentsRepositoryProvider.overrideWithValue(commentsRepository),
+            contentBlocklistRepositoryProvider.overrideWithValue(
+              blocklistRepository,
+            ),
+            bookmarkServiceProvider.overrideWith((_) => bookmarkService),
+            isFeatureEnabledProvider(
+              FeatureFlag.videoReplies,
+            ).overrideWith((_) => false),
+            isFeatureEnabledProvider(
+              FeatureFlag.curatedLists,
+            ).overrideWith((_) => false),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        await tester.pumpWidget(buildSubjectWithContainer(container));
+        await tester.pump();
+        await tester.tap(find.bySemanticsLabel('reposted_tab'));
+        await tester.pumpAndSettle();
+        expect(tester.widget<TabBar>(find.byType(TabBar)).controller?.index, 2);
+
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pumpWidget(buildSubjectWithContainer(container));
+        await tester.pump();
+        expect(tester.widget<TabBar>(find.byType(TabBar)).controller?.index, 2);
+
+        currentViewer = viewerB;
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pumpWidget(buildSubjectWithContainer(container));
+        await tester.pump();
+
+        expect(tester.widget<TabBar>(find.byType(TabBar)).controller?.index, 0);
       },
     );
 


### PR DESCRIPTION
## Summary

- Scope the persisted profile tab index by both viewer pubkey and target profile pubkey.
- Keep profile tab restore behavior across remounts for the same viewer while preventing account-switch bleed for the same target profile.
- Update the state-management rule snippet so future provider caches do not document the old target-only key shape.

## Root cause

`profileTabIndexProvider` stored tab indexes in a flat `Map<String, int>` keyed only by the target profile pubkey. When a different signed-in viewer opened the same target profile after an auth transition, `ProfileGridView` could restore the previous viewer's tab index.

## Validation

- `flutter test test/widgets/profile/profile_grid_test.dart`
- `flutter analyze`
- pre-push hook: changed-file analyze and `test/widgets/profile/profile_grid_test.dart`

Fixes #3222.
