### PR TITLE
perf(nostr): skip re-verifying already-known events on cold start

### DIFF
--- a/mobile/packages/db_client/lib/src/database/daos/nostr_events_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/nostr_events_dao.dart
@@ -624,18 +624,31 @@ class NostrEventsDao extends DatabaseAccessor<AppDatabase>
     return result.read<int>('count');
   }
 
-  /// Returns the ids of the most recently created events, newest first,
-  /// capped at [limit].
+  /// Returns the `(id, sig)` pairs of the most recently created events,
+  /// newest first, capped at [limit].
   ///
   /// Used to seed the relay pool's already-verified set: every event in this
   /// table was signature-verified before being written, so re-verifying the
-  /// same ids when relays re-send them on the next cold start is wasted work.
-  Future<List<String>> getRecentEventIds({int limit = 50000}) async {
+  /// same events when relays re-send them on the next cold start is wasted
+  /// work. The signature is returned alongside the id because a Nostr event
+  /// id commits to the event body but not to `sig`, so trust must be keyed by
+  /// the exact `(id, sig)` pair that was verified — an id alone would let a
+  /// replayed id carrying a forged signature bypass verification.
+  Future<List<({String id, String sig})>> getRecentEventIdSigs({
+    int limit = 50000,
+  }) async {
     final rows = await customSelect(
-      'SELECT id FROM event ORDER BY created_at DESC LIMIT ?',
+      'SELECT id, sig FROM event ORDER BY created_at DESC LIMIT ?',
       variables: [Variable.withInt(limit)],
       readsFrom: {nostrEvents},
     ).get();
-    return rows.map((row) => row.read<String>('id')).toList();
+    return rows
+        .map(
+          (row) => (
+            id: row.read<String>('id'),
+            sig: row.read<String>('sig'),
+          ),
+        )
+        .toList();
   }
 }

--- a/mobile/packages/db_client/lib/src/database/daos/nostr_events_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/nostr_events_dao.dart
@@ -634,6 +634,14 @@ class NostrEventsDao extends DatabaseAccessor<AppDatabase>
   /// id commits to the event body but not to `sig`, so trust must be keyed by
   /// the exact `(id, sig)` pair that was verified — an id alone would let a
   /// replayed id carrying a forged signature bypass verification.
+  ///
+  /// The default [limit] is intentionally large: on-device profiling showed
+  /// this seed take cold-start relay verify from ~37% of startup CPU to ~1%,
+  /// i.e. the re-send flood in this app approaches this scale, so a smaller
+  /// cap would re-introduce the expensive EC verify for the tail. The one-time
+  /// seed cost (~SQLite read + string/set builds) is negligible against the
+  /// per-event verify seconds it saves. Newest-first so the cap keeps the
+  /// most-likely-re-sent events.
   Future<List<({String id, String sig})>> getRecentEventIdSigs({
     int limit = 50000,
   }) async {

--- a/mobile/packages/db_client/lib/src/database/daos/nostr_events_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/nostr_events_dao.dart
@@ -623,4 +623,19 @@ class NostrEventsDao extends DatabaseAccessor<AppDatabase>
     ).getSingle();
     return result.read<int>('count');
   }
+
+  /// Returns the ids of the most recently created events, newest first,
+  /// capped at [limit].
+  ///
+  /// Used to seed the relay pool's already-verified set: every event in this
+  /// table was signature-verified before being written, so re-verifying the
+  /// same ids when relays re-send them on the next cold start is wasted work.
+  Future<List<String>> getRecentEventIds({int limit = 50000}) async {
+    final rows = await customSelect(
+      'SELECT id FROM event ORDER BY created_at DESC LIMIT ?',
+      variables: [Variable.withInt(limit)],
+      readsFrom: {nostrEvents},
+    ).get();
+    return rows.map((row) => row.read<String>('id')).toList();
+  }
 }

--- a/mobile/packages/db_client/test/src/database/daos/nostr_events_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/nostr_events_dao_test.dart
@@ -1745,17 +1745,23 @@ void main() {
       });
     });
 
-    group('getRecentEventIds', () {
-      test('returns ids ordered by created_at descending', () async {
-        final older = createEvent(content: 'older', createdAt: 1000);
-        final newer = createEvent(content: 'newer', createdAt: 2000);
-        await dao.upsertEvent(older);
-        await dao.upsertEvent(newer);
+    group('getRecentEventIdSigs', () {
+      test(
+        'returns (id, sig) pairs ordered by created_at descending',
+        () async {
+          final older = createEvent(content: 'older', createdAt: 1000);
+          final newer = createEvent(content: 'newer', createdAt: 2000);
+          await dao.upsertEvent(older);
+          await dao.upsertEvent(newer);
 
-        final ids = await dao.getRecentEventIds();
+          final pairs = await dao.getRecentEventIdSigs();
 
-        expect(ids, [newer.id, older.id]);
-      });
+          expect(pairs, [
+            (id: newer.id, sig: newer.sig),
+            (id: older.id, sig: older.sig),
+          ]);
+        },
+      );
 
       test('respects the limit', () async {
         for (var i = 0; i < 5; i++) {
@@ -1764,13 +1770,13 @@ void main() {
           );
         }
 
-        final ids = await dao.getRecentEventIds(limit: 2);
+        final pairs = await dao.getRecentEventIdSigs(limit: 2);
 
-        expect(ids, hasLength(2));
+        expect(pairs, hasLength(2));
       });
 
       test('returns empty when no events exist', () async {
-        expect(await dao.getRecentEventIds(), isEmpty);
+        expect(await dao.getRecentEventIdSigs(), isEmpty);
       });
     });
   });

--- a/mobile/packages/db_client/test/src/database/daos/nostr_events_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/nostr_events_dao_test.dart
@@ -1744,5 +1744,34 @@ void main() {
         });
       });
     });
+
+    group('getRecentEventIds', () {
+      test('returns ids ordered by created_at descending', () async {
+        final older = createEvent(content: 'older', createdAt: 1000);
+        final newer = createEvent(content: 'newer', createdAt: 2000);
+        await dao.upsertEvent(older);
+        await dao.upsertEvent(newer);
+
+        final ids = await dao.getRecentEventIds();
+
+        expect(ids, [newer.id, older.id]);
+      });
+
+      test('respects the limit', () async {
+        for (var i = 0; i < 5; i++) {
+          await dao.upsertEvent(
+            createEvent(content: 'e$i', createdAt: 1000 + i),
+          );
+        }
+
+        final ids = await dao.getRecentEventIds(limit: 2);
+
+        expect(ids, hasLength(2));
+      });
+
+      test('returns empty when no events exist', () async {
+        expect(await dao.getRecentEventIds(), isEmpty);
+      });
+    });
   });
 }

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -127,14 +127,17 @@ class NostrClient {
   /// Convenience getter for the NostrEventsDao
   NostrEventsDao? get _nostrEventsDao => _dbClient?.database.nostrEventsDao;
 
-  /// Ids of events already persisted — and therefore already
+  /// `"id:sig"` keys of events already persisted — and therefore already
   /// signature-verified — in a previous session. Seeded once at
   /// [initialize] so the relay pool can skip re-verifying events that relays
-  /// re-send on cold start.
-  final Set<String> _knownVerifiedEventIds = <String>{};
+  /// re-send on cold start. The signature is part of the key because a Nostr
+  /// event id does not commit to `sig`; trusting an id alone would let a
+  /// replayed id carrying a forged signature bypass verification.
+  final Set<String> _knownVerifiedEventKeys = <String>{};
 
-  /// Loads recently-persisted event ids into [_knownVerifiedEventIds] and
-  /// wires the relay pool to consult it. No-op when there is no local store.
+  /// Loads recently-persisted `(id, sig)` pairs into
+  /// [_knownVerifiedEventKeys] and wires the relay pool to consult it. No-op
+  /// when there is no local store.
   ///
   /// Called before relays connect so the lookup is in place before the
   /// cold-start event flood arrives.
@@ -142,13 +145,14 @@ class NostrClient {
     final dao = _nostrEventsDao;
     if (dao == null) return;
     try {
-      final ids = await dao.getRecentEventIds();
-      _knownVerifiedEventIds
+      final pairs = await dao.getRecentEventIdSigs();
+      _knownVerifiedEventKeys
         ..clear()
-        ..addAll(ids);
-      _nostr.relayPool.isKnownVerifiedEvent = _knownVerifiedEventIds.contains;
+        ..addAll(pairs.map((pair) => '${pair.id}:${pair.sig}'));
+      _nostr.relayPool.isKnownVerifiedEvent = (id, sig) =>
+          _knownVerifiedEventKeys.contains('$id:$sig');
       log(
-        '🔏 Seeded ${_knownVerifiedEventIds.length} known-verified event ids',
+        '🔏 Seeded ${_knownVerifiedEventKeys.length} known-verified events',
         name: 'NostrClient',
       );
     } on Object catch (e, st) {

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:developer';
 
 import 'package:crypto/crypto.dart';
 import 'package:db_client/db_client.dart' hide Filter;
@@ -125,6 +126,41 @@ class NostrClient {
 
   /// Convenience getter for the NostrEventsDao
   NostrEventsDao? get _nostrEventsDao => _dbClient?.database.nostrEventsDao;
+
+  /// Ids of events already persisted — and therefore already
+  /// signature-verified — in a previous session. Seeded once at
+  /// [initialize] so the relay pool can skip re-verifying events that relays
+  /// re-send on cold start.
+  final Set<String> _knownVerifiedEventIds = <String>{};
+
+  /// Loads recently-persisted event ids into [_knownVerifiedEventIds] and
+  /// wires the relay pool to consult it. No-op when there is no local store.
+  ///
+  /// Called before relays connect so the lookup is in place before the
+  /// cold-start event flood arrives.
+  Future<void> _seedVerifiedEventIds() async {
+    final dao = _nostrEventsDao;
+    if (dao == null) return;
+    try {
+      final ids = await dao.getRecentEventIds();
+      _knownVerifiedEventIds
+        ..clear()
+        ..addAll(ids);
+      _nostr.relayPool.isKnownVerifiedEvent = _knownVerifiedEventIds.contains;
+      log(
+        '🔏 Seeded ${_knownVerifiedEventIds.length} known-verified event ids',
+        name: 'NostrClient',
+      );
+    } on Object catch (e, st) {
+      // Non-fatal: without the seed the pool simply verifies every event.
+      log(
+        'Failed to seed known-verified event ids',
+        name: 'NostrClient',
+        error: e,
+        stackTrace: st,
+      );
+    }
+  }
 
   /// Helper to cache an event with default expiry.
   ///
@@ -306,6 +342,9 @@ class NostrClient {
     try {
       // Signer is the single source of truth for the public key.
       await _nostr.refreshPublicKey();
+      // Seed the already-verified set before relays connect, so re-sent
+      // events skip re-verification during the cold-start flood.
+      await _seedVerifiedEventIds();
       await _relayManager.initialize();
       if (!_readyCompleter.isCompleted) {
         _readyCompleter.complete();

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -130,6 +130,63 @@ void main() {
       });
     });
 
+    group('initialize seeds known-verified event ids', () {
+      late RelayPool realPool;
+
+      setUp(() {
+        RelayBase tempRelay(String url) => RelayBase(url, RelayStatus(url));
+        realPool = RelayPool(mockNostr, <EventFilter>[], tempRelay);
+        when(() => mockNostr.refreshPublicKey()).thenAnswer((_) async {});
+        when(() => mockNostr.relayPool).thenReturn(realPool);
+        when(mockRelayManager.initialize).thenAnswer((_) async {});
+      });
+
+      NostrClient buildClientWithDao(_MockNostrEventsDao dao) {
+        final dbClient = _MockAppDbClient();
+        final database = _MockAppDatabase();
+        when(() => dbClient.database).thenReturn(database);
+        when(() => database.nostrEventsDao).thenReturn(dao);
+        return NostrClient.forTesting(
+          nostr: mockNostr,
+          relayManager: mockRelayManager,
+          dbClient: dbClient,
+        );
+      }
+
+      test('wires the pool lookup from persisted ids', () async {
+        final dao = _MockNostrEventsDao();
+        when(dao.getRecentEventIds).thenAnswer((_) async => ['idA']);
+        final clientWithDb = buildClientWithDao(dao);
+
+        await clientWithDb.initialize();
+
+        final lookup = realPool.isKnownVerifiedEvent;
+        expect(lookup, isNotNull);
+        expect(lookup!('idA'), isTrue);
+        expect(lookup('never-seen'), isFalse);
+      });
+
+      test('leaves the lookup unset when there is no db client', () async {
+        final clientWithoutDb = NostrClient.forTesting(
+          nostr: mockNostr,
+          relayManager: mockRelayManager,
+        );
+
+        await clientWithoutDb.initialize();
+
+        expect(realPool.isKnownVerifiedEvent, isNull);
+      });
+
+      test('initialize still completes when seeding fails', () async {
+        final dao = _MockNostrEventsDao();
+        when(dao.getRecentEventIds).thenThrow(Exception('boom'));
+        final clientWithDb = buildClientWithDao(dao);
+
+        await expectLater(clientWithDb.initialize(), completes);
+        expect(realPool.isKnownVerifiedEvent, isNull);
+      });
+    });
+
     group('queryEvents', () {
       test('caps concurrent WebSocket queries and releases slots', () async {
         final originalMaxConcurrentQueries = NostrClient.maxConcurrentQueries;

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -153,17 +153,22 @@ void main() {
         );
       }
 
-      test('wires the pool lookup from persisted ids', () async {
+      test('wires the pool lookup from persisted (id, sig) pairs', () async {
         final dao = _MockNostrEventsDao();
-        when(dao.getRecentEventIds).thenAnswer((_) async => ['idA']);
+        when(
+          dao.getRecentEventIdSigs,
+        ).thenAnswer((_) async => [(id: 'idA', sig: 'sigA')]);
         final clientWithDb = buildClientWithDao(dao);
 
         await clientWithDb.initialize();
 
         final lookup = realPool.isKnownVerifiedEvent;
         expect(lookup, isNotNull);
-        expect(lookup!('idA'), isTrue);
-        expect(lookup('never-seen'), isFalse);
+        expect(lookup!('idA', 'sigA'), isTrue);
+        // A known id carrying a different signature is not trusted — the id
+        // does not commit to sig, so this must fall through to a full verify.
+        expect(lookup('idA', 'other-sig'), isFalse);
+        expect(lookup('never-seen', 'sigA'), isFalse);
       });
 
       test('leaves the lookup unset when there is no db client', () async {
@@ -179,7 +184,7 @@ void main() {
 
       test('initialize still completes when seeding fails', () async {
         final dao = _MockNostrEventsDao();
-        when(dao.getRecentEventIds).thenThrow(Exception('boom'));
+        when(dao.getRecentEventIdSigs).thenThrow(Exception('boom'));
         final clientWithDb = buildClientWithDao(dao);
 
         await expectLater(clientWithDb.initialize(), completes);

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -388,8 +388,8 @@ class RelayPool {
   /// been verified on this isolate. The same event arriving again from
   /// another relay skips the ~0.3ms secp256k1 verify that otherwise
   /// dominates cold start (signature verification was ~42% of startup CPU
-  /// in profiling). Only network-verified ids are recorded here; cache-relay
-  /// ids are deliberately not, so a later network copy is still verified.
+  /// in profiling). Only ids from a fresh network verify are recorded here,
+  /// so a known/duplicate hit never masks an unverified network copy.
   static const int _verifiedEventIdsCap = 20000;
   final LinkedHashSet<String> _verifiedEventIds = LinkedHashSet<String>();
 
@@ -404,11 +404,14 @@ class RelayPool {
   bool Function(String eventId)? isKnownVerifiedEvent;
 
   /// Diagnostic counters for how [_onEvent] treated each incoming event's
-  /// signature. Exposed so callers / tests can observe the skip rate.
-  int verifiesPerformed = 0;
-  int verifiesSkippedKnown = 0;
-  int verifiesSkippedSessionDup = 0;
-  int verifiesSkippedCache = 0;
+  /// signature. Read-only; exposed so callers / tests can observe the skip
+  /// rate.
+  int get verifiesPerformed => _verifiesPerformed;
+  int get verifiesSkippedKnown => _verifiesSkippedKnown;
+  int get verifiesSkippedSessionDup => _verifiesSkippedSessionDup;
+  int _verifiesPerformed = 0;
+  int _verifiesSkippedKnown = 0;
+  int _verifiesSkippedSessionDup = 0;
 
   /// Records [id] as verified, evicting the oldest id once the cap is hit.
   void _markEventVerified(String id) {
@@ -467,23 +470,19 @@ class RelayPool {
         // trusted. Because isValid proves id == sha256(content) (which
         // includes the pubkey), two events sharing an id are byte-identical,
         // so id-based trust is cryptographically sound.
-        //  - Cache-relay events were verified before being written, so they
-        //    are trusted by origin and never re-verified on cold start.
         //  - Events verified in a previous session (known to the injected
         //    [isKnownVerifiedEvent] store) skip re-verify on cold start.
         //  - Network events verified earlier this session (a duplicate
         //    delivery of the same id from another relay) skip re-verify.
         // Only fresh network verifications are recorded in [_verifiedEventIds]
-        // so cache/known events never mask an unverified network copy.
-        if (relay.relayStatus.relayType == RelayType.cache) {
-          verifiesSkippedCache++;
-        } else if (_verifiedEventIds.contains(event.id)) {
-          verifiesSkippedSessionDup++;
+        // so a known/duplicate hit never masks an unverified network copy.
+        if (_verifiedEventIds.contains(event.id)) {
+          _verifiesSkippedSessionDup++;
         } else if (isKnownVerifiedEvent?.call(event.id) ?? false) {
-          verifiesSkippedKnown++;
+          _verifiesSkippedKnown++;
         } else if (event.isSigned) {
           _markEventVerified(event.id);
-          verifiesPerformed++;
+          _verifiesPerformed++;
         } else {
           log(
             'Dropping relay event with invalid signature '

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -384,24 +384,32 @@ class RelayPool {
     return null;
   }
 
-  /// Session-scoped LRU of event ids whose Schnorr signature has already
-  /// been verified on this isolate. The same event arriving again from
-  /// another relay skips the ~0.3ms secp256k1 verify that otherwise
+  /// Session-scoped LRU of `"id:sig"` keys whose Schnorr signature has
+  /// already been verified on this isolate. The same event arriving again
+  /// from another relay skips the ~0.3ms secp256k1 verify that otherwise
   /// dominates cold start (signature verification was ~42% of startup CPU
-  /// in profiling). Only ids from a fresh network verify are recorded here,
-  /// so a known/duplicate hit never masks an unverified network copy.
-  static const int _verifiedEventIdsCap = 20000;
-  final LinkedHashSet<String> _verifiedEventIds = LinkedHashSet<String>();
+  /// in profiling).
+  ///
+  /// The signature is part of the key because a Nostr event id commits to
+  /// the event body only, *not* to `sig` — a relay can replay a known id
+  /// carrying a different, invalid signature. Keying by id alone would let
+  /// that copy skip verification; keying by `(id, sig)` forces a re-verify
+  /// whenever the signature differs. Only fresh network verifications are
+  /// recorded here, so a known/duplicate hit never masks an unverified copy.
+  static const int _verifiedEventKeysCap = 20000;
+  final LinkedHashSet<String> _verifiedEventKeys = LinkedHashSet<String>();
 
-  /// Optional lookup for event ids already verified in a *previous* session.
+  /// Optional lookup for `(event id, signature)` pairs already verified in a
+  /// *previous* session.
   ///
   /// Relays re-send events the app already downloaded and persisted, so on
-  /// every cold start those ids arrive again and would be re-verified. The
-  /// app injects a lookup backed by its local event store (all ids there
-  /// were verified before being written), letting [_onEvent] skip the
-  /// expensive Schnorr verify for known ids. Must be a cheap, synchronous,
-  /// side-effect-free membership test.
-  bool Function(String eventId)? isKnownVerifiedEvent;
+  /// every cold start those events arrive again and would be re-verified. The
+  /// app injects a lookup backed by its local event store (every persisted
+  /// event was verified before being written), letting [_onEvent] skip the
+  /// expensive Schnorr verify for a known id **only when the incoming
+  /// signature matches the one that was persisted** — the id alone does not
+  /// commit to `sig`. Must be a cheap, synchronous, side-effect-free test.
+  bool Function(String eventId, String signature)? isKnownVerifiedEvent;
 
   /// Diagnostic counters for how [_onEvent] treated each incoming event's
   /// signature. Read-only; exposed so callers / tests can observe the skip
@@ -413,13 +421,14 @@ class RelayPool {
   int _verifiesSkippedKnown = 0;
   int _verifiesSkippedSessionDup = 0;
 
-  /// Records [id] as verified, evicting the oldest id once the cap is hit.
-  void _markEventVerified(String id) {
-    _verifiedEventIds
-      ..remove(id)
-      ..add(id);
-    if (_verifiedEventIds.length > _verifiedEventIdsCap) {
-      _verifiedEventIds.remove(_verifiedEventIds.first);
+  /// Records [key] (an `"id:sig"` pair) as verified, evicting the oldest once
+  /// the cap is hit.
+  void _markEventVerified(String key) {
+    _verifiedEventKeys
+      ..remove(key)
+      ..add(key);
+    if (_verifiedEventKeys.length > _verifiedEventKeysCap) {
+      _verifiedEventKeys.remove(_verifiedEventKeys.first);
     }
   }
 
@@ -466,22 +475,23 @@ class RelayPool {
           return;
         }
 
-        // Skip the expensive Schnorr verify when the event is already
-        // trusted. Because isValid proves id == sha256(content) (which
-        // includes the pubkey), two events sharing an id are byte-identical,
-        // so id-based trust is cryptographically sound.
-        //  - Events verified in a previous session (known to the injected
+        // Skip the expensive Schnorr verify when this exact `(id, sig)` pair
+        // is already trusted. The event id commits to the body but not to
+        // `sig`, so trust is keyed by both — a replayed id carrying a
+        // different signature falls through to a full verify below.
+        //  - Pairs verified in a previous session (known to the injected
         //    [isKnownVerifiedEvent] store) skip re-verify on cold start.
-        //  - Network events verified earlier this session (a duplicate
-        //    delivery of the same id from another relay) skip re-verify.
-        // Only fresh network verifications are recorded in [_verifiedEventIds]
+        //  - Pairs verified earlier this session (a duplicate delivery of the
+        //    same event from another relay) skip re-verify.
+        // Only fresh network verifications are recorded in [_verifiedEventKeys]
         // so a known/duplicate hit never masks an unverified network copy.
-        if (_verifiedEventIds.contains(event.id)) {
+        final verifyKey = '${event.id}:${event.sig}';
+        if (_verifiedEventKeys.contains(verifyKey)) {
           _verifiesSkippedSessionDup++;
-        } else if (isKnownVerifiedEvent?.call(event.id) ?? false) {
+        } else if (isKnownVerifiedEvent?.call(event.id, event.sig) ?? false) {
           _verifiesSkippedKnown++;
         } else if (event.isSigned) {
-          _markEventVerified(event.id);
+          _markEventVerified(verifyKey);
           _verifiesPerformed++;
         } else {
           log(

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Handles relay lifecycle, message routing, authentication, and event filtering.
 
 import 'dart:async';
+import 'dart:collection';
 import 'dart:developer';
 
 import 'package:nostr_sdk/utils/relay_addr_util.dart';
@@ -383,6 +384,42 @@ class RelayPool {
     return null;
   }
 
+  /// Session-scoped LRU of event ids whose Schnorr signature has already
+  /// been verified on this isolate. The same event arriving again from
+  /// another relay skips the ~0.3ms secp256k1 verify that otherwise
+  /// dominates cold start (signature verification was ~42% of startup CPU
+  /// in profiling). Only network-verified ids are recorded here; cache-relay
+  /// ids are deliberately not, so a later network copy is still verified.
+  static const int _verifiedEventIdsCap = 20000;
+  final LinkedHashSet<String> _verifiedEventIds = LinkedHashSet<String>();
+
+  /// Optional lookup for event ids already verified in a *previous* session.
+  ///
+  /// Relays re-send events the app already downloaded and persisted, so on
+  /// every cold start those ids arrive again and would be re-verified. The
+  /// app injects a lookup backed by its local event store (all ids there
+  /// were verified before being written), letting [_onEvent] skip the
+  /// expensive Schnorr verify for known ids. Must be a cheap, synchronous,
+  /// side-effect-free membership test.
+  bool Function(String eventId)? isKnownVerifiedEvent;
+
+  /// Diagnostic counters for how [_onEvent] treated each incoming event's
+  /// signature. Exposed so callers / tests can observe the skip rate.
+  int verifiesPerformed = 0;
+  int verifiesSkippedKnown = 0;
+  int verifiesSkippedSessionDup = 0;
+  int verifiesSkippedCache = 0;
+
+  /// Records [id] as verified, evicting the oldest id once the cap is hit.
+  void _markEventVerified(String id) {
+    _verifiedEventIds
+      ..remove(id)
+      ..add(id);
+    if (_verifiedEventIds.length > _verifiedEventIdsCap) {
+      _verifiedEventIds.remove(_verifiedEventIds.first);
+    }
+  }
+
   Future<void> _onEvent(Relay relay, List<dynamic> json) async {
     final messageType = _stringAt(relay, json, 0, 'message type');
     if (messageType == null) return;
@@ -414,9 +451,42 @@ class RelayPool {
         if (eventJson == null) return;
 
         final event = Event.fromJson(eventJson);
-        if (!event.isValid || !event.isSigned) {
+
+        // Cheap integrity check first: [Event.isValid] recomputes the
+        // sha256 id from the event's own content, so a tampered payload is
+        // rejected here without touching the expensive EC verifier.
+        if (!event.isValid) {
           log(
-            'Dropping relay event with invalid id or signature '
+            'Dropping relay event with invalid id '
+            'from ${relay.url}: eventId=${event.id}',
+          );
+          return;
+        }
+
+        // Skip the expensive Schnorr verify when the event is already
+        // trusted. Because isValid proves id == sha256(content) (which
+        // includes the pubkey), two events sharing an id are byte-identical,
+        // so id-based trust is cryptographically sound.
+        //  - Cache-relay events were verified before being written, so they
+        //    are trusted by origin and never re-verified on cold start.
+        //  - Events verified in a previous session (known to the injected
+        //    [isKnownVerifiedEvent] store) skip re-verify on cold start.
+        //  - Network events verified earlier this session (a duplicate
+        //    delivery of the same id from another relay) skip re-verify.
+        // Only fresh network verifications are recorded in [_verifiedEventIds]
+        // so cache/known events never mask an unverified network copy.
+        if (relay.relayStatus.relayType == RelayType.cache) {
+          verifiesSkippedCache++;
+        } else if (_verifiedEventIds.contains(event.id)) {
+          verifiesSkippedSessionDup++;
+        } else if (isKnownVerifiedEvent?.call(event.id) ?? false) {
+          verifiesSkippedKnown++;
+        } else if (event.isSigned) {
+          _markEventVerified(event.id);
+          verifiesPerformed++;
+        } else {
+          log(
+            'Dropping relay event with invalid signature '
             'from ${relay.url}: eventId=${event.id}',
           );
           return;

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -384,11 +384,13 @@ class RelayPool {
     return null;
   }
 
-  /// Session-scoped LRU of `"id:sig"` keys whose Schnorr signature has
-  /// already been verified on this isolate. The same event arriving again
-  /// from another relay skips the ~0.3ms secp256k1 verify that otherwise
-  /// dominates cold start (signature verification was ~42% of startup CPU
-  /// in profiling).
+  /// Session-scoped, insertion-ordered set of `"id:sig"` keys whose Schnorr
+  /// signature has already been verified on this isolate. The same event
+  /// arriving again from another relay skips the ~0.3ms secp256k1 verify that
+  /// otherwise dominates cold start (signature verification was ~42% of
+  /// startup CPU in profiling). Eviction is oldest-inserted-first (FIFO); a
+  /// duplicate hit is not moved to most-recent, so it is not a true LRU — for
+  /// a bounded seen-set that distinction is immaterial.
   ///
   /// The signature is part of the key because a Nostr event id commits to
   /// the event body only, *not* to `sig` — a relay can replay a known id
@@ -412,8 +414,11 @@ class RelayPool {
   bool Function(String eventId, String signature)? isKnownVerifiedEvent;
 
   /// Diagnostic counters for how [_onEvent] treated each incoming event's
-  /// signature. Read-only; exposed so callers / tests can observe the skip
-  /// rate.
+  /// signature. Read-only; read by the dedup tests to assert that the skip
+  /// branches actually fire. There is no production reader by design — the
+  /// periodic verify-stats log was removed to keep the hot path quiet; wire
+  /// these into a diagnostics surface if on-device skip-rate visibility is
+  /// ever needed.
   int get verifiesPerformed => _verifiesPerformed;
   int get verifiesSkippedKnown => _verifiesSkippedKnown;
   int get verifiesSkippedSessionDup => _verifiesSkippedSessionDup;

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_verify_dedup_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_verify_dedup_test.dart
@@ -1,0 +1,199 @@
+// ABOUTME: Regression tests for RelayPool._onEvent signature-verification
+// ABOUTME: dedup and cache-relay trust (cold-start CPU optimization).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:nostr_sdk/relay/client_connected.dart';
+
+/// A fake relay that lets tests drive `onMessage` directly and records
+/// nothing else. No real network I/O.
+class _FakeRelay extends Relay {
+  _FakeRelay(String url, {int relayType = RelayType.normal})
+    : super(url, RelayStatus(url, relayType: relayType));
+
+  @override
+  Future<bool> doConnect() async {
+    relayStatus.connected = ClientConnected.connected;
+    return true;
+  }
+
+  @override
+  Future<void> disconnect() async {
+    relayStatus.connected = ClientConnected.disconnect;
+  }
+
+  @override
+  Future<bool> send(
+    List<dynamic> message, {
+    bool? forceSend,
+    bool queueIfFailed = true,
+    bool skipReconnect = false,
+    DateTime? deadline,
+  }) async {
+    return true;
+  }
+
+  /// Drive an inbound message through the handler RelayPool wired up.
+  Future<void> deliver(List<dynamic> json) async {
+    final handler = onMessage;
+    expect(handler, isNotNull, reason: 'RelayPool did not wire onMessage');
+    final dynamic result = handler!(this, json);
+    if (result is Future) {
+      await result;
+    }
+  }
+}
+
+void main() {
+  group('RelayPool._onEvent signature verify', () {
+    const privateKey =
+        '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12';
+    const subId = 'sub-verify-dedup';
+    // A 64-byte (128 hex char) but cryptographically invalid signature.
+    const badSig =
+        '0000000000000000000000000000000000000000000000000000000000000000'
+        '0000000000000000000000000000000000000000000000000000000000000000';
+
+    Relay dummyTempRelay(String url) => RelayBase(url, RelayStatus(url));
+
+    late Nostr nostr;
+    late List<Event> received;
+
+    setUp(() {
+      nostr = Nostr(LocalNostrSigner(privateKey), [], dummyTempRelay);
+      received = <Event>[];
+      nostr.relayPool.subscribe(
+        [
+          {
+            'kinds': [EventKind.textNote],
+          },
+        ],
+        received.add,
+        id: subId,
+      );
+    });
+
+    /// Builds a validly signed text-note event JSON for [content].
+    Map<String, dynamic> signedEventJson({String content = 'hello'}) {
+      final pubkey = getPublicKey(privateKey);
+      final event = Event(
+        pubkey,
+        EventKind.textNote,
+        [],
+        content,
+        createdAt: 1700000000,
+      );
+      event.sign(privateKey);
+      return event.toJson();
+    }
+
+    test('routes a validly signed network event', () async {
+      final relay = _FakeRelay('wss://n1.example');
+      await nostr.relayPool.add(relay);
+
+      await relay.deliver(['EVENT', subId, signedEventJson()]);
+
+      expect(received, hasLength(1));
+    });
+
+    test('drops a network event with an invalid signature', () async {
+      final relay = _FakeRelay('wss://n1.example');
+      await nostr.relayPool.add(relay);
+
+      final json = signedEventJson()..['sig'] = badSig;
+      await relay.deliver(['EVENT', subId, json]);
+
+      expect(received, isEmpty);
+    });
+
+    test('routes a duplicate id from a second relay (dedup skips verify, '
+        'never drops)', () async {
+      final r1 = _FakeRelay('wss://n1.example');
+      final r2 = _FakeRelay('wss://n2.example');
+      await nostr.relayPool.add(r1);
+      await nostr.relayPool.add(r2);
+
+      final json = signedEventJson();
+      await r1.deliver(['EVENT', subId, json]);
+      await r2.deliver(['EVENT', subId, Map<String, dynamic>.from(json)]);
+
+      expect(received, hasLength(2));
+    });
+
+    test(
+      'trusts cache-relay events without verifying their signature',
+      () async {
+        // A cache-relay event carrying a deliberately invalid signature is
+        // still routed: cache events were verified before being stored, so
+        // the expensive verify is skipped on cold-start replay.
+        final cache = _FakeRelay(
+          'wss://cache.example',
+          relayType: RelayType.cache,
+        );
+        await nostr.relayPool.add(cache, relayType: RelayType.cache);
+
+        final json = signedEventJson()..['sig'] = badSig;
+        await cache.deliver(['EVENT', subId, json]);
+
+        expect(received, hasLength(1));
+      },
+    );
+
+    test(
+      'skips verify for ids known-verified from a previous session',
+      () async {
+        // The app seeds ids verified and persisted in a prior session. A
+        // network event whose id is known — even with a bad signature here —
+        // is trusted and routed without re-verifying.
+        final relay = _FakeRelay('wss://n1.example');
+        await nostr.relayPool.add(relay);
+
+        final json = signedEventJson()..['sig'] = badSig;
+        nostr.relayPool.isKnownVerifiedEvent = {json['id'] as String}.contains;
+
+        await relay.deliver(['EVENT', subId, json]);
+
+        expect(received, hasLength(1));
+        expect(nostr.relayPool.verifiesSkippedKnown, 1);
+        expect(nostr.relayPool.verifiesPerformed, 0);
+      },
+    );
+
+    test('still verifies ids absent from the known-verified set', () async {
+      final relay = _FakeRelay('wss://n1.example');
+      await nostr.relayPool.add(relay);
+      nostr.relayPool.isKnownVerifiedEvent = (_) => false;
+
+      await relay.deliver(['EVENT', subId, signedEventJson(content: 'ok')]);
+
+      expect(received, hasLength(1));
+      expect(nostr.relayPool.verifiesPerformed, 1);
+      expect(nostr.relayPool.verifiesSkippedKnown, 0);
+    });
+
+    test(
+      'does not trust a network copy just because a cache copy arrived',
+      () async {
+        // Cache trust must not poison the network-verified set: the same id
+        // arriving from a network relay with a bad signature is still dropped.
+        final cache = _FakeRelay(
+          'wss://cache.example',
+          relayType: RelayType.cache,
+        );
+        final net = _FakeRelay('wss://n1.example');
+        await nostr.relayPool.add(cache, relayType: RelayType.cache);
+        await nostr.relayPool.add(net);
+
+        final badJson = signedEventJson()..['sig'] = badSig;
+        await cache.deliver(['EVENT', subId, badJson]);
+        await net.deliver(['EVENT', subId, Map<String, dynamic>.from(badJson)]);
+
+        expect(
+          received,
+          hasLength(1),
+          reason: 'network copy with bad sig must not be trusted via cache',
+        );
+      },
+    );
+  });
+}

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_verify_dedup_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_verify_dedup_test.dart
@@ -121,25 +121,6 @@ void main() {
     });
 
     test(
-      'trusts cache-relay events without verifying their signature',
-      () async {
-        // A cache-relay event carrying a deliberately invalid signature is
-        // still routed: cache events were verified before being stored, so
-        // the expensive verify is skipped on cold-start replay.
-        final cache = _FakeRelay(
-          'wss://cache.example',
-          relayType: RelayType.cache,
-        );
-        await nostr.relayPool.add(cache, relayType: RelayType.cache);
-
-        final json = signedEventJson()..['sig'] = badSig;
-        await cache.deliver(['EVENT', subId, json]);
-
-        expect(received, hasLength(1));
-      },
-    );
-
-    test(
       'skips verify for ids known-verified from a previous session',
       () async {
         // The app seeds ids verified and persisted in a prior session. A
@@ -170,30 +151,5 @@ void main() {
       expect(nostr.relayPool.verifiesPerformed, 1);
       expect(nostr.relayPool.verifiesSkippedKnown, 0);
     });
-
-    test(
-      'does not trust a network copy just because a cache copy arrived',
-      () async {
-        // Cache trust must not poison the network-verified set: the same id
-        // arriving from a network relay with a bad signature is still dropped.
-        final cache = _FakeRelay(
-          'wss://cache.example',
-          relayType: RelayType.cache,
-        );
-        final net = _FakeRelay('wss://n1.example');
-        await nostr.relayPool.add(cache, relayType: RelayType.cache);
-        await nostr.relayPool.add(net);
-
-        final badJson = signedEventJson()..['sig'] = badSig;
-        await cache.deliver(['EVENT', subId, badJson]);
-        await net.deliver(['EVENT', subId, Map<String, dynamic>.from(badJson)]);
-
-        expect(
-          received,
-          hasLength(1),
-          reason: 'network copy with bad sig must not be trusted via cache',
-        );
-      },
-    );
   });
 }

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_verify_dedup_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_verify_dedup_test.dart
@@ -117,8 +117,58 @@ void main() {
       await r1.deliver(['EVENT', subId, json]);
       await r2.deliver(['EVENT', subId, Map<String, dynamic>.from(json)]);
 
+      // Both copies route, but the second must be skipped (not re-verified):
+      // the counters pin that the session (id, sig) dedup actually fired.
       expect(received, hasLength(2));
+      expect(nostr.relayPool.verifiesPerformed, 1);
+      expect(nostr.relayPool.verifiesSkippedSessionDup, 1);
     });
+
+    test('re-verifies a same-session duplicate id delivered with a different, '
+        'invalid signature', () async {
+      // Pins that the *session* dedup key is (id, sig), not id alone. Relay A
+      // delivers a valid event (its (id, sig) enters the verified set); relay
+      // B replays the same id with a forged signature. Because the pair
+      // differs, it must fall through to a full verify, fail, and be dropped.
+      // If the session key were id-only this forged copy would be trusted.
+      final r1 = _FakeRelay('wss://n1.example');
+      final r2 = _FakeRelay('wss://n2.example');
+      await nostr.relayPool.add(r1);
+      await nostr.relayPool.add(r2);
+
+      final valid = signedEventJson();
+      await r1.deliver(['EVENT', subId, valid]);
+
+      final forged = Map<String, dynamic>.from(valid)..['sig'] = badSig;
+      await r2.deliver(['EVENT', subId, forged]);
+
+      expect(received, hasLength(1));
+      expect(nostr.relayPool.verifiesSkippedSessionDup, 0);
+    });
+
+    test(
+      'drops a known-verified pair whose body no longer hashes to its id',
+      () async {
+        // isValid (sha256 id recompute) runs before the skip branches and is the
+        // sole body-integrity guard. A "known" (id, sig) pair delivered with a
+        // tampered body must be dropped here, before the skip can trust it.
+        final relay = _FakeRelay('wss://n1.example');
+        await nostr.relayPool.add(relay);
+
+        final valid = signedEventJson();
+        final id = valid['id'] as String;
+        final sig = valid['sig'] as String;
+        nostr.relayPool.isKnownVerifiedEvent = (eventId, eventSig) =>
+            eventId == id && eventSig == sig;
+
+        final tampered = Map<String, dynamic>.from(valid)
+          ..['content'] = 'tampered body — id no longer matches';
+        await relay.deliver(['EVENT', subId, tampered]);
+
+        expect(received, isEmpty);
+        expect(nostr.relayPool.verifiesSkippedKnown, 0);
+      },
+    );
 
     test(
       'skips verify for (id, sig) pairs known-verified from a prior session',

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_verify_dedup_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_verify_dedup_test.dart
@@ -121,16 +121,19 @@ void main() {
     });
 
     test(
-      'skips verify for ids known-verified from a previous session',
+      'skips verify for (id, sig) pairs known-verified from a prior session',
       () async {
-        // The app seeds ids verified and persisted in a prior session. A
-        // network event whose id is known — even with a bad signature here —
-        // is trusted and routed without re-verifying.
+        // The app seeds (id, sig) pairs verified and persisted in a prior
+        // session. A network event whose exact pair is known is trusted and
+        // routed without re-verifying.
         final relay = _FakeRelay('wss://n1.example');
         await nostr.relayPool.add(relay);
 
-        final json = signedEventJson()..['sig'] = badSig;
-        nostr.relayPool.isKnownVerifiedEvent = {json['id'] as String}.contains;
+        final json = signedEventJson();
+        final id = json['id'] as String;
+        final sig = json['sig'] as String;
+        nostr.relayPool.isKnownVerifiedEvent = (eventId, eventSig) =>
+            eventId == id && eventSig == sig;
 
         await relay.deliver(['EVENT', subId, json]);
 
@@ -140,10 +143,32 @@ void main() {
       },
     );
 
+    test('re-verifies and drops a known id carrying a different, invalid '
+        'signature', () async {
+      // The id is known-verified, but the incoming signature differs from
+      // the one that was verified. A Nostr event id commits to the body,
+      // not to sig, so the pool must NOT trust the id alone: it re-verifies,
+      // the forged signature fails, and the event is dropped.
+      final relay = _FakeRelay('wss://n1.example');
+      await nostr.relayPool.add(relay);
+
+      final valid = signedEventJson();
+      final id = valid['id'] as String;
+      final validSig = valid['sig'] as String;
+      nostr.relayPool.isKnownVerifiedEvent = (eventId, eventSig) =>
+          eventId == id && eventSig == validSig;
+
+      final forged = Map<String, dynamic>.from(valid)..['sig'] = badSig;
+      await relay.deliver(['EVENT', subId, forged]);
+
+      expect(received, isEmpty);
+      expect(nostr.relayPool.verifiesSkippedKnown, 0);
+    });
+
     test('still verifies ids absent from the known-verified set', () async {
       final relay = _FakeRelay('wss://n1.example');
       await nostr.relayPool.add(relay);
-      nostr.relayPool.isKnownVerifiedEvent = (_) => false;
+      nostr.relayPool.isKnownVerifiedEvent = (_, _) => false;
 
       await relay.deliver(['EVENT', subId, signedEventJson(content: 'ok')]);
 

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_verify_dedup_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_verify_dedup_test.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Regression tests for RelayPool._onEvent signature-verification
-// ABOUTME: dedup and cache-relay trust (cold-start CPU optimization).
+// ABOUTME: dedup and known-verified event trust (cold-start CPU optimization).
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';


### PR DESCRIPTION
Closes #5889

## Description

On cold start, relays re-send events the app already downloaded and verified
in previous sessions. `RelayPool._onEvent` ran a full BIP340 Schnorr verify on
**every** one of them, with no memory across sessions. CPU profiling of a cold
start showed signature verification (`Event.isSigned` -> secp256k1 point
multiplication -> `BigInt.modInverse`) at **~42% of total startup CPU** --
enough to pin a core, overheat the device, and trigger thermal throttling that
made the whole UI laggy on low-end devices.

This PR makes `_onEvent` skip the expensive verify when the exact `(id, sig)`
pair is already trusted, while still fully verifying anything genuinely new.

**What changed**

- **`nostr_sdk` / `RelayPool`**: skip Schnorr verify when the exact event
  `(id, sig)` pair was verified earlier this session, or is known-verified from
  a previous session via an injected `isKnownVerifiedEvent` lookup. Only fresh
  network verifications are recorded in the session cache, so a known/duplicate
  hit never masks an unverified copy.
- **`db_client`**: `NostrEventsDao.getRecentEventIdSigs({limit})` returns
  newest-first persisted `(id, sig)` pairs for seeding.
- **`nostr_client`**: seeds the lookup from the local event store in
  `initialize()`, **before** relays connect, so the cold-start flood benefits.
- Adds read-only diagnostic counters for signature verification behavior:
  `verifiesPerformed`, `verifiesSkippedKnown`, and
  `verifiesSkippedSessionDup`.

**Why it's safe**

- `Event.isValid` (sha256 id recompute) still runs on **every** event first, so
  a forged payload cannot reuse a trusted id. Different body content yields a
  different id and falls through to full verification.
- Trust is keyed by `(id, sig)`, not id alone. A Nostr event id commits to the
  event body, but not to `sig`, so a known id carrying a different or forged
  signature is re-verified and dropped if invalid.
- The trust is not new: the app already reads events back from the same store
  and renders them without re-verifying. This PR applies that same pre-existing
  trust at the ingest gate for exact pairs that were already verified.
- Seeding is wrapped so a failure falls back to verifying everything, and the
  skip only ever accepts without verify; it never drops a legitimate event.
- No blind origin trust: an earlier revision skipped verify for `RelayType.cache`
  relays, but that dead branch was removed rather than shipping a latent
  signature-bypass surface.

**Measured impact (profile-mode / AOT cold start)**

| | Before | After |
|---|---|---|
| `RelayPool._onEvent` verify | ~38% of startup CPU | ~0% |
| `Event.isSigned` (all callers) | 42.5% | 2.7% (only own-event signing) |

## Out of Scope

The remaining startup bottleneck is a widget-rebuild storm (~50% of startup CPU
in AOT), driven by per-event state emissions churning the tree. That is
independent of this change and will be handled in a separate PR.

## Verification

- `flutter test test/unit/relay_pool_verify_dedup_test.dart` from
  `mobile/packages/nostr_sdk`
- Pre-push hook:
  - merge-conflict check against `main`
  - analyzer
  - generated-file verification
  - affected tests:
    - `packages/db_client/test/src/database/daos/nostr_events_dao_test.dart`
    - `packages/nostr_client/test/src/nostr_client_test.dart`
    - `packages/nostr_sdk/test/unit/relay_pool_verify_dedup_test.dart`
- Existing CI was green before the takeover push; new checks are expected on
  commit `93b7f4cc79`.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
