### PR TITLE
fix(video-editor): bump pro_video_editor to 2.5.1 to fix multi-clip editor freeze

### DIFF
--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1808,10 +1808,10 @@ packages:
     dependency: "direct main"
     description:
       name: pro_video_editor
-      sha256: b6630516cf203216620d17084f8ea7d3ec8971e7dc397ac6f51c669bcae4c4ad
+      sha256: "75ae478fa8e8f8090e72dcad907f5019a3b3c62d19ec69ccd93e97e24329e102"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.5.1"
   process:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -311,7 +311,7 @@ dependencies:
   firebase_messaging: ^16.1.1
   convert: ^3.1.2
   audio_session: ^0.2.2
-  pro_video_editor: ^2.4.0
+  pro_video_editor: ^2.5.1
   pro_image_editor: ^13.2.0
   flutter_colorpicker: ^1.1.0
   file_picker: ^10.3.7


### PR DESCRIPTION
## Description

The video editor freezes and draft saves fail when many clips (~40+) are loaded at once on iOS. Root-caused to a native thumbnail decoder race in `pro_video_editor`: `AVAssetImageGenerator`'s completion callbacks can fire out of order / concurrently on iOS 26.5, and the handler used a single unsynchronized counter as both the result index and the completion count. A lost update meant the continuation never resumed, so `getThumbnails` hung forever. Because the app funnels every thumbnail batch through one global serial queue (`VideoThumbnailService._runStripBatchExclusive`), a single hung call wedges thumbnail generation for **every** clip for the rest of the session — clips highlight but won't move, and the save path fails. Loading ~9 clips at a time avoided the race; 40+ triggered it "step by step". No crash — a freeze, matching the report.

`pro_video_editor` 2.5.1 fixes the race (index derived from the requested timestamp, synchronized completion, single resume). This PR is the dependency bump that pulls in the fix — no app code changes.

**Related Issue:** Closes #5843

## Out of Scope

A defensive timeout on the app-side serial thumbnail queue (`_runStripBatchExclusive` / `getThumbnails`) so a future native hang can never wedge the whole session again — noted as a possible follow-up, not included here.

## Verification

- `flutter pub get` resolves `pro_video_editor` to 2.5.1 (Changed 1 dependency, no transitive churn)
- `flutter analyze lib` — No issues found
- Device test (iOS): loaded 40+ clips — no freeze, clips trim/move normally, draft save succeeds ✅

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
