### PR TITLE
fix(profile): cancel route-scoped feed subscription

### DIFF
--- a/mobile/lib/blocs/profile_feed/profile_feed_cubit.dart
+++ b/mobile/lib/blocs/profile_feed/profile_feed_cubit.dart
@@ -763,11 +763,17 @@ class ProfileFeedCubit extends Bloc<ProfileFeedEvent, ProfileFeedState> {
   }
 
   @override
-  Future<void> close() {
+  Future<void> close() async {
     _removeChangeListener?.call();
     _unregisterUpdate?.call();
     _initialLoadTimer?.cancel();
     _flushSnapshot();
+    try {
+      await _videoEventService.unsubscribeFromUserVideos(_authorPubkey);
+    } on Object {
+      // Closing the Cubit must still complete; the service treats unsubscribe
+      // as best-effort route cleanup.
+    }
     return super.close();
   }
 }

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -2879,6 +2879,28 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     );
   }
 
+  /// Cancels the active profile-feed subscription only if it still belongs to
+  /// [pubkey]. Profile feeds are route-scoped, but the underlying subscription
+  /// registry is service-global; the author guard prevents an old route disposal
+  /// from cancelling a newer profile route.
+  Future<void> unsubscribeFromUserVideos(String pubkey) async {
+    final params = _subscriptionParams[SubscriptionType.profile];
+    final authors = params?['authors'] as List<String>?;
+    final isActiveAuthor =
+        authors != null && authors.length == 1 && authors.single == pubkey;
+
+    if (!isActiveAuthor) {
+      Log.debug(
+        'Skipping stale profile unsubscribe for $pubkey',
+        name: 'VideoEventService',
+        category: LogCategory.video,
+      );
+      return;
+    }
+
+    await _cancelSubscription(SubscriptionType.profile);
+  }
+
   /// Query historical videos for a specific user (for pagination)
   /// This is used by profile feed provider to load older videos beyond the initial subscription
   Future<void> queryHistoricalUserVideos(

--- a/mobile/test/blocs/profile_feed/profile_feed_cubit_test.dart
+++ b/mobile/test/blocs/profile_feed/profile_feed_cubit_test.dart
@@ -104,6 +104,7 @@ class _Harness {
     ).thenAnswer((i) => i.positionalArguments[0] as List<VideoEvent>);
     when(() => ves.isVideoEventLocallyDeleted(any())).thenReturn(false);
     when(() => ves.subscribeToUserVideos(any())).thenAnswer((_) async {});
+    when(() => ves.unsubscribeFromUserVideos(any())).thenAnswer((_) async {});
     when(
       () => ves.queryHistoricalUserVideos(any(), until: any(named: 'until')),
     ).thenAnswer((_) async {});
@@ -224,6 +225,16 @@ void main() {
           key: cacheKey,
           fromJson: ProfileVideoOffsetSnapshot.fromJson,
         );
+
+    test('close unsubscribes the active profile feed subscription', () async {
+      h.stubAuthorFeed(_result(const []));
+      final cubit = h.build();
+      await pumpEventQueue();
+
+      await cubit.close();
+
+      verify(() => h.ves.unsubscribeFromUserVideos(_author)).called(1);
+    });
 
     group('CacheSync stale-while-revalidate', () {
       test('reopen restores the persisted window + cursor instantly, then '

--- a/mobile/test/services/video_event_service_author_backfill_test.dart
+++ b/mobile/test/services/video_event_service_author_backfill_test.dart
@@ -61,6 +61,13 @@ void main() {
       when(() => nostr.connectedRelayCount).thenReturn(1);
       when(() => nostr.connectedRelays).thenReturn(['wss://relay.example.com']);
       when(() => nostr.subscribe(any())).thenAnswer((_) => eventStream.stream);
+      when(
+        () => nostr.subscribe(
+          any(),
+          subscriptionId: any(named: 'subscriptionId'),
+          onEose: any(named: 'onEose'),
+        ),
+      ).thenAnswer((_) => eventStream.stream);
 
       service = VideoEventService(
         nostr,
@@ -117,5 +124,42 @@ void main() {
       expect(authored, hasLength(1));
       expect(authored.single.id.toLowerCase(), 'dup');
     });
+
+    test(
+      'skips stale profile unsubscribe after another author is active',
+      () async {
+        final authorAStream = StreamController<Event>.broadcast();
+        final authorBStream = StreamController<Event>.broadcast();
+
+        when(
+          () => nostr.subscribe(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+            onEose: any(named: 'onEose'),
+          ),
+        ).thenAnswer((invocation) {
+          final filters = invocation.positionalArguments.single as List<Filter>;
+          final authors = filters.first.authors;
+          if (authors?.contains(_authorA) ?? false) {
+            return authorAStream.stream;
+          }
+          return authorBStream.stream;
+        });
+
+        await service.subscribeToUserVideos(_authorA);
+        expect(authorAStream.hasListener, isTrue);
+
+        await service.subscribeToUserVideos(_authorB);
+        expect(authorAStream.hasListener, isFalse);
+        expect(authorBStream.hasListener, isTrue);
+
+        await service.unsubscribeFromUserVideos(_authorA);
+
+        expect(authorBStream.hasListener, isTrue);
+
+        await authorAStream.close();
+        await authorBStream.close();
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary
- cancel the active profile relay subscription when `ProfileFeedCubit` closes
- guard the unsubscribe by author so disposal from an old profile route cannot cancel a newer profile route
- add regression coverage for Cubit cleanup and stale-author unsubscribe behavior

## Root cause from TestFlight logs
The exported `openvine_full_logs_2026-07-07T14-53-30.873591.txt` did not show a crash or memory spiral, but it did show profile relay work continuing after the route had already moved from profile to settings and then support center. That means the profile route cleaned up its Cubit listeners, but the global `VideoEventService` profile subscription stayed alive and continued ingesting relay events, resolving reposts, and doing persistence work off-screen.

This is separate from the broader relay verification jank tracked by #5863 and the open perf PRs #5894 / #5888. Those likely help app-wide relay-processing slowness; this PR fixes the route-scoped leak visible in the TestFlight log.

## Verification
- `cd mobile && flutter test test/blocs/profile_feed/profile_feed_cubit_test.dart test/services/video_event_service_author_backfill_test.dart`
- `cd mobile && flutter analyze lib/blocs/profile_feed/profile_feed_cubit.dart lib/services/video_event_service.dart test/blocs/profile_feed/profile_feed_cubit_test.dart test/services/video_event_service_author_backfill_test.dart`
- `cd mobile && flutter analyze`
- `git diff --check`
- pre-push hook reran full analyze and changed-file tests successfully
