### PR TITLE
chore(android): migrate internal plugins to Flutter 3.44 built-in Kotlin

### DIFF
--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -3,7 +3,6 @@ import java.io.FileInputStream
 
 plugins {
     id("com.android.application")
-    id("kotlin-android")
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
     id("com.google.gms.google-services")
@@ -26,10 +25,6 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
         isCoreLibraryDesugaringEnabled = true
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
     }
 
     defaultConfig {
@@ -111,6 +106,12 @@ android {
             pickFirsts.add("lib/x86/libc++_shared.so")
             pickFirsts.add("lib/x86_64/libc++_shared.so")
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }
 

--- a/mobile/android/gradle.properties
+++ b/mobile/android/gradle.properties
@@ -5,7 +5,8 @@ android.enableJetifier=true
 android.suppressUnsupportedOptionWarnings=true
 # Keep R8 in compatibility mode; full mode is more aggressive and needs a separate release smoke pass.
 android.enableR8.fullMode=false
-# Keep using the explicit org.jetbrains.kotlin.android plugin with AGP 8.11.
+# AGP 8.11: keep AGP's built-in Kotlin off; the Kotlin Gradle plugin is
+# applied by Flutter (built-in-Kotlin migration). Revisit with the AGP 9 upgrade.
 android.builtInKotlin=false
 # Preserve the existing Flutter Gradle DSL behavior during the 3.44 upgrade.
 android.newDsl=false

--- a/mobile/packages/background_uploader/android/build.gradle.kts
+++ b/mobile/packages/background_uploader/android/build.gradle.kts
@@ -23,7 +23,6 @@ allprojects {
 
 plugins {
     id("com.android.library")
-    id("org.jetbrains.kotlin.android")
 }
 
 android {

--- a/mobile/packages/divine_camera/android/build.gradle
+++ b/mobile/packages/divine_camera/android/build.gradle
@@ -22,7 +22,6 @@ allprojects {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
 
 android {
     namespace = "co.openvine.divine_camera"
@@ -32,10 +31,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17
     }
 
     sourceSets {
@@ -85,5 +80,11 @@ android {
                 }
             }
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }

--- a/mobile/packages/divine_quick_actions/android/build.gradle.kts
+++ b/mobile/packages/divine_quick_actions/android/build.gradle.kts
@@ -23,7 +23,6 @@ allprojects {
 
 plugins {
     id("com.android.library")
-    id("org.jetbrains.kotlin.android")
 }
 
 android {

--- a/mobile/packages/divine_video_player/android/build.gradle.kts
+++ b/mobile/packages/divine_video_player/android/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     id("com.android.library")
-    id("org.jetbrains.kotlin.android")
 }
 
 group = "com.divinevideo.divine_video_player"
@@ -19,12 +18,14 @@ android {
         targetCompatibility = JavaVersion.VERSION_11
     }
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11.toString()
-    }
-
     testOptions {
         unitTests.isReturnDefaultValues = true
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
     }
 }
 

--- a/mobile/packages/image_metadata_stripper/android/build.gradle
+++ b/mobile/packages/image_metadata_stripper/android/build.gradle
@@ -22,7 +22,6 @@ allprojects {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
 
 android {
     namespace = "co.openvine.image_metadata_stripper"
@@ -34,16 +33,18 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17
-    }
-
     sourceSets {
         main.java.srcDirs += "src/main/kotlin"
     }
 
     defaultConfig {
         minSdk = 24
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }
 

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1800,18 +1800,18 @@ packages:
     dependency: "direct main"
     description:
       name: pro_image_editor
-      sha256: f3bdc16e6e0cd748b63f99f594732225a74fb0266122eeecca3b98f9c90e7601
+      sha256: "401a4557e2c6d40a421668eeebfedc6cf715db0929abeee9b8e8560bba3187b8"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "13.1.0"
   pro_video_editor:
     dependency: "direct main"
     description:
       name: pro_video_editor
-      sha256: "591b3f92c03579a8a01bded652942f756b30305ee5644f380aabebb62ab7f3ee"
+      sha256: d217ca0934b1fa8e77b2a8c25169eddf59793f80eb1905d76a04c09c9fd72cf9
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.3"
+    version: "2.3.0"
   process:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -311,8 +311,8 @@ dependencies:
   firebase_messaging: ^16.1.1
   convert: ^3.1.2
   audio_session: ^0.2.2
-  pro_video_editor: ^2.2.3
-  pro_image_editor: ^13.0.0
+  pro_video_editor: ^2.3.0
+  pro_image_editor: ^13.1.0
   flutter_colorpicker: ^1.1.0
   file_picker: ^10.3.7
   sensors_plus: ^7.0.0


### PR DESCRIPTION
Closes #5923

Migrates everything we own to Flutter 3.44's **Built-in Kotlin**, clearing the KGP deprecation warnings for our code. Three clearly-separated parts (one commit each).

## Why

On Flutter 3.44 the Flutter Gradle plugin applies `kotlin-android` to the app + plugin subprojects itself. Anything of ours that *also* applies KGP shows up in these warnings and **will fail to build in future Flutter versions**:

> `WARNING: Your app uses the following plugins that apply Kotlin Gradle Plugin (KGP): ...`
> `WARNING: Your Android app project: app ... applies the Kotlin Gradle Plugin ...`

The fix for our own Android Gradle files follows Flutter 3.44's own templates: drop the explicit KGP application, keep KGP on the classpath (so Flutter can auto-apply it), and move `jvmTarget` out of the deprecated `kotlinOptions {}` into a top-level `kotlin { compilerOptions {} }` block. The remaining external plugins (firebase, share_plus, patrol, etc.) are upstream's to fix.

## Part 1 — internal plugins (commit 1)

Migrated the 5 internal Android plugins:

- `background_uploader`
- `divine_camera`
- `divine_quick_actions`
- `divine_video_player`
- `image_metadata_stripper`

Each dropped `id("org.jetbrains.kotlin.android")` / `apply plugin: "kotlin-android"`; the ones with a `kotlinOptions {}` block got a top-level `kotlin {}` block instead. The `buildscript` KGP classpath is intentionally kept.

## Part 2 — our published editor packages (commit 2)

`pro_video_editor` → `^2.3.0` and `pro_image_editor` → `^13.1.0`. These are our own pub.dev packages; the new versions migrate to built-in Kotlin, which drops them from the KGP warning list (fixed via publish + dep bump rather than in-repo).

## Part 3 — the app (commit 3)

The 3.44 toolchain upgrade (#4917) deliberately kept the app on explicit KGP via `android.builtInKotlin=false` / `android.newDsl=false`, deferring the app-side migration — which left the app-level KGP warning firing.

Mirrored the plugin fix on `android/app/build.gradle.kts`: removed `id("kotlin-android")`, moved `jvmTarget` into a top-level `kotlin {}` block. Flutter now applies KGP to `:app` itself (the `settings.gradle.kts` `apply false` declaration keeps it on the classpath), so `android.builtInKotlin` stays `false` on AGP 8.11 — only its now-stale comment was updated. This is really coupled to the eventual AGP 8.11 → 9 upgrade, called out in the comment.

## Out of scope

`mobile/overrides/app_device_integrity-1.1.0` is a vendored copy of the third-party `co.bubotech.app_device_integrity` plugin (patched for namespace/AGP compat, with its own self-contained legacy `buildscript` on KGP 1.7.10 / AGP 7.3.0). It still applies `kotlin-android` and stays in the KGP warning list, but it isn't first-party — migrating our vendored copy would only diverge it from upstream for no ownership benefit, so it's intentionally left as-is. "Everything we own" here means our first-party plugins, our published `pro_*` packages, and the app.

## Verification

`flutter pub get` + `./gradlew :app:help` (Gradle configuration):

- `BUILD SUCCESSFUL`; the new `kotlin { compilerOptions {} }` blocks resolve correctly.
- Both warnings clear for our code: the app-level warning is gone, and the plugin-list warning no longer contains any of our 5 plugins or the two `pro_*` packages — only genuinely external plugins remain.

**Tested on Android:** a debug build compiles cleanly through the migrated Gradle config and the app launches and runs fine on-device. A debug build fully exercises this change — it compiles all Kotlin (app + plugins) through the new config; release-only steps (R8/ProGuard, resource shrinking) are untouched by this diff and orthogonal to the KGP migration.
