### PR TITLE
fix(camera): fire the native permission dialog on the current page

### DIFF
--- a/mobile/integration_test/auth/user_journey_test.dart
+++ b/mobile/integration_test/auth/user_journey_test.dart
@@ -75,22 +75,9 @@ void main() {
         await tapSemantic(tester, 'camera_button');
         logPhase('Camera button tapped');
 
-        // The recorder's CameraPermissionGate renders a permission screen
-        // with a "Continue" button that triggers the native OS dialog.
-        // We must tap "Continue" first, then handle the native dialogs.
-        final continuePermission = find.text('Continue');
-        final foundContinue = await waitForWidget(
-          tester,
-          continuePermission,
-          maxSeconds: 10,
-        );
-        if (foundContinue) {
-          await tester.tap(continuePermission);
-          await tester.pump(const Duration(seconds: 1));
-          logPhase('Tapped Continue on pre-permission sheet');
-        }
-
-        // Grant camera permission via Patrol native automation
+        // Tapping the camera button fires the native OS permission dialog
+        // directly on the current page — no in-app "Continue" priming screen.
+        // Grant camera permission via Patrol native automation.
         if (await $.platformAutomator.mobile.isPermissionDialogVisible(
           timeout: const Duration(seconds: 5),
         )) {

--- a/mobile/lib/blocs/camera_permission/camera_permission_bloc.dart
+++ b/mobile/lib/blocs/camera_permission/camera_permission_bloc.dart
@@ -17,7 +17,8 @@ part 'camera_permission_state.dart';
 ///
 /// Handles:
 /// - Checking current permission status
-/// - Requesting permissions via OS dialog (from the gate)
+/// - Requesting permissions via the OS dialog (from
+///   `pushToCameraWithPermission` on the current page, or the gate)
 /// - Caching status to avoid repeated OS calls
 /// - Refreshing status when app resumes from background
 ///
@@ -28,6 +29,13 @@ part 'camera_permission_state.dart';
 /// dialog is dismissed with the back button — `droppable()` would then block
 /// every later request forever. `restartable()` lets the next camera tap
 /// abandon the stuck request and fire a fresh native dialog.
+///
+/// Accepted tradeoff of `restartable()`: on a fast double-tap, the second
+/// request supersedes the first while its dialog is still live, so a grant on
+/// that first dialog is dropped and that one tap resolves to nothing. It
+/// self-heals on the next tap (a refresh sees the OS grant and navigates), so
+/// the visible cost is a single dead tap on an uncommon race — preferred over
+/// permanently stranding the recorder on the back-dismiss hang.
 class CameraPermissionBloc
     extends Bloc<CameraPermissionEvent, CameraPermissionState> {
   CameraPermissionBloc({

--- a/mobile/lib/blocs/camera_permission/camera_permission_bloc.dart
+++ b/mobile/lib/blocs/camera_permission/camera_permission_bloc.dart
@@ -10,11 +10,10 @@ part 'camera_permission_state.dart';
 
 /// BLoC for managing camera and microphone permissions.
 ///
-/// Permission prompting is owned by the recorder gate
-/// (`CameraPermissionGate`): a [CameraPermissionRequest] is only dispatched
-/// from the gate's explicit "Continue" action, so the native media permission
-/// dialog always happens in response to a user gesture on the recorder
-/// screen. Callers that navigate to the recorder no longer prompt themselves.
+/// A [CameraPermissionRequest] fires the native OS permission dialog directly —
+/// dispatched by `pushToCameraWithPermission` on the current page, or by
+/// `CameraPermissionGate` on direct navigation to the recorder. There is no
+/// in-app priming screen; the dialog always follows the user's camera gesture.
 ///
 /// Handles:
 /// - Checking current permission status
@@ -69,9 +68,9 @@ class CameraPermissionBloc
       final cameraStatus = await _permissionsService.requestCameraPermission();
 
       if (cameraStatus != PermissionStatus.granted) {
-        // Stay on the recorder gate with the resolved status so the gate can
-        // re-prompt (canRequest) or send the user to Settings
-        // (requiresSettings) instead of silently bouncing back to the feed.
+        // Surface the resolved status so the caller can re-prompt (canRequest)
+        // or send the user to Settings (requiresSettings) instead of silently
+        // bouncing back to the feed.
         emit(CameraPermissionLoaded(_cameraStatusFromPermission(cameraStatus)));
         return;
       }

--- a/mobile/lib/blocs/camera_permission/camera_permission_bloc.dart
+++ b/mobile/lib/blocs/camera_permission/camera_permission_bloc.dart
@@ -22,11 +22,13 @@ part 'camera_permission_state.dart';
 /// - Caching status to avoid repeated OS calls
 /// - Refreshing status when app resumes from background
 ///
-/// Both [CameraPermissionRequest] and [CameraPermissionRefresh] use the
-/// `droppable()` transformer so duplicate requests/refreshes dispatched while
-/// one is already in flight are ignored. This replaces the previous in-flight
-/// boolean/future fields with the idiomatic bloc concurrency primitive and
-/// keeps all coordination out of mutable instance state.
+/// [CameraPermissionRefresh] uses `droppable()` so overlapping refreshes are
+/// ignored. [CameraPermissionRequest] uses `restartable()`: a new request
+/// supersedes an in-flight one. This matters because `permission_handler`'s
+/// native `request()` can hang and never complete when the Android permission
+/// dialog is dismissed with the back button — `droppable()` would then block
+/// every later request forever. `restartable()` lets the next camera tap
+/// abandon the stuck request and fire a fresh native dialog.
 class CameraPermissionBloc
     extends Bloc<CameraPermissionEvent, CameraPermissionState> {
   CameraPermissionBloc({
@@ -35,7 +37,7 @@ class CameraPermissionBloc
   }) : _permissionsService = permissionsService,
        _skipLinuxBypass = skipLinuxBypass ?? false,
        super(const CameraPermissionInitial()) {
-    on<CameraPermissionRequest>(_onRequest, transformer: droppable());
+    on<CameraPermissionRequest>(_onRequest, transformer: restartable());
     on<CameraPermissionRefresh>(_onRefresh, transformer: droppable());
     on<CameraPermissionOpenSettings>(_onOpenSettings);
   }
@@ -56,6 +58,12 @@ class CameraPermissionBloc
     if (currentState.status != CameraPermissionStatus.canRequest) {
       return;
     }
+
+    // Emit a distinct loading state so a denial that leaves the permission
+    // still requestable (canRequest -> canRequest) is observable as a real
+    // transition. Without it, the equal Loaded(canRequest) emit is suppressed
+    // by Equatable and the caller can't tell the request finished.
+    emit(const CameraPermissionLoading());
 
     try {
       final cameraStatus = await _permissionsService.requestCameraPermission();

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -3269,7 +3269,6 @@
     "cameraPermissionRetry": "እንደገና ይሞክሩ",
     "cameraPermissionAllowAccessTitle": "የካሜራ እና ማይክሮፎን መዳረሻ ፍቀድ",
     "cameraPermissionAllowAccessDescription": "ይህ በመተግበሪያው ውስጥ ቪዲዮዎችን እንዲቀርጹ እና እንዲያርትዑ ይፈቅድልዎታል፣ ምንም ተጨማሪ ነገር የለም።",
-    "cameraPermissionContinue": "ቀጥል",
     "cameraPermissionGoToSettings": "ወደ ቅንብሮች ይሂዱ",
     "videoRecorderWhySixSecondsTitle": "ለምን ስድስት ሰከንዶች?",
     "videoRecorderWhySixSecondsSubtitle": "ፈጣን ቅንጥቦች ለድንገተኛነት ቦታ ይፈጥራሉ። የ6 ሰከንድ ቅርጸት ትክክለኛ ጊዜዎችን በሚከሰቱበት ጊዜ እንዲይዙ ያግዝዎታል።",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2701,7 +2701,6 @@
     "cameraPermissionRetry": "إعادة المحاولة",
     "cameraPermissionAllowAccessTitle": "السماح بالوصول إلى الكاميرا والميكروفون",
     "cameraPermissionAllowAccessDescription": "يتيح لك هذا التقاط الفيديوهات وتعديلها مباشرة داخل التطبيق، ولا شيء أكثر.",
-    "cameraPermissionContinue": "متابعة",
     "cameraPermissionGoToSettings": "الذهاب إلى الإعدادات",
     "videoEditorAddClipFromLibrary": "إضافة مقطع من المكتبة",
     "videoEditorAddElementSemanticLabel": "إضافة عنصر",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -2959,7 +2959,6 @@
     "cameraPermissionRetry": "Опитай пак",
     "cameraPermissionAllowAccessTitle": "Разреши достъп до камерата и микрофона",
     "cameraPermissionAllowAccessDescription": "Това ти позволява да записваш и редактираш видеа директно в приложението. Нищо повече.",
-    "cameraPermissionContinue": "Продължи",
     "cameraPermissionGoToSettings": "Към настройките",
     "videoRecorderWhySixSecondsTitle": "Защо шест секунди?",
     "videoRecorderWhySixSecondsSubtitle": "Кратките клипове оставят място за спонтанност. 6-секундният формат ти помага да хванеш истинските моменти, докато се случват.",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2709,7 +2709,6 @@
     "cameraPermissionRetry": "Erneut versuchen",
     "cameraPermissionAllowAccessTitle": "Kamera- und Mikrofonzugriff erlauben",
     "cameraPermissionAllowAccessDescription": "Damit kannst du Videos direkt hier in der App aufnehmen und bearbeiten, sonst nichts.",
-    "cameraPermissionContinue": "Weiter",
     "cameraPermissionGoToSettings": "Zu den Einstellungen",
     "videoRecorderWhySixSecondsTitle": "Warum sechs Sekunden?",
     "videoRecorderWhySixSecondsSubtitle": "Kurze Clips schaffen Raum für Spontanität. Das 6-Sekunden-Format hilft dir, echte Momente festzuhalten, während sie passieren.",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -4407,7 +4407,6 @@
   "cameraPermissionRetry": "Retry",
   "cameraPermissionAllowAccessTitle": "Allow camera & microphone access",
   "cameraPermissionAllowAccessDescription": "This allows you to capture and edit videos right here in the app, nothing more.",
-  "cameraPermissionContinue": "Continue",
   "cameraPermissionGoToSettings": "Go to settings",
   "videoRecorderWhySixSecondsTitle": "Why six seconds?",
   "videoRecorderWhySixSecondsSubtitle": "Quick clips make space for spontaneity. The 6-second format helps you capture authentic moments as they happen.",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2717,7 +2717,6 @@
     "cameraPermissionRetry": "Reintentar",
     "cameraPermissionAllowAccessTitle": "Permitir acceso a cámara y micrófono",
     "cameraPermissionAllowAccessDescription": "Esto te permite capturar y editar videos aquí mismo en la app, nada más.",
-    "cameraPermissionContinue": "Continuar",
     "cameraPermissionGoToSettings": "Ir a ajustes",
     "videoRecorderWhySixSecondsTitle": "¿Por qué seis segundos?",
     "videoRecorderWhySixSecondsSubtitle": "Los clips cortos dejan espacio para la espontaneidad. El formato de 6 segundos te ayuda a capturar momentos auténticos tal como ocurren.",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1661,7 +1661,6 @@
     "cameraPermissionRetry": "Subukan ulit",
     "cameraPermissionAllowAccessTitle": "Payagan ang access sa camera at mikropono",
     "cameraPermissionAllowAccessDescription": "Pinapayagan ka nitong kumuha at mag-edit ng video dito mismo sa app, wala nang iba.",
-    "cameraPermissionContinue": "Magpatuloy",
     "cameraPermissionGoToSettings": "Pumunta sa settings",
     "videoRecorderWhySixSecondsTitle": "Bakit anim na segundo?",
     "videoRecorderWhySixSecondsSubtitle": "Ang mabilis na clip ay nagbibigay-daan sa pagiging spontaneous. Ang 6-second format ay tumutulong sa'yong makuha ang mga authentic na sandali habang nangyayari.",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2709,7 +2709,6 @@
     "cameraPermissionRetry": "Réessayer",
     "cameraPermissionAllowAccessTitle": "Autoriser l'accès à la caméra et au micro",
     "cameraPermissionAllowAccessDescription": "Cela vous permet de capturer et de modifier des vidéos directement dans l'application, rien de plus.",
-    "cameraPermissionContinue": "Continuer",
     "cameraPermissionGoToSettings": "Aller aux paramètres",
     "videoRecorderWhySixSecondsTitle": "Pourquoi six secondes ?",
     "videoRecorderWhySixSecondsSubtitle": "Les clips courts laissent place à la spontanéité. Le format de 6 secondes vous aide à capturer des moments authentiques au moment où ils se produisent.",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2708,7 +2708,6 @@
     "cameraPermissionRetry": "Coba lagi",
     "cameraPermissionAllowAccessTitle": "Izinkan akses kamera & mikrofon",
     "cameraPermissionAllowAccessDescription": "Ini memungkinkan Anda merekam dan mengedit video langsung di aplikasi, tidak lebih.",
-    "cameraPermissionContinue": "Lanjutkan",
     "cameraPermissionGoToSettings": "Buka pengaturan",
     "videoEditorAddClipFromLibrary": "Tambah klip dari Perpustakaan",
     "videoEditorAddElementSemanticLabel": "Tambah elemen",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2709,7 +2709,6 @@
     "cameraPermissionRetry": "Riprova",
     "cameraPermissionAllowAccessTitle": "Consenti accesso a fotocamera e microfono",
     "cameraPermissionAllowAccessDescription": "Questo ti consente di registrare e modificare video direttamente nell'app, niente di più.",
-    "cameraPermissionContinue": "Continua",
     "cameraPermissionGoToSettings": "Vai alle impostazioni",
     "videoRecorderWhySixSecondsTitle": "Perché sei secondi?",
     "videoRecorderWhySixSecondsSubtitle": "I clip brevi lasciano spazio alla spontaneità. Il formato da 6 secondi ti aiuta a catturare momenti autentici mentre accadono.",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2701,7 +2701,6 @@
     "cameraPermissionRetry": "再試行",
     "cameraPermissionAllowAccessTitle": "カメラとマイクへのアクセスを許可",
     "cameraPermissionAllowAccessDescription": "これにより、アプリ内で動画の撮影と編集ができるようになります。それ以外の用途はありません。",
-    "cameraPermissionContinue": "続行",
     "cameraPermissionGoToSettings": "設定に移動",
     "videoEditorAddClipFromLibrary": "ライブラリからクリップを追加",
     "videoEditorAddElementSemanticLabel": "要素を追加",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -2032,7 +2032,6 @@
     "cameraPermissionRetry": "다시 시도",
     "cameraPermissionAllowAccessTitle": "카메라 및 마이크 접근 허용",
     "cameraPermissionAllowAccessDescription": "이렇게 하면 앱에서 바로 동영상을 촬영하고 편집할 수 있으며, 그 외 용도는 없습니다.",
-    "cameraPermissionContinue": "계속",
     "cameraPermissionGoToSettings": "설정으로 이동",
     "videoEditorAddClipFromLibrary": "보관함에서 클립 추가",
     "videoEditorAddElementSemanticLabel": "요소 추가",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2709,7 +2709,6 @@
     "cameraPermissionRetry": "Opnieuw proberen",
     "cameraPermissionAllowAccessTitle": "Toegang tot camera en microfoon toestaan",
     "cameraPermissionAllowAccessDescription": "Hiermee kun je video's rechtstreeks in de app opnemen en bewerken, verder niets.",
-    "cameraPermissionContinue": "Doorgaan",
     "cameraPermissionGoToSettings": "Naar instellingen",
     "videoRecorderWhySixSecondsTitle": "Waarom zes seconden?",
     "videoRecorderWhySixSecondsSubtitle": "Korte clips geven ruimte aan spontaniteit. Het 6-secondenformaat helpt je om authentieke momenten vast te leggen terwijl ze gebeuren.",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2709,7 +2709,6 @@
     "cameraPermissionRetry": "Spróbuj ponownie",
     "cameraPermissionAllowAccessTitle": "Zezwól na dostęp do aparatu i mikrofonu",
     "cameraPermissionAllowAccessDescription": "To pozwala nagrywać i edytować filmy bezpośrednio w aplikacji i nic więcej.",
-    "cameraPermissionContinue": "Kontynuuj",
     "cameraPermissionGoToSettings": "Przejdź do ustawień",
     "videoRecorderWhySixSecondsTitle": "Dlaczego sześć sekund?",
     "videoRecorderWhySixSecondsSubtitle": "Krótkie klipy dają przestrzeń na spontaniczność. Format 6 sekund pomaga uchwycić autentyczne chwile w momencie, gdy się dzieją.",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2709,7 +2709,6 @@
     "cameraPermissionRetry": "Tentar novamente",
     "cameraPermissionAllowAccessTitle": "Permitir acesso à câmera e ao microfone",
     "cameraPermissionAllowAccessDescription": "Isso permite capturar e editar vídeos direto no app, nada além disso.",
-    "cameraPermissionContinue": "Continuar",
     "cameraPermissionGoToSettings": "Ir para configurações",
     "videoRecorderWhySixSecondsTitle": "Por que seis segundos?",
     "videoRecorderWhySixSecondsSubtitle": "Clipes curtos abrem espaço para a espontaneidade. O formato de 6 segundos ajuda você a capturar momentos autênticos enquanto acontecem.",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2709,7 +2709,6 @@
     "cameraPermissionRetry": "Încearcă din nou",
     "cameraPermissionAllowAccessTitle": "Permite accesul la cameră și microfon",
     "cameraPermissionAllowAccessDescription": "Aceasta îți permite să capturezi și să editezi videoclipuri direct în aplicație, nimic mai mult.",
-    "cameraPermissionContinue": "Continuă",
     "cameraPermissionGoToSettings": "Mergi la setări",
     "videoRecorderWhySixSecondsTitle": "De ce șase secunde?",
     "videoRecorderWhySixSecondsSubtitle": "Clipurile scurte lasă loc pentru spontaneitate. Formatul de 6 secunde te ajută să surprinzi momente autentice exact când se întâmplă.",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2709,7 +2709,6 @@
     "cameraPermissionRetry": "Försök igen",
     "cameraPermissionAllowAccessTitle": "Tillåt åtkomst till kamera och mikrofon",
     "cameraPermissionAllowAccessDescription": "Detta låter dig spela in och redigera videor direkt i appen, inget mer.",
-    "cameraPermissionContinue": "Fortsätt",
     "cameraPermissionGoToSettings": "Gå till inställningar",
     "videoRecorderWhySixSecondsTitle": "Varför sex sekunder?",
     "videoRecorderWhySixSecondsSubtitle": "Snabba klipp skapar utrymme för spontanitet. Formatet på 6 sekunder hjälper dig att fånga äkta ögonblick när de händer.",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2708,7 +2708,6 @@
     "cameraPermissionRetry": "Tekrar dene",
     "cameraPermissionAllowAccessTitle": "Kamera ve mikrofona erişime izin ver",
     "cameraPermissionAllowAccessDescription": "Bu, videoları doğrudan uygulama içinde çekip düzenlemeni sağlar, daha fazlasını değil.",
-    "cameraPermissionContinue": "Devam et",
     "cameraPermissionGoToSettings": "Ayarlara git",
     "videoEditorAddClipFromLibrary": "Kütüphaneden klip ekle",
     "videoEditorAddElementSemanticLabel": "Öğe ekle",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -13302,12 +13302,6 @@ abstract class AppLocalizations {
   /// **'This allows you to capture and edit videos right here in the app, nothing more.'**
   String get cameraPermissionAllowAccessDescription;
 
-  /// No description provided for @cameraPermissionContinue.
-  ///
-  /// In en, this message translates to:
-  /// **'Continue'**
-  String get cameraPermissionContinue;
-
   /// No description provided for @cameraPermissionGoToSettings.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -7522,9 +7522,6 @@ class AppLocalizationsAm extends AppLocalizations {
       'ይህ በመተግበሪያው ውስጥ ቪዲዮዎችን እንዲቀርጹ እና እንዲያርትዑ ይፈቅድልዎታል፣ ምንም ተጨማሪ ነገር የለም።';
 
   @override
-  String get cameraPermissionContinue => 'ቀጥል';
-
-  @override
   String get cameraPermissionGoToSettings => 'ወደ ቅንብሮች ይሂዱ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -7630,9 +7630,6 @@ class AppLocalizationsAr extends AppLocalizations {
       'يتيح لك هذا التقاط الفيديوهات وتعديلها مباشرة داخل التطبيق، ولا شيء أكثر.';
 
   @override
-  String get cameraPermissionContinue => 'متابعة';
-
-  @override
   String get cameraPermissionGoToSettings => 'الذهاب إلى الإعدادات';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -7747,9 +7747,6 @@ class AppLocalizationsBg extends AppLocalizations {
       'Това ти позволява да записваш и редактираш видеа директно в приложението. Нищо повече.';
 
   @override
-  String get cameraPermissionContinue => 'Продължи';
-
-  @override
   String get cameraPermissionGoToSettings => 'Към настройките';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -7766,9 +7766,6 @@ class AppLocalizationsDe extends AppLocalizations {
       'Damit kannst du Videos direkt hier in der App aufnehmen und bearbeiten, sonst nichts.';
 
   @override
-  String get cameraPermissionContinue => 'Weiter';
-
-  @override
   String get cameraPermissionGoToSettings => 'Zu den Einstellungen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -7666,9 +7666,6 @@ class AppLocalizationsEn extends AppLocalizations {
       'This allows you to capture and edit videos right here in the app, nothing more.';
 
   @override
-  String get cameraPermissionContinue => 'Continue';
-
-  @override
   String get cameraPermissionGoToSettings => 'Go to settings';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -7745,9 +7745,6 @@ class AppLocalizationsEs extends AppLocalizations {
       'Esto te permite capturar y editar videos aquí mismo en la app, nada más.';
 
   @override
-  String get cameraPermissionContinue => 'Continuar';
-
-  @override
   String get cameraPermissionGoToSettings => 'Ir a ajustes';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -7763,9 +7763,6 @@ class AppLocalizationsFil extends AppLocalizations {
       'Pinapayagan ka nitong kumuha at mag-edit ng video dito mismo sa app, wala nang iba.';
 
   @override
-  String get cameraPermissionContinue => 'Magpatuloy';
-
-  @override
   String get cameraPermissionGoToSettings => 'Pumunta sa settings';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -7776,9 +7776,6 @@ class AppLocalizationsFr extends AppLocalizations {
       'Cela vous permet de capturer et de modifier des vidéos directement dans l\'application, rien de plus.';
 
   @override
-  String get cameraPermissionContinue => 'Continuer';
-
-  @override
   String get cameraPermissionGoToSettings => 'Aller aux paramètres';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -7648,9 +7648,6 @@ class AppLocalizationsId extends AppLocalizations {
       'Ini memungkinkan Anda merekam dan mengedit video langsung di aplikasi, tidak lebih.';
 
   @override
-  String get cameraPermissionContinue => 'Lanjutkan';
-
-  @override
   String get cameraPermissionGoToSettings => 'Buka pengaturan';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -7746,9 +7746,6 @@ class AppLocalizationsIt extends AppLocalizations {
       'Questo ti consente di registrare e modificare video direttamente nell\'app, niente di più.';
 
   @override
-  String get cameraPermissionContinue => 'Continua';
-
-  @override
   String get cameraPermissionGoToSettings => 'Vai alle impostazioni';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -7369,9 +7369,6 @@ class AppLocalizationsJa extends AppLocalizations {
       'これにより、アプリ内で動画の撮影と編集ができるようになります。それ以外の用途はありません。';
 
   @override
-  String get cameraPermissionContinue => '続行';
-
-  @override
   String get cameraPermissionGoToSettings => '設定に移動';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -7392,9 +7392,6 @@ class AppLocalizationsKo extends AppLocalizations {
       '이렇게 하면 앱에서 바로 동영상을 촬영하고 편집할 수 있으며, 그 외 용도는 없습니다.';
 
   @override
-  String get cameraPermissionContinue => '계속';
-
-  @override
   String get cameraPermissionGoToSettings => '설정으로 이동';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -7707,9 +7707,6 @@ class AppLocalizationsNl extends AppLocalizations {
       'Hiermee kun je video\'s rechtstreeks in de app opnemen en bewerken, verder niets.';
 
   @override
-  String get cameraPermissionContinue => 'Doorgaan';
-
-  @override
   String get cameraPermissionGoToSettings => 'Naar instellingen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -7846,9 +7846,6 @@ class AppLocalizationsPl extends AppLocalizations {
       'To pozwala nagrywać i edytować filmy bezpośrednio w aplikacji i nic więcej.';
 
   @override
-  String get cameraPermissionContinue => 'Kontynuuj';
-
-  @override
   String get cameraPermissionGoToSettings => 'Przejdź do ustawień';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -7725,9 +7725,6 @@ class AppLocalizationsPt extends AppLocalizations {
       'Isso permite capturar e editar vídeos direto no app, nada além disso.';
 
   @override
-  String get cameraPermissionContinue => 'Continuar';
-
-  @override
   String get cameraPermissionGoToSettings => 'Ir para configurações';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -7848,9 +7848,6 @@ class AppLocalizationsRo extends AppLocalizations {
       'Aceasta îți permite să capturezi și să editezi videoclipuri direct în aplicație, nimic mai mult.';
 
   @override
-  String get cameraPermissionContinue => 'Continuă';
-
-  @override
   String get cameraPermissionGoToSettings => 'Mergi la setări';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -7673,9 +7673,6 @@ class AppLocalizationsSv extends AppLocalizations {
       'Detta låter dig spela in och redigera videor direkt i appen, inget mer.';
 
   @override
-  String get cameraPermissionContinue => 'Fortsätt';
-
-  @override
   String get cameraPermissionGoToSettings => 'Gå till inställningar';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -7648,9 +7648,6 @@ class AppLocalizationsTr extends AppLocalizations {
       'Bu, videoları doğrudan uygulama içinde çekip düzenlemeni sağlar, daha fazlasını değil.';
 
   @override
-  String get cameraPermissionContinue => 'Devam et';
-
-  @override
   String get cameraPermissionGoToSettings => 'Ayarlara git';
 
   @override

--- a/mobile/lib/utils/camera_permission_check.dart
+++ b/mobile/lib/utils/camera_permission_check.dart
@@ -37,24 +37,25 @@ extension CameraPermissionNavigation on BuildContext {
       return true;
     }
 
-    var status = await _resolveStatus(bloc);
+    final resolved = await _resolveStatus(bloc);
     if (!mounted) return false;
 
-    // Fire the native dialog while still on the current page. A null status
-    // means the bloc never settled on a Loaded state (e.g. a previous request
-    // is stuck); requesting supersedes it via the restartable transformer.
-    if (status == CameraPermissionStatus.canRequest || status == null) {
-      status = await _requestPermission(bloc);
+    if (resolved == CameraPermissionStatus.canRequest) {
+      // Fire the native dialog while still on the current page.
+      final requested = await _requestPermission(bloc);
       if (!mounted) return false;
+      // Denied-but-requestable, or superseded by a newer tap → stay put so the
+      // next camera tap re-prompts.
+      if (requested != CameraPermissionStatus.authorized &&
+          requested != CameraPermissionStatus.requiresSettings) {
+        return false;
+      }
     }
 
-    // Stay put unless the status is terminal; a denial that stays requestable
-    // (or a superseded/stuck request) keeps the user here to re-tap.
-    if (status != CameraPermissionStatus.authorized &&
-        status != CameraPermissionStatus.requiresSettings) {
-      return false;
-    }
-
+    // Navigate for a terminal status (authorized opens the camera,
+    // requiresSettings shows the settings prompt) or when the entry check
+    // couldn't settle (`resolved == null`: an errored/stalled pre-nav check) so
+    // the gate surfaces its Error + Retry screen instead of dead-waiting here.
     await pushWithVideoPause(VideoRecorderScreen.path);
     return true;
   }

--- a/mobile/lib/utils/camera_permission_check.dart
+++ b/mobile/lib/utils/camera_permission_check.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Pre-navigation camera permission check for camera routes
-// ABOUTME: Routes requestable permissions to VideoRecorderScreen's gate
+// ABOUTME: Fires the native permission dialog on the current page
 
 import 'dart:async';
 
@@ -10,17 +10,23 @@ import 'package:openvine/blocs/camera_permission/camera_permission_bloc.dart';
 import 'package:openvine/screens/video_recorder_screen.dart';
 import 'package:openvine/utils/pause_aware_modals.dart';
 
+/// Bumped by every camera permission request so a stale flow — one left
+/// awaiting a hung native `request()` — can't navigate once a newer camera tap
+/// has superseded it. Only the latest generation is allowed to act on its
+/// result.
+int _cameraRequestGeneration = 0;
+
 /// Extension for camera navigation with pre-flight permission check.
 extension CameraPermissionNavigation on BuildContext {
-  /// Navigates to [VideoRecorderScreen] after the permission status has
-  /// settled.
+  /// Resolves camera/microphone permission and navigates to
+  /// [VideoRecorderScreen] once it makes sense to.
   ///
-  /// Permission prompts are owned by [VideoRecorderScreen]'s
-  /// `CameraPermissionGate`, so the native media permission request happens
-  /// from the recorder's explicit Continue action rather than from a
-  /// pre-navigation bottom sheet. This method only waits for the bloc to
-  /// resolve out of its initial state so the gate renders the correct screen
-  /// immediately on arrival.
+  /// A still-requestable permission triggers the native OS dialog *on the
+  /// current page* — no pre-navigation screen or loading page. Navigation
+  /// happens only for a terminal status: [CameraPermissionStatus.authorized]
+  /// opens the camera and [CameraPermissionStatus.requiresSettings] lands on
+  /// the gate's settings prompt. A denial — including a dialog dismissed with
+  /// the back button — keeps the user here so the next camera tap re-prompts.
   ///
   /// Returns `true` if navigation occurred.
   Future<bool> pushToCameraWithPermission() async {
@@ -31,34 +37,47 @@ extension CameraPermissionNavigation on BuildContext {
       return true;
     }
 
-    await _awaitPermissionResolved(bloc);
+    var status = await _resolveStatus(bloc);
     if (!mounted) return false;
 
-    // Navigate for every resolved status. The route gate renders the
-    // authorized camera, the canRequest prompt, the requiresSettings prompt,
-    // or the loading/error UI, and owns the native permission request.
+    // Fire the native dialog while still on the current page. A null status
+    // means the bloc never settled on a Loaded state (e.g. a previous request
+    // is stuck); requesting supersedes it via the restartable transformer.
+    if (status == CameraPermissionStatus.canRequest || status == null) {
+      status = await _requestPermission(bloc);
+      if (!mounted) return false;
+    }
+
+    // Stay put unless the status is terminal; a denial that stays requestable
+    // (or a superseded/stuck request) keeps the user here to re-tap.
+    if (status != CameraPermissionStatus.authorized &&
+        status != CameraPermissionStatus.requiresSettings) {
+      return false;
+    }
+
     await pushWithVideoPause(VideoRecorderScreen.path);
     return true;
   }
 }
 
-/// Waits until the permission bloc has settled out of its initial/loading
-/// state so the recorder gate renders the correct screen on arrival.
-///
-/// Triggers a refresh first when no check has run yet, and falls back after a
-/// timeout so navigation is never blocked on a stream that never emits.
-Future<void> _awaitPermissionResolved(CameraPermissionBloc bloc) async {
+/// Reads the [CameraPermissionStatus] from a bloc state, or `null` when the
+/// state carries no status (initial/loading/error).
+CameraPermissionStatus? _statusOf(CameraPermissionState state) =>
+    state is CameraPermissionLoaded ? state.status : null;
+
+/// Returns the current permission status, forcing a fresh (non-hanging) status
+/// check when the bloc isn't already sitting on a settled
+/// [CameraPermissionLoaded] — e.g. after a previous request left it stuck in
+/// [CameraPermissionLoading]. The status check never triggers the OS dialog,
+/// so it can't hang the way a request can.
+Future<CameraPermissionStatus?> _resolveStatus(
+  CameraPermissionBloc bloc,
+) async {
   final current = bloc.state;
-  if (current is CameraPermissionLoaded || current is CameraPermissionError) {
-    return;
-  }
+  if (current is CameraPermissionLoaded) return current.status;
 
-  // Not yet loaded — trigger refresh and wait for the result.
-  if (current is CameraPermissionInitial) {
-    bloc.add(const CameraPermissionRefresh());
-  }
-
-  await bloc.stream
+  bloc.add(const CameraPermissionRefresh());
+  final settled = await bloc.stream
       .firstWhere(
         (s) => s is CameraPermissionLoaded || s is CameraPermissionError,
       )
@@ -66,4 +85,28 @@ Future<void> _awaitPermissionResolved(CameraPermissionBloc bloc) async {
         const Duration(seconds: 10),
         onTimeout: () => const CameraPermissionError(),
       );
+  return _statusOf(settled);
+}
+
+/// Dispatches the permission request and resolves to the resulting status.
+///
+/// The request is `restartable()`, so this tap supersedes any prior in-flight
+/// request (a back-dismissed dialog can leave one hung). Only the latest
+/// generation acts on its result, so a stale awaiting flow can't navigate
+/// after a newer tap took over.
+Future<CameraPermissionStatus?> _requestPermission(
+  CameraPermissionBloc bloc,
+) async {
+  final generation = ++_cameraRequestGeneration;
+  bloc.add(const CameraPermissionRequest());
+  final result = await bloc.stream
+      .firstWhere(
+        (s) => s is CameraPermissionLoaded || s is CameraPermissionError,
+      )
+      .timeout(
+        const Duration(seconds: 30),
+        onTimeout: () => const CameraPermissionError(),
+      );
+  if (generation != _cameraRequestGeneration) return null;
+  return _statusOf(result);
 }

--- a/mobile/lib/widgets/camera_permission_gate.dart
+++ b/mobile/lib/widgets/camera_permission_gate.dart
@@ -44,6 +44,10 @@ class _CameraPermissionGateState extends State<CameraPermissionGate>
     with WidgetsBindingObserver {
   bool _wasInBackground = false;
 
+  /// Guards the one auto-request per mount so a denial that stays requestable
+  /// doesn't immediately re-trigger the native dialog in a loop.
+  bool _autoRequested = false;
+
   @override
   void initState() {
     super.initState();
@@ -72,6 +76,11 @@ class _CameraPermissionGateState extends State<CameraPermissionGate>
           category: LogCategory.video,
         );
         bloc.add(const CameraPermissionRefresh());
+      } else {
+        // Already resolved before the gate mounted (the app-level bloc warms
+        // the check at startup). The listener won't fire for this initial
+        // state, so drive the auto-request here.
+        _onPermissionState(bloc.state);
       }
     });
   }
@@ -114,6 +123,24 @@ class _CameraPermissionGateState extends State<CameraPermissionGate>
     }
   }
 
+  /// Drives the direct-request flow for a still-requestable permission:
+  /// fire the native OS dialog immediately (no in-app priming screen) the
+  /// first time, and pop back on a denial that leaves it requestable so the
+  /// next camera tap re-prompts. A permanent denial resolves to
+  /// [CameraPermissionStatus.requiresSettings] and is surfaced by the builder.
+  void _onPermissionState(CameraPermissionState state) {
+    if (!mounted) return;
+    if (state is! CameraPermissionLoaded) return;
+    if (state.status != CameraPermissionStatus.canRequest) return;
+
+    if (!_autoRequested) {
+      _autoRequested = true;
+      context.read<CameraPermissionBloc>().add(const CameraPermissionRequest());
+    } else {
+      _popBack();
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return BlocConsumer<CameraPermissionBloc, CameraPermissionState>(
@@ -123,6 +150,7 @@ class _CameraPermissionGateState extends State<CameraPermissionGate>
           name: 'CameraPermissionGate',
           category: LogCategory.video,
         );
+        _onPermissionState(state);
       },
       builder: (context, state) {
         Log.debug(
@@ -157,17 +185,10 @@ class _CameraPermissionGateState extends State<CameraPermissionGate>
           ),
           CameraPermissionLoaded(:final status) => switch (status) {
             CameraPermissionStatus.authorized => widget.child,
-            CameraPermissionStatus.canRequest => _PermissionScreen(
-              title: context.l10n.cameraPermissionAllowAccessTitle,
-              description: context.l10n.cameraPermissionAllowAccessDescription,
-              buttonLabel: context.l10n.cameraPermissionContinue,
-              onAction: () {
-                context.read<CameraPermissionBloc>().add(
-                  const CameraPermissionRequest(),
-                );
-              },
-              onClose: _popBack,
-            ),
+            // Requestable permission fires the native OS dialog directly via
+            // [_onPermissionState]; no in-app priming screen. The indicator
+            // covers the brief window while the dialog is up.
+            CameraPermissionStatus.canRequest => const _LoadingIndicator(),
             CameraPermissionStatus.requiresSettings => _PermissionScreen(
               title: context.l10n.cameraPermissionAllowAccessTitle,
               description: context.l10n.cameraPermissionAllowAccessDescription,

--- a/mobile/lib/widgets/camera_permission_gate.dart
+++ b/mobile/lib/widgets/camera_permission_gate.dart
@@ -170,8 +170,8 @@ class _CameraPermissionGateState extends State<CameraPermissionGate>
         }
 
         return switch (state) {
-          CameraPermissionInitial() => const _LoadingIndicator(),
-          CameraPermissionLoading() => const _LoadingIndicator(),
+          CameraPermissionInitial() => _LoadingIndicator(onClose: _popBack),
+          CameraPermissionLoading() => _LoadingIndicator(onClose: _popBack),
           CameraPermissionError() => _PermissionScreen(
             title: context.l10n.cameraPermissionErrorTitle,
             description: context.l10n.cameraPermissionErrorDescription,
@@ -188,7 +188,9 @@ class _CameraPermissionGateState extends State<CameraPermissionGate>
             // Requestable permission fires the native OS dialog directly via
             // [_onPermissionState]; no in-app priming screen. The indicator
             // covers the brief window while the dialog is up.
-            CameraPermissionStatus.canRequest => const _LoadingIndicator(),
+            CameraPermissionStatus.canRequest => _LoadingIndicator(
+              onClose: _popBack,
+            ),
             CameraPermissionStatus.requiresSettings => _PermissionScreen(
               title: context.l10n.cameraPermissionAllowAccessTitle,
               description: context.l10n.cameraPermissionAllowAccessDescription,
@@ -207,14 +209,46 @@ class _CameraPermissionGateState extends State<CameraPermissionGate>
   }
 }
 
-/// Loading indicator centered on screen
+/// Centered loading indicator with an optional escape hatch.
+///
+/// The direct-navigation gate path (quick actions, deep links) can land here on
+/// a still-requestable permission whose native dialog was dismissed with the
+/// back button — the `permission_handler` hang that pins the bloc in
+/// [CameraPermissionLoading]. [onClose] lets the user bail back to the feed
+/// instead of being trapped on the spinner; re-entering re-fires the request.
 class _LoadingIndicator extends StatelessWidget {
-  const _LoadingIndicator();
+  const _LoadingIndicator({this.onClose});
+
+  final VoidCallback? onClose;
 
   @override
   Widget build(BuildContext context) {
-    return const Center(
-      child: CircularProgressIndicator(color: VineTheme.vineGreen),
+    return Scaffold(
+      backgroundColor: VineTheme.backgroundColor,
+      body: Stack(
+        fit: StackFit.expand,
+        children: [
+          const Center(
+            child: CircularProgressIndicator(color: VineTheme.vineGreen),
+          ),
+          if (onClose case final onClose?)
+            Align(
+              alignment: .topLeft,
+              child: SafeArea(
+                bottom: false,
+                child: Padding(
+                  padding: const .fromLTRB(16, 16, 0, 8),
+                  child: DivineIconButton(
+                    icon: .x,
+                    onPressed: onClose,
+                    size: .small,
+                    type: .ghost,
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
     );
   }
 }

--- a/mobile/lib/widgets/camera_permission_gate.dart
+++ b/mobile/lib/widgets/camera_permission_gate.dart
@@ -17,14 +17,14 @@ import 'package:unified_logger/unified_logger.dart';
 
 /// A declarative gate widget that handles camera/microphone permissions.
 ///
-/// This gate owns permission prompting: a denied or blocked request keeps the
-/// user here on the matching prompt instead of bouncing back to the feed, so
-/// the native permission dialog only ever fires from the explicit Continue
-/// action below.
+/// On direct navigation to the recorder (quick actions, deep links) a
+/// still-requestable permission fires the native OS dialog immediately via
+/// [_onPermissionState] — no in-app priming screen. A denial that stays
+/// requestable pops back so the next camera tap re-prompts.
 ///
 /// Renders appropriate UI based on permission state:
 /// - loading: Shows a loading indicator
-/// - canRequest: Shows the prompt with a Continue button that requests access
+/// - canRequest: Shows a loading indicator while the native dialog is up
 /// - requiresSettings: Shows the prompt with a Go to Settings button
 /// - authorized: Renders the [child] (camera screen)
 /// - error: Shows an error screen with a Retry button

--- a/mobile/test/blocs/camera_permission/camera_permission_bloc_test.dart
+++ b/mobile/test/blocs/camera_permission/camera_permission_bloc_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -102,12 +104,14 @@ void main() {
             const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
         act: (bloc) => bloc.add(const CameraPermissionRequest()),
         expect: () => [
+          const CameraPermissionLoading(),
           const CameraPermissionLoaded(CameraPermissionStatus.authorized),
         ],
       );
 
       blocTest<CameraPermissionBloc, CameraPermissionState>(
-        'stays on Loaded(canRequest) when camera request stays requestable',
+        'emits [Loading, Loaded(canRequest)] when camera request stays '
+        'requestable',
         setUp: () {
           when(
             () => mockPermissionsService.requestCameraPermission(),
@@ -120,9 +124,13 @@ void main() {
         seed: () =>
             const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
         act: (bloc) => bloc.add(const CameraPermissionRequest()),
-        // Mapped status equals the seeded state, so no new state is emitted —
-        // the gate keeps showing the canRequest prompt for a retry.
-        expect: () => <CameraPermissionState>[],
+        // The transient Loading makes the denial observable even though the
+        // mapped status equals the seeded canRequest, so the caller can tell
+        // the request finished and re-prompt on the next tap.
+        expect: () => [
+          const CameraPermissionLoading(),
+          const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
+        ],
         verify: (_) {
           verify(
             () => mockPermissionsService.requestCameraPermission(),
@@ -134,7 +142,8 @@ void main() {
       );
 
       blocTest<CameraPermissionBloc, CameraPermissionState>(
-        'stays on Loaded(canRequest) when microphone request stays requestable',
+        'emits [Loading, Loaded(canRequest)] when microphone request stays '
+        'requestable',
         setUp: () {
           when(
             () => mockPermissionsService.requestCameraPermission(),
@@ -150,7 +159,10 @@ void main() {
         seed: () =>
             const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
         act: (bloc) => bloc.add(const CameraPermissionRequest()),
-        expect: () => <CameraPermissionState>[],
+        expect: () => [
+          const CameraPermissionLoading(),
+          const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
+        ],
         verify: (_) {
           verify(
             () => mockPermissionsService.requestCameraPermission(),
@@ -162,7 +174,7 @@ void main() {
       );
 
       blocTest<CameraPermissionBloc, CameraPermissionState>(
-        'emits [Loaded(authorized)] when gallery permission denied '
+        'emits [Loading, Loaded(authorized)] when gallery permission denied '
         '(gallery is optional)',
         setUp: () {
           when(
@@ -183,6 +195,7 @@ void main() {
             const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
         act: (bloc) => bloc.add(const CameraPermissionRequest()),
         expect: () => [
+          const CameraPermissionLoading(),
           const CameraPermissionLoaded(CameraPermissionStatus.authorized),
         ],
       );
@@ -202,6 +215,7 @@ void main() {
             const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
         act: (bloc) => bloc.add(const CameraPermissionRequest()),
         expect: () => [
+          const CameraPermissionLoading(),
           const CameraPermissionLoaded(CameraPermissionStatus.requiresSettings),
         ],
         verify: (_) {
@@ -229,17 +243,24 @@ void main() {
             const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
         act: (bloc) => bloc.add(const CameraPermissionRequest()),
         expect: () => [
+          const CameraPermissionLoading(),
           const CameraPermissionLoaded(CameraPermissionStatus.requiresSettings),
         ],
       );
 
       blocTest<CameraPermissionBloc, CameraPermissionState>(
-        'drops a duplicate request dispatched while one is in flight',
+        'restartable request lets a refreshed retry supersede a stuck request',
         setUp: () {
+          var cameraCalls = 0;
           when(
             () => mockPermissionsService.requestCameraPermission(),
           ).thenAnswer((_) async {
-            await Future<void>.delayed(const Duration(milliseconds: 10));
+            cameraCalls++;
+            // The first request never completes (mimics the Android
+            // back-dismiss hang); the superseding request resolves.
+            if (cameraCalls == 1) {
+              return Completer<PermissionStatus>().future;
+            }
             return PermissionStatus.granted;
           });
           when(
@@ -248,6 +269,15 @@ void main() {
           when(
             () => mockPermissionsService.requestGalleryPermission(),
           ).thenAnswer((_) async => PermissionStatus.granted);
+          // The retry refreshes the stuck Loading back to a requestable status
+          // before re-requesting (mirrors pushToCameraWithPermission on a
+          // second camera tap).
+          when(
+            () => mockPermissionsService.checkCameraStatus(),
+          ).thenAnswer((_) async => PermissionStatus.canRequest);
+          when(
+            () => mockPermissionsService.checkMicrophoneStatus(),
+          ).thenAnswer((_) async => PermissionStatus.canRequest);
         },
         build: () => CameraPermissionBloc(
           permissionsService: mockPermissionsService,
@@ -255,24 +285,28 @@ void main() {
         ),
         seed: () =>
             const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
-        act: (bloc) {
-          bloc
-            ..add(const CameraPermissionRequest())
-            ..add(const CameraPermissionRequest());
+        act: (bloc) async {
+          // First request hangs on the camera prompt (state -> Loading).
+          bloc.add(const CameraPermissionRequest());
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+          // Refresh un-sticks Loading back to canRequest.
+          bloc.add(const CameraPermissionRefresh());
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+          // With droppable this would be dropped (the first is still in
+          // flight); restartable lets it supersede and resolve.
+          bloc.add(const CameraPermissionRequest());
         },
-        wait: const Duration(milliseconds: 20),
+        wait: const Duration(milliseconds: 50),
         expect: () => [
+          const CameraPermissionLoading(),
+          const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
+          const CameraPermissionLoading(),
           const CameraPermissionLoaded(CameraPermissionStatus.authorized),
         ],
-        verify: (_) {
-          verify(
-            () => mockPermissionsService.requestCameraPermission(),
-          ).called(1);
-        },
       );
 
       blocTest<CameraPermissionBloc, CameraPermissionState>(
-        'emits [Loaded(authorized)] when gallery permission requires settings '
+        'emits [Loading, Loaded(authorized)] when gallery requires settings '
         '(gallery is optional)',
         setUp: () {
           when(
@@ -293,12 +327,13 @@ void main() {
             const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
         act: (bloc) => bloc.add(const CameraPermissionRequest()),
         expect: () => [
+          const CameraPermissionLoading(),
           const CameraPermissionLoaded(CameraPermissionStatus.authorized),
         ],
       );
 
       blocTest<CameraPermissionBloc, CameraPermissionState>(
-        'emits [Error] when camera request throws',
+        'emits [Loading, Error] when camera request throws',
         setUp: () {
           when(
             () => mockPermissionsService.requestCameraPermission(),
@@ -311,11 +346,14 @@ void main() {
         seed: () =>
             const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
         act: (bloc) => bloc.add(const CameraPermissionRequest()),
-        expect: () => [const CameraPermissionError()],
+        expect: () => [
+          const CameraPermissionLoading(),
+          const CameraPermissionError(),
+        ],
       );
 
       blocTest<CameraPermissionBloc, CameraPermissionState>(
-        'emits [Error] when microphone request throws',
+        'emits [Loading, Error] when microphone request throws',
         setUp: () {
           when(
             () => mockPermissionsService.requestCameraPermission(),
@@ -331,11 +369,14 @@ void main() {
         seed: () =>
             const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
         act: (bloc) => bloc.add(const CameraPermissionRequest()),
-        expect: () => [const CameraPermissionError()],
+        expect: () => [
+          const CameraPermissionLoading(),
+          const CameraPermissionError(),
+        ],
       );
 
       blocTest<CameraPermissionBloc, CameraPermissionState>(
-        'emits [Error] when gallery request throws',
+        'emits [Loading, Error] when gallery request throws',
         setUp: () {
           when(
             () => mockPermissionsService.requestCameraPermission(),
@@ -354,7 +395,10 @@ void main() {
         seed: () =>
             const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
         act: (bloc) => bloc.add(const CameraPermissionRequest()),
-        expect: () => [const CameraPermissionError()],
+        expect: () => [
+          const CameraPermissionLoading(),
+          const CameraPermissionError(),
+        ],
       );
     });
 

--- a/mobile/test/utils/camera_permission_check_test.dart
+++ b/mobile/test/utils/camera_permission_check_test.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Tests for pushToCameraWithPermission extension on BuildContext
-// ABOUTME: Verifies pre-navigation permission checks route to the recorder gate
+// ABOUTME: Verifies the native permission request fires on the current page
 
 import 'dart:async';
 
@@ -87,9 +87,29 @@ void main() {
     );
   }
 
+  void verifyNavigated() {
+    verify(
+      () => mockGoRouter.push<Object?>(
+        VideoRecorderScreen.path,
+        extra: any(named: 'extra'),
+      ),
+    ).called(1);
+  }
+
+  void verifyNotNavigated() {
+    verifyNever(
+      () => mockGoRouter.push<Object?>(
+        VideoRecorderScreen.path,
+        extra: any(named: 'extra'),
+      ),
+    );
+  }
+
   group('pushToCameraWithPermission', () {
-    group('navigates directly', () {
-      testWidgets('when permission is authorized', (tester) async {
+    group('terminal statuses navigate without requesting', () {
+      testWidgets('authorized navigates and dispatches nothing', (
+        tester,
+      ) async {
         final bloc = _FakeCameraPermissionBloc(
           const CameraPermissionLoaded(CameraPermissionStatus.authorized),
         );
@@ -101,16 +121,14 @@ void main() {
         await tester.tap(find.text('Trigger'));
         await tester.pumpAndSettle();
 
-        verify(
-          () => mockGoRouter.push<Object?>(
-            VideoRecorderScreen.path,
-            extra: any(named: 'extra'),
-          ),
-        ).called(1);
+        verifyNavigated();
         expect(result, isTrue);
+        expect(bloc.addedEvents, isEmpty);
       });
 
-      testWidgets('when permission requires settings', (tester) async {
+      testWidgets('requiresSettings navigates and dispatches nothing', (
+        tester,
+      ) async {
         final bloc = _FakeCameraPermissionBloc(
           const CameraPermissionLoaded(CameraPermissionStatus.requiresSettings),
         );
@@ -122,18 +140,89 @@ void main() {
         await tester.tap(find.text('Trigger'));
         await tester.pumpAndSettle();
 
-        verify(
-          () => mockGoRouter.push<Object?>(
-            VideoRecorderScreen.path,
-            extra: any(named: 'extra'),
-          ),
-        ).called(1);
+        verifyNavigated();
+        expect(result, isTrue);
+        expect(bloc.addedEvents, isEmpty);
+      });
+    });
+
+    group('requestable permission fires the native request first', () {
+      testWidgets('dispatches request on the current page before navigating', (
+        tester,
+      ) async {
+        final bloc = _FakeCameraPermissionBloc(
+          const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
+        );
+        await tester.pumpWidget(buildSubject(bloc));
+
+        await tester.tap(find.text('Trigger'));
+        await tester.pump();
+
+        // The request fires while still on the current page — no navigation
+        // has happened yet.
+        expect(bloc.addedEvents, contains(isA<CameraPermissionRequest>()));
+        verifyNotNavigated();
+
+        bloc.emitState(
+          const CameraPermissionLoaded(CameraPermissionStatus.authorized),
+        );
+        await tester.pumpAndSettle();
+
+        verifyNavigated();
+      });
+
+      testWidgets(
+        'stays put when the request is denied but still requestable',
+        (
+          tester,
+        ) async {
+          final bloc = _FakeCameraPermissionBloc(
+            const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
+          );
+          bool? result;
+          await tester.pumpWidget(
+            buildSubject(bloc, onResult: (r) => result = r),
+          );
+
+          await tester.tap(find.text('Trigger'));
+          await tester.pump();
+
+          bloc.emitState(
+            const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
+          );
+          await tester.pumpAndSettle();
+
+          verifyNotNavigated();
+          expect(result, isFalse);
+        },
+      );
+
+      testWidgets('navigates when the request resolves to requiresSettings', (
+        tester,
+      ) async {
+        final bloc = _FakeCameraPermissionBloc(
+          const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
+        );
+        bool? result;
+        await tester.pumpWidget(
+          buildSubject(bloc, onResult: (r) => result = r),
+        );
+
+        await tester.tap(find.text('Trigger'));
+        await tester.pump();
+
+        bloc.emitState(
+          const CameraPermissionLoaded(CameraPermissionStatus.requiresSettings),
+        );
+        await tester.pumpAndSettle();
+
+        verifyNavigated();
         expect(result, isTrue);
       });
     });
 
-    group('waits for permission status', () {
-      testWidgets('adds $CameraPermissionRefresh when state is initial', (
+    group('resolves status first when not settled', () {
+      testWidgets('refreshes when initial, then navigates when authorized', (
         tester,
       ) async {
         final bloc = _FakeCameraPermissionBloc(const CameraPermissionInitial());
@@ -144,142 +233,41 @@ void main() {
 
         expect(bloc.addedEvents, contains(isA<CameraPermissionRefresh>()));
 
-        // Unblock the stream wait
-        bloc.emitState(
-          const CameraPermissionLoaded(CameraPermissionStatus.authorized),
-        );
-        await tester.pumpAndSettle();
-      });
-
-      testWidgets('navigates when permission resolves to authorized', (
-        tester,
-      ) async {
-        final bloc = _FakeCameraPermissionBloc(const CameraPermissionInitial());
-        bool? result;
-        await tester.pumpWidget(
-          buildSubject(bloc, onResult: (r) => result = r),
-        );
-
-        await tester.tap(find.text('Trigger'));
-        await tester.pump();
-
         bloc.emitState(
           const CameraPermissionLoaded(CameraPermissionStatus.authorized),
         );
         await tester.pumpAndSettle();
 
-        verify(
-          () => mockGoRouter.push<Object?>(
-            VideoRecorderScreen.path,
-            extra: any(named: 'extra'),
-          ),
-        ).called(1);
-        expect(result, isTrue);
+        verifyNavigated();
       });
 
-      testWidgets('navigates directly when resolve times out after 10s', (
+      testWidgets('refreshes when stuck in loading instead of hanging', (
         tester,
       ) async {
-        final bloc = _FakeCameraPermissionBloc(const CameraPermissionInitial());
-        bool? result;
-        await tester.pumpWidget(
-          buildSubject(bloc, onResult: (r) => result = r),
-        );
+        final bloc = _FakeCameraPermissionBloc(const CameraPermissionLoading());
+        await tester.pumpWidget(buildSubject(bloc));
 
         await tester.tap(find.text('Trigger'));
         await tester.pump();
 
-        // Stream never emits → 10s timeout fires → navigates anyway and lets
-        // the gate render the loading/error UI.
-        await tester.pump(const Duration(seconds: 11));
-        await tester.pumpAndSettle();
+        // A stuck Loading state must not block: a fresh refresh is dispatched.
+        expect(bloc.addedEvents, contains(isA<CameraPermissionRefresh>()));
 
-        verify(
-          () => mockGoRouter.push<Object?>(
-            VideoRecorderScreen.path,
-            extra: any(named: 'extra'),
-          ),
-        ).called(1);
-        expect(result, isTrue);
-      });
-
-      testWidgets('navigates when permission resolves to error', (
-        tester,
-      ) async {
-        final bloc = _FakeCameraPermissionBloc(const CameraPermissionInitial());
-        bool? result;
-        await tester.pumpWidget(
-          buildSubject(bloc, onResult: (r) => result = r),
+        bloc.emitState(
+          const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
         );
-
-        await tester.tap(find.text('Trigger'));
         await tester.pump();
 
-        bloc.emitState(const CameraPermissionError());
-        await tester.pumpAndSettle();
+        // Once resolved to canRequest, the native request fires.
+        expect(bloc.addedEvents, contains(isA<CameraPermissionRequest>()));
 
-        verify(
-          () => mockGoRouter.push<Object?>(
-            VideoRecorderScreen.path,
-            extra: any(named: 'extra'),
-          ),
-        ).called(1);
-        expect(result, isTrue);
-      });
-    });
-
-    group('returns immediately for terminal states', () {
-      testWidgets('navigates directly when state is $CameraPermissionError', (
-        tester,
-      ) async {
-        final bloc = _FakeCameraPermissionBloc(const CameraPermissionError());
-        bool? result;
-        await tester.pumpWidget(
-          buildSubject(bloc, onResult: (r) => result = r),
+        bloc.emitState(
+          const CameraPermissionLoaded(CameraPermissionStatus.authorized),
         );
-
-        await tester.tap(find.text('Trigger'));
         await tester.pumpAndSettle();
 
-        verify(
-          () => mockGoRouter.push<Object?>(
-            VideoRecorderScreen.path,
-            extra: any(named: 'extra'),
-          ),
-        ).called(1);
-        expect(result, isTrue);
-        expect(bloc.addedEvents, isEmpty);
+        verifyNavigated();
       });
-    });
-
-    group('routes requestable permissions to the recorder gate', () {
-      testWidgets(
-        'navigates without dispatching $CameraPermissionRequest when canRequest',
-        (tester) async {
-          final bloc = _FakeCameraPermissionBloc(
-            const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
-          );
-          bool? result;
-          await tester.pumpWidget(
-            buildSubject(bloc, onResult: (r) => result = r),
-          );
-
-          await tester.tap(find.text('Trigger'));
-          await tester.pumpAndSettle();
-
-          verify(
-            () => mockGoRouter.push<Object?>(
-              VideoRecorderScreen.path,
-              extra: any(named: 'extra'),
-            ),
-          ).called(1);
-          expect(
-            bloc.addedEvents,
-            isNot(contains(isA<CameraPermissionRequest>())),
-          );
-          expect(result, isTrue);
-        },
-      );
     });
   });
 }

--- a/mobile/test/utils/camera_permission_check_test.dart
+++ b/mobile/test/utils/camera_permission_check_test.dart
@@ -268,6 +268,63 @@ void main() {
 
         verifyNavigated();
       });
+
+      testWidgets(
+        'navigates to the gate when the entry check errors so Retry shows',
+        (tester) async {
+          final bloc = _FakeCameraPermissionBloc(
+            const CameraPermissionInitial(),
+          );
+          bool? result;
+          await tester.pumpWidget(
+            buildSubject(bloc, onResult: (r) => result = r),
+          );
+
+          await tester.tap(find.text('Trigger'));
+          await tester.pump();
+
+          // The entry check refreshes, then errors.
+          expect(bloc.addedEvents, contains(isA<CameraPermissionRefresh>()));
+          bloc.emitState(const CameraPermissionError());
+          await tester.pumpAndSettle();
+
+          // Navigate so the gate renders Error + Retry — no request is fired
+          // on the errored state (which would dead-wait the 30s timeout).
+          verifyNavigated();
+          expect(
+            bloc.addedEvents,
+            isNot(contains(isA<CameraPermissionRequest>())),
+          );
+          expect(result, isTrue);
+        },
+      );
+    });
+
+    group('supersedes stale concurrent flows', () {
+      testWidgets('only the latest of two concurrent taps navigates', (
+        tester,
+      ) async {
+        final bloc = _FakeCameraPermissionBloc(
+          const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
+        );
+        await tester.pumpWidget(buildSubject(bloc));
+
+        // Two overlapping camera taps each start a request flow; the
+        // generation guard must let only the latest act on the shared result,
+        // otherwise both would push the recorder.
+        await tester.tap(find.text('Trigger'));
+        await tester.pump();
+        await tester.tap(find.text('Trigger'));
+        await tester.pump();
+
+        bloc.emitState(
+          const CameraPermissionLoaded(CameraPermissionStatus.authorized),
+        );
+        await tester.pumpAndSettle();
+
+        // verifyNavigated asserts exactly one push, not two.
+        verifyNavigated();
+      });
     });
   });
 }

--- a/mobile/test/widgets/camera_permission_gate_test.dart
+++ b/mobile/test/widgets/camera_permission_gate_test.dart
@@ -3,13 +3,22 @@
 
 import 'dart:async';
 
+import 'package:bloc_test/bloc_test.dart';
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/camera_permission/camera_permission_bloc.dart';
+import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/clip_manager_state.dart';
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/providers/clip_manager_provider.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/widgets/camera_permission_gate.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../helpers/go_router.dart';
 
@@ -42,19 +51,55 @@ class _FakeCameraPermissionBloc extends Fake implements CameraPermissionBloc {
   Future<void> close() async => _controller.close();
 }
 
+class _MockVideoRecorderBloc
+    extends MockBloc<VideoRecorderEvent, VideoRecorderBlocState>
+    implements VideoRecorderBloc {}
+
+class _TestClipManagerNotifier extends ClipManagerNotifier {
+  @override
+  final List<DivineVideoClip> clips = const [];
+
+  @override
+  ClipManagerState build() => ClipManagerState(clips: clips);
+}
+
 void main() {
-  Widget buildSubject(
-    _FakeCameraPermissionBloc bloc,
-    MockGoRouter goRouter,
-  ) {
-    return MaterialApp(
-      localizationsDelegates: AppLocalizations.localizationsDelegates,
-      supportedLocales: AppLocalizations.supportedLocales,
-      home: MockGoRouterProvider(
-        goRouter: goRouter,
-        child: BlocProvider<CameraPermissionBloc>.value(
-          value: bloc,
-          child: const CameraPermissionGate(child: Text('CAMERA')),
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final l10n = lookupAppLocalizations(const Locale('en'));
+
+  late SharedPreferences prefs;
+  late _MockVideoRecorderBloc recorderBloc;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    recorderBloc = _MockVideoRecorderBloc();
+    when(() => recorderBloc.state).thenReturn(const VideoRecorderBlocState());
+  });
+
+  // The requiresSettings / error states render `_PermissionScreen`, which
+  // embeds the recorder bottom bar — hence the VideoRecorderBloc + clip
+  // provider scaffolding even though the gate itself only needs the
+  // permission bloc.
+  Widget buildSubject(_FakeCameraPermissionBloc bloc, MockGoRouter goRouter) {
+    return ProviderScope(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        clipManagerProvider.overrideWith(_TestClipManagerNotifier.new),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: MockGoRouterProvider(
+          goRouter: goRouter,
+          child: MultiBlocProvider(
+            providers: [
+              BlocProvider<CameraPermissionBloc>.value(value: bloc),
+              BlocProvider<VideoRecorderBloc>.value(value: recorderBloc),
+            ],
+            child: const CameraPermissionGate(child: Text('CAMERA')),
+          ),
         ),
       ),
     );
@@ -73,40 +118,38 @@ void main() {
         await tester.pumpWidget(buildSubject(bloc, MockGoRouter()));
         await tester.pump();
 
-        // The dialog is fired directly; the old "Continue" priming screen is
-        // gone and a spinner covers the brief window while it's up.
+        // The dialog is fired directly; the old priming screen (a DivineButton
+        // prompt) is gone and only a spinner covers the brief window.
         expect(bloc.addedEvents, contains(isA<CameraPermissionRequest>()));
         expect(find.byType(CircularProgressIndicator), findsOneWidget);
-        final l10n = lookupAppLocalizations(const Locale('en'));
-        expect(find.text(l10n.cameraPermissionContinue), findsNothing);
+        expect(find.byType(DivineButton), findsNothing);
       },
     );
 
-    testWidgets(
-      'pops back when the request is denied but stays requestable',
-      (tester) async {
-        final bloc = _FakeCameraPermissionBloc(
-          const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
-        );
-        addTearDown(bloc.close);
-        final goRouter = MockGoRouter();
-        when(goRouter.canPop).thenReturn(true);
+    testWidgets('pops back when the request is denied but stays requestable', (
+      tester,
+    ) async {
+      final bloc = _FakeCameraPermissionBloc(
+        const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
+      );
+      addTearDown(bloc.close);
+      final goRouter = MockGoRouter();
+      when(goRouter.canPop).thenReturn(true);
 
-        await tester.pumpWidget(buildSubject(bloc, goRouter));
-        await tester.pump();
+      await tester.pumpWidget(buildSubject(bloc, goRouter));
+      await tester.pump();
 
-        // The bloc emits the transient Loading before resolving back to a
-        // still-requestable status, mirroring a back-dismissed native dialog.
-        bloc.emitState(const CameraPermissionLoading());
-        await tester.pump();
-        bloc.emitState(
-          const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
-        );
-        await tester.pump();
+      // The bloc emits the transient Loading before resolving back to a
+      // still-requestable status, mirroring a back-dismissed native dialog.
+      bloc.emitState(const CameraPermissionLoading());
+      await tester.pump();
+      bloc.emitState(
+        const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
+      );
+      await tester.pump();
 
-        verify(goRouter.pop).called(1);
-      },
-    );
+      verify(goRouter.pop).called(1);
+    });
 
     testWidgets(
       'renders the child when already authorized without requesting',
@@ -125,5 +168,73 @@ void main() {
         expect(bloc.addedEvents, isEmpty);
       },
     );
+
+    testWidgets(
+      'requiresSettings shows the settings prompt and dispatches OpenSettings',
+      (tester) async {
+        final bloc = _FakeCameraPermissionBloc(
+          const CameraPermissionLoaded(CameraPermissionStatus.requiresSettings),
+        );
+        addTearDown(bloc.close);
+
+        await tester.pumpWidget(buildSubject(bloc, MockGoRouter()));
+        await tester.pump();
+
+        // A non-requestable permission never auto-fires a request.
+        expect(
+          bloc.addedEvents,
+          isNot(contains(isA<CameraPermissionRequest>())),
+        );
+        expect(find.text(l10n.cameraPermissionGoToSettings), findsOneWidget);
+
+        await tester.tap(find.text(l10n.cameraPermissionGoToSettings));
+        await tester.pump();
+
+        expect(bloc.addedEvents, contains(isA<CameraPermissionOpenSettings>()));
+      },
+    );
+
+    testWidgets('error shows the retry prompt that dispatches a refresh', (
+      tester,
+    ) async {
+      final bloc = _FakeCameraPermissionBloc(const CameraPermissionError());
+      addTearDown(bloc.close);
+
+      await tester.pumpWidget(buildSubject(bloc, MockGoRouter()));
+      await tester.pump();
+
+      expect(find.text(l10n.cameraPermissionErrorTitle), findsOneWidget);
+
+      // initState already refreshes on a non-Loaded mount; assert the button
+      // itself dispatches a further refresh rather than relying on that.
+      final before = bloc.addedEvents.length;
+      await tester.tap(find.text(l10n.cameraPermissionRetry));
+      await tester.pump();
+
+      expect(bloc.addedEvents.length, before + 1);
+      expect(bloc.addedEvents.last, isA<CameraPermissionRefresh>());
+    });
+
+    testWidgets('a stuck loading state offers a close affordance to bail out', (
+      tester,
+    ) async {
+      // Mirrors the back-dismiss hang on the direct-nav path: the bloc is
+      // pinned in Loading. The user must be able to escape the spinner.
+      final bloc = _FakeCameraPermissionBloc(const CameraPermissionLoading());
+      addTearDown(bloc.close);
+      final goRouter = MockGoRouter();
+      when(goRouter.canPop).thenReturn(true);
+
+      await tester.pumpWidget(buildSubject(bloc, goRouter));
+      await tester.pump();
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.byType(DivineIconButton), findsOneWidget);
+
+      await tester.tap(find.byType(DivineIconButton));
+      await tester.pump();
+
+      verify(goRouter.pop).called(1);
+    });
   });
 }

--- a/mobile/test/widgets/camera_permission_gate_test.dart
+++ b/mobile/test/widgets/camera_permission_gate_test.dart
@@ -1,0 +1,129 @@
+// ABOUTME: Tests for CameraPermissionGate's direct-request permission behavior
+// ABOUTME: Fires the native dialog directly, no in-app "Continue" priming screen
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/camera_permission/camera_permission_bloc.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/widgets/camera_permission_gate.dart';
+
+import '../helpers/go_router.dart';
+
+class _FakeCameraPermissionBloc extends Fake implements CameraPermissionBloc {
+  _FakeCameraPermissionBloc(CameraPermissionState initialState)
+    : _state = initialState;
+
+  final _controller = StreamController<CameraPermissionState>.broadcast();
+  final addedEvents = <CameraPermissionEvent>[];
+  CameraPermissionState _state;
+
+  @override
+  CameraPermissionState get state => _state;
+
+  @override
+  Stream<CameraPermissionState> get stream => _controller.stream;
+
+  @override
+  void add(CameraPermissionEvent event) => addedEvents.add(event);
+
+  void emitState(CameraPermissionState newState) {
+    _state = newState;
+    _controller.add(newState);
+  }
+
+  @override
+  bool get isClosed => false;
+
+  @override
+  Future<void> close() async => _controller.close();
+}
+
+void main() {
+  Widget buildSubject(
+    _FakeCameraPermissionBloc bloc,
+    MockGoRouter goRouter,
+  ) {
+    return MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: MockGoRouterProvider(
+        goRouter: goRouter,
+        child: BlocProvider<CameraPermissionBloc>.value(
+          value: bloc,
+          child: const CameraPermissionGate(child: Text('CAMERA')),
+        ),
+      ),
+    );
+  }
+
+  group(CameraPermissionGate, () {
+    testWidgets(
+      'auto-fires the native request for a requestable permission with no '
+      'in-app priming screen',
+      (tester) async {
+        final bloc = _FakeCameraPermissionBloc(
+          const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
+        );
+        addTearDown(bloc.close);
+
+        await tester.pumpWidget(buildSubject(bloc, MockGoRouter()));
+        await tester.pump();
+
+        // The dialog is fired directly; the old "Continue" priming screen is
+        // gone and a spinner covers the brief window while it's up.
+        expect(bloc.addedEvents, contains(isA<CameraPermissionRequest>()));
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(find.text(l10n.cameraPermissionContinue), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'pops back when the request is denied but stays requestable',
+      (tester) async {
+        final bloc = _FakeCameraPermissionBloc(
+          const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
+        );
+        addTearDown(bloc.close);
+        final goRouter = MockGoRouter();
+        when(goRouter.canPop).thenReturn(true);
+
+        await tester.pumpWidget(buildSubject(bloc, goRouter));
+        await tester.pump();
+
+        // The bloc emits the transient Loading before resolving back to a
+        // still-requestable status, mirroring a back-dismissed native dialog.
+        bloc.emitState(const CameraPermissionLoading());
+        await tester.pump();
+        bloc.emitState(
+          const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
+        );
+        await tester.pump();
+
+        verify(goRouter.pop).called(1);
+      },
+    );
+
+    testWidgets(
+      'renders the child when already authorized without requesting',
+      (
+        tester,
+      ) async {
+        final bloc = _FakeCameraPermissionBloc(
+          const CameraPermissionLoaded(CameraPermissionStatus.authorized),
+        );
+        addTearDown(bloc.close);
+
+        await tester.pumpWidget(buildSubject(bloc, MockGoRouter()));
+        await tester.pump();
+
+        expect(find.text('CAMERA'), findsOneWidget);
+        expect(bloc.addedEvents, isEmpty);
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes #5880

## What

When you tap the camera button on a fresh install, the app now fires the **native OS permission dialog directly on the current page** and only navigates to the recorder once permission resolves. Previously it navigated straight to the recorder route and showed a loading indicator while the gate asked — which read as "opening the recorder without ever asking".

## Why

This is a regression from #5644 (*route recorder permission asks through the gate*). That refactor removed the pre-navigation prompt and made `pushToCameraWithPermission` navigate for **every** resolved status, deferring the ask to the gate. The side effect: tapping the camera icon jumped to a loading screen instead of prompting in place.

Restoring "ask on the current page" also surfaced a real Android bug: **`permission_handler`'s native `request()` never completes when the permission dialog is dismissed with the back button.** With `droppable()` on the request event, the bloc got stuck in `Loading` and every subsequent tap was dropped — so after a back-cancel, the camera button did nothing at all. Confirmed on-device via temporary logging (`requesting camera…` logged, `camera result=` never followed).

## How

- **`CameraPermissionBloc`** — emit a transient `Loading` before the request so a denial that stays requestable (`canRequest → canRequest`, otherwise suppressed by Equatable) is observable; switch `CameraPermissionRequest` from `droppable()` to **`restartable()`** so a retry supersedes a stuck request instead of being dropped.
- **`camera_permission_check`** — fire the native dialog on the current page; navigate only for a terminal status (`authorized` / `requiresSettings`); refresh a stuck `Loading` back to a requestable status instead of hanging; generation guard so a stale flow can't navigate after a newer tap.
- **`CameraPermissionGate`** — `canRequest` fires the native dialog directly (no in-app priming screen) for direct-navigation entry points (quick actions, deep links).
- Updated bloc + nav unit tests; dropped the now-dead "Continue" priming step in the auth-journey integration test.

## Behavior

| Status | Result |
|---|---|
| `canRequest` | native dialog on current page → grant opens camera; deny stays put, next tap re-prompts |
| back-dismiss then re-tap | recovers (native dialog fires again) |
| 2× deny (permanent) | `requiresSettings` → settings prompt |
| `authorized` | opens the recorder |

## Test plan

- `flutter test test/blocs/camera_permission test/utils/camera_permission_check_test.dart` — green (44 tests), incl. a `restartable` recovery test that fails under `droppable`.
- `flutter analyze` on all touched files — clean.
- Manual on Android: revoke camera/mic, tap camera → native dialog on feed; back-cancel then re-tap → dialog reappears; grant → recorder. Verified by @hm21.