### PR TITLE
feat(analytics): add product event ingest queue

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -2384,6 +2384,10 @@ class _DivineAppState extends ConsumerState<DivineApp>
     // run for the durable pending_view_events queue without a UI consumer.
     ref.watch(viewEventRetryServiceProvider);
 
+    // Eagerly create the product-event queue so foreground sweeps run for the
+    // durable pending_product_events queue without a UI consumer.
+    ref.watch(productEventQueueProvider);
+
     // Wrap with geo-blocking check first, then lifecycle handler
     Widget wrapped = MultiRepositoryProvider(
       providers: [

--- a/mobile/lib/providers/auth_providers.dart
+++ b/mobile/lib/providers/auth_providers.dart
@@ -415,7 +415,9 @@ IdentityClaimsRepository identityClaimsRepository(Ref ref) {
 @riverpod
 Nip98AuthService nip98AuthService(Ref ref) {
   final authService = ref.watch(authServiceProvider);
-  return Nip98AuthService(authService: authService);
+  final service = Nip98AuthService(authService: authService);
+  ref.onDispose(service.dispose);
+  return service;
 }
 
 /// Account Deletion Service for NIP-62 Request to Vanish

--- a/mobile/lib/providers/auth_providers.g.dart
+++ b/mobile/lib/providers/auth_providers.g.dart
@@ -844,7 +844,7 @@ final class Nip98AuthServiceProvider
   }
 }
 
-String _$nip98AuthServiceHash() => r'cfc2e0a65e1dbd9c559886929257fa66a7afb1c6';
+String _$nip98AuthServiceHash() => r'2e5b190deac613283e316aadf81bc99d8d1778f2';
 
 /// Account Deletion Service for NIP-62 Request to Vanish
 

--- a/mobile/lib/providers/social_providers.dart
+++ b/mobile/lib/providers/social_providers.dart
@@ -283,9 +283,9 @@ ProductEventQueue productEventQueue(Ref ref) {
     ingestClient: ingestClient,
   );
 
-  queue.flush().catchError((Object e) {
+  queue.recoverPublishingAndFlush().catchError((Object e) {
     Log.debug(
-      'Initial ProductEventQueue flush failed: $e',
+      'Initial ProductEventQueue recovery/flush failed: $e',
       name: 'AppProviders',
       category: LogCategory.system,
     );

--- a/mobile/lib/providers/social_providers.dart
+++ b/mobile/lib/providers/social_providers.dart
@@ -7,6 +7,8 @@ import 'dart:async';
 import 'package:collaborator_repository/collaborator_repository.dart';
 import 'package:dm_repository/dm_repository.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
+import 'package:openvine/config/app_config.dart';
 import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/app_foreground_provider.dart';
 import 'package:openvine/providers/auth_providers.dart';
@@ -18,6 +20,7 @@ import 'package:openvine/providers/repository_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/upload_media_providers.dart';
 import 'package:openvine/providers/video_providers.dart';
+import 'package:openvine/services/analytics_ingest_client.dart';
 import 'package:openvine/services/analytics_service.dart';
 import 'package:openvine/services/bug_report_service.dart';
 import 'package:openvine/services/clip_library_service.dart';
@@ -31,6 +34,7 @@ import 'package:openvine/services/hashtag_cache_service.dart';
 import 'package:openvine/services/hashtag_service.dart';
 import 'package:openvine/services/outgoing_dm_retry_service.dart';
 import 'package:openvine/services/pending_action_service.dart';
+import 'package:openvine/services/product_event_queue.dart';
 import 'package:openvine/services/social_service.dart';
 import 'package:openvine/services/user_data_cleanup_service.dart';
 import 'package:openvine/services/view_event_publisher.dart';
@@ -261,18 +265,64 @@ ViewEventRetryService? viewEventRetryService(Ref ref) {
   return service;
 }
 
+/// Durable queue for first-party product analytics events.
+@Riverpod(keepAlive: true)
+ProductEventQueue productEventQueue(Ref ref) {
+  final db = ref.watch(databaseProvider);
+  final env = ref.watch(currentEnvironmentProvider);
+  final client = http.Client();
+  ref.onDispose(client.close);
+
+  final ingestClient = AnalyticsIngestClient(
+    httpClient: client,
+    nip98AuthService: ref.watch(nip98AuthServiceProvider),
+    apiBaseUrl: () => env.apiBaseUrl,
+  );
+  final queue = ProductEventQueue(
+    dao: db.pendingProductEventsDao,
+    ingestClient: ingestClient,
+  );
+
+  queue.flush().catchError((Object e) {
+    Log.debug(
+      'Initial ProductEventQueue flush failed: $e',
+      name: 'AppProviders',
+      category: LogCategory.system,
+    );
+  });
+
+  ref.listen<bool>(appForegroundProvider, (_, next) {
+    if (next) {
+      queue.flush().catchError((Object e) {
+        Log.debug(
+          'Foreground ProductEventQueue flush failed: $e',
+          name: 'AppProviders',
+          category: LogCategory.system,
+        );
+      });
+    }
+  }, fireImmediately: true);
+
+  return queue;
+}
+
 /// Analytics service with opt-out support.
 ///
 /// Publishes Kind 22236 ephemeral Nostr view events via [ViewEventPublisher].
 @Riverpod(keepAlive: true) // Keep alive to maintain singleton behavior
 AnalyticsService analyticsService(Ref ref) {
   final db = ref.watch(databaseProvider);
+  final authService = ref.watch(authServiceProvider);
   final viewPublisher = ref.watch(viewEventPublisherProvider);
   final retryService = ref.watch(viewEventRetryServiceProvider);
+  final productQueue = ref.watch(productEventQueueProvider);
   final service = AnalyticsService(
     viewEventPublisher: viewPublisher,
     pendingViewEventsDao: db.pendingViewEventsDao,
     flushPendingViewEvents: retryService?.sweep,
+    productEventQueue: productQueue,
+    currentUserPubkey: () => authService.currentPublicKeyHex,
+    appVersion: () => AppConfig.appVersion,
   );
 
   // Ensure cleanup on disposal

--- a/mobile/lib/providers/social_providers.g.dart
+++ b/mobile/lib/providers/social_providers.g.dart
@@ -262,7 +262,7 @@ final class ProductEventQueueProvider
   }
 }
 
-String _$productEventQueueHash() => r'5af5836ef23cef5c459a40814e8cbe0d46d8714e';
+String _$productEventQueueHash() => r'34617155654c8991021f5e8e9aaf1508da4e4db8';
 
 /// Analytics service with opt-out support.
 ///

--- a/mobile/lib/providers/social_providers.g.dart
+++ b/mobile/lib/providers/social_providers.g.dart
@@ -212,6 +212,58 @@ final class ViewEventRetryServiceProvider
 String _$viewEventRetryServiceHash() =>
     r'3d2bf5f8def6302b9cb64d60bc35e8a792dcc15f';
 
+/// Durable queue for first-party product analytics events.
+
+@ProviderFor(productEventQueue)
+final productEventQueueProvider = ProductEventQueueProvider._();
+
+/// Durable queue for first-party product analytics events.
+
+final class ProductEventQueueProvider
+    extends
+        $FunctionalProvider<
+          ProductEventQueue,
+          ProductEventQueue,
+          ProductEventQueue
+        >
+    with $Provider<ProductEventQueue> {
+  /// Durable queue for first-party product analytics events.
+  ProductEventQueueProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'productEventQueueProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$productEventQueueHash();
+
+  @$internal
+  @override
+  $ProviderElement<ProductEventQueue> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  ProductEventQueue create(Ref ref) {
+    return productEventQueue(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(ProductEventQueue value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<ProductEventQueue>(value),
+    );
+  }
+}
+
+String _$productEventQueueHash() => r'5af5836ef23cef5c459a40814e8cbe0d46d8714e';
+
 /// Analytics service with opt-out support.
 ///
 /// Publishes Kind 22236 ephemeral Nostr view events via [ViewEventPublisher].
@@ -267,7 +319,7 @@ final class AnalyticsServiceProvider
   }
 }
 
-String _$analyticsServiceHash() => r'afdabdf0b1d7c769d7b1219062de928f17d34633';
+String _$analyticsServiceHash() => r'd86ad0633e379e991437845121e14ac3820c96ce';
 
 /// Hashtag cache service for persistent hashtag storage
 

--- a/mobile/lib/services/analytics_ingest_client.dart
+++ b/mobile/lib/services/analytics_ingest_client.dart
@@ -1,0 +1,275 @@
+// ABOUTME: First-party product analytics ingest client.
+// ABOUTME: POSTs product event batches to /api/analytics/events with NIP-98 auth.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:openvine/services/nip98_auth_service.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// User-visible surface where a product analytics event occurred.
+enum AnalyticsSurface {
+  app('app'),
+  auth('auth'),
+  camera('camera'),
+  comments('comments'),
+  feed('feed'),
+  notifications('notifications'),
+  onboarding('onboarding'),
+  profile('profile'),
+  search('search'),
+  settings('settings'),
+  unknown('unknown');
+
+  const AnalyticsSurface(this.wireName);
+
+  final String wireName;
+
+  static AnalyticsSurface fromWireName(String raw) {
+    for (final surface in AnalyticsSurface.values) {
+      if (surface.wireName == raw) return surface;
+    }
+    return AnalyticsSurface.unknown;
+  }
+}
+
+/// Product analytics event payload matching the v0 event contract.
+class ProductAnalyticsEvent {
+  const ProductAnalyticsEvent({
+    required this.eventId,
+    required this.eventName,
+    required this.occurredAt,
+    required this.userPubkey,
+    required this.anonymousId,
+    required this.sessionId,
+    required this.platform,
+    required this.appVersion,
+    required this.buildNumber,
+    required this.surface,
+    this.targetId,
+    this.props = const {},
+    this.propsNum = const {},
+    this.schemaVersion = 1,
+  });
+
+  final String eventId;
+  final String eventName;
+  final DateTime occurredAt;
+  final String userPubkey;
+  final String anonymousId;
+  final String sessionId;
+  final String platform;
+  final String appVersion;
+  final String buildNumber;
+  final AnalyticsSurface surface;
+  final String? targetId;
+  final Map<String, String> props;
+  final Map<String, double> propsNum;
+  final int schemaVersion;
+
+  Map<String, Object?> toJson() {
+    final properties = <String, Object?>{
+      ...props,
+      for (final entry in propsNum.entries) entry.key: entry.value,
+      if (targetId != null && targetId!.isNotEmpty) 'target_id': targetId,
+    };
+
+    String stringProp(String key) => props[key] ?? '';
+    double doubleProp(String key) => propsNum[key] ?? 0;
+    int intProp(String key) => doubleProp(key).round();
+
+    return {
+      'event_id': eventId,
+      'occurred_at': occurredAt.toUtc().toIso8601String(),
+      'user_pubkey': userPubkey,
+      'anonymous_id': anonymousId,
+      'session_id': sessionId,
+      'platform': platform,
+      'app_version': appVersion,
+      'build_number': buildNumber,
+      'surface': surface.wireName,
+      'event_name': eventName,
+      'entry_point': stringProp('entry_point'),
+      'flow_name': stringProp('flow_name'),
+      'step_name': stringProp('step_name'),
+      'result': stringProp('result'),
+      'reason_code': stringProp('reason_code'),
+      'content_id': props['content_id'] ?? targetId ?? '',
+      'creator_pubkey': stringProp('creator_pubkey'),
+      'feed_algorithm': stringProp('feed_algorithm'),
+      'traffic_source': stringProp('traffic_source'),
+      'feature_key': stringProp('feature_key'),
+      'experiment_key': stringProp('experiment_key'),
+      'variant_key': stringProp('variant_key'),
+      'variation_id': intProp('variation_id'),
+      'duration_ms': intProp('duration_ms'),
+      'position_ms': intProp('position_ms'),
+      'loop_count': intProp('loop_count'),
+      'value': doubleProp('value'),
+      'schema_version': schemaVersion,
+      'properties': properties,
+    };
+  }
+
+  String toPayloadJson() => jsonEncode(toJson());
+
+  static ProductAnalyticsEvent fromPayloadJson(String payloadJson) {
+    final decoded = jsonDecode(payloadJson) as Map<String, dynamic>;
+    final properties =
+        (decoded['properties'] as Map<String, dynamic>?) ??
+        const <String, dynamic>{};
+    final props = <String, String>{};
+    final propsNum = <String, double>{};
+    for (final entry in properties.entries) {
+      final value = entry.value;
+      if (value is num) {
+        propsNum[entry.key] = value.toDouble();
+      } else if (value != null) {
+        props[entry.key] = value.toString();
+      }
+    }
+
+    return ProductAnalyticsEvent(
+      eventId: decoded['event_id'] as String,
+      eventName: decoded['event_name'] as String,
+      occurredAt: DateTime.parse(decoded['occurred_at'] as String),
+      userPubkey: decoded['user_pubkey'] as String? ?? '',
+      anonymousId: decoded['anonymous_id'] as String,
+      sessionId: decoded['session_id'] as String,
+      platform: decoded['platform'] as String? ?? '',
+      appVersion: decoded['app_version'] as String? ?? '',
+      buildNumber: decoded['build_number'] as String? ?? '',
+      surface: AnalyticsSurface.fromWireName(
+        decoded['surface'] as String? ?? '',
+      ),
+      targetId: properties['target_id'] as String?,
+      props: props,
+      propsNum: propsNum,
+      schemaVersion: decoded['schema_version'] as int? ?? 1,
+    );
+  }
+}
+
+sealed class AnalyticsIngestResult {
+  const AnalyticsIngestResult();
+}
+
+final class AnalyticsIngestAccepted extends AnalyticsIngestResult {
+  const AnalyticsIngestAccepted();
+}
+
+final class AnalyticsIngestRejected extends AnalyticsIngestResult {
+  const AnalyticsIngestRejected({
+    required this.statusCode,
+    required this.reason,
+  });
+
+  final int statusCode;
+  final String reason;
+}
+
+final class AnalyticsIngestTransientFailure extends AnalyticsIngestResult {
+  const AnalyticsIngestTransientFailure(this.reason);
+
+  final String reason;
+}
+
+class AnalyticsIngestClient {
+  AnalyticsIngestClient({
+    required http.Client httpClient,
+    required Nip98AuthService nip98AuthService,
+    required String Function() apiBaseUrl,
+    Duration timeout = const Duration(seconds: 15),
+  }) : _httpClient = httpClient,
+       _nip98 = nip98AuthService,
+       _apiBaseUrl = apiBaseUrl,
+       _timeout = timeout;
+
+  static const eventsPath = '/api/analytics/events';
+  static const _logName = 'AnalyticsIngestClient';
+
+  final http.Client _httpClient;
+  final Nip98AuthService _nip98;
+  final String Function() _apiBaseUrl;
+  final Duration _timeout;
+
+  String get publishUrl {
+    final base = _apiBaseUrl();
+    final trimmed = base.endsWith('/')
+        ? base.substring(0, base.length - 1)
+        : base;
+    return '$trimmed$eventsPath';
+  }
+
+  Future<AnalyticsIngestResult> publishBatch(
+    List<ProductAnalyticsEvent> events,
+  ) async {
+    if (events.isEmpty) return const AnalyticsIngestAccepted();
+
+    final url = publishUrl;
+    final body = jsonEncode({
+      'events': events.map((event) => event.toJson()).toList(),
+    });
+    final token = await _nip98.createAuthToken(
+      url: url,
+      method: HttpMethod.post,
+      payload: body,
+    );
+    if (token == null) {
+      return const AnalyticsIngestTransientFailure('nip98_token_unavailable');
+    }
+
+    final http.Response response;
+    try {
+      response = await _httpClient
+          .post(
+            Uri.parse(url),
+            headers: {
+              'Content-Type': 'application/json',
+              'Accept': 'application/json',
+              'Authorization': token.authorizationHeader,
+            },
+            body: body,
+          )
+          .timeout(_timeout);
+    } on TimeoutException {
+      return const AnalyticsIngestTransientFailure('timeout');
+    } catch (e) {
+      return AnalyticsIngestTransientFailure('network_error: $e');
+    }
+
+    return _classify(response);
+  }
+
+  AnalyticsIngestResult _classify(http.Response response) {
+    final status = response.statusCode;
+    if (status == 200 || status == 202) {
+      try {
+        final decoded = jsonDecode(response.body) as Map<String, dynamic>;
+        if (decoded['accepted'] == true) {
+          return const AnalyticsIngestAccepted();
+        }
+        return AnalyticsIngestTransientFailure(
+          'not_accepted: ${response.body}',
+        );
+      } catch (e) {
+        return AnalyticsIngestTransientFailure('invalid_response: $e');
+      }
+    }
+
+    if (status == 400 || status == 401 || status == 403 || status == 422) {
+      Log.error(
+        'Product analytics ingest rejected ($status): ${response.body}',
+        name: _logName,
+        category: LogCategory.system,
+      );
+      return AnalyticsIngestRejected(
+        statusCode: status,
+        reason: response.body,
+      );
+    }
+
+    return AnalyticsIngestTransientFailure('http_$status');
+  }
+}

--- a/mobile/lib/services/analytics_service.dart
+++ b/mobile/lib/services/analytics_service.dart
@@ -6,10 +6,13 @@ import 'dart:async';
 import 'package:db_client/db_client.dart';
 import 'package:flutter/foundation.dart';
 import 'package:models/models.dart' hide LogCategory;
+import 'package:openvine/services/analytics_ingest_client.dart';
 import 'package:openvine/services/background_activity_manager.dart';
+import 'package:openvine/services/product_event_queue.dart';
 import 'package:openvine/services/view_event_publisher.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:unified_logger/unified_logger.dart';
+import 'package:uuid/uuid.dart';
 
 /// Service for tracking video analytics with privacy controls.
 ///
@@ -25,17 +28,52 @@ class AnalyticsService implements BackgroundAwareService {
     ViewEventPublisher? viewEventPublisher,
     PendingViewEventsDao? pendingViewEventsDao,
     Future<void> Function()? flushPendingViewEvents,
+    ProductEventQueue? productEventQueue,
+    String? Function()? currentUserPubkey,
+    String Function()? anonymousId,
+    String Function()? sessionId,
+    String Function()? platform,
+    String Function()? appVersion,
+    String Function()? buildNumber,
+    DateTime Function()? now,
+    String Function()? eventIdFactory,
     @visibleForTesting bool? disableNostrPublishing,
   }) : _viewEventPublisher = viewEventPublisher,
        _pendingViewEventsDao = pendingViewEventsDao,
        _flushPendingViewEvents = flushPendingViewEvents,
+       _productEventQueue = productEventQueue,
+       _currentUserPubkey = currentUserPubkey,
+       _anonymousIdOverride = anonymousId,
+       _sessionIdOverride = sessionId,
+       _platform = platform ?? _defaultPlatform,
+       _appVersion = appVersion ?? _emptyString,
+       _buildNumber = buildNumber ?? _emptyString,
+       _now = now ?? DateTime.now,
+       _eventIdFactory = eventIdFactory ?? _uuidV4,
        _disableNostrPublishing = disableNostrPublishing ?? false;
+
+  static const Uuid _uuid = Uuid();
+
+  static String _uuidV4() => _uuid.v4();
+
+  static String _emptyString() => '';
+
+  static String _defaultPlatform() => defaultTargetPlatform.name;
 
   /// The view event publisher for Kind 22236 Nostr events.
   ViewEventPublisher? _viewEventPublisher;
 
   final PendingViewEventsDao? _pendingViewEventsDao;
   final Future<void> Function()? _flushPendingViewEvents;
+  final ProductEventQueue? _productEventQueue;
+  final String? Function()? _currentUserPubkey;
+  final String Function()? _anonymousIdOverride;
+  final String Function()? _sessionIdOverride;
+  final String Function() _platform;
+  final String Function() _appVersion;
+  final String Function() _buildNumber;
+  final DateTime Function() _now;
+  final String Function() _eventIdFactory;
 
   /// Testing flag to disable Nostr publishing in unit tests.
   final bool _disableNostrPublishing;
@@ -44,6 +82,8 @@ class AnalyticsService implements BackgroundAwareService {
 
   bool _analyticsEnabled = true; // Default to enabled
   bool _isInitialized = false;
+  late final String _anonymousId = _uuid.v4();
+  late String _sessionId = _uuid.v4();
 
   // Track recent views to prevent duplicate tracking
   final Set<String> _recentlyTrackedViews = {};
@@ -125,6 +165,46 @@ class AnalyticsService implements BackgroundAwareService {
     } catch (e) {
       Log.error(
         'Failed to save analytics preference: $e',
+        name: 'AnalyticsService',
+        category: LogCategory.system,
+      );
+    }
+  }
+
+  /// Track a first-party product analytics event into the durable ingest queue.
+  Future<void> track(
+    String eventName, {
+    required AnalyticsSurface surface,
+    Map<String, String> props = const {},
+    Map<String, double> propsNum = const {},
+    String? targetId,
+  }) async {
+    if (_isDisposed || !_analyticsEnabled) return;
+
+    final queue = _productEventQueue;
+    if (queue == null) return;
+
+    final event = ProductAnalyticsEvent(
+      eventId: _eventIdFactory(),
+      eventName: eventName,
+      occurredAt: _now(),
+      userPubkey: _currentUserPubkey?.call() ?? '',
+      anonymousId: _anonymousIdOverride?.call() ?? _anonymousId,
+      sessionId: _sessionIdOverride?.call() ?? _sessionId,
+      platform: _platform(),
+      appVersion: _appVersion(),
+      buildNumber: _buildNumber(),
+      surface: surface,
+      targetId: targetId,
+      props: props,
+      propsNum: propsNum,
+    );
+
+    try {
+      await queue.enqueue(event);
+    } catch (e) {
+      Log.warning(
+        'Failed to enqueue product analytics event $eventName: $e',
         name: 'AnalyticsService',
         category: LogCategory.system,
       );
@@ -388,6 +468,9 @@ class AnalyticsService implements BackgroundAwareService {
 
   @override
   void onAppResumed() {
+    if (_isInBackground && _sessionIdOverride == null) {
+      _sessionId = _uuid.v4();
+    }
     _isInBackground = false;
   }
 

--- a/mobile/lib/services/product_event_queue.dart
+++ b/mobile/lib/services/product_event_queue.dart
@@ -1,0 +1,114 @@
+// ABOUTME: Durable retry queue for first-party product analytics events.
+// ABOUTME: Persists payloads locally and flushes them to the analytics ingest API.
+
+import 'package:db_client/db_client.dart';
+import 'package:openvine/services/analytics_ingest_client.dart';
+
+class ProductEventRetryConfig {
+  const ProductEventRetryConfig({
+    this.maxAttempts = 5,
+    this.batchSize = 25,
+    this.initialDelay = const Duration(seconds: 2),
+    this.maxDelay = const Duration(minutes: 5),
+    this.backoffMultiplier = 2.0,
+  });
+
+  final int maxAttempts;
+  final int batchSize;
+  final Duration initialDelay;
+  final Duration maxDelay;
+  final double backoffMultiplier;
+
+  Duration backoffFor(int attemptCount) {
+    if (attemptCount <= 0) return initialDelay;
+    var ms = initialDelay.inMilliseconds.toDouble();
+    for (var i = 1; i < attemptCount; i++) {
+      ms *= backoffMultiplier;
+      if (ms >= maxDelay.inMilliseconds) return maxDelay;
+    }
+    return Duration(milliseconds: ms.round());
+  }
+}
+
+class ProductEventQueue {
+  ProductEventQueue({
+    required PendingProductEventsDao dao,
+    required AnalyticsIngestClient ingestClient,
+    ProductEventRetryConfig retryConfig = const ProductEventRetryConfig(),
+    DateTime Function() now = DateTime.now,
+  }) : _dao = dao,
+       _ingestClient = ingestClient,
+       _retryConfig = retryConfig,
+       _now = now;
+
+  final PendingProductEventsDao _dao;
+  final AnalyticsIngestClient _ingestClient;
+  final ProductEventRetryConfig _retryConfig;
+  final DateTime Function() _now;
+
+  bool _isFlushing = false;
+
+  Future<void> enqueue(ProductAnalyticsEvent event) async {
+    await _dao.enqueue(
+      PendingProductEvent(
+        id: event.eventId,
+        eventName: event.eventName,
+        payloadJson: event.toPayloadJson(),
+        status: PendingProductEventStatus.pending,
+        createdAt: event.occurredAt,
+      ),
+    );
+  }
+
+  Future<void> flush() async {
+    if (_isFlushing) return;
+    _isFlushing = true;
+    try {
+      final rows = await _dao.getRetryable(
+        now: _now(),
+        maxAttempts: _retryConfig.maxAttempts,
+        limit: _retryConfig.batchSize,
+      );
+      if (rows.isEmpty) return;
+
+      final claimed = <PendingProductEvent>[];
+      for (final row in rows) {
+        final marked = await _dao.markPublishing(row.id);
+        if (marked) claimed.add(row);
+      }
+      if (claimed.isEmpty) return;
+
+      final events = claimed
+          .map((row) => ProductAnalyticsEvent.fromPayloadJson(row.payloadJson))
+          .toList();
+      final result = await _ingestClient.publishBatch(events);
+
+      switch (result) {
+        case AnalyticsIngestAccepted():
+          for (final row in claimed) {
+            await _dao.deleteById(row.id);
+          }
+        case AnalyticsIngestRejected(:final reason):
+          for (final row in claimed) {
+            await _dao.markDeadLetter(row.id, reason);
+          }
+        case AnalyticsIngestTransientFailure(:final reason):
+          for (final row in claimed) {
+            if (row.attemptCount + 1 >= _retryConfig.maxAttempts) {
+              await _dao.markDeadLetter(row.id, reason);
+              continue;
+            }
+            await _dao.markFailed(
+              row.id,
+              reason,
+              nextAttemptAt: _now().add(
+                _retryConfig.backoffFor(row.attemptCount + 1),
+              ),
+            );
+          }
+      }
+    } finally {
+      _isFlushing = false;
+    }
+  }
+}

--- a/mobile/lib/services/product_event_queue.dart
+++ b/mobile/lib/services/product_event_queue.dart
@@ -64,51 +64,66 @@ class ProductEventQueue {
     if (_isFlushing) return;
     _isFlushing = true;
     try {
-      final rows = await _dao.getRetryable(
-        now: _now(),
-        maxAttempts: _retryConfig.maxAttempts,
-        limit: _retryConfig.batchSize,
-      );
-      if (rows.isEmpty) return;
-
-      final claimed = <PendingProductEvent>[];
-      for (final row in rows) {
-        final marked = await _dao.markPublishing(row.id);
-        if (marked) claimed.add(row);
-      }
-      if (claimed.isEmpty) return;
-
-      final events = claimed
-          .map((row) => ProductAnalyticsEvent.fromPayloadJson(row.payloadJson))
-          .toList();
-      final result = await _ingestClient.publishBatch(events);
-
-      switch (result) {
-        case AnalyticsIngestAccepted():
-          for (final row in claimed) {
-            await _dao.deleteById(row.id);
-          }
-        case AnalyticsIngestRejected(:final reason):
-          for (final row in claimed) {
-            await _dao.markDeadLetter(row.id, reason);
-          }
-        case AnalyticsIngestTransientFailure(:final reason):
-          for (final row in claimed) {
-            if (row.attemptCount + 1 >= _retryConfig.maxAttempts) {
-              await _dao.markDeadLetter(row.id, reason);
-              continue;
-            }
-            await _dao.markFailed(
-              row.id,
-              reason,
-              nextAttemptAt: _now().add(
-                _retryConfig.backoffFor(row.attemptCount + 1),
-              ),
-            );
-          }
-      }
+      await _flushUnlocked();
     } finally {
       _isFlushing = false;
+    }
+  }
+
+  Future<void> recoverPublishingAndFlush() async {
+    if (_isFlushing) return;
+    _isFlushing = true;
+    try {
+      await _dao.resetPublishingToPending();
+      await _flushUnlocked();
+    } finally {
+      _isFlushing = false;
+    }
+  }
+
+  Future<void> _flushUnlocked() async {
+    final rows = await _dao.getRetryable(
+      now: _now(),
+      maxAttempts: _retryConfig.maxAttempts,
+      limit: _retryConfig.batchSize,
+    );
+    if (rows.isEmpty) return;
+
+    final claimed = <PendingProductEvent>[];
+    for (final row in rows) {
+      final marked = await _dao.markPublishing(row.id);
+      if (marked) claimed.add(row);
+    }
+    if (claimed.isEmpty) return;
+
+    final events = claimed
+        .map((row) => ProductAnalyticsEvent.fromPayloadJson(row.payloadJson))
+        .toList();
+    final result = await _ingestClient.publishBatch(events);
+
+    switch (result) {
+      case AnalyticsIngestAccepted():
+        for (final row in claimed) {
+          await _dao.deleteById(row.id);
+        }
+      case AnalyticsIngestRejected(:final reason):
+        for (final row in claimed) {
+          await _dao.markDeadLetter(row.id, reason);
+        }
+      case AnalyticsIngestTransientFailure(:final reason):
+        for (final row in claimed) {
+          if (row.attemptCount + 1 >= _retryConfig.maxAttempts) {
+            await _dao.markDeadLetter(row.id, reason);
+            continue;
+          }
+          await _dao.markFailed(
+            row.id,
+            reason,
+            nextAttemptAt: _now().add(
+              _retryConfig.backoffFor(row.attemptCount + 1),
+            ),
+          );
+        }
     }
   }
 }

--- a/mobile/packages/db_client/lib/src/database/app_database.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.dart
@@ -35,6 +35,7 @@ const _notificationRetentionDays = 7;
     Conversations,
     OutgoingDms,
     PendingViewEvents,
+    PendingProductEvents,
     PendingGiftWraps,
     ProcessedGiftWraps,
   ],
@@ -57,6 +58,7 @@ const _notificationRetentionDays = 7;
     ConversationsDao,
     OutgoingDmsDao,
     PendingViewEventsDao,
+    PendingProductEventsDao,
     PendingGiftWrapsDao,
     ProcessedGiftWrapsDao,
   ],
@@ -626,6 +628,34 @@ class AppDatabase extends _$AppDatabase {
     await customStatement('''
       CREATE INDEX IF NOT EXISTS idx_pending_view_events_created_at
       ON pending_view_events (created_at)
+    ''');
+
+    final pendingProductEventsResult = await customSelect(
+      "SELECT name FROM sqlite_master WHERE type='table' "
+      "AND name='pending_product_events'",
+    ).get();
+
+    if (pendingProductEventsResult.isEmpty) {
+      await customStatement('''
+        CREATE TABLE pending_product_events (
+          id TEXT NOT NULL PRIMARY KEY,
+          event_name TEXT NOT NULL,
+          payload_json TEXT NOT NULL,
+          status TEXT NOT NULL,
+          attempt_count INTEGER NOT NULL DEFAULT 0,
+          next_attempt_at INTEGER,
+          last_error TEXT,
+          created_at INTEGER NOT NULL
+        )
+      ''');
+    }
+    await customStatement('''
+      CREATE INDEX IF NOT EXISTS idx_pending_product_events_status_next_attempt
+      ON pending_product_events (status, next_attempt_at)
+    ''');
+    await customStatement('''
+      CREATE INDEX IF NOT EXISTS idx_pending_product_events_created_at
+      ON pending_product_events (created_at)
     ''');
 
     // Check if pending_gift_wraps table exists, create if missing.

--- a/mobile/packages/db_client/lib/src/database/app_database.g.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.g.dart
@@ -13221,6 +13221,536 @@ class PendingViewEventsCompanion extends UpdateCompanion<PendingViewEventRow> {
   }
 }
 
+class $PendingProductEventsTable extends PendingProductEvents
+    with TableInfo<$PendingProductEventsTable, PendingProductEventRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $PendingProductEventsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<String> id = GeneratedColumn<String>(
+    'id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _eventNameMeta = const VerificationMeta(
+    'eventName',
+  );
+  @override
+  late final GeneratedColumn<String> eventName = GeneratedColumn<String>(
+    'event_name',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _payloadJsonMeta = const VerificationMeta(
+    'payloadJson',
+  );
+  @override
+  late final GeneratedColumn<String> payloadJson = GeneratedColumn<String>(
+    'payload_json',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _statusMeta = const VerificationMeta('status');
+  @override
+  late final GeneratedColumn<String> status = GeneratedColumn<String>(
+    'status',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _attemptCountMeta = const VerificationMeta(
+    'attemptCount',
+  );
+  @override
+  late final GeneratedColumn<int> attemptCount = GeneratedColumn<int>(
+    'attempt_count',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultValue: const Constant(0),
+  );
+  static const VerificationMeta _nextAttemptAtMeta = const VerificationMeta(
+    'nextAttemptAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> nextAttemptAt =
+      GeneratedColumn<DateTime>(
+        'next_attempt_at',
+        aliasedName,
+        true,
+        type: DriftSqlType.dateTime,
+        requiredDuringInsert: false,
+      );
+  static const VerificationMeta _lastErrorMeta = const VerificationMeta(
+    'lastError',
+  );
+  @override
+  late final GeneratedColumn<String> lastError = GeneratedColumn<String>(
+    'last_error',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _createdAtMeta = const VerificationMeta(
+    'createdAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
+    'created_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: true,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    eventName,
+    payloadJson,
+    status,
+    attemptCount,
+    nextAttemptAt,
+    lastError,
+    createdAt,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'pending_product_events';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<PendingProductEventRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    } else if (isInserting) {
+      context.missing(_idMeta);
+    }
+    if (data.containsKey('event_name')) {
+      context.handle(
+        _eventNameMeta,
+        eventName.isAcceptableOrUnknown(data['event_name']!, _eventNameMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_eventNameMeta);
+    }
+    if (data.containsKey('payload_json')) {
+      context.handle(
+        _payloadJsonMeta,
+        payloadJson.isAcceptableOrUnknown(
+          data['payload_json']!,
+          _payloadJsonMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_payloadJsonMeta);
+    }
+    if (data.containsKey('status')) {
+      context.handle(
+        _statusMeta,
+        status.isAcceptableOrUnknown(data['status']!, _statusMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_statusMeta);
+    }
+    if (data.containsKey('attempt_count')) {
+      context.handle(
+        _attemptCountMeta,
+        attemptCount.isAcceptableOrUnknown(
+          data['attempt_count']!,
+          _attemptCountMeta,
+        ),
+      );
+    }
+    if (data.containsKey('next_attempt_at')) {
+      context.handle(
+        _nextAttemptAtMeta,
+        nextAttemptAt.isAcceptableOrUnknown(
+          data['next_attempt_at']!,
+          _nextAttemptAtMeta,
+        ),
+      );
+    }
+    if (data.containsKey('last_error')) {
+      context.handle(
+        _lastErrorMeta,
+        lastError.isAcceptableOrUnknown(data['last_error']!, _lastErrorMeta),
+      );
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(
+        _createdAtMeta,
+        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_createdAtMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  PendingProductEventRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return PendingProductEventRow(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}id'],
+      )!,
+      eventName: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}event_name'],
+      )!,
+      payloadJson: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}payload_json'],
+      )!,
+      status: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}status'],
+      )!,
+      attemptCount: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}attempt_count'],
+      )!,
+      nextAttemptAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}next_attempt_at'],
+      ),
+      lastError: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}last_error'],
+      ),
+      createdAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}created_at'],
+      )!,
+    );
+  }
+
+  @override
+  $PendingProductEventsTable createAlias(String alias) {
+    return $PendingProductEventsTable(attachedDatabase, alias);
+  }
+}
+
+class PendingProductEventRow extends DataClass
+    implements Insertable<PendingProductEventRow> {
+  final String id;
+  final String eventName;
+  final String payloadJson;
+  final String status;
+  final int attemptCount;
+  final DateTime? nextAttemptAt;
+  final String? lastError;
+  final DateTime createdAt;
+  const PendingProductEventRow({
+    required this.id,
+    required this.eventName,
+    required this.payloadJson,
+    required this.status,
+    required this.attemptCount,
+    this.nextAttemptAt,
+    this.lastError,
+    required this.createdAt,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<String>(id);
+    map['event_name'] = Variable<String>(eventName);
+    map['payload_json'] = Variable<String>(payloadJson);
+    map['status'] = Variable<String>(status);
+    map['attempt_count'] = Variable<int>(attemptCount);
+    if (!nullToAbsent || nextAttemptAt != null) {
+      map['next_attempt_at'] = Variable<DateTime>(nextAttemptAt);
+    }
+    if (!nullToAbsent || lastError != null) {
+      map['last_error'] = Variable<String>(lastError);
+    }
+    map['created_at'] = Variable<DateTime>(createdAt);
+    return map;
+  }
+
+  PendingProductEventsCompanion toCompanion(bool nullToAbsent) {
+    return PendingProductEventsCompanion(
+      id: Value(id),
+      eventName: Value(eventName),
+      payloadJson: Value(payloadJson),
+      status: Value(status),
+      attemptCount: Value(attemptCount),
+      nextAttemptAt: nextAttemptAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(nextAttemptAt),
+      lastError: lastError == null && nullToAbsent
+          ? const Value.absent()
+          : Value(lastError),
+      createdAt: Value(createdAt),
+    );
+  }
+
+  factory PendingProductEventRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return PendingProductEventRow(
+      id: serializer.fromJson<String>(json['id']),
+      eventName: serializer.fromJson<String>(json['eventName']),
+      payloadJson: serializer.fromJson<String>(json['payloadJson']),
+      status: serializer.fromJson<String>(json['status']),
+      attemptCount: serializer.fromJson<int>(json['attemptCount']),
+      nextAttemptAt: serializer.fromJson<DateTime?>(json['nextAttemptAt']),
+      lastError: serializer.fromJson<String?>(json['lastError']),
+      createdAt: serializer.fromJson<DateTime>(json['createdAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<String>(id),
+      'eventName': serializer.toJson<String>(eventName),
+      'payloadJson': serializer.toJson<String>(payloadJson),
+      'status': serializer.toJson<String>(status),
+      'attemptCount': serializer.toJson<int>(attemptCount),
+      'nextAttemptAt': serializer.toJson<DateTime?>(nextAttemptAt),
+      'lastError': serializer.toJson<String?>(lastError),
+      'createdAt': serializer.toJson<DateTime>(createdAt),
+    };
+  }
+
+  PendingProductEventRow copyWith({
+    String? id,
+    String? eventName,
+    String? payloadJson,
+    String? status,
+    int? attemptCount,
+    Value<DateTime?> nextAttemptAt = const Value.absent(),
+    Value<String?> lastError = const Value.absent(),
+    DateTime? createdAt,
+  }) => PendingProductEventRow(
+    id: id ?? this.id,
+    eventName: eventName ?? this.eventName,
+    payloadJson: payloadJson ?? this.payloadJson,
+    status: status ?? this.status,
+    attemptCount: attemptCount ?? this.attemptCount,
+    nextAttemptAt: nextAttemptAt.present
+        ? nextAttemptAt.value
+        : this.nextAttemptAt,
+    lastError: lastError.present ? lastError.value : this.lastError,
+    createdAt: createdAt ?? this.createdAt,
+  );
+  PendingProductEventRow copyWithCompanion(PendingProductEventsCompanion data) {
+    return PendingProductEventRow(
+      id: data.id.present ? data.id.value : this.id,
+      eventName: data.eventName.present ? data.eventName.value : this.eventName,
+      payloadJson: data.payloadJson.present
+          ? data.payloadJson.value
+          : this.payloadJson,
+      status: data.status.present ? data.status.value : this.status,
+      attemptCount: data.attemptCount.present
+          ? data.attemptCount.value
+          : this.attemptCount,
+      nextAttemptAt: data.nextAttemptAt.present
+          ? data.nextAttemptAt.value
+          : this.nextAttemptAt,
+      lastError: data.lastError.present ? data.lastError.value : this.lastError,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('PendingProductEventRow(')
+          ..write('id: $id, ')
+          ..write('eventName: $eventName, ')
+          ..write('payloadJson: $payloadJson, ')
+          ..write('status: $status, ')
+          ..write('attemptCount: $attemptCount, ')
+          ..write('nextAttemptAt: $nextAttemptAt, ')
+          ..write('lastError: $lastError, ')
+          ..write('createdAt: $createdAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    eventName,
+    payloadJson,
+    status,
+    attemptCount,
+    nextAttemptAt,
+    lastError,
+    createdAt,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is PendingProductEventRow &&
+          other.id == this.id &&
+          other.eventName == this.eventName &&
+          other.payloadJson == this.payloadJson &&
+          other.status == this.status &&
+          other.attemptCount == this.attemptCount &&
+          other.nextAttemptAt == this.nextAttemptAt &&
+          other.lastError == this.lastError &&
+          other.createdAt == this.createdAt);
+}
+
+class PendingProductEventsCompanion
+    extends UpdateCompanion<PendingProductEventRow> {
+  final Value<String> id;
+  final Value<String> eventName;
+  final Value<String> payloadJson;
+  final Value<String> status;
+  final Value<int> attemptCount;
+  final Value<DateTime?> nextAttemptAt;
+  final Value<String?> lastError;
+  final Value<DateTime> createdAt;
+  final Value<int> rowid;
+  const PendingProductEventsCompanion({
+    this.id = const Value.absent(),
+    this.eventName = const Value.absent(),
+    this.payloadJson = const Value.absent(),
+    this.status = const Value.absent(),
+    this.attemptCount = const Value.absent(),
+    this.nextAttemptAt = const Value.absent(),
+    this.lastError = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  PendingProductEventsCompanion.insert({
+    required String id,
+    required String eventName,
+    required String payloadJson,
+    required String status,
+    this.attemptCount = const Value.absent(),
+    this.nextAttemptAt = const Value.absent(),
+    this.lastError = const Value.absent(),
+    required DateTime createdAt,
+    this.rowid = const Value.absent(),
+  }) : id = Value(id),
+       eventName = Value(eventName),
+       payloadJson = Value(payloadJson),
+       status = Value(status),
+       createdAt = Value(createdAt);
+  static Insertable<PendingProductEventRow> custom({
+    Expression<String>? id,
+    Expression<String>? eventName,
+    Expression<String>? payloadJson,
+    Expression<String>? status,
+    Expression<int>? attemptCount,
+    Expression<DateTime>? nextAttemptAt,
+    Expression<String>? lastError,
+    Expression<DateTime>? createdAt,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (eventName != null) 'event_name': eventName,
+      if (payloadJson != null) 'payload_json': payloadJson,
+      if (status != null) 'status': status,
+      if (attemptCount != null) 'attempt_count': attemptCount,
+      if (nextAttemptAt != null) 'next_attempt_at': nextAttemptAt,
+      if (lastError != null) 'last_error': lastError,
+      if (createdAt != null) 'created_at': createdAt,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  PendingProductEventsCompanion copyWith({
+    Value<String>? id,
+    Value<String>? eventName,
+    Value<String>? payloadJson,
+    Value<String>? status,
+    Value<int>? attemptCount,
+    Value<DateTime?>? nextAttemptAt,
+    Value<String?>? lastError,
+    Value<DateTime>? createdAt,
+    Value<int>? rowid,
+  }) {
+    return PendingProductEventsCompanion(
+      id: id ?? this.id,
+      eventName: eventName ?? this.eventName,
+      payloadJson: payloadJson ?? this.payloadJson,
+      status: status ?? this.status,
+      attemptCount: attemptCount ?? this.attemptCount,
+      nextAttemptAt: nextAttemptAt ?? this.nextAttemptAt,
+      lastError: lastError ?? this.lastError,
+      createdAt: createdAt ?? this.createdAt,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<String>(id.value);
+    }
+    if (eventName.present) {
+      map['event_name'] = Variable<String>(eventName.value);
+    }
+    if (payloadJson.present) {
+      map['payload_json'] = Variable<String>(payloadJson.value);
+    }
+    if (status.present) {
+      map['status'] = Variable<String>(status.value);
+    }
+    if (attemptCount.present) {
+      map['attempt_count'] = Variable<int>(attemptCount.value);
+    }
+    if (nextAttemptAt.present) {
+      map['next_attempt_at'] = Variable<DateTime>(nextAttemptAt.value);
+    }
+    if (lastError.present) {
+      map['last_error'] = Variable<String>(lastError.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<DateTime>(createdAt.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('PendingProductEventsCompanion(')
+          ..write('id: $id, ')
+          ..write('eventName: $eventName, ')
+          ..write('payloadJson: $payloadJson, ')
+          ..write('status: $status, ')
+          ..write('attemptCount: $attemptCount, ')
+          ..write('nextAttemptAt: $nextAttemptAt, ')
+          ..write('lastError: $lastError, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
 class $PendingGiftWrapsTable extends PendingGiftWraps
     with TableInfo<$PendingGiftWrapsTable, PendingGiftWrapRow> {
   @override
@@ -13998,6 +14528,8 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   late final $OutgoingDmsTable outgoingDms = $OutgoingDmsTable(this);
   late final $PendingViewEventsTable pendingViewEvents =
       $PendingViewEventsTable(this);
+  late final $PendingProductEventsTable pendingProductEvents =
+      $PendingProductEventsTable(this);
   late final $PendingGiftWrapsTable pendingGiftWraps = $PendingGiftWrapsTable(
     this,
   );
@@ -14052,6 +14584,8 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   late final PendingViewEventsDao pendingViewEventsDao = PendingViewEventsDao(
     this as AppDatabase,
   );
+  late final PendingProductEventsDao pendingProductEventsDao =
+      PendingProductEventsDao(this as AppDatabase);
   late final PendingGiftWrapsDao pendingGiftWrapsDao = PendingGiftWrapsDao(
     this as AppDatabase,
   );
@@ -14080,6 +14614,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     conversations,
     outgoingDms,
     pendingViewEvents,
+    pendingProductEvents,
     pendingGiftWraps,
     processedGiftWraps,
   ];
@@ -20189,6 +20724,285 @@ typedef $$PendingViewEventsTableProcessedTableManager =
       PendingViewEventRow,
       PrefetchHooks Function()
     >;
+typedef $$PendingProductEventsTableCreateCompanionBuilder =
+    PendingProductEventsCompanion Function({
+      required String id,
+      required String eventName,
+      required String payloadJson,
+      required String status,
+      Value<int> attemptCount,
+      Value<DateTime?> nextAttemptAt,
+      Value<String?> lastError,
+      required DateTime createdAt,
+      Value<int> rowid,
+    });
+typedef $$PendingProductEventsTableUpdateCompanionBuilder =
+    PendingProductEventsCompanion Function({
+      Value<String> id,
+      Value<String> eventName,
+      Value<String> payloadJson,
+      Value<String> status,
+      Value<int> attemptCount,
+      Value<DateTime?> nextAttemptAt,
+      Value<String?> lastError,
+      Value<DateTime> createdAt,
+      Value<int> rowid,
+    });
+
+class $$PendingProductEventsTableFilterComposer
+    extends Composer<_$AppDatabase, $PendingProductEventsTable> {
+  $$PendingProductEventsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get eventName => $composableBuilder(
+    column: $table.eventName,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get payloadJson => $composableBuilder(
+    column: $table.payloadJson,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get status => $composableBuilder(
+    column: $table.status,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get attemptCount => $composableBuilder(
+    column: $table.attemptCount,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get nextAttemptAt => $composableBuilder(
+    column: $table.nextAttemptAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get lastError => $composableBuilder(
+    column: $table.lastError,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$PendingProductEventsTableOrderingComposer
+    extends Composer<_$AppDatabase, $PendingProductEventsTable> {
+  $$PendingProductEventsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get eventName => $composableBuilder(
+    column: $table.eventName,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get payloadJson => $composableBuilder(
+    column: $table.payloadJson,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get status => $composableBuilder(
+    column: $table.status,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get attemptCount => $composableBuilder(
+    column: $table.attemptCount,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get nextAttemptAt => $composableBuilder(
+    column: $table.nextAttemptAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get lastError => $composableBuilder(
+    column: $table.lastError,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$PendingProductEventsTableAnnotationComposer
+    extends Composer<_$AppDatabase, $PendingProductEventsTable> {
+  $$PendingProductEventsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get eventName =>
+      $composableBuilder(column: $table.eventName, builder: (column) => column);
+
+  GeneratedColumn<String> get payloadJson => $composableBuilder(
+    column: $table.payloadJson,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get status =>
+      $composableBuilder(column: $table.status, builder: (column) => column);
+
+  GeneratedColumn<int> get attemptCount => $composableBuilder(
+    column: $table.attemptCount,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<DateTime> get nextAttemptAt => $composableBuilder(
+    column: $table.nextAttemptAt,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get lastError =>
+      $composableBuilder(column: $table.lastError, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => column);
+}
+
+class $$PendingProductEventsTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $PendingProductEventsTable,
+          PendingProductEventRow,
+          $$PendingProductEventsTableFilterComposer,
+          $$PendingProductEventsTableOrderingComposer,
+          $$PendingProductEventsTableAnnotationComposer,
+          $$PendingProductEventsTableCreateCompanionBuilder,
+          $$PendingProductEventsTableUpdateCompanionBuilder,
+          (
+            PendingProductEventRow,
+            BaseReferences<
+              _$AppDatabase,
+              $PendingProductEventsTable,
+              PendingProductEventRow
+            >,
+          ),
+          PendingProductEventRow,
+          PrefetchHooks Function()
+        > {
+  $$PendingProductEventsTableTableManager(
+    _$AppDatabase db,
+    $PendingProductEventsTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$PendingProductEventsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$PendingProductEventsTableOrderingComposer(
+                $db: db,
+                $table: table,
+              ),
+          createComputedFieldComposer: () =>
+              $$PendingProductEventsTableAnnotationComposer(
+                $db: db,
+                $table: table,
+              ),
+          updateCompanionCallback:
+              ({
+                Value<String> id = const Value.absent(),
+                Value<String> eventName = const Value.absent(),
+                Value<String> payloadJson = const Value.absent(),
+                Value<String> status = const Value.absent(),
+                Value<int> attemptCount = const Value.absent(),
+                Value<DateTime?> nextAttemptAt = const Value.absent(),
+                Value<String?> lastError = const Value.absent(),
+                Value<DateTime> createdAt = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => PendingProductEventsCompanion(
+                id: id,
+                eventName: eventName,
+                payloadJson: payloadJson,
+                status: status,
+                attemptCount: attemptCount,
+                nextAttemptAt: nextAttemptAt,
+                lastError: lastError,
+                createdAt: createdAt,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String id,
+                required String eventName,
+                required String payloadJson,
+                required String status,
+                Value<int> attemptCount = const Value.absent(),
+                Value<DateTime?> nextAttemptAt = const Value.absent(),
+                Value<String?> lastError = const Value.absent(),
+                required DateTime createdAt,
+                Value<int> rowid = const Value.absent(),
+              }) => PendingProductEventsCompanion.insert(
+                id: id,
+                eventName: eventName,
+                payloadJson: payloadJson,
+                status: status,
+                attemptCount: attemptCount,
+                nextAttemptAt: nextAttemptAt,
+                lastError: lastError,
+                createdAt: createdAt,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$PendingProductEventsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $PendingProductEventsTable,
+      PendingProductEventRow,
+      $$PendingProductEventsTableFilterComposer,
+      $$PendingProductEventsTableOrderingComposer,
+      $$PendingProductEventsTableAnnotationComposer,
+      $$PendingProductEventsTableCreateCompanionBuilder,
+      $$PendingProductEventsTableUpdateCompanionBuilder,
+      (
+        PendingProductEventRow,
+        BaseReferences<
+          _$AppDatabase,
+          $PendingProductEventsTable,
+          PendingProductEventRow
+        >,
+      ),
+      PendingProductEventRow,
+      PrefetchHooks Function()
+    >;
 typedef $$PendingGiftWrapsTableCreateCompanionBuilder =
     PendingGiftWrapsCompanion Function({
       required String giftWrapId,
@@ -20645,6 +21459,8 @@ class $AppDatabaseManager {
       $$OutgoingDmsTableTableManager(_db, _db.outgoingDms);
   $$PendingViewEventsTableTableManager get pendingViewEvents =>
       $$PendingViewEventsTableTableManager(_db, _db.pendingViewEvents);
+  $$PendingProductEventsTableTableManager get pendingProductEvents =>
+      $$PendingProductEventsTableTableManager(_db, _db.pendingProductEvents);
   $$PendingGiftWrapsTableTableManager get pendingGiftWraps =>
       $$PendingGiftWrapsTableTableManager(_db, _db.pendingGiftWraps);
   $$ProcessedGiftWrapsTableTableManager get processedGiftWraps =>

--- a/mobile/packages/db_client/lib/src/database/daos/daos.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/daos.dart
@@ -10,6 +10,7 @@ export 'notifications_dao.dart';
 export 'outgoing_dms_dao.dart';
 export 'pending_actions_dao.dart';
 export 'pending_gift_wraps_dao.dart';
+export 'pending_product_events_dao.dart';
 export 'pending_uploads_dao.dart';
 export 'pending_view_events_dao.dart';
 export 'personal_reactions_dao.dart';

--- a/mobile/packages/db_client/lib/src/database/daos/pending_product_events_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/pending_product_events_dao.dart
@@ -1,0 +1,195 @@
+// ABOUTME: Data Access Object for the durable product analytics outbox.
+// ABOUTME: Stores first-party product events until ingest accepts them.
+
+import 'package:db_client/db_client.dart';
+import 'package:drift/drift.dart';
+import 'package:meta/meta.dart';
+
+part 'pending_product_events_dao.g.dart';
+
+enum PendingProductEventStatus {
+  pending,
+  publishing,
+  failed,
+  deadLetter,
+}
+
+class UnknownPendingProductEventStatusException implements Exception {
+  const UnknownPendingProductEventStatusException(this.rawValue);
+
+  final String rawValue;
+
+  @override
+  String toString() {
+    final known = PendingProductEventStatus.values
+        .map((status) => status.name)
+        .join(', ');
+    return 'UnknownPendingProductEventStatusException: '
+        'unrecognised pending_product_events status "$rawValue"; '
+        'expected one of $known';
+  }
+}
+
+@immutable
+class PendingProductEvent {
+  const PendingProductEvent({
+    required this.id,
+    required this.eventName,
+    required this.payloadJson,
+    required this.status,
+    required this.createdAt,
+    this.attemptCount = 0,
+    this.nextAttemptAt,
+    this.lastError,
+  });
+
+  final String id;
+  final String eventName;
+  final String payloadJson;
+  final PendingProductEventStatus status;
+  final int attemptCount;
+  final DateTime? nextAttemptAt;
+  final String? lastError;
+  final DateTime createdAt;
+}
+
+@DriftAccessor(tables: [PendingProductEvents])
+class PendingProductEventsDao extends DatabaseAccessor<AppDatabase>
+    with _$PendingProductEventsDaoMixin {
+  PendingProductEventsDao(super.attachedDatabase);
+
+  PendingProductEventsCompanion _modelToCompanion(PendingProductEvent event) {
+    return PendingProductEventsCompanion.insert(
+      id: event.id,
+      eventName: event.eventName,
+      payloadJson: event.payloadJson,
+      status: event.status.name,
+      attemptCount: Value(event.attemptCount),
+      nextAttemptAt: Value(event.nextAttemptAt),
+      lastError: Value(event.lastError),
+      createdAt: event.createdAt,
+    );
+  }
+
+  PendingProductEvent _rowToModel(PendingProductEventRow row) {
+    return PendingProductEvent(
+      id: row.id,
+      eventName: row.eventName,
+      payloadJson: row.payloadJson,
+      status: _parseStatus(row.status),
+      attemptCount: row.attemptCount,
+      nextAttemptAt: row.nextAttemptAt,
+      lastError: row.lastError,
+      createdAt: row.createdAt,
+    );
+  }
+
+  PendingProductEventStatus _parseStatus(String raw) {
+    for (final status in PendingProductEventStatus.values) {
+      if (status.name == raw) return status;
+    }
+    throw UnknownPendingProductEventStatusException(raw);
+  }
+
+  Future<void> enqueue(PendingProductEvent event) async {
+    await into(pendingProductEvents).insert(
+      _modelToCompanion(event),
+      mode: InsertMode.insertOrIgnore,
+    );
+  }
+
+  Future<PendingProductEvent?> getById(String id) async {
+    final row = await (select(
+      pendingProductEvents,
+    )..where((table) => table.id.equals(id))).getSingleOrNull();
+    return row == null ? null : _rowToModel(row);
+  }
+
+  Future<List<PendingProductEvent>> getRetryable({
+    required DateTime now,
+    required int maxAttempts,
+    required int limit,
+  }) async {
+    final query = select(pendingProductEvents)
+      ..where(
+        (table) =>
+            table.attemptCount.isSmallerThanValue(maxAttempts) &
+            (table.status.equals(PendingProductEventStatus.pending.name) |
+                table.status.equals(PendingProductEventStatus.failed.name)) &
+            (table.nextAttemptAt.isNull() |
+                table.nextAttemptAt.isSmallerOrEqualValue(now)),
+      )
+      ..orderBy([(table) => OrderingTerm(expression: table.createdAt)])
+      ..limit(limit);
+    final rows = await query.get();
+    return rows.map(_rowToModel).toList();
+  }
+
+  Future<bool> markPublishing(String id) async {
+    final rows =
+        await (update(
+          pendingProductEvents,
+        )..where((table) => table.id.equals(id))).write(
+          PendingProductEventsCompanion(
+            status: Value(PendingProductEventStatus.publishing.name),
+          ),
+        );
+    return rows > 0;
+  }
+
+  Future<bool> markFailed(
+    String id,
+    String error, {
+    required DateTime nextAttemptAt,
+  }) async {
+    return transaction(() async {
+      final row = await (select(
+        pendingProductEvents,
+      )..where((table) => table.id.equals(id))).getSingleOrNull();
+      if (row == null) return false;
+      final rows =
+          await (update(
+            pendingProductEvents,
+          )..where((table) => table.id.equals(id))).write(
+            PendingProductEventsCompanion(
+              status: Value(PendingProductEventStatus.failed.name),
+              attemptCount: Value(row.attemptCount + 1),
+              nextAttemptAt: Value(nextAttemptAt),
+              lastError: Value(error),
+            ),
+          );
+      return rows > 0;
+    });
+  }
+
+  Future<bool> markDeadLetter(String id, String error) async {
+    final rows =
+        await (update(
+          pendingProductEvents,
+        )..where((table) => table.id.equals(id))).write(
+          PendingProductEventsCompanion(
+            status: Value(PendingProductEventStatus.deadLetter.name),
+            lastError: Value(error),
+          ),
+        );
+    return rows > 0;
+  }
+
+  Future<int> resetPublishingToPending() {
+    return (update(pendingProductEvents)..where(
+          (table) =>
+              table.status.equals(PendingProductEventStatus.publishing.name),
+        ))
+        .write(
+          PendingProductEventsCompanion(
+            status: Value(PendingProductEventStatus.pending.name),
+          ),
+        );
+  }
+
+  Future<int> deleteById(String id) {
+    return (delete(
+      pendingProductEvents,
+    )..where((table) => table.id.equals(id))).go();
+  }
+}

--- a/mobile/packages/db_client/lib/src/database/daos/pending_product_events_dao.g.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/pending_product_events_dao.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'pending_product_events_dao.dart';
+
+// ignore_for_file: type=lint
+mixin _$PendingProductEventsDaoMixin on DatabaseAccessor<AppDatabase> {
+  $PendingProductEventsTable get pendingProductEvents =>
+      attachedDatabase.pendingProductEvents;
+  PendingProductEventsDaoManager get managers =>
+      PendingProductEventsDaoManager(this);
+}
+
+class PendingProductEventsDaoManager {
+  final _$PendingProductEventsDaoMixin _db;
+  PendingProductEventsDaoManager(this._db);
+  $$PendingProductEventsTableTableManager get pendingProductEvents =>
+      $$PendingProductEventsTableTableManager(
+        _db.attachedDatabase,
+        _db.pendingProductEvents,
+      );
+}

--- a/mobile/packages/db_client/lib/src/database/tables.dart
+++ b/mobile/packages/db_client/lib/src/database/tables.dart
@@ -1251,6 +1251,48 @@ class PendingViewEvents extends Table {
   ];
 }
 
+/// Durable queue of product analytics events awaiting ingest publish.
+@DataClassName('PendingProductEventRow')
+class PendingProductEvents extends Table {
+  @override
+  String get tableName => 'pending_product_events';
+
+  TextColumn get id => text()();
+
+  TextColumn get eventName => text().named('event_name')();
+
+  TextColumn get payloadJson => text().named('payload_json')();
+
+  TextColumn get status => text()();
+
+  IntColumn get attemptCount =>
+      integer().withDefault(const Constant(0)).named('attempt_count')();
+
+  DateTimeColumn get nextAttemptAt =>
+      dateTime().nullable().named('next_attempt_at')();
+
+  TextColumn get lastError => text().nullable().named('last_error')();
+
+  DateTimeColumn get createdAt => dateTime().named('created_at')();
+
+  @override
+  Set<Column> get primaryKey => {id};
+
+  List<Index> get indexes => [
+    Index(
+      'idx_pending_product_events_status_next_attempt',
+      'CREATE INDEX IF NOT EXISTS '
+          'idx_pending_product_events_status_next_attempt '
+          'ON pending_product_events (status, next_attempt_at)',
+    ),
+    Index(
+      'idx_pending_product_events_created_at',
+      'CREATE INDEX IF NOT EXISTS idx_pending_product_events_created_at '
+          'ON pending_product_events (created_at)',
+    ),
+  ];
+}
+
 /// Durable queue of gift-wrap (kind 1059) events that failed NIP-44
 /// decryption — e.g. a transient Keycast RPC failure while the one-time
 /// history drain processes a burst of gift wraps for a remote-signer

--- a/mobile/packages/db_client/test/src/database/app_database_test.dart
+++ b/mobile/packages/db_client/test/src/database/app_database_test.dart
@@ -487,6 +487,117 @@ void main() {
         },
       );
 
+      test(
+        'upgrade path recreates pending_product_events when missing',
+        () async {
+          await database.customStatement('DROP TABLE pending_product_events');
+
+          final droppedCheck = await database
+              .customSelect(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name='pending_product_events'",
+              )
+              .get();
+          expect(
+            droppedCheck,
+            isEmpty,
+            reason: 'precondition: pending_product_events must be missing',
+          );
+
+          await database.close();
+          database = AppDatabase.test(NativeDatabase(File(tempDbPath)));
+
+          final tableCheck = await database
+              .customSelect(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name='pending_product_events'",
+              )
+              .get();
+          expect(
+            tableCheck,
+            hasLength(1),
+            reason: 'pending_product_events must be re-created on reopen',
+          );
+
+          final indexNames = await _collectIndexNames(
+            database,
+            'pending_product_events',
+          );
+          expect(
+            indexNames,
+            containsAll(<String>{
+              'idx_pending_product_events_status_next_attempt',
+              'idx_pending_product_events_created_at',
+            }),
+          );
+
+          final dao = database.pendingProductEventsDao;
+          await dao.enqueue(
+            PendingProductEvent(
+              id: 'upgrade-product-event-id',
+              eventName: 'screen_time',
+              payloadJson: '{"event_id":"upgrade-product-event-id"}',
+              status: PendingProductEventStatus.pending,
+              createdAt: DateTime.utc(2026, 7),
+            ),
+          );
+
+          final fetched = await dao.getById('upgrade-product-event-id');
+          expect(fetched, isNotNull);
+          expect(fetched!.status, PendingProductEventStatus.pending);
+          expect(fetched.eventName, 'screen_time');
+        },
+      );
+
+      test(
+        'schema parity — pending_product_events fresh-install matches runtime '
+        'CREATE-IF-NOT-EXISTS path',
+        () async {
+          final freshColumns = await _collectTableInfo(
+            database,
+            'pending_product_events',
+          );
+          final freshIndexes = await _collectIndexNames(
+            database,
+            'pending_product_events',
+          );
+
+          expect(
+            freshColumns,
+            isNotEmpty,
+            reason:
+                'precondition: fresh install should have '
+                'pending_product_events',
+          );
+
+          await database.customStatement('DROP TABLE pending_product_events');
+          for (final indexName in freshIndexes) {
+            await database.customStatement('DROP INDEX IF EXISTS $indexName');
+          }
+          await database.close();
+
+          database = AppDatabase.test(NativeDatabase(File(tempDbPath)));
+          await database
+              .customSelect(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name='pending_product_events'",
+              )
+              .get();
+
+          final recreatedColumns = await _collectTableInfo(
+            database,
+            'pending_product_events',
+          );
+          final recreatedIndexes = await _collectIndexNames(
+            database,
+            'pending_product_events',
+          );
+
+          expect(recreatedColumns, equals(freshColumns));
+          expect(recreatedIndexes, equals(freshIndexes));
+        },
+      );
+
       test('upgrade path recreates pending_gift_wraps when missing', () async {
         await database.customStatement('DROP TABLE pending_gift_wraps');
 

--- a/mobile/packages/db_client/test/src/database/daos/pending_product_events_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/pending_product_events_dao_test.dart
@@ -1,0 +1,159 @@
+// ABOUTME: Unit tests for PendingProductEventsDao durable analytics outbox.
+// ABOUTME: Covers enqueue, retry filtering, status transitions, and cleanup.
+
+import 'dart:io';
+
+import 'package:db_client/db_client.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late AppDatabase database;
+  late PendingProductEventsDao dao;
+  late String tempDbPath;
+
+  PendingProductEvent makeEvent({
+    required String id,
+    String eventName = 'screen_time',
+    PendingProductEventStatus status = PendingProductEventStatus.pending,
+    int attemptCount = 0,
+    DateTime? createdAt,
+    DateTime? nextAttemptAt,
+    String? lastError,
+  }) {
+    return PendingProductEvent(
+      id: id,
+      eventName: eventName,
+      payloadJson: '{"event_id":"$id","event_name":"$eventName"}',
+      status: status,
+      attemptCount: attemptCount,
+      createdAt: createdAt ?? DateTime.utc(2026, 7),
+      nextAttemptAt: nextAttemptAt,
+      lastError: lastError,
+    );
+  }
+
+  setUp(() async {
+    final tempDir = Directory.systemTemp.createTempSync(
+      'pending_product_events_test_',
+    );
+    tempDbPath = '${tempDir.path}/test.db';
+
+    database = AppDatabase.test(NativeDatabase(File(tempDbPath)));
+    dao = database.pendingProductEventsDao;
+  });
+
+  tearDown(() async {
+    await database.close();
+    final file = File(tempDbPath);
+    if (file.existsSync()) {
+      file.deleteSync();
+    }
+    final dir = Directory(tempDbPath).parent;
+    if (dir.existsSync()) {
+      dir.deleteSync(recursive: true);
+    }
+  });
+
+  group('PendingProductEventsDao', () {
+    test('inserts a pending product event with idempotency id', () async {
+      await dao.enqueue(makeEvent(id: 'event-a'));
+
+      final fetched = await dao.getById('event-a');
+
+      expect(fetched, isNotNull);
+      expect(fetched!.id, 'event-a');
+      expect(fetched.eventName, 'screen_time');
+      expect(fetched.payloadJson, contains('"event_id":"event-a"'));
+      expect(fetched.status, PendingProductEventStatus.pending);
+      expect(fetched.attemptCount, 0);
+      expect(fetched.nextAttemptAt, isNull);
+      expect(fetched.lastError, isNull);
+    });
+
+    test('re-enqueueing the same event id preserves delivery state', () async {
+      await dao.enqueue(makeEvent(id: 'event-a'));
+      await dao.markPublishing('event-a');
+      await dao.markFailed(
+        'event-a',
+        'timeout',
+        nextAttemptAt: DateTime.utc(2026, 7, 1, 0, 0, 30),
+      );
+
+      await dao.enqueue(makeEvent(id: 'event-a'));
+
+      final fetched = await dao.getById('event-a');
+      expect(fetched!.status, PendingProductEventStatus.failed);
+      expect(fetched.attemptCount, 1);
+      expect(fetched.lastError, 'timeout');
+      expect(
+        fetched.nextAttemptAt!.isAtSameMomentAs(
+          DateTime.utc(2026, 7, 1, 0, 0, 30),
+        ),
+        isTrue,
+      );
+    });
+
+    test('returns retryable rows due now in created order', () async {
+      await dao.enqueue(
+        makeEvent(
+          id: 'publishing',
+          status: PendingProductEventStatus.publishing,
+          createdAt: DateTime.utc(2026, 7),
+        ),
+      );
+      await dao.enqueue(
+        makeEvent(
+          id: 'failed-old',
+          status: PendingProductEventStatus.failed,
+          nextAttemptAt: DateTime.utc(2026, 7, 1, 0, 0, 5),
+          createdAt: DateTime.utc(2026, 7, 1, 0, 0, 1),
+        ),
+      );
+      await dao.enqueue(
+        makeEvent(
+          id: 'pending-new',
+          createdAt: DateTime.utc(2026, 7, 1, 0, 0, 2),
+        ),
+      );
+      await dao.enqueue(
+        makeEvent(
+          id: 'not-yet',
+          status: PendingProductEventStatus.failed,
+          nextAttemptAt: DateTime.utc(2026, 7, 1, 0, 1),
+          createdAt: DateTime.utc(2026, 7, 1, 0, 0, 3),
+        ),
+      );
+      await dao.enqueue(
+        makeEvent(
+          id: 'exhausted',
+          status: PendingProductEventStatus.failed,
+          attemptCount: 5,
+          createdAt: DateTime.utc(2026, 7, 1, 0, 0, 4),
+        ),
+      );
+
+      final retryable = await dao.getRetryable(
+        now: DateTime.utc(2026, 7, 1, 0, 0, 10),
+        maxAttempts: 5,
+        limit: 10,
+      );
+
+      expect(retryable.map((event) => event.id), [
+        'failed-old',
+        'pending-new',
+      ]);
+    });
+
+    test('markDeadLetter stops exhausted events from retrying', () async {
+      await dao.enqueue(makeEvent(id: 'event-a'));
+
+      final updated = await dao.markDeadLetter('event-a', 'too many attempts');
+
+      expect(updated, isTrue);
+      final fetched = await dao.getById('event-a');
+      expect(fetched!.status, PendingProductEventStatus.deadLetter);
+      expect(fetched.lastError, 'too many attempts');
+    });
+  });
+}

--- a/mobile/packages/db_client/test/src/database/daos/pending_product_events_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/pending_product_events_dao_test.dart
@@ -139,10 +139,7 @@ void main() {
         limit: 10,
       );
 
-      expect(retryable.map((event) => event.id), [
-        'failed-old',
-        'pending-new',
-      ]);
+      expect(retryable.map((event) => event.id), ['failed-old', 'pending-new']);
     });
 
     test('markDeadLetter stops exhausted events from retrying', () async {
@@ -154,6 +151,42 @@ void main() {
       final fetched = await dao.getById('event-a');
       expect(fetched!.status, PendingProductEventStatus.deadLetter);
       expect(fetched.lastError, 'too many attempts');
+    });
+
+    test('resetPublishingToPending recovers only in-flight rows', () async {
+      await dao.enqueue(
+        makeEvent(
+          id: 'publishing-a',
+          status: PendingProductEventStatus.publishing,
+        ),
+      );
+      await dao.enqueue(makeEvent(id: 'pending-a'));
+      await dao.enqueue(
+        makeEvent(id: 'failed-a', status: PendingProductEventStatus.failed),
+      );
+      await dao.enqueue(
+        makeEvent(id: 'dead-a', status: PendingProductEventStatus.deadLetter),
+      );
+
+      final updated = await dao.resetPublishingToPending();
+
+      expect(updated, 1);
+      expect(
+        (await dao.getById('publishing-a'))!.status,
+        PendingProductEventStatus.pending,
+      );
+      expect(
+        (await dao.getById('pending-a'))!.status,
+        PendingProductEventStatus.pending,
+      );
+      expect(
+        (await dao.getById('failed-a'))!.status,
+        PendingProductEventStatus.failed,
+      );
+      expect(
+        (await dao.getById('dead-a'))!.status,
+        PendingProductEventStatus.deadLetter,
+      );
     });
   });
 }

--- a/mobile/test/services/analytics_ingest_client_test.dart
+++ b/mobile/test/services/analytics_ingest_client_test.dart
@@ -1,0 +1,178 @@
+// ABOUTME: Tests for first-party product analytics ingest client.
+// ABOUTME: Covers NIP-98 auth, batch POST shape, and outcome classification.
+
+import 'dart:convert';
+
+import 'package:clock/clock.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:openvine/services/analytics_ingest_client.dart';
+import 'package:openvine/services/nip98_auth_service.dart';
+
+class _MockNip98AuthService extends Mock implements Nip98AuthService {}
+
+void main() {
+  const testPubkey =
+      '385c3a6ec0b9d57a4330dbd6284989be5bd00e41c535f9ca39b6ae7c521b81cd';
+
+  late _MockNip98AuthService mockNip98;
+
+  setUpAll(() {
+    registerFallbackValue(HttpMethod.post);
+  });
+
+  setUp(() {
+    mockNip98 = _MockNip98AuthService();
+  });
+
+  Nip98Token buildToken() {
+    final signedEvent = Event(
+      testPubkey,
+      27235,
+      const [
+        ['u', 'https://api.divine.video/api/analytics/events'],
+        ['method', 'POST'],
+      ],
+      '',
+      createdAt: 1700000000,
+    );
+    final now = clock.now();
+    return Nip98Token(
+      token: 'fake-base64-token',
+      signedEvent: signedEvent,
+      createdAt: now,
+      expiresAt: now.add(const Duration(seconds: 45)),
+    );
+  }
+
+  void stubToken(Nip98Token? token) {
+    when(
+      () => mockNip98.createAuthToken(
+        url: any(named: 'url'),
+        method: any(named: 'method'),
+        payload: any(named: 'payload'),
+      ),
+    ).thenAnswer((_) async => token);
+  }
+
+  AnalyticsIngestClient buildClient(http.Client httpClient) {
+    return AnalyticsIngestClient(
+      httpClient: httpClient,
+      nip98AuthService: mockNip98,
+      apiBaseUrl: () => 'https://api.divine.video',
+    );
+  }
+
+  ProductAnalyticsEvent buildEvent(String id) {
+    return ProductAnalyticsEvent(
+      eventId: id,
+      eventName: 'screen_time',
+      occurredAt: DateTime.utc(2026, 7, 7, 12),
+      userPubkey: testPubkey,
+      anonymousId: '018ff7d7-2ef5-7000-8000-000000000001',
+      sessionId: '018ff7d7-2ef5-7000-8000-000000000002',
+      platform: 'ios',
+      appVersion: '1.2.3',
+      buildNumber: '123',
+      surface: AnalyticsSurface.feed,
+      props: const {'screen_name': 'feed'},
+      propsNum: const {'duration_ms': 1500.0},
+    );
+  }
+
+  group(AnalyticsIngestClient, () {
+    test(
+      'POSTs batch JSON to /api/analytics/events with NIP-98 auth',
+      () async {
+        stubToken(buildToken());
+        http.Request? captured;
+        final client = buildClient(
+          MockClient((request) async {
+            captured = request;
+            return http.Response(jsonEncode({'accepted': true}), 200);
+          }),
+        );
+
+        await client.publishBatch([buildEvent('event-a')]);
+
+        expect(captured, isNotNull);
+        expect(captured!.method, equals('POST'));
+        expect(
+          captured!.url.toString(),
+          equals('https://api.divine.video/api/analytics/events'),
+        );
+        expect(captured!.headers['Authorization'], 'Nostr fake-base64-token');
+        final body = jsonDecode(captured!.body) as Map<String, dynamic>;
+        final events = body['events'] as List<dynamic>;
+        expect(events, hasLength(1));
+        expect(events.single, containsPair('event_id', 'event-a'));
+        expect(events.single, containsPair('event_name', 'screen_time'));
+        expect(events.single, containsPair('surface', 'feed'));
+        expect(events.single, containsPair('schema_version', 1));
+      },
+    );
+
+    test('returns accepted on 200 accepted response', () async {
+      stubToken(buildToken());
+      final client = buildClient(
+        MockClient(
+          (_) async => http.Response(jsonEncode({'accepted': true}), 200),
+        ),
+      );
+
+      final result = await client.publishBatch([buildEvent('event-a')]);
+
+      expect(result, isA<AnalyticsIngestAccepted>());
+    });
+
+    for (final status in [400, 401, 403, 422]) {
+      test('returns rejected on non-retryable $status', () async {
+        stubToken(buildToken());
+        final client = buildClient(
+          MockClient((_) async => http.Response('bad event', status)),
+        );
+
+        final result = await client.publishBatch([buildEvent('event-a')]);
+
+        expect(result, isA<AnalyticsIngestRejected>());
+        expect((result as AnalyticsIngestRejected).statusCode, status);
+      });
+    }
+
+    test('returns transient failure on timeout', () async {
+      stubToken(buildToken());
+      final client = AnalyticsIngestClient(
+        httpClient: MockClient((_) async {
+          await Future<void>.delayed(const Duration(seconds: 30));
+          return http.Response('', 200);
+        }),
+        nip98AuthService: mockNip98,
+        apiBaseUrl: () => 'https://api.divine.video',
+        timeout: const Duration(milliseconds: 50),
+      );
+
+      final result = await client.publishBatch([buildEvent('event-a')]);
+
+      expect(result, isA<AnalyticsIngestTransientFailure>());
+    });
+
+    test('does not POST without a NIP-98 token', () async {
+      stubToken(null);
+      var requested = false;
+      final client = buildClient(
+        MockClient((_) async {
+          requested = true;
+          return http.Response('', 200);
+        }),
+      );
+
+      final result = await client.publishBatch([buildEvent('event-a')]);
+
+      expect(result, isA<AnalyticsIngestTransientFailure>());
+      expect(requested, isFalse);
+    });
+  });
+}

--- a/mobile/test/services/analytics_service_test.dart
+++ b/mobile/test/services/analytics_service_test.dart
@@ -8,7 +8,9 @@ import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
+import 'package:openvine/services/analytics_ingest_client.dart';
 import 'package:openvine/services/analytics_service.dart';
+import 'package:openvine/services/product_event_queue.dart';
 import 'package:openvine/services/view_event_publisher.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -16,11 +18,17 @@ class _MockViewEventPublisher extends Mock implements ViewEventPublisher {}
 
 class _MockPendingViewEventsDao extends Mock implements PendingViewEventsDao {}
 
+class _MockProductEventQueue extends Mock implements ProductEventQueue {}
+
 class _FakeVideoEvent extends Fake implements VideoEvent {}
+
+class _FakeProductAnalyticsEvent extends Fake
+    implements ProductAnalyticsEvent {}
 
 void main() {
   setUpAll(() {
     registerFallbackValue(_FakeVideoEvent());
+    registerFallbackValue(_FakeProductAnalyticsEvent());
     registerFallbackValue(_pendingViewEventFallback());
     registerFallbackValue(ViewTrafficSource.unknown);
   });
@@ -125,6 +133,56 @@ void main() {
 
       // Should complete without error (dedup is internal)
       expect(true, isTrue);
+    });
+
+    test('track stamps identity and session before enqueueing', () async {
+      final queue = _MockProductEventQueue();
+      when(() => queue.enqueue(any())).thenAnswer((_) async {});
+      analyticsService.dispose();
+      analyticsService = AnalyticsService(
+        productEventQueue: queue,
+        currentUserPubkey: () =>
+            '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+        anonymousId: () => '018ff7d7-2ef5-7000-8000-000000000001',
+        sessionId: () => '018ff7d7-2ef5-7000-8000-000000000002',
+        platform: () => 'ios',
+        appVersion: () => '1.2.3',
+        buildNumber: () => '123',
+        now: () => DateTime.utc(2026, 7, 7, 12),
+        eventIdFactory: () => '018ff7d7-2ef5-7000-8000-000000000003',
+      );
+      await analyticsService.initialize();
+
+      await analyticsService.track(
+        'screen_time',
+        surface: AnalyticsSurface.feed,
+        props: const {'screen_name': 'feed'},
+        propsNum: const {'duration_ms': 1250.0},
+        targetId:
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      );
+
+      final captured =
+          verify(
+                () => queue.enqueue(captureAny()),
+              ).captured.single
+              as ProductAnalyticsEvent;
+      expect(captured.eventId, '018ff7d7-2ef5-7000-8000-000000000003');
+      expect(captured.eventName, 'screen_time');
+      expect(captured.occurredAt, DateTime.utc(2026, 7, 7, 12));
+      expect(
+        captured.userPubkey,
+        '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+      );
+      expect(captured.anonymousId, '018ff7d7-2ef5-7000-8000-000000000001');
+      expect(captured.sessionId, '018ff7d7-2ef5-7000-8000-000000000002');
+      expect(captured.platform, 'ios');
+      expect(captured.appVersion, '1.2.3');
+      expect(captured.buildNumber, '123');
+      expect(captured.surface, AnalyticsSurface.feed);
+      expect(captured.targetId, contains('aaaaaaaa'));
+      expect(captured.props, containsPair('screen_name', 'feed'));
+      expect(captured.propsNum, containsPair('duration_ms', 1250.0));
     });
 
     test('enqueues eligible view_end before triggering a retry flush', () async {

--- a/mobile/test/services/product_event_queue_test.dart
+++ b/mobile/test/services/product_event_queue_test.dart
@@ -76,6 +76,39 @@ void main() {
       verify(() => dao.deleteById('event-a')).called(1);
     });
 
+    test(
+      'recoverPublishingAndFlush resets orphaned publishing rows first',
+      () async {
+        when(() => dao.resetPublishingToPending()).thenAnswer((_) async => 1);
+        when(
+          () => dao.getRetryable(
+            now: any(named: 'now'),
+            maxAttempts: any(named: 'maxAttempts'),
+            limit: any(named: 'limit'),
+          ),
+        ).thenAnswer((_) async => [_row('event-a')]);
+        when(() => dao.markPublishing('event-a')).thenAnswer((_) async => true);
+        when(
+          () => client.publishBatch(any()),
+        ).thenAnswer((_) async => const AnalyticsIngestAccepted());
+        when(() => dao.deleteById('event-a')).thenAnswer((_) async => 1);
+
+        await queue.recoverPublishingAndFlush();
+
+        verifyInOrder([
+          () => dao.resetPublishingToPending(),
+          () => dao.getRetryable(
+            now: any(named: 'now'),
+            maxAttempts: any(named: 'maxAttempts'),
+            limit: any(named: 'limit'),
+          ),
+          () => dao.markPublishing('event-a'),
+          () => client.publishBatch(any(that: hasLength(1))),
+          () => dao.deleteById('event-a'),
+        ]);
+      },
+    );
+
     test('flush schedules retry after transient failure', () async {
       when(
         () => dao.getRetryable(

--- a/mobile/test/services/product_event_queue_test.dart
+++ b/mobile/test/services/product_event_queue_test.dart
@@ -1,0 +1,167 @@
+// ABOUTME: Tests for durable product analytics retry queue.
+// ABOUTME: Verifies enqueue, flush, transient retry, and dead-letter behavior.
+
+import 'package:db_client/db_client.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/services/analytics_ingest_client.dart';
+import 'package:openvine/services/product_event_queue.dart';
+
+class _MockPendingProductEventsDao extends Mock
+    implements PendingProductEventsDao {}
+
+class _MockAnalyticsIngestClient extends Mock
+    implements AnalyticsIngestClient {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(_pendingProductEventFallback());
+  });
+
+  group(ProductEventQueue, () {
+    late _MockPendingProductEventsDao dao;
+    late _MockAnalyticsIngestClient client;
+    late ProductEventQueue queue;
+
+    setUp(() {
+      dao = _MockPendingProductEventsDao();
+      client = _MockAnalyticsIngestClient();
+      queue = ProductEventQueue(
+        dao: dao,
+        ingestClient: client,
+        retryConfig: const ProductEventRetryConfig(
+          maxAttempts: 3,
+          initialDelay: Duration(seconds: 1),
+        ),
+        now: () => DateTime.utc(2026, 7, 7, 12),
+      );
+    });
+
+    test(
+      'enqueue persists complete payload and does not call network',
+      () async {
+        when(() => dao.enqueue(any())).thenAnswer((_) async {});
+        final event = _event('event-a');
+
+        await queue.enqueue(event);
+
+        final captured =
+            verify(() => dao.enqueue(captureAny())).captured.single
+                as PendingProductEvent;
+        expect(captured.id, 'event-a');
+        expect(captured.eventName, 'screen_time');
+        expect(captured.payloadJson, contains('"event_id":"event-a"'));
+        expect(captured.status, PendingProductEventStatus.pending);
+        verifyNever(() => client.publishBatch(any()));
+      },
+    );
+
+    test('flush deletes rows accepted by ingest', () async {
+      when(
+        () => dao.getRetryable(
+          now: any(named: 'now'),
+          maxAttempts: any(named: 'maxAttempts'),
+          limit: any(named: 'limit'),
+        ),
+      ).thenAnswer((_) async => [_row('event-a')]);
+      when(() => dao.markPublishing('event-a')).thenAnswer((_) async => true);
+      when(
+        () => client.publishBatch(any()),
+      ).thenAnswer((_) async => const AnalyticsIngestAccepted());
+      when(() => dao.deleteById('event-a')).thenAnswer((_) async => 1);
+
+      await queue.flush();
+
+      verify(() => client.publishBatch(any(that: hasLength(1)))).called(1);
+      verify(() => dao.deleteById('event-a')).called(1);
+    });
+
+    test('flush schedules retry after transient failure', () async {
+      when(
+        () => dao.getRetryable(
+          now: any(named: 'now'),
+          maxAttempts: any(named: 'maxAttempts'),
+          limit: any(named: 'limit'),
+        ),
+      ).thenAnswer((_) async => [_row('event-a')]);
+      when(() => dao.markPublishing('event-a')).thenAnswer((_) async => true);
+      when(() => client.publishBatch(any())).thenAnswer(
+        (_) async => const AnalyticsIngestTransientFailure('timeout'),
+      );
+      when(
+        () => dao.markFailed(
+          'event-a',
+          'timeout',
+          nextAttemptAt: any(named: 'nextAttemptAt'),
+        ),
+      ).thenAnswer((_) async => true);
+
+      await queue.flush();
+
+      final captured =
+          verify(
+                () => dao.markFailed(
+                  'event-a',
+                  'timeout',
+                  nextAttemptAt: captureAny(named: 'nextAttemptAt'),
+                ),
+              ).captured.single
+              as DateTime;
+      expect(captured, DateTime.utc(2026, 7, 7, 12, 0, 1));
+    });
+
+    test('flush dead-letters non-retryable rejected rows', () async {
+      when(
+        () => dao.getRetryable(
+          now: any(named: 'now'),
+          maxAttempts: any(named: 'maxAttempts'),
+          limit: any(named: 'limit'),
+        ),
+      ).thenAnswer((_) async => [_row('event-a')]);
+      when(() => dao.markPublishing('event-a')).thenAnswer((_) async => true);
+      when(() => client.publishBatch(any())).thenAnswer(
+        (_) async => const AnalyticsIngestRejected(
+          statusCode: 422,
+          reason: 'schema rejected',
+        ),
+      );
+      when(
+        () => dao.markDeadLetter('event-a', 'schema rejected'),
+      ).thenAnswer((_) async => true);
+
+      await queue.flush();
+
+      verify(() => dao.markDeadLetter('event-a', 'schema rejected')).called(1);
+    });
+  });
+}
+
+ProductAnalyticsEvent _event(String id) {
+  return ProductAnalyticsEvent(
+    eventId: id,
+    eventName: 'screen_time',
+    occurredAt: DateTime.utc(2026, 7, 7, 12),
+    userPubkey:
+        '385c3a6ec0b9d57a4330dbd6284989be5bd00e41c535f9ca39b6ae7c521b81cd',
+    anonymousId: '018ff7d7-2ef5-7000-8000-000000000001',
+    sessionId: '018ff7d7-2ef5-7000-8000-000000000002',
+    platform: 'ios',
+    appVersion: '1.2.3',
+    buildNumber: '123',
+    surface: AnalyticsSurface.feed,
+  );
+}
+
+PendingProductEvent _row(String id) {
+  return PendingProductEvent(
+    id: id,
+    eventName: 'screen_time',
+    payloadJson: _event(id).toPayloadJson(),
+    status: PendingProductEventStatus.pending,
+    createdAt: DateTime.utc(2026, 7, 7, 12),
+  );
+}
+
+PendingProductEvent _pendingProductEventFallback() {
+  return _row('fallback');
+}


### PR DESCRIPTION
Closes #5912

## Summary
- adds a durable `pending_product_events` Drift table/DAO for product analytics retry state
- adds `AnalyticsIngestClient` for NIP-98-signed POST batches to `/api/analytics/events`
- adds `ProductEventQueue` and `AnalyticsService.track()` with stable anonymous/session/user/app/platform metadata
- wires the queue into app providers and eager startup/foreground flushing
- recovers orphaned `publishing` rows on startup and disposes the NIP-98 auth provider timer

This is the divine-mobile Phase 1 / PR A foundation from the GrowthBook product analytics plan. It intentionally does not add the GrowthBook SDK, exposure callbacks, or concrete UI/feed event call sites; those belong in follow-up PRs after the backend contract lands.

## Verification
- `cd mobile && flutter analyze`
- `cd mobile && flutter test test/services/product_event_queue_test.dart test/services/analytics_ingest_client_test.dart test/services/analytics_service_test.dart`
- `cd mobile/packages/db_client && flutter test test/src/database/daos/pending_product_events_dao_test.dart test/src/database/app_database_test.dart`
- `cd mobile && flutter test test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart test/screens/feed/video_feed_page_test.dart`
- `cd mobile && mise exec -- dart run build_runner build --delete-conflicting-outputs`
- pre-push hook: merge conflict check, analyzer, generated files, changed-file tests
