### PR TITLE
fix(drafts): don't re-save a draft when reopening it to view

### DIFF
--- a/mobile/lib/providers/clip_manager_provider.dart
+++ b/mobile/lib/providers/clip_manager_provider.dart
@@ -374,7 +374,13 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
   /// Clears the current clip list and installs [clips] in a single state
   /// update so consumers never observe an intermediate empty-then-populated
   /// transition during restoration flows.
-  void replaceClips(List<DivineVideoClip> clips) {
+  ///
+  /// Pass [autosave] as `false` when installing clips that reflect no user
+  /// edit — e.g. restoring a draft for viewing. An autosave there would bump
+  /// the draft's `lastModified` (reordering it to the top of the drafts list
+  /// as if freshly saved) and invalidate/delete the just-restored
+  /// `finalRenderedClip`, mutating a draft the user only opened to watch.
+  void replaceClips(List<DivineVideoClip> clips, {bool autosave = true}) {
     final previousCount = _clips.length;
     _clips
       ..clear()
@@ -387,7 +393,7 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
     );
 
     state = state.copyWith(clips: List.unmodifiable(_clips));
-    _triggerAutosave();
+    if (autosave) _triggerAutosave();
   }
 
   /// Delete a clip by ID.

--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -977,7 +977,11 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
       clearCustomThumbnailPath: draft.customThumbnailPath == null,
     );
 
-    _clipManager.replaceClips(clipsWithThumbnails);
+    // Restoring is read-only: don't autosave here. An autosave would bump the
+    // draft's lastModified (reordering it to the top of the drafts list as if
+    // freshly saved) and invalidate/delete the finalRenderedClip we just
+    // restored above — mutating a draft the user only opened to view (#5956).
+    _clipManager.replaceClips(clipsWithThumbnails, autosave: false);
     if (clipsWithThumbnails.isEmpty) {
       Log.warning(
         '⚠️ Draft restored with no clips',

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -1619,6 +1619,60 @@ void main() {
           expect(result, isTrue);
         },
       );
+
+      test(
+        'viewing a draft is read-only: restore keeps the finalRenderedClip '
+        'instead of invalidating it (#5956)',
+        () async {
+          final renderedPath = '${tempDir.path}/rendered.mp4';
+          await File(renderedPath).writeAsBytes(const [0]);
+
+          final draft = DivineVideoDraft.create(
+            id: 'draft-1',
+            clips: [
+              DivineVideoClip(
+                id: 'c1',
+                video: EditorVideo.file(clipVideoPath),
+                thumbnailPath: clipThumbnailPath,
+                duration: const Duration(seconds: 3),
+                recordedAt: DateTime.now(),
+                targetAspectRatio: .vertical,
+                originalAspectRatio: 9 / 16,
+              ),
+            ],
+            title: 'Title',
+            description: '',
+            hashtags: const {},
+            selectedApproach: 'video',
+            finalRenderedClip: DivineVideoClip(
+              id: 'rendered',
+              video: EditorVideo.file(renderedPath),
+              thumbnailPath: clipThumbnailPath,
+              duration: const Duration(seconds: 3),
+              recordedAt: DateTime.now(),
+              targetAspectRatio: .vertical,
+              originalAspectRatio: 9 / 16,
+            ),
+          );
+          when(
+            () => mockDraftStorage.getDraftById('draft-1'),
+          ).thenAnswer((_) async => draft);
+
+          final result = await container
+              .read(videoEditorProvider.notifier)
+              .restoreDraft('draft-1');
+
+          expect(result, isTrue);
+          expect(
+            container.read(videoEditorProvider).finalRenderedClip?.id,
+            'rendered',
+            reason:
+                'restoring a draft to view it must not autosave: an autosave '
+                'invalidates (and deletes) the restored finalRenderedClip and '
+                'bumps lastModified, making the draft look freshly saved',
+          );
+        },
+      );
     });
   });
 

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -1307,6 +1307,19 @@ void main() {
       late String clipVideoPath;
       late String clipThumbnailPath;
 
+      setUpAll(() {
+        registerFallbackValue(
+          DivineVideoDraft.create(
+            id: 'fallback',
+            clips: const [],
+            title: '',
+            description: '',
+            hashtags: const {},
+            selectedApproach: 'video',
+          ),
+        );
+      });
+
       setUp(() async {
         SharedPreferences.setMockInitialValues({});
         final prefs = await SharedPreferences.getInstance();
@@ -1671,6 +1684,68 @@ void main() {
                 'invalidates (and deletes) the restored finalRenderedClip and '
                 'bumps lastModified, making the draft look freshly saved',
           );
+        },
+      );
+
+      test(
+        'viewing a draft is read-only: no re-save fires once the autosave '
+        'debounce elapses (#5956)',
+        () {
+          final renderedPath = '${tempDir.path}/rendered.mp4';
+          File(renderedPath).writeAsBytesSync(const [0]);
+
+          final draft = DivineVideoDraft.create(
+            id: 'draft-1',
+            clips: [
+              DivineVideoClip(
+                id: 'c1',
+                video: EditorVideo.file(clipVideoPath),
+                thumbnailPath: clipThumbnailPath,
+                duration: const Duration(seconds: 3),
+                recordedAt: DateTime.now(),
+                targetAspectRatio: .vertical,
+                originalAspectRatio: 9 / 16,
+              ),
+            ],
+            title: 'Title',
+            description: '',
+            hashtags: const {},
+            selectedApproach: 'video',
+            finalRenderedClip: DivineVideoClip(
+              id: 'rendered',
+              video: EditorVideo.file(renderedPath),
+              thumbnailPath: clipThumbnailPath,
+              duration: const Duration(seconds: 3),
+              recordedAt: DateTime.now(),
+              targetAspectRatio: .vertical,
+              originalAspectRatio: 9 / 16,
+            ),
+          );
+          when(
+            () => mockDraftStorage.getDraftById('draft-1'),
+          ).thenAnswer((_) async => draft);
+
+          fakeAsync((async) {
+            bool? result;
+            container
+                .read(videoEditorProvider.notifier)
+                .restoreDraft('draft-1')
+                .then((value) => result = value);
+            async.flushMicrotasks();
+            expect(result, isTrue);
+
+            // Elapse well past the autosave debounce; a restore that
+            // re-triggers autosave would re-save the draft here, bumping
+            // lastModified and reordering it to the top of the drafts list.
+            async.elapse(const Duration(seconds: 10));
+
+            verifyNever(
+              () => mockDraftStorage.saveDraft(
+                any(),
+                deferOrphanCleanup: any(named: 'deferOrphanCleanup'),
+              ),
+            );
+          });
         },
       );
     });


### PR DESCRIPTION
## Summary

Reopening a draft just to watch/rewatch it silently re-saved it: the draft jumped to the top of the drafts list with a fresh timestamp (looks like it "saved as new"), and its rendered video was quietly deleted.

Closes #5956

## Root cause

Opening a draft calls `restoreDraft`, which ends by installing the clips via `ClipManager.replaceClips`. That method **unconditionally** fired a debounced autosave, so merely viewing a draft:

1. **Bumped `lastModified`** — the drafts list is sorted newest-first, so the draft reordered to the top as if freshly saved (the reported "saves to the top of the list").
2. **Invalidated + deleted the just-restored `finalRenderedClip`** — `_triggerAutosave()` calls `invalidateFinalRenderedClip()`, which clears the reference and deletes the rendered file from disk. For single-clip drafts this also flips `canPost` to false.

Viewing a draft must be read-only.

## Fix

- `replaceClips` gains an `autosave` flag (default `true`, so every edit path — undo/redo, clip add/remove/reorder — is unchanged).
- `restoreDraft` passes `autosave: false`, so reopening a draft no longer mutates it.

Both halves of the old bug are gated by the single `autosave` flag: `_triggerAutosave()` does the invalidate *and* the debounced save together, so skipping it fixes both the reorder-to-top and the rendered-clip deletion in one branch. The other two `replaceClips` callers (clip-snapshot sync and clip-reverse in `video_editor_canvas.dart`) are genuine user edits and keep the `autosave: true` default.

## Behavior notes

Two things worth calling out up front so they don't read as oversights:

- **Restore keeps the `finalRenderedClip` even when orphaned clips are dropped.** `restoreDraft` filters out clips whose source file is gone, so in that rare case the kept render reflects a clip set now shorter than the timeline. This is intentional: the render is a self-contained merged mp4 that still holds the dropped clip's content, so keeping it is correct for both viewing and re-posting, and any real edit re-invalidates it. Invalidating on restore would *delete a file just to view a draft* — the exact bug class this PR removes.
- **`autosave: false` also skips `clearMergeOutputPath` on restore, which is a no-op.** `mergeOutputPath` is write-only in the current codebase (never read anywhere; `cacheMergeOutput` has no callers), so not clearing it has zero functional effect. Removing that dead field is left out of scope here.

## Tests

Added a regression test: restoring a draft with a valid `finalRenderedClip` keeps it (proves restore no longer autosaves/invalidates). I verified it **fails** on the pre-fix code and passes after. Since both bug halves flow through the same `autosave` branch, this single assertion pins the read-only contract without a redundant sibling. `flutter analyze` clean; `video_editor_provider` + `clip_manager_provider` suites green (106 tests).

## Not covered

The report also mentions "sometimes double save drafts after you post." That lives in the publish flow (source-draft deletion on success) — a separate area with no clean repro from this report. This PR squarely fixes the title bug (saves-on-view) and the rendered-clip data loss; the post-publish duplication, if still reproducible, needs its own investigation.

## Test plan

- Open an existing draft from the library, watch it, back out → draft stays in place (no reorder to top), keeps its rendered video / cover, stays postable.
- Edit a draft (text, clips, trim, sound, etc.) → still autosaves as before.
