### PR TITLE
fix(library): show snackbar feedback when downloading a clip

### DIFF
--- a/mobile/lib/screens/library_screen.dart
+++ b/mobile/lib/screens/library_screen.dart
@@ -467,101 +467,105 @@ class _LibraryViewState extends ConsumerState<_LibraryView>
                     .value
               : null;
 
-          return Stack(
-            children: [
-              Material(
-                color: VineTheme.onPrimary,
-                child: SafeArea(
-                  bottom: false,
-                  child: Column(
-                    children: [
-                      if (!widget.selectionMode)
-                        LibraryToolbar(
-                          isLibrarySelectionMode: isLibrarySelectionMode,
-                          canExitSelectionMode: !selectionLockedToCloseOnly,
-                          isClipsTabActive: isClipsTabActive,
-                          onLeadingPressed: () {
-                            if (isLibrarySelectionMode &&
-                                !selectionLockedToCloseOnly) {
-                              _exitLibrarySelectionMode(clipsBloc);
-                              return;
-                            }
-                            if (context.canPop()) {
-                              context.pop();
-                            } else {
-                              context.go(VideoFeedPage.pathForIndex(0));
-                            }
-                          },
-                          onOpenSortMenu: () => _openSortMenu(
-                            context,
-                            clipsBloc,
-                            clipsState.clipSort,
+          return Scaffold(
+            backgroundColor: VineTheme.onPrimary,
+            body: Stack(
+              children: [
+                Material(
+                  color: VineTheme.onPrimary,
+                  child: SafeArea(
+                    bottom: false,
+                    child: Column(
+                      children: [
+                        if (!widget.selectionMode)
+                          LibraryToolbar(
+                            isLibrarySelectionMode: isLibrarySelectionMode,
+                            canExitSelectionMode: !selectionLockedToCloseOnly,
+                            isClipsTabActive: isClipsTabActive,
+                            onLeadingPressed: () {
+                              if (isLibrarySelectionMode &&
+                                  !selectionLockedToCloseOnly) {
+                                _exitLibrarySelectionMode(clipsBloc);
+                                return;
+                              }
+                              if (context.canPop()) {
+                                context.pop();
+                              } else {
+                                context.go(VideoFeedPage.pathForIndex(0));
+                              }
+                            },
+                            onOpenSortMenu: () => _openSortMenu(
+                              context,
+                              clipsBloc,
+                              clipsState.clipSort,
+                            ),
+                            onEnterSelectionMode: () => clipsBloc.add(
+                              const ClipsLibraryEnterSelectionMode(),
+                            ),
+                            onOpenTrash: () => _openTrash(context, clipsBloc),
+                            onDeleteSelectedClips:
+                                clipsState.selectedClipIds.isNotEmpty
+                                ? () => _softDeleteSelectedClips(clipsBloc)
+                                : null,
                           ),
-                          onEnterSelectionMode: () => clipsBloc.add(
-                            const ClipsLibraryEnterSelectionMode(),
+                        Expanded(
+                          child: _LibraryContent(
+                            isClipsOnlyMode: _isClipsOnlyMode,
+                            tabController: _tabController,
+                            selectionMode: widget.selectionMode,
+                            scrollController: widget.scrollController,
+                            targetAspectRatio: targetAspectRatio,
+                            sortedClips: sortedClips,
+                            selectionEnabled: selectionEnabled,
+                            onCreateVideo: () => _createVideoFromSelected(
+                              context,
+                              selectedClips: clipsState.selectedClips,
+                              clipsBloc: clipsBloc,
+                            ),
                           ),
-                          onOpenTrash: () => _openTrash(context, clipsBloc),
-                          onDeleteSelectedClips:
-                              clipsState.selectedClipIds.isNotEmpty
-                              ? () => _softDeleteSelectedClips(clipsBloc)
-                              : null,
                         ),
-                      Expanded(
-                        child: _LibraryContent(
-                          isClipsOnlyMode: _isClipsOnlyMode,
-                          tabController: _tabController,
-                          selectionMode: widget.selectionMode,
-                          scrollController: widget.scrollController,
-                          targetAspectRatio: targetAspectRatio,
-                          sortedClips: sortedClips,
-                          selectionEnabled: selectionEnabled,
-                          onCreateVideo: () => _createVideoFromSelected(
+                        _CreateVideoBar(
+                          visible:
+                              !widget.selectionMode &&
+                              selectionEnabled &&
+                              (_activeTabIndex == 1 ||
+                                  widget.tabsMode ==
+                                      LibraryTabsMode.clipsOnly) &&
+                              clipsState.selectedClipIds.isNotEmpty,
+                          onPressed: () => _createVideoFromSelected(
                             context,
                             selectedClips: clipsState.selectedClips,
                             clipsBloc: clipsBloc,
                           ),
                         ),
-                      ),
-                      _CreateVideoBar(
-                        visible:
-                            !widget.selectionMode &&
-                            selectionEnabled &&
-                            (_activeTabIndex == 1 ||
-                                widget.tabsMode == LibraryTabsMode.clipsOnly) &&
-                            clipsState.selectedClipIds.isNotEmpty,
-                        onPressed: () => _createVideoFromSelected(
-                          context,
-                          selectedClips: clipsState.selectedClips,
-                          clipsBloc: clipsBloc,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-              if (clipsState.isDeleting ||
-                  clipsState.isSavingToGallery ||
-                  isPreparing)
-                Material(
-                  color: VineTheme.scrim65,
-                  child: Center(
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      spacing: 16,
-                      children: [
-                        const CircularProgressIndicator(
-                          color: VineTheme.vineGreen,
-                        ),
-                        if (isPreparing)
-                          Text(
-                            context.l10n.libraryPreparingVideo,
-                            style: VineTheme.bodyMediumFont(),
-                          ),
                       ],
                     ),
                   ),
                 ),
-            ],
+                if (clipsState.isDeleting ||
+                    clipsState.isSavingToGallery ||
+                    isPreparing)
+                  Material(
+                    color: VineTheme.scrim65,
+                    child: Center(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        spacing: 16,
+                        children: [
+                          const CircularProgressIndicator(
+                            color: VineTheme.vineGreen,
+                          ),
+                          if (isPreparing)
+                            Text(
+                              context.l10n.libraryPreparingVideo,
+                              style: VineTheme.bodyMediumFont(),
+                            ),
+                        ],
+                      ),
+                    ),
+                  ),
+              ],
+            ),
           );
         },
       ),

--- a/mobile/lib/widgets/video_clip/video_clip_preview.dart
+++ b/mobile/lib/widgets/video_clip/video_clip_preview.dart
@@ -100,38 +100,32 @@ class _VideoClipPreviewSheetState extends ConsumerState<VideoClipPreview> {
 
       if (!mounted) return;
 
+      final l10n = context.l10n;
       final destination = GallerySaveService.destinationName;
-      final message = switch (result) {
-        GallerySaveSuccess() => 'Clip saved to $destination',
-        GallerySavePermissionDenied() => '$destination permission denied',
-        GallerySaveFailure(:final reason) => 'Failed to save clip: $reason',
+      final (message, isError) = switch (result) {
+        GallerySaveSuccess() => (
+          l10n.libraryClipsSavedToDestination(1, destination),
+          false,
+        ),
+        GallerySavePermissionDenied() => (
+          l10n.libraryGalleryPermissionDenied(destination),
+          true,
+        ),
+        GallerySaveFailure() => (l10n.videoClipSaveFailed, true),
       };
 
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          backgroundColor: VineTheme.transparent,
-          elevation: 0,
-          behavior: SnackBarBehavior.floating,
-          content: DivineSnackbarContainer(
-            label: message,
-            error: result is! GallerySaveSuccess,
-          ),
-        ),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(DivineSnackbarContainer.snackBar(message, error: isError));
 
       context.pop();
     } catch (e, s) {
       Log.error('Failed to save clip to gallery', error: e, stackTrace: s);
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            backgroundColor: VineTheme.transparent,
-            elevation: 0,
-            behavior: SnackBarBehavior.floating,
-            content: DivineSnackbarContainer(
-              label: context.l10n.videoClipSaveFailed,
-              error: true,
-            ),
+          DivineSnackbarContainer.snackBar(
+            context.l10n.videoClipSaveFailed,
+            error: true,
           ),
         );
       }

--- a/mobile/lib/widgets/video_clip/video_clip_preview.dart
+++ b/mobile/lib/widgets/video_clip/video_clip_preview.dart
@@ -100,6 +100,10 @@ class _VideoClipPreviewSheetState extends ConsumerState<VideoClipPreview> {
 
       if (!mounted) return;
 
+      if (result case GallerySaveFailure(:final reason)) {
+        Log.warning('Failed to save clip to gallery: $reason');
+      }
+
       final l10n = context.l10n;
       final destination = GallerySaveService.destinationName;
       final (message, isError) = switch (result) {

--- a/mobile/test/screens/library_screen_test.dart
+++ b/mobile/test/screens/library_screen_test.dart
@@ -470,6 +470,50 @@ void main() {
 
         expect(tester.takeException(), isNull);
       });
+
+      testWidgets('renders without an external Scaffold because LibraryScreen '
+          'presents its own', (tester) async {
+        // Regression guard: in production LibraryScreen is a full-screen route
+        // with no ancestor Scaffold, so its floating snackbars (delete undo,
+        // clip download feedback) only render if LibraryScreen provides a
+        // Scaffold itself. `buildWidget` pumps LibraryScreen as `home:` with no
+        // Scaffold wrapper, mirroring that structure. Before the fix this found
+        // nothing.
+        final clip = DivineVideoClip(
+          id: 'undo-clip-2',
+          video: EditorVideo.file('/test/undo2.mp4'),
+          duration: const Duration(seconds: 2),
+          recordedAt: DateTime.now(),
+          targetAspectRatio: models.AspectRatio.vertical,
+          originalAspectRatio: 9 / 16,
+          thumbnailPath: '/test/undo2.jpg',
+          ghostFramePath: '/test/undo2_ghost.jpg',
+        );
+        when(
+          () => mockClipLibraryService.getAllClips(),
+        ).thenAnswer((_) async => [clip]);
+        when(
+          () => mockClipLibraryService.recoverMissingAssets(any()),
+        ).thenAnswer((_) async => [clip]);
+        when(
+          () => mockClipLibraryService.softDelete(any()),
+        ).thenAnswer((_) async => true);
+
+        await tester.pumpWidget(
+          buildWidget(
+            initialTabIndex: 1,
+            tabsMode: LibraryTabsMode.clipsOnly,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        BlocProvider.of<ClipsLibraryBloc>(
+          tester.element(find.byType(ClipsTab)),
+        ).add(ClipsLibraryDeleteClip(clip));
+        await tester.pumpAndSettle();
+
+        expect(find.text(en.libraryClipsDeletedUndoLabel), findsOneWidget);
+      });
     });
 
     group('web', () {

--- a/mobile/test/widgets/video_clip/video_clip_preview_test.dart
+++ b/mobile/test/widgets/video_clip/video_clip_preview_test.dart
@@ -10,17 +10,27 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/services/gallery_save_service.dart';
 import 'package:openvine/widgets/video_clip/video_clip_preview.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 
 import '../../helpers/go_router.dart';
 
+class _MockGallerySaveService extends Mock implements GallerySaveService {}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late MockGoRouter mockGoRouter;
+  late _MockGallerySaveService mockGallerySaveService;
+
+  setUpAll(() {
+    registerFallbackValue(EditorVideo.file('/fallback.mp4'));
+  });
 
   setUp(() {
+    mockGallerySaveService = _MockGallerySaveService();
     DivineVideoPlayerController.resetIdCounterForTesting();
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(const MethodChannel('divine_video_player'), (
@@ -58,6 +68,9 @@ void main() {
 
     Widget buildTestWidget({VoidCallback? onDelete}) {
       return ProviderScope(
+        overrides: [
+          gallerySaveServiceProvider.overrideWithValue(mockGallerySaveService),
+        ],
         child: MockGoRouterProvider(
           goRouter: mockGoRouter,
           child: MaterialApp(
@@ -179,6 +192,73 @@ void main() {
       await tester.pump(const Duration(milliseconds: 100));
 
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+
+    group('save result snackbar', () {
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      final destination = GallerySaveService.destinationName;
+
+      Future<void> pumpAndSave(
+        WidgetTester tester,
+        GallerySaveResult result,
+      ) async {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+              const MethodChannel('divine_video_player/player_0'),
+              (call) async => null,
+            );
+        addTearDown(() {
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+              .setMockMethodCallHandler(
+                const MethodChannel('divine_video_player/player_0'),
+                null,
+              );
+        });
+
+        when(
+          () => mockGallerySaveService.saveVideoToGallery(any()),
+        ).thenAnswer((_) async => result);
+
+        await tester.pumpWidget(buildTestWidget());
+        await tester.pump(const Duration(milliseconds: 100));
+
+        await tester.tap(
+          find.byWidgetPredicate(
+            (w) => w is DivineIcon && w.icon == DivineIconName.downloadSimple,
+          ),
+        );
+        await tester.pump();
+        await tester.pump();
+      }
+
+      testWidgets('shows saved message on $GallerySaveSuccess', (tester) async {
+        await pumpAndSave(tester, const GallerySaveSuccess());
+
+        expect(
+          find.text(l10n.libraryClipsSavedToDestination(1, destination)),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets(
+        'shows permission message on $GallerySavePermissionDenied',
+        (tester) async {
+          await pumpAndSave(tester, const GallerySavePermissionDenied());
+
+          expect(
+            find.text(l10n.libraryGalleryPermissionDenied(destination)),
+            findsOneWidget,
+          );
+        },
+      );
+
+      testWidgets('shows failure message on $GallerySaveFailure', (
+        tester,
+      ) async {
+        await pumpAndSave(tester, const GallerySaveFailure('disk full'));
+
+        expect(find.text(l10n.videoClipSaveFailed), findsOneWidget);
+      });
     });
   });
 }


### PR DESCRIPTION
Closes #5975

## Description

Downloading a clip from the Library preview (tap a clip → **download**) showed no confirmation snackbar — no "saved", no permission-denied, no failure feedback.

**Root cause:** a floating `SnackBar` only renders when there's a visible `Scaffold` to present it. `LibraryScreen` is opened as a full-screen route (`context.push('/clips')`), which pushes the shell's `Scaffold` offstage, and the screen itself was built on `Material` rather than `Scaffold`. So the snackbar was created but had no surface to render on. The same gap silently affected the Library's own delete/undo snackbar — the existing test only passed because it wrapped `LibraryScreen` in its own `Scaffold`, masking the production behaviour.

I confirmed the mechanism with a throwaway reproduction:

| Setup | Snackbar renders? |
|---|---|
| `LibraryScreen` = `Material` (production) | ❌ |
| `LibraryScreen` = `Scaffold` | ✅ |

### Changes
- **`library_screen.dart`** — wrap the view in a `Scaffold` (transparent `onPrimary` background, no visual change) so its floating snackbars have a surface. Fixes both the clip-download feedback and the delete/undo snackbar.
- **`video_clip_preview.dart`** — replace the hardcoded English result messages (`'Clip saved to Photos'`, …) with existing ARB keys (`libraryClipsSavedToDestination`, `libraryGalleryPermissionDenied`, `videoClipSaveFailed`) and use the shared `DivineSnackbarContainer.snackBar` helper. No new keys, so no translation debt.
- **`library_screen_test.dart`** — regression test that pumps `LibraryScreen` with **no** external `Scaffold` (the production structure) and asserts the snackbar renders. Verified it fails without the fix (`Found 0 widgets with text "Undo"`) and passes with it.

**Related Issue:** 

## Out of Scope

None.

## Verification

- `dart format` + `flutter analyze` clean on the 3 changed files
- `flutter test test/screens/library_screen_test.dart test/widgets/video_clip/video_clip_preview_test.dart` — all green (incl. new regression test)
- Pre-push hook (analyze + changed-file tests) green

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)