### PR TITLE
fix(feed): prefer hls for divine blob playback

### DIFF
--- a/mobile/packages/infinite_video_feed/lib/src/utils/playback_sources.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/utils/playback_sources.dart
@@ -10,10 +10,11 @@ import 'package:models/models.dart';
 ///
 /// **Fallback order rationale**: ExoPlayer uses `ProgressiveMediaSource` for
 /// `.mp4`-extension URLs and only switches to `HlsMediaSource` when the URL
-/// ends with `.m3u8`. Some Divine CDN paths (e.g. `<hash>/720p.mp4`) serve
-/// content that ExoPlayer cannot parse with its progressive extractors even
-/// though the file is reachable. HLS is tried second so at most one failed
-/// attempt is needed before ExoPlayer switches to the adaptive source.
+/// ends with `.m3u8`. Some Divine CDN paths (including raw blob URLs and
+/// `<hash>/720p.mp4`) serve content that ExoPlayer cannot parse or start
+/// quickly with its progressive extractors even though the file is reachable.
+/// HLS is preferred for canonical Divine blobs, with raw MP4 retained as a
+/// fallback for assets whose HLS rendition is still unavailable.
 List<String> resolvePlaybackSources(
   VideoEvent video, {
   String? Function(VideoEvent video)? urlResolver,
@@ -35,12 +36,13 @@ List<String> resolvePlaybackSources(
     }
 
     final isRawBlob = resolvedSource == rawUrl;
-    // For the raw blob, HLS is the first fallback.
+    // For the raw blob, prefer HLS so cold progressive MP4 metadata/layout
+    // does not stall feed playback before falling back to raw bytes.
     // For quality-specific variants (e.g. 720p.mp4), HLS comes before raw
     // because the variant URL may serve content ExoPlayer cannot parse as
     // a progressive stream.
     return isRawBlob
-        ? orderedUniqueSources([resolvedSource, hlsUrl, originalUrl])
+        ? orderedUniqueSources([hlsUrl, resolvedSource, originalUrl])
         : orderedUniqueSources([resolvedSource, hlsUrl, rawUrl, originalUrl]);
   }
 

--- a/mobile/packages/infinite_video_feed/test/src/utils/playback_sources_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/utils/playback_sources_test.dart
@@ -70,10 +70,10 @@ void main() {
     });
 
     group('when URL is the raw blob URL', () {
-      test('returns [rawUrl, hlsUrl, originalUrl] deduplicated', () {
+      test('returns [hlsUrl, rawUrl, originalUrl] deduplicated', () {
         final video = _makeVideo(videoUrl: _rawUrl);
-        // raw == original → [rawUrl, hlsUrl]
-        expect(resolvePlaybackSources(video), equals([_rawUrl, _hlsUrl]));
+        // raw == original -> [hlsUrl, rawUrl]
+        expect(resolvePlaybackSources(video), equals([_hlsUrl, _rawUrl]));
       });
 
       test('includes originalUrl when it differs from rawUrl', () {
@@ -83,7 +83,7 @@ void main() {
           video,
           urlResolver: (_) => _rawUrl,
         );
-        expect(result, equals([_rawUrl, _hlsUrl, otherOriginal]));
+        expect(result, equals([_hlsUrl, _rawUrl, otherOriginal]));
       });
     });
 


### PR DESCRIPTION
Closes #5936

## Summary
- prefer the canonical HLS rendition before raw MP4 for raw `media.divine.video/<hash>` playback URLs
- keep raw MP4 as fallback when HLS is unavailable
- update playback source tests to pin the source order

## Root Cause
The reported logs show the feed opening `https://media.divine.video/e770667c1a62cc394602fc07462fa0d7ba83441002d9aac662fb88d0cc575338`, reporting the player ready, but playback position stays at `0` until stale detection tries the HLS fallback. The fallback then fails on the already-stalled controller with `COMPOSITION_ERROR: No playable video tracks found`, and the feed marks the video errored.

The asset itself is present: HEAD returns `200 video/mp4`, and `ffprobe` sees valid AAC + H.264 streams. The cold remote probe is slow and the first bytes show C2PA/JUMBF metadata before normal playback metadata, matching the user report that the first try lags/fails but works after the file is loaded/cached. HLS is the streamable rendition and should be the first feed source for canonical Divine blob URLs.

## Verification
- RED: `cd mobile/packages/infinite_video_feed && flutter test test/src/utils/playback_sources_test.dart --plain-name 'when URL is the raw blob URL'` failed with raw-before-HLS order
- GREEN: same command passed after the source-order change
- `cd mobile/packages/infinite_video_feed && flutter test test/src/utils/playback_sources_test.dart`
- `cd mobile/packages/infinite_video_feed && flutter test test/src/services/playback_source_registry_test.dart test/src/services/stale_playback_detector_test.dart`
- `cd mobile/packages/infinite_video_feed && flutter analyze lib test`
- `cd mobile/packages/infinite_video_feed && flutter test` (221 tests)
- `git diff --check`
- pre-push hook: analyzer passed; changed-file `packages/infinite_video_feed/test/src/utils/playback_sources_test.dart` passed 27 tests