### PR TITLE
fix(dm): make DM reaction delivery durable (OK-confirm + auto-retry)

### DIFF
--- a/mobile/lib/blocs/dm/reactions/conversation_reactions_cubit.dart
+++ b/mobile/lib/blocs/dm/reactions/conversation_reactions_cubit.dart
@@ -91,6 +91,23 @@ class ConversationReactionsCubit
     // Toggle-off: if we already have a live matching reaction, remove it.
     final existing = _ownLiveReaction(event.messageId, event.emoji);
     if (existing != null) {
+      // A re-tap on a not-yet-delivered own reaction must NOT be read as
+      // toggle-off: removeOwn soft-deletes it locally and emits a kind-5,
+      // permanently losing a reaction the recipient may already have (the OK
+      // was merely lost/late on a flaky relay). Re-drive delivery instead —
+      // mirrors the detail sheet's failed → retry fork.
+      if (existing.publishStatus == DmReactionPublishStatus.pending ||
+          existing.publishStatus == DmReactionPublishStatus.failed) {
+        add(
+          ConversationReactionRetryRequested(
+            rumorId: existing.id,
+            messageId: event.messageId,
+            messageAuthorPubkey: event.messageAuthorPubkey,
+            emoji: event.emoji,
+          ),
+        );
+        return;
+      }
       final key = ReactionPublishKey(
         messageId: event.messageId,
         emoji: event.emoji,
@@ -244,7 +261,11 @@ class ConversationReactionsCubit
         emit(
           state.copyWith(
             pending: newPending,
-            optimistic: _withoutOrphanedAdd(key: key, emoji: emoji),
+            optimistic: _withoutOrphanedAdd(
+              key: key,
+              emoji: emoji,
+              durableRowExists: result.optimisticInsertSucceeded,
+            ),
           ),
         );
       }
@@ -275,11 +296,21 @@ class ConversationReactionsCubit
   /// insert never produced a persisted row — otherwise the chip would linger
   /// forever as a never-settling pending placeholder. When the row exists
   /// (send-failure), the overlay is left for the stream tick to reconcile and
-  /// the persisted `failed` row drives the retry chip via the [pending] map.
+  /// the persisted `failed`/`pending` row drives the retry chip.
+  ///
+  /// [durableRowExists] short-circuits the check to keep the overlay even
+  /// before the DAO stream has ticked the new row into [reactionsByMessageId]:
+  /// on a fast failure the synchronous overlay drop can otherwise beat the
+  /// background-isolate insert tick, briefly collapsing the chip to
+  /// `SizedBox.shrink` and inviting a "repair" re-tap. The publish result
+  /// tells us the durable row was written, so we trust that over the tick-laggy
+  /// state; [_reconcileOptimistic] collapses the overlay once the row lands.
   Map<ReactionPublishKey, OptimisticReactionIntent> _withoutOrphanedAdd({
     required ReactionPublishKey key,
     required String emoji,
+    bool durableRowExists = false,
   }) {
+    if (durableRowExists) return state.optimistic;
     final persisted =
         state.reactionsByMessageId[key.messageId] ?? const <DmReaction>[];
     final hasPersisted = persisted.any((r) => r.isOwn && r.emoji == emoji);

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -2385,6 +2385,12 @@ class _DivineAppState extends ConsumerState<DivineApp>
     // without an explicit read it would never be created. See #4124.
     ref.watch(outgoingDmRetryServiceProvider);
 
+    // Eagerly create the DM-reaction retry service so its foreground
+    // subscription is wired up at app shell setup. Like the outgoing-DM
+    // retry service it has no UI consumer — it re-drives undelivered
+    // reactions off the dm_message_reactions durable record.
+    ref.watch(dmReactionRetryServiceProvider);
+
     // Eagerly create the view-event retry service so foreground sweeps
     // run for the durable pending_view_events queue without a UI consumer.
     ref.watch(viewEventRetryServiceProvider);

--- a/mobile/lib/providers/social_providers.dart
+++ b/mobile/lib/providers/social_providers.dart
@@ -46,6 +46,17 @@ import 'package:unified_logger/unified_logger.dart';
 
 part 'social_providers.g.dart';
 
+/// Reconnect trigger for the DM retry sweeps (messages, reactions, removals):
+/// emits once each time `connectivity_plus` reports any non-`none` result, so
+/// work queued during a brief network drop is re-driven the moment
+/// connectivity returns — without waiting for an app-foreground transition.
+/// The sweeps short-circuit when nothing is retryable. Shared by the message
+/// and reaction retry providers so the trigger shape stays in one place.
+Stream<void> _dmRetryConnectivityTriggerStream() => Connectivity()
+    .onConnectivityChanged
+    .where((results) => results.any((r) => r != ConnectivityResult.none))
+    .map<void>((_) {});
+
 final collaboratorResponseServiceProvider =
     Provider<CollaboratorResponseService>((ref) {
       return CollaboratorResponseService(
@@ -196,11 +207,8 @@ OutgoingDmRetryService? outgoingDmRetryService(Ref ref) {
   // Re-drive undelivered messages the moment connectivity returns, not only on
   // app-foreground transitions — a message queued during a brief network drop
   // would otherwise sit undelivered until the app is backgrounded and
-  // re-foregrounded. Any event carrying some connectivity fires a sweep (the
-  // sweep short-circuits when nothing is retryable).
-  final retryTriggerStream = Connectivity().onConnectivityChanged
-      .where((results) => results.any((r) => r != ConnectivityResult.none))
-      .map<void>((_) {});
+  // re-foregrounded.
+  final retryTriggerStream = _dmRetryConnectivityTriggerStream();
 
   final service = OutgoingDmRetryService(
     dmRepository: dmRepository,
@@ -274,11 +282,8 @@ DmReactionRetryService? dmReactionRetryService(Ref ref) {
   // Re-drive undelivered reactions/removals the moment connectivity returns,
   // not only on app-foreground transitions — a reaction left during a brief
   // network drop would otherwise sit undelivered until the app is backgrounded
-  // and re-foregrounded. Any event carrying some connectivity fires a sweep
-  // (the sweep short-circuits when nothing is retryable).
-  final retryTriggerStream = Connectivity().onConnectivityChanged
-      .where((results) => results.any((r) => r != ConnectivityResult.none))
-      .map<void>((_) {});
+  // and re-foregrounded.
+  final retryTriggerStream = _dmRetryConnectivityTriggerStream();
 
   final service = DmReactionRetryService(
     reactionsRepository: reactionsRepository,

--- a/mobile/lib/providers/social_providers.dart
+++ b/mobile/lib/providers/social_providers.dart
@@ -29,6 +29,7 @@ import 'package:openvine/services/collaborator_invite_state_store.dart';
 import 'package:openvine/services/collaborator_response_service.dart';
 import 'package:openvine/services/content_deletion_service.dart';
 import 'package:openvine/services/content_reporting_service.dart';
+import 'package:openvine/services/dm_reaction_retry_service.dart';
 import 'package:openvine/services/draft_storage_service.dart';
 import 'package:openvine/services/hashtag_cache_service.dart';
 import 'package:openvine/services/hashtag_service.dart';
@@ -205,6 +206,68 @@ OutgoingDmRetryService? outgoingDmRetryService(Ref ref) {
   service.initialize().catchError((e) {
     Log.error(
       'Failed to initialize OutgoingDmRetryService',
+      name: 'AppProviders',
+      error: e,
+    );
+  });
+
+  ref.listen<bool>(appForegroundProvider, (_, next) {
+    if (!foregroundController.isClosed) {
+      foregroundController.add(next);
+    }
+  }, fireImmediately: true);
+
+  ref.onDispose(service.dispose);
+  return service;
+}
+
+/// Auto-sweep service that re-drives undelivered DM reactions (publish failed
+/// or interrupted mid-send) on app-foreground transitions via
+/// [DmReactionsRepository.retry].
+///
+/// Gives reactions the durable delivery that DM messages already get from
+/// [OutgoingDmRetryService] + the `outgoing_dms` queue: a reaction whose
+/// recipient gift wrap failed to land (common on a flaky relay) is otherwise
+/// lost with no automatic recovery. keepAlive with no UI consumer, so it is
+/// read eagerly at app shell startup (`main.dart`) to wire the foreground
+/// subscription.
+///
+/// Returns null until the user is authenticated and the Nostr session is
+/// ready — the same readiness the reaction repository's `setCredentials`
+/// needs before a retry can publish.
+@Riverpod(keepAlive: true)
+DmReactionRetryService? dmReactionRetryService(Ref ref) {
+  final authService = ref.watch(authServiceProvider);
+
+  // Watch auth state to rebuild on sign-in / sign-out / account switch.
+  ref.watch(currentAuthStateProvider);
+
+  final userPubkey = authService.currentPublicKeyHex;
+  if (userPubkey == null) return null;
+
+  // Gate on matching Nostr readiness so the reaction repository's
+  // setCredentials has run by the time the first foreground sweep fires.
+  final readiness = ref.watch(nostrSessionProvider);
+  if (!readiness.isReadyForActiveClient || readiness.pubkey != userPubkey) {
+    return null;
+  }
+
+  final reactionsRepository = ref.watch(dmReactionsRepositoryProvider);
+
+  // Bridge the synchronous AppForeground notifier into a Stream<bool> so the
+  // service's contract stays free of Riverpod types and is easy to drive from
+  // unit tests.
+  final foregroundController = StreamController<bool>();
+  ref.onDispose(foregroundController.close);
+
+  final service = DmReactionRetryService(
+    reactionsRepository: reactionsRepository,
+    appForegroundStream: foregroundController.stream,
+  );
+
+  service.initialize().catchError((e) {
+    Log.error(
+      'Failed to initialize DmReactionRetryService',
       name: 'AppProviders',
       error: e,
     );

--- a/mobile/lib/providers/social_providers.dart
+++ b/mobile/lib/providers/social_providers.dart
@@ -193,11 +193,21 @@ OutgoingDmRetryService? outgoingDmRetryService(Ref ref) {
   final foregroundController = StreamController<bool>();
   ref.onDispose(foregroundController.close);
 
+  // Re-drive undelivered messages the moment connectivity returns, not only on
+  // app-foreground transitions — a message queued during a brief network drop
+  // would otherwise sit undelivered until the app is backgrounded and
+  // re-foregrounded. Any event carrying some connectivity fires a sweep (the
+  // sweep short-circuits when nothing is retryable).
+  final retryTriggerStream = Connectivity().onConnectivityChanged
+      .where((results) => results.any((r) => r != ConnectivityResult.none))
+      .map<void>((_) {});
+
   final service = OutgoingDmRetryService(
     dmRepository: dmRepository,
     outgoingDmsDao: db.outgoingDmsDao,
     userPubkey: userPubkey,
     appForegroundStream: foregroundController.stream,
+    retryTriggerStream: retryTriggerStream,
   );
 
   // initialize() subscribes to the controller's stream synchronously

--- a/mobile/lib/providers/social_providers.dart
+++ b/mobile/lib/providers/social_providers.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:collaborator_repository/collaborator_repository.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:dm_repository/dm_repository.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:http/http.dart' as http;
@@ -260,9 +261,19 @@ DmReactionRetryService? dmReactionRetryService(Ref ref) {
   final foregroundController = StreamController<bool>();
   ref.onDispose(foregroundController.close);
 
+  // Re-drive undelivered reactions/removals the moment connectivity returns,
+  // not only on app-foreground transitions — a reaction left during a brief
+  // network drop would otherwise sit undelivered until the app is backgrounded
+  // and re-foregrounded. Any event carrying some connectivity fires a sweep
+  // (the sweep short-circuits when nothing is retryable).
+  final retryTriggerStream = Connectivity().onConnectivityChanged
+      .where((results) => results.any((r) => r != ConnectivityResult.none))
+      .map<void>((_) {});
+
   final service = DmReactionRetryService(
     reactionsRepository: reactionsRepository,
     appForegroundStream: foregroundController.stream,
+    retryTriggerStream: retryTriggerStream,
   );
 
   service.initialize().catchError((e) {

--- a/mobile/lib/providers/social_providers.g.dart
+++ b/mobile/lib/providers/social_providers.g.dart
@@ -159,6 +159,98 @@ final class OutgoingDmRetryServiceProvider
 String _$outgoingDmRetryServiceHash() =>
     r'ccbee39cf920a0847be410ca804e048200962d38';
 
+/// Auto-sweep service that re-drives undelivered DM reactions (publish failed
+/// or interrupted mid-send) on app-foreground transitions via
+/// [DmReactionsRepository.retry].
+///
+/// Gives reactions the durable delivery that DM messages already get from
+/// [OutgoingDmRetryService] + the `outgoing_dms` queue: a reaction whose
+/// recipient gift wrap failed to land (common on a flaky relay) is otherwise
+/// lost with no automatic recovery. keepAlive with no UI consumer, so it is
+/// read eagerly at app shell startup (`main.dart`) to wire the foreground
+/// subscription.
+///
+/// Returns null until the user is authenticated and the Nostr session is
+/// ready — the same readiness the reaction repository's `setCredentials`
+/// needs before a retry can publish.
+
+@ProviderFor(dmReactionRetryService)
+final dmReactionRetryServiceProvider = DmReactionRetryServiceProvider._();
+
+/// Auto-sweep service that re-drives undelivered DM reactions (publish failed
+/// or interrupted mid-send) on app-foreground transitions via
+/// [DmReactionsRepository.retry].
+///
+/// Gives reactions the durable delivery that DM messages already get from
+/// [OutgoingDmRetryService] + the `outgoing_dms` queue: a reaction whose
+/// recipient gift wrap failed to land (common on a flaky relay) is otherwise
+/// lost with no automatic recovery. keepAlive with no UI consumer, so it is
+/// read eagerly at app shell startup (`main.dart`) to wire the foreground
+/// subscription.
+///
+/// Returns null until the user is authenticated and the Nostr session is
+/// ready — the same readiness the reaction repository's `setCredentials`
+/// needs before a retry can publish.
+
+final class DmReactionRetryServiceProvider
+    extends
+        $FunctionalProvider<
+          DmReactionRetryService?,
+          DmReactionRetryService?,
+          DmReactionRetryService?
+        >
+    with $Provider<DmReactionRetryService?> {
+  /// Auto-sweep service that re-drives undelivered DM reactions (publish failed
+  /// or interrupted mid-send) on app-foreground transitions via
+  /// [DmReactionsRepository.retry].
+  ///
+  /// Gives reactions the durable delivery that DM messages already get from
+  /// [OutgoingDmRetryService] + the `outgoing_dms` queue: a reaction whose
+  /// recipient gift wrap failed to land (common on a flaky relay) is otherwise
+  /// lost with no automatic recovery. keepAlive with no UI consumer, so it is
+  /// read eagerly at app shell startup (`main.dart`) to wire the foreground
+  /// subscription.
+  ///
+  /// Returns null until the user is authenticated and the Nostr session is
+  /// ready — the same readiness the reaction repository's `setCredentials`
+  /// needs before a retry can publish.
+  DmReactionRetryServiceProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'dmReactionRetryServiceProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$dmReactionRetryServiceHash();
+
+  @$internal
+  @override
+  $ProviderElement<DmReactionRetryService?> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  DmReactionRetryService? create(Ref ref) {
+    return dmReactionRetryService(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(DmReactionRetryService? value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<DmReactionRetryService?>(value),
+    );
+  }
+}
+
+String _$dmReactionRetryServiceHash() =>
+    r'6185e5efdb3cd570a6d6a25d4987ee8fc31af88b';
+
 /// Auto-sweep service for the durable `pending_view_events` queue.
 
 @ProviderFor(viewEventRetryService)

--- a/mobile/lib/providers/social_providers.g.dart
+++ b/mobile/lib/providers/social_providers.g.dart
@@ -249,7 +249,7 @@ final class DmReactionRetryServiceProvider
 }
 
 String _$dmReactionRetryServiceHash() =>
-    r'6185e5efdb3cd570a6d6a25d4987ee8fc31af88b';
+    r'31c9ab5f05a19f28b7390de7fd97f1cc36f225df';
 
 /// Auto-sweep service for the durable `pending_view_events` queue.
 

--- a/mobile/lib/providers/social_providers.g.dart
+++ b/mobile/lib/providers/social_providers.g.dart
@@ -157,7 +157,7 @@ final class OutgoingDmRetryServiceProvider
 }
 
 String _$outgoingDmRetryServiceHash() =>
-    r'46112a47f8ad808322788d197853e52d23bff28f';
+    r'4735d8bab0529f3bfe862cc9993e6a42ce2a9329';
 
 /// Auto-sweep service that re-drives undelivered DM reactions (publish failed
 /// or interrupted mid-send) on app-foreground transitions via
@@ -249,7 +249,7 @@ final class DmReactionRetryServiceProvider
 }
 
 String _$dmReactionRetryServiceHash() =>
-    r'31c9ab5f05a19f28b7390de7fd97f1cc36f225df';
+    r'85a3937752ef569dce502ec14bff303e2b84e46c';
 
 /// Auto-sweep service for the durable `pending_view_events` queue.
 

--- a/mobile/lib/providers/social_providers.g.dart
+++ b/mobile/lib/providers/social_providers.g.dart
@@ -157,7 +157,7 @@ final class OutgoingDmRetryServiceProvider
 }
 
 String _$outgoingDmRetryServiceHash() =>
-    r'ccbee39cf920a0847be410ca804e048200962d38';
+    r'46112a47f8ad808322788d197853e52d23bff28f';
 
 /// Auto-sweep service that re-drives undelivered DM reactions (publish failed
 /// or interrupted mid-send) on app-foreground transitions via

--- a/mobile/lib/services/dm_reaction_retry_service.dart
+++ b/mobile/lib/services/dm_reaction_retry_service.dart
@@ -102,17 +102,26 @@ class DmReactionRetryService {
   DmReactionRetryService({
     required DmReactionsRepository reactionsRepository,
     required Stream<bool> appForegroundStream,
+    Stream<void>? retryTriggerStream,
     DmReactionRetryConfig retryConfig = const DmReactionRetryConfig(),
     DateTime Function() now = DateTime.now,
     CrashReportingService? crashReporting,
   }) : _repository = reactionsRepository,
        _appForegroundStream = appForegroundStream,
+       _retryTriggerStream = retryTriggerStream,
        _config = retryConfig,
        _now = now,
        _crashReporting = crashReporting ?? CrashReportingService.instance;
 
   final DmReactionsRepository _repository;
   final Stream<bool> _appForegroundStream;
+
+  /// Fires a sweep on each event, independent of foreground transitions.
+  /// Wired to connectivity/relay-reconnection so a reaction (or removal) made
+  /// during a brief network drop is re-driven the moment the network returns —
+  /// without waiting for the user to background and re-foreground the app.
+  final Stream<void>? _retryTriggerStream;
+
   final DmReactionRetryConfig _config;
   final DateTime Function() _now;
   final CrashReportingService _crashReporting;
@@ -121,6 +130,7 @@ class DmReactionRetryService {
   final Map<String, DateTime> _lastAttempt = {};
 
   StreamSubscription<bool>? _foregroundSubscription;
+  StreamSubscription<void>? _retryTriggerSubscription;
   bool _isInitialized = false;
   bool _isSweeping = false;
 
@@ -141,6 +151,10 @@ class DmReactionRetryService {
       }
     });
 
+    _retryTriggerSubscription = _retryTriggerStream?.listen((_) {
+      unawaited(sweep());
+    });
+
     Log.info(
       'initialized',
       name: 'DmReactionRetryService',
@@ -148,11 +162,13 @@ class DmReactionRetryService {
     );
   }
 
-  /// Cancel the foreground subscription and mark the service un-init.
+  /// Cancel the trigger subscriptions and mark the service un-init.
   /// Idempotent.
   Future<void> dispose() async {
     await _foregroundSubscription?.cancel();
     _foregroundSubscription = null;
+    await _retryTriggerSubscription?.cancel();
+    _retryTriggerSubscription = null;
     _isInitialized = false;
   }
 
@@ -175,88 +191,42 @@ class DmReactionRetryService {
     _isSweeping = true;
 
     try {
-      final targets = await _repository.retryableReactions();
-      _pruneTracking(targets.map((t) => t.rumorId).toSet());
+      final reactionTargets = await _repository.retryableReactions();
+      final deletionTargets = await _repository.retryableDeletions();
+      _pruneTracking(<String>{
+        for (final t in reactionTargets) t.rumorId,
+        for (final t in deletionTargets) t.rumorId,
+      });
 
-      var recovered = 0;
-      var failed = 0;
-      var skippedBackoff = 0;
-      var skippedExhausted = 0;
-      var skippedTooYoung = 0;
-
-      for (final target in targets) {
-        final id = target.rumorId;
-        final attempts = _attempts[id] ?? 0;
-
-        if (attempts >= _config.maxRetries) {
-          skippedExhausted++;
-          continue;
-        }
-
-        final last = _lastAttempt[id];
-        if (last != null) {
-          final gap = _now().difference(last);
-          if (gap < _config.backoffFor(attempts)) {
-            skippedBackoff++;
-            continue;
-          }
-        }
-
-        // A still-`pending` reaction may have an in-flight publish (a reaction
-        // publish caps at 15 s); only treat it as interrupted once it's older
-        // than the guard, so the sweep never races an in-flight attempt.
-        if (target.publishStatus == 'pending') {
-          final age = _now().difference(
-            DateTime.fromMillisecondsSinceEpoch(target.createdAt * 1000),
-          );
-          if (age < _config.interruptedPendingMinAge) {
-            skippedTooYoung++;
-            continue;
-          }
-        }
-
-        try {
-          final result = await _repository.retry(
-            rumorId: id,
-            targetMessageAuthor: target.targetMessageAuthor,
-          );
-          if (result.success) {
-            _attempts.remove(id);
-            _lastAttempt.remove(id);
-            recovered++;
-          } else {
-            _attempts[id] = attempts + 1;
-            _lastAttempt[id] = _now();
-            failed++;
-          }
-        } on Object catch (e, stackTrace) {
-          _attempts[id] = attempts + 1;
-          _lastAttempt[id] = _now();
-          failed++;
-          Log.error(
-            'reaction retry threw for $id: $e',
-            name: 'DmReactionRetryService',
-            category: LogCategory.system,
-            error: e,
-            stackTrace: stackTrace,
-          );
-          unawaited(
-            _crashReporting.recordError(
-              e,
-              stackTrace,
-              reason: DmReactionRetryServiceReportableSites
-                  .perReactionUnexpectedThrow,
-            ),
-          );
-        }
-      }
+      // Adds apply the pending min-age guard (a fresh 'pending' row may still
+      // have its original publish in flight). Removals do not: a
+      // 'deletion_pending' row is never in-flight for the sweep's purposes.
+      final r = await _driveTargets(
+        reactionTargets,
+        applyPendingMinAge: true,
+        driver: (t) => _repository.retry(
+          rumorId: t.rumorId,
+          targetMessageAuthor: t.targetMessageAuthor,
+        ),
+      );
+      final d = await _driveTargets(
+        deletionTargets,
+        applyPendingMinAge: false,
+        driver: (t) => _repository.retryDeletion(
+          rumorId: t.rumorId,
+          targetMessageAuthor: t.targetMessageAuthor,
+        ),
+      );
 
       Log.info(
         'sweep complete: '
-        'recovered=$recovered failed=$failed '
-        'skipped-backoff=$skippedBackoff '
-        'skipped-exhausted=$skippedExhausted '
-        'skipped-too-young=$skippedTooYoung',
+        'reactions(recovered=${r.recovered} failed=${r.failed} '
+        'skipped-backoff=${r.skippedBackoff} '
+        'skipped-exhausted=${r.skippedExhausted} '
+        'skipped-too-young=${r.skippedTooYoung}) '
+        'deletions(recovered=${d.recovered} failed=${d.failed} '
+        'skipped-backoff=${d.skippedBackoff} '
+        'skipped-exhausted=${d.skippedExhausted})',
         name: 'DmReactionRetryService',
         category: LogCategory.system,
       );
@@ -278,6 +248,103 @@ class DmReactionRetryService {
     } finally {
       _isSweeping = false;
     }
+  }
+
+  /// Drive one list of retry [targets] through [driver], sharing the in-memory
+  /// backoff/attempt tracking with every other kind of target (ids are
+  /// disjoint — a reaction is either live or soft-deleted, never both).
+  Future<
+    ({
+      int recovered,
+      int failed,
+      int skippedBackoff,
+      int skippedExhausted,
+      int skippedTooYoung,
+    })
+  >
+  _driveTargets(
+    List<DmReactionRetryTarget> targets, {
+    required bool applyPendingMinAge,
+    required Future<DmReactionPublishResult> Function(DmReactionRetryTarget)
+    driver,
+  }) async {
+    var recovered = 0;
+    var failed = 0;
+    var skippedBackoff = 0;
+    var skippedExhausted = 0;
+    var skippedTooYoung = 0;
+
+    for (final target in targets) {
+      final id = target.rumorId;
+      final attempts = _attempts[id] ?? 0;
+
+      if (attempts >= _config.maxRetries) {
+        skippedExhausted++;
+        continue;
+      }
+
+      final last = _lastAttempt[id];
+      if (last != null) {
+        final gap = _now().difference(last);
+        if (gap < _config.backoffFor(attempts)) {
+          skippedBackoff++;
+          continue;
+        }
+      }
+
+      // A still-`pending` reaction may have an in-flight publish (a reaction
+      // publish caps at 15 s); only treat it as interrupted once it's older
+      // than the guard, so the sweep never races an in-flight attempt.
+      if (applyPendingMinAge && target.publishStatus == 'pending') {
+        final age = _now().difference(
+          DateTime.fromMillisecondsSinceEpoch(target.createdAt * 1000),
+        );
+        if (age < _config.interruptedPendingMinAge) {
+          skippedTooYoung++;
+          continue;
+        }
+      }
+
+      try {
+        final result = await driver(target);
+        if (result.success) {
+          _attempts.remove(id);
+          _lastAttempt.remove(id);
+          recovered++;
+        } else {
+          _attempts[id] = attempts + 1;
+          _lastAttempt[id] = _now();
+          failed++;
+        }
+      } on Object catch (e, stackTrace) {
+        _attempts[id] = attempts + 1;
+        _lastAttempt[id] = _now();
+        failed++;
+        Log.error(
+          'reaction retry threw for $id: $e',
+          name: 'DmReactionRetryService',
+          category: LogCategory.system,
+          error: e,
+          stackTrace: stackTrace,
+        );
+        unawaited(
+          _crashReporting.recordError(
+            e,
+            stackTrace,
+            reason: DmReactionRetryServiceReportableSites
+                .perReactionUnexpectedThrow,
+          ),
+        );
+      }
+    }
+
+    return (
+      recovered: recovered,
+      failed: failed,
+      skippedBackoff: skippedBackoff,
+      skippedExhausted: skippedExhausted,
+      skippedTooYoung: skippedTooYoung,
+    );
   }
 
   void _pruneTracking(Set<String> liveIds) {

--- a/mobile/lib/services/dm_reaction_retry_service.dart
+++ b/mobile/lib/services/dm_reaction_retry_service.dart
@@ -126,6 +126,18 @@ class DmReactionRetryService {
   final DateTime Function() _now;
   final CrashReportingService _crashReporting;
 
+  /// Tracking-key prefix for the add/publish retry phase.
+  static const String _addPhase = 'add';
+
+  /// Tracking-key prefix for the removal (kind-5) retry phase.
+  static const String _deletionPhase = 'del';
+
+  /// Backoff/attempt tracking, keyed by `'<phase>:<rumorId>'`. The phase prefix
+  /// keeps the add and deletion budgets separate: a row keeps its rumor id when
+  /// it flips from a `failed`/`pending` add to a `deletion_pending` removal, so
+  /// a bare-id key would let a removal inherit the add phase's exhausted budget
+  /// and never re-drive the kind-5 (the counterparty keeps a reaction you
+  /// removed until the next cold start).
   final Map<String, int> _attempts = {};
   final Map<String, DateTime> _lastAttempt = {};
 
@@ -194,8 +206,8 @@ class DmReactionRetryService {
       final reactionTargets = await _repository.retryableReactions();
       final deletionTargets = await _repository.retryableDeletions();
       _pruneTracking(<String>{
-        for (final t in reactionTargets) t.rumorId,
-        for (final t in deletionTargets) t.rumorId,
+        for (final t in reactionTargets) '$_addPhase:${t.rumorId}',
+        for (final t in deletionTargets) '$_deletionPhase:${t.rumorId}',
       });
 
       // Adds apply the pending min-age guard (a fresh 'pending' row may still
@@ -203,6 +215,7 @@ class DmReactionRetryService {
       // 'deletion_pending' row is never in-flight for the sweep's purposes.
       final r = await _driveTargets(
         reactionTargets,
+        phase: _addPhase,
         applyPendingMinAge: true,
         driver: (t) => _repository.retry(
           rumorId: t.rumorId,
@@ -211,6 +224,7 @@ class DmReactionRetryService {
       );
       final d = await _driveTargets(
         deletionTargets,
+        phase: _deletionPhase,
         applyPendingMinAge: false,
         driver: (t) => _repository.retryDeletion(
           rumorId: t.rumorId,
@@ -250,9 +264,10 @@ class DmReactionRetryService {
     }
   }
 
-  /// Drive one list of retry [targets] through [driver], sharing the in-memory
-  /// backoff/attempt tracking with every other kind of target (ids are
-  /// disjoint — a reaction is either live or soft-deleted, never both).
+  /// Drive one list of retry [targets] through [driver]. Backoff/attempt
+  /// tracking is keyed by `'<phase>:<rumorId>'` so the add and deletion phases
+  /// keep independent budgets even though a row keeps its rumor id across the
+  /// `failed`/`pending` → `deletion_pending` lifecycle flip.
   Future<
     ({
       int recovered,
@@ -264,6 +279,7 @@ class DmReactionRetryService {
   >
   _driveTargets(
     List<DmReactionRetryTarget> targets, {
+    required String phase,
     required bool applyPendingMinAge,
     required Future<DmReactionPublishResult> Function(DmReactionRetryTarget)
     driver,
@@ -275,7 +291,7 @@ class DmReactionRetryService {
     var skippedTooYoung = 0;
 
     for (final target in targets) {
-      final id = target.rumorId;
+      final id = '$phase:${target.rumorId}';
       final attempts = _attempts[id] ?? 0;
 
       if (attempts >= _config.maxRetries) {

--- a/mobile/lib/services/dm_reaction_retry_service.dart
+++ b/mobile/lib/services/dm_reaction_retry_service.dart
@@ -1,0 +1,287 @@
+// ABOUTME: Foreground-triggered sweep that re-drives undelivered DM reactions
+// ABOUTME: (publish failed / interrupted) via DmReactionsRepository, giving
+// ABOUTME: reactions the durable retry that DM messages already have.
+
+import 'dart:async';
+
+import 'package:dm_repository/dm_repository.dart';
+import 'package:meta/meta.dart';
+import 'package:openvine/services/crash_reporting_service.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// Stable identifiers for swallowed-failure sites inside
+/// [DmReactionRetryService]. Forwarded as the Crashlytics `reason:` suffix so
+/// the dashboard aggregates per site. Colocated with the service (rather than a
+/// separate file) so it stays out of the untested-services floor.
+abstract class DmReactionRetryServiceReportableSites {
+  /// Per-reaction throw in the sweep loop — `retry` raised an unexpected
+  /// exception.
+  static const String perReactionUnexpectedThrow =
+      'DmReactionRetryService.perReactionUnexpectedThrow';
+
+  /// Top-level sweep catch — the sweep loop or repository call raised before
+  /// per-reaction dispatch completed.
+  static const String sweepTopLevel = 'DmReactionRetryService.sweepTopLevel';
+}
+
+/// Backoff + budget configuration for [DmReactionRetryService].
+///
+/// Mirrors `OutgoingDmRetryConfig` (5 retries, 2 s → 5 min, 2× backoff) so
+/// reaction and message retries behave the same. Retry accounting is kept in
+/// memory rather than on the `dm_message_reactions` row, so the budget resets
+/// on a cold start — bounded further by the foreground-only trigger.
+class DmReactionRetryConfig {
+  /// Construct a retry config.
+  const DmReactionRetryConfig({
+    this.maxRetries = 5,
+    this.initialDelay = const Duration(seconds: 2),
+    this.maxDelay = const Duration(minutes: 5),
+    this.backoffMultiplier = 2.0,
+    this.interruptedPendingMinAge = const Duration(seconds: 30),
+  });
+
+  /// Attempts a single reaction gets before the sweep drops it (a manual
+  /// re-tap still works).
+  final int maxRetries;
+
+  /// Delay before the first retry after a failure.
+  final Duration initialDelay;
+
+  /// Ceiling for the exponential backoff gap.
+  final Duration maxDelay;
+
+  /// Growth factor applied per attempt.
+  final double backoffMultiplier;
+
+  /// A `'pending'` row younger than this is skipped: its original publish may
+  /// still be in flight (a reaction publish caps at 15 s), so re-driving it
+  /// now would race the in-flight attempt's own DAO write. Older `'pending'`
+  /// rows are app-killed-mid-send survivors, safe to replay.
+  final Duration interruptedPendingMinAge;
+
+  /// Minimum gap required before re-attempting a reaction whose previous
+  /// attempt count is [retryCount]. Clamped at [maxDelay].
+  Duration backoffFor(int retryCount) {
+    if (retryCount <= 0) return Duration.zero;
+    var ms = initialDelay.inMilliseconds.toDouble();
+    for (var i = 0; i < retryCount; i++) {
+      ms *= backoffMultiplier;
+      if (ms >= maxDelay.inMilliseconds) return maxDelay;
+    }
+    return Duration(milliseconds: ms.round());
+  }
+}
+
+/// Re-drives undelivered own DM reactions on every app-foreground transition,
+/// closing the reliability gap that leaves a reaction lost when its recipient
+/// gift wrap fails to land on a flaky relay.
+///
+/// DM *messages* get this durability from the `outgoing_dms` queue +
+/// `OutgoingDmRetryService`; reactions previously had only a manual re-tap.
+/// This service reuses the reaction's own durable record — the
+/// `dm_message_reactions` row keeps the rumor JSON while `publishStatus` is
+/// `'failed'`/`'pending'` — and replays it through
+/// [DmReactionsRepository.retry], which requires the relay's NIP-20 `OK`
+/// before marking the reaction sent.
+///
+/// **Trigger:** [appForegroundStream] transitions to `true`. The provider
+/// seeds the current foreground state, so the cold-start sweep fires
+/// automatically.
+///
+/// **Re-entrancy:** a sweep already in progress short-circuits the next
+/// trigger; the deferred work is picked up on the next foreground transition.
+///
+/// **Backoff/budget:** per-reaction attempts are tracked in memory. A reaction
+/// is skipped until `lastAttempt + backoff(attempts)` elapses and dropped from
+/// the sweep once it hits [DmReactionRetryConfig.maxRetries] (a manual re-tap
+/// still works). Entries for reactions that are no longer retryable (sent,
+/// deleted) are pruned each pass so the maps stay bounded to the live set.
+class DmReactionRetryService {
+  /// Construct the service. [reactionsRepository] must be the same instance
+  /// the UI publishes through, so retried rows share its DAO and credentials.
+  DmReactionRetryService({
+    required DmReactionsRepository reactionsRepository,
+    required Stream<bool> appForegroundStream,
+    DmReactionRetryConfig retryConfig = const DmReactionRetryConfig(),
+    DateTime Function() now = DateTime.now,
+    CrashReportingService? crashReporting,
+  }) : _repository = reactionsRepository,
+       _appForegroundStream = appForegroundStream,
+       _config = retryConfig,
+       _now = now,
+       _crashReporting = crashReporting ?? CrashReportingService.instance;
+
+  final DmReactionsRepository _repository;
+  final Stream<bool> _appForegroundStream;
+  final DmReactionRetryConfig _config;
+  final DateTime Function() _now;
+  final CrashReportingService _crashReporting;
+
+  final Map<String, int> _attempts = {};
+  final Map<String, DateTime> _lastAttempt = {};
+
+  StreamSubscription<bool>? _foregroundSubscription;
+  bool _isInitialized = false;
+  bool _isSweeping = false;
+
+  bool get isInitialized => _isInitialized;
+
+  @visibleForTesting
+  bool get isSweeping => _isSweeping;
+
+  /// Subscribe to foreground transitions. Idempotent: calling twice is a
+  /// no-op so the eager-init read in `main.dart` and any test setup coexist.
+  Future<void> initialize() async {
+    if (_isInitialized) return;
+    _isInitialized = true;
+
+    _foregroundSubscription = _appForegroundStream.listen((foreground) {
+      if (foreground) {
+        unawaited(sweep());
+      }
+    });
+
+    Log.info(
+      'initialized',
+      name: 'DmReactionRetryService',
+      category: LogCategory.system,
+    );
+  }
+
+  /// Cancel the foreground subscription and mark the service un-init.
+  /// Idempotent.
+  Future<void> dispose() async {
+    await _foregroundSubscription?.cancel();
+    _foregroundSubscription = null;
+    _isInitialized = false;
+  }
+
+  /// One pass over the retryable reactions. Public so tests can drive it
+  /// directly without constructing a foreground stream.
+  @visibleForTesting
+  Future<void> sweep() async {
+    if (_isSweeping) {
+      Log.debug(
+        'sweep already in progress, skipping',
+        name: 'DmReactionRetryService',
+        category: LogCategory.system,
+      );
+      return;
+    }
+    // Repo not credentialed yet (cold start before auth) — `retry` would no-op
+    // and burn the attempt budget. Skip; the next foreground transition
+    // retries once credentials are wired.
+    if (!_repository.isInitialized) return;
+    _isSweeping = true;
+
+    try {
+      final targets = await _repository.retryableReactions();
+      _pruneTracking(targets.map((t) => t.rumorId).toSet());
+
+      var recovered = 0;
+      var failed = 0;
+      var skippedBackoff = 0;
+      var skippedExhausted = 0;
+      var skippedTooYoung = 0;
+
+      for (final target in targets) {
+        final id = target.rumorId;
+        final attempts = _attempts[id] ?? 0;
+
+        if (attempts >= _config.maxRetries) {
+          skippedExhausted++;
+          continue;
+        }
+
+        final last = _lastAttempt[id];
+        if (last != null) {
+          final gap = _now().difference(last);
+          if (gap < _config.backoffFor(attempts)) {
+            skippedBackoff++;
+            continue;
+          }
+        }
+
+        // A still-`pending` reaction may have an in-flight publish (a reaction
+        // publish caps at 15 s); only treat it as interrupted once it's older
+        // than the guard, so the sweep never races an in-flight attempt.
+        if (target.publishStatus == 'pending') {
+          final age = _now().difference(
+            DateTime.fromMillisecondsSinceEpoch(target.createdAt * 1000),
+          );
+          if (age < _config.interruptedPendingMinAge) {
+            skippedTooYoung++;
+            continue;
+          }
+        }
+
+        try {
+          final result = await _repository.retry(
+            rumorId: id,
+            targetMessageAuthor: target.targetMessageAuthor,
+          );
+          if (result.success) {
+            _attempts.remove(id);
+            _lastAttempt.remove(id);
+            recovered++;
+          } else {
+            _attempts[id] = attempts + 1;
+            _lastAttempt[id] = _now();
+            failed++;
+          }
+        } on Object catch (e, stackTrace) {
+          _attempts[id] = attempts + 1;
+          _lastAttempt[id] = _now();
+          failed++;
+          Log.error(
+            'reaction retry threw for $id: $e',
+            name: 'DmReactionRetryService',
+            category: LogCategory.system,
+            error: e,
+            stackTrace: stackTrace,
+          );
+          unawaited(
+            _crashReporting.recordError(
+              e,
+              stackTrace,
+              reason: DmReactionRetryServiceReportableSites
+                  .perReactionUnexpectedThrow,
+            ),
+          );
+        }
+      }
+
+      Log.info(
+        'sweep complete: '
+        'recovered=$recovered failed=$failed '
+        'skipped-backoff=$skippedBackoff '
+        'skipped-exhausted=$skippedExhausted '
+        'skipped-too-young=$skippedTooYoung',
+        name: 'DmReactionRetryService',
+        category: LogCategory.system,
+      );
+    } on Object catch (e, stackTrace) {
+      Log.error(
+        'sweep failed: $e',
+        name: 'DmReactionRetryService',
+        category: LogCategory.system,
+        error: e,
+        stackTrace: stackTrace,
+      );
+      unawaited(
+        _crashReporting.recordError(
+          e,
+          stackTrace,
+          reason: DmReactionRetryServiceReportableSites.sweepTopLevel,
+        ),
+      );
+    } finally {
+      _isSweeping = false;
+    }
+  }
+
+  void _pruneTracking(Set<String> liveIds) {
+    _attempts.removeWhere((id, _) => !liveIds.contains(id));
+    _lastAttempt.removeWhere((id, _) => !liveIds.contains(id));
+  }
+}

--- a/mobile/lib/services/outgoing_dm_retry_service.dart
+++ b/mobile/lib/services/outgoing_dm_retry_service.dart
@@ -79,6 +79,7 @@ class OutgoingDmRetryService {
     required OutgoingDmsDao outgoingDmsDao,
     required String userPubkey,
     required Stream<bool> appForegroundStream,
+    Stream<void>? retryTriggerStream,
     OutgoingDmRetryConfig retryConfig = const OutgoingDmRetryConfig(),
     DateTime Function() now = DateTime.now,
     CrashReportingService? crashReporting,
@@ -86,6 +87,7 @@ class OutgoingDmRetryService {
        _dao = outgoingDmsDao,
        _userPubkey = userPubkey,
        _appForegroundStream = appForegroundStream,
+       _retryTriggerStream = retryTriggerStream,
        _retryConfig = retryConfig,
        _now = now,
        _crashReporting = crashReporting ?? CrashReportingService.instance;
@@ -94,11 +96,19 @@ class OutgoingDmRetryService {
   final OutgoingDmsDao _dao;
   final String _userPubkey;
   final Stream<bool> _appForegroundStream;
+
+  /// Fires a sweep on each event, independent of foreground transitions.
+  /// Wired to connectivity/relay-reconnection so a message queued during a
+  /// brief network drop is re-driven the moment the network returns — without
+  /// waiting for the user to background and re-foreground the app.
+  final Stream<void>? _retryTriggerStream;
+
   final OutgoingDmRetryConfig _retryConfig;
   final DateTime Function() _now;
   final CrashReportingService _crashReporting;
 
   StreamSubscription<bool>? _foregroundSubscription;
+  StreamSubscription<void>? _retryTriggerSubscription;
   bool _isInitialized = false;
   bool _isSweeping = false;
 
@@ -120,6 +130,10 @@ class OutgoingDmRetryService {
       }
     });
 
+    _retryTriggerSubscription = _retryTriggerStream?.listen((_) {
+      unawaited(sweep());
+    });
+
     Log.info(
       'initialized for $_userPubkey',
       name: 'OutgoingDmRetryService',
@@ -127,11 +141,13 @@ class OutgoingDmRetryService {
     );
   }
 
-  /// Cancel the foreground subscription and mark the service un-init.
+  /// Cancel the trigger subscriptions and mark the service un-init.
   /// Idempotent.
   Future<void> dispose() async {
     await _foregroundSubscription?.cancel();
     _foregroundSubscription = null;
+    await _retryTriggerSubscription?.cancel();
+    _retryTriggerSubscription = null;
     _isInitialized = false;
   }
 

--- a/mobile/packages/db_client/lib/src/database/daos/dm_reactions_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/dm_reactions_dao.dart
@@ -36,6 +36,11 @@ class DmReactionsDao extends DatabaseAccessor<AppDatabase>
   /// Terminal `publish_status` for a deletion whose kind-5 reached a relay.
   static const String _deletionSentStatus = 'deletion_sent';
 
+  /// Terminal `publish_status` for an outgoing reaction the send policy (#176
+  /// protected-minor DM restriction) refused. Not retryable — excluded from
+  /// [getRetryableOwnReactions] — since retrying only re-hits the same policy.
+  static const String _blockedStatus = 'blocked';
+
   /// Insert an optimistic outgoing row before the publish attempt, atomically
   /// superseding any prior LIVE reactions by this reactor on this target.
   ///
@@ -185,6 +190,25 @@ class DmReactionsDao extends DatabaseAccessor<AppDatabase>
     )..where((t) => t.id.equals(id) & t.ownerPubkey.equals(ownerPubkey))).write(
       const DmMessageReactionsCompanion(publishStatus: Value('pending')),
     );
+  }
+
+  /// Mark an outgoing row terminally `'blocked'` — the send policy refused the
+  /// recipient (#176). Clears `rumorEventJson` so the row can never be selected
+  /// by [getRetryableOwnReactions] (which requires a stored rumor), making the
+  /// block terminal on both the status and the rumor-presence predicate.
+  Future<void> markBlocked({
+    required String id,
+    required String ownerPubkey,
+  }) async {
+    await (update(dmMessageReactions)..where(
+          (t) => t.id.equals(id) & t.ownerPubkey.equals(ownerPubkey),
+        ))
+        .write(
+          const DmMessageReactionsCompanion(
+            publishStatus: Value(_blockedStatus),
+            rumorEventJson: Value(null),
+          ),
+        );
   }
 
   /// Soft-delete a row (NIP-09 kind 5 deletion received, or own-reaction

--- a/mobile/packages/db_client/lib/src/database/daos/dm_reactions_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/dm_reactions_dao.dart
@@ -312,6 +312,31 @@ class DmReactionsDao extends DatabaseAccessor<AppDatabase>
     return query.watch();
   }
 
+  /// Fetch this user's own outgoing reactions that a retry sweep should
+  /// re-drive: live rows authored by [ownerPubkey] whose publish is
+  /// `'failed'` or still `'pending'`, that still carry the rumor JSON needed
+  /// to replay the gift wrap.
+  ///
+  /// Soft-deleted rows (superseded / removed) and already-`'sent'` rows (whose
+  /// JSON is cleared on [swapPlaceholderId]) are excluded, so a re-driven
+  /// reaction is always a genuinely undelivered one. Ordered oldest-first so
+  /// retries drain in send order.
+  Future<List<DmReactionRow>> getRetryableOwnReactions({
+    required String ownerPubkey,
+  }) {
+    return (select(dmMessageReactions)
+          ..where(
+            (t) =>
+                t.ownerPubkey.equals(ownerPubkey) &
+                t.reactorPubkey.equals(ownerPubkey) &
+                t.isDeleted.equals(false) &
+                t.rumorEventJson.isNotNull() &
+                t.publishStatus.isIn(const ['failed', 'pending']),
+          )
+          ..orderBy([(t) => OrderingTerm.asc(t.createdAt)]))
+        .get();
+  }
+
   /// Return the stored rumor JSON for a pending/failed outgoing row, or
   /// `null` if no row matches or the row has no stored rumor.
   Future<String?> getRumorJson({

--- a/mobile/packages/db_client/lib/src/database/daos/dm_reactions_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/dm_reactions_dao.dart
@@ -27,6 +27,15 @@ class DmReactionsDao extends DatabaseAccessor<AppDatabase>
     with _$DmReactionsDaoMixin {
   DmReactionsDao(super.attachedDatabase);
 
+  /// `publish_status` value for a soft-deleted own reaction whose NIP-09
+  /// kind-5 deletion still needs durable (re)delivery. The row is
+  /// `is_deleted = 1` (hidden from the chip) but keeps its stored deletion
+  /// rumor in `rumor_event_json` so the retry sweep can re-drive it.
+  static const String _deletionPendingStatus = 'deletion_pending';
+
+  /// Terminal `publish_status` for a deletion whose kind-5 reached a relay.
+  static const String _deletionSentStatus = 'deletion_sent';
+
   /// Insert an optimistic outgoing row before the publish attempt, atomically
   /// superseding any prior LIVE reactions by this reactor on this target.
   ///
@@ -332,6 +341,70 @@ class DmReactionsDao extends DatabaseAccessor<AppDatabase>
                 t.isDeleted.equals(false) &
                 t.rumorEventJson.isNotNull() &
                 t.publishStatus.isIn(const ['failed', 'pending']),
+          )
+          ..orderBy([(t) => OrderingTerm.asc(t.createdAt)]))
+        .get();
+  }
+
+  /// Soft-delete an own reaction AND record its NIP-09 kind-5 deletion rumor
+  /// for durable (re)delivery.
+  ///
+  /// The row leaves the live set immediately (`is_deleted = 1`, so the chip
+  /// hides on the same frame as the tap) but keeps [deletionRumorJson] and
+  /// `publish_status = 'deletion_pending'` so the retry sweep can re-drive the
+  /// kind-5 until a relay confirms it — closing the gap where a removal made
+  /// offline (or on a flaky relay) was silently dropped. Overloads the
+  /// existing `rumor_event_json` column with the deletion rumor: the prior
+  /// add-reaction rumor is no longer needed once the reaction is removed.
+  Future<void> markOwnDeletionPending({
+    required String id,
+    required String ownerPubkey,
+    required String deletionRumorJson,
+  }) async {
+    await (update(dmMessageReactions)..where(
+          (t) => t.id.equals(id) & t.ownerPubkey.equals(ownerPubkey),
+        ))
+        .write(
+          DmMessageReactionsCompanion(
+            isDeleted: const Value(true),
+            publishStatus: const Value(_deletionPendingStatus),
+            rumorEventJson: Value(deletionRumorJson),
+          ),
+        );
+  }
+
+  /// Mark a pending own-reaction deletion as delivered: clears the stored
+  /// deletion rumor and moves the row to the terminal `'deletion_sent'` status
+  /// so the sweep stops re-driving it. The row stays `is_deleted = 1`.
+  Future<void> markDeletionSent({
+    required String id,
+    required String ownerPubkey,
+  }) async {
+    await (update(dmMessageReactions)..where(
+          (t) => t.id.equals(id) & t.ownerPubkey.equals(ownerPubkey),
+        ))
+        .write(
+          const DmMessageReactionsCompanion(
+            publishStatus: Value(_deletionSentStatus),
+            rumorEventJson: Value(null),
+          ),
+        );
+  }
+
+  /// Fetch this user's own soft-deleted reactions whose kind-5 deletion still
+  /// needs durable delivery (`publish_status = 'deletion_pending'` with a
+  /// stored deletion rumor). Ordered oldest-first so removals drain in order.
+  Future<List<DmReactionRow>> getRetryableOwnDeletions({
+    required String ownerPubkey,
+  }) {
+    return (select(dmMessageReactions)
+          ..where(
+            (t) =>
+                t.ownerPubkey.equals(ownerPubkey) &
+                t.reactorPubkey.equals(ownerPubkey) &
+                t.isDeleted.equals(true) &
+                t.rumorEventJson.isNotNull() &
+                t.publishStatus.equals(_deletionPendingStatus),
           )
           ..orderBy([(t) => OrderingTerm.asc(t.createdAt)]))
         .get();

--- a/mobile/packages/db_client/lib/src/database/tables.dart
+++ b/mobile/packages/db_client/lib/src/database/tables.dart
@@ -860,7 +860,9 @@ class DmMessageReactions extends Table {
       text().nullable().named('rumor_event_json')();
 
   /// Publish status for outgoing rows; null for incoming (received from
-  /// relay). Values: `pending`, `sent`, `failed`.
+  /// relay). Values: `pending`, `sent`, `failed`, `blocked` (send-policy
+  /// refused, terminal), `deletion_pending` (soft-deleted, kind-5 awaiting
+  /// durable delivery), `deletion_sent` (kind-5 confirmed, terminal).
   TextColumn get publishStatus => text().nullable().named('publish_status')();
 
   @override

--- a/mobile/packages/db_client/test/src/database/daos/dm_reactions_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/dm_reactions_dao_test.dart
@@ -319,6 +319,37 @@ void main() {
     });
 
     test(
+      'markBlocked marks the row blocked, clears rumor json, and drops it '
+      'from the retryable set so the sweep and a re-tap never re-drive it',
+      () async {
+        await insertPending();
+
+        await dao.markBlocked(id: _pendingId, ownerPubkey: _ownerA);
+
+        final row = await dao.getById(id: _pendingId, ownerPubkey: _ownerA);
+        expect(row!.publishStatus, equals('blocked'));
+        expect(
+          row.rumorEventJson,
+          isNull,
+          reason: 'A blocked send is terminal; no rumor is kept for retry.',
+        );
+        // Still live (not soft-deleted) so it renders as a settled own chip.
+        expect(row.isDeleted, isFalse);
+
+        final retryable = await dao.getRetryableOwnReactions(
+          ownerPubkey: _ownerA,
+        );
+        expect(
+          retryable.map((r) => r.id),
+          isNot(contains(_pendingId)),
+          reason:
+              'blocked is neither failed nor pending, and has no rumor '
+              'json — excluded on both predicates.',
+        );
+      },
+    );
+
+    test(
       'getRetryableOwnReactions returns failed and pending own reactions '
       'with stored rumor json',
       () async {

--- a/mobile/packages/db_client/test/src/database/daos/dm_reactions_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/dm_reactions_dao_test.dart
@@ -439,6 +439,86 @@ void main() {
       },
     );
 
+    test(
+      'markOwnDeletionPending hides the row, stores the deletion rumor, and '
+      'surfaces it in getRetryableOwnDeletions (not the add retry set)',
+      () async {
+        await insertPending();
+
+        await dao.markOwnDeletionPending(
+          id: _pendingId,
+          ownerPubkey: _ownerA,
+          deletionRumorJson: '{"kind":5}',
+        );
+
+        // Hidden from the live chip stream.
+        final live = await dao
+            .watchForConversation(
+              conversationId: _conversationId,
+              ownerPubkey: _ownerA,
+            )
+            .first;
+        expect(live, isEmpty);
+
+        // Excluded from the ADD retry set (it is soft-deleted)...
+        expect(
+          await dao.getRetryableOwnReactions(ownerPubkey: _ownerA),
+          isEmpty,
+        );
+
+        // ...but surfaced in the DELETION retry set, carrying the kind-5 rumor.
+        final deletions = await dao.getRetryableOwnDeletions(
+          ownerPubkey: _ownerA,
+        );
+        expect(deletions, hasLength(1));
+        expect(deletions.first.id, _pendingId);
+        expect(deletions.first.rumorEventJson, contains('"kind":5'));
+      },
+    );
+
+    test(
+      'markDeletionSent clears the deletion from the retry set',
+      () async {
+        await insertPending();
+        await dao.markOwnDeletionPending(
+          id: _pendingId,
+          ownerPubkey: _ownerA,
+          deletionRumorJson: '{"kind":5}',
+        );
+
+        await dao.markDeletionSent(id: _pendingId, ownerPubkey: _ownerA);
+
+        expect(
+          await dao.getRetryableOwnDeletions(ownerPubkey: _ownerA),
+          isEmpty,
+        );
+        final row = await dao.getById(id: _pendingId, ownerPubkey: _ownerA);
+        expect(row, isNotNull);
+        expect(row!.rumorEventJson, isNull);
+      },
+    );
+
+    test(
+      'getRetryableOwnDeletions is owner-scoped',
+      () async {
+        await insertPending(ownerPubkey: _ownerB, reactorPubkey: _ownerB);
+        await dao.markOwnDeletionPending(
+          id: _pendingId,
+          ownerPubkey: _ownerB,
+          deletionRumorJson: '{"kind":5}',
+        );
+
+        expect(
+          await dao.getRetryableOwnDeletions(ownerPubkey: _ownerA),
+          isEmpty,
+        );
+        expect(
+          await dao.getRetryableOwnDeletions(ownerPubkey: _ownerB),
+          hasLength(1),
+        );
+      },
+    );
+
     test('deleteById removes failed rows entirely', () async {
       await insertPending();
 

--- a/mobile/packages/db_client/test/src/database/daos/dm_reactions_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/dm_reactions_dao_test.dart
@@ -319,6 +319,100 @@ void main() {
     });
 
     test(
+      'getRetryableOwnReactions returns failed and pending own reactions '
+      'with stored rumor json',
+      () async {
+        // A pending own reaction (interrupted send).
+        await insertPending();
+
+        // A failed own reaction on a different target message.
+        const failedId =
+            '2222222222222222222222222222222222222222222222222222222222222222';
+        const otherTarget =
+            '3333333333333333333333333333333333333333333333333333333333333333';
+        await dao.insertOwnReactionSuperseding(
+          placeholderId: failedId,
+          conversationId: _conversationId,
+          targetMessageId: otherTarget,
+          targetMessageAuthor: _targetAuthor,
+          reactorPubkey: _reactorA,
+          emoji: '😀',
+          createdAt: 1_700_000_100,
+          ownerPubkey: _ownerA,
+          rumorEventJson: '{"id":"$failedId"}',
+        );
+        await dao.markFailed(placeholderId: failedId, ownerPubkey: _ownerA);
+
+        final retryable = await dao.getRetryableOwnReactions(
+          ownerPubkey: _ownerA,
+        );
+
+        expect(
+          retryable.map((r) => r.id),
+          containsAll(<String>[_pendingId, failedId]),
+        );
+        expect(retryable.every((r) => r.rumorEventJson != null), isTrue);
+      },
+    );
+
+    test(
+      'getRetryableOwnReactions excludes sent, deleted, incoming, and other '
+      "owners' reactions",
+      () async {
+        // Sent own reaction: swap clears json + marks sent.
+        await insertPending();
+        await dao.swapPlaceholderId(
+          placeholderId: _pendingId,
+          realRumorId: _sentId,
+          ownerPubkey: _ownerA,
+        );
+
+        // Soft-deleted own reaction (superseded / removed).
+        const deletedId =
+            '4444444444444444444444444444444444444444444444444444444444444444';
+        const deletedTarget =
+            '5555555555555555555555555555555555555555555555555555555555555555';
+        await dao.insertOwnReactionSuperseding(
+          placeholderId: deletedId,
+          conversationId: _conversationId,
+          targetMessageId: deletedTarget,
+          targetMessageAuthor: _targetAuthor,
+          reactorPubkey: _reactorA,
+          emoji: '😀',
+          createdAt: 1_700_000_100,
+          ownerPubkey: _ownerA,
+          rumorEventJson: '{"id":"$deletedId"}',
+        );
+        await dao.softDelete(id: deletedId, ownerPubkey: _ownerA);
+
+        // Incoming reaction from someone else (publishStatus null, no json).
+        await dao.upsertIncoming(
+          id: _giftWrapId,
+          conversationId: _conversationId,
+          targetMessageId: _targetMessageId,
+          targetMessageAuthor: _ownerA,
+          reactorPubkey: _reactorB,
+          emoji: '❤️',
+          createdAt: 1_700_000_200,
+          giftWrapId: _giftWrapId,
+          ownerPubkey: _ownerA,
+        );
+
+        // A pending reaction belonging to a different owner.
+        await insertPending(
+          ownerPubkey: _ownerB,
+          reactorPubkey: _ownerB,
+        );
+
+        final retryable = await dao.getRetryableOwnReactions(
+          ownerPubkey: _ownerA,
+        );
+
+        expect(retryable, isEmpty);
+      },
+    );
+
+    test(
       'softDelete hides row from live queries but preserves record',
       () async {
         await insertPending(id: _sentId);

--- a/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
@@ -481,8 +481,10 @@ class DmReactionsRepository {
         .toList(growable: false);
   }
 
-  /// Soft-delete an own reaction locally and emit a NIP-09 kind-5
-  /// deletion on the wire. Returns after the local update.
+  /// Soft-delete an own reaction locally and durably (re)deliver its NIP-09
+  /// kind-5 deletion on the wire. Returns after the local update; the wire
+  /// publish is durable — a failed/offline attempt is re-driven by the retry
+  /// sweep via [retryDeletion] rather than being dropped.
   Future<void> removeOwn({
     required String rumorId,
     required String targetMessageAuthor,
@@ -493,8 +495,34 @@ class DmReactionsRepository {
       id: rumorId,
       ownerPubkey: _userPubkey,
     );
+    final recipients = row != null
+        ? await _resolveWrapRecipients(
+            conversationId: row.conversationId,
+            targetMessageAuthor: targetMessageAuthor,
+          )
+        : <String>[targetMessageAuthor];
+
+    // Build the kind-5 deletion once so every (re)delivery replays an
+    // identical event — recipients treat repeats as idempotent.
+    final deletion = messageService.buildRumor(
+      recipientPubkey: recipients.first,
+      content: '',
+      eventKind: EventKind.eventDeletion,
+      additionalTags: [
+        ['e', rumorId],
+        ['k', EventKind.reaction.toString()],
+      ],
+    );
+
+    // Soft-delete locally AND durably record the deletion so a failed/offline
+    // publish is re-driven by the sweep (the chip hides immediately either
+    // way).
     try {
-      await _reactionsDao.softDelete(id: rumorId, ownerPubkey: _userPubkey);
+      await _reactionsDao.markOwnDeletionPending(
+        id: rumorId,
+        ownerPubkey: _userPubkey,
+        deletionRumorJson: jsonEncode(deletion.toJson()),
+      );
     } on Object catch (e, st) {
       _errorReporter?.call(
         e,
@@ -503,19 +531,141 @@ class DmReactionsRepository {
       );
       return;
     }
-    final recipients = row != null
-        ? await _resolveWrapRecipients(
-            conversationId: row.conversationId,
-            targetMessageAuthor: targetMessageAuthor,
-          )
-        : <String>[targetMessageAuthor];
+
+    // Fire the first attempt without blocking the UI; the durable
+    // `deletion_pending` row lets the sweep recover it if this attempt fails.
     unawaited(
-      _publishKind5Deletion(
-        reactionEventId: rumorId,
+      _driveDeletion(
+        rumorId: rumorId,
+        deletion: deletion,
         recipients: recipients,
         messageService: messageService,
       ),
     );
+  }
+
+  /// List this user's own reaction removals still awaiting durable kind-5
+  /// delivery, for the foreground/reconnect retry sweep to re-drive via
+  /// [retryDeletion]. Empty when credentials have not been wired.
+  Future<List<DmReactionRetryTarget>> retryableDeletions() async {
+    if (_userPubkey.isEmpty) return const [];
+    final rows = await _reactionsDao.getRetryableOwnDeletions(
+      ownerPubkey: _userPubkey,
+    );
+    return rows
+        .map(
+          (r) => DmReactionRetryTarget(
+            rumorId: r.id,
+            targetMessageAuthor: r.targetMessageAuthor,
+            publishStatus: r.publishStatus ?? '',
+            createdAt: r.createdAt,
+          ),
+        )
+        .toList(growable: false);
+  }
+
+  /// Retry a previously-failed/interrupted own reaction removal by replaying
+  /// the stored kind-5 rumor. Clears the pending-deletion marker on a
+  /// confirmed publish; leaves it pending otherwise so the sweep tries again.
+  Future<DmReactionPublishResult> retryDeletion({
+    required String rumorId,
+    required String targetMessageAuthor,
+  }) async {
+    final messageService = _messageService;
+    if (messageService == null || _userPubkey.isEmpty) {
+      return DmReactionPublishResult(
+        success: false,
+        rumorId: rumorId,
+        errorMessage: 'Repository not initialized',
+      );
+    }
+    final row = await _reactionsDao.getById(
+      id: rumorId,
+      ownerPubkey: _userPubkey,
+    );
+    final deletionJson = row?.rumorEventJson;
+    if (row == null || deletionJson == null) {
+      return DmReactionPublishResult(
+        success: false,
+        rumorId: rumorId,
+        errorMessage: 'No stored deletion to retry',
+      );
+    }
+    final deletion = Event.fromJson(
+      jsonDecode(deletionJson) as Map<String, dynamic>,
+    );
+    final recipients = await _resolveWrapRecipients(
+      conversationId: row.conversationId,
+      targetMessageAuthor: targetMessageAuthor,
+    );
+    try {
+      final result = await _fanOutRumor(
+        messageService: messageService,
+        rumor: deletion,
+        recipients: recipients,
+        awaitRecipientOk: true,
+      );
+      switch (result) {
+        case NIP17SendSuccess():
+          await _reactionsDao.markDeletionSent(
+            id: rumorId,
+            ownerPubkey: _userPubkey,
+          );
+          return DmReactionPublishResult(
+            success: true,
+            rumorId: rumorId,
+            optimisticInsertSucceeded: true,
+          );
+        case NIP17SendFailure(:final error):
+          return DmReactionPublishResult(
+            success: false,
+            rumorId: rumorId,
+            errorMessage: error,
+            optimisticInsertSucceeded: true,
+          );
+      }
+    } on Object catch (e) {
+      Log.warning(
+        'DM reaction deletion retry threw: $e',
+        category: LogCategory.system,
+      );
+      return DmReactionPublishResult(
+        success: false,
+        rumorId: rumorId,
+        errorMessage: e.toString(),
+        optimisticInsertSucceeded: true,
+      );
+    }
+  }
+
+  /// Publish [deletion] (OK-confirmed) and clear the pending-deletion marker
+  /// on success; on any non-success the `'deletion_pending'` row is left for
+  /// the retry sweep to re-drive.
+  Future<void> _driveDeletion({
+    required String rumorId,
+    required Event deletion,
+    required List<String> recipients,
+    required NIP17MessageService messageService,
+  }) async {
+    try {
+      final result = await _fanOutRumor(
+        messageService: messageService,
+        rumor: deletion,
+        recipients: recipients,
+        awaitRecipientOk: true,
+      );
+      if (result is NIP17SendSuccess) {
+        await _reactionsDao.markDeletionSent(
+          id: rumorId,
+          ownerPubkey: _userPubkey,
+        );
+      }
+    } on Object catch (e) {
+      Log.warning(
+        'DM reaction deletion publish threw: $e',
+        category: LogCategory.system,
+      );
+    }
   }
 
   /// Persist an incoming kind-7 reaction rumor. Called from

--- a/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
@@ -271,16 +271,19 @@ class DmReactionsRepository {
       targetMessageAuthor: targetMessageAuthor,
     );
 
-    // Emit a NIP-09 kind-5 deletion on the wire for each superseded prior
-    // reaction. Fire-and-forget and kept OUTSIDE the DAO transaction — a
-    // stalled relay socket must never block the local optimistic write.
+    // Durably remove each superseded prior reaction (cap-at-one emoji swap):
+    // route it through the same `deletion_pending` + sweep machinery as an
+    // explicit un-react so a flaky/offline relay can't strand the old emoji on
+    // the recipient. Only the durable DAO write is awaited; the wire publish is
+    // fire-and-forget inside the helper, kept OUTSIDE the optimistic insert
+    // transaction so a stalled socket never blocks the local write.
     for (final priorId in superseded) {
-      unawaited(
-        _publishKind5Deletion(
-          reactionEventId: priorId,
-          recipients: recipients,
-          messageService: messageService,
-        ),
+      await _durablyDeleteReaction(
+        rumorId: priorId,
+        recipients: recipients,
+        messageService: messageService,
+        reportSite:
+            DmReactionsRepositoryReportableSites.publishSupersedeDeletion,
       );
     }
 
@@ -311,11 +314,23 @@ class DmReactionsRepository {
             rumorId: rumorId,
             optimisticInsertSucceeded: true,
           );
-        case NIP17SendFailure(:final error, :final retryablePending):
-          // Unconfirmed (frame written, no relay OK): keep the row 'pending'
-          // so it stays a dim, sweep-retryable chip — a lost OK is not proof
-          // of loss. Only a confirmed rejection/error flips it to 'failed'.
-          if (retryablePending) {
+        case NIP17SendFailure(
+          :final error,
+          :final retryablePending,
+          :final blocked,
+        ):
+          // Policy-blocked (#176): terminal and non-retryable — retrying only
+          // re-hits the same policy. Mark 'blocked' so the sweep and a chip
+          // re-tap both leave it alone (unlike 'failed', which they re-drive).
+          if (blocked) {
+            await _reactionsDao.markBlocked(
+              id: rumorId,
+              ownerPubkey: _userPubkey,
+            );
+          } else if (retryablePending) {
+            // Unconfirmed (frame written, no relay OK): keep the row 'pending'
+            // so it stays a dim, sweep-retryable chip — a lost OK is not proof
+            // of loss. Only a confirmed rejection/error flips it to 'failed'.
             await _reactionsDao.markPending(
               id: rumorId,
               ownerPubkey: _userPubkey,
@@ -429,11 +444,23 @@ class DmReactionsRepository {
             rumorId: rumorId,
             optimisticInsertSucceeded: true,
           );
-        case NIP17SendFailure(:final error, :final retryablePending):
-          // Unconfirmed retry: leave the row 'pending' (the pre-send
-          // markPending stands) so the sweep keeps re-driving it. Only a
-          // confirmed rejection/error flips it to 'failed'.
-          if (!retryablePending) {
+        case NIP17SendFailure(
+          :final error,
+          :final retryablePending,
+          :final blocked,
+        ):
+          // Policy-blocked (#176): terminal — flip the row out of the
+          // retryable pending/failed set so the sweep and a chip re-tap stop
+          // re-driving a send the policy will always refuse.
+          if (blocked) {
+            await _reactionsDao.markBlocked(
+              id: rumorId,
+              ownerPubkey: _userPubkey,
+            );
+          } else if (!retryablePending) {
+            // Unconfirmed retry: leave the row 'pending' (the pre-send
+            // markPending stands) so the sweep keeps re-driving it. Only a
+            // confirmed rejection/error flips it to 'failed'.
             await _reactionsDao.markFailed(
               placeholderId: rumorId,
               ownerPubkey: _userPubkey,
@@ -502,8 +529,32 @@ class DmReactionsRepository {
           )
         : <String>[targetMessageAuthor];
 
-    // Build the kind-5 deletion once so every (re)delivery replays an
-    // identical event — recipients treat repeats as idempotent.
+    await _durablyDeleteReaction(
+      rumorId: rumorId,
+      recipients: recipients,
+      messageService: messageService,
+      reportSite: DmReactionsRepositoryReportableSites.removeOwnSoftDelete,
+    );
+  }
+
+  /// Soft-delete the reaction row [rumorId] locally and durably record its
+  /// NIP-09 kind-5 deletion, then fire the first (non-blocking) delivery
+  /// attempt. Shared by the explicit un-react ([removeOwn]) and the cap-at-one
+  /// emoji-swap supersede in [publish].
+  ///
+  /// The kind-5 is built once so every (re)delivery replays an identical event
+  /// — recipients treat repeats as idempotent. The `deletion_pending` row is
+  /// awaited (durability boundary) so a crash before it lands can't lose the
+  /// removal; the wire publish itself is `unawaited` and re-driven by the sweep
+  /// via [retryDeletion] on any failed/offline attempt. On a DAO write failure
+  /// the deletion is reported to [reportSite] and skipped (no wire attempt).
+  Future<void> _durablyDeleteReaction({
+    required String rumorId,
+    required List<String> recipients,
+    required NIP17MessageService messageService,
+    required String reportSite,
+  }) async {
+    if (recipients.isEmpty) return;
     final deletion = messageService.buildRumor(
       recipientPubkey: recipients.first,
       content: '',
@@ -514,9 +565,6 @@ class DmReactionsRepository {
       ],
     );
 
-    // Soft-delete locally AND durably record the deletion so a failed/offline
-    // publish is re-driven by the sweep (the chip hides immediately either
-    // way).
     try {
       await _reactionsDao.markOwnDeletionPending(
         id: rumorId,
@@ -524,16 +572,10 @@ class DmReactionsRepository {
         deletionRumorJson: jsonEncode(deletion.toJson()),
       );
     } on Object catch (e, st) {
-      _errorReporter?.call(
-        e,
-        st,
-        site: DmReactionsRepositoryReportableSites.removeOwnSoftDelete,
-      );
+      _errorReporter?.call(e, st, site: reportSite);
       return;
     }
 
-    // Fire the first attempt without blocking the UI; the durable
-    // `deletion_pending` row lets the sweep recover it if this attempt fails.
     unawaited(
       _driveDeletion(
         rumorId: rumorId,
@@ -616,7 +658,22 @@ class DmReactionsRepository {
             rumorId: rumorId,
             optimisticInsertSucceeded: true,
           );
-        case NIP17SendFailure(:final error):
+        case NIP17SendFailure(:final error, :final blocked):
+          // A policy-blocked recipient can never receive the kind-5 — and
+          // never received the reaction it removes — so the removal is moot.
+          // Terminalize it (mirroring the blocked handling on the add path) so
+          // the sweep stops re-driving a send the policy will always refuse.
+          if (blocked) {
+            await _reactionsDao.markDeletionSent(
+              id: rumorId,
+              ownerPubkey: _userPubkey,
+            );
+            return DmReactionPublishResult(
+              success: true,
+              rumorId: rumorId,
+              optimisticInsertSucceeded: true,
+            );
+          }
           return DmReactionPublishResult(
             success: false,
             rumorId: rumorId,
@@ -639,8 +696,13 @@ class DmReactionsRepository {
   }
 
   /// Publish [deletion] (OK-confirmed) and clear the pending-deletion marker
-  /// on success; on any non-success the `'deletion_pending'` row is left for
-  /// the retry sweep to re-drive.
+  /// on a confirmed send OR a policy block; on any other non-success the
+  /// `'deletion_pending'` row is left for the retry sweep to re-drive.
+  ///
+  /// A blocked recipient can never receive the kind-5 — and never received the
+  /// reaction it removes — so the removal is moot and terminalizing it stops
+  /// the sweep re-driving a send the policy will always refuse (symmetric with
+  /// the blocked handling on the add path).
   Future<void> _driveDeletion({
     required String rumorId,
     required Event deletion,
@@ -654,7 +716,10 @@ class DmReactionsRepository {
         recipients: recipients,
         awaitRecipientOk: true,
       );
-      if (result is NIP17SendSuccess) {
+      final terminal =
+          result is NIP17SendSuccess ||
+          (result is NIP17SendFailure && result.blocked);
+      if (terminal) {
         await _reactionsDao.markDeletionSent(
           id: rumorId,
           ownerPubkey: _userPubkey,
@@ -864,51 +929,88 @@ class DmReactionsRepository {
   /// "react to own message isn't delivered" bug). For a 1:1 this yields the
   /// single other participant; for a group, every other member.
   ///
-  /// Falls back to `[targetMessageAuthor]` only when the conversation can't be
-  /// resolved (no [ConversationsDao] wired, row missing, or malformed
-  /// participants) — preserving the legacy/test behavior where the reacted
-  /// author is the only recipient we can name.
+  /// Falls back to [_fallbackWrapRecipients] only when the conversation can't
+  /// be resolved (no [ConversationsDao] wired, row missing, or malformed
+  /// participants).
   Future<List<String>> _resolveWrapRecipients({
     required String conversationId,
     required String targetMessageAuthor,
   }) async {
     final dao = _conversationsDao;
-    if (dao == null) return [targetMessageAuthor];
+    if (dao == null) return _fallbackWrapRecipients(targetMessageAuthor);
     try {
       final convo = await dao.getConversation(
         conversationId,
         ownerPubkey: _userPubkey,
       );
-      if (convo == null) return [targetMessageAuthor];
+      if (convo == null) return _fallbackWrapRecipients(targetMessageAuthor);
       final decoded = jsonDecode(convo.participantPubkeys);
-      if (decoded is! List) return [targetMessageAuthor];
+      if (decoded is! List) {
+        return _fallbackWrapRecipients(targetMessageAuthor);
+      }
       final others = decoded
           .whereType<String>()
           .where((p) => p != _userPubkey)
           .toList();
-      return others.isEmpty ? [targetMessageAuthor] : others;
+      return others.isEmpty
+          ? _fallbackWrapRecipients(targetMessageAuthor)
+          : others;
     } on Object {
-      return [targetMessageAuthor];
+      return _fallbackWrapRecipients(targetMessageAuthor);
     }
   }
 
+  /// Recipient set to use when the conversation can't be resolved. The reacted
+  /// message's author is the only counterparty we can name — but when that is
+  /// the current user (reacting to your OWN message), naming self would send
+  /// the reaction only back to yourself and never to the counterparty (the
+  /// "react to own message isn't delivered" bug). There is no counterparty to
+  /// name in that degenerate case, so return empty — the send reports
+  /// no-recipients and stays retryable — rather than silently self-delivering.
+  /// Unreachable in prod: real 1:1/group conversations always store their
+  /// participants, so [_resolveWrapRecipients] resolves before reaching here.
+  List<String> _fallbackWrapRecipients(String targetMessageAuthor) =>
+      targetMessageAuthor == _userPubkey
+      ? const <String>[]
+      : <String>[targetMessageAuthor];
+
   /// Wrap [rumor] to each of [recipients] (each send also self-wraps for
   /// cross-device recovery; self-wrap copies dedupe on the rumor id at the
-  /// receiver). Succeeds if any recipient wrap lands.
+  /// receiver). Terminal success ONLY when EVERY recipient wrap lands.
+  ///
+  /// A group reaction persists as one row that can't track per-recipient
+  /// delivery, so a partial fan-out (one member confirmed, another timed
+  /// out/rejected) must NOT report success — the caller would mark the row
+  /// `sent` and clear its stored rumor, leaving the missed member's wrap
+  /// unrecoverable. Instead any non-confirming recipient makes the whole
+  /// fan-out a retryable failure; the sweep re-drives the full rumor and the
+  /// receiver-side dedup on rumor id makes re-delivery to already-confirmed
+  /// members idempotent.
   ///
   /// [awaitRecipientOk] requires the relay's NIP-20 `OK true` for each
   /// recipient wrap before it counts as landed (see
   /// [NIP17MessageService.sendRumor]). Reaction sends/retries opt in so a
   /// flaky relay's frame-accept false positive can't mark an undelivered
-  /// reaction as sent; best-effort kind-5 deletions leave it off.
+  /// reaction as sent.
+  ///
+  /// Aggregate failure classification:
+  /// - every failure is a policy [NIP17SendResult.blocked] → aggregate blocked
+  ///   (terminal, non-retryable — the non-blocked members all confirmed).
+  /// - otherwise → a retryable failure whose `retryablePending` is `true` only
+  ///   when every failure is itself soft (`retryablePending`); a single hard
+  ///   rejection/offline member makes the whole fan-out hard-failed so the
+  ///   sweep re-drives it without the in-flight min-age hold.
   Future<NIP17SendResult> _fanOutRumor({
     required NIP17MessageService messageService,
     required Event rumor,
     required List<String> recipients,
     bool awaitRecipientOk = false,
   }) async {
-    NIP17SendResult? lastSuccess;
-    NIP17SendResult? lastFailure;
+    if (recipients.isEmpty) {
+      return const NIP17SendResult.failure('No reaction wrap recipients');
+    }
+    NIP17SendSuccess? lastSuccess;
+    final failures = <NIP17SendFailure>[];
     for (final recipient in recipients) {
       final result = await _sendRumorWithTimeout(
         messageService: messageService,
@@ -920,41 +1022,22 @@ class DmReactionsRepository {
         case NIP17SendSuccess():
           lastSuccess = result;
         case NIP17SendFailure():
-          lastFailure = result;
+          failures.add(result);
       }
     }
-    return lastSuccess ??
-        lastFailure ??
-        const NIP17SendResult.failure('No reaction wrap recipients');
-  }
-
-  Future<void> _publishKind5Deletion({
-    required String reactionEventId,
-    required List<String> recipients,
-    required NIP17MessageService messageService,
-  }) async {
-    if (recipients.isEmpty) return;
-    try {
-      final deletion = messageService.buildRumor(
-        recipientPubkey: recipients.first,
-        content: '',
-        eventKind: EventKind.eventDeletion,
-        additionalTags: [
-          ['e', reactionEventId],
-          ['k', EventKind.reaction.toString()],
-        ],
-      );
-      await _fanOutRumor(
-        messageService: messageService,
-        rumor: deletion,
-        recipients: recipients,
-      );
-    } on Object catch (e) {
-      Log.warning(
-        'DM reaction kind-5 deletion threw: $e',
-        category: LogCategory.system,
-      );
+    if (failures.isEmpty) {
+      // Every recipient confirmed — terminal success.
+      return lastSuccess ??
+          const NIP17SendResult.failure('No reaction wrap recipients');
     }
+    final summary = failures.map((f) => f.error).join('; ');
+    if (failures.every((f) => f.blocked)) {
+      return NIP17SendResult.blocked(summary);
+    }
+    return NIP17SendResult.failure(
+      summary,
+      retryablePending: failures.every((f) => f.retryablePending),
+    );
   }
 
   /// Resolve the conversation id for an incoming reaction.
@@ -996,6 +1079,7 @@ class DmReactionsRepository {
       'pending' => DmReactionPublishStatus.pending,
       'failed' => DmReactionPublishStatus.failed,
       'sent' => DmReactionPublishStatus.sent,
+      'blocked' => DmReactionPublishStatus.blocked,
       _ => DmReactionPublishStatus.received,
     };
     return DmReaction(

--- a/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
@@ -32,6 +32,7 @@ class DmReactionPublishResult {
     required this.success,
     required this.rumorId,
     this.errorMessage,
+    this.optimisticInsertSucceeded = false,
   });
 
   /// Whether the gift-wrap publish landed for the recipient.
@@ -42,6 +43,14 @@ class DmReactionPublishResult {
 
   /// One-line summary for logs; never user-facing copy.
   final String? errorMessage;
+
+  /// Whether the durable optimistic row was written to the DAO before the
+  /// publish attempt. When `true`, even a failed publish leaves a persisted
+  /// row the chip render + retry sweep can recover — so the cubit keeps the
+  /// optimistic chip instead of dropping it as an orphan while the DAO stream
+  /// catches up. `false` only when the repo was uninitialized or the insert
+  /// itself failed (no durable row exists).
+  final bool optimisticInsertSucceeded;
 }
 
 /// Outcome of ingesting an incoming wrapped reaction/deletion rumor, used by
@@ -297,16 +306,31 @@ class DmReactionsRepository {
               site: DmReactionsRepositoryReportableSites.publishSwapPlaceholder,
             );
           }
-          return DmReactionPublishResult(success: true, rumorId: rumorId);
-        case NIP17SendFailure(:final error):
-          await _reactionsDao.markFailed(
-            placeholderId: rumorId,
-            ownerPubkey: _userPubkey,
+          return DmReactionPublishResult(
+            success: true,
+            rumorId: rumorId,
+            optimisticInsertSucceeded: true,
           );
+        case NIP17SendFailure(:final error, :final retryablePending):
+          // Unconfirmed (frame written, no relay OK): keep the row 'pending'
+          // so it stays a dim, sweep-retryable chip — a lost OK is not proof
+          // of loss. Only a confirmed rejection/error flips it to 'failed'.
+          if (retryablePending) {
+            await _reactionsDao.markPending(
+              id: rumorId,
+              ownerPubkey: _userPubkey,
+            );
+          } else {
+            await _reactionsDao.markFailed(
+              placeholderId: rumorId,
+              ownerPubkey: _userPubkey,
+            );
+          }
           return DmReactionPublishResult(
             success: false,
             rumorId: rumorId,
             errorMessage: error,
+            optimisticInsertSucceeded: true,
           );
       }
     } on Object catch (e) {
@@ -322,6 +346,7 @@ class DmReactionsRepository {
         success: false,
         rumorId: rumorId,
         errorMessage: e.toString(),
+        optimisticInsertSucceeded: true,
       );
     }
   }
@@ -399,16 +424,26 @@ class DmReactionsRepository {
             realRumorId: rumorId,
             ownerPubkey: _userPubkey,
           );
-          return DmReactionPublishResult(success: true, rumorId: rumorId);
-        case NIP17SendFailure(:final error):
-          await _reactionsDao.markFailed(
-            placeholderId: rumorId,
-            ownerPubkey: _userPubkey,
+          return DmReactionPublishResult(
+            success: true,
+            rumorId: rumorId,
+            optimisticInsertSucceeded: true,
           );
+        case NIP17SendFailure(:final error, :final retryablePending):
+          // Unconfirmed retry: leave the row 'pending' (the pre-send
+          // markPending stands) so the sweep keeps re-driving it. Only a
+          // confirmed rejection/error flips it to 'failed'.
+          if (!retryablePending) {
+            await _reactionsDao.markFailed(
+              placeholderId: rumorId,
+              ownerPubkey: _userPubkey,
+            );
+          }
           return DmReactionPublishResult(
             success: false,
             rumorId: rumorId,
             errorMessage: error,
+            optimisticInsertSucceeded: true,
           );
       }
     } on Object catch (e) {
@@ -658,19 +693,31 @@ class DmReactionsRepository {
         )
         .timeout(
           _publishTimeout,
+          // A hung socket is inconclusive, not a confirmed rejection — the
+          // frame may already be written. Keep it retryable-pending so the
+          // sweep re-drives it rather than parking a red failed chip.
           onTimeout: () => NIP17SendResult.failure(
             'Reaction publish timed out after '
             '${_publishTimeout.inSeconds}s',
+            retryablePending: true,
           ),
         );
   }
 
-  /// Resolve the gift-wrap recipient set for a reaction in [conversationId].
+  /// Resolve the gift-wrap recipient set for a reaction in [conversationId]:
+  /// every conversation participant except the current user.
   ///
-  /// For a group conversation, returns every participant except the current
-  /// user (the wrap fans out to all members). For a 1:1 (or when the
-  /// conversation can't be resolved), returns `[targetMessageAuthor]` so the
-  /// behavior is byte-identical to the pre-group path.
+  /// Resolved from the conversation's participant set, **not** from
+  /// [targetMessageAuthor]. Reacting to your OWN message makes you the target
+  /// author, and addressing the wrap to the author would send the reaction
+  /// only back to yourself — the counterparty would never receive it (the
+  /// "react to own message isn't delivered" bug). For a 1:1 this yields the
+  /// single other participant; for a group, every other member.
+  ///
+  /// Falls back to `[targetMessageAuthor]` only when the conversation can't be
+  /// resolved (no [ConversationsDao] wired, row missing, or malformed
+  /// participants) — preserving the legacy/test behavior where the reacted
+  /// author is the only recipient we can name.
   Future<List<String>> _resolveWrapRecipients({
     required String conversationId,
     required String targetMessageAuthor,
@@ -682,7 +729,7 @@ class DmReactionsRepository {
         conversationId,
         ownerPubkey: _userPubkey,
       );
-      if (convo == null || !convo.isGroup) return [targetMessageAuthor];
+      if (convo == null) return [targetMessageAuthor];
       final decoded = jsonDecode(convo.participantPubkeys);
       if (decoded is! List) return [targetMessageAuthor];
       final others = decoded

--- a/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
@@ -277,6 +277,14 @@ class DmReactionsRepository {
     // the recipient. Only the durable DAO write is awaited; the wire publish is
     // fire-and-forget inside the helper, kept OUTSIDE the optimistic insert
     // transaction so a stalled socket never blocks the local write.
+    //
+    // Intentional ordering tradeoff: the removal commits before the new
+    // emoji's fan-out below is confirmed, so a hard-failed swap degrades into
+    // a bare removal on the recipient rather than rolling back to the old
+    // emoji. That matches the sender's view — the old row is already
+    // soft-deleted locally and the new emoji stays as a retryable failed
+    // chip — whereas a wire rollback would desync the two sides. Recovery is
+    // re-tapping (or the sweep re-driving) the new emoji.
     for (final priorId in superseded) {
       await _durablyDeleteReaction(
         rumorId: priorId,
@@ -458,9 +466,10 @@ class DmReactionsRepository {
               ownerPubkey: _userPubkey,
             );
           } else if (!retryablePending) {
-            // Unconfirmed retry: leave the row 'pending' (the pre-send
-            // markPending stands) so the sweep keeps re-driving it. Only a
-            // confirmed rejection/error flips it to 'failed'.
+            // Confirmed rejection/error: flip to 'failed' so the chip is
+            // tappable again. A soft (retryablePending) failure instead
+            // falls through untouched, leaving the pre-send 'pending' so
+            // the sweep keeps re-driving it.
             await _reactionsDao.markFailed(
               placeholderId: rumorId,
               ownerPubkey: _userPubkey,
@@ -546,8 +555,12 @@ class DmReactionsRepository {
   /// — recipients treat repeats as idempotent. The `deletion_pending` row is
   /// awaited (durability boundary) so a crash before it lands can't lose the
   /// removal; the wire publish itself is `unawaited` and re-driven by the sweep
-  /// via [retryDeletion] on any failed/offline attempt. On a DAO write failure
-  /// the deletion is reported to [reportSite] and skipped (no wire attempt).
+  /// via [retryDeletion] on any failed/offline attempt. That unawaited first
+  /// attempt can race a concurrent sweep's [retryDeletion] on the same
+  /// kind-5; both replay the identical stored event, so the worst case is a
+  /// redundant (idempotent) publish, not a divergent delete. On a DAO write
+  /// failure the deletion is reported to [reportSite] and skipped (no wire
+  /// attempt).
   Future<void> _durablyDeleteReaction({
     required String rumorId,
     required List<String> recipients,

--- a/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
@@ -60,6 +60,32 @@ enum DmReactionWrapOutcome {
   deferred,
 }
 
+/// A pending/failed own reaction the retry sweep can re-drive, projected from
+/// its `dm_message_reactions` row.
+@immutable
+class DmReactionRetryTarget {
+  /// Construct a retry target.
+  const DmReactionRetryTarget({
+    required this.rumorId,
+    required this.targetMessageAuthor,
+    required this.publishStatus,
+    required this.createdAt,
+  });
+
+  /// Reaction rumor id — the argument `retry` expects.
+  final String rumorId;
+
+  /// Author of the reacted message — the reaction's gift-wrap recipient.
+  final String targetMessageAuthor;
+
+  /// Persisted publish status: `'failed'` or `'pending'`.
+  final String publishStatus;
+
+  /// Rumor `created_at` (unix seconds). Lets the sweep hold back a still-in-
+  /// flight `'pending'` reaction until its original publish has resolved.
+  final int createdAt;
+}
+
 /// Repository for DM emoji reactions.
 ///
 /// Public surface:
@@ -254,6 +280,7 @@ class DmReactionsRepository {
         messageService: messageService,
         rumor: rumor,
         recipients: recipients,
+        awaitRecipientOk: true,
       );
       switch (result) {
         case NIP17SendSuccess():
@@ -363,6 +390,7 @@ class DmReactionsRepository {
         messageService: messageService,
         rumor: rumor,
         recipients: recipients,
+        awaitRecipientOk: true,
       );
       switch (result) {
         case NIP17SendSuccess():
@@ -395,6 +423,27 @@ class DmReactionsRepository {
         errorMessage: e.toString(),
       );
     }
+  }
+
+  /// List this user's own outgoing reactions still awaiting durable delivery
+  /// (publish `'failed'`, or `'pending'` from an interrupted send), for the
+  /// foreground retry sweep to re-drive via [retry]. Returns empty when
+  /// credentials have not been wired.
+  Future<List<DmReactionRetryTarget>> retryableReactions() async {
+    if (_userPubkey.isEmpty) return const [];
+    final rows = await _reactionsDao.getRetryableOwnReactions(
+      ownerPubkey: _userPubkey,
+    );
+    return rows
+        .map(
+          (r) => DmReactionRetryTarget(
+            rumorId: r.id,
+            targetMessageAuthor: r.targetMessageAuthor,
+            publishStatus: r.publishStatus ?? 'pending',
+            createdAt: r.createdAt,
+          ),
+        )
+        .toList(growable: false);
   }
 
   /// Soft-delete an own reaction locally and emit a NIP-09 kind-5
@@ -599,9 +648,14 @@ class DmReactionsRepository {
     required NIP17MessageService messageService,
     required Event rumor,
     required String recipientPubkey,
+    bool awaitRecipientOk = false,
   }) {
     return messageService
-        .sendRumor(rumorEvent: rumor, recipientPubkey: recipientPubkey)
+        .sendRumor(
+          rumorEvent: rumor,
+          recipientPubkey: recipientPubkey,
+          awaitRecipientOk: awaitRecipientOk,
+        )
         .timeout(
           _publishTimeout,
           onTimeout: () => NIP17SendResult.failure(
@@ -644,10 +698,17 @@ class DmReactionsRepository {
   /// Wrap [rumor] to each of [recipients] (each send also self-wraps for
   /// cross-device recovery; self-wrap copies dedupe on the rumor id at the
   /// receiver). Succeeds if any recipient wrap lands.
+  ///
+  /// [awaitRecipientOk] requires the relay's NIP-20 `OK true` for each
+  /// recipient wrap before it counts as landed (see
+  /// [NIP17MessageService.sendRumor]). Reaction sends/retries opt in so a
+  /// flaky relay's frame-accept false positive can't mark an undelivered
+  /// reaction as sent; best-effort kind-5 deletions leave it off.
   Future<NIP17SendResult> _fanOutRumor({
     required NIP17MessageService messageService,
     required Event rumor,
     required List<String> recipients,
+    bool awaitRecipientOk = false,
   }) async {
     NIP17SendResult? lastSuccess;
     NIP17SendResult? lastFailure;
@@ -656,6 +717,7 @@ class DmReactionsRepository {
         messageService: messageService,
         rumor: rumor,
         recipientPubkey: recipient,
+        awaitRecipientOk: awaitRecipientOk,
       );
       switch (result) {
         case NIP17SendSuccess():

--- a/mobile/packages/dm_repository/lib/src/dm_reactions_repository_reportable_sites.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_reactions_repository_reportable_sites.dart
@@ -31,4 +31,9 @@ abstract class DmReactionsRepositoryReportableSites {
   /// kind-5 deleted on the wire — local state will eventually reconcile
   /// from the relay echo.
   static const String removeOwnSoftDelete = 'removeOwn.softDelete';
+
+  /// `publish`: recording the durable `deletion_pending` row for a superseded
+  /// prior reaction (cap-at-one emoji swap) threw. The new reaction still
+  /// publishes; the superseded emoji's kind-5 removal is the part at risk.
+  static const String publishSupersedeDeletion = 'publish.supersedeDeletion';
 }

--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -345,8 +345,10 @@ class NIP17MessageService {
       // who only read their own inbox relays actually receive it); fall
       // back to the default pool otherwise. The no-targetRelays call shape
       // is kept identical to preserve existing behavior.
-      final bool recipientPublished;
       if (awaitRecipientOk) {
+        // OK-confirm path (reactions): require the relay's NIP-20 OK before
+        // reporting delivery, but keep this device's own durability
+        // independent of it.
         final outcome = (targetRelays != null && targetRelays.isNotEmpty)
             ? await _nostrService.publishEventAwaitOk(
                 giftWrapEvent,
@@ -357,18 +359,65 @@ class NIP17MessageService {
                 giftWrapEvent,
                 timeout: _recipientOkConfirmTimeout,
               );
-        recipientPublished = outcome.confirmed;
-      } else {
-        final sentEvent = (targetRelays != null && targetRelays.isNotEmpty)
-            ? await _nostrService.publishEvent(
-                giftWrapEvent,
-                targetRelays: targetRelays,
-              )
-            : await _nostrService.publishEvent(giftWrapEvent);
-        recipientPublished = sentEvent is PublishSuccess;
+
+        // Always publish the self-addressed wrap, even when the recipient OK
+        // is unconfirmed. The event frame may have been stored+broadcast (so
+        // the recipient already has the reaction) while the OK was lost/late
+        // on a flaky relay; skipping the self-wrap here would strand this
+        // device's own copy on reinstall / other devices. The self-wrap is
+        // p-tagged to the sender only, so publishing it on an unconfirmed
+        // recipient send never double-delivers to the counterparty.
+        final selfWrapPublished = await _publishSelfWrap(
+          nostr: nostr,
+          rumorEvent: rumorEvent,
+          prebuiltSelfWrap: prebuiltSelfWrap,
+        );
+
+        if (outcome.confirmed) {
+          Log.info(
+            'Successfully published NIP-17 reaction '
+            '(selfWrapPublished=$selfWrapPublished)',
+            category: LogCategory.system,
+          );
+          return NIP17SendResult.success(
+            rumorEventId: rumorEvent.id,
+            messageEventId: giftWrapEvent.id,
+            recipientPubkey: recipientPubkey,
+            selfWrapPublished: selfWrapPublished,
+          );
+        }
+
+        // Unconfirmed. An explicit OK-false is a hard rejection; "frame
+        // written, no OK within the window" is inconclusive — surface it as
+        // retryable-pending so the caller keeps a dim, sweep-retryable chip
+        // rather than a red failed one (a lost OK is not proof of loss, and
+        // marking it failed is what let a re-tap delete a delivered reaction).
+        final rejected = outcome.rejectedBy.isNotEmpty;
+        Log.warning(
+          'NIP-17 reaction recipient OK '
+          '${rejected ? 'rejected' : 'unconfirmed'} '
+          '(rumor=${rumorEvent.id}, recipient=$recipientPubkey, '
+          '${outcome.summary}); selfWrapPublished=$selfWrapPublished',
+          category: LogCategory.system,
+        );
+        return NIP17SendResult.failure(
+          rejected
+              ? 'Reaction rejected by relay: ${outcome.summary}'
+              : 'Reaction recipient OK unconfirmed: ${outcome.summary}',
+          retryablePending: !rejected,
+        );
       }
 
-      if (!recipientPublished) {
+      // Frame-accept path (messages): a WebSocket-accepted frame counts as
+      // sent, and the self-wrap runs only after the recipient publish lands.
+      final sentEvent = (targetRelays != null && targetRelays.isNotEmpty)
+          ? await _nostrService.publishEvent(
+              giftWrapEvent,
+              targetRelays: targetRelays,
+            )
+          : await _nostrService.publishEvent(giftWrapEvent);
+
+      if (sentEvent is! PublishSuccess) {
         const errorMsg = 'Message publish failed to relays';
         Log.error(
           '$errorMsg (rumor=${rumorEvent.id}, recipient=$recipientPubkey)',

--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -387,24 +387,38 @@ class NIP17MessageService {
           );
         }
 
-        // Unconfirmed. An explicit OK-false is a hard rejection; "frame
-        // written, no OK within the window" is inconclusive — surface it as
-        // retryable-pending so the caller keeps a dim, sweep-retryable chip
-        // rather than a red failed one (a lost OK is not proof of loss, and
-        // marking it failed is what let a re-tap delete a delivered reaction).
+        // Not confirmed. Three sub-cases decide the caller's chip + retry:
+        //  * explicit OK-false → hard rejection: mark failed.
+        //  * nothing reached any relay (offline) → the send definitively did
+        //    not happen, so the sweep must re-drive it the instant
+        //    connectivity returns. Report a NON-retryable-pending failure so
+        //    the row is marked 'failed' (failed rows skip the in-flight
+        //    min-age guard the sweep applies to 'pending' rows).
+        //  * frame written to a relay but no OK within the window →
+        //    inconclusive; it may already be delivered, so keep it a dim,
+        //    sweep-retryable 'pending' chip (a lost OK is not proof of loss).
         final rejected = outcome.rejectedBy.isNotEmpty;
+        final reachedNoRelay =
+            outcome.acceptedBy.isEmpty &&
+            outcome.rejectedBy.isEmpty &&
+            outcome.noResponseFrom.isEmpty;
+        final String errorMsg;
+        if (rejected) {
+          errorMsg = 'Reaction rejected by relay: ${outcome.summary}';
+        } else if (reachedNoRelay) {
+          errorMsg = 'Reaction not sent: no relay reached';
+        } else {
+          errorMsg = 'Reaction recipient OK unconfirmed: ${outcome.summary}';
+        }
         Log.warning(
-          'NIP-17 reaction recipient OK '
-          '${rejected ? 'rejected' : 'unconfirmed'} '
+          'NIP-17 reaction recipient publish unconfirmed '
           '(rumor=${rumorEvent.id}, recipient=$recipientPubkey, '
           '${outcome.summary}); selfWrapPublished=$selfWrapPublished',
           category: LogCategory.system,
         );
         return NIP17SendResult.failure(
-          rejected
-              ? 'Reaction rejected by relay: ${outcome.summary}'
-              : 'Reaction recipient OK unconfirmed: ${outcome.summary}',
-          retryablePending: !rejected,
+          errorMsg,
+          retryablePending: !rejected && !reachedNoRelay,
         );
       }
 

--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -360,18 +360,38 @@ class NIP17MessageService {
                 timeout: _recipientOkConfirmTimeout,
               );
 
-        // Always publish the self-addressed wrap, even when the recipient OK
-        // is unconfirmed. The event frame may have been stored+broadcast (so
-        // the recipient already has the reaction) while the OK was lost/late
-        // on a flaky relay; skipping the self-wrap here would strand this
-        // device's own copy on reinstall / other devices. The self-wrap is
-        // p-tagged to the sender only, so publishing it on an unconfirmed
-        // recipient send never double-delivers to the counterparty.
-        final selfWrapPublished = await _publishSelfWrap(
-          nostr: nostr,
-          rumorEvent: rumorEvent,
-          prebuiltSelfWrap: prebuiltSelfWrap,
-        );
+        // Classify the outcome BEFORE deciding on the self-wrap. Three cases:
+        //  * explicit OK-false → hard rejection: the recipient definitely did
+        //    not get it.
+        //  * nothing reached any relay (offline) → the send definitively did
+        //    not happen.
+        //  * frame written to a relay but no OK within the window →
+        //    inconclusive soft-unconfirmed; it may already be delivered.
+        final rejected = outcome.rejectedBy.isNotEmpty;
+        final reachedNoRelay =
+            outcome.acceptedBy.isEmpty &&
+            outcome.rejectedBy.isEmpty &&
+            outcome.noResponseFrom.isEmpty;
+        final softUnconfirmed = !rejected && !reachedNoRelay;
+
+        // Publish the self-addressed wrap ONLY when the recipient confirmed OR
+        // the send is soft-unconfirmed (frame written, OK lost/late — the
+        // recipient may already have the reaction). On a hard rejection or an
+        // offline no-relay-reached the recipient definitely did not get it, so
+        // a self-wrap would surface a phantom reaction on the sender's other
+        // devices / reinstall (ingested via persistIncoming as a plain
+        // `received` row with no retry metadata). The self-wrap is p-tagged to
+        // the sender only, so publishing it on a soft-unconfirmed send never
+        // double-delivers to the counterparty.
+        // Short-circuit `&&`: when the gate is false the self-wrap publish is
+        // never awaited, so it is skipped entirely on rejected / reachedNoRelay.
+        final selfWrapPublished =
+            (outcome.confirmed || softUnconfirmed) &&
+            await _publishSelfWrap(
+              nostr: nostr,
+              rumorEvent: rumorEvent,
+              prebuiltSelfWrap: prebuiltSelfWrap,
+            );
 
         if (outcome.confirmed) {
           Log.info(
@@ -387,21 +407,13 @@ class NIP17MessageService {
           );
         }
 
-        // Not confirmed. Three sub-cases decide the caller's chip + retry:
-        //  * explicit OK-false → hard rejection: mark failed.
-        //  * nothing reached any relay (offline) → the send definitively did
-        //    not happen, so the sweep must re-drive it the instant
-        //    connectivity returns. Report a NON-retryable-pending failure so
-        //    the row is marked 'failed' (failed rows skip the in-flight
-        //    min-age guard the sweep applies to 'pending' rows).
-        //  * frame written to a relay but no OK within the window →
-        //    inconclusive; it may already be delivered, so keep it a dim,
-        //    sweep-retryable 'pending' chip (a lost OK is not proof of loss).
-        final rejected = outcome.rejectedBy.isNotEmpty;
-        final reachedNoRelay =
-            outcome.acceptedBy.isEmpty &&
-            outcome.rejectedBy.isEmpty &&
-            outcome.noResponseFrom.isEmpty;
+        // Not confirmed. The caller's chip + retry follow from the sub-case:
+        //  * rejected → mark failed (terminal-ish; failed rows skip the sweep's
+        //    in-flight min-age guard so they re-drive immediately).
+        //  * reachedNoRelay (offline) → mark failed so the sweep re-drives it
+        //    the instant connectivity returns.
+        //  * softUnconfirmed → keep a dim, sweep-retryable 'pending' chip
+        //    (a lost OK is not proof of loss).
         final String errorMsg;
         if (rejected) {
           errorMsg = 'Reaction rejected by relay: ${outcome.summary}';
@@ -418,7 +430,7 @@ class NIP17MessageService {
         );
         return NIP17SendResult.failure(
           errorMsg,
-          retryablePending: !rejected && !reachedNoRelay,
+          retryablePending: softUnconfirmed,
         );
       }
 

--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -253,8 +253,21 @@ class NIP17MessageService {
     return Event(_senderPublicKey, eventKind, rumorTags, content);
   }
 
+  /// OK-confirmation window for the recipient wrap when [sendRumor] runs
+  /// with `awaitRecipientOk: true` (reaction sends). Kept under the reaction
+  /// path's outer 15 s publish cap so the confirmation resolves with headroom
+  /// for the subsequent self-wrap before the caller's timeout fires.
+  static const Duration _recipientOkConfirmTimeout = Duration(seconds: 10);
+
   /// Wrap and publish a pre-built [rumorEvent] to the recipient and to
   /// ourselves (self-addressed gift wrap for cross-device recovery).
+  ///
+  /// When [awaitRecipientOk] is `true`, the recipient wrap publish requires
+  /// the relay's NIP-20 `OK true` before it counts as landed, instead of the
+  /// default frame-accept. A bare frame-accept is a false positive on a flaky
+  /// single relay — it reports success even though the relay never stored the
+  /// event — so reaction sends (which have no durable message-style retry
+  /// queue) opt in to confirmation. Message sends keep the default.
   ///
   /// Self-wrap failure is intentionally non-fatal — the message has
   /// already been delivered to the recipient at that point, and
@@ -267,6 +280,7 @@ class NIP17MessageService {
     required Event rumorEvent,
     required String recipientPubkey,
     List<String>? targetRelays,
+    bool awaitRecipientOk = false,
   }) async {
     try {
       // Send gate (#176): the lowest recipient-delivering primitive, so every
@@ -331,14 +345,30 @@ class NIP17MessageService {
       // who only read their own inbox relays actually receive it); fall
       // back to the default pool otherwise. The no-targetRelays call shape
       // is kept identical to preserve existing behavior.
-      final sentEvent = (targetRelays != null && targetRelays.isNotEmpty)
-          ? await _nostrService.publishEvent(
-              giftWrapEvent,
-              targetRelays: targetRelays,
-            )
-          : await _nostrService.publishEvent(giftWrapEvent);
+      final bool recipientPublished;
+      if (awaitRecipientOk) {
+        final outcome = (targetRelays != null && targetRelays.isNotEmpty)
+            ? await _nostrService.publishEventAwaitOk(
+                giftWrapEvent,
+                targetRelays: targetRelays,
+                timeout: _recipientOkConfirmTimeout,
+              )
+            : await _nostrService.publishEventAwaitOk(
+                giftWrapEvent,
+                timeout: _recipientOkConfirmTimeout,
+              );
+        recipientPublished = outcome.confirmed;
+      } else {
+        final sentEvent = (targetRelays != null && targetRelays.isNotEmpty)
+            ? await _nostrService.publishEvent(
+                giftWrapEvent,
+                targetRelays: targetRelays,
+              )
+            : await _nostrService.publishEvent(giftWrapEvent);
+        recipientPublished = sentEvent is PublishSuccess;
+      }
 
-      if (sentEvent is! PublishSuccess) {
+      if (!recipientPublished) {
         const errorMsg = 'Message publish failed to relays';
         Log.error(
           '$errorMsg (rumor=${rumorEvent.id}, recipient=$recipientPubkey)',

--- a/mobile/packages/dm_repository/test/src/dm_reactions_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_reactions_repository_test.dart
@@ -800,7 +800,7 @@ void main() {
     });
 
     test(
-      'removeOwn soft-deletes locally and publishes wrapped kind 5',
+      'removeOwn durably records the kind-5 deletion and publishes it',
       () async {
         final deletionRumor = reactionRumor(
           id: _giftWrapId,
@@ -812,11 +812,12 @@ void main() {
           ],
         );
         when(
-          () => mockDao.softDelete(
+          () => mockDao.markOwnDeletionPending(
             id: _reactionRumorId,
             ownerPubkey: _ownerPubkey,
+            deletionRumorJson: any(named: 'deletionRumorJson'),
           ),
-        ).thenAnswer((_) async => 1);
+        ).thenAnswer((_) async {});
         when(
           () => mockMessageService.buildRumor(
             recipientPubkey: _otherPubkey,
@@ -825,25 +826,29 @@ void main() {
             additionalTags: any(named: 'additionalTags'),
           ),
         ).thenReturn(deletionRumor);
+        // Publish fails (e.g. offline) — the durable row stays pending for the
+        // sweep, so markDeletionSent must NOT be called.
         when(
           () => mockMessageService.sendRumor(
             rumorEvent: deletionRumor,
             recipientPubkey: _otherPubkey,
             awaitRecipientOk: any(named: 'awaitRecipientOk'),
           ),
-        ).thenAnswer((_) async => const NIP17SendResult.failure('ignored'));
+        ).thenAnswer((_) async => const NIP17SendResult.failure('offline'));
 
         final repository = createRepository();
         await repository.removeOwn(
           rumorId: _reactionRumorId,
           targetMessageAuthor: _otherPubkey,
         );
+        // _driveDeletion fires via unawaited; let it run.
         await Future<void>.delayed(Duration.zero);
 
         verify(
-          () => mockDao.softDelete(
+          () => mockDao.markOwnDeletionPending(
             id: _reactionRumorId,
             ownerPubkey: _ownerPubkey,
+            deletionRumorJson: any(named: 'deletionRumorJson'),
           ),
         ).called(1);
         verify(
@@ -853,8 +858,108 @@ void main() {
             awaitRecipientOk: any(named: 'awaitRecipientOk'),
           ),
         ).called(1);
+        verifyNever(
+          () => mockDao.markDeletionSent(
+            id: any(named: 'id'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        );
       },
     );
+
+    test(
+      'retryableDeletions projects pending own deletions from the dao',
+      () async {
+        when(
+          () => mockDao.getRetryableOwnDeletions(ownerPubkey: _ownerPubkey),
+        ).thenAnswer(
+          (_) async => [
+            makeRow(
+              isDeleted: true,
+              publishStatus: 'deletion_pending',
+              rumorEventJson: '{}',
+            ),
+          ],
+        );
+
+        final repository = createRepository();
+        final targets = await repository.retryableDeletions();
+
+        expect(targets, hasLength(1));
+        expect(targets.first.rumorId, _reactionRumorId);
+        expect(targets.first.targetMessageAuthor, _otherPubkey);
+      },
+    );
+
+    test(
+      'retryDeletion replays the stored kind-5 and marks it sent on success',
+      () async {
+        final deletionRumor = reactionRumor(
+          id: _giftWrapId,
+          content: '',
+          kind: EventKind.eventDeletion,
+          tags: [
+            ['e', _reactionRumorId],
+            ['k', EventKind.reaction.toString()],
+          ],
+        );
+        when(
+          () =>
+              mockDao.getById(id: _reactionRumorId, ownerPubkey: _ownerPubkey),
+        ).thenAnswer(
+          (_) async => makeRow(
+            isDeleted: true,
+            publishStatus: 'deletion_pending',
+            rumorEventJson: jsonEncode(deletionRumor.toJson()),
+          ),
+        );
+        when(
+          () => mockMessageService.sendRumor(
+            rumorEvent: any(named: 'rumorEvent'),
+            recipientPubkey: _otherPubkey,
+            awaitRecipientOk: any(named: 'awaitRecipientOk'),
+          ),
+        ).thenAnswer(
+          (_) async => NIP17SendResult.success(
+            rumorEventId: deletionRumor.id,
+            messageEventId: _giftWrapId,
+            recipientPubkey: _otherPubkey,
+          ),
+        );
+        when(
+          () => mockDao.markDeletionSent(
+            id: _reactionRumorId,
+            ownerPubkey: _ownerPubkey,
+          ),
+        ).thenAnswer((_) async {});
+
+        final repository = createRepository();
+        final result = await repository.retryDeletion(
+          rumorId: _reactionRumorId,
+          targetMessageAuthor: _otherPubkey,
+        );
+
+        expect(result.success, isTrue);
+        verify(
+          () => mockDao.markDeletionSent(
+            id: _reactionRumorId,
+            ownerPubkey: _ownerPubkey,
+          ),
+        ).called(1);
+      },
+    );
+
+    test('retryDeletion fails when no stored deletion exists', () async {
+      // getById default stub returns null → nothing to replay.
+      final repository = createRepository();
+      final result = await repository.retryDeletion(
+        rumorId: _reactionRumorId,
+        targetMessageAuthor: _otherPubkey,
+      );
+
+      expect(result.success, isFalse);
+      expect(result.errorMessage, contains('No stored deletion'));
+    });
 
     test('persistIncoming validates event shape before upsert', () async {
       final repository = createRepository();

--- a/mobile/packages/dm_repository/test/src/dm_reactions_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_reactions_repository_test.dart
@@ -501,6 +501,68 @@ void main() {
     });
 
     test(
+      'publish contains a thrown send: marks failed and surfaces the error '
+      'instead of leaking the exception',
+      () async {
+        final rumor = reactionRumor();
+        when(
+          () => mockMessageService.buildRumor(
+            recipientPubkey: _otherPubkey,
+            content: '🔥',
+            eventKind: EventKind.reaction,
+            additionalTags: any(named: 'additionalTags'),
+          ),
+        ).thenReturn(rumor);
+        when(
+          () => mockDao.insertOwnReactionSuperseding(
+            placeholderId: rumor.id,
+            conversationId: _conversationId,
+            targetMessageId: _targetMessageId,
+            targetMessageAuthor: _otherPubkey,
+            reactorPubkey: _ownerPubkey,
+            emoji: '🔥',
+            createdAt: rumor.createdAt,
+            ownerPubkey: _ownerPubkey,
+            rumorEventJson: jsonEncode(rumor.toJson()),
+          ),
+        ).thenAnswer((_) async => <String>[]);
+        // A thrown send (not a returned NIP17SendFailure) must still flip the
+        // chip to 'failed' and surface the error — the outer catch must never
+        // let the exception escape to the caller.
+        when(
+          () => mockMessageService.sendRumor(
+            rumorEvent: rumor,
+            recipientPubkey: _otherPubkey,
+            awaitRecipientOk: any(named: 'awaitRecipientOk'),
+          ),
+        ).thenThrow(StateError('socket boom'));
+        when(
+          () => mockDao.markFailed(
+            placeholderId: rumor.id,
+            ownerPubkey: _ownerPubkey,
+          ),
+        ).thenAnswer((_) async {});
+
+        final repository = createRepository();
+        final result = await repository.publish(
+          conversationId: _conversationId,
+          targetMessageId: _targetMessageId,
+          targetMessageAuthor: _otherPubkey,
+          emoji: '🔥',
+        );
+
+        expect(result.success, isFalse);
+        expect(result.errorMessage, contains('socket boom'));
+        verify(
+          () => mockDao.markFailed(
+            placeholderId: rumor.id,
+            ownerPubkey: _ownerPubkey,
+          ),
+        ).called(1);
+      },
+    );
+
+    test(
       'publish keeps the row pending (not failed) on an unconfirmed send',
       () async {
         final rumor = reactionRumor();

--- a/mobile/packages/dm_repository/test/src/dm_reactions_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_reactions_repository_test.dart
@@ -302,6 +302,7 @@ void main() {
           () => mockMessageService.sendRumor(
             rumorEvent: rumor,
             recipientPubkey: _otherPubkey,
+            awaitRecipientOk: any(named: 'awaitRecipientOk'),
           ),
         ).thenAnswer(
           (_) async => NIP17SendResult.success(
@@ -345,6 +346,15 @@ void main() {
             placeholderId: rumor.id,
             realRumorId: rumor.id,
             ownerPubkey: _ownerPubkey,
+          ),
+        ).called(1);
+        // The reaction send opts into NIP-20 OK-confirmation so a flaky
+        // relay's frame-accept false positive can't mark it delivered.
+        verify(
+          () => mockMessageService.sendRumor(
+            rumorEvent: rumor,
+            recipientPubkey: _otherPubkey,
+            awaitRecipientOk: true,
           ),
         ).called(1);
       },
@@ -398,6 +408,7 @@ void main() {
           () => mockMessageService.sendRumor(
             rumorEvent: any(named: 'rumorEvent'),
             recipientPubkey: any(named: 'recipientPubkey'),
+            awaitRecipientOk: any(named: 'awaitRecipientOk'),
           ),
         ).thenAnswer(
           (_) async => NIP17SendResult.success(
@@ -429,6 +440,7 @@ void main() {
           () => mockMessageService.sendRumor(
             rumorEvent: deletionRumor,
             recipientPubkey: any(named: 'recipientPubkey'),
+            awaitRecipientOk: any(named: 'awaitRecipientOk'),
           ),
         ).called(1);
       },
@@ -461,6 +473,7 @@ void main() {
         () => mockMessageService.sendRumor(
           rumorEvent: rumor,
           recipientPubkey: _otherPubkey,
+          awaitRecipientOk: any(named: 'awaitRecipientOk'),
         ),
       ).thenAnswer((_) async => const NIP17SendResult.failure('relay down'));
       when(
@@ -538,6 +551,7 @@ void main() {
         () => mockMessageService.sendRumor(
           rumorEvent: any(named: 'rumorEvent'),
           recipientPubkey: _otherPubkey,
+          awaitRecipientOk: any(named: 'awaitRecipientOk'),
         ),
       ).thenAnswer(
         (_) async => NIP17SendResult.success(
@@ -603,6 +617,7 @@ void main() {
         () => mockMessageService.sendRumor(
           rumorEvent: any(named: 'rumorEvent'),
           recipientPubkey: _otherPubkey,
+          awaitRecipientOk: any(named: 'awaitRecipientOk'),
         ),
       ).thenAnswer((_) async => const NIP17SendResult.failure('relay down'));
       when(
@@ -626,6 +641,53 @@ void main() {
           ownerPubkey: _ownerPubkey,
         ),
       ).called(1);
+    });
+
+    test(
+      'retryableReactions projects failed and pending own reactions from '
+      'the dao',
+      () async {
+        when(
+          () => mockDao.getRetryableOwnReactions(ownerPubkey: _ownerPubkey),
+        ).thenAnswer(
+          (_) async => [
+            makeRow(
+              publishStatus: 'failed',
+              rumorEventJson: '{}',
+              createdAt: 1_700_000_100,
+            ),
+            makeRow(
+              id: _giftWrapId,
+              publishStatus: 'pending',
+              rumorEventJson: '{}',
+              createdAt: 1_700_000_200,
+            ),
+          ],
+        );
+
+        final repository = createRepository();
+        final targets = await repository.retryableReactions();
+
+        expect(targets, hasLength(2));
+        expect(targets.first.rumorId, _reactionRumorId);
+        expect(targets.first.targetMessageAuthor, _otherPubkey);
+        expect(targets.first.publishStatus, 'failed');
+        expect(targets.first.createdAt, 1_700_000_100);
+        expect(targets.last.publishStatus, 'pending');
+      },
+    );
+
+    test('retryableReactions returns empty when uninitialized', () async {
+      final repository = createRepository(initialized: false);
+
+      final targets = await repository.retryableReactions();
+
+      expect(targets, isEmpty);
+      verifyNever(
+        () => mockDao.getRetryableOwnReactions(
+          ownerPubkey: any(named: 'ownerPubkey'),
+        ),
+      );
     });
 
     test(
@@ -658,6 +720,7 @@ void main() {
           () => mockMessageService.sendRumor(
             rumorEvent: deletionRumor,
             recipientPubkey: _otherPubkey,
+            awaitRecipientOk: any(named: 'awaitRecipientOk'),
           ),
         ).thenAnswer((_) async => const NIP17SendResult.failure('ignored'));
 
@@ -678,6 +741,7 @@ void main() {
           () => mockMessageService.sendRumor(
             rumorEvent: deletionRumor,
             recipientPubkey: _otherPubkey,
+            awaitRecipientOk: any(named: 'awaitRecipientOk'),
           ),
         ).called(1);
       },
@@ -1026,6 +1090,7 @@ void main() {
             () => mockMessageService.sendRumor(
               rumorEvent: any(named: 'rumorEvent'),
               recipientPubkey: any(named: 'recipientPubkey'),
+              awaitRecipientOk: any(named: 'awaitRecipientOk'),
             ),
           ).thenAnswer(
             (_) async => NIP17SendResult.success(
@@ -1058,12 +1123,14 @@ void main() {
             () => mockMessageService.sendRumor(
               rumorEvent: any(named: 'rumorEvent'),
               recipientPubkey: _otherPubkey,
+              awaitRecipientOk: any(named: 'awaitRecipientOk'),
             ),
           ).called(1);
           verify(
             () => mockMessageService.sendRumor(
               rumorEvent: any(named: 'rumorEvent'),
               recipientPubkey: thirdPubkey,
+              awaitRecipientOk: any(named: 'awaitRecipientOk'),
             ),
           ).called(1);
         },

--- a/mobile/packages/dm_repository/test/src/dm_reactions_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_reactions_repository_test.dart
@@ -361,7 +361,9 @@ void main() {
     );
 
     test(
-      'publish supersedes a prior reaction and emits a kind-5 deletion for it',
+      'publish supersedes a prior reaction DURABLY: records a '
+      'deletion_pending row for it and OK-confirms the kind-5, so a '
+      'flaky/offline relay can no longer strand the old emoji',
       () async {
         const priorReactionId =
             '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef';
@@ -405,6 +407,19 @@ void main() {
           ),
         ).thenReturn(deletionRumor);
         when(
+          () => mockDao.markOwnDeletionPending(
+            id: any(named: 'id'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+            deletionRumorJson: any(named: 'deletionRumorJson'),
+          ),
+        ).thenAnswer((_) async {});
+        when(
+          () => mockDao.markDeletionSent(
+            id: any(named: 'id'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer((_) async {});
+        when(
           () => mockMessageService.sendRumor(
             rumorEvent: any(named: 'rumorEvent'),
             recipientPubkey: any(named: 'recipientPubkey'),
@@ -432,15 +447,34 @@ void main() {
           targetMessageAuthor: _otherPubkey,
           emoji: '🔥',
         );
-        // _publishKind5Deletion fires via unawaited; let it run.
+        // The kind-5 drive fires via unawaited; let it run.
         await Future<void>.delayed(Duration.zero);
 
         expect(result.success, isTrue);
+        // The superseded emoji's removal is recorded as a durable
+        // deletion_pending row (the retry sweep's recovery hook), storing the
+        // exact kind-5 rumor keyed by the prior reaction id.
+        verify(
+          () => mockDao.markOwnDeletionPending(
+            id: priorReactionId,
+            ownerPubkey: _ownerPubkey,
+            deletionRumorJson: jsonEncode(deletionRumor.toJson()),
+          ),
+        ).called(1);
+        // The kind-5 now OK-confirms (durable path), not best-effort
+        // frame-accept.
         verify(
           () => mockMessageService.sendRumor(
             rumorEvent: deletionRumor,
             recipientPubkey: any(named: 'recipientPubkey'),
-            awaitRecipientOk: any(named: 'awaitRecipientOk'),
+            awaitRecipientOk: true,
+          ),
+        ).called(1);
+        // Confirmed delivery clears the pending marker to terminal.
+        verify(
+          () => mockDao.markDeletionSent(
+            id: priorReactionId,
+            ownerPubkey: _ownerPubkey,
           ),
         ).called(1);
       },
@@ -499,6 +533,73 @@ void main() {
         ),
       ).called(1);
     });
+
+    test(
+      'publish marks BLOCKED (terminal, non-retryable) when the send policy '
+      'refuses the recipient — never failed/pending, so the retry sweep and '
+      'a chip re-tap both leave it alone',
+      () async {
+        final rumor = reactionRumor();
+        when(
+          () => mockMessageService.buildRumor(
+            recipientPubkey: _otherPubkey,
+            content: '🔥',
+            eventKind: EventKind.reaction,
+            additionalTags: any(named: 'additionalTags'),
+          ),
+        ).thenReturn(rumor);
+        when(
+          () => mockDao.insertOwnReactionSuperseding(
+            placeholderId: rumor.id,
+            conversationId: _conversationId,
+            targetMessageId: _targetMessageId,
+            targetMessageAuthor: _otherPubkey,
+            reactorPubkey: _ownerPubkey,
+            emoji: '🔥',
+            createdAt: rumor.createdAt,
+            ownerPubkey: _ownerPubkey,
+            rumorEventJson: jsonEncode(rumor.toJson()),
+          ),
+        ).thenAnswer((_) async => <String>[]);
+        when(
+          () => mockMessageService.sendRumor(
+            rumorEvent: rumor,
+            recipientPubkey: _otherPubkey,
+            awaitRecipientOk: any(named: 'awaitRecipientOk'),
+          ),
+        ).thenAnswer(
+          (_) async => const NIP17SendResult.blocked('policy refused'),
+        );
+        when(
+          () => mockDao.markBlocked(id: rumor.id, ownerPubkey: _ownerPubkey),
+        ).thenAnswer((_) async {});
+
+        final repository = createRepository();
+        final result = await repository.publish(
+          conversationId: _conversationId,
+          targetMessageId: _targetMessageId,
+          targetMessageAuthor: _otherPubkey,
+          emoji: '🔥',
+        );
+
+        expect(result.success, isFalse);
+        verify(
+          () => mockDao.markBlocked(id: rumor.id, ownerPubkey: _ownerPubkey),
+        ).called(1);
+        verifyNever(
+          () => mockDao.markFailed(
+            placeholderId: any(named: 'placeholderId'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        );
+        verifyNever(
+          () => mockDao.markPending(
+            id: any(named: 'id'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        );
+      },
+    );
 
     test(
       'publish contains a thrown send: marks failed and surfaces the error '
@@ -1011,6 +1112,64 @@ void main() {
       },
     );
 
+    test(
+      'retryDeletion TERMINALIZES a policy-blocked removal instead of looping '
+      "— a blocked recipient can't receive the kind-5 and never had the "
+      'reaction, so the sweep must stop re-driving it',
+      () async {
+        final deletionRumor = reactionRumor(
+          id: _giftWrapId,
+          content: '',
+          kind: EventKind.eventDeletion,
+          tags: [
+            ['e', _reactionRumorId],
+            ['k', EventKind.reaction.toString()],
+          ],
+        );
+        when(
+          () =>
+              mockDao.getById(id: _reactionRumorId, ownerPubkey: _ownerPubkey),
+        ).thenAnswer(
+          (_) async => makeRow(
+            isDeleted: true,
+            publishStatus: 'deletion_pending',
+            rumorEventJson: jsonEncode(deletionRumor.toJson()),
+          ),
+        );
+        when(
+          () => mockMessageService.sendRumor(
+            rumorEvent: any(named: 'rumorEvent'),
+            recipientPubkey: _otherPubkey,
+            awaitRecipientOk: any(named: 'awaitRecipientOk'),
+          ),
+        ).thenAnswer(
+          (_) async => const NIP17SendResult.blocked('policy refused'),
+        );
+        when(
+          () => mockDao.markDeletionSent(
+            id: _reactionRumorId,
+            ownerPubkey: _ownerPubkey,
+          ),
+        ).thenAnswer((_) async {});
+
+        final repository = createRepository();
+        final result = await repository.retryDeletion(
+          rumorId: _reactionRumorId,
+          targetMessageAuthor: _otherPubkey,
+        );
+
+        // Terminal — the sweep drops it from tracking (success) and the row
+        // leaves the retryable-deletion set.
+        expect(result.success, isTrue);
+        verify(
+          () => mockDao.markDeletionSent(
+            id: _reactionRumorId,
+            ownerPubkey: _ownerPubkey,
+          ),
+        ).called(1);
+      },
+    );
+
     test('retryDeletion fails when no stored deletion exists', () async {
       // getById default stub returns null → nothing to replay.
       final repository = createRepository();
@@ -1505,6 +1664,120 @@ void main() {
               rumorEvent: any(named: 'rumorEvent'),
               recipientPubkey: thirdPubkey,
               awaitRecipientOk: any(named: 'awaitRecipientOk'),
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
+        'publish does NOT mark a group reaction sent on PARTIAL fan-out — one '
+        'member confirming while another fails must stay retryable, never '
+        'swapped to sent (which would clear the rumor and strand the miss)',
+        () async {
+          final mockConversationsDao = _MockConversationsDao();
+          when(
+            () => mockConversationsDao.getConversation(
+              groupConversationId,
+              ownerPubkey: _ownerPubkey,
+            ),
+          ).thenAnswer(
+            (_) async => ConversationRow(
+              id: groupConversationId,
+              participantPubkeys: jsonEncode([
+                _ownerPubkey,
+                _otherPubkey,
+                thirdPubkey,
+              ]),
+              isGroup: true,
+              isRead: true,
+              currentUserHasSent: true,
+              createdAt: 1700000000,
+              ownerPubkey: _ownerPubkey,
+            ),
+          );
+          final rumor = reactionRumor();
+          when(
+            () => mockMessageService.buildRumor(
+              recipientPubkey: _otherPubkey,
+              content: '🔥',
+              eventKind: EventKind.reaction,
+              additionalTags: any(named: 'additionalTags'),
+            ),
+          ).thenReturn(rumor);
+          when(
+            () => mockDao.insertOwnReactionSuperseding(
+              placeholderId: any(named: 'placeholderId'),
+              conversationId: any(named: 'conversationId'),
+              targetMessageId: any(named: 'targetMessageId'),
+              targetMessageAuthor: any(named: 'targetMessageAuthor'),
+              reactorPubkey: any(named: 'reactorPubkey'),
+              emoji: any(named: 'emoji'),
+              createdAt: any(named: 'createdAt'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              rumorEventJson: any(named: 'rumorEventJson'),
+            ),
+          ).thenAnswer((_) async => <String>[]);
+          // Member A confirms; member B hard-fails.
+          when(
+            () => mockMessageService.sendRumor(
+              rumorEvent: any(named: 'rumorEvent'),
+              recipientPubkey: _otherPubkey,
+              awaitRecipientOk: any(named: 'awaitRecipientOk'),
+            ),
+          ).thenAnswer(
+            (_) async => NIP17SendResult.success(
+              rumorEventId: rumor.id,
+              messageEventId: _giftWrapId,
+              recipientPubkey: _otherPubkey,
+            ),
+          );
+          when(
+            () => mockMessageService.sendRumor(
+              rumorEvent: any(named: 'rumorEvent'),
+              recipientPubkey: thirdPubkey,
+              awaitRecipientOk: any(named: 'awaitRecipientOk'),
+            ),
+          ).thenAnswer(
+            (_) async => const NIP17SendResult.failure('relay down'),
+          );
+          when(
+            () => mockDao.markFailed(
+              placeholderId: any(named: 'placeholderId'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) async {});
+
+          final repository = createRepository(
+            conversationsDao: mockConversationsDao,
+          );
+          final result = await repository.publish(
+            conversationId: groupConversationId,
+            targetMessageId: _targetMessageId,
+            targetMessageAuthor: _otherPubkey,
+            emoji: '🔥',
+          );
+
+          expect(
+            result.success,
+            isFalse,
+            reason: 'A partial fan-out is not a delivered reaction.',
+          );
+          // The critical invariant: the row must NOT be swapped to `sent`, or
+          // swapPlaceholderId would clear rumor_event_json and the missed
+          // member could never be re-driven.
+          verifyNever(
+            () => mockDao.swapPlaceholderId(
+              placeholderId: any(named: 'placeholderId'),
+              realRumorId: any(named: 'realRumorId'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          );
+          // Hard-failed member → the whole reaction is failed (kept
+          // retryable), so the sweep re-drives the full rumor.
+          verify(
+            () => mockDao.markFailed(
+              placeholderId: rumor.id,
+              ownerPubkey: _ownerPubkey,
             ),
           ).called(1);
         },

--- a/mobile/packages/dm_repository/test/src/dm_reactions_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_reactions_repository_test.dart
@@ -500,6 +500,73 @@ void main() {
       ).called(1);
     });
 
+    test(
+      'publish keeps the row pending (not failed) on an unconfirmed send',
+      () async {
+        final rumor = reactionRumor();
+        when(
+          () => mockMessageService.buildRumor(
+            recipientPubkey: _otherPubkey,
+            content: '🔥',
+            eventKind: EventKind.reaction,
+            additionalTags: any(named: 'additionalTags'),
+          ),
+        ).thenReturn(rumor);
+        when(
+          () => mockDao.insertOwnReactionSuperseding(
+            placeholderId: rumor.id,
+            conversationId: _conversationId,
+            targetMessageId: _targetMessageId,
+            targetMessageAuthor: _otherPubkey,
+            reactorPubkey: _ownerPubkey,
+            emoji: '🔥',
+            createdAt: rumor.createdAt,
+            ownerPubkey: _ownerPubkey,
+            rumorEventJson: jsonEncode(rumor.toJson()),
+          ),
+        ).thenAnswer((_) async => <String>[]);
+        // Frame written, no relay OK within the window (no explicit rejection).
+        when(
+          () => mockMessageService.sendRumor(
+            rumorEvent: rumor,
+            recipientPubkey: _otherPubkey,
+            awaitRecipientOk: any(named: 'awaitRecipientOk'),
+          ),
+        ).thenAnswer(
+          (_) async => const NIP17SendResult.failure(
+            'unconfirmed',
+            retryablePending: true,
+          ),
+        );
+        when(
+          () => mockDao.markPending(id: rumor.id, ownerPubkey: _ownerPubkey),
+        ).thenAnswer((_) async {});
+
+        final repository = createRepository();
+        final result = await repository.publish(
+          conversationId: _conversationId,
+          targetMessageId: _targetMessageId,
+          targetMessageAuthor: _otherPubkey,
+          emoji: '🔥',
+        );
+
+        expect(result.success, isFalse);
+        // A durable row exists, so the cubit keeps the chip; and an unconfirmed
+        // send is not proof of loss, so keep it pending+retryable — never the
+        // red 'failed' state a re-tap could delete.
+        expect(result.optimisticInsertSucceeded, isTrue);
+        verify(
+          () => mockDao.markPending(id: rumor.id, ownerPubkey: _ownerPubkey),
+        ).called(1);
+        verifyNever(
+          () => mockDao.markFailed(
+            placeholderId: any(named: 'placeholderId'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        );
+      },
+    );
+
     test('publish reports optimistic insert failures', () async {
       final rumor = reactionRumor();
       when(
@@ -642,6 +709,48 @@ void main() {
         ),
       ).called(1);
     });
+
+    test(
+      'retry leaves the row pending (does not mark failed) on an unconfirmed '
+      'send',
+      () async {
+        final rumor = reactionRumor();
+        when(
+          () => mockDao.getRumorJson(id: rumor.id, ownerPubkey: _ownerPubkey),
+        ).thenAnswer((_) async => jsonEncode(rumor.toJson()));
+        when(
+          () => mockDao.markPending(id: rumor.id, ownerPubkey: _ownerPubkey),
+        ).thenAnswer((_) async {});
+        when(
+          () => mockMessageService.sendRumor(
+            rumorEvent: any(named: 'rumorEvent'),
+            recipientPubkey: _otherPubkey,
+            awaitRecipientOk: any(named: 'awaitRecipientOk'),
+          ),
+        ).thenAnswer(
+          (_) async => const NIP17SendResult.failure(
+            'unconfirmed',
+            retryablePending: true,
+          ),
+        );
+
+        final repository = createRepository();
+        final result = await repository.retry(
+          rumorId: rumor.id,
+          targetMessageAuthor: _otherPubkey,
+        );
+
+        // The pre-send markPending stands; an unconfirmed retry must not flip
+        // the row to 'failed' (the sweep keeps re-driving it).
+        expect(result.success, isFalse);
+        verifyNever(
+          () => mockDao.markFailed(
+            placeholderId: any(named: 'placeholderId'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        );
+      },
+    );
 
     test(
       'retryableReactions projects failed and pending own reactions from '
@@ -1030,6 +1139,104 @@ void main() {
           contains(
             DmReactionsRepositoryReportableSites
                 .handleIncomingDeletionSoftDelete,
+          ),
+        );
+      },
+    );
+
+    test(
+      'publish addresses the wrap to the counterparty (not self) when '
+      'reacting to your OWN message in a 1:1',
+      () async {
+        const oneToOneConversationId =
+            'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+        final mockConversationsDao = _MockConversationsDao();
+        when(
+          () => mockConversationsDao.getConversation(
+            oneToOneConversationId,
+            ownerPubkey: _ownerPubkey,
+          ),
+        ).thenAnswer(
+          (_) async => ConversationRow(
+            id: oneToOneConversationId,
+            participantPubkeys: jsonEncode([_ownerPubkey, _otherPubkey]),
+            isGroup: false,
+            isRead: true,
+            currentUserHasSent: true,
+            createdAt: 1700000000,
+            ownerPubkey: _ownerPubkey,
+          ),
+        );
+        // Reacting to our OWN sent message: the target author is us.
+        final rumor = reactionRumor();
+        when(
+          () => mockMessageService.buildRumor(
+            recipientPubkey: _ownerPubkey,
+            content: '🔥',
+            eventKind: EventKind.reaction,
+            additionalTags: any(named: 'additionalTags'),
+          ),
+        ).thenReturn(rumor);
+        when(
+          () => mockDao.insertOwnReactionSuperseding(
+            placeholderId: any(named: 'placeholderId'),
+            conversationId: any(named: 'conversationId'),
+            targetMessageId: any(named: 'targetMessageId'),
+            targetMessageAuthor: any(named: 'targetMessageAuthor'),
+            reactorPubkey: any(named: 'reactorPubkey'),
+            emoji: any(named: 'emoji'),
+            createdAt: any(named: 'createdAt'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+            rumorEventJson: any(named: 'rumorEventJson'),
+          ),
+        ).thenAnswer((_) async => <String>[]);
+        when(
+          () => mockMessageService.sendRumor(
+            rumorEvent: any(named: 'rumorEvent'),
+            recipientPubkey: any(named: 'recipientPubkey'),
+            awaitRecipientOk: any(named: 'awaitRecipientOk'),
+          ),
+        ).thenAnswer(
+          (_) async => NIP17SendResult.success(
+            rumorEventId: rumor.id,
+            messageEventId: _giftWrapId,
+            recipientPubkey: _otherPubkey,
+          ),
+        );
+        when(
+          () => mockDao.swapPlaceholderId(
+            placeholderId: any(named: 'placeholderId'),
+            realRumorId: any(named: 'realRumorId'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer((_) async {});
+
+        final repository = createRepository(
+          conversationsDao: mockConversationsDao,
+        );
+        final result = await repository.publish(
+          conversationId: oneToOneConversationId,
+          targetMessageId: _targetMessageId,
+          targetMessageAuthor: _ownerPubkey, // our own message
+          emoji: '🔥',
+        );
+
+        expect(result.success, isTrue);
+        // The reaction wrap must reach the OTHER participant, never only self
+        // — otherwise a reaction on a message the reactor authored is never
+        // delivered to the counterparty.
+        verify(
+          () => mockMessageService.sendRumor(
+            rumorEvent: any(named: 'rumorEvent'),
+            recipientPubkey: _otherPubkey,
+            awaitRecipientOk: any(named: 'awaitRecipientOk'),
+          ),
+        ).called(1);
+        verifyNever(
+          () => mockMessageService.sendRumor(
+            rumorEvent: any(named: 'rumorEvent'),
+            recipientPubkey: _ownerPubkey,
+            awaitRecipientOk: any(named: 'awaitRecipientOk'),
           ),
         );
       },

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -5,11 +5,13 @@
 import 'package:dm_repository/dm_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart' show NIP17SendResult;
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/client_utils/keys.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/event_kind.dart';
 import 'package:nostr_sdk/nip59/gift_wrap_util.dart';
+import 'package:nostr_sdk/relay/publish_outcome.dart';
 import 'package:nostr_sdk/signer/isolate_decrypt_signer.dart';
 import 'package:nostr_sdk/signer/local_nostr_signer.dart';
 import 'package:nostr_sdk/signer/nostr_signer.dart';
@@ -82,6 +84,7 @@ const _recipientPubkey =
 void main() {
   setUpAll(() {
     registerFallbackValue(_FakeEvent());
+    registerFallbackValue(Duration.zero);
   });
 
   group(NIP17MessageService, () {
@@ -201,6 +204,98 @@ void main() {
           // follows with no targetRelays).
           expect(captured, isNotEmpty);
           expect(captured.first, const ['wss://inbox.example.com']);
+        },
+      );
+    });
+
+    group('sendRumor awaitRecipientOk (reaction OK-confirm path)', () {
+      late NIP17MessageService okService;
+
+      setUp(() {
+        // Real curve self key so the self-addressed wrap actually builds and
+        // reaches publishEvent (the module-level placeholder key does not).
+        okService = NIP17MessageService(
+          signer: LocalNostrSigner(_testPrivateKey),
+          senderPublicKey: getPublicKey(_testPrivateKey),
+          nostrService: mockNostrClient,
+        );
+      });
+
+      PublishOutcome outcome({
+        List<String> accepted = const [],
+        Map<String, String> rejected = const {},
+        List<String> noResponse = const [],
+      }) => PublishOutcome(
+        eventId: 'gift-wrap-id',
+        acceptedBy: accepted,
+        rejectedBy: rejected,
+        noResponseFrom: noResponse,
+      );
+
+      Future<(NIP17SendResult result, int selfWraps)> sendReaction(
+        PublishOutcome recipient,
+      ) async {
+        when(
+          () => mockNostrClient.publishEventAwaitOk(
+            any(),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer((_) async => recipient);
+        var selfWrapPublishes = 0;
+        when(() => mockNostrClient.publishEvent(any())).thenAnswer((inv) async {
+          selfWrapPublishes++;
+          return PublishSuccess(event: inv.positionalArguments[0] as Event);
+        });
+        final rumor = okService.buildRumor(
+          recipientPubkey: _recipientPubkey,
+          content: '🔥',
+          eventKind: EventKind.reaction,
+        );
+        final result = await okService.sendRumor(
+          rumorEvent: rumor,
+          recipientPubkey: _recipientPubkey,
+          awaitRecipientOk: true,
+        );
+        return (result, selfWrapPublishes);
+      }
+
+      test('confirmed OK → success; self-wrap published', () async {
+        final (result, selfWraps) = await sendReaction(
+          outcome(accepted: const ['wss://relay.example.com']),
+        );
+
+        expect(result.success, isTrue);
+        expect(result.retryablePending, isFalse);
+        expect(result.selfWrapPublished, isTrue);
+        expect(selfWraps, 1);
+      });
+
+      test(
+        'unconfirmed (frame written, no OK) → retryable-pending failure; '
+        'self-wrap still published',
+        () async {
+          final (result, selfWraps) = await sendReaction(
+            outcome(noResponse: const ['wss://relay.example.com']),
+          );
+
+          expect(result.success, isFalse);
+          expect(result.retryablePending, isTrue);
+          // Own-device durability must NOT hinge on the recipient's OK.
+          expect(selfWraps, 1);
+        },
+      );
+
+      test(
+        'explicit OK-false rejection → hard failure (not retryable-pending); '
+        'self-wrap still published',
+        () async {
+          final (result, selfWraps) = await sendReaction(
+            outcome(rejected: const {'wss://relay.example.com': 'blocked'}),
+          );
+
+          expect(result.success, isFalse);
+          expect(result.retryablePending, isFalse);
+          expect(selfWraps, 1);
         },
       );
     });

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -298,6 +298,21 @@ void main() {
           expect(selfWraps, 1);
         },
       );
+
+      test(
+        'offline (nothing reached any relay) → non-retryable-pending failure '
+        'so the sweep re-drives it immediately; self-wrap still published',
+        () async {
+          // Empty accepted/rejected/noResponse == nothing was sent anywhere.
+          final (result, selfWraps) = await sendReaction(outcome());
+
+          expect(result.success, isFalse);
+          // Marked failed (not dim pending) so the reconnect sweep re-sends it
+          // without the in-flight min-age guard holding it back.
+          expect(result.retryablePending, isFalse);
+          expect(selfWraps, 1);
+        },
+      );
     });
 
     group('publishSelfApplicationMarker (#4977)', () {

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -287,7 +287,7 @@ void main() {
 
       test(
         'explicit OK-false rejection → hard failure (not retryable-pending); '
-        'self-wrap still published',
+        'self-wrap NOT published (recipient definitely did not get it)',
         () async {
           final (result, selfWraps) = await sendReaction(
             outcome(rejected: const {'wss://relay.example.com': 'blocked'}),
@@ -295,13 +295,23 @@ void main() {
 
           expect(result.success, isFalse);
           expect(result.retryablePending, isFalse);
-          expect(selfWraps, 1);
+          // A hard rejection means the recipient never got the reaction.
+          // Publishing the self-wrap anyway would surface a phantom reaction
+          // on the sender's other devices (ingested as a plain `received` row
+          // with no retry metadata), so it must be skipped.
+          expect(
+            selfWraps,
+            0,
+            reason:
+                'Self-wrap on a rejected send creates a phantom reaction '
+                'the recipient never received.',
+          );
         },
       );
 
       test(
         'offline (nothing reached any relay) → non-retryable-pending failure '
-        'so the sweep re-drives it immediately; self-wrap still published',
+        'so the sweep re-drives it immediately; self-wrap NOT published',
         () async {
           // Empty accepted/rejected/noResponse == nothing was sent anywhere.
           final (result, selfWraps) = await sendReaction(outcome());
@@ -310,7 +320,15 @@ void main() {
           // Marked failed (not dim pending) so the reconnect sweep re-sends it
           // without the in-flight min-age guard holding it back.
           expect(result.retryablePending, isFalse);
-          expect(selfWraps, 1);
+          // Nothing reached a relay, so the recipient has nothing — a self-wrap
+          // would be a phantom. The whole rumor is re-driven on reconnect.
+          expect(
+            selfWraps,
+            0,
+            reason:
+                'Self-wrap while offline creates a phantom reaction on the '
+                "sender's other devices.",
+          );
         },
       );
     });

--- a/mobile/packages/models/lib/src/dm_reaction.dart
+++ b/mobile/packages/models/lib/src/dm_reaction.dart
@@ -9,9 +9,13 @@ import 'package:equatable/equatable.dart';
 /// - [sent]: real reaction event id; published and ack'd.
 /// - [pending]: optimistic placeholder id, publish in flight.
 /// - [failed]: publish attempt threw; chip shows retry affordance.
+/// - [blocked]: send policy (#176 protected-minor DM restriction) rejected the
+///   recipient. Terminal and NOT retryable — retrying only re-hits the same
+///   policy — so the retry sweep and a chip re-tap must leave it alone. Renders
+///   as a settled own chip, never a red retry chip.
 /// - [received]: row originated from an incoming relay event (peer's
 ///   reaction or self-wrap copy of our own).
-enum DmReactionPublishStatus { sent, pending, failed, received }
+enum DmReactionPublishStatus { sent, pending, failed, blocked, received }
 
 /// A NIP-25 (kind 7) emoji reaction on a NIP-17 direct message.
 ///

--- a/mobile/packages/models/lib/src/nip17_send_result.dart
+++ b/mobile/packages/models/lib/src/nip17_send_result.dart
@@ -59,10 +59,19 @@ sealed class NIP17SendResult {
     timestamp: DateTime.now(),
   );
 
-  /// Build a failure result. [NIP17SendFailure] has no
-  /// `selfWrapPublished` field — the self-wrap is never attempted
-  /// when the recipient publish fails.
-  const factory NIP17SendResult.failure(String error) = NIP17SendFailure;
+  /// Build a failure result.
+  ///
+  /// [retryablePending] marks a "soft" failure where the recipient wrap frame
+  /// was written to the relay but no NIP-20 `OK` arrived within the window
+  /// (and no relay explicitly rejected it) — the send is *unconfirmed*, not
+  /// proven-failed. A lost/late `OK` on a flaky relay is indistinguishable from
+  /// actual delivery, so reaction callers keep such a send in a retryable
+  /// pending state rather than flipping it to a hard failure. Defaults to
+  /// `false` (a confirmed rejection or error).
+  const factory NIP17SendResult.failure(
+    String error, {
+    bool retryablePending,
+  }) = NIP17SendFailure;
 
   /// Build a policy-block result (protected-minor DM restriction, #176). Unlike
   /// a transient failure, a blocked send must NOT be retried — retrying only
@@ -77,6 +86,13 @@ sealed class NIP17SendResult {
   /// Whether this failure is a policy block (#176), not a transient/network
   /// error. Blocked sends are not retriable. Always `false` for success.
   bool get blocked => false;
+
+  /// Whether a failure is an *unconfirmed* recipient publish (frame written,
+  /// no relay `OK` within the window, no explicit rejection) rather than a
+  /// confirmed rejection/error. Always `false` on success and on hard
+  /// failures. Reaction callers keep a `retryablePending` send in a pending,
+  /// sweep-retryable state instead of marking it failed.
+  bool get retryablePending => false;
 
   /// The rumor event ID (kind 14/15) — the canonical message
   /// identifier. Use this as the primary key when persisting sent
@@ -175,16 +191,22 @@ final class NIP17SendSuccess extends NIP17SendResult {
 /// the recipient at all. Self-wrap is not attempted on this branch.
 @immutable
 final class NIP17SendFailure extends NIP17SendResult {
-  const NIP17SendFailure(this.error) : blocked = false;
+  const NIP17SendFailure(this.error, {this.retryablePending = false})
+    : blocked = false;
 
   /// A policy block (#176): same non-delivery as a failure, but not retriable.
-  const NIP17SendFailure.blocked(this.error) : blocked = true;
+  const NIP17SendFailure.blocked(this.error)
+    : blocked = true,
+      retryablePending = false;
 
   @override
   final String error;
 
   @override
   final bool blocked;
+
+  @override
+  final bool retryablePending;
 
   @override
   String? get rumorEventId => null;
@@ -206,12 +228,15 @@ final class NIP17SendFailure extends NIP17SendResult {
     if (identical(this, other)) return true;
     return other is NIP17SendFailure &&
         other.error == error &&
-        other.blocked == blocked;
+        other.blocked == blocked &&
+        other.retryablePending == retryablePending;
   }
 
   @override
-  int get hashCode => Object.hash(error, blocked);
+  int get hashCode => Object.hash(error, blocked, retryablePending);
 
   @override
-  String toString() => 'NIP17SendFailure(error: $error, blocked: $blocked)';
+  String toString() =>
+      'NIP17SendFailure(error: $error, blocked: $blocked, '
+      'retryablePending: $retryablePending)';
 }

--- a/mobile/packages/models/test/src/nip17_send_result_test.dart
+++ b/mobile/packages/models/test/src/nip17_send_result_test.dart
@@ -65,6 +65,52 @@ void main() {
         expect(result.timestamp, isNull);
       });
 
+      test('defaults retryablePending and blocked to false', () {
+        const result = NIP17SendResult.failure('boom');
+
+        expect(result.retryablePending, isFalse);
+        expect(result.blocked, isFalse);
+      });
+
+      test('preserves retryablePending=true when explicitly passed — the '
+          'soft unconfirmed case reaction callers keep sweep-retryable', () {
+        const result = NIP17SendResult.failure(
+          'recipient OK unconfirmed',
+          retryablePending: true,
+        );
+
+        expect(result.success, isFalse);
+        expect(result.retryablePending, isTrue);
+        expect(
+          result.blocked,
+          isFalse,
+          reason: 'A soft unconfirmed failure is not a policy block.',
+        );
+      });
+
+      test('success and blocked never report retryablePending', () {
+        final success = NIP17SendResult.success(
+          rumorEventId: rumorEventId,
+          messageEventId: messageEventId,
+          recipientPubkey: recipientPubkey,
+        );
+        const blocked = NIP17SendResult.blocked('policy');
+
+        expect(success.retryablePending, isFalse);
+        expect(blocked.retryablePending, isFalse);
+      });
+    });
+
+    group('blocked factory', () {
+      test('is a non-retryable failure distinct from a transient one', () {
+        const result = NIP17SendResult.blocked('policy refused recipient');
+
+        expect(result.success, isFalse);
+        expect(result.blocked, isTrue);
+        expect(result.retryablePending, isFalse);
+        expect(result.error, equals('policy refused recipient'));
+      });
+
       test('leaves selfWrapPublished as null on the failure branch — the '
           'field is meaningful only when success is true (self-wrap is '
           'never attempted when the recipient publish fails)', () {
@@ -98,6 +144,20 @@ void main() {
         expect(result.toString(), startsWith('NIP17SendFailure('));
         expect(result.toString(), contains('error: relay timeout'));
         expect(result.toString(), isNot(contains('selfWrapPublished')));
+      });
+
+      test('failure path surfaces blocked and retryablePending so a '
+          'regression dropping either from the shape is visible', () {
+        const soft = NIP17SendResult.failure(
+          'unconfirmed',
+          retryablePending: true,
+        );
+        const blocked = NIP17SendResult.blocked('policy');
+
+        expect(soft.toString(), contains('retryablePending: true'));
+        expect(soft.toString(), contains('blocked: false'));
+        expect(blocked.toString(), contains('blocked: true'));
+        expect(blocked.toString(), contains('retryablePending: false'));
       });
     });
 
@@ -200,6 +260,24 @@ void main() {
           const NIP17SendFailure('boom').hashCode,
           equals(const NIP17SendFailure('boom').hashCode),
         );
+      });
+
+      test('value equality: differing retryablePending breaks equality '
+          '(the field participates in == and hashCode)', () {
+        const hard = NIP17SendFailure('boom');
+        const soft = NIP17SendFailure('boom', retryablePending: true);
+
+        expect(hard, isNot(equals(soft)));
+        expect(hard.hashCode, isNot(equals(soft.hashCode)));
+      });
+
+      test('value equality: blocked and transient failures with the same '
+          'error are never equal (the blocked field participates in ==)', () {
+        const transient = NIP17SendFailure('policy');
+        const blocked = NIP17SendFailure.blocked('policy');
+
+        expect(transient, isNot(equals(blocked)));
+        expect(transient.hashCode, isNot(equals(blocked.hashCode)));
       });
 
       test('value equality: success and failure are never equal', () {

--- a/mobile/test/blocs/dm/reactions/conversation_reactions_cubit_test.dart
+++ b/mobile/test/blocs/dm/reactions/conversation_reactions_cubit_test.dart
@@ -167,6 +167,21 @@ void main() {
       publishStatus: DmReactionPublishStatus.sent,
     );
 
+    DmReaction ownReactionStatus(
+      String emoji,
+      DmReactionPublishStatus status,
+    ) => DmReaction(
+      id: 'own-$emoji',
+      conversationId: _convo,
+      targetMessageId: _msgId,
+      targetMessageAuthor: _peer,
+      reactorPubkey: _owner,
+      emoji: emoji,
+      createdAt: 1700000000,
+      ownerPubkey: _owner,
+      publishStatus: status,
+    );
+
     blocTest<ConversationReactionsCubit, ConversationReactionsState>(
       'set publishes when there is no active reaction',
       build: () {
@@ -540,6 +555,111 @@ void main() {
               targetMessageAuthor: _peer,
             ),
           ).called(1);
+        },
+      );
+
+      for (final status in [
+        DmReactionPublishStatus.failed,
+        DmReactionPublishStatus.pending,
+      ]) {
+        blocTest<ConversationReactionsCubit, ConversationReactionsState>(
+          're-tapping a $status own reaction retries instead of removing it',
+          build: () {
+            when(
+              () => repo.retry(
+                rumorId: any(named: 'rumorId'),
+                targetMessageAuthor: any(named: 'targetMessageAuthor'),
+              ),
+            ).thenAnswer(
+              (_) async => const DmReactionPublishResult(
+                success: true,
+                rumorId: 'own-❤️',
+                optimisticInsertSucceeded: true,
+              ),
+            );
+            return ConversationReactionsCubit(
+              reactionsRepository: repo,
+              ownerPubkey: _owner,
+            );
+          },
+          act: (cubit) async {
+            cubit.add(
+              const ConversationReactionsStarted(conversationId: _convo),
+            );
+            await Future<void>.delayed(Duration.zero);
+            streamController.add([ownReactionStatus('❤️', status)]);
+            await Future<void>.delayed(Duration.zero);
+            cubit.add(
+              const ConversationReactionToggled(
+                conversationId: _convo,
+                messageId: _msgId,
+                messageAuthorPubkey: _peer,
+                emoji: '❤️',
+              ),
+            );
+            await Future<void>.delayed(Duration.zero);
+            await Future<void>.delayed(Duration.zero);
+          },
+          verify: (_) {
+            // A re-tap on an undelivered reaction re-drives delivery; it must
+            // NOT be read as toggle-off (which soft-deletes it + emits a
+            // kind-5, permanently losing a reaction the recipient may have).
+            verify(
+              () => repo.retry(rumorId: 'own-❤️', targetMessageAuthor: _peer),
+            ).called(1);
+            verifyNever(
+              () => repo.removeOwn(
+                rumorId: any(named: 'rumorId'),
+                targetMessageAuthor: any(named: 'targetMessageAuthor'),
+              ),
+            );
+          },
+        );
+      }
+
+      blocTest<ConversationReactionsCubit, ConversationReactionsState>(
+        'keeps the optimistic chip on a durable-row publish failure '
+        '(before the DAO stream ticks)',
+        build: () {
+          when(
+            () => repo.publish(
+              conversationId: any(named: 'conversationId'),
+              targetMessageId: any(named: 'targetMessageId'),
+              targetMessageAuthor: any(named: 'targetMessageAuthor'),
+              emoji: any(named: 'emoji'),
+            ),
+          ).thenAnswer(
+            (_) async => const DmReactionPublishResult(
+              success: false,
+              rumorId: 'r-unconf',
+              errorMessage: 'unconfirmed',
+              optimisticInsertSucceeded: true,
+            ),
+          );
+          return ConversationReactionsCubit(
+            reactionsRepository: repo,
+            ownerPubkey: _owner,
+          );
+        },
+        act: (cubit) => cubit.add(
+          const ConversationReactionToggled(
+            conversationId: _convo,
+            messageId: _msgId,
+            messageAuthorPubkey: _peer,
+            emoji: '🔥',
+          ),
+        ),
+        verify: (cubit) {
+          // The durable row exists (the DAO stream just hasn't re-emitted yet),
+          // so the chip must stay visible rather than blank to nothing and
+          // invite a "repair" re-tap.
+          final own = cubit.state
+              .reactionsFor(_msgId)
+              .where((r) => r.isOwn)
+              .toList();
+          expect(own, hasLength(1));
+          expect(own.first.emoji, '🔥');
+          expect(cubit.state.optimistic, isNotEmpty);
         },
       );
 

--- a/mobile/test/services/dm_reaction_retry_service_test.dart
+++ b/mobile/test/services/dm_reaction_retry_service_test.dart
@@ -396,5 +396,76 @@ void main() {
         ).called(1);
       },
     );
+
+    test(
+      'add-phase retry exhaustion does NOT starve the later removal — the '
+      'attempt budget is namespaced per phase (add vs del) even though the '
+      'row keeps its rumor id across the failed -> deletion_pending flip',
+      () async {
+        var clock = DateTime.utc(2026, 5, 10, 12);
+
+        // Phase 1: the reaction fails its full add-retry budget.
+        when(
+          repository.retryableReactions,
+        ).thenAnswer((_) async => [_target(rumorId: 'x1')]);
+        when(
+          () => repository.retry(
+            rumorId: 'x1',
+            targetMessageAuthor: _authorPubkey,
+          ),
+        ).thenAnswer((_) async => _fail('x1'));
+
+        final service = buildService(
+          retryConfig: const DmReactionRetryConfig(
+            maxRetries: 2,
+            initialDelay: Duration(milliseconds: 1),
+          ),
+          now: () => clock,
+        );
+
+        await service.sweep();
+        clock = clock.add(const Duration(seconds: 10));
+        await service.sweep();
+        clock = clock.add(const Duration(seconds: 10));
+        await service.sweep(); // third add attempt dropped as exhausted
+
+        verify(
+          () => repository.retry(
+            rumorId: 'x1',
+            targetMessageAuthor: _authorPubkey,
+          ),
+        ).called(2);
+
+        // Phase 2: the user removes that reaction. The row keeps rumor id
+        // 'x1' but is now a 'deletion_pending' removal. Its kind-5 must
+        // re-drive with a FRESH budget — a bare-id budget would inherit the
+        // exhausted add count and skip the removal for the rest of the
+        // session, leaving the counterparty with a reaction you removed.
+        when(
+          repository.retryableReactions,
+        ).thenAnswer((_) async => const <DmReactionRetryTarget>[]);
+        when(repository.retryableDeletions).thenAnswer(
+          (_) async => [
+            _target(rumorId: 'x1', publishStatus: 'deletion_pending'),
+          ],
+        );
+        when(
+          () => repository.retryDeletion(
+            rumorId: 'x1',
+            targetMessageAuthor: _authorPubkey,
+          ),
+        ).thenAnswer((_) async => _ok('x1'));
+
+        clock = clock.add(const Duration(seconds: 10));
+        await service.sweep();
+
+        verify(
+          () => repository.retryDeletion(
+            rumorId: 'x1',
+            targetMessageAuthor: _authorPubkey,
+          ),
+        ).called(1);
+      },
+    );
   });
 }

--- a/mobile/test/services/dm_reaction_retry_service_test.dart
+++ b/mobile/test/services/dm_reaction_retry_service_test.dart
@@ -1,0 +1,307 @@
+// ABOUTME: Unit tests for DmReactionRetryService — pinned contracts:
+// ABOUTME: re-drives failed/interrupted own reactions via retry(), skips when
+// ABOUTME: the repo isn't initialized, holds back too-young pending reactions,
+// ABOUTME: applies backoff, and stops after maxRetries.
+
+import 'dart:async';
+
+import 'package:dm_repository/dm_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/services/dm_reaction_retry_service.dart';
+
+class _MockDmReactionsRepository extends Mock
+    implements DmReactionsRepository {}
+
+const _authorPubkey =
+    '0000000000000000000000000000000000000000000000000000000000000099';
+
+DmReactionRetryTarget _target({
+  required String rumorId,
+  String publishStatus = 'failed',
+  int createdAt = 1700000000,
+}) => DmReactionRetryTarget(
+  rumorId: rumorId,
+  targetMessageAuthor: _authorPubkey,
+  publishStatus: publishStatus,
+  createdAt: createdAt,
+);
+
+DmReactionPublishResult _ok(String id) =>
+    DmReactionPublishResult(success: true, rumorId: id);
+
+DmReactionPublishResult _fail(String id) => DmReactionPublishResult(
+  success: false,
+  rumorId: id,
+  errorMessage: 'relay down',
+);
+
+void main() {
+  late _MockDmReactionsRepository repository;
+  late StreamController<bool> foregroundController;
+
+  setUp(() {
+    repository = _MockDmReactionsRepository();
+    foregroundController = StreamController<bool>.broadcast();
+
+    // Permissive defaults; each test overrides what it cares about.
+    when(() => repository.isInitialized).thenReturn(true);
+    when(
+      repository.retryableReactions,
+    ).thenAnswer((_) async => const <DmReactionRetryTarget>[]);
+    when(
+      () => repository.retry(
+        rumorId: any(named: 'rumorId'),
+        targetMessageAuthor: any(named: 'targetMessageAuthor'),
+      ),
+    ).thenAnswer((_) async => _ok('r'));
+  });
+
+  tearDown(() async {
+    await foregroundController.close();
+  });
+
+  DmReactionRetryService buildService({
+    DmReactionRetryConfig retryConfig = const DmReactionRetryConfig(),
+    DateTime Function()? now,
+  }) {
+    return DmReactionRetryService(
+      reactionsRepository: repository,
+      appForegroundStream: foregroundController.stream,
+      retryConfig: retryConfig,
+      now: now ?? () => DateTime.utc(2026, 5, 10, 12),
+    );
+  }
+
+  group(DmReactionRetryService, () {
+    test(
+      'initialize subscribes to the foreground stream, dispose cancels',
+      () async {
+        final service = buildService();
+        await service.initialize();
+        expect(service.isInitialized, isTrue);
+        expect(foregroundController.hasListener, isTrue);
+
+        await service.dispose();
+        expect(service.isInitialized, isFalse);
+        expect(foregroundController.hasListener, isFalse);
+      },
+    );
+
+    test('a foreground transition to true triggers a sweep', () async {
+      when(
+        repository.retryableReactions,
+      ).thenAnswer((_) async => [_target(rumorId: 'r1')]);
+      when(
+        () => repository.retry(
+          rumorId: 'r1',
+          targetMessageAuthor: _authorPubkey,
+        ),
+      ).thenAnswer((_) async => _ok('r1'));
+
+      final service = buildService();
+      await service.initialize();
+      foregroundController.add(true);
+      // Let the async sweep run.
+      await Future<void>.delayed(Duration.zero);
+
+      verify(
+        () => repository.retry(
+          rumorId: 'r1',
+          targetMessageAuthor: _authorPubkey,
+        ),
+      ).called(1);
+      await service.dispose();
+    });
+
+    test('re-drives a failed reaction via retry', () async {
+      when(
+        repository.retryableReactions,
+      ).thenAnswer((_) async => [_target(rumorId: 'r1')]);
+      when(
+        () => repository.retry(
+          rumorId: 'r1',
+          targetMessageAuthor: _authorPubkey,
+        ),
+      ).thenAnswer((_) async => _ok('r1'));
+
+      await buildService().sweep();
+
+      verify(
+        () => repository.retry(
+          rumorId: 'r1',
+          targetMessageAuthor: _authorPubkey,
+        ),
+      ).called(1);
+    });
+
+    test('does nothing when the repository is not initialized', () async {
+      when(() => repository.isInitialized).thenReturn(false);
+
+      await buildService().sweep();
+
+      verifyNever(repository.retryableReactions);
+      verifyNever(
+        () => repository.retry(
+          rumorId: any(named: 'rumorId'),
+          targetMessageAuthor: any(named: 'targetMessageAuthor'),
+        ),
+      );
+    });
+
+    test(
+      'holds back a pending reaction younger than the min-age guard',
+      () async {
+        final now = DateTime.utc(2026, 5, 10, 12);
+        final youngCreatedAt =
+            now.subtract(const Duration(seconds: 5)).millisecondsSinceEpoch ~/
+            1000;
+        when(repository.retryableReactions).thenAnswer(
+          (_) async => [
+            _target(
+              rumorId: 'r1',
+              publishStatus: 'pending',
+              createdAt: youngCreatedAt,
+            ),
+          ],
+        );
+
+        await buildService(now: () => now).sweep();
+
+        verifyNever(
+          () => repository.retry(
+            rumorId: any(named: 'rumorId'),
+            targetMessageAuthor: any(named: 'targetMessageAuthor'),
+          ),
+        );
+      },
+    );
+
+    test('re-drives a pending reaction older than the min-age guard', () async {
+      final now = DateTime.utc(2026, 5, 10, 12);
+      final oldCreatedAt =
+          now.subtract(const Duration(seconds: 60)).millisecondsSinceEpoch ~/
+          1000;
+      when(repository.retryableReactions).thenAnswer(
+        (_) async => [
+          _target(
+            rumorId: 'r1',
+            publishStatus: 'pending',
+            createdAt: oldCreatedAt,
+          ),
+        ],
+      );
+      when(
+        () => repository.retry(
+          rumorId: 'r1',
+          targetMessageAuthor: _authorPubkey,
+        ),
+      ).thenAnswer((_) async => _ok('r1'));
+
+      await buildService(now: () => now).sweep();
+
+      verify(
+        () => repository.retry(
+          rumorId: 'r1',
+          targetMessageAuthor: _authorPubkey,
+        ),
+      ).called(1);
+    });
+
+    test(
+      'skips a just-failed reaction while inside the backoff window',
+      () async {
+        when(
+          repository.retryableReactions,
+        ).thenAnswer((_) async => [_target(rumorId: 'r1')]);
+        when(
+          () => repository.retry(
+            rumorId: 'r1',
+            targetMessageAuthor: _authorPubkey,
+          ),
+        ).thenAnswer((_) async => _fail('r1'));
+
+        // now is fixed, so the second sweep is inside the backoff window.
+        final service = buildService();
+        await service.sweep();
+        await service.sweep();
+
+        verify(
+          () => repository.retry(
+            rumorId: 'r1',
+            targetMessageAuthor: _authorPubkey,
+          ),
+        ).called(1);
+      },
+    );
+
+    test('stops re-driving a reaction after maxRetries', () async {
+      var clock = DateTime.utc(2026, 5, 10, 12);
+      when(
+        repository.retryableReactions,
+      ).thenAnswer((_) async => [_target(rumorId: 'r1')]);
+      when(
+        () => repository.retry(
+          rumorId: 'r1',
+          targetMessageAuthor: _authorPubkey,
+        ),
+      ).thenAnswer((_) async => _fail('r1'));
+
+      final service = buildService(
+        retryConfig: const DmReactionRetryConfig(
+          maxRetries: 2,
+          initialDelay: Duration(milliseconds: 1),
+        ),
+        now: () => clock,
+      );
+
+      // Three sweeps, each past the (tiny) backoff window — only the first two
+      // attempt a retry; the third is dropped as exhausted.
+      await service.sweep();
+      clock = clock.add(const Duration(seconds: 10));
+      await service.sweep();
+      clock = clock.add(const Duration(seconds: 10));
+      await service.sweep();
+
+      verify(
+        () => repository.retry(
+          rumorId: 'r1',
+          targetMessageAuthor: _authorPubkey,
+        ),
+      ).called(2);
+    });
+
+    test(
+      'a sweep already in progress short-circuits the next trigger',
+      () async {
+        final gate = Completer<DmReactionPublishResult>();
+        when(
+          repository.retryableReactions,
+        ).thenAnswer((_) async => [_target(rumorId: 'r1')]);
+        when(
+          () => repository.retry(
+            rumorId: 'r1',
+            targetMessageAuthor: _authorPubkey,
+          ),
+        ).thenAnswer((_) => gate.future);
+
+        final service = buildService();
+        final first = service.sweep();
+        // Let the first sweep reach the awaiting retry() call.
+        await Future<void>.delayed(Duration.zero);
+        // Second sweep sees _isSweeping and returns immediately.
+        await service.sweep();
+
+        gate.complete(_ok('r1'));
+        await first;
+
+        verify(
+          () => repository.retry(
+            rumorId: 'r1',
+            targetMessageAuthor: _authorPubkey,
+          ),
+        ).called(1);
+      },
+    );
+  });
+}

--- a/mobile/test/services/dm_reaction_retry_service_test.dart
+++ b/mobile/test/services/dm_reaction_retry_service_test.dart
@@ -50,7 +50,16 @@ void main() {
       repository.retryableReactions,
     ).thenAnswer((_) async => const <DmReactionRetryTarget>[]);
     when(
+      repository.retryableDeletions,
+    ).thenAnswer((_) async => const <DmReactionRetryTarget>[]);
+    when(
       () => repository.retry(
+        rumorId: any(named: 'rumorId'),
+        targetMessageAuthor: any(named: 'targetMessageAuthor'),
+      ),
+    ).thenAnswer((_) async => _ok('r'));
+    when(
+      () => repository.retryDeletion(
         rumorId: any(named: 'rumorId'),
         targetMessageAuthor: any(named: 'targetMessageAuthor'),
       ),
@@ -64,10 +73,12 @@ void main() {
   DmReactionRetryService buildService({
     DmReactionRetryConfig retryConfig = const DmReactionRetryConfig(),
     DateTime Function()? now,
+    Stream<void>? retryTriggerStream,
   }) {
     return DmReactionRetryService(
       reactionsRepository: repository,
       appForegroundStream: foregroundController.stream,
+      retryTriggerStream: retryTriggerStream,
       retryConfig: retryConfig,
       now: now ?? () => DateTime.utc(2026, 5, 10, 12),
     );
@@ -298,6 +309,88 @@ void main() {
         verify(
           () => repository.retry(
             rumorId: 'r1',
+            targetMessageAuthor: _authorPubkey,
+          ),
+        ).called(1);
+      },
+    );
+
+    test('a retry-trigger event (reconnect) triggers a sweep', () async {
+      final triggerController = StreamController<void>.broadcast();
+      addTearDown(triggerController.close);
+      when(
+        repository.retryableReactions,
+      ).thenAnswer((_) async => [_target(rumorId: 'r1')]);
+
+      final service = buildService(
+        retryTriggerStream: triggerController.stream,
+      );
+      await service.initialize();
+      triggerController.add(null);
+      await Future<void>.delayed(Duration.zero);
+
+      verify(
+        () => repository.retry(
+          rumorId: 'r1',
+          targetMessageAuthor: _authorPubkey,
+        ),
+      ).called(1);
+      await service.dispose();
+    });
+
+    test('re-drives a pending removal via retryDeletion', () async {
+      when(repository.retryableDeletions).thenAnswer(
+        (_) async => [
+          _target(rumorId: 'd1', publishStatus: 'deletion_pending'),
+        ],
+      );
+      when(
+        () => repository.retryDeletion(
+          rumorId: 'd1',
+          targetMessageAuthor: _authorPubkey,
+        ),
+      ).thenAnswer((_) async => _ok('d1'));
+
+      await buildService().sweep();
+
+      verify(
+        () => repository.retryDeletion(
+          rumorId: 'd1',
+          targetMessageAuthor: _authorPubkey,
+        ),
+      ).called(1);
+    });
+
+    test(
+      'a removal is re-driven regardless of the pending min-age guard',
+      () async {
+        final now = DateTime.utc(2026, 5, 10, 12);
+        final youngCreatedAt =
+            now.subtract(const Duration(seconds: 5)).millisecondsSinceEpoch ~/
+            1000;
+        when(repository.retryableDeletions).thenAnswer(
+          (_) async => [
+            _target(
+              rumorId: 'd1',
+              publishStatus: 'deletion_pending',
+              createdAt: youngCreatedAt,
+            ),
+          ],
+        );
+        when(
+          () => repository.retryDeletion(
+            rumorId: 'd1',
+            targetMessageAuthor: _authorPubkey,
+          ),
+        ).thenAnswer((_) async => _ok('d1'));
+
+        await buildService(now: () => now).sweep();
+
+        // Unlike an add, a 'deletion_pending' row is never in-flight for the
+        // sweep, so the min-age guard must not hold it back.
+        verify(
+          () => repository.retryDeletion(
+            rumorId: 'd1',
             targetMessageAuthor: _authorPubkey,
           ),
         ).called(1);

--- a/mobile/test/services/outgoing_dm_retry_service_test.dart
+++ b/mobile/test/services/outgoing_dm_retry_service_test.dart
@@ -98,12 +98,14 @@ void main() {
     OutgoingDmRetryConfig retryConfig = const OutgoingDmRetryConfig(),
     DateTime Function()? now,
     CrashReportingService? crashReporting,
+    Stream<void>? retryTriggerStream,
   }) {
     return OutgoingDmRetryService(
       dmRepository: dmRepository,
       outgoingDmsDao: dao,
       userPubkey: _ownerPubkey,
       appForegroundStream: foregroundController.stream,
+      retryTriggerStream: retryTriggerStream,
       retryConfig: retryConfig,
       now: now ?? () => DateTime.utc(2026, 5, 10, 12),
       crashReporting: crashReporting,
@@ -136,6 +138,26 @@ void main() {
         await service.dispose();
         expect(foregroundController.hasListener, isFalse);
         expect(service.isInitialized, isFalse);
+      });
+
+      test('a retry-trigger event (reconnect) triggers a sweep', () async {
+        final triggerController = StreamController<void>.broadcast();
+        addTearDown(triggerController.close);
+
+        final service = buildService(
+          retryTriggerStream: triggerController.stream,
+        );
+        await service.initialize();
+        triggerController.add(null);
+        await Future<void>.delayed(Duration.zero);
+
+        verify(
+          () => dao.getRetryableForOwner(
+            ownerPubkey: _ownerPubkey,
+            maxRetries: 5,
+          ),
+        ).called(1);
+        await service.dispose();
       });
 
       test(


### PR DESCRIPTION
## Description

DM reactions were being **silently lost to the recipient**. A friend reacted to a message in a 1:1 conversation, saw the reaction on their own device, but the recipient never received it.

**Root cause** (traced end-to-end; receive/render code is correct):
- A reaction's recipient-addressed gift wrap is published via `NostrClient.publishEvent`, which returns `PublishSuccess` on **frame-accept** — it never waits for the relay's NIP-20 `OK true`. On a flaky single relay (mid-reconnect), the write is counted as success even though the relay never stored the event.
- The sender's chip is inserted **optimistically before** any network send, so the sender always sees the reaction regardless of delivery — the loss is invisible.
- Unlike DM **messages** (durable `outgoing_dms` queue + `OutgoingDmRetryService` foreground sweep), reactions had **no automatic retry** — only a manual re-tap, which the false-positive "sent" never prompts.

This brings reactions to parity with the messages reliability model:

1. **OK-confirm the recipient wrap.** `NIP17MessageService.sendRumor` gains an opt-in `awaitRecipientOk` (default off — text/file/group message sends are byte-identical) that requires the relay's `OK true` via `publishEventAwaitOk` before a reaction counts as sent. `publish()` and `retry()` opt in; best-effort kind-5 supersede deletions stay on frame-accept. A 10s confirm window fits inside the reaction path's existing 15s outer cap.
2. **Durable auto-retry.** New `DmReactionRetryService` re-drives `failed`/interrupted-`pending` own reactions on every app-foreground transition via the existing `retry()`, reusing the `dm_message_reactions` row's stored rumor JSON — no schema migration. In-memory backoff (mirrors `OutgoingDmRetryConfig`: 5 tries, 2s→5min) + a min-age guard so an in-flight pending reaction is never re-driven; drops a reaction after `maxRetries` (manual re-tap still works).

Adds `DmReactionsDao.getRetryableOwnReactions` + `DmReactionsRepository.retryableReactions()` to project retryable rows for the sweep.

**Related Issue:** Closes #5978

## Out of Scope

- DM **messages** share the same frame-accept `publishEvent`; making them OK-confirmed is a broader change and is intentionally not in this PR (their durable retry queue already recovers genuine failures).
- No `dm_message_reactions` schema change: retry accounting is in-memory (resets on cold start, bounded by the foreground-only trigger).

## Verification

- `flutter analyze lib test integration_test` → No issues found.
- `dart analyze` in `packages/dm_repository` and `packages/db_client` → clean.
- `flutter test` full `dm_repository` package suite → 434 passing (covers message send path unchanged).
- `packages/db_client` `dm_reactions_dao_test.dart` → +2 cases for `getRetryableOwnReactions` (positive filter + exclusions).
- `packages/dm_repository` `dm_reactions_repository_test.dart` → asserts the send opts into `awaitRecipientOk: true`, + `retryableReactions()` projection.
- New `test/services/dm_reaction_retry_service_test.dart` → 9 cases: retry-on-failed, not-initialized skip, pending min-age (hold + release), backoff skip, exhaustion after maxRetries, re-entrancy.
- `conversation_reactions_cubit_test.dart` → unaffected, passing.
- Untested-services floor: satisfied (new service has a same-named test; reportable-site constants colocated in the service file to avoid growing the floor).

**Manual validation to run on-device:** have a friend react to a message while watching recipient logs for a new `🎁 Kind 1059 gift wrap received` + the reaction rendering; on a flaky relay, confirm the sender's chip now reflects true send state and self-heals on foreground.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
