### PR TITLE
fix(videos_repository): refresh new feed from relays

### DIFF
--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -56,6 +56,13 @@ const Duration _relaySearchTimeout = Duration(seconds: 15);
 /// healthy Funnelcake responses while still bounding degraded-service latency.
 const Duration _statsFetchTimeout = Duration(seconds: 3);
 
+/// Bounds the relay freshness check used by manual New-feed refreshes.
+///
+/// The REST recent feed can lag briefly behind relays due to ingestion and edge
+/// caching. Pull-to-refresh asks relays for just the first page too, but should
+/// still complete quickly when a relay is slow.
+const Duration _recentRelayRefreshTimeout = Duration(seconds: 3);
+
 /// Per-call timeout for relay queries inside the route-lookup orchestrator.
 ///
 /// `NostrClient.queryEvents` waits for EOSE from every relay in the pool with
@@ -663,8 +670,14 @@ class VideosRepository {
           limit: limit,
           until: until,
         );
+        final mergedVideos = skipCache && until == null
+            ? await _mergeRecentApiVideosWithRelayRefresh(
+                videos,
+                limit: limit,
+              )
+            : videos;
         // Hydrate views/loops — list endpoint omits them for some rows.
-        final hydrated = await _hydrateVideosWithBulkStats(videos);
+        final hydrated = await _hydrateVideosWithBulkStats(mergedVideos);
         if (until == null) {
           _inMemoryFeedCache?.set('latest', HomeFeedResult(videos: hydrated));
         }
@@ -711,6 +724,35 @@ class VideosRepository {
     }
 
     return visible.take(limit).toList();
+  }
+
+  Future<List<VideoEvent>> _mergeRecentApiVideosWithRelayRefresh(
+    List<VideoEvent> apiVideos, {
+    required int limit,
+  }) async {
+    try {
+      final relayVideos = await _fetchVisibleRecentVideosFromRelays(
+        limit: limit,
+      ).timeout(_recentRelayRefreshTimeout);
+      if (relayVideos.isEmpty) return apiVideos;
+
+      final candidates = [...relayVideos, ...apiVideos]
+        ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+      final merged = <VideoEvent>[];
+      _appendUniqueVideos(
+        merged,
+        candidates,
+        seenVideoKeys: <String>{},
+      );
+      return merged.take(limit).toList();
+    } on Object catch (e) {
+      Log.warning(
+        'Recent relay refresh enrichment failed: $e',
+        name: 'VideosRepository',
+        category: LogCategory.video,
+      );
+      return apiVideos;
+    }
   }
 
   Future<List<VideoEvent>> _fetchVisibleRecentVideosFromRelays({

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -143,6 +143,55 @@ void main() {
           verifyNever(() => mockNostrClient.queryEvents(any()));
         });
 
+        test(
+          'refresh merges newer relay videos ahead of API results',
+          () async {
+            when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+            when(
+              () => mockFunnelcakeClient.getRecentVideos(
+                limit: any(named: 'limit'),
+                before: any(named: 'before'),
+              ),
+            ).thenAnswer(
+              (_) async => [
+                _createVideoStats(
+                  id: 'api-video',
+                  pubkey: 'api-pubkey',
+                  dTag: 'api-dtag',
+                  videoUrl: 'https://example.com/api.mp4',
+                ),
+              ],
+            );
+            when(
+              () => mockNostrClient.queryEvents(any()),
+            ).thenAnswer(
+              (_) async => [
+                _createVideoEvent(
+                  id: 'relay-video',
+                  pubkey: 'relay-pubkey',
+                  videoUrl: 'https://example.com/relay.mp4',
+                  createdAt: 1704067300,
+                ),
+              ],
+            );
+
+            final repositoryWithApi = VideosRepository(
+              nostrClient: mockNostrClient,
+              funnelcakeApiClient: mockFunnelcakeClient,
+            );
+
+            final result = await repositoryWithApi.getNewVideos(
+              skipCache: true,
+            );
+
+            expect(result.map((video) => video.id), [
+              'relay-video',
+              'api-video',
+            ]);
+            verify(() => mockNostrClient.queryEvents(any())).called(1);
+          },
+        );
+
         test('passes limit and before to Funnelcake API', () async {
           when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
           when(


### PR DESCRIPTION
Closes #5915

## Summary
- merge relay results into manual New-feed refreshes when the recent REST feed succeeds but may lag behind relays
- bound the relay enrichment to 3 seconds and keep it scoped to first-page pull-to-refresh (`skipCache: true`, no pagination cursor)
- add a regression test proving a newer relay video appears ahead of stale API results

## Root Cause
Pull-to-refresh on New was firing and bypassing the repository memory cache, but `VideosRepository.getNewVideos(skipCache: true)` still stopped at the Funnelcake recent REST response whenever that endpoint succeeded. If Funnelcake ingestion or edge caching lagged, the app never queried relays for newer events during manual refresh.

## Verification
- `cd mobile/packages/videos_repository && flutter analyze lib test`
- `cd mobile/packages/videos_repository && flutter test test/src/videos_repository_test.dart --plain-name 'VideosRepository getNewVideos'`
- `cd mobile && flutter test test/widgets/new_videos_tab_test.dart`
- `cd mobile/packages/videos_repository && flutter test --coverage` (435 tests; LCOV 100.00%, 1086/1086 lines)
- `git diff --check`
- pre-push hook: analyzer passed; changed-file `packages/videos_repository/test/src/videos_repository_test.dart` passed 342 tests