### PR TITLE
fix(comments): hide stranded keyboard on sheet dismiss after background/resume

### DIFF
--- a/mobile/lib/screens/comments/widgets/unfocus_on_sheet_dismiss.dart
+++ b/mobile/lib/screens/comments/widgets/unfocus_on_sheet_dismiss.dart
@@ -1,20 +1,35 @@
 // ABOUTME: Drops the keyboard when the enclosing modal sheet starts dismissing
 // ABOUTME: so iOS does not strand an orphaned keyboard over the screen below.
 
-import 'package:flutter/material.dart';
+import 'dart:async';
 
-/// Unfocuses the active text field the moment the enclosing [ModalRoute] begins
-/// its dismiss transition.
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// Unfocuses the active text field and hides the software keyboard the moment
+/// the enclosing [ModalRoute] begins its dismiss transition.
 ///
 /// The comments bottom sheet has no close button — it is dismissed by dragging
-/// it down, tapping the scrim, or the system back gesture. Every one of those
-/// vectors reverses the modal route's transition animation (the same
-/// `AnimationStatus.reverse` signal Flutter's own `_dismissUnderway` checks in
-/// `material/bottom_sheet.dart`). On iOS, tearing the route down does not
-/// reliably resign first responder, so the software keyboard is left visible
-/// over the feed below (#5604). Reacting to [AnimationStatus.reverse] unfocuses
-/// while the field is still mounted and focused, which closes the text-input
-/// connection in time for the keyboard to animate away with the sheet.
+/// it down, tapping the scrim, or the system back gesture. Most of those
+/// vectors reverse the modal route's transition animation, so
+/// [AnimationStatus.reverse] is the primary dismiss signal (#5604). Two
+/// teardown paths never emit it (#5959):
+///
+/// * a chrome drag that rides the route controller to its 0.0 clamp goes
+///   completed→forward→dismissed (both fling branches in
+///   `material/bottom_sheet.dart` are guarded by `value > 0.0`, and the
+///   follow-up pop's `reverse()` takes the zero-duration branch), covered by
+///   also reacting to [AnimationStatus.dismissed];
+/// * route removal without a pop emits no status change at all, covered by
+///   the [dispose] fallback.
+///
+/// `unfocus()` alone is not enough: when iOS tears down the text-input
+/// session during a background/resume cycle, the framework nulls its side of
+/// the connection without any outbound `TextInput.hide`, while iOS
+/// re-presents the keyboard for the stale first responder on resume. In that
+/// split-brain state `unfocus()` produces zero text-input channel traffic, so
+/// an explicit `TextInput.hide` — which resigns the first responder
+/// engine-side regardless of framework connection state — is sent as well.
 ///
 /// Renders [child] unchanged; it only observes the route animation. No-op when
 /// there is no enclosing modal route (e.g. a non-modal host).
@@ -43,17 +58,31 @@ class _UnfocusOnSheetDismissState extends State<UnfocusOnSheetDismiss> {
   }
 
   void _onStatusChanged(AnimationStatus status) {
-    // The route only reverses when it is actually being dismissed (partial
-    // sheet resizes do not touch the route animation), so this fires once per
-    // dismiss, while the comment field still holds focus.
-    if (status == AnimationStatus.reverse) {
-      FocusManager.instance.primaryFocus?.unfocus();
+    // reverse: pop-driven dismissals (scrim tap, drag release, back, pop),
+    // fired while the comment field still holds focus. dismissed: a chrome
+    // drag that reaches the route controller's 0.0 clamp skips reverse
+    // entirely — see the class doc.
+    if (status == AnimationStatus.reverse ||
+        status == AnimationStatus.dismissed) {
+      _dismissKeyboard();
     }
+  }
+
+  void _dismissKeyboard() {
+    FocusManager.instance.primaryFocus?.unfocus();
+    // unfocus() sends nothing over the text-input channel when the framework
+    // side of the connection is already gone (platform-initiated teardown
+    // during background/resume — see the class doc). Hide explicitly; this is
+    // a harmless no-op when the keyboard is already down.
+    unawaited(SystemChannels.textInput.invokeMethod<void>('TextInput.hide'));
   }
 
   @override
   void dispose() {
     _animation?.removeStatusListener(_onStatusChanged);
+    // Covers teardown paths that never change the route animation status
+    // (route removal without a pop). Redundant but harmless on popped paths.
+    _dismissKeyboard();
     super.dispose();
   }
 

--- a/mobile/lib/screens/comments/widgets/unfocus_on_sheet_dismiss.dart
+++ b/mobile/lib/screens/comments/widgets/unfocus_on_sheet_dismiss.dart
@@ -31,6 +31,11 @@ import 'package:flutter/services.dart';
 /// an explicit `TextInput.hide` — which resigns the first responder
 /// engine-side regardless of framework connection state — is sent as well.
 ///
+/// The [dispose] fallback runs only when no route-status change already
+/// dismissed the keyboard and only when there was an enclosing modal route, so
+/// it is scoped to a sheet actually tearing down rather than firing on every
+/// disposal of a generic subtree.
+///
 /// Renders [child] unchanged; it only observes the route animation. No-op when
 /// there is no enclosing modal route (e.g. a non-modal host).
 class UnfocusOnSheetDismiss extends StatefulWidget {
@@ -45,6 +50,7 @@ class UnfocusOnSheetDismiss extends StatefulWidget {
 
 class _UnfocusOnSheetDismissState extends State<UnfocusOnSheetDismiss> {
   Animation<double>? _animation;
+  bool _dismissed = false;
 
   @override
   void didChangeDependencies() {
@@ -69,6 +75,10 @@ class _UnfocusOnSheetDismissState extends State<UnfocusOnSheetDismiss> {
   }
 
   void _dismissKeyboard() {
+    // A single teardown can surface more than one signal (a pop emits reverse
+    // then dismissed); dismiss exactly once so we don't re-send TextInput.hide.
+    if (_dismissed) return;
+    _dismissed = true;
     FocusManager.instance.primaryFocus?.unfocus();
     // unfocus() sends nothing over the text-input channel when the framework
     // side of the connection is already gone (platform-initiated teardown
@@ -80,9 +90,14 @@ class _UnfocusOnSheetDismissState extends State<UnfocusOnSheetDismiss> {
   @override
   void dispose() {
     _animation?.removeStatusListener(_onStatusChanged);
-    // Covers teardown paths that never change the route animation status
-    // (route removal without a pop). Redundant but harmless on popped paths.
-    _dismissKeyboard();
+    // Fallback for the one teardown that emits no status change at all: a
+    // route removed without a pop. Gated on `!_dismissed` so a status-handled
+    // close doesn't fire it again, and on an enclosing modal route having
+    // existed so a generic non-sheet host that never stranded a keyboard
+    // doesn't yank global focus / hide another route's keyboard on disposal.
+    if (!_dismissed && _animation != null) {
+      _dismissKeyboard();
+    }
     super.dispose();
   }
 

--- a/mobile/test/screens/comments/widgets/unfocus_on_sheet_dismiss_test.dart
+++ b/mobile/test/screens/comments/widgets/unfocus_on_sheet_dismiss_test.dart
@@ -151,6 +151,53 @@ void main() {
       },
     );
 
+    testWidgets(
+      'sends TextInput.hide exactly once on a pop that emits both reverse '
+      'and dismissed',
+      (tester) async {
+        final focusNode = await pumpHostAndOpenSheet(tester);
+        // Sever the connection first so unfocus() contributes no framework
+        // hide of its own — every logged hide is then our explicit one,
+        // isolating the dedup guard.
+        await severConnectionPlatformSide(tester, focusNode);
+
+        tester.testTextInput.log.clear();
+        Navigator.of(tester.element(find.byType(UnfocusOnSheetDismiss))).pop();
+        await tester.pumpAndSettle();
+
+        // A pop drives the route controller reverse → dismissed, so both
+        // status branches fire; the dedup guard must collapse them to a
+        // single explicit hide.
+        expect(
+          tester.testTextInput.log
+              .where((call) => call.method == 'TextInput.hide')
+              .length,
+          1,
+        );
+      },
+    );
+
+    testWidgets(
+      'does not touch the keyboard on disposal when there is no enclosing '
+      'modal route',
+      (tester) async {
+        // A generic host with no modal route never stranded a keyboard, so
+        // tearing it down must not reach for global focus or the IME. Pump
+        // without any Navigator/route so ModalRoute.of resolves to null.
+        await tester.pumpWidget(
+          const Directionality(
+            textDirection: TextDirection.ltr,
+            child: UnfocusOnSheetDismiss(child: SizedBox()),
+          ),
+        );
+
+        tester.testTextInput.log.clear();
+        await tester.pumpWidget(const SizedBox());
+
+        expect(tester.testTextInput.log, isEmpty);
+      },
+    );
+
     testWidgets('renders its child unchanged', (tester) async {
       await tester.pumpWidget(
         const MaterialApp(home: UnfocusOnSheetDismiss(child: Text('hello'))),

--- a/mobile/test/screens/comments/widgets/unfocus_on_sheet_dismiss_test.dart
+++ b/mobile/test/screens/comments/widgets/unfocus_on_sheet_dismiss_test.dart
@@ -7,39 +7,76 @@ import 'package:openvine/screens/comments/widgets/unfocus_on_sheet_dismiss.dart'
 
 void main() {
   group(UnfocusOnSheetDismiss, () {
-    testWidgets(
-      'unfocuses the active field when the enclosing sheet starts dismissing',
-      (tester) async {
-        final focusNode = FocusNode();
-        addTearDown(focusNode.dispose);
+    Future<FocusNode> pumpHostAndOpenSheet(WidgetTester tester) async {
+      final focusNode = FocusNode();
+      addTearDown(focusNode.dispose);
 
-        await tester.pumpWidget(
-          MaterialApp(
-            home: Scaffold(
-              body: Builder(
-                builder: (context) => Center(
-                  child: ElevatedButton(
-                    onPressed: () => showModalBottomSheet<void>(
-                      context: context,
-                      isScrollControlled: true,
-                      builder: (_) => UnfocusOnSheetDismiss(
-                        child: TextField(focusNode: focusNode, autofocus: true),
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => Center(
+                child: ElevatedButton(
+                  onPressed: () => showModalBottomSheet<void>(
+                    context: context,
+                    isScrollControlled: true,
+                    builder: (_) => UnfocusOnSheetDismiss(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          const SizedBox(
+                            height: 48,
+                            width: double.infinity,
+                            child: Text('drag handle'),
+                          ),
+                          TextField(focusNode: focusNode, autofocus: true),
+                        ],
                       ),
                     ),
-                    child: const Text('open'),
                   ),
+                  child: const Text('open'),
                 ),
               ),
             ),
           ),
-        );
+        ),
+      );
 
-        await tester.tap(find.text('open'));
-        await tester.pumpAndSettle();
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
 
-        // The comment field is focused and the keyboard connection is open.
-        expect(focusNode.hasFocus, isTrue);
-        expect(tester.testTextInput.isVisible, isTrue);
+      // The comment field is focused and the keyboard connection is open.
+      expect(focusNode.hasFocus, isTrue);
+      expect(tester.testTextInput.isVisible, isTrue);
+      return focusNode;
+    }
+
+    /// Reproduces the iOS background/resume split-brain (#5959): the platform
+    /// closes the text-input connection, the framework detaches and unfocuses
+    /// WITHOUT sending TextInput.hide, and iOS re-presents the keyboard for
+    /// the stale first responder — so the keyboard stays visible while the
+    /// framework believes nothing is focused.
+    Future<void> severConnectionPlatformSide(
+      WidgetTester tester,
+      FocusNode focusNode,
+    ) async {
+      tester.testTextInput.closeConnection();
+      await tester.pump();
+
+      expect(focusNode.hasFocus, isFalse);
+      expect(
+        tester.testTextInput.isVisible,
+        isTrue,
+        reason:
+            'platform-initiated teardown must leave the keyboard '
+            'stranded — that is the bug precondition',
+      );
+    }
+
+    testWidgets(
+      'unfocuses the active field when the enclosing sheet starts dismissing',
+      (tester) async {
+        final focusNode = await pumpHostAndOpenSheet(tester);
 
         // Dismiss the sheet. The route's transition reverses immediately —
         // the signal UnfocusOnSheetDismiss reacts to — while the field is
@@ -53,6 +90,64 @@ void main() {
         expect(tester.testTextInput.isVisible, isFalse);
 
         await tester.pumpAndSettle();
+      },
+    );
+
+    testWidgets(
+      'hides the stranded keyboard on dismiss after the platform closed the '
+      'connection during background/resume',
+      (tester) async {
+        final focusNode = await pumpHostAndOpenSheet(tester);
+        await severConnectionPlatformSide(tester, focusNode);
+
+        // Dismiss the sheet normally. unfocus() alone is a no-op here (the
+        // framework already lost focus and connection), so only an explicit
+        // TextInput.hide can drop the stranded keyboard (#5959).
+        Navigator.of(tester.element(find.byType(UnfocusOnSheetDismiss))).pop();
+        await tester.pump();
+
+        expect(tester.testTextInput.isVisible, isFalse);
+
+        await tester.pumpAndSettle();
+      },
+    );
+
+    testWidgets(
+      'hides the stranded keyboard when a chrome drag rides the route '
+      'controller to its 0.0 clamp without ever reversing',
+      (tester) async {
+        final focusNode = await pumpHostAndOpenSheet(tester);
+        await severConnectionPlatformSide(tester, focusNode);
+
+        // Drag the sheet chrome down past the sheet's full height in one
+        // continuous gesture. This drives the modal route's controller value
+        // straight to 0.0: the status goes completed→forward→dismissed and
+        // AnimationStatus.reverse never fires (both fling branches in
+        // material/bottom_sheet.dart are guarded by `value > 0.0`).
+        await tester.drag(find.text('drag handle'), const Offset(0, 700));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(UnfocusOnSheetDismiss), findsNothing);
+        expect(tester.testTextInput.isVisible, isFalse);
+      },
+    );
+
+    testWidgets(
+      'hides the stranded keyboard when the sheet subtree is disposed '
+      'without any route status change',
+      (tester) async {
+        final focusNode = await pumpHostAndOpenSheet(tester);
+        await severConnectionPlatformSide(tester, focusNode);
+
+        // Remove the sheet's route without popping it (what a navigator
+        // page-stack rebuild does to pageless routes) — no animation status
+        // change ever fires, only dispose runs.
+        final element = tester.element(find.byType(UnfocusOnSheetDismiss));
+        Navigator.of(element).removeRoute(ModalRoute.of(element)!);
+        await tester.pump();
+
+        expect(find.byType(UnfocusOnSheetDismiss), findsNothing);
+        expect(tester.testTextInput.isVisible, isFalse);
       },
     );
 


### PR DESCRIPTION
## Description

The software keyboard stayed visible over the video feed after closing the comments sheet, when the app had been backgrounded and resumed while the sheet was open (in-app bug report, build 1.0.16+791, iOS 26.5.1 — the build already contained the #5616 fix, verified by dating the build via the `ingest_queue_depth` telemetry from #5906).

`UnfocusOnSheetDismiss` reacted only to `AnimationStatus.reverse` and only called `primaryFocus?.unfocus()`. Traced against the Flutter 3.44 framework and iOS engine sources, that leaves three gaps:

1. **Platform-initiated text-input teardown during background/resume (this report's repro).** iOS resigns `FlutterTextInputView` during a background/resume cycle; the engine sends `TextInputClient.onConnectionClosed`; the framework nulls its side of the connection **without any outbound `TextInput.hide`** (`connectionClosedReceived`) and unfocuses. The engine keeps the stale first responder, so on resume iOS re-presents the keyboard while the framework believes nothing is focused. At dismissal, `unfocus()` produces zero text-input channel traffic and the keyboard is stranded with no recovery affordance on the feed.
2. **Chrome drag to the route controller's 0.0 clamp.** Status goes `completed→forward→dismissed` — never `reverse` (`_direction` is still forward, both fling branches in `material/bottom_sheet.dart` are guarded by `value > 0.0`, and the follow-up pop's `reverse()` takes the zero-duration branch).
3. **Route removal without a pop** (navigator page-stack rebuild): no status change fires at all.

The fix hardens the widget on all three: also react to `AnimationStatus.dismissed`, send an explicit `TextInput.hide` alongside `unfocus()` (the engine's `hideTextInput` resigns the first responder regardless of framework connection state and is a no-op otherwise), and dismiss from `dispose()` as a fallback.

Each vector is pinned by a regression test that reproduces the split-brain in-harness via `tester.testTextInput.closeConnection()` (the exact message the engine sends), asserting the keyboard stays stranded pre-dismiss and is hidden post-dismiss. All three new tests fail on the previous implementation and pass with the fix; the two pre-existing tests pass in both states.

**Related Issue:** Closes #5959

## Out of Scope

- On-device manual verification of the exact iOS 26.5.1 trigger that resigns the first responder during backgrounding (scene snapshotting / keyboard session churn) — the framework-side split-brain state is fully reproduced in the widget tests regardless of the trigger.
- Any change to `VineBottomSheet` presentation or the feed's `viewInsets` handling.

## Verification

- `flutter test test/screens/comments/` — 100 tests pass
- Red/green: the 3 new regression tests fail against the previous `UnfocusOnSheetDismiss` implementation (verified by stashing the fix) and pass with it
- `flutter analyze lib test integration_test` — no issues
- `dart format` — no changes

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
