### PR TITLE
perf(nostr): verify inbound relay events off the main isolate

### DIFF
--- a/mobile/lib/services/nostr_service_factory.dart
+++ b/mobile/lib/services/nostr_service_factory.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Handles platform-appropriate client creation with proper configuration
 
 import 'package:db_client/db_client.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:openvine/constants/app_constants.dart';
@@ -43,7 +44,12 @@ class NostrServiceFactory {
 
     final effectiveSigner = signer ?? LocalKeySigner(null);
 
-    final config = NostrClientConfig(signer: effectiveSigner);
+    final config = NostrClientConfig(
+      signer: effectiveSigner,
+      // Verify inbound relay-event signatures off the main isolate (#5863).
+      // Web has no Isolate.spawn, so it stays on the inline path there.
+      eventVerifyWorkerSpawner: kIsWeb ? null : EventVerifyIsolate.spawn,
+    );
 
     // In non-production environments, lock relays to the environment host so a
     // user's NIP-65 list (which may carry production relays) cannot pull the

--- a/mobile/packages/nostr_client/lib/src/models/nostr_client_config.dart
+++ b/mobile/packages/nostr_client/lib/src/models/nostr_client_config.dart
@@ -12,6 +12,7 @@ class NostrClientConfig {
     this.gatewayUrl,
     this.enableGateway = false,
     this.webSocketChannelFactory,
+    this.eventVerifyWorkerSpawner,
   });
 
   /// Signer for event signing - the single source of truth for the public key.
@@ -33,4 +34,12 @@ class NostrClientConfig {
 
   /// WebSocket channel factory for testing (optional)
   final WebSocketChannelFactory? webSocketChannelFactory;
+
+  /// Optional spawner for the off-main relay-event verify isolate (#5863).
+  ///
+  /// When provided, `NostrClient.initialize` spawns it and wires it into the
+  /// relay pool so inbound-event signature verification runs off the main
+  /// isolate. When null (tests, web), verification runs inline on the main
+  /// isolate exactly as before. The app passes `EventVerifyIsolate.spawn`.
+  final EventVerifyWorkerSpawner? eventVerifyWorkerSpawner;
 }

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -64,6 +64,7 @@ class NostrClient {
       nostr: nostr,
       relayManager: relayManager,
       dbClient: dbClient,
+      eventVerifyWorkerSpawner: config.eventVerifyWorkerSpawner,
     );
   }
 
@@ -72,9 +73,11 @@ class NostrClient {
     required Nostr nostr,
     required RelayManager relayManager,
     AppDbClient? dbClient,
+    EventVerifyWorkerSpawner? eventVerifyWorkerSpawner,
   }) : _nostr = nostr,
        _relayManager = relayManager,
-       _dbClient = dbClient;
+       _dbClient = dbClient,
+       _eventVerifyWorkerSpawner = eventVerifyWorkerSpawner;
 
   /// Creates a NostrClient with injected dependencies for testing
   @visibleForTesting
@@ -82,9 +85,11 @@ class NostrClient {
     required Nostr nostr,
     required RelayManager relayManager,
     AppDbClient? dbClient,
+    EventVerifyWorkerSpawner? eventVerifyWorkerSpawner,
   }) : _nostr = nostr,
        _relayManager = relayManager,
-       _dbClient = dbClient;
+       _dbClient = dbClient,
+       _eventVerifyWorkerSpawner = eventVerifyWorkerSpawner;
 
   static Nostr _createNostr(NostrClientConfig config) {
     RelayBase tempRelayGenerator(String url) => RelayBase(
@@ -104,6 +109,13 @@ class NostrClient {
   final Nostr _nostr;
   final RelayManager _relayManager;
   final AppDbClient? _dbClient;
+
+  /// Spawns the off-main event-verify isolate (#5863). Null in tests / on web,
+  /// where verify falls back to the main isolate.
+  final EventVerifyWorkerSpawner? _eventVerifyWorkerSpawner;
+
+  /// The spawned verify worker, if any. Closed on [dispose].
+  EventVerifyWorker? _verifyWorker;
 
   /// Maximum number of concurrent one-shot relay queries ([queryEvents]).
   ///
@@ -163,6 +175,21 @@ class NostrClient {
         error: e,
         stackTrace: st,
       );
+    }
+  }
+
+  /// Spawns the off-main relay-event verify isolate (if a spawner was
+  /// configured) and wires it into the relay pool. A spawn failure is
+  /// non-fatal: the relay pool falls back to inline main-isolate verification.
+  Future<void> _maybeStartEventVerifyWorker() async {
+    final spawner = _eventVerifyWorkerSpawner;
+    if (spawner == null || _verifyWorker != null) return;
+    try {
+      final worker = await spawner();
+      _verifyWorker = worker;
+      _nostr.relayPool.eventVerifyWorker = worker;
+    } on Object catch (_) {
+      // Non-fatal: without a worker the relay pool verifies inline as before.
     }
   }
 
@@ -349,6 +376,9 @@ class NostrClient {
       // Seed the already-verified set before relays connect, so re-sent
       // events skip re-verification during the cold-start flood.
       await _seedVerifiedEventIds();
+      // Wire the off-main verify isolate before relays connect, so the fresh
+      // verifies during the cold-start flood run off the main isolate (#5863).
+      await _maybeStartEventVerifyWorker();
       await _relayManager.initialize();
       if (!_readyCompleter.isCompleted) {
         _readyCompleter.complete();
@@ -1356,6 +1386,8 @@ class NostrClient {
     await _relayManager.dispose();
     await _queryPool.close();
     _nostr.close();
+    _verifyWorker?.close();
+    _verifyWorker = null;
     _subscriptionFilters.clear();
     _isDisposed = true;
   }

--- a/mobile/packages/nostr_sdk/lib/nostr_sdk.dart
+++ b/mobile/packages/nostr_sdk/lib/nostr_sdk.dart
@@ -50,6 +50,7 @@ export 'relay/relay_mode.dart';
 export 'relay/relay.dart';
 export 'relay/relay_base.dart';
 export 'relay/publish_outcome.dart';
+export 'relay/event_verify_isolate.dart';
 export 'relay/relay_pool.dart';
 export 'relay/relay_status.dart';
 export 'relay/relay_type.dart';

--- a/mobile/packages/nostr_sdk/lib/relay/event_verify_isolate.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/event_verify_isolate.dart
@@ -1,0 +1,148 @@
+// ABOUTME: A single long-lived, KEY-LESS background isolate that runs inbound
+// ABOUTME: relay-event id (sha256) + Schnorr signature verification off the
+// ABOUTME: main isolate (#5863). Feed relays (RelayBase) decode + verify every
+// ABOUTME: EVENT frame on the main/UI isolate today; a cold-start backfill
+// ABOUTME: burst of ~6.5ms/verify blocks frame callbacks. Verification reads
+// ABOUTME: only the event's own public fields and needs no private key, so it
+// ABOUTME: moves here safely — nothing secret ever crosses the SendPort.
+// ABOUTME: Persistent (spawned once, reused for the app's lifetime), unlike the
+// ABOUTME: drain-scoped DmVerifyIsolate it mirrors.
+
+import 'dart:async';
+import 'dart:isolate';
+
+import '../event.dart';
+
+/// Verifies inbound relay events (id recompute + Schnorr) off the main isolate.
+///
+/// Implementations must never leave a [verify] future hanging: a failure
+/// (isolate death, malformed payload) resolves to an error or `false`, never a
+/// stuck future, so the caller can fall back to inline verification.
+abstract interface class EventVerifyWorker {
+  /// Returns `true` iff the raw event [eventJson] recomputes its own id
+  /// (sha256 over the NIP-01 serialization) and carries a valid Schnorr
+  /// signature. Throws [StateError] only if called after [close].
+  Future<bool> verify(Map<String, dynamic> eventJson);
+
+  /// Releases the worker. Idempotent. Any still-pending [verify] futures
+  /// complete with an error so their awaiters can fall back rather than hang.
+  void close();
+}
+
+/// Spawns an [EventVerifyWorker]. Injected into `RelayPool` so tests can swap in
+/// a synchronous fake and the app wires the real isolate.
+typedef EventVerifyWorkerSpawner = Future<EventVerifyWorker> Function();
+
+/// Production [EventVerifyWorker] backed by a long-lived, KEY-LESS Dart isolate.
+///
+/// Mirrors `dm_repository`'s `DmVerifyIsolate` (same handshake + `_pending`
+/// request/response protocol) but is persistent rather than drain-scoped, and
+/// verifies generic relay events (`Event.isValid && Event.isSigned`) instead of
+/// gift-wrap parts. Verification needs no private key, so — unlike a decrypt
+/// isolate — nothing secret is sent across the port.
+class EventVerifyIsolate implements EventVerifyWorker {
+  EventVerifyIsolate._({
+    required Isolate isolate,
+    required ReceivePort responses,
+  }) : _isolate = isolate,
+       _responses = responses;
+
+  final Isolate _isolate;
+  final ReceivePort _responses;
+
+  /// The worker's command port, received during the spawn handshake.
+  late final SendPort _commands;
+
+  /// Routes worker responses back to their awaiting [verify] callers.
+  late final StreamSubscription<dynamic> _subscription;
+
+  /// Outstanding requests keyed by id so concurrent / interleaved [verify]
+  /// calls each resolve to their own result.
+  final Map<int, Completer<bool>> _pending = <int, Completer<bool>>{};
+
+  int _nextRequestId = 0;
+  bool _closed = false;
+
+  /// Spawns the worker and completes once it has reported its command port.
+  /// No key or other secret crosses the boundary.
+  static Future<EventVerifyIsolate> spawn() async {
+    final responses = ReceivePort();
+    final isolate = await Isolate.spawn(
+      _eventVerifyIsolateEntry,
+      responses.sendPort,
+      debugName: 'event-verify-isolate',
+    );
+
+    final ready = Completer<SendPort>();
+    final instance = EventVerifyIsolate._(
+      isolate: isolate,
+      responses: responses,
+    );
+    instance._subscription = responses.listen((dynamic message) {
+      if (!ready.isCompleted) {
+        // First message is the worker's command port (handshake).
+        ready.complete(message as SendPort);
+        return;
+      }
+      final (int id, bool result) = message as (int, bool);
+      instance._pending.remove(id)?.complete(result);
+    });
+
+    final commandPort = await ready.future;
+    instance._commands = commandPort;
+    return instance;
+  }
+
+  @override
+  Future<bool> verify(Map<String, dynamic> eventJson) {
+    if (_closed) {
+      throw StateError('EventVerifyIsolate has been closed');
+    }
+    final id = _nextRequestId++;
+    final completer = Completer<bool>();
+    _pending[id] = completer;
+    _commands.send((id, eventJson));
+    return completer.future;
+  }
+
+  /// Kills the worker, stops listening, and fails any still-pending requests so
+  /// their awaiters never hang. Idempotent.
+  @override
+  void close() {
+    if (_closed) return;
+    _closed = true;
+    unawaited(_subscription.cancel());
+    _responses.close();
+    _isolate.kill(priority: Isolate.immediate);
+    for (final completer in _pending.values) {
+      if (!completer.isCompleted) {
+        completer.completeError(
+          StateError('EventVerifyIsolate closed before the verify completed'),
+        );
+      }
+    }
+    _pending.clear();
+  }
+}
+
+/// Worker entry: handshakes its command port back to the spawner, then verifies
+/// each `(id, eventJson)` request and replies `(id, result)`. The body never
+/// throws (malformed payload → `false`), so the loop is crash-free; the isolate
+/// is torn down via [Isolate.kill] from [EventVerifyIsolate.close].
+Future<void> _eventVerifyIsolateEntry(SendPort replyTo) async {
+  final commands = ReceivePort();
+  replyTo.send(commands.sendPort);
+
+  await for (final dynamic message in commands) {
+    final (int id, Map<dynamic, dynamic> rawEvent) =
+        message as (int, Map<dynamic, dynamic>);
+    var result = false;
+    try {
+      final event = Event.fromJson(Map<String, dynamic>.from(rawEvent));
+      result = event.isValid && event.isSigned;
+    } catch (_) {
+      result = false;
+    }
+    replyTo.send((id, result));
+  }
+}

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -16,6 +16,7 @@ import '../subscription.dart';
 import '../utils/string_util.dart';
 import 'client_connected.dart';
 import 'event_filter.dart';
+import 'event_verify_isolate.dart';
 import 'publish_outcome.dart';
 import 'relay.dart';
 import 'relay_base.dart';
@@ -50,6 +51,21 @@ class RelayPool {
   final Map<String, Relay> _relays = {};
 
   final Map<String, Relay> _cacheRelays = {};
+
+  /// Optional off-main signature-verify worker (#5863). When set, the fresh
+  /// Schnorr verify for a not-yet-trusted inbound event runs on a background
+  /// isolate instead of the main/UI isolate. When null, verify runs inline on
+  /// the main isolate exactly as before (the default, and every existing test).
+  /// Wired by the app to an [EventVerifyIsolate]; injectable for tests.
+  EventVerifyWorker? _verifyWorker;
+
+  set eventVerifyWorker(EventVerifyWorker? worker) => _verifyWorker = worker;
+
+  /// Per-relay serial tail used to keep EVENT/EOSE frames in order once verify
+  /// becomes asynchronous (an EOSE must not complete a query before its
+  /// preceding events finish verifying). One entry per relay url; only used
+  /// when [_verifyWorker] is set.
+  final Map<String, Future<void>> _orderedFrameTails = {};
 
   // subscription
   final Map<String, Subscription> _subscriptions = {};
@@ -437,6 +453,36 @@ class RelayPool {
     }
   }
 
+  /// Verifies [event]'s Schnorr signature, off the main isolate when a verify
+  /// worker is wired (#5863), else inline via [Event.isSigned]. The caller has
+  /// already run [Event.isValid] (id recompute), so only the signature is
+  /// checked here. On any worker failure (isolate closed / died) it degrades
+  /// to the inline check so a verify never hangs and correctness is preserved.
+  Future<bool> _verifySignatureOffMain(
+    Event event,
+    Map<String, dynamic> eventJson,
+  ) async {
+    final worker = _verifyWorker;
+    if (worker == null) return event.isSigned;
+    try {
+      return await worker.verify(eventJson);
+    } catch (_) {
+      return event.isSigned;
+    }
+  }
+
+  /// Runs [work] after the previous EVENT/EOSE frame from the same relay,
+  /// preserving per-relay in-order delivery once verify is asynchronous. Errors
+  /// are swallowed on the retained tail so one bad frame can't wedge the chain;
+  /// the returned future still surfaces them to the immediate caller.
+  Future<void> _enqueueOrdered(Relay relay, Future<void> Function() work) {
+    final key = relay.url;
+    final prev = _orderedFrameTails[key] ?? Future<void>.value();
+    final next = prev.then((_) => work());
+    _orderedFrameTails[key] = next.catchError((Object _) {});
+    return next;
+  }
+
   Future<void> _onEvent(Relay relay, List<dynamic> json) async {
     final messageType = _stringAt(relay, json, 0, 'message type');
     if (messageType == null) return;
@@ -459,6 +505,25 @@ class RelayPool {
       log('📡 Raw message from ${relay.url}: $json');
     }
 
+    // #5863: when an off-main verify worker is wired, serialize EVENT/EOSE
+    // per relay so the asynchronous verify preserves in-order delivery — an
+    // EOSE must not complete a query before its preceding events finish
+    // verifying. With no worker the original synchronous path runs unchanged.
+    if (_verifyWorker != null &&
+        (messageType == 'EVENT' || messageType == 'EOSE')) {
+      return _enqueueOrdered(
+        relay,
+        () => _dispatchTypedFrame(relay, json, messageType),
+      );
+    }
+    return _dispatchTypedFrame(relay, json, messageType);
+  }
+
+  Future<void> _dispatchTypedFrame(
+    Relay relay,
+    List<dynamic> json,
+    String messageType,
+  ) async {
     if (messageType == 'EVENT') {
       try {
         final subId = _stringAt(relay, json, 1, 'EVENT subscription id');
@@ -495,7 +560,7 @@ class RelayPool {
           _verifiesSkippedSessionDup++;
         } else if (isKnownVerifiedEvent?.call(event.id, event.sig) ?? false) {
           _verifiesSkippedKnown++;
-        } else if (event.isSigned) {
+        } else if (await _verifySignatureOffMain(event, eventJson)) {
           _markEventVerified(verifyKey);
           _verifiesPerformed++;
         } else {

--- a/mobile/packages/nostr_sdk/test/unit/event_verify_isolate_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/event_verify_isolate_test.dart
@@ -1,0 +1,84 @@
+// ABOUTME: Tests for the off-main relay-event verify isolate (#5863 P2).
+// ABOUTME: Verifies id+signature off the main isolate; safe close semantics.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+
+Future<Event> _signedEvent(String content) async {
+  const privateKey =
+      '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12';
+  final signer = LocalNostrSigner(privateKey);
+  final pubkey = await signer.getPublicKey();
+  final event = Event(
+    pubkey!,
+    EventKind.textNote,
+    [],
+    content,
+    createdAt: 1780000000,
+  );
+  await signer.signEvent(event);
+  return event;
+}
+
+Map<String, dynamic> _json(Event e) => Map<String, dynamic>.from(e.toJson());
+
+void main() {
+  group(EventVerifyIsolate, () {
+    test('verifies a valid event off the main isolate', () async {
+      final worker = await EventVerifyIsolate.spawn();
+      addTearDown(worker.close);
+      final event = await _signedEvent('valid');
+      expect(await worker.verify(_json(event)), isTrue);
+    });
+
+    test(
+      'rejects an event whose content no longer matches its signed id',
+      () async {
+        final worker = await EventVerifyIsolate.spawn();
+        addTearDown(worker.close);
+        final event = await _signedEvent('original');
+        final tampered = _json(event)..['content'] = 'tampered';
+        expect(await worker.verify(tampered), isFalse);
+      },
+    );
+
+    test('rejects an unsigned event', () async {
+      final worker = await EventVerifyIsolate.spawn();
+      addTearDown(worker.close);
+      final unsigned = Event(
+        getPublicKey(generatePrivateKey()),
+        EventKind.textNote,
+        [],
+        'unsigned',
+        createdAt: 1780000000,
+      );
+      expect(await worker.verify(_json(unsigned)), isFalse);
+    });
+
+    test('resolves interleaved requests to their own results', () async {
+      final worker = await EventVerifyIsolate.spawn();
+      addTearDown(worker.close);
+      final good = await _signedEvent('good');
+      final bad = _json(await _signedEvent('bad'))..['content'] = 'x';
+      final results = await Future.wait([
+        worker.verify(_json(good)),
+        worker.verify(bad),
+        worker.verify(_json(good)),
+      ]);
+      expect(results, [true, false, true]);
+    });
+
+    test('verify after close throws StateError', () async {
+      final worker = await EventVerifyIsolate.spawn();
+      final event = await _signedEvent('x');
+      worker.close();
+      expect(() => worker.verify(_json(event)), throwsStateError);
+    });
+
+    test('close is idempotent', () async {
+      final worker = await EventVerifyIsolate.spawn();
+      worker.close();
+      expect(worker.close, returnsNormally);
+    });
+  });
+}

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_offmain_verify_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_offmain_verify_test.dart
@@ -1,0 +1,176 @@
+// ABOUTME: Tests RelayPool's off-main verify integration (#5863 P2).
+// ABOUTME: Worker verify, per-relay ordering, and inline fallback.
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:nostr_sdk/relay/client_connected.dart';
+
+class _FakeRelay extends Relay {
+  _FakeRelay(String url) : super(url, RelayStatus(url));
+
+  @override
+  Future<bool> doConnect() async {
+    relayStatus.connected = ClientConnected.connected;
+    return true;
+  }
+
+  @override
+  Future<void> disconnect() async {
+    relayStatus.connected = ClientConnected.disconnect;
+  }
+
+  @override
+  Future<bool> send(
+    List<dynamic> message, {
+    bool? forceSend,
+    bool queueIfFailed = true,
+    bool skipReconnect = false,
+    DateTime? deadline,
+  }) async => true;
+
+  Future<void> deliver(List<dynamic> json) async {
+    final dynamic result = onMessage!(this, json);
+    if (result is Future) await result;
+  }
+}
+
+/// A verify worker whose per-event decision (and optional delay) the test
+/// controls, so ordering and fallback are deterministic.
+class _FakeVerifyWorker implements EventVerifyWorker {
+  _FakeVerifyWorker(this._decide);
+
+  final FutureOr<bool> Function(Map<String, dynamic> json) _decide;
+  int calls = 0;
+  bool closed = false;
+
+  @override
+  Future<bool> verify(Map<String, dynamic> eventJson) async {
+    if (closed) throw StateError('closed');
+    calls++;
+    return _decide(eventJson);
+  }
+
+  @override
+  void close() => closed = true;
+}
+
+Future<Event> _signedEvent(String content) async {
+  const privateKey =
+      '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12';
+  final signer = LocalNostrSigner(privateKey);
+  final pubkey = await signer.getPublicKey();
+  final event = Event(
+    pubkey!,
+    EventKind.textNote,
+    [],
+    content,
+    createdAt: 1780000000,
+  );
+  await signer.signEvent(event);
+  return event;
+}
+
+Nostr _nostr() => Nostr(
+  LocalNostrSigner(generatePrivateKey()),
+  [],
+  (url) => RelayBase(url, RelayStatus(url)),
+);
+
+List<Event> _subscribe(Nostr nostr) {
+  final delivered = <Event>[];
+  nostr.subscribe(
+    [
+      {
+        'kinds': [EventKind.textNote],
+      },
+    ],
+    delivered.add,
+    id: 'sub',
+  );
+  return delivered;
+}
+
+void main() {
+  group('RelayPool off-main verify (#5863 P2)', () {
+    test('routes verify to the worker and delivers accepted events', () async {
+      final nostr = _nostr();
+      final worker = _FakeVerifyWorker((_) => true);
+      nostr.relayPool.eventVerifyWorker = worker;
+      final relay = _FakeRelay('wss://relay.a');
+      expect(await nostr.relayPool.add(relay), isTrue);
+      final delivered = _subscribe(nostr);
+
+      final event = await _signedEvent('accepted');
+      await relay.deliver(['EVENT', 'sub', event.toJson()]);
+
+      expect(delivered, hasLength(1));
+      expect(worker.calls, 1, reason: 'verify ran on the worker, not inline');
+    });
+
+    test('drops events the worker rejects', () async {
+      final nostr = _nostr();
+      nostr.relayPool.eventVerifyWorker = _FakeVerifyWorker((_) => false);
+      final relay = _FakeRelay('wss://relay.a');
+      expect(await nostr.relayPool.add(relay), isTrue);
+      final delivered = _subscribe(nostr);
+
+      // A genuinely valid event, but the worker says no → dropped.
+      final event = await _signedEvent('rejected-by-worker');
+      await relay.deliver(['EVENT', 'sub', event.toJson()]);
+
+      expect(delivered, isEmpty);
+    });
+
+    test('falls back to inline verify when the worker throws', () async {
+      final nostr = _nostr();
+      nostr.relayPool.eventVerifyWorker = _FakeVerifyWorker(
+        (_) => throw StateError('isolate died'),
+      );
+      final relay = _FakeRelay('wss://relay.a');
+      expect(await nostr.relayPool.add(relay), isTrue);
+      final delivered = _subscribe(nostr);
+
+      // Worker throws → inline check runs; the real signature is valid → kept.
+      final valid = await _signedEvent('fallback-valid');
+      await relay.deliver(['EVENT', 'sub', valid.toJson()]);
+      expect(delivered, hasLength(1));
+
+      // And a tampered event still fails the inline fallback → dropped.
+      final tampered = (await _signedEvent('orig')).toJson()
+        ..['content'] = 'tampered';
+      await relay.deliver(['EVENT', 'sub', tampered]);
+      expect(delivered, hasLength(1));
+    });
+
+    test(
+      'preserves per-relay delivery order despite out-of-order verify',
+      () async {
+        final nostr = _nostr();
+        final gate = Completer<void>();
+        // 'A' verifies slowly (gated); 'B' verifies immediately. Without ordering
+        // B would dispatch first; the per-relay chain must still deliver A then B.
+        nostr.relayPool.eventVerifyWorker = _FakeVerifyWorker((json) async {
+          if (json['content'] == 'A') await gate.future;
+          return true;
+        });
+        final relay = _FakeRelay('wss://relay.a');
+        expect(await nostr.relayPool.add(relay), isTrue);
+        final delivered = _subscribe(nostr);
+
+        final a = await _signedEvent('A');
+        final b = await _signedEvent('B');
+        final dA = relay.deliver(['EVENT', 'sub', a.toJson()]);
+        final dB = relay.deliver(['EVENT', 'sub', b.toJson()]);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(delivered, isEmpty, reason: 'A gated, B queued behind it');
+        gate.complete();
+        await Future.wait([dA, dB]);
+
+        expect(delivered.map((e) => e.content), ['A', 'B']);
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes #5863

## What & why

Runs the inbound relay-event **Schnorr signature verify off the main isolate**, composed on top of #5888 (now merged). #5888 added the `(id, sig)` dedup — session-dup and known-verified (seeded from the local store) events skip verify entirely. This PR moves the *remaining* fresh verify — the events #5888 does **not** already trust — off the main/UI isolate, so the cold-start burst of genuinely-new events (and steady-state new events) no longer blocks frame callbacks.

## What's in this PR

- **`EventVerifyIsolate`** — a keyless, long-lived background isolate that recomputes the event id + verifies the Schnorr signature. Nothing secret crosses the port (verification needs no private key). Mirrors `dm_repository`'s `DmVerifyIsolate`, but persistent rather than drain-scoped.
- Slots into #5888's verify ladder: `_verifySignatureOffMain` replaces the `else if (event.isSigned)` fresh-verify branch, so only events that fall through the session-dup / known-verified skips reach the worker.
- Wired **opt-in** via `NostrClientConfig.eventVerifyWorkerSpawner`, spawned in `initialize()` right after #5888's `_seedVerifiedEventIds()` and before relays connect; the app passes `EventVerifyIsolate.spawn` (null on web/tests → inline main-isolate verify, unchanged).
- EVENT/EOSE frames are **serialized per relay** so the now-async verify preserves in-order delivery (an EOSE must not complete a query before its preceding events finish verifying).
- **Inline fallback** on any worker failure, so a verify never hangs. **Dispatch is unchanged** — every verified event flows through the normal path, so per-relay `noteReceive()` / `event.sources.add(relay.url)` source attribution is fully preserved.

## Testing

- `event_verify_isolate_test.dart` — spawn/verify/close, malformed payload → `false`, post-close throws.
- `relay_pool_offmain_verify_test.dart` — worker verify routing, worker-reject drop, inline fallback on throw, per-relay in-order delivery under out-of-order verify.
- #5888's `relay_pool_verify_dedup_test.dart` stays green (the worker-less path is unchanged), plus the `nostr_client` initialize/dispose suites.
