### PR TITLE
perf(badges): batch dashboard relay lookups instead of serial awaits

### DIFF
--- a/mobile/lib/services/badges/badge_repository.dart
+++ b/mobile/lib/services/badges/badge_repository.dart
@@ -111,35 +111,58 @@ class BadgeRepository {
   final BadgeEventSigner _signEvent;
 
   Future<BadgeDashboardData> loadDashboard() async {
-    final awarded = await loadAwardedBadges();
-    final issued = await loadIssuedBadges();
-    return BadgeDashboardData(awarded: awarded, issued: issued);
+    final memo = _DashboardLookupMemo();
+    final awardedFuture = _loadAwardedBadges(memo);
+    final issuedFuture = _loadIssuedBadges(memo);
+    await Future.wait<void>([awardedFuture, issuedFuture]);
+    return BadgeDashboardData(
+      awarded: await awardedFuture,
+      issued: await issuedFuture,
+    );
   }
 
-  Future<List<BadgeAwardViewData>> loadAwardedBadges() async {
+  Future<List<BadgeAwardViewData>> loadAwardedBadges() =>
+      _loadAwardedBadges(_DashboardLookupMemo());
+
+  Future<List<BadgeAwardViewData>> _loadAwardedBadges(
+    _DashboardLookupMemo memo,
+  ) async {
     final pubkey = _requireCurrentPubkey();
     final dismissedAwardIds = _dismissedAwardIds(pubkey);
-    final awards = await _queryAwardsForRecipient(pubkey);
-    final profileBadges = await _latestProfileBadges(pubkey);
-
-    final viewData = <BadgeAwardViewData>[];
-    for (final award in awards) {
-      if (dismissedAwardIds.contains(award.event.id)) continue;
-
-      final definition = await _loadDefinition(award.definitionCoordinate);
-      viewData.add(
-        BadgeAwardViewData(
-          award: award,
-          definition: definition,
-          isAccepted: _containsAward(profileBadges, award),
-        ),
-      );
-    }
-
-    viewData.sort(
-      (left, right) =>
-          right.award.event.createdAt.compareTo(left.award.event.createdAt),
+    final awardsFuture = _queryAwardsForRecipient(pubkey);
+    final profileBadgesFuture = memo.profileBadges(
+      pubkey,
+      () => _latestProfileBadges(pubkey),
     );
+    // Future.wait (not sequential awaits) so a failure in one query cannot
+    // leave the other as an unawaited error.
+    final results = await Future.wait<Object?>([
+      awardsFuture,
+      profileBadgesFuture,
+    ]);
+    final awards = results[0]! as List<Nip58BadgeAward>;
+    final profileBadges = results[1] as Nip58ProfileBadges?;
+
+    final visibleAwards = [
+      for (final award in awards)
+        if (!dismissedAwardIds.contains(award.event.id)) award,
+    ];
+    final definitions = await _definitionsByCoordinate(memo, [
+      for (final award in visibleAwards) award.definitionCoordinate,
+    ]);
+
+    final viewData =
+        [
+          for (final award in visibleAwards)
+            BadgeAwardViewData(
+              award: award,
+              definition: definitions[award.definitionCoordinate],
+              isAccepted: _containsAward(profileBadges, award),
+            ),
+        ]..sort(
+          (left, right) =>
+              right.award.event.createdAt.compareTo(left.award.event.createdAt),
+        );
     return List<BadgeAwardViewData>.unmodifiable(viewData);
   }
 
@@ -170,47 +193,90 @@ class BadgeRepository {
 
   Future<List<IssuedBadgeViewData>> loadIssuedBadges({
     int recipientCheckLimit = 50,
+  }) => _loadIssuedBadges(
+    _DashboardLookupMemo(),
+    recipientCheckLimit: recipientCheckLimit,
+  );
+
+  Future<List<IssuedBadgeViewData>> _loadIssuedBadges(
+    _DashboardLookupMemo memo, {
+    int recipientCheckLimit = 50,
   }) async {
     final pubkey = _requireCurrentPubkey();
     final events = await _nostrClient.queryEvents([
       Filter(authors: [pubkey], kinds: [EventKind.badgeAward], limit: 100),
     ]);
 
-    final issued = <IssuedBadgeViewData>[];
-    for (final event in events) {
-      final award = Nip58BadgeParser.parseAward(event);
-      if (award == null) continue;
-
-      final definition = await _loadDefinition(award.definitionCoordinate);
-      final recipients = <IssuedBadgeRecipientViewData>[];
-      for (final recipientPubkey in award.recipientPubkeys.take(
-        recipientCheckLimit,
-      )) {
-        final profileBadges = await _latestProfileBadges(recipientPubkey);
-        recipients.add(
-          IssuedBadgeRecipientViewData(
-            pubkey: recipientPubkey,
-            isAccepted: _containsAward(profileBadges, award),
-          ),
+    final awards = events
+        .map(Nip58BadgeParser.parseAward)
+        .whereType<Nip58BadgeAward>()
+        .toList(growable: false);
+    List<String> cappedRecipients(Nip58BadgeAward award) => award
+        .recipientPubkeys
+        .take(recipientCheckLimit)
+        .toList(
+          growable: false,
         );
-      }
 
-      issued.add(
-        IssuedBadgeViewData(
-          award: award,
-          definition: definition,
-          recipients: List<IssuedBadgeRecipientViewData>.unmodifiable(
-            recipients,
-          ),
-        ),
-      );
-    }
+    final definitionsFuture = _definitionsByCoordinate(memo, [
+      for (final award in awards) award.definitionCoordinate,
+    ]);
+    final profileBadgesFuture = _profileBadgesByPubkey(memo, [
+      for (final award in awards) ...cappedRecipients(award),
+    ]);
+    final results = await Future.wait<Object?>([
+      definitionsFuture,
+      profileBadgesFuture,
+    ]);
+    final definitions = results[0]! as Map<String, Nip58BadgeDefinition?>;
+    final profileBadges = results[1]! as Map<String, Nip58ProfileBadges?>;
 
-    issued.sort(
-      (left, right) =>
-          right.award.event.createdAt.compareTo(left.award.event.createdAt),
-    );
+    final issued =
+        [
+          for (final award in awards)
+            IssuedBadgeViewData(
+              award: award,
+              definition: definitions[award.definitionCoordinate],
+              recipients: List<IssuedBadgeRecipientViewData>.unmodifiable([
+                for (final recipientPubkey in cappedRecipients(award))
+                  IssuedBadgeRecipientViewData(
+                    pubkey: recipientPubkey,
+                    isAccepted: _containsAward(
+                      profileBadges[recipientPubkey],
+                      award,
+                    ),
+                  ),
+              ]),
+            ),
+        ]..sort(
+          (left, right) =>
+              right.award.event.createdAt.compareTo(left.award.event.createdAt),
+        );
     return List<IssuedBadgeViewData>.unmodifiable(issued);
+  }
+
+  Future<Map<String, Nip58BadgeDefinition?>> _definitionsByCoordinate(
+    _DashboardLookupMemo memo,
+    Iterable<String> coordinates,
+  ) async {
+    final unique = coordinates.toSet().toList(growable: false);
+    final loaded = await Future.wait([
+      for (final coordinate in unique)
+        memo.definition(coordinate, () => _loadDefinition(coordinate)),
+    ]);
+    return {for (var i = 0; i < unique.length; i++) unique[i]: loaded[i]};
+  }
+
+  Future<Map<String, Nip58ProfileBadges?>> _profileBadgesByPubkey(
+    _DashboardLookupMemo memo,
+    Iterable<String> pubkeys,
+  ) async {
+    final unique = pubkeys.toSet().toList(growable: false);
+    final loaded = await Future.wait([
+      for (final pubkey in unique)
+        memo.profileBadges(pubkey, () => _latestProfileBadges(pubkey)),
+    ]);
+    return {for (var i = 0; i < unique.length; i++) unique[i]: loaded[i]};
   }
 
   Future<void> acceptAward(BadgeAwardViewData award) async {
@@ -277,21 +343,23 @@ class BadgeRepository {
   }
 
   Future<Nip58ProfileBadges?> _latestProfileBadges(String pubkey) async {
-    final currentEvents = await _nostrClient.queryEvents([
-      Filter(authors: [pubkey], kinds: [EventKind.profileBadges], limit: 10),
+    // Both kinds are queried concurrently; the current kind keeps
+    // precedence and legacy is consulted only when it parses to nothing.
+    final results = await Future.wait([
+      _nostrClient.queryEvents([
+        Filter(authors: [pubkey], kinds: [EventKind.profileBadges], limit: 10),
+      ]),
+      _nostrClient.queryEvents([
+        Filter(
+          authors: [pubkey],
+          kinds: [EventKind.badgeSet],
+          d: ['profile_badges'],
+          limit: 10,
+        ),
+      ]),
     ]);
-    final current = _newestParsedProfileBadges(currentEvents);
-    if (current != null) return current;
-
-    final legacyEvents = await _nostrClient.queryEvents([
-      Filter(
-        authors: [pubkey],
-        kinds: [EventKind.badgeSet],
-        d: ['profile_badges'],
-        limit: 10,
-      ),
-    ]);
-    return _newestParsedProfileBadges(legacyEvents);
+    return _newestParsedProfileBadges(results[0]) ??
+        _newestParsedProfileBadges(results[1]);
   }
 
   Future<Nip58BadgeDefinition?> _loadDefinition(String coordinate) async {
@@ -408,6 +476,27 @@ class BadgeRepository {
   static String _dismissedAwardsKey(String pubkey) {
     return 'dismissed_badge_awards_$pubkey';
   }
+}
+
+/// Deduplicates identical relay lookups within one dashboard load pass.
+///
+/// Memoizes futures so concurrent requests for the same definition
+/// coordinate or pubkey share a single relay query. Created per public
+/// load call — never stored on the repository — so a failed pass does not
+/// poison a retry with cached errors.
+class _DashboardLookupMemo {
+  final Map<String, Future<Nip58BadgeDefinition?>> _definitions = {};
+  final Map<String, Future<Nip58ProfileBadges?>> _profileBadges = {};
+
+  Future<Nip58BadgeDefinition?> definition(
+    String coordinate,
+    Future<Nip58BadgeDefinition?> Function() load,
+  ) => _definitions.putIfAbsent(coordinate, load);
+
+  Future<Nip58ProfileBadges?> profileBadges(
+    String pubkey,
+    Future<Nip58ProfileBadges?> Function() load,
+  ) => _profileBadges.putIfAbsent(pubkey, load);
 }
 
 String _definitionNameFromCoordinate(String coordinate) {

--- a/mobile/test/services/badges/badge_repository_test.dart
+++ b/mobile/test/services/badges/badge_repository_test.dart
@@ -268,6 +268,229 @@ void main() {
       );
     });
 
+    test('loadAwardedBadges loads each unique definition once', () async {
+      final coordinate = '30009:${_pubkey(2)}:daily-diviner';
+      final awardA = _awardEvent(
+        id: _eventId(20),
+        issuerPubkey: _pubkey(2),
+        definitionCoordinate: coordinate,
+        recipients: [_pubkey(1)],
+      );
+      final awardB = _awardEvent(
+        id: _eventId(21),
+        issuerPubkey: _pubkey(2),
+        definitionCoordinate: coordinate,
+        recipients: [_pubkey(1)],
+      );
+      final definition = _definitionEvent(
+        pubkey: _pubkey(2),
+        dTag: 'daily-diviner',
+        name: 'Diviner of the Day',
+      );
+      final callCounts = _stubQueries(nostrClient, {
+        'awarded': [awardA, awardB],
+        'definition:$coordinate': [definition],
+      });
+
+      final awards = await repository.loadAwardedBadges();
+
+      expect(awards, hasLength(2));
+      expect(
+        awards.map((award) => award.definition?.name),
+        everyElement('Diviner of the Day'),
+      );
+      expect(callCounts['definition:$coordinate'], 1);
+    });
+
+    test(
+      'loadIssuedBadges checks each unique recipient once across awards',
+      () async {
+        final coordinate = '30009:${_pubkey(1)}:creator-badge';
+        final awardA = _awardEvent(
+          id: _eventId(32),
+          issuerPubkey: _pubkey(1),
+          definitionCoordinate: coordinate,
+          recipients: [_pubkey(2)],
+        );
+        final awardB = _awardEvent(
+          id: _eventId(33),
+          issuerPubkey: _pubkey(1),
+          definitionCoordinate: coordinate,
+          recipients: [_pubkey(2)],
+        );
+        final callCounts = _stubQueries(nostrClient, {
+          'issued': [awardA, awardB],
+        });
+
+        final issued = await repository.loadIssuedBadges();
+
+        expect(issued, hasLength(2));
+        expect(callCounts['profileCurrent:${_pubkey(2)}'], 1);
+        expect(callCounts['profileLegacy:${_pubkey(2)}'], 1);
+        expect(callCounts['definition:$coordinate'], 1);
+      },
+    );
+
+    test(
+      'loadDashboard shares the own profile badges lookup between halves',
+      () async {
+        final awardedAward = _awardEvent(
+          id: _eventId(22),
+          issuerPubkey: _pubkey(2),
+          definitionCoordinate: '30009:${_pubkey(2)}:daily-diviner',
+          recipients: [_pubkey(1)],
+        );
+        final selfIssuedAward = _awardEvent(
+          id: _eventId(23),
+          issuerPubkey: _pubkey(1),
+          definitionCoordinate: '30009:${_pubkey(1)}:creator-badge',
+          recipients: [_pubkey(1)],
+        );
+        final callCounts = _stubQueries(nostrClient, {
+          'awarded': [awardedAward],
+          'issued': [selfIssuedAward],
+        });
+
+        final dashboard = await repository.loadDashboard();
+
+        expect(dashboard.awarded, hasLength(1));
+        expect(dashboard.issued, hasLength(1));
+        expect(callCounts['profileCurrent:${_pubkey(1)}'], 1);
+        expect(callCounts['profileLegacy:${_pubkey(1)}'], 1);
+      },
+    );
+
+    test('loadAwardedBadges rethrows when a definition query fails', () async {
+      final coordinate = '30009:${_pubkey(2)}:daily-diviner';
+      final award = _awardEvent(
+        id: _eventId(24),
+        issuerPubkey: _pubkey(2),
+        definitionCoordinate: coordinate,
+        recipients: [_pubkey(1)],
+      );
+      _stubQueries(
+        nostrClient,
+        {
+          'awarded': [award],
+        },
+        errorsByQueryKey: {
+          'definition:$coordinate': Exception('relay unavailable'),
+        },
+      );
+
+      await expectLater(repository.loadAwardedBadges(), throwsException);
+    });
+
+    test(
+      'loadIssuedBadges preserves recipient order under concurrency',
+      () async {
+        final coordinate = '30009:${_pubkey(1)}:creator-badge';
+        final award = _awardEvent(
+          id: _eventId(25),
+          issuerPubkey: _pubkey(1),
+          definitionCoordinate: coordinate,
+          recipients: [_pubkey(2), _pubkey(3)],
+        );
+        final acceptance = _profileBadgesEvent(
+          id: _eventId(26),
+          pubkey: _pubkey(3),
+          tags: [
+            ['a', coordinate],
+            ['e', _eventId(25)],
+          ],
+        );
+        _stubQueries(
+          nostrClient,
+          {
+            'issued': [award],
+            'profileCurrent:${_pubkey(3)}': [acceptance],
+          },
+          delaysByQueryKey: {
+            'profileCurrent:${_pubkey(2)}': const Duration(milliseconds: 40),
+            'profileCurrent:${_pubkey(3)}': const Duration(milliseconds: 1),
+          },
+        );
+
+        final issued = await repository.loadIssuedBadges();
+
+        final recipients = issued.single.recipients;
+        expect(
+          [for (final recipient in recipients) recipient.pubkey],
+          [_pubkey(2), _pubkey(3)],
+        );
+        expect(recipients[0].isAccepted, isFalse);
+        expect(recipients[1].isAccepted, isTrue);
+      },
+    );
+
+    test(
+      'loadAwardedBadges prefers current profile badges over newer legacy',
+      () async {
+        final coordinate = '30009:${_pubkey(2)}:daily-diviner';
+        final award = _awardEvent(
+          id: _eventId(27),
+          issuerPubkey: _pubkey(2),
+          definitionCoordinate: coordinate,
+          recipients: [_pubkey(1)],
+        );
+        final currentProfileBadges = _profileBadgesEvent(
+          id: _eventId(28),
+          pubkey: _pubkey(1),
+          tags: [
+            ['a', coordinate],
+            ['e', _eventId(27)],
+          ],
+        );
+        final newerLegacyWithoutAward = _event(
+          id: _eventId(29),
+          pubkey: _pubkey(1),
+          kind: EventKind.badgeSet,
+          createdAt: 2000,
+          tags: [
+            ['d', 'profile_badges'],
+            ['a', '30009:${_pubkey(3)}:weekly-diviner'],
+            ['e', _eventId(30)],
+          ],
+        );
+        _stubQueries(nostrClient, {
+          'awarded': [award],
+          'profileCurrent:${_pubkey(1)}': [currentProfileBadges],
+          'profileLegacy:${_pubkey(1)}': [newerLegacyWithoutAward],
+        });
+
+        final awards = await repository.loadAwardedBadges();
+
+        expect(awards.single.isAccepted, isTrue);
+      },
+    );
+
+    test(
+      'loadIssuedBadges caps recipient checks at recipientCheckLimit',
+      () async {
+        final award = _awardEvent(
+          id: _eventId(31),
+          issuerPubkey: _pubkey(1),
+          definitionCoordinate: '30009:${_pubkey(1)}:creator-badge',
+          recipients: [_pubkey(2), _pubkey(3), _pubkey(4)],
+        );
+        final callCounts = _stubQueries(nostrClient, {
+          'issued': [award],
+        });
+
+        final issued = await repository.loadIssuedBadges(
+          recipientCheckLimit: 2,
+        );
+
+        expect(
+          [
+            for (final recipient in issued.single.recipients) recipient.pubkey,
+          ],
+          [_pubkey(2), _pubkey(3)],
+        );
+        expect(callCounts['profileCurrent:${_pubkey(4)}'], isNull);
+      },
+    );
+
     test(
       'loadIssuedBadges marks recipients accepted when they publish award',
       () async {
@@ -301,16 +524,31 @@ void main() {
   });
 }
 
-void _stubQueries(
+/// Stubs [NostrClient.queryEvents] with answer-keyed canned events and
+/// returns a live map of query-key invocation counts for dedup assertions.
+Map<String, int> _stubQueries(
   _MockNostrClient nostrClient,
-  Map<String, List<Event>> eventsByQueryKey,
-) {
+  Map<String, List<Event>> eventsByQueryKey, {
+  Map<String, Duration> delaysByQueryKey = const {},
+  Map<String, Object> errorsByQueryKey = const {},
+}) {
+  final callCounts = <String, int>{};
   when(() => nostrClient.queryEvents(any())).thenAnswer((invocation) async {
     final filters = invocation.positionalArguments.single as List<Filter>;
     final filter = filters.single;
     final key = _queryKey(filter);
+    callCounts.update(key, (count) => count + 1, ifAbsent: () => 1);
+    final delay = delaysByQueryKey[key];
+    if (delay != null) {
+      await Future<void>.delayed(delay);
+    }
+    final error = errorsByQueryKey[key];
+    if (error != null) {
+      throw error;
+    }
     return eventsByQueryKey[key] ?? const <Event>[];
   });
+  return callCounts;
 }
 
 String _queryKey(Filter filter) {


### PR DESCRIPTION
## Description

`BadgeRepository`'s dashboard paths issued every relay query strictly sequentially: one `_loadDefinition` await per award, and per issued badge one definition await plus one `_latestProfileBadges` await per recipient — where each profile-badges lookup is itself two serial queries (kind 10008 primary, kind 30008 `d=profile_badges` legacy fallback). For a high-volume issuer account (~100 award events) that is ~300 sequential round-trips, tens of seconds at typical relay latency. Verified empirically against `wss://relay.divine.video`: acceptance data lives on kind 30008, so the legacy fallback runs on every lookup, and repeated awards reuse a handful of definition coordinates, making duplicate lookups the dominant cost.

This PR keeps every query shape unchanged (single-filter calls, `limit:1` definition semantics, local-cache merge intact) and changes only scheduling and deduplication inside the repository:

- `loadDashboard` runs the awarded and issued halves concurrently and shares one per-pass lookup memo between them.
- `_loadAwardedBadges` / `_loadIssuedBadges` collect unique definition coordinates and unique (capped) recipient pubkeys, then `Future.wait` memoized lookup futures; results are reassembled by index so recipient order stays pinned to p-tag order, and both lists keep their existing `createdAt` sort.
- `_latestProfileBadges` fires the current-kind and legacy-kind queries concurrently with unchanged precedence (current kind wins whenever it parses to anything).
- Error behavior is preserved: `Future.wait` defaults rethrow the first failure after all futures settle, so any query failure still surfaces as a thrown error to `BadgesCubit` (→ `BadgesStatus.error`); there is no catch-and-null anywhere.
- Concurrency is bounded by the existing `NostrClient.maxConcurrentQueries = 6` query pool, whose doc comment names badge fan-out as an intended consumer, so no bespoke limiter is added and the relay's concurrent-REQ limits are respected.

The memo lives per load call (never on the repository instance), so a failed pass cannot poison a retry and there is no cross-pass staleness.

**Related Issue:** Closes #3865

## Out of Scope

- Combining lookups into wide multi-item filters (fewest possible REQs). Deliberately deferred: it trades new correctness surface (NIP-01 cross-product matching, per-filter limit headroom, chunking under relay filter/frame limits) for speed the dashboard does not currently need. Escalation path documented in the issue investigation.
- #5937 — badge acceptance publishes kind 10008, which the relay's allow-list blocks (found during this investigation). This PR stays kind-agnostic: it changes when the two profile-badges kinds are queried, not which kinds are queried or published.

## Verification

- `dart format --output=none --set-exit-if-changed` on changed files — clean
- `flutter analyze lib test integration_test` — no issues
- `flutter test test/services/badges/badge_repository_test.dart test/blocs/badges/badges_cubit_test.dart` — 21 tests pass (14 pre-existing pass unchanged, which pins that no public behavior changed; 7 new)
- `flutter test test/screens/badges/badges_screen_test.dart test/widgets/profile/profile_header_widget_test.dart` — 64 tests pass
- New tests cover: definition dedup within a pass, recipient dedup across awards, own-profile lookup shared across the dashboard halves, error rethrow when a definition query fails, recipient-order preservation under out-of-order async completion, current-kind precedence over a newer legacy event, and `recipientCheckLimit` capping (including that uncapped recipients are never queried).

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
