### PR TITLE
feat(obs): memory + video-controller + ingestion telemetry and pressure shedding

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -63,6 +63,8 @@ import 'package:openvine/providers/db_cipher_key_provider.dart';
 import 'package:openvine/providers/deep_link_provider.dart';
 import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/foreground_idle_warmup_provider.dart';
+import 'package:openvine/providers/individual_video_providers.dart'
+    show fvpLiveControllerCount;
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/service_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
@@ -86,6 +88,8 @@ import 'package:openvine/services/database_encryption_bootstrap.dart';
 import 'package:openvine/services/deep_link_service.dart';
 import 'package:openvine/services/firebase_initialization.dart';
 import 'package:openvine/services/locale_preference_service.dart';
+import 'package:openvine/services/memory_pressure_handler.dart';
+import 'package:openvine/services/memory_telemetry_service.dart';
 import 'package:openvine/services/mention_resolution_service.dart';
 import 'package:openvine/services/nip98_auth_service.dart' show HttpMethod;
 import 'package:openvine/services/notification_helpers.dart'
@@ -1581,16 +1585,39 @@ class DivineApp extends ConsumerStatefulWidget {
   ConsumerState<DivineApp> createState() => _DivineAppState();
 }
 
-class _DivineAppState extends ConsumerState<DivineApp> {
+class _DivineAppState extends ConsumerState<DivineApp>
+    with WidgetsBindingObserver {
   bool _backgroundInitDone = false;
   StreamSubscription<void>? _shakeSubscription;
   StreamSubscription<NotificationTapEvent>? _notificationTapSubscription;
   QuickActionsCoordinator? _quickActionsCoordinator;
   late final StartupSplashReleaseController _splashReleaseController;
+  late final MemoryPressureHandler _memoryPressureHandler;
+  late final MemoryTelemetryService _memoryTelemetry;
 
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    _memoryPressureHandler = MemoryPressureHandler(
+      clearImageCache: () {
+        PaintingBinding.instance.imageCache
+          ..clear()
+          ..clearLiveImages();
+      },
+      shedIngestion: () {
+        ref.read(videoEventServiceProvider).eventRouter?.shedLowPriority();
+      },
+    );
+    _memoryTelemetry = MemoryTelemetryService(
+      readRssBytes: () => kIsWeb ? 0 : io.ProcessInfo.currentRss,
+      nativeControllerCount: () =>
+          DivineVideoPlayerController.liveControllerCount,
+      fvpControllerCount: () => fvpLiveControllerCount,
+      queueDepth: () =>
+          ref.read(videoEventServiceProvider).eventRouter?.queuedLength ?? 0,
+      emit: _emitMemorySnapshot,
+    );
     // Subscribe before deferred startup settles auth; routerDelegate reliably
     // notifies after redirect configuration changes (#5242).
     final router = ref.read(goRouterProvider);
@@ -1616,17 +1643,51 @@ class _DivineAppState extends ConsumerState<DivineApp> {
         _initializeDeepLinkServices();
         _initializeQuickActions();
         _initializeBackgroundServices();
+        _memoryTelemetry.start();
       }
     });
   }
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    _memoryTelemetry.stop();
     _splashReleaseController.dispose();
     _notificationTapSubscription?.cancel();
     unawaited(_quickActionsCoordinator?.dispose());
     _shakeSubscription?.cancel();
     super.dispose();
+  }
+
+  @override
+  void didHaveMemoryPressure() {
+    _memoryPressureHandler.onMemoryPressure();
+  }
+
+  /// Logs a memory snapshot at info and annotates Crashlytics custom keys so
+  /// OOM crash reports carry the last-seen memory footprint and gauges.
+  void _emitMemorySnapshot(MemorySnapshot snapshot) {
+    const bytesPerMb = 1024 * 1024;
+    final rssMb = (snapshot.rssBytes / bytesPerMb).toStringAsFixed(1);
+    final peakMb = (snapshot.peakRssBytes / bytesPerMb).toStringAsFixed(1);
+    Log.info(
+      'Memory: rss $rssMb MB (peak $peakMb MB), '
+      'vc_native=${snapshot.nativeControllers}, '
+      'vc_fvp=${snapshot.fvpControllers}, '
+      'ingest_queue_depth=${snapshot.queueDepth}',
+      name: 'MemoryTelemetry',
+      category: LogCategory.system,
+    );
+    final crashReporting = CrashReportingService.instance;
+    unawaited(crashReporting.setCustomKey('mem_rss_mb', rssMb));
+    unawaited(crashReporting.setCustomKey('mem_peak_mb', peakMb));
+    unawaited(
+      crashReporting.setCustomKey('vc_native', snapshot.nativeControllers),
+    );
+    unawaited(crashReporting.setCustomKey('vc_fvp', snapshot.fvpControllers));
+    unawaited(
+      crashReporting.setCustomKey('ingest_queue_depth', snapshot.queueDepth),
+    );
   }
 
   void _initializeDeepLinkServices() {

--- a/mobile/lib/providers/individual_video_providers.dart
+++ b/mobile/lib/providers/individual_video_providers.dart
@@ -298,6 +298,15 @@ class VideoLoadingState {
       'VideoLoadingState(videoId: $videoId, isLoading: $isLoading, isInitialized: $isInitialized, hasError: $hasError, errorMessage: $errorMessage)';
 }
 
+int _fvpLiveControllers = 0;
+
+/// Number of `video_player`/FVP controllers currently held live by
+/// [individualVideoControllerProvider].
+///
+/// Exposed as an always-on gauge for memory instrumentation; each live
+/// controller holds a native player and its decode buffers.
+int get fvpLiveControllerCount => _fvpLiveControllers;
+
 /// Provider for individual video controllers with autoDispose
 /// Each video gets its own controller instance
 @riverpod
@@ -471,6 +480,10 @@ VideoPlayerController individualVideoController(
       ? const Duration(seconds: 60)
       : const Duration(seconds: 30);
   final formatType = isHls ? 'HLS' : 'MP4';
+
+  // Count this controller as live for memory instrumentation. Decremented
+  // exactly once in the provider's onDispose below.
+  _fvpLiveControllers++;
 
   // Track significant video state changes only (initialization, errors, buffering)
   // Previous state tracking to avoid logging every frame update
@@ -978,6 +991,9 @@ VideoPlayerController individualVideoController(
   // AutoDispose: Cleanup controller when provider is disposed
   ref.onDispose(() {
     cacheTimer?.cancel();
+    // Decrement the live-controller gauge once per provider disposal, before
+    // the deferred native dispose runs in the microtask below.
+    _fvpLiveControllers--;
     Log.info(
       '🧹 Disposing VideoPlayerController for video ${params.videoId.length > 8 ? params.videoId : params.videoId}...',
       name: 'IndividualVideoController',

--- a/mobile/lib/providers/individual_video_providers.g.dart
+++ b/mobile/lib/providers/individual_video_providers.g.dart
@@ -81,7 +81,7 @@ final class IndividualVideoControllerProvider
 }
 
 String _$individualVideoControllerHash() =>
-    r'7ff310a3be6c3dc95425400a49b29ad9a0fa207c';
+    r'2e6638de2c0898dbda50424e7c2df4f0e0fa81d1';
 
 /// Provider for individual video controllers with autoDispose
 /// Each video gets its own controller instance

--- a/mobile/lib/services/event_router.dart
+++ b/mobile/lib/services/event_router.dart
@@ -13,11 +13,7 @@ import 'package:unified_logger/unified_logger.dart';
 
 const eventRouterBatchFlushThreshold = 50;
 
-enum EventIngestionPriority {
-  visible,
-  normal,
-  background,
-}
+enum EventIngestionPriority { visible, normal, background }
 
 class EventRouterConfig {
   const EventRouterConfig({
@@ -88,6 +84,41 @@ class EventRouter {
 
   int get _queuedLength =>
       _visibleQueue.length + _normalQueue.length + _backgroundQueue.length;
+
+  /// Total number of events currently queued across all priorities.
+  ///
+  /// Exposed as an always-on gauge for memory instrumentation; a growing
+  /// value points at ingestion outrunning persistence.
+  int get queuedLength => _queuedLength;
+
+  int _droppedEventCount = 0;
+
+  /// Number of events dropped by [shedLowPriority] over this router's
+  /// lifetime.
+  int get droppedEventCount => _droppedEventCount;
+
+  /// Drops all queued background- and normal-priority events, preserving the
+  /// visible queue so the on-screen feed still persists.
+  ///
+  /// Called under memory pressure to shed ingestion backlog. Returns the
+  /// number of events dropped.
+  int shedLowPriority() {
+    // Mirror [handleEvent]'s guard: after dispose the queues are cleared and
+    // the database may be closing, so there is nothing to shed.
+    if (_disposed) return 0;
+    final dropped = _backgroundQueue.length + _normalQueue.length;
+    _backgroundQueue.clear();
+    _normalQueue.clear();
+    _droppedEventCount += dropped;
+    if (dropped > 0) {
+      Log.info(
+        'Shed $dropped low-priority events under memory pressure',
+        name: 'EventRouter',
+        category: LogCategory.system,
+      );
+    }
+    return dropped;
+  }
 
   void _scheduleProcessing({bool immediate = false}) {
     if (_disposed || _isProcessingBatch) return;

--- a/mobile/lib/services/memory_pressure_handler.dart
+++ b/mobile/lib/services/memory_pressure_handler.dart
@@ -1,0 +1,25 @@
+// ABOUTME: Fans a memory-pressure signal out to load-shedding actions
+// ABOUTME: Clears the image cache and sheds low-priority ingestion backlog
+
+/// Coordinates the app's response to an OS memory-pressure signal.
+///
+/// Both actions are injected so the handler stays free of Flutter and service
+/// dependencies and is trivially testable. Production wiring supplies an image
+/// cache clear and an [EventRouter]-backed ingestion shed.
+class MemoryPressureHandler {
+  MemoryPressureHandler({
+    required void Function() clearImageCache,
+    required void Function() shedIngestion,
+  }) : _clearImageCache = clearImageCache,
+       _shedIngestion = shedIngestion;
+
+  final void Function() _clearImageCache;
+  final void Function() _shedIngestion;
+
+  /// Sheds load in response to memory pressure by clearing the image cache
+  /// and dropping low-priority ingestion backlog.
+  void onMemoryPressure() {
+    _clearImageCache();
+    _shedIngestion();
+  }
+}

--- a/mobile/lib/services/memory_telemetry_service.dart
+++ b/mobile/lib/services/memory_telemetry_service.dart
@@ -1,0 +1,95 @@
+// ABOUTME: Always-on memory gauge sampler (RSS + peak) for OOM instrumentation
+// ABOUTME: Reads injected gauges on an interval and emits a MemorySnapshot
+
+import 'dart:async';
+import 'dart:math' as math;
+
+/// An immutable point-in-time reading of the app's memory-relevant gauges.
+class MemorySnapshot {
+  const MemorySnapshot({
+    required this.rssBytes,
+    required this.peakRssBytes,
+    required this.nativeControllers,
+    required this.fvpControllers,
+    required this.queueDepth,
+  });
+
+  /// Resident set size at sample time, in bytes.
+  final int rssBytes;
+
+  /// Highest [rssBytes] observed by the sampler so far, in bytes.
+  final int peakRssBytes;
+
+  /// Live `divine_video_player` native controllers.
+  final int nativeControllers;
+
+  /// Live `video_player`/FVP controllers.
+  final int fvpControllers;
+
+  /// Events queued for ingestion across all priorities.
+  final int queueDepth;
+
+  @override
+  String toString() =>
+      'MemorySnapshot(rssBytes: $rssBytes, peakRssBytes: $peakRssBytes, '
+      'nativeControllers: $nativeControllers, fvpControllers: $fvpControllers, '
+      'queueDepth: $queueDepth)';
+}
+
+/// Samples memory-relevant gauges and emits a [MemorySnapshot].
+///
+/// All inputs are injected as callbacks so the service stays Flutter-free and
+/// trivially testable. Production wiring supplies a `readRssBytes` backed by
+/// `ProcessInfo.currentRss` and an `emit` that logs and annotates Crashlytics.
+class MemoryTelemetryService {
+  MemoryTelemetryService({
+    required int Function() readRssBytes,
+    required int Function() nativeControllerCount,
+    required int Function() fvpControllerCount,
+    required int Function() queueDepth,
+    required void Function(MemorySnapshot) emit,
+    this.interval = const Duration(seconds: 30),
+  }) : _readRssBytes = readRssBytes,
+       _nativeControllerCount = nativeControllerCount,
+       _fvpControllerCount = fvpControllerCount,
+       _queueDepth = queueDepth,
+       _emit = emit;
+
+  final int Function() _readRssBytes;
+  final int Function() _nativeControllerCount;
+  final int Function() _fvpControllerCount;
+  final int Function() _queueDepth;
+  final void Function(MemorySnapshot) _emit;
+
+  /// How often [start] samples the gauges.
+  final Duration interval;
+
+  Timer? _timer;
+  int _peakRssBytes = 0;
+
+  /// Reads every gauge once, updates the running peak, and emits a snapshot.
+  void sampleOnce() {
+    final rss = _readRssBytes();
+    _peakRssBytes = math.max(_peakRssBytes, rss);
+    _emit(
+      MemorySnapshot(
+        rssBytes: rss,
+        peakRssBytes: _peakRssBytes,
+        nativeControllers: _nativeControllerCount(),
+        fvpControllers: _fvpControllerCount(),
+        queueDepth: _queueDepth(),
+      ),
+    );
+  }
+
+  /// Begins periodic sampling on [interval]. Safe to call after [stop].
+  void start() {
+    _timer ??= Timer.periodic(interval, (_) => sampleOnce());
+  }
+
+  /// Stops periodic sampling. Idempotent.
+  void stop() {
+    _timer?.cancel();
+    _timer = null;
+  }
+}

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -147,6 +147,13 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   late final RepostResolver _repostResolver;
   final ProfileRepository? _profileRepository;
   final EventRouter? _eventRouter;
+
+  /// The ingestion router backing this service, if one was injected.
+  ///
+  /// Exposed so app-level memory instrumentation can read its queue depth and
+  /// shed low-priority backlog under memory pressure.
+  EventRouter? get eventRouter => _eventRouter;
+
   final VideoFilterBuilder? _videoFilterBuilder;
   final PerformanceTraceMonitor _performanceMonitor;
   final ConnectionStatusService _connectionService;

--- a/mobile/lib/utils/platform_io_web.dart
+++ b/mobile/lib/utils/platform_io_web.dart
@@ -152,6 +152,12 @@ class ProcessResult {
   final dynamic stderr;
 }
 
+// ProcessInfo stub for web platform
+class ProcessInfo {
+  static int get currentRss => 0;
+  static int get maxRss => 0;
+}
+
 // HttpClient stub for web platform
 class HttpClient {
   Duration? connectionTimeout;

--- a/mobile/packages/divine_video_player/lib/src/divine_video_player_controller.dart
+++ b/mobile/packages/divine_video_player/lib/src/divine_video_player_controller.dart
@@ -213,6 +213,12 @@ class DivineVideoPlayerController {
   static final Set<DivineVideoPlayerController> _liveControllers =
       <DivineVideoPlayerController>{};
 
+  /// Number of controllers that have been initialized and not yet disposed.
+  ///
+  /// Exposed as an always-on gauge for memory instrumentation; each live
+  /// controller holds a native player and its buffers.
+  static int get liveControllerCount => _liveControllers.length;
+
   /// Disposes all native player instances that may still be alive.
   ///
   /// Call at app startup to clean up zombie players from a previous

--- a/mobile/packages/divine_video_player/test/src/divine_video_player_controller_test.dart
+++ b/mobile/packages/divine_video_player/test/src/divine_video_player_controller_test.dart
@@ -891,6 +891,22 @@ void main() {
       });
     });
 
+    group('liveControllerCount', () {
+      test('is zero after resetIdCounterForTesting', () {
+        expect(DivineVideoPlayerController.liveControllerCount, equals(0));
+      });
+
+      test('reflects live instances across initialize and dispose', () async {
+        expect(DivineVideoPlayerController.liveControllerCount, equals(0));
+
+        await initController();
+        expect(DivineVideoPlayerController.liveControllerCount, equals(1));
+
+        await controller.dispose();
+        expect(DivineVideoPlayerController.liveControllerCount, equals(0));
+      });
+    });
+
     group('static methods', () {
       test('configureCache invokes global channel', () async {
         TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger

--- a/mobile/test/providers/individual_video_providers_test.dart
+++ b/mobile/test/providers/individual_video_providers_test.dart
@@ -1,8 +1,10 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/models/viewer_auth_result.dart';
 import 'package:openvine/providers/individual_video_providers.dart';
+import 'package:openvine/providers/upload_media_providers.dart';
 import 'package:openvine/services/media_viewer_auth_service.dart';
 
 class MockMediaViewerAuthService extends Mock
@@ -13,6 +15,36 @@ void main() {
 
   setUp(() {
     mockMediaViewerAuthService = MockMediaViewerAuthService();
+  });
+
+  group('fvpLiveControllerCount', () {
+    test('rises when a controller is read and falls after disposal', () {
+      // Controller construction reads mediaViewerAuthServiceProvider for
+      // sync auth headers; override it so the read doesn't pull the whole
+      // auth/Nostr graph into the test.
+      final authService = MockMediaViewerAuthService();
+      when(() => authService.canCreateHeaders).thenReturn(false);
+
+      final baseline = fvpLiveControllerCount;
+      final container = ProviderContainer(
+        overrides: [
+          mediaViewerAuthServiceProvider.overrideWithValue(authService),
+        ],
+      );
+
+      const params = VideoControllerParams(
+        videoId: 'gauge-video',
+        videoUrl: 'https://example.com/gauge.mp4',
+      );
+
+      // Reading the provider constructs the controller (no initialize()),
+      // which increments the gauge.
+      container.read(individualVideoControllerProvider(params));
+      expect(fvpLiveControllerCount, equals(baseline + 1));
+
+      container.dispose();
+      expect(fvpLiveControllerCount, equals(baseline));
+    });
   });
 
   group('createViewerAuthHeadersForVideo', () {

--- a/mobile/test/services/event_router_test.dart
+++ b/mobile/test/services/event_router_test.dart
@@ -99,10 +99,7 @@ void main() {
       router.dispose();
       router = EventRouter(
         db,
-        config: const EventRouterConfig(
-          autoStart: false,
-          maxBatchSize: 1,
-        ),
+        config: const EventRouterConfig(autoStart: false, maxBatchSize: 1),
       );
 
       router.handleEvent(
@@ -124,10 +121,7 @@ void main() {
         router.dispose();
         router = EventRouter(
           db,
-          config: const EventRouterConfig(
-            autoStart: false,
-            maxBatchSize: 10,
-          ),
+          config: const EventRouterConfig(autoStart: false, maxBatchSize: 10),
           yieldToEventLoop: () async {
             yieldCount++;
             await Future<void>.delayed(Duration.zero);
@@ -143,10 +137,7 @@ void main() {
 
         expect(yieldCount, greaterThanOrEqualTo(2));
         for (final event in events) {
-          expect(
-            await db.nostrEventsDao.getEventById(event.id),
-            isNotNull,
-          );
+          expect(await db.nostrEventsDao.getEventById(event.id), isNotNull);
         }
       },
     );
@@ -230,15 +221,61 @@ void main() {
       expect(await db.nostrEventsDao.getEventById(event.id), isNull);
     });
 
+    test('queuedLength reflects the number of enqueued events', () {
+      router.handleEvent(
+        profileEvent(1, content: jsonEncode({'name': 'a'})),
+        priority: EventIngestionPriority.background,
+      );
+      router.handleEvent(
+        videoEvent(2),
+        priority: EventIngestionPriority.visible,
+      );
+
+      expect(router.queuedLength, equals(2));
+    });
+
+    test(
+      'shedLowPriority drops background and normal but keeps visible',
+      () async {
+        router.handleEvent(
+          videoEvent(1),
+          priority: EventIngestionPriority.background,
+        );
+        // Enqueued at the default (normal) priority.
+        router.handleEvent(videoEvent(2));
+        final visible = videoEvent(3);
+        router.handleEvent(visible, priority: EventIngestionPriority.visible);
+        expect(router.queuedLength, equals(3));
+
+        final dropped = router.shedLowPriority();
+
+        expect(dropped, equals(2));
+        expect(router.droppedEventCount, equals(2));
+        expect(router.queuedLength, equals(1));
+
+        // The retained visible event still persists on the next drain.
+        await router.drainForTesting();
+        expect(await db.nostrEventsDao.getEventById(visible.id), isNotNull);
+      },
+    );
+
+    test('shedLowPriority is a no-op after dispose', () {
+      router.handleEvent(
+        videoEvent(1),
+        priority: EventIngestionPriority.background,
+      );
+      router.dispose();
+
+      expect(router.shedLowPriority(), equals(0));
+      expect(router.droppedEventCount, equals(0));
+    });
+
     test(
       'handleEvent enqueues without synchronously persisting the event',
       () async {
         final event = videoEvent(99);
 
-        router.handleEvent(
-          event,
-          priority: EventIngestionPriority.background,
-        );
+        router.handleEvent(event, priority: EventIngestionPriority.background);
 
         // Enqueue is intentionally fire-and-forget. Persistence happens when the
         // cooperative router drain runs, so the relay callback can keep updating

--- a/mobile/test/services/memory_pressure_handler_test.dart
+++ b/mobile/test/services/memory_pressure_handler_test.dart
@@ -1,0 +1,24 @@
+// ABOUTME: Tests MemoryPressureHandler fans out to both load-shedding callbacks
+// ABOUTME: Injects spies and asserts image-cache clear + ingestion shed both fire
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/memory_pressure_handler.dart';
+
+void main() {
+  group(MemoryPressureHandler, () {
+    test('onMemoryPressure invokes both shedding callbacks once', () {
+      var clearImageCacheCalls = 0;
+      var shedIngestionCalls = 0;
+
+      final handler = MemoryPressureHandler(
+        clearImageCache: () => clearImageCacheCalls++,
+        shedIngestion: () => shedIngestionCalls++,
+      );
+
+      handler.onMemoryPressure();
+
+      expect(clearImageCacheCalls, equals(1));
+      expect(shedIngestionCalls, equals(1));
+    });
+  });
+}

--- a/mobile/test/services/memory_telemetry_service_test.dart
+++ b/mobile/test/services/memory_telemetry_service_test.dart
@@ -1,0 +1,98 @@
+// ABOUTME: Tests MemoryTelemetryService RSS/peak sampling and snapshot assembly
+// ABOUTME: Drives sampleOnce() with injected gauges and asserts the emitted data
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/memory_telemetry_service.dart';
+
+void main() {
+  group(MemoryTelemetryService, () {
+    late List<MemorySnapshot> emitted;
+
+    setUp(() {
+      emitted = <MemorySnapshot>[];
+    });
+
+    MemoryTelemetryService build({
+      required int Function() readRssBytes,
+      int Function() nativeControllerCount = _zero,
+      int Function() fvpControllerCount = _zero,
+      int Function() queueDepth = _zero,
+      Duration interval = const Duration(seconds: 30),
+    }) {
+      return MemoryTelemetryService(
+        readRssBytes: readRssBytes,
+        nativeControllerCount: nativeControllerCount,
+        fvpControllerCount: fvpControllerCount,
+        queueDepth: queueDepth,
+        emit: emitted.add,
+        interval: interval,
+      );
+    }
+
+    test('peakRssBytes holds the max across rising then falling rss', () {
+      final readings = [100, 300, 200];
+      var index = 0;
+      final service = build(readRssBytes: () => readings[index++]);
+
+      service
+        ..sampleOnce()
+        ..sampleOnce()
+        ..sampleOnce();
+
+      expect(emitted.map((s) => s.rssBytes), equals([100, 300, 200]));
+      expect(emitted.map((s) => s.peakRssBytes), equals([100, 300, 300]));
+    });
+
+    test('snapshot carries the injected controller and queue gauges', () {
+      final service = build(
+        readRssBytes: () => 4242,
+        nativeControllerCount: () => 3,
+        fvpControllerCount: () => 5,
+        queueDepth: () => 7,
+      );
+
+      service.sampleOnce();
+
+      expect(emitted, hasLength(1));
+      final snapshot = emitted.single;
+      expect(snapshot.rssBytes, equals(4242));
+      expect(snapshot.peakRssBytes, equals(4242));
+      expect(snapshot.nativeControllers, equals(3));
+      expect(snapshot.fvpControllers, equals(5));
+      expect(snapshot.queueDepth, equals(7));
+    });
+
+    test('start samples periodically on the interval', () {
+      fakeAsync((async) {
+        var rss = 10;
+        // Default interval is 30s.
+        final service = build(readRssBytes: () => rss++)..start();
+
+        async.elapse(const Duration(seconds: 90));
+        service.stop();
+
+        expect(emitted, hasLength(3));
+      });
+    });
+
+    test('stop is idempotent and halts sampling', () {
+      fakeAsync((async) {
+        // Default interval is 30s.
+        final service = build(readRssBytes: () => 1)..start();
+
+        async.elapse(const Duration(seconds: 30));
+        expect(emitted, hasLength(1));
+
+        service
+          ..stop()
+          ..stop();
+
+        async.elapse(const Duration(seconds: 90));
+        expect(emitted, hasLength(1));
+      });
+    });
+  });
+}
+
+int _zero() => 0;

--- a/mobile/test/services/video_event_service_with_event_router_test.dart
+++ b/mobile/test/services/video_event_service_with_event_router_test.dart
@@ -111,6 +111,10 @@ void main() {
       }
     });
 
+    test('exposes the injected EventRouter via eventRouter getter', () {
+      expect(videoEventService.eventRouter, same(eventRouter));
+    });
+
     test('Video events (kind 34236) are cached to NostrEvents table', () async {
       // Create test video event
       final videoEvent = Event(


### PR DESCRIPTION
Closes #5905

Part of the 1.0.15 OOM incident response (Phase 1 of the gate-approved OOM plan). Independent of the cipher-migration fix (#5903) — separate concern, separate PR.

## Why
Crash telemetry shows 1.0.15 resident memory climbing to **2.8–10.2 GB** on 4–8 GB phones, but the app has **no in-app memory / controller / queue instrumentation** — so field logs (and the user log that opened this investigation) show only *symptoms* (`SqliteException(779)` retry storms), never the *cause* (what's eating the memory). This PR makes the next release self-diagnosing and adds a load-shedding mitigation.

## Instrumentation (always-on gauges)
- **`EventRouter.queuedLength`** — ingestion backlog; a growing value means ingestion is outrunning the background-isolate persistence.
- **`DivineVideoPlayerController.liveControllerCount`** — the native (feed) video stack, hard-bounded to ≤3.
- **`fvpLiveControllerCount`** — the official `video_player` (comments / individual-video) stack, currently **uncapped**. Splitting the two gauges is deliberate: a crash report will show *which* stack is accumulating.
- **`MemoryTelemetryService`** — periodic RSS + running-peak sampler (`ProcessInfo.currentRss`, `0` on web) that logs at info **and** sets Crashlytics custom keys `mem_rss_mb`, `mem_peak_mb`, `vc_native`, `vc_fvp`, `ingest_queue_depth`, so every subsequent crash carries the last-seen footprint.

## Partial mitigation
- `WidgetsBindingObserver.didHaveMemoryPressure` → **`MemoryPressureHandler`** clears the image cache (`imageCache..clear()..clearLiveImages()`) and calls **`EventRouter.shedLowPriority()`**, which drops the background + normal ingestion queues (**never** the visible queue) under OS memory pressure. All actions are injected callbacks; the services are Flutter-free and fully unit-tested.

## What this does NOT do
No bounding of controllers or queues yet — that's **Phase 2**, which this telemetry exists to target with real numbers (which stack dominates the 10 GB, and the steady-state queue depth to tune the bound to). No runtime behavior change beyond the gauges and the pressure handler.

## Tests / verification
- New `MemoryTelemetryService` + `MemoryPressureHandler` with same-named tests (untested-services floor check passes — no baseline change needed).
- `EventRouter` (`queuedLength`, `shedLowPriority` preserves the visible queue + carries the `_disposed` guard, `droppedEventCount`), both controller gauges, and the FVP inc/dec (rise-on-read, fall-on-dispose) all have tests.
- `flutter analyze lib test` clean; app-layer scoped suites green (21); `divine_video_player` package green (247).
- `individual_video_providers.g.dart` regenerated (provider hash only) since instrumentation was added inside the `@riverpod` function body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)