### PR TITLE
chore(main): route error-handler reporting through CrashReportingService (#4596)

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1201,13 +1201,13 @@ Future<void> _startOpenVineApp() async {
         'Cache manager error (non-fatal): ${details.exception}',
         name: 'Main',
       );
-      try {
-        FirebaseCrashlytics.instance.recordError(
+      unawaited(
+        CrashReportingService.instance.recordError(
           details.exception,
           details.stack,
           reason: 'Cache manager JSON corruption',
-        );
-      } catch (_) {}
+        ),
+      );
       return;
     }
 
@@ -1228,13 +1228,13 @@ Future<void> _startOpenVineApp() async {
       );
       // Record as non-fatal in Crashlytics (if available) instead of
       // letting it propagate as a fatal crash.
-      try {
-        FirebaseCrashlytics.instance.recordError(
+      unawaited(
+        CrashReportingService.instance.recordError(
           details.exception,
           details.stack,
           reason: 'Video player disposed race condition',
-        );
-      } catch (_) {}
+        ),
+      );
       // Still show the error widget (dark placeholder) but don't report
       // as fatal.
       FlutterError.presentError(details);
@@ -1248,13 +1248,13 @@ Future<void> _startOpenVineApp() async {
         '${details.exception}',
         name: 'Main',
       );
-      try {
-        FirebaseCrashlytics.instance.recordError(
+      unawaited(
+        CrashReportingService.instance.recordError(
           details.exception,
           details.stack,
           reason: recoverableReason,
-        );
-      } catch (_) {}
+        ),
+      );
       FlutterError.presentError(details);
       return;
     }
@@ -1265,7 +1265,11 @@ Future<void> _startOpenVineApp() async {
       if (previousOnError != null) {
         previousOnError(details);
       }
-    } catch (_) {}
+    } catch (_) {
+      // No-op: a foreign FlutterError handler (e.g. Crashlytics') threw while
+      // we forwarded to it. Rethrowing here would re-enter FlutterError.onError,
+      // so swallow and fall through to presentError below.
+    }
     FlutterError.presentError(details);
   };
 
@@ -1559,14 +1563,13 @@ void main() {
       await _startOpenVineApp();
     },
     (error, stack) async {
-      // Best-effort logging; if Crashlytics isn't ready, still print
-      try {
-        await CrashReportingService.instance.recordError(
-          error,
-          stack,
-          reason: 'runZonedGuarded',
-        );
-      } catch (_) {}
+      // CrashReportingService.recordError self-guards (no-ops if uninitialized)
+      // and logs its own failure internally, so no outer catch is needed here.
+      await CrashReportingService.instance.recordError(
+        error,
+        stack,
+        reason: 'runZonedGuarded',
+      );
     },
   );
 }
@@ -2758,9 +2761,7 @@ class _CrashProbeHotspotState extends State<_CrashProbeHotspot> {
     _taps++;
     if (_taps >= 7) {
       // Record a breadcrumb, then crash the app (TestFlight validation)
-      try {
-        FirebaseCrashlytics.instance.log('CrashProbe: triggering test crash');
-      } catch (_) {}
+      CrashReportingService.instance.log('CrashProbe: triggering test crash');
       // Force a native crash to ensure reporting in TF
       FirebaseCrashlytics.instance.crash();
     }

--- a/mobile/scripts/baseline/empty_catches.txt
+++ b/mobile/scripts/baseline/empty_catches.txt
@@ -3,7 +3,6 @@
 # may only SHRINK (a new empty catch fails CI vs origin/main). Log + classify or
 # document an intentional no-op. Epic: #4336 (#3588).
 lib/blocs/video_recorder/video_recorder_bloc.dart
-lib/main.dart
 lib/services/auth_service.dart
 lib/services/relay_discovery_service.dart
 lib/services/video_editor/clip_thumbnail_manager.dart


### PR DESCRIPTION
## Description

#4596 (PR K of epic #4336) flagged 6 empty `catch (_) {}` blocks in
`mobile/lib/main.dart`, described as "startup-coordinator phase" failures that
hide cold-start regressions. On investigation the framing doesn't hold: **all 6
swallow a failure of the crash reporter itself** inside global error handlers
(`FlutterError.onError`, `runZonedGuarded`) or the TestFlight crash probe — not
cold-start initialization steps. The issue's "forward to `recordError`" bucket is
self-defeating for these, because the thing that failed *is* `recordError`.

`CrashReportingService.recordError` / `.log` already `_initialized`-gate and
internally `try/catch` + `Log.error`, so instead of merely documenting the
catches, this routes the direct `FirebaseCrashlytics.instance` calls through the
service and removes the now-unnecessary catches.

Reframed classification table (`line` = post-change):

| Line | What it guards | Classification | Change |
|-----:|----------------|----------------|--------|
| 1205 | `recordError` in `FlutterError.onError` (cache-manager path) | reporter guard | route via `CrashReportingService`; drop catch |
| 1232 | `recordError` in `FlutterError.onError` (video-player disposed race) | reporter guard | route via service; drop catch |
| 1252 | `recordError` in `FlutterError.onError` (recoverable-resource path) | reporter guard | route via service; drop catch |
| 1268 | `previousOnError(details)` forwarding to a foreign `FlutterError` handler | intentional no-op | documented no-op (can't route through the service) |
| 1568 | `recordError` in the `runZonedGuarded` handler | dead code | delete the dead try/catch (service can't throw + already logs); fix the misleading "still print" comment |
| 2764 | `.log` breadcrumb in the TestFlight crash probe | reporter guard | route via service; drop catch (`.crash()` stays raw) |

Result: `main.dart` has zero single-line empty catches, so it is dropped from the
empty-catch ceiling baseline (`mobile/scripts/baseline/empty_catches.txt`). The
issue body has been updated to correct the stale line numbers and the
misclassification.

**Related Issue:** Closes #4596 · Relates to #4336, #3588

## Out of Scope

- The other 6 files still in the empty-catch baseline (`auth_service`,
  `relay_discovery_service`, `clip_thumbnail_manager`, `video_event_service`,
  `video_publish_service`, `video_recorder_bloc`) — those belong to #3588's
  broader audit, not this `main.dart` slice.
- No new unit test: this is call-routing + dead-code removal + one documented
  no-op; the empty-catch ceiling ratchet is the CI enforcement of the DoD.

## Verification

- `flutter analyze lib test integration_test` → No issues found.
- `bash mobile/scripts/check_empty_catch_ceiling.sh` → green (baseline ratcheted
  down; `lib/main.dart` removed, 6 files remain).
- `grep -cE 'catch\s*\([_e]\)\s*\{\s*\}' mobile/lib/main.dart` → `0` (epic #4336 DoD).
- `firebase_crashlytics` import stays used by `FirebaseCrashlytics.instance.crash()`
  in the crash probe (`.crash()` has no service equivalent).
- Init ordering: `CrashReportingService.initialize()` is awaited before
  `FlutterError.onError` is installed, so the routed sites record rather than
  no-op — no behavior change at the four live sites.

## Type of Change

- [x] 🧹 Code refactor
- [x] 🗑️ Chore
