### PR TITLE
feat(proofmode): carry C2PA manifest forward on watermark download

### DIFF
--- a/mobile/lib/providers/watermark_download_provider.dart
+++ b/mobile/lib/providers/watermark_download_provider.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Constructs service with MediaCacheManager and GallerySaveService dependencies
 
 import 'package:openvine/providers/permissions_providers.dart';
+import 'package:openvine/services/c2pa_signing_service.dart';
 import 'package:openvine/services/openvine_media_cache.dart';
 import 'package:openvine/services/watermark_download_service.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -14,5 +15,6 @@ WatermarkDownloadService watermarkDownloadService(Ref ref) {
   return WatermarkDownloadService(
     mediaCache: ref.watch(mediaCacheProvider),
     gallerySaveService: ref.watch(gallerySaveServiceProvider),
+    c2paSigningService: C2paSigningService(),
   );
 }

--- a/mobile/lib/providers/watermark_download_provider.g.dart
+++ b/mobile/lib/providers/watermark_download_provider.g.dart
@@ -59,4 +59,4 @@ final class WatermarkDownloadServiceProvider
 }
 
 String _$watermarkDownloadServiceHash() =>
-    r'90e0376eb0765575ba8d07e98c4a1aa550174df2';
+    r'7b6bfd4ec13343e0d7305340455dc2c41b6768ef';

--- a/mobile/lib/services/c2pa_identity_manifest_service.dart
+++ b/mobile/lib/services/c2pa_identity_manifest_service.dart
@@ -88,6 +88,35 @@ class C2paIdentityManifestService {
     );
   }
 
+  /// Builds the C2PA manifest for a *derived* video — one produced by
+  /// re-encoding an already-signed source (an aspect-ratio crop or a
+  /// watermark burn-in) that has therefore lost its embedded manifest.
+  ///
+  /// The already-signed source is carried forward as a `parentOf` ingredient
+  /// by the caller via [ManifestBuilder.addIngredient], and the transform is
+  /// recorded as a `c2pa.*` edit action via [ManifestBuilder.addAction], so
+  /// this definition intentionally declares neither: it only supplies the
+  /// title, claim generator, and the always-on `cawg.training-mining` opt-out
+  /// (Divine policy — see `mobile/docs/AI_TRAINING_POLICY.md`).
+  C2paIdentityManifestBuildResult buildDerivedVideoManifest({
+    required String claimGenerator,
+    required String title,
+  }) {
+    final manifest = ManifestDefinition(
+      title: title,
+      claimGeneratorInfo: <ClaimGeneratorInfo>[
+        _parseClaimGenerator(claimGenerator),
+      ],
+      format: 'video/mp4',
+      assertions: <AssertionDefinition>[_buildTrainingMiningAssertion()],
+    );
+
+    return C2paIdentityManifestBuildResult(
+      manifestDefinition: manifest,
+      requiresAdvancedEmbedding: false,
+    );
+  }
+
   ClaimGeneratorInfo _parseClaimGenerator(String claimGenerator) {
     final separatorIndex = claimGenerator.lastIndexOf('/');
     if (separatorIndex <= 0 || separatorIndex == claimGenerator.length - 1) {

--- a/mobile/lib/services/c2pa_signing_service.dart
+++ b/mobile/lib/services/c2pa_signing_service.dart
@@ -14,7 +14,7 @@ import 'package:unified_logger/unified_logger.dart';
 /// re-encoded ("derived") video via [C2paSigningService.resignDerived].
 abstract class C2paEditActions {
   /// The derived file had a watermark / overlay burned into the frame.
-  static const String watermarked = 'c2pa.edited';
+  static const String watermarked = 'c2pa.watermarked';
 }
 
 /// Result of a C2PA signing operation
@@ -170,7 +170,7 @@ class C2paSigningService {
   /// watermark burn-in — that has lost the provenance embedded in its source.
   /// [sourcePath] is the already-signed original it was produced from. The
   /// source's active manifest is attached as a `parentOf` ingredient, [action]
-  /// (a `c2pa.*` edit action such as [C2paEditActions.cropped]) is recorded,
+  /// (a `c2pa.*` edit action such as [C2paEditActions.watermarked]) is recorded,
   /// and the result is signed and embedded back into [outputPath] in place.
   ///
   /// Returns `success: false` without touching [outputPath] when [sourcePath]

--- a/mobile/lib/services/c2pa_signing_service.dart
+++ b/mobile/lib/services/c2pa_signing_service.dart
@@ -10,6 +10,13 @@ import 'package:openvine/services/nostr_creator_binding_service.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:unified_logger/unified_logger.dart';
 
+/// C2PA edit actions recorded when carrying a manifest forward onto a
+/// re-encoded ("derived") video via [C2paSigningService.resignDerived].
+abstract class C2paEditActions {
+  /// The derived file had a watermark / overlay burned into the frame.
+  static const String watermarked = 'c2pa.edited';
+}
+
 /// Result of a C2PA signing operation
 class C2paSigningResult {
   const C2paSigningResult({
@@ -40,6 +47,8 @@ class C2paSigningService {
 
   final C2pa _c2pa;
   final C2paIdentityManifestService _manifestService;
+
+  static const String _videoMimeType = 'video/mp4';
 
   /// Signs a video file with C2PA content credentials.
   ///
@@ -149,6 +158,121 @@ class C2paSigningService {
       // Return original path - signing is best-effort, not blocking
       return C2paSigningResult(
         signedFilePath: videoPath,
+        success: false,
+        error: e.toString(),
+      );
+    }
+  }
+
+  /// Carries an existing C2PA manifest forward onto a *derived* video file.
+  ///
+  /// [outputPath] is a freshly re-encoded file — an aspect-ratio crop or a
+  /// watermark burn-in — that has lost the provenance embedded in its source.
+  /// [sourcePath] is the already-signed original it was produced from. The
+  /// source's active manifest is attached as a `parentOf` ingredient, [action]
+  /// (a `c2pa.*` edit action such as [C2paEditActions.cropped]) is recorded,
+  /// and the result is signed and embedded back into [outputPath] in place.
+  ///
+  /// Returns `success: false` without touching [outputPath] when [sourcePath]
+  /// carries no manifest — third-party downloads are never given fabricated
+  /// provenance. Signing is best-effort and never throws.
+  Future<C2paSigningResult> resignDerived({
+    required String outputPath,
+    required String sourcePath,
+    required String action,
+  }) async {
+    try {
+      final outputFile = File(outputPath);
+      if (!outputFile.existsSync()) {
+        return C2paSigningResult(
+          signedFilePath: outputPath,
+          success: false,
+          error: 'Output file does not exist',
+        );
+      }
+
+      // Gate: only carry provenance forward when the source actually has some.
+      final sourceManifest = await readManifest(sourcePath);
+      if (sourceManifest?.activeManifest == null) {
+        Log.info(
+          'Skipping derived re-sign: source has no manifest to carry forward',
+          name: 'C2paSigningService',
+          category: LogCategory.video,
+        );
+        return C2paSigningResult(
+          signedFilePath: outputPath,
+          success: false,
+          error: 'Source has no manifest to carry forward',
+        );
+      }
+
+      final PackageInfo packageInfo = await PackageInfo.fromPlatform();
+      final String claimGenerator =
+          '${packageInfo.appName}/${packageInfo.version}';
+      final String outputTitle = outputFile.path.split('/').last;
+
+      final manifestJson = _manifestService
+          .buildDerivedVideoManifest(
+            claimGenerator: claimGenerator,
+            title: outputTitle,
+          )
+          .manifestJson;
+
+      final builder = await _c2pa.createBuilder(manifestJson);
+      try {
+        builder.setIntent(ManifestIntent.edit);
+
+        final sourceBytes = await File(sourcePath).readAsBytes();
+        await builder.addIngredient(
+          data: sourceBytes,
+          mimeType: _videoMimeType,
+          config: IngredientConfig(
+            title: sourcePath.split('/').last,
+            relationship: Relationship.parentOf,
+          ),
+        );
+
+        builder.addAction(
+          ActionConfig(
+            action: action,
+            softwareAgent: claimGenerator,
+            when: DateTime.now().toUtc(),
+          ),
+        );
+
+        final outputBytes = await outputFile.readAsBytes();
+        final signer = await _createSigner();
+        final result = await builder.sign(
+          sourceData: outputBytes,
+          mimeType: _videoMimeType,
+          signer: signer,
+        );
+
+        await outputFile.writeAsBytes(result.signedData, flush: true);
+
+        Log.info(
+          'C2PA manifest carried forward onto derived file '
+          '($action): $outputPath (${result.signedData.length ~/ 1024} KB)',
+          name: 'C2paSigningService',
+          category: LogCategory.video,
+        );
+
+        return C2paSigningResult(signedFilePath: outputPath, success: true);
+      } finally {
+        builder.dispose();
+      }
+    } catch (e, stackTrace) {
+      Log.error(
+        'C2PA derived re-sign failed: $e',
+        name: 'C2paSigningService',
+        category: LogCategory.video,
+        error: e,
+        stackTrace: stackTrace,
+      );
+
+      // Best-effort: leave the (unsigned) re-encoded file as-is on failure.
+      return C2paSigningResult(
+        signedFilePath: outputPath,
         success: false,
         error: e.toString(),
       );

--- a/mobile/lib/services/c2pa_signing_service.dart
+++ b/mobile/lib/services/c2pa_signing_service.dart
@@ -13,8 +13,15 @@ import 'package:unified_logger/unified_logger.dart';
 /// C2PA edit actions recorded when carrying a manifest forward onto a
 /// re-encoded ("derived") video via [C2paSigningService.resignDerived].
 abstract class C2paEditActions {
-  /// The derived file had a watermark / overlay burned into the frame.
-  static const String watermarked = 'c2pa.watermarked';
+  /// The derived file is an editorial transformation of its source — e.g. a
+  /// watermark / overlay burned into the frame.
+  ///
+  /// Deliberately not `c2pa.watermarked`: the spec reserves that action for
+  /// *invisible* soft-binding watermarks and requires an accompanying
+  /// soft-binding assertion (C2PA 2.2 §18.14.5). `c2pa.transcoded` is also
+  /// wrong — the spec defines it as a non-editorial transformation, and a
+  /// visible overlay is editorial.
+  static const String edited = 'c2pa.edited';
 }
 
 /// Result of a C2PA signing operation
@@ -170,7 +177,7 @@ class C2paSigningService {
   /// watermark burn-in — that has lost the provenance embedded in its source.
   /// [sourcePath] is the already-signed original it was produced from. The
   /// source's active manifest is attached as a `parentOf` ingredient, [action]
-  /// (a `c2pa.*` edit action such as [C2paEditActions.watermarked]) is recorded,
+  /// (a `c2pa.*` edit action such as [C2paEditActions.edited]) is recorded,
   /// and the result is signed and embedded back into [outputPath] in place.
   ///
   /// Returns `success: false` without touching [outputPath] when [sourcePath]

--- a/mobile/lib/services/watermark_download_service.dart
+++ b/mobile/lib/services/watermark_download_service.dart
@@ -7,6 +7,7 @@ import 'package:flutter/foundation.dart';
 import 'package:media_cache/media_cache.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/extensions/video_event_extensions.dart';
+import 'package:openvine/services/c2pa_signing_service.dart';
 import 'package:openvine/services/gallery_save_service.dart';
 import 'package:openvine/services/video_editor/video_editor_render_service.dart';
 import 'package:openvine/services/watermark_image_generator.dart';
@@ -77,14 +78,20 @@ String _redownloadCacheKey(String videoId) =>
 /// the result to the device gallery.
 class WatermarkDownloadService {
   /// Creates a [WatermarkDownloadService] with required dependencies.
+  ///
+  /// [c2paSigningService] carries an embedded C2PA manifest forward onto the
+  /// watermarked output, which the render step would otherwise strip.
   const WatermarkDownloadService({
     required MediaCacheManager mediaCache,
     required GallerySaveService gallerySaveService,
+    required C2paSigningService c2paSigningService,
   }) : _mediaCache = mediaCache,
-       _gallerySaveService = gallerySaveService;
+       _gallerySaveService = gallerySaveService,
+       _c2paSigningService = c2paSigningService;
 
   final MediaCacheManager _mediaCache;
   final GallerySaveService _gallerySaveService;
+  final C2paSigningService _c2paSigningService;
 
   static const _logName = 'WatermarkDownloadService';
 
@@ -170,6 +177,15 @@ class WatermarkDownloadService {
           'Failed to render watermarked video',
         );
       }
+
+      // The watermark render re-encodes and strips any embedded C2PA manifest.
+      // Carry the source's manifest forward onto the watermarked file — a
+      // no-op when the source (e.g. a third-party download) was never signed.
+      await _c2paSigningService.resignDerived(
+        outputPath: tempOutputPath,
+        sourcePath: videoFile.path,
+        action: C2paEditActions.watermarked,
+      );
 
       // Stage 3: Save to gallery
       onProgress(WatermarkDownloadStage.saving);

--- a/mobile/lib/services/watermark_download_service.dart
+++ b/mobile/lib/services/watermark_download_service.dart
@@ -184,7 +184,7 @@ class WatermarkDownloadService {
       await _c2paSigningService.resignDerived(
         outputPath: tempOutputPath,
         sourcePath: videoFile.path,
-        action: C2paEditActions.watermarked,
+        action: C2paEditActions.edited,
       );
 
       // Stage 3: Save to gallery

--- a/mobile/scripts/baseline/untested_services.txt
+++ b/mobile/scripts/baseline/untested_services.txt
@@ -10,7 +10,6 @@ back_button_handler
 bookmark_service
 broken_video_tracker
 bug_report_service_stub # noise: stub
-c2pa_signing_service
 camera_base_service
 camera_mobile_service
 collaborator_invite_local_state_adapter # noise: local-state adapter

--- a/mobile/test/services/c2pa_identity_manifest_service_test.dart
+++ b/mobile/test/services/c2pa_identity_manifest_service_test.dart
@@ -35,6 +35,32 @@ void main() {
       expect(trainingAssertion['label'], equals('cawg.training-mining'));
     });
 
+    test(
+      'builds the derived manifest with only the training-mining opt-out',
+      () {
+        final result = service.buildDerivedVideoManifest(
+          claimGenerator: 'DiVine/1.0',
+          title: 'watermarked.mp4',
+        );
+
+        final json = jsonDecode(result.manifestJson) as Map<String, dynamic>;
+        final assertions = json['assertions'] as List<dynamic>;
+        final labels = assertions
+            .map((assertion) => (assertion as Map<String, dynamic>)['label'])
+            .toList();
+
+        expect(result.requiresAdvancedEmbedding, isFalse);
+        expect(json['title'], equals('watermarked.mp4'));
+        expect(json['claim_generator'], equals('DiVine/1.0'));
+        expect(json['format'], equals('video/mp4'));
+        // The parentOf ingredient and the edit action are attached by the
+        // caller via the ManifestBuilder, so the definition must not declare
+        // them — unlike buildCreatedVideoManifest, which does.
+        expect(json.containsKey('ingredients'), isFalse);
+        expect(labels, equals(['cawg.training-mining']));
+      },
+    );
+
     test('includes creator binding and final cawg assertions when available', () {
       final result = service.buildCreatedVideoManifest(
         claimGenerator: 'DiVine/1.0',

--- a/mobile/test/services/c2pa_signing_service_test.dart
+++ b/mobile/test/services/c2pa_signing_service_test.dart
@@ -66,7 +66,7 @@ void main() {
           final result = await service.resignDerived(
             outputPath: output.path,
             sourcePath: source.path,
-            action: C2paEditActions.watermarked,
+            action: C2paEditActions.edited,
           );
 
           expect(result.success, isFalse);
@@ -112,7 +112,7 @@ void main() {
           final result = await service.resignDerived(
             outputPath: output.path,
             sourcePath: source.path,
-            action: C2paEditActions.watermarked,
+            action: C2paEditActions.edited,
           );
 
           expect(result.success, isTrue);
@@ -131,7 +131,8 @@ void main() {
           final recordedAction =
               verify(() => builder.addAction(captureAny())).captured.single
                   as ActionConfig;
-          expect(recordedAction.action, C2paEditActions.watermarked);
+          // Literal token: pins the protocol surface, not just the constant.
+          expect(recordedAction.action, 'c2pa.edited');
 
           verify(() => builder.setIntent(ManifestIntent.edit)).called(1);
           verify(builder.dispose).called(1);
@@ -145,7 +146,7 @@ void main() {
           final result = await service.resignDerived(
             outputPath: '${tempDir.path}/missing.mp4',
             sourcePath: '${tempDir.path}/also-missing.mp4',
-            action: C2paEditActions.watermarked,
+            action: C2paEditActions.edited,
           );
 
           expect(result.success, isFalse);

--- a/mobile/test/services/c2pa_signing_service_test.dart
+++ b/mobile/test/services/c2pa_signing_service_test.dart
@@ -1,0 +1,158 @@
+// ABOUTME: Tests for C2paSigningService.resignDerived carry-forward behaviour
+// ABOUTME: Covers the manifest-present gate and the parent-ingredient re-sign
+
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:c2pa_flutter/c2pa.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/services/c2pa_signing_service.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+class _MockC2pa extends Mock implements C2pa {}
+
+class _MockManifestBuilder extends Mock implements ManifestBuilder {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() {
+    registerFallbackValue(Uint8List(0));
+    registerFallbackValue(const IngredientConfig());
+    registerFallbackValue(const ActionConfig(action: 'c2pa.edited'));
+    registerFallbackValue(RemoteSigner(configurationUrl: ''));
+  });
+
+  group(C2paSigningService, () {
+    late _MockC2pa mockC2pa;
+    late C2paSigningService service;
+    late Directory tempDir;
+
+    setUp(() {
+      PackageInfo.setMockInitialValues(
+        appName: 'Divine',
+        packageName: 'app.divine',
+        version: '1.2.3',
+        buildNumber: '10',
+        buildSignature: '',
+      );
+      mockC2pa = _MockC2pa();
+      service = C2paSigningService(c2pa: mockC2pa);
+      tempDir = Directory.systemTemp.createTempSync('c2pa_resign_test_');
+    });
+
+    tearDown(() {
+      if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+    });
+
+    File writeFile(String name, List<int> bytes) {
+      final file = File('${tempDir.path}/$name')..writeAsBytesSync(bytes);
+      return file;
+    }
+
+    group('resignDerived', () {
+      test(
+        'skips re-signing and leaves the file untouched when the source '
+        'carries no manifest',
+        () async {
+          when(
+            () => mockC2pa.readManifestFromFile(any()),
+          ).thenAnswer((_) async => const ManifestStoreInfo());
+
+          final output = writeFile('out.mp4', const [1, 2, 3]);
+          final source = writeFile('src.mp4', const [4, 5, 6]);
+
+          final result = await service.resignDerived(
+            outputPath: output.path,
+            sourcePath: source.path,
+            action: C2paEditActions.watermarked,
+          );
+
+          expect(result.success, isFalse);
+          verifyNever(() => mockC2pa.createBuilder(any()));
+          expect(output.readAsBytesSync(), equals([1, 2, 3]));
+        },
+      );
+
+      test(
+        'carries the source manifest forward: parentOf ingredient, edit '
+        'action, and writes the signed bytes back in place',
+        () async {
+          when(() => mockC2pa.readManifestFromFile(any())).thenAnswer(
+            (_) async => const ManifestStoreInfo(activeManifest: 'urn:c2pa:x'),
+          );
+
+          final builder = _MockManifestBuilder();
+          when(
+            () => mockC2pa.createBuilder(any()),
+          ).thenAnswer((_) async => builder);
+          when(
+            () => builder.addIngredient(
+              data: any(named: 'data'),
+              mimeType: any(named: 'mimeType'),
+              config: any(named: 'config'),
+            ),
+          ).thenAnswer((_) async {});
+          final signedBytes = Uint8List.fromList(const [9, 9, 9, 9, 9]);
+          when(
+            () => builder.sign(
+              sourceData: any(named: 'sourceData'),
+              mimeType: any(named: 'mimeType'),
+              signer: any(named: 'signer'),
+            ),
+          ).thenAnswer(
+            (_) async =>
+                BuilderSignResult(signedData: signedBytes, manifestSize: 5),
+          );
+
+          final output = writeFile('out.mp4', const [1, 2, 3]);
+          final source = writeFile('src.mp4', const [4, 5, 6]);
+
+          final result = await service.resignDerived(
+            outputPath: output.path,
+            sourcePath: source.path,
+            action: C2paEditActions.watermarked,
+          );
+
+          expect(result.success, isTrue);
+
+          final ingredientConfig =
+              verify(
+                    () => builder.addIngredient(
+                      data: any(named: 'data'),
+                      mimeType: any(named: 'mimeType'),
+                      config: captureAny(named: 'config'),
+                    ),
+                  ).captured.single
+                  as IngredientConfig;
+          expect(ingredientConfig.relationship, Relationship.parentOf);
+
+          final recordedAction =
+              verify(() => builder.addAction(captureAny())).captured.single
+                  as ActionConfig;
+          expect(recordedAction.action, C2paEditActions.watermarked);
+
+          verify(() => builder.setIntent(ManifestIntent.edit)).called(1);
+          verify(builder.dispose).called(1);
+          expect(output.readAsBytesSync(), equals(signedBytes));
+        },
+      );
+
+      test(
+        'returns failure without signing when the output does not exist',
+        () async {
+          final result = await service.resignDerived(
+            outputPath: '${tempDir.path}/missing.mp4',
+            sourcePath: '${tempDir.path}/also-missing.mp4',
+            action: C2paEditActions.watermarked,
+          );
+
+          expect(result.success, isFalse);
+          verifyNever(() => mockC2pa.readManifestFromFile(any()));
+          verifyNever(() => mockC2pa.createBuilder(any()));
+        },
+      );
+    });
+  });
+}

--- a/mobile/test/services/watermark_download_service_test.dart
+++ b/mobile/test/services/watermark_download_service_test.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Validates the sealed class hierarchy and download flow contracts
 
 import 'dart:io';
+import 'dart:ui' show Size;
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:media_cache/media_cache.dart';
@@ -10,13 +11,53 @@ import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/services/c2pa_signing_service.dart';
 import 'package:openvine/services/gallery_save_service.dart';
 import 'package:openvine/services/watermark_download_service.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
+
+import '../mocks/mock_path_provider_platform.dart';
 
 class _MockMediaCacheManager extends Mock implements MediaCacheManager {}
 
 class _MockGallerySaveService extends Mock implements GallerySaveService {}
 
 class _MockC2paSigningService extends Mock implements C2paSigningService {}
+
+/// Fake native editor: reports fixed metadata and "renders" by writing the
+/// output file, so [WatermarkDownloadService.downloadWithWatermark] can run
+/// end-to-end without a native platform.
+class _FakeProVideoEditor extends ProVideoEditor {
+  @override
+  void initializeStream() {}
+
+  @override
+  Future<VideoMetadata> getMetadata(
+    EditorVideo value, {
+    bool checkStreamingOptimization = false,
+    NativeLogLevel? nativeLogLevel,
+  }) async {
+    return VideoMetadata(
+      duration: const Duration(seconds: 6),
+      extension: 'mp4',
+      fileSize: 1024,
+      resolution: const Size(320, 568),
+      rotation: 0,
+      bitrate: 1_000_000,
+    );
+  }
+
+  @override
+  Future<String> renderVideoToFile(
+    String filePath,
+    VideoRenderData value, {
+    NativeLogLevel? nativeLogLevel,
+  }) async {
+    File(filePath).writeAsStringSync('watermarked');
+    return filePath;
+  }
+
+  @override
+  Future<void> cancel(String taskId) async {}
+}
 
 VideoEvent _createTestVideo() => VideoEvent(
   id: 'test-video-id-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
@@ -29,6 +70,8 @@ VideoEvent _createTestVideo() => VideoEvent(
 );
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   setUpAll(() {
     registerFallbackValue(EditorVideo.file('/tmp/fallback.mp4'));
   });
@@ -197,6 +240,66 @@ void main() {
           lessThan(WatermarkDownloadStage.saving.index),
         );
       });
+
+      test(
+        'carries the C2PA manifest onto the rendered file before the '
+        'gallery save',
+        () async {
+          final tempDir = await Directory.systemTemp.createTemp(
+            'watermark-c2pa-test',
+          );
+          final videoFile = File('${tempDir.path}/video.mp4');
+          await videoFile.writeAsBytes(const [1, 2, 3, 4]);
+          addTearDown(() async {
+            if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+          });
+
+          final originalPathProvider = PathProviderPlatform.instance;
+          PathProviderPlatform.instance = MockPathProviderPlatform()
+            ..setTemporaryPath(tempDir.path);
+          addTearDown(() {
+            PathProviderPlatform.instance = originalPathProvider;
+          });
+
+          final originalProVideoEditor = ProVideoEditor.instance;
+          ProVideoEditor.instance = _FakeProVideoEditor();
+          addTearDown(() {
+            ProVideoEditor.instance = originalProVideoEditor;
+          });
+
+          when(() => mockCache.getCachedFileSync(any())).thenReturn(videoFile);
+          when(
+            () => mockGallerySave.saveVideoToGallery(any()),
+          ).thenAnswer((_) async => const GallerySaveSuccess());
+
+          final stages = <WatermarkDownloadStage>[];
+          final result = await service.downloadWithWatermark(
+            video: _createTestVideo(),
+            watermarkText: 'alice@divine.video',
+            onProgress: stages.add,
+          );
+
+          expect(result, isA<WatermarkDownloadSuccess>());
+          final outputPath = (result as WatermarkDownloadSuccess).filePath;
+          expect(outputPath, isNot(equals(videoFile.path)));
+
+          final ordered = verifyInOrder([
+            () => mockC2pa.resignDerived(
+              outputPath: outputPath,
+              sourcePath: videoFile.path,
+              action: C2paEditActions.edited,
+            ),
+            () => mockGallerySave.saveVideoToGallery(captureAny()),
+          ]);
+          final savedVideo = ordered.last.captured.single as EditorVideo;
+          expect(savedVideo.file!.path, equals(outputPath));
+          expect(stages, [
+            WatermarkDownloadStage.downloading,
+            WatermarkDownloadStage.watermarking,
+            WatermarkDownloadStage.saving,
+          ]);
+        },
+      );
     });
 
     group('_getVideoFile (cached file fallback)', () {

--- a/mobile/test/services/watermark_download_service_test.dart
+++ b/mobile/test/services/watermark_download_service_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:media_cache/media_cache.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart' hide LogCategory;
+import 'package:openvine/services/c2pa_signing_service.dart';
 import 'package:openvine/services/gallery_save_service.dart';
 import 'package:openvine/services/watermark_download_service.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
@@ -14,6 +15,8 @@ import 'package:pro_video_editor/pro_video_editor.dart';
 class _MockMediaCacheManager extends Mock implements MediaCacheManager {}
 
 class _MockGallerySaveService extends Mock implements GallerySaveService {}
+
+class _MockC2paSigningService extends Mock implements C2paSigningService {}
 
 VideoEvent _createTestVideo() => VideoEvent(
   id: 'test-video-id-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
@@ -103,14 +106,27 @@ void main() {
   group(WatermarkDownloadService, () {
     late _MockMediaCacheManager mockCache;
     late _MockGallerySaveService mockGallerySave;
+    late _MockC2paSigningService mockC2pa;
     late WatermarkDownloadService service;
 
     setUp(() {
       mockCache = _MockMediaCacheManager();
       mockGallerySave = _MockGallerySaveService();
+      mockC2pa = _MockC2paSigningService();
+      when(
+        () => mockC2pa.resignDerived(
+          outputPath: any(named: 'outputPath'),
+          sourcePath: any(named: 'sourcePath'),
+          action: any(named: 'action'),
+        ),
+      ).thenAnswer(
+        (_) async =>
+            const C2paSigningResult(signedFilePath: '', success: false),
+      );
       service = WatermarkDownloadService(
         mediaCache: mockCache,
         gallerySaveService: mockGallerySave,
+        c2paSigningService: mockC2pa,
       );
     });
 


### PR DESCRIPTION
## Description

The watermark burn-in in `WatermarkDownloadService` re-encodes the video via `pro_video_editor`, producing a fresh MP4 that drops the embedded C2PA manifest. This adds `C2paSigningService.resignDerived`, which carries an existing manifest forward onto a re-encoded ("derived") file:

- **Gates on the source already carrying a manifest** (`readManifest`) — a third-party download with no provenance is never given fabricated provenance; it's left untouched.
- Attaches the source as a `parentOf` **ingredient** and records a `c2pa.*` **edit action** via the `ManifestBuilder` API (rather than minting a fresh `digitalCapture` claim, which would misrepresent an edited file as a capture).
- Re-signs and embeds the manifest back into the derived file in place.

Wired into the watermark-download path only — the other #3491 drop points are already covered by existing signing (see Out of Scope).

**Related Issue:** Closes #3491

## ⚠️ Reviewers: this needs the proofsign signing key to verify end-to-end — and that verification is what closes the issue

We do **not** have the proofsign signing credentials, so this could not be verified on a real device here. Signing is gated on `PROOFMODE_SIGNING_SERVER_ENDPOINT` / `PROOFMODE_SIGNING_SERVER_TOKEN` (`String.fromEnvironment`), which are absent from a default dev build — without them `signVideo`/`resignDerived` best-effort no-op and return the unsigned file.

Because the remaining acceptance criteria are verification (not more code), a reviewer who holds the key (cc @n8fr8) needs to run the checks below. Seeing a valid manifest in a saved file validates the **whole chain at once**: the source blob preserved its manifest, the carry-forward embedded it, and the OS Photos/MediaStore import (`Gal.putVideo`) did **not** strip the JUMBF box (#3491 AC #4).

Build a **signing build** first (`PROOFMODE_SIGNING_SERVER_*` dart-defines set, e.g. `run_dev.sh` with the env vars exported), record a clip, then on **both iOS and Android**:

1. **Plain save** (AC #1/#2) — save a recorded/rendered clip to the gallery, pull it, and confirm `c2patool` reports a valid Divine manifest.
2. **Watermark download** (AC #3, this PR) — watermark-download an already-signed clip, pull it, and confirm `c2patool` reports a valid manifest with the `parentOf` ingredient + edit action.

If any file comes back **without** a manifest, that's the signal to diagnose which link broke — most likely candidate is the source blob not carrying a manifest after HLS transcoding (`getPlayableUrl()`, likely HLS after #5935), in which case the fix is upstream (Blossom/transcode), not this diff. If it's specifically the OS import stripping the box, AC #4's fallback (a non-Photos Files/MediaStore-SAF save path) becomes the follow-up.

## Out of Scope

- **Aspect-ratio crop re-sign** — the `aspectRatio` path in `GallerySaveService.saveVideoToGallery` is never reached (no production caller passes `aspectRatio`), and the editor render pipeline already re-signs its output via `NativeProofModeService.proofFile` (`video_editor_render_service.dart:398`), so a crop-time hook would be dead code.
- **Fresh claim vs. ingredient carry-forward for the render pipeline** — a provenance-semantics decision owned by the proofmode side, not changed here.

## Verification

- `flutter analyze` (services + providers + touched tests): clean.
- `flutter test` — `c2pa_signing_service_test.dart` (new), plus `watermark_download_service_test.dart` and `c2pa_identity_manifest_service_test.dart`: all green.
- Untested-services floor ratcheted (`c2pa_signing_service` now has a test).
- `build_runner` re-run; only the watermark provider hash regenerated.
- **Device / `c2patool` verification is deferred to a key-holding reviewer** — see the reviewer note above.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
