### PR TITLE
fix(c2pa): clarify signing TLS failures

### DIFF
--- a/mobile/lib/services/c2pa_signing_service.dart
+++ b/mobile/lib/services/c2pa_signing_service.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 
 import 'package:c2pa_flutter/c2pa.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:openvine/services/c2pa_identity_manifest_service.dart';
 import 'package:openvine/services/nostr_creator_binding_service.dart';
 import 'package:package_info_plus/package_info_plus.dart';
@@ -24,12 +25,22 @@ abstract class C2paEditActions {
   static const String edited = 'c2pa.edited';
 }
 
+/// High-level reason a C2PA signing operation failed.
+enum C2paSigningFailureReason {
+  inputMissing,
+  outputMissing,
+  tls,
+  network,
+  other,
+}
+
 /// Result of a C2PA signing operation
 class C2paSigningResult {
   const C2paSigningResult({
     required this.signedFilePath,
     required this.success,
     this.error,
+    this.failureReason,
   });
 
   /// Path to the signed video file
@@ -40,6 +51,9 @@ class C2paSigningResult {
 
   /// Error message if signing failed
   final String? error;
+
+  /// Machine-readable reason when signing failed.
+  final C2paSigningFailureReason? failureReason;
 }
 
 /// Service for signing videos with C2PA content credentials.
@@ -87,6 +101,7 @@ class C2paSigningService {
           signedFilePath: videoPath,
           success: false,
           error: 'Input file does not exist',
+          failureReason: C2paSigningFailureReason.inputMissing,
         );
       }
 
@@ -136,6 +151,7 @@ class C2paSigningService {
           signedFilePath: videoPath,
           success: false,
           error: 'Signed file was not created',
+          failureReason: C2paSigningFailureReason.outputMissing,
         );
       }
 
@@ -154,8 +170,9 @@ class C2paSigningService {
 
       return C2paSigningResult(signedFilePath: sFileNew.path, success: true);
     } catch (e, stackTrace) {
+      final failureReason = classifyFailureReason(e);
       Log.error(
-        'C2PA signing failed: $e',
+        'C2PA signing failed (${failureReason.name}): $e',
         name: 'C2paSigningService',
         category: LogCategory.video,
         error: e,
@@ -167,6 +184,7 @@ class C2paSigningService {
         signedFilePath: videoPath,
         success: false,
         error: e.toString(),
+        failureReason: failureReason,
       );
     }
   }
@@ -284,6 +302,49 @@ class C2paSigningService {
         error: e.toString(),
       );
     }
+  }
+
+  @visibleForTesting
+  static C2paSigningFailureReason classifyFailureReason(Object error) {
+    final message = switch (error) {
+      PlatformException(:final code, :final message, :final details) =>
+        '$code $message $details'.toLowerCase(),
+      _ => error.toString().toLowerCase(),
+    };
+
+    if (_containsAny(message, const [
+      'tls',
+      'ssl',
+      'secure connection',
+      'certificate',
+      'cert chain',
+      'trust',
+      'handshake',
+    ])) {
+      return C2paSigningFailureReason.tls;
+    }
+
+    if (_containsAny(message, const [
+      'network',
+      'not connected',
+      'connection',
+      'timed out',
+      'timeout',
+      'offline',
+      'host',
+      'dns',
+      'socket',
+      'internet',
+      'reset by peer',
+    ])) {
+      return C2paSigningFailureReason.network;
+    }
+
+    return C2paSigningFailureReason.other;
+  }
+
+  static bool _containsAny(String message, List<String> needles) {
+    return needles.any(message.contains);
   }
 
   /// Reads and validates C2PA manifest from a signed file.

--- a/mobile/lib/services/c2pa_signing_service.dart
+++ b/mobile/lib/services/c2pa_signing_service.dart
@@ -327,6 +327,7 @@ class C2paSigningService {
     if (_containsAny(message, const [
       'network',
       'not connected',
+      'connect',
       'connection',
       'timed out',
       'timeout',

--- a/mobile/lib/services/native_proofmode_service.dart
+++ b/mobile/lib/services/native_proofmode_service.dart
@@ -5,6 +5,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:app_device_integrity/app_device_integrity.dart';
+import 'package:c2pa_flutter/c2pa.dart';
 import 'package:crypto/crypto.dart' as crypto;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
@@ -33,6 +34,9 @@ class NativeProofModeService {
     Map<String, dynamic>? editorStateHistory,
   })?
   proofFileOverride;
+
+  @visibleForTesting
+  static C2paSigningService Function()? c2paSigningServiceFactoryOverride;
 
   /// Generate native ProofMode proof for a video file.
   ///
@@ -89,7 +93,8 @@ class NativeProofModeService {
         return null;
       }
 
-      final C2paSigningService c2paSigningService = C2paSigningService();
+      final c2paSigningService =
+          c2paSigningServiceFactoryOverride?.call() ?? C2paSigningService();
 
       try {
         final String proofHash = await generateSha256FileHash(videoFile.path);
@@ -169,21 +174,31 @@ class NativeProofModeService {
 
       if (c2paResult.success) {
         Log.info(
-          'C2PA signing complete: $c2paResult.signedFilePath : File Length=${videoFile.lengthSync()}',
+          'C2PA signing complete: ${c2paResult.signedFilePath} : File Length=${videoFile.lengthSync()}',
           name: 'VideoRecorderProofService',
           category: LogCategory.video,
         );
       } else {
         Log.warning(
-          'C2PA signing failed (continuing without): ${c2paResult.error}',
+          'C2PA signing failed (${c2paResult.failureReason?.name ?? 'unknown'}; continuing without): ${c2paResult.error}',
           name: 'VideoRecorderProofService',
           category: LogCategory.video,
         );
       }
 
-      final manifestInfo = await c2paSigningService.readManifest(
-        c2paResult.signedFilePath,
-      );
+      final ManifestStoreInfo? manifestInfo;
+      if (c2paResult.success) {
+        manifestInfo = await c2paSigningService.readManifest(
+          c2paResult.signedFilePath,
+        );
+      } else {
+        manifestInfo = null;
+        Log.info(
+          'Skipping C2PA manifest read after failed signing (${c2paResult.failureReason?.name ?? 'unknown'})',
+          name: 'VideoRecorderProofService',
+          category: LogCategory.video,
+        );
+      }
       if (manifestInfo?.validationStatus != null) {
         Log.debug('C2PA Active Manifest ID: ${manifestInfo?.activeManifest}');
       }

--- a/mobile/test/services/c2pa_signing_service_test.dart
+++ b/mobile/test/services/c2pa_signing_service_test.dart
@@ -2,7 +2,6 @@
 // ABOUTME: Covers typed failures, manifest gates, and parent ingredients
 
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:c2pa_flutter/c2pa.dart';
 import 'package:flutter/services.dart';
@@ -69,6 +68,17 @@ void main() {
           PlatformException(
             code: 'C2PA_ERROR',
             message: 'Connection reset by peer',
+          ),
+        );
+
+        expect(reason, C2paSigningFailureReason.network);
+      });
+
+      test('classifies cannot-connect failures as network errors', () {
+        final reason = C2paSigningService.classifyFailureReason(
+          PlatformException(
+            code: 'C2PA_ERROR',
+            message: 'Could not connect to the server.',
           ),
         );
 

--- a/mobile/test/services/c2pa_signing_service_test.dart
+++ b/mobile/test/services/c2pa_signing_service_test.dart
@@ -1,10 +1,11 @@
-// ABOUTME: Tests for C2paSigningService.resignDerived carry-forward behaviour
-// ABOUTME: Covers the manifest-present gate and the parent-ingredient re-sign
+// ABOUTME: Tests C2PA signing failure handling and derived-file re-signing
+// ABOUTME: Covers typed failures, manifest gates, and parent ingredients
 
 import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:c2pa_flutter/c2pa.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/services/c2pa_signing_service.dart';
@@ -50,6 +51,49 @@ void main() {
       final file = File('${tempDir.path}/$name')..writeAsBytesSync(bytes);
       return file;
     }
+
+    group('failure classification', () {
+      test('classifies iOS secure connection failures as TLS errors', () {
+        final reason = C2paSigningService.classifyFailureReason(
+          PlatformException(
+            code: 'C2PA_ERROR',
+            message: 'A TLS error caused the secure connection to fail.',
+          ),
+        );
+
+        expect(reason, C2paSigningFailureReason.tls);
+      });
+
+      test('classifies connection failures as network errors', () {
+        final reason = C2paSigningService.classifyFailureReason(
+          PlatformException(
+            code: 'C2PA_ERROR',
+            message: 'Connection reset by peer',
+          ),
+        );
+
+        expect(reason, C2paSigningFailureReason.network);
+      });
+
+      test('returns typed failure reason when remote signing throws', () async {
+        final video = writeFile('video.mp4', const [0, 1, 2, 3]);
+        final failingService = C2paSigningService(
+          c2pa: _FailingC2pa(
+            PlatformException(
+              code: 'C2PA_ERROR',
+              message: 'A TLS error caused the secure connection to fail.',
+            ),
+          ),
+        );
+
+        final result = await failingService.signVideo(videoPath: video.path);
+
+        expect(result.success, isFalse);
+        expect(result.signedFilePath, video.path);
+        expect(result.failureReason, C2paSigningFailureReason.tls);
+        expect(result.error, contains('A TLS error caused'));
+      });
+    });
 
     group('resignDerived', () {
       test(
@@ -156,4 +200,20 @@ void main() {
       );
     });
   });
+}
+
+class _FailingC2pa extends C2pa {
+  _FailingC2pa(this.error);
+
+  final Object error;
+
+  @override
+  Future<void> signFile({
+    required String sourcePath,
+    required String destPath,
+    required String manifestJson,
+    required C2paSigner signer,
+  }) async {
+    throw error;
+  }
 }

--- a/mobile/test/services/native_proofmode_service_test.dart
+++ b/mobile/test/services/native_proofmode_service_test.dart
@@ -1,8 +1,11 @@
 import 'dart:io';
 
+import 'package:c2pa_flutter/c2pa.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/c2pa_signing_service.dart';
 import 'package:openvine/services/native_proofmode_service.dart';
+import 'package:openvine/services/nostr_creator_binding_service.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 void main() {
@@ -17,6 +20,7 @@ void main() {
   });
 
   tearDown(() async {
+    NativeProofModeService.c2paSigningServiceFactoryOverride = null;
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(proofModeChannel, null);
     await LogCaptureService().clearAllLogs();
@@ -105,6 +109,63 @@ void main() {
       },
     );
   });
+
+  group('proofFile C2PA failure handling', () {
+    test('skips manifest read after failed signing', () async {
+      final directory = await Directory.systemTemp.createTemp(
+        'native-proofmode-test-',
+      );
+      addTearDown(() async {
+        if (directory.existsSync()) {
+          await directory.delete(recursive: true);
+        }
+      });
+
+      final video = File('${directory.path}/video.mp4');
+      await video.writeAsBytes(const [1, 2, 3, 4]);
+
+      const generatedProofHash =
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      final proofDir = Directory('${directory.path}/$generatedProofHash');
+      await proofDir.create();
+      await File(
+        '${proofDir.path}/$generatedProofHash.asc',
+      ).writeAsString('signature');
+
+      final c2paService = _FailingC2paSigningService(video.path);
+      NativeProofModeService.c2paSigningServiceFactoryOverride = () =>
+          c2paService;
+
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(proofModeChannel, (call) async {
+            switch (call.method) {
+              case 'isAvailable':
+                return true;
+              case 'getProofDir':
+                final args = call.arguments as Map<Object?, Object?>;
+                return args['proofHash'] == generatedProofHash
+                    ? proofDir.path
+                    : null;
+              case 'generateProof':
+                return generatedProofHash;
+              default:
+                fail('Unexpected proof mode method call: ${call.method}');
+            }
+          });
+
+      final proofData = await NativeProofModeService.proofFile(video);
+
+      expect(proofData, isNotNull);
+      expect(proofData!.videoHash, generatedProofHash);
+      expect(c2paService.readManifestCallCount, 0);
+      expect(
+        _latestLogContaining(
+          'Skipping C2PA manifest read after failed signing (tls)',
+        ),
+        isNotNull,
+      );
+    });
+  });
 }
 
 Iterable<LogEntry> _logsContaining(String message) {
@@ -116,4 +177,33 @@ Iterable<LogEntry> _logsContaining(String message) {
 LogEntry? _latestLogContaining(String message) {
   final matches = _logsContaining(message);
   return matches.isEmpty ? null : matches.last;
+}
+
+class _FailingC2paSigningService extends C2paSigningService {
+  _FailingC2paSigningService(this.videoPath);
+
+  final String videoPath;
+  int readManifestCallCount = 0;
+
+  @override
+  Future<C2paSigningResult> signVideo({
+    required String videoPath,
+    NostrCreatorBindingAssertion? creatorBindingAssertion,
+    Map<String, dynamic>? cawgIdentityAssertion,
+    bool enableAdvancedCawgEmbedding = false,
+  }) async {
+    return C2paSigningResult(
+      signedFilePath: this.videoPath,
+      success: false,
+      error:
+          'PlatformException(C2PA_ERROR, A TLS error caused the secure connection to fail., null, null)',
+      failureReason: C2paSigningFailureReason.tls,
+    );
+  }
+
+  @override
+  Future<ManifestStoreInfo?> readManifest(String filePath) async {
+    readManifestCallCount += 1;
+    return null;
+  }
 }


### PR DESCRIPTION
## Summary

- add typed C2PA signing failure reasons so TLS/network endpoint failures are logged distinctly
- skip the follow-on C2PA manifest read after signing fails, preserving graceful ProofMode fallback without noisy `ManifestNotFound` logs
- fix the `VideoRecorderProofService` signed-file path interpolation log and add regression coverage

## Scope

This PR covers the **mobile logging + graceful-degradation half** of #5941: distinct TLS/network failure classification and no misleading `ManifestNotFound` warning after a failed sign. The **backend/infra TLS root cause** on the deployed signing endpoint is not fixed here and still needs separate investigation, so this PR intentionally does **not** close #5941.

## Root Cause

Mobile was already degrading gracefully, but after `RemoteSigner` failed the code returned the original unsigned file path and then unconditionally called `readManifest` on it. That produced a misleading `ManifestNotFound: no JUMBF data found` warning after the real endpoint/TLS failure.

I also reproduced the endpoint side of the issue from this workstation:

```sh
curl -Iv 'https://proofsign.proofmode.org/api/v1/c2pa/configuration?platform=ios'
```

DNS and TCP connect succeeded, then TLS reset during the handshake with `curl: (35) Recv failure: Connection reset by peer`. That still needs backend/infra verification for the deployed signing endpoint, returned `signing_url`, and returned `timestamp_url`/TSA; this PR does not loosen ATS, cleartext policy, or user-CA trust.

## Validation

- `flutter analyze`
- `flutter test test/services/c2pa_signing_service_test.dart test/services/native_proofmode_service_test.dart test/services/c2pa_training_mining_assertion_test.dart`
- `flutter test`

Part of #5941
