### PR TITLE
perf(feed): cache action-button icon shadows in a RepaintBoundary

### DIFF
--- a/mobile/lib/widgets/video_feed_item/actions/video_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/video_action_button.dart
@@ -180,13 +180,27 @@ class _ShadowedIcon extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Stack(
-      alignment: Alignment.center,
-      children: [
-        _IconShadow(icon: icon, offset: const Offset(1, 1), blurSigma: 1),
-        _IconShadow(icon: icon, offset: const Offset(0.4, 0.4), blurSigma: 0.6),
-        DivineIcon(icon: icon, color: color),
-      ],
+    // Isolate the two ImageFiltered (saveLayer) shadow blurs in their own
+    // repaint layer. In the feed these icons sit over a playing video, whose
+    // texture changes every frame; without a boundary the blurs share the
+    // video's layer and are re-rasterised on every frame (profiling showed
+    // this as the dominant raster cost — a constant red/raster-bound frame
+    // graph). A boundary here — rather than around the whole overlay — keeps
+    // the cached layer alive even while sibling overlay content (subtitles,
+    // counts) repaints, since the icon itself changes only on icon/color.
+    return RepaintBoundary(
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          _IconShadow(icon: icon, offset: const Offset(1, 1), blurSigma: 1),
+          _IconShadow(
+            icon: icon,
+            offset: const Offset(0.4, 0.4),
+            blurSigma: 0.6,
+          ),
+          DivineIcon(icon: icon, color: color),
+        ],
+      ),
     );
   }
 }

--- a/mobile/test/widgets/video_feed_item/actions/video_action_button_test.dart
+++ b/mobile/test/widgets/video_feed_item/actions/video_action_button_test.dart
@@ -251,5 +251,29 @@ void main() {
         expect(semantics.properties.label, equals('Like video'));
       });
     });
+
+    group('raster', () {
+      testWidgets(
+        'wraps the blurred icon shadows in a RepaintBoundary so they are '
+        'cached over the playing feed video',
+        (tester) async {
+          await tester.pumpWidget(buildSubject());
+
+          // The foreground glyph must sit inside a RepaintBoundary that lives
+          // under the button, so the ImageFiltered shadow blurs rasterise once
+          // and are cached instead of re-rastered on every video frame.
+          expect(
+            find.ancestor(
+              of: find.byType(DivineIcon).last,
+              matching: find.descendant(
+                of: find.byType(VideoActionButton),
+                matching: find.byType(RepaintBoundary),
+              ),
+            ),
+            findsOneWidget,
+          );
+        },
+      );
+    });
   });
 }


### PR DESCRIPTION
Closes #5900

## Description

The like / comment / repost icons each render **two `ImageFiltered` (saveLayer) blur shadow layers**. In the feed these icons sit over a **playing video whose texture changes every frame**. Without a repaint boundary, the blurs share the video's compositing layer, so the **raster thread re-executes all of them on every frame**.

Profiling the home feed showed a **constantly raster-bound frame graph** (red bars over the 60 fps line) while just watching a video. Isolating the diagnosis:

- The **repaint rainbow** (`debugRepaintRainbowEnabled`) showed **nothing was repainting** per frame → not a rebuild/repaint problem.
- So the cost was **pure per-frame re-compositing of the uncached blurs** over the animating video texture — a **compositing** problem.
- Removing the shadows dropped the graph to blue (confirming they were the cost); the fix keeps them.

**Fix:** wrap the shadowed icon in a `RepaintBoundary`, so the blurs rasterise **once** into their own cached layer and are just composited over the changing video (cheap).

- Kept **narrow** (per icon, not around the whole overlay): the overlay repaints per frame via the subtitle layer, which would invalidate a wider boundary; a per-icon boundary survives those repaints.
- Shadows are **visually unchanged**.

**Measured (on-device, home feed):** frame graph goes from constantly raster-bound (red, over budget) to under the 60 fps line (blue), with the shadows intact.

> Note (debug builds use Skia; `saveLayer` is cheaper on Impeller in release/profile), so this is most visible in debug — but it is a real per-frame raster cost.

## Out of Scope

- A separate residual: the bottom-left author/caption block shares one repaint layer with the per-frame subtitle overlay, so it repaints together. It's cheap (text + `Shadow`, no `saveLayer`) and does not cause raster jank — left as a possible follow-up.
- Touches `video_action_button.dart`, which #5890 also edits (in a different method: `VideoActionButton` vs `_ShadowedIcon`) — independent, may need a trivial rebase depending on merge order.

**Related Issue:** 

## Verification

- `flutter analyze` on the changed lib + test — clean.
- New regression test: `raster > wraps the blurred icon shadows in a RepaintBoundary ...` (fails if the boundary is removed).
- Full `VideoActionButton` widget-test suite green (22).
- Validated on-device via before/after Flutter frame graphs + repaint-rainbow diagnosis.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)