### PR TITLE
perf(feed): cut startup widget rebuilds (profile dedup, icon cache, scroll-fade isolation)

### DIFF
--- a/mobile/lib/widgets/video_feed_item/actions/video_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/video_action_button.dart
@@ -25,7 +25,7 @@ import 'package:openvine/utils/string_utils.dart';
 ///   labelWhenZero: 'Like',
 /// )
 /// ```
-class VideoActionButton extends StatelessWidget {
+class VideoActionButton extends StatefulWidget {
   const VideoActionButton({
     required this.icon,
     required this.semanticIdentifier,
@@ -76,17 +76,44 @@ class VideoActionButton extends StatelessWidget {
   final String? labelWhenZero;
 
   @override
+  State<VideoActionButton> createState() => _VideoActionButtonState();
+}
+
+class _VideoActionButtonState extends State<VideoActionButton> {
+  /// Cached icon subtree. The icon — a [DivineIcon] with two blurred
+  /// ([ImageFiltered]) shadow layers — depends only on [VideoActionButton.icon]
+  /// and [VideoActionButton.iconColor], never on the [VideoActionButton.count].
+  /// Reusing the same widget instance across rebuilds lets Flutter skip
+  /// re-running — and re-rasterising the shadow blur of — the icon when only
+  /// the interaction count changes, which happens once per incoming
+  /// like/comment/repost event during the cold-start flood.
+  Widget? _icon;
+
+  @override
+  void didUpdateWidget(VideoActionButton oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.icon != widget.icon ||
+        oldWidget.iconColor != widget.iconColor) {
+      _icon = null;
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final icon = _icon ??= _ShadowedIcon(
+      icon: widget.icon,
+      color: widget.iconColor,
+    );
     return Semantics(
-      identifier: semanticIdentifier,
+      identifier: widget.semanticIdentifier,
       container: true,
       explicitChildNodes: true,
       button: true,
-      label: semanticLabel,
+      label: widget.semanticLabel,
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
-        onTap: isLoading ? null : onPressed,
-        onLongPress: isLoading ? null : onLongPress,
+        onTap: widget.isLoading ? null : widget.onPressed,
+        onLongPress: widget.isLoading ? null : widget.onLongPress,
         child: SizedBox(
           width: 48,
           child: ConstrainedBox(
@@ -95,7 +122,7 @@ class VideoActionButton extends StatelessWidget {
               mainAxisSize: MainAxisSize.min,
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                if (isLoading)
+                if (widget.isLoading)
                   const SizedBox.square(
                     dimension: 24,
                     child: CircularProgressIndicator(
@@ -104,12 +131,12 @@ class VideoActionButton extends StatelessWidget {
                     ),
                   )
                 else
-                  _ShadowedIcon(icon: icon, color: iconColor),
-                if (!isLoading)
+                  icon,
+                if (!widget.isLoading)
                   _VideoActionCaption(
-                    caption: caption,
-                    count: count,
-                    labelWhenZero: labelWhenZero,
+                    caption: widget.caption,
+                    count: widget.count,
+                    labelWhenZero: widget.labelWhenZero,
                   ),
               ],
             ),

--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -765,20 +765,65 @@ class _FeedItemActions extends StatelessWidget {
       );
     }
 
+    // The overlay content (author row, every action button, caption) does
+    // not depend on the scroll-driven opacity, so it is built once and
+    // reused. Only [ScrollFadeOverlay]'s Opacity / IgnorePointer rebuild as
+    // the page position ticks, instead of the whole overlay — the dominant
+    // feed rebuild in profiling (~150 overlay rebuilds fanning out into ~900
+    // action-button rebuilds).
+    return ScrollFadeOverlay(
+      pagePosition: listenable,
+      index: index,
+      child: _FeedItemOverlayActions(
+        video: video,
+        contextTitle: contextTitle,
+        isOwnVideo: isOwnVideo,
+        autoAdvanceAvailable: autoAdvanceAvailable,
+        effectiveAutoEnabled: effectiveAutoEnabled,
+        onToggleAutoAdvance: onToggleAutoAdvance,
+        onSuppressAutoAdvance: onSuppressAutoAdvance,
+        subtitleLayer: subtitleLayer,
+      ),
+    );
+  }
+}
+
+/// Applies the scroll-driven fade to a feed item's overlay without rebuilding
+/// it on every page-position tick.
+///
+/// [child] — the overlay content — is built once by the caller and reused;
+/// only the wrapping [Opacity] / [IgnorePointer] rebuild as [pagePosition]
+/// changes. This keeps a scroll frame from fanning out into a full overlay
+/// (author row + all action buttons + caption) rebuild.
+class ScrollFadeOverlay extends StatelessWidget {
+  const ScrollFadeOverlay({
+    required this.pagePosition,
+    required this.index,
+    required this.child,
+    super.key,
+  });
+
+  /// Current fractional page offset of the enclosing [PageView].
+  final ValueListenable<double> pagePosition;
+
+  /// This item's page index; the fade is driven by the distance between
+  /// [pagePosition] and [index].
+  final int index;
+
+  /// Overlay content, built once and shared across page-position ticks.
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
     return ValueListenableBuilder<double>(
-      valueListenable: listenable,
-      builder: (context, page, _) {
+      valueListenable: pagePosition,
+      child: child,
+      builder: (context, page, child) {
         final distance = (page - index).abs().clamp(0.0, 1.0);
-        return _FeedItemOverlayActions(
-          video: video,
-          contextTitle: contextTitle,
-          isOwnVideo: isOwnVideo,
-          autoAdvanceAvailable: autoAdvanceAvailable,
-          effectiveAutoEnabled: effectiveAutoEnabled,
-          onToggleAutoAdvance: onToggleAutoAdvance,
-          onSuppressAutoAdvance: onSuppressAutoAdvance,
-          subtitleLayer: subtitleLayer,
-          overlayOpacity: scrollDrivenOpacity(distance),
+        final opacity = scrollDrivenOpacity(distance);
+        return Opacity(
+          opacity: opacity,
+          child: IgnorePointer(ignoring: opacity < 0.01, child: child),
         );
       },
     );
@@ -795,7 +840,6 @@ class _FeedItemOverlayActions extends StatelessWidget {
     required this.onToggleAutoAdvance,
     required this.onSuppressAutoAdvance,
     this.subtitleLayer,
-    this.overlayOpacity,
   });
 
   final VideoEvent video;
@@ -806,31 +850,16 @@ class _FeedItemOverlayActions extends StatelessWidget {
   final VoidCallback? onToggleAutoAdvance;
   final VoidCallback? onSuppressAutoAdvance;
   final Widget? subtitleLayer;
-  final double? overlayOpacity;
 
   @override
   Widget build(BuildContext context) {
-    final opacity = overlayOpacity;
-    if (opacity == null) {
-      return VideoOverlayActions(
-        video: video,
-        isVisible: true,
-        isActive: true,
-        hasBottomNavigation: false,
-        contextTitle: contextTitle,
-        isFullscreen: true,
-        topOffset: isOwnVideo ? 64 : 8,
-        showAutoButton: autoAdvanceAvailable,
-        onInteracted: onSuppressAutoAdvance,
-        subtitleLayer: subtitleLayer,
-      );
-    }
-
+    // Rendered at full opacity; the scroll-driven fade is applied by the
+    // enclosing ValueListenableBuilder so this subtree stays stable across
+    // page-position ticks.
     return VideoOverlayActions(
       video: video,
       isVisible: true,
       isActive: true,
-      overlayOpacity: opacity,
       hasBottomNavigation: false,
       contextTitle: contextTitle,
       isFullscreen: true,

--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -86,7 +86,6 @@ class VideoOverlayActions extends ConsumerWidget {
     this.showBottomGradient = true,
     this.showTopGradient = false,
     this.topOffset = 8.0,
-    this.overlayOpacity = 1.0,
     this.showAutoButton = false,
     this.onInteracted,
     this.omitAuthorBlock = false,
@@ -108,7 +107,6 @@ class VideoOverlayActions extends ConsumerWidget {
     this.showBottomGradient = true,
     this.showTopGradient = false,
     this.topOffset = 8.0,
-    this.overlayOpacity = 1.0,
     this.showAutoButton = false,
     this.onInteracted,
     this.omitAuthorBlock = false,
@@ -159,12 +157,6 @@ class VideoOverlayActions extends ConsumerWidget {
   /// doesn't have a transparent AppBar over the video) is unaffected.
   final bool showTopGradient;
 
-  /// Opacity for the entire overlay, driven by scroll position.
-  ///
-  /// Callers can supply a value in [0.0, 1.0] to fade the overlay in/out
-  /// during page transitions. Transitions are animated by [AnimatedOpacity]
-  /// inside [build]. Defaults to 1.0 (fully visible).
-  final double overlayOpacity;
   final bool showAutoButton;
   final VoidCallback? onInteracted;
 
@@ -208,431 +200,420 @@ class VideoOverlayActions extends ConsumerWidget {
         ? 20.0 + MediaQuery.viewPaddingOf(context).bottom
         : 14.0 + MediaQuery.viewPaddingOf(context).bottom;
 
-    return Opacity(
-      opacity: overlayOpacity,
-      child: IgnorePointer(
-        ignoring: overlayOpacity < 0.01,
-        child: Stack(
-          children: [
-            // Top gradient overlay — sits behind the (transparent) app
-            // bar so the white title / back button / More popover stay
-            // readable over light video frames. Lives inside the body's
-            // Stack so it overlays the video, NOT the app bar (Scaffold
-            // paints the app bar above the body) and is wrapped in
-            // [IgnorePointer] so tapping the gradient region falls
-            // through to the video (or, in the top strip, to the
-            // already-z-above app bar's controls).
-            if (showTopGradient)
-              Positioned(
-                left: 0,
-                right: 0,
-                top: 0,
-                child: IgnorePointer(
-                  child: FractionallySizedBox(
-                    widthFactor: 1.0,
-                    child: SizedBox(
-                      height: MediaQuery.of(context).size.height * 0.2,
-                      child: DecoratedBox(
-                        decoration: BoxDecoration(
-                          gradient: LinearGradient(
-                            begin: Alignment.topCenter,
-                            end: Alignment.bottomCenter,
-                            colors: [
-                              VineTheme.backgroundColor.withValues(alpha: 0.35),
-                              VineTheme.backgroundColor.withValues(alpha: 0.0),
-                            ],
-                          ),
-                        ),
+    return Stack(
+      children: [
+        // Top gradient overlay — sits behind the (transparent) app
+        // bar so the white title / back button / More popover stay
+        // readable over light video frames. Lives inside the body's
+        // Stack so it overlays the video, NOT the app bar (Scaffold
+        // paints the app bar above the body) and is wrapped in
+        // [IgnorePointer] so tapping the gradient region falls
+        // through to the video (or, in the top strip, to the
+        // already-z-above app bar's controls).
+        if (showTopGradient)
+          Positioned(
+            left: 0,
+            right: 0,
+            top: 0,
+            child: IgnorePointer(
+              child: FractionallySizedBox(
+                widthFactor: 1.0,
+                child: SizedBox(
+                  height: MediaQuery.of(context).size.height * 0.2,
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.topCenter,
+                        end: Alignment.bottomCenter,
+                        colors: [
+                          VineTheme.backgroundColor.withValues(alpha: 0.35),
+                          VineTheme.backgroundColor.withValues(alpha: 0.0),
+                        ],
                       ),
                     ),
                   ),
                 ),
               ),
-            // Bottom gradient overlay (sits below UI elements, only overlays video)
-            if (showBottomGradient)
-              Positioned(
-                left: 0,
-                right: 0,
-                bottom: 0,
-                child: IgnorePointer(
-                  child: FractionallySizedBox(
-                    widthFactor: 1.0,
-                    child: SizedBox(
-                      height: MediaQuery.of(context).size.height / 4,
-                      child: DecoratedBox(
-                        decoration: BoxDecoration(
-                          gradient: LinearGradient(
-                            begin: Alignment.topCenter,
-                            end: Alignment.bottomCenter,
-                            colors: [
-                              VineTheme.backgroundColor.withValues(alpha: 0.0),
-                              VineTheme.backgroundColor.withValues(alpha: 0.5),
-                            ],
-                          ),
-                        ),
+            ),
+          ),
+        // Bottom gradient overlay (sits below UI elements, only overlays video)
+        if (showBottomGradient)
+          Positioned(
+            left: 0,
+            right: 0,
+            bottom: 0,
+            child: IgnorePointer(
+              child: FractionallySizedBox(
+                widthFactor: 1.0,
+                child: SizedBox(
+                  height: MediaQuery.of(context).size.height / 4,
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.topCenter,
+                        end: Alignment.bottomCenter,
+                        colors: [
+                          VineTheme.backgroundColor.withValues(alpha: 0.0),
+                          VineTheme.backgroundColor.withValues(alpha: 0.5),
+                        ],
                       ),
                     ),
                   ),
                 ),
               ),
-            // Content warning badge below back button area
-            if (video != null &&
-                video.hasContentWarning &&
-                !shouldShowContentWarningOverlay(
-                  contentWarningLabels: video.contentWarningLabels,
-                  warnLabels: video.warnLabels,
-                ))
-              PositionedDirectional(
-                top: safeAreaTop + topOffset + 56,
-                start: 16,
-                child: GestureDetector(
-                  onTap: () => _showContentWarningDetails(
-                    context,
-                    ref,
-                    video.contentWarningLabels,
-                    isActive,
-                  ),
-                  child: _ContentWarningBadge(
-                    labels: video.contentWarningLabels,
-                  ),
-                ),
+            ),
+          ),
+        // Content warning badge below back button area
+        if (video != null &&
+            video.hasContentWarning &&
+            !shouldShowContentWarningOverlay(
+              contentWarningLabels: video.contentWarningLabels,
+              warnLabels: video.warnLabels,
+            ))
+          PositionedDirectional(
+            top: safeAreaTop + topOffset + 56,
+            start: 16,
+            child: GestureDetector(
+              onTap: () => _showContentWarningDetails(
+                context,
+                ref,
+                video.contentWarningLabels,
+                isActive,
               ),
-            // Author info and video description overlay at bottom left.
-            // Suppressed when the caller renders its own metadata container
-            // (see [omitAuthorBlock]).
-            if (!omitAuthorBlock)
-              Positioned(
-                bottom: bottomOffset,
-                left: 16,
-                right: 80, // Leave space for action buttons
-                child: AnimatedOpacity(
-                  opacity: isActive ? 1.0 : 0.0,
-                  duration: const Duration(milliseconds: 200),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      ?subtitleLayer,
+              child: _ContentWarningBadge(
+                labels: video.contentWarningLabels,
+              ),
+            ),
+          ),
+        // Author info and video description overlay at bottom left.
+        // Suppressed when the caller renders its own metadata container
+        // (see [omitAuthorBlock]).
+        if (!omitAuthorBlock)
+          Positioned(
+            bottom: bottomOffset,
+            left: 16,
+            right: 80, // Leave space for action buttons
+            child: AnimatedOpacity(
+              opacity: isActive ? 1.0 : 0.0,
+              duration: const Duration(milliseconds: 200),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  ?subtitleLayer,
 
-                      // Repost banner (if video is a repost)
-                      if (video != null &&
-                          video.isRepost &&
-                          video.reposterPubkey != null) ...[
-                        VideoRepostHeader(
-                          reposterPubkey: video.reposterPubkey!,
+                  // Repost banner (if video is a repost)
+                  if (video != null &&
+                      video.isRepost &&
+                      video.reposterPubkey != null) ...[
+                    VideoRepostHeader(
+                      reposterPubkey: video.reposterPubkey!,
+                    ),
+                    const SizedBox(height: 8),
+                  ],
+                  // Author avatar and info row
+                  Consumer(
+                    builder: (context, ref, _) {
+                      final profile = ref
+                          .watch(userProfileReactiveProvider(authorPubkey))
+                          .value;
+                      // Use embedded author data from REST API as fallback
+                      // This avoids WebSocket profile fetches for videos
+                      // that already have author_name/author_avatar embedded
+                      final avatarUrl = profile?.picture ?? video?.authorAvatar;
+                      final displayName =
+                          profile?.bestDisplayName ??
+                          video?.authorName ??
+                          UserProfile.generatedNameFor(authorPubkey);
+                      final isOgViner = ref.watch(
+                        ogVinerCacheServiceProvider.select(
+                          (service) => service.isOgViner(authorPubkey),
                         ),
-                        const SizedBox(height: 8),
-                      ],
-                      // Author avatar and info row
-                      Consumer(
-                        builder: (context, ref, _) {
-                          final profile = ref
-                              .watch(userProfileReactiveProvider(authorPubkey))
-                              .value;
-                          // Use embedded author data from REST API as fallback
-                          // This avoids WebSocket profile fetches for videos
-                          // that already have author_name/author_avatar embedded
-                          final avatarUrl =
-                              profile?.picture ?? video?.authorAvatar;
-                          final displayName =
-                              profile?.bestDisplayName ??
-                              video?.authorName ??
-                              UserProfile.generatedNameFor(authorPubkey);
-                          final isOgViner = ref.watch(
-                            ogVinerCacheServiceProvider.select(
-                              (service) => service.isOgViner(authorPubkey),
-                            ),
+                      );
+
+                      void navigateToProfile() {
+                        onInteracted?.call();
+                        Log.info(
+                          '👤 User tapped profile: videoId=${video?.id ?? "preview"}, authorPubkey=$authorPubkey',
+                          name: 'VideoFeedItem',
+                          category: LogCategory.ui,
+                        );
+                        final npub = normalizeToNpub(authorPubkey);
+                        if (npub != null) {
+                          context.push(
+                            OtherProfileScreen.pathForNpub(npub),
                           );
+                        }
+                      }
 
-                          void navigateToProfile() {
-                            onInteracted?.call();
-                            Log.info(
-                              '👤 User tapped profile: videoId=${video?.id ?? "preview"}, authorPubkey=$authorPubkey',
-                              name: 'VideoFeedItem',
-                              category: LogCategory.ui,
-                            );
-                            final npub = normalizeToNpub(authorPubkey);
-                            if (npub != null) {
-                              context.push(
-                                OtherProfileScreen.pathForNpub(npub),
-                              );
-                            }
-                          }
-
-                          return Row(
-                            children: [
-                              // Avatar with follow button overlay
-                              SizedBox(
-                                width:
-                                    58, // 48 avatar + space for follow button overflow
-                                height: 58,
-                                child: Stack(
-                                  clipBehavior: Clip.none,
-                                  children: [
-                                    // Avatar (tappable to go to profile)
-                                    UserAvatar(
-                                      imageUrl: avatarUrl,
-                                      name: displayName,
-                                      size: 48,
-                                      semanticLabel: context
-                                          .l10n
-                                          .videoAuthorAvatarSemanticLabel,
-                                      onTap: navigateToProfile,
-                                    ),
-                                    // Follow button positioned at bottom-right of avatar
-                                    if (video != null)
-                                      PositionedDirectional(
-                                        start: 31,
-                                        top: 31,
-                                        child: VideoFollowButton(
-                                          pubkey: authorPubkey,
-                                        ),
-                                      ),
-                                  ],
-                                ),
-                              ),
-                              const SizedBox(width: 6),
-                              // User name and loop count (tappable to go to profile)
-                              Expanded(
-                                child: GestureDetector(
+                      return Row(
+                        children: [
+                          // Avatar with follow button overlay
+                          SizedBox(
+                            width:
+                                58, // 48 avatar + space for follow button overflow
+                            height: 58,
+                            child: Stack(
+                              clipBehavior: Clip.none,
+                              children: [
+                                // Avatar (tappable to go to profile)
+                                UserAvatar(
+                                  imageUrl: avatarUrl,
+                                  name: displayName,
+                                  size: 48,
+                                  semanticLabel: context
+                                      .l10n
+                                      .videoAuthorAvatarSemanticLabel,
                                   onTap: navigateToProfile,
-                                  child: Column(
-                                    crossAxisAlignment:
-                                        CrossAxisAlignment.start,
-                                    mainAxisSize: MainAxisSize.min,
+                                ),
+                                // Follow button positioned at bottom-right of avatar
+                                if (video != null)
+                                  PositionedDirectional(
+                                    start: 31,
+                                    top: 31,
+                                    child: VideoFollowButton(
+                                      pubkey: authorPubkey,
+                                    ),
+                                  ),
+                              ],
+                            ),
+                          ),
+                          const SizedBox(width: 6),
+                          // User name and loop count (tappable to go to profile)
+                          Expanded(
+                            child: GestureDetector(
+                              onTap: navigateToProfile,
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  Row(
                                     children: [
-                                      Row(
-                                        children: [
-                                          Flexible(
-                                            child: Semantics(
-                                              identifier: 'video_author_name',
-                                              container: true,
-                                              explicitChildNodes: true,
-                                              label: context.l10n
-                                                  .videoAuthorSemanticLabel(
-                                                    displayName,
-                                                  ),
-                                              child: Text(
+                                      Flexible(
+                                        child: Semantics(
+                                          identifier: 'video_author_name',
+                                          container: true,
+                                          explicitChildNodes: true,
+                                          label: context.l10n
+                                              .videoAuthorSemanticLabel(
                                                 displayName,
-                                                style:
-                                                    VineTheme.titleSmallFont(),
-                                                maxLines: 1,
-                                                overflow: TextOverflow.ellipsis,
                                               ),
-                                            ),
+                                          child: Text(
+                                            displayName,
+                                            style: VineTheme.titleSmallFont(),
+                                            maxLines: 1,
+                                            overflow: TextOverflow.ellipsis,
                                           ),
-                                          if (shouldShowSpecialProfileCheckmark(
-                                            profile,
-                                          ))
-                                            const SpecialProfileCheckmark(),
-                                          if (isOgViner) const OgVinerBadge(),
-                                        ],
-                                      ),
-                                      Text(
-                                        context.l10n.videoFeedLoopCountLine(
-                                          StringUtils.formatCompactNumber(
-                                            video?.totalLoops ?? 0,
-                                          ),
-                                          video?.totalLoops ?? 0,
-                                        ),
-                                        style: const TextStyle(
-                                          fontFamily: 'Inter',
-                                          fontSize: 14,
-                                          height: 20 / 14,
-                                          color: VineTheme.onSurfaceVariant,
                                         ),
                                       ),
+                                      if (shouldShowSpecialProfileCheckmark(
+                                        profile,
+                                      ))
+                                        const SpecialProfileCheckmark(),
+                                      if (isOgViner) const OgVinerBadge(),
                                     ],
                                   ),
-                                ),
-                              ),
-                            ],
-                          );
-                        },
-                      ),
-                      // List attribution chip (shown when video is from subscribed curated list)
-                      if (video != null &&
-                          showListAttribution &&
-                          listSources != null &&
-                          listSources!.isNotEmpty) ...[
-                        const SizedBox(height: 8),
-                        Consumer(
-                          builder: (context, ref, _) {
-                            final curatedListState = ref.watch(
-                              curatedListsStateProvider,
-                            );
-                            final curatedListService = curatedListState
-                                .whenOrNull(
-                                  data: (_) => ref
-                                      .read(curatedListsStateProvider.notifier)
-                                      .service,
-                                );
-
-                            return ListAttributionChip(
-                              listIds: listSources!,
-                              listLookup: (listId) =>
-                                  curatedListService?.getListById(listId),
-                              onListTap: (listId, listName) {
-                                final list = curatedListService?.getListById(
-                                  listId,
-                                );
-                                Navigator.of(context).push(
-                                  MaterialPageRoute<void>(
-                                    builder: (context) => CuratedListFeedScreen(
-                                      listId: listId,
-                                      listName: listName,
-                                      videoIds: list?.videoEventIds,
-                                      authorPubkey: list?.pubkey,
+                                  Text(
+                                    context.l10n.videoFeedLoopCountLine(
+                                      StringUtils.formatCompactNumber(
+                                        video?.totalLoops ?? 0,
+                                      ),
+                                      video?.totalLoops ?? 0,
+                                    ),
+                                    style: const TextStyle(
+                                      fontFamily: 'Inter',
+                                      fontSize: 14,
+                                      height: 20 / 14,
+                                      color: VineTheme.onSurfaceVariant,
                                     ),
                                   ),
-                                );
-                              },
+                                ],
+                              ),
+                            ),
+                          ),
+                        ],
+                      );
+                    },
+                  ),
+                  // List attribution chip (shown when video is from subscribed curated list)
+                  if (video != null &&
+                      showListAttribution &&
+                      listSources != null &&
+                      listSources!.isNotEmpty) ...[
+                    const SizedBox(height: 8),
+                    Consumer(
+                      builder: (context, ref, _) {
+                        final curatedListState = ref.watch(
+                          curatedListsStateProvider,
+                        );
+                        final curatedListService = curatedListState.whenOrNull(
+                          data: (_) => ref
+                              .read(curatedListsStateProvider.notifier)
+                              .service,
+                        );
+
+                        return ListAttributionChip(
+                          listIds: listSources!,
+                          listLookup: (listId) =>
+                              curatedListService?.getListById(listId),
+                          onListTap: (listId, listName) {
+                            final list = curatedListService?.getListById(
+                              listId,
+                            );
+                            Navigator.of(context).push(
+                              MaterialPageRoute<void>(
+                                builder: (context) => CuratedListFeedScreen(
+                                  listId: listId,
+                                  listName: listName,
+                                  videoIds: list?.videoEventIds,
+                                  authorPubkey: list?.pubkey,
+                                ),
+                              ),
                             );
                           },
+                        );
+                      },
+                    ),
+                  ],
+                  // Video title and description (caption block).
+                  // Title and description render independently — both are
+                  // shown when both are present, matching the new
+                  // [VideoAuthorInfoSection] used in fullscreen / overlay
+                  // surfaces (PR #4087).
+                  if (hasTextContent) ...[
+                    const SizedBox(
+                      height: 2,
+                    ), // 2px + 10px from avatar container = 12px total
+                    // Title (when present)
+                    if (titleText != null)
+                      Semantics(
+                        identifier: 'video_title',
+                        container: true,
+                        explicitChildNodes: true,
+                        button: true,
+                        label: context.l10n.videoOverlayOpenMetadataFromTitle,
+                        child: GestureDetector(
+                          behavior: HitTestBehavior.opaque,
+                          onTap: video == null
+                              ? null
+                              : () {
+                                  onInteracted?.call();
+                                  MetadataExpandedSheet.show(
+                                    context,
+                                    video,
+                                  );
+                                },
+                          child: Text(
+                            titleText,
+                            style: VineTheme.labelMediumFont().copyWith(
+                              shadows: VineTheme.buttonShadows,
+                            ),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
                         ),
-                      ],
-                      // Video title and description (caption block).
-                      // Title and description render independently — both are
-                      // shown when both are present, matching the new
-                      // [VideoAuthorInfoSection] used in fullscreen / overlay
-                      // surfaces (PR #4087).
-                      if (hasTextContent) ...[
-                        const SizedBox(
-                          height: 2,
-                        ), // 2px + 10px from avatar container = 12px total
-                        // Title (when present)
-                        if (titleText != null)
-                          Semantics(
-                            identifier: 'video_title',
-                            container: true,
-                            explicitChildNodes: true,
-                            button: true,
-                            label:
-                                context.l10n.videoOverlayOpenMetadataFromTitle,
-                            child: GestureDetector(
-                              behavior: HitTestBehavior.opaque,
-                              onTap: video == null
-                                  ? null
-                                  : () {
-                                      onInteracted?.call();
-                                      MetadataExpandedSheet.show(
-                                        context,
-                                        video,
-                                      );
-                                    },
-                              child: Text(
-                                titleText,
-                                style: VineTheme.labelMediumFont().copyWith(
-                                  shadows: VineTheme.buttonShadows,
-                                ),
-                                maxLines: 1,
-                                overflow: TextOverflow.ellipsis,
-                              ),
-                            ),
-                          ),
-                        // 4 px gap between title and description when both
-                        // are present (matches the Figma caption spacing).
-                        if (titleText != null && descriptionText.isNotEmpty)
-                          const SizedBox(height: 4),
-                        // Description (only when actual content exists — the
-                        // title has its own row above, so no fallback here).
-                        if (descriptionText.isNotEmpty)
-                          Semantics(
-                            identifier: 'video_description',
-                            container: true,
-                            explicitChildNodes: true,
-                            button: true,
-                            label: context
-                                .l10n
-                                .videoOverlayOpenMetadataFromDescription,
-                            child: GestureDetector(
-                              behavior: HitTestBehavior.opaque,
-                              onTap: video == null
-                                  ? null
-                                  : () {
-                                      onInteracted?.call();
-                                      MetadataExpandedSheet.show(
-                                        context,
-                                        video,
-                                      );
-                                    },
-                              child: LinkifiedText(
-                                text: descriptionText,
-                                style: VineTheme.bodySmallFont().copyWith(
-                                  shadows: VineTheme.buttonShadows,
-                                ),
-                                linkStyle: VineTheme.bodySmallFont().copyWith(
-                                  shadows: VineTheme.buttonShadows,
-                                ),
-                                maxLines: 3,
-                                overflow: TextOverflow.ellipsis,
-                              ),
-                            ),
-                          ),
-                        // Collaborator avatar row (if video has collaborators)
-                        if (video != null && video.hasCollaborators) ...[
-                          const SizedBox(height: 4),
-                          CollaboratorAvatarRow(video: video),
-                        ],
-                        if (video != null && video.isVideoReply) ...[
-                          const SizedBox(height: 4),
-                          VideoReplyParentLink(
-                            video: video,
-                            variant: VideoReplyParentLinkVariant.overlay,
-                            onInteracted: onInteracted,
-                          ),
-                        ],
-                        // Inspired-by attribution row (if video credits another creator)
-                        if (video != null && video.hasInspiredBy) ...[
-                          const SizedBox(height: 4),
-                          InspiredByAttributionRow(
-                            video: video,
-                            isActive: isActive,
-                          ),
-                        ],
-                      ],
-                      // Audio attribution row (all videos)
+                      ),
+                    // 4 px gap between title and description when both
+                    // are present (matches the Figma caption spacing).
+                    if (titleText != null && descriptionText.isNotEmpty)
                       const SizedBox(height: 4),
-                      if (video != null) AudioAttributionRow(video: video),
-                      const SizedBox(height: 8),
-                    ],
-                  ),
-                ),
-              ),
-            // Action buttons at bottom right.
-            // In fullscreen mode the right inset tightens to 12 px to match
-            // the trailing inset on the fullscreen app bar's More popover.
-            // Other consumers (video metadata preview, video editor preview)
-            // keep the legacy 16 px so their layouts are unaffected.
-            // Suppressed when [omitActionColumn] is true — the caller
-            // renders the column in their own Stack to keep it vertically
-            // aligned with their own author info block.
-            if (!omitActionColumn)
-              PositionedDirectional(
-                bottom: isFullscreen ? bottomOffset : bottomOffset - 6,
-                end: isFullscreen ? 12 : 16,
-                child: AnimatedOpacity(
-                  opacity: isActive ? 1.0 : 0.0,
-                  duration: const Duration(milliseconds: 200),
-                  child: IgnorePointer(
-                    ignoring: false, // Action buttons SHOULD receive taps
-                    child: video == null
-                        ? _PreviewOverlayActionColumn(
-                            onInteracted: onInteracted,
-                          )
-                        : VideoOverlayActionColumn(
-                            video: video,
-                            isFullscreen: isFullscreen,
-                            isPreviewMode: isPreviewMode,
-                            showAutoButton: showAutoButton,
-                            onInteracted: onInteracted,
+                    // Description (only when actual content exists — the
+                    // title has its own row above, so no fallback here).
+                    if (descriptionText.isNotEmpty)
+                      Semantics(
+                        identifier: 'video_description',
+                        container: true,
+                        explicitChildNodes: true,
+                        button: true,
+                        label: context
+                            .l10n
+                            .videoOverlayOpenMetadataFromDescription,
+                        child: GestureDetector(
+                          behavior: HitTestBehavior.opaque,
+                          onTap: video == null
+                              ? null
+                              : () {
+                                  onInteracted?.call();
+                                  MetadataExpandedSheet.show(
+                                    context,
+                                    video,
+                                  );
+                                },
+                          child: LinkifiedText(
+                            text: descriptionText,
+                            style: VineTheme.bodySmallFont().copyWith(
+                              shadows: VineTheme.buttonShadows,
+                            ),
+                            linkStyle: VineTheme.bodySmallFont().copyWith(
+                              shadows: VineTheme.buttonShadows,
+                            ),
+                            maxLines: 3,
+                            overflow: TextOverflow.ellipsis,
                           ),
-                  ),
-                ),
+                        ),
+                      ),
+                    // Collaborator avatar row (if video has collaborators)
+                    if (video != null && video.hasCollaborators) ...[
+                      const SizedBox(height: 4),
+                      CollaboratorAvatarRow(video: video),
+                    ],
+                    if (video != null && video.isVideoReply) ...[
+                      const SizedBox(height: 4),
+                      VideoReplyParentLink(
+                        video: video,
+                        variant: VideoReplyParentLinkVariant.overlay,
+                        onInteracted: onInteracted,
+                      ),
+                    ],
+                    // Inspired-by attribution row (if video credits another creator)
+                    if (video != null && video.hasInspiredBy) ...[
+                      const SizedBox(height: 4),
+                      InspiredByAttributionRow(
+                        video: video,
+                        isActive: isActive,
+                      ),
+                    ],
+                  ],
+                  // Audio attribution row (all videos)
+                  const SizedBox(height: 4),
+                  if (video != null) AudioAttributionRow(video: video),
+                  const SizedBox(height: 8),
+                ],
               ),
-          ],
-        ),
-      ),
+            ),
+          ),
+        // Action buttons at bottom right.
+        // In fullscreen mode the right inset tightens to 12 px to match
+        // the trailing inset on the fullscreen app bar's More popover.
+        // Other consumers (video metadata preview, video editor preview)
+        // keep the legacy 16 px so their layouts are unaffected.
+        // Suppressed when [omitActionColumn] is true — the caller
+        // renders the column in their own Stack to keep it vertically
+        // aligned with their own author info block.
+        if (!omitActionColumn)
+          PositionedDirectional(
+            bottom: isFullscreen ? bottomOffset : bottomOffset - 6,
+            end: isFullscreen ? 12 : 16,
+            child: AnimatedOpacity(
+              opacity: isActive ? 1.0 : 0.0,
+              duration: const Duration(milliseconds: 200),
+              child: IgnorePointer(
+                ignoring: false, // Action buttons SHOULD receive taps
+                child: video == null
+                    ? _PreviewOverlayActionColumn(
+                        onInteracted: onInteracted,
+                      )
+                    : VideoOverlayActionColumn(
+                        video: video,
+                        isFullscreen: isFullscreen,
+                        isPreviewMode: isPreviewMode,
+                        showAutoButton: showAutoButton,
+                        onInteracted: onInteracted,
+                      ),
+              ),
+            ),
+          ),
+      ],
     );
   }
 

--- a/mobile/packages/db_client/lib/src/database/daos/user_profiles_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/user_profiles_dao.dart
@@ -79,17 +79,33 @@ class UserProfilesDao extends DatabaseAccessor<AppDatabase>
   /// the profile changes in the database.
   ///
   /// Drift re-runs a table watcher on *every* write to `user_profiles`, so
-  /// without [Stream.distinct] each watcher would re-emit on unrelated
-  /// profile writes too — during the cold-start kind-0 flood that fans out
-  /// into a rebuild for every author row and caption. [UserProfile] equality
-  /// is by (pubkey, eventId), so `distinct` collapses those no-op re-emissions
-  /// and still fires whenever the profile advances to a newer event.
+  /// without a distinct guard each watcher would re-emit on unrelated profile
+  /// writes too — during the cold-start kind-0 flood that fans out into a
+  /// rebuild for every author row and caption.
+  ///
+  /// The dedup key is (pubkey, eventId, createdAt), not `UserProfile` value
+  /// equality. `UserProfile.==` is (pubkey, eventId) only, but the Funnelcake
+  /// REST path mints a content-independent synthetic eventId (`rest-<pubkey>`),
+  /// so a newer profile version can reuse the same eventId. Comparing
+  /// [UserProfile.createdAt] too — which the newest-wins cache only ever
+  /// advances — keeps a real update flowing through while still collapsing the
+  /// no-op re-emissions.
   Stream<UserProfile?> watchProfile(String pubkey) {
     final query = select(userProfiles)..where((t) => t.pubkey.equals(pubkey));
     return query
         .watchSingleOrNull()
         .map((row) => row == null ? null : _rowToUserProfile(row))
-        .distinct();
+        .distinct(_isSameProfileVersion);
+  }
+
+  /// Whether two consecutive [watchProfile] emissions are the same profile
+  /// version. Compares `createdAt` on top of `UserProfile.==` — see
+  /// [watchProfile] for why the eventId alone is not enough.
+  static bool _isSameProfileVersion(UserProfile? a, UserProfile? b) {
+    if (a == null || b == null) return identical(a, b);
+    return a.pubkey == b.pubkey &&
+        a.eventId == b.eventId &&
+        a.createdAt == b.createdAt;
   }
 
   /// Get multiple profiles by pubkeys with domain model conversion.

--- a/mobile/packages/db_client/lib/src/database/daos/user_profiles_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/user_profiles_dao.dart
@@ -77,12 +77,19 @@ class UserProfilesDao extends DatabaseAccessor<AppDatabase>
   ///
   /// Returns a stream that emits UserProfile domain model whenever
   /// the profile changes in the database.
+  ///
+  /// Drift re-runs a table watcher on *every* write to `user_profiles`, so
+  /// without [Stream.distinct] each watcher would re-emit on unrelated
+  /// profile writes too — during the cold-start kind-0 flood that fans out
+  /// into a rebuild for every author row and caption. [UserProfile] equality
+  /// is by (pubkey, eventId), so `distinct` collapses those no-op re-emissions
+  /// and still fires whenever the profile advances to a newer event.
   Stream<UserProfile?> watchProfile(String pubkey) {
     final query = select(userProfiles)..where((t) => t.pubkey.equals(pubkey));
-    return query.watchSingleOrNull().map((row) {
-      if (row == null) return null;
-      return _rowToUserProfile(row);
-    });
+    return query
+        .watchSingleOrNull()
+        .map((row) => row == null ? null : _rowToUserProfile(row))
+        .distinct();
   }
 
   /// Get multiple profiles by pubkeys with domain model conversion.

--- a/mobile/packages/db_client/test/src/database/daos/user_profiles_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/user_profiles_dao_test.dart
@@ -325,36 +325,76 @@ void main() {
 
     group('watchProfile', () {
       test(
-        'collapses no-op re-emissions and emits only on real changes',
+        'emits when content advances under an unchanged synthetic eventId',
         () async {
-          // Seed so the initial emission is the current profile version.
-          await dao.upsertProfile(createProfile(eventId: 'e1', name: 'A'));
-
-          final stream = dao.watchProfile(testPubkey);
-
-          Future.delayed(const Duration(milliseconds: 50), () async {
-            // Identical re-write of the same version -> no new emission.
-            await dao.upsertProfile(createProfile(eventId: 'e1', name: 'A'));
-            // Unrelated profile write -> Drift re-runs this watcher, but the
-            // value for testPubkey is unchanged -> distinct drops it.
-            await dao.upsertProfile(
-              createProfile(pubkey: testPubkey2, eventId: 'other'),
-            );
-            // Genuine update (new event id) -> should emit.
-            await dao.upsertProfile(createProfile(eventId: 'e2', name: 'A2'));
-          });
-
-          // Without distinct this would be [e1, e1, ...]; the second distinct
-          // value is only ever reached once the real update lands.
-          await expectLater(
-            stream.take(2),
-            emitsInOrder([
-              isA<UserProfile>().having((p) => p.eventId, 'eventId', 'e1'),
-              isA<UserProfile>().having((p) => p.eventId, 'eventId', 'e2'),
-            ]),
+          // Funnelcake REST profiles carry a content-independent synthetic
+          // eventId (`rest-<pubkey>`), so a newer profile version reuses the
+          // same eventId. Dedup on (pubkey, eventId) alone would drop the
+          // update; watchProfile must still surface it.
+          const syntheticId = 'rest-$testPubkey';
+          await dao.upsertProfile(
+            createProfile(
+              eventId: syntheticId,
+              name: 'Old',
+              createdAt: DateTime(2024),
+            ),
           );
+
+          final names = <String?>[];
+          final sub = dao
+              .watchProfile(testPubkey)
+              .listen((p) => names.add(p?.name));
+          addTearDown(sub.cancel);
+          await pumpEventQueue();
+
+          await dao.upsertProfile(
+            createProfile(
+              eventId: syntheticId,
+              name: 'New',
+              createdAt: DateTime(2024, 1, 2),
+            ),
+          );
+          await pumpEventQueue();
+
+          expect(names, ['Old', 'New']);
         },
       );
+
+      test('collapses identical and unrelated-write re-emissions', () async {
+        await dao.upsertProfile(
+          createProfile(eventId: 'e1', name: 'A', createdAt: DateTime(2024)),
+        );
+
+        final eventIds = <String?>[];
+        final sub = dao
+            .watchProfile(testPubkey)
+            .listen((p) => eventIds.add(p?.eventId));
+        addTearDown(sub.cancel);
+        await pumpEventQueue();
+
+        // Identical re-write of the same version -> no new emission.
+        await dao.upsertProfile(
+          createProfile(eventId: 'e1', name: 'A', createdAt: DateTime(2024)),
+        );
+        // Unrelated profile write -> Drift re-runs this watcher, but the value
+        // for testPubkey is unchanged -> the guard drops it.
+        await dao.upsertProfile(
+          createProfile(pubkey: testPubkey2, eventId: 'other'),
+        );
+        await pumpEventQueue();
+
+        // Genuine update -> emits.
+        await dao.upsertProfile(
+          createProfile(
+            eventId: 'e2',
+            name: 'A2',
+            createdAt: DateTime(2024, 1, 2),
+          ),
+        );
+        await pumpEventQueue();
+
+        expect(eventIds, ['e1', 'e2']);
+      });
     });
   });
 }

--- a/mobile/packages/db_client/test/src/database/daos/user_profiles_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/user_profiles_dao_test.dart
@@ -322,5 +322,39 @@ void main() {
         expect(byPubkey[testPubkey2]!.name, equals('New'));
       });
     });
+
+    group('watchProfile', () {
+      test(
+        'collapses no-op re-emissions and emits only on real changes',
+        () async {
+          // Seed so the initial emission is the current profile version.
+          await dao.upsertProfile(createProfile(eventId: 'e1', name: 'A'));
+
+          final stream = dao.watchProfile(testPubkey);
+
+          Future.delayed(const Duration(milliseconds: 50), () async {
+            // Identical re-write of the same version -> no new emission.
+            await dao.upsertProfile(createProfile(eventId: 'e1', name: 'A'));
+            // Unrelated profile write -> Drift re-runs this watcher, but the
+            // value for testPubkey is unchanged -> distinct drops it.
+            await dao.upsertProfile(
+              createProfile(pubkey: testPubkey2, eventId: 'other'),
+            );
+            // Genuine update (new event id) -> should emit.
+            await dao.upsertProfile(createProfile(eventId: 'e2', name: 'A2'));
+          });
+
+          // Without distinct this would be [e1, e1, ...]; the second distinct
+          // value is only ever reached once the real update lands.
+          await expectLater(
+            stream.take(2),
+            emitsInOrder([
+              isA<UserProfile>().having((p) => p.eventId, 'eventId', 'e1'),
+              isA<UserProfile>().having((p) => p.eventId, 'eventId', 'e2'),
+            ]),
+          );
+        },
+      );
+    });
   });
 }

--- a/mobile/test/widgets/video_feed_item/actions/video_action_button_test.dart
+++ b/mobile/test/widgets/video_feed_item/actions/video_action_button_test.dart
@@ -275,5 +275,37 @@ void main() {
         },
       );
     });
+
+    group('icon caching', () {
+      DivineIcon foregroundIcon(WidgetTester tester) =>
+          tester.widgetList<DivineIcon>(find.byType(DivineIcon)).last;
+
+      testWidgets('does not rebuild the icon when only the count changes', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildSubject(count: 1));
+        final before = foregroundIcon(tester);
+        expect(find.text('1'), findsOneWidget);
+
+        await tester.pumpWidget(buildSubject(count: 2));
+        final after = foregroundIcon(tester);
+
+        // Same widget instance => Flutter skipped rebuilding (and
+        // re-rasterising) the blurred icon subtree; only the caption changed.
+        expect(identical(before, after), isTrue);
+        expect(find.text('2'), findsOneWidget);
+      });
+
+      testWidgets('rebuilds the icon when the icon changes', (tester) async {
+        await tester.pumpWidget(buildSubject());
+        final before = foregroundIcon(tester);
+
+        await tester.pumpWidget(buildSubject(icon: DivineIconName.chat));
+        final after = foregroundIcon(tester);
+
+        expect(identical(before, after), isFalse);
+        expect(after.icon, equals(DivineIconName.chat));
+      });
+    });
   });
 }

--- a/mobile/test/widgets/video_feed_item/scroll_fade_overlay_test.dart
+++ b/mobile/test/widgets/video_feed_item/scroll_fade_overlay_test.dart
@@ -1,0 +1,85 @@
+// ABOUTME: Tests for ScrollFadeOverlay — the scroll-driven opacity wrapper
+// ABOUTME: that must not rebuild its overlay child on page-position ticks.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/utils/scroll_driven_opacity.dart';
+import 'package:openvine/widgets/video_feed_item/feed_videos.dart';
+
+// Scoped to the widget under test — MaterialApp/Navigator introduce their own
+// Opacity/IgnorePointer widgets that would otherwise match.
+Finder _in<T extends Widget>() => find.descendant(
+  of: find.byType(ScrollFadeOverlay),
+  matching: find.byType(T),
+);
+
+void main() {
+  group(ScrollFadeOverlay, () {
+    testWidgets('does not rebuild the child when the page position changes', (
+      tester,
+    ) async {
+      final pagePosition = ValueNotifier<double>(0);
+      addTearDown(pagePosition.dispose);
+      var childBuilds = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ScrollFadeOverlay(
+            pagePosition: pagePosition,
+            index: 0,
+            child: Builder(
+              builder: (context) {
+                childBuilds++;
+                return const SizedBox(width: 10, height: 10);
+              },
+            ),
+          ),
+        ),
+      );
+
+      expect(childBuilds, 1);
+      final opacityBefore = tester.widget<Opacity>(_in<Opacity>()).opacity;
+
+      // A page-position tick (scroll away) must fade the overlay without
+      // rebuilding the (expensive) overlay content.
+      pagePosition.value = 0.5;
+      await tester.pump();
+
+      expect(
+        childBuilds,
+        1,
+        reason: 'overlay child must be reused across page-position ticks',
+      );
+      final opacityAfter = tester.widget<Opacity>(_in<Opacity>()).opacity;
+      expect(opacityAfter, lessThan(opacityBefore));
+    });
+
+    testWidgets('ignores pointer input once fully faded out', (tester) async {
+      final pagePosition = ValueNotifier<double>(0);
+      addTearDown(pagePosition.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ScrollFadeOverlay(
+            pagePosition: pagePosition,
+            index: 0,
+            child: const SizedBox(width: 10, height: 10),
+          ),
+        ),
+      );
+
+      IgnorePointer ignorePointer() =>
+          tester.widget<IgnorePointer>(_in<IgnorePointer>());
+
+      expect(ignorePointer().ignoring, isFalse);
+
+      // Scroll a full page away — opacity collapses and the overlay stops
+      // absorbing taps meant for the video beneath it.
+      pagePosition.value = 1;
+      await tester.pump();
+
+      expect(scrollDrivenOpacity(1), lessThan(0.01));
+      expect(ignorePointer().ignoring, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
Closes #5891

## Description

Profiling a cold start showed ~50% of startup CPU going into a widget-rebuild
storm: the feed overlay and its action buttons rebuilt thousands of times.
"Track Widget Builds" pinned three independent drivers, each fixed here with a
regression test. Grand-total widget rebuilds over a comparable capture dropped
from **12,347 to 4,215**, and the action-button caption/gesture cluster from
**906 to 144**.

**Three fixes (one commit each):**

1. **Dedup redundant profile stream emissions** — `UserProfilesDao.watchProfile`
   used Drift's `watchSingleOrNull()` with no `distinct`, so it re-emitted on
   every write to `user_profiles` (including unrelated profiles and duplicate
   re-sends during the cold-start kind-0 flood). `UserProfile` equality is
   `(pubkey, eventId)`, so `.distinct()` collapses the no-op re-emissions and
   still fires when a profile advances to a newer event.

2. **Cache the action-button icon across count changes** — `VideoActionButton`
   rebuilt its whole subtree (SVG icon + two `ImageFiltered` blur shadows) on
   every count change. The icon depends only on `icon`/`iconColor`, so caching
   the widget instance lets Flutter skip rebuilding — and re-rasterising the
   blur of — the icon; only the caption rebuilds. `SvgPicture` rebuilds went
   from 2436 to ~108.

3. **Stop rebuilding the overlay on every scroll tick** — a page-position
   `ValueListenableBuilder` threaded `overlayOpacity` as a constructor param
   through the whole overlay, so every scroll/settle tick rebuilt the author
   row + all action buttons + caption to change one opacity value. Extracted
   `ScrollFadeOverlay`: the overlay content is built once as a stable `child`
   and only the wrapping `Opacity`/`IgnorePointer` rebuilds per tick.

## Out of Scope

The remaining startup jank is **raster-bound**, not build-bound. On the debug
build that is largely a Skia shader-compilation artifact (Impeller is disabled
in the debug manifest for the CI emulators); release/profile uses Impeller. A
real assessment needs a profile-mode capture and is a separate follow-up
(e.g. `RepaintBoundary` around static overlays), independent of this PR.

**Related Issue:** 

## Verification

- `flutter analyze` clean on all changed dirs.
- New tests: `user_profiles_dao_test` distinct-dedup; `video_action_button_test`
  icon-instance-stable-across-count-change (+ invalidation on icon change);
  `scroll_fade_overlay_test` child-not-rebuilt-on-page-tick (+ ignore-pointer
  when faded).
- Full suites green: `db_client` (746), `video_feed_item` widget tests (278).
- Validated on-device via "Track Widget Builds" before/after captures.

## Type of Change

- [x] 🧹 Code refactor
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)