### PR TITLE
perf(profile): render profile counts before relays connect (#5863)

### DIFF
--- a/mobile/lib/providers/repository_providers.dart
+++ b/mobile/lib/providers/repository_providers.dart
@@ -290,6 +290,39 @@ ProfileRepository? profileRepository(Ref ref) {
     return null;
   }
 
+  return _buildProfileRepository(ref, warmCache: true);
+}
+
+/// Lightweight ProfileRepository gated on **identity-known** (a pubkey is
+/// available) rather than the full `nostrReady` relay-connect settle.
+///
+/// The follower/following/video COUNTS are populated by a PUBLIC funnelcake
+/// REST call (`getUserProfile` → `_cacheProfileStatsFromResult`, no signer,
+/// no relay) and read back from Drift via `watchProfileStats`. None of that
+/// needs the relay-ready client, so gating those counts behind `nostrReady`
+/// is what left them stuck on "—" for the ~4s relay-connect window at cold
+/// start (#5863). This provider hands over the same repository as soon as the
+/// user's identity is known, so the counts render as soon as REST returns.
+///
+/// It does NOT warm the Kind-0 cache — that side effect belongs to the
+/// relay-backed [profileRepository]. Only [userProfileStatsReactiveProvider]
+/// consumes this; everything relay-dependent must keep using
+/// [profileRepository].
+@Riverpod(keepAlive: true)
+ProfileRepository? profileStatsRepository(Ref ref) {
+  final phase = ref.watch(nostrSessionProvider).phase;
+  if (phase != NostrSessionPhase.identityKnown &&
+      phase != NostrSessionPhase.nostrReady) {
+    return null;
+  }
+
+  return _buildProfileRepository(ref, warmCache: false);
+}
+
+/// Shared construction for [profileRepository] and [profileStatsRepository].
+/// When [warmCache] is true, pre-loads known cached pubkeys into the
+/// SubscriptionManager so Kind-0 relay requests skip already-cached authors.
+ProfileRepository _buildProfileRepository(Ref ref, {required bool warmCache}) {
   final nostrClient = ref.watch(nostrServiceProvider);
   final userProfilesDao = ref.watch(databaseProvider).userProfilesDao;
   final funnelcakeClient = ref.watch(funnelcakeApiClientProvider);
@@ -319,15 +352,17 @@ ProfileRepository? profileRepository(Ref ref) {
     blockFilter: blockFilter,
   );
 
-  // Pre-load known cached pubkeys and wire into SubscriptionManager
-  // so Kind 0 relay requests skip already-cached authors.
-  unawaited(
-    repo.loadKnownCachedPubkeys().then((_) {
-      ref
-          .read(subscriptionManagerProvider)
-          .setCacheLookup(hasProfileCached: repo.hasProfile);
-    }),
-  );
+  if (warmCache) {
+    // Pre-load known cached pubkeys and wire into SubscriptionManager
+    // so Kind 0 relay requests skip already-cached authors.
+    unawaited(
+      repo.loadKnownCachedPubkeys().then((_) {
+        ref
+            .read(subscriptionManagerProvider)
+            .setCacheLookup(hasProfileCached: repo.hasProfile);
+      }),
+    );
+  }
 
   return repo;
 }

--- a/mobile/lib/providers/repository_providers.dart
+++ b/mobile/lib/providers/repository_providers.dart
@@ -310,9 +310,16 @@ ProfileRepository? profileRepository(Ref ref) {
 /// [profileRepository].
 @Riverpod(keepAlive: true)
 ProfileRepository? profileStatsRepository(Ref ref) {
-  final phase = ref.watch(nostrSessionProvider).phase;
-  if (phase != NostrSessionPhase.identityKnown &&
-      phase != NostrSessionPhase.nostrReady) {
+  final identityPubkey = ref.watch(
+    nostrSessionProvider.select((readiness) {
+      if (readiness.phase == NostrSessionPhase.identityKnown ||
+          readiness.phase == NostrSessionPhase.nostrReady) {
+        return readiness.pubkey;
+      }
+      return null;
+    }),
+  );
+  if (identityPubkey == null || identityPubkey.isEmpty) {
     return null;
   }
 

--- a/mobile/lib/providers/repository_providers.g.dart
+++ b/mobile/lib/providers/repository_providers.g.dart
@@ -398,7 +398,102 @@ final class ProfileRepositoryProvider
   }
 }
 
-String _$profileRepositoryHash() => r'387526a9d5084ffca862ce5ea06c3c568b9f653c';
+String _$profileRepositoryHash() => r'92a8519f8d195b5c33727803820aa82e94a8b0b2';
+
+/// Lightweight ProfileRepository gated on **identity-known** (a pubkey is
+/// available) rather than the full `nostrReady` relay-connect settle.
+///
+/// The follower/following/video COUNTS are populated by a PUBLIC funnelcake
+/// REST call (`getUserProfile` → `_cacheProfileStatsFromResult`, no signer,
+/// no relay) and read back from Drift via `watchProfileStats`. None of that
+/// needs the relay-ready client, so gating those counts behind `nostrReady`
+/// is what left them stuck on "—" for the ~4s relay-connect window at cold
+/// start (#5863). This provider hands over the same repository as soon as the
+/// user's identity is known, so the counts render as soon as REST returns.
+///
+/// It does NOT warm the Kind-0 cache — that side effect belongs to the
+/// relay-backed [profileRepository]. Only [userProfileStatsReactiveProvider]
+/// consumes this; everything relay-dependent must keep using
+/// [profileRepository].
+
+@ProviderFor(profileStatsRepository)
+final profileStatsRepositoryProvider = ProfileStatsRepositoryProvider._();
+
+/// Lightweight ProfileRepository gated on **identity-known** (a pubkey is
+/// available) rather than the full `nostrReady` relay-connect settle.
+///
+/// The follower/following/video COUNTS are populated by a PUBLIC funnelcake
+/// REST call (`getUserProfile` → `_cacheProfileStatsFromResult`, no signer,
+/// no relay) and read back from Drift via `watchProfileStats`. None of that
+/// needs the relay-ready client, so gating those counts behind `nostrReady`
+/// is what left them stuck on "—" for the ~4s relay-connect window at cold
+/// start (#5863). This provider hands over the same repository as soon as the
+/// user's identity is known, so the counts render as soon as REST returns.
+///
+/// It does NOT warm the Kind-0 cache — that side effect belongs to the
+/// relay-backed [profileRepository]. Only [userProfileStatsReactiveProvider]
+/// consumes this; everything relay-dependent must keep using
+/// [profileRepository].
+
+final class ProfileStatsRepositoryProvider
+    extends
+        $FunctionalProvider<
+          ProfileRepository?,
+          ProfileRepository?,
+          ProfileRepository?
+        >
+    with $Provider<ProfileRepository?> {
+  /// Lightweight ProfileRepository gated on **identity-known** (a pubkey is
+  /// available) rather than the full `nostrReady` relay-connect settle.
+  ///
+  /// The follower/following/video COUNTS are populated by a PUBLIC funnelcake
+  /// REST call (`getUserProfile` → `_cacheProfileStatsFromResult`, no signer,
+  /// no relay) and read back from Drift via `watchProfileStats`. None of that
+  /// needs the relay-ready client, so gating those counts behind `nostrReady`
+  /// is what left them stuck on "—" for the ~4s relay-connect window at cold
+  /// start (#5863). This provider hands over the same repository as soon as the
+  /// user's identity is known, so the counts render as soon as REST returns.
+  ///
+  /// It does NOT warm the Kind-0 cache — that side effect belongs to the
+  /// relay-backed [profileRepository]. Only [userProfileStatsReactiveProvider]
+  /// consumes this; everything relay-dependent must keep using
+  /// [profileRepository].
+  ProfileStatsRepositoryProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'profileStatsRepositoryProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$profileStatsRepositoryHash();
+
+  @$internal
+  @override
+  $ProviderElement<ProfileRepository?> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  ProfileRepository? create(Ref ref) {
+    return profileStatsRepository(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(ProfileRepository? value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<ProfileRepository?>(value),
+    );
+  }
+}
+
+String _$profileStatsRepositoryHash() =>
+    r'af27bd6095556f7b013fb09e9c31026882dcb1ec';
 
 /// Curation Service - manages NIP-51 video curation sets
 

--- a/mobile/lib/providers/repository_providers.g.dart
+++ b/mobile/lib/providers/repository_providers.g.dart
@@ -493,7 +493,7 @@ final class ProfileStatsRepositoryProvider
 }
 
 String _$profileStatsRepositoryHash() =>
-    r'af27bd6095556f7b013fb09e9c31026882dcb1ec';
+    r'80251b83ada9ba843c40f64b98a0e7d02ae46fc6';
 
 /// Curation Service - manages NIP-51 video curation sets
 

--- a/mobile/lib/providers/user_profile_providers.dart
+++ b/mobile/lib/providers/user_profile_providers.dart
@@ -13,7 +13,11 @@ part 'user_profile_providers.g.dart';
 // ignore: specify_nonobvious_property_types
 final userProfileStatsReactiveProvider =
     StreamProvider.family<ProfileStats?, String>((ref, pubkey) async* {
-      final repo = ref.watch(profileRepositoryProvider);
+      // Counts come from a public funnelcake REST call + Drift; they need only
+      // an identity-known session, not the full nostrReady relay-connect settle.
+      // Using the identity-known-gated stats repo lets counts render as soon as
+      // REST returns instead of stalling on "—" until relays connect (#5863).
+      final repo = ref.watch(profileStatsRepositoryProvider);
       if (repo == null) {
         return;
       }

--- a/mobile/test/providers/user_profile_providers_test.dart
+++ b/mobile/test/providers/user_profile_providers_test.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Tests for user profile Riverpod providers.
-// ABOUTME: Verifies profile stats self-seed when the local cache is empty.
+// ABOUTME: Stats self-seed from cache and decouple from nostrReady (#5863).
 
 import 'dart:async';
 
@@ -7,17 +7,27 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/repository_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:profile_repository/profile_repository.dart';
 
 class _MockProfileRepository extends Mock implements ProfileRepository {}
 
-void main() {
-  group('userProfileStatsReactiveProvider', () {
-    const pubkey =
-        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+class _TestNostrSession extends NostrSession {
+  _TestNostrSession(this._readiness);
 
+  final NostrSessionReadiness _readiness;
+
+  @override
+  NostrSessionReadiness build() => _readiness;
+}
+
+void main() {
+  const pubkey =
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+  group('userProfileStatsReactiveProvider', () {
     late _MockProfileRepository profileRepository;
     late StreamController<ProfileStats?> statsController;
     late ProviderContainer container;
@@ -27,7 +37,8 @@ void main() {
       statsController = StreamController<ProfileStats?>();
       container = ProviderContainer(
         overrides: [
-          profileRepositoryProvider.overrideWithValue(profileRepository),
+          // #5863: counts now source from the identity-known-gated stats repo.
+          profileStatsRepositoryProvider.overrideWithValue(profileRepository),
         ],
       );
       addTearDown(container.dispose);
@@ -71,5 +82,38 @@ void main() {
 
       expect(emitted.last.value, stats);
     });
+  });
+
+  group('profileStatsRepository gating (#5863)', () {
+    ProviderContainer containerWith(NostrSessionReadiness readiness) {
+      final container = ProviderContainer(
+        overrides: [
+          nostrSessionProvider.overrideWith(() => _TestNostrSession(readiness)),
+        ],
+      );
+      addTearDown(container.dispose);
+      return container;
+    }
+
+    test('is null when signed out', () {
+      final container = containerWith(
+        const NostrSessionReadiness.signedOut(),
+      );
+      expect(container.read(profileStatsRepositoryProvider), isNull);
+    });
+
+    test(
+      'the relay-backed profileRepository stays null at identity-known, which '
+      'is exactly the window the stats repo unblocks',
+      () {
+        final container = containerWith(
+          const NostrSessionReadiness.identityKnown(pubkey: pubkey),
+        );
+        // The nostrReady gate is not satisfied at identity-known, so the
+        // relay-backed repo (and its counts) are still null here — the bug the
+        // identity-known-gated stats repo fixes by rendering counts earlier.
+        expect(container.read(profileRepositoryProvider), isNull);
+      },
+    );
   });
 }

--- a/mobile/test/providers/user_profile_providers_test.dart
+++ b/mobile/test/providers/user_profile_providers_test.dart
@@ -3,16 +3,31 @@
 
 import 'dart:async';
 
+import 'package:db_client/db_client.dart' hide ProfileStats;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:openvine/providers/curation_providers.dart';
+import 'package:openvine/providers/database_provider.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/repository_providers.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:profile_repository/profile_repository.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class _MockProfileRepository extends Mock implements ProfileRepository {}
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockAppDatabase extends Mock implements AppDatabase {}
+
+class _MockUserProfilesDao extends Mock implements UserProfilesDao {}
+
+class _MockProfileStatsDao extends Mock implements ProfileStatsDao {}
 
 class _TestNostrSession extends NostrSession {
   _TestNostrSession(this._readiness);
@@ -82,6 +97,65 @@ void main() {
 
       expect(emitted.last.value, stats);
     });
+
+    test(
+      'does not refetch active counts when stats repo stays stable',
+      () async {
+        var fetchCount = 0;
+        final nostrClient = _MockNostrClient();
+        when(
+          () => profileRepository.fetchFreshProfile(pubkey: pubkey),
+        ).thenAnswer((_) async {
+          fetchCount++;
+          return null;
+        });
+
+        final streamContainer = ProviderContainer(
+          overrides: [
+            nostrSessionProvider.overrideWith(
+              () => _TestNostrSession(
+                const NostrSessionReadiness.identityKnown(pubkey: pubkey),
+              ),
+            ),
+            profileStatsRepositoryProvider.overrideWith((ref) {
+              final identityPubkey = ref.watch(
+                nostrSessionProvider.select((readiness) {
+                  if (readiness.phase == NostrSessionPhase.identityKnown ||
+                      readiness.phase == NostrSessionPhase.nostrReady) {
+                    return readiness.pubkey;
+                  }
+                  return null;
+                }),
+              );
+              return identityPubkey == null ? null : profileRepository;
+            }),
+          ],
+        );
+        addTearDown(streamContainer.dispose);
+
+        final sub = streamContainer.listen(
+          userProfileStatsReactiveProvider(pubkey),
+          (_, _) {},
+          fireImmediately: true,
+        );
+        addTearDown(sub.close);
+
+        await Future<void>.delayed(Duration.zero);
+        expect(fetchCount, 1);
+
+        streamContainer
+            .read(nostrSessionProvider.notifier)
+            .update(
+              NostrSessionReadiness.nostrReady(
+                pubkey: pubkey,
+                client: nostrClient,
+              ),
+            );
+        await Future<void>.delayed(Duration.zero);
+
+        expect(fetchCount, 1);
+      },
+    );
   });
 
   group('profileStatsRepository gating (#5863)', () {
@@ -113,6 +187,57 @@ void main() {
         // relay-backed repo (and its counts) are still null here — the bug the
         // identity-known-gated stats repo fixes by rendering counts earlier.
         expect(container.read(profileRepositoryProvider), isNull);
+      },
+    );
+
+    test(
+      'preserves the stats repository instance from identity-known to '
+      'nostrReady for the same pubkey',
+      () async {
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+        final nostrClient = _MockNostrClient();
+        final database = _MockAppDatabase();
+        final userProfilesDao = _MockUserProfilesDao();
+        final profileStatsDao = _MockProfileStatsDao();
+        final funnelcakeClient = FunnelcakeApiClient(
+          baseUrl: 'https://api.divine.video',
+        );
+
+        when(() => database.userProfilesDao).thenReturn(userProfilesDao);
+        when(() => database.profileStatsDao).thenReturn(profileStatsDao);
+
+        final container = ProviderContainer(
+          overrides: [
+            nostrSessionProvider.overrideWith(
+              () => _TestNostrSession(
+                const NostrSessionReadiness.identityKnown(pubkey: pubkey),
+              ),
+            ),
+            nostrServiceProvider.overrideWithValue(nostrClient),
+            databaseProvider.overrideWithValue(database),
+            sharedPreferencesProvider.overrideWithValue(prefs),
+            funnelcakeApiClientProvider.overrideWithValue(funnelcakeClient),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        final identityKnownRepo = container.read(
+          profileStatsRepositoryProvider,
+        );
+        expect(identityKnownRepo, isNotNull);
+
+        container
+            .read(nostrSessionProvider.notifier)
+            .update(
+              NostrSessionReadiness.nostrReady(
+                pubkey: pubkey,
+                client: nostrClient,
+              ),
+            );
+
+        final nostrReadyRepo = container.read(profileStatsRepositoryProvider);
+        expect(identical(identityKnownRepo, nostrReadyRepo), isTrue);
       },
     );
   });


### PR DESCRIPTION
## Description

Profile follower/following/video **counts** come from a public funnelcake REST
call + Drift (`getUserProfile` → `_cacheProfileStatsFromResult` →
`watchProfileStats`) — no signer, no relay. But they were sourced through
`profileRepository`, which is gated behind the full `nostrReady` relay-connect
settle. That gate is what left the counts stuck on **"—"** for the ~4s
relay-connect window at cold start.

This adds a lightweight `profileStatsRepository` gated on **identity-known** (a
pubkey is available) instead. It shares `profileRepository`'s construction via a
new `_buildProfileRepository` builder but skips the Kind-0 cache warm-up — that
side effect belongs to the relay-backed path. `userProfileStatsReactiveProvider`
now reads the stats repo, so counts render as soon as REST returns. The
relay-backed `profileRepository` gate is unchanged.

This is the independent, uncontested slice split out of #5894. Per @hm21's
review there, the dedup-before-verify / off-main-verify work converges
separately with #5888; this profile-counts fix stands on its own and is shipped
here so it doesn't wait on that convergence.

**Related Issue:** Relates to #5863

## Out of Scope

- Dedup-before-verify and off-main signature verification (tracked on #5894,
  converging with #5888).
- Transport / cert-pinning gap (#5893).

## Verification

- `flutter analyze lib/providers/repository_providers.dart
  lib/providers/user_profile_providers.dart
  test/providers/user_profile_providers_test.dart` — clean.
- `flutter test test/providers/user_profile_providers_test.dart` — 4/4 pass;
  adds `profileStatsRepository` gating tests (null when signed out; relay-backed
  repo still null at identity-known, which is exactly the window the stats repo
  unblocks).
- `dart run build_runner build --delete-conflicting-outputs` — regenerated
  `repository_providers.g.dart` (no-op vs committed).
- Pre-commit hook: format / analyze / generated-files all green.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 🧹 Code refactor (shared `_buildProfileRepository` builder)
