### PR TITLE
fix(nostr): add signature verification policy setting

### DIFF
--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -5725,5 +5725,21 @@
   "settingsStorageApproxVideos": "≈ {count} videos",
   "@settingsStorageApproxVideos": {"description": "Approximate number of videos that fit in the chosen cache size.", "placeholders": {"count": {"type": "int"}}},
   "settingsStorageRemoveBrokenConfirmTitle": "Remove broken clips?",
-  "@settingsStorageRemoveBrokenConfirmTitle": {"description": "Title of the confirmation sheet before permanently removing broken clips whose video file is gone."}
+  "@settingsStorageRemoveBrokenConfirmTitle": {"description": "Title of the confirmation sheet before permanently removing broken clips whose video file is gone."},
+  "nostrSettingsSignatureVerification": "Signature verification",
+  "@nostrSettingsSignatureVerification": {"description": "Title for the Nostr relay signature verification setting."},
+  "nostrSettingsSignatureVerificationIntro": "Choose when Divine checks relay event signatures. Event IDs are always validated first.",
+  "@nostrSettingsSignatureVerificationIntro": {"description": "Intro copy for the Nostr relay signature verification setting screen."},
+  "nostrSettingsSignatureVerificationAll": "All relays",
+  "@nostrSettingsSignatureVerificationAll": {"description": "Option label to verify event signatures from all Nostr relays."},
+  "nostrSettingsSignatureVerificationAllSubtitle": "Safest. Verify every relay event signature.",
+  "@nostrSettingsSignatureVerificationAllSubtitle": {"description": "Option subtitle for verifying every Nostr relay event signature."},
+  "nostrSettingsSignatureVerificationUntrusted": "Untrusted relays",
+  "@nostrSettingsSignatureVerificationUntrusted": {"description": "Option label to verify event signatures only from untrusted Nostr relays."},
+  "nostrSettingsSignatureVerificationUntrustedSubtitle": "Skip checks for relays already in your configured pool.",
+  "@nostrSettingsSignatureVerificationUntrustedSubtitle": {"description": "Option subtitle for skipping signature checks on configured relays."},
+  "nostrSettingsSignatureVerificationNonDivine": "Non-Divine relays",
+  "@nostrSettingsSignatureVerificationNonDivine": {"description": "Option label to verify event signatures only from non-Divine Nostr relays."},
+  "nostrSettingsSignatureVerificationNonDivineSubtitle": "Trust Divine relays, verify the rest.",
+  "@nostrSettingsSignatureVerificationNonDivineSubtitle": {"description": "Option subtitle for trusting Divine-hosted relays while verifying other relay signatures."}
 }

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -16977,6 +16977,54 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Remove broken clips?'**
   String get settingsStorageRemoveBrokenConfirmTitle;
+
+  /// Title for the Nostr relay signature verification setting.
+  ///
+  /// In en, this message translates to:
+  /// **'Signature verification'**
+  String get nostrSettingsSignatureVerification;
+
+  /// Intro copy for the Nostr relay signature verification setting screen.
+  ///
+  /// In en, this message translates to:
+  /// **'Choose when Divine checks relay event signatures. Event IDs are always validated first.'**
+  String get nostrSettingsSignatureVerificationIntro;
+
+  /// Option label to verify event signatures from all Nostr relays.
+  ///
+  /// In en, this message translates to:
+  /// **'All relays'**
+  String get nostrSettingsSignatureVerificationAll;
+
+  /// Option subtitle for verifying every Nostr relay event signature.
+  ///
+  /// In en, this message translates to:
+  /// **'Safest. Verify every relay event signature.'**
+  String get nostrSettingsSignatureVerificationAllSubtitle;
+
+  /// Option label to verify event signatures only from untrusted Nostr relays.
+  ///
+  /// In en, this message translates to:
+  /// **'Untrusted relays'**
+  String get nostrSettingsSignatureVerificationUntrusted;
+
+  /// Option subtitle for skipping signature checks on configured relays.
+  ///
+  /// In en, this message translates to:
+  /// **'Skip checks for relays already in your configured pool.'**
+  String get nostrSettingsSignatureVerificationUntrustedSubtitle;
+
+  /// Option label to verify event signatures only from non-Divine Nostr relays.
+  ///
+  /// In en, this message translates to:
+  /// **'Non-Divine relays'**
+  String get nostrSettingsSignatureVerificationNonDivine;
+
+  /// Option subtitle for trusting Divine-hosted relays while verifying other relay signatures.
+  ///
+  /// In en, this message translates to:
+  /// **'Trust Divine relays, verify the rest.'**
+  String get nostrSettingsSignatureVerificationNonDivineSubtitle;
 }
 
 class _AppLocalizationsDelegate

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -9624,4 +9624,32 @@ class AppLocalizationsAm extends AppLocalizations {
 
   @override
   String get settingsStorageRemoveBrokenConfirmTitle => 'የተበላሹ ክሊፖችን ማስወገድ?';
+
+  @override
+  String get nostrSettingsSignatureVerification => 'Signature verification';
+
+  @override
+  String get nostrSettingsSignatureVerificationIntro =>
+      'Choose when Divine checks relay event signatures. Event IDs are always validated first.';
+
+  @override
+  String get nostrSettingsSignatureVerificationAll => 'All relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationAllSubtitle =>
+      'Safest. Verify every relay event signature.';
+
+  @override
+  String get nostrSettingsSignatureVerificationUntrusted => 'Untrusted relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationUntrustedSubtitle =>
+      'Skip checks for relays already in your configured pool.';
+
+  @override
+  String get nostrSettingsSignatureVerificationNonDivine => 'Non-Divine relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationNonDivineSubtitle =>
+      'Trust Divine relays, verify the rest.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -9765,4 +9765,32 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String get settingsStorageRemoveBrokenConfirmTitle =>
       'إزالة المقاطع التالفة؟';
+
+  @override
+  String get nostrSettingsSignatureVerification => 'Signature verification';
+
+  @override
+  String get nostrSettingsSignatureVerificationIntro =>
+      'Choose when Divine checks relay event signatures. Event IDs are always validated first.';
+
+  @override
+  String get nostrSettingsSignatureVerificationAll => 'All relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationAllSubtitle =>
+      'Safest. Verify every relay event signature.';
+
+  @override
+  String get nostrSettingsSignatureVerificationUntrusted => 'Untrusted relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationUntrustedSubtitle =>
+      'Skip checks for relays already in your configured pool.';
+
+  @override
+  String get nostrSettingsSignatureVerificationNonDivine => 'Non-Divine relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationNonDivineSubtitle =>
+      'Trust Divine relays, verify the rest.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -9934,4 +9934,32 @@ class AppLocalizationsBg extends AppLocalizations {
   @override
   String get settingsStorageRemoveBrokenConfirmTitle =>
       'Премахване на повредените клипове?';
+
+  @override
+  String get nostrSettingsSignatureVerification => 'Signature verification';
+
+  @override
+  String get nostrSettingsSignatureVerificationIntro =>
+      'Choose when Divine checks relay event signatures. Event IDs are always validated first.';
+
+  @override
+  String get nostrSettingsSignatureVerificationAll => 'All relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationAllSubtitle =>
+      'Safest. Verify every relay event signature.';
+
+  @override
+  String get nostrSettingsSignatureVerificationUntrusted => 'Untrusted relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationUntrustedSubtitle =>
+      'Skip checks for relays already in your configured pool.';
+
+  @override
+  String get nostrSettingsSignatureVerificationNonDivine => 'Non-Divine relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationNonDivineSubtitle =>
+      'Trust Divine relays, verify the rest.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -9942,4 +9942,32 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get settingsStorageRemoveBrokenConfirmTitle =>
       'Defekte Clips entfernen?';
+
+  @override
+  String get nostrSettingsSignatureVerification => 'Signature verification';
+
+  @override
+  String get nostrSettingsSignatureVerificationIntro =>
+      'Choose when Divine checks relay event signatures. Event IDs are always validated first.';
+
+  @override
+  String get nostrSettingsSignatureVerificationAll => 'All relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationAllSubtitle =>
+      'Safest. Verify every relay event signature.';
+
+  @override
+  String get nostrSettingsSignatureVerificationUntrusted => 'Untrusted relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationUntrustedSubtitle =>
+      'Skip checks for relays already in your configured pool.';
+
+  @override
+  String get nostrSettingsSignatureVerificationNonDivine => 'Non-Divine relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationNonDivineSubtitle =>
+      'Trust Divine relays, verify the rest.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -9805,4 +9805,32 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get settingsStorageRemoveBrokenConfirmTitle => 'Remove broken clips?';
+
+  @override
+  String get nostrSettingsSignatureVerification => 'Signature verification';
+
+  @override
+  String get nostrSettingsSignatureVerificationIntro =>
+      'Choose when Divine checks relay event signatures. Event IDs are always validated first.';
+
+  @override
+  String get nostrSettingsSignatureVerificationAll => 'All relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationAllSubtitle =>
+      'Safest. Verify every relay event signature.';
+
+  @override
+  String get nostrSettingsSignatureVerificationUntrusted => 'Untrusted relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationUntrustedSubtitle =>
+      'Skip checks for relays already in your configured pool.';
+
+  @override
+  String get nostrSettingsSignatureVerificationNonDivine => 'Non-Divine relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationNonDivineSubtitle =>
+      'Trust Divine relays, verify the rest.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -9928,4 +9928,32 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get settingsStorageRemoveBrokenConfirmTitle =>
       '¿Eliminar clips dañados?';
+
+  @override
+  String get nostrSettingsSignatureVerification => 'Signature verification';
+
+  @override
+  String get nostrSettingsSignatureVerificationIntro =>
+      'Choose when Divine checks relay event signatures. Event IDs are always validated first.';
+
+  @override
+  String get nostrSettingsSignatureVerificationAll => 'All relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationAllSubtitle =>
+      'Safest. Verify every relay event signature.';
+
+  @override
+  String get nostrSettingsSignatureVerificationUntrusted => 'Untrusted relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationUntrustedSubtitle =>
+      'Skip checks for relays already in your configured pool.';
+
+  @override
+  String get nostrSettingsSignatureVerificationNonDivine => 'Non-Divine relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationNonDivineSubtitle =>
+      'Trust Divine relays, verify the rest.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -9937,4 +9937,32 @@ class AppLocalizationsFil extends AppLocalizations {
   @override
   String get settingsStorageRemoveBrokenConfirmTitle =>
       'Alisin ang mga sirang clip?';
+
+  @override
+  String get nostrSettingsSignatureVerification => 'Signature verification';
+
+  @override
+  String get nostrSettingsSignatureVerificationIntro =>
+      'Choose when Divine checks relay event signatures. Event IDs are always validated first.';
+
+  @override
+  String get nostrSettingsSignatureVerificationAll => 'All relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationAllSubtitle =>
+      'Safest. Verify every relay event signature.';
+
+  @override
+  String get nostrSettingsSignatureVerificationUntrusted => 'Untrusted relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationUntrustedSubtitle =>
+      'Skip checks for relays already in your configured pool.';
+
+  @override
+  String get nostrSettingsSignatureVerificationNonDivine => 'Non-Divine relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationNonDivineSubtitle =>
+      'Trust Divine relays, verify the rest.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -9969,4 +9969,32 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get settingsStorageRemoveBrokenConfirmTitle =>
       'Supprimer les clips défectueux ?';
+
+  @override
+  String get nostrSettingsSignatureVerification => 'Signature verification';
+
+  @override
+  String get nostrSettingsSignatureVerificationIntro =>
+      'Choose when Divine checks relay event signatures. Event IDs are always validated first.';
+
+  @override
+  String get nostrSettingsSignatureVerificationAll => 'All relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationAllSubtitle =>
+      'Safest. Verify every relay event signature.';
+
+  @override
+  String get nostrSettingsSignatureVerificationUntrusted => 'Untrusted relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationUntrustedSubtitle =>
+      'Skip checks for relays already in your configured pool.';
+
+  @override
+  String get nostrSettingsSignatureVerificationNonDivine => 'Non-Divine relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationNonDivineSubtitle =>
+      'Trust Divine relays, verify the rest.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -9805,4 +9805,32 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get settingsStorageRemoveBrokenConfirmTitle => 'Hapus klip rusak?';
+
+  @override
+  String get nostrSettingsSignatureVerification => 'Signature verification';
+
+  @override
+  String get nostrSettingsSignatureVerificationIntro =>
+      'Choose when Divine checks relay event signatures. Event IDs are always validated first.';
+
+  @override
+  String get nostrSettingsSignatureVerificationAll => 'All relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationAllSubtitle =>
+      'Safest. Verify every relay event signature.';
+
+  @override
+  String get nostrSettingsSignatureVerificationUntrusted => 'Untrusted relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationUntrustedSubtitle =>
+      'Skip checks for relays already in your configured pool.';
+
+  @override
+  String get nostrSettingsSignatureVerificationNonDivine => 'Non-Divine relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationNonDivineSubtitle =>
+      'Trust Divine relays, verify the rest.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -9925,4 +9925,32 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get settingsStorageRemoveBrokenConfirmTitle =>
       'Rimuovere le clip danneggiate?';
+
+  @override
+  String get nostrSettingsSignatureVerification => 'Signature verification';
+
+  @override
+  String get nostrSettingsSignatureVerificationIntro =>
+      'Choose when Divine checks relay event signatures. Event IDs are always validated first.';
+
+  @override
+  String get nostrSettingsSignatureVerificationAll => 'All relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationAllSubtitle =>
+      'Safest. Verify every relay event signature.';
+
+  @override
+  String get nostrSettingsSignatureVerificationUntrusted => 'Untrusted relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationUntrustedSubtitle =>
+      'Skip checks for relays already in your configured pool.';
+
+  @override
+  String get nostrSettingsSignatureVerificationNonDivine => 'Non-Divine relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationNonDivineSubtitle =>
+      'Trust Divine relays, verify the rest.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -9450,4 +9450,32 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get settingsStorageRemoveBrokenConfirmTitle => '壊れたクリップを削除しますか？';
+
+  @override
+  String get nostrSettingsSignatureVerification => 'Signature verification';
+
+  @override
+  String get nostrSettingsSignatureVerificationIntro =>
+      'Choose when Divine checks relay event signatures. Event IDs are always validated first.';
+
+  @override
+  String get nostrSettingsSignatureVerificationAll => 'All relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationAllSubtitle =>
+      'Safest. Verify every relay event signature.';
+
+  @override
+  String get nostrSettingsSignatureVerificationUntrusted => 'Untrusted relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationUntrustedSubtitle =>
+      'Skip checks for relays already in your configured pool.';
+
+  @override
+  String get nostrSettingsSignatureVerificationNonDivine => 'Non-Divine relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationNonDivineSubtitle =>
+      'Trust Divine relays, verify the rest.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -9475,4 +9475,32 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get settingsStorageRemoveBrokenConfirmTitle => '손상된 클립을 제거할까요?';
+
+  @override
+  String get nostrSettingsSignatureVerification => 'Signature verification';
+
+  @override
+  String get nostrSettingsSignatureVerificationIntro =>
+      'Choose when Divine checks relay event signatures. Event IDs are always validated first.';
+
+  @override
+  String get nostrSettingsSignatureVerificationAll => 'All relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationAllSubtitle =>
+      'Safest. Verify every relay event signature.';
+
+  @override
+  String get nostrSettingsSignatureVerificationUntrusted => 'Untrusted relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationUntrustedSubtitle =>
+      'Skip checks for relays already in your configured pool.';
+
+  @override
+  String get nostrSettingsSignatureVerificationNonDivine => 'Non-Divine relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationNonDivineSubtitle =>
+      'Trust Divine relays, verify the rest.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -9874,4 +9874,32 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get settingsStorageRemoveBrokenConfirmTitle =>
       'Kapotte clips verwijderen?';
+
+  @override
+  String get nostrSettingsSignatureVerification => 'Signature verification';
+
+  @override
+  String get nostrSettingsSignatureVerificationIntro =>
+      'Choose when Divine checks relay event signatures. Event IDs are always validated first.';
+
+  @override
+  String get nostrSettingsSignatureVerificationAll => 'All relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationAllSubtitle =>
+      'Safest. Verify every relay event signature.';
+
+  @override
+  String get nostrSettingsSignatureVerificationUntrusted => 'Untrusted relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationUntrustedSubtitle =>
+      'Skip checks for relays already in your configured pool.';
+
+  @override
+  String get nostrSettingsSignatureVerificationNonDivine => 'Non-Divine relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationNonDivineSubtitle =>
+      'Trust Divine relays, verify the rest.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -10017,4 +10017,32 @@ class AppLocalizationsPl extends AppLocalizations {
   @override
   String get settingsStorageRemoveBrokenConfirmTitle =>
       'Usunąć uszkodzone klipy?';
+
+  @override
+  String get nostrSettingsSignatureVerification => 'Signature verification';
+
+  @override
+  String get nostrSettingsSignatureVerificationIntro =>
+      'Choose when Divine checks relay event signatures. Event IDs are always validated first.';
+
+  @override
+  String get nostrSettingsSignatureVerificationAll => 'All relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationAllSubtitle =>
+      'Safest. Verify every relay event signature.';
+
+  @override
+  String get nostrSettingsSignatureVerificationUntrusted => 'Untrusted relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationUntrustedSubtitle =>
+      'Skip checks for relays already in your configured pool.';
+
+  @override
+  String get nostrSettingsSignatureVerificationNonDivine => 'Non-Divine relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationNonDivineSubtitle =>
+      'Trust Divine relays, verify the rest.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -9895,4 +9895,32 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get settingsStorageRemoveBrokenConfirmTitle =>
       'Remover clipes quebrados?';
+
+  @override
+  String get nostrSettingsSignatureVerification => 'Signature verification';
+
+  @override
+  String get nostrSettingsSignatureVerificationIntro =>
+      'Choose when Divine checks relay event signatures. Event IDs are always validated first.';
+
+  @override
+  String get nostrSettingsSignatureVerificationAll => 'All relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationAllSubtitle =>
+      'Safest. Verify every relay event signature.';
+
+  @override
+  String get nostrSettingsSignatureVerificationUntrusted => 'Untrusted relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationUntrustedSubtitle =>
+      'Skip checks for relays already in your configured pool.';
+
+  @override
+  String get nostrSettingsSignatureVerificationNonDivine => 'Non-Divine relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationNonDivineSubtitle =>
+      'Trust Divine relays, verify the rest.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -10037,4 +10037,32 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String get settingsStorageRemoveBrokenConfirmTitle =>
       'Elimini clipurile deteriorate?';
+
+  @override
+  String get nostrSettingsSignatureVerification => 'Signature verification';
+
+  @override
+  String get nostrSettingsSignatureVerificationIntro =>
+      'Choose when Divine checks relay event signatures. Event IDs are always validated first.';
+
+  @override
+  String get nostrSettingsSignatureVerificationAll => 'All relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationAllSubtitle =>
+      'Safest. Verify every relay event signature.';
+
+  @override
+  String get nostrSettingsSignatureVerificationUntrusted => 'Untrusted relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationUntrustedSubtitle =>
+      'Skip checks for relays already in your configured pool.';
+
+  @override
+  String get nostrSettingsSignatureVerificationNonDivine => 'Non-Divine relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationNonDivineSubtitle =>
+      'Trust Divine relays, verify the rest.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -9832,4 +9832,32 @@ class AppLocalizationsSv extends AppLocalizations {
   @override
   String get settingsStorageRemoveBrokenConfirmTitle =>
       'Ta bort trasiga klipp?';
+
+  @override
+  String get nostrSettingsSignatureVerification => 'Signature verification';
+
+  @override
+  String get nostrSettingsSignatureVerificationIntro =>
+      'Choose when Divine checks relay event signatures. Event IDs are always validated first.';
+
+  @override
+  String get nostrSettingsSignatureVerificationAll => 'All relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationAllSubtitle =>
+      'Safest. Verify every relay event signature.';
+
+  @override
+  String get nostrSettingsSignatureVerificationUntrusted => 'Untrusted relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationUntrustedSubtitle =>
+      'Skip checks for relays already in your configured pool.';
+
+  @override
+  String get nostrSettingsSignatureVerificationNonDivine => 'Non-Divine relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationNonDivineSubtitle =>
+      'Trust Divine relays, verify the rest.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -9802,4 +9802,32 @@ class AppLocalizationsTr extends AppLocalizations {
   @override
   String get settingsStorageRemoveBrokenConfirmTitle =>
       'Bozuk klipler kaldırılsın mı?';
+
+  @override
+  String get nostrSettingsSignatureVerification => 'Signature verification';
+
+  @override
+  String get nostrSettingsSignatureVerificationIntro =>
+      'Choose when Divine checks relay event signatures. Event IDs are always validated first.';
+
+  @override
+  String get nostrSettingsSignatureVerificationAll => 'All relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationAllSubtitle =>
+      'Safest. Verify every relay event signature.';
+
+  @override
+  String get nostrSettingsSignatureVerificationUntrusted => 'Untrusted relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationUntrustedSubtitle =>
+      'Skip checks for relays already in your configured pool.';
+
+  @override
+  String get nostrSettingsSignatureVerificationNonDivine => 'Non-Divine relays';
+
+  @override
+  String get nostrSettingsSignatureVerificationNonDivineSubtitle =>
+      'Trust Divine relays, verify the rest.';
 }

--- a/mobile/lib/providers/nostr_client_provider.dart
+++ b/mobile/lib/providers/nostr_client_provider.dart
@@ -8,9 +8,11 @@ import 'package:openvine/models/environment_config.dart';
 import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/database_provider.dart';
 import 'package:openvine/providers/environment_provider.dart';
+import 'package:openvine/providers/preferences_providers.dart';
 import 'package:openvine/providers/relay_providers.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/nostr_service_factory.dart';
+import 'package:openvine/services/nostr_signature_verification_preference_service.dart';
 import 'package:openvine/services/relay_statistics_service.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -172,6 +174,12 @@ class NostrService extends _$NostrService {
     ref.watch(currentEnvironmentProvider);
     ref.watch(appDbClientProvider);
     ref.watch(nostrClientFactoryProvider);
+    ref.listen<NostrSignatureVerificationPolicy>(
+      nostrSignatureVerificationPolicyProvider,
+      (_, next) {
+        state.signatureVerificationPolicy = next.toSdkPolicy();
+      },
+    );
 
     final initialPubkey = authService.currentIdentity?.pubkey;
 
@@ -237,6 +245,9 @@ class NostrService extends _$NostrService {
       environmentConfig: ref.read(currentEnvironmentProvider),
       dbClient: ref.read(appDbClientProvider),
     );
+    client.signatureVerificationPolicy = ref
+        .read(nostrSignatureVerificationPolicyProvider)
+        .toSdkPolicy();
     _trackedClients.add(client);
     return client;
   }

--- a/mobile/lib/providers/nostr_client_provider.g.dart
+++ b/mobile/lib/providers/nostr_client_provider.g.dart
@@ -109,7 +109,7 @@ final class NostrServiceProvider
   }
 }
 
-String _$nostrServiceHash() => r'090b2e8cd2adf62b7406e3472ab857c1091fa4de';
+String _$nostrServiceHash() => r'79f3643e74227a0de2d009979fdbbde50a955b3c';
 
 /// Core Nostr service via NostrClient for relay communication
 /// Uses a Notifier to react to auth state changes and recreate the client

--- a/mobile/lib/providers/preferences_providers.dart
+++ b/mobile/lib/providers/preferences_providers.dart
@@ -8,6 +8,7 @@ import 'package:openvine/services/audio_sharing_preference_service.dart';
 import 'package:openvine/services/feed_aspect_ratio_preference_service.dart';
 import 'package:openvine/services/hold_to_record_preference_service.dart';
 import 'package:openvine/services/language_preference_service.dart';
+import 'package:openvine/services/nostr_signature_verification_preference_service.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'preferences_providers.g.dart';
@@ -30,6 +31,20 @@ final holdToRecordPreferenceServiceProvider =
     Provider<HoldToRecordPreferenceService>((ref) {
       final prefs = ref.watch(sharedPreferencesProvider);
       return HoldToRecordPreferenceService(prefs);
+    });
+
+final nostrSignatureVerificationPreferenceServiceProvider =
+    Provider<NostrSignatureVerificationPreferenceService>((ref) {
+      final prefs = ref.watch(sharedPreferencesProvider);
+      return NostrSignatureVerificationPreferenceService(prefs);
+    });
+
+final nostrSignatureVerificationPolicyProvider =
+    Provider<NostrSignatureVerificationPolicy>((ref) {
+      final service = ref.watch(
+        nostrSignatureVerificationPreferenceServiceProvider,
+      );
+      return service.currentPolicy;
     });
 
 /// Audio device preference service for managing the preferred input device

--- a/mobile/lib/screens/settings/nostr_settings_screen.dart
+++ b/mobile/lib/screens/settings/nostr_settings_screen.dart
@@ -314,7 +314,7 @@ class _SignatureVerificationTile extends ConsumerWidget {
     final policy = ref.watch(nostrSignatureVerificationPolicyProvider);
 
     return _SettingsTile(
-      icon: Icons.verified_user,
+      divineIcon: DivineIconName.shieldCheck,
       title: context.l10n.nostrSettingsSignatureVerification,
       subtitle: _policySubtitle(context, policy),
       onTap: () => Navigator.of(context).push(
@@ -437,15 +437,17 @@ String _policySubtitle(
 
 class _SettingsTile extends StatelessWidget {
   const _SettingsTile({
-    required this.icon,
     required this.title,
     required this.subtitle,
     required this.onTap,
+    this.icon,
+    this.divineIcon,
     this.iconColor,
     this.titleColor,
-  });
+  }) : assert(icon != null || divineIcon != null);
 
-  final IconData icon;
+  final IconData? icon;
+  final DivineIconName? divineIcon;
   final String title;
   final String subtitle;
   final VoidCallback onTap;
@@ -455,7 +457,12 @@ class _SettingsTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ListTile(
-      leading: Icon(icon, color: iconColor ?? VineTheme.vineGreen),
+      leading: divineIcon != null
+          ? DivineIcon(
+              icon: divineIcon!,
+              color: iconColor ?? VineTheme.vineGreen,
+            )
+          : Icon(icon, color: iconColor ?? VineTheme.vineGreen),
       title: Text(
         title,
         style: TextStyle(

--- a/mobile/lib/screens/settings/nostr_settings_screen.dart
+++ b/mobile/lib/screens/settings/nostr_settings_screen.dart
@@ -23,6 +23,7 @@ import 'package:openvine/screens/relay_diagnostic_screen.dart';
 import 'package:openvine/screens/relay_settings_screen.dart';
 import 'package:openvine/screens/settings/nip05_settings_screen.dart';
 import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/nostr_signature_verification_preference_service.dart';
 import 'package:openvine/widgets/delete_account_dialog.dart';
 
 class NostrSettingsScreen extends ConsumerWidget {
@@ -85,6 +86,7 @@ class NostrSettingsScreen extends ConsumerWidget {
                 subtitle: context.l10n.nostrSettingsMediaServersSubtitle,
                 onTap: () => context.push(BlossomSettingsScreen.path),
               ),
+              const _SignatureVerificationTile(),
               _SettingsTile(
                 icon: Icons.science,
                 title: context.l10n.settingsExperimentalFeatures,
@@ -159,9 +161,7 @@ class _RemoveKeysTile extends StatelessWidget {
 
         final progressOverlay = _ProgressOverlay.show(context);
 
-        unawaited(
-          progressOverlay.closed,
-        );
+        unawaited(progressOverlay.closed);
 
         try {
           await authService.signOut(
@@ -226,11 +226,7 @@ class _ProgressOverlay {
     );
 
     final closed = navigator.push(route);
-    return _ProgressOverlay._(
-      navigator,
-      route: route,
-      closed: closed,
-    );
+    return _ProgressOverlay._(navigator, route: route, closed: closed);
   }
 
   void dismiss() {
@@ -307,6 +303,135 @@ class _ClientAttributionToggle extends ConsumerWidget {
       activeThumbColor: VineTheme.vineGreen,
       secondary: const Icon(Icons.travel_explore, color: VineTheme.vineGreen),
     );
+  }
+}
+
+class _SignatureVerificationTile extends ConsumerWidget {
+  const _SignatureVerificationTile();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final policy = ref.watch(nostrSignatureVerificationPolicyProvider);
+
+    return _SettingsTile(
+      icon: Icons.verified_user,
+      title: context.l10n.nostrSettingsSignatureVerification,
+      subtitle: _policySubtitle(context, policy),
+      onTap: () => Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (_) => const _SignatureVerificationPolicyScreen(),
+        ),
+      ),
+    );
+  }
+}
+
+class _SignatureVerificationPolicyScreen extends ConsumerWidget {
+  const _SignatureVerificationPolicyScreen();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final current = ref.watch(nostrSignatureVerificationPolicyProvider);
+
+    return Scaffold(
+      appBar: DiVineAppBar(
+        title: context.l10n.nostrSettingsSignatureVerification,
+        showBackButton: true,
+        onBackPressed: () => Navigator.of(context).pop(),
+      ),
+      backgroundColor: VineTheme.backgroundColor,
+      body: Align(
+        alignment: Alignment.topCenter,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 600),
+          child: ListView(
+            children: [
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+                child: Text(
+                  context.l10n.nostrSettingsSignatureVerificationIntro,
+                  style: const TextStyle(
+                    color: VineTheme.lightText,
+                    fontSize: 14,
+                  ),
+                ),
+              ),
+              RadioGroup<NostrSignatureVerificationPolicy>(
+                groupValue: current,
+                onChanged: (value) {
+                  if (value == null || value == current) return;
+                  unawaited(_setPolicy(ref, value));
+                },
+                child: Column(
+                  children: [
+                    for (final policy
+                        in NostrSignatureVerificationPolicy.values)
+                      RadioListTile<NostrSignatureVerificationPolicy>(
+                        value: policy,
+                        activeColor: VineTheme.vineGreen,
+                        title: Text(
+                          _policyTitle(context, policy),
+                          style: const TextStyle(
+                            color: VineTheme.whiteText,
+                            fontSize: 16,
+                            fontWeight: FontWeight.w500,
+                          ),
+                        ),
+                        subtitle: Text(
+                          _policySubtitle(context, policy),
+                          style: const TextStyle(
+                            color: VineTheme.lightText,
+                            fontSize: 14,
+                          ),
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _setPolicy(
+    WidgetRef ref,
+    NostrSignatureVerificationPolicy value,
+  ) async {
+    final service = ref.read(
+      nostrSignatureVerificationPreferenceServiceProvider,
+    );
+    await service.setPolicy(value);
+    ref.invalidate(nostrSignatureVerificationPolicyProvider);
+  }
+}
+
+String _policyTitle(
+  BuildContext context,
+  NostrSignatureVerificationPolicy policy,
+) {
+  switch (policy) {
+    case NostrSignatureVerificationPolicy.all:
+      return context.l10n.nostrSettingsSignatureVerificationAll;
+    case NostrSignatureVerificationPolicy.untrustedRelays:
+      return context.l10n.nostrSettingsSignatureVerificationUntrusted;
+    case NostrSignatureVerificationPolicy.nonDivineRelays:
+      return context.l10n.nostrSettingsSignatureVerificationNonDivine;
+  }
+}
+
+String _policySubtitle(
+  BuildContext context,
+  NostrSignatureVerificationPolicy policy,
+) {
+  switch (policy) {
+    case NostrSignatureVerificationPolicy.all:
+      return context.l10n.nostrSettingsSignatureVerificationAllSubtitle;
+    case NostrSignatureVerificationPolicy.untrustedRelays:
+      return context.l10n.nostrSettingsSignatureVerificationUntrustedSubtitle;
+    case NostrSignatureVerificationPolicy.nonDivineRelays:
+      return context.l10n.nostrSettingsSignatureVerificationNonDivineSubtitle;
   }
 }
 

--- a/mobile/lib/services/nostr_signature_verification_preference_service.dart
+++ b/mobile/lib/services/nostr_signature_verification_preference_service.dart
@@ -1,0 +1,51 @@
+// ABOUTME: Persists the user's Nostr relay signature verification policy.
+// ABOUTME: Maps app settings onto the nostr_sdk relay-pool verification modes.
+
+import 'package:nostr_sdk/nostr_sdk.dart' as nostr_sdk;
+import 'package:shared_preferences/shared_preferences.dart';
+
+enum NostrSignatureVerificationPolicy {
+  all('all'),
+  untrustedRelays('untrusted_relays'),
+  nonDivineRelays('non_divine_relays');
+
+  const NostrSignatureVerificationPolicy(this.storageValue);
+
+  final String storageValue;
+
+  nostr_sdk.SignatureVerificationPolicy toSdkPolicy() {
+    switch (this) {
+      case NostrSignatureVerificationPolicy.all:
+        return nostr_sdk.SignatureVerificationPolicy.all;
+      case NostrSignatureVerificationPolicy.untrustedRelays:
+        return nostr_sdk.SignatureVerificationPolicy.untrustedRelays;
+      case NostrSignatureVerificationPolicy.nonDivineRelays:
+        return nostr_sdk.SignatureVerificationPolicy.nonDivineRelays;
+    }
+  }
+
+  static NostrSignatureVerificationPolicy fromStorage(String? value) {
+    for (final policy in values) {
+      if (policy.storageValue == value) return policy;
+    }
+    return NostrSignatureVerificationPreferenceService.defaultPolicy;
+  }
+}
+
+class NostrSignatureVerificationPreferenceService {
+  NostrSignatureVerificationPreferenceService(this._prefs);
+
+  static const prefsKey = 'nostr_signature_verification_policy';
+
+  static const NostrSignatureVerificationPolicy defaultPolicy =
+      NostrSignatureVerificationPolicy.nonDivineRelays;
+
+  final SharedPreferences _prefs;
+
+  NostrSignatureVerificationPolicy get currentPolicy =>
+      NostrSignatureVerificationPolicy.fromStorage(_prefs.getString(prefsKey));
+
+  Future<void> setPolicy(NostrSignatureVerificationPolicy policy) async {
+    await _prefs.setString(prefsKey, policy.storageValue);
+  }
+}

--- a/mobile/lib/services/nostr_signature_verification_preference_service.dart
+++ b/mobile/lib/services/nostr_signature_verification_preference_service.dart
@@ -38,7 +38,7 @@ class NostrSignatureVerificationPreferenceService {
   static const prefsKey = 'nostr_signature_verification_policy';
 
   static const NostrSignatureVerificationPolicy defaultPolicy =
-      NostrSignatureVerificationPolicy.nonDivineRelays;
+      NostrSignatureVerificationPolicy.all;
 
   final SharedPreferences _prefs;
 

--- a/mobile/packages/nostr_client/lib/src/models/nostr_client_config.dart
+++ b/mobile/packages/nostr_client/lib/src/models/nostr_client_config.dart
@@ -13,8 +13,7 @@ class NostrClientConfig {
     this.enableGateway = false,
     this.webSocketChannelFactory,
     this.eventVerifyWorkerSpawner,
-    this.signatureVerificationPolicy =
-        SignatureVerificationPolicy.nonDivineRelays,
+    this.signatureVerificationPolicy = SignatureVerificationPolicy.all,
   });
 
   /// Signer for event signing - the single source of truth for the public key.

--- a/mobile/packages/nostr_client/lib/src/models/nostr_client_config.dart
+++ b/mobile/packages/nostr_client/lib/src/models/nostr_client_config.dart
@@ -13,6 +13,8 @@ class NostrClientConfig {
     this.enableGateway = false,
     this.webSocketChannelFactory,
     this.eventVerifyWorkerSpawner,
+    this.signatureVerificationPolicy =
+        SignatureVerificationPolicy.nonDivineRelays,
   });
 
   /// Signer for event signing - the single source of truth for the public key.
@@ -42,4 +44,7 @@ class NostrClientConfig {
   /// isolate. When null (tests, web), verification runs inline on the main
   /// isolate exactly as before. The app passes `EventVerifyIsolate.spawn`.
   final EventVerifyWorkerSpawner? eventVerifyWorkerSpawner;
+
+  /// Policy for verifying inbound relay EVENT signatures.
+  final SignatureVerificationPolicy signatureVerificationPolicy;
 }

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -103,6 +103,7 @@ class NostrClient {
       tempRelayGenerator,
       onNotice: config.onNotice,
       channelFactory: config.webSocketChannelFactory,
+      signatureVerificationPolicy: config.signatureVerificationPolicy,
     );
   }
 
@@ -135,6 +136,14 @@ class NostrClient {
   /// reuse this signer rather than creating their own, to ensure consistent
   /// key material.
   NostrSigner get signer => _nostr.nostrSigner;
+
+  /// Policy for expensive inbound relay EVENT signature verification.
+  SignatureVerificationPolicy get signatureVerificationPolicy =>
+      _nostr.relayPool.signatureVerificationPolicy;
+
+  set signatureVerificationPolicy(SignatureVerificationPolicy policy) {
+    _nostr.relayPool.signatureVerificationPolicy = policy;
+  }
 
   /// Convenience getter for the NostrEventsDao
   NostrEventsDao? get _nostrEventsDao => _dbClient?.database.nostrEventsDao;

--- a/mobile/packages/nostr_client/test/src/models/nostr_client_config_test.dart
+++ b/mobile/packages/nostr_client/test/src/models/nostr_client_config_test.dart
@@ -24,6 +24,10 @@ void main() {
         expect(config.onNotice, isNull);
         expect(config.gatewayUrl, isNull);
         expect(config.enableGateway, isFalse);
+        expect(
+          config.signatureVerificationPolicy,
+          SignatureVerificationPolicy.all,
+        );
       });
 
       test('creates config with all fields', () {
@@ -56,6 +60,10 @@ void main() {
         expect(config.onNotice, isNull);
         expect(config.gatewayUrl, isNull);
         expect(config.enableGateway, isFalse);
+        expect(
+          config.signatureVerificationPolicy,
+          SignatureVerificationPolicy.all,
+        );
       });
     });
   });

--- a/mobile/packages/nostr_sdk/lib/nostr.dart
+++ b/mobile/packages/nostr_sdk/lib/nostr.dart
@@ -36,7 +36,7 @@ class Nostr {
     this.onNotice,
     WebSocketChannelFactory? channelFactory,
     SignatureVerificationPolicy signatureVerificationPolicy =
-        SignatureVerificationPolicy.nonDivineRelays,
+        SignatureVerificationPolicy.all,
   }) {
     // Public key starts empty - call refreshPublicKey() after construction
     // to populate from the signer (single source of truth).

--- a/mobile/packages/nostr_sdk/lib/nostr.dart
+++ b/mobile/packages/nostr_sdk/lib/nostr.dart
@@ -11,6 +11,7 @@ import 'relay/publish_outcome.dart';
 import 'relay/relay.dart';
 import 'relay/relay_pool.dart';
 import 'relay/relay_type.dart';
+import 'relay/signature_verification_policy.dart';
 import 'relay/web_socket_connection_manager.dart';
 import 'signer/nostr_signer.dart';
 import 'signer/pubkey_only_nostr_signer.dart';
@@ -34,10 +35,18 @@ class Nostr {
     this.tempRelayGener, {
     this.onNotice,
     WebSocketChannelFactory? channelFactory,
+    SignatureVerificationPolicy signatureVerificationPolicy =
+        SignatureVerificationPolicy.nonDivineRelays,
   }) {
     // Public key starts empty - call refreshPublicKey() after construction
     // to populate from the signer (single source of truth).
-    _pool = RelayPool(this, eventFilters, tempRelayGener, onNotice: onNotice);
+    _pool = RelayPool(
+      this,
+      eventFilters,
+      tempRelayGener,
+      onNotice: onNotice,
+      signatureVerificationPolicy: signatureVerificationPolicy,
+    );
   }
 
   /// Public key of the client.

--- a/mobile/packages/nostr_sdk/lib/nostr_sdk.dart
+++ b/mobile/packages/nostr_sdk/lib/nostr_sdk.dart
@@ -54,6 +54,7 @@ export 'relay/event_verify_isolate.dart';
 export 'relay/relay_pool.dart';
 export 'relay/relay_status.dart';
 export 'relay/relay_type.dart';
+export 'relay/signature_verification_policy.dart';
 export 'relay/web_socket_connection_manager.dart';
 // Local storage
 export 'signer/local_nostr_signer.dart';

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -21,6 +21,7 @@ import 'publish_outcome.dart';
 import 'relay.dart';
 import 'relay_base.dart';
 import 'relay_type.dart';
+import 'signature_verification_policy.dart';
 
 class RelayPool {
   // avoid to send these events to cache relay
@@ -96,7 +97,15 @@ class RelayPool {
     this.eventFilters,
     this.tempRelayGener, {
     this.onNotice,
+    this.signatureVerificationPolicy =
+        SignatureVerificationPolicy.nonDivineRelays,
   });
+
+  /// Controls whether [_dispatchTypedFrame] performs expensive Schnorr
+  /// verification. The event id is always recomputed first; policy skips only
+  /// bypass the signature check for relay origins the app is configured to
+  /// trust.
+  SignatureVerificationPolicy signatureVerificationPolicy;
 
   List<Subscription> _subscriptionsSnapshot() =>
       _subscriptions.values.toList(growable: false);
@@ -438,9 +447,11 @@ class RelayPool {
   int get verifiesPerformed => _verifiesPerformed;
   int get verifiesSkippedKnown => _verifiesSkippedKnown;
   int get verifiesSkippedSessionDup => _verifiesSkippedSessionDup;
+  int get verifiesSkippedByPolicy => _verifiesSkippedByPolicy;
   int _verifiesPerformed = 0;
   int _verifiesSkippedKnown = 0;
   int _verifiesSkippedSessionDup = 0;
+  int _verifiesSkippedByPolicy = 0;
 
   /// Records [key] (an `"id:sig"` pair) as verified, evicting the oldest once
   /// the cap is hit.
@@ -558,20 +569,32 @@ class RelayPool {
         //    same event from another relay) skip re-verify.
         // Only fresh network verifications are recorded in [_verifiedEventKeys]
         // so a known/duplicate hit never masks an unverified network copy.
+        if (event.sig.isEmpty) {
+          log(
+            'Dropping relay event with empty signature '
+            'from ${relay.url}: eventId=${event.id}',
+          );
+          return;
+        }
+
         final verifyKey = '${event.id}:${event.sig}';
         if (_verifiedEventKeys.contains(verifyKey)) {
           _verifiesSkippedSessionDup++;
         } else if (isKnownVerifiedEvent?.call(event.id, event.sig) ?? false) {
           _verifiesSkippedKnown++;
-        } else if (await _verifySignatureOffMain(event, eventJson)) {
-          _markEventVerified(verifyKey);
-          _verifiesPerformed++;
+        } else if (_shouldVerifySignature(relay)) {
+          if (await _verifySignatureOffMain(event, eventJson)) {
+            _markEventVerified(verifyKey);
+            _verifiesPerformed++;
+          } else {
+            log(
+              'Dropping relay event with invalid signature '
+              'from ${relay.url}: eventId=${event.id}',
+            );
+            return;
+          }
         } else {
-          log(
-            'Dropping relay event with invalid signature '
-            'from ${relay.url}: eventId=${event.id}',
-          );
-          return;
+          _verifiesSkippedByPolicy++;
         }
 
         if ((relay.relayStatus.relayType != RelayType.cache)) {
@@ -1859,5 +1882,23 @@ class RelayPool {
     }
 
     return relays;
+  }
+
+  bool _shouldVerifySignature(Relay relay) {
+    switch (signatureVerificationPolicy) {
+      case SignatureVerificationPolicy.all:
+        return true;
+      case SignatureVerificationPolicy.untrustedRelays:
+        return !_relays.containsKey(relay.url);
+      case SignatureVerificationPolicy.nonDivineRelays:
+        return !_isDivineRelayHost(relay.url);
+    }
+  }
+
+  bool _isDivineRelayHost(String relayUrl) {
+    final uri = Uri.tryParse(relayUrl);
+    final host = uri?.host.toLowerCase();
+    if (host == null || host.isEmpty) return false;
+    return host == 'divine.video' || host.endsWith('.divine.video');
   }
 }

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -97,8 +97,7 @@ class RelayPool {
     this.eventFilters,
     this.tempRelayGener, {
     this.onNotice,
-    this.signatureVerificationPolicy =
-        SignatureVerificationPolicy.nonDivineRelays,
+    this.signatureVerificationPolicy = SignatureVerificationPolicy.all,
   });
 
   /// Controls whether [_dispatchTypedFrame] performs expensive Schnorr

--- a/mobile/packages/nostr_sdk/lib/relay/signature_verification_policy.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/signature_verification_policy.dart
@@ -1,0 +1,13 @@
+// ABOUTME: Defines relay-origin policy for inbound Nostr event signature checks.
+// ABOUTME: Lets clients trade trusted-relay performance against full verification.
+
+enum SignatureVerificationPolicy {
+  /// Verify every inbound relay EVENT signature.
+  all,
+
+  /// Verify only relay EVENT signatures from relays outside the configured pool.
+  untrustedRelays,
+
+  /// Verify only relay EVENT signatures from non-Divine relay hosts.
+  nonDivineRelays,
+}

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_signature_verification_policy_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_signature_verification_policy_test.dart
@@ -75,6 +75,12 @@ Nostr _nostr(SignatureVerificationPolicy policy) => Nostr(
   signatureVerificationPolicy: policy,
 );
 
+Nostr _nostrWithDefaultPolicy() => Nostr(
+  LocalNostrSigner(generatePrivateKey()),
+  [],
+  (url) => RelayBase(url, RelayStatus(url)),
+);
+
 List<Event> _subscribe(Nostr nostr) {
   final delivered = <Event>[];
   nostr.subscribe(
@@ -91,6 +97,21 @@ List<Event> _subscribe(Nostr nostr) {
 
 void main() {
   group('RelayPool signature verification policy', () {
+    test('defaults to verifying events from all relays', () async {
+      final nostr = _nostrWithDefaultPolicy();
+      final worker = _FakeVerifyWorker((_) => false);
+      nostr.relayPool.eventVerifyWorker = worker;
+      final relay = _FakeRelay('wss://relay.divine.video');
+      expect(await nostr.relayPool.add(relay), isTrue);
+      final delivered = _subscribe(nostr);
+
+      final event = await _signedEvent('default-policy');
+      await relay.deliver(['EVENT', 'sub', event.toJson()]);
+
+      expect(worker.calls, 1);
+      expect(delivered, isEmpty);
+    });
+
     test('all relays policy verifies through the worker', () async {
       final nostr = _nostr(SignatureVerificationPolicy.all);
       final worker = _FakeVerifyWorker((_) => false);
@@ -163,6 +184,23 @@ void main() {
 
       final eventJson = (await _signedEvent('empty-signature')).toJson()
         ..['sig'] = '';
+      await relay.deliver(['EVENT', 'sub', eventJson]);
+
+      expect(worker.calls, 0);
+      expect(nostr.relayPool.verifiesSkippedByPolicy, 0);
+      expect(delivered, isEmpty);
+    });
+
+    test('policy-skipped relays still reject mismatched event ids', () async {
+      final nostr = _nostr(SignatureVerificationPolicy.nonDivineRelays);
+      final worker = _FakeVerifyWorker((_) => true);
+      nostr.relayPool.eventVerifyWorker = worker;
+      final relay = _FakeRelay('wss://relay.divine.video');
+      expect(await nostr.relayPool.add(relay), isTrue);
+      final delivered = _subscribe(nostr);
+
+      final eventJson = (await _signedEvent('original-body')).toJson()
+        ..['content'] = 'tampered-body';
       await relay.deliver(['EVENT', 'sub', eventJson]);
 
       expect(worker.calls, 0);

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_signature_verification_policy_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_signature_verification_policy_test.dart
@@ -1,0 +1,173 @@
+// ABOUTME: Tests RelayPool signature-verification policy decisions.
+// ABOUTME: Ensures policy skips compose with the off-main verify worker.
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:nostr_sdk/relay/client_connected.dart';
+
+class _FakeRelay extends Relay {
+  _FakeRelay(String url) : super(url, RelayStatus(url));
+
+  @override
+  Future<bool> doConnect() async {
+    relayStatus.connected = ClientConnected.connected;
+    return true;
+  }
+
+  @override
+  Future<void> disconnect() async {
+    relayStatus.connected = ClientConnected.disconnect;
+  }
+
+  @override
+  Future<bool> send(
+    List<dynamic> message, {
+    bool? forceSend,
+    bool queueIfFailed = true,
+    bool skipReconnect = false,
+    DateTime? deadline,
+  }) async => true;
+
+  Future<void> deliver(List<dynamic> json) async {
+    final dynamic result = onMessage!(this, json);
+    if (result is Future) await result;
+  }
+}
+
+class _FakeVerifyWorker implements EventVerifyWorker {
+  _FakeVerifyWorker(this._decide);
+
+  final FutureOr<bool> Function(Map<String, dynamic> json) _decide;
+  int calls = 0;
+
+  @override
+  Future<bool> verify(Map<String, dynamic> eventJson) async {
+    calls++;
+    return _decide(eventJson);
+  }
+
+  @override
+  void close() {}
+}
+
+Future<Event> _signedEvent(String content) async {
+  const privateKey =
+      '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12';
+  final signer = LocalNostrSigner(privateKey);
+  final pubkey = await signer.getPublicKey();
+  final event = Event(
+    pubkey!,
+    EventKind.textNote,
+    [],
+    content,
+    createdAt: 1780000000,
+  );
+  await signer.signEvent(event);
+  return event;
+}
+
+Nostr _nostr(SignatureVerificationPolicy policy) => Nostr(
+  LocalNostrSigner(generatePrivateKey()),
+  [],
+  (url) => RelayBase(url, RelayStatus(url)),
+  signatureVerificationPolicy: policy,
+);
+
+List<Event> _subscribe(Nostr nostr) {
+  final delivered = <Event>[];
+  nostr.subscribe(
+    [
+      {
+        'kinds': [EventKind.textNote],
+      },
+    ],
+    delivered.add,
+    id: 'sub',
+  );
+  return delivered;
+}
+
+void main() {
+  group('RelayPool signature verification policy', () {
+    test('all relays policy verifies through the worker', () async {
+      final nostr = _nostr(SignatureVerificationPolicy.all);
+      final worker = _FakeVerifyWorker((_) => false);
+      nostr.relayPool.eventVerifyWorker = worker;
+      final relay = _FakeRelay('wss://relay.divine.video');
+      expect(await nostr.relayPool.add(relay), isTrue);
+      final delivered = _subscribe(nostr);
+
+      final event = await _signedEvent('rejected-by-worker');
+      await relay.deliver(['EVENT', 'sub', event.toJson()]);
+
+      expect(worker.calls, 1);
+      expect(delivered, isEmpty);
+    });
+
+    test('non-Divine policy skips worker for Divine relay hosts', () async {
+      final nostr = _nostr(SignatureVerificationPolicy.nonDivineRelays);
+      final worker = _FakeVerifyWorker((_) => false);
+      nostr.relayPool.eventVerifyWorker = worker;
+      final relay = _FakeRelay('wss://relay.divine.video');
+      expect(await nostr.relayPool.add(relay), isTrue);
+      final delivered = _subscribe(nostr);
+
+      final event = await _signedEvent('trusted-host');
+      await relay.deliver(['EVENT', 'sub', event.toJson()]);
+
+      expect(worker.calls, 0);
+      expect(nostr.relayPool.verifiesSkippedByPolicy, 1);
+      expect(delivered, hasLength(1));
+    });
+
+    test('non-Divine policy does not trust lookalike relay hosts', () async {
+      final nostr = _nostr(SignatureVerificationPolicy.nonDivineRelays);
+      final worker = _FakeVerifyWorker((_) => false);
+      nostr.relayPool.eventVerifyWorker = worker;
+      final relay = _FakeRelay('wss://divine.video.evil.example');
+      expect(await nostr.relayPool.add(relay), isTrue);
+      final delivered = _subscribe(nostr);
+
+      final event = await _signedEvent('lookalike-host');
+      await relay.deliver(['EVENT', 'sub', event.toJson()]);
+
+      expect(worker.calls, 1);
+      expect(delivered, isEmpty);
+    });
+
+    test('untrusted relays policy skips configured relays', () async {
+      final nostr = _nostr(SignatureVerificationPolicy.untrustedRelays);
+      final worker = _FakeVerifyWorker((_) => false);
+      nostr.relayPool.eventVerifyWorker = worker;
+      final relay = _FakeRelay('wss://configured.example');
+      expect(await nostr.relayPool.add(relay), isTrue);
+      final delivered = _subscribe(nostr);
+
+      final event = await _signedEvent('configured-relay');
+      await relay.deliver(['EVENT', 'sub', event.toJson()]);
+
+      expect(worker.calls, 0);
+      expect(nostr.relayPool.verifiesSkippedByPolicy, 1);
+      expect(delivered, hasLength(1));
+    });
+
+    test('empty signatures are rejected before policy skips', () async {
+      final nostr = _nostr(SignatureVerificationPolicy.nonDivineRelays);
+      final worker = _FakeVerifyWorker((_) => true);
+      nostr.relayPool.eventVerifyWorker = worker;
+      final relay = _FakeRelay('wss://relay.divine.video');
+      expect(await nostr.relayPool.add(relay), isTrue);
+      final delivered = _subscribe(nostr);
+
+      final eventJson = (await _signedEvent('empty-signature')).toJson()
+        ..['sig'] = '';
+      await relay.deliver(['EVENT', 'sub', eventJson]);
+
+      expect(worker.calls, 0);
+      expect(nostr.relayPool.verifiesSkippedByPolicy, 0);
+      expect(delivered, isEmpty);
+    });
+  });
+}

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -144,7 +144,16 @@ void main() {
 
 // Every key in app_en.arb is currently translated in all 16 locales.
 // Add keys here only when a translation pass is intentionally deferred.
-const _knownUntranslatedDebt = <String>{};
+const _knownUntranslatedDebt = <String>{
+  'nostrSettingsSignatureVerification',
+  'nostrSettingsSignatureVerificationIntro',
+  'nostrSettingsSignatureVerificationAll',
+  'nostrSettingsSignatureVerificationAllSubtitle',
+  'nostrSettingsSignatureVerificationUntrusted',
+  'nostrSettingsSignatureVerificationUntrustedSubtitle',
+  'nostrSettingsSignatureVerificationNonDivine',
+  'nostrSettingsSignatureVerificationNonDivineSubtitle',
+};
 
 Map<String, Object?> _readArb(File file) {
   return (jsonDecode(file.readAsStringSync()) as Map).cast<String, Object?>();

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -145,6 +145,7 @@ void main() {
 // Every key in app_en.arb is currently translated in all 16 locales.
 // Add keys here only when a translation pass is intentionally deferred.
 const _knownUntranslatedDebt = <String>{
+  // Nostr signature verification settings; English fallback until translated.
   'nostrSettingsSignatureVerification',
   'nostrSettingsSignatureVerificationIntro',
   'nostrSettingsSignatureVerificationAll',

--- a/mobile/test/providers/nostr_service_identity_source_test.dart
+++ b/mobile/test/providers/nostr_service_identity_source_test.dart
@@ -18,6 +18,7 @@ import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/services/auth/nostr_identity.dart';
 import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/nostr_signature_verification_preference_service.dart';
 import 'package:openvine/services/relay_discovery_service.dart';
 import 'package:openvine/services/relay_statistics_service.dart';
 
@@ -165,6 +166,9 @@ void main() {
         ),
         appDbClientProvider.overrideWithValue(mockDbClient),
         nostrClientFactoryProvider.overrideWithValue(factory.call),
+        nostrSignatureVerificationPolicyProvider.overrideWithValue(
+          NostrSignatureVerificationPolicy.nonDivineRelays,
+        ),
       ],
     );
   }
@@ -182,6 +186,9 @@ void main() {
         ),
         appDbClientProvider.overrideWithValue(mockDbClient),
         nostrClientFactoryProvider.overrideWithValue(factory.call),
+        nostrSignatureVerificationPolicyProvider.overrideWithValue(
+          NostrSignatureVerificationPolicy.nonDivineRelays,
+        ),
         nostrInitRetryDelayProvider.overrideWithValue(
           retryDelay ?? (_) => Duration.zero,
         ),

--- a/mobile/test/services/nostr_signature_verification_preference_service_test.dart
+++ b/mobile/test/services/nostr_signature_verification_preference_service_test.dart
@@ -12,13 +12,13 @@ void main() {
       SharedPreferences.setMockInitialValues({});
     });
 
-    test('defaults to non-Divine relays', () async {
+    test('defaults to verifying all relays', () async {
       final prefs = await SharedPreferences.getInstance();
       final service = NostrSignatureVerificationPreferenceService(prefs);
 
       expect(
         service.currentPolicy,
-        NostrSignatureVerificationPolicy.nonDivineRelays,
+        NostrSignatureVerificationPolicy.all,
       );
     });
 
@@ -45,7 +45,7 @@ void main() {
 
       expect(
         service.currentPolicy,
-        NostrSignatureVerificationPolicy.nonDivineRelays,
+        NostrSignatureVerificationPolicy.all,
       );
     });
 

--- a/mobile/test/services/nostr_signature_verification_preference_service_test.dart
+++ b/mobile/test/services/nostr_signature_verification_preference_service_test.dart
@@ -1,0 +1,67 @@
+// ABOUTME: Tests persistence and SDK mapping for Nostr signature policy prefs.
+// ABOUTME: Covers default, invalid stored values, and round-trip storage.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/nostr_sdk.dart' as nostr_sdk;
+import 'package:openvine/services/nostr_signature_verification_preference_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  group(NostrSignatureVerificationPreferenceService, () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    test('defaults to non-Divine relays', () async {
+      final prefs = await SharedPreferences.getInstance();
+      final service = NostrSignatureVerificationPreferenceService(prefs);
+
+      expect(
+        service.currentPolicy,
+        NostrSignatureVerificationPolicy.nonDivineRelays,
+      );
+    });
+
+    test('round-trips every policy through storage', () async {
+      final prefs = await SharedPreferences.getInstance();
+      final service = NostrSignatureVerificationPreferenceService(prefs);
+
+      for (final policy in NostrSignatureVerificationPolicy.values) {
+        await service.setPolicy(policy);
+        expect(service.currentPolicy, policy);
+        expect(
+          prefs.getString(NostrSignatureVerificationPreferenceService.prefsKey),
+          policy.storageValue,
+        );
+      }
+    });
+
+    test('falls back to default for unknown stored values', () async {
+      SharedPreferences.setMockInitialValues({
+        NostrSignatureVerificationPreferenceService.prefsKey: 'mystery',
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final service = NostrSignatureVerificationPreferenceService(prefs);
+
+      expect(
+        service.currentPolicy,
+        NostrSignatureVerificationPolicy.nonDivineRelays,
+      );
+    });
+
+    test('maps app policies to SDK policies', () {
+      expect(
+        NostrSignatureVerificationPolicy.all.toSdkPolicy(),
+        nostr_sdk.SignatureVerificationPolicy.all,
+      );
+      expect(
+        NostrSignatureVerificationPolicy.untrustedRelays.toSdkPolicy(),
+        nostr_sdk.SignatureVerificationPolicy.untrustedRelays,
+      );
+      expect(
+        NostrSignatureVerificationPolicy.nonDivineRelays.toSdkPolicy(),
+        nostr_sdk.SignatureVerificationPolicy.nonDivineRelays,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- add a persisted Nostr signature verification setting with All, Untrusted relays, and Non-Divine relays options
- keep the off-main relay-event verifier from #5863 in place, and apply the policy gate only around fresh Schnorr checks
- default to All relays across the app, nostr_client, and nostr_sdk; the relaxed policies remain explicit user choices
- wire the policy through nostr_sdk, nostr_client, and NostrService with live policy updates instead of reconnecting the relay pool
- add a full-screen settings picker and regression tests for defaults, relay policy behavior, tampered event ids, and preference persistence

Relates to #5863.
Closes #5951 with the stricter verify-all default.

## Verification

- `flutter test --no-pub packages/nostr_sdk/test/unit/relay_pool_signature_verification_policy_test.dart packages/nostr_sdk/test/unit/relay_pool_offmain_verify_test.dart packages/nostr_sdk/test/unit/relay_pool_verify_dedup_test.dart packages/nostr_sdk/test/nip59/gift_wrap_util_test.dart packages/nostr_client/test/src/models/nostr_client_config_test.dart packages/nostr_client/test/src/nostr_client_test.dart test/services/nostr_signature_verification_preference_service_test.dart test/l10n/arb_consistency_test.dart test/providers/nostr_service_identity_source_test.dart`
- `flutter analyze`
- `bash scripts/golden.sh verify`
- `bash scripts/check_untested_services_floor.sh`
- `bash scripts/check_raw_icons_ceiling.sh`
- `dart run build_runner build --delete-conflicting-outputs`