### PR TITLE
fix(oom): instrument + bound the 1.0.15 feed-video and ingestion memory sources

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -63,6 +63,8 @@ import 'package:openvine/providers/db_cipher_key_provider.dart';
 import 'package:openvine/providers/deep_link_provider.dart';
 import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/foreground_idle_warmup_provider.dart';
+import 'package:openvine/providers/individual_video_providers.dart'
+    show fvpLiveControllerCount;
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/service_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
@@ -86,6 +88,8 @@ import 'package:openvine/services/database_encryption_bootstrap.dart';
 import 'package:openvine/services/deep_link_service.dart';
 import 'package:openvine/services/firebase_initialization.dart';
 import 'package:openvine/services/locale_preference_service.dart';
+import 'package:openvine/services/memory_pressure_handler.dart';
+import 'package:openvine/services/memory_telemetry_service.dart';
 import 'package:openvine/services/mention_resolution_service.dart';
 import 'package:openvine/services/nip98_auth_service.dart' show HttpMethod;
 import 'package:openvine/services/notification_helpers.dart'
@@ -1581,16 +1585,39 @@ class DivineApp extends ConsumerStatefulWidget {
   ConsumerState<DivineApp> createState() => _DivineAppState();
 }
 
-class _DivineAppState extends ConsumerState<DivineApp> {
+class _DivineAppState extends ConsumerState<DivineApp>
+    with WidgetsBindingObserver {
   bool _backgroundInitDone = false;
   StreamSubscription<void>? _shakeSubscription;
   StreamSubscription<NotificationTapEvent>? _notificationTapSubscription;
   QuickActionsCoordinator? _quickActionsCoordinator;
   late final StartupSplashReleaseController _splashReleaseController;
+  late final MemoryPressureHandler _memoryPressureHandler;
+  late final MemoryTelemetryService _memoryTelemetry;
 
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    _memoryPressureHandler = MemoryPressureHandler(
+      clearImageCache: () {
+        PaintingBinding.instance.imageCache
+          ..clear()
+          ..clearLiveImages();
+      },
+      shedIngestion: () {
+        ref.read(videoEventServiceProvider).eventRouter?.shedLowPriority();
+      },
+    );
+    _memoryTelemetry = MemoryTelemetryService(
+      readRssBytes: () => kIsWeb ? 0 : io.ProcessInfo.currentRss,
+      nativeControllerCount: () =>
+          DivineVideoPlayerController.liveControllerCount,
+      fvpControllerCount: () => fvpLiveControllerCount,
+      queueDepth: () =>
+          ref.read(videoEventServiceProvider).eventRouter?.queuedLength ?? 0,
+      emit: _emitMemorySnapshot,
+    );
     // Subscribe before deferred startup settles auth; routerDelegate reliably
     // notifies after redirect configuration changes (#5242).
     final router = ref.read(goRouterProvider);
@@ -1616,17 +1643,51 @@ class _DivineAppState extends ConsumerState<DivineApp> {
         _initializeDeepLinkServices();
         _initializeQuickActions();
         _initializeBackgroundServices();
+        _memoryTelemetry.start();
       }
     });
   }
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    _memoryTelemetry.stop();
     _splashReleaseController.dispose();
     _notificationTapSubscription?.cancel();
     unawaited(_quickActionsCoordinator?.dispose());
     _shakeSubscription?.cancel();
     super.dispose();
+  }
+
+  @override
+  void didHaveMemoryPressure() {
+    _memoryPressureHandler.onMemoryPressure();
+  }
+
+  /// Logs a memory snapshot at info and annotates Crashlytics custom keys so
+  /// OOM crash reports carry the last-seen memory footprint and gauges.
+  void _emitMemorySnapshot(MemorySnapshot snapshot) {
+    const bytesPerMb = 1024 * 1024;
+    final rssMb = (snapshot.rssBytes / bytesPerMb).toStringAsFixed(1);
+    final peakMb = (snapshot.peakRssBytes / bytesPerMb).toStringAsFixed(1);
+    Log.info(
+      'Memory: rss $rssMb MB (peak $peakMb MB), '
+      'vc_native=${snapshot.nativeControllers}, '
+      'vc_fvp=${snapshot.fvpControllers}, '
+      'ingest_queue_depth=${snapshot.queueDepth}',
+      name: 'MemoryTelemetry',
+      category: LogCategory.system,
+    );
+    final crashReporting = CrashReportingService.instance;
+    unawaited(crashReporting.setCustomKey('mem_rss_mb', rssMb));
+    unawaited(crashReporting.setCustomKey('mem_peak_mb', peakMb));
+    unawaited(
+      crashReporting.setCustomKey('vc_native', snapshot.nativeControllers),
+    );
+    unawaited(crashReporting.setCustomKey('vc_fvp', snapshot.fvpControllers));
+    unawaited(
+      crashReporting.setCustomKey('ingest_queue_depth', snapshot.queueDepth),
+    );
   }
 
   void _initializeDeepLinkServices() {

--- a/mobile/lib/providers/individual_video_providers.dart
+++ b/mobile/lib/providers/individual_video_providers.dart
@@ -298,14 +298,65 @@ class VideoLoadingState {
       'VideoLoadingState(videoId: $videoId, isLoading: $isLoading, isInitialized: $isInitialized, hasError: $hasError, errorMessage: $errorMessage)';
 }
 
-int _fvpLiveControllers = 0;
+/// Hard cap on the number of concurrent `video_player`/FVP controllers held
+/// live by [individualVideoControllerProvider].
+///
+/// Each live controller holds a native player and its decode buffers (4K =
+/// ~25MB/frame), so an unbounded population is the Phase-2 OOM source. When the
+/// cap is reached a new controller evicts the least-recently-used *idle*
+/// controller; an on-screen (actively-listened) controller is never evicted.
+const kMaxFvpControllers = 8;
+
+/// Registry entry tracking a live controller's keep-alive link and whether it
+/// currently has an active listener (i.e. is on-screen).
+class _FvpEntry {
+  _FvpEntry(this.close, {required this.hasListener});
+
+  /// Closes the provider's keep-alive link, triggering its `onDispose`.
+  final void Function() close;
+
+  /// True while a listener is attached (on-screen); such entries are never
+  /// evicted to make room for a new controller.
+  bool hasListener;
+}
+
+/// Insertion-ordered registry of live controllers keyed by `videoId`.
+///
+/// A plain `Map` literal is a `LinkedHashMap`, so iteration order is insertion
+/// order — the first idle entry encountered is the least-recently-used one.
+final _fvpControllerRegistry = <String, _FvpEntry>{};
 
 /// Number of `video_player`/FVP controllers currently held live by
 /// [individualVideoControllerProvider].
 ///
 /// Exposed as an always-on gauge for memory instrumentation; each live
 /// controller holds a native player and its decode buffers.
-int get fvpLiveControllerCount => _fvpLiveControllers;
+int get fvpLiveControllerCount => _fvpControllerRegistry.length;
+
+/// Evicts the least-recently-used idle controller(s) until there is room for a
+/// new one within [kMaxFvpControllers].
+///
+/// Only entries with `hasListener == false` are candidates; if every live
+/// controller is on-screen a transient overage is allowed rather than killing a
+/// visible player. Eviction removes the entry synchronously (so the gauge and
+/// subsequent size checks are accurate) and closes its keep-alive link, which
+/// tears the controller down on a microtask via the provider's `onDispose`.
+void _evictIdleFvpControllersIfNeeded() {
+  while (_fvpControllerRegistry.length >= kMaxFvpControllers) {
+    String? oldestIdleId;
+    for (final entry in _fvpControllerRegistry.entries) {
+      if (!entry.value.hasListener) {
+        oldestIdleId = entry.key;
+        break;
+      }
+    }
+    if (oldestIdleId == null) {
+      // All live controllers are on-screen; allow the transient overage.
+      break;
+    }
+    _fvpControllerRegistry.remove(oldestIdleId)?.close();
+  }
+}
 
 /// Provider for individual video controllers with autoDispose
 /// Each video gets its own controller instance
@@ -320,9 +371,16 @@ VideoPlayerController individualVideoController(
   final link = ref.keepAlive();
   Timer? cacheTimer;
 
+  // Track this controller in the global registry so the population stays
+  // bounded (see [kMaxFvpControllers]). Assume it is on-screen until onCancel
+  // reports the last listener has gone.
+  final entry = _FvpEntry(link.close, hasListener: true);
+
   // Riverpod lifecycle hooks for idiomatic cache behavior
   ref.onCancel(() {
-    // Last listener removed - start cache timeout before disposal
+    // Last listener removed - now idle and eligible for LRU eviction.
+    entry.hasListener = false;
+    // Start cache timeout before disposal.
     // Android uses shorter timeout (3s) to prevent MediaCodec accumulation crash
     // iOS/desktop use longer timeout (15s) for smoother scroll-back experience
     // Short timeout prevents OOM with high-resolution videos (4K = ~25MB/frame)
@@ -333,9 +391,19 @@ VideoPlayerController individualVideoController(
   });
 
   ref.onResume(() {
-    // New listener added - cancel the disposal timer
+    // New listener added - cancel the disposal timer and mark on-screen again.
     cacheTimer?.cancel();
+    entry.hasListener = true;
+    // Move to newest so LRU ordering reflects recency.
+    if (identical(_fvpControllerRegistry[params.videoId], entry)) {
+      _fvpControllerRegistry.remove(params.videoId);
+      _fvpControllerRegistry[params.videoId] = entry;
+    }
   });
+
+  // Make room within the cap before registering this controller, then register.
+  _evictIdleFvpControllersIfNeeded();
+  _fvpControllerRegistry[params.videoId] = entry;
 
   // Clear the disposed flag for this video since we are creating a fresh
   // controller (handles retries and scroll-back scenarios).
@@ -480,10 +548,6 @@ VideoPlayerController individualVideoController(
       ? const Duration(seconds: 60)
       : const Duration(seconds: 30);
   final formatType = isHls ? 'HLS' : 'MP4';
-
-  // Count this controller as live for memory instrumentation. Decremented
-  // exactly once in the provider's onDispose below.
-  _fvpLiveControllers++;
 
   // Track significant video state changes only (initialization, errors, buffering)
   // Previous state tracking to avoid logging every frame update
@@ -991,9 +1055,12 @@ VideoPlayerController individualVideoController(
   // AutoDispose: Cleanup controller when provider is disposed
   ref.onDispose(() {
     cacheTimer?.cancel();
-    // Decrement the live-controller gauge once per provider disposal, before
-    // the deferred native dispose runs in the microtask below.
-    _fvpLiveControllers--;
+    // Drop this controller from the registry so the gauge and the cap reflect
+    // the live population. Identity-guarded so a deferred eviction of a stale
+    // entry can't remove a freshly-rebuilt controller for the same videoId.
+    if (identical(_fvpControllerRegistry[params.videoId], entry)) {
+      _fvpControllerRegistry.remove(params.videoId);
+    }
     Log.info(
       '🧹 Disposing VideoPlayerController for video ${params.videoId.length > 8 ? params.videoId : params.videoId}...',
       name: 'IndividualVideoController',
@@ -1014,10 +1081,12 @@ VideoPlayerController individualVideoController(
 
     // Defer controller disposal to avoid triggering listener callbacks during lifecycle
     // This prevents "Cannot use Ref inside life-cycles" errors when listeners try to access providers
-    Future.microtask(() {
-      // Only dispose if controller exists
+    // Pause before dispose so the native CADisplayLink stops firing frames
+    // into freed memory (FVPFrameUpdater EXC_BAD_ACCESS crash).
+    Future.microtask(() async {
       try {
-        controller.dispose();
+        await controller.pause();
+        await controller.dispose();
       } catch (e) {
         Log.warning(
           'Failed to dispose controller: $e',

--- a/mobile/lib/providers/individual_video_providers.dart
+++ b/mobile/lib/providers/individual_video_providers.dart
@@ -320,11 +320,13 @@ class _FvpEntry {
   bool hasListener;
 }
 
-/// Insertion-ordered registry of live controllers keyed by `videoId`.
+/// Insertion-ordered registry of live controllers keyed by provider params.
 ///
-/// A plain `Map` literal is a `LinkedHashMap`, so iteration order is insertion
-/// order — the first idle entry encountered is the least-recently-used one.
-final _fvpControllerRegistry = <String, _FvpEntry>{};
+/// [VideoControllerParams] is the Riverpod family key; using the same key keeps
+/// alternate playback URLs for a video visible to the cap. A plain `Map` literal
+/// is a `LinkedHashMap`, so iteration order is insertion order — the first idle
+/// entry encountered is the least-recently-used one.
+final _fvpControllerRegistry = <VideoControllerParams, _FvpEntry>{};
 
 /// Number of `video_player`/FVP controllers currently held live by
 /// [individualVideoControllerProvider].
@@ -343,18 +345,18 @@ int get fvpLiveControllerCount => _fvpControllerRegistry.length;
 /// tears the controller down on a microtask via the provider's `onDispose`.
 void _evictIdleFvpControllersIfNeeded() {
   while (_fvpControllerRegistry.length >= kMaxFvpControllers) {
-    String? oldestIdleId;
+    VideoControllerParams? oldestIdleParams;
     for (final entry in _fvpControllerRegistry.entries) {
       if (!entry.value.hasListener) {
-        oldestIdleId = entry.key;
+        oldestIdleParams = entry.key;
         break;
       }
     }
-    if (oldestIdleId == null) {
+    if (oldestIdleParams == null) {
       // All live controllers are on-screen; allow the transient overage.
       break;
     }
-    _fvpControllerRegistry.remove(oldestIdleId)?.close();
+    _fvpControllerRegistry.remove(oldestIdleParams)?.close();
   }
 }
 
@@ -395,15 +397,15 @@ VideoPlayerController individualVideoController(
     cacheTimer?.cancel();
     entry.hasListener = true;
     // Move to newest so LRU ordering reflects recency.
-    if (identical(_fvpControllerRegistry[params.videoId], entry)) {
-      _fvpControllerRegistry.remove(params.videoId);
-      _fvpControllerRegistry[params.videoId] = entry;
+    if (identical(_fvpControllerRegistry[params], entry)) {
+      _fvpControllerRegistry.remove(params);
+      _fvpControllerRegistry[params] = entry;
     }
   });
 
   // Make room within the cap before registering this controller, then register.
   _evictIdleFvpControllersIfNeeded();
-  _fvpControllerRegistry[params.videoId] = entry;
+  _fvpControllerRegistry[params] = entry;
 
   // Clear the disposed flag for this video since we are creating a fresh
   // controller (handles retries and scroll-back scenarios).
@@ -1057,9 +1059,9 @@ VideoPlayerController individualVideoController(
     cacheTimer?.cancel();
     // Drop this controller from the registry so the gauge and the cap reflect
     // the live population. Identity-guarded so a deferred eviction of a stale
-    // entry can't remove a freshly-rebuilt controller for the same videoId.
-    if (identical(_fvpControllerRegistry[params.videoId], entry)) {
-      _fvpControllerRegistry.remove(params.videoId);
+    // entry can't remove a freshly-rebuilt controller for the same params.
+    if (identical(_fvpControllerRegistry[params], entry)) {
+      _fvpControllerRegistry.remove(params);
     }
     Log.info(
       '🧹 Disposing VideoPlayerController for video ${params.videoId.length > 8 ? params.videoId : params.videoId}...',
@@ -1086,6 +1088,14 @@ VideoPlayerController individualVideoController(
     Future.microtask(() async {
       try {
         await controller.pause();
+      } catch (e) {
+        Log.warning(
+          'Failed to pause controller before dispose: $e',
+          name: 'IndividualVideoController',
+          category: LogCategory.system,
+        );
+      }
+      try {
         await controller.dispose();
       } catch (e) {
         Log.warning(

--- a/mobile/lib/providers/individual_video_providers.dart
+++ b/mobile/lib/providers/individual_video_providers.dart
@@ -298,6 +298,15 @@ class VideoLoadingState {
       'VideoLoadingState(videoId: $videoId, isLoading: $isLoading, isInitialized: $isInitialized, hasError: $hasError, errorMessage: $errorMessage)';
 }
 
+int _fvpLiveControllers = 0;
+
+/// Number of `video_player`/FVP controllers currently held live by
+/// [individualVideoControllerProvider].
+///
+/// Exposed as an always-on gauge for memory instrumentation; each live
+/// controller holds a native player and its decode buffers.
+int get fvpLiveControllerCount => _fvpLiveControllers;
+
 /// Provider for individual video controllers with autoDispose
 /// Each video gets its own controller instance
 @riverpod
@@ -471,6 +480,10 @@ VideoPlayerController individualVideoController(
       ? const Duration(seconds: 60)
       : const Duration(seconds: 30);
   final formatType = isHls ? 'HLS' : 'MP4';
+
+  // Count this controller as live for memory instrumentation. Decremented
+  // exactly once in the provider's onDispose below.
+  _fvpLiveControllers++;
 
   // Track significant video state changes only (initialization, errors, buffering)
   // Previous state tracking to avoid logging every frame update
@@ -978,6 +991,9 @@ VideoPlayerController individualVideoController(
   // AutoDispose: Cleanup controller when provider is disposed
   ref.onDispose(() {
     cacheTimer?.cancel();
+    // Decrement the live-controller gauge once per provider disposal, before
+    // the deferred native dispose runs in the microtask below.
+    _fvpLiveControllers--;
     Log.info(
       '🧹 Disposing VideoPlayerController for video ${params.videoId.length > 8 ? params.videoId : params.videoId}...',
       name: 'IndividualVideoController',

--- a/mobile/lib/providers/individual_video_providers.g.dart
+++ b/mobile/lib/providers/individual_video_providers.g.dart
@@ -81,7 +81,7 @@ final class IndividualVideoControllerProvider
 }
 
 String _$individualVideoControllerHash() =>
-    r'2e6638de2c0898dbda50424e7c2df4f0e0fa81d1';
+    r'35d2f0e22862ca3bcb02e34ad2269b63b1418750';
 
 /// Provider for individual video controllers with autoDispose
 /// Each video gets its own controller instance

--- a/mobile/lib/providers/individual_video_providers.g.dart
+++ b/mobile/lib/providers/individual_video_providers.g.dart
@@ -81,7 +81,7 @@ final class IndividualVideoControllerProvider
 }
 
 String _$individualVideoControllerHash() =>
-    r'35d2f0e22862ca3bcb02e34ad2269b63b1418750';
+    r'41171da0921a39bcedec61fca58d98b37e4879b0';
 
 /// Provider for individual video controllers with autoDispose
 /// Each video gets its own controller instance

--- a/mobile/lib/providers/individual_video_providers.g.dart
+++ b/mobile/lib/providers/individual_video_providers.g.dart
@@ -81,7 +81,7 @@ final class IndividualVideoControllerProvider
 }
 
 String _$individualVideoControllerHash() =>
-    r'7ff310a3be6c3dc95425400a49b29ad9a0fa207c';
+    r'2e6638de2c0898dbda50424e7c2df4f0e0fa81d1';
 
 /// Provider for individual video controllers with autoDispose
 /// Each video gets its own controller instance

--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -128,7 +128,13 @@ VideoEventService videoEventService(Ref ref) {
   final profileRepository = ref.watch(profileRepositoryProvider);
   final videoFilterBuilder = ref.watch(videoFilterBuilderProvider);
   final db = ref.watch(databaseProvider);
-  final eventRouter = EventRouter(db);
+  // Bound the ingestion backlog so a burst of relay events can't grow the
+  // queues without limit (a Phase-2 OOM source). 2000 sits well above
+  // steady-state depth; tune from the Phase-1 `ingest_queue_depth` telemetry.
+  final eventRouter = EventRouter(
+    db,
+    config: const EventRouterConfig(maxQueueDepth: 2000),
+  );
   ref.onDispose(eventRouter.dispose);
 
   final likesRepository = ref.watch(likesRepositoryProvider);

--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -49,6 +49,8 @@ import 'package:videos_repository/videos_repository.dart';
 
 part 'video_providers.g.dart';
 
+const _maxEventRouterQueueDepth = 2000;
+
 /// Video filter builder for constructing relay-aware filters with server-side sorting
 @riverpod
 VideoFilterBuilder videoFilterBuilder(Ref ref) {
@@ -133,7 +135,7 @@ VideoEventService videoEventService(Ref ref) {
   // steady-state depth; tune from the Phase-1 `ingest_queue_depth` telemetry.
   final eventRouter = EventRouter(
     db,
-    config: const EventRouterConfig(maxQueueDepth: 2000),
+    config: const EventRouterConfig(maxQueueDepth: _maxEventRouterQueueDepth),
   );
   ref.onDispose(eventRouter.dispose);
 

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -269,7 +269,7 @@ final class VideoEventServiceProvider
   }
 }
 
-String _$videoEventServiceHash() => r'ec5d5dc866e6ad30a269785c57dda8abc0ffa655';
+String _$videoEventServiceHash() => r'fc7641c67bd08d04d656a7e69ef9668ff5beaee2';
 
 /// Video event publisher for publishing video events to Nostr relays
 

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -269,7 +269,7 @@ final class VideoEventServiceProvider
   }
 }
 
-String _$videoEventServiceHash() => r'9795e17f42ef25c2af8e036b10ca4e043babf179';
+String _$videoEventServiceHash() => r'ec5d5dc866e6ad30a269785c57dda8abc0ffa655';
 
 /// Video event publisher for publishing video events to Nostr relays
 

--- a/mobile/lib/screens/comments/widgets/video_comment_player.dart
+++ b/mobile/lib/screens/comments/widgets/video_comment_player.dart
@@ -60,8 +60,12 @@ class _VideoCommentPlayerState extends State<VideoCommentPlayer>
     _controller = null;
     controller?.removeListener(_syncPlaybackState);
     unawaited(() async {
-      await controller?.pause();
-      await controller?.dispose();
+      try {
+        await controller?.pause();
+      } catch (_) {}
+      try {
+        await controller?.dispose();
+      } catch (_) {}
     }());
     super.dispose();
   }
@@ -177,10 +181,7 @@ class _VideoCommentPlayerState extends State<VideoCommentPlayer>
                   Positioned(
                     right: 8,
                     bottom: 8,
-                    child: _MuteButton(
-                      isMuted: _isMuted,
-                      onTap: _toggleMute,
-                    ),
+                    child: _MuteButton(isMuted: _isMuted, onTap: _toggleMute),
                   ),
                 if (widget.onOpenVideo != null)
                   Positioned(
@@ -200,10 +201,7 @@ class _VideoCommentPlayerState extends State<VideoCommentPlayer>
       return player;
     }
 
-    return ClipRRect(
-      borderRadius: borderRadius,
-      child: player,
-    );
+    return ClipRRect(borderRadius: borderRadius, child: player);
   }
 }
 

--- a/mobile/lib/screens/comments/widgets/video_comment_player.dart
+++ b/mobile/lib/screens/comments/widgets/video_comment_player.dart
@@ -1,12 +1,19 @@
 // ABOUTME: Inline video attachment player for video comments.
 // ABOUTME: Starts from thumbnail and plays the attached NIP-92 video in-place.
 
+import 'dart:async';
+
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
 import 'package:video_player/video_player.dart';
 import 'package:visibility_detector/visibility_detector.dart';
+
+/// Builds a [VideoPlayerController] for the given [url].
+///
+/// Injectable so tests can supply a fake/recording controller.
+typedef VideoControllerFactory = VideoPlayerController Function(Uri url);
 
 class VideoCommentPlayer extends StatefulWidget {
   const VideoCommentPlayer({
@@ -15,6 +22,7 @@ class VideoCommentPlayer extends StatefulWidget {
     this.blurhash,
     this.borderRadius,
     this.onOpenVideo,
+    this.controllerFactory = VideoPlayerController.networkUrl,
     super.key,
   });
 
@@ -23,21 +31,49 @@ class VideoCommentPlayer extends StatefulWidget {
   final String? blurhash;
   final BorderRadiusGeometry? borderRadius;
   final VoidCallback? onOpenVideo;
+  final VideoControllerFactory controllerFactory;
 
   @override
   State<VideoCommentPlayer> createState() => _VideoCommentPlayerState();
 }
 
-class _VideoCommentPlayerState extends State<VideoCommentPlayer> {
+class _VideoCommentPlayerState extends State<VideoCommentPlayer>
+    with WidgetsBindingObserver {
   VideoPlayerController? _controller;
   bool _isInitializing = false;
   bool _isPlaying = false;
   bool _isMuted = true;
 
   @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
   void dispose() {
-    _controller?.dispose();
+    WidgetsBinding.instance.removeObserver(this);
+    // Pause before dispose so the native CADisplayLink stops firing frames
+    // into freed memory (FVPFrameUpdater EXC_BAD_ACCESS crash). State.dispose
+    // can't await, so hand the teardown to an async closure.
+    final controller = _controller;
+    _controller = null;
+    controller?.removeListener(_syncPlaybackState);
+    unawaited(() async {
+      await controller?.pause();
+      await controller?.dispose();
+    }());
     super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    // All crash samples are processState=BACKGROUND: stop playback the moment
+    // the app is backgrounded so no frame lands after the view is torn down.
+    if (state == AppLifecycleState.paused ||
+        state == AppLifecycleState.hidden) {
+      _controller?.pause();
+    }
   }
 
   Future<void> _togglePlay() async {
@@ -45,15 +81,15 @@ class _VideoCommentPlayerState extends State<VideoCommentPlayer> {
 
     if (_controller == null) {
       setState(() => _isInitializing = true);
-      final controller = VideoPlayerController.networkUrl(
-        Uri.parse(widget.videoUrl),
-      );
+      final controller = widget.controllerFactory(Uri.parse(widget.videoUrl));
       try {
         await controller.initialize();
         await controller.setLooping(true);
         await controller.setVolume(0);
         controller.addListener(_syncPlaybackState);
         if (!mounted) {
+          controller.removeListener(_syncPlaybackState);
+          await controller.pause();
           await controller.dispose();
           return;
         }

--- a/mobile/lib/screens/comments/widgets/video_comment_player.dart
+++ b/mobile/lib/screens/comments/widgets/video_comment_player.dart
@@ -7,6 +7,7 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
+import 'package:unified_logger/unified_logger.dart';
 import 'package:video_player/video_player.dart';
 import 'package:visibility_detector/visibility_detector.dart';
 
@@ -62,10 +63,22 @@ class _VideoCommentPlayerState extends State<VideoCommentPlayer>
     unawaited(() async {
       try {
         await controller?.pause();
-      } catch (_) {}
+      } catch (e) {
+        Log.warning(
+          'Failed to pause comment video before dispose: $e',
+          name: 'VideoCommentPlayer',
+          category: LogCategory.video,
+        );
+      }
       try {
         await controller?.dispose();
-      } catch (_) {}
+      } catch (e) {
+        Log.warning(
+          'Failed to dispose comment video controller: $e',
+          name: 'VideoCommentPlayer',
+          category: LogCategory.video,
+        );
+      }
     }());
     super.dispose();
   }

--- a/mobile/lib/services/event_router.dart
+++ b/mobile/lib/services/event_router.dart
@@ -20,11 +20,20 @@ class EventRouterConfig {
     this.flushDelay = const Duration(milliseconds: 50),
     this.maxBatchSize = eventRouterBatchFlushThreshold,
     this.autoStart = true,
+    this.maxQueueDepth,
   });
 
   final Duration flushDelay;
   final int maxBatchSize;
   final bool autoStart;
+
+  /// Hard cap on the total number of queued events across all priorities.
+  ///
+  /// When null (the default) the queues are unbounded — every existing caller
+  /// is unaffected. When set, [EventRouter.handleEvent] drops the oldest
+  /// low-priority events (background, then normal, then visible only if it
+  /// alone exceeds the cap) once the total exceeds this depth.
+  final int? maxQueueDepth;
 }
 
 typedef EventRouterYield = Future<void> Function();
@@ -66,8 +75,42 @@ class EventRouter {
     // not re-arm a drain that would run SQLite against a closed connection.
     if (_disposed) return;
     _queueFor(priority).add(event);
+    _enforceQueueBound();
     if (_config.autoStart) {
       _scheduleProcessing(immediate: _queuedLength >= _config.maxBatchSize);
+    }
+  }
+
+  /// Drops the oldest low-priority events until the total queued count is back
+  /// within [EventRouterConfig.maxQueueDepth]. No-op when the cap is null.
+  ///
+  /// Background is shed first, then normal; visible is only dropped when it
+  /// alone exceeds the cap, so the on-screen feed keeps persisting.
+  void _enforceQueueBound() {
+    final maxQueueDepth = _config.maxQueueDepth;
+    if (maxQueueDepth == null) return;
+
+    var dropped = 0;
+    while (_queuedLength > maxQueueDepth) {
+      final Queue<Event> queue;
+      if (_backgroundQueue.isNotEmpty) {
+        queue = _backgroundQueue;
+      } else if (_normalQueue.isNotEmpty) {
+        queue = _normalQueue;
+      } else {
+        queue = _visibleQueue;
+      }
+      queue.removeFirst();
+      dropped++;
+    }
+
+    if (dropped > 0) {
+      _droppedEventCount += dropped;
+      Log.warning(
+        'Dropped $dropped events to bound ingestion queue at $maxQueueDepth',
+        name: 'EventRouter',
+        category: LogCategory.system,
+      );
     }
   }
 

--- a/mobile/lib/services/event_router.dart
+++ b/mobile/lib/services/event_router.dart
@@ -13,11 +13,7 @@ import 'package:unified_logger/unified_logger.dart';
 
 const eventRouterBatchFlushThreshold = 50;
 
-enum EventIngestionPriority {
-  visible,
-  normal,
-  background,
-}
+enum EventIngestionPriority { visible, normal, background }
 
 class EventRouterConfig {
   const EventRouterConfig({
@@ -88,6 +84,41 @@ class EventRouter {
 
   int get _queuedLength =>
       _visibleQueue.length + _normalQueue.length + _backgroundQueue.length;
+
+  /// Total number of events currently queued across all priorities.
+  ///
+  /// Exposed as an always-on gauge for memory instrumentation; a growing
+  /// value points at ingestion outrunning persistence.
+  int get queuedLength => _queuedLength;
+
+  int _droppedEventCount = 0;
+
+  /// Number of events dropped by [shedLowPriority] over this router's
+  /// lifetime.
+  int get droppedEventCount => _droppedEventCount;
+
+  /// Drops all queued background- and normal-priority events, preserving the
+  /// visible queue so the on-screen feed still persists.
+  ///
+  /// Called under memory pressure to shed ingestion backlog. Returns the
+  /// number of events dropped.
+  int shedLowPriority() {
+    // Mirror [handleEvent]'s guard: after dispose the queues are cleared and
+    // the database may be closing, so there is nothing to shed.
+    if (_disposed) return 0;
+    final dropped = _backgroundQueue.length + _normalQueue.length;
+    _backgroundQueue.clear();
+    _normalQueue.clear();
+    _droppedEventCount += dropped;
+    if (dropped > 0) {
+      Log.info(
+        'Shed $dropped low-priority events under memory pressure',
+        name: 'EventRouter',
+        category: LogCategory.system,
+      );
+    }
+    return dropped;
+  }
 
   void _scheduleProcessing({bool immediate = false}) {
     if (_disposed || _isProcessingBatch) return;

--- a/mobile/lib/services/memory_pressure_handler.dart
+++ b/mobile/lib/services/memory_pressure_handler.dart
@@ -1,0 +1,25 @@
+// ABOUTME: Fans a memory-pressure signal out to load-shedding actions
+// ABOUTME: Clears the image cache and sheds low-priority ingestion backlog
+
+/// Coordinates the app's response to an OS memory-pressure signal.
+///
+/// Both actions are injected so the handler stays free of Flutter and service
+/// dependencies and is trivially testable. Production wiring supplies an image
+/// cache clear and an [EventRouter]-backed ingestion shed.
+class MemoryPressureHandler {
+  MemoryPressureHandler({
+    required void Function() clearImageCache,
+    required void Function() shedIngestion,
+  }) : _clearImageCache = clearImageCache,
+       _shedIngestion = shedIngestion;
+
+  final void Function() _clearImageCache;
+  final void Function() _shedIngestion;
+
+  /// Sheds load in response to memory pressure by clearing the image cache
+  /// and dropping low-priority ingestion backlog.
+  void onMemoryPressure() {
+    _clearImageCache();
+    _shedIngestion();
+  }
+}

--- a/mobile/lib/services/memory_telemetry_service.dart
+++ b/mobile/lib/services/memory_telemetry_service.dart
@@ -1,0 +1,95 @@
+// ABOUTME: Always-on memory gauge sampler (RSS + peak) for OOM instrumentation
+// ABOUTME: Reads injected gauges on an interval and emits a MemorySnapshot
+
+import 'dart:async';
+import 'dart:math' as math;
+
+/// An immutable point-in-time reading of the app's memory-relevant gauges.
+class MemorySnapshot {
+  const MemorySnapshot({
+    required this.rssBytes,
+    required this.peakRssBytes,
+    required this.nativeControllers,
+    required this.fvpControllers,
+    required this.queueDepth,
+  });
+
+  /// Resident set size at sample time, in bytes.
+  final int rssBytes;
+
+  /// Highest [rssBytes] observed by the sampler so far, in bytes.
+  final int peakRssBytes;
+
+  /// Live `divine_video_player` native controllers.
+  final int nativeControllers;
+
+  /// Live `video_player`/FVP controllers.
+  final int fvpControllers;
+
+  /// Events queued for ingestion across all priorities.
+  final int queueDepth;
+
+  @override
+  String toString() =>
+      'MemorySnapshot(rssBytes: $rssBytes, peakRssBytes: $peakRssBytes, '
+      'nativeControllers: $nativeControllers, fvpControllers: $fvpControllers, '
+      'queueDepth: $queueDepth)';
+}
+
+/// Samples memory-relevant gauges and emits a [MemorySnapshot].
+///
+/// All inputs are injected as callbacks so the service stays Flutter-free and
+/// trivially testable. Production wiring supplies a `readRssBytes` backed by
+/// `ProcessInfo.currentRss` and an `emit` that logs and annotates Crashlytics.
+class MemoryTelemetryService {
+  MemoryTelemetryService({
+    required int Function() readRssBytes,
+    required int Function() nativeControllerCount,
+    required int Function() fvpControllerCount,
+    required int Function() queueDepth,
+    required void Function(MemorySnapshot) emit,
+    this.interval = const Duration(seconds: 30),
+  }) : _readRssBytes = readRssBytes,
+       _nativeControllerCount = nativeControllerCount,
+       _fvpControllerCount = fvpControllerCount,
+       _queueDepth = queueDepth,
+       _emit = emit;
+
+  final int Function() _readRssBytes;
+  final int Function() _nativeControllerCount;
+  final int Function() _fvpControllerCount;
+  final int Function() _queueDepth;
+  final void Function(MemorySnapshot) _emit;
+
+  /// How often [start] samples the gauges.
+  final Duration interval;
+
+  Timer? _timer;
+  int _peakRssBytes = 0;
+
+  /// Reads every gauge once, updates the running peak, and emits a snapshot.
+  void sampleOnce() {
+    final rss = _readRssBytes();
+    _peakRssBytes = math.max(_peakRssBytes, rss);
+    _emit(
+      MemorySnapshot(
+        rssBytes: rss,
+        peakRssBytes: _peakRssBytes,
+        nativeControllers: _nativeControllerCount(),
+        fvpControllers: _fvpControllerCount(),
+        queueDepth: _queueDepth(),
+      ),
+    );
+  }
+
+  /// Begins periodic sampling on [interval]. Safe to call after [stop].
+  void start() {
+    _timer ??= Timer.periodic(interval, (_) => sampleOnce());
+  }
+
+  /// Stops periodic sampling. Idempotent.
+  void stop() {
+    _timer?.cancel();
+    _timer = null;
+  }
+}

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -147,6 +147,13 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   late final RepostResolver _repostResolver;
   final ProfileRepository? _profileRepository;
   final EventRouter? _eventRouter;
+
+  /// The ingestion router backing this service, if one was injected.
+  ///
+  /// Exposed so app-level memory instrumentation can read its queue depth and
+  /// shed low-priority backlog under memory pressure.
+  EventRouter? get eventRouter => _eventRouter;
+
   final VideoFilterBuilder? _videoFilterBuilder;
   final PerformanceTraceMonitor _performanceMonitor;
   final ConnectionStatusService _connectionService;

--- a/mobile/lib/utils/platform_io_web.dart
+++ b/mobile/lib/utils/platform_io_web.dart
@@ -152,6 +152,12 @@ class ProcessResult {
   final dynamic stderr;
 }
 
+// ProcessInfo stub for web platform
+class ProcessInfo {
+  static int get currentRss => 0;
+  static int get maxRss => 0;
+}
+
 // HttpClient stub for web platform
 class HttpClient {
   Duration? connectionTimeout;

--- a/mobile/packages/divine_video_player/lib/src/divine_video_player_controller.dart
+++ b/mobile/packages/divine_video_player/lib/src/divine_video_player_controller.dart
@@ -213,6 +213,12 @@ class DivineVideoPlayerController {
   static final Set<DivineVideoPlayerController> _liveControllers =
       <DivineVideoPlayerController>{};
 
+  /// Number of controllers that have been initialized and not yet disposed.
+  ///
+  /// Exposed as an always-on gauge for memory instrumentation; each live
+  /// controller holds a native player and its buffers.
+  static int get liveControllerCount => _liveControllers.length;
+
   /// Disposes all native player instances that may still be alive.
   ///
   /// Call at app startup to clean up zombie players from a previous

--- a/mobile/packages/divine_video_player/test/src/divine_video_player_controller_test.dart
+++ b/mobile/packages/divine_video_player/test/src/divine_video_player_controller_test.dart
@@ -891,6 +891,22 @@ void main() {
       });
     });
 
+    group('liveControllerCount', () {
+      test('is zero after resetIdCounterForTesting', () {
+        expect(DivineVideoPlayerController.liveControllerCount, equals(0));
+      });
+
+      test('reflects live instances across initialize and dispose', () async {
+        expect(DivineVideoPlayerController.liveControllerCount, equals(0));
+
+        await initController();
+        expect(DivineVideoPlayerController.liveControllerCount, equals(1));
+
+        await controller.dispose();
+        expect(DivineVideoPlayerController.liveControllerCount, equals(0));
+      });
+    });
+
     group('static methods', () {
       test('configureCache invokes global channel', () async {
         TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger

--- a/mobile/test/providers/individual_video_providers_test.dart
+++ b/mobile/test/providers/individual_video_providers_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -6,9 +7,38 @@ import 'package:openvine/models/viewer_auth_result.dart';
 import 'package:openvine/providers/individual_video_providers.dart';
 import 'package:openvine/providers/upload_media_providers.dart';
 import 'package:openvine/services/media_viewer_auth_service.dart';
+import 'package:video_player_platform_interface/video_player_platform_interface.dart'
+    as video_platform;
+
+import '../helpers/web_video_player_test_doubles.dart';
 
 class MockMediaViewerAuthService extends Mock
     implements MediaViewerAuthService {}
+
+/// A [FakeVideoPlayerPlatform] that records the order of `pause` and `dispose`
+/// and reports the player as initialized so `controller.pause()` reaches the
+/// platform (an uninitialized controller's pause is a no-op).
+class _RecordingVideoPlayerPlatform extends FakeVideoPlayerPlatform {
+  _RecordingVideoPlayerPlatform(this.calls);
+
+  final List<String> calls;
+
+  @override
+  Stream<video_platform.VideoEvent> videoEventsFor(int playerId) =>
+      Stream.value(
+        video_platform.VideoEvent(
+          eventType: video_platform.VideoEventType.initialized,
+          duration: const Duration(seconds: 1),
+          size: const Size(1, 1),
+        ),
+      );
+
+  @override
+  Future<void> pause(int playerId) async => calls.add('pause');
+
+  @override
+  Future<void> dispose(int playerId) async => calls.add('dispose');
+}
 
 void main() {
   late MockMediaViewerAuthService mockMediaViewerAuthService;
@@ -44,6 +74,113 @@ void main() {
 
       container.dispose();
       expect(fvpLiveControllerCount, equals(baseline));
+    });
+  });
+
+  group('kMaxFvpControllers cap', () {
+    ProviderContainer buildContainer() {
+      final authService = MockMediaViewerAuthService();
+      when(() => authService.canCreateHeaders).thenReturn(false);
+      return ProviderContainer(
+        overrides: [
+          mediaViewerAuthServiceProvider.overrideWithValue(authService),
+        ],
+      );
+    }
+
+    test('caps live controllers when many idle videos are read', () async {
+      final container = buildContainer();
+      addTearDown(container.dispose);
+
+      for (var i = 0; i < 20; i++) {
+        container.read(
+          individualVideoControllerProvider(
+            VideoControllerParams(
+              videoId: 'cap-video-$i',
+              videoUrl: 'https://example.com/cap-$i.mp4',
+            ),
+          ),
+        );
+      }
+      await Future<void>.delayed(Duration.zero);
+
+      expect(fvpLiveControllerCount, lessThanOrEqualTo(kMaxFvpControllers));
+    });
+
+    test('never evicts an actively-listened controller under flood', () async {
+      final container = buildContainer();
+      addTearDown(container.dispose);
+
+      const listenedParams = VideoControllerParams(
+        videoId: 'v0',
+        videoUrl: 'https://example.com/v0.mp4',
+      );
+
+      // Keep v0 on-screen via an active listener.
+      final subscription = container.listen(
+        individualVideoControllerProvider(listenedParams),
+        (_, _) {},
+        fireImmediately: true,
+      );
+      addTearDown(subscription.close);
+
+      // Flood the registry with idle reads that must not evict v0.
+      for (var i = 1; i <= 30; i++) {
+        container.read(
+          individualVideoControllerProvider(
+            VideoControllerParams(
+              videoId: 'flood-$i',
+              videoUrl: 'https://example.com/flood-$i.mp4',
+            ),
+          ),
+        );
+      }
+      await Future<void>.delayed(Duration.zero);
+
+      // v0 was never torn down and still reads normally.
+      expect(disposedControllersTracker.contains('v0'), isFalse);
+      expect(
+        () => container.read(
+          individualVideoControllerProvider(listenedParams),
+        ),
+        returnsNormally,
+      );
+    });
+  });
+
+  group('onDispose teardown', () {
+    test('pauses the controller before disposing it', () async {
+      final calls = <String>[];
+      final previousPlatform = video_platform.VideoPlayerPlatform.instance;
+      video_platform.VideoPlayerPlatform.instance =
+          _RecordingVideoPlayerPlatform(calls);
+      addTearDown(
+        () => video_platform.VideoPlayerPlatform.instance = previousPlatform,
+      );
+
+      final authService = MockMediaViewerAuthService();
+      when(() => authService.canCreateHeaders).thenReturn(false);
+      final container = ProviderContainer(
+        overrides: [
+          mediaViewerAuthServiceProvider.overrideWithValue(authService),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      const params = VideoControllerParams(
+        videoId: 'dispose-order',
+        videoUrl: 'https://example.com/dispose-order.mp4',
+      );
+
+      container.read(individualVideoControllerProvider(params));
+      // Let create()/initialize() resolve so the controller is initialized.
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      container.dispose();
+      // Flush the onDispose microtask (pause then dispose).
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(calls, containsAllInOrder(['pause', 'dispose']));
     });
   });
 

--- a/mobile/test/providers/individual_video_providers_test.dart
+++ b/mobile/test/providers/individual_video_providers_test.dart
@@ -1,8 +1,10 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/models/viewer_auth_result.dart';
 import 'package:openvine/providers/individual_video_providers.dart';
+import 'package:openvine/providers/upload_media_providers.dart';
 import 'package:openvine/services/media_viewer_auth_service.dart';
 
 class MockMediaViewerAuthService extends Mock
@@ -13,6 +15,36 @@ void main() {
 
   setUp(() {
     mockMediaViewerAuthService = MockMediaViewerAuthService();
+  });
+
+  group('fvpLiveControllerCount', () {
+    test('rises when a controller is read and falls after disposal', () {
+      // Controller construction reads mediaViewerAuthServiceProvider for
+      // sync auth headers; override it so the read doesn't pull the whole
+      // auth/Nostr graph into the test.
+      final authService = MockMediaViewerAuthService();
+      when(() => authService.canCreateHeaders).thenReturn(false);
+
+      final baseline = fvpLiveControllerCount;
+      final container = ProviderContainer(
+        overrides: [
+          mediaViewerAuthServiceProvider.overrideWithValue(authService),
+        ],
+      );
+
+      const params = VideoControllerParams(
+        videoId: 'gauge-video',
+        videoUrl: 'https://example.com/gauge.mp4',
+      );
+
+      // Reading the provider constructs the controller (no initialize()),
+      // which increments the gauge.
+      container.read(individualVideoControllerProvider(params));
+      expect(fvpLiveControllerCount, equals(baseline + 1));
+
+      container.dispose();
+      expect(fvpLiveControllerCount, equals(baseline));
+    });
   });
 
   group('createViewerAuthHeadersForVideo', () {

--- a/mobile/test/providers/individual_video_providers_test.dart
+++ b/mobile/test/providers/individual_video_providers_test.dart
@@ -140,11 +140,32 @@ void main() {
       // v0 was never torn down and still reads normally.
       expect(disposedControllersTracker.contains('v0'), isFalse);
       expect(
-        () => container.read(
-          individualVideoControllerProvider(listenedParams),
-        ),
+        () => container.read(individualVideoControllerProvider(listenedParams)),
         returnsNormally,
       );
+    });
+
+    test('tracks alternate params for the same video independently', () {
+      final baseline = fvpLiveControllerCount;
+      final container = buildContainer();
+
+      const mediumParams = VideoControllerParams(
+        videoId: 'same-video',
+        videoUrl: 'https://example.com/same-video-720p.mp4',
+      );
+      const fallbackParams = VideoControllerParams(
+        videoId: 'same-video',
+        videoUrl: 'https://example.com/same-video-fallback.mp4',
+      );
+
+      container
+        ..read(individualVideoControllerProvider(mediumParams))
+        ..read(individualVideoControllerProvider(fallbackParams));
+
+      expect(fvpLiveControllerCount, equals(baseline + 2));
+
+      container.dispose();
+      expect(fvpLiveControllerCount, equals(baseline));
     });
   });
 
@@ -154,9 +175,9 @@ void main() {
       final previousPlatform = video_platform.VideoPlayerPlatform.instance;
       video_platform.VideoPlayerPlatform.instance =
           _RecordingVideoPlayerPlatform(calls);
-      addTearDown(
-        () => video_platform.VideoPlayerPlatform.instance = previousPlatform,
-      );
+      addTearDown(() {
+        video_platform.VideoPlayerPlatform.instance = previousPlatform;
+      });
 
       final authService = MockMediaViewerAuthService();
       when(() => authService.canCreateHeaders).thenReturn(false);

--- a/mobile/test/screens/comments/widgets/video_comment_player_test.dart
+++ b/mobile/test/screens/comments/widgets/video_comment_player_test.dart
@@ -1,9 +1,60 @@
+import 'dart:async';
+
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/screens/comments/widgets/video_comment_player.dart';
+import 'package:video_player/video_player.dart';
 import 'package:visibility_detector/visibility_detector.dart';
+
+import '../../../helpers/web_video_player_test_doubles.dart';
+
+/// A fake controller that records the order of [pause] and [dispose] and never
+/// marks itself initialized (so the widget doesn't build a real [VideoPlayer]).
+class _RecordingController extends FakeVideoPlayerController {
+  _RecordingController(this.calls);
+
+  final List<String> calls;
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<void> pause() async {
+    calls.add('pause');
+    await super.pause();
+  }
+
+  @override
+  Future<void> dispose() async {
+    calls.add('dispose');
+    await super.dispose();
+  }
+}
+
+/// A recording fake whose [initialize] blocks on [initCompleter], so a test can
+/// unmount the widget while the first play is still in flight.
+class _DeferredInitController extends FakeVideoPlayerController {
+  _DeferredInitController(this.calls, this.initCompleter);
+
+  final List<String> calls;
+  final Completer<void> initCompleter;
+
+  @override
+  Future<void> initialize() => initCompleter.future;
+
+  @override
+  Future<void> pause() async {
+    calls.add('pause');
+  }
+
+  @override
+  Future<void> dispose() async {
+    calls.add('dispose');
+    await super.dispose();
+  }
+}
 
 void main() {
   setUp(() {
@@ -58,5 +109,67 @@ void main() {
     await tester.pump();
 
     expect(opened, isTrue);
+  });
+
+  testWidgets('pauses before disposing when unmounted after play', (
+    tester,
+  ) async {
+    final calls = <String>[];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: VideoCommentPlayer(
+            videoUrl: 'https://media.divine.video/comment-video.mp4',
+            controllerFactory: (_) => _RecordingController(calls),
+          ),
+        ),
+      ),
+    );
+
+    // Tap the player surface to start playback.
+    await tester.tap(find.byType(VideoCommentPlayer));
+    await tester.pump();
+
+    // Unmount the widget, then flush the async teardown closure.
+    await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+    await tester.pump();
+
+    expect(calls, equals(['pause', 'dispose']));
+  });
+
+  testWidgets('pauses before disposing on the in-flight !mounted path', (
+    tester,
+  ) async {
+    final calls = <String>[];
+    final initCompleter = Completer<void>();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: VideoCommentPlayer(
+            videoUrl: 'https://media.divine.video/comment-video.mp4',
+            controllerFactory: (_) =>
+                _DeferredInitController(calls, initCompleter),
+          ),
+        ),
+      ),
+    );
+
+    // Start playback; initialize() is now pending.
+    await tester.tap(find.byType(VideoCommentPlayer));
+    await tester.pump();
+
+    // Unmount before initialization completes, then let it complete so the
+    // in-flight _togglePlay hits the !mounted teardown branch.
+    await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+    initCompleter.complete();
+    await tester.pump();
+
+    expect(calls, equals(['pause', 'dispose']));
   });
 }

--- a/mobile/test/services/event_router_test.dart
+++ b/mobile/test/services/event_router_test.dart
@@ -287,5 +287,68 @@ void main() {
         expect(await db.nostrEventsDao.getEventById(event.id), isNotNull);
       },
     );
+
+    group('maxQueueDepth', () {
+      test('bounds the queue and drops events once the cap is exceeded', () {
+        router.dispose();
+        router = EventRouter(
+          db,
+          config: const EventRouterConfig(autoStart: false, maxQueueDepth: 500),
+        );
+
+        for (var i = 0; i < 5000; i++) {
+          router.handleEvent(
+            videoEvent(3000 + i),
+            priority: EventIngestionPriority.background,
+          );
+        }
+
+        expect(router.queuedLength, lessThanOrEqualTo(500));
+        expect(router.droppedEventCount, greaterThan(0));
+      });
+
+      test('drops oldest background events but never visible ones', () async {
+        router.dispose();
+        router = EventRouter(
+          db,
+          config: const EventRouterConfig(autoStart: false, maxQueueDepth: 10),
+        );
+
+        final visible = List.generate(5, (i) => videoEvent(4000 + i));
+        for (final event in visible) {
+          router.handleEvent(event, priority: EventIngestionPriority.visible);
+        }
+
+        // Flood background well past the cap to force drops.
+        for (var i = 0; i < 200; i++) {
+          router.handleEvent(
+            videoEvent(5000 + i),
+            priority: EventIngestionPriority.background,
+          );
+        }
+
+        expect(router.queuedLength, lessThanOrEqualTo(10));
+        expect(router.droppedEventCount, greaterThan(0));
+
+        // Every visible event survives the bound and still persists.
+        await router.drainForTesting();
+        for (final event in visible) {
+          expect(await db.nostrEventsDao.getEventById(event.id), isNotNull);
+        }
+      });
+
+      test('is unbounded by default so existing callers are unaffected', () {
+        // Default config leaves maxQueueDepth null.
+        for (var i = 0; i < 1000; i++) {
+          router.handleEvent(
+            videoEvent(6000 + i),
+            priority: EventIngestionPriority.background,
+          );
+        }
+
+        expect(router.queuedLength, equals(1000));
+        expect(router.droppedEventCount, equals(0));
+      });
+    });
   });
 }

--- a/mobile/test/services/event_router_test.dart
+++ b/mobile/test/services/event_router_test.dart
@@ -99,10 +99,7 @@ void main() {
       router.dispose();
       router = EventRouter(
         db,
-        config: const EventRouterConfig(
-          autoStart: false,
-          maxBatchSize: 1,
-        ),
+        config: const EventRouterConfig(autoStart: false, maxBatchSize: 1),
       );
 
       router.handleEvent(
@@ -124,10 +121,7 @@ void main() {
         router.dispose();
         router = EventRouter(
           db,
-          config: const EventRouterConfig(
-            autoStart: false,
-            maxBatchSize: 10,
-          ),
+          config: const EventRouterConfig(autoStart: false, maxBatchSize: 10),
           yieldToEventLoop: () async {
             yieldCount++;
             await Future<void>.delayed(Duration.zero);
@@ -143,10 +137,7 @@ void main() {
 
         expect(yieldCount, greaterThanOrEqualTo(2));
         for (final event in events) {
-          expect(
-            await db.nostrEventsDao.getEventById(event.id),
-            isNotNull,
-          );
+          expect(await db.nostrEventsDao.getEventById(event.id), isNotNull);
         }
       },
     );
@@ -230,15 +221,61 @@ void main() {
       expect(await db.nostrEventsDao.getEventById(event.id), isNull);
     });
 
+    test('queuedLength reflects the number of enqueued events', () {
+      router.handleEvent(
+        profileEvent(1, content: jsonEncode({'name': 'a'})),
+        priority: EventIngestionPriority.background,
+      );
+      router.handleEvent(
+        videoEvent(2),
+        priority: EventIngestionPriority.visible,
+      );
+
+      expect(router.queuedLength, equals(2));
+    });
+
+    test(
+      'shedLowPriority drops background and normal but keeps visible',
+      () async {
+        router.handleEvent(
+          videoEvent(1),
+          priority: EventIngestionPriority.background,
+        );
+        // Enqueued at the default (normal) priority.
+        router.handleEvent(videoEvent(2));
+        final visible = videoEvent(3);
+        router.handleEvent(visible, priority: EventIngestionPriority.visible);
+        expect(router.queuedLength, equals(3));
+
+        final dropped = router.shedLowPriority();
+
+        expect(dropped, equals(2));
+        expect(router.droppedEventCount, equals(2));
+        expect(router.queuedLength, equals(1));
+
+        // The retained visible event still persists on the next drain.
+        await router.drainForTesting();
+        expect(await db.nostrEventsDao.getEventById(visible.id), isNotNull);
+      },
+    );
+
+    test('shedLowPriority is a no-op after dispose', () {
+      router.handleEvent(
+        videoEvent(1),
+        priority: EventIngestionPriority.background,
+      );
+      router.dispose();
+
+      expect(router.shedLowPriority(), equals(0));
+      expect(router.droppedEventCount, equals(0));
+    });
+
     test(
       'handleEvent enqueues without synchronously persisting the event',
       () async {
         final event = videoEvent(99);
 
-        router.handleEvent(
-          event,
-          priority: EventIngestionPriority.background,
-        );
+        router.handleEvent(event, priority: EventIngestionPriority.background);
 
         // Enqueue is intentionally fire-and-forget. Persistence happens when the
         // cooperative router drain runs, so the relay callback can keep updating

--- a/mobile/test/services/memory_pressure_handler_test.dart
+++ b/mobile/test/services/memory_pressure_handler_test.dart
@@ -1,0 +1,24 @@
+// ABOUTME: Tests MemoryPressureHandler fans out to both load-shedding callbacks
+// ABOUTME: Injects spies and asserts image-cache clear + ingestion shed both fire
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/memory_pressure_handler.dart';
+
+void main() {
+  group(MemoryPressureHandler, () {
+    test('onMemoryPressure invokes both shedding callbacks once', () {
+      var clearImageCacheCalls = 0;
+      var shedIngestionCalls = 0;
+
+      final handler = MemoryPressureHandler(
+        clearImageCache: () => clearImageCacheCalls++,
+        shedIngestion: () => shedIngestionCalls++,
+      );
+
+      handler.onMemoryPressure();
+
+      expect(clearImageCacheCalls, equals(1));
+      expect(shedIngestionCalls, equals(1));
+    });
+  });
+}

--- a/mobile/test/services/memory_telemetry_service_test.dart
+++ b/mobile/test/services/memory_telemetry_service_test.dart
@@ -1,0 +1,98 @@
+// ABOUTME: Tests MemoryTelemetryService RSS/peak sampling and snapshot assembly
+// ABOUTME: Drives sampleOnce() with injected gauges and asserts the emitted data
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/memory_telemetry_service.dart';
+
+void main() {
+  group(MemoryTelemetryService, () {
+    late List<MemorySnapshot> emitted;
+
+    setUp(() {
+      emitted = <MemorySnapshot>[];
+    });
+
+    MemoryTelemetryService build({
+      required int Function() readRssBytes,
+      int Function() nativeControllerCount = _zero,
+      int Function() fvpControllerCount = _zero,
+      int Function() queueDepth = _zero,
+      Duration interval = const Duration(seconds: 30),
+    }) {
+      return MemoryTelemetryService(
+        readRssBytes: readRssBytes,
+        nativeControllerCount: nativeControllerCount,
+        fvpControllerCount: fvpControllerCount,
+        queueDepth: queueDepth,
+        emit: emitted.add,
+        interval: interval,
+      );
+    }
+
+    test('peakRssBytes holds the max across rising then falling rss', () {
+      final readings = [100, 300, 200];
+      var index = 0;
+      final service = build(readRssBytes: () => readings[index++]);
+
+      service
+        ..sampleOnce()
+        ..sampleOnce()
+        ..sampleOnce();
+
+      expect(emitted.map((s) => s.rssBytes), equals([100, 300, 200]));
+      expect(emitted.map((s) => s.peakRssBytes), equals([100, 300, 300]));
+    });
+
+    test('snapshot carries the injected controller and queue gauges', () {
+      final service = build(
+        readRssBytes: () => 4242,
+        nativeControllerCount: () => 3,
+        fvpControllerCount: () => 5,
+        queueDepth: () => 7,
+      );
+
+      service.sampleOnce();
+
+      expect(emitted, hasLength(1));
+      final snapshot = emitted.single;
+      expect(snapshot.rssBytes, equals(4242));
+      expect(snapshot.peakRssBytes, equals(4242));
+      expect(snapshot.nativeControllers, equals(3));
+      expect(snapshot.fvpControllers, equals(5));
+      expect(snapshot.queueDepth, equals(7));
+    });
+
+    test('start samples periodically on the interval', () {
+      fakeAsync((async) {
+        var rss = 10;
+        // Default interval is 30s.
+        final service = build(readRssBytes: () => rss++)..start();
+
+        async.elapse(const Duration(seconds: 90));
+        service.stop();
+
+        expect(emitted, hasLength(3));
+      });
+    });
+
+    test('stop is idempotent and halts sampling', () {
+      fakeAsync((async) {
+        // Default interval is 30s.
+        final service = build(readRssBytes: () => 1)..start();
+
+        async.elapse(const Duration(seconds: 30));
+        expect(emitted, hasLength(1));
+
+        service
+          ..stop()
+          ..stop();
+
+        async.elapse(const Duration(seconds: 90));
+        expect(emitted, hasLength(1));
+      });
+    });
+  });
+}
+
+int _zero() => 0;

--- a/mobile/test/services/video_event_service_with_event_router_test.dart
+++ b/mobile/test/services/video_event_service_with_event_router_test.dart
@@ -111,6 +111,10 @@ void main() {
       }
     });
 
+    test('exposes the injected EventRouter via eventRouter getter', () {
+      expect(videoEventService.eventRouter, same(eventRouter));
+    });
+
     test('Video events (kind 34236) are cached to NostrEvents table', () async {
       // Create test video event
       final videoEvent = Event(


### PR DESCRIPTION
Closes #5908

Fixes the OOM half of the 1.0.15 incident (resident memory climbing to **2.8–10.2 GB** on 4–8 GB phones → `FVPFrameUpdater` EXC_BAD_ACCESS + `hashmap.cc` SIGABRT). Two commits: **instrument** (make the growth attributable + shed under pressure) then **bound** (cap the two memory sources). Independent of the cipher-migration corruption fix (#5903).

*(Was briefly split into #5904 + this; folded into one PR since they ship together in 1.0.16 and were stacked — one review, one merge.)*

## Commit 1 — Instrumentation + pressure shedding
The app had **no in-app memory/controller/queue telemetry**, so field logs showed only symptoms (779 retry storms), never the cause.
- `EventRouter.queuedLength` — ingestion backlog gauge.
- `DivineVideoPlayerController.liveControllerCount` (native feed stack, bounded ≤3) + `fvpLiveControllerCount` (official `video_player`, comments/individual) — split so a crash report shows *which* stack accumulates.
- `MemoryTelemetryService` — periodic RSS + peak sampler → Crashlytics keys `mem_rss_mb`, `mem_peak_mb`, `vc_native`, `vc_fvp`, `ingest_queue_depth`, so every crash carries the last-seen footprint.
- `didHaveMemoryPressure` → `MemoryPressureHandler` clears the image cache + sheds background/normal ingestion (`EventRouter.shedLowPriority()`).

## Commit 2 — Bounding
- **Cap FVP controllers (regression of #102):** `individualVideoController` was `keepAlive()`'d with no count cap → unbounded native players. Adds `kMaxFvpControllers = 8` + an insertion-ordered registry with **LRU-among-idle** eviction — an on-screen (actively-listened) controller is **never** evicted (transient overage allowed). Identity-guarded synchronous removal handles Riverpod's sync-`onCancel` / microtask-`onDispose` ordering.
- **Pause before dispose (fixes the #1 native crash, 45 users):** all three FVP teardown sites `pause()` before `dispose()` (comment player `dispose()`, its in-flight `!mounted` path, a background-lifecycle pause, and the provider `onDispose` microtask). `VideoCommentPlayer` gains a `controllerFactory` seam for testability.
- **Bound EventRouter queues:** `maxQueueDepth` (nullable, default `null` = unbounded so existing callers/tests are unaffected); `handleEvent` drops oldest `background → normal → visible` while over the cap (never the visible queue unless it alone exceeds it). Production `2000` — **tune from the `ingest_queue_depth` telemetry** once a build reports back. Data-loss checked: droppable priorities carry only relay-resyncable events.

## Tests / verification
- Gauges (both stacks), RSS+peak sampler, pressure-shed; cap ≤ 8 + **eviction-safety** (listened controller survives a flood); pause-before-dispose at all 3 sites; queue bound + visible-never-dropped + unbounded-by-default. All injected/mockable.
- Scoped suites green; `flutter analyze` clean; `dart format` clean; `.g.dart` regenerated (hashes only); untested-services floor passes.

Phase-2 of the OOM plan — nothing further pending except tuning `maxQueueDepth` from field telemetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)