### PR TITLE
feat(divine_ui): enable region-aware spell check in DivineTextField

### DIFF
--- a/mobile/packages/divine_ui/lib/src/text_field/divine_text_field.dart
+++ b/mobile/packages/divine_ui/lib/src/text_field/divine_text_field.dart
@@ -29,6 +29,7 @@ class DivineTextField extends StatelessWidget {
     this.onSubmitted,
     this.onChanged,
     this.primaryWhenFilled = false,
+    this.spellCheckConfiguration,
   });
 
   /// Default content padding around the input. Exposed so overlays
@@ -102,6 +103,30 @@ class DivineTextField extends StatelessWidget {
   /// has content (in addition to when it is focused).
   final bool primaryWhenFilled;
 
+  /// Configures the spell check / "Replace" suggestion flow.
+  ///
+  /// Defaults to [defaultSpellCheckConfiguration], which enables the native
+  /// spell checker so natural-language fields get misspelling underlines and
+  /// replacement suggestions for free. On platforms without a native spell
+  /// check service (desktop, tests) it is a harmless no-op. Pass an explicit
+  /// config to override, e.g. `SpellCheckConfiguration.disabled()` for
+  /// technical inputs (search, keys, URLs) where spell check adds noise.
+  final SpellCheckConfiguration? spellCheckConfiguration;
+
+  /// The spell check configuration used when [spellCheckConfiguration] is not
+  /// provided.
+  ///
+  /// Uses [RegionAwareSpellCheckService] so the platform checker receives a
+  /// region-qualified locale (iOS' `UITextChecker` returns nothing for a bare
+  /// language code). Supplying a service explicitly also means this never trips
+  /// the framework assertion that fires when spell check is enabled on a
+  /// platform with no native service (desktop, widget tests); there it simply
+  /// yields no suggestions instead of throwing.
+  static final SpellCheckConfiguration defaultSpellCheckConfiguration =
+      SpellCheckConfiguration(
+        spellCheckService: RegionAwareSpellCheckService(),
+      );
+
   @override
   Widget build(BuildContext context) {
     return TextField(
@@ -122,6 +147,8 @@ class DivineTextField extends StatelessWidget {
       obscureText: obscureText,
       canRequestFocus: canRequestFocus,
       expands: expands,
+      spellCheckConfiguration:
+          spellCheckConfiguration ?? defaultSpellCheckConfiguration,
       onTap: onTap,
       onEditingComplete: onEditingComplete,
       decoration: InputDecoration(

--- a/mobile/packages/divine_ui/lib/src/text_field/region_aware_spell_check_service.dart
+++ b/mobile/packages/divine_ui/lib/src/text_field/region_aware_spell_check_service.dart
@@ -29,8 +29,8 @@ class RegionAwareSpellCheckService implements SpellCheckService {
   final SpellCheckService _delegate;
   final List<Locale>? _deviceLocales;
 
-  /// Default region per language for the app's supported locales, used to
-  /// produce a candidate the platform checker is known to support.
+  /// Default region per language for locales with platform spell-check support,
+  /// used to produce a candidate the platform checker is known to support.
   static const Map<String, String> fallbackRegions = {
     'ar': 'SA',
     'bg': 'BG',
@@ -52,6 +52,8 @@ class RegionAwareSpellCheckService implements SpellCheckService {
 
   List<Locale> get _locales =>
       _deviceLocales ?? PlatformDispatcher.instance.locales;
+
+  final Map<String, Locale> _resolvedLocaleCache = {};
 
   /// The locales to try, most-preferred first: the locale's own region (when it
   /// already carries one), then the device's regional variant of the language,
@@ -90,13 +92,31 @@ class RegionAwareSpellCheckService implements SpellCheckService {
     Locale locale,
     String text,
   ) async {
+    final candidates = localeCandidates(locale);
+    final cacheKey = _cacheKeyFor(candidates);
+    final cachedLocale = _resolvedLocaleCache[cacheKey];
+    if (cachedLocale != null) {
+      final result = await _delegate.fetchSpellCheckSuggestions(
+        cachedLocale,
+        text,
+      );
+      if (result != null) return result;
+      _resolvedLocaleCache.remove(cacheKey);
+    }
+
     List<SuggestionSpan>? result;
-    for (final candidate in localeCandidates(locale)) {
+    for (final candidate in candidates) {
       // A supported language returns a (possibly empty) list; an unsupported
       // one returns null. Stop at the first supported candidate.
       result = await _delegate.fetchSpellCheckSuggestions(candidate, text);
-      if (result != null) return result;
+      if (result != null) {
+        _resolvedLocaleCache[cacheKey] = candidate;
+        return result;
+      }
     }
     return result;
   }
+
+  String _cacheKeyFor(List<Locale> candidates) =>
+      candidates.map((locale) => locale.toLanguageTag()).join('|');
 }

--- a/mobile/packages/divine_ui/lib/src/text_field/region_aware_spell_check_service.dart
+++ b/mobile/packages/divine_ui/lib/src/text_field/region_aware_spell_check_service.dart
@@ -1,0 +1,97 @@
+import 'dart:ui';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+/// A [SpellCheckService] that guarantees the locale handed to the platform
+/// spell checker carries a country/region code the checker actually supports.
+///
+/// iOS' `UITextChecker` only recognises specific region-qualified languages —
+/// it has `en_US`/`en_GB` but neither bare `en` nor uncommon regions like
+/// `en_CH` — and returns `null` (no spell check at all) for anything it does
+/// not know. The app resolves UI locales without a region (`en`, `de`, …), and
+/// a device in an unsupported region (e.g. Switzerland) would otherwise pick a
+/// language variant the checker rejects. This service tries a prioritized list
+/// of region-qualified candidates and uses the first the platform accepts.
+class RegionAwareSpellCheckService implements SpellCheckService {
+  /// Creates a region-aware spell check service.
+  ///
+  /// [delegate] performs the actual platform lookup and defaults to
+  /// [DefaultSpellCheckService]. [deviceLocales] overrides the source of the
+  /// device's preferred locales (defaults to [PlatformDispatcher.locales]);
+  /// both parameters exist for testing.
+  RegionAwareSpellCheckService({
+    SpellCheckService? delegate,
+    List<Locale>? deviceLocales,
+  }) : _delegate = delegate ?? DefaultSpellCheckService(),
+       _deviceLocales = deviceLocales;
+
+  final SpellCheckService _delegate;
+  final List<Locale>? _deviceLocales;
+
+  /// Default region per language for the app's supported locales, used to
+  /// produce a candidate the platform checker is known to support.
+  static const Map<String, String> fallbackRegions = {
+    'ar': 'SA',
+    'bg': 'BG',
+    'de': 'DE',
+    'en': 'US',
+    'es': 'ES',
+    'fr': 'FR',
+    'id': 'ID',
+    'it': 'IT',
+    'ja': 'JP',
+    'ko': 'KR',
+    'nl': 'NL',
+    'pl': 'PL',
+    'pt': 'BR',
+    'ro': 'RO',
+    'sv': 'SE',
+    'tr': 'TR',
+  };
+
+  List<Locale> get _locales =>
+      _deviceLocales ?? PlatformDispatcher.instance.locales;
+
+  /// The region-qualified locales to try, most-preferred first: the device's
+  /// own regional variant of the language, then the [fallbackRegions] default,
+  /// then the bare locale as a last resort. An already-region-qualified locale
+  /// is returned as the single candidate.
+  @visibleForTesting
+  List<Locale> localeCandidates(Locale locale) {
+    if (locale.countryCode != null) return [locale];
+
+    final candidates = <Locale>[];
+    for (final device in _locales) {
+      if (device.languageCode == locale.languageCode &&
+          device.countryCode != null) {
+        candidates.add(Locale(locale.languageCode, device.countryCode));
+        break;
+      }
+    }
+
+    final region = fallbackRegions[locale.languageCode];
+    if (region != null) {
+      final mapped = Locale(locale.languageCode, region);
+      if (!candidates.contains(mapped)) candidates.add(mapped);
+    }
+
+    candidates.add(locale);
+    return candidates;
+  }
+
+  @override
+  Future<List<SuggestionSpan>?> fetchSpellCheckSuggestions(
+    Locale locale,
+    String text,
+  ) async {
+    List<SuggestionSpan>? result;
+    for (final candidate in localeCandidates(locale)) {
+      // A supported language returns a (possibly empty) list; an unsupported
+      // one returns null. Stop at the first supported candidate.
+      result = await _delegate.fetchSpellCheckSuggestions(candidate, text);
+      if (result != null) return result;
+    }
+    return result;
+  }
+}

--- a/mobile/packages/divine_ui/lib/src/text_field/region_aware_spell_check_service.dart
+++ b/mobile/packages/divine_ui/lib/src/text_field/region_aware_spell_check_service.dart
@@ -53,30 +53,35 @@ class RegionAwareSpellCheckService implements SpellCheckService {
   List<Locale> get _locales =>
       _deviceLocales ?? PlatformDispatcher.instance.locales;
 
-  /// The region-qualified locales to try, most-preferred first: the device's
-  /// own regional variant of the language, then the [fallbackRegions] default,
-  /// then the bare locale as a last resort. An already-region-qualified locale
-  /// is returned as the single candidate.
+  /// The locales to try, most-preferred first: the locale's own region (when it
+  /// already carries one), then the device's regional variant of the language,
+  /// then the [fallbackRegions] default, then the bare locale as a last resort.
+  /// Duplicates are dropped while preserving that order.
+  ///
+  /// A region-qualified input is tried first but still falls back, so an
+  /// unsupported region (e.g. `en_VN`) resolves to a supported one instead of
+  /// disabling spell check outright.
   @visibleForTesting
   List<Locale> localeCandidates(Locale locale) {
-    if (locale.countryCode != null) return [locale];
-
     final candidates = <Locale>[];
+    void add(Locale candidate) {
+      if (!candidates.contains(candidate)) candidates.add(candidate);
+    }
+
+    if (locale.countryCode != null) add(locale);
+
     for (final device in _locales) {
       if (device.languageCode == locale.languageCode &&
           device.countryCode != null) {
-        candidates.add(Locale(locale.languageCode, device.countryCode));
+        add(Locale(locale.languageCode, device.countryCode));
         break;
       }
     }
 
     final region = fallbackRegions[locale.languageCode];
-    if (region != null) {
-      final mapped = Locale(locale.languageCode, region);
-      if (!candidates.contains(mapped)) candidates.add(mapped);
-    }
+    if (region != null) add(Locale(locale.languageCode, region));
 
-    candidates.add(locale);
+    add(Locale(locale.languageCode));
     return candidates;
   }
 

--- a/mobile/packages/divine_ui/lib/src/text_field/text_field.dart
+++ b/mobile/packages/divine_ui/lib/src/text_field/text_field.dart
@@ -1,2 +1,3 @@
 export 'divine_auth_text_field.dart';
 export 'divine_text_field.dart';
+export 'region_aware_spell_check_service.dart';

--- a/mobile/packages/divine_ui/test/src/text_field/divine_text_field_test.dart
+++ b/mobile/packages/divine_ui/test/src/text_field/divine_text_field_test.dart
@@ -308,6 +308,47 @@ void main() {
       );
     });
 
+    group('spellCheckConfiguration', () {
+      test('default config is enabled and carries a spell check service', () {
+        final config = DivineTextField.defaultSpellCheckConfiguration;
+
+        expect(config, isNot(const SpellCheckConfiguration.disabled()));
+        expect(config.spellCheckService, isNotNull);
+      });
+
+      testWidgets('enables spell check by default', (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(body: DivineTextField()),
+          ),
+        );
+
+        final textField = tester.widget<TextField>(find.byType(TextField));
+        expect(
+          textField.spellCheckConfiguration,
+          DivineTextField.defaultSpellCheckConfiguration,
+        );
+      });
+
+      testWidgets('passes a provided config through unchanged', (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: DivineTextField(
+                spellCheckConfiguration: SpellCheckConfiguration.disabled(),
+              ),
+            ),
+          ),
+        );
+
+        final textField = tester.widget<TextField>(find.byType(TextField));
+        expect(
+          textField.spellCheckConfiguration,
+          const SpellCheckConfiguration.disabled(),
+        );
+      });
+    });
+
     group('defaultContentPadding', () {
       test('exposes a 16px-all default for overlay alignment', () {
         expect(

--- a/mobile/packages/divine_ui/test/src/text_field/region_aware_spell_check_service_test.dart
+++ b/mobile/packages/divine_ui/test/src/text_field/region_aware_spell_check_service_test.dart
@@ -73,10 +73,9 @@ void main() {
       test('falls back to just the bare locale when no region is known', () {
         final service = RegionAwareSpellCheckService(deviceLocales: const []);
 
-        expect(
-          service.localeCandidates(const Locale('am')),
-          const [Locale('am')],
-        );
+        expect(service.localeCandidates(const Locale('am')), const [
+          Locale('am'),
+        ]);
       });
 
       test('uses the platform locales by default', () {
@@ -132,6 +131,105 @@ void main() {
         expect(delegate.calls, const [Locale('en', 'VN'), Locale('en', 'US')]);
         expect(result, const [span]);
       });
+
+      test(
+        'caches the first supported locale for the same candidate list',
+        () async {
+          const span = SuggestionSpan(TextRange(start: 0, end: 3), ['The']);
+          final delegate = _FakeSpellCheckService(
+            (locale, _) async =>
+                locale == const Locale('en', 'US') ? const [span] : null,
+          );
+          final service = RegionAwareSpellCheckService(
+            delegate: delegate,
+            deviceLocales: const [Locale('en', 'VN')],
+          );
+
+          await service.fetchSpellCheckSuggestions(const Locale('en'), 'Teh');
+          expect(delegate.calls, const [
+            Locale('en', 'VN'),
+            Locale('en', 'US'),
+          ]);
+
+          delegate.calls.clear();
+          final result = await service.fetchSpellCheckSuggestions(
+            const Locale('en'),
+            'Helo',
+          );
+
+          expect(delegate.calls, const [Locale('en', 'US')]);
+          expect(result, const [span]);
+        },
+      );
+
+      test('re-resolves when the candidate list changes', () async {
+        const span = SuggestionSpan(TextRange(start: 0, end: 3), ['The']);
+        final deviceLocales = [const Locale('en', 'VN')];
+        final delegate = _FakeSpellCheckService((locale, _) async {
+          return switch (locale) {
+            Locale(languageCode: 'en', countryCode: 'GB') => const [span],
+            Locale(languageCode: 'en', countryCode: 'US') => const [span],
+            _ => null,
+          };
+        });
+        final service = RegionAwareSpellCheckService(
+          delegate: delegate,
+          deviceLocales: deviceLocales,
+        );
+
+        await service.fetchSpellCheckSuggestions(const Locale('en'), 'Teh');
+        expect(delegate.calls, const [Locale('en', 'VN'), Locale('en', 'US')]);
+
+        delegate.calls.clear();
+        deviceLocales[0] = const Locale('en', 'GB');
+        final result = await service.fetchSpellCheckSuggestions(
+          const Locale('en'),
+          'Helo',
+        );
+
+        expect(delegate.calls, const [Locale('en', 'GB')]);
+        expect(result, const [span]);
+      });
+
+      test(
+        'drops the cached locale when it stops returning suggestions',
+        () async {
+          const span = SuggestionSpan(TextRange(start: 0, end: 3), ['The']);
+          var supportsFallbackRegion = true;
+          final delegate = _FakeSpellCheckService((locale, _) async {
+            if (locale == const Locale('en', 'US') && supportsFallbackRegion) {
+              return const [span];
+            }
+            if (locale == const Locale('en')) return const [span];
+            return null;
+          });
+          final service = RegionAwareSpellCheckService(
+            delegate: delegate,
+            deviceLocales: const [Locale('en', 'VN')],
+          );
+
+          await service.fetchSpellCheckSuggestions(const Locale('en'), 'Teh');
+          expect(delegate.calls, const [
+            Locale('en', 'VN'),
+            Locale('en', 'US'),
+          ]);
+
+          delegate.calls.clear();
+          supportsFallbackRegion = false;
+          final result = await service.fetchSpellCheckSuggestions(
+            const Locale('en'),
+            'Helo',
+          );
+
+          expect(delegate.calls, const [
+            Locale('en', 'US'),
+            Locale('en', 'VN'),
+            Locale('en', 'US'),
+            Locale('en'),
+          ]);
+          expect(result, const [span]);
+        },
+      );
 
       test(
         'stops at a supported language that reports no misspellings',

--- a/mobile/packages/divine_ui/test/src/text_field/region_aware_spell_check_service_test.dart
+++ b/mobile/packages/divine_ui/test/src/text_field/region_aware_spell_check_service_test.dart
@@ -25,13 +25,15 @@ class _FakeSpellCheckService implements SpellCheckService {
 void main() {
   group(RegionAwareSpellCheckService, () {
     group('localeCandidates', () {
-      test('returns the single locale when it already has a country', () {
+      test('tries an already-region-qualified locale first, then falls '
+          'back', () {
         final service = RegionAwareSpellCheckService(deviceLocales: const []);
 
-        expect(
-          service.localeCandidates(const Locale('en', 'GB')),
-          [const Locale('en', 'GB')],
-        );
+        expect(service.localeCandidates(const Locale('en', 'GB')), const [
+          Locale('en', 'GB'),
+          Locale('en', 'US'),
+          Locale('en'),
+        ]);
       });
 
       test('prefers device region, then fallback, then the bare locale', () {
@@ -107,6 +109,27 @@ void main() {
         );
 
         expect(delegate.calls, const [Locale('en', 'CH'), Locale('en', 'US')]);
+        expect(result, const [span]);
+      });
+
+      test('falls back when the incoming locale has an unsupported '
+          'region', () async {
+        const span = SuggestionSpan(TextRange(start: 0, end: 3), ['The']);
+        final delegate = _FakeSpellCheckService(
+          (locale, _) async =>
+              locale == const Locale('en', 'US') ? const [span] : null,
+        );
+        final service = RegionAwareSpellCheckService(
+          delegate: delegate,
+          deviceLocales: const [],
+        );
+
+        final result = await service.fetchSpellCheckSuggestions(
+          const Locale('en', 'VN'),
+          'Teh',
+        );
+
+        expect(delegate.calls, const [Locale('en', 'VN'), Locale('en', 'US')]);
         expect(result, const [span]);
       });
 

--- a/mobile/packages/divine_ui/test/src/text_field/region_aware_spell_check_service_test.dart
+++ b/mobile/packages/divine_ui/test/src/text_field/region_aware_spell_check_service_test.dart
@@ -1,0 +1,149 @@
+import 'dart:ui';
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _FakeSpellCheckService implements SpellCheckService {
+  _FakeSpellCheckService(this._responder);
+
+  final Future<List<SuggestionSpan>?> Function(Locale locale, String text)
+  _responder;
+
+  final List<Locale> calls = [];
+
+  @override
+  Future<List<SuggestionSpan>?> fetchSpellCheckSuggestions(
+    Locale locale,
+    String text,
+  ) {
+    calls.add(locale);
+    return _responder(locale, text);
+  }
+}
+
+void main() {
+  group(RegionAwareSpellCheckService, () {
+    group('localeCandidates', () {
+      test('returns the single locale when it already has a country', () {
+        final service = RegionAwareSpellCheckService(deviceLocales: const []);
+
+        expect(
+          service.localeCandidates(const Locale('en', 'GB')),
+          [const Locale('en', 'GB')],
+        );
+      });
+
+      test('prefers device region, then fallback, then the bare locale', () {
+        final service = RegionAwareSpellCheckService(
+          deviceLocales: const [Locale('en', 'CH')],
+        );
+
+        expect(service.localeCandidates(const Locale('en')), const [
+          Locale('en', 'CH'),
+          Locale('en', 'US'),
+          Locale('en'),
+        ]);
+      });
+
+      test('ignores a device locale without a country code', () {
+        final service = RegionAwareSpellCheckService(
+          deviceLocales: const [Locale('en')],
+        );
+
+        expect(service.localeCandidates(const Locale('en')), const [
+          Locale('en', 'US'),
+          Locale('en'),
+        ]);
+      });
+
+      test('does not duplicate when device region equals the fallback', () {
+        final service = RegionAwareSpellCheckService(
+          deviceLocales: const [Locale('en', 'US')],
+        );
+
+        expect(service.localeCandidates(const Locale('en')), const [
+          Locale('en', 'US'),
+          Locale('en'),
+        ]);
+      });
+
+      test('falls back to just the bare locale when no region is known', () {
+        final service = RegionAwareSpellCheckService(deviceLocales: const []);
+
+        expect(
+          service.localeCandidates(const Locale('am')),
+          const [Locale('am')],
+        );
+      });
+
+      test('uses the platform locales by default', () {
+        final service = RegionAwareSpellCheckService();
+
+        // The test binding reports an en-US platform locale; the first
+        // candidate resolves the region to US either way.
+        expect(
+          service.localeCandidates(const Locale('en')).first.countryCode,
+          'US',
+        );
+      });
+    });
+
+    group('fetchSpellCheckSuggestions', () {
+      test('returns the first candidate the platform supports', () async {
+        const span = SuggestionSpan(TextRange(start: 0, end: 3), ['The']);
+        final delegate = _FakeSpellCheckService(
+          (locale, _) async =>
+              locale == const Locale('en', 'US') ? const [span] : null,
+        );
+        final service = RegionAwareSpellCheckService(
+          delegate: delegate,
+          deviceLocales: const [Locale('en', 'CH')],
+        );
+
+        final result = await service.fetchSpellCheckSuggestions(
+          const Locale('en'),
+          'Teh',
+        );
+
+        expect(delegate.calls, const [Locale('en', 'CH'), Locale('en', 'US')]);
+        expect(result, const [span]);
+      });
+
+      test(
+        'stops at a supported language that reports no misspellings',
+        () async {
+          final delegate = _FakeSpellCheckService((_, _) async => const []);
+          final service = RegionAwareSpellCheckService(
+            delegate: delegate,
+            deviceLocales: const [],
+          );
+
+          final result = await service.fetchSpellCheckSuggestions(
+            const Locale('en'),
+            'hello',
+          );
+
+          expect(delegate.calls, const [Locale('en', 'US')]);
+          expect(result, isEmpty);
+        },
+      );
+
+      test('returns null when no candidate is supported', () async {
+        final delegate = _FakeSpellCheckService((_, _) async => null);
+        final service = RegionAwareSpellCheckService(
+          delegate: delegate,
+          deviceLocales: const [],
+        );
+
+        final result = await service.fetchSpellCheckSuggestions(
+          const Locale('en'),
+          'Teh',
+        );
+
+        expect(delegate.calls, const [Locale('en', 'US'), Locale('en')]);
+        expect(result, isNull);
+      });
+    });
+  });
+}


### PR DESCRIPTION
Closes #5887

## What

`DivineTextField` wrapped Flutter's `TextField` but never set `spellCheckConfiguration`, so the OS spell-check underline and the tap-a-misspelled-word → suggestions ("Replace") flow was **off on every text field in the app**. This enables it by default via a new `RegionAwareSpellCheckService`.

## Why it needed more than just flipping it on

Simply enabling spell check surfaced nothing on real devices:

- **iOS** `UITextChecker` only accepts region-qualified languages it actually supports — `en_US`, `en_GB`, … — and returns `null` (no spell check at all) for a bare `en` or an unsupported region. The app resolves UI locales **without** a region, and a device set to an unsupported region (this was reproduced on an iPad set to **Vietnam** → `en_VN`, and applies equally to e.g. `en_CH`) gets rejected outright.
- **Android** depends on the system spell-checker service, which often returns nothing.

`RegionAwareSpellCheckService` resolves a working locale by trying a prioritized list of candidates — the device's own regional variant → a known-good fallback region (`en`→`US`, `de`→`DE`, …) → the bare locale — and using the first the platform accepts. Providing the service explicitly also sidesteps the framework assertion that fires when spell check is enabled on a platform with no native checker (desktop, widget tests): there it degrades to a harmless no-op instead of throwing.

The default keeps the platform-standard misspelled styling (the familiar red dotted underline); tapping an underlined word shows the native suggestions toolbar.

## Testing

- `flutter test` (divine_ui) — all green; new service at 100% line coverage (strict-coverage package).
- Device-verified on iOS (iPad): misspelled words now underline and produce replacement suggestions once a supported region is resolved.

## Notes

- Autocorrect (keyboard-level) is unchanged and independent; it can still auto-correct common typos before the underline shows. Unusual words (names, "Piñon", etc.) stay flagged.
- Flutter renders its own selection menu, so the literal iOS "Replace…" menu item is not reproduced — the equivalent is a single tap on the underlined word.