### PR TITLE
fix(camera): release iOS mic on pause and log audio diagnostics

### DIFF
--- a/mobile/packages/divine_camera/ios/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/ios/Classes/CameraController.swift
@@ -422,6 +422,9 @@ class CameraController: NSObject {
             // flag set so the next recording continues without audio.
             sessionQueue.async { [weak self] in
                 guard let self = self else { return }
+                // While paused (app locked / backgrounded) don't re-grab
+                // the mic; resumePreview() recovers instead.
+                guard !self.isPaused else { return }
                 if self.attachAudioToSessionIfNeeded() {
                     self.audioInterrupted = false
                 } else {
@@ -1136,7 +1139,12 @@ class CameraController: NSObject {
         // the status bar shortly after the camera page opens (TikTok,
         // Instagram, and Snapchat all behave the same way).
         sessionQueue.asyncAfter(deadline: .now() + 1.0) { [weak self] in
-            _ = self?.attachAudioToSessionIfNeeded()
+            // Skip when the preview was paused before the pre-build fired
+            // (locked / backgrounded within 1s of the first frame) —
+            // attaching would grab the mic while the app isn't visible.
+            // resumePreview() / startRecording() attach on demand instead.
+            guard let self = self, !self.isPaused else { return }
+            _ = self.attachAudioToSessionIfNeeded()
         }
     }
     
@@ -2379,9 +2387,46 @@ class CameraController: NSObject {
                     self.recordingStartTime = nil
                     self.isWriterSessionStarted = false
                     self.lastVideoFrameEndPTS = nil
+
+                    // pausePreview() keeps the mic attached while a
+                    // recording is draining. If the preview is still
+                    // paused now (app locked mid-recording), release the
+                    // mic so the lock screen stops showing the recording
+                    // indicator.
+                    if self.isPaused {
+                        self.sessionQueue.async { [weak self] in
+                            guard let self = self,
+                                  self.isPaused,
+                                  !self.isRecording else { return }
+                            self.releaseAudioForPause()
+                        }
+                    }
                 }
             }
         }
+    }
+
+    /// Releases the microphone while the preview is paused.
+    ///
+    /// The dedicated audio capture session normally keeps running between
+    /// recordings so record-start stays instant, but holding it across an
+    /// app pause leaves the app owning the mic — iOS surfaces that as a
+    /// recording indicator on the lock screen. Stop the capture session
+    /// BEFORE deactivating the shared AVAudioSession; the reverse order
+    /// leaves a stale route delivering digital-silence buffers (see
+    /// attachAudioToSessionIfNeeded()).
+    ///
+    /// Must run on `sessionQueue`.
+    private func releaseAudioForPause() {
+        audioCaptureSession?.stopRunning()
+        try? AVAudioSession.sharedInstance().setActive(
+            false,
+            options: .notifyOthersOnDeactivation
+        )
+        DivineCameraLog.shared.info(
+            "Released mic for pause (audio capture stopped, session inactive)",
+            name: "DivineCamera.AudioSession"
+        )
     }
 
     /// Pauses the camera preview.
@@ -2389,7 +2434,14 @@ class CameraController: NSObject {
         disableScreenFlash()
         isPaused = true
         sessionQueue.async { [weak self] in
-            self?.captureSession?.stopRunning()
+            guard let self = self else { return }
+            self.captureSession?.stopRunning()
+            // Keep the mic during an active recording — the writer is
+            // still draining; stopRecording() releases it if the preview
+            // is still paused once the file is finalized.
+            if !self.isRecording {
+                self.releaseAudioForPause()
+            }
         }
     }
     
@@ -2403,11 +2455,23 @@ class CameraController: NSObject {
         }
         
         sessionQueue.async { [weak self] in
-            self?.captureSession?.startRunning()
-            
+            guard let self = self else { return }
+            self.captureSession?.startRunning()
+
             DispatchQueue.main.async { [weak self] in
                 guard let self = self else { return }
                 completion(self.getCameraState(), nil)
+            }
+
+            // Restore the audio path released by releaseAudioForPause().
+            // A successful attach proves the path is live again, so also
+            // clear a stale interruption flag — iOS delivers no `.ended`
+            // for lock-screen interruptions, and a stuck flag would drop
+            // the audio track from every later recording in this session.
+            // Skip the never-built case (paused before the pre-build
+            // fired); startRecording() builds on demand.
+            if self.audioCaptureSession != nil, self.attachAudioToSessionIfNeeded() {
+                self.audioInterrupted = false
             }
         }
     }

--- a/mobile/packages/divine_camera/ios/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/ios/Classes/CameraController.swift
@@ -2475,10 +2475,22 @@ class CameraController: NSObject {
     /// Must run on `sessionQueue`.
     private func releaseAudioForPause() {
         audioCaptureSession?.stopRunning()
-        try? AVAudioSession.sharedInstance().setActive(
-            false,
-            options: .notifyOthersOnDeactivation
-        )
+        do {
+            try AVAudioSession.sharedInstance().setActive(
+                false,
+                options: .notifyOthersOnDeactivation
+            )
+        } catch {
+            // A failing deactivation (session busy / insufficient priority) is
+            // exactly the "mic not released" symptom this path guards against,
+            // so surface it instead of swallowing. stopRunning() above is the
+            // primary indicator-clearer, so this stays a warning.
+            DivineCameraLog.shared.warning(
+                "Failed to deactivate audio session on pause — mic may stay "
+                    + "held (error=\(error.localizedDescription))",
+                name: "DivineCamera.AudioSession"
+            )
+        }
         DivineCameraLog.shared.info(
             "Released mic for pause (audio capture stopped, session inactive)",
             name: "DivineCamera.AudioSession"
@@ -2486,7 +2498,15 @@ class CameraController: NSObject {
     }
 
     /// Pauses the camera preview.
-    func pausePreview() {
+    ///
+    /// Pass `releaseAudio: false` for transient foreground interruptions
+    /// (iOS `.inactive` from a Control Center / app-switcher pull) to stop
+    /// only the video session and leave the shared audio session running —
+    /// releasing it there would signal other apps to resume and then re-cut
+    /// their playback on every pull. `releaseAudio: true` (genuine
+    /// background) additionally frees the mic so the lock screen stops
+    /// showing the recording indicator.
+    func pausePreview(releaseAudio: Bool = true) {
         disableScreenFlash()
         isPaused = true
         sessionQueue.async { [weak self] in
@@ -2495,7 +2515,7 @@ class CameraController: NSObject {
             // Keep the mic during an active recording — the writer is
             // still draining; stopRecording() releases it if the preview
             // is still paused once the file is finalized.
-            if !self.isRecording {
+            if releaseAudio, !self.isRecording {
                 self.releaseAudioForPause()
             }
         }

--- a/mobile/packages/divine_camera/ios/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/ios/Classes/CameraController.swift
@@ -68,6 +68,15 @@ class CameraController: NSObject {
             audioInterruptedLock.unlock()
         }
     }
+
+    /// Diagnostics for the finished-clip audio log (#4779 family): how many
+    /// audio buffers reached the writer and the loudest peak seen during
+    /// the recording (dBFS, 0 = full scale). A populated track whose peak
+    /// stayed near -160 is the silent-AAC signature. Written on
+    /// `videoOutputQueue`, read once after the writer finished — same loose
+    /// cross-queue convention as `lastVideoFrameEndPTS`.
+    private var appendedAudioBufferCount = 0
+    private var maxAudioPeakDb: Float = -160
     
     private var textureRegistry: FlutterTextureRegistry
 
@@ -396,7 +405,8 @@ class CameraController: NSObject {
             // (captureOutput) see a consistent value.
             self.audioInterrupted = true
             DivineCameraLog.shared.warning(
-                "AVAudioSession interruption began — audio capture paused",
+                "AVAudioSession interruption began — audio capture paused "
+                    + "(reason=\(Self.interruptionReasonDescription(info)))",
                 name: "DivineCamera.AudioSession"
             )
         case .ended:
@@ -438,7 +448,28 @@ class CameraController: NSObject {
             break
         }
     }
-    
+
+    /// Human-readable interruption reason for the diagnostics log.
+    /// `builtInMicMuted` (iPad hardware mic mute) silently kills capture
+    /// and is invisible without this.
+    private static func interruptionReasonDescription(
+        _ info: [AnyHashable: Any]
+    ) -> String {
+        guard #available(iOS 14.5, *),
+              let raw = info[AVAudioSessionInterruptionReasonKey] as? UInt else {
+            return "unspecified"
+        }
+        if #available(iOS 17.0, *),
+           AVAudioSession.InterruptionReason(rawValue: raw) == .routeDisconnected {
+            return "routeDisconnected"
+        }
+        switch AVAudioSession.InterruptionReason(rawValue: raw) {
+        case .default: return "default"
+        case .builtInMicMuted: return "builtInMicMuted"
+        default: return "raw(\(raw))"
+        }
+    }
+
     /// Gets metadata for the currently active camera lens.
     private func getCurrentLensMetadata() -> [String: Any]? {
         guard let device = videoDevice else {
@@ -2087,6 +2118,27 @@ class CameraController: NSObject {
                 )
             }
 
+            // One state line per recording so a silent clip can be traced
+            // to its cause: no input in the route, a system-level input
+            // mute, or a category another player stole.
+            let session = AVAudioSession.sharedInstance()
+            let inputs = session.currentRoute.inputs
+                .map(\.portType.rawValue).joined(separator: "+")
+            let outputs = session.currentRoute.outputs
+                .map(\.portType.rawValue).joined(separator: "+")
+            var inputMuted = "n/a"
+            if #available(iOS 17.0, *) {
+                inputMuted = AVAudioApplication.shared.isInputMuted
+                    ? "true" : "false"
+            }
+            DivineCameraLog.shared.info(
+                "Recording audio state: ready=\(audioReady), "
+                    + "category=\(session.category.rawValue), "
+                    + "inputs=[\(inputs)], outputs=[\(outputs)], "
+                    + "inputMuted=\(inputMuted)",
+                name: "DivineCamera.Recording"
+            )
+
             self.videoOutputQueue.async { [weak self] in
                 guard let self = self else { return }
                 self.startRecordingAfterAudioReady(
@@ -2214,6 +2266,8 @@ class CameraController: NSObject {
             self.isWriterSessionStarted = false  // Will be set to true when first frame is received
             self.lastVideoFrameEndPTS = nil
             self.recordingStartTime = Date()
+            self.appendedAudioBufferCount = 0
+            self.maxAudioPeakDb = -160
 
             // Check and enable auto-flash if needed
             self.checkAndEnableAutoFlash()
@@ -2349,14 +2403,16 @@ class CameraController: NSObject {
                         // reports (#4779): inspect the finished file rather than
                         // trusting the in-flight audioReady flag.
                         let hasAudioTrack = !asset.tracks(withMediaType: .audio).isEmpty
+                        let audioStats = "audioBuffers=\(self.appendedAudioBufferCount), "
+                            + "maxPeakDb=\(String(format: "%.1f", self.maxAudioPeakDb))"
                         if hasAudioTrack {
                             DivineCameraLog.shared.info(
-                                "Recording completed with audio track (durationMs=\(duration))",
+                                "Recording completed with audio track (durationMs=\(duration), \(audioStats))",
                                 name: "DivineCamera.Recording"
                             )
                         } else {
                             DivineCameraLog.shared.warning(
-                                "Recording completed WITHOUT audio track (durationMs=\(duration))",
+                                "Recording completed WITHOUT audio track (durationMs=\(duration), \(audioStats))",
                                 name: "DivineCamera.Recording"
                             )
                         }
@@ -2713,6 +2769,10 @@ extension CameraController: AVCaptureVideoDataOutputSampleBufferDelegate {
                 // Only append audio after session has started
                 if isWriterSessionStarted && writer.status == .writing && audioInput.isReadyForMoreMediaData {
                     audioInput.append(sampleBuffer)
+                    appendedAudioBufferCount += 1
+                    for channel in connection.audioChannels {
+                        maxAudioPeakDb = max(maxAudioPeakDb, channel.peakHoldLevel)
+                    }
                 }
             }
         }

--- a/mobile/packages/divine_camera/ios/Classes/DivineCameraPlugin.swift
+++ b/mobile/packages/divine_camera/ios/Classes/DivineCameraPlugin.swift
@@ -235,7 +235,7 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
             capturePhoto(useCache: useCache, outputDirectory: outputDirectory, result: result)
 
         case "pausePreview":
-            pausePreview(result: result)
+            pausePreview(call: call, result: result)
             
         case "resumePreview":
             resumePreview(result: result)
@@ -472,8 +472,9 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
         }
     }
     
-    private func pausePreview(result: @escaping FlutterResult) {
-        cameraController?.pausePreview()
+    private func pausePreview(call: FlutterMethodCall, result: @escaping FlutterResult) {
+        let releaseAudio = (call.arguments as? [String: Any])?["releaseAudio"] as? Bool ?? true
+        cameraController?.pausePreview(releaseAudio: releaseAudio)
         result(nil)
     }
     

--- a/mobile/packages/divine_camera/lib/divine_camera.dart
+++ b/mobile/packages/divine_camera/lib/divine_camera.dart
@@ -331,6 +331,12 @@ class DivineCamera {
 
     switch (appState) {
       case AppLifecycleState.inactive:
+        // `.inactive` fires on transient foreground interruptions (Control
+        // Center / notification shade / app-switcher pulls) with no real
+        // background transition. Stop the preview but keep the audio session
+        // so we don't churn other apps' playback on every such pull; genuine
+        // background always follows with `.paused`/`.hidden`.
+        await _platform.pausePreview(releaseAudio: false);
       case AppLifecycleState.paused:
       case AppLifecycleState.detached:
       case AppLifecycleState.hidden:

--- a/mobile/packages/divine_camera/lib/divine_camera_method_channel.dart
+++ b/mobile/packages/divine_camera/lib/divine_camera_method_channel.dart
@@ -293,8 +293,10 @@ class MethodChannelDivineCamera extends DivineCameraPlatform {
   }
 
   @override
-  Future<void> pausePreview() async {
-    await methodChannel.invokeMethod<void>('pausePreview');
+  Future<void> pausePreview({bool releaseAudio = true}) async {
+    await methodChannel.invokeMethod<void>('pausePreview', <String, dynamic>{
+      'releaseAudio': releaseAudio,
+    });
   }
 
   @override

--- a/mobile/packages/divine_camera/lib/divine_camera_platform_interface.dart
+++ b/mobile/packages/divine_camera/lib/divine_camera_platform_interface.dart
@@ -136,7 +136,14 @@ abstract class DivineCameraPlatform extends PlatformInterface {
   }
 
   /// Pauses the camera preview.
-  Future<void> pausePreview() {
+  ///
+  /// When [releaseAudio] is `true` (genuine background), the platform also
+  /// releases the microphone and deactivates the shared audio session so the
+  /// OS stops attributing an active recording to the app. Pass `false` for
+  /// transient foreground interruptions (e.g. iOS `.inactive` from a Control
+  /// Center / app-switcher pull), which stop only the video preview and leave
+  /// the audio session untouched to avoid churning other apps' playback.
+  Future<void> pausePreview({bool releaseAudio = true}) {
     throw UnimplementedError('pausePreview() has not been implemented.');
   }
 

--- a/mobile/packages/divine_camera/test/divine_camera_method_channel_test.dart
+++ b/mobile/packages/divine_camera/test/divine_camera_method_channel_test.dart
@@ -396,8 +396,34 @@ void main() {
       expect(logged, isTrue);
     });
 
-    test('pausePreview completes without error', () async {
-      await expectLater(platform.pausePreview(), completes);
+    test('pausePreview forwards releaseAudio: true by default', () async {
+      Map<dynamic, dynamic>? pauseArgs;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (methodCall) async {
+            if (methodCall.method == 'pausePreview') {
+              pauseArgs = methodCall.arguments as Map<dynamic, dynamic>?;
+            }
+            return null;
+          });
+
+      await platform.pausePreview();
+
+      expect(pauseArgs?['releaseAudio'], isTrue);
+    });
+
+    test('pausePreview forwards releaseAudio: false when passed', () async {
+      Map<dynamic, dynamic>? pauseArgs;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (methodCall) async {
+            if (methodCall.method == 'pausePreview') {
+              pauseArgs = methodCall.arguments as Map<dynamic, dynamic>?;
+            }
+            return null;
+          });
+
+      await platform.pausePreview(releaseAudio: false);
+
+      expect(pauseArgs?['releaseAudio'], isFalse);
     });
 
     test('resumePreview completes without error', () async {

--- a/mobile/packages/divine_camera/test/divine_camera_platform_interface_test.dart
+++ b/mobile/packages/divine_camera/test/divine_camera_platform_interface_test.dart
@@ -54,7 +54,7 @@ class TestDivineCameraPlatform extends DivineCameraPlatform
   Future<VideoRecordingResult?> stopRecording() async => null;
 
   @override
-  Future<void> pausePreview() async {}
+  Future<void> pausePreview({bool releaseAudio = true}) async {}
 
   @override
   Future<void> resumePreview() async {}

--- a/mobile/packages/divine_camera/test/divine_camera_test.dart
+++ b/mobile/packages/divine_camera/test/divine_camera_test.dart
@@ -12,6 +12,10 @@ class MockDivineCameraPlatform
   CameraState _state = const CameraState();
   bool _isRecording = false;
   bool throwOnStopRecording = false;
+
+  /// Records the `releaseAudio` argument of the last [pausePreview] call, or
+  /// `null` if it was never called.
+  bool? lastPauseReleaseAudio;
   void Function(VideoRecordingResult result)? _onRecordingAutoStopped;
   void Function(RemoteRecordTrigger trigger)? _onRemoteRecordTrigger;
 
@@ -167,7 +171,9 @@ class MockDivineCameraPlatform
   }
 
   @override
-  Future<void> pausePreview() async {}
+  Future<void> pausePreview({bool releaseAudio = true}) async {
+    lastPauseReleaseAudio = releaseAudio;
+  }
 
   @override
   Future<void> resumePreview() async {}
@@ -1312,25 +1318,28 @@ void main() {
       expect(result, isNull);
     });
 
-    test('handleAppLifecycleState paused calls pausePreview', () async {
+    test('handleAppLifecycleState paused releases audio on pause', () async {
       await DivineCamera.instance.initialize();
 
-      // pausePreview is called - no exception means it worked
       await DivineCamera.instance.handleAppLifecycleState(
         AppLifecycleState.paused,
       );
 
-      // Camera should still be initialized after pause
+      // Genuine background frees the mic to clear the lock-screen indicator.
+      expect(mockPlatform.lastPauseReleaseAudio, isTrue);
       expect(DivineCamera.instance.isInitialized, isTrue);
     });
 
-    test('handleAppLifecycleState inactive calls pausePreview', () async {
+    test('handleAppLifecycleState inactive keeps audio session', () async {
       await DivineCamera.instance.initialize();
 
       await DivineCamera.instance.handleAppLifecycleState(
         AppLifecycleState.inactive,
       );
 
+      // Transient interruption stops video only — leaving audio alone avoids
+      // churning other apps' playback on Control Center / app-switcher pulls.
+      expect(mockPlatform.lastPauseReleaseAudio, isFalse);
       expect(DivineCamera.instance.isInitialized, isTrue);
     });
 

--- a/mobile/packages/divine_camera/test/widgets/camera_preview_widget_test.dart
+++ b/mobile/packages/divine_camera/test/widgets/camera_preview_widget_test.dart
@@ -116,7 +116,7 @@ class MockDivineCameraPlatform
   }) async => null;
 
   @override
-  Future<void> pausePreview() async {}
+  Future<void> pausePreview({bool releaseAudio = true}) async {}
 
   @override
   Future<void> resumePreview() async {}


### PR DESCRIPTION
Closes #5885

## Description

**Related Issue:**  (relates to #4779 — fixes the remaining trigger)

Users report two connected symptoms on iOS: a recording indicator on the lock screen after locking the phone while the recorder is open, and intermittently silent clips afterwards.

Root cause: the recorder's dedicated audio `AVCaptureSession` is deliberately kept running between recordings (instant record-start), but `pausePreview()` only stopped the *video* session. Locking/backgrounding therefore left the app holding the microphone — iOS truthfully surfaces that as a recording indicator on the lock screen. That held session also turns every lock into an `AVAudioSession` interruption, and iOS does not guarantee a matching `.ended` notification for lock-screen interruptions, so `audioInterrupted` could stay latched and later clips in that camera session were recorded without an audio track (the #4779 symptom). The `startRecording` recovery shipped for #4779 covers the record tap, but nothing recovered on foreground return, and two code paths (the 1s deferred pre-build and the `.ended` recovery) could even re-grab the mic while the app was not visible.

Changes (all in `mobile/packages/divine_camera/ios/Classes/CameraController.swift`):

- `pausePreview()` now also stops the audio capture session and deactivates the shared `AVAudioSession` (stop **before** deactivate — the reverse order is the documented digital-silence hazard). During an active recording the mic is kept so the writer can finish; `stopRecording()` releases it afterwards if the preview is still paused.
- `resumePreview()` re-attaches the audio path and clears a stale `audioInterrupted` flag on success, so the first clip after unlock records audio even when iOS never delivered `.ended`.
- The 1s deferred audio pre-build and the `.ended` recovery skip attaching while `isPaused` — previously they could re-grab the mic while the phone was locked.

Why release-on-pause rather than only patching the interruption flag: holding the mic across a lock is itself the privacy problem users see, and it is what turns every lock into an audio-session interruption in the first place. Releasing on pause removes the trigger; the resume/record recovery paths stay as the safety net for interruptions from calls/Siri/other apps. Record-start stays instant because `resumePreview()` re-attaches eagerly on foreground return.

### Diagnostics (second commit)

The existing logs cover every decision point of the no-audio-track paths, but a *silent* AAC track (the documented race / digital-silence family) was indistinguishable from a healthy clip in the logs. Three additions close that blind spot, all bridged into user log exports via `DivineCameraLog`:

- One state line per recording start: `Recording audio state: ready=…, category=…, inputs=[…], outputs=[…], inputMuted=…` — surfaces an empty input route, a stolen session category, and the iOS 17+ system-level input mute (`AVAudioApplication.isInputMuted`), a previously invisible candidate cause for "intermittent muted clips".
- The finished-clip line now includes `audioBuffers=N, maxPeakDb=X` (buffer count appended to the writer + loudest `AVCaptureAudioChannel.peakHoldLevel` seen). A populated track whose peak stayed near -160 dBFS is the silent-track signature; "0 buffers" vs "buffers but silent" separates the two remaining failure modes.
- The interruption `began` line now logs the reason (`builtInMicMuted`, `routeDisconnected`, …) instead of just "began" — iPad hardware mic mute kills capture silently and was invisible before.

## Out of Scope

- Locking mid-recording keeps the mic until the writer finalizes (released right after); stopping the recording on background would be a Bloc-level behavior decision.
- Android parity — the mic indicator semantics differ and the report is iOS-only.
- `dispose()` already stops the audio capture session when leaving the recorder; its session-category handling is untouched.

## Verification

- `swiftc -typecheck` of the full plugin module (all 5 Swift files) against the iphonesimulator SDK + `Flutter.xcframework`: passes, only pre-existing warnings in untouched files.
- `flutter build ios --simulator --debug`: builds and links clean (`✓ Built build/ios/iphonesimulator/Runner.app`), re-run after the diagnostics commit.
- No Dart changes; `divine_camera` CI (Dart tests/analyze/format + Android unit tests) is unaffected. Note for reviewers: CI has no Swift compile job for this package — the local build above is the compile check.
- Manual on-device plan (lock-screen mic attribution needs a physical device): 1) open the recorder, record a clip with sound; 2) lock the phone → expect **no** recording indicator on the lock screen and the new `Released mic for pause` log line; 3) unlock, record another clip → expect `Recording completed with audio track` in the log export and an audio stream in `ffprobe`; 4) repeat with a phone-call interruption instead of a lock.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore