### PR TITLE
fix(db): quick_check the cipher-migration artifact before promotion

### DIFF
--- a/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
@@ -667,7 +667,7 @@ CipherMigrationOutcome _rekeyPlaintextInPlace({
     return CipherMigrationOutcome.failed;
   }
 
-  if (!_encryptedCopyMatchesSource(
+  if (!encryptedCopyMatchesSource(
     plaintextPath: dbPath,
     encryptedPath: encryptedPath,
     rawKeyHex: rawKeyHex,
@@ -721,13 +721,24 @@ void promoteEncryptedMigrationArtifact({
   _moveSidecars(fromPath: encryptedPath, toPath: dbPath);
 }
 
-/// Verifies the encrypted copy opens with [rawKeyHex] and that its
-/// `user_version` (drift's schema version) and user-table row counts match the
-/// plaintext source — the gate before swapping files.
-bool _encryptedCopyMatchesSource({
+/// Verifies the encrypted copy opens with [rawKeyHex], that its `user_version`
+/// (drift's schema version) and user-table row counts match the plaintext
+/// source, and that it is structurally sound — the gate before swapping files.
+///
+/// The structural check ([integrityCheck], defaulting to
+/// [databasePassesIntegrityCheck] which runs `PRAGMA quick_check`) is the
+/// load-bearing addition: `user_version` + row counts can match on an encrypted
+/// artifact whose index b-tree is corrupt, and promoting such a file throws
+/// `SqliteException(779)` ("database disk image is malformed") on the first
+/// index-traversing write. [integrityCheck] is injectable only so the gate's
+/// fail-closed behaviour can be exercised deterministically in tests.
+@visibleForTesting
+bool encryptedCopyMatchesSource({
   required String plaintextPath,
   required String encryptedPath,
   required String rawKeyHex,
+  bool Function(CommonDatabase db) integrityCheck =
+      databasePassesIntegrityCheck,
 }) {
   Database? encrypted;
   Database? plaintext;
@@ -739,10 +750,14 @@ bool _encryptedCopyMatchesSource({
 
     if (_userVersion(encrypted) != _userVersion(plaintext)) return false;
 
-    return const MapEquality<String, int>().equals(
+    if (!const MapEquality<String, int>().equals(
       _userTableRowCounts(encrypted),
       _userTableRowCounts(plaintext),
-    );
+    )) {
+      return false;
+    }
+
+    return integrityCheck(encrypted);
   } on SqliteException {
     return false;
   } finally {

--- a/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
+++ b/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
@@ -613,6 +613,140 @@ void main() {
     });
   });
 
+  group('encryptedCopyMatchesSource', () {
+    const validKey =
+        '2dd29ca851e7b56e4697b0e1f08507293d761a05ce4d1b628663f411a8086d99';
+    late Directory tempRoot;
+    late String plaintextPath;
+    late String encryptedPath;
+
+    setUp(() {
+      tempRoot = Directory.systemTemp.createTempSync(
+        'db_client_copy_matches_test_',
+      );
+      plaintextPath = p.join(tempRoot.path, 'plain.db');
+      encryptedPath = p.join(tempRoot.path, 'enc.db');
+    });
+
+    tearDown(() {
+      if (tempRoot.existsSync()) tempRoot.deleteSync(recursive: true);
+    });
+
+    // Builds a plaintext source and a keyed encrypted copy that agree on
+    // user_version and user-table row counts, so the only thing that can flip
+    // the verifier's verdict is the structural integrity check.
+    void seedMatchingPair() {
+      sqlite3.open(plaintextPath)
+        ..execute('CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT);')
+        ..execute("INSERT INTO t (v) VALUES ('a');")
+        ..execute("INSERT INTO t (v) VALUES ('b');")
+        ..execute('PRAGMA user_version = 7;')
+        ..close();
+
+      final encrypted = sqlite3.open(encryptedPath);
+      applyCipherKey(encrypted, validKey);
+      encrypted
+        ..execute('CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT);')
+        ..execute("INSERT INTO t (v) VALUES ('a');")
+        ..execute("INSERT INTO t (v) VALUES ('b');")
+        ..execute('PRAGMA user_version = 7;')
+        ..close();
+    }
+
+    test('rejects the artifact when the integrity check fails, even though row '
+        'counts and user_version match', () {
+      seedMatchingPair();
+
+      expect(
+        encryptedCopyMatchesSource(
+          plaintextPath: plaintextPath,
+          encryptedPath: encryptedPath,
+          rawKeyHex: validKey,
+          integrityCheck: (_) => false,
+        ),
+        isFalse,
+        reason:
+            'quick_check must gate promotion even when counts and version '
+            'match — this is the 1.0.15 index-corruption vector',
+      );
+    });
+
+    test(
+      'accepts a healthy copy whose counts, version, and integrity hold',
+      () {
+        seedMatchingPair();
+
+        expect(
+          encryptedCopyMatchesSource(
+            plaintextPath: plaintextPath,
+            encryptedPath: encryptedPath,
+            rawKeyHex: validKey,
+          ),
+          isTrue,
+        );
+      },
+    );
+
+    test('rejects a copy whose row counts differ from the source', () {
+      seedMatchingPair();
+      final encrypted = sqlite3.open(encryptedPath);
+      applyCipherKey(encrypted, validKey);
+      encrypted
+        ..execute("INSERT INTO t (v) VALUES ('c');")
+        ..close();
+
+      expect(
+        encryptedCopyMatchesSource(
+          plaintextPath: plaintextPath,
+          encryptedPath: encryptedPath,
+          rawKeyHex: validKey,
+        ),
+        isFalse,
+      );
+    });
+
+    test('rejects a copy whose user_version differs from the source', () {
+      seedMatchingPair();
+      final encrypted = sqlite3.open(encryptedPath);
+      applyCipherKey(encrypted, validKey);
+      encrypted
+        ..execute('PRAGMA user_version = 8;')
+        ..close();
+
+      expect(
+        encryptedCopyMatchesSource(
+          plaintextPath: plaintextPath,
+          encryptedPath: encryptedPath,
+          rawKeyHex: validKey,
+        ),
+        isFalse,
+      );
+    });
+
+    test('fails closed when a database cannot be read (SqliteException)', () {
+      // A valid encrypted copy but a non-database plaintext source: reading it
+      // raises SqliteException, which the verifier must treat as "no match"
+      // rather than promoting an unverifiable pair.
+      final encrypted = sqlite3.open(encryptedPath);
+      applyCipherKey(encrypted, validKey);
+      encrypted
+        ..execute('CREATE TABLE t (id INTEGER PRIMARY KEY);')
+        ..close();
+      File(
+        plaintextPath,
+      ).writeAsBytesSync(List<int>.generate(2048, (i) => i % 256));
+
+      expect(
+        encryptedCopyMatchesSource(
+          plaintextPath: plaintextPath,
+          encryptedPath: encryptedPath,
+          rawKeyHex: validKey,
+        ),
+        isFalse,
+      );
+    });
+  });
+
   group('encryptedDatabaseOpensWithKey', () {
     const validKey =
         '2dd29ca851e7b56e4697b0e1f08507293d761a05ce4d1b628663f411a8086d99';
@@ -717,9 +851,7 @@ void main() {
     late String dbPath;
 
     setUp(() {
-      tempRoot = Directory.systemTemp.createTempSync(
-        'db_client_salvage_test_',
-      );
+      tempRoot = Directory.systemTemp.createTempSync('db_client_salvage_test_');
       dbPath = p.join(tempRoot.path, 'divine_db.db');
     });
 


### PR DESCRIPTION
Refs #5873 · part of the 1.0.15 "database disk image is malformed" (`SqliteException(779)`) incident response.

## Problem
The plaintext→encrypted SQLite rekey (`_rekeyPlaintextInPlace`) promotes its encrypted artifact into place only after `encryptedCopyMatchesSource` verifies it. That verifier checked **`user_version` + user-table row counts only** — never a structural check. An encrypted artifact whose **index b-tree** is corrupt (interrupted rekey, page/param mismatch) can match both and get promoted, then throw `SqliteException(779)` on the first index-traversing write — e.g. `DELETE FROM event WHERE expire_at IS NULL OR expire_at < ?`, the exact statement seen in 1.0.15 crash telemetry. Because the startup probe only read `sqlite_master` (which passes on b-tree corruption), the 779 then surfaced app-wide on every DB access.

## Fix
Gate promotion on the **existing** `databasePassesIntegrityCheck` (`PRAGMA quick_check`) helper as the final verification step in `encryptedCopyMatchesSource` (renamed from the private `_encryptedCopyMatchesSource`, now `@visibleForTesting`). The integrity check is injectable (`integrityCheck`, defaulted to the real helper) **only** so the fail-closed path can be exercised deterministically in tests.

This is **prevention** that complements the already-shipped post-hoc **recovery** (#5873): recovery salvages an already-corrupt DB on the next launch; this stops a structurally-corrupt artifact from ever being promoted in the first place.

### Deliberately NOT in this PR (per adversarial plan review)
- **No SQLCipher param-pinning.** A draft proposed pinning `cipher_page_size`/`kdf_iter`/`hmac`; cut because `_applySqlCipherCompatibility` runs on the DB-**open** path for every already-migrated user — a wrong pinned value would brick every existing encrypted DB, and no test can catch an old-encoding→new-param mismatch (no old-encoding fixture exists).
- **No runtime-779 recovery changes.** #5871/#5873 already shipped and tested that path.

## Tests
New `encryptedCopyMatchesSource` group (all green; the function is now 100% line-covered):
- rejects when the integrity check fails **even though counts + version match** (the 1.0.15 vector)
- accepts a healthy copy (counts + version + integrity all hold)
- rejects on row-count mismatch
- rejects on `user_version` mismatch
- fails closed on `SqliteException` (unreadable source)

## Verification
- `flutter analyze lib test` (db_client) — no issues
- `flutter test test/src/database/connection/connection_native_test.dart` — all pass
- full `db_client` suite green
- `dart format` clean

## Release note
The 1.0.16 store build must be cut from a commit that includes #5873's recovery (it landed after the 1.0.15+778 build, so 1.0.15 users have no recovery). This PR + #5873 together close the loop: prevent new corruption, recover existing corruption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)