### PR TITLE
feat(logging): persist log sessions to disk for bug-report exports

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -115,6 +115,7 @@ import 'package:openvine/widgets/app_lifecycle_handler.dart';
 import 'package:openvine/widgets/geo_blocking_gate.dart';
 import 'package:openvine/widgets/upload_failure_sheet.dart';
 import 'package:package_info_plus/package_info_plus.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:permissions_service/permissions_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -777,6 +778,15 @@ StartupCoordinator _createStartupCoordinator(ProviderContainer container) {
         task: () async {
           await container.read(loggingConfigServiceProvider).initialize();
           LogMessageBatcher.instance.initialize();
+          // Cross-session log files so bug-report exports cover previous
+          // sessions — user reports usually arrive a day after the bug.
+          // Web has no dart:io file system.
+          if (!kIsWeb) {
+            final supportDir = await getApplicationSupportDirectory();
+            await LogCaptureService().enablePersistence(
+              directoryPath: '${supportDir.path}/logs',
+            );
+          }
         },
       );
     },

--- a/mobile/packages/unified_logger/lib/src/log_capture_service.dart
+++ b/mobile/packages/unified_logger/lib/src/log_capture_service.dart
@@ -1,10 +1,20 @@
-// ABOUTME: Service for capturing log entries in memory for bug reports
-// ABOUTME: Maintains a ring buffer of recent logs without file I/O overhead
+// ABOUTME: Service for capturing log entries for bug reports — in-memory
+// ABOUTME: ring buffer plus opt-in on-disk session files so exports cover
+// ABOUTME: previous app sessions.
 
 import 'dart:collection';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:models/models.dart' show LogEntry, LogLevel;
 
-/// Service for capturing and storing log entries in memory for bug reports
+/// Service for capturing and storing log entries for bug reports.
+///
+/// Always maintains an in-memory ring buffer (fast path, no I/O). When
+/// [enablePersistence] is called with a directory, entries are additionally
+/// appended to per-session log files so exports cover previous app
+/// sessions — user reports like "this happened yesterday morning" are
+/// undiagnosable from a memory-only buffer that dies with the process.
 class LogCaptureService {
   /// Returns the singleton [LogCaptureService] instance.
   factory LogCaptureService() => _instance ??= LogCaptureService._();
@@ -19,8 +29,46 @@ class LogCaptureService {
   /// Maximum memory buffer size (50k entries ~5-10MB).
   static const int _memoryBufferSize = 50000;
 
+  /// Default retention window for persisted session files.
+  static const Duration defaultMaxFileAge = Duration(hours: 72);
+
+  /// Default cap on the summed size of all persisted session files.
+  static const int defaultMaxTotalBytes = 24 * 1024 * 1024;
+
+  /// Default size at which the current session file rolls to a new part.
+  static const int defaultMaxBytesPerFile = 4 * 1024 * 1024;
+
+  /// Default number of pending lines that triggers a disk flush.
+  static const int defaultFlushThreshold = 64;
+
+  /// Persistence disables itself after this many consecutive write
+  /// failures (e.g. disk full) instead of retrying forever.
+  static const int _maxConsecutiveWriteFailures = 3;
+
+  static const String _fileSuffix = '.log';
+  static const String _filePrefix = 'divine_logs_';
+
   /// Total entries captured in current session
   int _totalEntriesWritten = 0;
+
+  Directory? _persistDirectory;
+  Duration _maxFileAge = defaultMaxFileAge;
+  int _maxTotalBytes = defaultMaxTotalBytes;
+  int _maxBytesPerFile = defaultMaxBytesPerFile;
+  int _flushThreshold = defaultFlushThreshold;
+
+  int _sessionStartMillis = 0;
+  int _sessionFileSeq = 0;
+  int _currentFileBytes = 0;
+  int _consecutiveWriteFailures = 0;
+
+  final List<String> _pendingLines = <String>[];
+
+  /// Serializes file appends so chunks never interleave.
+  Future<void> _writeChain = Future<void>.value();
+
+  /// Whether entries are currently being persisted to disk.
+  bool get isPersistenceEnabled => _persistDirectory != null;
 
   /// Format a log entry as a text line
   String _formatLogEntry(LogEntry entry) {
@@ -56,6 +104,184 @@ class LogCaptureService {
     }
     _memoryBuffer.add(entry);
     _totalEntriesWritten++;
+
+    if (_persistDirectory != null) {
+      _pendingLines.add(_formatLogEntry(entry));
+      // Warnings/errors flush immediately: they are rare, they are the
+      // lines support actually needs, and an app killed in the background
+      // must not lose them to the batch window.
+      if (_pendingLines.length >= _flushThreshold ||
+          entry.level.value >= LogLevel.warning.value) {
+        _scheduleFlush();
+      }
+    }
+  }
+
+  /// Enables cross-session persistence of captured logs.
+  ///
+  /// Creates [directoryPath] if needed, prunes session files older than
+  /// [maxFileAge] and beyond [maxTotalBytes] (oldest first), then starts a
+  /// new session file seeded with everything already in the memory buffer,
+  /// so startup lines logged before this call are not lost.
+  ///
+  /// Not supported on web (uses `dart:io`); callers guard with `kIsWeb`.
+  Future<void> enablePersistence({
+    required String directoryPath,
+    Duration maxFileAge = defaultMaxFileAge,
+    int maxTotalBytes = defaultMaxTotalBytes,
+    int maxBytesPerFile = defaultMaxBytesPerFile,
+    int flushThreshold = defaultFlushThreshold,
+  }) async {
+    await disablePersistence();
+
+    final directory = Directory(directoryPath);
+    await directory.create(recursive: true);
+
+    _maxFileAge = maxFileAge;
+    _maxTotalBytes = maxTotalBytes;
+    _maxBytesPerFile = maxBytesPerFile;
+    _flushThreshold = flushThreshold;
+    _sessionStartMillis = DateTime.now().millisecondsSinceEpoch;
+    _sessionFileSeq = 0;
+    _currentFileBytes = 0;
+    _consecutiveWriteFailures = 0;
+
+    await _pruneOldFiles(directory);
+
+    _persistDirectory = directory;
+
+    // Seed the session file with lines captured before persistence was
+    // wired (startup runs for a while before the deferred phase).
+    _pendingLines.insertAll(0, _memoryBuffer.map(_formatLogEntry));
+    if (_pendingLines.isNotEmpty) {
+      _scheduleFlush();
+    }
+    await _writeChain;
+  }
+
+  /// Stops persisting, after flushing pending lines. Memory capture
+  /// continues unchanged. Existing session files stay on disk.
+  Future<void> disablePersistence() async {
+    if (_persistDirectory == null) return;
+    await flush();
+    _persistDirectory = null;
+    _pendingLines.clear();
+  }
+
+  /// Writes all pending lines to the current session file.
+  Future<void> flush() {
+    if (_persistDirectory != null && _pendingLines.isNotEmpty) {
+      _scheduleFlush();
+    }
+    return _writeChain;
+  }
+
+  void _scheduleFlush() {
+    final directory = _persistDirectory;
+    if (directory == null || _pendingLines.isEmpty) return;
+    final chunk = _pendingLines.join('\n');
+    _pendingLines.clear();
+    _writeChain = _writeChain.then((_) => _appendChunk(directory, chunk));
+  }
+
+  Future<void> _appendChunk(Directory directory, String chunk) async {
+    // Persistence may have been disabled or retargeted while this chunk
+    // waited in the write chain.
+    if (_persistDirectory != directory) return;
+    final bytes = chunk.length + 1;
+    if (_currentFileBytes > 0 && _currentFileBytes + bytes > _maxBytesPerFile) {
+      _sessionFileSeq++;
+      _currentFileBytes = 0;
+    }
+    final file = File(
+      '${directory.path}${Platform.pathSeparator}'
+      '$_filePrefix${_sessionStartMillis}_'
+      '${_sessionFileSeq.toString().padLeft(3, '0')}$_fileSuffix',
+    );
+    try {
+      await file.writeAsString('$chunk\n', mode: FileMode.append);
+      _currentFileBytes += bytes;
+      _consecutiveWriteFailures = 0;
+    } on FileSystemException {
+      _consecutiveWriteFailures++;
+      if (_consecutiveWriteFailures >= _maxConsecutiveWriteFailures) {
+        _persistDirectory = null;
+        _pendingLines.clear();
+        captureLog(
+          LogEntry(
+            timestamp: DateTime.now(),
+            level: LogLevel.warning,
+            message:
+                'Log persistence disabled after '
+                '$_consecutiveWriteFailures consecutive write failures',
+            name: 'LogCaptureService',
+          ),
+        );
+      }
+    }
+  }
+
+  Future<List<File>> _sessionFiles(Directory directory) async {
+    if (!directory.existsSync()) return const [];
+    final files = await directory
+        .list()
+        .where(
+          (e) =>
+              e is File &&
+              _fileName(e).startsWith(_filePrefix) &&
+              _fileName(e).endsWith(_fileSuffix),
+        )
+        .cast<File>()
+        .toList();
+    // Names embed a fixed-width millis timestamp + zero-padded part
+    // sequence, so a lexicographic sort is chronological.
+    files.sort((a, b) => _fileName(a).compareTo(_fileName(b)));
+    return files;
+  }
+
+  String _fileName(FileSystemEntity entity) =>
+      entity.uri.pathSegments.isEmpty ? '' : entity.uri.pathSegments.last;
+
+  int _fileStartMillis(File file) {
+    final name = _fileName(file);
+    final core = name.substring(
+      _filePrefix.length,
+      name.length - _fileSuffix.length,
+    );
+    final millis = int.tryParse(core.split('_').first);
+    return millis ?? file.statSync().modified.millisecondsSinceEpoch;
+  }
+
+  Future<void> _pruneOldFiles(Directory directory) async {
+    final files = await _sessionFiles(directory);
+    final cutoff = DateTime.now().subtract(_maxFileAge).millisecondsSinceEpoch;
+    final kept = <File>[];
+    for (final file in files) {
+      if (_fileStartMillis(file) < cutoff) {
+        await _deleteIgnoringErrors(file);
+      } else {
+        kept.add(file);
+      }
+    }
+
+    var totalBytes = 0;
+    for (final file in kept) {
+      totalBytes += file.statSync().size;
+    }
+    // Oldest first until back under the cap.
+    for (final file in kept) {
+      if (totalBytes <= _maxTotalBytes) break;
+      totalBytes -= file.statSync().size;
+      await _deleteIgnoringErrors(file);
+    }
+  }
+
+  Future<void> _deleteIgnoringErrors(File file) async {
+    try {
+      await file.delete();
+    } on FileSystemException {
+      // Ignore: an undeletable file must not block logging or clearing.
+    }
   }
 
   /// Get recent logs from memory buffer (fast access)
@@ -80,19 +306,52 @@ class LogCaptureService {
     return logs;
   }
 
-  /// Get ALL logs as formatted text lines (for export/bug reports)
+  /// Get ALL logs as formatted text lines (for export/bug reports).
   ///
-  /// This returns all logs from the memory buffer
+  /// With persistence enabled this spans every retained session file
+  /// (previous app sessions first, current session last); otherwise it
+  /// falls back to the in-memory buffer of the current session.
   Future<List<String>> getAllLogsAsText() async {
-    if (_memoryBuffer.isEmpty) {
-      return [];
+    final directory = _persistDirectory;
+    if (directory == null) {
+      if (_memoryBuffer.isEmpty) {
+        return [];
+      }
+      return _memoryBuffer.map(_formatLogEntry).toList();
     }
 
-    return _memoryBuffer.map(_formatLogEntry).toList();
+    await flush();
+    final lines = <String>[];
+    int? previousSessionMillis;
+    for (final file in await _sessionFiles(directory)) {
+      final startMillis = _fileStartMillis(file);
+      // One marker per app session (rotated parts share the timestamp),
+      // so support can tell where a report's session actually begins.
+      if (startMillis != previousSessionMillis) {
+        previousSessionMillis = startMillis;
+        final startedAt = DateTime.fromMillisecondsSinceEpoch(
+          startMillis,
+        ).toIso8601String();
+        lines.add('───── app session started $startedAt ─────');
+      }
+      try {
+        lines.addAll(await file.readAsLines());
+      } on FileSystemException {
+        // Skip unreadable files rather than failing the whole export.
+      }
+    }
+    return lines;
   }
 
   /// Get statistics about log storage
   Future<Map<String, dynamic>> getLogStatistics() async {
+    final directory = _persistDirectory;
+    var fileCount = 0;
+    if (directory != null) {
+      await flush();
+      fileCount = (await _sessionFiles(directory)).length;
+    }
+
     final allLogLines = await getAllLogsAsText();
     final totalSize = allLogLines.fold<int>(
       0,
@@ -100,7 +359,7 @@ class LogCaptureService {
     );
 
     return {
-      'fileCount': 0, // No file storage
+      'fileCount': fileCount,
       'totalSizeBytes': totalSize,
       'totalSizeMB': (totalSize / (1024 * 1024)).toStringAsFixed(2),
       'totalLogLines': allLogLines.length,
@@ -109,10 +368,26 @@ class LogCaptureService {
     };
   }
 
-  /// Clear all logs
+  /// Clear all logs, including persisted session files.
   Future<void> clearAllLogs() async {
     _memoryBuffer.clear();
+    _pendingLines.clear();
     _totalEntriesWritten = 0;
+    final directory = _persistDirectory;
+    if (directory != null) {
+      await _writeChain;
+      for (final file in await _sessionFiles(directory)) {
+        await _deleteIgnoringErrors(file);
+      }
+      _currentFileBytes = 0;
+      _sessionFileSeq = 0;
+    }
+  }
+
+  /// Resets the singleton so each test starts from a clean instance.
+  @visibleForTesting
+  static void resetForTesting() {
+    _instance = null;
   }
 
   /// Get current buffer size

--- a/mobile/packages/unified_logger/test/src/log_persistence_test.dart
+++ b/mobile/packages/unified_logger/test/src/log_persistence_test.dart
@@ -1,0 +1,204 @@
+// ABOUTME: Tests for LogCaptureService on-disk session persistence:
+// ABOUTME: cross-session export, flush behavior, pruning, and rotation.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+void main() {
+  group('LogCaptureService persistence', () {
+    late LogCaptureService service;
+    late Directory tempDir;
+
+    setUp(() {
+      LogCaptureService.resetForTesting();
+      service = LogCaptureService();
+      tempDir = Directory.systemTemp.createTempSync('log_persistence_test');
+    });
+
+    tearDown(() async {
+      await service.disablePersistence();
+      // Also release any instance created mid-test (simulated restarts).
+      await LogCaptureService().disablePersistence();
+      LogCaptureService.resetForTesting();
+      if (tempDir.existsSync()) {
+        tempDir.deleteSync(recursive: true);
+      }
+    });
+
+    LogEntry entry(String message, {LogLevel level = LogLevel.info}) =>
+        LogEntry(timestamp: DateTime.now(), level: level, message: message);
+
+    List<File> sessionFiles() =>
+        tempDir.listSync().whereType<File>().toList()
+          ..sort((a, b) => a.path.compareTo(b.path));
+
+    test('export spans previous sessions after a simulated restart', () async {
+      await service.enablePersistence(directoryPath: tempDir.path);
+      service.captureLog(entry('from-first-session'));
+      await service.flush();
+
+      // Simulated app restart: new singleton, same log directory.
+      LogCaptureService.resetForTesting();
+      final secondSession = LogCaptureService();
+      await secondSession.enablePersistence(directoryPath: tempDir.path);
+      secondSession.captureLog(entry('from-second-session'));
+
+      final lines = await secondSession.getAllLogsAsText();
+      final first = lines.indexWhere((l) => l.contains('from-first-session'));
+      final second = lines.indexWhere((l) => l.contains('from-second-session'));
+      expect(first, isNonNegative);
+      expect(second, isNonNegative);
+      expect(first, lessThan(second));
+      expect(
+        lines.where((l) => l.contains('app session started')),
+        hasLength(2),
+      );
+
+      final stats = await secondSession.getLogStatistics();
+      expect(stats['fileCount'], equals(2));
+    });
+
+    test('warning entries reach disk without an explicit flush', () async {
+      await service.enablePersistence(directoryPath: tempDir.path);
+      service.captureLog(entry('important-warning', level: LogLevel.warning));
+
+      // Wait only for the internal write chain — no manual flush() call.
+      await service.disablePersistence();
+
+      final contents = sessionFiles().map((f) => f.readAsStringSync()).join();
+      expect(contents, contains('important-warning'));
+    });
+
+    test('info entries below the threshold stay pending until flush', () async {
+      await service.enablePersistence(
+        directoryPath: tempDir.path,
+        flushThreshold: 100,
+      );
+      final baseline = sessionFiles().map((f) => f.readAsStringSync()).join();
+
+      service.captureLog(entry('buffered-info'));
+      expect(
+        sessionFiles().map((f) => f.readAsStringSync()).join(),
+        equals(baseline),
+      );
+
+      await service.flush();
+      expect(
+        sessionFiles().map((f) => f.readAsStringSync()).join(),
+        contains('buffered-info'),
+      );
+    });
+
+    test('enablePersistence prunes files older than maxFileAge', () async {
+      final oldMillis = DateTime.now()
+          .subtract(const Duration(hours: 2))
+          .millisecondsSinceEpoch;
+      final oldFile = File('${tempDir.path}/divine_logs_${oldMillis}_000.log')
+        ..writeAsStringSync('stale line\n');
+
+      await service.enablePersistence(
+        directoryPath: tempDir.path,
+        maxFileAge: const Duration(hours: 1),
+      );
+
+      expect(oldFile.existsSync(), isFalse);
+    });
+
+    test(
+      'enablePersistence prunes oldest files beyond maxTotalBytes',
+      () async {
+        final now = DateTime.now().millisecondsSinceEpoch;
+        final older = File('${tempDir.path}/divine_logs_${now - 2000}_000.log')
+          ..writeAsStringSync('x' * 80);
+        final newer = File('${tempDir.path}/divine_logs_${now - 1000}_000.log')
+          ..writeAsStringSync('y' * 80);
+
+        await service.enablePersistence(
+          directoryPath: tempDir.path,
+          maxTotalBytes: 100,
+        );
+
+        expect(older.existsSync(), isFalse);
+        expect(newer.existsSync(), isTrue);
+      },
+    );
+
+    test(
+      'rotates to a new part file when maxBytesPerFile is exceeded',
+      () async {
+        await service.enablePersistence(
+          directoryPath: tempDir.path,
+          maxBytesPerFile: 50,
+        );
+        service.captureLog(entry('first-part-message'));
+        await service.flush();
+        service.captureLog(entry('second-part-message'));
+        await service.flush();
+
+        expect(sessionFiles().length, greaterThanOrEqualTo(2));
+
+        final lines = await service.getAllLogsAsText();
+        final first = lines.indexWhere((l) => l.contains('first-part-message'));
+        final second = lines.indexWhere(
+          (l) => l.contains('second-part-message'),
+        );
+        expect(first, isNonNegative);
+        expect(second, isNonNegative);
+        expect(first, lessThan(second));
+        // Rotated parts belong to one session — exactly one marker.
+        expect(
+          lines.where((l) => l.contains('app session started')),
+          hasLength(1),
+        );
+      },
+    );
+
+    test(
+      'without persistence, export uses memory and reports zero files',
+      () async {
+        service.captureLog(entry('memory-only'));
+
+        final lines = await service.getAllLogsAsText();
+        expect(lines.single, contains('memory-only'));
+
+        final stats = await service.getLogStatistics();
+        expect(stats['fileCount'], equals(0));
+        expect(sessionFiles(), isEmpty);
+      },
+    );
+
+    test('clearAllLogs deletes persisted session files', () async {
+      await service.enablePersistence(directoryPath: tempDir.path);
+      service.captureLog(entry('to-be-cleared'));
+      await service.flush();
+      expect(sessionFiles(), isNotEmpty);
+
+      await service.clearAllLogs();
+
+      expect(sessionFiles(), isEmpty);
+      expect(await service.getAllLogsAsText(), isEmpty);
+    });
+
+    test(
+      'disablePersistence flushes pending lines and stops writing',
+      () async {
+        await service.enablePersistence(
+          directoryPath: tempDir.path,
+          flushThreshold: 100,
+        );
+        service.captureLog(entry('flushed-on-disable'));
+        await service.disablePersistence();
+
+        final contents = sessionFiles().map((f) => f.readAsStringSync()).join();
+        expect(contents, contains('flushed-on-disable'));
+
+        service.captureLog(entry('after-disable'));
+        await service.flush();
+        final after = sessionFiles().map((f) => f.readAsStringSync()).join();
+        expect(after, isNot(contains('after-disable')));
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes #5882

## Description

**Related Issue:**  (motivated by the silent-clip report behind #4779 / #5869: the user's log export could not cover the session where the bug happened)

`LogCaptureService` was a pure in-memory ring buffer — `fileCount` was hardcoded to 0 and every app restart wiped all diagnostics. A real support case demonstrated the cost: a user reported clips recorded the previous morning losing audio, and her "Comprehensive Log Export" contained only the current session (app start 09:58 → export 10:42), zero lines from the session where the recordings happened. The native camera diagnostics that would have answered the question (`Recording completed WITHOUT audio track`, audio-session interruption lines) are already bridged into the unified log — they just don't survive a restart.

Changes:

- `LogCaptureService.enablePersistence(directoryPath: …)` (opt-in) appends captured entries to per-session files under the app-support directory. Writes are batched (64-line threshold); warnings and errors flush immediately so an app killed in the background cannot lose the lines support actually needs. Repeated write failures (disk full) disable persistence instead of retrying forever.
- Retention: session files older than 72h are pruned at startup, total size is capped at 24MB (oldest first), and a session file rolls to a new part at 4MB. All limits are parameters with defaults, exposed as public constants.
- `getAllLogsAsText()` / `getLogStatistics()` now span all retained sessions (previous sessions first, current last) and report the real file count, so `bug_report_service`'s export gains cross-session coverage **without any change to the export code**. A `───── app session started <ISO time> ─────` marker precedes each session, because the same support case showed users (and support) cannot tell where a session begins in the dump.
- App wiring: the deferred `LoggingConfig` startup task enables persistence (`<app-support>/logs`), seeding the session file with the startup lines captured before the deferred phase runs. Web keeps the memory-only behavior (`kIsWeb` guard — no `dart:io`).
- The memory ring buffer is untouched and remains the fast path; with persistence disabled (all existing tests, web) behavior is byte-for-byte the old one.

Privacy note: persisted files live in the app container, are covered by the same retention window deliberately kept short (72h), and only leave the device through the existing user-initiated export, which already sanitizes each line.

## Out of Scope

- Attaching the persisted files as separate export attachments — the existing single-file export format is kept.
- Capping the export payload size for Zendesk; retention caps (24MB raw, before dedupe by level) bound it implicitly.

## Verification

- `cd mobile/packages/unified_logger && flutter test` — 24 tests pass (9 new: cross-session export after simulated restart, immediate warning flush, batching below threshold, age pruning, size pruning, part rotation, memory-only fallback, clearAllLogs file deletion, disablePersistence flush semantics). Package coverage 73.2% (gate: 40%).
- `flutter analyze lib test integration_test` (app) and `flutter analyze` (package) — clean.
- `flutter test test/startup/app_startup_test.dart test/services/logging_config_service_test.dart` — pass (these exercise `LoggingConfigService` directly and never run the main.dart wiring, so no test leaks a persistence-enabled singleton into the merged VGV bundle).

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore