### PR TITLE
fix(video): enforce declared bitrate across recording and render

### DIFF
--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/CameraController.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/CameraController.kt
@@ -839,6 +839,11 @@ class CameraController(
      * device encoder's default, which for FHD typically lands at 15–25 Mbit/s
      * instead of the intended 8 Mbit/s. Callers that lower [videoQuality]
      * (encoder-failure retry) pick up the matching lower bitrate on rebuild.
+     *
+     * The bitrate keys off the requested [videoQuality]; if [FallbackStrategy]
+     * silently selects a lower resolution the device can actually record, the
+     * target is a bounded overshoot for that tier (never above the requested
+     * one) — still far below the uncapped device default, so acceptable.
      */
     private fun buildRecorder(aspectRatio: Int): Recorder = Recorder.Builder()
         .setQualitySelector(

--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/CameraController.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/CameraController.kt
@@ -835,6 +835,26 @@ class CameraController(
     /**
      * Starts the camera with preview and video capture use cases.
      */
+    /**
+     * Builds the video [Recorder] for the current [videoQuality].
+     *
+     * Sets an explicit target encoding bitrate — without it CameraX uses the
+     * device encoder's default, which for FHD typically lands at 15–25 Mbit/s
+     * instead of the intended 8 Mbit/s. Callers that lower [videoQuality]
+     * (encoder-failure retry) pick up the matching lower bitrate on rebuild.
+     */
+    private fun buildRecorder(aspectRatio: Int): Recorder = Recorder.Builder()
+        .setQualitySelector(
+            QualitySelector.from(
+                videoQuality,
+                FallbackStrategy.lowerQualityOrHigherThan(Quality.SD)
+            )
+        )
+        .setAspectRatio(aspectRatio)
+        .setExecutor(cameraExecutor)
+        .setTargetVideoEncodingBitRate(videoEncodingBitRate(videoQuality))
+        .build()
+
     private fun startCamera(callback: (Map<String, Any?>?, String?) -> Unit) {
         val provider = cameraProvider ?: run {
             DivineCameraLog.e(TAG, "Camera provider not available")
@@ -939,16 +959,7 @@ class CameraController(
 
             // Build video capture with same aspect ratio as preview
             // Mirror front camera video to match preview
-            val recorder = Recorder.Builder()
-                .setQualitySelector(
-                    QualitySelector.from(
-                        videoQuality,
-                        FallbackStrategy.lowerQualityOrHigherThan(Quality.SD)
-                    )
-                )
-                .setAspectRatio(targetAspectRatio)
-                .setExecutor(cameraExecutor)
-                .build()
+            val recorder = buildRecorder(targetAspectRatio)
 
             // Mirror front camera video output based on mirrorFrontCameraOutput setting
             videoCapture = VideoCapture.Builder(recorder)
@@ -1086,16 +1097,7 @@ class CameraController(
             }
 
             // Create recorder with same quality and aspect ratio
-            val recorder = Recorder.Builder()
-                .setQualitySelector(
-                    QualitySelector.from(
-                        videoQuality,
-                        FallbackStrategy.lowerQualityOrHigherThan(Quality.SD)
-                    )
-                )
-                .setAspectRatio(targetAspectRatio)
-                .setExecutor(cameraExecutor)
-                .build()
+            val recorder = buildRecorder(targetAspectRatio)
 
             // Mirror front camera video output based on mirrorFrontCameraOutput setting
             videoCapture = VideoCapture.Builder(recorder)
@@ -1675,18 +1677,7 @@ class CameraController(
                 }, 100)
             }
 
-            val recorder = Recorder.Builder()
-                .setQualitySelector(
-                    QualitySelector.from(
-                        videoQuality,
-                        FallbackStrategy.lowerQualityOrHigherThan(
-                            Quality.SD
-                        )
-                    )
-                )
-                .setAspectRatio(targetAspectRatio)
-                .setExecutor(cameraExecutor)
-                .build()
+            val recorder = buildRecorder(targetAspectRatio)
 
             videoCapture = VideoCapture.Builder(recorder)
                 .setMirrorMode(

--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/CameraController.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/CameraController.kt
@@ -833,9 +833,6 @@ class CameraController(
     }
 
     /**
-     * Starts the camera with preview and video capture use cases.
-     */
-    /**
      * Builds the video [Recorder] for the current [videoQuality].
      *
      * Sets an explicit target encoding bitrate — without it CameraX uses the
@@ -855,6 +852,9 @@ class CameraController(
         .setTargetVideoEncodingBitRate(videoEncodingBitRate(videoQuality))
         .build()
 
+    /**
+     * Starts the camera with preview and video capture use cases.
+     */
     private fun startCamera(callback: (Map<String, Any?>?, String?) -> Unit) {
         val provider = cameraProvider ?: run {
             DivineCameraLog.e(TAG, "Camera provider not available")

--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/VideoEncodingBitrate.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/VideoEncodingBitrate.kt
@@ -1,0 +1,22 @@
+// ABOUTME: Maps CameraX video quality to a target encoder bitrate
+// ABOUTME: Mirrors DivineVideoQuality.bitrate in lib/src/models/video_quality.dart
+
+package co.openvine.divine_camera
+
+import androidx.camera.video.Quality
+
+/**
+ * Target video encoding bitrate in bits per second for [quality].
+ *
+ * Without an explicit target, CameraX falls back to the device encoder's
+ * default, which for FHD typically lands at 15–25 Mbit/s — roughly twice
+ * the intended file size. Values must stay in sync with the Dart
+ * `DivineVideoQuality` enum (`lib/src/models/video_quality.dart`).
+ */
+internal fun videoEncodingBitRate(quality: Quality): Int = when (quality) {
+    Quality.SD, Quality.LOWEST -> 2_000_000
+    Quality.HD -> 4_000_000
+    Quality.FHD -> 8_000_000
+    Quality.UHD, Quality.HIGHEST -> 20_000_000
+    else -> 8_000_000
+}

--- a/mobile/packages/divine_camera/android/src/test/kotlin/co/openvine/divine_camera/VideoEncodingBitrateTest.kt
+++ b/mobile/packages/divine_camera/android/src/test/kotlin/co/openvine/divine_camera/VideoEncodingBitrateTest.kt
@@ -1,0 +1,26 @@
+package co.openvine.divine_camera
+
+import androidx.camera.video.Quality
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.assertEquals
+
+/*
+ * Pins the quality → target-bitrate table used by the recording Recorder.
+ * Without an explicit target bitrate, CameraX falls back to device encoder
+ * defaults (15–25 Mbit/s for FHD). The values must stay in sync with the
+ * Dart `DivineVideoQuality` enum in lib/src/models/video_quality.dart.
+ */
+@RunWith(RobolectricTestRunner::class)
+internal class VideoEncodingBitrateTest {
+    @Test
+    fun videoEncodingBitRate_matchesDivineVideoQualityTable() {
+        assertEquals(2_000_000, videoEncodingBitRate(Quality.SD))
+        assertEquals(2_000_000, videoEncodingBitRate(Quality.LOWEST))
+        assertEquals(4_000_000, videoEncodingBitRate(Quality.HD))
+        assertEquals(8_000_000, videoEncodingBitRate(Quality.FHD))
+        assertEquals(20_000_000, videoEncodingBitRate(Quality.UHD))
+        assertEquals(20_000_000, videoEncodingBitRate(Quality.HIGHEST))
+    }
+}

--- a/mobile/packages/divine_camera/ios/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/ios/Classes/CameraController.swift
@@ -647,7 +647,12 @@ class CameraController: NSObject {
     
     /// Initializes the camera with the specified lens.
     private var videoQualityPreset: AVCaptureSession.Preset = .high
-    
+
+    /// Target H.264 bitrate in bits per second for the recording
+    /// AVAssetWriter. Mirrors `DivineVideoQuality.bitrate` in
+    /// `lib/src/models/video_quality.dart`.
+    private var videoEncodingBitRate = 8_000_000
+
     /// Initializes the camera with the specified lens and video quality.
     func initialize(lens: String, videoQuality: String, enableScreenFlash: Bool = true, mirrorFrontCameraOutput: Bool = true, enableAutoLensSwitch: Bool = true, completion: @escaping ([String: Any]?, String?) -> Void) {
         self.autoLensSwitchRequested = enableAutoLensSwitch
@@ -676,26 +681,33 @@ class CameraController: NSObject {
             }
         }
         
-        // Map video quality string to AVCaptureSession.Preset
+        // Map video quality string to AVCaptureSession.Preset and target bitrate
         switch videoQuality {
         case "sd":
             videoQualityPreset = .medium
+            videoEncodingBitRate = 2_000_000
         case "hd":
             videoQualityPreset = .hd1280x720
+            videoEncodingBitRate = 4_000_000
         case "fhd":
             videoQualityPreset = .hd1920x1080
+            videoEncodingBitRate = 8_000_000
         case "uhd":
             if #available(iOS 9.0, *) {
                 videoQualityPreset = .hd4K3840x2160
             } else {
                 videoQualityPreset = .hd1920x1080
             }
+            videoEncodingBitRate = 20_000_000
         case "highest":
             videoQualityPreset = .high
+            videoEncodingBitRate = 20_000_000
         case "lowest":
             videoQualityPreset = .low
+            videoEncodingBitRate = 2_000_000
         default:
             videoQualityPreset = .hd1920x1080
+            videoEncodingBitRate = 8_000_000
         }
         
         sessionQueue.async { [weak self] in
@@ -2206,7 +2218,7 @@ class CameraController: NSObject {
                 AVVideoWidthKey: videoWidth,
                 AVVideoHeightKey: videoHeight,
                 AVVideoCompressionPropertiesKey: [
-                    AVVideoAverageBitRateKey: 6000000,
+                    AVVideoAverageBitRateKey: self.videoEncodingBitRate,
                     AVVideoProfileLevelKey: AVVideoProfileLevelH264HighAutoLevel,
                 ],
             ]

--- a/mobile/packages/divine_camera/lib/src/models/video_quality.dart
+++ b/mobile/packages/divine_camera/lib/src/models/video_quality.dart
@@ -35,8 +35,8 @@ enum DivineVideoQuality {
   ///
   /// The native recorders apply these values per quality tier and keep
   /// their own mirror of this table — update `VideoEncodingBitrate.kt`
-  /// (Android) and the `initialize` quality switch in
-  /// `CameraController.swift` (iOS) when changing them here.
+  /// (Android) and the `initialize` quality switch in `CameraController.swift`
+  /// (iOS and macOS) when changing them here.
   final int bitrate;
 
   /// Converts to a string representation for platform channels.

--- a/mobile/packages/divine_camera/lib/src/models/video_quality.dart
+++ b/mobile/packages/divine_camera/lib/src/models/video_quality.dart
@@ -32,6 +32,11 @@ enum DivineVideoQuality {
   final Size resolution;
 
   /// The target bitrate in bits per second for this quality level.
+  ///
+  /// The native recorders apply these values per quality tier and keep
+  /// their own mirror of this table — update `VideoEncodingBitrate.kt`
+  /// (Android) and the `initialize` quality switch in
+  /// `CameraController.swift` (iOS) when changing them here.
   final int bitrate;
 
   /// Converts to a string representation for platform channels.

--- a/mobile/packages/divine_camera/macos/Classes/CameraController+Recording.swift
+++ b/mobile/packages/divine_camera/macos/Classes/CameraController+Recording.swift
@@ -88,7 +88,7 @@ extension CameraController {
                     AVVideoWidthKey: videoWidth,
                     AVVideoHeightKey: videoHeight,
                     AVVideoCompressionPropertiesKey: [
-                        AVVideoAverageBitRateKey: 6_000_000,
+                        AVVideoAverageBitRateKey: self.videoEncodingBitRate,
                         AVVideoProfileLevelKey:
                             AVVideoProfileLevelH264HighAutoLevel,
                     ],

--- a/mobile/packages/divine_camera/macos/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/macos/Classes/CameraController.swift
@@ -209,6 +209,11 @@ class CameraController: NSObject {
 
     var videoQualityPreset: AVCaptureSession.Preset = .high
 
+    /// Target H.264 bitrate in bits per second for the recording
+    /// AVAssetWriter. Mirrors `DivineVideoQuality.bitrate` in
+    /// `lib/src/models/video_quality.dart`.
+    var videoEncodingBitRate = 8_000_000
+
     /// Initializes the camera with the specified lens and video quality.
     func initialize(
         lens: String,
@@ -227,22 +232,29 @@ class CameraController: NSObject {
             }
         }
 
-        // Map video quality string to AVCaptureSession.Preset
+        // Map video quality string to AVCaptureSession.Preset and target bitrate
         switch videoQuality {
         case "sd":
             videoQualityPreset = .medium
+            videoEncodingBitRate = 2_000_000
         case "hd":
             videoQualityPreset = .hd1280x720
+            videoEncodingBitRate = 4_000_000
         case "fhd":
             videoQualityPreset = .hd1920x1080
+            videoEncodingBitRate = 8_000_000
         case "uhd":
             videoQualityPreset = .hd4K3840x2160
+            videoEncodingBitRate = 20_000_000
         case "highest":
             videoQualityPreset = .high
+            videoEncodingBitRate = 20_000_000
         case "lowest":
             videoQualityPreset = .low
+            videoEncodingBitRate = 2_000_000
         default:
             videoQualityPreset = .hd1920x1080
+            videoEncodingBitRate = 8_000_000
         }
 
         sessionQueue.async { [weak self] in

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1808,10 +1808,10 @@ packages:
     dependency: "direct main"
     description:
       name: pro_video_editor
-      sha256: d217ca0934b1fa8e77b2a8c25169eddf59793f80eb1905d76a04c09c9fd72cf9
+      sha256: b6630516cf203216620d17084f8ea7d3ec8971e7dc397ac6f51c669bcae4c4ad
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "2.4.0"
   process:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -311,7 +311,7 @@ dependencies:
   firebase_messaging: ^16.1.1
   convert: ^3.1.2
   audio_session: ^0.2.2
-  pro_video_editor: ^2.3.0
+  pro_video_editor: ^2.4.0
   pro_image_editor: ^13.1.0
   flutter_colorpicker: ^1.1.0
   file_picker: ^10.3.7


### PR DESCRIPTION
Closes #5929

## Description

Recordings and renders both shipped video well above the declared 8 Mbit/s FHD target, roughly doubling upload size (measured 10–18 Mbit/s on fresh production uploads via ffprobe). Two independent causes, fixed together:

- **Recording (`divine_camera`, this repo):** the native recorders never pinned an encoding bitrate. Android's CameraX `Recorder` fell back to the device encoder default (15–25 Mbit/s for FHD); iOS hardcoded 6 Mbit/s. `DivineVideoQuality.bitrate` is now wired through to `setTargetVideoEncodingBitRate` (Android) and `AVVideoAverageBitRateKey` (iOS), with the native quality→bitrate tables kept in sync with the Dart enum.
- **Rendering (`pro_video_editor` 2.3.0 → 2.4.0):** the render bitrate was silently ignored — Android transmuxed the source untouched, iOS/macOS picked an `AVAssetExportSession` preset with its own bitrate. 2.4.0 enforces it as a real maximum: over-cap sources are re-encoded down, sources already within the cap keep a lossless transmux/passthrough fast path.

Together these cap uploads at the declared quality target across capture and render. The recording fix also matters for the fast path: without it, every Android camera upload (~18 Mbit/s) would now trigger a re-encode in 2.4.0's render instead of a lossless transmux.

## Design Notes

**The quality→bitrate table is mirrored in three places on purpose** — the Dart `DivineVideoQuality` enum, `VideoEncodingBitrate.kt` (Android), and the `initialize` switch in `CameraController.swift` (iOS) — rather than sourced once from Dart and passed over the channel. Android's encoder-failure retry lowers the recording quality at runtime (e.g. FHD→HD) and rebuilds the `Recorder`; the native table re-derives the matching lower bitrate (8→4 Mbit/s) on that rebuild. A single scalar sent at init couldn't auto-adjust there — it would keep the original cap on a lowered-resolution encode, which is exactly the over-shipping this PR sets out to prevent. The tables are kept in sync by cross-reference comments on each side and pinned by `VideoEncodingBitrateTest`. iOS has no runtime quality-lowering, so its mirror exists only for symmetry.

**Related Issue:** 

## Out of Scope

- Optional prefetch-duration cap with `setClips` file-first playback (#4354) — worth revisiting only after this lands, since ~halved file sizes shrink its benefit.

## Verification

- `gradle :divine_camera:testDebugUnitTest` — 32/32 green (incl. new `VideoEncodingBitrateTest`)
- `flutter analyze lib test` — clean
- `dart format` — clean
- Swift parse — clean (no local iOS test harness)
- On-device ffprobe check — Android upload confirmed at ~8 Mbit/s, down from ~18 Mbit/s.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 🗑️ Chore (dependency bump)

