### PR TITLE
perf(feed): paint the video backdrop only in the letterbox bars

### DIFF
--- a/mobile/lib/widgets/video_feed_item/blurred_video_backdrop.dart
+++ b/mobile/lib/widgets/video_feed_item/blurred_video_backdrop.dart
@@ -17,6 +17,14 @@ import 'package:openvine/widgets/vine_cached_image.dart';
 /// without a blurhash; that fullscreen blur pass over the live video
 /// texture was a major raster-thread cost (on-device: Impeller janked
 /// every frame), so the blurhash path is strongly preferred.
+///
+/// When [videoAspectRatio] is known, the backdrop paints only in the letterbox
+/// bars — one `RepaintBoundary`-isolated fill per bar, from the screen edge up
+/// to the video — instead of a single fullscreen layer behind the (opaque)
+/// video. That occluded fullscreen fill, composited whole every frame, was the
+/// backdrop's per-frame overdraw cost on Skia; the per-bar layers are cached
+/// and never re-rastered by the video texture (PR #5957). When the aspect
+/// ratio is unknown the backdrop falls back to a fullscreen fill.
 class BlurredVideoBackdrop extends StatelessWidget {
   /// Creates a blurred backdrop for a video poster.
   ///
@@ -24,7 +32,59 @@ class BlurredVideoBackdrop extends StatelessWidget {
   /// thumbnail used for the runtime-blur fallback; when neither is
   /// available, or the image fails to load, the widget renders as empty
   /// ([SizedBox.shrink]) and lets the parent background show through.
-  const BlurredVideoBackdrop({super.key, this.url, this.blurhash});
+  const BlurredVideoBackdrop({
+    super.key,
+    this.url,
+    this.blurhash,
+    this.videoAspectRatio,
+  });
+
+  final String? url;
+  final String? blurhash;
+
+  /// Intrinsic aspect ratio (width / height) of the video sitting on this
+  /// backdrop. Drives the letterbox bar geometry. When null the backdrop
+  /// paints fullscreen — the safe fallback when dimensions are unknown.
+  final double? videoAspectRatio;
+
+  @override
+  Widget build(BuildContext context) {
+    final aspectRatio = videoAspectRatio;
+    if (aspectRatio == null) {
+      return _BackdropContent(url: url, blurhash: blurhash);
+    }
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final size = constraints.biggest;
+        final bands = _letterboxBands(
+          letterboxVideoRect(aspectRatio, size),
+          size,
+        );
+        return Stack(
+          children: [
+            for (final band in bands)
+              Positioned.fromRect(
+                rect: band,
+                // Its own RepaintBoundary per bar: the bar's fill is isolated
+                // from the video texture's per-frame markNeedsPaint, so it is
+                // rastered once and then only composited — and it never covers
+                // the video area, so there is no occluded fullscreen overdraw
+                // (PR #5957).
+                child: RepaintBoundary(
+                  child: _BackdropContent(url: url, blurhash: blurhash),
+                ),
+              ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+/// The blurred fill itself, without any letterbox clip. Prefers the cheap
+/// stretched-blurhash path and falls back to a runtime gaussian of the poster.
+class _BackdropContent extends StatelessWidget {
+  const _BackdropContent({this.url, this.blurhash});
 
   final String? url;
   final String? blurhash;
@@ -58,4 +118,64 @@ class BlurredVideoBackdrop extends StatelessWidget {
       ),
     );
   }
+}
+
+/// The letterbox bars a blurred fill covers — the full gap between each box
+/// edge and the contain-fit [video], so the blur runs from the screen edge
+/// right up to the video with no dark band between. Only the sides where
+/// [video] doesn't reach the [box] edge produce a bar. Top/bottom bars span the
+/// full width (owning the corners); left/right bars span only the video's
+/// height, so bars never overlap and never cover the video area. Each bar is
+/// painted in its own `RepaintBoundary`, keeping it isolated from the video
+/// texture's per-frame repaint.
+List<Rect> _letterboxBands(Rect video, Size box) {
+  final bands = <Rect>[];
+  if (video.top > 0) {
+    bands.add(Rect.fromLTWH(0, 0, box.width, video.top));
+  }
+  if (video.bottom < box.height) {
+    bands.add(
+      Rect.fromLTWH(0, video.bottom, box.width, box.height - video.bottom),
+    );
+  }
+  if (video.left > 0) {
+    bands.add(Rect.fromLTWH(0, video.top, video.left, video.height));
+  }
+  if (video.right < box.width) {
+    bands.add(
+      Rect.fromLTWH(
+        video.right,
+        video.top,
+        box.width - video.right,
+        video.height,
+      ),
+    );
+  }
+  return bands;
+}
+
+/// The rect a video of [aspectRatio] occupies when `BoxFit.contain`-fitted and
+/// centered in [box] — mirrors the player's `FittedBox(fit: contain)`. Locates
+/// the letterbox bars the blurred fill covers. Exposed for testing the
+/// letterbox geometry, which is the seam-risk load-bearing logic.
+@visibleForTesting
+Rect letterboxVideoRect(double aspectRatio, Size box) {
+  final boxAspect = box.width / box.height;
+  final double width;
+  final double height;
+  if (aspectRatio > boxAspect) {
+    // Wider than the box → full width, letterbox top and bottom.
+    width = box.width;
+    height = box.width / aspectRatio;
+  } else {
+    // Taller/narrower than the box → full height, pillarbox left and right.
+    height = box.height;
+    width = box.height * aspectRatio;
+  }
+  return Rect.fromLTWH(
+    (box.width - width) / 2,
+    (box.height - height) / 2,
+    width,
+    height,
+  );
 }

--- a/mobile/lib/widgets/video_feed_item/blurred_video_backdrop.dart
+++ b/mobile/lib/widgets/video_feed_item/blurred_video_backdrop.dart
@@ -179,3 +179,21 @@ Rect letterboxVideoRect(double aspectRatio, Size box) {
     height,
   );
 }
+
+/// The intrinsic aspect ratio (width / height) that drives the backdrop's
+/// letterbox geometry, or null when the video's dimensions are unknown — in
+/// which case the backdrop paints fullscreen, the safe fallback.
+double? backdropAspectRatio(int? width, int? height) {
+  if (width == null || height == null || height <= 0) return null;
+  return width / height;
+}
+
+/// Whether a video of [aspectRatio] fully covers (occludes) the feed viewport,
+/// so the backdrop must not be mounted at all. Mirrors the cover branch of
+/// `VideoItem._resolveBoxFit`: with [shouldPortraitExpand] every non-square
+/// video is `BoxFit.cover`-fitted and hides the backdrop, while square (1:1)
+/// and non-expanded videos stay contain-fit and keep their letterbox bars.
+bool videoCoversFeedViewport({
+  required double? aspectRatio,
+  required bool shouldPortraitExpand,
+}) => shouldPortraitExpand && aspectRatio != null && aspectRatio != 1.0;

--- a/mobile/lib/widgets/video_feed_item/blurred_video_backdrop.dart
+++ b/mobile/lib/widgets/video_feed_item/blurred_video_backdrop.dart
@@ -56,7 +56,7 @@ class BlurredVideoBackdrop extends StatelessWidget {
     return LayoutBuilder(
       builder: (context, constraints) {
         final size = constraints.biggest;
-        final bands = _letterboxBands(
+        final bands = letterboxBands(
           letterboxVideoRect(aspectRatio, size),
           size,
         );
@@ -127,8 +127,10 @@ class _BackdropContent extends StatelessWidget {
 /// full width (owning the corners); left/right bars span only the video's
 /// height, so bars never overlap and never cover the video area. Each bar is
 /// painted in its own `RepaintBoundary`, keeping it isolated from the video
-/// texture's per-frame repaint.
-List<Rect> _letterboxBands(Rect video, Size box) {
+/// texture's per-frame repaint. Exposed for testing the band tiling, which is
+/// the seam-risk load-bearing logic.
+@visibleForTesting
+List<Rect> letterboxBands(Rect video, Size box) {
   final bands = <Rect>[];
   if (video.top > 0) {
     bands.add(Rect.fromLTWH(0, 0, box.width, video.top));
@@ -190,7 +192,8 @@ double? backdropAspectRatio(int? width, int? height) {
 
 /// Whether a video of [aspectRatio] fully covers (occludes) the feed viewport,
 /// so the backdrop must not be mounted at all. Mirrors the cover branch of
-/// `VideoItem._resolveBoxFit`: with [shouldPortraitExpand] every non-square
+/// `VideoItemWidget._resolveBoxFit`: with [shouldPortraitExpand] every
+/// non-square
 /// video is `BoxFit.cover`-fitted and hides the backdrop, while square (1:1)
 /// and non-expanded videos stay contain-fit and keep their letterbox bars.
 bool videoCoversFeedViewport({

--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -316,19 +316,18 @@ class FeedVideosState extends ConsumerState<FeedVideos> with RouteAware {
 
           final thumbnailUrl = video.thumbnailUrl;
           final blurhash = video.blurhash;
-          final width = video.width;
-          final height = video.height;
-          final aspectRatio = (width != null && height != null && height > 0)
-              ? width / height
-              : null;
+          // Metadata (dim-tag) ratio, which the player's decoded ratio is
+          // expected to match; a stale/wrong dim tag only mis-sizes the bars,
+          // and a missing one falls back to a fullscreen fill.
+          final aspectRatio = backdropAspectRatio(video.width, video.height);
           // The player covers (fills) the screen for every non-square video
           // when shouldPortraitExpand is set (see VideoItem._resolveBoxFit),
           // fully occluding the backdrop — so only mount it for the
           // contain-fit (letterboxed) case where it is actually visible.
-          final coversScreen =
-              widget.shouldPortraitExpand &&
-              aspectRatio != null &&
-              aspectRatio != 1.0;
+          final coversScreen = videoCoversFeedViewport(
+            aspectRatio: aspectRatio,
+            shouldPortraitExpand: widget.shouldPortraitExpand,
+          );
           // Either source can carry the backdrop: the blurhash path needs
           // no poster URL (PR #5957 review). The backdrop paints only in the
           // letterbox bars (each bar in its own RepaintBoundary), so no outer

--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -316,10 +316,27 @@ class FeedVideosState extends ConsumerState<FeedVideos> with RouteAware {
 
           final thumbnailUrl = video.thumbnailUrl;
           final blurhash = video.blurhash;
+          final width = video.width;
+          final height = video.height;
+          final aspectRatio = (width != null && height != null && height > 0)
+              ? width / height
+              : null;
+          // The player covers (fills) the screen for every non-square video
+          // when shouldPortraitExpand is set (see VideoItem._resolveBoxFit),
+          // fully occluding the backdrop — so only mount it for the
+          // contain-fit (letterboxed) case where it is actually visible.
+          final coversScreen =
+              widget.shouldPortraitExpand &&
+              aspectRatio != null &&
+              aspectRatio != 1.0;
           // Either source can carry the backdrop: the blurhash path needs
-          // no poster URL (PR #5957 review).
+          // no poster URL (PR #5957 review). The backdrop paints only in the
+          // letterbox bars (each bar in its own RepaintBoundary), so no outer
+          // boundary here — a fullscreen boundary would be composited whole
+          // every frame and undo the per-bar isolation (PR #5957).
           final showBlurBackdrop =
               !video.isPortrait &&
+              !coversScreen &&
               ((thumbnailUrl != null && thumbnailUrl.isNotEmpty) ||
                   (blurhash != null && blurhash.isNotEmpty));
           return Stack(
@@ -330,6 +347,7 @@ class FeedVideosState extends ConsumerState<FeedVideos> with RouteAware {
                   child: BlurredVideoBackdrop(
                     url: thumbnailUrl,
                     blurhash: blurhash,
+                    videoAspectRatio: aspectRatio,
                   ),
                 ),
               child,

--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -316,12 +316,14 @@ class FeedVideosState extends ConsumerState<FeedVideos> with RouteAware {
 
           final thumbnailUrl = video.thumbnailUrl;
           final blurhash = video.blurhash;
-          // Metadata (dim-tag) ratio, which the player's decoded ratio is
-          // expected to match; a stale/wrong dim tag only mis-sizes the bars,
-          // and a missing one falls back to a fullscreen fill.
+          // Metadata (dim-tag) ratio, expected to match the player's decoded
+          // ratio. A wrong dim mis-sizes the bars, or — when it flips the
+          // square/non-square split the cover gate below keys off — drops the
+          // backdrop entirely; no publisher emits such a dim (PR #5965 review).
+          // A missing dim falls back to a fullscreen fill.
           final aspectRatio = backdropAspectRatio(video.width, video.height);
           // The player covers (fills) the screen for every non-square video
-          // when shouldPortraitExpand is set (see VideoItem._resolveBoxFit),
+          // when shouldPortraitExpand is set (see VideoItemWidget._resolveBoxFit),
           // fully occluding the backdrop — so only mount it for the
           // contain-fit (letterboxed) case where it is actually visible.
           final coversScreen = videoCoversFeedViewport(

--- a/mobile/test/widgets/video_feed_item/blurred_video_backdrop_test.dart
+++ b/mobile/test/widgets/video_feed_item/blurred_video_backdrop_test.dart
@@ -215,6 +215,31 @@ void main() {
       });
     });
 
+    group('letterboxBands', () {
+      // Assert the exact band rects (not just the count): a regression that
+      // keeps two bands but shifts or shrinks one — a 1px seam — must fail.
+      test(
+        'tiles full-width top and bottom bars around a letterboxed video',
+        () {
+          const box = Size(400, 800);
+          // 1:1 in a portrait box → 400×400 video centered → 200px top/bottom.
+          final bands = letterboxBands(letterboxVideoRect(1, box), box);
+          expect(bands, hasLength(2));
+          expect(bands, contains(const Rect.fromLTWH(0, 0, 400, 200)));
+          expect(bands, contains(const Rect.fromLTWH(0, 600, 400, 200)));
+        },
+      );
+
+      test('tiles left and right bars around a pillarboxed video', () {
+        const box = Size(800, 400);
+        // 1:1 in a landscape box → 400×400 video centered → 200px left/right.
+        final bands = letterboxBands(letterboxVideoRect(1, box), box);
+        expect(bands, hasLength(2));
+        expect(bands, contains(const Rect.fromLTWH(0, 0, 200, 400)));
+        expect(bands, contains(const Rect.fromLTWH(600, 0, 200, 400)));
+      });
+    });
+
     group('backdropAspectRatio', () {
       test('returns width / height when both dimensions are known', () {
         expect(backdropAspectRatio(1920, 1080), closeTo(16 / 9, 0.0001));
@@ -231,9 +256,11 @@ void main() {
     });
 
     group('videoCoversFeedViewport', () {
-      // Mirrors VideoItem._resolveBoxFit: the video is cover-fit (and so
-      // occludes the backdrop) only when portrait-expand is on and it is not
-      // square. These pin that contract so it can't silently drift.
+      // Mirrors the cover branch of VideoItemWidget._resolveBoxFit: the video
+      // is cover-fit (and so occludes the backdrop) only when portrait-expand
+      // is on and it is not square. These pin the local mirror; the real
+      // _resolveBoxFit is private and driven by the decoded ratio, so nothing
+      // binds the two — keep them in sync by hand.
       test('landscape with portrait-expand covers the viewport', () {
         expect(
           videoCoversFeedViewport(

--- a/mobile/test/widgets/video_feed_item/blurred_video_backdrop_test.dart
+++ b/mobile/test/widgets/video_feed_item/blurred_video_backdrop_test.dart
@@ -9,13 +9,21 @@ void main() {
     const testUrl = 'https://example.com/poster.jpg';
     const testBlurhash = 'L6Pj0^jE.AyE_3t7t7R**0o#DgR4';
 
-    Widget buildWidget({String url = testUrl, String? blurhash}) {
+    Widget buildWidget({
+      String url = testUrl,
+      String? blurhash,
+      double? videoAspectRatio,
+    }) {
       return WidgetsApp(
         color: const Color(0xFF000000),
         builder: (_, _) => SizedBox(
           width: 400,
           height: 800,
-          child: BlurredVideoBackdrop(url: url, blurhash: blurhash),
+          child: BlurredVideoBackdrop(
+            url: url,
+            blurhash: blurhash,
+            videoAspectRatio: videoAspectRatio,
+          ),
         ),
       );
     }
@@ -83,7 +91,7 @@ void main() {
             builder: (_, _) => const SizedBox(
               width: 400,
               height: 800,
-              child: BlurredVideoBackdrop(),
+              child: BlurredVideoBackdrop(url: ''),
             ),
           ),
         );
@@ -132,6 +140,59 @@ void main() {
       final box = fallback as SizedBox;
       expect(box.width, equals(0));
       expect(box.height, equals(0));
+    });
+
+    group('letterbox bands', () {
+      testWidgets(
+        'renders a RepaintBoundary-isolated blur fill in each letterbox bar '
+        'when the aspect ratio is known',
+        (tester) async {
+          // 1:1 video in the 400×800 box → top and bottom bars → two fills.
+          await tester.pumpWidget(
+            buildWidget(blurhash: testBlurhash, videoAspectRatio: 1),
+          );
+
+          expect(find.byType(BlurhashDisplay), findsNWidgets(2));
+          // Each bar is isolated in its own RepaintBoundary.
+          expect(find.byType(RepaintBoundary), findsNWidgets(2));
+        },
+      );
+
+      testWidgets(
+        'paints a single fullscreen fill when the aspect ratio is unknown',
+        (tester) async {
+          await tester.pumpWidget(buildWidget(blurhash: testBlurhash));
+
+          expect(find.byType(BlurhashDisplay), findsOneWidget);
+          expect(find.byType(RepaintBoundary), findsNothing);
+        },
+      );
+    });
+
+    group('letterboxVideoRect', () {
+      test('centers a 1:1 video with symmetric top/bottom bars', () {
+        // 1:1 into 400×800 → 400×400 centered → 200 px bars top and bottom.
+        expect(
+          letterboxVideoRect(1, const Size(400, 800)),
+          equals(const Rect.fromLTWH(0, 200, 400, 400)),
+        );
+      });
+
+      test('pillarboxes a video wider than a landscape box', () {
+        // 1:1 into 800×400 → 400×400 centered → 200 px bars left and right.
+        expect(
+          letterboxVideoRect(1, const Size(800, 400)),
+          equals(const Rect.fromLTWH(200, 0, 400, 400)),
+        );
+      });
+
+      test('letterboxes a 16:9 video in a portrait box', () {
+        // 16:9 (≈1.778) into 400×800 → full width, height 225, centered.
+        final rect = letterboxVideoRect(16 / 9, const Size(400, 800));
+        expect(rect.width, equals(400));
+        expect(rect.height, closeTo(225, 0.001));
+        expect(rect.top, closeTo((800 - 225) / 2, 0.001));
+      });
     });
   });
 }

--- a/mobile/test/widgets/video_feed_item/blurred_video_backdrop_test.dart
+++ b/mobile/test/widgets/video_feed_item/blurred_video_backdrop_test.dart
@@ -153,8 +153,21 @@ void main() {
           );
 
           expect(find.byType(BlurhashDisplay), findsNWidgets(2));
-          // Each bar is isolated in its own RepaintBoundary.
-          expect(find.byType(RepaintBoundary), findsNWidgets(2));
+          // Each bar wraps its fill in its own RepaintBoundary. Assert that
+          // structure directly instead of counting RepaintBoundary widgets:
+          // BlurhashDisplay adds its own internal RepaintBoundary once its
+          // async image decode resolves, so a global count would be
+          // timing-dependent.
+          final bars = tester.widgetList<Positioned>(
+            find.descendant(
+              of: find.byType(BlurredVideoBackdrop),
+              matching: find.byType(Positioned),
+            ),
+          );
+          expect(bars, hasLength(2));
+          for (final bar in bars) {
+            expect(bar.child, isA<RepaintBoundary>());
+          }
         },
       );
 
@@ -164,7 +177,14 @@ void main() {
           await tester.pumpWidget(buildWidget(blurhash: testBlurhash));
 
           expect(find.byType(BlurhashDisplay), findsOneWidget);
-          expect(find.byType(RepaintBoundary), findsNothing);
+          // No letterbox bars: the fullscreen fill has no Positioned wrapper.
+          expect(
+            find.descendant(
+              of: find.byType(BlurredVideoBackdrop),
+              matching: find.byType(Positioned),
+            ),
+            findsNothing,
+          );
         },
       );
     });
@@ -193,6 +213,66 @@ void main() {
         expect(rect.height, closeTo(225, 0.001));
         expect(rect.top, closeTo((800 - 225) / 2, 0.001));
       });
+    });
+
+    group('backdropAspectRatio', () {
+      test('returns width / height when both dimensions are known', () {
+        expect(backdropAspectRatio(1920, 1080), closeTo(16 / 9, 0.0001));
+      });
+
+      test('returns null when either dimension is missing', () {
+        expect(backdropAspectRatio(null, 1080), isNull);
+        expect(backdropAspectRatio(1920, null), isNull);
+      });
+
+      test('returns null when height is zero (avoids divide-by-zero)', () {
+        expect(backdropAspectRatio(1920, 0), isNull);
+      });
+    });
+
+    group('videoCoversFeedViewport', () {
+      // Mirrors VideoItem._resolveBoxFit: the video is cover-fit (and so
+      // occludes the backdrop) only when portrait-expand is on and it is not
+      // square. These pin that contract so it can't silently drift.
+      test('landscape with portrait-expand covers the viewport', () {
+        expect(
+          videoCoversFeedViewport(
+            aspectRatio: 16 / 9,
+            shouldPortraitExpand: true,
+          ),
+          isTrue,
+        );
+      });
+
+      test('square stays contain-fit even with portrait-expand', () {
+        expect(
+          videoCoversFeedViewport(aspectRatio: 1, shouldPortraitExpand: true),
+          isFalse,
+        );
+      });
+
+      test('portrait-expand off never covers the viewport', () {
+        expect(
+          videoCoversFeedViewport(
+            aspectRatio: 16 / 9,
+            shouldPortraitExpand: false,
+          ),
+          isFalse,
+        );
+      });
+
+      test(
+        'unknown aspect ratio never covers (backdrop paints fullscreen)',
+        () {
+          expect(
+            videoCoversFeedViewport(
+              aspectRatio: null,
+              shouldPortraitExpand: true,
+            ),
+            isFalse,
+          );
+        },
+      );
     });
   });
 }


### PR DESCRIPTION
Closes #5966

## What

Renders the feed's blurred video backdrop (behind contain-fit / non-portrait videos) only in the letterbox bars — each bar isolated in its own `RepaintBoundary` — instead of one fullscreen blurred layer behind the video.

## Why

Profiling on Skia/Android traced the feed's dominant raster cost to the fullscreen backdrop:

- it was composited whole every frame, **including the area occluded by the opaque video** (pure overdraw), and
- sharing the video texture's layer, it **re-rastered on every video frame**.

On-device this roughly 2–3×'d the per-frame time (~5–8 ms → ~15–17 ms), pinning scroll frames at the 60 FPS budget.

Painting only in the bars with a per-bar `RepaintBoundary` isolates each bar's fill from the texture's per-frame `markNeedsPaint` (rastered once, then only composited) and removes the occluded overdraw. Landscape (cover-fit) videos, whose backdrop was 100% occluded, no longer mount it at all. Feed raster drops back to ~5–8 ms with the blurred-poster look intact.

The bar geometry mirrors the player's `BoxFit.contain` fit and the bars never touch the video, so no seam can appear from an aspect-ratio mismatch.

## Relationship to #5957 (draft until it merges)

Follow-up to #5957. This branch's first two commits (blurhash backdrop; backdrop-without-thumbnail) also live in #5957 — they are the base this optimization builds on, cherry-picked here so the PR builds standalone. Kept as a **draft** until #5957 merges; once it does, this branch is rebased onto `main` and those two commits drop out (already in `main`), leaving just the letterbox commit for review.