### PR TITLE
fix(notifications): classify likes on comments via targetCommentId

### DIFF
--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -1592,9 +1592,14 @@ class NotificationRepository {
   /// Maps a relay notification type string + source kind to
   /// [NotificationKind].
   ///
-  /// Likes (and zaps) on a non-video target — typically a kind 1111
-  /// comment — map to [NotificationKind.likeComment] so the UI can
-  /// render "liked your comment" instead of "liked your video".
+  /// Likes (and zaps) on a comment map to [NotificationKind.likeComment]
+  /// so the UI can render "liked your comment" instead of "liked your
+  /// video". A comment target is identified by a non-empty
+  /// `targetCommentId`, which Funnelcake sets to the comment's event ID
+  /// for reactions on a kind 1111 comment. `isReferencedVideo` cannot be
+  /// used for this split: Funnelcake populates `referenced_video` from the
+  /// notification's root video, so it is set for a like on a comment (whose
+  /// root is that video) exactly as it is for a like on the video itself.
   ///
   /// Replies (kind 1111) split by the immediate target, not by whether the
   /// payload also carries root video metadata. A reply directly on a video
@@ -1608,6 +1613,10 @@ class NotificationRepository {
       _ => n.sourceKind == 7,
     };
     if (isReaction) {
+      final targetCommentId = n.targetCommentId;
+      final targetsComment =
+          targetCommentId != null && targetCommentId.isNotEmpty;
+      if (targetsComment) return NotificationKind.likeComment;
       return n.isReferencedVideo
           ? NotificationKind.like
           : NotificationKind.likeComment;

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -1314,11 +1314,12 @@ void main() {
 
       test('reaction on a non-owned video is reclassified as likeComment '
           'instead of liked your video (#4813)', () async {
+        // No targetCommentId, so this genuinely exercises the owner-mismatch
+        // reclassification: _mapNotificationKind returns `like`, which the
+        // #4813 path rewrites to likeComment. A comment-like that *does* carry
+        // a targetCommentId is covered by the direct-classification test above.
         stubNotifications([
-          makeNotification(
-            referencedEventId: 'foreign_video',
-            targetCommentId: 'comment_event_xyz',
-          ),
+          makeNotification(referencedEventId: 'foreign_video'),
         ]);
         stubProfiles({});
         stubVideoStats(
@@ -1331,7 +1332,7 @@ void main() {
         expect(page.items, hasLength(1));
         final item = page.items.single as ActorNotification;
         expect(item.type, equals(NotificationKind.likeComment));
-        expect(item.targetEventId, equals('comment_event_xyz'));
+        expect(item.targetEventId, equals('foreign_video'));
       });
 
       test('comment on a non-owned video is reclassified as reply '

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -1293,6 +1293,25 @@ void main() {
         expect(item.type, equals(NotificationKind.like));
       });
 
+      test('reaction with a target comment maps to likeComment even when '
+          'referenced_video is populated from the root video', () async {
+        // Funnelcake fills referenced_video from the notification's root
+        // video, so isReferencedVideo is true for a like on a comment exactly
+        // as for a like on the video itself. targetCommentId is the reliable
+        // comment signal. Without an owner mismatch the #4813 path never fires
+        // (this is a like on your own comment on your own video), so before
+        // this fix the like was surfaced as "liked your video".
+        stubNotifications([
+          makeNotification(targetCommentId: 'comment_event_xyz'),
+        ]);
+        stubProfiles({});
+
+        final page = await repository.getNotifications();
+        final item = page.items.single as ActorNotification;
+        expect(item.type, equals(NotificationKind.likeComment));
+        expect(item.targetEventId, equals('comment_event_xyz'));
+      });
+
       test('reaction on a non-owned video is reclassified as likeComment '
           'instead of liked your video (#4813)', () async {
         stubNotifications([


### PR DESCRIPTION
Closes #5884

## Description

Notifications rendered "liked your video" for **every** like, including likes on comments.

**Root cause:** `_mapNotificationKind` split a reaction into `like` vs `likeComment` solely by `isReferencedVideo`. That flag is set whenever the payload carries `referenced_video` — but Funnelcake populates `referenced_video` from the notification's **root video** (`root_rv` JOIN on `root_event_*`), and for a reaction on a comment the root resolves to the comment's parent video. So `referenced_video` is present for a like on a comment exactly as for a like on the video itself, and every reaction fell into the `like` branch.

The existing #4813 owner-mismatch reclassification only fires when the referenced video is owned by a **different** user, so a like on your **own** comment on your **own** video never got corrected.

**Fix:** classify the reaction by `targetCommentId`, which Funnelcake sets to the comment event ID for reactions on a kind 1111 comment (and leaves empty for a like on the video). This is independent of ownership and of the root-video metadata. `isReferencedVideo` is kept only as the fallback for the no-comment-id case.

**Related Issue:** 

## Out of Scope

- A deeper server-side fix (make `referenced_video` / `isReferencedVideo` reflect the *liked* event rather than the root video) would restore the original field contract for all clients, but touches ClickHouse queries and risks losing thumbnail context for comment-likes. Not done here — this client-side fix uses an already-correct signal. One residual edge case remains: if Funnelcake omits `target_comment_id` for a comment-like (comment event not resolved in the batch), it still falls back to "liked your video" — rarer than before, and the server fix would be the way to close it fully.

## Verification

- `flutter test` (notification_repository) → 118/118 pass, incl. new regression test and unchanged #4813 tests
- `flutter analyze lib test` → No issues found

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)