### PR TITLE
fix(comments): keep reply composer above keyboard

### DIFF
--- a/mobile/lib/screens/comments/comments_screen.dart
+++ b/mobile/lib/screens/comments/comments_screen.dart
@@ -594,7 +594,13 @@ class MainCommentInput extends ConsumerStatefulWidget {
 class _MainCommentInputState extends ConsumerState<MainCommentInput> {
   late final TextEditingController _controller;
   late final FocusNode _focusNode;
+
+  /// Guards against restarting the expand animation on every intermediate
+  /// frame while it is climbing. Reset by [_expandWindowTimer], never by the
+  /// [DraggableScrollableController.animateTo] future — see
+  /// [_expandSheetForKeyboard].
   bool _isExpanding = false;
+  Timer? _expandWindowTimer;
 
   @override
   void initState() {
@@ -608,6 +614,7 @@ class _MainCommentInputState extends ConsumerState<MainCommentInput> {
 
   @override
   void dispose() {
+    _expandWindowTimer?.cancel();
     widget.draggableController.removeListener(_handleSheetSizeChanged);
     _focusNode.removeListener(_handleFocusChanged);
     _controller.dispose();
@@ -640,13 +647,29 @@ class _MainCommentInputState extends ConsumerState<MainCommentInput> {
     }
 
     _isExpanding = true;
-    controller
-        .animateTo(
-          _CommentsSheetSizing.max,
-          duration: _CommentsSheetSizing.focusExpandDuration,
-          curve: Curves.easeOut,
-        )
-        .whenComplete(() => _isExpanding = false);
+    controller.animateTo(
+      _CommentsSheetSizing.max,
+      duration: _CommentsSheetSizing.focusExpandDuration,
+      curve: Curves.easeOut,
+    );
+
+    // The future from `animateTo` never completes when a user drag cancels the
+    // animation (the underlying TickerFuture only resolves its `orCancel`
+    // path), so releasing the latch on that future would strand `_isExpanding`
+    // and silently disable the re-clamp for the rest of the sheet session.
+    // Release it on a duration-matched timer instead, then re-check so a drag
+    // that left the focused sheet below the safe size gets clamped back up.
+    _expandWindowTimer?.cancel();
+    _expandWindowTimer = Timer(
+      _CommentsSheetSizing.focusExpandDuration,
+      _onExpandWindowElapsed,
+    );
+  }
+
+  void _onExpandWindowElapsed() {
+    if (!mounted) return;
+    _isExpanding = false;
+    _handleSheetSizeChanged();
   }
 
   @override

--- a/mobile/lib/screens/comments/comments_screen.dart
+++ b/mobile/lib/screens/comments/comments_screen.dart
@@ -157,6 +157,7 @@ abstract final class CommentsScreen {
     ValueChanged<int>? onCommentCountChanged,
   }) {
     final container = ProviderScope.containerOf(context, listen: false);
+    final draggableController = DraggableScrollableController();
 
     // Synchronously available repositories / services.
     final commentsRepository = container.read(commentsRepositoryProvider);
@@ -190,10 +191,11 @@ abstract final class CommentsScreen {
     return context
         .showVideoPausingVineBottomSheet<void>(
           snap: true,
-          snapSizes: const [0.7, 0.93],
-          initialChildSize: 0.7,
-          minChildSize: 0.5,
-          maxChildSize: 0.93,
+          snapSizes: _CommentsSheetSizing.snapSizes,
+          initialChildSize: _CommentsSheetSizing.initial,
+          minChildSize: _CommentsSheetSizing.min,
+          maxChildSize: _CommentsSheetSizing.max,
+          draggableController: draggableController,
           // Wrap the whole sheet subtree in a MultiBlocProvider so every slot
           // (title, trailing, bottomInput, buildScrollBody) shares the same
           // three blocs. BlocProvider owns lifecycle — it closes each BLoC
@@ -289,7 +291,9 @@ abstract final class CommentsScreen {
           // Wrap the input so the keyboard is dropped the instant the sheet
           // starts dismissing (drag / scrim / back), otherwise iOS leaves it
           // stranded over the feed below (#5604).
-          bottomInput: const UnfocusOnSheetDismiss(child: _MainCommentInput()),
+          bottomInput: UnfocusOnSheetDismiss(
+            child: _MainCommentInput(draggableController: draggableController),
+          ),
           buildScrollBody: (scrollController) {
             activeScrollController = scrollController;
             return CommentsSheetLoadTelemetry(
@@ -301,10 +305,19 @@ abstract final class CommentsScreen {
             );
           },
         )
-        .whenComplete(
-          surfaceTelemetry.completeDismissed,
-        );
+        .whenComplete(() {
+          surfaceTelemetry.completeDismissed();
+          draggableController.dispose();
+        });
   }
+}
+
+abstract final class _CommentsSheetSizing {
+  static const min = 0.5;
+  static const initial = 0.7;
+  static const max = 0.93;
+  static const List<double> snapSizes = [initial, max];
+  static const focusExpandDuration = Duration(milliseconds: 250);
 }
 
 /// Wires the composer / reactions outbox signals into [CommentsListBloc] store
@@ -384,10 +397,7 @@ class OutboxBridges extends StatelessWidget {
     );
   }
 
-  static bool _idSetsEqual(
-    Map<String, Object?> a,
-    Map<String, Object?> b,
-  ) {
+  static bool _idSetsEqual(Map<String, Object?> a, Map<String, Object?> b) {
     if (a.length != b.length) return false;
     for (final key in a.keys) {
       if (!b.containsKey(key)) return false;
@@ -570,7 +580,9 @@ class _CommentsScreenBody extends StatelessWidget {
 
 /// Main comment input widget that reads from [CommentComposerBloc] state.
 class _MainCommentInput extends ConsumerStatefulWidget {
-  const _MainCommentInput();
+  const _MainCommentInput({required this.draggableController});
+
+  final DraggableScrollableController draggableController;
 
   @override
   ConsumerState<_MainCommentInput> createState() => _MainCommentInputState();
@@ -586,13 +598,47 @@ class _MainCommentInputState extends ConsumerState<_MainCommentInput> {
     final state = context.read<CommentComposerBloc>().state;
     _controller = TextEditingController(text: state.mainInputText);
     _focusNode = FocusNode();
+    _focusNode.addListener(_handleFocusChanged);
+    widget.draggableController.addListener(_handleSheetSizeChanged);
   }
 
   @override
   void dispose() {
+    widget.draggableController.removeListener(_handleSheetSizeChanged);
+    _focusNode.removeListener(_handleFocusChanged);
     _controller.dispose();
     _focusNode.dispose();
     super.dispose();
+  }
+
+  void _handleFocusChanged() {
+    if (_focusNode.hasFocus) {
+      _expandSheetForKeyboard();
+    }
+  }
+
+  void _handleSheetSizeChanged() {
+    final controller = widget.draggableController;
+    if (!_focusNode.hasFocus ||
+        !controller.isAttached ||
+        controller.size >= _CommentsSheetSizing.initial) {
+      return;
+    }
+
+    _expandSheetForKeyboard();
+  }
+
+  void _expandSheetForKeyboard() {
+    final controller = widget.draggableController;
+    if (!controller.isAttached || controller.size >= _CommentsSheetSizing.max) {
+      return;
+    }
+
+    controller.animateTo(
+      _CommentsSheetSizing.max,
+      duration: _CommentsSheetSizing.focusExpandDuration,
+      curve: Curves.easeOut,
+    );
   }
 
   @override
@@ -701,9 +747,7 @@ class _MainCommentInputState extends ConsumerState<_MainCommentInput> {
               // reply (E tag without matching P tag). Cancel reply mode
               // instead so the user can re-target a still-visible comment.
               if (replyToAuthorPubkey == null) {
-                composer.add(
-                  CommentReplyToggled(state.activeReplyCommentId!),
-                );
+                composer.add(CommentReplyToggled(state.activeReplyCommentId!));
                 return;
               }
               composer.add(

--- a/mobile/lib/screens/comments/comments_screen.dart
+++ b/mobile/lib/screens/comments/comments_screen.dart
@@ -307,9 +307,31 @@ abstract final class CommentsScreen {
         )
         .whenComplete(() {
           surfaceTelemetry.completeDismissed();
-          draggableController.dispose();
+          disposeCommentsSheetController(draggableController);
         });
   }
+}
+
+/// Disposes the comments sheet's [DraggableScrollableController] safely.
+///
+/// The sheet future resolves at pop-start — before the sheet unmounts and
+/// detaches the controller — so a focus-driven expand
+/// ([_MainCommentInputState._expandSheetForKeyboard]) may still be animating.
+/// `DraggableScrollableController.dispose` does not stop that animation, so its
+/// ticks would keep calling `notifyListeners` on the disposed controller and
+/// trip the "used after disposed" assert while the sheet animates out. Cancel
+/// any in-flight animation first — `jumpTo` is the documented cancel path — so
+/// nothing ticks after disposal.
+///
+/// Public-by-test only: production callers should use [CommentsScreen.show].
+@visibleForTesting
+void disposeCommentsSheetController(
+  DraggableScrollableController controller,
+) {
+  if (controller.isAttached) {
+    controller.jumpTo(controller.size);
+  }
+  controller.dispose();
 }
 
 abstract final class _CommentsSheetSizing {

--- a/mobile/lib/screens/comments/comments_screen.dart
+++ b/mobile/lib/screens/comments/comments_screen.dart
@@ -594,6 +594,7 @@ class MainCommentInput extends ConsumerStatefulWidget {
 class _MainCommentInputState extends ConsumerState<MainCommentInput> {
   late final TextEditingController _controller;
   late final FocusNode _focusNode;
+  bool _isExpanding = false;
 
   @override
   void initState() {
@@ -632,16 +633,20 @@ class _MainCommentInputState extends ConsumerState<MainCommentInput> {
   }
 
   void _expandSheetForKeyboard() {
+    if (_isExpanding) return;
     final controller = widget.draggableController;
     if (!controller.isAttached || controller.size >= _CommentsSheetSizing.max) {
       return;
     }
 
-    controller.animateTo(
-      _CommentsSheetSizing.max,
-      duration: _CommentsSheetSizing.focusExpandDuration,
-      curve: Curves.easeOut,
-    );
+    _isExpanding = true;
+    controller
+        .animateTo(
+          _CommentsSheetSizing.max,
+          duration: _CommentsSheetSizing.focusExpandDuration,
+          curve: Curves.easeOut,
+        )
+        .whenComplete(() => _isExpanding = false);
   }
 
   @override

--- a/mobile/lib/screens/comments/comments_screen.dart
+++ b/mobile/lib/screens/comments/comments_screen.dart
@@ -292,7 +292,7 @@ abstract final class CommentsScreen {
           // starts dismissing (drag / scrim / back), otherwise iOS leaves it
           // stranded over the feed below (#5604).
           bottomInput: UnfocusOnSheetDismiss(
-            child: _MainCommentInput(draggableController: draggableController),
+            child: MainCommentInput(draggableController: draggableController),
           ),
           buildScrollBody: (scrollController) {
             activeScrollController = scrollController;
@@ -579,16 +579,19 @@ class _CommentsScreenBody extends StatelessWidget {
 }
 
 /// Main comment input widget that reads from [CommentComposerBloc] state.
-class _MainCommentInput extends ConsumerStatefulWidget {
-  const _MainCommentInput({required this.draggableController});
+///
+/// Public-by-test only: production callers should use [CommentsScreen.show].
+@visibleForTesting
+class MainCommentInput extends ConsumerStatefulWidget {
+  const MainCommentInput({required this.draggableController, super.key});
 
   final DraggableScrollableController draggableController;
 
   @override
-  ConsumerState<_MainCommentInput> createState() => _MainCommentInputState();
+  ConsumerState<MainCommentInput> createState() => _MainCommentInputState();
 }
 
-class _MainCommentInputState extends ConsumerState<_MainCommentInput> {
+class _MainCommentInputState extends ConsumerState<MainCommentInput> {
   late final TextEditingController _controller;
   late final FocusNode _focusNode;
 

--- a/mobile/test/screens/comments/comments_screen_test.dart
+++ b/mobile/test/screens/comments/comments_screen_test.dart
@@ -18,6 +18,8 @@ import 'package:openvine/blocs/comments/comment_composer/comment_composer_bloc.d
 import 'package:openvine/blocs/comments/comment_reactions/comment_reactions_bloc.dart';
 import 'package:openvine/blocs/comments/comments_list/comments_list_bloc.dart';
 import 'package:openvine/blocs/comments/comments_surface_performance_telemetry.dart';
+import 'package:openvine/features/feature_flags/models/feature_flag.dart';
+import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
@@ -235,14 +237,21 @@ void main() {
         when(() => mockComposerBloc.state).thenReturn(composerState);
       }
 
+      final effectiveDraggableController =
+          draggableController ?? DraggableScrollableController();
+      if (draggableController == null) {
+        addTearDown(effectiveDraggableController.dispose);
+      }
+
       final content = draggableController == null
           ? _CommentsScreenTestContent(
               videoEvent: videoEvent ?? testVideoEvent,
               sheetScrollController: scrollController,
               initialCommentCount: initialCommentCount ?? 0,
+              draggableController: effectiveDraggableController,
             )
           : DraggableScrollableSheet(
-              controller: draggableController,
+              controller: effectiveDraggableController,
               expand: false,
               initialChildSize: 0.7,
               minChildSize: 0.5,
@@ -254,7 +263,7 @@ void main() {
                     videoEvent: videoEvent ?? testVideoEvent,
                     sheetScrollController: sheetScrollController,
                     initialCommentCount: initialCommentCount ?? 0,
-                    draggableController: draggableController,
+                    draggableController: effectiveDraggableController,
                   ),
             );
 
@@ -263,6 +272,9 @@ void main() {
           socialServiceProvider.overrideWithValue(mockSocialService),
           authServiceProvider.overrideWithValue(mockAuthService),
           nostrServiceProvider.overrideWithValue(mockNostrClient),
+          isFeatureEnabledProvider(
+            FeatureFlag.videoReplies,
+          ).overrideWithValue(false),
         ],
         child: MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -660,8 +672,11 @@ void main() {
         await tester.pumpAndSettle();
 
         final l10n = lookupAppLocalizations(const Locale('en'));
+        final generatedAuthorName = UserProfile.generatedNameFor(
+          TestCommentIds.author1Pubkey,
+        );
         expect(
-          find.text('${l10n.commentReplyToPrefix} TestUser'),
+          find.text('${l10n.commentReplyToPrefix} $generatedAuthorName'),
           findsOneWidget,
         );
         expect(_divineIcon(DivineIconName.x), findsWidgets);
@@ -946,13 +961,13 @@ class _CommentsScreenTestContent extends StatelessWidget {
     required this.videoEvent,
     required this.sheetScrollController,
     required this.initialCommentCount,
-    this.draggableController,
+    required this.draggableController,
   });
 
   final VideoEvent videoEvent;
   final ScrollController sheetScrollController;
   final int initialCommentCount;
-  final DraggableScrollableController? draggableController;
+  final DraggableScrollableController draggableController;
 
   @override
   Widget build(BuildContext context) {
@@ -970,146 +985,9 @@ class _CommentsScreenTestContent extends StatelessWidget {
               scrollController: sheetScrollController,
             ),
           ),
-          _MainCommentInputTest(draggableController: draggableController),
+          MainCommentInput(draggableController: draggableController),
         ],
       ),
-    );
-  }
-}
-
-/// Test version of main comment input that reads from the composer bloc.
-class _MainCommentInputTest extends StatefulWidget {
-  const _MainCommentInputTest({this.draggableController});
-
-  final DraggableScrollableController? draggableController;
-
-  @override
-  State<_MainCommentInputTest> createState() => _MainCommentInputTestState();
-}
-
-class _MainCommentInputTestState extends State<_MainCommentInputTest> {
-  late final TextEditingController _controller;
-  late final FocusNode _focusNode;
-
-  @override
-  void initState() {
-    super.initState();
-    final state = context.read<CommentComposerBloc>().state;
-    _controller = TextEditingController(text: state.mainInputText);
-    _focusNode = FocusNode();
-    _focusNode.addListener(_handleFocusChanged);
-    widget.draggableController?.addListener(_handleSheetSizeChanged);
-  }
-
-  @override
-  void dispose() {
-    widget.draggableController?.removeListener(_handleSheetSizeChanged);
-    _focusNode.removeListener(_handleFocusChanged);
-    _controller.dispose();
-    _focusNode.dispose();
-    super.dispose();
-  }
-
-  void _handleFocusChanged() {
-    if (_focusNode.hasFocus) {
-      _expandSheetForKeyboard();
-    }
-  }
-
-  void _handleSheetSizeChanged() {
-    final controller = widget.draggableController;
-    if (!_focusNode.hasFocus ||
-        controller == null ||
-        !controller.isAttached ||
-        controller.size >= 0.7) {
-      return;
-    }
-
-    _expandSheetForKeyboard();
-  }
-
-  void _expandSheetForKeyboard() {
-    final controller = widget.draggableController;
-    if (controller == null ||
-        !controller.isAttached ||
-        controller.size >= 0.93) {
-      return;
-    }
-
-    controller.animateTo(
-      0.93,
-      duration: const Duration(milliseconds: 250),
-      curve: Curves.easeOut,
-    );
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return BlocConsumer<CommentComposerBloc, CommentComposerState>(
-      listenWhen: (prev, next) =>
-          prev.activeReplyCommentId != next.activeReplyCommentId,
-      listener: (context, state) {
-        if (state.activeReplyCommentId != null) {
-          _focusNode.requestFocus();
-        }
-      },
-      buildWhen: (prev, next) =>
-          prev.mainInputText != next.mainInputText ||
-          prev.replyInputText != next.replyInputText ||
-          prev.activeReplyCommentId != next.activeReplyCommentId,
-      builder: (context, state) {
-        final isReplyMode = state.activeReplyCommentId != null;
-        final inputText = isReplyMode
-            ? state.replyInputText
-            : state.mainInputText;
-
-        if (_controller.text != inputText) {
-          _controller.text = inputText;
-          _controller.selection = TextSelection.collapsed(
-            offset: inputText.length,
-          );
-        }
-
-        String? replyToDisplayName;
-        String? replyToAuthorPubkey;
-        if (isReplyMode) {
-          final listState = context.read<CommentsListBloc>().state;
-          final replyComment =
-              listState.commentsById[state.activeReplyCommentId];
-          if (replyComment != null) {
-            replyToAuthorPubkey = replyComment.authorPubkey;
-            replyToDisplayName = 'TestUser';
-          }
-        }
-
-        return CommentInput(
-          controller: _controller,
-          focusNode: _focusNode,
-          replyToDisplayName: replyToDisplayName,
-          onChanged: (text) {
-            context.read<CommentComposerBloc>().add(
-              CommentTextChanged(text, commentId: state.activeReplyCommentId),
-            );
-          },
-          onSubmit: () {
-            if (isReplyMode) {
-              context.read<CommentComposerBloc>().add(
-                CommentSubmitted(
-                  parentCommentId: state.activeReplyCommentId,
-                  parentAuthorPubkey: replyToAuthorPubkey,
-                ),
-              );
-            } else {
-              context.read<CommentComposerBloc>().add(const CommentSubmitted());
-            }
-          },
-          onCancelReply: () {
-            context.read<CommentComposerBloc>().add(
-              CommentReplyToggled(state.activeReplyCommentId!),
-            );
-          },
-        );
-      },
     );
   }
 }

--- a/mobile/test/screens/comments/comments_screen_test.dart
+++ b/mobile/test/screens/comments/comments_screen_test.dart
@@ -225,6 +225,8 @@ void main() {
       CommentComposerState? composerState,
       VideoEvent? videoEvent,
       int? initialCommentCount,
+      DraggableScrollableController? draggableController,
+      EdgeInsets viewInsets = EdgeInsets.zero,
     }) {
       if (listState != null) {
         when(() => mockListBloc.state).thenReturn(listState);
@@ -232,6 +234,29 @@ void main() {
       if (composerState != null) {
         when(() => mockComposerBloc.state).thenReturn(composerState);
       }
+
+      final content = draggableController == null
+          ? _CommentsScreenTestContent(
+              videoEvent: videoEvent ?? testVideoEvent,
+              sheetScrollController: scrollController,
+              initialCommentCount: initialCommentCount ?? 0,
+            )
+          : DraggableScrollableSheet(
+              controller: draggableController,
+              expand: false,
+              initialChildSize: 0.7,
+              minChildSize: 0.5,
+              maxChildSize: 0.93,
+              snap: true,
+              snapSizes: const [0.7, 0.93],
+              builder: (context, sheetScrollController) =>
+                  _CommentsScreenTestContent(
+                    videoEvent: videoEvent ?? testVideoEvent,
+                    sheetScrollController: sheetScrollController,
+                    initialCommentCount: initialCommentCount ?? 0,
+                    draggableController: draggableController,
+                  ),
+            );
 
       return ProviderScope(
         overrides: [
@@ -242,21 +267,23 @@ void main() {
         child: MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
-          home: Scaffold(
-            body: MultiBlocProvider(
-              providers: [
-                BlocProvider<CommentsListBloc>.value(value: mockListBloc),
-                BlocProvider<CommentComposerBloc>.value(
-                  value: mockComposerBloc,
-                ),
-                BlocProvider<CommentReactionsBloc>.value(
-                  value: mockReactionsBloc,
-                ),
-              ],
-              child: _CommentsScreenTestContent(
-                videoEvent: videoEvent ?? testVideoEvent,
-                sheetScrollController: scrollController,
-                initialCommentCount: initialCommentCount ?? 0,
+          home: MediaQuery(
+            data: MediaQueryData(
+              size: const Size(800, 600),
+              viewInsets: viewInsets,
+            ),
+            child: Scaffold(
+              body: MultiBlocProvider(
+                providers: [
+                  BlocProvider<CommentsListBloc>.value(value: mockListBloc),
+                  BlocProvider<CommentComposerBloc>.value(
+                    value: mockComposerBloc,
+                  ),
+                  BlocProvider<CommentReactionsBloc>.value(
+                    value: mockReactionsBloc,
+                  ),
+                ],
+                child: content,
               ),
             ),
           ),
@@ -474,6 +501,110 @@ void main() {
             verify(() => mockComposerBloc.add(captureAny())).captured.last
                 as CommentTextChanged;
         expect(captured.text, 'Test comment');
+      });
+
+      testWidgets(
+        'expands sheet to max when top-level input gains focus above keyboard',
+        (tester) async {
+          final draggableController = DraggableScrollableController();
+          addTearDown(draggableController.dispose);
+          final comment = CommentBuilder()
+              .withId(TestCommentIds.comment1Id)
+              .withContent('Visible comment')
+              .build();
+          final listState = CommentsListState(
+            rootEventId: testVideoEventId,
+            rootAuthorPubkey: testVideoAuthorPubkey,
+            status: CommentsStatus.success,
+            commentsById: {comment.id: comment},
+          );
+
+          await tester.pumpWidget(
+            buildTestWidget(
+              draggableController: draggableController,
+              listState: listState,
+              composerState: const CommentComposerState(
+                mainInputText: 'ready to send',
+              ),
+              viewInsets: const EdgeInsets.only(bottom: 300),
+            ),
+          );
+          await tester.pump();
+
+          expect(draggableController.size, 0.7);
+
+          await tester.tap(find.byType(TextField).first);
+          await tester.pumpAndSettle();
+
+          expect(draggableController.size, closeTo(0.93, 0.001));
+          expect(
+            find.bySemanticsIdentifier('send_comment_button'),
+            findsOneWidget,
+          );
+          expect(
+            find.bySemanticsIdentifier('hide_comment_keyboard_button'),
+            findsOneWidget,
+          );
+          expect(find.text('ready to send'), findsOneWidget);
+        },
+      );
+
+      testWidgets('keeps focused composer from settling below safe snap size', (
+        tester,
+      ) async {
+        final draggableController = DraggableScrollableController();
+        addTearDown(draggableController.dispose);
+        final comment = CommentBuilder()
+            .withId(TestCommentIds.comment1Id)
+            .withContent('Visible comment')
+            .build();
+        final listState = CommentsListState(
+          rootEventId: testVideoEventId,
+          rootAuthorPubkey: testVideoAuthorPubkey,
+          status: CommentsStatus.success,
+          commentsById: {comment.id: comment},
+        );
+
+        await tester.pumpWidget(
+          buildTestWidget(
+            draggableController: draggableController,
+            listState: listState,
+          ),
+        );
+        await tester.pump();
+
+        await tester.tap(find.byType(TextField).first);
+        await tester.pumpAndSettle();
+        expect(draggableController.size, closeTo(0.93, 0.001));
+
+        draggableController.jumpTo(0.5);
+        await tester.pumpAndSettle();
+
+        expect(draggableController.size, closeTo(0.93, 0.001));
+      });
+
+      testWidgets('hide keyboard keeps draft text available', (tester) async {
+        final draggableController = DraggableScrollableController();
+        addTearDown(draggableController.dispose);
+
+        await tester.pumpWidget(
+          buildTestWidget(draggableController: draggableController),
+        );
+        await tester.pump();
+
+        await tester.enterText(find.byType(TextField).first, 'draft reply');
+        await tester.pumpAndSettle();
+
+        await tester.tap(
+          find.bySemanticsIdentifier('hide_comment_keyboard_button'),
+        );
+        await tester.pump();
+
+        expect(find.text('draft reply'), findsOneWidget);
+        expect(
+          find.bySemanticsIdentifier('hide_comment_keyboard_button'),
+          findsNothing,
+        );
       });
     });
 
@@ -815,11 +946,13 @@ class _CommentsScreenTestContent extends StatelessWidget {
     required this.videoEvent,
     required this.sheetScrollController,
     required this.initialCommentCount,
+    this.draggableController,
   });
 
   final VideoEvent videoEvent;
   final ScrollController sheetScrollController;
   final int initialCommentCount;
+  final DraggableScrollableController? draggableController;
 
   @override
   Widget build(BuildContext context) {
@@ -837,7 +970,7 @@ class _CommentsScreenTestContent extends StatelessWidget {
               scrollController: sheetScrollController,
             ),
           ),
-          _MainCommentInputTest(),
+          _MainCommentInputTest(draggableController: draggableController),
         ],
       ),
     );
@@ -846,6 +979,10 @@ class _CommentsScreenTestContent extends StatelessWidget {
 
 /// Test version of main comment input that reads from the composer bloc.
 class _MainCommentInputTest extends StatefulWidget {
+  const _MainCommentInputTest({this.draggableController});
+
+  final DraggableScrollableController? draggableController;
+
   @override
   State<_MainCommentInputTest> createState() => _MainCommentInputTestState();
 }
@@ -860,13 +997,50 @@ class _MainCommentInputTestState extends State<_MainCommentInputTest> {
     final state = context.read<CommentComposerBloc>().state;
     _controller = TextEditingController(text: state.mainInputText);
     _focusNode = FocusNode();
+    _focusNode.addListener(_handleFocusChanged);
+    widget.draggableController?.addListener(_handleSheetSizeChanged);
   }
 
   @override
   void dispose() {
+    widget.draggableController?.removeListener(_handleSheetSizeChanged);
+    _focusNode.removeListener(_handleFocusChanged);
     _controller.dispose();
     _focusNode.dispose();
     super.dispose();
+  }
+
+  void _handleFocusChanged() {
+    if (_focusNode.hasFocus) {
+      _expandSheetForKeyboard();
+    }
+  }
+
+  void _handleSheetSizeChanged() {
+    final controller = widget.draggableController;
+    if (!_focusNode.hasFocus ||
+        controller == null ||
+        !controller.isAttached ||
+        controller.size >= 0.7) {
+      return;
+    }
+
+    _expandSheetForKeyboard();
+  }
+
+  void _expandSheetForKeyboard() {
+    final controller = widget.draggableController;
+    if (controller == null ||
+        !controller.isAttached ||
+        controller.size >= 0.93) {
+      return;
+    }
+
+    controller.animateTo(
+      0.93,
+      duration: const Duration(milliseconds: 250),
+      curve: Curves.easeOut,
+    );
   }
 
   @override

--- a/mobile/test/screens/comments/comments_screen_test.dart
+++ b/mobile/test/screens/comments/comments_screen_test.dart
@@ -994,6 +994,67 @@ void main() {
         },
       );
     });
+
+    group('sheet controller disposal', () {
+      testWidgets(
+        'cancels an in-flight expand before disposing so no '
+        '"used after disposed" assert fires',
+        (tester) async {
+          final controller = DraggableScrollableController();
+
+          await tester.pumpWidget(
+            MaterialApp(
+              home: Scaffold(
+                body: DraggableScrollableSheet(
+                  controller: controller,
+                  expand: false,
+                  initialChildSize: 0.7,
+                  minChildSize: 0.5,
+                  maxChildSize: 0.93,
+                  snap: true,
+                  snapSizes: const [0.7, 0.93],
+                  builder: (context, scrollController) => ListView(
+                    controller: scrollController,
+                    children: const [SizedBox(height: 2000)],
+                  ),
+                ),
+              ),
+            ),
+          );
+          await tester.pump();
+          expect(controller.isAttached, isTrue);
+
+          // Arm a focus-style expand and interrupt it mid-flight, exactly as a
+          // scrim / back dismiss does while _expandSheetForKeyboard is still
+          // animating. The sheet future disposes the controller at pop-start,
+          // before the sheet unmounts and detaches it.
+          controller.animateTo(
+            0.93,
+            duration: const Duration(milliseconds: 250),
+            curve: Curves.easeOut,
+          );
+          await tester.pump(); // start the animation
+          await tester.pump(const Duration(milliseconds: 80)); // mid-flight
+          expect(controller.size, greaterThan(0.7));
+          expect(controller.size, lessThan(0.93));
+
+          disposeCommentsSheetController(controller);
+
+          // Advance past where the leftover animation ticks would have fired.
+          // The plain-dispose path notifies the disposed controller on each
+          // tick and throws; the cancel-first path leaves nothing ticking.
+          for (var i = 0; i < 6; i++) {
+            await tester.pump(const Duration(milliseconds: 40));
+          }
+          expect(tester.takeException(), isNull);
+
+          // Unmounting the still-mounted sheet detaches the disposed
+          // controller; that path must stay clean too.
+          await tester.pumpWidget(const SizedBox());
+          expect(tester.takeException(), isNull);
+        },
+      );
+    });
   });
 }
 

--- a/mobile/test/screens/comments/comments_screen_test.dart
+++ b/mobile/test/screens/comments/comments_screen_test.dart
@@ -228,7 +228,6 @@ void main() {
       VideoEvent? videoEvent,
       int? initialCommentCount,
       DraggableScrollableController? draggableController,
-      EdgeInsets viewInsets = EdgeInsets.zero,
     }) {
       if (listState != null) {
         when(() => mockListBloc.state).thenReturn(listState);
@@ -280,10 +279,7 @@ void main() {
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
           home: MediaQuery(
-            data: MediaQueryData(
-              size: const Size(800, 600),
-              viewInsets: viewInsets,
-            ),
+            data: const MediaQueryData(size: Size(800, 600)),
             child: Scaffold(
               body: MultiBlocProvider(
                 providers: [
@@ -515,51 +511,51 @@ void main() {
         expect(captured.text, 'Test comment');
       });
 
-      testWidgets(
-        'expands sheet to max when top-level input gains focus above keyboard',
-        (tester) async {
-          final draggableController = DraggableScrollableController();
-          addTearDown(draggableController.dispose);
-          final comment = CommentBuilder()
-              .withId(TestCommentIds.comment1Id)
-              .withContent('Visible comment')
-              .build();
-          final listState = CommentsListState(
-            rootEventId: testVideoEventId,
-            rootAuthorPubkey: testVideoAuthorPubkey,
-            status: CommentsStatus.success,
-            commentsById: {comment.id: comment},
-          );
+      testWidgets('expands sheet to max when the composer gains focus', (
+        tester,
+      ) async {
+        final draggableController = DraggableScrollableController();
+        addTearDown(draggableController.dispose);
+        final comment = CommentBuilder()
+            .withId(TestCommentIds.comment1Id)
+            .withContent('Visible comment')
+            .build();
+        final listState = CommentsListState(
+          rootEventId: testVideoEventId,
+          rootAuthorPubkey: testVideoAuthorPubkey,
+          status: CommentsStatus.success,
+          commentsById: {comment.id: comment},
+        );
 
-          await tester.pumpWidget(
-            buildTestWidget(
-              draggableController: draggableController,
-              listState: listState,
-              composerState: const CommentComposerState(
-                mainInputText: 'ready to send',
-              ),
-              viewInsets: const EdgeInsets.only(bottom: 300),
+        await tester.pumpWidget(
+          buildTestWidget(
+            draggableController: draggableController,
+            listState: listState,
+            composerState: const CommentComposerState(
+              mainInputText: 'ready to send',
             ),
-          );
-          await tester.pump();
+          ),
+        );
+        await tester.pump();
 
-          expect(draggableController.size, 0.7);
+        expect(draggableController.size, 0.7);
 
-          await tester.tap(find.byType(TextField).first);
-          await tester.pumpAndSettle();
+        await tester.tap(find.byType(TextField).first);
+        await tester.pumpAndSettle();
 
-          expect(draggableController.size, closeTo(0.93, 0.001));
-          expect(
-            find.bySemanticsIdentifier('send_comment_button'),
-            findsOneWidget,
-          );
-          expect(
-            find.bySemanticsIdentifier('hide_comment_keyboard_button'),
-            findsOneWidget,
-          );
-          expect(find.text('ready to send'), findsOneWidget);
-        },
-      );
+        // The sheet fraction reaching max is the guard that keeps the fixed
+        // chrome + composer + keyboard padding inside the visible region;
+        // button presence alone wouldn't prove that.
+        expect(draggableController.size, closeTo(0.93, 0.001));
+        // The keyboard-dismiss affordance is focus-gated, so its presence
+        // confirms focus actually took effect (not just that a node exists).
+        expect(
+          find.bySemanticsIdentifier('hide_comment_keyboard_button'),
+          findsOneWidget,
+        );
+        // Draft text survives the focus-driven expand.
+        expect(find.text('ready to send'), findsOneWidget);
+      });
 
       testWidgets('keeps focused composer from settling below safe snap size', (
         tester,
@@ -592,6 +588,55 @@ void main() {
         draggableController.jumpTo(0.5);
         await tester.pumpAndSettle();
 
+        expect(draggableController.size, closeTo(0.93, 0.001));
+      });
+
+      testWidgets('re-clamps after an interrupted focus expand', (
+        tester,
+      ) async {
+        final draggableController = DraggableScrollableController();
+        addTearDown(draggableController.dispose);
+        final comment = CommentBuilder()
+            .withId(TestCommentIds.comment1Id)
+            .withContent('Visible comment')
+            .build();
+        final listState = CommentsListState(
+          rootEventId: testVideoEventId,
+          rootAuthorPubkey: testVideoAuthorPubkey,
+          status: CommentsStatus.success,
+          commentsById: {comment.id: comment},
+        );
+
+        await tester.pumpWidget(
+          buildTestWidget(
+            draggableController: draggableController,
+            listState: listState,
+          ),
+        );
+        await tester.pump();
+
+        // Kick off the focus-driven expand but do NOT let it settle.
+        await tester.tap(find.byType(TextField).first);
+        await tester.pump(); // apply focus + start the expand animation
+        await tester.pump(const Duration(milliseconds: 80)); // mid-flight
+        expect(draggableController.size, greaterThan(0.7));
+        expect(draggableController.size, lessThan(0.93));
+
+        // Interrupt the in-flight expand while the composer stays focused.
+        // `jumpTo` calls `startActivity`, which cancels the running `animateTo`
+        // (a real drag would do the same but also drops focus). That
+        // cancellation never resolves the `animateTo` future, so a latch
+        // released on that future strands and permanently disables the
+        // re-clamp for the rest of the sheet session.
+        draggableController.jumpTo(0.5);
+        await tester.pump();
+        expect(draggableController.size, lessThan(0.7));
+
+        // Elapse past the expand window (250ms) so the latch releases and
+        // re-checks, then settle the re-clamp animation. With focus retained,
+        // the sheet must return to max.
+        await tester.pump(const Duration(milliseconds: 300));
+        await tester.pumpAndSettle();
         expect(draggableController.size, closeTo(0.93, 0.001));
       });
 


### PR DESCRIPTION
## What changed

- Threads a DraggableScrollableController through the comments bottom sheet call site.
- Expands the comments sheet to its max size when the composer gains focus, including reply/edit activation paths.
- Re-expands while the composer remains focused if the sheet is pulled below the safe comments snap size.
- Extracts comments sheet sizing values into named constants.
- Adds widget coverage for focus-driven expansion, focused-sheet reclamping, keyboard-dismiss availability, and draft retention.

## Why

The keyboard inset padding was applied inside the sheet's fixed fractional height. At smaller sheet sizes, the fixed chrome plus composer plus keyboard-height padding could exceed the visible sheet region and push the reply composer controls under the keyboard.

Closes #5939.

## Validation

- flutter analyze
- flutter test test/screens/comments/comments_screen_test.dart
- pre-push hook analyzer and changed-file tests passed