### PR TITLE
fix(feed): skip + prune dead-media items in the home scrolling feed

### DIFF
--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -385,8 +385,16 @@ VideoMetadataUpdateService videoMetadataUpdateService(Ref ref) {
   );
 }
 
-/// Broken video tracker service for filtering non-functional videos
-@riverpod
+/// Broken video tracker service for filtering non-functional videos.
+///
+/// `keepAlive: true` so this stays the single app-session-stable instance —
+/// [videoEventServiceProvider] attaches it to `VideoEventService` for
+/// `filterVideoList`, and [deadMediaFeedGuardProvider] must mark broken
+/// videos on that *same* instance. Without `keepAlive`, this autodisposes
+/// once its initial watchers drop, so a later read can rebuild a fresh
+/// tracker that `VideoEventService` never sees — the home feed would then
+/// mark an item broken without it ever being filtered. See #5953 review.
+@Riverpod(keepAlive: true)
 Future<BrokenVideoTracker> brokenVideoTracker(Ref ref) async {
   final tracker = BrokenVideoTracker();
   await tracker.initialize();

--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -27,6 +27,7 @@ import 'package:openvine/services/auth_service.dart' show AuthState;
 import 'package:openvine/services/broken_video_tracker.dart';
 import 'package:openvine/services/collaborator_invite_service.dart';
 import 'package:openvine/services/content_deletion_service.dart';
+import 'package:openvine/services/dead_media_feed_guard.dart';
 import 'package:openvine/services/event_api_client.dart';
 import 'package:openvine/services/event_router.dart';
 import 'package:openvine/services/nsfw_content_filter.dart';
@@ -390,6 +391,16 @@ Future<BrokenVideoTracker> brokenVideoTracker(Ref ref) async {
   final tracker = BrokenVideoTracker();
   await tracker.initialize();
   return tracker;
+}
+
+/// Guard that HEAD-confirms a feed item's media is a hard 404 and marks it
+/// broken so the home feed can skip past + persistently prune it. Reuses the
+/// singleton [brokenVideoTrackerProvider] so a mark here is visible to every
+/// surface's `filterVideoList`. See #5953.
+@riverpod
+Future<DeadMediaFeedGuard> deadMediaFeedGuard(Ref ref) async {
+  final tracker = await ref.watch(brokenVideoTrackerProvider.future);
+  return DeadMediaFeedGuard(brokenVideoTracker: tracker);
 }
 
 /// Provider for VideoLocalStorage instance (SQLite-backed)

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -614,12 +614,28 @@ final class VideoMetadataUpdateServiceProvider
 String _$videoMetadataUpdateServiceHash() =>
     r'411d6327e9cdd7e14c307357ac64d337d52dc99d';
 
-/// Broken video tracker service for filtering non-functional videos
+/// Broken video tracker service for filtering non-functional videos.
+///
+/// `keepAlive: true` so this stays the single app-session-stable instance —
+/// [videoEventServiceProvider] attaches it to `VideoEventService` for
+/// `filterVideoList`, and [deadMediaFeedGuardProvider] must mark broken
+/// videos on that *same* instance. Without `keepAlive`, this autodisposes
+/// once its initial watchers drop, so a later read can rebuild a fresh
+/// tracker that `VideoEventService` never sees — the home feed would then
+/// mark an item broken without it ever being filtered. See #5953 review.
 
 @ProviderFor(brokenVideoTracker)
 final brokenVideoTrackerProvider = BrokenVideoTrackerProvider._();
 
-/// Broken video tracker service for filtering non-functional videos
+/// Broken video tracker service for filtering non-functional videos.
+///
+/// `keepAlive: true` so this stays the single app-session-stable instance —
+/// [videoEventServiceProvider] attaches it to `VideoEventService` for
+/// `filterVideoList`, and [deadMediaFeedGuardProvider] must mark broken
+/// videos on that *same* instance. Without `keepAlive`, this autodisposes
+/// once its initial watchers drop, so a later read can rebuild a fresh
+/// tracker that `VideoEventService` never sees — the home feed would then
+/// mark an item broken without it ever being filtered. See #5953 review.
 
 final class BrokenVideoTrackerProvider
     extends
@@ -631,14 +647,22 @@ final class BrokenVideoTrackerProvider
     with
         $FutureModifier<BrokenVideoTracker>,
         $FutureProvider<BrokenVideoTracker> {
-  /// Broken video tracker service for filtering non-functional videos
+  /// Broken video tracker service for filtering non-functional videos.
+  ///
+  /// `keepAlive: true` so this stays the single app-session-stable instance —
+  /// [videoEventServiceProvider] attaches it to `VideoEventService` for
+  /// `filterVideoList`, and [deadMediaFeedGuardProvider] must mark broken
+  /// videos on that *same* instance. Without `keepAlive`, this autodisposes
+  /// once its initial watchers drop, so a later read can rebuild a fresh
+  /// tracker that `VideoEventService` never sees — the home feed would then
+  /// mark an item broken without it ever being filtered. See #5953 review.
   BrokenVideoTrackerProvider._()
     : super(
         from: null,
         argument: null,
         retry: null,
         name: r'brokenVideoTrackerProvider',
-        isAutoDispose: true,
+        isAutoDispose: false,
         dependencies: null,
         $allTransitiveDependencies: null,
       );
@@ -659,7 +683,7 @@ final class BrokenVideoTrackerProvider
 }
 
 String _$brokenVideoTrackerHash() =>
-    r'36268bd477659a229f13da325ac23403a20e7fa7';
+    r'c22a5abecce15fbb6194948c3b23af91f1a7ebab';
 
 /// Guard that HEAD-confirms a feed item's media is a hard 404 and marks it
 /// broken so the home feed can skip past + persistently prune it. Reuses the

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -661,6 +661,62 @@ final class BrokenVideoTrackerProvider
 String _$brokenVideoTrackerHash() =>
     r'36268bd477659a229f13da325ac23403a20e7fa7';
 
+/// Guard that HEAD-confirms a feed item's media is a hard 404 and marks it
+/// broken so the home feed can skip past + persistently prune it. Reuses the
+/// singleton [brokenVideoTrackerProvider] so a mark here is visible to every
+/// surface's `filterVideoList`. See #5953.
+
+@ProviderFor(deadMediaFeedGuard)
+final deadMediaFeedGuardProvider = DeadMediaFeedGuardProvider._();
+
+/// Guard that HEAD-confirms a feed item's media is a hard 404 and marks it
+/// broken so the home feed can skip past + persistently prune it. Reuses the
+/// singleton [brokenVideoTrackerProvider] so a mark here is visible to every
+/// surface's `filterVideoList`. See #5953.
+
+final class DeadMediaFeedGuardProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<DeadMediaFeedGuard>,
+          DeadMediaFeedGuard,
+          FutureOr<DeadMediaFeedGuard>
+        >
+    with
+        $FutureModifier<DeadMediaFeedGuard>,
+        $FutureProvider<DeadMediaFeedGuard> {
+  /// Guard that HEAD-confirms a feed item's media is a hard 404 and marks it
+  /// broken so the home feed can skip past + persistently prune it. Reuses the
+  /// singleton [brokenVideoTrackerProvider] so a mark here is visible to every
+  /// surface's `filterVideoList`. See #5953.
+  DeadMediaFeedGuardProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'deadMediaFeedGuardProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$deadMediaFeedGuardHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<DeadMediaFeedGuard> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<DeadMediaFeedGuard> create(Ref ref) {
+    return deadMediaFeedGuard(ref);
+  }
+}
+
+String _$deadMediaFeedGuardHash() =>
+    r'c0eed3bb2461ee831a2619dd662ebaf88f0da3a5';
+
 /// Provider for VideoLocalStorage instance (SQLite-backed)
 ///
 /// Creates a DbVideoLocalStorage for caching video events locally.

--- a/mobile/lib/screens/feed/feed_auto_advance_error_listener.dart
+++ b/mobile/lib/screens/feed/feed_auto_advance_error_listener.dart
@@ -1,18 +1,30 @@
+import 'dart:async';
+
 import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_state.dart';
 
-/// Fires [onSkipBrokenVideo] once when the active feed item's video enters a
+/// Fires [onSkipBrokenVideo] when the active feed item's video enters a
 /// non-ready [PlaybackStatus] (error / forbidden / not-found / age-restricted).
 ///
 /// Needed because loop-completion detection only fires when the player crosses
-/// a loop boundary — a broken video never emits positions,
-/// so without this, Auto gets stuck on the error overlay.
+/// a loop boundary — a broken video never emits positions, so without this,
+/// Auto gets stuck on the error overlay.
 ///
-/// Gated on [isAutoAdvanceActive] and [isActive] so background / preloaded
-/// pages can't yank the feed forward if they fail while the user is still
-/// on an earlier page.
+/// Behavior by mode (see #5953):
+/// * **Auto mode** ([isAutoAdvanceActive] true) — skips immediately on any
+///   non-ready status (unchanged), and additionally, when
+///   [confirmAndMarkMissing] is supplied, marks a HEAD-confirmed hard-404 item
+///   broken (fire-and-forget) so it is pruned from every surface on refetch.
+/// * **Manual scroll** — skips *only* when [confirmAndMarkMissing] resolves
+///   `true` (a HEAD-confirmed hard 404, which also marks it broken). Transient
+///   or non-404 failures keep the error tile, so a network flake can't evict a
+///   valid video. Without a [confirmAndMarkMissing] callback, manual scroll
+///   never auto-skips (prior behavior).
+///
+/// Gated on [isActive] so background / preloaded pages can't yank the feed
+/// forward if they fail while the user is still on an earlier page.
 class FeedAutoAdvancePastErrorListener extends StatefulWidget {
   const FeedAutoAdvancePastErrorListener({
     required this.videoId,
@@ -20,6 +32,7 @@ class FeedAutoAdvancePastErrorListener extends StatefulWidget {
     required this.isAutoAdvanceActive,
     required this.onSkipBrokenVideo,
     required this.child,
+    this.confirmAndMarkMissing,
     super.key,
   });
 
@@ -28,6 +41,11 @@ class FeedAutoAdvancePastErrorListener extends StatefulWidget {
   final bool isAutoAdvanceActive;
   final VoidCallback onSkipBrokenVideo;
   final Widget child;
+
+  /// Confirms (via a HEAD request) whether the active item's media is a hard
+  /// 404 and, if so, marks it broken. Returns `true` only for a confirmed 404.
+  /// Injected by the feed item from `deadMediaFeedGuardProvider`.
+  final Future<bool> Function()? confirmAndMarkMissing;
 
   @override
   State<FeedAutoAdvancePastErrorListener> createState() =>
@@ -74,10 +92,31 @@ class _FeedAutoAdvancePastErrorListenerState
   void _maybeFire(PlaybackStatus status) {
     if (_firedForCurrentBreak) return;
     if (!widget.isActive) return;
-    if (!widget.isAutoAdvanceActive) return;
     if (status == PlaybackStatus.ready) return;
 
     _firedForCurrentBreak = true;
+
+    final confirm = widget.confirmAndMarkMissing;
+    if (widget.isAutoAdvanceActive) {
+      // Auto already skips any non-ready item — preserve that immediately, and
+      // mark a hard-404 item broken (fire-and-forget) so it's pruned on refetch.
+      _deferSkip();
+      if (confirm != null) unawaited(confirm());
+      return;
+    }
+
+    // Manual scroll: only skip past a HEAD-confirmed hard 404 (which also marks
+    // it broken). Transient / non-404 failures keep the error tile.
+    if (confirm == null) return;
+    unawaited(
+      confirm().then((isMissing) {
+        if (!mounted) return;
+        if (isMissing) _deferSkip();
+      }),
+    );
+  }
+
+  void _deferSkip() {
     // Defer so we don't advance mid-build while the cubit is emitting.
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;

--- a/mobile/lib/screens/feed/feed_auto_advance_error_listener.dart
+++ b/mobile/lib/screens/feed/feed_auto_advance_error_listener.dart
@@ -76,10 +76,16 @@ class _FeedAutoAdvancePastErrorListenerState
     }
 
     // Re-evaluate when any gate flips — e.g. user swiped onto an already-
-    // errored video (isActive false → true), or Auto was just enabled.
+    // errored video (isActive false → true), Auto was just enabled, or the
+    // home-feed guard ([confirmAndMarkMissing]) just resolved for an item
+    // that already failed while it was still null. Without this branch, an
+    // item that failed before the guard loaded latches `_firedForCurrentBreak`
+    // and never gets a confirm attempt (see #5953 review).
     if (oldWidget.videoId != widget.videoId ||
         oldWidget.isActive != widget.isActive ||
-        oldWidget.isAutoAdvanceActive != widget.isAutoAdvanceActive) {
+        oldWidget.isAutoAdvanceActive != widget.isAutoAdvanceActive ||
+        (oldWidget.confirmAndMarkMissing == null &&
+            widget.confirmAndMarkMissing != null)) {
       _evaluateCurrentStatus();
     }
   }
@@ -94,24 +100,37 @@ class _FeedAutoAdvancePastErrorListenerState
     if (!widget.isActive) return;
     if (status == PlaybackStatus.ready) return;
 
-    _firedForCurrentBreak = true;
-
     final confirm = widget.confirmAndMarkMissing;
     if (widget.isAutoAdvanceActive) {
       // Auto already skips any non-ready item — preserve that immediately, and
       // mark a hard-404 item broken (fire-and-forget) so it's pruned on refetch.
+      _firedForCurrentBreak = true;
       _deferSkip();
       if (confirm != null) unawaited(confirm());
       return;
     }
 
-    // Manual scroll: only skip past a HEAD-confirmed hard 404 (which also marks
-    // it broken). Transient / non-404 failures keep the error tile.
+    // Manual scroll: only skip past a HEAD-confirmed hard 404 (which also
+    // marks it broken). Transient / non-404 failures keep the error tile.
+    //
+    // Don't latch `_firedForCurrentBreak` when the guard isn't loaded yet —
+    // no confirmation attempt happened, so `didUpdateWidget` must be able to
+    // retry once [confirmAndMarkMissing] becomes available for this same
+    // failed item.
     if (confirm == null) return;
+    _firedForCurrentBreak = true;
+    final videoId = widget.videoId;
     unawaited(
       confirm().then((isMissing) {
         if (!mounted) return;
-        if (isMissing) _deferSkip();
+        if (!isMissing) return;
+        // The result raced a page change, a deactivation, or a recovery —
+        // none of which should move a different/now-ready item.
+        if (!widget.isActive) return;
+        if (widget.videoId != videoId) return;
+        final cubit = context.read<VideoPlaybackStatusCubit>();
+        if (cubit.state.statusFor(videoId) == PlaybackStatus.ready) return;
+        _deferSkip();
       }),
     );
   }

--- a/mobile/lib/services/broken_video_tracker.dart
+++ b/mobile/lib/services/broken_video_tracker.dart
@@ -3,7 +3,6 @@
 
 import 'dart:convert';
 
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -160,8 +159,3 @@ class BrokenVideoTracker {
     );
   }
 }
-
-// Riverpod provider for BrokenVideoTracker
-final brokenVideoTrackerProvider = Provider<BrokenVideoTracker>((ref) {
-  return BrokenVideoTracker();
-});

--- a/mobile/lib/services/dead_media_feed_guard.dart
+++ b/mobile/lib/services/dead_media_feed_guard.dart
@@ -47,7 +47,7 @@ class DeadMediaFeedGuard {
     if (!missing) return false;
     await _tracker.markVideoBroken(
       videoId,
-      'Confirmed 404 in home feed (#5953)',
+      'Confirmed 404 in home feed',
     );
     return true;
   }

--- a/mobile/lib/services/dead_media_feed_guard.dart
+++ b/mobile/lib/services/dead_media_feed_guard.dart
@@ -1,0 +1,54 @@
+// ABOUTME: Confirms a feed item's media is a hard 404 and marks it broken so
+// ABOUTME: the home feed can skip past + persistently prune it. See #5953.
+
+import 'package:openvine/services/broken_video_tracker.dart';
+import 'package:openvine/services/media_availability_checker.dart';
+
+/// Decides whether a feed item whose player failed should be treated as
+/// permanently unavailable.
+///
+/// Imported classic-Vine clips can point at `media.divine.video/<sha256>` blobs
+/// that were never stored and return a hard **HTTP 404**. Playback then fails
+/// (iOS `COMPOSITION_ERROR` → `notFound`; Android `PLAYER_ERROR "Source error"`
+/// → `generic`), but the home scrolling feed neither skips nor prunes them —
+/// unlike the fullscreen feed, which HEAD-confirms the 404 and marks it broken.
+///
+/// This guard lifts that "confirm → mark" contract into a layer below the
+/// widget so the home feed can reuse it. Detection is a deterministic HEAD 404
+/// via [MediaAvailabilityChecker] — NOT the playback error string, which is
+/// platform-divergent (see #5953 findings).
+class DeadMediaFeedGuard {
+  const DeadMediaFeedGuard({
+    required BrokenVideoTracker brokenVideoTracker,
+    MediaAvailabilityChecker availabilityChecker =
+        const MediaAvailabilityChecker(),
+  }) : _tracker = brokenVideoTracker,
+       _checker = availabilityChecker;
+
+  final BrokenVideoTracker _tracker;
+  final MediaAvailabilityChecker _checker;
+
+  /// Returns `true` iff [videoUrl] is a HEAD-confirmed hard 404, in which case
+  /// [videoId] is persisted as broken so [BrokenVideoTracker.isVideoBroken]
+  /// (and therefore `filterVideoList`) drops it from every list surface across
+  /// restarts.
+  ///
+  /// Returns `false` when [videoUrl] is missing, reachable, returns any status
+  /// other than 404, or the HEAD request fails with a network error — the
+  /// caller must then treat the failure as transient and keep the item. This
+  /// conservative gate is what prevents a one-off network flake from evicting a
+  /// valid video.
+  Future<bool> confirmAndMarkMissing({
+    required String videoId,
+    required String? videoUrl,
+  }) async {
+    if (videoUrl == null || videoUrl.isEmpty) return false;
+    final missing = await _checker.isConfirmedMissing(videoUrl);
+    if (!missing) return false;
+    await _tracker.markVideoBroken(
+      videoId,
+      'Confirmed 404 in home feed (#5953)',
+    );
+    return true;
+  }
+}

--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -610,6 +610,11 @@ class __OverlayState extends ConsumerState<_Overlay> {
 
     final effectiveAutoActive = autoAdvanceAvailable && autoEffectivelyActive;
 
+    // Guard that HEAD-confirms a hard 404 and marks the item broken so the home
+    // feed can skip past + prune dead imported-Vine media. Null until its
+    // one-time tracker init resolves. See #5953.
+    final deadMediaGuard = ref.watch(deadMediaFeedGuardProvider).asData?.value;
+
     final playbackStatus = context.select(
       (VideoPlaybackStatusCubit cubit) => cubit.state.statusFor(video.id),
     );
@@ -659,6 +664,12 @@ class __OverlayState extends ConsumerState<_Overlay> {
           isActive: widget.isActive,
           isAutoAdvanceActive: effectiveAutoActive,
           onSkipBrokenVideo: _skipToNextVideo,
+          confirmAndMarkMissing: deadMediaGuard == null
+              ? null
+              : () => deadMediaGuard.confirmAndMarkMissing(
+                  videoId: video.id,
+                  videoUrl: video.videoUrl,
+                ),
           child: BlocProvider<VideoInteractionsBloc>(
             key: videoInteractionsBlocKey(
               likesRepository: likesRepository,

--- a/mobile/test/providers/broken_video_tracker_identity_test.dart
+++ b/mobile/test/providers/broken_video_tracker_identity_test.dart
@@ -5,9 +5,21 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/providers/video_providers.dart';
+import 'package:openvine/services/dead_media_feed_guard.dart';
+import 'package:openvine/services/media_availability_checker.dart';
 
 import '../helpers/test_helpers.dart';
 import '../helpers/test_provider_overrides.dart';
+
+/// Always reports the checked URL as a confirmed 404 with no network I/O, so
+/// the guard-mark regression below can exercise the real
+/// [DeadMediaFeedGuard.confirmAndMarkMissing] path deterministically.
+class _AlwaysConfirmedMissingChecker implements MediaAvailabilityChecker {
+  const _AlwaysConfirmedMissingChecker();
+
+  @override
+  Future<bool> isConfirmedMissing(String url) async => true;
+}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -52,9 +64,31 @@ void main() {
     );
 
     test(
-      "a mark made through deadMediaFeedGuardProvider's tracker is reflected "
-      'by VideoEventService.filterVideoList',
+      'a mark made through deadMediaFeedGuardProvider.confirmAndMarkMissing '
+      'is reflected by VideoEventService.filterVideoList',
       () async {
+        // Rebuild the container with deadMediaFeedGuardProvider overridden to
+        // swap in a checker that deterministically reports a confirmed 404 —
+        // everything else about the provider's body (resolving the tracker
+        // via brokenVideoTrackerProvider) matches production exactly, so this
+        // still exercises the real provider identifier and the real
+        // confirmAndMarkMissing mark path, just without a live HEAD request.
+        container.dispose();
+        container = ProviderContainer(
+          overrides: [
+            ...getStandardTestOverrides().cast(),
+            deadMediaFeedGuardProvider.overrideWith((ref) async {
+              final tracker = await ref.watch(
+                brokenVideoTrackerProvider.future,
+              );
+              return DeadMediaFeedGuard(
+                brokenVideoTracker: tracker,
+                availabilityChecker: const _AlwaysConfirmedMissingChecker(),
+              );
+            }),
+          ],
+        );
+
         // Build VideoEventService first (production attaches its tracker via
         // a fire-and-forget ref.read inside the provider's build function).
         final service = container.read(videoEventServiceProvider);
@@ -81,13 +115,12 @@ void main() {
           containsAll(<String>['good1', 'dead1']),
         );
 
-        // deadMediaFeedGuardProvider wraps *the same* brokenVideoTrackerProvider
-        // future with no other logic, so marking through the tracker it
-        // resolves to is equivalent to a guard-confirmed mark.
         final guard = await container.read(deadMediaFeedGuardProvider.future);
-        expect(guard, isA<Object>());
-        final tracker = await container.read(brokenVideoTrackerProvider.future);
-        await tracker.markVideoBroken('dead1', 'test: confirmed 404');
+        final marked = await guard.confirmAndMarkMissing(
+          videoId: 'dead1',
+          videoUrl: dead.videoUrl,
+        );
+        expect(marked, isTrue);
 
         expect(
           service.filterVideoList([good, dead]).map((v) => v.id),

--- a/mobile/test/providers/broken_video_tracker_identity_test.dart
+++ b/mobile/test/providers/broken_video_tracker_identity_test.dart
@@ -1,0 +1,104 @@
+// ABOUTME: Regression test for the #5953 PR review — deadMediaFeedGuardProvider
+// ABOUTME: must mark the same BrokenVideoTracker instance videoEventServiceProvider
+// ABOUTME: attaches to VideoEventService.filterVideoList, not a re-created one.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/providers/video_providers.dart';
+
+import '../helpers/test_helpers.dart';
+import '../helpers/test_provider_overrides.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('brokenVideoTrackerProvider identity (#5953 review)', () {
+    late ProviderContainer container;
+
+    setUp(() {
+      container = ProviderContainer(
+        overrides: getStandardTestOverrides().cast(),
+      );
+    });
+
+    tearDown(() {
+      container.dispose();
+    });
+
+    test(
+      'brokenVideoTrackerProvider returns the same instance on every read',
+      () async {
+        // videoEventServiceProvider builds first and captures whatever
+        // instance brokenVideoTrackerProvider hands back at that moment —
+        // exactly like production startup order.
+        container.read(videoEventServiceProvider);
+
+        final first = await container.read(brokenVideoTrackerProvider.future);
+        final second = await container.read(
+          brokenVideoTrackerProvider.future,
+        );
+
+        expect(
+          identical(first, second),
+          isTrue,
+          reason:
+              'brokenVideoTrackerProvider must be keepAlive. Without it, the '
+              "provider can autodispose once videoEventServiceProvider's "
+              'one-off ref.read completes, so a later read (e.g. from '
+              'deadMediaFeedGuardProvider) rebuilds a fresh tracker instance '
+              'that VideoEventService never attached.',
+        );
+      },
+    );
+
+    test(
+      "a mark made through deadMediaFeedGuardProvider's tracker is reflected "
+      'by VideoEventService.filterVideoList',
+      () async {
+        // Build VideoEventService first (production attaches its tracker via
+        // a fire-and-forget ref.read inside the provider's build function).
+        final service = container.read(videoEventServiceProvider);
+
+        // Let the fire-and-forget setBrokenVideoTracker(...) attach.
+        await container.read(brokenVideoTrackerProvider.future);
+        await Future<void>.delayed(Duration.zero);
+
+        // media.divine.video so the videos survive the default
+        // divine-hosted-only preference and only the tracker mark decides
+        // whether they're filtered — matching the real #5953 scenario of a
+        // missing media.divine.video blob.
+        final good = TestHelpers.createVideoEvent(
+          id: 'good1',
+          videoUrl: 'https://media.divine.video/good1hash',
+        );
+        final dead = TestHelpers.createVideoEvent(
+          id: 'dead1',
+          videoUrl: 'https://media.divine.video/dead1hash',
+        );
+
+        expect(
+          service.filterVideoList([good, dead]).map((v) => v.id),
+          containsAll(<String>['good1', 'dead1']),
+        );
+
+        // deadMediaFeedGuardProvider wraps *the same* brokenVideoTrackerProvider
+        // future with no other logic, so marking through the tracker it
+        // resolves to is equivalent to a guard-confirmed mark.
+        final guard = await container.read(deadMediaFeedGuardProvider.future);
+        expect(guard, isA<Object>());
+        final tracker = await container.read(brokenVideoTrackerProvider.future);
+        await tracker.markVideoBroken('dead1', 'test: confirmed 404');
+
+        expect(
+          service.filterVideoList([good, dead]).map((v) => v.id),
+          equals(['good1']),
+          reason:
+              'VideoEventService must filter against the exact tracker '
+              'instance the home-feed guard marks — a stale/duplicate '
+              'tracker (the pre-fix autoDispose bug) would leave the dead '
+              'item visible in the home scrolling feed.',
+        );
+      },
+    );
+  });
+}

--- a/mobile/test/screens/feed/feed_auto_advance_error_listener_test.dart
+++ b/mobile/test/screens/feed/feed_auto_advance_error_listener_test.dart
@@ -2,6 +2,8 @@
 // ABOUTME: onSkipBrokenVideo exactly once when the active item's playback
 // ABOUTME: status goes non-ready, and only while Auto is effectively active.
 
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -364,6 +366,198 @@ void main() {
 
         expect(skipCount, equals(1));
         expect(confirmCalls, equals(1));
+      },
+    );
+
+    testWidgets(
+      'manual scroll: retries confirmation once the guard becomes available '
+      'for an item that already failed while it was still null',
+      (tester) async {
+        var confirmCalls = 0;
+        final confirmCompleter = Completer<bool>();
+        final notFound = VideoPlaybackStatusState().withStatus(
+          'video-1',
+          PlaybackStatus.notFound,
+        );
+        when(() => cubit.state).thenReturn(notFound);
+        whenListen(
+          cubit,
+          const Stream<VideoPlaybackStatusState>.empty(),
+          initialState: notFound,
+        );
+
+        // Mounts already-failed with no guard loaded yet (deadMediaFeedGuard
+        // is still resolving its async provider).
+        await tester.pumpWidget(
+          _host(
+            cubit: cubit,
+            videoId: 'video-1',
+            isActive: true,
+            isAutoAdvanceActive: false, // manual scroll
+            onSkip: () => skipCount++,
+          ),
+        );
+        await tester.pump();
+
+        expect(
+          confirmCalls,
+          equals(0),
+          reason: 'no confirm attempt is possible without the guard',
+        );
+        expect(skipCount, equals(0));
+
+        // The guard finishes loading — confirmAndMarkMissing flips null →
+        // non-null for the same still-failed item.
+        await tester.pumpWidget(
+          _host(
+            cubit: cubit,
+            videoId: 'video-1',
+            isActive: true,
+            isAutoAdvanceActive: false,
+            onSkip: () => skipCount++,
+            confirmAndMarkMissing: () {
+              confirmCalls++;
+              return confirmCompleter.future;
+            },
+          ),
+        );
+
+        expect(
+          confirmCalls,
+          equals(1),
+          reason:
+              'didUpdateWidget must retry the confirm attempt as soon as '
+              'confirmAndMarkMissing becomes available for this same item',
+        );
+
+        confirmCompleter.complete(true); // confirmed hard 404
+        // A bare completer resolving outside any widget rebuild doesn't
+        // schedule a frame on its own, so nudge the test binding to draw one
+        // — otherwise pump() only flushes microtasks and the post-frame
+        // callback that fires the skip never runs.
+        tester.binding.scheduleFrame();
+        await tester.pump();
+
+        expect(skipCount, equals(1));
+      },
+    );
+
+    testWidgets(
+      'manual scroll: ignores a stale confirm result once the item is no '
+      'longer active',
+      (tester) async {
+        var confirmCalls = 0;
+        final confirmCompleter = Completer<bool>();
+        final updated = VideoPlaybackStatusState().withStatus(
+          'video-1',
+          PlaybackStatus.notFound,
+        );
+        whenListen(
+          cubit,
+          Stream<VideoPlaybackStatusState>.fromIterable([updated]),
+          initialState: VideoPlaybackStatusState(),
+        );
+        Future<bool> confirm() {
+          confirmCalls++;
+          return confirmCompleter.future;
+        }
+
+        await tester.pumpWidget(
+          _host(
+            cubit: cubit,
+            videoId: 'video-1',
+            isActive: true,
+            isAutoAdvanceActive: false, // manual scroll
+            onSkip: () => skipCount++,
+            confirmAndMarkMissing: confirm,
+          ),
+        );
+        await tester.pump(); // deliver stream event -> starts confirm()
+
+        // The user scrolls away before the HEAD confirmation resolves.
+        await tester.pumpWidget(
+          _host(
+            cubit: cubit,
+            videoId: 'video-1',
+            isActive: false,
+            isAutoAdvanceActive: false,
+            onSkip: () => skipCount++,
+            confirmAndMarkMissing: confirm,
+          ),
+        );
+
+        confirmCompleter.complete(true); // confirms a hard 404, too late
+        await tester.pump();
+        await tester.pump();
+
+        expect(confirmCalls, equals(1));
+        expect(
+          skipCount,
+          equals(0),
+          reason:
+              'a confirmation racing a deactivation must not move a '
+              'page the user is no longer on',
+        );
+      },
+    );
+
+    testWidgets(
+      'manual scroll: ignores a stale confirm result once the item recycled '
+      'to a different video',
+      (tester) async {
+        var confirmCalls = 0;
+        final confirmCompleter = Completer<bool>();
+        final updated = VideoPlaybackStatusState().withStatus(
+          'video-1',
+          PlaybackStatus.notFound,
+        );
+        whenListen(
+          cubit,
+          Stream<VideoPlaybackStatusState>.fromIterable([updated]),
+          initialState: VideoPlaybackStatusState(),
+        );
+        Future<bool> confirm() {
+          confirmCalls++;
+          return confirmCompleter.future;
+        }
+
+        await tester.pumpWidget(
+          _host(
+            cubit: cubit,
+            videoId: 'video-1',
+            isActive: true,
+            isAutoAdvanceActive: false, // manual scroll
+            onSkip: () => skipCount++,
+            confirmAndMarkMissing: confirm,
+          ),
+        );
+        await tester.pump(); // deliver stream event -> starts confirm()
+
+        // The pooled feed item recycles to a different video before the HEAD
+        // confirmation for the old one resolves.
+        await tester.pumpWidget(
+          _host(
+            cubit: cubit,
+            videoId: 'video-2',
+            isActive: true,
+            isAutoAdvanceActive: false,
+            onSkip: () => skipCount++,
+            confirmAndMarkMissing: confirm,
+          ),
+        );
+
+        confirmCompleter.complete(true); // confirms video-1, now stale
+        await tester.pump();
+        await tester.pump();
+
+        expect(confirmCalls, equals(1));
+        expect(
+          skipCount,
+          equals(0),
+          reason:
+              'a stale confirmation for the previous video must not '
+              'skip the newly recycled one',
+        );
       },
     );
   });

--- a/mobile/test/screens/feed/feed_auto_advance_error_listener_test.dart
+++ b/mobile/test/screens/feed/feed_auto_advance_error_listener_test.dart
@@ -20,6 +20,7 @@ Widget _host({
   required bool isActive,
   required bool isAutoAdvanceActive,
   required VoidCallback onSkip,
+  Future<bool> Function()? confirmAndMarkMissing,
 }) {
   return Directionality(
     textDirection: TextDirection.ltr,
@@ -30,6 +31,7 @@ Widget _host({
         isActive: isActive,
         isAutoAdvanceActive: isAutoAdvanceActive,
         onSkipBrokenVideo: onSkip,
+        confirmAndMarkMissing: confirmAndMarkMissing,
         child: const SizedBox.shrink(),
       ),
     ),
@@ -252,6 +254,116 @@ void main() {
         await tester.pump();
         await tester.pump();
         expect(skipCount, equals(2));
+      },
+    );
+
+    testWidgets(
+      'manual scroll: skips when confirmAndMarkMissing confirms a hard 404',
+      (tester) async {
+        var confirmCalls = 0;
+        final updated = VideoPlaybackStatusState().withStatus(
+          'video-1',
+          PlaybackStatus.notFound,
+        );
+        whenListen(
+          cubit,
+          Stream<VideoPlaybackStatusState>.fromIterable([updated]),
+          initialState: VideoPlaybackStatusState(),
+        );
+
+        await tester.pumpWidget(
+          _host(
+            cubit: cubit,
+            videoId: 'video-1',
+            isActive: true,
+            isAutoAdvanceActive: false, // manual scroll
+            onSkip: () => skipCount++,
+            confirmAndMarkMissing: () async {
+              confirmCalls++;
+              return true; // confirmed hard 404
+            },
+          ),
+        );
+
+        await tester.pump(); // deliver stream event
+        await tester.pump(); // resolve confirm future
+        await tester.pump(); // run post-frame skip
+
+        expect(confirmCalls, equals(1));
+        expect(skipCount, equals(1));
+      },
+    );
+
+    testWidgets(
+      'manual scroll: does NOT skip when the failure is not a confirmed 404',
+      (tester) async {
+        var confirmCalls = 0;
+        final updated = VideoPlaybackStatusState().withStatus(
+          'video-1',
+          PlaybackStatus.generic,
+        );
+        whenListen(
+          cubit,
+          Stream<VideoPlaybackStatusState>.fromIterable([updated]),
+          initialState: VideoPlaybackStatusState(),
+        );
+
+        await tester.pumpWidget(
+          _host(
+            cubit: cubit,
+            videoId: 'video-1',
+            isActive: true,
+            isAutoAdvanceActive: false, // manual scroll
+            onSkip: () => skipCount++,
+            confirmAndMarkMissing: () async {
+              confirmCalls++;
+              return false; // transient / non-404 — keep the item
+            },
+          ),
+        );
+
+        await tester.pump();
+        await tester.pump();
+        await tester.pump();
+
+        expect(confirmCalls, equals(1));
+        expect(skipCount, equals(0));
+      },
+    );
+
+    testWidgets(
+      'auto mode: skips immediately and still runs confirmAndMarkMissing',
+      (tester) async {
+        var confirmCalls = 0;
+        final updated = VideoPlaybackStatusState().withStatus(
+          'video-1',
+          PlaybackStatus.notFound,
+        );
+        whenListen(
+          cubit,
+          Stream<VideoPlaybackStatusState>.fromIterable([updated]),
+          initialState: VideoPlaybackStatusState(),
+        );
+
+        await tester.pumpWidget(
+          _host(
+            cubit: cubit,
+            videoId: 'video-1',
+            isActive: true,
+            isAutoAdvanceActive: true, // auto
+            onSkip: () => skipCount++,
+            confirmAndMarkMissing: () async {
+              confirmCalls++;
+              return true;
+            },
+          ),
+        );
+
+        await tester.pump();
+        await tester.pump();
+
+        expect(skipCount, equals(1));
+        expect(confirmCalls, equals(1));
       },
     );
   });

--- a/mobile/test/services/dead_media_feed_guard_test.dart
+++ b/mobile/test/services/dead_media_feed_guard_test.dart
@@ -1,0 +1,90 @@
+// ABOUTME: Tests DeadMediaFeedGuard — confirms a hard 404 via HEAD and marks
+// ABOUTME: the item broken; transient / non-404 / missing-URL cases keep it.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/services/broken_video_tracker.dart';
+import 'package:openvine/services/dead_media_feed_guard.dart';
+import 'package:openvine/services/media_availability_checker.dart';
+
+class _MockChecker extends Mock implements MediaAvailabilityChecker {}
+
+class _MockTracker extends Mock implements BrokenVideoTracker {}
+
+void main() {
+  group(DeadMediaFeedGuard, () {
+    late _MockChecker checker;
+    late _MockTracker tracker;
+    late DeadMediaFeedGuard guard;
+
+    setUp(() {
+      checker = _MockChecker();
+      tracker = _MockTracker();
+      when(
+        () => tracker.markVideoBroken(any(), any()),
+      ).thenAnswer((_) async {});
+      guard = DeadMediaFeedGuard(
+        brokenVideoTracker: tracker,
+        availabilityChecker: checker,
+      );
+    });
+
+    group('confirmAndMarkMissing', () {
+      test(
+        'returns true and marks broken when HEAD confirms a hard 404',
+        () async {
+          const url = 'https://media.divine.video/deadhash';
+          when(
+            () => checker.isConfirmedMissing(url),
+          ).thenAnswer((_) async => true);
+
+          final result = await guard.confirmAndMarkMissing(
+            videoId: 'v1',
+            videoUrl: url,
+          );
+
+          expect(result, isTrue);
+          verify(() => tracker.markVideoBroken('v1', any())).called(1);
+        },
+      );
+
+      test(
+        'returns false and does NOT mark broken when the media is reachable / non-404',
+        () async {
+          when(
+            () => checker.isConfirmedMissing(any()),
+          ).thenAnswer((_) async => false);
+
+          final result = await guard.confirmAndMarkMissing(
+            videoId: 'v1',
+            videoUrl: 'https://media.divine.video/live',
+          );
+
+          expect(result, isFalse);
+          verifyNever(() => tracker.markVideoBroken(any(), any()));
+        },
+      );
+
+      test('returns false without a HEAD when videoUrl is null', () async {
+        final result = await guard.confirmAndMarkMissing(
+          videoId: 'v1',
+          videoUrl: null,
+        );
+
+        expect(result, isFalse);
+        verifyNever(() => checker.isConfirmedMissing(any()));
+        verifyNever(() => tracker.markVideoBroken(any(), any()));
+      });
+
+      test('returns false without a HEAD when videoUrl is empty', () async {
+        final result = await guard.confirmAndMarkMissing(
+          videoId: 'v1',
+          videoUrl: '',
+        );
+
+        expect(result, isFalse);
+        verifyNever(() => checker.isConfirmedMissing(any()));
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Description

Imported classic-Vine clips whose media points at `media.divine.video/<sha256>` blobs that **404** (missing divine-hosted blobs — ~10% of recent imports; the legacy `web.archive.org`/`v.cdn.vine.co` URL is only the *avatar*) were served in the home scrolling feed and failed to play. The home feed never skipped them (manual scroll), never pruned them, and re-attempted the dead URL on every window revisit — the "wall of composition errors" from the report. The **fullscreen** feed already HEAD-confirms the 404 and marks it broken; the **home** feed never wired that path.

This PR adds that resilience to the home feed:

- **`DeadMediaFeedGuard`** (new service) — HEAD-confirms a hard 404 via the existing `MediaAvailabilityChecker` and marks the item broken on the shared `BrokenVideoTracker`. Returns `false` for a reachable URL, any non-404 status, a network error, or a missing URL, so a transient flake can't evict a valid video.
- **`FeedAutoAdvancePastErrorListener`** now drives the guard: in **manual scroll** it auto-advances past a confirmed-dead item (matching Auto mode / fullscreen); in **both** modes it marks the item broken so `filterVideoList` prunes it from every surface on the next fetch.
- Detection keys on the **deterministic HTTP 404**, not the playback error string — which is platform-divergent (iOS `COMPOSITION_ERROR`→`notFound` vs Android `PLAYER_ERROR "Source error"`→`generic`+retry). This also stops Android's wasted 4× auto-retry on a confirmed-dead blob.

Reuses the singleton `brokenVideoTrackerProvider` (already attached to `VideoEventService`), so a mark here propagates to For You, profile, hashtag, and grid surfaces.

**Related Issue:** Relates to #5953 (client-resilience angle)

## Out of Scope

- **Backend eligibility** (funnelcake should not *serve* items whose blob is missing) and **import-pipeline repair** (confirm the blob is stored before publishing the event; backfill/prune already-published dead events) — these are the primary/root fixes and are tracked for **#5467** (per the reframing noted on #5953). This PR is the client-resilience companion.

## Verification

- `flutter analyze lib test integration_test` — no issues.
- `flutter test test/services/dead_media_feed_guard_test.dart test/screens/feed/feed_auto_advance_error_listener_test.dart` — new guard tests (404 → mark+skip; non-404 / network-error / missing-URL → keep) and listener tests (manual-scroll skips only on confirmed 404; auto mode unchanged; transient errors not skipped).
- Regression: `feed_videos_test.dart`, `feed_videos_repo_swap_test.dart`, `video_feed_page_test.dart` — green.
- `dart format` clean; untested-services floor unchanged.
- Root cause confirmed against production data (the real failing event's `media.divine.video` URL returns a live 404) and the local stack (funnelcake serves such items with no eligibility gate; the relay accepts them). A full in-app playback recording was not captured because the local stack's fresh-account feeds don't surface seeded items; the failure path and fix are covered by the widget/unit tests above.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
