### PR TITLE
fix(db): recover corrupt local database by salvaging drafts/clips, not wiping

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1309,6 +1309,11 @@ Future<void> _startOpenVineApp() async {
         // re-drain instead of skipping it as "already complete" (which had
         // left recovered chats stranded under "Message requests"). See #5304.
         onDatabaseReset: () => DmSyncState(sharedPreferences).clearAll(),
+        // Recovery succeeds silently (returns a key, never throws), so record
+        // it as a non-fatal to surface the corruption rate and any
+        // recover-every-launch loop in Crashlytics.
+        recordRecovery: (error, stack) => CrashReportingService.instance
+            .recordError(error, stack, reason: 'DB startup recovery'),
       ).resolveCipherKey(),
       // SQLite3MultipleCiphers build misconfiguration or secure-storage
       // failures must fail closed after reporting. Continuing with a null key

--- a/mobile/lib/services/database_encryption_bootstrap.dart
+++ b/mobile/lib/services/database_encryption_bootstrap.dart
@@ -32,6 +32,7 @@ class DatabaseEncryptionBootstrap {
     Future<void> Function()? onDatabaseReset,
     Future<bool> Function(String rawKeyHex)? canOpenEncryptedDatabase,
     Future<bool> Function(String rawKeyHex)? salvageDatabase,
+    Future<bool> Function(String rawKeyHex)? encryptedKeyMatches,
   }) : _secureStorage = secureStorage,
        _ensureRuntime = ensureRuntime ?? ensureSqlCipherRuntime,
        _isCipherAvailable = isCipherAvailable ?? isSqlCipherAvailable,
@@ -46,7 +47,10 @@ class DatabaseEncryptionBootstrap {
        _salvageDatabase =
            salvageDatabase ??
            ((rawKeyHex) =>
-               salvageCorruptEncryptedDatabase(rawKeyHex: rawKeyHex));
+               salvageCorruptEncryptedDatabase(rawKeyHex: rawKeyHex)),
+       _encryptedKeyMatches =
+           encryptedKeyMatches ??
+           ((rawKeyHex) => encryptedDatabaseKeyDecrypts(rawKeyHex: rawKeyHex));
 
   final FlutterSecureStorage _secureStorage;
   final Future<void> Function() _ensureRuntime;
@@ -56,9 +60,15 @@ class DatabaseEncryptionBootstrap {
   final Future<bool> Function(String rawKeyHex) _canOpenEncryptedDatabase;
 
   /// Attempts to salvage the local-only data from a corrupt encrypted database
-  /// (rebuilding it in place under the same key) before the destructive
-  /// key-rotation wipe. Returns `false` on genuine key loss.
+  /// (rebuilding it in place under the same key) before the destructive wipe.
+  /// Returns `false` on key loss or when a sound copy could not be rebuilt;
+  /// [_encryptedKeyMatches] then decides whether the wipe rotates the key.
   final Future<bool> Function(String rawKeyHex) _salvageDatabase;
+
+  /// Whether the key still decrypts the corrupt DB's schema page. Used only
+  /// when salvage fails, to keep a still-valid key (so the backup stays
+  /// readable) instead of rotating it. Returns `false` on genuine key loss.
+  final Future<bool> Function(String rawKeyHex) _encryptedKeyMatches;
 
   /// Invoked after the key-loss recreate wipes the Drift DB, so callers can
   /// clear local state that lives OUTSIDE the database (e.g. the DM sync
@@ -106,11 +116,11 @@ class DatabaseEncryptionBootstrap {
         }
         // The key either no longer opens the DB (stale) or opens it but
         // on-disk corruption surfaced when the Drift startup cleanup ran. Before
-        // the destructive key-rotation wipe, try to salvage the local-only data
-        // (drafts, clips, pending queues) into a fresh DB rebuilt in place
-        // under the SAME key. Local-only data cannot be re-fetched from relays,
-        // so preserving it matters. Salvage returns false on genuine key loss
-        // (nothing is readable), which falls through to the wipe.
+        // the destructive wipe, try to salvage the local-only data (drafts,
+        // clips, pending queues) into a fresh DB rebuilt in place under the SAME
+        // key. Local-only data cannot be re-fetched from relays, so preserving
+        // it matters. Salvage returns false on key loss (nothing decryptable)
+        // or a failure to rebuild a sound copy; the wipe below handles both.
         if (await _salvageDatabase(key)) {
           Log.warning(
             'Recovered a corrupt encrypted database by salvaging local-only '
@@ -121,6 +131,19 @@ class DatabaseEncryptionBootstrap {
           await _runPostDatabaseReset(_onDatabaseReset);
           return key;
         }
+        // Salvage failed. Only rotate the cipher key when it genuinely cannot
+        // decrypt the file: rotating a still-valid key would overwrite the only
+        // key that can read the `.pre_key_loss_wipe_backup` we are about to
+        // create, silently breaking the "backup stays readable" guarantee. A
+        // decryptable-but-unsalvageable DB (transient salvage failure, or a
+        // rebuilt copy that failed its own integrity check) is recreated under
+        // the SAME key so the backup stays recoverable.
+        if (await _encryptedKeyMatches(key)) {
+          return _recoverUnusableEncryptedDatabase(
+            key,
+            reason: 'corrupt and unsalvageable (key still valid)',
+          );
+        }
         final replacementKey = generateCipherKeyHex();
         await _secureStorage.write(
           key: dbCipherKeyStorageKey,
@@ -128,7 +151,7 @@ class DatabaseEncryptionBootstrap {
         );
         return _recoverUnusableEncryptedDatabase(
           replacementKey,
-          reason: 'stale',
+          reason: 'key loss',
         );
       case CipherMigrationOutcome.failed:
         Log.warning(
@@ -155,14 +178,14 @@ class DatabaseEncryptionBootstrap {
     String key, {
     required String reason,
   }) async {
-    // Key-loss recovery (#570 §6): the keystore was cleared, or it contains a
-    // valid-looking key that no longer opens the encrypted DB. Either way the
-    // DB is cryptographically unrecoverable, so it is backed up (not
-    // hard-deleted) and recreated under the current key. Local-only data is
-    // preserved in the backup; DMs resync from relays.
+    // Terminal recovery (#570 §6): the DB could not be used and could not be
+    // salvaged. It is backed up (not hard-deleted) and recreated under [key] —
+    // which the caller has either rotated (genuine key loss) or kept unchanged
+    // (decryptable-but-unsalvageable corruption, so the backup stays readable).
+    // Local-only data is preserved in the backup; DMs resync from relays.
     Log.warning(
-      'Encrypted database is unrecoverable ($reason cipher key). Backing it '
-      'up and recreating under a new key.',
+      'Encrypted database is unrecoverable ($reason). Backing it up and '
+      'recreating.',
       name: _logName,
     );
     await _deleteDatabase();

--- a/mobile/lib/services/database_encryption_bootstrap.dart
+++ b/mobile/lib/services/database_encryption_bootstrap.dart
@@ -31,6 +31,7 @@ class DatabaseEncryptionBootstrap {
     Future<void> Function()? deleteDatabase,
     Future<void> Function()? onDatabaseReset,
     Future<bool> Function(String rawKeyHex)? canOpenEncryptedDatabase,
+    Future<bool> Function(String rawKeyHex)? salvageDatabase,
   }) : _secureStorage = secureStorage,
        _ensureRuntime = ensureRuntime ?? ensureSqlCipherRuntime,
        _isCipherAvailable = isCipherAvailable ?? isSqlCipherAvailable,
@@ -41,7 +42,11 @@ class DatabaseEncryptionBootstrap {
        _onDatabaseReset = onDatabaseReset,
        _canOpenEncryptedDatabase =
            canOpenEncryptedDatabase ??
-           ((rawKeyHex) => encryptedDatabaseOpensWithKey(rawKeyHex: rawKeyHex));
+           ((rawKeyHex) => encryptedDatabaseOpensWithKey(rawKeyHex: rawKeyHex)),
+       _salvageDatabase =
+           salvageDatabase ??
+           ((rawKeyHex) =>
+               salvageCorruptEncryptedDatabase(rawKeyHex: rawKeyHex));
 
   final FlutterSecureStorage _secureStorage;
   final Future<void> Function() _ensureRuntime;
@@ -49,6 +54,11 @@ class DatabaseEncryptionBootstrap {
   final Future<CipherMigrationOutcome> Function(String rawKeyHex) _migrate;
   final Future<void> Function() _deleteDatabase;
   final Future<bool> Function(String rawKeyHex) _canOpenEncryptedDatabase;
+
+  /// Attempts to salvage the local-only data from a corrupt encrypted database
+  /// (rebuilding it in place under the same key) before the destructive
+  /// key-rotation wipe. Returns `false` on genuine key loss.
+  final Future<bool> Function(String rawKeyHex) _salvageDatabase;
 
   /// Invoked after the key-loss recreate wipes the Drift DB, so callers can
   /// clear local state that lives OUTSIDE the database (e.g. the DM sync
@@ -91,18 +101,35 @@ class DatabaseEncryptionBootstrap {
         if (wasGenerated) {
           return _recoverUnusableEncryptedDatabase(key, reason: 'missing');
         }
-        if (!await _canOpenEncryptedDatabase(key)) {
-          final replacementKey = generateCipherKeyHex();
-          await _secureStorage.write(
-            key: dbCipherKeyStorageKey,
-            value: replacementKey,
-          );
-          return _recoverUnusableEncryptedDatabase(
-            replacementKey,
-            reason: 'stale',
-          );
+        if (await _canOpenEncryptedDatabase(key)) {
+          return key;
         }
-        return key;
+        // The key either no longer opens the DB (stale) or opens it but it
+        // failed the integrity check (on-disk corruption). Before the
+        // destructive key-rotation wipe, try to salvage the local-only data
+        // (drafts, clips, pending queues) into a fresh DB rebuilt in place
+        // under the SAME key. Local-only data cannot be re-fetched from relays,
+        // so preserving it matters. Salvage returns false on genuine key loss
+        // (nothing is readable), which falls through to the wipe.
+        if (await _salvageDatabase(key)) {
+          Log.warning(
+            'Recovered a corrupt encrypted database by salvaging local-only '
+            'data into a fresh database; the corrupt file was backed up. DMs '
+            'and relay-backed caches resync.',
+            name: _logName,
+          );
+          await _runPostDatabaseReset(_onDatabaseReset);
+          return key;
+        }
+        final replacementKey = generateCipherKeyHex();
+        await _secureStorage.write(
+          key: dbCipherKeyStorageKey,
+          value: replacementKey,
+        );
+        return _recoverUnusableEncryptedDatabase(
+          replacementKey,
+          reason: 'stale',
+        );
       case CipherMigrationOutcome.failed:
         Log.warning(
           'At-rest DB migration did not complete; opening plaintext this '

--- a/mobile/lib/services/database_encryption_bootstrap.dart
+++ b/mobile/lib/services/database_encryption_bootstrap.dart
@@ -33,7 +33,9 @@ class DatabaseEncryptionBootstrap {
     Future<bool> Function(String rawKeyHex)? canOpenEncryptedDatabase,
     Future<bool> Function(String rawKeyHex)? salvageDatabase,
     Future<bool> Function(String rawKeyHex)? encryptedKeyMatches,
+    Future<void> Function(Object error, StackTrace stack)? recordRecovery,
   }) : _secureStorage = secureStorage,
+       _recordRecovery = recordRecovery,
        _ensureRuntime = ensureRuntime ?? ensureSqlCipherRuntime,
        _isCipherAvailable = isCipherAvailable ?? isSqlCipherAvailable,
        _migrate =
@@ -69,6 +71,13 @@ class DatabaseEncryptionBootstrap {
   /// when salvage fails, to keep a still-valid key (so the backup stays
   /// readable) instead of rotating it. Returns `false` on genuine key loss.
   final Future<bool> Function(String rawKeyHex) _encryptedKeyMatches;
+
+  /// Records a startup DB recovery (salvage or wipe) as a non-fatal so the
+  /// corruption rate — and a device recovering on every launch — is observable
+  /// in Crashlytics. Recovery succeeds silently otherwise: it does not throw,
+  /// so it never reaches the startup error reporter. Best-effort; `null` in
+  /// tests that don't assert on it.
+  final Future<void> Function(Object error, StackTrace stack)? _recordRecovery;
 
   /// Invoked after the key-loss recreate wipes the Drift DB, so callers can
   /// clear local state that lives OUTSIDE the database (e.g. the DM sync
@@ -128,6 +137,7 @@ class DatabaseEncryptionBootstrap {
             'and relay-backed caches resync.',
             name: _logName,
           );
+          await _reportRecovery('salvaged local-only data into a fresh DB');
           await _runPostDatabaseReset(_onDatabaseReset);
           return key;
         }
@@ -189,9 +199,36 @@ class DatabaseEncryptionBootstrap {
       name: _logName,
     );
     await _deleteDatabase();
+    await _reportRecovery('backed up + recreated ($reason)');
     await _runPostDatabaseReset(_onDatabaseReset);
     return key;
   }
+
+  /// Records a recovery as a non-fatal Crashlytics event. Best-effort: a
+  /// reporting failure must never fail startup now that recovery has succeeded.
+  Future<void> _reportRecovery(String reason) async {
+    try {
+      await _recordRecovery?.call(
+        DatabaseRecoveryEvent(reason),
+        StackTrace.current,
+      );
+    } on Object catch (e) {
+      Log.warning('Recovery reporting failed (non-fatal): $e', name: _logName);
+    }
+  }
+}
+
+/// Non-fatal marker recorded to Crashlytics when the startup DB recovery runs
+/// (salvage or wipe), so the corruption/recovery rate — and a device recovering
+/// on every launch — is observable. Not a programming error; it carries only
+/// the recovery [reason] and never embeds key material or DB contents.
+class DatabaseRecoveryEvent implements Exception {
+  DatabaseRecoveryEvent(this.reason);
+
+  final String reason;
+
+  @override
+  String toString() => 'DatabaseRecoveryEvent: $reason';
 }
 
 class DatabaseCipherUnavailableError extends StateError {

--- a/mobile/lib/services/database_encryption_bootstrap.dart
+++ b/mobile/lib/services/database_encryption_bootstrap.dart
@@ -42,7 +42,7 @@ class DatabaseEncryptionBootstrap {
        _onDatabaseReset = onDatabaseReset,
        _canOpenEncryptedDatabase =
            canOpenEncryptedDatabase ??
-           ((rawKeyHex) => encryptedDatabaseOpensWithKey(rawKeyHex: rawKeyHex)),
+           ((rawKeyHex) => encryptedDatabaseOpensCleanly(rawKeyHex: rawKeyHex)),
        _salvageDatabase =
            salvageDatabase ??
            ((rawKeyHex) =>
@@ -104,9 +104,9 @@ class DatabaseEncryptionBootstrap {
         if (await _canOpenEncryptedDatabase(key)) {
           return key;
         }
-        // The key either no longer opens the DB (stale) or opens it but it
-        // failed the integrity check (on-disk corruption). Before the
-        // destructive key-rotation wipe, try to salvage the local-only data
+        // The key either no longer opens the DB (stale) or opens it but
+        // on-disk corruption surfaced when the Drift startup cleanup ran. Before
+        // the destructive key-rotation wipe, try to salvage the local-only data
         // (drafts, clips, pending queues) into a fresh DB rebuilt in place
         // under the SAME key. Local-only data cannot be re-fetched from relays,
         // so preserving it matters. Salvage returns false on genuine key loss

--- a/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
@@ -8,7 +8,8 @@ import 'package:drift/native.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
-import 'package:sqlite3/common.dart' show CommonDatabase;
+import 'package:sqlite3/common.dart'
+    show CommonDatabase, CommonPreparedStatement;
 import 'package:sqlite3/sqlite3.dart';
 
 /// Open a database connection for native platforms
@@ -119,6 +120,39 @@ Future<bool> encryptedDatabaseOpensWithKey({
   }
 }
 
+/// Whether [rawKeyHex] can decrypt the database at [databasePath] — i.e. it is
+/// the correct cipher key, independent of deeper b-tree integrity.
+///
+/// [applyCipherKey] reads `sqlite_master` (the schema page), so this returns
+/// `true` for a decryptable-but-corrupt database and `false` only on a genuine
+/// key mismatch (SQLITE_NOTADB) or an unreadable schema page (SQLITE_CORRUPT).
+/// The app-layer recovery uses it to tell "salvage failed under a working key"
+/// (keep the key so the `.pre_key_loss_wipe_backup` stays readable) apart from
+/// real key loss (rotate). Returns `false` when the file is missing.
+Future<bool> encryptedDatabaseKeyDecrypts({
+  required String rawKeyHex,
+  String? databasePath,
+}) async {
+  _rawKeyLiteral(rawKeyHex);
+
+  final dbPath = databasePath ?? await getSharedDatabasePath();
+  if (!File(dbPath).existsSync()) return false;
+
+  Database? db;
+  try {
+    db = sqlite3.open(dbPath);
+    applyCipherKey(db, rawKeyHex);
+    return true;
+  } on SqliteException catch (e) {
+    if (e.resultCode == _sqliteNotADb || e.resultCode == _sqliteCorrupt) {
+      return false;
+    }
+    rethrow;
+  } finally {
+    db?.close();
+  }
+}
+
 /// Returns whether [db] passes SQLite's `PRAGMA quick_check` — i.e. every
 /// table and index b-tree is structurally sound.
 ///
@@ -160,6 +194,11 @@ const _corruptionBackupSuffix = '.pre_corruption_recovery_backup';
 /// re-drain from gift wraps on relays, which the app-layer recovery triggers by
 /// clearing the DM sync state after a salvage. `outgoing_dms` is kept because
 /// unsent outbound messages are not yet on any relay.
+///
+/// This is the local-only set also tracked by [_localOnlyDataQueries] (the
+/// legacy-migration "is there actionable data worth preserving" probe), minus
+/// `direct_messages` / `conversations`. A new local-only table added to one
+/// list should be considered for the other.
 @visibleForTesting
 const salvageableLocalOnlyTables = <String>[
   'drafts',
@@ -245,13 +284,21 @@ bool _buildSalvageCopy({
     target = sqlite3.open(salvagePath);
     applyCipherKey(target, rawKeyHex);
     _copyDatabaseSchema(source: source, target: target);
-    // Carry Drift's schema version so it opens the salvaged file as an
-    // existing database (running beforeOpen) instead of a fresh one — a fresh
-    // open re-runs onCreate and fails with "table already exists".
-    target.execute('PRAGMA user_version = ${_userVersion(source)};');
+    // Carry Drift's schema version so it opens the salvaged file as an existing
+    // database (running beforeOpen) instead of a fresh one — a fresh open
+    // re-runs onCreate and fails with "table already exists". Then wrap the row
+    // copy in one transaction: without it each INSERT is its own fsync'd
+    // autocommit, so salvaging thousands of rows can take many seconds on
+    // device flash. The per-row skips inside [_copySalvageableRows] never
+    // throw, so COMMIT is always reached; a schema/DDL failure above is caught
+    // before BEGIN.
+    target
+      ..execute('PRAGMA user_version = ${_userVersion(source)};')
+      ..execute('BEGIN;');
     for (final table in salvageableLocalOnlyTables) {
       _copySalvageableRows(source: source, target: target, table: table);
     }
+    target.execute('COMMIT;');
     return true;
   } on SqliteException {
     return false;
@@ -280,33 +327,60 @@ void _copyDatabaseSchema({
   }
 }
 
-/// Copies every readable row of [table] from [source] to [target], skipping the
-/// table entirely if its own pages are corrupt and skipping any individual row
-/// that cannot be read or re-inserted.
+/// Copies the readable rows of [table] from [source] to [target], keeping every
+/// row before a corrupt page and skipping any individual row that cannot be
+/// re-inserted.
+///
+/// Iterates a statement **cursor** rather than materializing `SELECT *`
+/// eagerly: an eager `select()` on a table whose own pages are corrupt throws
+/// before yielding anything, salvaging **zero** rows — even for the
+/// drafts/clips this exists to save. A cursor yields every row up to the
+/// corrupt page, then
+/// `moveNext()` throws and the readable prefix is kept.
 void _copySalvageableRows({
   required CommonDatabase source,
   required CommonDatabase target,
   required String table,
 }) {
-  final ResultSet rows;
+  final CommonPreparedStatement select;
   try {
-    rows = source.select('SELECT * FROM "$table";');
+    select = source.prepare('SELECT * FROM "$table";');
   } on SqliteException {
     return;
   }
-  if (rows.isEmpty) return;
+  try {
+    final cursor = select.selectCursor();
+    String? insert;
+    List<String>? columns;
+    while (_cursorHasNextRow(cursor)) {
+      final row = cursor.current;
+      final resolvedColumns = columns ??= cursor.columnNames;
+      insert ??= _buildRowInsert(table, resolvedColumns);
+      try {
+        target.execute(insert, [for (final c in resolvedColumns) row[c]]);
+      } on SqliteException {
+        // Skip an individual unreadable / conflicting row; keep the rest.
+      }
+    }
+  } finally {
+    select.close();
+  }
+}
 
-  final columns = rows.columnNames;
+/// Advances [cursor], treating a mid-iteration corruption as end-of-data so the
+/// readable prefix already copied is kept.
+bool _cursorHasNextRow(IteratingCursor cursor) {
+  try {
+    return cursor.moveNext();
+  } on SqliteException {
+    return false;
+  }
+}
+
+String _buildRowInsert(String table, List<String> columns) {
   final columnList = columns.map((c) => '"$c"').join(', ');
   final placeholders = List.filled(columns.length, '?').join(', ');
-  final insert = 'INSERT INTO "$table" ($columnList) VALUES ($placeholders);';
-  for (final row in rows) {
-    try {
-      target.execute(insert, [for (final column in columns) row[column]]);
-    } on SqliteException {
-      // Skip an individual unreadable / conflicting row; keep the rest.
-    }
-  }
+  return 'INSERT INTO "$table" ($columnList) VALUES ($placeholders);';
 }
 
 /// Keys [rawDb] with [rawKeyHex] and verifies SQLite3MultipleCiphers is active.
@@ -434,6 +508,17 @@ Future<CipherMigrationOutcome> migratePlaintextToEncrypted({
     return CipherMigrationOutcome.migrated;
   }
 
+  // Resume an interrupted salvage swap (see [salvageCorruptEncryptedDatabase]).
+  // A force-kill after the corrupt original was renamed to its backup but
+  // before the verified salvage copy was promoted leaves the salvage file with
+  // no file at [dbPath] — the same window the migration resume above covers.
+  // Promoting the still-sound salvage completes the swap instead of stranding
+  // the recovered drafts/clips and creating a fresh empty database.
+  if (!File(dbPath).existsSync() &&
+      await _resumeInterruptedSalvage(dbPath: dbPath, rawKeyHex: rawKeyHex)) {
+    return CipherMigrationOutcome.alreadyEncrypted;
+  }
+
   if (!File(dbPath).existsSync()) return CipherMigrationOutcome.noDatabase;
 
   switch (_classifyDatabase(dbPath)) {
@@ -451,6 +536,35 @@ Future<CipherMigrationOutcome> migratePlaintextToEncrypted({
     case _DbClassification.populatedPlaintext:
       return _rekeyPlaintextInPlace(dbPath: dbPath, rawKeyHex: rawKeyHex);
   }
+}
+
+/// Completes a salvage swap that was interrupted after the corrupt original was
+/// backed up but before the verified salvage copy was promoted into place.
+/// Mirrors the `.sqlcipher_migrating` resume in [migratePlaintextToEncrypted].
+///
+/// The salvage copy is re-verified under [rawKeyHex] before promotion; an
+/// unusable leftover is discarded so startup falls through to creating a fresh
+/// database. Returns whether a salvage copy was promoted into [dbPath].
+Future<bool> _resumeInterruptedSalvage({
+  required String dbPath,
+  required String rawKeyHex,
+}) async {
+  final salvagePath = '$dbPath$_salvageSuffix';
+  if (!File(salvagePath).existsSync()) return false;
+
+  if (await encryptedDatabaseOpensWithKey(
+    rawKeyHex: rawKeyHex,
+    databasePath: salvagePath,
+  )) {
+    promoteEncryptedMigrationArtifact(
+      encryptedPath: salvagePath,
+      dbPath: dbPath,
+    );
+    return true;
+  }
+
+  _deleteDatabaseAndSidecars(salvagePath);
+  return false;
 }
 
 const _migratingSuffix = '.sqlcipher_migrating';

--- a/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
@@ -190,10 +190,13 @@ const _corruptionBackupSuffix = '.pre_corruption_recovery_backup';
 /// The large relay-backed caches (`event`, `video_metrics`, profile/hashtag
 /// stats, `user_profiles`, `notifications`, `nip05_verifications`) are
 /// intentionally omitted: they resync from relays and copying them would be
-/// unbounded. `direct_messages` / `conversations` are also omitted — they
-/// re-drain from gift wraps on relays, which the app-layer recovery triggers by
-/// clearing the DM sync state after a salvage. `outgoing_dms` is kept because
-/// unsent outbound messages are not yet on any relay.
+/// unbounded. `direct_messages` / `conversations` / `dm_message_reactions` are
+/// also omitted — they re-drain from gift wraps on relays, which the app-layer
+/// recovery triggers by clearing the DM sync state after a salvage. (A DM
+/// reaction whose gift wrap has not been sent yet is re-derivable from the
+/// relay-backed conversation, unlike an `outgoing_dms` message.) `outgoing_dms`
+/// is kept because unsent outbound messages are not yet on any relay.
+/// `pending_view_events` is omitted as best-effort view telemetry.
 ///
 /// This is the local-only set also tracked by [_localOnlyDataQueries] (the
 /// legacy-migration "is there actionable data worth preserving" probe), minus

--- a/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
@@ -73,13 +73,23 @@ QueryExecutor openEncryptedConnection({required String rawKeyHex}) {
   });
 }
 
-/// Returns whether the shared encrypted database opens with [rawKeyHex].
+/// Returns whether the shared encrypted database opens **and is structurally
+/// intact** with [rawKeyHex].
 ///
 /// This is a startup guard for the app layer: a valid-looking key can remain
 /// in secure storage while the database file belongs to a different key
 /// (backup/restore drift, partial reinstall, manual sandbox surgery). In that
 /// case the DB is just as unrecoverable as a missing key and should be backed
 /// up/recreated before the first Drift provider touches it.
+///
+/// It also runs [databasePassesIntegrityCheck]. [applyCipherKey] only reads
+/// `sqlite_master` (the schema page), so on-disk corruption localised to a
+/// table or index b-tree passes this guard and only surfaces later inside
+/// Drift's `beforeOpen` startup cleanup (`DELETE FROM event …`) — past the
+/// recovery gate, where SQLITE_CORRUPT then throws on every query and bricks
+/// the session until reinstall. Walking every b-tree here lets that corruption
+/// be detected at the same gate that already handles a stale cipher key, so
+/// the caller backs the file up and recreates it.
 Future<bool> encryptedDatabaseOpensWithKey({
   required String rawKeyHex,
   String? databasePath,
@@ -93,12 +103,204 @@ Future<bool> encryptedDatabaseOpensWithKey({
   try {
     db = sqlite3.open(dbPath);
     applyCipherKey(db, rawKeyHex);
-    return true;
+    return databasePassesIntegrityCheck(db);
   } on SqliteException catch (e) {
-    if (e.resultCode == _sqliteNotADb) return false;
+    if (e.resultCode == _sqliteNotADb || e.resultCode == _sqliteCorrupt) {
+      return false;
+    }
     rethrow;
   } finally {
     db?.close();
+  }
+}
+
+/// Returns whether [db] passes SQLite's `PRAGMA quick_check` — i.e. every
+/// table and index b-tree is structurally sound.
+///
+/// `quick_check` walks the page structure of all b-trees (skipping only the
+/// slower row-content and foreign-key validation that `integrity_check` adds),
+/// so it detects the malformed-index / malformed-page corruption that a bare
+/// `sqlite_master` read misses, while staying cheap enough for a startup
+/// probe. It returns a single `'ok'` row on a healthy database; any other
+/// output — or a thrown [SqliteException] on a badly damaged file — is treated
+/// as corruption.
+@visibleForTesting
+bool databasePassesIntegrityCheck(CommonDatabase db) {
+  try {
+    final rows = db.select('PRAGMA quick_check;');
+    if (rows.length != 1) return false;
+    final result = rows.first.values.first;
+    return result is String && result.toLowerCase() == 'ok';
+  } on SqliteException {
+    return false;
+  }
+}
+
+/// Suffix for the in-progress salvage copy built by
+/// [salvageCorruptEncryptedDatabase].
+const _salvageSuffix = '.corruption_salvage';
+
+/// Suffix for the corrupt original preserved by
+/// [salvageCorruptEncryptedDatabase]. Kept (not deleted) under the same cipher
+/// key, so it stays readable for any later recovery.
+const _corruptionBackupSuffix = '.pre_corruption_recovery_backup';
+
+/// Tables whose rows are local-only and cannot be re-fetched from relays, so
+/// they are copied during salvage.
+///
+/// The large relay-backed caches (`event`, `video_metrics`, profile/hashtag
+/// stats, `user_profiles`, `notifications`, `nip05_verifications`) are
+/// intentionally omitted: they resync from relays and copying them would be
+/// unbounded. `direct_messages` / `conversations` are also omitted — they
+/// re-drain from gift wraps on relays, which the app-layer recovery triggers by
+/// clearing the DM sync state after a salvage. `outgoing_dms` is kept because
+/// unsent outbound messages are not yet on any relay.
+@visibleForTesting
+const salvageableLocalOnlyTables = <String>[
+  'drafts',
+  'clips',
+  'pending_uploads',
+  'pending_actions',
+  'outgoing_dms',
+  'personal_reactions',
+  'personal_reposts',
+];
+
+/// Salvages a corrupt encrypted database in place, preserving the local-only
+/// data ([salvageableLocalOnlyTables]) that cannot be re-fetched from relays.
+///
+/// The app-layer startup recovery calls this when [rawKeyHex] opens the
+/// database but it fails [databasePassesIntegrityCheck]. Reading a *table* does
+/// not traverse a corrupt *index*, so rows on intact pages are recovered even
+/// when `PRAGMA quick_check` fails. Readable rows are copied into a fresh
+/// database keyed with the **same** [rawKeyHex]; the fresh database replaces
+/// the corrupt one, which is renamed to a `.pre_corruption_recovery_backup`
+/// backup (still readable under the same key). Re-fetchable caches are dropped
+/// and resync.
+///
+/// Returns `true` when a fresh, integrity-clean database was swapped into
+/// place. Returns `false` when [rawKeyHex] cannot decrypt the file (genuine
+/// key loss — nothing is salvageable) or the salvage copy could not be made
+/// sound; in both cases the original file is left untouched and the caller
+/// should rotate the key and recreate.
+Future<bool> salvageCorruptEncryptedDatabase({
+  required String rawKeyHex,
+  String? databasePath,
+}) async {
+  _rawKeyLiteral(rawKeyHex);
+
+  final dbPath = databasePath ?? await getSharedDatabasePath();
+  if (!File(dbPath).existsSync()) return false;
+
+  final salvagePath = '$dbPath$_salvageSuffix';
+  _deleteDatabaseAndSidecars(salvagePath);
+
+  // Build the salvage copy, then only swap it in if it is itself sound. On any
+  // failure (wrong key, unbuildable, unsound copy) leave the original intact.
+  final built = _buildSalvageCopy(
+    sourcePath: dbPath,
+    salvagePath: salvagePath,
+    rawKeyHex: rawKeyHex,
+  );
+  final usable =
+      built &&
+      await encryptedDatabaseOpensWithKey(
+        rawKeyHex: rawKeyHex,
+        databasePath: salvagePath,
+      );
+  if (!usable) {
+    _deleteDatabaseAndSidecars(salvagePath);
+    return false;
+  }
+
+  final backupPath = _nextDatabaseBackupPath(
+    dbPath,
+    suffix: _corruptionBackupSuffix,
+  );
+  File(dbPath).renameSync(backupPath);
+  _moveSidecars(fromPath: dbPath, toPath: backupPath);
+  promoteEncryptedMigrationArtifact(encryptedPath: salvagePath, dbPath: dbPath);
+  return true;
+}
+
+/// Opens the corrupt source and a fresh keyed target, recreates the schema, and
+/// copies the salvageable rows. Returns `false` when the key cannot decrypt the
+/// source (`SqliteException`) — a build-level cipher failure (`StateError`) is
+/// left to propagate, matching the rest of this file.
+bool _buildSalvageCopy({
+  required String sourcePath,
+  required String salvagePath,
+  required String rawKeyHex,
+}) {
+  Database? source;
+  Database? target;
+  try {
+    source = sqlite3.open(sourcePath);
+    applyCipherKey(source, rawKeyHex);
+    target = sqlite3.open(salvagePath);
+    applyCipherKey(target, rawKeyHex);
+    _copyDatabaseSchema(source: source, target: target);
+    // Carry Drift's schema version so it opens the salvaged file as an
+    // existing database (running beforeOpen) instead of a fresh one — a fresh
+    // open re-runs onCreate and fails with "table already exists".
+    target.execute('PRAGMA user_version = ${_userVersion(source)};');
+    for (final table in salvageableLocalOnlyTables) {
+      _copySalvageableRows(source: source, target: target, table: table);
+    }
+    return true;
+  } on SqliteException {
+    return false;
+  } finally {
+    source?.close();
+    target?.close();
+  }
+}
+
+/// Recreates every schema object from [source] in [target] so the salvaged
+/// database matches the schema Drift expects. Tables are created before the
+/// views / indexes / triggers that depend on them.
+void _copyDatabaseSchema({
+  required CommonDatabase source,
+  required CommonDatabase target,
+}) {
+  for (final type in const ['table', 'view', 'index', 'trigger']) {
+    final rows = source.select(
+      'SELECT sql FROM sqlite_master WHERE type = ? AND sql IS NOT NULL '
+      "AND name NOT LIKE 'sqlite_%';",
+      [type],
+    );
+    for (final row in rows) {
+      target.execute(row['sql'] as String);
+    }
+  }
+}
+
+/// Copies every readable row of [table] from [source] to [target], skipping the
+/// table entirely if its own pages are corrupt and skipping any individual row
+/// that cannot be read or re-inserted.
+void _copySalvageableRows({
+  required CommonDatabase source,
+  required CommonDatabase target,
+  required String table,
+}) {
+  final ResultSet rows;
+  try {
+    rows = source.select('SELECT * FROM "$table";');
+  } on SqliteException {
+    return;
+  }
+  if (rows.isEmpty) return;
+
+  final columns = rows.columnNames;
+  final columnList = columns.map((c) => '"$c"').join(', ');
+  final placeholders = List.filled(columns.length, '?').join(', ');
+  final insert = 'INSERT INTO "$table" ($columnList) VALUES ($placeholders);';
+  for (final row in rows) {
+    try {
+      target.execute(insert, [for (final column in columns) row[column]]);
+    } on SqliteException {
+      // Skip an individual unreadable / conflicting row; keep the rest.
+    }
   }
 }
 
@@ -248,6 +450,9 @@ Future<CipherMigrationOutcome> migratePlaintextToEncrypted({
 
 const _migratingSuffix = '.sqlcipher_migrating';
 const _sqliteNotADb = 26; // SQLITE_NOTADB
+// Primary result code for every SQLITE_CORRUPT_* extended code (e.g. 779
+// SQLITE_CORRUPT_INDEX), so this matches whichever variant SQLite reports.
+const _sqliteCorrupt = 11; // SQLITE_CORRUPT
 
 enum _DbClassification {
   encrypted,

--- a/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
@@ -49,14 +49,21 @@ bool get _isFlutterTestProcess =>
 /// throws
 /// rather than silently writing plaintext.
 ///
+/// [databasePath] overrides the shared database location; it defaults to
+/// [getSharedDatabasePath] and exists so probes/tests
+/// (`encryptedDatabaseOpensCleanly`) can point at a specific file.
+///
 /// Throws [ArgumentError] if [rawKeyHex] is malformed (the error never embeds
 /// the key — see [formatCipherKeyPragma]).
-QueryExecutor openEncryptedConnection({required String rawKeyHex}) {
+QueryExecutor openEncryptedConnection({
+  required String rawKeyHex,
+  String? databasePath,
+}) {
   // Validate eagerly so a malformed key fails fast at construction time.
   _rawKeyLiteral(rawKeyHex);
 
   return LazyDatabase(() async {
-    final dbPath = await getSharedDatabasePath();
+    final dbPath = databasePath ?? await getSharedDatabasePath();
     final dbFile = prepareDatabaseFile(dbPath);
     // Open on a background isolate so the SQLite3MultipleCiphers per-page
     // AES-256-CBC + HMAC-SHA512 work (every read and write) never runs on the
@@ -73,23 +80,21 @@ QueryExecutor openEncryptedConnection({required String rawKeyHex}) {
   });
 }
 
-/// Returns whether the shared encrypted database opens **and is structurally
-/// intact** with [rawKeyHex].
+/// Returns whether the encrypted database at [databasePath] opens with
+/// [rawKeyHex] and is structurally intact, via
+/// [databasePassesIntegrityCheck].
 ///
-/// This is a startup guard for the app layer: a valid-looking key can remain
-/// in secure storage while the database file belongs to a different key
-/// (backup/restore drift, partial reinstall, manual sandbox surgery). In that
-/// case the DB is just as unrecoverable as a missing key and should be backed
-/// up/recreated before the first Drift provider touches it.
+/// This verifies a freshly-rebuilt salvage copy before
+/// [salvageCorruptEncryptedDatabase] swaps it into place: it must open under
+/// the same key and pass a full `PRAGMA quick_check`. The whole-database scan
+/// is appropriate here because the salvage copy is small (local-only rows plus
+/// empty caches).
 ///
-/// It also runs [databasePassesIntegrityCheck]. [applyCipherKey] only reads
-/// `sqlite_master` (the schema page), so on-disk corruption localised to a
-/// table or index b-tree passes this guard and only surfaces later inside
-/// Drift's `beforeOpen` startup cleanup (`DELETE FROM event …`) — past the
-/// recovery gate, where SQLITE_CORRUPT then throws on every query and bricks
-/// the session until reinstall. Walking every b-tree here lets that corruption
-/// be detected at the same gate that already handles a stale cipher key, so
-/// the caller backs the file up and recreates it.
+/// It is intentionally **not** used as the startup guard for the large
+/// production database — that would add an unbounded whole-DB scan to every
+/// launch. The app-layer startup recovery instead uses the reactive
+/// `encryptedDatabaseOpensCleanly`, which forces Drift's `beforeOpen` cleanup
+/// (the operation that trips on the field corruption) rather than pre-scanning.
 Future<bool> encryptedDatabaseOpensWithKey({
   required String rawKeyHex,
   String? databasePath,

--- a/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
@@ -124,11 +124,15 @@ Future<bool> encryptedDatabaseOpensWithKey({
 /// the correct cipher key, independent of deeper b-tree integrity.
 ///
 /// [applyCipherKey] reads `sqlite_master` (the schema page), so this returns
-/// `true` for a decryptable-but-corrupt database and `false` only on a genuine
-/// key mismatch (SQLITE_NOTADB) or an unreadable schema page (SQLITE_CORRUPT).
-/// The app-layer recovery uses it to tell "salvage failed under a working key"
-/// (keep the key so the `.pre_key_loss_wipe_backup` stays readable) apart from
-/// real key loss (rotate). Returns `false` when the file is missing.
+/// `true` for a decryptable-but-corrupt database — including SQLITE_CORRUPT,
+/// which means the key decrypted the page far enough to hit a *structural*
+/// error, so the key is valid. It returns `false` only on SQLITE_NOTADB (the
+/// key cannot decrypt the file). The app-layer recovery uses it to tell
+/// "salvage failed under a working key" (keep the key so the
+/// `.pre_key_loss_wipe_backup` stays readable) apart from real key loss
+/// (rotate); classifying schema-page corruption as key loss would rotate a
+/// still-valid key and orphan that backup. Returns `false` when the file is
+/// missing.
 Future<bool> encryptedDatabaseKeyDecrypts({
   required String rawKeyHex,
   String? databasePath,
@@ -144,9 +148,10 @@ Future<bool> encryptedDatabaseKeyDecrypts({
     applyCipherKey(db, rawKeyHex);
     return true;
   } on SqliteException catch (e) {
-    if (e.resultCode == _sqliteNotADb || e.resultCode == _sqliteCorrupt) {
-      return false;
-    }
+    if (e.resultCode == _sqliteNotADb) return false;
+    // SQLITE_CORRUPT means the key decrypted the page but the b-tree is
+    // structurally damaged — the key is valid, so keep it (don't rotate).
+    if (e.resultCode == _sqliteCorrupt) return true;
     rethrow;
   } finally {
     db?.close();
@@ -190,18 +195,23 @@ const _corruptionBackupSuffix = '.pre_corruption_recovery_backup';
 /// The large relay-backed caches (`event`, `video_metrics`, profile/hashtag
 /// stats, `user_profiles`, `notifications`, `nip05_verifications`) are
 /// intentionally omitted: they resync from relays and copying them would be
-/// unbounded. `direct_messages` / `conversations` / `dm_message_reactions` are
-/// also omitted — they re-drain from gift wraps on relays, which the app-layer
-/// recovery triggers by clearing the DM sync state after a salvage. (A DM
-/// reaction whose gift wrap has not been sent yet is re-derivable from the
-/// relay-backed conversation, unlike an `outgoing_dms` message.) `outgoing_dms`
-/// is kept because unsent outbound messages are not yet on any relay.
-/// `pending_view_events` is omitted as best-effort view telemetry.
+/// unbounded. `direct_messages` / `conversations` are also omitted — they
+/// re-drain from gift wraps on relays, which the app-layer recovery triggers by
+/// clearing the DM sync state after a salvage. `pending_view_events` is omitted
+/// as best-effort view telemetry.
 ///
-/// This is the local-only set also tracked by [_localOnlyDataQueries] (the
-/// legacy-migration "is there actionable data worth preserving" probe), minus
-/// `direct_messages` / `conversations`. A new local-only table added to one
-/// list should be considered for the other.
+/// `outgoing_dms` and `dm_message_reactions` are kept: an unsent outbound
+/// message or a `failed`/`pending` reaction (`gift_wrap_id IS NULL`) was never
+/// wrapped to any relay, and the reaction rumor lives **only** in
+/// `dm_message_reactions.rumor_event_json` (read back by
+/// `DmReactionsRepository` on retry). Re-draining restores the target message,
+/// not the user's unsent reaction, so it is the same only-copy case as
+/// `outgoing_dms`.
+///
+/// This overlaps the [_localOnlyDataQueries] legacy-migration probe but is not
+/// identical: salvage drops `direct_messages` / `conversations` (re-drainable)
+/// and adds `dm_message_reactions` (only-copy). A new local-only table added to
+/// one list should be considered for the other.
 @visibleForTesting
 const salvageableLocalOnlyTables = <String>[
   'drafts',
@@ -211,6 +221,7 @@ const salvageableLocalOnlyTables = <String>[
   'outgoing_dms',
   'personal_reactions',
   'personal_reposts',
+  'dm_message_reactions',
 ];
 
 /// Salvages a corrupt encrypted database in place, preserving the local-only

--- a/mobile/packages/db_client/lib/src/database/connection/connection_stub.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_stub.dart
@@ -26,6 +26,14 @@ Future<bool> encryptedDatabaseOpensWithKey({
   throw UnsupportedError('No database implementation found for this platform');
 }
 
+/// Stub implementation - will be replaced by conditional imports
+Future<bool> salvageCorruptEncryptedDatabase({
+  required String rawKeyHex,
+  String? databasePath,
+}) async {
+  throw UnsupportedError('No database implementation found for this platform');
+}
+
 /// Outcome of [migratePlaintextToEncrypted]. Mirrors the native enum so app
 /// code that switches on it compiles when only the stub is available.
 enum CipherMigrationOutcome {

--- a/mobile/packages/db_client/lib/src/database/connection/connection_stub.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_stub.dart
@@ -14,7 +14,10 @@ Future<String> getSharedDatabasePath() async {
 }
 
 /// Stub implementation - will be replaced by conditional imports
-QueryExecutor openEncryptedConnection({required String rawKeyHex}) {
+QueryExecutor openEncryptedConnection({
+  required String rawKeyHex,
+  String? databasePath,
+}) {
   throw UnsupportedError('No database implementation found for this platform');
 }
 

--- a/mobile/packages/db_client/lib/src/database/connection/connection_stub.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_stub.dart
@@ -37,6 +37,14 @@ Future<bool> salvageCorruptEncryptedDatabase({
   throw UnsupportedError('No database implementation found for this platform');
 }
 
+/// Stub implementation - will be replaced by conditional imports
+Future<bool> encryptedDatabaseKeyDecrypts({
+  required String rawKeyHex,
+  String? databasePath,
+}) async {
+  throw UnsupportedError('No database implementation found for this platform');
+}
+
 /// Outcome of [migratePlaintextToEncrypted]. Mirrors the native enum so app
 /// code that switches on it compiles when only the stub is available.
 enum CipherMigrationOutcome {

--- a/mobile/packages/db_client/lib/src/database/connection/connection_web.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_web.dart
@@ -25,7 +25,10 @@ Future<String> getSharedDatabasePath() async {
 /// Web at-rest encryption is deferred behind the OPFS migration (#373). The
 /// app guards encryption with `kIsWeb`, so this is never reached at runtime —
 /// it exists only so app code compiles for web. See the native variant.
-QueryExecutor openEncryptedConnection({required String rawKeyHex}) {
+QueryExecutor openEncryptedConnection({
+  required String rawKeyHex,
+  String? databasePath,
+}) {
   throw UnsupportedError(
     'Native at-rest encryption is not supported on web',
   );

--- a/mobile/packages/db_client/lib/src/database/connection/connection_web.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_web.dart
@@ -42,6 +42,17 @@ Future<bool> encryptedDatabaseOpensWithKey({
   );
 }
 
+/// Corruption salvage is native-only; startup skips DB encryption on web.
+/// Never reached at runtime (guarded by `kIsWeb` in the app).
+Future<bool> salvageCorruptEncryptedDatabase({
+  required String rawKeyHex,
+  String? databasePath,
+}) async {
+  throw UnsupportedError(
+    'Native at-rest encryption is not supported on web',
+  );
+}
+
 /// No-op on web (key-loss recovery is native-only). Never reached at runtime.
 Future<void> backUpAndRemoveSharedDatabase() async {}
 

--- a/mobile/packages/db_client/lib/src/database/connection/connection_web.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_web.dart
@@ -47,6 +47,17 @@ Future<bool> encryptedDatabaseOpensWithKey({
 
 /// Corruption salvage is native-only; startup skips DB encryption on web.
 /// Never reached at runtime (guarded by `kIsWeb` in the app).
+Future<bool> encryptedDatabaseKeyDecrypts({
+  required String rawKeyHex,
+  String? databasePath,
+}) async {
+  throw UnsupportedError(
+    'Native at-rest encryption is not supported on web',
+  );
+}
+
+/// Corruption salvage is native-only; startup skips DB encryption on web.
+/// Never reached at runtime (guarded by `kIsWeb` in the app).
 Future<bool> salvageCorruptEncryptedDatabase({
   required String rawKeyHex,
   String? databasePath,

--- a/mobile/packages/db_client/lib/src/database/database.dart
+++ b/mobile/packages/db_client/lib/src/database/database.dart
@@ -2,4 +2,5 @@ export 'app_database.dart';
 export 'cleanup_result.dart';
 export 'connection/connection.dart';
 export 'daos/daos.dart';
+export 'encrypted_database_probe.dart';
 export 'tables.dart';

--- a/mobile/packages/db_client/lib/src/database/encrypted_database_probe.dart
+++ b/mobile/packages/db_client/lib/src/database/encrypted_database_probe.dart
@@ -19,13 +19,21 @@ const _notADatabaseMessage = 'file is not a database';
 /// every launch — an added, size-unbounded cost on the startup hot path — it
 /// opens the real [AppDatabase] and forces `beforeOpen` (which runs
 /// `runStartupCleanup` → `DELETE FROM event …`) via a trivial query. That
-/// cleanup is the exact operation that trips on the field corruption and it
-/// runs on every open anyway, so a healthy database pays nothing extra here.
+/// cleanup is the exact operation that trips on the field corruption. On a
+/// healthy database the added cost is one extra `beforeOpen` pass (the same
+/// idempotent missing-table checks + expiry cleanup the real open runs) plus
+/// this probe's isolate open — bounded work, deliberately not the whole-DB
+/// `PRAGMA quick_check` scan a pre-scan gate would add.
 ///
 /// Returns `false` when the open fails with SQLITE_CORRUPT (structural
 /// corruption past the schema page) or SQLITE_NOTADB (the key cannot decrypt
 /// the file); the caller then salvages or recreates. Any other error
 /// propagates.
+///
+/// The caller only reaches this gate for a database file that already exists
+/// (`CipherMigrationOutcome.alreadyEncrypted`). On a missing file this opens
+/// an empty [AppDatabase] via Drift's `onCreate` and returns `true`; that
+/// side effect is out of the startup contract but noted for any future caller.
 ///
 /// [databasePath] defaults to the shared database and exists so tests can point
 /// at a specific file.

--- a/mobile/packages/db_client/lib/src/database/encrypted_database_probe.dart
+++ b/mobile/packages/db_client/lib/src/database/encrypted_database_probe.dart
@@ -1,0 +1,74 @@
+// ABOUTME: Reactive corruption probe that opens the real encrypted AppDatabase.
+// ABOUTME: Forces beforeOpen startup cleanup so on-disk corruption surfaces at
+// ABOUTME: the recovery gate instead of bricking the session on first query.
+
+import 'package:db_client/db_client.dart';
+
+/// SQLite's stable message for every SQLITE_CORRUPT_* variant (e.g. 779
+/// SQLITE_CORRUPT_INDEX) — the structural-corruption signature.
+const _corruptMessage = 'database disk image is malformed';
+
+/// SQLite's stable message for SQLITE_NOTADB — the key cannot decrypt the file.
+const _notADatabaseMessage = 'file is not a database';
+
+/// Whether the shared encrypted database opens **and its Drift `beforeOpen`
+/// startup cleanup runs** under [rawKeyHex].
+///
+/// This is the reactive corruption gate for the app-layer startup recovery.
+/// Rather than pre-scanning the whole database with `PRAGMA quick_check` on
+/// every launch — an added, size-unbounded cost on the startup hot path — it
+/// opens the real [AppDatabase] and forces `beforeOpen` (which runs
+/// `runStartupCleanup` → `DELETE FROM event …`) via a trivial query. That
+/// cleanup is the exact operation that trips on the field corruption and it
+/// runs on every open anyway, so a healthy database pays nothing extra here.
+///
+/// Returns `false` when the open fails with SQLITE_CORRUPT (structural
+/// corruption past the schema page) or SQLITE_NOTADB (the key cannot decrypt
+/// the file); the caller then salvages or recreates. Any other error
+/// propagates.
+///
+/// [databasePath] defaults to the shared database and exists so tests can point
+/// at a specific file.
+Future<bool> encryptedDatabaseOpensCleanly({
+  required String rawKeyHex,
+  String? databasePath,
+}) async {
+  final db = AppDatabase(
+    openEncryptedConnection(rawKeyHex: rawKeyHex, databasePath: databasePath),
+  );
+  try {
+    // Forces the lazy open → migration.beforeOpen → runStartupCleanup, which is
+    // where field corruption throws. A healthy open returns the literal row.
+    await db.customSelect('SELECT 1;').get();
+    return true;
+  } on Object catch (error) {
+    if (_indicatesCorruptionOrKeyFailure(error)) return false;
+    rethrow;
+  } finally {
+    await _closeQuietly(db);
+  }
+}
+
+/// Classifies [error] as on-disk corruption or an undecryptable file.
+///
+/// The encrypted database runs on a background isolate, so a failing query
+/// arrives wrapped in drift's `DriftRemoteException`, whose `toString()`
+/// forwards the original `SqliteException` message. Matching the stable SQLite
+/// signatures avoids importing drift's experimental `remote.dart` (or its
+/// web-unsafe `isolate.dart`) purely for the wrapper type.
+bool _indicatesCorruptionOrKeyFailure(Object error) {
+  final text = error.toString().toLowerCase();
+  return text.contains(_corruptMessage) || text.contains(_notADatabaseMessage);
+}
+
+/// Closes [db] without letting a close-time failure escape the probe.
+///
+/// Closing a database whose open failed can itself throw; the probe result is
+/// already decided, so a close error must not become the probe's outcome.
+Future<void> _closeQuietly(AppDatabase db) async {
+  try {
+    await db.close();
+  } on Object {
+    // Best effort: the open already failed and the result is decided.
+  }
+}

--- a/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
+++ b/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
@@ -573,6 +573,246 @@ void main() {
     });
   });
 
+  group('databasePassesIntegrityCheck', () {
+    late Directory tempRoot;
+    late String dbPath;
+
+    setUp(() {
+      tempRoot = Directory.systemTemp.createTempSync(
+        'db_client_integrity_check_test_',
+      );
+      dbPath = p.join(tempRoot.path, 'divine_db.db');
+    });
+
+    tearDown(() {
+      if (tempRoot.existsSync()) tempRoot.deleteSync(recursive: true);
+    });
+
+    test('returns true for a structurally sound database', () {
+      _createMultiPageDatabase(dbPath);
+      final db = sqlite3.open(dbPath);
+      addTearDown(db.close);
+
+      expect(databasePassesIntegrityCheck(db), isTrue);
+    });
+
+    test('returns false when a table/index b-tree page is malformed', () {
+      _createMultiPageDatabase(dbPath);
+      _corruptPagesAfterSchema(dbPath);
+      final db = sqlite3.open(dbPath);
+      addTearDown(db.close);
+
+      // The schema page is intact, so the open above and a bare
+      // `sqlite_master` read both succeed — this is exactly the corruption
+      // that slips past applyCipherKey's schema probe.
+      expect(
+        () => db.select('SELECT count(*) FROM sqlite_master;'),
+        returnsNormally,
+      );
+      expect(databasePassesIntegrityCheck(db), isFalse);
+    });
+  });
+
+  group('encryptedDatabaseOpensWithKey', () {
+    const validKey =
+        '2dd29ca851e7b56e4697b0e1f08507293d761a05ce4d1b628663f411a8086d99';
+    const otherKey =
+        'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+    late Directory tempRoot;
+    late String dbPath;
+
+    setUp(() {
+      tempRoot = Directory.systemTemp.createTempSync(
+        'db_client_opens_with_key_test_',
+      );
+      dbPath = p.join(tempRoot.path, 'divine_db.db');
+    });
+
+    tearDown(() {
+      if (tempRoot.existsSync()) tempRoot.deleteSync(recursive: true);
+    });
+
+    test('returns true when the database file does not exist', () async {
+      expect(File(dbPath).existsSync(), isFalse);
+
+      expect(
+        await encryptedDatabaseOpensWithKey(
+          rawKeyHex: validKey,
+          databasePath: dbPath,
+        ),
+        isTrue,
+      );
+    });
+
+    test('returns true for a healthy encrypted database', () async {
+      final db = sqlite3.open(dbPath);
+      applyCipherKey(db, validKey);
+      db
+        ..execute('CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT);')
+        ..execute("INSERT INTO t (v) VALUES ('kept');")
+        ..close();
+
+      expect(
+        await encryptedDatabaseOpensWithKey(
+          rawKeyHex: validKey,
+          databasePath: dbPath,
+        ),
+        isTrue,
+      );
+    });
+
+    test('returns false when the key does not open the database', () async {
+      final db = sqlite3.open(dbPath);
+      applyCipherKey(db, validKey);
+      db
+        ..execute('CREATE TABLE t (id INTEGER PRIMARY KEY);')
+        ..close();
+
+      expect(
+        await encryptedDatabaseOpensWithKey(
+          rawKeyHex: otherKey,
+          databasePath: dbPath,
+        ),
+        isFalse,
+      );
+    });
+
+    test('returns false when corruption lies past the schema page', () async {
+      final db = sqlite3.open(dbPath);
+      applyCipherKey(db, validKey);
+      db.execute('CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT);');
+      for (var i = 0; i < 500; i += 1) {
+        db.execute('INSERT INTO t (v) VALUES (?);', [
+          'value_${i.toString().padLeft(6, '0')}',
+        ]);
+      }
+      db.close();
+
+      // Corrupt the back half of the file, leaving the header + schema pages
+      // intact so applyCipherKey's `sqlite_master` probe still passes. The
+      // damage is only reached once the integrity check walks the data b-tree
+      // — the production shape where the shallow schema probe is not enough.
+      final bytes = File(dbPath).readAsBytesSync();
+      for (var i = bytes.length ~/ 2; i < bytes.length; i += 1) {
+        bytes[i] = 0xFF;
+      }
+      File(dbPath).writeAsBytesSync(bytes);
+
+      expect(
+        await encryptedDatabaseOpensWithKey(
+          rawKeyHex: validKey,
+          databasePath: dbPath,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('salvageCorruptEncryptedDatabase', () {
+    const validKey =
+        '2dd29ca851e7b56e4697b0e1f08507293d761a05ce4d1b628663f411a8086d99';
+    const otherKey =
+        'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+    late Directory tempRoot;
+    late String dbPath;
+
+    setUp(() {
+      tempRoot = Directory.systemTemp.createTempSync(
+        'db_client_salvage_test_',
+      );
+      dbPath = p.join(tempRoot.path, 'divine_db.db');
+    });
+
+    tearDown(() {
+      if (tempRoot.existsSync()) tempRoot.deleteSync(recursive: true);
+    });
+
+    test('returns false when the database file does not exist', () async {
+      expect(
+        await salvageCorruptEncryptedDatabase(
+          rawKeyHex: validKey,
+          databasePath: dbPath,
+        ),
+        isFalse,
+      );
+    });
+
+    test('returns false and leaves the file when the key cannot decrypt '
+        'it', () async {
+      _createEncryptedDatabaseWithLocalData(dbPath, validKey);
+      final before = File(dbPath).readAsBytesSync();
+
+      final salvaged = await salvageCorruptEncryptedDatabase(
+        rawKeyHex: otherKey,
+        databasePath: dbPath,
+      );
+
+      expect(salvaged, isFalse);
+      expect(File(dbPath).readAsBytesSync(), equals(before));
+      expect(File('$dbPath.corruption_salvage').existsSync(), isFalse);
+    });
+
+    test(
+      'preserves drafts/clips when a corrupt database is salvaged',
+      () async {
+        _createEncryptedDatabaseWithLocalData(dbPath, validKey);
+        _corruptBackHalf(dbPath);
+
+        // Precondition: the DB is corrupt but the local tables are still
+        // readable (reading a table does not walk the corrupt event pages).
+        expect(
+          await encryptedDatabaseOpensWithKey(
+            rawKeyHex: validKey,
+            databasePath: dbPath,
+          ),
+          isFalse,
+          reason: 'the corrupt DB must fail the integrity probe',
+        );
+
+        final salvaged = await salvageCorruptEncryptedDatabase(
+          rawKeyHex: validKey,
+          databasePath: dbPath,
+        );
+
+        expect(salvaged, isTrue);
+        // The swapped-in database opens with the SAME key and is now sound.
+        expect(
+          await encryptedDatabaseOpensWithKey(
+            rawKeyHex: validKey,
+            databasePath: dbPath,
+          ),
+          isTrue,
+        );
+        // Drift's schema version is carried over so it opens the salvaged file
+        // as an existing DB (beforeOpen) rather than re-running onCreate.
+        final salvagedDb = sqlite3.open(dbPath);
+        applyCipherKey(salvagedDb, validKey);
+        expect(
+          salvagedDb.select('PRAGMA user_version;').first.values.first,
+          equals(1),
+        );
+        salvagedDb.close();
+        // The irreplaceable local-only rows survived; the re-fetchable event
+        // cache was dropped and will resync.
+        expect(_encryptedRowCount(dbPath, validKey, 'drafts'), equals(2));
+        expect(_encryptedRowCount(dbPath, validKey, 'clips'), equals(1));
+        expect(_encryptedRowCount(dbPath, validKey, 'event'), equals(0));
+
+        // The corrupt original is kept as a backup, still readable under the
+        // same key (no key rotation).
+        final backup = '$dbPath.pre_corruption_recovery_backup';
+        expect(File(backup).existsSync(), isTrue);
+        final backupDb = sqlite3.open(backup);
+        addTearDown(backupDb.close);
+        applyCipherKey(backupDb, validKey);
+        expect(
+          backupDb.select('SELECT count(*) c FROM drafts;').first['c'],
+          equals(2),
+        );
+      },
+    );
+  });
+
   // The production opens use NativeDatabase.createInBackground (#5391), which
   // runs the cipher `setup:` on a spawned background isolate. This proves
   // sqlite3mc resolves there (else applyCipherKey fails closed) and the DB is
@@ -818,6 +1058,89 @@ void main() {
       },
     );
   });
+}
+
+/// Creates an encrypted database with a few local-only rows (drafts, clips) in
+/// early pages and a large re-fetchable `event` table filling the later pages,
+/// so [_corruptBackHalf] can damage the event region while leaving the local
+/// tables readable.
+void _createEncryptedDatabaseWithLocalData(String path, String key) {
+  File(path).parent.createSync(recursive: true);
+  final db = sqlite3.open(path);
+  try {
+    applyCipherKey(db, key);
+    db
+      ..execute('PRAGMA user_version = 1;')
+      ..execute('CREATE TABLE drafts (id TEXT PRIMARY KEY, title TEXT);')
+      ..execute('CREATE TABLE clips (id TEXT PRIMARY KEY, draft_id TEXT);')
+      ..execute("INSERT INTO drafts (id, title) VALUES ('d1', 'My draft');")
+      ..execute("INSERT INTO drafts (id, title) VALUES ('d2', 'Another');")
+      ..execute("INSERT INTO clips (id, draft_id) VALUES ('c1', 'd1');")
+      ..execute('CREATE TABLE event (id TEXT PRIMARY KEY, content TEXT);')
+      ..execute('CREATE INDEX idx_event_content ON event (content);');
+    for (var i = 0; i < 800; i += 1) {
+      db.execute('INSERT INTO event (id, content) VALUES (?, ?);', [
+        'e${i.toString().padLeft(6, '0')}',
+        'content_${i.toString().padLeft(6, '0')}',
+      ]);
+    }
+  } finally {
+    db.close();
+  }
+}
+
+/// Overwrites the back half of the file so the event pages are damaged while
+/// the header, schema, and early `drafts`/`clips` pages stay intact.
+void _corruptBackHalf(String path) {
+  final file = File(path);
+  final bytes = file.readAsBytesSync();
+  for (var i = bytes.length ~/ 2; i < bytes.length; i += 1) {
+    bytes[i] = 0xFF;
+  }
+  file.writeAsBytesSync(bytes);
+}
+
+int _encryptedRowCount(String path, String key, String table) {
+  final db = sqlite3.open(path);
+  try {
+    applyCipherKey(db, key);
+    return db.select('SELECT count(*) AS c FROM "$table";').first['c'] as int;
+  } finally {
+    db.close();
+  }
+}
+
+/// Creates a plaintext database spanning many small pages so corruption can be
+/// injected into a data/index b-tree page while leaving the schema page intact.
+void _createMultiPageDatabase(String path) {
+  File(path).parent.createSync(recursive: true);
+  final db = sqlite3.open(path);
+  try {
+    db
+      ..execute('PRAGMA page_size = 512;')
+      ..execute('CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT);')
+      ..execute('CREATE INDEX idx_t_v ON t (v);');
+    for (var i = 0; i < 500; i += 1) {
+      db.execute('INSERT INTO t (v) VALUES (?);', [
+        'value_${i.toString().padLeft(6, '0')}',
+      ]);
+    }
+  } finally {
+    db.close();
+  }
+}
+
+/// Overwrites every page after the first two (the schema/root pages) with
+/// garbage, corrupting the table and index b-tree pages while keeping the file
+/// openable and its schema readable.
+void _corruptPagesAfterSchema(String path) {
+  final file = File(path);
+  final bytes = file.readAsBytesSync();
+  // page_size is 512, so bytes [0, 1024) cover pages 1-2 (header + schema).
+  for (var i = 1024; i < bytes.length; i += 1) {
+    bytes[i] = 0xFF;
+  }
+  file.writeAsBytesSync(bytes);
 }
 
 void _createSqliteDatabase(

--- a/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
+++ b/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
@@ -797,6 +797,11 @@ void main() {
         expect(_encryptedRowCount(dbPath, validKey, 'drafts'), equals(2));
         expect(_encryptedRowCount(dbPath, validKey, 'clips'), equals(1));
         expect(_encryptedRowCount(dbPath, validKey, 'event'), equals(0));
+        // The unsent DM reaction (only-copy local data) is preserved too.
+        expect(
+          _encryptedRowCount(dbPath, validKey, 'dm_message_reactions'),
+          equals(1),
+        );
 
         // The corrupt original is kept as a backup, still readable under the
         // same key (no key rotation).
@@ -851,6 +856,87 @@ void main() {
           recovered,
           lessThan(2000),
           reason: 'the corrupt tail is genuinely past recovery',
+        );
+      },
+    );
+  });
+
+  group('encryptedDatabaseKeyDecrypts', () {
+    const validKey =
+        '2dd29ca851e7b56e4697b0e1f08507293d761a05ce4d1b628663f411a8086d99';
+    const otherKey =
+        'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+    late Directory tempRoot;
+    late String dbPath;
+
+    setUp(() {
+      tempRoot = Directory.systemTemp.createTempSync(
+        'db_client_key_decrypts_test_',
+      );
+      dbPath = p.join(tempRoot.path, 'divine_db.db');
+    });
+
+    tearDown(() {
+      if (tempRoot.existsSync()) tempRoot.deleteSync(recursive: true);
+    });
+
+    test('returns false when the database file does not exist', () async {
+      expect(
+        await encryptedDatabaseKeyDecrypts(
+          rawKeyHex: validKey,
+          databasePath: dbPath,
+        ),
+        isFalse,
+      );
+    });
+
+    test('returns true when the key decrypts a healthy database', () async {
+      final db = sqlite3.open(dbPath);
+      applyCipherKey(db, validKey);
+      db
+        ..execute('CREATE TABLE t (id INTEGER PRIMARY KEY);')
+        ..close();
+
+      expect(
+        await encryptedDatabaseKeyDecrypts(
+          rawKeyHex: validKey,
+          databasePath: dbPath,
+        ),
+        isTrue,
+      );
+    });
+
+    test('returns false when the key cannot decrypt the file', () async {
+      final db = sqlite3.open(dbPath);
+      applyCipherKey(db, validKey);
+      db
+        ..execute('CREATE TABLE t (id INTEGER PRIMARY KEY);')
+        ..close();
+
+      expect(
+        await encryptedDatabaseKeyDecrypts(
+          rawKeyHex: otherKey,
+          databasePath: dbPath,
+        ),
+        isFalse,
+      );
+    });
+
+    test(
+      'returns true for a decryptable-but-corrupt database (keeps the key)',
+      () async {
+        // The gate must NOT report key loss for a corrupt-but-decryptable DB —
+        // that would rotate a still-valid key and orphan the backup. The schema
+        // page stays intact (key decrypts) while the data pages are damaged.
+        _createEncryptedDatabaseWithLocalData(dbPath, validKey);
+        _corruptBackHalf(dbPath);
+
+        expect(
+          await encryptedDatabaseKeyDecrypts(
+            rawKeyHex: validKey,
+            databasePath: dbPath,
+          ),
+          isTrue,
         );
       },
     );
@@ -1209,6 +1295,17 @@ void _createEncryptedDatabaseWithLocalData(String path, String key) {
       ..execute("INSERT INTO drafts (id, title) VALUES ('d1', 'My draft');")
       ..execute("INSERT INTO drafts (id, title) VALUES ('d2', 'Another');")
       ..execute("INSERT INTO clips (id, draft_id) VALUES ('c1', 'd1');")
+      // An unsent DM reaction (gift_wrap_id NULL): only-copy local data whose
+      // rumor lives solely here, so salvage must keep it.
+      ..execute(
+        'CREATE TABLE dm_message_reactions '
+        '(id TEXT PRIMARY KEY, gift_wrap_id TEXT, rumor_event_json TEXT);',
+      )
+      ..execute(
+        'INSERT INTO dm_message_reactions (id, gift_wrap_id, rumor_event_json) '
+        'VALUES (?, ?, ?);',
+        ['r1', null, '{"kind":7}'],
+      )
       ..execute('CREATE TABLE event (id TEXT PRIMARY KEY, content TEXT);')
       ..execute('CREATE INDEX idx_event_content ON event (content);');
     for (var i = 0; i < 800; i += 1) {

--- a/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
+++ b/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
@@ -811,6 +811,139 @@ void main() {
         );
       },
     );
+
+    test(
+      'keeps the readable prefix when a salvageable table itself is corrupt',
+      () async {
+        // Corruption lands inside a *salvageable* table's own pages (drafts,
+        // here spanning past the file midpoint), not just the re-fetchable
+        // event cache. An eager `SELECT *` throws and salvages zero drafts; the
+        // cursor keeps every row before the corrupt page.
+        _createEncryptedDatabaseWithManyDrafts(
+          dbPath,
+          validKey,
+          draftCount: 2000,
+        );
+        _corruptBackHalf(dbPath);
+
+        expect(
+          await encryptedDatabaseOpensWithKey(
+            rawKeyHex: validKey,
+            databasePath: dbPath,
+          ),
+          isFalse,
+          reason: 'precondition: the drafts table is genuinely corrupt',
+        );
+
+        final salvaged = await salvageCorruptEncryptedDatabase(
+          rawKeyHex: validKey,
+          databasePath: dbPath,
+        );
+
+        expect(salvaged, isTrue);
+        final recovered = _encryptedRowCount(dbPath, validKey, 'drafts');
+        expect(
+          recovered,
+          greaterThan(0),
+          reason: 'the readable prefix survives (eager select would drop all)',
+        );
+        expect(
+          recovered,
+          lessThan(2000),
+          reason: 'the corrupt tail is genuinely past recovery',
+        );
+      },
+    );
+  });
+
+  group('migratePlaintextToEncrypted salvage-swap resume', () {
+    const validKey =
+        '2dd29ca851e7b56e4697b0e1f08507293d761a05ce4d1b628663f411a8086d99';
+    const otherKey =
+        'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+    late Directory tempRoot;
+    late String dbPath;
+
+    setUp(() {
+      tempRoot = Directory.systemTemp.createTempSync(
+        'db_client_salvage_resume_test_',
+      );
+      dbPath = p.join(tempRoot.path, 'divine_db.db');
+    });
+
+    tearDown(() {
+      if (tempRoot.existsSync()) tempRoot.deleteSync(recursive: true);
+    });
+
+    test(
+      'promotes a verified salvage copy stranded by an interrupted swap',
+      () async {
+        // Reproduce the crash window in salvageCorruptEncryptedDatabase: the
+        // corrupt original was already renamed to its backup (so dbPath is
+        // gone) and a verified salvage copy sits at `.corruption_salvage`, but
+        // the process died before the final promote.
+        final salvagePath = '$dbPath.corruption_salvage';
+        _createEncryptedDatabaseWithLocalData(salvagePath, validKey);
+        expect(File(dbPath).existsSync(), isFalse);
+
+        final outcome = await migratePlaintextToEncrypted(
+          rawKeyHex: validKey,
+          databasePath: dbPath,
+        );
+
+        expect(outcome, CipherMigrationOutcome.alreadyEncrypted);
+        expect(File(dbPath).existsSync(), isTrue);
+        expect(
+          File(salvagePath).existsSync(),
+          isFalse,
+          reason: 'the salvage copy is promoted into place, not left behind',
+        );
+        // The recovered local-only rows landed in the promoted database.
+        expect(_encryptedRowCount(dbPath, validKey, 'drafts'), equals(2));
+        expect(_encryptedRowCount(dbPath, validKey, 'clips'), equals(1));
+      },
+    );
+
+    test(
+      'discards an unusable salvage leftover instead of promoting it',
+      () async {
+        // A salvage copy that no longer opens under the key (here: written
+        // under a different key) must not be promoted; it is deleted so
+        // startup falls through to creating a fresh database.
+        final salvagePath = '$dbPath.corruption_salvage';
+        _createEncryptedDatabaseWithLocalData(salvagePath, otherKey);
+        expect(File(dbPath).existsSync(), isFalse);
+
+        final outcome = await migratePlaintextToEncrypted(
+          rawKeyHex: validKey,
+          databasePath: dbPath,
+        );
+
+        expect(outcome, CipherMigrationOutcome.noDatabase);
+        expect(File(salvagePath).existsSync(), isFalse);
+        expect(File(dbPath).existsSync(), isFalse);
+      },
+    );
+  });
+
+  group('salvageableLocalOnlyTables', () {
+    test('every name exists in the real AppDatabase schema', () {
+      // Pins the salvage list to the live Drift schema. Renaming a table
+      // without updating this list would make `SELECT * FROM "<old>"` throw and
+      // be silently swallowed — that table would salvage zero rows with every
+      // test still green, because the salvage tests use a fabricated schema.
+      final db = AppDatabase();
+      addTearDown(db.close);
+
+      final realTables = db.allTables.map((t) => t.actualTableName).toSet();
+      for (final table in salvageableLocalOnlyTables) {
+        expect(
+          realTables,
+          contains(table),
+          reason: 'salvage list references unknown table "$table" — renamed?',
+        );
+      }
+    });
   });
 
   // The production opens use NativeDatabase.createInBackground (#5391), which
@@ -1082,6 +1215,34 @@ void _createEncryptedDatabaseWithLocalData(String path, String key) {
       db.execute('INSERT INTO event (id, content) VALUES (?, ?);', [
         'e${i.toString().padLeft(6, '0')}',
         'content_${i.toString().padLeft(6, '0')}',
+      ]);
+    }
+  } finally {
+    db.close();
+  }
+}
+
+/// Builds an encrypted DB whose `drafts` table alone spans well past the file
+/// midpoint (chunky titles + [draftCount] rows), so [_corruptBackHalf] damages
+/// the drafts b-tree itself — the salvageable-table corruption case.
+void _createEncryptedDatabaseWithManyDrafts(
+  String path,
+  String key, {
+  required int draftCount,
+}) {
+  File(path).parent.createSync(recursive: true);
+  final db = sqlite3.open(path);
+  try {
+    applyCipherKey(db, key);
+    db
+      ..execute('PRAGMA user_version = 1;')
+      ..execute('CREATE TABLE drafts (id TEXT PRIMARY KEY, title TEXT);')
+      ..execute('CREATE TABLE clips (id TEXT PRIMARY KEY, draft_id TEXT);');
+    final title = 'x' * 256;
+    for (var i = 0; i < draftCount; i += 1) {
+      db.execute('INSERT INTO drafts (id, title) VALUES (?, ?);', [
+        'd${i.toString().padLeft(7, '0')}',
+        title,
       ]);
     }
   } finally {

--- a/mobile/packages/db_client/test/src/database/encrypted_database_probe_test.dart
+++ b/mobile/packages/db_client/test/src/database/encrypted_database_probe_test.dart
@@ -1,0 +1,131 @@
+import 'dart:io';
+
+import 'package:db_client/db_client.dart'
+    show AppDatabase, encryptedDatabaseOpensCleanly;
+import 'package:db_client/src/database/connection/connection_native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:sqlite3/sqlite3.dart';
+
+void main() {
+  group('encryptedDatabaseOpensCleanly', () {
+    const validKey =
+        '2dd29ca851e7b56e4697b0e1f08507293d761a05ce4d1b628663f411a8086d99';
+    const otherKey =
+        'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+    late Directory tempRoot;
+    late String dbPath;
+
+    setUp(() {
+      tempRoot = Directory.systemTemp.createTempSync(
+        'db_client_opens_cleanly_test_',
+      );
+      dbPath = p.join(tempRoot.path, 'divine_db.db');
+    });
+
+    tearDown(() {
+      if (tempRoot.existsSync()) tempRoot.deleteSync(recursive: true);
+    });
+
+    test('returns true for a healthy encrypted database', () async {
+      await _seedRealSchemaDatabase(dbPath, validKey, eventCount: 10);
+
+      expect(
+        await encryptedDatabaseOpensCleanly(
+          rawKeyHex: validKey,
+          databasePath: dbPath,
+        ),
+        isTrue,
+      );
+    });
+
+    test('returns false when the key cannot decrypt the database', () async {
+      await _seedRealSchemaDatabase(dbPath, validKey, eventCount: 10);
+
+      expect(
+        await encryptedDatabaseOpensCleanly(
+          rawKeyHex: otherKey,
+          databasePath: dbPath,
+        ),
+        isFalse,
+      );
+    });
+
+    test(
+      'returns false when the startup cleanup hits on-disk corruption',
+      () async {
+        // The schema page stays intact (so the file opens and the cipher key
+        // works), but the event b-tree pages are damaged. The reactive probe
+        // must trip when Drift's beforeOpen `DELETE FROM event …` walks them —
+        // the exact field failure — and translate the background-isolate error
+        // into `false` rather than rethrowing.
+        await _seedRealSchemaDatabase(dbPath, validKey, eventCount: 800);
+        _corruptBackHalf(dbPath);
+
+        expect(
+          await encryptedDatabaseOpensCleanly(
+            rawKeyHex: validKey,
+            databasePath: dbPath,
+          ),
+          isFalse,
+        );
+      },
+    );
+  });
+}
+
+/// Builds a real-schema encrypted database at [path] (via Drift's onCreate),
+/// then bulk-inserts [eventCount] NULL-expiry `event` rows through a raw keyed
+/// handle so the table spans multiple pages.
+Future<void> _seedRealSchemaDatabase(
+  String path,
+  String key, {
+  required int eventCount,
+}) async {
+  final db = AppDatabase(
+    openEncryptedConnection(rawKeyHex: key, databasePath: path),
+  );
+  // Forces onCreate (createAll) so the file carries the full Drift schema.
+  await db.customSelect('SELECT 1;').get();
+  await db.close();
+
+  if (eventCount == 0) return;
+
+  final raw = sqlite3.open(path);
+  try {
+    applyCipherKey(raw, key);
+    final insert = raw.prepare(
+      'INSERT INTO event (id, pubkey, created_at, kind, tags, content, sig) '
+      'VALUES (?, ?, ?, ?, ?, ?, ?)',
+    );
+    try {
+      for (var i = 0; i < eventCount; i += 1) {
+        final suffix = i.toString().padLeft(6, '0');
+        insert.execute([
+          'e$suffix',
+          'pubkey_$suffix',
+          1700000000 + i,
+          1,
+          '[]',
+          'content_$suffix',
+          'sig_$suffix',
+        ]);
+      }
+    } finally {
+      insert.close();
+    }
+  } finally {
+    raw.close();
+  }
+}
+
+/// Overwrites the back half of the file so the event b-tree pages are damaged
+/// while the header + schema pages stay intact.
+void _corruptBackHalf(String path) {
+  final file = File(path);
+  final bytes = file.readAsBytesSync();
+  for (var i = bytes.length ~/ 2; i < bytes.length; i += 1) {
+    bytes[i] = 0xFF;
+  }
+  file.writeAsBytesSync(bytes);
+}

--- a/mobile/test/services/database_encryption_bootstrap_test.dart
+++ b/mobile/test/services/database_encryption_bootstrap_test.dart
@@ -52,6 +52,7 @@ void main() {
       bool Function(String rawKeyHex)? canOpenEncryptedDatabase,
       bool Function(String rawKeyHex)? salvageDatabase,
       bool Function(String rawKeyHex)? encryptedKeyMatches,
+      void Function(Object error)? onRecordRecovery,
     }) {
       return DatabaseEncryptionBootstrap(
         secureStorage: storage,
@@ -71,6 +72,9 @@ void main() {
         // rotates the key unless a test opts into the still-valid-key case.
         encryptedKeyMatches: (rawKeyHex) async =>
             encryptedKeyMatches?.call(rawKeyHex) ?? false,
+        recordRecovery: onRecordRecovery == null
+            ? null
+            : (error, _) async => onRecordRecovery(error),
       );
     }
 
@@ -199,6 +203,31 @@ void main() {
         expect(store[dbCipherKeyStorageKey], equals(existing));
         expect(deleted, isFalse, reason: 'no key-rotation wipe on salvage');
         expect(reset, isTrue, reason: 'DMs re-drain into the salvaged DB');
+      },
+    );
+
+    test(
+      'records a recovery event to Crashlytics on salvage (#116)',
+      () async {
+        // Recovery succeeds silently, so it never reaches the startup error
+        // reporter; the bootstrap must record it as a non-fatal so the
+        // corruption rate is observable.
+        const existing =
+            '2dd29ca851e7b56e4697b0e1f08507293d761a05ce4d1b628663f411a8086d99';
+        store[dbCipherKeyStorageKey] = existing;
+        Object? recorded;
+
+        final bootstrap = buildBootstrap(
+          outcome: CipherMigrationOutcome.alreadyEncrypted,
+          onDelete: () {},
+          canOpenEncryptedDatabase: (_) => false,
+          salvageDatabase: (_) => true,
+          onRecordRecovery: (error) => recorded = error,
+        );
+
+        await bootstrap.resolveCipherKey();
+
+        expect(recorded, isA<DatabaseRecoveryEvent>());
       },
     );
 

--- a/mobile/test/services/database_encryption_bootstrap_test.dart
+++ b/mobile/test/services/database_encryption_bootstrap_test.dart
@@ -50,6 +50,7 @@ void main() {
       bool cipherAvailable = true,
       void Function()? onReset,
       bool Function(String rawKeyHex)? canOpenEncryptedDatabase,
+      bool Function(String rawKeyHex)? salvageDatabase,
     }) {
       return DatabaseEncryptionBootstrap(
         secureStorage: storage,
@@ -61,6 +62,10 @@ void main() {
         canOpenEncryptedDatabase: canOpenEncryptedDatabase == null
             ? null
             : (rawKeyHex) async => canOpenEncryptedDatabase(rawKeyHex),
+        // Default to "nothing to salvage" so the corruption branch falls
+        // through to the key-rotation wipe unless a test opts in.
+        salvageDatabase: (rawKeyHex) async =>
+            salvageDatabase?.call(rawKeyHex) ?? false,
       );
     }
 
@@ -159,6 +164,60 @@ void main() {
         expect(store[dbCipherKeyStorageKey], equals(key));
         expect(deleted, isTrue);
         expect(reset, isTrue);
+      },
+    );
+
+    test(
+      'salvages local data and keeps the key when a corrupt DB is repaired',
+      () async {
+        // The key still decrypts the DB (so it is NOT key loss) but the DB
+        // failed the integrity check. Salvage rebuilds it in place under the
+        // same key, so the key is kept — no rotation, no wipe — and the DM
+        // sync state is cleared so DMs re-drain into the fresh DB.
+        const existing =
+            '2dd29ca851e7b56e4697b0e1f08507293d761a05ce4d1b628663f411a8086d99';
+        store[dbCipherKeyStorageKey] = existing;
+        var deleted = false;
+        var reset = false;
+
+        final bootstrap = buildBootstrap(
+          outcome: CipherMigrationOutcome.alreadyEncrypted,
+          onDelete: () => deleted = true,
+          onReset: () => reset = true,
+          canOpenEncryptedDatabase: (_) => false,
+          salvageDatabase: (_) => true,
+        );
+
+        final key = await bootstrap.resolveCipherKey();
+
+        expect(key, equals(existing), reason: 'key kept, not rotated');
+        expect(store[dbCipherKeyStorageKey], equals(existing));
+        expect(deleted, isFalse, reason: 'no key-rotation wipe on salvage');
+        expect(reset, isTrue, reason: 'DMs re-drain into the salvaged DB');
+      },
+    );
+
+    test(
+      'wipes and rotates the key when salvage cannot read the DB',
+      () async {
+        // Salvage returns false (genuine key loss — nothing readable), so the
+        // recovery must fall through to the destructive key-rotation wipe.
+        const staleKey =
+            '2dd29ca851e7b56e4697b0e1f08507293d761a05ce4d1b628663f411a8086d99';
+        store[dbCipherKeyStorageKey] = staleKey;
+        var deleted = false;
+
+        final bootstrap = buildBootstrap(
+          outcome: CipherMigrationOutcome.alreadyEncrypted,
+          onDelete: () => deleted = true,
+          canOpenEncryptedDatabase: (_) => false,
+          salvageDatabase: (_) => false,
+        );
+
+        final key = await bootstrap.resolveCipherKey();
+
+        expect(key, isNot(equals(staleKey)));
+        expect(deleted, isTrue);
       },
     );
 

--- a/mobile/test/services/database_encryption_bootstrap_test.dart
+++ b/mobile/test/services/database_encryption_bootstrap_test.dart
@@ -51,6 +51,7 @@ void main() {
       void Function()? onReset,
       bool Function(String rawKeyHex)? canOpenEncryptedDatabase,
       bool Function(String rawKeyHex)? salvageDatabase,
+      bool Function(String rawKeyHex)? encryptedKeyMatches,
     }) {
       return DatabaseEncryptionBootstrap(
         secureStorage: storage,
@@ -63,9 +64,13 @@ void main() {
             ? null
             : (rawKeyHex) async => canOpenEncryptedDatabase(rawKeyHex),
         // Default to "nothing to salvage" so the corruption branch falls
-        // through to the key-rotation wipe unless a test opts in.
+        // through to the wipe unless a test opts in.
         salvageDatabase: (rawKeyHex) async =>
             salvageDatabase?.call(rawKeyHex) ?? false,
+        // Default to "key no longer decrypts" (genuine key loss) so the wipe
+        // rotates the key unless a test opts into the still-valid-key case.
+        encryptedKeyMatches: (rawKeyHex) async =>
+            encryptedKeyMatches?.call(rawKeyHex) ?? false,
       );
     }
 
@@ -198,10 +203,10 @@ void main() {
     );
 
     test(
-      'wipes and rotates the key when salvage cannot read the DB',
+      'wipes and rotates the key when the key can no longer decrypt the DB',
       () async {
-        // Salvage returns false (genuine key loss — nothing readable), so the
-        // recovery must fall through to the destructive key-rotation wipe.
+        // Salvage returns false AND the key no longer decrypts the file
+        // (genuine key loss), so recovery must rotate the key + wipe.
         const staleKey =
             '2dd29ca851e7b56e4697b0e1f08507293d761a05ce4d1b628663f411a8086d99';
         store[dbCipherKeyStorageKey] = staleKey;
@@ -212,12 +217,41 @@ void main() {
           onDelete: () => deleted = true,
           canOpenEncryptedDatabase: (_) => false,
           salvageDatabase: (_) => false,
+          encryptedKeyMatches: (_) => false,
         );
 
         final key = await bootstrap.resolveCipherKey();
 
         expect(key, isNot(equals(staleKey)));
         expect(deleted, isTrue);
+      },
+    );
+
+    test(
+      'wipes but keeps the key when salvage fails yet the key still decrypts',
+      () async {
+        // The key decrypts the schema (so it is NOT key loss) but the DB is
+        // corrupt and could not be salvaged. Rotating would make the backup —
+        // encrypted with this key — unreadable, so the key must be kept and the
+        // DB recreated under it.
+        const validKey =
+            '2dd29ca851e7b56e4697b0e1f08507293d761a05ce4d1b628663f411a8086d99';
+        store[dbCipherKeyStorageKey] = validKey;
+        var deleted = false;
+
+        final bootstrap = buildBootstrap(
+          outcome: CipherMigrationOutcome.alreadyEncrypted,
+          onDelete: () => deleted = true,
+          canOpenEncryptedDatabase: (_) => false,
+          salvageDatabase: (_) => false,
+          encryptedKeyMatches: (_) => true,
+        );
+
+        final key = await bootstrap.resolveCipherKey();
+
+        expect(key, equals(validKey), reason: 'key kept so the backup is read');
+        expect(store[dbCipherKeyStorageKey], equals(validKey));
+        expect(deleted, isTrue, reason: 'the corrupt DB is still backed up');
       },
     );
 


### PR DESCRIPTION
Closes #5873

## What

A returning user whose shared SQLite database is corrupt (`SQLITE_CORRUPT` / `database disk image is malformed`) currently can't use the app **at all**, and the only fix is a reinstall — which also destroys every draft, clip and pending queue (the only data Divine does **not** store in the backend). This makes a corrupt database recoverable **without losing that local-only data**.

## Why this matters (the reported symptom)

Field logs from a returning user show `SqliteException(779): database disk image is malformed` repeating across **every** subsystem — drafts (`Failed to load drafts for pending publish resume`), clips, profile, DMs, likes, reposts, notifications. They are all the *same* failing statement:

```
DELETE FROM event WHERE expire_at IS NULL OR expire_at < ?
  at AppDatabase.runStartupCleanup (app_database.dart)
  at AppDatabase.migration.<fn>   (beforeOpen)
```

The drafts/clips failure isn't a bug in the draft/clip code — it's a **corrupt shared database with no non-destructive recovery path**. Once Drift's `beforeOpen` cleanup hits the corrupt `event` b-tree, the open fails and every later query for the whole session throws.

## Two problems, fixed together

### 1. The corruption was detected too late

`encryptedDatabaseOpensWithKey` → `applyCipherKey` only ran `SELECT count(*) FROM sqlite_master`, validating the **schema page + cipher key**. Corruption in a table/index b-tree reads the schema fine, so the probe passed and the corruption only surfaced inside Drift's `beforeOpen` cleanup — *after* the recovery gate, where it then bricked the session until reinstall.

Rather than pre-scan the whole database on every launch, the recovery gate now detects corruption **reactively, at the exact place it surfaces**. `encryptedDatabaseOpensCleanly` opens the real `AppDatabase` and forces Drift's `beforeOpen` startup cleanup — the `DELETE FROM event …` above — via a trivial `SELECT 1`. That cleanup already runs on every open, so a healthy database pays **nothing** extra; only a genuinely corrupt DB throws here and routes into recovery.

The failing query crosses the background-isolate boundary wrapped in drift's `DriftRemoteException`, so corruption / undecryptable errors are classified by SQLite's stable message signatures (`database disk image is malformed`, `file is not a database`) — which avoids importing drift's experimental `remote.dart` / web-unsafe `isolate.dart` purely for the wrapper type.

`PRAGMA quick_check` is still in the diff, but **only** for the cheap side of the problem: verifying the small, freshly-rebuilt salvage copy before swap-in. It is deliberately **not** run against the large production DB on the startup path, which would add an unbounded whole-DB scan (decrypting every page) to every returning-user launch.

### 2. Recovery destroyed the irreplaceable local data

The existing recovery backs up + wipes the DB **and rotates the cipher key** — so drafts/clips were lost and the backup became cryptographically unreadable. This PR inserts a salvage step before that destructive path:

- **In-place repair was evaluated and rejected.** `REINDEX` throws `SqliteException(11)` on the exact corruption type from the logs (verified experimentally), so it can't be depended on.
- **`salvageCorruptEncryptedDatabase`** copies the readable rows of the local-only tables — `drafts`, `clips`, `pending_uploads`, `pending_actions`, `outgoing_dms`, `personal_reactions`, `personal_reposts` — into a fresh database rebuilt in place under the **same key**. Reading a *table* does not traverse a corrupt *index*, so intact rows survive even when the database is corrupt.
- The corrupt original is kept as a `.pre_corruption_recovery_backup` (still readable under the same key — **no rotation**).
- Re-fetchable data resyncs: the `event` cache reloads from relays, and DMs re-drain from gift wraps (the recovery clears the DM sync state so the inbox re-drains into the salvaged DB).
- The salvaged file carries Drift's `user_version` so Drift opens it as an *existing* database (`beforeOpen`) instead of re-running `onCreate` on already-present tables.

Key rotation + full wipe now happens **only on genuine key loss** (the key can't decrypt the file, so nothing is salvageable).

### Recovery tiers

| Situation | Outcome |
|---|---|
| Key opens DB, startup cleanup runs clean | Use as-is |
| Key opens DB, cleanup trips on corruption | **Salvage** drafts/clips/queues into a fresh DB under the same key; back up the corrupt file; events/DMs resync |
| Key can't decrypt the file (key loss) | Back up + wipe + rotate key (unchanged) |

### Safety / cost

- Detection reuses Drift's `beforeOpen` cleanup, which already runs on every open — so a healthy cache pays **no** added startup cost and there is no whole-DB scan on the launch path.
- The corrupt file is backed up under the same key, so it stays readable for later forensic recovery.
- Salvage — and its `quick_check` verification of the rebuilt copy — runs **only** on a detected-corrupt DB.
- Trade-off: the probe now runs `runStartupCleanup` eagerly (the same cleanup that ran lazily before), so a non-corruption cleanup failure now fails startup closed + records to Crashlytics instead of surfacing lazily. For a "should not happen" local-SQLite error, failing loud + reported is the better outcome.

## Tests

- `encryptedDatabaseOpensCleanly` — healthy real-schema DB → `true`; wrong key → `false`; **corrupt event pages → `false`** (drives the real `AppDatabase` open through the background isolate; a broken error-matcher would rethrow instead of returning `false`, so the test can fail).
- `databasePassesIntegrityCheck` / `encryptedDatabaseOpensWithKey` — now guard the **salvage-copy** verification: sound → `true`; malformed table/index b-tree or corruption past the schema page → `false`.
- `salvageCorruptEncryptedDatabase` — missing file / wrong key → `false` (original untouched); **corrupt DB → drafts (2) & clips (1) preserved, event dropped (0), backup readable under the same key, `user_version` carried over**.
- `DatabaseEncryptionBootstrap` — salvage success keeps the key (no wipe) + resets DM sync state; salvage failure falls through to key-rotation wipe.

`flutter analyze` clean (`lib test` + `db_client`); full `db_client` suite (737) and app bootstrap suites green.

## Manual verification note

The recovery is proven at unit level (byte-corrupting a real encrypted multi-page DB and asserting drafts/clips survive the salvage into a fresh, integrity-clean DB with the schema version carried over; and driving the real `AppDatabase` open through a corrupt DB to confirm the reactive gate returns `false`). End-to-end on a physical device (corrupt DB → salvage → drafts/clips still present after relaunch, events/DMs resync) has **not** been exercised on hardware in this PR.
