### PR TITLE
chore: remove dead support-key placeholder constant

### DIFF
--- a/mobile/lib/config/bug_report_config.dart
+++ b/mobile/lib/config/bug_report_config.dart
@@ -1,4 +1,4 @@
-// ABOUTME: Configuration for bug report system including support pubkey and limits
+// ABOUTME: Configuration for bug report system including support email and limits
 // ABOUTME: Defines sensitive data patterns for sanitization and report size constraints
 
 import 'package:unified_logger/unified_logger.dart';
@@ -10,11 +10,6 @@ class BugReportConfig {
   /// Will move to reports.divine.video once custom domain is configured
   static const String bugReportApiUrl =
       'https://bug-reports.protestnet.workers.dev/api/bug-reports';
-
-  /// Pubkey for receiving bug reports (hex format)
-  /// Currently set to Rabble's personal Nostr key
-  static const String supportPubkey =
-      '78a5c21b5166dc1474b64ddf7454bf79e6b5d6b4a77148593bf1e866b73c2738';
 
   /// Email address for receiving bug reports (fallback only)
   static const String supportEmail = 'contact@divine.video';


### PR DESCRIPTION
Removes `BugReportConfig.supportPubkey`, a dead constant.

It held `78a5c21b5166dc1474b64ddf7454bf79e6b5d6b4a77148593bf1e866b73c2738`, a personal Nostr key (its own comment described it as "Rabble's personal Nostr key") with no profile and no NIP-05.

**Why it's dead (verified):**

- The symbol `BugReportConfig.supportPubkey` is never read anywhere in `mobile/lib`, `mobile/test`, or `mobile/packages`. The definition was its only occurrence.
- The only method that consumes a recipient pubkey, `sendBugReportToRecipient` in `bug_report_service.dart`, has no callers in `lib`. Its own doc comment marks it "for testing", and only test files call it, passing a literal test pubkey.
- The live bug-report path submits via `supportEmail` (`contact@divine.video`) and `bugReportApiUrl`, never via this constant.

I also corrected the file's ABOUTME header, which still named the removed pubkey.

No behavior change.

**Scope:** This is a standalone dead-code removal touching one file. It does not close support-trust-safety#184 (replace the placeholder support identity with a real NIP-05 identity). That broader cleanup, including the remaining doc references to this key, is tracked there.
