### PR TITLE
fix(avatar): cache broken avatar URLs

### DIFF
--- a/mobile/lib/widgets/avatar_failure_cache.dart
+++ b/mobile/lib/widgets/avatar_failure_cache.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Prevents repeated fetch/log loops for broken profile images
 
 import 'package:flutter/foundation.dart';
+import 'package:media_cache/media_cache.dart';
 
 typedef AvatarFailureClock = DateTime Function();
 
@@ -73,16 +74,32 @@ class AvatarFailureCache {
 
   @visibleForTesting
   static AvatarFailureKind classifyFailure(Object error) {
-    final message = error.toString().toLowerCase();
-    if (message.contains('load cancelled')) {
-      return AvatarFailureKind.cancelled;
+    // A completed raster download that produced no file — a dead or broken
+    // URL, non-2xx response, or DNS failure. This is distinct from a benign
+    // scroll-away cancellation (which never surfaces as an error), so cache it
+    // with the short TTL to stop the retry-and-relog loop while still letting
+    // a recovered host reload soon. Matched by type rather than message so it
+    // survives any future rewording in media_cache.
+    if (error is MediaCacheImageLoadException) {
+      return AvatarFailureKind.transient;
     }
+
+    final message = error.toString().toLowerCase();
+
     if (message.contains('invalid image data') ||
         message.contains('image codec failed') ||
         message.contains('xmlparserexception') ||
-        message.contains('invalid svg data')) {
+        message.contains('invalid svg data') ||
+        message.contains('empty and cannot be loaded')) {
       return AvatarFailureKind.deterministic;
     }
+
+    // A genuine in-flight cancellation (e.g. flutter_svg aborting a request)
+    // says nothing about whether the URL is broken, so never cache it.
+    if (message.contains('load cancelled')) {
+      return AvatarFailureKind.cancelled;
+    }
+
     return AvatarFailureKind.transient;
   }
 

--- a/mobile/lib/widgets/avatar_failure_cache.dart
+++ b/mobile/lib/widgets/avatar_failure_cache.dart
@@ -5,6 +5,8 @@ import 'package:flutter/foundation.dart';
 
 typedef AvatarFailureClock = DateTime Function();
 
+enum AvatarFailureKind { deterministic, transient, cancelled }
+
 class AvatarFailureCache {
   AvatarFailureCache._({
     required AvatarFailureClock clock,
@@ -56,14 +58,35 @@ class AvatarFailureCache {
     }
   }
 
-  @visibleForTesting
-  void clear() {
-    _failedUrls.clear();
+  AvatarFailureKind recordFailureForError(String url, Object error) {
+    final kind = classifyFailure(error);
+    switch (kind) {
+      case AvatarFailureKind.deterministic:
+        recordFailure(url, ttl: deterministicFailureTtl);
+      case AvatarFailureKind.transient:
+        recordFailure(url, ttl: transientFailureTtl);
+      case AvatarFailureKind.cancelled:
+        break;
+    }
+    return kind;
   }
 
   @visibleForTesting
-  void setClockForTesting(AvatarFailureClock clock) {
-    _clock = clock;
+  static AvatarFailureKind classifyFailure(Object error) {
+    final message = error.toString().toLowerCase();
+    if (message.contains('load cancelled')) {
+      return AvatarFailureKind.cancelled;
+    }
+    if (message.contains('invalid image data') ||
+        message.contains('image codec failed')) {
+      return AvatarFailureKind.deterministic;
+    }
+    return AvatarFailureKind.transient;
+  }
+
+  @visibleForTesting
+  void clear() {
+    _failedUrls.clear();
   }
 
   @visibleForTesting

--- a/mobile/lib/widgets/avatar_failure_cache.dart
+++ b/mobile/lib/widgets/avatar_failure_cache.dart
@@ -6,7 +6,7 @@ import 'package:media_cache/media_cache.dart';
 
 typedef AvatarFailureClock = DateTime Function();
 
-enum AvatarFailureKind { deterministic, transient, cancelled }
+enum AvatarFailureKind { deterministic, transient }
 
 class AvatarFailureCache {
   AvatarFailureCache._({
@@ -66,8 +66,6 @@ class AvatarFailureCache {
         recordFailure(url, ttl: deterministicFailureTtl);
       case AvatarFailureKind.transient:
         recordFailure(url, ttl: transientFailureTtl);
-      case AvatarFailureKind.cancelled:
-        break;
     }
     return kind;
   }
@@ -92,12 +90,6 @@ class AvatarFailureCache {
         message.contains('invalid svg data') ||
         message.contains('empty and cannot be loaded')) {
       return AvatarFailureKind.deterministic;
-    }
-
-    // A genuine in-flight cancellation (e.g. flutter_svg aborting a request)
-    // says nothing about whether the URL is broken, so never cache it.
-    if (message.contains('load cancelled')) {
-      return AvatarFailureKind.cancelled;
     }
 
     return AvatarFailureKind.transient;

--- a/mobile/lib/widgets/avatar_failure_cache.dart
+++ b/mobile/lib/widgets/avatar_failure_cache.dart
@@ -1,0 +1,73 @@
+// ABOUTME: Bounded TTL cache for avatar URLs known to have failed loading
+// ABOUTME: Prevents repeated fetch/log loops for broken profile images
+
+import 'package:flutter/foundation.dart';
+
+typedef AvatarFailureClock = DateTime Function();
+
+class AvatarFailureCache {
+  AvatarFailureCache._({
+    required AvatarFailureClock clock,
+    required int maxEntries,
+  }) : _clock = clock,
+       _maxEntries = maxEntries;
+
+  static final AvatarFailureCache instance = AvatarFailureCache._(
+    clock: DateTime.now,
+    maxEntries: maxEntries,
+  );
+
+  @visibleForTesting
+  factory AvatarFailureCache.testing({
+    required AvatarFailureClock clock,
+    int maxEntries = AvatarFailureCache.maxEntries,
+  }) {
+    return AvatarFailureCache._(clock: clock, maxEntries: maxEntries);
+  }
+
+  static const int maxEntries = 128;
+  static const Duration deterministicFailureTtl = Duration(hours: 1);
+  static const Duration transientFailureTtl = Duration(seconds: 30);
+
+  final int _maxEntries;
+  AvatarFailureClock _clock;
+  final _failedUrls = <String, DateTime>{};
+
+  bool isFailed(String url) {
+    final expiresAt = _failedUrls.remove(url);
+    if (expiresAt == null) return false;
+
+    if (!_clock().isBefore(expiresAt)) {
+      return false;
+    }
+
+    _failedUrls[url] = expiresAt;
+    return true;
+  }
+
+  void recordFailure(String url, {required Duration ttl}) {
+    if (url.isEmpty || ttl <= Duration.zero) return;
+
+    _failedUrls.remove(url);
+    _failedUrls[url] = _clock().add(ttl);
+
+    while (_failedUrls.length > _maxEntries) {
+      _failedUrls.remove(_failedUrls.keys.first);
+    }
+  }
+
+  @visibleForTesting
+  void clear() {
+    _failedUrls.clear();
+  }
+
+  @visibleForTesting
+  void setClockForTesting(AvatarFailureClock clock) {
+    _clock = clock;
+  }
+
+  @visibleForTesting
+  void resetClockForTesting() {
+    _clock = DateTime.now;
+  }
+}

--- a/mobile/lib/widgets/avatar_failure_cache.dart
+++ b/mobile/lib/widgets/avatar_failure_cache.dart
@@ -78,7 +78,9 @@ class AvatarFailureCache {
       return AvatarFailureKind.cancelled;
     }
     if (message.contains('invalid image data') ||
-        message.contains('image codec failed')) {
+        message.contains('image codec failed') ||
+        message.contains('xmlparserexception') ||
+        message.contains('invalid svg data')) {
       return AvatarFailureKind.deterministic;
     }
     return AvatarFailureKind.transient;

--- a/mobile/lib/widgets/user_avatar.dart
+++ b/mobile/lib/widgets/user_avatar.dart
@@ -6,6 +6,7 @@ import 'dart:math' as math;
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:openvine/widgets/avatar_failure_cache.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -19,6 +20,8 @@ enum UserAvatarPlaceholderTone {
   purple,
   blue,
 }
+
+enum _AvatarFailureKind { deterministic, transient, cancelled }
 
 class UserAvatar extends StatelessWidget {
   const UserAvatar({
@@ -110,6 +113,35 @@ class UserAvatar extends StatelessWidget {
 
   bool get _isSvgImageUrl => isSvgImageUrl(imageUrl);
 
+  _AvatarFailureKind _classifyAvatarFailure(Object error) {
+    final message = error.toString().toLowerCase();
+    if (message.contains('load cancelled')) {
+      return _AvatarFailureKind.cancelled;
+    }
+    if (message.contains('invalid image data') ||
+        message.contains('image codec failed')) {
+      return _AvatarFailureKind.deterministic;
+    }
+    return _AvatarFailureKind.transient;
+  }
+
+  void _recordAvatarFailure(String url, _AvatarFailureKind kind) {
+    switch (kind) {
+      case _AvatarFailureKind.deterministic:
+        AvatarFailureCache.instance.recordFailure(
+          url,
+          ttl: AvatarFailureCache.deterministicFailureTtl,
+        );
+      case _AvatarFailureKind.transient:
+        AvatarFailureCache.instance.recordFailure(
+          url,
+          ttl: AvatarFailureCache.transientFailureTtl,
+        );
+      case _AvatarFailureKind.cancelled:
+        break;
+    }
+  }
+
   Widget _buildPlaceholder() => _Placeholder(
     size: size,
     placeholderTone: placeholderTone,
@@ -129,6 +161,10 @@ class UserAvatar extends StatelessWidget {
     }
 
     if (_hasNetworkImage && _isSvgImageUrl) {
+      if (AvatarFailureCache.instance.isFailed(imageUrl!)) {
+        return _buildPlaceholder();
+      }
+
       return SvgPicture.network(
         imageUrl!,
         fit: BoxFit.cover,
@@ -138,18 +174,28 @@ class UserAvatar extends StatelessWidget {
             'Avatar SVG failed to load URL: $imageUrl - Error: $error',
             name: 'UserAvatar',
           );
+          AvatarFailureCache.instance.recordFailure(
+            imageUrl!,
+            ttl: AvatarFailureCache.deterministicFailureTtl,
+          );
           return _buildPlaceholder();
         },
       );
     }
 
     if (_hasNetworkImage) {
+      if (AvatarFailureCache.instance.isFailed(imageUrl!)) {
+        return _buildPlaceholder();
+      }
+
       return VineCachedImage(
         imageUrl: imageUrl!,
         placeholder: (context, url) => _buildPlaceholder(),
         errorWidget: (context, url, error) {
-          if (error.toString().contains('Invalid image data') ||
-              error.toString().contains('Image codec failed')) {
+          final failureKind = _classifyAvatarFailure(error);
+          _recordAvatarFailure(url, failureKind);
+
+          if (failureKind == _AvatarFailureKind.deterministic) {
             UnifiedLogger.warning(
               '🖼️ Invalid image data for avatar URL: $url - Error: $error',
               name: 'UserAvatar',

--- a/mobile/lib/widgets/user_avatar.dart
+++ b/mobile/lib/widgets/user_avatar.dart
@@ -21,8 +21,6 @@ enum UserAvatarPlaceholderTone {
   blue,
 }
 
-enum _AvatarFailureKind { deterministic, transient, cancelled }
-
 class UserAvatar extends StatelessWidget {
   const UserAvatar({
     super.key,
@@ -113,35 +111,6 @@ class UserAvatar extends StatelessWidget {
 
   bool get _isSvgImageUrl => isSvgImageUrl(imageUrl);
 
-  _AvatarFailureKind _classifyAvatarFailure(Object error) {
-    final message = error.toString().toLowerCase();
-    if (message.contains('load cancelled')) {
-      return _AvatarFailureKind.cancelled;
-    }
-    if (message.contains('invalid image data') ||
-        message.contains('image codec failed')) {
-      return _AvatarFailureKind.deterministic;
-    }
-    return _AvatarFailureKind.transient;
-  }
-
-  void _recordAvatarFailure(String url, _AvatarFailureKind kind) {
-    switch (kind) {
-      case _AvatarFailureKind.deterministic:
-        AvatarFailureCache.instance.recordFailure(
-          url,
-          ttl: AvatarFailureCache.deterministicFailureTtl,
-        );
-      case _AvatarFailureKind.transient:
-        AvatarFailureCache.instance.recordFailure(
-          url,
-          ttl: AvatarFailureCache.transientFailureTtl,
-        );
-      case _AvatarFailureKind.cancelled:
-        break;
-    }
-  }
-
   Widget _buildPlaceholder() => _Placeholder(
     size: size,
     placeholderTone: placeholderTone,
@@ -174,10 +143,7 @@ class UserAvatar extends StatelessWidget {
             'Avatar SVG failed to load URL: $imageUrl - Error: $error',
             name: 'UserAvatar',
           );
-          AvatarFailureCache.instance.recordFailure(
-            imageUrl!,
-            ttl: AvatarFailureCache.deterministicFailureTtl,
-          );
+          AvatarFailureCache.instance.recordFailureForError(imageUrl!, error);
           return _buildPlaceholder();
         },
       );
@@ -192,10 +158,12 @@ class UserAvatar extends StatelessWidget {
         imageUrl: imageUrl!,
         placeholder: (context, url) => _buildPlaceholder(),
         errorWidget: (context, url, error) {
-          final failureKind = _classifyAvatarFailure(error);
-          _recordAvatarFailure(url, failureKind);
+          final failureKind = AvatarFailureCache.instance.recordFailureForError(
+            url,
+            error,
+          );
 
-          if (failureKind == _AvatarFailureKind.deterministic) {
+          if (failureKind == AvatarFailureKind.deterministic) {
             UnifiedLogger.warning(
               '🖼️ Invalid image data for avatar URL: $url - Error: $error',
               name: 'UserAvatar',

--- a/mobile/packages/media_cache/lib/media_cache.dart
+++ b/mobile/packages/media_cache/lib/media_cache.dart
@@ -59,7 +59,8 @@ export 'src/cancellable_downloader.dart'
         CancellableDownloadResult,
         CancellableDownloader,
         HttpCancellableDownloader;
-export 'src/media_cache_image_provider.dart' show MediaCacheImageProvider;
+export 'src/media_cache_image_provider.dart'
+    show MediaCacheImageLoadException, MediaCacheImageProvider;
 export 'src/media_cache_manager.dart'
     show CacheMetrics, MediaCacheConfig, MediaCacheManager;
 export 'src/safe_cache_info_repository.dart'

--- a/mobile/packages/media_cache/lib/src/media_cache_image_provider.dart
+++ b/mobile/packages/media_cache/lib/src/media_cache_image_provider.dart
@@ -98,7 +98,11 @@ class MediaCacheImageProvider extends ImageProvider<MediaCacheImageProvider> {
         return _abortCancelledLoad(key);
       }
       if (file == null) {
-        throw const _ImageLoadCancelledException();
+        // The download completed but produced no file (network/DNS failure,
+        // non-2xx response, …). This is a genuine load failure, distinct from
+        // the benign scroll-away cancellation handled above via
+        // `_abortCancelledLoad` — the latter never throws.
+        throw MediaCacheImageLoadException(url);
       }
 
       return _decodeFile(file, decode: decode);
@@ -204,9 +208,23 @@ class _ImageLoadHandle {
   }
 }
 
-class _ImageLoadCancelledException implements Exception {
-  const _ImageLoadCancelledException();
+/// Thrown by [MediaCacheImageProvider] when a download completes without
+/// producing a usable file.
+///
+/// This signals a genuine load failure — a network or DNS error, a non-2xx
+/// response, or an otherwise dead URL — and is distinct from the benign
+/// scroll-away cancellation the provider handles silently (which returns a
+/// never-completing future rather than throwing). Callers that maintain a
+/// negative cache of broken URLs should treat this as a cacheable failure.
+class MediaCacheImageLoadException implements Exception {
+  /// Creates an exception for the [url] whose download produced no file.
+  const MediaCacheImageLoadException(this.url);
+
+  /// The URL whose download completed without a file.
+  final String url;
 
   @override
-  String toString() => 'MediaCacheImageProvider load cancelled';
+  String toString() =>
+      'MediaCacheImageProvider failed to load "$url": '
+      'download completed without a file';
 }

--- a/mobile/packages/media_cache/test/src/media_cache_image_provider_test.dart
+++ b/mobile/packages/media_cache/test/src/media_cache_image_provider_test.dart
@@ -388,10 +388,11 @@ void main() {
       await Future<void>.delayed(Duration.zero);
 
       expect(errors, hasLength(1));
-      expect(
-        errors.single.toString(),
-        contains('MediaCacheImageProvider load cancelled'),
-      );
+      final failure = errors.single;
+      expect(failure, isA<MediaCacheImageLoadException>());
+      expect((failure as MediaCacheImageLoadException).url, equals(url));
+      expect(failure.toString(), contains(url));
+      expect(failure.toString(), contains('download completed without a file'));
       expect(
         PaintingBinding.instance.imageCache.containsKey(provider),
         isFalse,

--- a/mobile/test/flutter_test_config.dart
+++ b/mobile/test/flutter_test_config.dart
@@ -7,6 +7,7 @@ import 'package:alchemist/alchemist.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:golden_toolkit/golden_toolkit.dart';
+import 'package:openvine/widgets/avatar_failure_cache.dart';
 
 import 'helpers/shared_channel_override.dart';
 import 'test_setup.dart';
@@ -31,6 +32,12 @@ Future<void> testExecutable(FutureOr<void> Function() testMain) async {
   // from its canonical handler, and — under DIVINE_STRICT_CHANNELS — blames
   // the perpetrating test. Compliant tests never trip it.
   tearDown(() => healAndBlameSharedChannels(strict: _strictChannels));
+
+  // UserAvatar records broken image URLs in a process-global negative cache.
+  // In the merged optimizer isolate that state would otherwise leak a failed
+  // URL into a later test that expects the same avatar to load. Reset it after
+  // every test so avatar failure caching stays test-local.
+  tearDown(AvatarFailureCache.instance.clear);
 
   // Web / `flutter test --platform chrome`: skip golden font loading and
   // Alchemist. Those paths can stall headless Chrome with almost no CPU while

--- a/mobile/test/notifications/widgets/notification_avatar_stack_test.dart
+++ b/mobile/test/notifications/widgets/notification_avatar_stack_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/notifications/widgets/notification_avatar_stack.dart';
+import 'package:openvine/widgets/avatar_failure_cache.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
 
@@ -41,8 +42,15 @@ void main() {
     // Stub the image cache (#5158 seam) so VineCachedImage does no real
     // path_provider / cache-manager work that could settle after the test and
     // cascade in the merged VGV optimizer isolate (#5159).
-    setUp(() => debugImageCacheOverride = createMockMediaCacheManager());
-    tearDown(() => debugImageCacheOverride = null);
+    setUp(() {
+      AvatarFailureCache.instance.clear();
+      debugImageCacheOverride = createMockMediaCacheManager();
+    });
+
+    tearDown(() {
+      debugImageCacheOverride = null;
+      AvatarFailureCache.instance.clear();
+    });
 
     testWidgets('renders single avatar for one actor', (tester) async {
       await tester.pumpWidget(buildSubject(actors: const [actor1]));

--- a/mobile/test/widgets/avatar_failure_cache_test.dart
+++ b/mobile/test/widgets/avatar_failure_cache_test.dart
@@ -60,6 +60,21 @@ void main() {
       expect(cache.isFailed(url), isFalse);
     });
 
+    test('treats malformed SVG parse errors as deterministic', () {
+      const url = 'https://divine.video/divine-logo.svg';
+
+      final kind = cache.recordFailureForError(
+        url,
+        Exception('XmlParserException: ">" expected at 1:5'),
+      );
+
+      expect(kind, AvatarFailureKind.deterministic);
+      expect(cache.isFailed(url), isTrue);
+
+      now = now.add(AvatarFailureCache.transientFailureTtl);
+      expect(cache.isFailed(url), isTrue);
+    });
+
     test('records unknown failures as transient', () {
       const url = 'https://example.com/avatar.png';
 

--- a/mobile/test/widgets/avatar_failure_cache_test.dart
+++ b/mobile/test/widgets/avatar_failure_cache_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/widgets/avatar_failure_cache.dart';
+
+void main() {
+  group(AvatarFailureCache, () {
+    late DateTime now;
+    late AvatarFailureCache cache;
+
+    setUp(() {
+      now = DateTime.utc(2026, 7, 7, 12);
+      cache = AvatarFailureCache.testing(clock: () => now);
+    });
+
+    test('records and reports a failed URL until its TTL expires', () {
+      const url = 'https://example.com/avatar.png';
+
+      cache.recordFailure(url, ttl: AvatarFailureCache.deterministicFailureTtl);
+
+      expect(cache.isFailed(url), isTrue);
+
+      now = now.add(AvatarFailureCache.deterministicFailureTtl);
+
+      expect(cache.isFailed(url), isFalse);
+      expect(cache.isFailed(url), isFalse);
+    });
+
+    test('supports short transient failures', () {
+      const url = 'https://example.com/avatar.png';
+
+      cache.recordFailure(url, ttl: AvatarFailureCache.transientFailureTtl);
+
+      now = now.add(
+        AvatarFailureCache.transientFailureTtl -
+            const Duration(milliseconds: 1),
+      );
+      expect(cache.isFailed(url), isTrue);
+
+      now = now.add(const Duration(milliseconds: 1));
+      expect(cache.isFailed(url), isFalse);
+    });
+
+    test('evicts least recently used entries when bounded', () {
+      cache = AvatarFailureCache.testing(clock: () => now, maxEntries: 2);
+
+      cache.recordFailure(
+        'https://example.com/a.png',
+        ttl: AvatarFailureCache.deterministicFailureTtl,
+      );
+      cache.recordFailure(
+        'https://example.com/b.png',
+        ttl: AvatarFailureCache.deterministicFailureTtl,
+      );
+      expect(cache.isFailed('https://example.com/a.png'), isTrue);
+
+      cache.recordFailure(
+        'https://example.com/c.png',
+        ttl: AvatarFailureCache.deterministicFailureTtl,
+      );
+
+      expect(cache.isFailed('https://example.com/a.png'), isTrue);
+      expect(cache.isFailed('https://example.com/b.png'), isFalse);
+      expect(cache.isFailed('https://example.com/c.png'), isTrue);
+    });
+
+    test('clear removes cached failures', () {
+      const url = 'https://example.com/avatar.png';
+
+      cache.recordFailure(url, ttl: AvatarFailureCache.deterministicFailureTtl);
+      cache.clear();
+
+      expect(cache.isFailed(url), isFalse);
+    });
+  });
+}

--- a/mobile/test/widgets/avatar_failure_cache_test.dart
+++ b/mobile/test/widgets/avatar_failure_cache_test.dart
@@ -39,6 +39,51 @@ void main() {
       expect(cache.isFailed(url), isFalse);
     });
 
+    test('records deterministic failures for one hour', () {
+      const url = 'https://example.com/avatar.png';
+
+      final kind = cache.recordFailureForError(
+        url,
+        Exception('Invalid image data'),
+      );
+
+      expect(kind, AvatarFailureKind.deterministic);
+      expect(cache.isFailed(url), isTrue);
+
+      now = now.add(AvatarFailureCache.transientFailureTtl);
+      expect(cache.isFailed(url), isTrue);
+
+      now = now.add(
+        AvatarFailureCache.deterministicFailureTtl -
+            AvatarFailureCache.transientFailureTtl,
+      );
+      expect(cache.isFailed(url), isFalse);
+    });
+
+    test('records unknown failures as transient', () {
+      const url = 'https://example.com/avatar.png';
+
+      final kind = cache.recordFailureForError(url, Exception('HTTP 503'));
+
+      expect(kind, AvatarFailureKind.transient);
+      expect(cache.isFailed(url), isTrue);
+
+      now = now.add(AvatarFailureCache.transientFailureTtl);
+      expect(cache.isFailed(url), isFalse);
+    });
+
+    test('does not record cancelled failures', () {
+      const url = 'https://example.com/avatar.png';
+
+      final kind = cache.recordFailureForError(
+        url,
+        Exception('MediaCacheImageProvider load cancelled'),
+      );
+
+      expect(kind, AvatarFailureKind.cancelled);
+      expect(cache.isFailed(url), isFalse);
+    });
+
     test('evicts least recently used entries when bounded', () {
       cache = AvatarFailureCache.testing(clock: () => now, maxEntries: 2);
 

--- a/mobile/test/widgets/avatar_failure_cache_test.dart
+++ b/mobile/test/widgets/avatar_failure_cache_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:media_cache/media_cache.dart';
 import 'package:openvine/widgets/avatar_failure_cache.dart';
 
 void main() {
@@ -87,12 +88,44 @@ void main() {
       expect(cache.isFailed(url), isFalse);
     });
 
-    test('does not record cancelled failures', () {
+    test('caches completed raster download failures transiently', () {
+      const url = 'https://blotcdn.com/broken-avatar.png';
+
+      final kind = cache.recordFailureForError(
+        url,
+        const MediaCacheImageLoadException(url),
+      );
+
+      expect(kind, AvatarFailureKind.transient);
+      expect(cache.isFailed(url), isTrue);
+
+      now = now.add(AvatarFailureCache.transientFailureTtl);
+      expect(cache.isFailed(url), isFalse);
+    });
+
+    test('treats empty cached image files as deterministic', () {
       const url = 'https://example.com/avatar.png';
 
       final kind = cache.recordFailureForError(
         url,
-        Exception('MediaCacheImageProvider load cancelled'),
+        StateError(
+          "File: '/tmp/avatar.png' is empty and cannot be loaded as an image.",
+        ),
+      );
+
+      expect(kind, AvatarFailureKind.deterministic);
+      expect(cache.isFailed(url), isTrue);
+
+      now = now.add(AvatarFailureCache.transientFailureTtl);
+      expect(cache.isFailed(url), isTrue);
+    });
+
+    test('does not record genuine load cancellations', () {
+      const url = 'https://example.com/avatar.png';
+
+      final kind = cache.recordFailureForError(
+        url,
+        Exception('SvgPicture load cancelled'),
       );
 
       expect(kind, AvatarFailureKind.cancelled);

--- a/mobile/test/widgets/avatar_failure_cache_test.dart
+++ b/mobile/test/widgets/avatar_failure_cache_test.dart
@@ -120,7 +120,7 @@ void main() {
       expect(cache.isFailed(url), isTrue);
     });
 
-    test('does not record genuine load cancellations', () {
+    test('caches surfaced cancellation-shaped errors transiently', () {
       const url = 'https://example.com/avatar.png';
 
       final kind = cache.recordFailureForError(
@@ -128,8 +128,8 @@ void main() {
         Exception('SvgPicture load cancelled'),
       );
 
-      expect(kind, AvatarFailureKind.cancelled);
-      expect(cache.isFailed(url), isFalse);
+      expect(kind, AvatarFailureKind.transient);
+      expect(cache.isFailed(url), isTrue);
     });
 
     test('evicts least recently used entries when bounded', () {

--- a/mobile/test/widgets/user_avatar_svg_test.dart
+++ b/mobile/test/widgets/user_avatar_svg_test.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
@@ -83,6 +86,19 @@ void main() {
       home: Scaffold(
         body: UserAvatar(imageUrl: imageUrl, name: 'Test User'),
       ),
+    );
+  }
+
+  Future<void> pumpAvatarWithValidSvgResponse(
+    WidgetTester tester,
+    String imageUrl,
+  ) {
+    return HttpOverrides.runZoned(
+      () async {
+        await tester.pumpWidget(buildAvatar(imageUrl: imageUrl));
+        await tester.pump();
+      },
+      createHttpClient: (_) => _ValidSvgHttpClient(),
     );
   }
 
@@ -204,6 +220,36 @@ void main() {
       expect(AvatarFailureCache.instance.isFailed(failedUrl), isTrue);
     });
 
+    testWidgets('SVG transient failures are cached briefly', (tester) async {
+      const failedUrl = 'https://divine.video/divine-logo.svg';
+
+      await pumpAvatarWithValidSvgResponse(tester, failedUrl);
+      final svg = tester.widget<SvgPicture>(find.byType(SvgPicture));
+
+      svg.errorBuilder!(
+        tester.element(find.byType(SvgPicture)),
+        Exception('HTTP 503'),
+        StackTrace.current,
+      );
+
+      expect(AvatarFailureCache.instance.isFailed(failedUrl), isTrue);
+    });
+
+    testWidgets('SVG load cancellations are not cached', (tester) async {
+      const cancelledUrl = 'https://divine.video/divine-logo.svg';
+
+      await pumpAvatarWithValidSvgResponse(tester, cancelledUrl);
+      final svg = tester.widget<SvgPicture>(find.byType(SvgPicture));
+
+      svg.errorBuilder!(
+        tester.element(find.byType(SvgPicture)),
+        Exception('SvgPicture load cancelled'),
+        StackTrace.current,
+      );
+
+      expect(AvatarFailureCache.instance.isFailed(cancelledUrl), isFalse);
+    });
+
     testWidgets('raster load cancellations are not cached', (tester) async {
       const cancelledUrl = 'https://divine.video/avatar.png';
 
@@ -247,4 +293,111 @@ void main() {
       expect(find.byType(VineCachedImage), findsNothing);
     });
   });
+}
+
+class _ValidSvgHttpClient implements HttpClient {
+  @override
+  Future<HttpClientRequest> openUrl(String method, Uri url) async =>
+      _ValidSvgRequest();
+
+  @override
+  Future<HttpClientRequest> getUrl(Uri url) async => _ValidSvgRequest();
+
+  @override
+  void close({bool force = false}) {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _ValidSvgRequest implements HttpClientRequest {
+  final _headers = _EmptyHttpHeaders();
+
+  @override
+  bool followRedirects = true;
+
+  @override
+  int maxRedirects = 5;
+
+  @override
+  bool persistentConnection = false;
+
+  @override
+  int contentLength = 0;
+
+  @override
+  HttpHeaders get headers => _headers;
+
+  @override
+  Future<void> addStream(Stream<List<int>> stream) async {
+    await stream.drain<void>();
+  }
+
+  @override
+  Future<HttpClientResponse> close() async => _ValidSvgResponse();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _ValidSvgResponse extends Stream<List<int>>
+    implements HttpClientResponse {
+  _ValidSvgResponse()
+    : _body = utf8.encode(
+        '<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1" />',
+      );
+
+  final List<int> _body;
+  final _headers = _EmptyHttpHeaders();
+
+  @override
+  int get statusCode => HttpStatus.ok;
+
+  @override
+  int get contentLength => _body.length;
+
+  @override
+  bool get persistentConnection => false;
+
+  @override
+  HttpHeaders get headers => _headers;
+
+  @override
+  bool get isRedirect => false;
+
+  @override
+  List<RedirectInfo> get redirects => const [];
+
+  @override
+  String get reasonPhrase => 'OK';
+
+  @override
+  HttpClientResponseCompressionState get compressionState =>
+      HttpClientResponseCompressionState.notCompressed;
+
+  @override
+  StreamSubscription<List<int>> listen(
+    void Function(List<int> event)? onData, {
+    Function? onError,
+    void Function()? onDone,
+    bool? cancelOnError,
+  }) {
+    return Stream<List<int>>.value(_body).listen(
+      onData,
+      onError: onError,
+      onDone: onDone,
+      cancelOnError: cancelOnError,
+    );
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _EmptyHttpHeaders implements HttpHeaders {
+  @override
+  void forEach(void Function(String name, List<String> values) action) {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/mobile/test/widgets/user_avatar_svg_test.dart
+++ b/mobile/test/widgets/user_avatar_svg_test.dart
@@ -4,11 +4,16 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:media_cache/media_cache.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:openvine/widgets/avatar_failure_cache.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
+
+class _MockMediaCacheManager extends Mock implements MediaCacheManager {}
 
 final Uint8List _transparentImageBytes = Uint8List.fromList(<int>[
   0x89,
@@ -250,22 +255,56 @@ void main() {
       expect(AvatarFailureCache.instance.isFailed(cancelledUrl), isFalse);
     });
 
-    testWidgets('raster load cancellations are not cached', (tester) async {
-      const cancelledUrl = 'https://divine.video/avatar.png';
+    testWidgets('raster completed download failures are cached', (
+      tester,
+    ) async {
+      const failedUrl = 'https://blotcdn.com/broken-avatar.png';
 
-      await tester.pumpWidget(buildAvatar(imageUrl: cancelledUrl));
+      await tester.pumpWidget(buildAvatar(imageUrl: failedUrl));
       final image = tester.widget<VineCachedImage>(
         find.byType(VineCachedImage),
       );
 
       image.errorWidget!(
         tester.element(find.byType(VineCachedImage)),
-        cancelledUrl,
-        Exception('MediaCacheImageProvider load cancelled'),
+        failedUrl,
+        const MediaCacheImageLoadException(failedUrl),
       );
 
-      expect(AvatarFailureCache.instance.isFailed(cancelledUrl), isFalse);
+      expect(AvatarFailureCache.instance.isFailed(failedUrl), isTrue);
     });
+
+    testWidgets(
+      'caches a broken raster URL through the real image provider',
+      (tester) async {
+        const brokenUrl = 'https://blotcdn.com/dead-avatar.png';
+        final cache = _MockMediaCacheManager();
+        when(
+          () => cache.getFileFromCache(any()),
+        ).thenAnswer((_) async => null);
+        when(
+          () => cache.cacheFileCancellable(
+            any(),
+            key: any(named: 'key'),
+            aliasKey: any(named: 'aliasKey'),
+            authHeaders: any(named: 'authHeaders'),
+          ),
+          // An empty stream resolves the download to a null file — exactly
+          // what a dead URL (non-2xx / DNS failure) produces in production.
+        ).thenReturn(
+          CancellableCacheOperation.fromStream(
+            const Stream<FileResponse>.empty(),
+          ),
+        );
+        debugImageCacheOverride = cache;
+        addTearDown(() => debugImageCacheOverride = null);
+
+        await tester.pumpWidget(buildAvatar(imageUrl: brokenUrl));
+        await tester.pumpAndSettle();
+
+        expect(AvatarFailureCache.instance.isFailed(brokenUrl), isTrue);
+      },
+    );
 
     testWidgets('keeps raster avatar URLs on VineCachedImage', (tester) async {
       await tester.pumpWidget(

--- a/mobile/test/widgets/user_avatar_svg_test.dart
+++ b/mobile/test/widgets/user_avatar_svg_test.dart
@@ -1,7 +1,9 @@
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/widgets/avatar_failure_cache.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
 
@@ -84,6 +86,22 @@ void main() {
     );
   }
 
+  Finder gradientPlaceholderFinder() => find.byWidgetPredicate((widget) {
+    if (widget is! DecoratedBox) return false;
+    final decoration = widget.decoration;
+    return decoration is BoxDecoration && decoration.gradient != null;
+  }, description: 'generated avatar placeholder');
+
+  setUp(() {
+    AvatarFailureCache.instance.clear();
+    AvatarFailureCache.instance.resetClockForTesting();
+  });
+
+  tearDown(() {
+    AvatarFailureCache.instance.clear();
+    AvatarFailureCache.instance.resetClockForTesting();
+  });
+
   group('UserAvatar.isSvgImageUrl', () {
     test('returns true for svg URLs', () {
       expect(
@@ -116,6 +134,93 @@ void main() {
   });
 
   group('UserAvatar rendering', () {
+    testWidgets('skips SvgPicture for cached failed SVG avatar URLs', (
+      tester,
+    ) async {
+      const failedUrl = 'https://divine.video/divine-logo.svg';
+      AvatarFailureCache.instance.recordFailure(
+        failedUrl,
+        ttl: AvatarFailureCache.deterministicFailureTtl,
+      );
+
+      await tester.pumpWidget(buildAvatar(imageUrl: failedUrl));
+
+      expect(find.byType(SvgPicture), findsNothing);
+      expect(find.byType(VineCachedImage), findsNothing);
+      expect(gradientPlaceholderFinder(), findsAtLeastNWidgets(1));
+    });
+
+    testWidgets('skips VineCachedImage for cached failed raster avatar URLs', (
+      tester,
+    ) async {
+      const failedUrl = 'https://divine.video/avatar.png';
+      AvatarFailureCache.instance.recordFailure(
+        failedUrl,
+        ttl: AvatarFailureCache.deterministicFailureTtl,
+      );
+
+      await tester.pumpWidget(buildAvatar(imageUrl: failedUrl));
+
+      expect(find.byType(SvgPicture), findsNothing);
+      expect(find.byType(VineCachedImage), findsNothing);
+      expect(gradientPlaceholderFinder(), findsAtLeastNWidgets(1));
+    });
+
+    testWidgets('cached failures are scoped to the exact avatar URL', (
+      tester,
+    ) async {
+      const failedUrl = 'https://divine.video/broken-avatar.png';
+      const workingUrl = 'https://divine.video/avatar.png';
+      AvatarFailureCache.instance.recordFailure(
+        failedUrl,
+        ttl: AvatarFailureCache.deterministicFailureTtl,
+      );
+
+      await tester.pumpWidget(buildAvatar(imageUrl: failedUrl));
+      expect(find.byType(VineCachedImage), findsNothing);
+
+      await tester.pumpWidget(buildAvatar(imageUrl: workingUrl));
+      expect(find.byType(VineCachedImage), findsOneWidget);
+      expect(
+        tester.widget<VineCachedImage>(find.byType(VineCachedImage)).imageUrl,
+        workingUrl,
+      );
+    });
+
+    testWidgets('raster deterministic failures are cached', (tester) async {
+      const failedUrl = 'https://divine.video/avatar.png';
+
+      await tester.pumpWidget(buildAvatar(imageUrl: failedUrl));
+      final image = tester.widget<VineCachedImage>(
+        find.byType(VineCachedImage),
+      );
+
+      image.errorWidget!(
+        tester.element(find.byType(VineCachedImage)),
+        failedUrl,
+        Exception('Invalid image data'),
+      );
+
+      expect(AvatarFailureCache.instance.isFailed(failedUrl), isTrue);
+    });
+
+    testWidgets('raster load cancellations are not cached', (tester) async {
+      const cancelledUrl = 'https://divine.video/avatar.png';
+
+      await tester.pumpWidget(buildAvatar(imageUrl: cancelledUrl));
+      final image = tester.widget<VineCachedImage>(
+        find.byType(VineCachedImage),
+      );
+
+      image.errorWidget!(
+        tester.element(find.byType(VineCachedImage)),
+        cancelledUrl,
+        Exception('MediaCacheImageProvider load cancelled'),
+      );
+
+      expect(AvatarFailureCache.instance.isFailed(cancelledUrl), isFalse);
+    });
+
     testWidgets('keeps raster avatar URLs on VineCachedImage', (tester) async {
       await tester.pumpWidget(
         buildAvatar(imageUrl: 'https://divine.video/avatar.png'),

--- a/mobile/test/widgets/user_avatar_svg_test.dart
+++ b/mobile/test/widgets/user_avatar_svg_test.dart
@@ -240,19 +240,38 @@ void main() {
       expect(AvatarFailureCache.instance.isFailed(failedUrl), isTrue);
     });
 
-    testWidgets('SVG load cancellations are not cached', (tester) async {
-      const cancelledUrl = 'https://divine.video/divine-logo.svg';
+    testWidgets('caches malformed SVG errors from the real parser', (
+      tester,
+    ) async {
+      const failedUrl = 'https://divine.video/malformed-avatar.svg';
+      Object? parsingError;
 
-      await pumpAvatarWithValidSvgResponse(tester, cancelledUrl);
+      await tester.pumpWidget(
+        SvgPicture.string(
+          '<!-- invalid svg -->',
+          errorBuilder: (context, error, stackTrace) {
+            parsingError = error;
+            return const SizedBox.shrink();
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(parsingError, isNotNull);
+      expect(
+        AvatarFailureCache.classifyFailure(parsingError!),
+        AvatarFailureKind.deterministic,
+      );
+
+      await pumpAvatarWithValidSvgResponse(tester, failedUrl);
       final svg = tester.widget<SvgPicture>(find.byType(SvgPicture));
-
       svg.errorBuilder!(
         tester.element(find.byType(SvgPicture)),
-        Exception('SvgPicture load cancelled'),
+        parsingError!,
         StackTrace.current,
       );
 
-      expect(AvatarFailureCache.instance.isFailed(cancelledUrl), isFalse);
+      expect(AvatarFailureCache.instance.isFailed(failedUrl), isTrue);
     });
 
     testWidgets('raster completed download failures are cached', (


### PR DESCRIPTION
## Summary
- Add a bounded TTL negative cache for avatar image URLs that fail to load.
- Short-circuit cached failed SVG and raster avatar URLs to the existing generated placeholder.
- Classify raster failures so deterministic codec/data errors get a longer cache TTL, transient failures get a short TTL, and load cancellations are not cached.

## Root Cause
`UserAvatar` is stateless and had no memory of failed network avatar URLs. Rebuilt list rows would retry the same broken URL and re-log the same failure each time.

## Validation
- `flutter analyze lib test`
- `flutter test test/widgets/user_avatar_svg_test.dart test/widgets/avatar_failure_cache_test.dart test/widgets/comprehensive_user_avatar_test.dart`
- Pre-push hook: analyzer and changed-file tests passed

Closes #5940