### PR TITLE
feat(video-editor): keep marker controls open for rapid beat marking

### DIFF
--- a/mobile/lib/blocs/video_editor/main_editor/video_editor_main_bloc.dart
+++ b/mobile/lib/blocs/video_editor/main_editor/video_editor_main_bloc.dart
@@ -36,6 +36,7 @@ class VideoEditorMainBloc
     on<VideoEditorVolumeEditModeToggled>(_onVolumeEditModeToggled);
     on<VideoEditorReorderingChanged>(_onReorderingChanged);
     on<VideoEditorTimelineVisibilityToggled>(_onTimelineVisibilityToggled);
+    on<VideoEditorMarkerModeChanged>(_onMarkerModeChanged);
   }
 
   /// Updates undo/redo/subEditor state based on editor capabilities.
@@ -178,5 +179,12 @@ class VideoEditorMainBloc
     Emitter<VideoEditorMainState> emit,
   ) {
     emit(state.copyWith(isTimelineHiddenByUser: !state.isTimelineHiddenByUser));
+  }
+
+  void _onMarkerModeChanged(
+    VideoEditorMarkerModeChanged event,
+    Emitter<VideoEditorMainState> emit,
+  ) {
+    emit(state.copyWith(isMarkerMode: event.isActive));
   }
 }

--- a/mobile/lib/blocs/video_editor/main_editor/video_editor_main_event.dart
+++ b/mobile/lib/blocs/video_editor/main_editor/video_editor_main_event.dart
@@ -161,3 +161,13 @@ class VideoEditorReorderingChanged extends VideoEditorMainEvent {
 class VideoEditorTimelineVisibilityToggled extends VideoEditorMainEvent {
   const VideoEditorTimelineVisibilityToggled();
 }
+
+/// Enters or exits marker-placement mode.
+class VideoEditorMarkerModeChanged extends VideoEditorMainEvent {
+  const VideoEditorMarkerModeChanged({required this.isActive});
+
+  final bool isActive;
+
+  @override
+  List<Object?> get props => [isActive];
+}

--- a/mobile/lib/blocs/video_editor/main_editor/video_editor_main_state.dart
+++ b/mobile/lib/blocs/video_editor/main_editor/video_editor_main_state.dart
@@ -20,6 +20,7 @@ class VideoEditorMainState extends Equatable {
     this.isVolumeEditMode = false,
     this.isReordering = false,
     this.isTimelineHiddenByUser = false,
+    this.isMarkerMode = false,
   });
 
   /// Whether the undo action is available.
@@ -84,6 +85,12 @@ class VideoEditorMainState extends Equatable {
   /// Whether timeline visibility was manually toggled off by the user.
   final bool isTimelineHiddenByUser;
 
+  /// Whether the timeline is in marker-placement mode.
+  ///
+  /// While active, the bottom controls bar shows add/delete-marker actions so
+  /// the user can drop markers repeatedly while playback runs.
+  final bool isMarkerMode;
+
   /// Creates a copy with the given fields replaced.
   ///
   /// Use [clearOpenSubEditor] to explicitly close the sub-editor.
@@ -106,6 +113,7 @@ class VideoEditorMainState extends Equatable {
     Duration? totalDuration,
     bool? isReordering,
     bool? isTimelineHiddenByUser,
+    bool? isMarkerMode,
   }) {
     return VideoEditorMainState(
       canUndo: canUndo ?? this.canUndo,
@@ -133,6 +141,7 @@ class VideoEditorMainState extends Equatable {
       isReordering: isReordering ?? this.isReordering,
       isTimelineHiddenByUser:
           isTimelineHiddenByUser ?? this.isTimelineHiddenByUser,
+      isMarkerMode: isMarkerMode ?? this.isMarkerMode,
     );
   }
 
@@ -155,5 +164,6 @@ class VideoEditorMainState extends Equatable {
     isVolumeEditMode,
     isReordering,
     isTimelineHiddenByUser,
+    isMarkerMode,
   ];
 }

--- a/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart
+++ b/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart
@@ -56,7 +56,11 @@ class TimelineOverlayBloc
     );
   }
 
-  static const _markerMatchTolerance = Duration(milliseconds: 50);
+  /// A playhead within this distance of a marker counts as "on" that marker.
+  ///
+  /// Shared with the marker-mode controls so the UI's add/delete affordance
+  /// matches the dedup/removal behaviour here.
+  static const markerMatchTolerance = Duration(milliseconds: 50);
 
   /// Adjustment kind → display label for tune timeline bars. Uses the same
   /// English names the (non-localized) filter bars use; the tune editor's
@@ -584,7 +588,7 @@ class TimelineOverlayBloc
     );
     final markers = List<Duration>.from(state.timelineMarkers);
     final alreadyExists = markers.any(
-      (marker) => (marker - clampedPosition).abs() <= _markerMatchTolerance,
+      (marker) => (marker - clampedPosition).abs() <= markerMatchTolerance,
     );
 
     if (alreadyExists) return;
@@ -605,7 +609,7 @@ class TimelineOverlayBloc
   ) {
     final markers = List<Duration>.from(state.timelineMarkers);
     final existingIndex = markers.indexWhere(
-      (marker) => (marker - event.position).abs() <= _markerMatchTolerance,
+      (marker) => (marker - event.position).abs() <= markerMatchTolerance,
     );
 
     if (existingIndex == -1) return;

--- a/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart
+++ b/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart
@@ -62,6 +62,17 @@ class TimelineOverlayBloc
   /// matches the dedup/removal behaviour here.
   static const markerMatchTolerance = Duration(milliseconds: 50);
 
+  /// Index of the marker within [markerMatchTolerance] of [position], or `-1`
+  /// when the playhead is not on any marker.
+  ///
+  /// The single source of truth for "is the playhead on a marker" — used by
+  /// add dedup and removal here and by the marker-mode add/delete gating.
+  static int markerIndexAt(List<Duration> markers, Duration position) {
+    return markers.indexWhere(
+      (marker) => (marker - position).abs() <= markerMatchTolerance,
+    );
+  }
+
   /// Adjustment kind → display label for tune timeline bars. Uses the same
   /// English names the (non-localized) filter bars use; the tune editor's
   /// bottom bar shows the localized names.
@@ -587,11 +598,7 @@ class TimelineOverlayBloc
       event.totalDuration,
     );
     final markers = List<Duration>.from(state.timelineMarkers);
-    final alreadyExists = markers.any(
-      (marker) => (marker - clampedPosition).abs() <= markerMatchTolerance,
-    );
-
-    if (alreadyExists) return;
+    if (markerIndexAt(markers, clampedPosition) != -1) return;
 
     markers.add(clampedPosition);
     markers.sort();
@@ -608,9 +615,7 @@ class TimelineOverlayBloc
     Emitter<TimelineOverlayState> emit,
   ) {
     final markers = List<Duration>.from(state.timelineMarkers);
-    final existingIndex = markers.indexWhere(
-      (marker) => (marker - event.position).abs() <= markerMatchTolerance,
-    );
+    final existingIndex = markerIndexAt(markers, event.position);
 
     if (existingIndex == -1) return;
 

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -3352,6 +3352,7 @@
     "videoEditorMarkerLabel": "ማርከር",
     "videoEditorAddTimelineMarkerSemanticLabel": "የጊዜ መስመር ማርከር አክል",
     "videoEditorRemoveTimelineMarkerSemanticLabel": "የጊዜ መስመር ማርከር አስወግድ",
+    "videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel": "በማጫወቻ ቦታ ያለውን ማርከር አስወግድ",
     "videoEditorDeleteTimelineMarkerTitle": "ማርከሩን ይሰርዙ?",
     "videoEditorDeleteTimelineMarkerSubtitle": "ይህ ማርከሩን ከጊዜ መስመሩ ያስወግዳል። አርትዖትዎ እንዳለ ይቀራል።",
     "videoEditorAddTitle": "አክል",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2714,6 +2714,7 @@
     "videoEditorMarkerLabel": "علامة",
     "videoEditorAddTimelineMarkerSemanticLabel": "إضافة علامة إلى المخطط الزمني",
     "videoEditorRemoveTimelineMarkerSemanticLabel": "إزالة علامة من المخطط الزمني",
+    "videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel": "إزالة العلامة عند رأس التشغيل",
     "videoEditorDeleteTimelineMarkerTitle": "حذف العلامة؟",
     "videoEditorDeleteTimelineMarkerSubtitle": "سيؤدي هذا إلى إزالة العلامة من المخطط الزمني. سيبقى تعديلك كما هو.",
     "videoEditorAudioNoSoundsAvailableSubtitle": "ستظهر الأصوات هنا عندما يشاركها المبدعون",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -3042,6 +3042,7 @@
     "videoEditorMarkerLabel": "Маркер",
     "videoEditorAddTimelineMarkerSemanticLabel": "Добавяне на маркер в хронологията",
     "videoEditorRemoveTimelineMarkerSemanticLabel": "Премахване на маркер от хронологията",
+    "videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel": "Премахване на маркера при плейхеда",
     "videoEditorDeleteTimelineMarkerTitle": "Да се изтрие ли маркерът?",
     "videoEditorDeleteTimelineMarkerSubtitle": "Това премахва маркера от хронологията. Редакцията ви остава непроменена.",
     "videoEditorAddTitle": "Добави",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2791,6 +2791,7 @@
     "videoEditorMarkerLabel": "Markierung",
     "videoEditorAddTimelineMarkerSemanticLabel": "Timeline-Markierung hinzufügen",
     "videoEditorRemoveTimelineMarkerSemanticLabel": "Timeline-Markierung entfernen",
+    "videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel": "Markierung an der Abspielposition entfernen",
     "videoEditorDeleteTimelineMarkerTitle": "Markierung löschen?",
     "videoEditorDeleteTimelineMarkerSubtitle": "Das entfernt die Markierung aus der Timeline. Deine Bearbeitung bleibt erhalten.",
     "videoEditorAddTitle": "Hinzufügen",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -5487,6 +5487,10 @@
     "videoEditorMarkerLabel": "Marker",
     "videoEditorAddTimelineMarkerSemanticLabel": "Add timeline marker",
     "videoEditorRemoveTimelineMarkerSemanticLabel": "Remove timeline marker",
+    "videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel": "Remove marker at playhead",
+    "@videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel": {
+        "description": "Semantic label for the marker-mode bottom-bar delete button, which immediately removes the marker at the current playhead position. Distinct from videoEditorRemoveTimelineMarkerSemanticLabel (the per-marker dot, which asks for confirmation) so screen-reader users can tell the two delete controls apart."
+    },
     "videoEditorDeleteTimelineMarkerTitle": "Delete marker?",
     "videoEditorDeleteTimelineMarkerSubtitle": "This removes the marker from the timeline. Your edit stays intact.",
     "videoEditorVolumeLongPressHint": "Mute or unmute all tracks",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2799,6 +2799,7 @@
     "videoEditorMarkerLabel": "Marcador",
     "videoEditorAddTimelineMarkerSemanticLabel": "Añadir marcador a la línea de tiempo",
     "videoEditorRemoveTimelineMarkerSemanticLabel": "Quitar marcador de la línea de tiempo",
+    "videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel": "Quitar marcador en la posición de reproducción",
     "videoEditorDeleteTimelineMarkerTitle": "¿Eliminar marcador?",
     "videoEditorDeleteTimelineMarkerSubtitle": "Esto quita el marcador de la línea de tiempo. Tu edición permanece intacta.",
     "videoEditorAddTitle": "Agregar",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1737,6 +1737,7 @@
     "videoEditorMarkerLabel": "Marker",
     "videoEditorAddTimelineMarkerSemanticLabel": "Magdagdag ng marker sa timeline",
     "videoEditorRemoveTimelineMarkerSemanticLabel": "Alisin ang marker sa timeline",
+    "videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel": "Alisin ang marker sa posisyon ng pagpapatugtog",
     "videoEditorDeleteTimelineMarkerTitle": "Burahin ang marker?",
     "videoEditorDeleteTimelineMarkerSubtitle": "Aalisin nito ang marker sa timeline. Mananatili ang iyong edit.",
     "videoEditorAddTitle": "Idagdag",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2791,6 +2791,7 @@
     "videoEditorMarkerLabel": "Marqueur",
     "videoEditorAddTimelineMarkerSemanticLabel": "Ajouter un marqueur à la chronologie",
     "videoEditorRemoveTimelineMarkerSemanticLabel": "Supprimer le marqueur de la chronologie",
+    "videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel": "Supprimer le marqueur à la tête de lecture",
     "videoEditorDeleteTimelineMarkerTitle": "Supprimer le marqueur ?",
     "videoEditorDeleteTimelineMarkerSubtitle": "Cela retire le marqueur de la chronologie. Votre montage reste intact.",
     "videoEditorAddTitle": "Ajouter",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2721,6 +2721,7 @@
     "videoEditorMarkerLabel": "Penanda",
     "videoEditorAddTimelineMarkerSemanticLabel": "Tambahkan penanda timeline",
     "videoEditorRemoveTimelineMarkerSemanticLabel": "Hapus penanda timeline",
+    "videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel": "Hapus penanda di posisi pemutaran",
     "videoEditorDeleteTimelineMarkerTitle": "Hapus penanda?",
     "videoEditorDeleteTimelineMarkerSubtitle": "Ini menghapus penanda dari timeline. Editan Anda tetap utuh.",
     "videoEditorAudioNoSoundsAvailableSubtitle": "Suara akan muncul di sini saat kreator berbagi audio",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2791,6 +2791,7 @@
     "videoEditorMarkerLabel": "Marcatore",
     "videoEditorAddTimelineMarkerSemanticLabel": "Aggiungi marcatore alla timeline",
     "videoEditorRemoveTimelineMarkerSemanticLabel": "Rimuovi marcatore dalla timeline",
+    "videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel": "Rimuovi marcatore alla testina di riproduzione",
     "videoEditorDeleteTimelineMarkerTitle": "Eliminare il marcatore?",
     "videoEditorDeleteTimelineMarkerSubtitle": "Questo rimuove il marcatore dalla timeline. La tua modifica resta intatta.",
     "videoEditorAddTitle": "Aggiungi",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2714,6 +2714,7 @@
     "videoEditorMarkerLabel": "マーカー",
     "videoEditorAddTimelineMarkerSemanticLabel": "タイムラインマーカーを追加",
     "videoEditorRemoveTimelineMarkerSemanticLabel": "タイムラインマーカーを削除",
+    "videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel": "再生ヘッド位置のマーカーを削除",
     "videoEditorDeleteTimelineMarkerTitle": "マーカーを削除しますか？",
     "videoEditorDeleteTimelineMarkerSubtitle": "タイムラインからマーカーを削除します。編集内容はそのまま残ります。",
     "videoEditorAudioNoSoundsAvailableSubtitle": "クリエイターがオーディオを共有するとここに表示されます",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -2045,6 +2045,7 @@
     "videoEditorMarkerLabel": "마커",
     "videoEditorAddTimelineMarkerSemanticLabel": "타임라인 마커 추가",
     "videoEditorRemoveTimelineMarkerSemanticLabel": "타임라인 마커 제거",
+    "videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel": "재생 헤드의 마커 제거",
     "videoEditorDeleteTimelineMarkerTitle": "마커를 삭제할까요?",
     "videoEditorDeleteTimelineMarkerSubtitle": "타임라인에서 마커만 제거합니다. 편집 내용은 그대로 유지됩니다.",
     "videoEditorAudioNoSoundsAvailableSubtitle": "크리에이터가 오디오를 공유하면 여기에 표시됩니다",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2791,6 +2791,7 @@
     "videoEditorMarkerLabel": "Markering",
     "videoEditorAddTimelineMarkerSemanticLabel": "Tijdlijnmarkering toevoegen",
     "videoEditorRemoveTimelineMarkerSemanticLabel": "Tijdlijnmarkering verwijderen",
+    "videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel": "Markering bij de afspeelkop verwijderen",
     "videoEditorDeleteTimelineMarkerTitle": "Markering verwijderen?",
     "videoEditorDeleteTimelineMarkerSubtitle": "Dit verwijdert de markering uit de tijdlijn. Je bewerking blijft intact.",
     "videoEditorAddTitle": "Toevoegen",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2791,6 +2791,7 @@
     "videoEditorMarkerLabel": "Znacznik",
     "videoEditorAddTimelineMarkerSemanticLabel": "Dodaj znacznik osi czasu",
     "videoEditorRemoveTimelineMarkerSemanticLabel": "Usuń znacznik osi czasu",
+    "videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel": "Usuń znacznik przy głowicy odtwarzania",
     "videoEditorDeleteTimelineMarkerTitle": "Usunąć znacznik?",
     "videoEditorDeleteTimelineMarkerSubtitle": "Spowoduje to usunięcie znacznika z osi czasu. Twoja edycja pozostanie bez zmian.",
     "videoEditorAddTitle": "Dodaj",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2791,6 +2791,7 @@
     "videoEditorMarkerLabel": "Marcador",
     "videoEditorAddTimelineMarkerSemanticLabel": "Adicionar marcador à linha do tempo",
     "videoEditorRemoveTimelineMarkerSemanticLabel": "Remover marcador da linha do tempo",
+    "videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel": "Remover marcador no cursor de reprodução",
     "videoEditorDeleteTimelineMarkerTitle": "Excluir marcador?",
     "videoEditorDeleteTimelineMarkerSubtitle": "Isso remove o marcador da linha do tempo. Sua edição permanece intacta.",
     "videoEditorAddTitle": "Adicionar",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2791,6 +2791,7 @@
     "videoEditorMarkerLabel": "Marcator",
     "videoEditorAddTimelineMarkerSemanticLabel": "Adaugă marcator pe cronologie",
     "videoEditorRemoveTimelineMarkerSemanticLabel": "Elimină marcatorul de pe cronologie",
+    "videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel": "Elimină marcatorul de la capul de redare",
     "videoEditorDeleteTimelineMarkerTitle": "Ștergi marcatorul?",
     "videoEditorDeleteTimelineMarkerSubtitle": "Aceasta elimină marcatorul de pe cronologie. Editarea rămâne intactă.",
     "videoEditorAddTitle": "Adaugă",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2791,6 +2791,7 @@
     "videoEditorMarkerLabel": "Markör",
     "videoEditorAddTimelineMarkerSemanticLabel": "Lägg till tidslinjemarkör",
     "videoEditorRemoveTimelineMarkerSemanticLabel": "Ta bort tidslinjemarkör",
+    "videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel": "Ta bort markör vid spelhuvudet",
     "videoEditorDeleteTimelineMarkerTitle": "Radera markör?",
     "videoEditorDeleteTimelineMarkerSubtitle": "Detta tar bort markören från tidslinjen. Din redigering behålls.",
     "videoEditorAddTitle": "Lägg till",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2721,6 +2721,7 @@
     "videoEditorMarkerLabel": "İşaretçi",
     "videoEditorAddTimelineMarkerSemanticLabel": "Zaman çizelgesi işaretçisi ekle",
     "videoEditorRemoveTimelineMarkerSemanticLabel": "Zaman çizelgesi işaretçisini kaldır",
+    "videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel": "Oynatma başlığındaki işaretçiyi kaldır",
     "videoEditorDeleteTimelineMarkerTitle": "İşaretçi silinsin mi?",
     "videoEditorDeleteTimelineMarkerSubtitle": "Bu, işaretçiyi zaman çizelgesinden kaldırır. Düzenlemeniz olduğu gibi kalır.",
     "videoEditorAudioNoSoundsAvailableSubtitle": "İçerik üreticileri ses paylaştığında burada görünür",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -16306,6 +16306,12 @@ abstract class AppLocalizations {
   /// **'Remove timeline marker'**
   String get videoEditorRemoveTimelineMarkerSemanticLabel;
 
+  /// Semantic label for the marker-mode bottom-bar delete button, which immediately removes the marker at the current playhead position. Distinct from videoEditorRemoveTimelineMarkerSemanticLabel (the per-marker dot, which asks for confirmation) so screen-reader users can tell the two delete controls apart.
+  ///
+  /// In en, this message translates to:
+  /// **'Remove marker at playhead'**
+  String get videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel;
+
   /// No description provided for @videoEditorDeleteTimelineMarkerTitle.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -9232,6 +9232,10 @@ class AppLocalizationsAm extends AppLocalizations {
       'የጊዜ መስመር ማርከር አስወግድ';
 
   @override
+  String get videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel =>
+      'በማጫወቻ ቦታ ያለውን ማርከር አስወግድ';
+
+  @override
   String get videoEditorDeleteTimelineMarkerTitle => 'ማርከሩን ይሰርዙ?';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -9363,6 +9363,10 @@ class AppLocalizationsAr extends AppLocalizations {
       'إزالة علامة من المخطط الزمني';
 
   @override
+  String get videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel =>
+      'إزالة العلامة عند رأس التشغيل';
+
+  @override
   String get videoEditorDeleteTimelineMarkerTitle => 'حذف العلامة؟';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -9524,6 +9524,10 @@ class AppLocalizationsBg extends AppLocalizations {
       'Премахване на маркер от хронологията';
 
   @override
+  String get videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel =>
+      'Премахване на маркера при плейхеда';
+
+  @override
   String get videoEditorDeleteTimelineMarkerTitle =>
       'Да се изтрие ли маркерът?';
 

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -9539,6 +9539,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Timeline-Markierung entfernen';
 
   @override
+  String get videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel =>
+      'Markierung an der Abspielposition entfernen';
+
+  @override
   String get videoEditorDeleteTimelineMarkerTitle => 'Markierung löschen?';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -9408,6 +9408,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Remove timeline marker';
 
   @override
+  String get videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel =>
+      'Remove marker at playhead';
+
+  @override
   String get videoEditorDeleteTimelineMarkerTitle => 'Delete marker?';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -9523,6 +9523,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'Quitar marcador de la línea de tiempo';
 
   @override
+  String get videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel =>
+      'Quitar marcador en la posición de reproducción';
+
+  @override
   String get videoEditorDeleteTimelineMarkerTitle => '¿Eliminar marcador?';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -9535,6 +9535,10 @@ class AppLocalizationsFil extends AppLocalizations {
       'Alisin ang marker sa timeline';
 
   @override
+  String get videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel =>
+      'Alisin ang marker sa posisyon ng pagpapatugtog';
+
+  @override
   String get videoEditorDeleteTimelineMarkerTitle => 'Burahin ang marker?';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -9565,6 +9565,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Supprimer le marqueur de la chronologie';
 
   @override
+  String get videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel =>
+      'Supprimer le marqueur à la tête de lecture';
+
+  @override
   String get videoEditorDeleteTimelineMarkerTitle => 'Supprimer le marqueur ?';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -9404,6 +9404,10 @@ class AppLocalizationsId extends AppLocalizations {
       'Hapus penanda timeline';
 
   @override
+  String get videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel =>
+      'Hapus penanda di posisi pemutaran';
+
+  @override
   String get videoEditorDeleteTimelineMarkerTitle => 'Hapus penanda?';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -9521,6 +9521,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Rimuovi marcatore dalla timeline';
 
   @override
+  String get videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel =>
+      'Rimuovi marcatore alla testina di riproduzione';
+
+  @override
   String get videoEditorDeleteTimelineMarkerTitle => 'Eliminare il marcatore?';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -9061,6 +9061,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get videoEditorRemoveTimelineMarkerSemanticLabel => 'タイムラインマーカーを削除';
 
   @override
+  String get videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel =>
+      '再生ヘッド位置のマーカーを削除';
+
+  @override
   String get videoEditorDeleteTimelineMarkerTitle => 'マーカーを削除しますか？';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -9085,6 +9085,10 @@ class AppLocalizationsKo extends AppLocalizations {
   String get videoEditorRemoveTimelineMarkerSemanticLabel => '타임라인 마커 제거';
 
   @override
+  String get videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel =>
+      '재생 헤드의 마커 제거';
+
+  @override
   String get videoEditorDeleteTimelineMarkerTitle => '마커를 삭제할까요?';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -9471,6 +9471,10 @@ class AppLocalizationsNl extends AppLocalizations {
       'Tijdlijnmarkering verwijderen';
 
   @override
+  String get videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel =>
+      'Markering bij de afspeelkop verwijderen';
+
+  @override
   String get videoEditorDeleteTimelineMarkerTitle => 'Markering verwijderen?';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -9611,6 +9611,10 @@ class AppLocalizationsPl extends AppLocalizations {
       'Usuń znacznik osi czasu';
 
   @override
+  String get videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel =>
+      'Usuń znacznik przy głowicy odtwarzania';
+
+  @override
   String get videoEditorDeleteTimelineMarkerTitle => 'Usunąć znacznik?';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -9491,6 +9491,10 @@ class AppLocalizationsPt extends AppLocalizations {
       'Remover marcador da linha do tempo';
 
   @override
+  String get videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel =>
+      'Remover marcador no cursor de reprodução';
+
+  @override
   String get videoEditorDeleteTimelineMarkerTitle => 'Excluir marcador?';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -9630,6 +9630,10 @@ class AppLocalizationsRo extends AppLocalizations {
       'Elimină marcatorul de pe cronologie';
 
   @override
+  String get videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel =>
+      'Elimină marcatorul de la capul de redare';
+
+  @override
   String get videoEditorDeleteTimelineMarkerTitle => 'Ștergi marcatorul?';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -9432,6 +9432,10 @@ class AppLocalizationsSv extends AppLocalizations {
       'Ta bort tidslinjemarkör';
 
   @override
+  String get videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel =>
+      'Ta bort markör vid spelhuvudet';
+
+  @override
   String get videoEditorDeleteTimelineMarkerTitle => 'Radera markör?';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -9398,6 +9398,10 @@ class AppLocalizationsTr extends AppLocalizations {
       'Zaman çizelgesi işaretçisini kaldır';
 
   @override
+  String get videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel =>
+      'Oynatma başlığındaki işaretçiyi kaldır';
+
+  @override
   String get videoEditorDeleteTimelineMarkerTitle => 'İşaretçi silinsin mi?';
 
   @override

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_main_actions_sheet.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_main_actions_sheet.dart
@@ -6,7 +6,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
 import 'package:openvine/blocs/video_editor/main_editor/video_editor_main_bloc.dart';
-import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
 import 'package:openvine/blocs/video_editor/tune_editor/video_editor_tune_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
@@ -32,7 +31,6 @@ class VideoEditorMainActionsSheet extends StatelessWidget {
     final scope = VideoEditorScope.of(context);
     final videoEditorMainBloc = context.read<VideoEditorMainBloc>();
     final clipEditorBloc = context.read<ClipEditorBloc>();
-    final timelineOverlayBloc = context.read<TimelineOverlayBloc>();
     final tuneBloc = context.read<VideoEditorTuneBloc>();
 
     return VineBottomSheet.show(
@@ -51,9 +49,6 @@ class VideoEditorMainActionsSheet extends StatelessWidget {
               value: videoEditorMainBloc,
             ),
             BlocProvider<ClipEditorBloc>.value(value: clipEditorBloc),
-            BlocProvider<TimelineOverlayBloc>.value(
-              value: timelineOverlayBloc,
-            ),
             BlocProvider<VideoEditorTuneBloc>.value(value: tuneBloc),
           ],
           child: VideoEditorMainActionsSheet(scope: scope),
@@ -64,9 +59,6 @@ class VideoEditorMainActionsSheet extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final currentPosition = context.select(
-      (VideoEditorMainBloc b) => b.state.currentPosition,
-    );
     final totalDuration = context.select(
       (ClipEditorBloc b) => b.state.totalDuration,
     );
@@ -178,11 +170,11 @@ class VideoEditorMainActionsSheet extends StatelessWidget {
                   Navigator.pop(context);
                   if (totalDuration <= Duration.zero) return;
 
-                  context.read<TimelineOverlayBloc>().add(
-                    TimelineMarkerAdded(
-                      position: currentPosition,
-                      totalDuration: totalDuration,
-                    ),
+                  // Enter marker mode instead of dropping a single marker, so
+                  // the bottom bar exposes add/delete-marker controls and the
+                  // user can keep marking beats while playback runs.
+                  context.read<VideoEditorMainBloc>().add(
+                    const VideoEditorMarkerModeChanged(isActive: true),
                   );
                 },
               ),

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_control_bar.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_control_bar.dart
@@ -3,20 +3,23 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
 import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart';
+import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_timeline_marker_controls.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_timeline_multi_select_controls.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_timeline_overlay_controls.dart';
 
 /// Shows context-specific controls at the bottom of the timeline based on
-/// what is currently selected: a clip (editing), a layer overlay, or a filter
-/// overlay.
+/// what is currently active: marker mode, a clip (editing), a layer overlay,
+/// or a filter overlay.
 class TimelineControlsBar extends StatelessWidget {
   const TimelineControlsBar({
     required this.isEditing,
     required this.playheadPosition,
+    this.isMarkerMode = false,
     super.key,
   });
 
   final bool isEditing;
+  final bool isMarkerMode;
   final ValueNotifier<Duration> playheadPosition;
 
   static const _animationDuration = Duration(milliseconds: 200);
@@ -34,24 +37,32 @@ class TimelineControlsBar extends StatelessWidget {
     });
 
     final showControls =
-        isMultiSelectMode || isEditing || selectedOverlayItem != null;
+        isMarkerMode ||
+        isMultiSelectMode ||
+        isEditing ||
+        selectedOverlayItem != null;
     final controlsChild = switch ((
+      isMarkerMode,
       isMultiSelectMode,
       showControls,
       isEditing,
     )) {
-      (true, _, _) => const TimelineMultiSelectControls(
+      (true, _, _, _) => TimelineMarkerControls(
+        key: const ValueKey('timeline_controls_marker'),
+        playheadPosition: playheadPosition,
+      ),
+      (false, true, _, _) => const TimelineMultiSelectControls(
         key: ValueKey('timeline_controls_multi_select'),
       ),
-      (false, true, true) => TimelineClipControls(
+      (false, false, true, true) => TimelineClipControls(
         key: const ValueKey('timeline_controls_clip'),
         playheadPosition: playheadPosition,
       ),
-      (false, true, false) => TimelineOverlayControls(
+      (false, false, true, false) => TimelineOverlayControls(
         key: const ValueKey('timeline_controls_overlay'),
         item: selectedOverlayItem!,
       ),
-      (false, false, _) => const SizedBox(
+      (false, false, false, _) => const SizedBox(
         key: ValueKey('timeline_controls_hidden'),
         width: double.infinity,
       ),

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_marker_controls.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_marker_controls.dart
@@ -78,7 +78,7 @@ class TimelineMarkerControls extends StatelessWidget {
                         label: context.l10n.videoEditorDeleteLabel,
                         semanticLabel: context
                             .l10n
-                            .videoEditorRemoveTimelineMarkerSemanticLabel,
+                            .videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel,
                         onPressed: markerAtPlayhead == null
                             ? null
                             : () => _removeMarker(context, markerAtPlayhead),

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_marker_controls.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_marker_controls.dart
@@ -1,0 +1,172 @@
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
+import 'package:openvine/blocs/video_editor/main_editor/video_editor_main_bloc.dart';
+import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
+import 'package:openvine/l10n/l10n.dart';
+
+/// Action bar shown while the timeline is in marker-placement mode.
+///
+/// Lets the user drop markers at the playhead repeatedly while playback runs.
+/// Add is disabled while the playhead already sits on a marker; Delete is only
+/// enabled there, targeting that marker. Done leaves the mode.
+///
+/// Both the add position and the add/delete gating track [playheadPosition] —
+/// the scroll-derived visual playhead that updates on every frame — so the
+/// controls stay responsive while the user scrubs the timeline. The player's
+/// reported position lags scrubbing badly and would keep Add blocked until the
+/// scroll fully settled.
+class TimelineMarkerControls extends StatelessWidget {
+  const TimelineMarkerControls({required this.playheadPosition, super.key});
+
+  final ValueNotifier<Duration> playheadPosition;
+
+  @override
+  Widget build(BuildContext context) {
+    final totalDuration = context.select(
+      (ClipEditorBloc b) => b.state.totalDuration,
+    );
+    final markers = context.select(
+      (TimelineOverlayBloc b) => b.state.timelineMarkers,
+    );
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: VineTheme.backgroundCamera,
+        boxShadow: [
+          BoxShadow(
+            color: VineTheme.backgroundColor.withValues(alpha: 0.4),
+            blurRadius: 8,
+            offset: const Offset(0, -4),
+          ),
+        ],
+      ),
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.fromLTRB(0, 16, 0, 8),
+        child: SafeArea(
+          top: false,
+          child: Center(
+            child: SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: ValueListenableBuilder<Duration>(
+                valueListenable: playheadPosition,
+                builder: (context, position, _) {
+                  final markerAtPlayhead = _markerAtPlayhead(markers, position);
+                  final canAdd =
+                      totalDuration > Duration.zero && markerAtPlayhead == null;
+
+                  return Row(
+                    spacing: 16,
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      _ControlButton(
+                        icon: .bookmarkPlus,
+                        label: context.l10n.videoEditorAddTitle,
+                        semanticLabel: context
+                            .l10n
+                            .videoEditorAddTimelineMarkerSemanticLabel,
+                        onPressed: canAdd
+                            ? () => _addMarker(context, position, totalDuration)
+                            : null,
+                        type: .primary,
+                      ),
+                      _ControlButton(
+                        icon: .trash,
+                        label: context.l10n.videoEditorDeleteLabel,
+                        semanticLabel: context
+                            .l10n
+                            .videoEditorRemoveTimelineMarkerSemanticLabel,
+                        onPressed: markerAtPlayhead == null
+                            ? null
+                            : () => _removeMarker(context, markerAtPlayhead),
+                        type: .error,
+                      ),
+                      _ControlButton(
+                        icon: .check,
+                        label: context.l10n.videoEditorDoneLabel,
+                        semanticLabel: context
+                            .l10n
+                            .videoEditorFinishTimelineEditingSemanticLabel,
+                        onPressed: () =>
+                            context.read<VideoEditorMainBloc>().add(
+                              const VideoEditorMarkerModeChanged(
+                                isActive: false,
+                              ),
+                            ),
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Returns the marker within [TimelineOverlayBloc.markerMatchTolerance] of
+  /// [position], or `null` when the playhead is not on a marker.
+  static Duration? _markerAtPlayhead(
+    List<Duration> markers,
+    Duration position,
+  ) {
+    for (final marker in markers) {
+      if ((marker - position).abs() <=
+          TimelineOverlayBloc.markerMatchTolerance) {
+        return marker;
+      }
+    }
+    return null;
+  }
+
+  void _addMarker(
+    BuildContext context,
+    Duration position,
+    Duration totalDuration,
+  ) {
+    context.read<TimelineOverlayBloc>().add(
+      TimelineMarkerAdded(position: position, totalDuration: totalDuration),
+    );
+  }
+
+  void _removeMarker(BuildContext context, Duration marker) {
+    context.read<TimelineOverlayBloc>().add(TimelineMarkerRemoved(marker));
+  }
+}
+
+class _ControlButton extends StatelessWidget {
+  const _ControlButton({
+    required this.icon,
+    required this.label,
+    required this.semanticLabel,
+    required this.onPressed,
+    this.type = .secondary,
+  });
+
+  final DivineIconName icon;
+  final String label;
+  final String semanticLabel;
+  final VoidCallback? onPressed;
+  final DivineIconButtonType type;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      spacing: 8,
+      children: [
+        DivineIconButton(
+          icon: icon,
+          semanticLabel: semanticLabel,
+          onPressed: onPressed,
+          type: type,
+          size: .small,
+        ),
+        Text(label, style: VineTheme.bodySmallFont()),
+      ],
+    );
+  }
+}

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_marker_controls.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_marker_controls.dart
@@ -108,19 +108,14 @@ class TimelineMarkerControls extends StatelessWidget {
     );
   }
 
-  /// Returns the marker within [TimelineOverlayBloc.markerMatchTolerance] of
-  /// [position], or `null` when the playhead is not on a marker.
+  /// Returns the marker the playhead currently sits on, or `null` when it is
+  /// not on one, using the same tolerance as add dedup / removal.
   static Duration? _markerAtPlayhead(
     List<Duration> markers,
     Duration position,
   ) {
-    for (final marker in markers) {
-      if ((marker - position).abs() <=
-          TimelineOverlayBloc.markerMatchTolerance) {
-        return marker;
-      }
-    }
-    return null;
+    final index = TimelineOverlayBloc.markerIndexAt(markers, position);
+    return index == -1 ? null : markers[index];
   }
 
   void _addMarker(

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart
@@ -228,7 +228,10 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
           },
         ),
         // Marker mode owns the bottom controls bar exclusively, so entering it
-        // clears any clip edit / overlay selection / volume mode.
+        // clears any clip edit / overlay selection / volume mode. Reordering
+        // needs no clearing here even though it isn't in the FAB's hide
+        // condition: it's an active single-pointer drag holding the touch that
+        // would otherwise tap the FAB, so entry can't race an ongoing reorder.
         BlocListener<VideoEditorMainBloc, VideoEditorMainState>(
           listenWhen: (prev, curr) => !prev.isMarkerMode && curr.isMarkerMode,
           listener: (context, state) {

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart
@@ -139,6 +139,9 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
     final isTimelineHiddenByUser = context.select(
       (VideoEditorMainBloc b) => b.state.isTimelineHiddenByUser,
     );
+    final isMarkerMode = context.select(
+      (VideoEditorMainBloc b) => b.state.isMarkerMode,
+    );
     // Sync layers from main editor to timeline overlay bloc, and
     // sync scroll to playback position while not user-scrolling.
     return MultiBlocListener(
@@ -197,6 +200,7 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
             context.read<TimelineOverlayBloc>().add(
               const TimelineOverlayItemSelected(null),
             );
+            _exitMarkerMode(context);
           },
         ),
         BlocListener<VideoEditorMainBloc, VideoEditorMainState>(
@@ -220,7 +224,39 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
 
             final bloc = context.read<TimelineOverlayBloc>();
             bloc.add(const TimelineOverlayItemSelected(null));
+            _exitMarkerMode(context);
           },
+        ),
+        // Marker mode owns the bottom controls bar exclusively, so entering it
+        // clears any clip edit / overlay selection / volume mode.
+        BlocListener<VideoEditorMainBloc, VideoEditorMainState>(
+          listenWhen: (prev, curr) => !prev.isMarkerMode && curr.isMarkerMode,
+          listener: (context, state) {
+            final clipBloc = context.read<ClipEditorBloc>();
+            if (clipBloc.state.isEditing) {
+              clipBloc.add(const ClipEditorEditingToggled());
+            }
+            context.read<TimelineOverlayBloc>().add(
+              const TimelineOverlayItemSelected(null),
+            );
+            final mainBloc = context.read<VideoEditorMainBloc>();
+            if (mainBloc.state.isVolumeEditMode) {
+              mainBloc.add(const VideoEditorVolumeEditModeToggled());
+            }
+          },
+        ),
+        // Selecting an overlay item leaves marker mode.
+        BlocListener<TimelineOverlayBloc, TimelineOverlayState>(
+          listenWhen: (prev, curr) =>
+              prev.selectedItemId == null && curr.selectedItemId != null,
+          listener: (context, state) => _exitMarkerMode(context),
+        ),
+        // Starting clip editing or multi-select leaves marker mode.
+        BlocListener<ClipEditorBloc, ClipEditorState>(
+          listenWhen: (prev, curr) =>
+              (!prev.isEditing && curr.isEditing) ||
+              (!prev.isMultiSelectMode && curr.isMultiSelectMode),
+          listener: (context, state) => _exitMarkerMode(context),
         ),
       ],
       child: GestureDetector(
@@ -307,6 +343,7 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
 
             TimelineControlsBar(
               isEditing: isEditing,
+              isMarkerMode: isMarkerMode,
               playheadPosition: _playheadPosition,
             ),
           ],
@@ -379,6 +416,15 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
       context.read<TimelineOverlayBloc>().add(
         const TimelineOverlayItemSelected(null),
       );
+      _exitMarkerMode(context);
+    }
+  }
+
+  /// Leaves marker-placement mode if it is active.
+  void _exitMarkerMode(BuildContext context) {
+    final bloc = context.read<VideoEditorMainBloc>();
+    if (bloc.state.isMarkerMode) {
+      bloc.add(const VideoEditorMarkerModeChanged(isActive: false));
     }
   }
 

--- a/mobile/lib/widgets/video_editor/video_editor_scaffold.dart
+++ b/mobile/lib/widgets/video_editor/video_editor_scaffold.dart
@@ -769,7 +769,9 @@ class _AddElementFab extends StatelessWidget {
   Widget build(BuildContext context) {
     final shouldHide = context.select(
       (VideoEditorMainBloc b) =>
-          b.state.isSubEditorOpen || b.state.isTimelineHiddenByUser,
+          b.state.isSubEditorOpen ||
+          b.state.isTimelineHiddenByUser ||
+          b.state.isMarkerMode,
     );
     final hasSelectedOverlay = context.select(
       (TimelineOverlayBloc b) => b.state.selectedItemId != null,

--- a/mobile/test/blocs/video_editor/main_editor/video_editor_main_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/main_editor/video_editor_main_bloc_test.dart
@@ -28,6 +28,7 @@ void main() {
       expect(bloc.state.totalDuration, equals(Duration.zero));
       expect(bloc.state.isVolumeEditMode, isFalse);
       expect(bloc.state.isReordering, isFalse);
+      expect(bloc.state.isMarkerMode, isFalse);
       bloc.close();
     });
 
@@ -458,6 +459,37 @@ void main() {
           isA<VideoEditorMainState>().having(
             (s) => s.isVolumeEditMode,
             'isVolumeEditMode',
+            isFalse,
+          ),
+        ],
+      );
+    });
+
+    group(VideoEditorMarkerModeChanged, () {
+      blocTest<VideoEditorMainBloc, VideoEditorMainState>(
+        'enters marker mode when isActive is true',
+        build: buildBloc,
+        act: (bloc) =>
+            bloc.add(const VideoEditorMarkerModeChanged(isActive: true)),
+        expect: () => [
+          isA<VideoEditorMainState>().having(
+            (s) => s.isMarkerMode,
+            'isMarkerMode',
+            isTrue,
+          ),
+        ],
+      );
+
+      blocTest<VideoEditorMainBloc, VideoEditorMainState>(
+        'leaves marker mode when isActive is false',
+        build: buildBloc,
+        seed: () => const VideoEditorMainState(isMarkerMode: true),
+        act: (bloc) =>
+            bloc.add(const VideoEditorMarkerModeChanged(isActive: false)),
+        expect: () => [
+          isA<VideoEditorMainState>().having(
+            (s) => s.isMarkerMode,
+            'isMarkerMode',
             isFalse,
           ),
         ],

--- a/mobile/test/widgets/video_editor/main_editor/video_editor_main_actions_sheet_test.dart
+++ b/mobile/test/widgets/video_editor/main_editor/video_editor_main_actions_sheet_test.dart
@@ -31,11 +31,23 @@ class _MockVideoEditorTuneBloc
     extends MockBloc<VideoEditorTuneEvent, VideoEditorTuneState>
     implements VideoEditorTuneBloc {}
 
+/// [ClipEditorState.totalDuration] is derived from clips; this fake supplies it
+/// directly so tests don't need to construct clip fixtures.
+class _FakeClipEditorState extends ClipEditorState {
+  const _FakeClipEditorState(this._total);
+
+  final Duration _total;
+
+  @override
+  Duration get totalDuration => _total;
+}
+
 void main() {
   final l10n = lookupAppLocalizations(const Locale('en'));
 
   setUpAll(() {
     registerFallbackValue(const VideoEditorTuneSessionStarted());
+    registerFallbackValue(const VideoEditorMarkerModeChanged(isActive: false));
   });
 
   group(VideoEditorMainActionsSheet, () {
@@ -159,6 +171,52 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(addedStickers, isTrue);
+    });
+
+    testWidgets('tap on Marker enters marker mode', (tester) async {
+      when(
+        () => clipBloc.state,
+      ).thenReturn(const _FakeClipEditorState(Duration(seconds: 5)));
+
+      await tester.pumpWidget(
+        _buildWidget(
+          mainBloc: mainBloc,
+          clipBloc: clipBloc,
+          timelineOverlayBloc: timelineOverlayBloc,
+        ),
+      );
+
+      await tester.tap(
+        find.bySemanticsLabel(l10n.videoEditorAddTimelineMarkerSemanticLabel),
+      );
+      await tester.pumpAndSettle();
+
+      verify(
+        () => mainBloc.add(
+          const VideoEditorMarkerModeChanged(isActive: true),
+        ),
+      ).called(1);
+    });
+
+    testWidgets('tap on Marker does nothing when there is no duration', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _buildWidget(
+          mainBloc: mainBloc,
+          clipBloc: clipBloc,
+          timelineOverlayBloc: timelineOverlayBloc,
+        ),
+      );
+
+      await tester.tap(
+        find.bySemanticsLabel(l10n.videoEditorAddTimelineMarkerSemanticLabel),
+      );
+      await tester.pumpAndSettle();
+
+      verifyNever(
+        () => mainBloc.add(any(that: isA<VideoEditorMarkerModeChanged>())),
+      );
     });
 
     // Regression: the sheet opens on a separate route, so `show` must

--- a/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_control_bar_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_control_bar_test.dart
@@ -8,10 +8,16 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
+import 'package:openvine/blocs/video_editor/main_editor/video_editor_main_bloc.dart';
 import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_timeline_control_bar.dart';
+import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_timeline_marker_controls.dart';
+
+class _MockVideoEditorMainBloc
+    extends MockBloc<VideoEditorMainEvent, VideoEditorMainState>
+    implements VideoEditorMainBloc {}
 
 class _MockClipEditorBloc extends MockBloc<ClipEditorEvent, ClipEditorState>
     implements ClipEditorBloc {}
@@ -22,12 +28,16 @@ class _MockTimelineOverlayBloc
 
 void main() {
   group(TimelineControlsBar, () {
+    late _MockVideoEditorMainBloc mainBloc;
     late _MockClipEditorBloc clipBloc;
     late _MockTimelineOverlayBloc overlayBloc;
 
     setUp(() {
+      mainBloc = _MockVideoEditorMainBloc();
       clipBloc = _MockClipEditorBloc();
       overlayBloc = _MockTimelineOverlayBloc();
+
+      when(() => mainBloc.state).thenReturn(const VideoEditorMainState());
 
       when(() => clipBloc.state).thenReturn(const ClipEditorState());
       when(
@@ -40,7 +50,7 @@ void main() {
       ).thenAnswer((_) => const Stream<TimelineOverlayState>.empty());
     });
 
-    Widget build({required bool isEditing}) {
+    Widget build({required bool isEditing, bool isMarkerMode = false}) {
       return ProviderScope(
         child: MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -48,11 +58,13 @@ void main() {
           home: Scaffold(
             body: MultiBlocProvider(
               providers: [
+                BlocProvider<VideoEditorMainBloc>.value(value: mainBloc),
                 BlocProvider<ClipEditorBloc>.value(value: clipBloc),
                 BlocProvider<TimelineOverlayBloc>.value(value: overlayBloc),
               ],
               child: TimelineControlsBar(
                 isEditing: isEditing,
+                isMarkerMode: isMarkerMode,
                 playheadPosition: ValueNotifier(Duration.zero),
               ),
             ),
@@ -73,6 +85,15 @@ void main() {
       await tester.pumpWidget(build(isEditing: true));
 
       expect(find.byType(TimelineClipControls), findsOneWidget);
+    });
+
+    testWidgets('shows marker controls when marker mode is active', (
+      tester,
+    ) async {
+      await tester.pumpWidget(build(isEditing: false, isMarkerMode: true));
+
+      expect(find.byType(TimelineMarkerControls), findsOneWidget);
+      expect(find.byType(TimelineClipControls), findsNothing);
     });
   });
 }

--- a/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_marker_controls_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_marker_controls_test.dart
@@ -1,0 +1,224 @@
+// ABOUTME: Widget tests for TimelineMarkerControls.
+// ABOUTME: Verifies add/delete gating and the marker-mode exit action.
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
+import 'package:openvine/blocs/video_editor/main_editor/video_editor_main_bloc.dart';
+import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_timeline_marker_controls.dart';
+
+class _MockVideoEditorMainBloc
+    extends MockBloc<VideoEditorMainEvent, VideoEditorMainState>
+    implements VideoEditorMainBloc {}
+
+class _MockClipEditorBloc extends MockBloc<ClipEditorEvent, ClipEditorState>
+    implements ClipEditorBloc {}
+
+class _MockTimelineOverlayBloc
+    extends MockBloc<TimelineOverlayEvent, TimelineOverlayState>
+    implements TimelineOverlayBloc {}
+
+/// [ClipEditorState.totalDuration] is derived from clips; this fake supplies it
+/// directly so tests don't need to construct clip fixtures.
+class _FakeClipEditorState extends ClipEditorState {
+  const _FakeClipEditorState(this._total);
+
+  final Duration _total;
+
+  @override
+  Duration get totalDuration => _total;
+}
+
+void main() {
+  final l10n = lookupAppLocalizations(const Locale('en'));
+
+  setUpAll(() {
+    registerFallbackValue(const TimelineMarkerRemoved(Duration.zero));
+  });
+
+  group(TimelineMarkerControls, () {
+    late _MockVideoEditorMainBloc mainBloc;
+    late _MockClipEditorBloc clipBloc;
+    late _MockTimelineOverlayBloc overlayBloc;
+
+    setUp(() {
+      mainBloc = _MockVideoEditorMainBloc();
+      clipBloc = _MockClipEditorBloc();
+      overlayBloc = _MockTimelineOverlayBloc();
+
+      when(() => clipBloc.state).thenReturn(
+        const _FakeClipEditorState(Duration(seconds: 10)),
+      );
+      when(
+        () => mainBloc.stream,
+      ).thenAnswer((_) => const Stream<VideoEditorMainState>.empty());
+      when(
+        () => clipBloc.stream,
+      ).thenAnswer((_) => const Stream<ClipEditorState>.empty());
+      when(
+        () => overlayBloc.stream,
+      ).thenAnswer((_) => const Stream<TimelineOverlayState>.empty());
+    });
+
+    Widget build({
+      required Duration currentPosition,
+      required List<Duration> markers,
+      ValueNotifier<Duration>? playhead,
+    }) {
+      when(
+        () => mainBloc.state,
+      ).thenReturn(const VideoEditorMainState(isMarkerMode: true));
+      when(() => overlayBloc.state).thenReturn(
+        TimelineOverlayState(timelineMarkers: markers),
+      );
+
+      return MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: MultiBlocProvider(
+            providers: [
+              BlocProvider<VideoEditorMainBloc>.value(value: mainBloc),
+              BlocProvider<ClipEditorBloc>.value(value: clipBloc),
+              BlocProvider<TimelineOverlayBloc>.value(value: overlayBloc),
+            ],
+            child: TimelineMarkerControls(
+              playheadPosition: playhead ?? ValueNotifier(currentPosition),
+            ),
+          ),
+        ),
+      );
+    }
+
+    Finder addButton() =>
+        find.bySemanticsLabel(l10n.videoEditorAddTimelineMarkerSemanticLabel);
+    Finder deleteButton() => find.bySemanticsLabel(
+      l10n.videoEditorRemoveTimelineMarkerSemanticLabel,
+    );
+
+    testWidgets('renders add, delete and done controls', (tester) async {
+      await tester.pumpWidget(
+        build(currentPosition: const Duration(seconds: 2), markers: const []),
+      );
+
+      expect(addButton(), findsOneWidget);
+      expect(deleteButton(), findsOneWidget);
+      expect(find.text(l10n.videoEditorDoneLabel), findsOneWidget);
+    });
+
+    testWidgets('adds a marker at the playhead when not on a marker', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        build(currentPosition: const Duration(seconds: 3), markers: const []),
+      );
+
+      await tester.tap(addButton());
+      await tester.pump();
+
+      verify(
+        () => overlayBloc.add(
+          const TimelineMarkerAdded(
+            position: Duration(seconds: 3),
+            totalDuration: Duration(seconds: 10),
+          ),
+        ),
+      ).called(1);
+    });
+
+    testWidgets('deletes the marker under the playhead', (tester) async {
+      const marker = Duration(seconds: 4);
+      await tester.pumpWidget(
+        build(currentPosition: marker, markers: const [marker]),
+      );
+
+      await tester.tap(deleteButton());
+      await tester.pump();
+
+      verify(
+        () => overlayBloc.add(const TimelineMarkerRemoved(marker)),
+      ).called(1);
+    });
+
+    testWidgets('does not add while the playhead sits on a marker', (
+      tester,
+    ) async {
+      const marker = Duration(seconds: 4);
+      await tester.pumpWidget(
+        build(currentPosition: marker, markers: const [marker]),
+      );
+
+      await tester.tap(addButton());
+      await tester.pump();
+
+      verifyNever(
+        () => overlayBloc.add(any(that: isA<TimelineMarkerAdded>())),
+      );
+    });
+
+    testWidgets(
+      'add re-enables as the playhead scrolls off a marker, tracking the '
+      'notifier without any bloc update',
+      (tester) async {
+        const marker = Duration(seconds: 4);
+        final playhead = ValueNotifier<Duration>(marker);
+        addTearDown(playhead.dispose);
+
+        await tester.pumpWidget(
+          build(
+            currentPosition: marker,
+            markers: const [marker],
+            playhead: playhead,
+          ),
+        );
+
+        // Sitting on the marker: add is blocked.
+        await tester.tap(addButton());
+        await tester.pump();
+        verifyNever(
+          () => overlayBloc.add(any(that: isA<TimelineMarkerAdded>())),
+        );
+
+        // Scrolling moves only the visual playhead notifier — the player's
+        // bloc position never changes here. Add must re-enable regardless.
+        playhead.value = const Duration(seconds: 6);
+        await tester.pump();
+
+        await tester.tap(addButton());
+        await tester.pump();
+        verify(
+          () => overlayBloc.add(
+            const TimelineMarkerAdded(
+              position: Duration(seconds: 6),
+              totalDuration: Duration(seconds: 10),
+            ),
+          ),
+        ).called(1);
+      },
+    );
+
+    testWidgets('Done leaves marker mode', (tester) async {
+      await tester.pumpWidget(
+        build(currentPosition: const Duration(seconds: 2), markers: const []),
+      );
+
+      await tester.tap(
+        find.bySemanticsLabel(
+          l10n.videoEditorFinishTimelineEditingSemanticLabel,
+        ),
+      );
+      await tester.pump();
+
+      verify(
+        () => mainBloc.add(
+          const VideoEditorMarkerModeChanged(isActive: false),
+        ),
+      ).called(1);
+    });
+  });
+}

--- a/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_marker_controls_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_marker_controls_test.dart
@@ -98,7 +98,7 @@ void main() {
     Finder addButton() =>
         find.bySemanticsLabel(l10n.videoEditorAddTimelineMarkerSemanticLabel);
     Finder deleteButton() => find.bySemanticsLabel(
-      l10n.videoEditorRemoveTimelineMarkerSemanticLabel,
+      l10n.videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel,
     );
 
     testWidgets('renders add, delete and done controls', (tester) async {

--- a/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_test.dart
@@ -503,6 +503,77 @@ void main() {
         },
       );
     });
+
+    group('marker-mode mutual exclusion', () {
+      testWidgets(
+        'entering marker mode clears volume mode, clip edit, and overlay '
+        'selection',
+        (tester) async {
+          final clips = [_createTestClip(id: 'a')];
+          final mainStates = StreamController<VideoEditorMainState>.broadcast();
+          addTearDown(mainStates.close);
+          // Start already in volume mode with a clip being edited: entering
+          // marker mode must clear all of it. Volume mode starts on so the
+          // enter-volume listener can't also fire and inflate the counts.
+          whenListen(
+            mockMainBloc,
+            mainStates.stream,
+            initialState: const VideoEditorMainState(isVolumeEditMode: true),
+          );
+
+          await tester.pumpWidget(
+            buildWidget(
+              clipState: ClipEditorState(clips: clips, isEditing: true),
+            ),
+          );
+
+          mainStates.add(
+            const VideoEditorMainState(
+              isMarkerMode: true,
+              isVolumeEditMode: true,
+            ),
+          );
+          await tester.pump();
+
+          verify(
+            () => mockClipBloc.add(const ClipEditorEditingToggled()),
+          ).called(1);
+          verify(
+            () => mockOverlayBloc.add(const TimelineOverlayItemSelected(null)),
+          ).called(1);
+          verify(
+            () => mockMainBloc.add(const VideoEditorVolumeEditModeToggled()),
+          ).called(1);
+        },
+      );
+
+      testWidgets('starting clip editing exits marker mode', (tester) async {
+        final clips = [_createTestClip(id: 'a')];
+        final clipStates = StreamController<ClipEditorState>.broadcast();
+        addTearDown(clipStates.close);
+        whenListen(
+          mockMainBloc,
+          const Stream<VideoEditorMainState>.empty(),
+          initialState: const VideoEditorMainState(isMarkerMode: true),
+        );
+        whenListen(
+          mockClipBloc,
+          clipStates.stream,
+          initialState: ClipEditorState(clips: clips),
+        );
+
+        await tester.pumpWidget(buildWidget());
+
+        clipStates.add(ClipEditorState(clips: clips, isEditing: true));
+        await tester.pump();
+
+        verify(
+          () => mockMainBloc.add(
+            const VideoEditorMarkerModeChanged(isActive: false),
+          ),
+        ).called(1);
+      });
+    });
   });
 }
 


### PR DESCRIPTION
Closes #5069

## What

Tapping **Marker** in the editor add-sheet no longer drops a single marker and closes. It now enters a persistent **marker mode** whose controls live in the timeline's bottom controls bar — the same slot used when a clip or overlay is selected:

- **Add** drops a marker at the playhead. You can keep tapping it while the video plays — nothing closes.
- **Delete** (red) is enabled only when the playhead sits on an existing marker (within the existing 50 ms match tolerance), targeting that marker; **Add** disables there.
- **Done** leaves the mode.

The add-element FAB hides in marker mode. Marker mode is mutually exclusive with clip-edit, overlay-selection, volume, multi-select, and reorder: **starting any of them exits marker mode**, and **entering marker mode clears an active volume mode**. It never has to clear clip-edit / overlay-selection / multi-select on entry, because the FAB — the only way into marker mode — is already hidden in those states, so they can't overlap on entry.

## Why these choices

- **Controls track the visual scroll playhead, not the player's reported position.** The player's `currentPosition` lags badly while scrubbing, which left **Add** blocked (stuck near the just-placed marker) until the scroll fully settled. Driving the controls off the scroll-derived playhead notifier makes Add responsive during scrubbing and drops the marker exactly at the visible playhead line.
- **Delete is immediate (no confirm dialog)** to keep the mode fast — it's undoable via editor history, and the marker-dot delete (with its own confirm prompt) still exists as a second path.
- **Single source of truth for "on a marker".** The 50 ms tolerance match now lives in one `TimelineOverlayBloc.markerIndexAt` helper, shared by add dedup, removal, and the marker-mode add/delete gating.
- **Zero new l10n keys** — reused the existing Add / Delete / Done labels and the existing marker semantic labels.

## Design note

Issue is labelled `needs design`; a maintainer requested a brainstorming gate. This implements a concrete direction agreed with the requester (persistent mode + contextual add/delete + done). Opening as **draft** for design/UX feedback before marking ready.

## Test plan

- New/updated tests: marker-mode bloc transitions, `TimelineMarkerControls` (add/delete gating, done, and a regression test that Add re-enables as the playhead notifier moves off a marker without any bloc update), the control-bar marker branch, and the sheet entering marker mode.
- `flutter analyze` + `dart format` clean; affected suites and the timeline/scaffold suites pass locally (pre-push hook green).

Manual: enter marker mode, play, tap Add repeatedly; scrub onto a marker and Delete; scroll and confirm Add stays responsive; Done exits.
