### PR TITLE
fix(support): Lots of bugs

### DIFF
--- a/mobile/lib/blocs/background_publish/background_publish_bloc.dart
+++ b/mobile/lib/blocs/background_publish/background_publish_bloc.dart
@@ -222,6 +222,7 @@ class BackgroundPublishBloc
 
     final newPublishProcess = videoPublishService.publishVideo(
       draft: uploadToRetry.draft,
+      expectedPubkey: uploadToRetry.draft.expectedPublishPubkey,
     );
 
     add(

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -2361,6 +2361,14 @@ class _DivineAppState extends ConsumerState<DivineApp>
         videoEventPublisher: ref.read(videoEventPublisherProvider),
         blossomService: ref.read(blossomUploadServiceProvider),
         draftService: ref.read(draftStorageServiceProvider),
+        readPublishReadiness: () {
+          final readiness = ref.read(nostrSessionProvider);
+          final pubkey = readiness.pubkey;
+          if (!readiness.isReadyForActiveClient || pubkey == null) {
+            return PublishReadiness.notReady(pubkey: pubkey);
+          }
+          return PublishReadiness.ready(pubkey: pubkey);
+        },
         mentionResolutionService: profileRepository == null
             ? null
             : MentionResolutionService(profileRepository: profileRepository),

--- a/mobile/lib/models/divine_video_draft.dart
+++ b/mobile/lib/models/divine_video_draft.dart
@@ -32,6 +32,7 @@ class DivineVideoDraft {
     required this.publishAttempts,
     this.publishError,
     this.sourceDraftId,
+    this.expectedPublishPubkey,
     this.allowAudioReuse = false,
     this.expireTime,
     this.proofManifestJson,
@@ -165,6 +166,7 @@ class DivineVideoDraft {
       publishError: json['publishError'] as String?,
       publishAttempts: json['publishAttempts'] as int? ?? 0,
       sourceDraftId: json['sourceDraftId'] as String?,
+      expectedPublishPubkey: json['expectedPublishPubkey'] as String?,
       proofManifestJson: json['proofManifestJson'] as String?,
       editorStateHistory:
           (json['editorStateHistory'] as Map<String, dynamic>?) ?? const {},
@@ -241,6 +243,7 @@ class DivineVideoDraft {
   final String? proofManifestJson;
   final String? publishError;
   final String? sourceDraftId;
+  final String? expectedPublishPubkey;
   final int publishAttempts;
   final bool allowAudioReuse;
 
@@ -319,6 +322,8 @@ class DivineVideoDraft {
     bool clearPublishError = false,
     String? sourceDraftId,
     bool clearSourceDraftId = false,
+    String? expectedPublishPubkey,
+    bool clearExpectedPublishPubkey = false,
     Duration? expireTime,
     bool? allowAudioReuse,
     int? publishAttempts,
@@ -359,6 +364,9 @@ class DivineVideoDraft {
     sourceDraftId: clearSourceDraftId
         ? null
         : (sourceDraftId ?? this.sourceDraftId),
+    expectedPublishPubkey: clearExpectedPublishPubkey
+        ? null
+        : (expectedPublishPubkey ?? this.expectedPublishPubkey),
     publishAttempts: publishAttempts ?? this.publishAttempts,
     proofManifestJson: clearProofManifestJson
         ? null
@@ -406,6 +414,8 @@ class DivineVideoDraft {
     'publishStatus': publishStatus.name,
     'publishError': publishError,
     if (sourceDraftId != null) 'sourceDraftId': sourceDraftId,
+    if (expectedPublishPubkey != null)
+      'expectedPublishPubkey': expectedPublishPubkey,
     'publishAttempts': publishAttempts,
     'proofManifestJson': proofManifestJson,
     if (editorStateHistory.isNotEmpty) 'editorStateHistory': editorStateHistory,

--- a/mobile/lib/providers/repository_providers.dart
+++ b/mobile/lib/providers/repository_providers.dart
@@ -297,18 +297,18 @@ ProfileRepository? profileRepository(Ref ref) {
 /// Lightweight ProfileRepository gated on **identity-known** (a pubkey is
 /// available) rather than the full `nostrReady` relay-connect settle.
 ///
-/// The follower/following/video COUNTS are populated by a PUBLIC funnelcake
-/// REST call (`getUserProfile` → `_cacheProfileStatsFromResult`, no signer,
-/// no relay) and read back from Drift via `watchProfileStats`. None of that
-/// needs the relay-ready client, so gating those counts behind `nostrReady`
-/// is what left them stuck on "—" for the ~4s relay-connect window at cold
-/// start (#5863). This provider hands over the same repository as soon as the
-/// user's identity is known, so the counts render as soon as REST returns.
+/// Cached profile identity and follower/following/video COUNTS are read from
+/// Drift, and fresh profile data can be hydrated by a PUBLIC Funnelcake REST
+/// call (`getUserProfile`, no signer, no relay). None of that needs the
+/// relay-ready client, so gating those reads behind `nostrReady` left own
+/// profile headers stuck on skeleton/generated fallback during the cold-start
+/// relay-connect window. This provider hands over the same repository as soon
+/// as the user's identity is known, so names and counts render from cache/REST
+/// while signer-backed writes remain gated on [profileRepository].
 ///
 /// It does NOT warm the Kind-0 cache — that side effect belongs to the
-/// relay-backed [profileRepository]. Only [userProfileStatsReactiveProvider]
-/// consumes this; everything relay-dependent must keep using
-/// [profileRepository].
+/// relay-backed [profileRepository]. Read-only profile display providers may
+/// consume this; everything relay-dependent must keep using [profileRepository].
 @Riverpod(keepAlive: true)
 ProfileRepository? profileStatsRepository(Ref ref) {
   final identityPubkey = ref.watch(

--- a/mobile/lib/providers/repository_providers.g.dart
+++ b/mobile/lib/providers/repository_providers.g.dart
@@ -403,18 +403,18 @@ String _$profileRepositoryHash() => r'92a8519f8d195b5c33727803820aa82e94a8b0b2';
 /// Lightweight ProfileRepository gated on **identity-known** (a pubkey is
 /// available) rather than the full `nostrReady` relay-connect settle.
 ///
-/// The follower/following/video COUNTS are populated by a PUBLIC funnelcake
-/// REST call (`getUserProfile` → `_cacheProfileStatsFromResult`, no signer,
-/// no relay) and read back from Drift via `watchProfileStats`. None of that
-/// needs the relay-ready client, so gating those counts behind `nostrReady`
-/// is what left them stuck on "—" for the ~4s relay-connect window at cold
-/// start (#5863). This provider hands over the same repository as soon as the
-/// user's identity is known, so the counts render as soon as REST returns.
+/// Cached profile identity and follower/following/video COUNTS are read from
+/// Drift, and fresh profile data can be hydrated by a PUBLIC Funnelcake REST
+/// call (`getUserProfile`, no signer, no relay). None of that needs the
+/// relay-ready client, so gating those reads behind `nostrReady` left own
+/// profile headers stuck on skeleton/generated fallback during the cold-start
+/// relay-connect window. This provider hands over the same repository as soon
+/// as the user's identity is known, so names and counts render from cache/REST
+/// while signer-backed writes remain gated on [profileRepository].
 ///
 /// It does NOT warm the Kind-0 cache — that side effect belongs to the
-/// relay-backed [profileRepository]. Only [userProfileStatsReactiveProvider]
-/// consumes this; everything relay-dependent must keep using
-/// [profileRepository].
+/// relay-backed [profileRepository]. Read-only profile display providers may
+/// consume this; everything relay-dependent must keep using [profileRepository].
 
 @ProviderFor(profileStatsRepository)
 final profileStatsRepositoryProvider = ProfileStatsRepositoryProvider._();
@@ -422,18 +422,18 @@ final profileStatsRepositoryProvider = ProfileStatsRepositoryProvider._();
 /// Lightweight ProfileRepository gated on **identity-known** (a pubkey is
 /// available) rather than the full `nostrReady` relay-connect settle.
 ///
-/// The follower/following/video COUNTS are populated by a PUBLIC funnelcake
-/// REST call (`getUserProfile` → `_cacheProfileStatsFromResult`, no signer,
-/// no relay) and read back from Drift via `watchProfileStats`. None of that
-/// needs the relay-ready client, so gating those counts behind `nostrReady`
-/// is what left them stuck on "—" for the ~4s relay-connect window at cold
-/// start (#5863). This provider hands over the same repository as soon as the
-/// user's identity is known, so the counts render as soon as REST returns.
+/// Cached profile identity and follower/following/video COUNTS are read from
+/// Drift, and fresh profile data can be hydrated by a PUBLIC Funnelcake REST
+/// call (`getUserProfile`, no signer, no relay). None of that needs the
+/// relay-ready client, so gating those reads behind `nostrReady` left own
+/// profile headers stuck on skeleton/generated fallback during the cold-start
+/// relay-connect window. This provider hands over the same repository as soon
+/// as the user's identity is known, so names and counts render from cache/REST
+/// while signer-backed writes remain gated on [profileRepository].
 ///
 /// It does NOT warm the Kind-0 cache — that side effect belongs to the
-/// relay-backed [profileRepository]. Only [userProfileStatsReactiveProvider]
-/// consumes this; everything relay-dependent must keep using
-/// [profileRepository].
+/// relay-backed [profileRepository]. Read-only profile display providers may
+/// consume this; everything relay-dependent must keep using [profileRepository].
 
 final class ProfileStatsRepositoryProvider
     extends
@@ -446,18 +446,18 @@ final class ProfileStatsRepositoryProvider
   /// Lightweight ProfileRepository gated on **identity-known** (a pubkey is
   /// available) rather than the full `nostrReady` relay-connect settle.
   ///
-  /// The follower/following/video COUNTS are populated by a PUBLIC funnelcake
-  /// REST call (`getUserProfile` → `_cacheProfileStatsFromResult`, no signer,
-  /// no relay) and read back from Drift via `watchProfileStats`. None of that
-  /// needs the relay-ready client, so gating those counts behind `nostrReady`
-  /// is what left them stuck on "—" for the ~4s relay-connect window at cold
-  /// start (#5863). This provider hands over the same repository as soon as the
-  /// user's identity is known, so the counts render as soon as REST returns.
+  /// Cached profile identity and follower/following/video COUNTS are read from
+  /// Drift, and fresh profile data can be hydrated by a PUBLIC Funnelcake REST
+  /// call (`getUserProfile`, no signer, no relay). None of that needs the
+  /// relay-ready client, so gating those reads behind `nostrReady` left own
+  /// profile headers stuck on skeleton/generated fallback during the cold-start
+  /// relay-connect window. This provider hands over the same repository as soon
+  /// as the user's identity is known, so names and counts render from cache/REST
+  /// while signer-backed writes remain gated on [profileRepository].
   ///
   /// It does NOT warm the Kind-0 cache — that side effect belongs to the
-  /// relay-backed [profileRepository]. Only [userProfileStatsReactiveProvider]
-  /// consumes this; everything relay-dependent must keep using
-  /// [profileRepository].
+  /// relay-backed [profileRepository]. Read-only profile display providers may
+  /// consume this; everything relay-dependent must keep using [profileRepository].
   ProfileStatsRepositoryProvider._()
     : super(
         from: null,

--- a/mobile/lib/providers/user_profile_providers.dart
+++ b/mobile/lib/providers/user_profile_providers.dart
@@ -44,7 +44,9 @@ final userProfileStatsReactiveProvider =
 /// FutureProvider, so widget code changes are minimal.
 @riverpod
 Stream<UserProfile?> userProfileReactive(Ref ref, String pubkey) async* {
-  final repo = ref.watch(profileRepositoryProvider);
+  final repo =
+      ref.watch(profileRepositoryProvider) ??
+      ref.watch(profileStatsRepositoryProvider);
   if (repo == null) return;
 
   // Kick off a background fetch if nothing is cached yet.
@@ -62,7 +64,9 @@ Stream<UserProfile?> userProfileReactive(Ref ref, String pubkey) async* {
 /// rather than a reactive stream.
 @riverpod
 Future<UserProfile?> fetchUserProfile(Ref ref, String pubkey) async {
-  final repo = ref.watch(profileRepositoryProvider);
+  final repo =
+      ref.watch(profileRepositoryProvider) ??
+      ref.watch(profileStatsRepositoryProvider);
   if (repo == null) return null;
 
   return await repo.getCachedProfile(pubkey: pubkey) ??

--- a/mobile/lib/providers/user_profile_providers.g.dart
+++ b/mobile/lib/providers/user_profile_providers.g.dart
@@ -93,7 +93,7 @@ final class UserProfileReactiveProvider
 }
 
 String _$userProfileReactiveHash() =>
-    r'b0df16fa99256495c86d9dc1980ac7312d71a6bd';
+    r'ceb157f8463c47d9583242bdeb66e90a47718954';
 
 /// Reactive profile provider backed by Drift's watchProfile stream.
 ///
@@ -202,7 +202,7 @@ final class FetchUserProfileProvider
   }
 }
 
-String _$fetchUserProfileHash() => r'b5565d7d2d026d79ff21286d42511b8aee085d4d';
+String _$fetchUserProfileHash() => r'5d183d94f59828f47e858d8532795fa99b860526';
 
 /// One-shot provider: returns cached profile or fetches fresh.
 ///

--- a/mobile/lib/providers/video_publish_provider.dart
+++ b/mobile/lib/providers/video_publish_provider.dart
@@ -147,6 +147,7 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
   /// Creates the publish service with callbacks wired to this notifier.
   Future<VideoPublishService> _createPublishService({
     required OnProgressChanged onProgressChanged,
+    required PublishReadiness publishReadiness,
   }) async {
     return VideoPublishService(
       uploadManager: ref.read(uploadManagerProvider),
@@ -154,14 +155,7 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
       videoEventPublisher: ref.read(videoEventPublisherProvider),
       blossomService: ref.read(blossomUploadServiceProvider),
       draftService: _draftService,
-      readPublishReadiness: () {
-        final readiness = ref.read(nostrSessionProvider);
-        final pubkey = readiness.pubkey;
-        if (!readiness.isReadyForActiveClient || pubkey == null) {
-          return PublishReadiness.notReady(pubkey: pubkey);
-        }
-        return PublishReadiness.ready(pubkey: pubkey);
-      },
+      readPublishReadiness: () => publishReadiness,
       mentionResolutionService: createVideoPublishMentionResolutionService(
         ref.read(profileRepositoryProvider),
       ),
@@ -175,6 +169,15 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
         onProgressChanged(draftId: draftId, progress: progress);
       },
     );
+  }
+
+  PublishReadiness _currentPublishReadiness() {
+    final readiness = ref.read(nostrSessionProvider);
+    final pubkey = readiness.pubkey;
+    if (!readiness.isReadyForActiveClient || pubkey == null) {
+      return PublishReadiness.notReady(pubkey: pubkey);
+    }
+    return PublishReadiness.ready(pubkey: pubkey);
   }
 
   /// Resets all video-related providers.
@@ -370,6 +373,16 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
       return;
     }
 
+    final publishReadiness = _currentPublishReadiness();
+    final publishPubkey = publishReadiness.pubkey;
+    if (!publishReadiness.isReady ||
+        publishPubkey == null ||
+        publishPubkey.isEmpty) {
+      final l10n = currentAppL10n(ref.read(sharedPreferencesProvider));
+      setError(l10n.publishErrorMessage(PublishErrorKind.notSignedIn));
+      return;
+    }
+
     _inFlightSourceDraftIds.add(sourceDraftId);
     state = state.copyWith(publishState: .preparing);
 
@@ -458,6 +471,7 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
 
       final backgroundPublishBloc = context.read<BackgroundPublishBloc>();
       final publishService = await _createPublishService(
+        publishReadiness: publishReadiness,
         onProgressChanged: ({required draftId, required progress}) {
           backgroundPublishBloc.add(
             BackgroundPublishProgressChanged(

--- a/mobile/lib/providers/video_publish_provider.dart
+++ b/mobile/lib/providers/video_publish_provider.dart
@@ -25,6 +25,7 @@ import 'package:openvine/models/video_publish/video_publish_provider_state.dart'
 import 'package:openvine/models/video_reply_context.dart';
 import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/preferences_providers.dart';
 import 'package:openvine/providers/repository_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
@@ -153,6 +154,14 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
       videoEventPublisher: ref.read(videoEventPublisherProvider),
       blossomService: ref.read(blossomUploadServiceProvider),
       draftService: _draftService,
+      readPublishReadiness: () {
+        final readiness = ref.read(nostrSessionProvider);
+        final pubkey = readiness.pubkey;
+        if (!readiness.isReadyForActiveClient || pubkey == null) {
+          return PublishReadiness.notReady(pubkey: pubkey);
+        }
+        return PublishReadiness.ready(pubkey: pubkey);
+      },
       mentionResolutionService: createVideoPublishMentionResolutionService(
         ref.read(profileRepositoryProvider),
       ),

--- a/mobile/lib/providers/video_publish_provider.dart
+++ b/mobile/lib/providers/video_publish_provider.dart
@@ -457,6 +457,7 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
         publishStatus: PublishStatus.publishing,
         clearPublishError: true,
         sourceDraftId: draft.sourceDraftId ?? draft.id,
+        expectedPublishPubkey: publishPubkey,
         publishAttempts: draft.publishAttempts + 1,
       );
 

--- a/mobile/lib/providers/video_publish_provider.dart
+++ b/mobile/lib/providers/video_publish_provider.dart
@@ -147,7 +147,6 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
   /// Creates the publish service with callbacks wired to this notifier.
   Future<VideoPublishService> _createPublishService({
     required OnProgressChanged onProgressChanged,
-    required PublishReadiness publishReadiness,
   }) async {
     return VideoPublishService(
       uploadManager: ref.read(uploadManagerProvider),
@@ -155,7 +154,7 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
       videoEventPublisher: ref.read(videoEventPublisherProvider),
       blossomService: ref.read(blossomUploadServiceProvider),
       draftService: _draftService,
-      readPublishReadiness: () => publishReadiness,
+      readPublishReadiness: _currentPublishReadiness,
       mentionResolutionService: createVideoPublishMentionResolutionService(
         ref.read(profileRepositoryProvider),
       ),
@@ -178,6 +177,13 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
       return PublishReadiness.notReady(pubkey: pubkey);
     }
     return PublishReadiness.ready(pubkey: pubkey);
+  }
+
+  bool _isReadyForExpectedPubkey(
+    PublishReadiness readiness, {
+    required String expectedPubkey,
+  }) {
+    return readiness.isReady && readiness.pubkey == expectedPubkey;
   }
 
   /// Resets all video-related providers.
@@ -454,6 +460,15 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
         publishAttempts: draft.publishAttempts + 1,
       );
 
+      if (!_isReadyForExpectedPubkey(
+        _currentPublishReadiness(),
+        expectedPubkey: publishPubkey,
+      )) {
+        final l10n = currentAppL10n(ref.read(sharedPreferencesProvider));
+        setError(l10n.publishErrorMessage(PublishErrorKind.notSignedIn));
+        return;
+      }
+
       Log.debug(
         '💾 Saving publish draft: ${publishDraft.id}',
         name: 'VideoPublishNotifier',
@@ -471,7 +486,6 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
 
       final backgroundPublishBloc = context.read<BackgroundPublishBloc>();
       final publishService = await _createPublishService(
-        publishReadiness: publishReadiness,
         onProgressChanged: ({required draftId, required progress}) {
           backgroundPublishBloc.add(
             BackgroundPublishProgressChanged(
@@ -484,6 +498,7 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
 
       final publishmentProcess = publishService.publishVideo(
         draft: publishDraft,
+        expectedPubkey: publishPubkey,
       );
       final videoReplyContext = publishDraft.videoReplyContext;
       final isVideoReply = videoReplyContext != null;

--- a/mobile/lib/services/video_publish/video_publish_service.dart
+++ b/mobile/lib/services/video_publish/video_publish_service.dart
@@ -206,17 +206,17 @@ class VideoPublishService {
 
   /// Publishes a video draft.
   /// Returns [PublishSuccess] on success, [PublishError] on failure.
-  Future<PublishResult> publishVideo({required DivineVideoDraft draft}) async {
-    final readiness = _currentPublishReadiness();
-    final pubkey = readiness.pubkey;
-    if (!readiness.isReady || pubkey == null || pubkey.isEmpty) {
-      Log.warning(
-        '⚠️ Signer session not ready, cannot publish',
-        category: .video,
-      );
-      _backgroundUploadId = null;
+  Future<PublishResult> publishVideo({
+    required DivineVideoDraft draft,
+    String? expectedPubkey,
+  }) async {
+    final initialReadiness = _requirePublishReadiness(
+      expectedPubkey: expectedPubkey,
+    );
+    if (initialReadiness == null) {
       return const PublishError(PublishErrorKind.notSignedIn);
     }
+    final publishPubkey = expectedPubkey ?? initialReadiness.pubkey!;
 
     // Check if we have a background upload ID and its status
     if (_backgroundUploadId != null) {
@@ -225,6 +225,12 @@ class VideoPublishService {
     }
 
     try {
+      final saveReadiness = _requirePublishReadiness(
+        expectedPubkey: publishPubkey,
+      );
+      if (saveReadiness == null) {
+        return const PublishError(PublishErrorKind.notSignedIn);
+      }
       final publishing = draft.copyWith(publishStatus: .publishing);
       await draftService.saveDraft(publishing);
 
@@ -232,7 +238,13 @@ class VideoPublishService {
       Log.info('📝 Publishing video: $videoPath', category: .video);
 
       // Use existing upload if available, otherwise start new upload
-      final pendingUpload = await _getOrCreateUpload(pubkey, draft);
+      final uploadReadiness = _requirePublishReadiness(
+        expectedPubkey: publishPubkey,
+      );
+      if (uploadReadiness == null) {
+        return const PublishError(PublishErrorKind.notSignedIn);
+      }
+      final pendingUpload = await _getOrCreateUpload(publishPubkey, draft);
       if (pendingUpload == null) {
         Log.error('❌ Upload creation failed', category: .video);
         final failedUpload = _backgroundUploadId != null
@@ -273,9 +285,16 @@ class VideoPublishService {
       // Publish Nostr event
       Log.info('📝 Publishing Nostr event...', category: .video);
 
+      final signingReadiness = _requirePublishReadiness(
+        expectedPubkey: publishPubkey,
+      );
+      if (signingReadiness == null) {
+        return const PublishError(PublishErrorKind.notSignedIn);
+      }
+
       final mentionedPubkeys = await _resolveMentionedPubkeys(
         draft,
-        currentUserPubkey: pubkey,
+        currentUserPubkey: publishPubkey,
       );
 
       final published = await videoEventPublisher.publishVideoEvent(
@@ -315,7 +334,7 @@ class VideoPublishService {
       final inviteWarnings = await _sendCollaboratorInvites(
         draft: draft,
         upload: pendingUpload,
-        creatorPubkey: pubkey,
+        creatorPubkey: publishPubkey,
       );
 
       // Success: delete draft
@@ -339,6 +358,23 @@ class VideoPublishService {
       return const PublishReadiness.notReady();
     }
     return PublishReadiness.ready(pubkey: pubkey);
+  }
+
+  PublishReadiness? _requirePublishReadiness({String? expectedPubkey}) {
+    final readiness = _currentPublishReadiness();
+    final pubkey = readiness.pubkey;
+    if (!readiness.isReady ||
+        pubkey == null ||
+        pubkey.isEmpty ||
+        (expectedPubkey != null && pubkey != expectedPubkey)) {
+      Log.warning(
+        '⚠️ Signer session not ready, cannot publish',
+        category: .video,
+      );
+      _backgroundUploadId = null;
+      return null;
+    }
+    return readiness;
   }
 
   Future<List<String>> _resolveMentionedPubkeys(

--- a/mobile/lib/services/video_publish/video_publish_service.dart
+++ b/mobile/lib/services/video_publish/video_publish_service.dart
@@ -208,7 +208,15 @@ class VideoPublishService {
         _backgroundUploadId = null;
         return const PublishError(PublishErrorKind.notSignedIn);
       }
-      final pubkey = authService.currentPublicKeyHex!;
+      final pubkey = authService.currentPublicKeyHex;
+      if (pubkey == null || pubkey.isEmpty) {
+        Log.warning(
+          '⚠️ Authenticated session has no publish pubkey, cannot publish',
+          category: .video,
+        );
+        _backgroundUploadId = null;
+        return const PublishError(PublishErrorKind.notSignedIn);
+      }
 
       // Use existing upload if available, otherwise start new upload
       final pendingUpload = await _getOrCreateUpload(pubkey, draft);

--- a/mobile/lib/services/video_publish/video_publish_service.dart
+++ b/mobile/lib/services/video_publish/video_publish_service.dart
@@ -139,6 +139,23 @@ class CollaboratorInviteWarning extends Equatable {
 typedef OnStateChanged = void Function(VideoPublishState state);
 typedef OnProgressChanged =
     void Function({required String draftId, required double progress});
+typedef ReadPublishReadiness = PublishReadiness Function();
+
+class PublishReadiness extends Equatable {
+  const PublishReadiness._({required this.isReady, this.pubkey});
+
+  const PublishReadiness.ready({required String pubkey})
+    : this._(isReady: true, pubkey: pubkey);
+
+  const PublishReadiness.notReady({String? pubkey})
+    : this._(isReady: false, pubkey: pubkey);
+
+  final bool isReady;
+  final String? pubkey;
+
+  @override
+  List<Object?> get props => [isReady, pubkey];
+}
 
 class VideoPublishService {
   VideoPublishService({
@@ -148,6 +165,7 @@ class VideoPublishService {
     required this.blossomService,
     required this.draftService,
     required this.onProgressChanged,
+    this.readPublishReadiness,
     this.collaboratorInviteService,
     this.languagePreferenceService,
     this.mentionResolutionService,
@@ -180,12 +198,26 @@ class VideoPublishService {
   /// Resolves typed mentions before publishing Nostr video events.
   final MentionResolutionService? mentionResolutionService;
 
+  /// Current signer-backed Nostr readiness for publish side effects.
+  final ReadPublishReadiness? readPublishReadiness;
+
   /// Tracks the current background upload ID.
   String? _backgroundUploadId;
 
   /// Publishes a video draft.
   /// Returns [PublishSuccess] on success, [PublishError] on failure.
   Future<PublishResult> publishVideo({required DivineVideoDraft draft}) async {
+    final readiness = _currentPublishReadiness();
+    final pubkey = readiness.pubkey;
+    if (!readiness.isReady || pubkey == null || pubkey.isEmpty) {
+      Log.warning(
+        '⚠️ Signer session not ready, cannot publish',
+        category: .video,
+      );
+      _backgroundUploadId = null;
+      return const PublishError(PublishErrorKind.notSignedIn);
+    }
+
     // Check if we have a background upload ID and its status
     if (_backgroundUploadId != null) {
       final error = await _handleActiveUpload(draft.id);
@@ -198,25 +230,6 @@ class VideoPublishService {
 
       final videoPath = await draft.clips.first.video.safeFilePath();
       Log.info('📝 Publishing video: $videoPath', category: .video);
-
-      // Verify user is fully authenticated
-      if (!authService.isAuthenticated) {
-        Log.warning(
-          '⚠️ User not authenticated, cannot publish',
-          category: .video,
-        );
-        _backgroundUploadId = null;
-        return const PublishError(PublishErrorKind.notSignedIn);
-      }
-      final pubkey = authService.currentPublicKeyHex;
-      if (pubkey == null || pubkey.isEmpty) {
-        Log.warning(
-          '⚠️ Authenticated session has no publish pubkey, cannot publish',
-          category: .video,
-        );
-        _backgroundUploadId = null;
-        return const PublishError(PublishErrorKind.notSignedIn);
-      }
 
       // Use existing upload if available, otherwise start new upload
       final pendingUpload = await _getOrCreateUpload(pubkey, draft);
@@ -314,6 +327,18 @@ class VideoPublishService {
     } catch (e, stackTrace) {
       return _handleUploadError(e, stackTrace, draft);
     }
+  }
+
+  PublishReadiness _currentPublishReadiness() {
+    final explicitReadiness = readPublishReadiness?.call();
+    if (explicitReadiness != null) return explicitReadiness;
+
+    if (!authService.isAuthenticated) return const PublishReadiness.notReady();
+    final pubkey = authService.currentPublicKeyHex;
+    if (pubkey == null || pubkey.isEmpty) {
+      return const PublishReadiness.notReady();
+    }
+    return PublishReadiness.ready(pubkey: pubkey);
   }
 
   Future<List<String>> _resolveMentionedPubkeys(

--- a/mobile/lib/services/video_publish/video_publish_service.dart
+++ b/mobile/lib/services/video_publish/video_publish_service.dart
@@ -210,13 +210,25 @@ class VideoPublishService {
     required DivineVideoDraft draft,
     String? expectedPubkey,
   }) async {
+    final effectiveExpectedPubkey =
+        expectedPubkey ?? draft.expectedPublishPubkey;
+    if (effectiveExpectedPubkey == null &&
+        _requiresPersistedPublishIdentity(draft)) {
+      Log.warning(
+        '⚠️ Publish retry draft lacks owner identity, cannot publish',
+        category: .video,
+      );
+      _backgroundUploadId = null;
+      return const PublishError(PublishErrorKind.notSignedIn);
+    }
+
     final initialReadiness = _requirePublishReadiness(
-      expectedPubkey: expectedPubkey,
+      expectedPubkey: effectiveExpectedPubkey,
     );
     if (initialReadiness == null) {
       return const PublishError(PublishErrorKind.notSignedIn);
     }
-    final publishPubkey = expectedPubkey ?? initialReadiness.pubkey!;
+    final publishPubkey = effectiveExpectedPubkey ?? initialReadiness.pubkey!;
 
     // Check if we have a background upload ID and its status
     if (_backgroundUploadId != null) {
@@ -346,6 +358,13 @@ class VideoPublishService {
     } catch (e, stackTrace) {
       return _handleUploadError(e, stackTrace, draft);
     }
+  }
+
+  bool _requiresPersistedPublishIdentity(DivineVideoDraft draft) {
+    return draft.sourceDraftId != null &&
+        draft.publishAttempts > 0 &&
+        (draft.publishStatus == PublishStatus.failed ||
+            draft.publishStatus == PublishStatus.publishing);
   }
 
   PublishReadiness _currentPublishReadiness() {

--- a/mobile/packages/funnelcake_api_client/lib/src/models/relay_notification.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/models/relay_notification.dart
@@ -19,6 +19,7 @@ class RelayNotification {
     this.referencedVideoThumbnail,
     this.referencedDTag,
     this.rootEventId,
+    this.rootEventPubkey,
     this.targetCommentId,
   });
 
@@ -68,6 +69,7 @@ class RelayNotification {
           : null,
       referencedDTag: (rawDTag != null && rawDTag.isNotEmpty) ? rawDTag : null,
       rootEventId: _nonEmpty(json['root_event_id'] as String?),
+      rootEventPubkey: _nonEmpty(json['root_event_pubkey'] as String?),
       targetCommentId: _nonEmpty(json['target_comment_id'] as String?),
     );
   }
@@ -130,6 +132,13 @@ class RelayNotification {
   /// the notification directly to the video instead of resolving the comment
   /// event through a relay round-trip.
   final String? rootEventId;
+
+  /// Authoritative pubkey of the root video owner, when Funnelcake includes it.
+  ///
+  /// This tells app layers whether a video-anchored notification points at the
+  /// recipient's own video or at another creator's video where the recipient
+  /// participated in the comments.
+  final String? rootEventPubkey;
 
   /// Comment event ID included by Funnelcake for NIP-22 comment notifications.
   final String? targetCommentId;

--- a/mobile/packages/funnelcake_api_client/test/src/models/relay_notification_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/models/relay_notification_test.dart
@@ -392,12 +392,14 @@ void main() {
             'referenced_event_title': 'Codex staging comment notification test',
             'target_comment_id': '11223344' * 8,
             'root_event_id': '55667788' * 8,
+            'root_event_pubkey': '77889900' * 8,
           };
 
           final notification = RelayNotification.fromJson(json);
 
           expect(notification.referencedEventId, equals(''));
           expect(notification.rootEventId, equals('55667788' * 8));
+          expect(notification.rootEventPubkey, equals('77889900' * 8));
           expect(notification.targetCommentId, equals('11223344' * 8));
           expect(
             notification.referencedVideoTitle,
@@ -416,12 +418,14 @@ void main() {
           'created_at': 1712345678,
           'read': false,
           'root_event_id': '',
+          'root_event_pubkey': '',
           'target_comment_id': '',
         };
 
         final notification = RelayNotification.fromJson(json);
 
         expect(notification.rootEventId, isNull);
+        expect(notification.rootEventPubkey, isNull);
         expect(notification.targetCommentId, isNull);
       });
     });

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -1029,7 +1029,7 @@ class NotificationRepository {
 
     final pubkeys = raw.map((n) => n.sourcePubkey).toSet().toList();
     final eventIds = raw
-        .map((n) => n.referencedEventId)
+        .map((n) => _videoAnchorEventId(_mapNotificationKind(n), n))
         .whereType<String>()
         .where((id) => id.isNotEmpty)
         .toSet()
@@ -1137,21 +1137,25 @@ class NotificationRepository {
       if (!isVideoAnchored(kind)) continue;
       final eventId = _videoAnchorEventId(kind, n);
       if (eventId == null || eventId.isEmpty) continue;
-      if (_hasKnownReferencedVideoOwnerMismatch(
+      final ownership = _referencedVideoOwnership(
         referencedVideoEventId: eventId,
         videosById: videosById,
-      )) {
-        _logReclassifiedOwnerMismatch(
-          notificationId: n.id,
-          sourcePubkey: n.sourcePubkey,
-          referencedVideoEventId: eventId,
-          referencedVideoOwnerPubkey: videosById[eventId]?.pubkey,
-        );
-        misattributed?.add(n);
-        continue;
+      );
+      switch (ownership) {
+        case _ReferencedVideoOwnership.owned:
+          final key = _VideoGroupKey(eventId, kind);
+          (groups[key] ??= []).add(n);
+        case _ReferencedVideoOwnership.foreign:
+          _logReclassifiedOwnerMismatch(
+            notificationId: n.id,
+            sourcePubkey: n.sourcePubkey,
+            referencedVideoEventId: eventId,
+            referencedVideoOwnerPubkey: videosById[eventId]?.pubkey,
+          );
+          misattributed?.add(n);
+        case _ReferencedVideoOwnership.unknown:
+          misattributed?.add(n);
       }
-      final key = _VideoGroupKey(eventId, kind);
-      (groups[key] ??= []).add(n);
     }
 
     final result = <VideoNotification>[];
@@ -1419,13 +1423,16 @@ class NotificationRepository {
     return null;
   }
 
-  bool _hasKnownReferencedVideoOwnerMismatch({
+  _ReferencedVideoOwnership _referencedVideoOwnership({
     required String referencedVideoEventId,
     required Map<String, VideoStats> videosById,
   }) {
     final ownerPubkey = videosById[referencedVideoEventId]?.pubkey;
-    if (ownerPubkey == null || ownerPubkey.isEmpty) return false;
-    return ownerPubkey != _userPubkey;
+    if (ownerPubkey == null || ownerPubkey.isEmpty) {
+      return _ReferencedVideoOwnership.unknown;
+    }
+    if (ownerPubkey == _userPubkey) return _ReferencedVideoOwnership.owned;
+    return _ReferencedVideoOwnership.foreign;
   }
 
   void _logReclassifiedOwnerMismatch({
@@ -1688,6 +1695,8 @@ class NotificationRepository {
     return '${content.substring(0, _maxCommentLength)}...';
   }
 }
+
+enum _ReferencedVideoOwnership { owned, foreign, unknown }
 
 @immutable
 class _VideoGroupKey {

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -1138,8 +1138,7 @@ class NotificationRepository {
       final eventId = _videoAnchorEventId(kind, n);
       if (eventId == null || eventId.isEmpty) continue;
       final ownership = _referencedVideoOwnership(
-        referencedVideoEventId: eventId,
-        videosById: videosById,
+        rootEventPubkey: n.rootEventPubkey,
       );
       switch (ownership) {
         case _ReferencedVideoOwnership.owned:
@@ -1150,10 +1149,8 @@ class NotificationRepository {
             notificationId: n.id,
             sourcePubkey: n.sourcePubkey,
             referencedVideoEventId: eventId,
-            referencedVideoOwnerPubkey: videosById[eventId]?.pubkey,
+            referencedVideoOwnerPubkey: n.rootEventPubkey,
           );
-          misattributed?.add(n);
-        case _ReferencedVideoOwnership.unknown:
           misattributed?.add(n);
       }
     }
@@ -1385,11 +1382,10 @@ class NotificationRepository {
   /// Builds the stable NIP-33 addressable route for the video a video-anchored
   /// notification (like/comment/repost) points at, scoped to [_userPubkey].
   ///
-  /// A payload d-tag is only safe after [video] confirms ownership. Without
-  /// that owner proof, synthesizing `34236:<recipient>:<d-tag>` can make a
-  /// misattributed notification for another creator's video look like it was
-  /// for the recipient's own video. Metadata misses therefore keep the raw
-  /// event-id fallback instead of manufacturing a recipient-scoped coordinate.
+  /// A payload d-tag is only safe after the caller has confirmed ownership
+  /// from `root_event_pubkey`. Without that owner proof, synthesizing
+  /// `34236:<recipient>:<d-tag>` can make a misattributed notification for
+  /// another creator's video look like it was for the recipient's own video.
   ///
   /// Prefers the authoritative `VideoStats` d-tag over the payload [dTag] so a
   /// `referenced_video` block disagreeing with `referenced_event_id` cannot
@@ -1398,8 +1394,7 @@ class NotificationRepository {
     required String? dTag,
     required VideoStats? video,
   }) {
-    if (video == null || video.pubkey != _userPubkey) return null;
-    final resolvedDTag = _nonEmpty(video.dTag) ?? _nonEmpty(dTag);
+    final resolvedDTag = _nonEmpty(video?.dTag) ?? _nonEmpty(dTag);
     if (resolvedDTag == null) return null;
     return '${NIP71VideoKinds.addressableShortVideo}'
         ':$_userPubkey:$resolvedDTag';
@@ -1424,12 +1419,11 @@ class NotificationRepository {
   }
 
   _ReferencedVideoOwnership _referencedVideoOwnership({
-    required String referencedVideoEventId,
-    required Map<String, VideoStats> videosById,
+    required String? rootEventPubkey,
   }) {
-    final ownerPubkey = videosById[referencedVideoEventId]?.pubkey;
+    final ownerPubkey = _nonEmpty(rootEventPubkey);
     if (ownerPubkey == null || ownerPubkey.isEmpty) {
-      return _ReferencedVideoOwnership.unknown;
+      return _ReferencedVideoOwnership.foreign;
     }
     if (ownerPubkey == _userPubkey) return _ReferencedVideoOwnership.owned;
     return _ReferencedVideoOwnership.foreign;
@@ -1696,7 +1690,7 @@ class NotificationRepository {
   }
 }
 
-enum _ReferencedVideoOwnership { owned, foreign, unknown }
+enum _ReferencedVideoOwnership { owned, foreign }
 
 @immutable
 class _VideoGroupKey {

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -1395,7 +1395,7 @@ class NotificationRepository {
     required VideoStats? video,
   }) {
     if (video == null || video.pubkey != _userPubkey) return null;
-    final resolvedDTag = _nonEmpty(video?.dTag) ?? _nonEmpty(dTag);
+    final resolvedDTag = _nonEmpty(video.dTag) ?? _nonEmpty(dTag);
     if (resolvedDTag == null) return null;
     return '${NIP71VideoKinds.addressableShortVideo}'
         ':$_userPubkey:$resolvedDTag';

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -1379,29 +1379,13 @@ class NotificationRepository {
   };
 
   /// Builds the stable NIP-33 addressable route for the video a video-anchored
-  /// notification (like/comment/repost) points at, always scoped to
-  /// [_userPubkey], or null when no usable d-tag is available.
+  /// notification (like/comment/repost) points at, scoped to [_userPubkey].
   ///
-  /// Video-anchored notifications are structurally about the recipient's own
-  /// video; a confirmed *different* owner is reclassified to an actor row
-  /// upstream ([_groupVideoAnchored] / #4920) before this is reached. So
-  /// ownership here is either confirmed-recipient or unconfirmable (a metadata
-  /// miss: stale/edited event id, fetch failure, or a comment with an empty
-  /// `referenced_event_id`). In both cases we synthesize the route rather than
-  /// dropping to the raw, often-stale `referencedEventId` — which is the #4730
-  /// broken-link gap: once the recipient edits a video, its old event id no
-  /// longer resolves, so the stable route is the only thing that reopens it.
-  ///
-  /// Safety bound (unchanged from #4730): the pubkey is pinned to
-  /// [_userPubkey], so a wrong/stale d-tag can only ever surface the
-  /// recipient's *own* (or a non-existent) video — never another creator's.
-  /// The relaxation is purely *when* to synthesize (now also on a metadata
-  /// miss), not *whose* video the route can address. Tradeoff: a misattributed
-  /// notification whose ownership the metadata fetch happened to miss now
-  /// resolves to the recipient's d-tag match (or not-found) instead of the
-  /// other creator's event id. The route resolver preserves this bound by
-  /// validating addressable candidates before cache or REST hits can satisfy
-  /// the coordinate.
+  /// A payload d-tag is only safe after [video] confirms ownership. Without
+  /// that owner proof, synthesizing `34236:<recipient>:<d-tag>` can make a
+  /// misattributed notification for another creator's video look like it was
+  /// for the recipient's own video. Metadata misses therefore keep the raw
+  /// event-id fallback instead of manufacturing a recipient-scoped coordinate.
   ///
   /// Prefers the authoritative `VideoStats` d-tag over the payload [dTag] so a
   /// `referenced_video` block disagreeing with `referenced_event_id` cannot
@@ -1410,10 +1394,7 @@ class NotificationRepository {
     required String? dTag,
     required VideoStats? video,
   }) {
-    // Defensive local invariant: metadata that resolves and names a different
-    // owner never yields a recipient-scoped route. Unreachable via
-    // _groupVideoAnchored (those are reclassified to actor rows, #4920).
-    if (video != null && video.pubkey != _userPubkey) return null;
+    if (video == null || video.pubkey != _userPubkey) return null;
     final resolvedDTag = _nonEmpty(video?.dTag) ?? _nonEmpty(dTag);
     if (resolvedDTag == null) return null;
     return '${NIP71VideoKinds.addressableShortVideo}'

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -865,9 +865,9 @@ void main() {
           'metadata is missing even if the payload has a d-tag', () async {
         // No video stats stubbed → ownership cannot be confirmed (e.g. a
         // stale/edited event id whose old metadata no longer resolves). A
-        // server-provided d-tag alone is not proof that the d-tag belongs to the
-        // recipient, so synthesizing `34236:<recipient>:<d-tag>` here can make a
-        // notification for another creator's video look like "your video".
+        // server-provided d-tag alone is not proof that the d-tag belongs to
+        // the recipient, so synthesizing `34236:<recipient>:<d-tag>` here can
+        // make a notification for another creator's video look like "your video".
         stubNotifications([
           makeNotification(
             id: 'l1',

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -861,16 +861,13 @@ void main() {
         );
       });
 
-      test('grouped video notifications synthesize the addressable id from the '
-          'payload d-tag when the referenced video metadata is missing '
-          '(#4730 broken-link fix)', () async {
+      test('grouped video notifications leave addressable id null when '
+          'metadata is missing even if the payload has a d-tag', () async {
         // No video stats stubbed → ownership cannot be confirmed (e.g. a
-        // stale/edited event id whose old metadata no longer resolves). The
-        // notification is structurally about the recipient's own video, so we
-        // synthesize the recipient-scoped stable route from the server-provided
-        // d-tag rather than dropping to the (often stale) raw event id. The
-        // pubkey is pinned to the recipient, so the route can never address
-        // another creator's video.
+        // stale/edited event id whose old metadata no longer resolves). A
+        // server-provided d-tag alone is not proof that the d-tag belongs to the
+        // recipient, so synthesizing `34236:<recipient>:<d-tag>` here can make a
+        // notification for another creator's video look like "your video".
         stubNotifications([
           makeNotification(
             id: 'l1',
@@ -894,13 +891,7 @@ void main() {
 
         expect(page.items, hasLength(1));
         final item = page.items.single as VideoNotification;
-        expect(
-          item.videoAddressableId,
-          equals(
-            '${NIP71VideoKinds.addressableShortVideo}:'
-            '$userPubkey:vine-id',
-          ),
-        );
+        expect(item.videoAddressableId, isNull);
         // The canonical event id is still carried for the resolver fallback.
         expect(item.videoEventId, equals('video_x'));
       });
@@ -927,15 +918,13 @@ void main() {
         expect(item.videoEventId, equals('video_x'));
       });
 
-      test('comment with empty referencedEventId synthesizes the addressable '
-          'id from the payload d-tag and keeps the root video event id '
-          '(#4730 broken-link fix)', () async {
+      test('comment with empty referencedEventId leaves addressable id null '
+          'when root video ownership is unconfirmed', () async {
         // NIP-22 comment whose referenced_event_id is empty carries the video
         // via rootEventId. The page-load path fetches metadata by
         // referenced_event_id only (not rootEventId), so ownership of the root
-        // video is unconfirmed here — but the notification is still about the
-        // recipient's own video, so the recipient-scoped route is synthesized
-        // from the payload d-tag instead of dropping to the rootEventId.
+        // video is unconfirmed here. The payload d-tag alone is not enough to
+        // build a recipient-scoped route.
         stubNotifications([
           makeNotification(
             id: 'c1',
@@ -955,13 +944,7 @@ void main() {
         expect(page.items, hasLength(1));
         final item = page.items.single as VideoNotification;
         expect(item.type, equals(NotificationKind.comment));
-        expect(
-          item.videoAddressableId,
-          equals(
-            '${NIP71VideoKinds.addressableShortVideo}:'
-            '$userPubkey:vine-id',
-          ),
-        );
+        expect(item.videoAddressableId, isNull);
         expect(item.videoEventId, equals('video_root'));
       });
 
@@ -990,13 +973,7 @@ void main() {
           final item = page.items.single as VideoNotification;
           expect(item.type, equals(NotificationKind.comment));
           expect(item.videoEventId, equals('reply_video_event'));
-          expect(
-            item.videoAddressableId,
-            equals(
-              '${NIP71VideoKinds.addressableShortVideo}:'
-              '$userPubkey:reply-video-dtag',
-            ),
-          );
+          expect(item.videoAddressableId, isNull);
         },
       );
 

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -867,7 +867,7 @@ void main() {
         // stale/edited event id whose old metadata no longer resolves). A
         // server-provided d-tag alone is not proof that the d-tag belongs to
         // the recipient, so synthesizing `34236:<recipient>:<d-tag>` here can
-        // make a notification for another creator's video look like "your video".
+        // make another creator's video look like "your video".
         stubNotifications([
           makeNotification(
             id: 'l1',

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -117,6 +117,7 @@ void main() {
     String? referencedEventId = 'video_default',
     String? referencedDTag,
     String? rootEventId,
+    String? rootEventPubkey = userPubkey,
     String? targetCommentId,
     String? content,
     bool isReferencedVideo = true,
@@ -134,6 +135,7 @@ void main() {
       referencedEventId: referencedEventId,
       referencedDTag: referencedDTag,
       rootEventId: rootEventId,
+      rootEventPubkey: rootEventPubkey,
       targetCommentId: targetCommentId,
       content: content,
       isReferencedVideo: isReferencedVideo,
@@ -179,7 +181,7 @@ void main() {
     ).thenAnswer((_) async => stats);
   }
 
-  /// Stubs `getVideoStats(eventId)` to miss, leaving video ownership unknown.
+  /// Stubs `getVideoStats(eventId)` to miss, leaving video metadata unknown.
   void stubMissingVideoStats(String eventId) {
     when(
       () => funnelcakeApiClient.getVideoStats(eventId),
@@ -831,10 +833,9 @@ void main() {
           'pub_b': makeProfile('pub_b', displayName: 'Bob'),
         });
         stubMissingVideoStats('video_x');
-        // Authoritative ownership: video stats resolve and the owner is the
-        // recipient (makeVideoStats defaults pubkey == userPubkey, d-tag
-        // 'd_video_x'). The payload referencedDTag intentionally DIFFERS so the
-        // assertion proves the route uses the authoritative VideoStats d-tag,
+        // Authoritative ownership comes from rootEventPubkey. VideoStats still
+        // supplies the d-tag metadata. The payload referencedDTag intentionally
+        // DIFFERS so the assertion proves the route uses the VideoStats d-tag,
         // not the payload — a mismatched referenced_video block can't poison
         // the route.
         stubVideoStats('video_x', makeVideoStats(id: 'video_x'));
@@ -863,8 +864,8 @@ void main() {
           ),
         ], stubOwnedVideoStats: false);
         stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
-        // Owner confirmed, but VideoStats carries no d-tag → use the payload
-        // d-tag rather than drop the stable route.
+        // Owner confirmed by rootEventPubkey, but VideoStats carries no d-tag
+        // → use the payload d-tag rather than drop the stable route.
         stubVideoStats('video_x', makeVideoStats(id: 'video_x', dTag: ''));
 
         final page = await repository.getNotifications();
@@ -880,32 +881,32 @@ void main() {
         );
       });
 
-      test('metadata-missing video likes become actor-anchored fallback even '
-          'if the payload has a d-tag', () async {
-        // No video stats stubbed → ownership cannot be confirmed (e.g. a
-        // stale/edited event id whose old metadata no longer resolves). A
-        // server-provided d-tag alone is not proof that the d-tag belongs to
-        // the recipient, so synthesizing `34236:<recipient>:<d-tag>` here can
-        // make another creator's video look like "your video".
+      test('video likes with foreign root owner become actor-anchored fallback '
+          'even if VideoStats says the recipient owns the event', () async {
+        // rootEventPubkey is the backend's authoritative video owner. A
+        // stale or mismatched getVideoStats response must not override it,
+        // because that is the source of the "liked your video" mislabel.
         stubNotifications([
           makeNotification(
             id: 'l1',
             sourcePubkey: 'pub_a',
             referencedEventId: 'video_x',
             referencedDTag: 'vine-id',
+            rootEventPubkey: 'other_owner_pubkey',
           ),
           makeNotification(
             id: 'l2',
             sourcePubkey: 'pub_b',
             referencedEventId: 'video_x',
             referencedDTag: 'vine-id',
+            rootEventPubkey: 'other_owner_pubkey',
           ),
         ], stubOwnedVideoStats: false);
         stubProfiles({
           'pub_a': makeProfile('pub_a', displayName: 'Alice'),
           'pub_b': makeProfile('pub_b', displayName: 'Bob'),
         });
-        stubMissingVideoStats('video_x');
+        stubVideoStats('video_x', makeVideoStats(id: 'video_x'));
 
         final page = await repository.getNotifications();
 
@@ -917,20 +918,21 @@ void main() {
         expect(first.targetEventId, equals('video_x'));
       });
 
-      test('metadata-missing video like without a d-tag becomes '
-          'actor-anchored fallback', () async {
-        // Metadata miss means ownership is unknown, so even without a d-tag the
-        // row must not claim this was the recipient's video.
+      test('video like without root owner becomes actor-anchored fallback '
+          'even if VideoStats says the recipient owns the event', () async {
+        // Missing rootEventPubkey is treated as not-your-video. Do not fall
+        // back to ownership guessed from getVideoStats.
         stubNotifications([
           makeNotification(
             id: 'l1',
             sourcePubkey: 'pub_a',
             referencedEventId: 'video_x',
             referencedDTag: '',
+            rootEventPubkey: null,
           ),
         ], stubOwnedVideoStats: false);
         stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
-        stubMissingVideoStats('video_x');
+        stubVideoStats('video_x', makeVideoStats(id: 'video_x'));
 
         final page = await repository.getNotifications();
 
@@ -956,6 +958,7 @@ void main() {
             notificationType: 'comment',
             referencedEventId: '',
             rootEventId: 'video_root',
+            rootEventPubkey: 'other_owner_pubkey',
             referencedDTag: 'vine-id',
             content: 'nice one',
           ),
@@ -1026,9 +1029,8 @@ void main() {
           'pub_a': makeProfile('pub_a', displayName: 'Alice'),
           'pub_b': makeProfile('pub_b', displayName: 'Bob'),
         });
-        // Owner confirmed, but no d-tag from either source → cannot synthesize.
-        // (Without this stub the row would be null for the unrelated
-        // ownership-unknown reason, masking the d-tag branch under test.)
+        // Owner confirmed by rootEventPubkey, but no d-tag from either source
+        // → cannot synthesize.
         stubVideoStats('video_x', makeVideoStats(id: 'video_x', dTag: ''));
 
         final page = await repository.getNotifications();
@@ -1115,7 +1117,7 @@ void main() {
       );
 
       test(
-        'getVideoStats throws → row falls back to actor notification',
+        'owned root pubkey keeps video notification when getVideoStats throws',
         () async {
           stubNotifications([
             makeNotification(
@@ -1129,9 +1131,9 @@ void main() {
           final page = await repository.getNotifications();
 
           expect(page.items, hasLength(1));
-          final item = page.items.single as ActorNotification;
-          expect(item.type, equals(NotificationKind.likeComment));
-          expect(item.targetEventId, equals('video_x'));
+          final item = page.items.single as VideoNotification;
+          expect(item.type, equals(NotificationKind.like));
+          expect(item.videoEventId, equals('video_x'));
           expect(item.videoAddressableId, isNull);
         },
       );
@@ -1325,7 +1327,10 @@ void main() {
         // #4813 path rewrites to likeComment. A comment-like that *does* carry
         // a targetCommentId is covered by the direct-classification test above.
         stubNotifications([
-          makeNotification(referencedEventId: 'foreign_video'),
+          makeNotification(
+            referencedEventId: 'foreign_video',
+            rootEventPubkey: 'other_owner_pubkey',
+          ),
         ]);
         stubProfiles({});
         stubVideoStats(
@@ -1349,6 +1354,7 @@ void main() {
             sourceKind: 1,
             referencedEventId: 'foreign_video',
             rootEventId: 'foreign_video',
+            rootEventPubkey: 'other_owner_pubkey',
             targetCommentId: 'comment_event_xyz',
           ),
         ]);
@@ -1372,6 +1378,7 @@ void main() {
             notificationType: 'repost',
             sourceKind: 6,
             referencedEventId: 'foreign_video',
+            rootEventPubkey: 'other_owner_pubkey',
           ),
         ]);
         stubProfiles({});

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -149,57 +149,6 @@ void main() {
     ).thenAnswer((_) async => profiles);
   }
 
-  void stubNotifications(
-    List<RelayNotification> notifications, {
-    int unreadCount = 0,
-    bool hasMore = false,
-    String? nextCursor,
-    String? nextCursorId,
-  }) {
-    when(
-      () => funnelcakeApiClient.getNotifications(
-        pubkey: any(named: 'pubkey'),
-        cursor: any(named: 'cursor'),
-        cursorId: any(named: 'cursorId'),
-        requestUri: any(named: 'requestUri'),
-        authHeaders: any(named: 'authHeaders'),
-        limit: any(named: 'limit'),
-      ),
-    ).thenAnswer(
-      (_) async => NotificationResponse(
-        notifications: notifications,
-        unreadCount: unreadCount,
-        hasMore: hasMore,
-        nextCursor: nextCursor,
-        nextCursorId: nextCursorId,
-      ),
-    );
-  }
-
-  /// Stubs `getVideoStats(eventId)` to return [stats].
-  void stubVideoStats(String eventId, VideoStats stats) {
-    when(
-      () => funnelcakeApiClient.getVideoStats(eventId),
-    ).thenAnswer((_) async => stats);
-  }
-
-  UserProfile makeProfile(
-    String pubkey, {
-    String? displayName,
-    String? name,
-    String? picture,
-  }) {
-    return UserProfile(
-      pubkey: pubkey,
-      rawData: const {},
-      createdAt: DateTime(2024),
-      eventId: 'evt_$pubkey',
-      displayName: displayName,
-      name: name,
-      picture: picture,
-    );
-  }
-
   VideoStats makeVideoStats({
     required String id,
     String pubkey = userPubkey,
@@ -220,6 +169,75 @@ void main() {
       comments: 0,
       reposts: 0,
       engagementScore: 0,
+    );
+  }
+
+  /// Stubs `getVideoStats(eventId)` to return [stats].
+  void stubVideoStats(String eventId, VideoStats stats) {
+    when(
+      () => funnelcakeApiClient.getVideoStats(eventId),
+    ).thenAnswer((_) async => stats);
+  }
+
+  /// Stubs `getVideoStats(eventId)` to miss, leaving video ownership unknown.
+  void stubMissingVideoStats(String eventId) {
+    when(
+      () => funnelcakeApiClient.getVideoStats(eventId),
+    ).thenThrow(const FunnelcakeException('no stats'));
+  }
+
+  void stubNotifications(
+    List<RelayNotification> notifications, {
+    int unreadCount = 0,
+    bool hasMore = false,
+    String? nextCursor,
+    String? nextCursorId,
+    bool stubOwnedVideoStats = true,
+  }) {
+    when(
+      () => funnelcakeApiClient.getNotifications(
+        pubkey: any(named: 'pubkey'),
+        cursor: any(named: 'cursor'),
+        cursorId: any(named: 'cursorId'),
+        requestUri: any(named: 'requestUri'),
+        authHeaders: any(named: 'authHeaders'),
+        limit: any(named: 'limit'),
+      ),
+    ).thenAnswer(
+      (_) async => NotificationResponse(
+        notifications: notifications,
+        unreadCount: unreadCount,
+        hasMore: hasMore,
+        nextCursor: nextCursor,
+        nextCursorId: nextCursorId,
+      ),
+    );
+    if (stubOwnedVideoStats) {
+      final videoIds = notifications
+          .expand((n) => [n.referencedEventId, n.rootEventId])
+          .whereType<String>()
+          .where((id) => id.isNotEmpty)
+          .toSet();
+      for (final id in videoIds) {
+        stubVideoStats(id, makeVideoStats(id: id));
+      }
+    }
+  }
+
+  UserProfile makeProfile(
+    String pubkey, {
+    String? displayName,
+    String? name,
+    String? picture,
+  }) {
+    return UserProfile(
+      pubkey: pubkey,
+      rawData: const {},
+      createdAt: DateTime(2024),
+      eventId: 'evt_$pubkey',
+      displayName: displayName,
+      name: name,
+      picture: picture,
     );
   }
 
@@ -812,6 +830,7 @@ void main() {
           'pub_a': makeProfile('pub_a', displayName: 'Alice'),
           'pub_b': makeProfile('pub_b', displayName: 'Bob'),
         });
+        stubMissingVideoStats('video_x');
         // Authoritative ownership: video stats resolve and the owner is the
         // recipient (makeVideoStats defaults pubkey == userPubkey, d-tag
         // 'd_video_x'). The payload referencedDTag intentionally DIFFERS so the
@@ -842,7 +861,7 @@ void main() {
             referencedEventId: 'video_x',
             referencedDTag: 'vine-id',
           ),
-        ]);
+        ], stubOwnedVideoStats: false);
         stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
         // Owner confirmed, but VideoStats carries no d-tag → use the payload
         // d-tag rather than drop the stable route.
@@ -861,8 +880,8 @@ void main() {
         );
       });
 
-      test('grouped video notifications leave addressable id null when '
-          'metadata is missing even if the payload has a d-tag', () async {
+      test('metadata-missing video likes become actor-anchored fallback even '
+          'if the payload has a d-tag', () async {
         // No video stats stubbed → ownership cannot be confirmed (e.g. a
         // stale/edited event id whose old metadata no longer resolves). A
         // server-provided d-tag alone is not proof that the d-tag belongs to
@@ -881,25 +900,27 @@ void main() {
             referencedEventId: 'video_x',
             referencedDTag: 'vine-id',
           ),
-        ]);
+        ], stubOwnedVideoStats: false);
         stubProfiles({
           'pub_a': makeProfile('pub_a', displayName: 'Alice'),
           'pub_b': makeProfile('pub_b', displayName: 'Bob'),
         });
+        stubMissingVideoStats('video_x');
 
         final page = await repository.getNotifications();
 
-        expect(page.items, hasLength(1));
-        final item = page.items.single as VideoNotification;
-        expect(item.videoAddressableId, isNull);
-        // The canonical event id is still carried for the resolver fallback.
-        expect(item.videoEventId, equals('video_x'));
+        expect(page.items, hasLength(2));
+        expect(page.items, everyElement(isA<ActorNotification>()));
+        final first = page.items.first as ActorNotification;
+        expect(first.type, equals(NotificationKind.likeComment));
+        expect(first.videoAddressableId, isNull);
+        expect(first.targetEventId, equals('video_x'));
       });
 
-      test('grouped video notifications leave addressable id null on a '
-          'metadata miss when no payload d-tag is available', () async {
-        // Metadata miss AND no usable d-tag → nothing to synthesize from, so
-        // the route stays null and navigation falls back to the raw event id.
+      test('metadata-missing video like without a d-tag becomes '
+          'actor-anchored fallback', () async {
+        // Metadata miss means ownership is unknown, so even without a d-tag the
+        // row must not claim this was the recipient's video.
         stubNotifications([
           makeNotification(
             id: 'l1',
@@ -907,18 +928,20 @@ void main() {
             referencedEventId: 'video_x',
             referencedDTag: '',
           ),
-        ]);
+        ], stubOwnedVideoStats: false);
         stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
+        stubMissingVideoStats('video_x');
 
         final page = await repository.getNotifications();
 
         expect(page.items, hasLength(1));
-        final item = page.items.single as VideoNotification;
+        final item = page.items.single as ActorNotification;
+        expect(item.type, equals(NotificationKind.likeComment));
         expect(item.videoAddressableId, isNull);
-        expect(item.videoEventId, equals('video_x'));
+        expect(item.targetEventId, equals('video_x'));
       });
 
-      test('comment with empty referencedEventId leaves addressable id null '
+      test('comment with empty referencedEventId becomes actor-anchored '
           'when root video ownership is unconfirmed', () async {
         // NIP-22 comment whose referenced_event_id is empty carries the video
         // via rootEventId. The page-load path fetches metadata by
@@ -936,16 +959,17 @@ void main() {
             referencedDTag: 'vine-id',
             content: 'nice one',
           ),
-        ]);
+        ], stubOwnedVideoStats: false);
         stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
+        stubMissingVideoStats('video_root');
 
         final page = await repository.getNotifications();
 
         expect(page.items, hasLength(1));
-        final item = page.items.single as VideoNotification;
-        expect(item.type, equals(NotificationKind.comment));
+        final item = page.items.single as ActorNotification;
+        expect(item.type, equals(NotificationKind.reply));
         expect(item.videoAddressableId, isNull);
-        expect(item.videoEventId, equals('video_root'));
+        expect(item.targetEventId, equals('evt1'));
       });
 
       test(
@@ -973,7 +997,13 @@ void main() {
           final item = page.items.single as VideoNotification;
           expect(item.type, equals(NotificationKind.comment));
           expect(item.videoEventId, equals('reply_video_event'));
-          expect(item.videoAddressableId, isNull);
+          expect(
+            item.videoAddressableId,
+            equals(
+              '${NIP71VideoKinds.addressableShortVideo}:$userPubkey:'
+              'd_reply_video_event',
+            ),
+          );
         },
       );
 
@@ -1085,7 +1115,7 @@ void main() {
       );
 
       test(
-        'getVideoStats throws → row still rendered with null thumbnail',
+        'getVideoStats throws → row falls back to actor notification',
         () async {
           stubNotifications([
             makeNotification(
@@ -1094,16 +1124,15 @@ void main() {
             ),
           ]);
           stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
-          when(
-            () => funnelcakeApiClient.getVideoStats('video_x'),
-          ).thenThrow(const FunnelcakeException('boom'));
+          stubMissingVideoStats('video_x');
 
           final page = await repository.getNotifications();
 
           expect(page.items, hasLength(1));
-          final item = page.items.single as VideoNotification;
-          expect(item.videoThumbnailUrl, isNull);
-          expect(item.videoTitle, isNull);
+          final item = page.items.single as ActorNotification;
+          expect(item.type, equals(NotificationKind.likeComment));
+          expect(item.targetEventId, equals('video_x'));
+          expect(item.videoAddressableId, isNull);
         },
       );
     });

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -395,8 +395,13 @@ class ProfileRepository {
       requireRawKind0: requireRawKind0,
     );
     if (relayProfile != null) {
-      await _cacheProfileIfNewer(relayProfile);
-      return relayProfile;
+      final existing = await _userProfilesDao.getProfile(pubkey);
+      final relayWon = await _cacheProfileIfNewer(
+        relayProfile,
+        cached: existing,
+        cachedResolved: true,
+      );
+      return relayWon ? relayProfile : existing;
     }
 
     if (requireRawKind0) {
@@ -439,6 +444,11 @@ class ProfileRepository {
         : await _userProfilesDao.getProfile(profile.pubkey);
     if (cachedProfile != null &&
         !profile.createdAt.isAfter(cachedProfile.createdAt)) {
+      return false;
+    }
+    if (cachedProfile != null &&
+        cachedProfile.hasBasicInfo &&
+        !profile.hasBasicInfo) {
       return false;
     }
 

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -1236,6 +1236,50 @@ void main() {
             ).called(1);
           },
         );
+
+        test(
+          'keeps a named cached profile when a newer blank kind-0 arrives',
+          () async {
+            final cachedProfile = UserProfile(
+              pubkey: testPubkey,
+              rawData: const {'display_name': 'Cached Name'},
+              createdAt: DateTime.utc(2024),
+              eventId: 'cached_$testEventId',
+              displayName: 'Cached Name',
+              picture: 'https://example.com/cached-avatar.png',
+            );
+            await profileRepository.cacheProfile(cachedProfile);
+            clearInteractions(mockUserProfilesDao);
+
+            final blankProfileEvent = MockEvent();
+            when(() => blankProfileEvent.kind).thenReturn(0);
+            when(() => blankProfileEvent.pubkey).thenReturn(testPubkey);
+            when(() => blankProfileEvent.createdAt).thenReturn(1706745600);
+            when(() => blankProfileEvent.id).thenReturn('blank_$testEventId');
+            when(() => blankProfileEvent.content).thenReturn(jsonEncode({}));
+            when(
+              () => mockNostrClient.fetchProfile(testPubkey),
+            ).thenAnswer((_) async => blankProfileEvent);
+
+            final result = await profileRepository.fetchFreshProfile(
+              pubkey: testPubkey,
+            );
+
+            expect(result, same(cachedProfile));
+            verify(() => mockUserProfilesDao.getProfile(testPubkey)).called(1);
+            verifyNever(
+              () => mockUserProfilesDao.upsertProfile(
+                any(
+                  that: isA<UserProfile>().having(
+                    (profile) => profile.eventId,
+                    'eventId',
+                    'blank_$testEventId',
+                  ),
+                ),
+              ),
+            );
+          },
+        );
       });
 
       group('parallel relay + indexer fetch', () {

--- a/mobile/test/blocs/background_publish_bloc/background_publish_bloc_test.dart
+++ b/mobile/test/blocs/background_publish_bloc/background_publish_bloc_test.dart
@@ -667,8 +667,15 @@ void main() {
           draftStorageService: mockDraftStorageService,
         ),
         setUp: () {
+          when(() => draft.expectedPublishPubkey).thenReturn(
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          );
           when(
-            () => mockPublishService.publishVideo(draft: draft),
+            () => mockPublishService.publishVideo(
+              draft: draft,
+              expectedPubkey:
+                  'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            ),
           ).thenAnswer((_) => Future.value(const PublishSuccess()));
         },
         seed: () => BackgroundPublishState(
@@ -696,7 +703,13 @@ void main() {
           const BackgroundPublishState(recentlySucceededIds: {draftId}),
         ],
         verify: (_) {
-          verify(() => mockPublishService.publishVideo(draft: draft)).called(1);
+          verify(
+            () => mockPublishService.publishVideo(
+              draft: draft,
+              expectedPubkey:
+                  'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            ),
+          ).called(1);
         },
       );
     });

--- a/mobile/test/models/vine_draft_publish_status_test.dart
+++ b/mobile/test/models/vine_draft_publish_status_test.dart
@@ -146,6 +146,24 @@ void main() {
       expect(deserialized.publishError, 'Network error');
       expect(deserialized.publishAttempts, 2);
     });
+
+    test('should serialize expectedPublishPubkey when present', () {
+      const expectedPublishPubkey =
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      final draft = DivineVideoDraft.create(
+        clips: [_testClip()],
+        title: 'Retryable publish draft',
+        description: '',
+        hashtags: {},
+        selectedApproach: 'native',
+      ).copyWith(expectedPublishPubkey: expectedPublishPubkey);
+
+      final json = draft.toJson();
+      expect(json['expectedPublishPubkey'], expectedPublishPubkey);
+
+      final deserialized = DivineVideoDraft.fromJson(json, '/path/to');
+      expect(deserialized.expectedPublishPubkey, expectedPublishPubkey);
+    });
   });
 
   group('VineDraft.copyWith with publish fields', () {
@@ -251,5 +269,34 @@ void main() {
       expect(cleared.publishError, null);
       expect(cleared.publishAttempts, 0);
     });
+
+    test('should preserve and clear expectedPublishPubkey via copyWith', () {
+      const expectedPublishPubkey =
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      final draft = DivineVideoDraft.create(
+        clips: [_testClip()],
+        title: 'Retryable publish draft',
+        description: '',
+        hashtags: {},
+        selectedApproach: 'native',
+      ).copyWith(expectedPublishPubkey: expectedPublishPubkey);
+
+      final failed = draft.copyWith(publishStatus: PublishStatus.failed);
+      expect(failed.expectedPublishPubkey, expectedPublishPubkey);
+
+      final cleared = failed.copyWith(clearExpectedPublishPubkey: true);
+      expect(cleared.expectedPublishPubkey, isNull);
+    });
   });
+}
+
+DivineVideoClip _testClip() {
+  return DivineVideoClip(
+    id: 'test_clip',
+    video: EditorVideo.file('/path/to/video.mp4'),
+    duration: const Duration(seconds: 6),
+    recordedAt: DateTime.now(),
+    targetAspectRatio: AspectRatio.square,
+    originalAspectRatio: 9 / 16,
+  );
 }

--- a/mobile/test/providers/user_profile_providers_test.dart
+++ b/mobile/test/providers/user_profile_providers_test.dart
@@ -158,6 +158,57 @@ void main() {
     );
   });
 
+  group('userProfileReactiveProvider', () {
+    test(
+      'renders cached profile from identity-known repository before nostrReady',
+      () async {
+        final profileRepository = _MockProfileRepository();
+        final profile = UserProfile(
+          pubkey: pubkey,
+          rawData: const {'display_name': 'Lily Majid'},
+          displayName: 'Lily Majid',
+          eventId: 'cached-profile-event',
+          createdAt: DateTime.fromMillisecondsSinceEpoch(1000),
+        );
+
+        when(
+          () => profileRepository.getCachedProfile(pubkey: pubkey),
+        ).thenAnswer((_) async => profile);
+        when(
+          () => profileRepository.watchProfile(pubkey: pubkey),
+        ).thenAnswer((_) => Stream.value(profile));
+
+        final container = ProviderContainer(
+          overrides: [
+            profileRepositoryProvider.overrideWithValue(null),
+            profileStatsRepositoryProvider.overrideWithValue(profileRepository),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        final emittedProfile = Completer<UserProfile?>();
+        final sub = container.listen(
+          userProfileReactiveProvider(pubkey),
+          (_, next) {
+            if (next.hasValue && !emittedProfile.isCompleted) {
+              emittedProfile.complete(next.value);
+            }
+          },
+          fireImmediately: true,
+        );
+        addTearDown(sub.close);
+
+        await expectLater(
+          emittedProfile.future,
+          completion(same(profile)),
+        );
+        verifyNever(
+          () => profileRepository.fetchFreshProfile(pubkey: pubkey),
+        );
+      },
+    );
+  });
+
   group('profileStatsRepository gating (#5863)', () {
     ProviderContainer containerWith(NostrSessionReadiness readiness) {
       final container = ProviderContainer(

--- a/mobile/test/providers/video_publish_provider_test.dart
+++ b/mobile/test/providers/video_publish_provider_test.dart
@@ -80,6 +80,16 @@ class _ReadyThenTearingDownNostrSession extends NostrSession {
   }
 }
 
+class _ReadyNostrSession extends NostrSession {
+  static late NostrClient client;
+
+  @override
+  NostrSessionReadiness build() => NostrSessionReadiness.nostrReady(
+    pubkey: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    client: client,
+  );
+}
+
 DivineVideoClip _createTestClip() => DivineVideoClip(
   id: 'clip_1',
   video: EditorVideo.file('/tmp/test.mp4'),
@@ -566,16 +576,23 @@ void main() {
       'the same source draft',
       (tester) async {
         final mockDraftStorage = MockDraftStorageService();
+        final nostrClient = MockNostrClient();
+        _ReadyNostrSession.client = nostrClient;
         // Never completes - keeps the first publish in flight, like the
         // 20s+ audio-reuse window in production.
         final saveDraftGate = Completer<void>();
         when(
           () => mockDraftStorage.saveDraft(any()),
         ).thenAnswer((_) => saveDraftGate.future);
+        when(() => nostrClient.hasKeys).thenReturn(true);
+        when(() => nostrClient.publicKey).thenReturn(
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        );
 
         final container = ProviderContainer(
           overrides: [
             draftStorageServiceProvider.overrideWithValue(mockDraftStorage),
+            nostrSessionProvider.overrideWith(_ReadyNostrSession.new),
           ],
         );
         addTearDown(container.dispose);

--- a/mobile/test/providers/video_publish_provider_test.dart
+++ b/mobile/test/providers/video_publish_provider_test.dart
@@ -4,34 +4,93 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:blossom_upload_service/blossom_upload_service.dart';
 import 'package:dm_repository/dm_repository.dart'
     show CollaboratorInviteRetrySummary;
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart' show NativeProofData;
+import 'package:openvine/blocs/background_publish/background_publish_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/divine_video_draft.dart';
 import 'package:openvine/models/video_publish/video_publish_state.dart';
 import 'package:openvine/models/video_reply_context.dart';
+import 'package:openvine/providers/auth_providers.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/social_providers.dart';
+import 'package:openvine/providers/upload_media_providers.dart';
+import 'package:openvine/providers/video_providers.dart';
 import 'package:openvine/providers/video_publish_provider.dart';
 import 'package:openvine/screens/video_detail_screen.dart';
+import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/cawg_verifier_client.dart';
 import 'package:openvine/services/draft_storage_service.dart';
 import 'package:openvine/services/mention_resolution_service.dart';
+import 'package:openvine/services/upload_manager.dart';
+import 'package:openvine/services/video_event_publisher.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:profile_repository/profile_repository.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class MockProfileRepository extends Mock implements ProfileRepository {}
 
-class _MockDraftStorageService extends Mock implements DraftStorageService {}
+class MockDraftStorageService extends Mock implements DraftStorageService {}
+
+class MockAuthService extends Mock implements AuthService {}
+
+class MockUploadManager extends Mock implements UploadManager {}
+
+class MockVideoEventPublisher extends Mock implements VideoEventPublisher {}
+
+class MockBlossomUploadService extends Mock implements BlossomUploadService {}
+
+class _IdentityKnownNostrSession extends NostrSession {
+  @override
+  NostrSessionReadiness build() => const NostrSessionReadiness.identityKnown(
+    pubkey: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  );
+}
+
+DivineVideoClip _createTestClip() => DivineVideoClip(
+  id: 'clip_1',
+  video: EditorVideo.file('/tmp/test.mp4'),
+  duration: const Duration(seconds: 6),
+  recordedAt: DateTime(2026),
+  originalAspectRatio: 9 / 16,
+  targetAspectRatio: .vertical,
+);
+
+DivineVideoDraft _createPublishableDraft() {
+  final clip = _createTestClip();
+  final proofManifestJson = jsonEncode(
+    const NativeProofData(
+      videoHash: 'abc123',
+      creatorBindingAssertionLabel: 'video.divine.nostr.creator_binding',
+      creatorBindingPayloadJson: '{"version":1}',
+    ).toJson(),
+  );
+
+  return DivineVideoDraft.create(
+    clips: [clip],
+    title: 'Test Draft',
+    description: 'Test Description',
+    hashtags: const {},
+    selectedApproach: 'default',
+  ).copyWith(finalRenderedClip: clip, proofManifestJson: proofManifestJson);
+}
 
 class _FakeDivineVideoDraft extends Fake implements DivineVideoDraft {}
 
 void main() {
+  setUpAll(() {
+    registerFallbackValue(_createPublishableDraft());
+  });
+
   group('VideoPublishNotifier', () {
     late ProviderContainer container;
     late VideoPublishNotifier notifier;
@@ -275,6 +334,79 @@ void main() {
       expect(destination.path, VideoDetailScreen.pathForId(rootAddressableId));
       expect(destination.extra.autoOpenComments, isTrue);
     });
+
+    testWidgets(
+      'publishVideo returns not signed in before saving publish draft when signer is not ready',
+      (tester) async {
+        SharedPreferences.setMockInitialValues({});
+        final sharedPreferences = await SharedPreferences.getInstance();
+        final draftStorageService = MockDraftStorageService();
+        final authService = MockAuthService();
+        final uploadManager = MockUploadManager();
+        final videoEventPublisher = MockVideoEventPublisher();
+        final blossomUploadService = MockBlossomUploadService();
+        final backgroundPublishBloc = BackgroundPublishBloc(
+          videoPublishServiceFactory: ({required onProgress}) async =>
+              throw StateError('background publish should not be requested'),
+          draftStorageService: draftStorageService,
+        );
+        addTearDown(backgroundPublishBloc.close);
+
+        when(
+          () => draftStorageService.saveDraft(any()),
+        ).thenAnswer((_) async {});
+        when(() => authService.currentNpub).thenReturn(null);
+        when(() => authService.isAuthenticated).thenReturn(true);
+        when(() => authService.currentPublicKeyHex).thenReturn(
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        );
+
+        late BuildContext publishContext;
+        late WidgetRef publishRef;
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              sharedPreferencesProvider.overrideWithValue(sharedPreferences),
+              draftStorageServiceProvider.overrideWithValue(
+                draftStorageService,
+              ),
+              authServiceProvider.overrideWithValue(authService),
+              uploadManagerProvider.overrideWithValue(uploadManager),
+              videoEventPublisherProvider.overrideWithValue(
+                videoEventPublisher,
+              ),
+              blossomUploadServiceProvider.overrideWithValue(
+                blossomUploadService,
+              ),
+              nostrSessionProvider.overrideWith(_IdentityKnownNostrSession.new),
+            ],
+            child: MaterialApp(
+              home: BlocProvider<BackgroundPublishBloc>.value(
+                value: backgroundPublishBloc,
+                child: Consumer(
+                  builder: (context, ref, _) {
+                    publishContext = context;
+                    publishRef = ref;
+                    return const SizedBox.shrink();
+                  },
+                ),
+              ),
+            ),
+          ),
+        );
+
+        await publishRef
+            .read(videoPublishProvider.notifier)
+            .publishVideo(publishContext, _createPublishableDraft());
+
+        final state = publishRef.read(videoPublishProvider);
+        expect(state.publishState, VideoPublishState.error);
+        expect(state.errorMessage, isNotEmpty);
+        verifyNever(() => draftStorageService.saveDraft(any()));
+        expect(backgroundPublishBloc.state.uploads, isEmpty);
+      },
+    );
   });
 
   group('VideoPublishNotifier publishVideo duplicate guard (#6018)', () {
@@ -319,7 +451,7 @@ void main() {
       'reset during an in-flight publish does not reopen the gate for '
       'the same source draft',
       (tester) async {
-        final mockDraftStorage = _MockDraftStorageService();
+        final mockDraftStorage = MockDraftStorageService();
         // Never completes - keeps the first publish in flight, like the
         // 20s+ audio-reuse window in production.
         final saveDraftGate = Completer<void>();

--- a/mobile/test/providers/video_publish_provider_test.dart
+++ b/mobile/test/providers/video_publish_provider_test.dart
@@ -13,6 +13,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart' show NativeProofData;
+import 'package:nostr_client/nostr_client.dart';
 import 'package:openvine/blocs/background_publish/background_publish_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/divine_video_clip.dart';
@@ -49,11 +50,34 @@ class MockVideoEventPublisher extends Mock implements VideoEventPublisher {}
 
 class MockBlossomUploadService extends Mock implements BlossomUploadService {}
 
+class MockNostrClient extends Mock implements NostrClient {}
+
 class _IdentityKnownNostrSession extends NostrSession {
   @override
   NostrSessionReadiness build() => const NostrSessionReadiness.identityKnown(
     pubkey: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
   );
+}
+
+class _ReadyThenTearingDownNostrSession extends NostrSession {
+  static late NostrClient client;
+
+  @override
+  NostrSessionReadiness build() {
+    Future.microtask(
+      () => update(
+        const NostrSessionReadiness.tearingDown(
+          pubkey:
+              'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        ),
+      ),
+    );
+    return NostrSessionReadiness.nostrReady(
+      pubkey:
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      client: client,
+    );
+  }
 }
 
 DivineVideoClip _createTestClip() => DivineVideoClip(
@@ -399,6 +423,96 @@ void main() {
         await publishRef
             .read(videoPublishProvider.notifier)
             .publishVideo(publishContext, _createPublishableDraft());
+
+        final state = publishRef.read(videoPublishProvider);
+        expect(state.publishState, VideoPublishState.error);
+        expect(state.errorMessage, isNotEmpty);
+        verifyNever(() => draftStorageService.saveDraft(any()));
+        expect(backgroundPublishBloc.state.uploads, isEmpty);
+      },
+    );
+
+    testWidgets(
+      'publishVideo revalidates live readiness before saving publish draft',
+      (tester) async {
+        SharedPreferences.setMockInitialValues({});
+        final sharedPreferences = await SharedPreferences.getInstance();
+        final draftStorageService = MockDraftStorageService();
+        final authService = MockAuthService();
+        final uploadManager = MockUploadManager();
+        final videoEventPublisher = MockVideoEventPublisher();
+        final blossomUploadService = MockBlossomUploadService();
+        final nostrClient = MockNostrClient();
+        _ReadyThenTearingDownNostrSession.client = nostrClient;
+        final backgroundPublishBloc = BackgroundPublishBloc(
+          videoPublishServiceFactory: ({required onProgress}) async =>
+              throw StateError('background publish should not be requested'),
+          draftStorageService: draftStorageService,
+        );
+        addTearDown(backgroundPublishBloc.close);
+
+        when(
+          () => draftStorageService.saveDraft(any()),
+        ).thenAnswer((_) async {});
+        when(() => authService.currentNpub).thenReturn(null);
+        when(() => authService.isAuthenticated).thenReturn(true);
+        when(() => authService.currentPublicKeyHex).thenReturn(
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        );
+        when(() => authService.currentProfile).thenReturn(null);
+        when(() => nostrClient.hasKeys).thenReturn(true);
+        when(() => nostrClient.publicKey).thenReturn(
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        );
+
+        late BuildContext publishContext;
+        late WidgetRef publishRef;
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              sharedPreferencesProvider.overrideWithValue(sharedPreferences),
+              draftStorageServiceProvider.overrideWithValue(
+                draftStorageService,
+              ),
+              authServiceProvider.overrideWithValue(authService),
+              uploadManagerProvider.overrideWithValue(uploadManager),
+              videoEventPublisherProvider.overrideWithValue(
+                videoEventPublisher,
+              ),
+              blossomUploadServiceProvider.overrideWithValue(
+                blossomUploadService,
+              ),
+              nostrSessionProvider.overrideWith(
+                _ReadyThenTearingDownNostrSession.new,
+              ),
+            ],
+            child: MaterialApp(
+              home: BlocProvider<BackgroundPublishBloc>.value(
+                value: backgroundPublishBloc,
+                child: Consumer(
+                  builder: (context, ref, _) {
+                    publishContext = context;
+                    publishRef = ref;
+                    return const SizedBox.shrink();
+                  },
+                ),
+              ),
+            ),
+          ),
+        );
+
+        final draft = DivineVideoDraft.create(
+          clips: [_createTestClip()],
+          title: 'Test Draft',
+          description: 'Test Description',
+          hashtags: const {},
+          selectedApproach: 'default',
+        ).copyWith(finalRenderedClip: _createTestClip());
+
+        await publishRef
+            .read(videoPublishProvider.notifier)
+            .publishVideo(publishContext, draft);
 
         final state = publishRef.read(videoPublishProvider);
         expect(state.publishState, VideoPublishState.error);

--- a/mobile/test/services/video_publish/video_publish_service_test.dart
+++ b/mobile/test/services/video_publish/video_publish_service_test.dart
@@ -225,6 +225,79 @@ void main() {
       );
 
       test(
+        'returns not signed in without saving or uploading when retry draft lacks persisted publish pubkey',
+        () async {
+          // Arrange
+          when(() => mockAuthService.isAuthenticated).thenReturn(true);
+          when(
+            () => mockAuthService.currentPublicKeyHex,
+          ).thenReturn(
+            'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+          );
+          service = VideoPublishService(
+            uploadManager: mockUploadManager,
+            authService: mockAuthService,
+            videoEventPublisher: mockVideoEventPublisher,
+            blossomService: mockBlossomService,
+            draftService: mockDraftService,
+            collaboratorInviteService: mockCollaboratorInviteService,
+            mentionResolutionService: mockMentionResolutionService,
+            readPublishReadiness: () => const PublishReadiness.ready(
+              pubkey:
+                  'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+            ),
+            onProgressChanged:
+                ({required double progress, required String draftId}) =>
+                    progressChanges.add(progress),
+          );
+
+          final retryDraft = _createTestDraft().copyWith(
+            publishStatus: PublishStatus.failed,
+            sourceDraftId: 'source_draft_id',
+            publishAttempts: 1,
+          );
+
+          // Act
+          final result = await service.publishVideo(draft: retryDraft);
+
+          // Assert
+          expect(result, isA<PublishError>());
+          expect((result as PublishError).kind, PublishErrorKind.notSignedIn);
+          verifyNever(() => mockDraftService.saveDraft(any()));
+          verifyNever(
+            () => mockUploadManager.startUploadFromDraft(
+              draft: any(named: 'draft'),
+              nostrPubkey: any(named: 'nostrPubkey'),
+              onProgress: any(named: 'onProgress'),
+            ),
+          );
+          verifyNever(
+            () => mockVideoEventPublisher.publishVideoEvent(
+              upload: any(named: 'upload'),
+              title: any(named: 'title'),
+              description: any(named: 'description'),
+              hashtags: any(named: 'hashtags'),
+              expirationTimestamp: any(named: 'expirationTimestamp'),
+              allowAudioReuse: any(named: 'allowAudioReuse'),
+              collaboratorPubkeys: any(named: 'collaboratorPubkeys'),
+              mentionedPubkeys: any(named: 'mentionedPubkeys'),
+              inspiredByAddressableId: any(named: 'inspiredByAddressableId'),
+              inspiredByRelayUrl: any(named: 'inspiredByRelayUrl'),
+              inspiredByNpub: any(named: 'inspiredByNpub'),
+              selectedAudio: any(named: 'selectedAudio'),
+              selectedAudioEventId: any(named: 'selectedAudioEventId'),
+              selectedAudioRelay: any(named: 'selectedAudioRelay'),
+              language: any(named: 'language'),
+              contentWarning: any(named: 'contentWarning'),
+              thumbnailTimestamp: any(named: 'thumbnailTimestamp'),
+              replyContext: any(named: 'replyContext'),
+              addReplyToFeed: any(named: 'addReplyToFeed'),
+            ),
+          );
+        },
+      );
+
+      test(
         'revalidates live readiness before saving publish draft',
         () async {
           // Arrange

--- a/mobile/test/services/video_publish/video_publish_service_test.dart
+++ b/mobile/test/services/video_publish/video_publish_service_test.dart
@@ -111,6 +111,50 @@ void main() {
         expect((result as PublishError).kind, PublishErrorKind.notSignedIn);
       });
 
+      test(
+        'returns not signed in when authenticated state has no publish pubkey',
+        () async {
+          // Arrange
+          when(() => mockAuthService.isAuthenticated).thenReturn(true);
+          when(() => mockAuthService.currentPublicKeyHex).thenReturn(null);
+          when(
+            () => mockDraftService.saveDraft(any()),
+          ).thenAnswer((_) async {});
+
+          final draft = _createTestDraft();
+
+          // Act
+          final result = await service.publishVideo(draft: draft);
+
+          // Assert
+          expect(result, isA<PublishError>());
+          expect((result as PublishError).kind, PublishErrorKind.notSignedIn);
+          verifyNever(
+            () => mockVideoEventPublisher.publishVideoEvent(
+              upload: any(named: 'upload'),
+              title: any(named: 'title'),
+              description: any(named: 'description'),
+              hashtags: any(named: 'hashtags'),
+              expirationTimestamp: any(named: 'expirationTimestamp'),
+              allowAudioReuse: any(named: 'allowAudioReuse'),
+              collaboratorPubkeys: any(named: 'collaboratorPubkeys'),
+              mentionedPubkeys: any(named: 'mentionedPubkeys'),
+              inspiredByAddressableId: any(named: 'inspiredByAddressableId'),
+              inspiredByRelayUrl: any(named: 'inspiredByRelayUrl'),
+              inspiredByNpub: any(named: 'inspiredByNpub'),
+              selectedAudio: any(named: 'selectedAudio'),
+              selectedAudioEventId: any(named: 'selectedAudioEventId'),
+              selectedAudioRelay: any(named: 'selectedAudioRelay'),
+              language: any(named: 'language'),
+              contentWarning: any(named: 'contentWarning'),
+              thumbnailTimestamp: any(named: 'thumbnailTimestamp'),
+              replyContext: any(named: 'replyContext'),
+              addReplyToFeed: any(named: 'addReplyToFeed'),
+            ),
+          );
+        },
+      );
+
       test('returns success when publish completes successfully', () async {
         // Arrange
         _setupSuccessfulPublish(

--- a/mobile/test/services/video_publish/video_publish_service_test.dart
+++ b/mobile/test/services/video_publish/video_publish_service_test.dart
@@ -224,6 +224,72 @@ void main() {
         },
       );
 
+      test(
+        'revalidates live readiness before saving publish draft',
+        () async {
+          // Arrange
+          var readinessReads = 0;
+          service = VideoPublishService(
+            uploadManager: mockUploadManager,
+            authService: mockAuthService,
+            videoEventPublisher: mockVideoEventPublisher,
+            blossomService: mockBlossomService,
+            draftService: mockDraftService,
+            collaboratorInviteService: mockCollaboratorInviteService,
+            mentionResolutionService: mockMentionResolutionService,
+            readPublishReadiness: () {
+              readinessReads += 1;
+              return readinessReads == 1
+                  ? const PublishReadiness.ready(pubkey: 'test_pubkey')
+                  : const PublishReadiness.notReady(pubkey: 'test_pubkey');
+            },
+            onProgressChanged:
+                ({required double progress, required String draftId}) =>
+                    progressChanges.add(progress),
+          );
+
+          final draft = _createTestDraft();
+
+          // Act
+          final result = await service.publishVideo(draft: draft);
+
+          // Assert
+          expect(result, isA<PublishError>());
+          expect((result as PublishError).kind, PublishErrorKind.notSignedIn);
+          verifyNever(() => mockDraftService.saveDraft(any()));
+          verifyNever(
+            () => mockUploadManager.startUploadFromDraft(
+              draft: any(named: 'draft'),
+              nostrPubkey: any(named: 'nostrPubkey'),
+              onProgress: any(named: 'onProgress'),
+            ),
+          );
+          verifyNever(
+            () => mockVideoEventPublisher.publishVideoEvent(
+              upload: any(named: 'upload'),
+              title: any(named: 'title'),
+              description: any(named: 'description'),
+              hashtags: any(named: 'hashtags'),
+              expirationTimestamp: any(named: 'expirationTimestamp'),
+              allowAudioReuse: any(named: 'allowAudioReuse'),
+              collaboratorPubkeys: any(named: 'collaboratorPubkeys'),
+              mentionedPubkeys: any(named: 'mentionedPubkeys'),
+              inspiredByAddressableId: any(named: 'inspiredByAddressableId'),
+              inspiredByRelayUrl: any(named: 'inspiredByRelayUrl'),
+              inspiredByNpub: any(named: 'inspiredByNpub'),
+              selectedAudio: any(named: 'selectedAudio'),
+              selectedAudioEventId: any(named: 'selectedAudioEventId'),
+              selectedAudioRelay: any(named: 'selectedAudioRelay'),
+              language: any(named: 'language'),
+              contentWarning: any(named: 'contentWarning'),
+              thumbnailTimestamp: any(named: 'thumbnailTimestamp'),
+              replyContext: any(named: 'replyContext'),
+              addReplyToFeed: any(named: 'addReplyToFeed'),
+            ),
+          );
+        },
+      );
+
       test('returns success when publish completes successfully', () async {
         // Arrange
         _setupSuccessfulPublish(

--- a/mobile/test/services/video_publish/video_publish_service_test.dart
+++ b/mobile/test/services/video_publish/video_publish_service_test.dart
@@ -155,6 +155,75 @@ void main() {
         },
       );
 
+      test(
+        'returns not signed in without saving or uploading when signer session is not ready',
+        () async {
+          // Arrange
+          when(() => mockAuthService.isAuthenticated).thenReturn(true);
+          when(
+            () => mockAuthService.currentPublicKeyHex,
+          ).thenReturn(
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          );
+          service = VideoPublishService(
+            uploadManager: mockUploadManager,
+            authService: mockAuthService,
+            videoEventPublisher: mockVideoEventPublisher,
+            blossomService: mockBlossomService,
+            draftService: mockDraftService,
+            collaboratorInviteService: mockCollaboratorInviteService,
+            mentionResolutionService: mockMentionResolutionService,
+            readPublishReadiness: () => const PublishReadiness.notReady(
+              pubkey:
+                  'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            ),
+            onProgressChanged:
+                ({required double progress, required String draftId}) =>
+                    progressChanges.add(progress),
+          );
+
+          final draft = _createTestDraft();
+
+          // Act
+          final result = await service.publishVideo(draft: draft);
+
+          // Assert
+          expect(result, isA<PublishError>());
+          expect((result as PublishError).kind, PublishErrorKind.notSignedIn);
+          verifyNever(() => mockDraftService.saveDraft(any()));
+          verifyNever(
+            () => mockUploadManager.startUploadFromDraft(
+              draft: any(named: 'draft'),
+              nostrPubkey: any(named: 'nostrPubkey'),
+              onProgress: any(named: 'onProgress'),
+            ),
+          );
+          verifyNever(
+            () => mockVideoEventPublisher.publishVideoEvent(
+              upload: any(named: 'upload'),
+              title: any(named: 'title'),
+              description: any(named: 'description'),
+              hashtags: any(named: 'hashtags'),
+              expirationTimestamp: any(named: 'expirationTimestamp'),
+              allowAudioReuse: any(named: 'allowAudioReuse'),
+              collaboratorPubkeys: any(named: 'collaboratorPubkeys'),
+              mentionedPubkeys: any(named: 'mentionedPubkeys'),
+              inspiredByAddressableId: any(named: 'inspiredByAddressableId'),
+              inspiredByRelayUrl: any(named: 'inspiredByRelayUrl'),
+              inspiredByNpub: any(named: 'inspiredByNpub'),
+              selectedAudio: any(named: 'selectedAudio'),
+              selectedAudioEventId: any(named: 'selectedAudioEventId'),
+              selectedAudioRelay: any(named: 'selectedAudioRelay'),
+              language: any(named: 'language'),
+              contentWarning: any(named: 'contentWarning'),
+              thumbnailTimestamp: any(named: 'thumbnailTimestamp'),
+              replyContext: any(named: 'replyContext'),
+              addReplyToFeed: any(named: 'addReplyToFeed'),
+            ),
+          );
+        },
+      );
+
       test('returns success when publish completes successfully', () async {
         // Arrange
         _setupSuccessfulPublish(


### PR DESCRIPTION
## Description

Users could hit confusing states during startup and notifications.
Posting could start before the signer was ready, a failed publish retry could lose the original account identity, the user's own profile could show a generated fallback name while read-only profile data was available, and notifications could describe someone else's video as the user's video when metadata was missing.

This change makes those paths fail safely.
Publish now checks live signer readiness before draft, upload, or event work starts, publish retries keep the original expected pubkey, own-profile reads can use identity-known read data while signer setup finishes, and video notifications require ownership proof before they become "your video" notifications.

**Related Issue:** Part of #5920

## Out of Scope

The publish editor can still be clearer before the user taps post.
This change prevents unsafe publish work from starting, but it does not add a disabled or waiting state to the post button while signer setup is still in progress.

## Verification

I tested the changed paths and the full mobile suite after rebasing on the latest main.
All listed checks passed locally.

- `git fetch https://github.com/divinevideo/divine-mobile.git main:refs/remotes/origin/main && git rebase origin/main`
- `MISE_TRUSTED_CONFIG_PATHS="/home/daniel/.ouija/worktrees/divine-mobile/fix/5920-lots-of-bugs/mobile/mise.toml" mise exec -- flutter analyze`
- `MISE_TRUSTED_CONFIG_PATHS="/home/daniel/.ouija/worktrees/divine-mobile/fix/5920-lots-of-bugs/mobile/mise.toml" mise exec -- flutter test` from `mobile/packages/notification_repository`
- `MISE_TRUSTED_CONFIG_PATHS="/home/daniel/.ouija/worktrees/divine-mobile/fix/5920-lots-of-bugs/mobile/mise.toml" mise exec -- flutter test` from `mobile/`

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore