### PR TITLE
fix(share-videos): hydrate loop counts on shared-video previews

### DIFF
--- a/mobile/lib/screens/inbox/conversation/widgets/collaborator_invite_card.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/collaborator_invite_card.dart
@@ -12,7 +12,6 @@ import 'package:openvine/blocs/dm/conversation/collaborator_invite_actions_cubit
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/collaborator_invite.dart';
 import 'package:openvine/providers/app_providers.dart';
-import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/screens/comments/widgets/video_comment_player.dart';
 import 'package:openvine/screens/inbox/conversation/widgets/video_link_preview_cubit.dart';
 import 'package:openvine/services/collaborator_invite_state_store.dart';
@@ -169,8 +168,7 @@ class _CardChrome extends ConsumerWidget {
               videoStableId: invite.videoDTag,
               authorPubkey: invite.creatorPubkey,
               videoKind: invite.videoKind,
-              videoEventService: ref.read(videoEventServiceProvider),
-              nostrClient: ref.read(nostrServiceProvider),
+              videosRepository: ref.read(videosRepositoryProvider),
             ),
             child: _InviteVideoContent(
               inviteThumbnailUrl: _inviteThumbnailUrl,

--- a/mobile/lib/screens/inbox/conversation/widgets/collaborator_invite_card.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/collaborator_invite_card.dart
@@ -144,6 +144,10 @@ class _CardChrome extends ConsumerWidget {
       maxVisibleVideoWidth,
     );
 
+    // Re-key the cubit on the repository identity: videosRepositoryProvider
+    // yields a fresh instance when filter/aspect/host preferences change.
+    final videosRepository = ref.watch(videosRepositoryProvider);
+
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: Align(
@@ -164,11 +168,12 @@ class _CardChrome extends ConsumerWidget {
           ),
           clipBehavior: Clip.antiAlias,
           child: BlocProvider(
+            key: ValueKey(videosRepository),
             create: (_) => VideoLinkPreviewCubit(
               videoStableId: invite.videoDTag,
               authorPubkey: invite.creatorPubkey,
               videoKind: invite.videoKind,
-              videosRepository: ref.read(videosRepositoryProvider),
+              videosRepository: videosRepository,
             ),
             child: _InviteVideoContent(
               inviteThumbnailUrl: _inviteThumbnailUrl,

--- a/mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart
@@ -581,10 +581,15 @@ class _VideoLinkPreview extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    // Re-key on the repository identity: videosRepositoryProvider yields a
+    // fresh instance when filter/aspect/host preferences change, and a bare
+    // ref.read inside create: would keep the stale one for the cubit's life.
+    final videosRepository = ref.watch(videosRepositoryProvider);
     return BlocProvider(
+      key: ValueKey(videosRepository),
       create: (_) => VideoLinkPreviewCubit(
         videoStableId: videoStableId,
-        videosRepository: ref.read(videosRepositoryProvider),
+        videosRepository: videosRepository,
         authorPubkey: authorPubkey,
         videoKind: videoKind,
       ),
@@ -649,8 +654,8 @@ const double _quotedPlayGlyphSize = 11;
 
 /// Compact WhatsApp-style quoted preview of the video a reply references.
 ///
-/// Reuses the [VideoLinkPreviewCubit] resolve harness (cache → relay fetch) so
-/// it can render even when the cited video was never seen locally, and swaps
+/// Reuses the [VideoLinkPreviewCubit] resolve harness so it can render even
+/// when the cited video was never seen locally, and swaps
 /// the full [_VideoCard] for a small thumbnail + label strip rendered above the
 /// reply text.
 class _QuotedVideoPreview extends ConsumerWidget {
@@ -668,10 +673,12 @@ class _QuotedVideoPreview extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final target = _videoTargetFromRef(quotedVideoRef);
     if (target == null) return const SizedBox.shrink();
+    final videosRepository = ref.watch(videosRepositoryProvider);
     return BlocProvider(
+      key: ValueKey(videosRepository),
       create: (_) => VideoLinkPreviewCubit(
         videoStableId: target.stableId,
-        videosRepository: ref.read(videosRepositoryProvider),
+        videosRepository: videosRepository,
         authorPubkey: target.authorPubkey,
         videoKind: target.videoKind,
       ),

--- a/mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart
@@ -14,7 +14,6 @@ import 'package:models/models.dart' hide AspectRatio, LogCategory;
 import 'package:openvine/blocs/dm/conversation/conversation_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
-import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/router/nav_extensions.dart';
 import 'package:openvine/screens/feed/dm_reply_context.dart';
@@ -585,8 +584,7 @@ class _VideoLinkPreview extends ConsumerWidget {
     return BlocProvider(
       create: (_) => VideoLinkPreviewCubit(
         videoStableId: videoStableId,
-        videoEventService: ref.read(videoEventServiceProvider),
-        nostrClient: ref.read(nostrServiceProvider),
+        videosRepository: ref.read(videosRepositoryProvider),
         authorPubkey: authorPubkey,
         videoKind: videoKind,
       ),
@@ -673,8 +671,7 @@ class _QuotedVideoPreview extends ConsumerWidget {
     return BlocProvider(
       create: (_) => VideoLinkPreviewCubit(
         videoStableId: target.stableId,
-        videoEventService: ref.read(videoEventServiceProvider),
-        nostrClient: ref.read(nostrServiceProvider),
+        videosRepository: ref.read(videosRepositoryProvider),
         authorPubkey: target.authorPubkey,
         videoKind: target.videoKind,
       ),

--- a/mobile/lib/screens/inbox/conversation/widgets/video_link_preview_cubit.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/video_link_preview_cubit.dart
@@ -1,13 +1,12 @@
 // ABOUTME: Cubit that resolves a video from a divine.video stableId.
-// ABOUTME: Checks the VideoEventService cache first, then fetches from relay.
+// ABOUTME: Delegates to VideosRepository so the resolved event carries the
+// ABOUTME: REST-hydrated loop/view counts, not a bare relay event.
 
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:models/models.dart' hide LogCategory;
-import 'package:nostr_client/nostr_client.dart';
-import 'package:nostr_sdk/filter.dart';
-import 'package:openvine/services/video_event_service.dart';
 import 'package:unified_logger/unified_logger.dart';
+import 'package:videos_repository/videos_repository.dart';
 
 /// State for [VideoLinkPreviewCubit].
 sealed class VideoLinkPreviewState extends Equatable {
@@ -34,26 +33,25 @@ class VideoLinkPreviewNotFound extends VideoLinkPreviewState {
   const VideoLinkPreviewNotFound();
 }
 
-/// Resolves a [VideoEvent] from a `divine.video/video/{stableId}` URL.
+/// Resolves a [VideoEvent] from a `divine.video/video/{stableId}` reference.
 ///
-/// Resolution strategy:
-/// 1. Check [VideoEventService] cache by event ID.
-/// 2. Check cache by vine ID (d-tag).
-/// 3. Fetch from relay by event ID.
-/// 4. Query relay by d-tag for addressable video events (kind 34236).
-/// 5. Emit [VideoLinkPreviewNotFound] if all lookups fail.
+/// Resolution is delegated to [VideosRepository.fetchVideoWithStatsForRouteId],
+/// the same canonical resolver the video-detail screen and deep-link paths use.
+/// That path runs local cache → Funnelcake REST → relay across every acceptable
+/// video kind, and — crucially for the loop counter — enriches the event with
+/// REST-sourced view/loop stats. Resolving a bare relay event here instead
+/// (the previous implementation) left `rawTags['views']` empty, so a shared
+/// video's card and detail screen showed `0 loops` (see #5844).
 class VideoLinkPreviewCubit extends Cubit<VideoLinkPreviewState> {
   VideoLinkPreviewCubit({
     required String videoStableId,
-    required VideoEventService videoEventService,
-    required NostrClient nostrClient,
+    required VideosRepository videosRepository,
     String? authorPubkey,
     int? videoKind,
   }) : _videoStableId = videoStableId,
        _authorPubkey = authorPubkey,
        _videoKind = videoKind,
-       _videoEventService = videoEventService,
-       _nostrClient = nostrClient,
+       _videosRepository = videosRepository,
        super(const VideoLinkPreviewLoading()) {
     // Schedule as microtask so the first emit happens after callers
     // (BlocProvider, blocTest) have subscribed to the stream.
@@ -63,53 +61,40 @@ class VideoLinkPreviewCubit extends Cubit<VideoLinkPreviewState> {
   final String _videoStableId;
   final String? _authorPubkey;
   final int? _videoKind;
-  final VideoEventService _videoEventService;
-  final NostrClient _nostrClient;
+  final VideosRepository _videosRepository;
 
   Future<void> _resolve() async {
-    // Try cache: first by event ID, then by vine ID (d-tag).
-    final cached =
-        _videoEventService.getVideoById(_videoStableId) ??
-        _videoEventService.getVideoEventByVineId(_videoStableId);
-    if (cached != null) {
-      if (!isClosed) emit(VideoLinkPreviewResolved(cached));
-      return;
-    }
-
-    // Fetch from relay when not in cache.
     try {
-      // Try by event ID first.
-      var event = await _nostrClient.fetchEventById(_videoStableId);
-
-      // If not found, query by d-tag for addressable video events.
-      if (event == null) {
-        final results = await _nostrClient.queryEvents([
-          Filter(
-            kinds: [_videoKind ?? NIP71VideoKinds.addressableShortVideo],
-            authors: _authorPubkey == null ? null : [_authorPubkey],
-            d: [_videoStableId],
-            limit: 1,
-          ),
-        ]);
-        if (results.isNotEmpty) {
-          event = results.first;
-        }
-      }
-
-      if (event != null) {
-        if (!isClosed) {
-          emit(VideoLinkPreviewResolved(VideoEvent.fromNostrEvent(event)));
-        }
+      final video = await _videosRepository.fetchVideoWithStatsForRouteId(
+        _videoStableId,
+        fallbackRouteIds: _authorScopedFallbackRouteIds(),
+      );
+      if (isClosed) return;
+      if (video != null) {
+        emit(VideoLinkPreviewResolved(video));
         return;
       }
     } catch (e) {
       Log.warning(
-        'Video link preview relay fetch failed for $_videoStableId: $e',
+        'Video link preview resolve failed for $_videoStableId: $e',
         name: 'VideoLinkPreviewCubit',
         category: LogCategory.ui,
       );
     }
 
     if (!isClosed) emit(const VideoLinkPreviewNotFound());
+  }
+
+  /// Author/kind-scoped addressable coordinate used as a resolution fallback.
+  ///
+  /// The primary bare-id lookup already covers every acceptable video kind, but
+  /// an invite preview knows the exact creator and kind, so an addressable
+  /// `kind:pubkey:d-tag` route lets the repository disambiguate should the bare
+  /// d-tag ever be shared across authors.
+  List<String> _authorScopedFallbackRouteIds() {
+    final author = _authorPubkey;
+    final kind = _videoKind;
+    if (author == null || kind == null) return const [];
+    return ['$kind:$author:$_videoStableId'];
   }
 }

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -2793,9 +2793,12 @@ class _VideoRouteCandidate {
 
     // Raw NIP-33 addressable coordinate: "kind:pubkey:d-tag"
     // Produced by VideoNotification.videoAddressableId for stable notification
-    // navigation. AId.fromString validates the format and extracts the d-tag.
+    // navigation and by DM share-card fallbacks, which can reference any
+    // acceptable NIP-71 kind (e.g. 34235). Accepts the same kinds as the
+    // naddr branch above; the 34236-only isVideoKind check would let a
+    // 34235 coordinate fall through to an unmatched d-tag lookup.
     final aid = AId.fromString(trimmed);
-    if (aid != null && NIP71VideoKinds.isVideoKind(aid.kind)) {
+    if (aid != null && NIP71VideoKinds.isAcceptableVideoKind(aid.kind)) {
       return _VideoRouteCandidate(
         addressableId: trimmed,
         addressablePubkey: aid.pubkey,

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -10187,6 +10187,71 @@ void main() {
       );
 
       test(
+        'raw addressable coordinates accept legacy NIP-71 kinds — '
+        'a 34235:pubkey:d-tag route must stay author-scoped instead of '
+        'degrading to a bare d-tag lookup of the whole coordinate string',
+        () async {
+          const eventId =
+              'b995f6b60119d9521934a691347d9f78'
+              'e8770b56da16bb255ee77ac112b4c1f6';
+          const author =
+              '4bf0c63fcb93463407af97a5e5ee64fa'
+              '883d107ef9e558472c4eb9aaaefa459d';
+          const dTag = 'normal-video-34235';
+          // DM share-card fallbacks build raw coordinates from the shared
+          // ref's kind, which can be 34235 (addressable normal video). The
+          // pre-fix parse branch gated on isVideoKind() (34236 only), so
+          // this string fell through to a stableId candidate whose relay
+          // query searched d: ['34235:<pubkey>:<d-tag>'] — unmatched.
+          const rawAddressableId = '34235:$author:$dTag';
+          final legacyEvent = Event.fromJson({
+            'id': eventId,
+            'pubkey': author,
+            'created_at': 1739350000,
+            'kind': 34235,
+            'tags': [
+              ['d', dTag],
+              ['url', 'https://example.com/normal.mp4'],
+              ['title', 'Kind-34235 addressable'],
+            ],
+            'content': '',
+            'sig': 'sig',
+          });
+
+          when(() => mockNostrClient.queryEvents(any())).thenAnswer((
+            invocation,
+          ) async {
+            final filters =
+                invocation.positionalArguments.single as List<Filter>;
+            final filter = filters.single;
+            // Only match the addressable filter (kind + author + d-tag),
+            // so the test fails loudly if the parse gate degrades the
+            // coordinate to an unscoped stable-id lookup again.
+            if ((filter.kinds?.contains(34235) ?? false) &&
+                (filter.authors?.contains(author) ?? false) &&
+                (filter.d?.contains(dTag) ?? false)) {
+              return [legacyEvent];
+            }
+            return <Event>[];
+          });
+
+          final repo = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          final result = await repo.fetchVideoWithStatsForRouteId(
+            rawAddressableId,
+          );
+
+          expect(result, isNotNull);
+          expect(result!.id, equals(eventId));
+          expect(result.vineId, equals(dTag));
+          expect(result.pubkey, equals(author));
+        },
+      );
+
+      test(
         'resolves plain stable IDs from local storage before relay',
         () async {
           const eventId =

--- a/mobile/scripts/baseline/ui_service_imports.txt
+++ b/mobile/scripts/baseline/ui_service_imports.txt
@@ -21,7 +21,6 @@ lib/screens/geo_blocked_screen.dart
 lib/screens/hashtag_feed_screen.dart
 lib/screens/inbox/conversation/conversation_view.dart
 lib/screens/inbox/conversation/widgets/collaborator_invite_card.dart
-lib/screens/inbox/conversation/widgets/video_link_preview_cubit.dart
 lib/screens/inbox/message_requests/request_preview_view.dart
 lib/screens/inbox/widgets/conversation_tile.dart
 lib/screens/key_import_screen.dart

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -22,8 +22,8 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/inbox/conversation/conversation_view.dart';
 import 'package:openvine/screens/inbox/conversation/widgets/widgets.dart';
-import 'package:openvine/services/video_event_service.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
+import 'package:videos_repository/videos_repository.dart';
 import 'package:visibility_detector/visibility_detector.dart';
 
 import '../../../builders/video_event_builder.dart';
@@ -42,7 +42,7 @@ class _MockConversationReactionsCubit
     extends MockBloc<ConversationReactionsEvent, ConversationReactionsState>
     implements ConversationReactionsCubit {}
 
-class _MockVideoEventService extends Mock implements VideoEventService {}
+class _MockVideosRepository extends Mock implements VideosRepository {}
 
 class _MockContentBlocklistRepository extends Mock
     implements ContentBlocklistRepository {}
@@ -78,7 +78,7 @@ void main() {
     late _MockConversationBloc mockBloc;
     late _MockCollaboratorInviteActionsCubit mockInviteActionsCubit;
     late _MockConversationReactionsCubit mockReactionsCubit;
-    late _MockVideoEventService mockVideoEventService;
+    late _MockVideosRepository mockVideosRepository;
     late MockNostrClient mockNostrClient;
     late _MockAuthService mockAuthService;
     late _MockContentBlocklistRepository mockBlocklist;
@@ -86,6 +86,7 @@ void main() {
     setUpAll(() {
       registerFallbackValue(fallbackInvite);
       registerFallbackValue(<CollaboratorInvite>[]);
+      registerFallbackValue(<String>[]);
       registerFallbackValue(
         const ConversationMessageSent(
           recipientPubkeys: [otherPubkey],
@@ -110,7 +111,7 @@ void main() {
       mockBloc = _MockConversationBloc();
       mockInviteActionsCubit = _MockCollaboratorInviteActionsCubit();
       mockReactionsCubit = _MockConversationReactionsCubit();
-      mockVideoEventService = _MockVideoEventService();
+      mockVideosRepository = _MockVideosRepository();
       mockNostrClient = createMockNostrService();
       mockAuthService = _MockAuthService(currentPubkey);
       mockBlocklist = _MockContentBlocklistRepository();
@@ -136,12 +137,11 @@ void main() {
       when(
         () => mockInviteActionsCubit.ignoreInvite(any()),
       ).thenAnswer((_) async {});
-      when(() => mockVideoEventService.getVideoById(any())).thenReturn(null);
       when(
-        () => mockVideoEventService.getVideoEventByVineId(any()),
-      ).thenReturn(null);
-      when(
-        () => mockNostrClient.fetchEventById(any()),
+        () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+          any(),
+          fallbackRouteIds: any(named: 'fallbackRouteIds'),
+        ),
       ).thenAnswer((_) async => null);
     });
 
@@ -161,7 +161,7 @@ void main() {
         mockAuthService: mockAuthService,
         mockNostrService: mockNostrClient,
         additionalOverrides: [
-          videoEventServiceProvider.overrideWithValue(mockVideoEventService),
+          videosRepositoryProvider.overrideWithValue(mockVideosRepository),
           fetchUserProfileProvider(
             otherPubkey,
           ).overrideWith((ref) async => otherProfile),
@@ -644,9 +644,12 @@ void main() {
           final mockGoRouter = MockGoRouter();
           when(() => mockGoRouter.push(any())).thenAnswer((_) async => null);
           when(
-            () => mockVideoEventService.getVideoEventByVineId('skate-loop'),
-          ).thenReturn(
-            VideoEventBuilder(
+            () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+              'skate-loop',
+              fallbackRouteIds: any(named: 'fallbackRouteIds'),
+            ),
+          ).thenAnswer(
+            (_) async => VideoEventBuilder(
               id: '7777777777777777777777777777777777777777777777777777777777777777',
               pubkey: otherPubkey,
               title: 'Skate loop',

--- a/mobile/test/screens/inbox/conversation/widgets/collaborator_invite_card_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/collaborator_invite_card_test.dart
@@ -14,7 +14,7 @@ import 'package:openvine/models/collaborator_invite.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/screens/inbox/conversation/widgets/collaborator_invite_card.dart';
-import 'package:openvine/services/video_event_service.dart';
+import 'package:videos_repository/videos_repository.dart';
 
 import '../../../../helpers/test_provider_overrides.dart';
 
@@ -22,7 +22,7 @@ class _MockCollaboratorInviteActionsCubit
     extends MockCubit<CollaboratorInviteActionsState>
     implements CollaboratorInviteActionsCubit {}
 
-class _MockVideoEventService extends Mock implements VideoEventService {}
+class _MockVideosRepository extends Mock implements VideosRepository {}
 
 const _creatorPubkey =
     '1122334411223344112233441122334411223344112233441122334411223344';
@@ -40,12 +40,16 @@ const _testInvite = CollaboratorInvite(
 
 void main() {
   late _MockCollaboratorInviteActionsCubit mockCubit;
-  late _MockVideoEventService mockVideoEventService;
+  late _MockVideosRepository mockVideosRepository;
   late MockNostrClient mockNostrClient;
+
+  setUpAll(() {
+    registerFallbackValue(<String>[]);
+  });
 
   setUp(() {
     mockCubit = _MockCollaboratorInviteActionsCubit();
-    mockVideoEventService = _MockVideoEventService();
+    mockVideosRepository = _MockVideosRepository();
     mockNostrClient = createMockNostrService();
 
     when(() => mockCubit.state).thenReturn(
@@ -54,17 +58,19 @@ void main() {
     when(
       () => mockCubit.loadInvites(any()),
     ).thenReturn(null);
-    when(() => mockVideoEventService.getVideoById(any())).thenReturn(null);
     when(
-      () => mockVideoEventService.getVideoEventByVineId(any()),
-    ).thenReturn(null);
+      () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+        any(),
+        fallbackRouteIds: any(named: 'fallbackRouteIds'),
+      ),
+    ).thenAnswer((_) async => null);
   });
 
   Widget buildSubject({bool isSent = false}) {
     return ProviderScope(
       overrides: [
         nostrServiceProvider.overrideWithValue(mockNostrClient),
-        videoEventServiceProvider.overrideWithValue(mockVideoEventService),
+        videosRepositoryProvider.overrideWithValue(mockVideosRepository),
       ],
       child: MaterialApp(
         localizationsDelegates: AppLocalizations.localizationsDelegates,

--- a/mobile/test/screens/inbox/conversation/widgets/message_bubble_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/message_bubble_test.dart
@@ -19,13 +19,13 @@ import 'package:openvine/l10n/generated/app_localizations_en.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/inbox/conversation/widgets/message_bubble.dart';
-import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/widgets/video_thumbnail_widget.dart';
+import 'package:videos_repository/videos_repository.dart';
 
 import '../../../../helpers/test_provider_overrides.dart';
 
-class _MockVideoEventService extends Mock implements VideoEventService {}
+class _MockVideosRepository extends Mock implements VideosRepository {}
 
 const _testHexPubkey =
     '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
@@ -103,6 +103,10 @@ TapGestureRecognizer? _findRecognizer(InlineSpan span, String linkText) {
 
 void main() {
   final strings = AppLocalizationsEn();
+
+  setUpAll(() {
+    registerFallbackValue(<String>[]);
+  });
 
   group(MessageBubble, () {
     group('renders', () {
@@ -742,7 +746,7 @@ void main() {
     });
 
     group('video preview card', () {
-      late _MockVideoEventService mockVideoEventService;
+      late _MockVideosRepository mockVideosRepository;
       late MockNostrClient mockNostrClient;
 
       final testVideo = VideoEvent(
@@ -759,17 +763,15 @@ void main() {
       );
 
       setUp(() {
-        mockVideoEventService = _MockVideoEventService();
+        mockVideosRepository = _MockVideosRepository();
         mockNostrClient = createMockNostrService();
 
-        // Default stubs: nothing in cache.
-        when(() => mockVideoEventService.getVideoById(any())).thenReturn(null);
+        // Default: the repository resolves nothing (unavailable card).
         when(
-          () => mockVideoEventService.getVideoEventByVineId(any()),
-        ).thenReturn(null);
-        // Stub fetchEventById for video link preview lookups.
-        when(
-          () => mockNostrClient.fetchEventById(any()),
+          () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+            any(),
+            fallbackRouteIds: any(named: 'fallbackRouteIds'),
+          ),
         ).thenAnswer((_) async => null);
       });
 
@@ -789,9 +791,7 @@ void main() {
         ),
         mockNostrService: mockNostrClient,
         additionalOverrides: [
-          videoEventServiceProvider.overrideWithValue(
-            mockVideoEventService,
-          ),
+          videosRepositoryProvider.overrideWithValue(mockVideosRepository),
         ],
       );
 
@@ -831,9 +831,12 @@ void main() {
       ) async {
         // Use a Completer that never completes so the cubit stays in
         // the loading state without leaving a pending Timer.
-        final neverCompletes = Completer<Never>();
+        final neverCompletes = Completer<VideoEvent?>();
         when(
-          () => mockNostrClient.fetchEventById(any()),
+          () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+            any(),
+            fallbackRouteIds: any(named: 'fallbackRouteIds'),
+          ),
         ).thenAnswer((_) => neverCompletes.future);
 
         await tester.pumpWidget(
@@ -850,8 +853,11 @@ void main() {
         tester,
       ) async {
         when(
-          () => mockVideoEventService.getVideoById('abc123'),
-        ).thenReturn(testVideo);
+          () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+            'abc123',
+            fallbackRouteIds: any(named: 'fallbackRouteIds'),
+          ),
+        ).thenAnswer((_) async => testVideo);
 
         await tester.pumpWidget(
           buildWithVideoMessage(message: 'https://divine.video/video/abc123'),
@@ -866,8 +872,11 @@ void main() {
         tester,
       ) async {
         when(
-          () => mockVideoEventService.getVideoEventByVineId('abc123'),
-        ).thenReturn(testVideo);
+          () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+            'abc123',
+            fallbackRouteIds: any(named: 'fallbackRouteIds'),
+          ),
+        ).thenAnswer((_) async => testVideo);
 
         await tester.pumpWidget(
           buildWithVideoMessage(
@@ -889,7 +898,10 @@ void main() {
         expect(find.text('watch this'), findsOneWidget);
         expect(find.textContaining('nostr:'), findsNothing);
         verify(
-          () => mockVideoEventService.getVideoEventByVineId('abc123'),
+          () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+            'abc123',
+            fallbackRouteIds: any(named: 'fallbackRouteIds'),
+          ),
         ).called(greaterThanOrEqualTo(1));
       });
 
@@ -897,8 +909,11 @@ void main() {
         tester,
       ) async {
         when(
-          () => mockVideoEventService.getVideoById('abc123'),
-        ).thenReturn(testVideo);
+          () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+            'abc123',
+            fallbackRouteIds: any(named: 'fallbackRouteIds'),
+          ),
+        ).thenAnswer((_) async => testVideo);
 
         await tester.pumpWidget(
           buildWithVideoMessage(message: 'https://divine.video/video/abc123'),
@@ -923,8 +938,11 @@ void main() {
 
       testWidgets('shared-video card matches Figma geometry', (tester) async {
         when(
-          () => mockVideoEventService.getVideoById('abc123'),
-        ).thenReturn(testVideo);
+          () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+            'abc123',
+            fallbackRouteIds: any(named: 'fallbackRouteIds'),
+          ),
+        ).thenAnswer((_) async => testVideo);
 
         await tester.pumpWidget(
           buildWithVideoMessage(message: 'https://divine.video/video/abc123'),
@@ -961,8 +979,11 @@ void main() {
         tester,
       ) async {
         when(
-          () => mockVideoEventService.getVideoById('abc123'),
-        ).thenReturn(testVideo);
+          () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+            'abc123',
+            fallbackRouteIds: any(named: 'fallbackRouteIds'),
+          ),
+        ).thenAnswer((_) async => testVideo);
 
         await tester.pumpWidget(
           buildWithVideoMessage(
@@ -1024,9 +1045,7 @@ void main() {
             router,
             mockNostrService: mockNostrClient,
             additionalOverrides: [
-              videoEventServiceProvider.overrideWithValue(
-                mockVideoEventService,
-              ),
+              videosRepositoryProvider.overrideWithValue(mockVideosRepository),
             ],
           ),
         );
@@ -1045,8 +1064,11 @@ void main() {
         tester,
       ) async {
         when(
-          () => mockVideoEventService.getVideoById('abc123'),
-        ).thenReturn(testVideo);
+          () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+            'abc123',
+            fallbackRouteIds: any(named: 'fallbackRouteIds'),
+          ),
+        ).thenAnswer((_) async => testVideo);
 
         await tester.pumpWidget(
           buildWithVideoMessage(
@@ -1067,8 +1089,11 @@ void main() {
 
       testWidgets('preserves text before video URL only', (tester) async {
         when(
-          () => mockVideoEventService.getVideoById('abc123'),
-        ).thenReturn(testVideo);
+          () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+            'abc123',
+            fallbackRouteIds: any(named: 'fallbackRouteIds'),
+          ),
+        ).thenAnswer((_) async => testVideo);
 
         await tester.pumpWidget(
           buildWithVideoMessage(
@@ -1094,8 +1119,11 @@ void main() {
           // bubble text. Pin that contract — without this, the title
           // can silently leak back above the thumbnail.
           when(
-            () => mockVideoEventService.getVideoById('abc123'),
-          ).thenReturn(testVideo);
+            () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+              'abc123',
+              fallbackRouteIds: any(named: 'fallbackRouteIds'),
+            ),
+          ).thenAnswer((_) async => testVideo);
 
           await tester.pumpWidget(
             buildWithVideoMessage(
@@ -1119,8 +1147,11 @@ void main() {
           // must render under the thumbnail; the "<title>" line above
           // it (also part of the template) must NOT render.
           when(
-            () => mockVideoEventService.getVideoById('abc123'),
-          ).thenReturn(testVideo);
+            () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+              'abc123',
+              fallbackRouteIds: any(named: 'fallbackRouteIds'),
+            ),
+          ).thenAnswer((_) async => testVideo);
 
           await tester.pumpWidget(
             buildWithVideoMessage(
@@ -1143,8 +1174,11 @@ void main() {
         'embedded quotes',
         (tester) async {
           when(
-            () => mockVideoEventService.getVideoById('abc123'),
-          ).thenReturn(testVideo);
+            () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+              'abc123',
+              fallbackRouteIds: any(named: 'fallbackRouteIds'),
+            ),
+          ).thenAnswer((_) async => testVideo);
 
           await tester.pumpWidget(
             buildWithVideoMessage(
@@ -1162,7 +1196,7 @@ void main() {
     });
 
     group('quoted video reply preview', () {
-      late _MockVideoEventService mockVideoEventService;
+      late _MockVideosRepository mockVideosRepository;
       late MockNostrClient mockNostrClient;
 
       final testVideo = VideoEvent(
@@ -1186,15 +1220,14 @@ void main() {
       );
 
       setUp(() {
-        mockVideoEventService = _MockVideoEventService();
+        mockVideosRepository = _MockVideosRepository();
         mockNostrClient = createMockNostrService();
 
-        when(() => mockVideoEventService.getVideoById(any())).thenReturn(null);
         when(
-          () => mockVideoEventService.getVideoEventByVineId(any()),
-        ).thenReturn(null);
-        when(
-          () => mockNostrClient.fetchEventById(any()),
+          () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+            any(),
+            fallbackRouteIds: any(named: 'fallbackRouteIds'),
+          ),
         ).thenAnswer((_) async => null);
       });
 
@@ -1214,9 +1247,7 @@ void main() {
         ),
         mockNostrService: mockNostrClient,
         additionalOverrides: [
-          videoEventServiceProvider.overrideWithValue(
-            mockVideoEventService,
-          ),
+          videosRepositoryProvider.overrideWithValue(mockVideosRepository),
         ],
       );
 
@@ -1255,8 +1286,11 @@ void main() {
         'full share card',
         (tester) async {
           when(
-            () => mockVideoEventService.getVideoEventByVineId('abc123'),
-          ).thenReturn(testVideo);
+            () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+              'abc123',
+              fallbackRouteIds: any(named: 'fallbackRouteIds'),
+            ),
+          ).thenAnswer((_) async => testVideo);
 
           await tester.pumpWidget(
             buildWithQuotedReply(
@@ -1311,8 +1345,11 @@ void main() {
         'exposes the resolved quoted preview as a button with the reply hint',
         (tester) async {
           when(
-            () => mockVideoEventService.getVideoEventByVineId('abc123'),
-          ).thenReturn(testVideo);
+            () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+              'abc123',
+              fallbackRouteIds: any(named: 'fallbackRouteIds'),
+            ),
+          ).thenAnswer((_) async => testVideo);
 
           await tester.pumpWidget(
             buildWithQuotedReply(
@@ -1342,8 +1379,11 @@ void main() {
         '(sharedVideoRef set, quotedVideoRef null)',
         (tester) async {
           when(
-            () => mockVideoEventService.getVideoEventByVineId('abc123'),
-          ).thenReturn(testVideo);
+            () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+              'abc123',
+              fallbackRouteIds: any(named: 'fallbackRouteIds'),
+            ),
+          ).thenAnswer((_) async => testVideo);
 
           await tester.pumpWidget(
             testMaterialApp(
@@ -1357,8 +1397,8 @@ void main() {
               ),
               mockNostrService: mockNostrClient,
               additionalOverrides: [
-                videoEventServiceProvider.overrideWithValue(
-                  mockVideoEventService,
+                videosRepositoryProvider.overrideWithValue(
+                  mockVideosRepository,
                 ),
               ],
             ),
@@ -1414,8 +1454,11 @@ void main() {
         'text when quotedVideoRef is set',
         (tester) async {
           when(
-            () => mockVideoEventService.getVideoEventByVineId('abc123'),
-          ).thenReturn(testVideo);
+            () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+              'abc123',
+              fallbackRouteIds: any(named: 'fallbackRouteIds'),
+            ),
+          ).thenAnswer((_) async => testVideo);
 
           await tester.pumpWidget(
             buildWithQuotedReply(

--- a/mobile/test/screens/inbox/conversation/widgets/video_link_preview_cubit_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/video_link_preview_cubit_test.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Unit tests for VideoLinkPreviewCubit.
-// ABOUTME: Tests cache hit, relay fetch, d-tag fallback, and not-found paths.
+// ABOUTME: Tests repository-delegated resolve, hydration, fallback, not-found.
 
 import 'dart:async';
 
@@ -7,25 +7,21 @@ import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
-import 'package:nostr_client/nostr_client.dart';
-import 'package:nostr_sdk/event.dart';
-import 'package:nostr_sdk/filter.dart';
 import 'package:openvine/screens/inbox/conversation/widgets/video_link_preview_cubit.dart';
-import 'package:openvine/services/video_event_service.dart';
+import 'package:videos_repository/videos_repository.dart';
 
-class _MockVideoEventService extends Mock implements VideoEventService {}
-
-class _MockNostrClient extends Mock implements NostrClient {}
+class _MockVideosRepository extends Mock implements VideosRepository {}
 
 void main() {
   setUpAll(() {
-    registerFallbackValue(<Filter>[]);
+    registerFallbackValue(<String>[]);
   });
 
   group(VideoLinkPreviewCubit, () {
-    late _MockVideoEventService mockVideoEventService;
-    late _MockNostrClient mockNostrClient;
+    late _MockVideosRepository mockVideosRepository;
 
+    // Carries a hydrated `views` tag so totalLoops is non-zero: the exact
+    // count the shared-video card and detail screen must surface (see #5844).
     final testVideo = VideoEvent(
       id:
           '0123456789abcdef0123456789abcdef'
@@ -37,151 +33,95 @@ void main() {
       content: 'Test',
       timestamp: DateTime.fromMillisecondsSinceEpoch(1757385263 * 1000),
       title: 'My Cool Video',
+      rawTags: const {'views': '1234'},
     );
 
     setUp(() {
-      mockVideoEventService = _MockVideoEventService();
-      mockNostrClient = _MockNostrClient();
+      mockVideosRepository = _MockVideosRepository();
 
-      // Default stubs: nothing in cache, nothing from relay.
-      when(() => mockVideoEventService.getVideoById(any())).thenReturn(null);
+      // Default: repository resolves nothing.
       when(
-        () => mockVideoEventService.getVideoEventByVineId(any()),
-      ).thenReturn(null);
-      when(
-        () => mockNostrClient.fetchEventById(any()),
+        () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+          any(),
+          fallbackRouteIds: any(named: 'fallbackRouteIds'),
+        ),
       ).thenAnswer((_) async => null);
-      when(
-        () => mockNostrClient.queryEvents(any()),
-      ).thenAnswer((_) async => <Event>[]);
     });
 
     VideoLinkPreviewCubit createCubit({String stableId = 'test-id'}) =>
         VideoLinkPreviewCubit(
           videoStableId: stableId,
-          videoEventService: mockVideoEventService,
-          nostrClient: mockNostrClient,
+          videosRepository: mockVideosRepository,
         );
 
-    group('cache hit', () {
+    group('resolve', () {
       blocTest<VideoLinkPreviewCubit, VideoLinkPreviewState>(
-        'emits $VideoLinkPreviewResolved when found by event ID',
+        'emits $VideoLinkPreviewResolved with the repository-hydrated video',
         setUp: () {
           when(
-            () => mockVideoEventService.getVideoById('test-id'),
-          ).thenReturn(testVideo);
+            () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+              'test-id',
+              fallbackRouteIds: any(named: 'fallbackRouteIds'),
+            ),
+          ).thenAnswer((_) async => testVideo);
         },
         build: createCubit,
         expect: () => [
-          isA<VideoLinkPreviewResolved>().having(
-            (s) => s.video.id,
-            'video.id',
-            testVideo.id,
-          ),
+          isA<VideoLinkPreviewResolved>()
+              .having((s) => s.video.id, 'video.id', testVideo.id)
+              .having((s) => s.video.totalLoops, 'video.totalLoops', 1234),
         ],
-        verify: (_) {
-          verifyNever(() => mockNostrClient.fetchEventById(any()));
-        },
       );
 
       blocTest<VideoLinkPreviewCubit, VideoLinkPreviewState>(
-        'emits $VideoLinkPreviewResolved when found by vine ID (d-tag)',
-        setUp: () {
-          when(
-            () => mockVideoEventService.getVideoEventByVineId('vine-tag'),
-          ).thenReturn(testVideo);
-        },
-        build: () => createCubit(stableId: 'vine-tag'),
-        expect: () => [
-          isA<VideoLinkPreviewResolved>().having(
-            (s) => s.video.id,
-            'video.id',
-            testVideo.id,
-          ),
-        ],
-        verify: (_) {
-          verifyNever(() => mockNostrClient.fetchEventById(any()));
-        },
-      );
-    });
-
-    group('relay fetch', () {
-      blocTest<VideoLinkPreviewCubit, VideoLinkPreviewState>(
-        'emits $VideoLinkPreviewResolved when relay returns event by ID',
-        setUp: () {
-          when(() => mockNostrClient.fetchEventById('test-id')).thenAnswer(
-            (_) async => Event.fromJson({
-              'id': testVideo.id,
-              'pubkey': testVideo.pubkey,
-              'created_at': testVideo.createdAt,
-              'kind': 34236,
-              'tags': <List<String>>[],
-              'content': '',
-              'sig': '0' * 128,
-            }),
-          );
-        },
-        build: createCubit,
-        expect: () => [isA<VideoLinkPreviewResolved>()],
-      );
-
-      blocTest<VideoLinkPreviewCubit, VideoLinkPreviewState>(
-        'emits $VideoLinkPreviewResolved when relay returns event by d-tag',
-        setUp: () {
-          when(() => mockNostrClient.queryEvents(any())).thenAnswer(
-            (_) async => [
-              Event.fromJson({
-                'id': testVideo.id,
-                'pubkey': testVideo.pubkey,
-                'created_at': testVideo.createdAt,
-                'kind': 34236,
-                'tags': <List<String>>[],
-                'content': '',
-                'sig': '0' * 128,
-              }),
-            ],
-          );
-        },
-        build: createCubit,
-        expect: () => [isA<VideoLinkPreviewResolved>()],
-      );
-
-      blocTest<VideoLinkPreviewCubit, VideoLinkPreviewState>(
-        'queries invite d-tag with creator and kind when provided',
+        'passes an author/kind addressable fallback route when both are given',
         build: () => VideoLinkPreviewCubit(
           videoStableId: 'skate-loop',
           authorPubkey: testVideo.pubkey,
           videoKind: 34235,
-          videoEventService: mockVideoEventService,
-          nostrClient: mockNostrClient,
+          videosRepository: mockVideosRepository,
         ),
         expect: () => [isA<VideoLinkPreviewNotFound>()],
         verify: (_) {
-          final captured =
-              verify(
-                    () => mockNostrClient.queryEvents(captureAny()),
-                  ).captured.single
-                  as List<Filter>;
-          final filter = captured.single;
-          expect(filter.kinds, [34235]);
-          expect(filter.authors, [testVideo.pubkey]);
-          expect(filter.d, ['skate-loop']);
+          verify(
+            () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+              'skate-loop',
+              fallbackRouteIds: ['34235:${testVideo.pubkey}:skate-loop'],
+            ),
+          ).called(1);
+        },
+      );
+
+      blocTest<VideoLinkPreviewCubit, VideoLinkPreviewState>(
+        'passes no fallback route when author/kind are absent',
+        build: createCubit,
+        expect: () => [isA<VideoLinkPreviewNotFound>()],
+        verify: (_) {
+          verify(
+            () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+              'test-id',
+              fallbackRouteIds: any(named: 'fallbackRouteIds', that: isEmpty),
+            ),
+          ).called(1);
         },
       );
     });
 
     group('not found', () {
       blocTest<VideoLinkPreviewCubit, VideoLinkPreviewState>(
-        'emits $VideoLinkPreviewNotFound when cache and relay return nothing',
+        'emits $VideoLinkPreviewNotFound when the repository resolves nothing',
         build: createCubit,
         expect: () => [isA<VideoLinkPreviewNotFound>()],
       );
 
       blocTest<VideoLinkPreviewCubit, VideoLinkPreviewState>(
-        'emits $VideoLinkPreviewNotFound when relay fetch throws',
+        'emits $VideoLinkPreviewNotFound when the repository throws',
         setUp: () {
           when(
-            () => mockNostrClient.fetchEventById(any()),
+            () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+              any(),
+              fallbackRouteIds: any(named: 'fallbackRouteIds'),
+            ),
           ).thenThrow(Exception('network error'));
         },
         build: createCubit,
@@ -190,23 +130,26 @@ void main() {
     });
 
     group('close during in-flight resolve', () {
-      test('does not emit or throw when closed mid relay fetch', () async {
-        final completer = Completer<Event?>();
+      test('does not emit or throw when closed mid resolve', () async {
+        final completer = Completer<VideoEvent?>();
         when(
-          () => mockNostrClient.fetchEventById(any()),
+          () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+            any(),
+            fallbackRouteIds: any(named: 'fallbackRouteIds'),
+          ),
         ).thenAnswer((_) => completer.future);
 
         final cubit = createCubit();
-        // Let _resolve run past the cache miss to the awaited fetch.
+        // Let _resolve run past scheduling to the awaited repository call.
         await pumpEventQueue();
         expect(cubit.state, isA<VideoLinkPreviewLoading>());
 
-        // Close while the relay fetch is still in flight.
+        // Close while the resolve is still in flight.
         await cubit.close();
 
-        // Completing drives the post-await not-found path; without the
-        // isClosed guard this emits on the closed cubit and throws StateError.
-        completer.complete(null);
+        // Completing drives the post-await path; without the isClosed guard
+        // this emits on the closed cubit and throws StateError.
+        completer.complete(testVideo);
         await pumpEventQueue();
 
         expect(cubit.state, isA<VideoLinkPreviewLoading>());

--- a/mobile/test/screens/inbox/message_requests/request_preview_view_test.dart
+++ b/mobile/test/screens/inbox/message_requests/request_preview_view_test.dart
@@ -19,8 +19,8 @@ import 'package:openvine/router/app_router.dart';
 import 'package:openvine/screens/inbox/conversation/conversation_page.dart';
 import 'package:openvine/screens/inbox/message_requests/request_preview_view.dart';
 import 'package:openvine/services/auth_service.dart' hide UserProfile;
-import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/widgets/user_avatar.dart';
+import 'package:videos_repository/videos_repository.dart';
 
 import '../../../helpers/go_router.dart';
 import '../../../helpers/test_provider_overrides.dart';
@@ -36,7 +36,7 @@ class _MockCollaboratorInviteActionsCubit
     extends MockCubit<CollaboratorInviteActionsState>
     implements CollaboratorInviteActionsCubit {}
 
-class _MockVideoEventService extends Mock implements VideoEventService {}
+class _MockVideosRepository extends Mock implements VideosRepository {}
 
 class _MockAuthService extends MockAuthService {
   _MockAuthService(this._pubkey) {
@@ -74,7 +74,7 @@ void main() {
     late _MockMessageRequestActionsCubit mockActionsCubit;
     late _MockRequestPreviewCubit mockPreviewCubit;
     late _MockCollaboratorInviteActionsCubit mockInviteActionsCubit;
-    late _MockVideoEventService mockVideoEventService;
+    late _MockVideosRepository mockVideosRepository;
     late MockNostrClient mockNostrClient;
     late _MockAuthService mockAuthService;
     late MockGoRouter mockGoRouter;
@@ -82,13 +82,14 @@ void main() {
 
     setUpAll(() {
       registerFallbackValue(fallbackInvite);
+      registerFallbackValue(<String>[]);
     });
 
     setUp(() {
       mockActionsCubit = _MockMessageRequestActionsCubit();
       mockPreviewCubit = _MockRequestPreviewCubit();
       mockInviteActionsCubit = _MockCollaboratorInviteActionsCubit();
-      mockVideoEventService = _MockVideoEventService();
+      mockVideosRepository = _MockVideosRepository();
       mockNostrClient = createMockNostrService();
       mockAuthService = _MockAuthService(currentPubkey);
       mockGoRouter = MockGoRouter();
@@ -115,12 +116,11 @@ void main() {
       when(
         () => mockInviteActionsCubit.ignoreInvite(any()),
       ).thenAnswer((_) async {});
-      when(() => mockVideoEventService.getVideoById(any())).thenReturn(null);
       when(
-        () => mockVideoEventService.getVideoEventByVineId(any()),
-      ).thenReturn(null);
-      when(
-        () => mockNostrClient.fetchEventById(any()),
+        () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+          any(),
+          fallbackRouteIds: any(named: 'fallbackRouteIds'),
+        ),
       ).thenAnswer((_) async => null);
 
       testProfile = UserProfile(
@@ -143,7 +143,7 @@ void main() {
         mockNostrService: mockNostrClient,
         additionalOverrides: [
           goRouterProvider.overrideWithValue(mockGoRouter),
-          videoEventServiceProvider.overrideWithValue(mockVideoEventService),
+          videosRepositoryProvider.overrideWithValue(mockVideosRepository),
           userProfileReactiveProvider(
             otherPubkey,
           ).overrideWith((ref) => Stream.value(testProfile)),


### PR DESCRIPTION
## Description

A video shared in a DM showed **"0 loops"** on its detail screen even when the video had a nonzero count.

`VideoLinkPreviewCubit` resolved the shared video from a **raw relay event** (`VideoEvent.fromNostrEvent`), which never carries the REST-sourced `views` tag. Since `totalLoops = originalLoops + rawTags['views']`, the count collapsed to `0`. That unhydrated event was then handed to `VideoDetailScreen` as `initialVideo`, which trusts it as-is and renders the bottom-left loop line unconditionally — so the user saw `0 loops`.

**Why this layer:** loop/view counts are hydrated from the Funnelcake REST bulk-stats endpoint and merged into `rawTags['views']`; they are not stored on the raw kind-34236 event. The DM/share path was the only single-video surface still bypassing that hydration.

**Fix:** resolve through `VideosRepository.fetchVideoWithStatsForRouteId` — the same canonical resolver the detail screen and `divine.video/video/:id` deep links already use. It runs local cache → Funnelcake REST → relay across every acceptable video kind **and** enriches the event with view/loop stats, so both the DM share card and the detail screen surface the real count. This also removes a parallel, duplicated resolution implementation and broadens kind coverage (older shared links resolve too).

`authorPubkey`/`videoKind` are kept as an addressable-coordinate (`kind:pubkey:d-tag`) fallback so collaborator-invite previews still resolve the exact `(kind, author, d-tag)`.

**Related Issue:** Closes #5844

### After result 
<img width="322" alt="image" src="https://github.com/user-attachments/assets/1ff21ca1-026f-468a-93e6-419c1a5f0c15" />


## Out of Scope

The bottom-left loop line in `video_feed_item.dart` renders `totalLoops` unconditionally (unlike `video_description_overlay.dart`, which gates on `hasLoopMetadata && totalLoops > 0`). Gating it here would change behavior for genuinely-zero-loop videos across the whole feed — a separate product decision, and only symptom-hiding. The hydration fix addresses the root cause, so this is intentionally left alone.

## Verification

- `flutter analyze lib/screens/inbox/conversation/widgets test/screens/inbox/conversation/widgets` — clean
- `flutter test` for the three affected suites (cubit + message bubble + collaborator invite card) — all green
- Manual: shared a video via DM to an account that had not seen it in-feed; the detail screen now shows the real loop count instead of `0 loops`

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)