### PR TITLE
fix(feed): auto-dismiss the tuning Undo snackbar

### DIFF
--- a/mobile/lib/screens/feed/feed_tuning_snackbar.dart
+++ b/mobile/lib/screens/feed/feed_tuning_snackbar.dart
@@ -1,0 +1,40 @@
+// ABOUTME: Shared Undo snackbar for feed-tuning swipes (home + fullscreen feed)
+// ABOUTME: Uses DivineSnackbarContainer so the receipt always auto-dismisses
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:feed_tuning_repository/feed_tuning_repository.dart';
+import 'package:flutter/material.dart';
+import 'package:openvine/l10n/l10n.dart';
+
+/// Auto-dismiss window for the feed-tuning receipt.
+const _feedTuningSnackbarDuration = Duration(seconds: 4);
+
+/// Shows the "More/Less like this" receipt after a feed-tuning swipe, with an
+/// optional Undo action.
+///
+/// Uses [DivineSnackbarContainer] rather than a bare [SnackBar] with a
+/// [SnackBarAction]: a Material action defaults `SnackBar.persist` to `true`,
+/// which suppresses the auto-dismiss timer and pins the snackbar on screen
+/// until it's manually dismissed. Rendering the Undo button inside the
+/// snackbar content keeps `persist == false`, so the receipt always clears on
+/// its own after [_feedTuningSnackbarDuration].
+void showFeedTuningSnackbar(
+  BuildContext context, {
+  required FeedTuningDirection direction,
+  VoidCallback? onUndo,
+}) {
+  final l10n = context.l10n;
+  final label = direction == FeedTuningDirection.more
+      ? l10n.feedTuningMoreLabel
+      : l10n.feedTuningLessLabel;
+  ScaffoldMessenger.of(context)
+    ..clearSnackBars()
+    ..showSnackBar(
+      DivineSnackbarContainer.snackBar(
+        label,
+        duration: _feedTuningSnackbarDuration,
+        actionLabel: onUndo == null ? null : l10n.feedTuningUndo,
+        onActionPressed: onUndo,
+      ),
+    );
+}

--- a/mobile/lib/screens/feed/feed_tuning_snackbar.dart
+++ b/mobile/lib/screens/feed/feed_tuning_snackbar.dart
@@ -18,6 +18,9 @@ const _feedTuningSnackbarDuration = Duration(seconds: 4);
 /// until it's manually dismissed. Rendering the Undo button inside the
 /// snackbar content keeps `persist == false`, so the receipt always clears on
 /// its own after [_feedTuningSnackbarDuration].
+///
+/// Tapping Undo hides the receipt before running [onUndo], matching the
+/// dismiss-on-tap and single-fire behavior a [SnackBarAction] provides.
 void showFeedTuningSnackbar(
   BuildContext context, {
   required FeedTuningDirection direction,
@@ -27,14 +30,20 @@ void showFeedTuningSnackbar(
   final label = direction == FeedTuningDirection.more
       ? l10n.feedTuningMoreLabel
       : l10n.feedTuningLessLabel;
-  ScaffoldMessenger.of(context)
-    ..clearSnackBars()
-    ..showSnackBar(
-      DivineSnackbarContainer.snackBar(
-        label,
-        duration: _feedTuningSnackbarDuration,
-        actionLabel: onUndo == null ? null : l10n.feedTuningUndo,
-        onActionPressed: onUndo,
-      ),
-    );
+  final messenger = ScaffoldMessenger.of(context)..clearSnackBars();
+  messenger.showSnackBar(
+    DivineSnackbarContainer.snackBar(
+      label,
+      duration: _feedTuningSnackbarDuration,
+      actionLabel: onUndo == null ? null : l10n.feedTuningUndo,
+      onActionPressed: onUndo == null
+          ? null
+          : () {
+              messenger.removeCurrentSnackBar(
+                reason: SnackBarClosedReason.action,
+              );
+              onUndo();
+            },
+    ),
+  );
 }

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -29,6 +29,7 @@ import 'package:openvine/screens/feed/dm_reply_context.dart';
 import 'package:openvine/screens/feed/feed_auto_advance_coordinator.dart';
 import 'package:openvine/screens/feed/feed_auto_advance_cubit.dart';
 import 'package:openvine/screens/feed/feed_settings_menu.dart';
+import 'package:openvine/screens/feed/feed_tuning_snackbar.dart';
 import 'package:openvine/services/openvine_media_cache.dart';
 import 'package:openvine/services/view_event_publisher.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
@@ -496,25 +497,14 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
   }
 
   void _showTuningSnackbar(FullscreenFeedTuningAction action) {
-    final l10n = context.l10n;
-    final label = action.direction == FeedTuningDirection.more
-        ? l10n.feedTuningMoreLabel
-        : l10n.feedTuningLessLabel;
     final eventId = action.publishedEventId;
-    ScaffoldMessenger.of(context)
-      ..clearSnackBars()
-      ..showSnackBar(
-        SnackBar(
-          behavior: SnackBarBehavior.floating,
-          content: Text(label),
-          action: eventId == null
-              ? null
-              : SnackBarAction(
-                  label: l10n.feedTuningUndo,
-                  onPressed: () => _undoTuning(eventId, action.videoId),
-                ),
-        ),
-      );
+    showFeedTuningSnackbar(
+      context,
+      direction: action.direction,
+      onUndo: eventId == null
+          ? null
+          : () => _undoTuning(eventId, action.videoId),
+    );
   }
 
   void _undoTuning(String feedTuningEventId, String videoId) {

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -10,7 +10,6 @@ import 'package:openvine/blocs/video_feed/video_feed_bloc.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
-import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/foreground_idle_warmup_provider.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
@@ -21,6 +20,7 @@ import 'package:openvine/providers/shell_obscured_provider.dart';
 import 'package:openvine/router/router.dart';
 import 'package:openvine/screens/feed/feed_auto_advance_cubit.dart';
 import 'package:openvine/screens/feed/feed_mode_switch.dart';
+import 'package:openvine/screens/feed/feed_tuning_snackbar.dart';
 import 'package:openvine/screens/feed/video_feed_page/feed_empty_widget.dart';
 import 'package:openvine/screens/feed/video_feed_page/feed_error_widget.dart';
 import 'package:openvine/services/startup_performance_service.dart';
@@ -230,25 +230,14 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
   }
 
   void _showTuningSnackbar(VideoFeedTuningAction action) {
-    final l10n = context.l10n;
-    final label = action.direction == FeedTuningDirection.more
-        ? l10n.feedTuningMoreLabel
-        : l10n.feedTuningLessLabel;
     final eventId = action.publishedEventId;
-    ScaffoldMessenger.of(context)
-      ..clearSnackBars()
-      ..showSnackBar(
-        SnackBar(
-          behavior: SnackBarBehavior.floating,
-          content: Text(label),
-          action: eventId == null
-              ? null
-              : SnackBarAction(
-                  label: l10n.feedTuningUndo,
-                  onPressed: () => _undoTuning(eventId, action.videoId),
-                ),
-        ),
-      );
+    showFeedTuningSnackbar(
+      context,
+      direction: action.direction,
+      onUndo: eventId == null
+          ? null
+          : () => _undoTuning(eventId, action.videoId),
+    );
   }
 
   void _dismissTuningSnackbar() {

--- a/mobile/test/screens/feed/feed_tuning_snackbar_test.dart
+++ b/mobile/test/screens/feed/feed_tuning_snackbar_test.dart
@@ -59,6 +59,28 @@ void main() {
       },
     );
 
+    testWidgets('dismisses the receipt and fires the callback on Undo tap', (
+      tester,
+    ) async {
+      var undoCount = 0;
+      await tester.pumpWidget(
+        harness(direction: FeedTuningDirection.less, onUndo: () => undoCount++),
+      );
+
+      await tester.tap(find.text('trigger'));
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+
+      await tester.tap(find.text(l10n.feedTuningUndo));
+      await tester.pump();
+
+      // The receipt is removed immediately, so Undo cannot fire twice and the
+      // snackbar does not linger for the rest of its 4s window.
+      expect(undoCount, equals(1));
+      expect(find.text(l10n.feedTuningLessLabel), findsNothing);
+      expect(find.text(l10n.feedTuningUndo), findsNothing);
+    });
+
     testWidgets('omits the Undo action when no callback is given', (
       tester,
     ) async {

--- a/mobile/test/screens/feed/feed_tuning_snackbar_test.dart
+++ b/mobile/test/screens/feed/feed_tuning_snackbar_test.dart
@@ -1,0 +1,75 @@
+import 'package:feed_tuning_repository/feed_tuning_repository.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/screens/feed/feed_tuning_snackbar.dart';
+
+void main() {
+  final l10n = lookupAppLocalizations(const Locale('en'));
+
+  Widget harness({
+    required FeedTuningDirection direction,
+    VoidCallback? onUndo,
+  }) {
+    return MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => Center(
+            child: ElevatedButton(
+              onPressed: () => showFeedTuningSnackbar(
+                context,
+                direction: direction,
+                onUndo: onUndo,
+              ),
+              child: const Text('trigger'),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  group('showFeedTuningSnackbar', () {
+    testWidgets(
+      'auto-dismisses the receipt after its timeout even with an Undo action',
+      (tester) async {
+        await tester.pumpWidget(
+          harness(direction: FeedTuningDirection.less, onUndo: () {}),
+        );
+
+        await tester.tap(find.text('trigger'));
+        await tester.pump();
+        // Let the reveal animation finish so the auto-dismiss timer starts.
+        await tester.pump(const Duration(seconds: 1));
+
+        // The Undo action is the case that used to pin the receipt on screen
+        // forever: a Material SnackBarAction defaults SnackBar.persist to true,
+        // which suppresses the timer. The design-system container keeps persist
+        // false, so the timer still fires with the action present.
+        expect(find.text(l10n.feedTuningLessLabel), findsOneWidget);
+        expect(find.text(l10n.feedTuningUndo), findsOneWidget);
+
+        await tester.pump(const Duration(seconds: 4)); // auto-dismiss window
+        await tester.pump(const Duration(seconds: 1)); // exit animation
+
+        expect(find.text(l10n.feedTuningLessLabel), findsNothing);
+        expect(find.text(l10n.feedTuningUndo), findsNothing);
+      },
+    );
+
+    testWidgets('omits the Undo action when no callback is given', (
+      tester,
+    ) async {
+      await tester.pumpWidget(harness(direction: FeedTuningDirection.more));
+
+      await tester.tap(find.text('trigger'));
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+
+      expect(find.text(l10n.feedTuningMoreLabel), findsOneWidget);
+      expect(find.text(l10n.feedTuningUndo), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
Closes #5973

## Problem

A user reported the feed-tuning receipt ("More like this" / "Less like this") **never disappears**. Reproduces whenever the Undo button is present.

Root cause is not accessibility — it's a Flutter default. `SnackBar` sets:

```dart
persist = persist ?? action != null;
```

So any `SnackBar` carrying a Material `SnackBarAction` (our Undo button) gets `persist == true`, and `ScaffoldMessengerState` then skips the auto-dismiss timer:

```dart
_snackBarTimer = Timer(snackBar.duration, () {
  if (snackBar.persist) return; // ← never hides
  hideCurrentSnackBar(reason: SnackBarClosedReason.timeout);
});
```

The receipt therefore stayed on screen until manually dismissed or replaced. The no-Undo case (`eventId == null`, no action) dismissed normally, which is why it looked intermittent. A plain `duration:` would **not** have fixed it.

## Fix

Route the receipt through the design system's `DivineSnackbarContainer.snackBar(...)`, which renders the Undo button *inside* the snackbar content rather than as a Material `SnackBarAction`. With no Material action, `persist` stays `false` and the auto-dismiss timer fires as intended.

## Deduplication

`_showTuningSnackbar` / `_undoTuning` were duplicated almost verbatim across the home feed (`video_feed_page.dart`) and the fullscreen feed (`pooled_fullscreen_video_feed_screen.dart`), differing only by bloc/action type. Both carried the same bug. Extracted the shared show logic into `showFeedTuningSnackbar(...)`; each screen keeps its own `_undoTuning` and passes it as the `onUndo` callback.

## Verification

- `flutter analyze` on the three files: no issues.
- `video_feed_page_test.dart` + `pooled_fullscreen_video_feed_screen_test.dart`: all pass (the `find.text('More/Less like this')` assertions still hold — the container renders the label as `Text`).

## Note (out of scope)

Seven other files use `SnackBarAction(` and would exhibit the same "never auto-dismiss" behaviour unless they set `persist: false`/`duration` explicitly. Not touched here; flagging for a possible follow-up.