### PR TITLE
refactor(providers): replace private Riverpod src imports

### DIFF
--- a/mobile/analysis_options.yaml
+++ b/mobile/analysis_options.yaml
@@ -57,7 +57,6 @@ linter:
     cancel_subscriptions: false
     depend_on_referenced_packages: false
     flutter_style_todos: false
-    implementation_imports: false
     lines_longer_than_80_chars: false
     missing_code_block_language_in_doc_comment: false
     no_default_cases: false

--- a/mobile/lib/providers/feed_refresh_helpers.dart
+++ b/mobile/lib/providers/feed_refresh_helpers.dart
@@ -1,9 +1,9 @@
 // ABOUTME: Shared helpers for explore feed providers
 // ABOUTME: Extracts common stale-while-revalidate refresh pattern and utility functions
 
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:models/models.dart';
 import 'package:openvine/state/video_feed_state.dart';
-import 'package:riverpod/riverpod.dart';
 
 /// Implements the stale-while-revalidate pattern for feed refresh.
 ///

--- a/mobile/lib/providers/feed_viewer_preference_hints.dart
+++ b/mobile/lib/providers/feed_viewer_preference_hints.dart
@@ -4,11 +4,11 @@
 import 'dart:async';
 import 'dart:ui';
 
+import 'package:flutter_riverpod/misc.dart';
 import 'package:openvine/providers/permissions_providers.dart';
 import 'package:openvine/providers/preferences_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/services/locale_preference_service.dart';
-import 'package:riverpod/misc.dart';
 
 const _countryHintTimeout = Duration(milliseconds: 250);
 

--- a/mobile/lib/providers/og_viner_cache_provider.dart
+++ b/mobile/lib/providers/og_viner_cache_provider.dart
@@ -2,9 +2,9 @@
 // ABOUTME: Keeps badge reads local-only and avoids per-user server lookups.
 
 import 'package:flutter_riverpod/legacy.dart';
+import 'package:flutter_riverpod/misc.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/services/og_viner_cache_service.dart';
-import 'package:riverpod/misc.dart';
 
 final ogVinerCacheServiceProvider = ChangeNotifierProvider<OgVinerCacheService>(
   (ref) {

--- a/mobile/lib/providers/relay_discovery_provider.dart
+++ b/mobile/lib/providers/relay_discovery_provider.dart
@@ -2,9 +2,9 @@
 // ABOUTME: Manages relay discovery lifecycle and provides access to the service
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart';
 import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/services/relay_discovery_service.dart';
-import 'package:riverpod/src/providers/future_provider.dart';
 
 /// Provider for RelayDiscoveryService
 final relayDiscoveryServiceProvider = Provider<RelayDiscoveryService>((ref) {

--- a/mobile/lib/router/providers/page_context_provider.dart
+++ b/mobile/lib/router/providers/page_context_provider.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Derived provider that parses router location into structured context
 // ABOUTME: Single source of truth for "what page are we on?" with route types and parsing
 
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/features/people_lists/view/create_people_list_page.dart';
 import 'package:openvine/notifications/view/notifications_page.dart';
 import 'package:openvine/router/router.dart';
@@ -53,7 +54,6 @@ import 'package:openvine/screens/video_editor/video_editor_screen.dart';
 import 'package:openvine/screens/video_metadata/video_metadata_edit_screen.dart';
 import 'package:openvine/screens/video_metadata/video_metadata_screen.dart';
 import 'package:openvine/screens/video_recorder_screen.dart';
-import 'package:riverpod/riverpod.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Route types supported by the app

--- a/mobile/lib/router/providers/redirect_provider.dart
+++ b/mobile/lib/router/providers/redirect_provider.dart
@@ -3,10 +3,11 @@
 
 import 'dart:convert';
 
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/screens/auth/welcome_screen.dart';
 import 'package:openvine/screens/explore/explore_screen.dart';
-import 'package:riverpod/src/providers/provider.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Checks if the current user has any following in cache.

--- a/mobile/lib/router/providers/router_location_provider.dart
+++ b/mobile/lib/router/providers/router_location_provider.dart
@@ -3,8 +3,8 @@
 
 import 'dart:async';
 
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/router/app_router.dart';
-import 'package:riverpod/riverpod.dart';
 
 /// Provider that exposes the raw router location stream
 ///

--- a/mobile/test/providers/classic_vines_refresh_test.dart
+++ b/mobile/test/providers/classic_vines_refresh_test.dart
@@ -4,6 +4,7 @@
 import 'dart:async';
 
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:mocktail/mocktail.dart';
@@ -14,7 +15,6 @@ import 'package:openvine/providers/curation_providers.dart';
 import 'package:openvine/providers/readiness_gate_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/services/video_event_service.dart';
-import 'package:riverpod/riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class _MockFunnelcakeApiClient extends Mock implements FunnelcakeApiClient {}

--- a/mobile/test/providers/curation_provider_lifecycle_test.dart
+++ b/mobile/test/providers/curation_provider_lifecycle_test.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Verifies editor's picks persist when navigating away and back to tab
 
 import 'package:curation_repository/curation_repository.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:likes_repository/likes_repository.dart';
@@ -16,7 +17,6 @@ import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/social_service.dart';
 import 'package:openvine/services/video_event_service.dart';
-import 'package:riverpod/riverpod.dart';
 
 class _MockNostrClient extends Mock implements NostrClient {}
 

--- a/mobile/test/providers/curation_provider_tab_refresh_test.dart
+++ b/mobile/test/providers/curation_provider_tab_refresh_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Tests that curation provider refreshes when Editor's Pick tab becomes active
 // ABOUTME: Verifies the fix for videos showing blank when navigating from video back to tab
 
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:likes_repository/likes_repository.dart';
@@ -14,7 +15,6 @@ import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/social_service.dart';
 import 'package:openvine/services/video_event_service.dart';
-import 'package:riverpod/riverpod.dart';
 
 class _MockNostrClient extends Mock implements NostrClient {}
 

--- a/mobile/test/providers/database_provider_test.dart
+++ b/mobile/test/providers/database_provider_test.dart
@@ -5,10 +5,10 @@ import 'dart:io';
 
 import 'package:db_client/db_client.dart';
 import 'package:drift/native.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/providers/database_provider.dart';
 import 'package:path/path.dart' as p;
-import 'package:riverpod/riverpod.dart';
 
 void main() {
   group('Database Provider', () {

--- a/mobile/test/providers/feed_background_preservation_test.dart
+++ b/mobile/test/providers/feed_background_preservation_test.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Verifies fix for feeds going empty when app resumes from background
 
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:mocktail/mocktail.dart';
@@ -12,7 +13,6 @@ import 'package:openvine/providers/curation_providers.dart';
 import 'package:openvine/providers/readiness_gate_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/services/video_event_service.dart';
-import 'package:riverpod/riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class _MockFunnelcakeApiClient extends Mock implements FunnelcakeApiClient {}

--- a/mobile/test/providers/feed_refresh_helpers_test.dart
+++ b/mobile/test/providers/feed_refresh_helpers_test.dart
@@ -1,9 +1,9 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart';
 import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/providers/feed_refresh_helpers.dart';
 import 'package:openvine/state/video_feed_state.dart';
-import 'package:riverpod/riverpod.dart';
 
 void main() {
   group('staleWhileRevalidate', () {

--- a/mobile/test/providers/feed_viewer_preference_hints_test.dart
+++ b/mobile/test/providers/feed_viewer_preference_hints_test.dart
@@ -1,13 +1,13 @@
 import 'dart:async';
 import 'dart:ui';
 
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/providers/feed_viewer_preference_hints.dart';
 import 'package:openvine/providers/permissions_providers.dart';
 import 'package:openvine/providers/preferences_providers.dart';
 import 'package:openvine/services/geo_blocking_service.dart';
 import 'package:openvine/services/language_preference_service.dart';
-import 'package:riverpod/riverpod.dart';
 
 class _TestLanguagePreferenceService extends LanguagePreferenceService {
   _TestLanguagePreferenceService(this._contentLanguage);

--- a/mobile/test/providers/funnelcake_available_provider_test.dart
+++ b/mobile/test/providers/funnelcake_available_provider_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Tests for FunnelcakeAvailable provider fast-path and probe logic
 // ABOUTME: Verifies Divine relay detection skips probe, unknown relays still probe
 
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:mocktail/mocktail.dart';
@@ -10,7 +11,6 @@ import 'package:openvine/models/environment_config.dart';
 import 'package:openvine/providers/curation_providers.dart';
 import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
-import 'package:riverpod/riverpod.dart';
 
 class _MockNostrClient extends Mock implements NostrClient {}
 

--- a/mobile/test/providers/og_viner_cache_provider_test.dart
+++ b/mobile/test/providers/og_viner_cache_provider_test.dart
@@ -3,12 +3,12 @@
 
 import 'dart:convert';
 
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart';
 import 'package:openvine/providers/og_viner_cache_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/services/og_viner_cache_service.dart';
-import 'package:riverpod/riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {


### PR DESCRIPTION
## Description

Removes the two `package:riverpod/src/...` implementation imports and re-enables the `implementation_imports` lint so the analyzer catches any future private import.

**Commit 1 — the #3341 fix.** `redirect_provider.dart` and `relay_discovery_provider.dart` annotate providers with `ProviderFamily` / `FutureProviderFamily`, type names Riverpod 3 exports only from its secondary public entrypoint `misc.dart` — not from `flutter_riverpod.dart`. When PR #1649 added those annotations, an IDE quick-fix imported the defining `riverpod/src` files instead, and the same commit disabled `implementation_imports`, so nothing flagged it. The fix swaps the src imports for `package:flutter_riverpod/flutter_riverpod.dart` + `package:flutter_riverpod/misc.dart` — the exact pattern already used by `video_reply_parent_provider.dart`, `active_video_provider.dart`, and `repository_providers.dart` — and deletes the `implementation_imports: false` override (very_good_analysis enables the rule).

**Commit 2 — public riverpod-import migration.** `riverpod` is only a transitive dependency; `flutter_riverpod` is the declared one and re-exports the identical library with an exact version pin. The 14 remaining files importing `package:riverpod/riverpod.dart` / `package:riverpod/misc.dart` (5 lib, 9 test) now import the `flutter_riverpod` equivalents. An export-surface audit of flutter_riverpod 3.3.2 confirmed every symbol maps 1:1 (`riverpod.dart` ⊂ `flutter_riverpod.dart`, `misc.dart` ⊆ `misc.dart`), so this is a zero-behavior-change swap. After this PR, no file under `lib/`, `test/`, or `integration_test/` imports `package:riverpod` at all.

**Related Issue:** Closes #3341, relates to #3342

## Out of Scope

The remaining #3342 items: the `**/packages/**` analyzer exclusion, `depend_on_referenced_packages`, and the `errors:` ignores in `mobile/analysis_options.yaml`.

## Verification

- `flutter analyze lib test integration_test` — clean (the CI command; verified it exits non-zero on an `implementation_imports` violation before the fix, so the re-enabled lint is an enforced guard, not advisory)
- 13 targeted test files (the 9 touched `test/providers/*` suites plus `page_context_provider_test.dart`, `router_location_provider_test.dart`, `empty_contacts_redirect_test.dart`, `relay_discovery_service_test.dart`) — 79 passed
- `grep -rn "package:riverpod/" lib test integration_test` — zero matches
- `dart format` — no changes needed

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore