### PR TITLE
fix(feed): dedupe addressable videos by coordinate across feeds

### DIFF
--- a/mobile/lib/blocs/video_feed/home_feed_resume_manager.dart
+++ b/mobile/lib/blocs/video_feed/home_feed_resume_manager.dart
@@ -77,6 +77,12 @@ class HomeFeedResumeManager {
   /// the current video instead of behind the whole cached window. The kept
   /// prefix leaves the active video's controller untouched, so it does not
   /// restart when fresh lands.
+  ///
+  /// Dedup uses [VideoEvent.feedDedupKey] (the addressable coordinate when
+  /// present, else the event id) to match the pagination merge in
+  /// [VideoFeedBloc]. A cached addressable video republished with a fresh event
+  /// id shares its coordinate with the fresh copy, so keying on the raw id
+  /// would let both through as a visible duplicate.
   List<VideoEvent> splice({
     required List<VideoEvent> existing,
     required List<VideoEvent> fresh,
@@ -90,8 +96,8 @@ class HomeFeedResumeManager {
       existing.length,
     );
     final head = existing.sublist(0, keepCount);
-    final headIds = head.map((v) => v.id.toLowerCase()).toSet();
-    final tail = fresh.where((v) => !headIds.contains(v.id.toLowerCase()));
+    final headKeys = head.map((v) => v.feedDedupKey).toSet();
+    final tail = fresh.where((v) => !headKeys.contains(v.feedDedupKey));
     return [...head, ...tail];
   }
 

--- a/mobile/lib/providers/classic_vines_provider.dart
+++ b/mobile/lib/providers/classic_vines_provider.dart
@@ -103,14 +103,16 @@ class ClassicVinesFeed extends _$ClassicVinesFeed {
           final videos = stats.toVideoEvents();
 
           // Filter for platform compatibility, content preferences,
-          // blocked users, and shuffle
-          final filteredVideos = videoEventService.filterVideoList(
-            videos
-                .where((v) => v.isSupportedOnCurrentPlatform)
-                .where(
-                  (v) => !blocklistRepository.shouldFilterFromFeeds(v.pubkey),
-                )
-                .toList(),
+          // blocked users, dedupe by addressable identity, and shuffle
+          final filteredVideos = dedupeByFeedKey(
+            videoEventService.filterVideoList(
+              videos
+                  .where((v) => v.isSupportedOnCurrentPlatform)
+                  .where(
+                    (v) => !blocklistRepository.shouldFilterFromFeeds(v.pubkey),
+                  )
+                  .toList(),
+            ),
           );
 
           return filteredVideos..shuffle(_random);
@@ -210,13 +212,20 @@ class ClassicVinesFeed extends _$ClassicVinesFeed {
     );
 
     final allVideos = videoEventService.discoveryVideos;
-    final classicVideos = videoEventService.filterVideoList(
-      allVideos
-          .where((v) => v.isOriginalVine)
-          .where((v) => v.isSupportedOnCurrentPlatform)
-          .where((v) => !blocklistRepository.shouldFilterFromFeeds(v.pubkey))
-          .toList(),
-    )..sort((a, b) => (b.originalLoops ?? 0).compareTo(a.originalLoops ?? 0));
+    final classicVideos =
+        dedupeByFeedKey(
+          videoEventService.filterVideoList(
+            allVideos
+                .where((v) => v.isOriginalVine)
+                .where((v) => v.isSupportedOnCurrentPlatform)
+                .where(
+                  (v) => !blocklistRepository.shouldFilterFromFeeds(v.pubkey),
+                )
+                .toList(),
+          ),
+        )..sort(
+          (a, b) => (b.originalLoops ?? 0).compareTo(a.originalLoops ?? 0),
+        );
 
     // Take top entries then shuffle for variety
     final topClassics = classicVideos.take(_pageSize).toList()
@@ -282,11 +291,16 @@ class ClassicVinesFeed extends _$ClassicVinesFeed {
 
       final videoEventService = ref.read(videoEventServiceProvider);
       final blocklistRepository = ref.read(contentBlocklistRepositoryProvider);
-      final filteredVideos = videoEventService.filterVideoList(
-        videos
-            .where((v) => v.isSupportedOnCurrentPlatform)
-            .where((v) => !blocklistRepository.shouldFilterFromFeeds(v.pubkey))
-            .toList(),
+      final filteredVideos = dedupeByFeedKey(
+        videoEventService.filterVideoList(
+          videos
+              .where((v) => v.isSupportedOnCurrentPlatform)
+              .where(
+                (v) => !blocklistRepository.shouldFilterFromFeeds(v.pubkey),
+              )
+              .toList(),
+        ),
+        alreadySeen: currentState.videos.map((v) => v.feedDedupKey),
       );
 
       final allVideos = [...currentState.videos, ...filteredVideos];

--- a/mobile/lib/providers/classic_vines_provider.g.dart
+++ b/mobile/lib/providers/classic_vines_provider.g.dart
@@ -54,7 +54,7 @@ final class ClassicVinesFeedProvider
   ClassicVinesFeed create() => ClassicVinesFeed();
 }
 
-String _$classicVinesFeedHash() => r'ea3cbaa8514eda258c00dada696d256c279d91e4';
+String _$classicVinesFeedHash() => r'081600c9119922b6177b9d06f744c4f13346dcef';
 
 /// ClassicVines feed provider - shows pre-2017 Vine archive sorted by loops
 ///

--- a/mobile/lib/providers/curation_providers.dart
+++ b/mobile/lib/providers/curation_providers.dart
@@ -6,6 +6,7 @@ import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/providers/environment_provider.dart';
+import 'package:openvine/providers/feed_refresh_helpers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/repository_providers.dart';
 import 'package:openvine/providers/video_events_providers.dart';
@@ -338,11 +339,13 @@ class AnalyticsTrending extends _$AnalyticsTrending {
       if (!ref.mounted) return;
 
       if (videos.isNotEmpty) {
-        // Deduplicate and merge (case-insensitive for Nostr IDs)
-        final existingIds = state.map((v) => v.id.toLowerCase()).toSet();
-        final newVideos = videos
-            .where((v) => !existingIds.contains(v.id.toLowerCase()))
-            .toList();
+        // Deduplicate and merge by addressable identity, so a republished
+        // coordinate (same kind:pubkey:d-tag, fresh event id) is not appended
+        // as a duplicate.
+        final newVideos = dedupeByFeedKey(
+          videos,
+          alreadySeen: state.map((v) => v.feedDedupKey),
+        );
 
         if (newVideos.isNotEmpty) {
           state = [...state, ...newVideos];

--- a/mobile/lib/providers/curation_providers.g.dart
+++ b/mobile/lib/providers/curation_providers.g.dart
@@ -331,7 +331,7 @@ final class AnalyticsTrendingProvider
   }
 }
 
-String _$analyticsTrendingHash() => r'86366ccca08a9c190f948a0d1c1d51f566d0913b';
+String _$analyticsTrendingHash() => r'5f350bca12baa278295901c155736d8bf63a8822';
 
 /// Provider for analytics-based trending videos with cursor pagination
 

--- a/mobile/lib/providers/feed_refresh_helpers.dart
+++ b/mobile/lib/providers/feed_refresh_helpers.dart
@@ -78,6 +78,28 @@ List<VideoEvent> mergeEnrichedVideos({
   }).toList();
 }
 
+/// Removes videos whose [VideoEvent.feedDedupKey] has already been seen,
+/// preserving first-occurrence order.
+///
+/// Deduplicates by the addressable coordinate (`kind:pubkey:d-tag`) when
+/// present, else the event id — so a video republished with a fresh event id
+/// (which the Funnelcake emitted-id cursor dedupes only by event id) never
+/// appears twice. Seed [alreadySeen] with the keys already displayed to also
+/// drop cross-page duplicates when appending a paginated page.
+List<VideoEvent> dedupeByFeedKey(
+  List<VideoEvent> videos, {
+  Iterable<String> alreadySeen = const [],
+}) {
+  final seen = alreadySeen.toSet();
+  final result = <VideoEvent>[];
+  for (final video in videos) {
+    if (seen.add(video.feedDedupKey)) {
+      result.add(video);
+    }
+  }
+  return result;
+}
+
 /// Compares two video lists for equality by element identity.
 bool videoListsEqual(List<VideoEvent> a, List<VideoEvent> b) {
   if (identical(a, b)) return true;

--- a/mobile/lib/providers/for_you_provider.dart
+++ b/mobile/lib/providers/for_you_provider.dart
@@ -135,15 +135,20 @@ class ForYouFeed extends _$ForYouFeed {
         category: LogCategory.video,
       );
 
-      // Filter for platform compatibility, content preferences,
-      // and blocked users
+      // Filter for platform compatibility, content preferences, blocked
+      // users, and dedupe by addressable identity (the recommendation cursor
+      // dedupes by event id, so a republished coordinate arrives twice).
       final videoEventService = ref.read(videoEventServiceProvider);
       final blocklistRepository = ref.read(contentBlocklistRepositoryProvider);
-      final filteredVideos = videoEventService.filterVideoList(
-        resultVideos
-            .where((v) => v.isSupportedOnCurrentPlatform)
-            .where((v) => !blocklistRepository.shouldFilterFromFeeds(v.pubkey))
-            .toList(),
+      final filteredVideos = dedupeByFeedKey(
+        videoEventService.filterVideoList(
+          resultVideos
+              .where((v) => v.isSupportedOnCurrentPlatform)
+              .where(
+                (v) => !blocklistRepository.shouldFilterFromFeeds(v.pubkey),
+              )
+              .toList(),
+        ),
       );
 
       _sessionSeed = requestSeed;
@@ -228,12 +233,10 @@ class ForYouFeed extends _$ForYouFeed {
             .where((v) => !blocklistRepository.shouldFilterFromFeeds(v.pubkey))
             .toList(),
       );
-      final existingIds = currentState.videos
-          .map((video) => video.id.toLowerCase())
-          .toSet();
-      final newVideos = filteredVideos
-          .where((video) => existingIds.add(video.id.toLowerCase()))
-          .toList();
+      final newVideos = dedupeByFeedKey(
+        filteredVideos,
+        alreadySeen: currentState.videos.map((video) => video.feedDedupKey),
+      );
       final mergedVideos = [...currentState.videos, ...newVideos];
       final newEventsLoaded = newVideos.length;
 

--- a/mobile/lib/providers/for_you_provider.g.dart
+++ b/mobile/lib/providers/for_you_provider.g.dart
@@ -48,7 +48,7 @@ final class ForYouFeedProvider
   ForYouFeed create() => ForYouFeed();
 }
 
-String _$forYouFeedHash() => r'99fea132c17a4c236b75cd70e8dcc4d7a06f3dad';
+String _$forYouFeedHash() => r'0a1d1bbd0ef8509befd8dcd3f4f30e20a6b172ae';
 
 /// For You recommendations feed provider - ML-powered personalized videos
 ///

--- a/mobile/lib/providers/new_videos_feed_provider.dart
+++ b/mobile/lib/providers/new_videos_feed_provider.dart
@@ -133,12 +133,10 @@ class NewVideosFeed extends _$NewVideosFeed {
 
       _nextCursor = getOldestTimestamp(newVideos);
 
-      final existingIds = currentState.videos
-          .map((v) => v.id.toLowerCase())
-          .toSet();
-      final dedupedNew = newVideos
-          .where((v) => !existingIds.contains(v.id.toLowerCase()))
-          .toList();
+      final dedupedNew = dedupeByFeedKey(
+        newVideos,
+        alreadySeen: currentState.videos.map((v) => v.feedDedupKey),
+      );
       final filteredNew = _filterVideos(dedupedNew);
 
       if (filteredNew.isEmpty) {

--- a/mobile/lib/providers/new_videos_feed_provider.g.dart
+++ b/mobile/lib/providers/new_videos_feed_provider.g.dart
@@ -45,7 +45,7 @@ final class NewVideosFeedProvider
   NewVideosFeed create() => NewVideosFeed();
 }
 
-String _$newVideosFeedHash() => r'faa810e056887ad2f420147a187bc4e82bbdf861';
+String _$newVideosFeedHash() => r'c3f4833685ed2b951e85628c74629ca8ef233847';
 
 /// New Videos feed provider - shows newest videos first.
 ///

--- a/mobile/lib/providers/popular_videos_feed_provider.dart
+++ b/mobile/lib/providers/popular_videos_feed_provider.dart
@@ -205,13 +205,11 @@ class PopularVideosFeed extends _$PopularVideosFeed {
 
       _applyPage(newVideos);
 
-      // Deduplicate against existing videos
-      final existingIds = currentState.videos
-          .map((v) => v.id.toLowerCase())
-          .toSet();
-      final dedupedNew = newVideos.videos
-          .where((v) => !existingIds.contains(v.id.toLowerCase()))
-          .toList();
+      // Deduplicate against existing videos by addressable identity.
+      final dedupedNew = dedupeByFeedKey(
+        newVideos.videos,
+        alreadySeen: currentState.videos.map((v) => v.feedDedupKey),
+      );
 
       final filteredNew = _filterVideos(dedupedNew, variant);
 

--- a/mobile/lib/providers/popular_videos_feed_provider.g.dart
+++ b/mobile/lib/providers/popular_videos_feed_provider.g.dart
@@ -60,7 +60,7 @@ final class PopularVideosFeedProvider
   PopularVideosFeed create() => PopularVideosFeed();
 }
 
-String _$popularVideosFeedHash() => r'c057c58282d3be8f0d5869b38b94b33cb05bff63';
+String _$popularVideosFeedHash() => r'78744d8b8cc02dd4a4f03d53c9bd58421e565c53';
 
 /// Popular Videos feed provider - shows trending videos by recent engagement.
 ///

--- a/mobile/packages/categories_repository/lib/src/categories_repository.dart
+++ b/mobile/packages/categories_repository/lib/src/categories_repository.dart
@@ -132,6 +132,12 @@ class CategoriesRepository {
   }
 
   /// Returns filtered personalized recommendations for [pubkey].
+  ///
+  /// Recommendation responses can carry the same addressable video more than
+  /// once in a single page: the server's emitted-id cursor dedupes by event
+  /// id, so a republished coordinate (same kind:pubkey:d-tag, fresh event id)
+  /// slips through. Dedupe by [VideoEvent.feedDedupKey] here so the category
+  /// gallery never shows the same video twice.
   Future<List<VideoEvent>> getRecommendedVideos({
     required String pubkey,
     String? category,
@@ -142,13 +148,22 @@ class CategoriesRepository {
       category: category,
       limit: limit,
     );
-    return _filterVideos(response.videos.toVideoEvents());
+    return _dedupeByFeedKey(_filterVideos(response.videos.toVideoEvents()));
   }
 
   List<VideoEvent> _filterVideos(List<VideoEvent> videos) {
     final blockFilter = _blockFilter;
     if (blockFilter == null) return videos;
     return videos.where((video) => !blockFilter(video.pubkey)).toList();
+  }
+
+  /// Removes videos whose [VideoEvent.feedDedupKey] has already been seen,
+  /// preserving first-occurrence order.
+  List<VideoEvent> _dedupeByFeedKey(List<VideoEvent> videos) {
+    final seen = <String>{};
+    return videos
+        .where((video) => seen.add(video.feedDedupKey))
+        .toList(growable: false);
   }
 
   /// Clears the in-memory cache so the next call fetches fresh data.

--- a/mobile/packages/categories_repository/test/src/categories_repository_test.dart
+++ b/mobile/packages/categories_repository/test/src/categories_repository_test.dart
@@ -238,6 +238,41 @@ void main() {
         expect(videos.single.id, 'allowed-id');
         expect(videos.single.pubkey, allowedPubkey);
       });
+
+      test(
+        'collapses a republished coordinate returned twice in one page',
+        () async {
+          when(
+            () => apiClient.getRecommendations(
+              pubkey: 'viewer_pubkey',
+              limit: 50,
+            ),
+          ).thenAnswer(
+            (_) async => RecommendationsResponse(
+              videos: [
+                _videoStats(
+                  id: 'event-a',
+                  pubkey: allowedPubkey,
+                  dTag: 'shared-d-tag',
+                ),
+                _videoStats(
+                  id: 'event-b',
+                  pubkey: allowedPubkey,
+                  dTag: 'shared-d-tag',
+                ),
+              ],
+              source: 'personalized',
+            ),
+          );
+
+          final videos = await repository.getRecommendedVideos(
+            pubkey: 'viewer_pubkey',
+          );
+
+          expect(videos, hasLength(1));
+          expect(videos.single.id, 'event-a');
+        },
+      );
     });
 
     group('invalidateCache', () {
@@ -256,7 +291,11 @@ void main() {
   });
 }
 
-VideoStats _videoStats({required String id, required String pubkey}) {
+VideoStats _videoStats({
+  required String id,
+  required String pubkey,
+  String? dTag,
+}) {
   return VideoStats(
     id: id,
     pubkey: pubkey,
@@ -265,7 +304,7 @@ VideoStats _videoStats({required String id, required String pubkey}) {
     title: 'Video $id',
     createdAt: DateTime(2026),
     kind: 34236,
-    dTag: id,
+    dTag: dTag ?? id,
     reactions: 0,
     comments: 0,
     reposts: 0,

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -2515,7 +2515,18 @@ class VideosRepository {
         ),
       );
     }
-    final videos = _transformVideoStats(response.videos);
+    // Recommendation responses can carry the same addressable video more than
+    // once in a single page: the server's emitted-id cursor dedupes by event
+    // id, so a republished coordinate (same kind:pubkey:d-tag, fresh event id)
+    // slips through. Dedupe by feedDedupKey here — as getNewVideos already does
+    // — so the forYou feed never shows the same video twice.
+    final videos = <VideoEvent>[];
+    _appendUniqueVideos(
+      videos,
+      _transformVideoStats(response.videos),
+      seenVideoKeys: <String>{},
+    );
+
     if (videos.isEmpty) {
       return HomeFeedResult(
         videos: await getPopularVideos(

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -10462,6 +10462,76 @@ void main() {
         ).called(1);
       });
 
+      test(
+        'deduplicates videos sharing an addressable identity in one page',
+        () async {
+          const author = 'recommended-pubkey';
+          const sharedDTag = 'shared-dtag';
+          // Same kind:pubkey:d-tag republished with a fresh event id — the
+          // server's emitted-id cursor dedupes by event id, so this slips
+          // through and must be collapsed by feedDedupKey here.
+          final first = _createVideoStats(
+            id: 'first-event-id',
+            pubkey: author,
+            dTag: sharedDTag,
+            videoUrl: 'https://example.com/first.mp4',
+            createdAt: 1704067250,
+          );
+          final republished = _createVideoStats(
+            id: 'republished-event-id',
+            pubkey: author,
+            dTag: sharedDTag,
+            videoUrl: 'https://example.com/republished.mp4',
+            createdAt: 1704067150,
+          );
+          final other = _createVideoStats(
+            id: 'other-event-id',
+            pubkey: 'other-pubkey',
+            dTag: 'other-dtag',
+            videoUrl: 'https://example.com/other.mp4',
+            createdAt: 1704067100,
+          );
+          when(
+            () => mockFunnelcakeClient.getRecommendations(
+              seed: any(named: 'seed'),
+              pubkey: any(named: 'pubkey'),
+              limit: any(named: 'limit'),
+              fallback: any(named: 'fallback'),
+              category: any(named: 'category'),
+              preferredLanguages: any(named: 'preferredLanguages'),
+              viewerCountry: any(named: 'viewerCountry'),
+            ),
+          ).thenAnswer(
+            (_) async => RecommendationsResponse(
+              videos: [first, republished, other],
+              source: 'personalized',
+            ),
+          );
+
+          final repo = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          final result = await repo.getRecommendedVideos(
+            userPubkey: 'user-pubkey',
+            limit: 10,
+          );
+
+          expect(result.videos, hasLength(2));
+          expect(
+            result.videos.map((v) => v.feedDedupKey).toSet(),
+            hasLength(2),
+            reason: 'no duplicate feedDedupKey survives',
+          );
+          expect(
+            result.videos.where((v) => v.pubkey == author).length,
+            1,
+            reason: 'the republished addressable video collapses to one entry',
+          );
+        },
+      );
+
       test('caches refreshed recommendations for feed remounts', () async {
         final requestedSeeds = <String?>[];
         var callCount = 0;

--- a/mobile/test/blocs/video_feed/home_feed_resume_manager_test.dart
+++ b/mobile/test/blocs/video_feed/home_feed_resume_manager_test.dart
@@ -53,7 +53,7 @@ class _GatedCache implements HomeFeedCache {
   }) async => null;
 }
 
-VideoEvent _video(String id) => VideoEvent(
+VideoEvent _video(String id, {String? vineId}) => VideoEvent(
   id: id,
   pubkey: 'a' * 64,
   createdAt: 1700000000,
@@ -63,6 +63,7 @@ VideoEvent _video(String id) => VideoEvent(
     isUtc: true,
   ),
   videoUrl: 'https://cdn.divine.video/$id.mp4',
+  vineId: vineId,
 );
 
 Future<void> _pump() => Future<void>.delayed(Duration.zero);
@@ -179,6 +180,47 @@ void main() {
       cache.releaseNextWrite();
       await _pump();
       expect(cache.clearCallCount, 1);
+    });
+
+    group('splice', () {
+      test(
+        'drops a fresh addressable video republished with a new event id',
+        () {
+          // Cached head holds the addressable video under its original event
+          // id; the fresh page carries the same kind:pubkey:d-tag video under a
+          // fresh event id. Keyed on the raw event id they would both survive
+          // as a visible duplicate; keyed on feedDedupKey the fresh copy drops.
+          final result = manager.splice(
+            existing: [
+              _video('old-event', vineId: 'shared-d'),
+              _video('c1'),
+            ],
+            fresh: [
+              _video('new-event', vineId: 'shared-d'),
+              _video('f1'),
+            ],
+            currentIndex: 0,
+          );
+
+          expect(
+            result.map((v) => v.id),
+            equals(['old-event', 'c1', 'f1']),
+          );
+        },
+      );
+
+      test('keeps fresh videos with distinct identities', () {
+        final result = manager.splice(
+          existing: [_video('c0'), _video('c1')],
+          fresh: [_video('f0'), _video('f1')],
+          currentIndex: 0,
+        );
+
+        expect(
+          result.map((v) => v.id),
+          equals(['c0', 'c1', 'f0', 'f1']),
+        );
+      });
     });
   });
 }

--- a/mobile/test/providers/explore_feed_refresh_retention_test.dart
+++ b/mobile/test/providers/explore_feed_refresh_retention_test.dart
@@ -775,6 +775,69 @@ void main() {
     );
 
     test(
+      'for you collapses a republished coordinate returned twice in one page',
+      () async {
+        when(
+          () => mockFunnelcakeApiClient.getRecommendations(
+            pubkey: any(named: 'pubkey'),
+            limit: any(named: 'limit'),
+            fallback: any(named: 'fallback'),
+            category: any(named: 'category'),
+            cursor: any(named: 'cursor'),
+            seed: any(named: 'seed'),
+            preferredLanguages: any(named: 'preferredLanguages'),
+            viewerCountry: any(named: 'viewerCountry'),
+          ),
+        ).thenAnswer(
+          (_) => Future.value(
+            RecommendationsResponse(
+              videos: [
+                _videoStats(
+                  'for-you-a',
+                  pubkey: 'author-shared',
+                  dTag: 'shared-d-tag',
+                ),
+                _videoStats(
+                  'for-you-b',
+                  pubkey: 'author-shared',
+                  dTag: 'shared-d-tag',
+                ),
+              ],
+              source: 'personalized',
+              nextCursor: 'cursor-2',
+            ),
+          ),
+        );
+
+        final container = ProviderContainer(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(sharedPreferences),
+            appReadyProvider.overrideWithValue(true),
+            videoEventServiceProvider.overrideWithValue(mockVideoEventService),
+            contentBlocklistRepositoryProvider.overrideWithValue(
+              mockBlocklistRepository,
+            ),
+            funnelcakeApiClientProvider.overrideWithValue(
+              mockFunnelcakeApiClient,
+            ),
+            authServiceProvider.overrideWithValue(mockAuthService),
+            funnelcakeAvailableProvider.overrideWith(
+              _AlwaysAvailableFunnelcake.new,
+            ),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        await container.read(funnelcakeAvailableProvider.future);
+        final subscription = container.listen(forYouFeedProvider, (_, _) {});
+        addTearDown(subscription.close);
+
+        final state = await container.read(forYouFeedProvider.future);
+        expect(state.videos.map((video) => video.id), ['for-you-a']);
+      },
+    );
+
+    test(
       'for you load more keeps cursor and seed paired across rebuilds',
       () async {
         final geoCompleter = Completer<GeoBlockResponse>();
@@ -1116,13 +1179,13 @@ VideoEvent _vineArchiveVideo(String id, {int createdAt = 1_742_169_600}) {
   );
 }
 
-VideoStats _videoStats(String id) {
+VideoStats _videoStats(String id, {String? pubkey, String? dTag}) {
   return VideoStats(
     id: id,
-    pubkey: 'author-$id',
+    pubkey: pubkey ?? 'author-$id',
     createdAt: DateTime(2026, 3, 17),
     kind: 34236,
-    dTag: id,
+    dTag: dTag ?? id,
     title: id,
     thumbnail: 'https://example.com/$id.jpg',
     videoUrl: 'https://example.com/$id.mp4',

--- a/mobile/test/providers/feed_refresh_helpers_test.dart
+++ b/mobile/test/providers/feed_refresh_helpers_test.dart
@@ -290,4 +290,67 @@ void main() {
       expect(getOldestTimestamp([videoAt(42)]), 42);
     });
   });
+
+  group('dedupeByFeedKey', () {
+    VideoEvent video(String id, {String? pubkey, String? dTag}) {
+      return VideoEvent(
+        id: id,
+        pubkey: pubkey ?? 'author-$id',
+        createdAt: 1700000000,
+        content: '',
+        timestamp: DateTime.fromMillisecondsSinceEpoch(
+          1700000000 * 1000,
+          isUtc: true,
+        ),
+        videoUrl: 'https://example.com/$id.mp4',
+        vineId: dTag,
+      );
+    }
+
+    test('collapses videos sharing an addressable coordinate', () {
+      // Same kind:pubkey:d-tag republished with a fresh event id — the
+      // Funnelcake emitted-id cursor only dedupes by event id, so this pair
+      // reaches the client and must collapse to one.
+      final result = dedupeByFeedKey([
+        video('first-event', pubkey: 'p1', dTag: 'shared'),
+        video('republished-event', pubkey: 'p1', dTag: 'shared'),
+        video('other', pubkey: 'p2', dTag: 'unique'),
+      ]);
+
+      expect(result.map((v) => v.id), equals(['first-event', 'other']));
+    });
+
+    test('drops videos already seen when appending a page', () {
+      final existing = [video('a', pubkey: 'p1', dTag: 'shared')];
+      final result = dedupeByFeedKey(
+        [
+          video('a-republished', pubkey: 'p1', dTag: 'shared'),
+          video('b', pubkey: 'p2', dTag: 'other'),
+        ],
+        alreadySeen: existing.map((v) => v.feedDedupKey),
+      );
+
+      expect(result.map((v) => v.id), equals(['b']));
+    });
+
+    test('dedupes by event id when no d-tag is present', () {
+      final result = dedupeByFeedKey([
+        video('dup', pubkey: 'p1'),
+        video('dup', pubkey: 'p1'),
+        video('keep', pubkey: 'p1'),
+      ]);
+
+      expect(result.map((v) => v.id), equals(['dup', 'keep']));
+    });
+
+    test('keeps distinct videos and preserves order', () {
+      final result = dedupeByFeedKey([
+        video('x'),
+        video('y'),
+        video('z'),
+      ]);
+
+      expect(result.map((v) => v.id), equals(['x', 'y', 'z']));
+    });
+  });
 }


### PR DESCRIPTION
Closes #5878

## What

Feeds could show the same video twice. Root cause: the Funnelcake recommendation endpoint (forYou) can return the same addressable video (`kind:pubkey:d-tag`) twice in a single page — its `emitted_ids` cursor dedupes by **event id**, so a coordinate republished under a fresh event id slips through. `getRecommendedVideos` forwarded that straight to the feed (unlike `getNewVideos`, it never deduped), and the `createdAt` sort placed the pair adjacent → a visible duplicate.

Confirmed from device logs: `raw=25 transformed=25 duplicatesInPage=1` with dupe key `34236:<pubkey>:<d-tag>` — the duplicate was already present in the raw API response (`_transformVideoStats` is a strict 1:1 map, so it can't create it). Popular (`getV2PopularVideosPage`, native + classic) logged `duplicatesInPage=0` — it already dedupes correctly.

## Why this is not purely a backend issue

The same duplicate class also surfaces client-side, independent of any single bad response, because addressable Nostr events are legitimately republished with new event ids and different layers hold different versions:

- **Cache splice** (home): a cached window from a previous session holds event id A; the fresh feed brings the same coordinate as event id B. The old splice deduped by raw event id and kept both.
- **Local relay store** (Explore Classics `discoveryVideos`, relay fallbacks): can hold one coordinate under multiple event ids.

So the client fix is defense-in-depth. The within-response dedupe should **also** be fixed in `divine-funnelcake` (dedupe the recommendation cursor by addressable coordinate, not event id).

## Changes

Dedupe by `feedDedupKey` (addressable coordinate, else event id) at every feed merge point, via a new shared `dedupeByFeedKey` helper:

- `getRecommendedVideos` dedupes its page (root-cause forYou fix)
- `ForYouFeed` provider (the For You tab's ML feed, which calls `getRecommendations()` directly) dedupes first page + `loadMore`
- Explore new / popular / classic providers dedupe `loadMore` + first page
- Analytics **trending** feed dedupes appended pages
- Home cache `splice` dedupes by coordinate instead of raw event id

Every For You surface (home forYou via `VideoFeedBloc` + the `ForYouFeed` provider tab), New, Followed, Classic, Popular, and Trending now dedupe consistently, within-page and cross-page.

### Intentionally deferred

- **Curated lists** (`list_providers`) dedupe raw Nostr events by `event.id` at the stream level, *before* `VideoEvent` construction. Switching that to coordinate dedupe is a structurally different change, and relays already collapse replaceable events per coordinate, so the exposure is lower. Left for a focused follow-up.

## Tests

- `dedupeByFeedKey`: coordinate collapse, cross-page seed, id fallback, order preservation
- `getRecommendedVideos`: republished-coordinate regression
- `splice`: republished-coordinate regression + distinct-identity keep
- Provider call sites delegate to the tested helper (same coverage approach as the New/Popular/Classic providers already in this PR)
- `flutter analyze` clean; affected suites green

## Test plan

- [ ] For You tab (both the home forYou feed and the ML For You tab) shows no duplicate videos
- [ ] Explore New / Popular / Classics / Trending show no duplicates on scroll / loadMore
- [ ] Home feed resume (cold start → fresh splice) has no duplicate at the splice boundary