### PR TITLE
fix(infinite_video_feed): guard playback activation against disposed controller

### DIFF
--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -813,14 +813,22 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     DivineVideoPlayerController controller,
     int index,
   ) async {
-    if (!_isActive || index != _currentIndex || !controller.isInitialized) {
-      return;
-    }
+    // The captured [controller] can be disposed mid-await by a window update,
+    // failover, or re-init — each removes it from [_controllers] before
+    // disposing. Re-checking identity (not just _isActive/_currentIndex, which
+    // miss a same-index controller swap) avoids calling setVolume()/play() on a
+    // disposed controller, which throws StateError from _ensureInitialized().
+    bool stillOwnsController() =>
+        _isActive &&
+        index == _currentIndex &&
+        identical(_controllers[index], controller);
+
+    if (!stillOwnsController() || !controller.isInitialized) return;
     if (!_canAutoPlayAt(index)) return;
     await controller.setVolume(_volume);
-    if (!_isActive || index != _currentIndex) return;
+    if (!stillOwnsController()) return;
     await controller.play();
-    if (!_isActive || index != _currentIndex) return;
+    if (!stillOwnsController()) return;
     // Playback resumed cleanly — clear any auto-retry budget spent on this
     // slot so a later, unrelated stall starts from a fresh backoff.
     _autoRetryAttempts.remove(index);

--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -818,6 +818,9 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     // disposing. Re-checking identity (not just _isActive/_currentIndex, which
     // miss a same-index controller swap) avoids calling setVolume()/play() on a
     // disposed controller, which throws StateError from _ensureInitialized().
+    // Unlike ownsInit()/ownsRetry(), `mounted` is intentionally omitted:
+    // dispose() clears [_controllers] before super.dispose(), so the identity
+    // check already fails after unmount.
     bool stillOwnsController() =>
         _isActive &&
         index == _currentIndex &&


### PR DESCRIPTION
Closes #5927

## What

`_activateCurrentController` in `infinite_video_feed.dart` re-checked only `_isActive` / `_currentIndex` between its `await`s. It now re-checks controller **identity** against `_controllers[index]` before each native call (`setVolume`, `play`) via a local `stillOwnsController()` guard.

## Why

The method holds a captured `controller` reference. A window update, failover, or re-init can dispose and replace the controller at the same index while the feed stays active on the same index — cases the old `_isActive`/`_currentIndex` guards don't catch. `controller.play()` then hit a disposed controller and threw `StateError('Controller has been disposed.')` from `_ensureInitialized()`.

Every dispose path removes the controller from `_controllers` **before** disposing it (`_controllers.remove(index)?.dispose()`), so an identity check against the map reliably detects both a same-index swap and a plain disposal. This mirrors the existing `ownsInit()` guard already used in `_initController` for the same class of init-time race.

`isInitialized` stays `true` after dispose (only `_disposed` flips), so an initialization check alone wouldn't have caught this — the identity guard is the correct signal.

## Testing

- `flutter test` in `mobile/packages/infinite_video_feed` — all 221 tests pass.
- `flutter analyze` clean.

Note: like the sibling init-race guards in the same file (marked `coverage:ignore` with the rationale that they're "not reproducible in package widget tests without microsecond-precise control over native platform-channel timing"), this dispose-between-awaits race isn't deterministically reproducible in a widget test.