### PR TITLE
fix(router): keep shell app bar stable during full-screen route push

### DIFF
--- a/mobile/lib/router/app_shell.dart
+++ b/mobile/lib/router/app_shell.dart
@@ -34,6 +34,28 @@ import 'package:unified_logger/unified_logger.dart';
 /// Kept short so tab switches stay snappy.
 const Duration _kTabFadeDuration = Duration(milliseconds: 120);
 
+/// Resolves the route context the shell chrome (app bar) should render for,
+/// plus the value the caller must cache for the next build.
+///
+/// While a full-screen route is pushed above the whole shell —
+/// [isShellCovered] true, i.e. the shell's `ModalRoute.isCurrent` is false —
+/// the global pageContext points at that pushed route (camera, editor, …)
+/// rather than the active tab underneath. Rendering the chrome off it would
+/// pop a suppressed app bar (own-profile grid, inbox) in and out for the
+/// length of the push/pop transition, shoving the still-visible tab content
+/// down. So while covered the chrome freezes to [lastTabContext] — the last
+/// context seen while the shell was on top — and the cache is left untouched.
+({RouteContext? context, RouteContext? nextCache}) resolveShellChromeContext({
+  required bool isShellCovered,
+  required RouteContext? liveContext,
+  required RouteContext? lastTabContext,
+}) {
+  if (isShellCovered) {
+    return (context: lastTabContext ?? liveContext, nextCache: lastTabContext);
+  }
+  return (context: liveContext, nextCache: liveContext ?? lastTabContext);
+}
+
 /// Shell chrome (app bar + bottom nav) wrapped around the [StatefulShellRoute]
 /// branch container.
 ///
@@ -54,6 +76,13 @@ class AppShell extends ConsumerStatefulWidget {
 class _AppShellState extends ConsumerState<AppShell> with RouteAware {
   int get currentIndex => widget.currentIndex;
   Widget get child => widget.child;
+
+  /// Last route context observed while the shell was the top-most route.
+  ///
+  /// Used to freeze the chrome (app bar) while a full-screen route is pushed
+  /// above the shell — see the note in [build] — so the global pageContext
+  /// flipping to the pushed route can't pop the app bar in/out mid-transition.
+  RouteContext? _lastTabRouteContext;
 
   @override
   void didChangeDependencies() {
@@ -97,9 +126,8 @@ class _AppShellState extends ConsumerState<AppShell> with RouteAware {
   @override
   void didPopNext() => _setShellObscured(obscured: false);
 
-  String _titleFor(BuildContext context, WidgetRef ref) {
+  String _titleFor(BuildContext context, WidgetRef ref, RouteContext? ctx) {
     final l10n = context.l10n;
-    final ctx = ref.watch(pageContextProvider).asData?.value;
     switch (ctx?.type) {
       case RouteType.home:
         return l10n.navHome;
@@ -201,13 +229,35 @@ class _AppShellState extends ConsumerState<AppShell> with RouteAware {
     }
   }
 
+  /// Whether the shell app bar should show a back button for [ctx].
+  bool _showBackButton(RouteContext? ctx) {
+    if (ctx == null) return false;
+    final isExploreVideo =
+        ctx.type == RouteType.explore && ctx.videoIndex != null;
+    // Notifications base state is index 0, not null.
+    final isNotificationVideo =
+        ctx.type == RouteType.notifications &&
+        ctx.videoIndex != null &&
+        ctx.videoIndex != 0;
+    final isOtherUserProfile =
+        ctx.type == RouteType.profile &&
+        ctx.npub != ref.read(authServiceProvider).currentNpub;
+    final isProfileVideo =
+        ctx.type == RouteType.profile && ctx.videoIndex != null;
+
+    return isExploreVideo ||
+        isNotificationVideo ||
+        isOtherUserProfile ||
+        isProfileVideo;
+  }
+
   /// Builds the header title - tappable for Explore and Hashtag routes to navigate back
   Widget _buildTappableTitle(
     BuildContext context,
     WidgetRef ref,
     String title,
+    RouteContext? ctx,
   ) {
-    final ctx = ref.watch(pageContextProvider).asData?.value;
     final routeType = ctx?.type;
 
     // Check if title should be tappable (Explore-related routes)
@@ -251,8 +301,6 @@ class _AppShellState extends ConsumerState<AppShell> with RouteAware {
 
   @override
   Widget build(BuildContext context) {
-    final title = _titleFor(context, ref);
-
     // Publish the authoritative active branch (navigationShell.currentIndex)
     // so backgrounded tab screens can pause off it. Deferred to a post-frame
     // callback because a provider must not be mutated during build. This is
@@ -289,57 +337,52 @@ class _AppShellState extends ConsumerState<AppShell> with RouteAware {
     // TODO(#4338): remove when BlocklistCubit owns post-login sync.
     ref.watch(blocklistSyncBridgeProvider);
 
-    // Watch page context to determine if back button should show and if on search route
+    // The shell chrome (app bar) mirrors the *active tab's* route. While a
+    // full-screen route is pushed above the whole shell (camera, editor,
+    // video detail, …) the global pageContext points at that pushed route,
+    // not the tab underneath. Recomputing the chrome off it makes a
+    // suppressed app bar (own-profile grid, inbox) pop in for the length of
+    // the push/pop transition, shoving the still-visible tab content down.
+    // Freeze the chrome to the last tab context while the shell is covered so
+    // the transition stays still. `isCurrent` is false exactly when a route
+    // sits on top of the shell (it also gates resizeToAvoidBottomInset below).
+    final shellRoute = ModalRoute.of(context);
+    final isShellCovered = !(shellRoute?.isCurrent ?? true);
     final pageCtxAsync = ref.watch(pageContextProvider);
+    final chrome = resolveShellChromeContext(
+      isShellCovered: isShellCovered,
+      liveContext: pageCtxAsync.asData?.value,
+      lastTabContext: _lastTabRouteContext,
+    );
+    _lastTabRouteContext = chrome.nextCache;
+    final chromeCtx = chrome.context;
+
+    final title = _titleFor(context, ref, chromeCtx);
 
     // Own profile grid renders its own scrollable header (avatar + stats), so
     // AppShell suppresses its app bar for it — like home / inbox / explore grid.
-    final isOwnProfileGrid = pageCtxAsync.maybeWhen(
-      data: (ctx) {
-        if (ctx.type != RouteType.profile) return false;
-        if (ctx.videoIndex != null) return false; // Video mode uses the app bar
-        final currentNpub = ref.read(authServiceProvider).currentNpub;
-        return ctx.npub == 'me' || ctx.npub == currentNpub;
-      },
-      orElse: () => false,
-    );
+    final isOwnProfileGrid =
+        chromeCtx != null &&
+        chromeCtx.type == RouteType.profile &&
+        chromeCtx.videoIndex == null && // Video mode uses the app bar
+        (chromeCtx.npub == 'me' ||
+            chromeCtx.npub == ref.read(authServiceProvider).currentNpub);
 
     // Inbox manages its own header (segmented toggle replaces app bar)
-    final isInbox = pageCtxAsync.maybeWhen(
-      data: (ctx) =>
-          ctx.type == RouteType.inbox || ctx.type == RouteType.conversation,
-      orElse: () => false,
-    );
+    final isInbox =
+        chromeCtx != null &&
+        (chromeCtx.type == RouteType.inbox ||
+            chromeCtx.type == RouteType.conversation);
 
     // Explore grid mode manages its own header (search bar + tabs).
-    final isExploreGrid = pageCtxAsync.maybeWhen(
-      data: (ctx) => ctx.type == RouteType.explore
-          ? ctx.videoIndex == null
-          : currentIndex == 1,
-      orElse: () => currentIndex == 1,
-    );
-    final showBackButton = pageCtxAsync.maybeWhen(
-      data: (ctx) {
-        final isExploreVideo =
-            ctx.type == RouteType.explore && ctx.videoIndex != null;
-        // Notifications base state is index 0, not null
-        final isNotificationVideo =
-            ctx.type == RouteType.notifications &&
-            ctx.videoIndex != null &&
-            ctx.videoIndex != 0;
-        final isOtherUserProfile =
-            ctx.type == RouteType.profile &&
-            ctx.npub != ref.read(authServiceProvider).currentNpub;
-        final isProfileVideo =
-            ctx.type == RouteType.profile && ctx.videoIndex != null;
+    final bool isExploreGrid;
+    if (chromeCtx?.type == RouteType.explore) {
+      isExploreGrid = chromeCtx!.videoIndex == null;
+    } else {
+      isExploreGrid = currentIndex == 1;
+    }
 
-        return isExploreVideo ||
-            isNotificationVideo ||
-            isOtherUserProfile ||
-            isProfileVideo;
-      },
-      orElse: () => false,
-    );
+    final showBackButton = _showBackButton(chromeCtx);
 
     // Get environment config for app bar styling
     final environment = ref.watch(currentEnvironmentProvider);
@@ -352,7 +395,7 @@ class _AppShellState extends ConsumerState<AppShell> with RouteAware {
       // laggy on older devices (Galaxy S10, reported on #5758). While the feed
       // is the topmost route the default resize behaviour is preserved so its
       // own bottom composers still lift above the keyboard.
-      resizeToAvoidBottomInset: ModalRoute.of(context)?.isCurrent ?? true,
+      resizeToAvoidBottomInset: shellRoute?.isCurrent ?? true,
       // Home tab uses FeedModeSwitch overlay (menu + mode dropdown + search)
       // instead of the standard AppBar, for full-screen video UX.
       // Inbox uses its own segmented toggle header.
@@ -361,7 +404,7 @@ class _AppShellState extends ConsumerState<AppShell> with RouteAware {
       appBar: currentIndex == 0 || isInbox || isExploreGrid || isOwnProfileGrid
           ? null
           : DiVineAppBar(
-              titleWidget: _buildTappableTitle(context, ref, title),
+              titleWidget: _buildTappableTitle(context, ref, title, chromeCtx),
               titleSuffix: const EnvironmentBadge(),
               backgroundColor: getEnvironmentAppBarColor(environment),
               showBackButton: showBackButton,

--- a/mobile/test/router/app_shell_chrome_freeze_test.dart
+++ b/mobile/test/router/app_shell_chrome_freeze_test.dart
@@ -1,0 +1,190 @@
+// ABOUTME: Widget regression test for AppShell chrome freezing (#5925).
+// ABOUTME: A full-screen route pushed above the shell must not pop the
+// ABOUTME: suppressed app bar in (own-profile grid / inbox shift-down).
+
+import 'dart:async';
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/app_update/app_update.dart';
+import 'package:openvine/blocs/dm/unread_count/dm_unread_count_cubit.dart';
+import 'package:openvine/blocs/notifications/badge/notification_badge_cubit.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/environment_config.dart';
+import 'package:openvine/providers/active_video_provider.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/environment_provider.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/router/router.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockAuthService extends Mock implements AuthService {}
+
+class _MockDmUnreadCountCubit extends MockCubit<int>
+    implements DmUnreadCountCubit {}
+
+class _MockNotificationBadgeCubit extends MockCubit<int>
+    implements NotificationBadgeCubit {}
+
+class _MockAppUpdateBloc extends MockBloc<AppUpdateEvent, AppUpdateState>
+    implements AppUpdateBloc {}
+
+List<Override> _overrides({
+  required _MockAuthService mockAuthService,
+  required SharedPreferences sharedPreferences,
+  required Stream<RouteContext> contextStream,
+}) => [
+  pageContextProvider.overrideWith((ref) => contextStream),
+  videoControllerAutoCleanupProvider.overrideWithValue(null),
+  relayStatisticsBridgeProvider.overrideWithValue(null),
+  relaySetChangeBridgeProvider.overrideWithValue(null),
+  zendeskIdentitySyncProvider.overrideWithValue(null),
+  pushNotificationSyncProvider.overrideWithValue(null),
+  blocklistSyncBridgeProvider.overrideWithValue(null),
+  authServiceProvider.overrideWithValue(mockAuthService),
+  sharedPreferencesProvider.overrideWithValue(sharedPreferences),
+  currentEnvironmentProvider.overrideWithValue(EnvironmentConfig.production),
+];
+
+Widget _wrapWithBlocs(Widget child) {
+  final dmCubit = _MockDmUnreadCountCubit();
+  when(() => dmCubit.state).thenReturn(0);
+
+  final notifBadgeCubit = _MockNotificationBadgeCubit();
+  when(() => notifBadgeCubit.state).thenReturn(0);
+
+  final appUpdateBloc = _MockAppUpdateBloc();
+  when(() => appUpdateBloc.state).thenReturn(const AppUpdateState());
+
+  return MultiBlocProvider(
+    providers: [
+      BlocProvider<DmUnreadCountCubit>.value(value: dmCubit),
+      BlocProvider<NotificationBadgeCubit>.value(value: notifBadgeCubit),
+      BlocProvider<AppUpdateBloc>.value(value: appUpdateBloc),
+    ],
+    child: child,
+  );
+}
+
+// The shell subscribes to [routeObserver] to learn when a full-screen route
+// covers it, so the test app must register it on the navigator. currentIndex 3
+// (profile tab) keeps the home/explore app-bar suppression rules out of play,
+// so the app bar is governed solely by the own-profile-grid flag under test.
+Widget _appShellMaterialApp() => MaterialApp(
+  localizationsDelegates: AppLocalizations.localizationsDelegates,
+  supportedLocales: AppLocalizations.supportedLocales,
+  navigatorObservers: [routeObserver],
+  home: const AppShell(currentIndex: 3, child: SizedBox.shrink()),
+);
+
+Widget _buildSubject({
+  required _MockAuthService mockAuthService,
+  required SharedPreferences sharedPreferences,
+  required Stream<RouteContext> contextStream,
+}) => _wrapWithBlocs(
+  ProviderScope(
+    overrides: _overrides(
+      mockAuthService: mockAuthService,
+      sharedPreferences: sharedPreferences,
+      contextStream: contextStream,
+    ),
+    child: _appShellMaterialApp(),
+  ),
+);
+
+void main() {
+  late _MockAuthService mockAuthService;
+  late SharedPreferences sharedPreferences;
+
+  setUp(() async {
+    mockAuthService = _MockAuthService();
+    when(() => mockAuthService.currentPublicKeyHex).thenReturn(null);
+    when(() => mockAuthService.currentNpub).thenReturn(null);
+    when(() => mockAuthService.isAuthenticated).thenReturn(false);
+    when(() => mockAuthService.authState).thenReturn(AuthState.unauthenticated);
+
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    sharedPreferences = await SharedPreferences.getInstance();
+  });
+
+  testWidgets(
+    'keeps the own-profile-grid app bar suppressed while a full-screen route '
+    'covers the shell (#5925)',
+    (tester) async {
+      final contextController = StreamController<RouteContext>();
+      addTearDown(contextController.close);
+
+      await tester.pumpWidget(
+        _buildSubject(
+          mockAuthService: mockAuthService,
+          sharedPreferences: sharedPreferences,
+          contextStream: contextController.stream,
+        ),
+      );
+
+      // Land on the own-profile grid — it renders its own scrollable header, so
+      // AppShell suppresses its app bar (npub 'me' is the own-profile sentinel).
+      contextController.add(
+        const RouteContext(type: RouteType.profile, npub: 'me'),
+      );
+      await tester.pumpAndSettle();
+
+      Scaffold shellScaffold() => tester.widget<Scaffold>(
+        find
+            .descendant(
+              of: find.byType(AppShell, skipOffstage: false),
+              matching: find.byType(Scaffold, skipOffstage: false),
+            )
+            .first,
+      );
+
+      expect(
+        shellScaffold().appBar,
+        isNull,
+        reason: 'own-profile grid suppresses the shell app bar',
+      );
+      // Precondition: the shell is the top route, so it is not yet frozen.
+      expect(shellScaffold().resizeToAvoidBottomInset, isTrue);
+
+      // Cover the shell: any route pushed above it flips the shell's
+      // ModalRoute.isCurrent to false (the same signal that gates
+      // resizeToAvoidBottomInset). A modal barrier stands in for the camera
+      // here — unlike a full-screen opaque route it keeps the shell onstage,
+      // which is the frame the user actually sees glitch mid-transition. Then
+      // the global pageContext flips to the recorder while the profile tab
+      // underneath is still visible.
+      final shellContext = tester.element(find.byType(AppShell));
+      unawaited(
+        showModalBottomSheet<void>(
+          context: shellContext,
+          builder: (_) => const SizedBox(height: 200),
+        ),
+      );
+      await tester.pumpAndSettle();
+      contextController.add(const RouteContext(type: RouteType.videoRecorder));
+      await tester.pumpAndSettle();
+
+      // The shell is now covered (same isCurrent signal), so the freeze must
+      // be in effect.
+      expect(
+        shellScaffold().resizeToAvoidBottomInset,
+        isFalse,
+        reason: 'the pushed route must actually cover the shell',
+      );
+
+      // Frozen to the last tab context: the recorder must not recompute the
+      // chrome and pop the suppressed app bar in during the push transition.
+      expect(
+        shellScaffold().appBar,
+        isNull,
+        reason: 'chrome frozen to the covered tab; app bar must not pop in',
+      );
+    },
+  );
+}

--- a/mobile/test/router/shell_chrome_context_test.dart
+++ b/mobile/test/router/shell_chrome_context_test.dart
@@ -1,0 +1,70 @@
+// ABOUTME: Unit tests for resolveShellChromeContext (shell app bar freezing)
+// ABOUTME: Regression: camera/editor pushed above the shell must not pop the
+// ABOUTME: app bar in/out mid-transition (own-profile grid & inbox shift-down).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/router/router.dart';
+
+void main() {
+  // An own-profile grid / inbox tab suppresses the shell app bar; the recorder
+  // is a full-screen route pushed *above* the whole shell.
+  const profile = RouteContext(type: RouteType.profile, npub: 'me');
+  const inbox = RouteContext(type: RouteType.inbox);
+  const recorder = RouteContext(type: RouteType.videoRecorder);
+
+  group('resolveShellChromeContext', () {
+    test('uses and caches the live context while the shell is on top', () {
+      final result = resolveShellChromeContext(
+        isShellCovered: false,
+        liveContext: profile,
+        lastTabContext: inbox,
+      );
+
+      expect(result.context, profile);
+      expect(result.nextCache, profile);
+    });
+
+    test('freezes to the cached tab context while the shell is covered', () {
+      // Camera pushed over an own-profile grid: the global pageContext flips
+      // to the recorder, but the chrome must keep rendering the tab beneath so
+      // the suppressed app bar does not pop in during the push transition.
+      final result = resolveShellChromeContext(
+        isShellCovered: true,
+        liveContext: recorder,
+        lastTabContext: profile,
+      );
+
+      expect(result.context, profile);
+      expect(
+        result.nextCache,
+        profile,
+        reason: 'cache untouched while covered',
+      );
+    });
+
+    test(
+      'keeps the previous cache when uncovered but live context is null',
+      () {
+        final result = resolveShellChromeContext(
+          isShellCovered: false,
+          liveContext: null,
+          lastTabContext: profile,
+        );
+
+        expect(result.context, isNull);
+        expect(result.nextCache, profile);
+      },
+    );
+
+    test('falls back to the live context while covered with no cache yet', () {
+      final result = resolveShellChromeContext(
+        isShellCovered: true,
+        liveContext: recorder,
+        lastTabContext: null,
+      );
+
+      expect(result.context, recorder);
+      expect(result.nextCache, isNull);
+    });
+  });
+}


### PR DESCRIPTION
Closes #5925

## What

When opening the camera from the **own-profile grid** or the **inbox**, the tab content visibly jumped down for the length of the open/close animation — as if an invisible app bar appeared in those screens during the transition.

| Before | After |
| ------ | ----- |
| <video src="https://github.com/user-attachments/assets/9d55a486-853f-4df1-9080-07eebdd67910" controls width="300"></video> | <video src="https://github.com/user-attachments/assets/e38b622d-4367-4284-bc63-9762db374e46" controls width="300"></video> |

## Why

`AppShell` derives its `DiVineAppBar` visibility from the **global** `pageContextProvider`. The camera route lives on the **root navigator**, so pushing it sits *above the whole shell* and flips the global context to `videoRecorder` while the tab underneath is still visible during the push animation.

The app-bar suppression flags for the tabs that draw their own header — `isOwnProfileGrid` and `isInbox` — read the route type with **no `currentIndex` fallback**. So when the context flips to `videoRecorder`, they go `true → false`, the shell's `DiVineAppBar` pops in, and the still-visible tab content is shoved down by the app bar's height. Home and explore never glitched precisely because their suppression falls back to `currentIndex`, which survives the flip.

## Fix

While the shell is covered by a pushed route (`ModalRoute.isCurrent == false` — the same signal already used for `resizeToAvoidBottomInset`), freeze the chrome to the **last tab context** instead of recomputing it from the pushed route. A route pushed above the shell can no longer change the shell's app bar during the push/pop transition.

- Extracted the decision into a pure, unit-testable `resolveShellChromeContext(...)`.
- Routed the four chrome flags (`isOwnProfileGrid`, `isInbox`, `isExploreGrid`, `showBackButton`) + title through it.
- No behaviour change while the shell is on top (uncovered), so normal tab switches and within-branch grid→feed navigation are unaffected.

## Test plan

- New `test/router/shell_chrome_context_test.dart` pins the freeze behaviour.
- `flutter test test/router/` → all green; `flutter analyze lib test integration_test` clean.
- Manual: open the camera from own profile and from the notifications/inbox tab — the tab content underneath should stay put during the open and close animations.

## Note

Tab 2 has two sub-pages: **Inbox** (own header → suppressed → was shifting, fixed here) and the **Notifications list** (always shows the shell app bar, so it shouldn't shift from this mechanism). The freeze is universal, so it covers whichever sub-page is on screen.