### PR TITLE
feat(video-editor): loop-restart transition between last and first clip

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -3455,6 +3455,8 @@
     "videoEditorTransitionPush": "መግፋት",
     "videoEditorTransitionWipe": "ማበስ",
     "videoEditorTransitionButtonSemanticLabel": "ሽግግርን አርትዕ",
+    "videoEditorLoopTransitionSheetTitle": "የዙር ሽግግር",
+    "videoEditorLoopTransitionButtonSemanticLabel": "የዙር ሽግግርን አርትዕ",
     "videoEditorTransitionDuration": "ቆይታ",
     "videoEditorTransitionDurationLimitedHint": "በአጎራባች ሽግግር ላይ እንዳይደራረብ ተቀንሷል።",
     "videoEditorTransitionCurve": "ኩርባ",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2870,6 +2870,8 @@
     "videoEditorTransitionPush": "دفع",
     "videoEditorTransitionWipe": "مسح",
     "videoEditorTransitionButtonSemanticLabel": "تعديل الانتقال",
+    "videoEditorLoopTransitionSheetTitle": "انتقال التكرار",
+    "videoEditorLoopTransitionButtonSemanticLabel": "تعديل انتقال التكرار",
     "videoEditorTransitionDuration": "المدة",
     "videoEditorTransitionDurationLimitedHint": "تم تقصيرها لتجنّب التداخل مع الانتقال المجاور.",
     "videoEditorTransitionCurve": "المنحنى",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -3145,6 +3145,8 @@
     "videoEditorTransitionPush": "Избутване",
     "videoEditorTransitionWipe": "Избърсване",
     "videoEditorTransitionButtonSemanticLabel": "Редактиране на преход",
+    "videoEditorLoopTransitionSheetTitle": "Циклов преход",
+    "videoEditorLoopTransitionButtonSemanticLabel": "Редактиране на циклов преход",
     "videoEditorTransitionDuration": "Продължителност",
     "videoEditorTransitionDurationLimitedHint": "Съкратено, за да не се припокрива със съседния преход.",
     "videoEditorTransitionCurve": "Крива",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2895,6 +2895,8 @@
     "videoEditorTransitionPush": "Verdrängen",
     "videoEditorTransitionWipe": "Wischen",
     "videoEditorTransitionButtonSemanticLabel": "Übergang bearbeiten",
+    "videoEditorLoopTransitionSheetTitle": "Loop-Übergang",
+    "videoEditorLoopTransitionButtonSemanticLabel": "Loop-Übergang bearbeiten",
     "videoEditorTransitionDuration": "Dauer",
     "videoEditorTransitionDurationLimitedHint": "Gekürzt, damit sie sich nicht mit dem benachbarten Übergang überlappt.",
     "videoEditorTransitionCurve": "Kurve",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -4790,6 +4790,14 @@
   "@videoEditorTransitionButtonSemanticLabel": {
     "description": "Accessibility label for the button between two clips that opens the transition picker."
   },
+  "videoEditorLoopTransitionSheetTitle": "Loop transition",
+  "@videoEditorLoopTransitionSheetTitle": {
+    "description": "Title of the bottom sheet for choosing the loop-restart transition, where the last clip's tail blends into the first clip's head so the video loops seamlessly."
+  },
+  "videoEditorLoopTransitionButtonSemanticLabel": "Edit loop transition",
+  "@videoEditorLoopTransitionButtonSemanticLabel": {
+    "description": "Accessibility label for the button at the end of the timeline that opens the loop-restart transition picker."
+  },
   "videoEditorTransitionDuration": "Duration",
   "@videoEditorTransitionDuration": {
     "description": "Section label above the transition duration presets in the transition picker."

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2903,6 +2903,8 @@
     "videoEditorTransitionPush": "Empujar",
     "videoEditorTransitionWipe": "Barrido",
     "videoEditorTransitionButtonSemanticLabel": "Editar transición",
+    "videoEditorLoopTransitionSheetTitle": "Transición de bucle",
+    "videoEditorLoopTransitionButtonSemanticLabel": "Editar transición de bucle",
     "videoEditorTransitionDuration": "Duración",
     "videoEditorTransitionDurationLimitedHint": "Acortada para no superponerse con la transición adyacente.",
     "videoEditorTransitionCurve": "Curva",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1833,6 +1833,8 @@
     "videoEditorTransitionPush": "Pagtulak",
     "videoEditorTransitionWipe": "Pagpunas",
     "videoEditorTransitionButtonSemanticLabel": "I-edit ang transisyon",
+    "videoEditorLoopTransitionSheetTitle": "Transisyon ng loop",
+    "videoEditorLoopTransitionButtonSemanticLabel": "I-edit ang transisyon ng loop",
     "videoEditorTransitionDuration": "Tagal",
     "videoEditorTransitionDurationLimitedHint": "Pinaikli para hindi mag-overlap sa katabing transition.",
     "videoEditorTransitionCurve": "Kurba",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2895,6 +2895,8 @@
     "videoEditorTransitionPush": "Poussée",
     "videoEditorTransitionWipe": "Balayage",
     "videoEditorTransitionButtonSemanticLabel": "Modifier la transition",
+    "videoEditorLoopTransitionSheetTitle": "Transition en boucle",
+    "videoEditorLoopTransitionButtonSemanticLabel": "Modifier la transition en boucle",
     "videoEditorTransitionDuration": "Durée",
     "videoEditorTransitionDurationLimitedHint": "Raccourcie pour ne pas chevaucher la transition voisine.",
     "videoEditorTransitionCurve": "Courbe",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2877,6 +2877,8 @@
     "videoEditorTransitionPush": "Dorong",
     "videoEditorTransitionWipe": "Sapu",
     "videoEditorTransitionButtonSemanticLabel": "Edit transisi",
+    "videoEditorLoopTransitionSheetTitle": "Transisi loop",
+    "videoEditorLoopTransitionButtonSemanticLabel": "Edit transisi loop",
     "videoEditorTransitionDuration": "Durasi",
     "videoEditorTransitionDurationLimitedHint": "Dipendekkan agar tidak tumpang tindih dengan transisi di sebelahnya.",
     "videoEditorTransitionCurve": "Kurva",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2895,6 +2895,8 @@
     "videoEditorTransitionPush": "Spinta",
     "videoEditorTransitionWipe": "Tendina",
     "videoEditorTransitionButtonSemanticLabel": "Modifica transizione",
+    "videoEditorLoopTransitionSheetTitle": "Transizione in loop",
+    "videoEditorLoopTransitionButtonSemanticLabel": "Modifica transizione in loop",
     "videoEditorTransitionDuration": "Durata",
     "videoEditorTransitionDurationLimitedHint": "Ridotta per non sovrapporsi alla transizione adiacente.",
     "videoEditorTransitionCurve": "Curva",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2870,6 +2870,8 @@
     "videoEditorTransitionPush": "プッシュ",
     "videoEditorTransitionWipe": "ワイプ",
     "videoEditorTransitionButtonSemanticLabel": "トランジションを編集",
+    "videoEditorLoopTransitionSheetTitle": "ループトランジション",
+    "videoEditorLoopTransitionButtonSemanticLabel": "ループトランジションを編集",
     "videoEditorTransitionDuration": "長さ",
     "videoEditorTransitionDurationLimitedHint": "隣接するトランジションと重ならないように短縮されました。",
     "videoEditorTransitionCurve": "カーブ",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -2201,6 +2201,8 @@
     "videoEditorTransitionPush": "밀기",
     "videoEditorTransitionWipe": "와이프",
     "videoEditorTransitionButtonSemanticLabel": "전환 편집",
+    "videoEditorLoopTransitionSheetTitle": "루프 전환",
+    "videoEditorLoopTransitionButtonSemanticLabel": "루프 전환 편집",
     "videoEditorTransitionDuration": "길이",
     "videoEditorTransitionDurationLimitedHint": "인접한 전환과 겹치지 않도록 길이가 제한되었습니다.",
     "videoEditorTransitionCurve": "커브",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2895,6 +2895,8 @@
     "videoEditorTransitionPush": "Duwen",
     "videoEditorTransitionWipe": "Vegen",
     "videoEditorTransitionButtonSemanticLabel": "Overgang bewerken",
+    "videoEditorLoopTransitionSheetTitle": "Loop-overgang",
+    "videoEditorLoopTransitionButtonSemanticLabel": "Loop-overgang bewerken",
     "videoEditorTransitionDuration": "Duur",
     "videoEditorTransitionDurationLimitedHint": "Ingekort zodat deze niet overlapt met de aangrenzende overgang.",
     "videoEditorTransitionCurve": "Curve",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2895,6 +2895,8 @@
     "videoEditorTransitionPush": "Wypychanie",
     "videoEditorTransitionWipe": "Wycieranie",
     "videoEditorTransitionButtonSemanticLabel": "Edytuj przejście",
+    "videoEditorLoopTransitionSheetTitle": "Przejście pętli",
+    "videoEditorLoopTransitionButtonSemanticLabel": "Edytuj przejście pętli",
     "videoEditorTransitionDuration": "Czas trwania",
     "videoEditorTransitionDurationLimitedHint": "Skrócono, aby nie nakładała się na sąsiednie przejście.",
     "videoEditorTransitionCurve": "Krzywa",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2895,6 +2895,8 @@
     "videoEditorTransitionPush": "Empurrar",
     "videoEditorTransitionWipe": "Varredura",
     "videoEditorTransitionButtonSemanticLabel": "Editar transição",
+    "videoEditorLoopTransitionSheetTitle": "Transição de loop",
+    "videoEditorLoopTransitionButtonSemanticLabel": "Editar transição de loop",
     "videoEditorTransitionDuration": "Duração",
     "videoEditorTransitionDurationLimitedHint": "Encurtada para não se sobrepor à transição adjacente.",
     "videoEditorTransitionCurve": "Curva",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2895,6 +2895,8 @@
     "videoEditorTransitionPush": "Împingere",
     "videoEditorTransitionWipe": "Ștergere",
     "videoEditorTransitionButtonSemanticLabel": "Editează tranziția",
+    "videoEditorLoopTransitionSheetTitle": "Tranziție în buclă",
+    "videoEditorLoopTransitionButtonSemanticLabel": "Editează tranziția în buclă",
     "videoEditorTransitionDuration": "Durată",
     "videoEditorTransitionDurationLimitedHint": "Scurtată pentru a nu se suprapune cu tranziția alăturată.",
     "videoEditorTransitionCurve": "Curbă",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2895,6 +2895,8 @@
     "videoEditorTransitionPush": "Putta",
     "videoEditorTransitionWipe": "Svep",
     "videoEditorTransitionButtonSemanticLabel": "Redigera övergång",
+    "videoEditorLoopTransitionSheetTitle": "Loopövergång",
+    "videoEditorLoopTransitionButtonSemanticLabel": "Redigera loopövergång",
     "videoEditorTransitionDuration": "Längd",
     "videoEditorTransitionDurationLimitedHint": "Förkortad så att den inte överlappar den intilliggande övergången.",
     "videoEditorTransitionCurve": "Kurva",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2877,6 +2877,8 @@
     "videoEditorTransitionPush": "İtme",
     "videoEditorTransitionWipe": "Silme",
     "videoEditorTransitionButtonSemanticLabel": "Geçişi düzenle",
+    "videoEditorLoopTransitionSheetTitle": "Döngü geçişi",
+    "videoEditorLoopTransitionButtonSemanticLabel": "Döngü geçişini düzenle",
     "videoEditorTransitionDuration": "Süre",
     "videoEditorTransitionDurationLimitedHint": "Komşu geçişle çakışmaması için kısaltıldı.",
     "videoEditorTransitionCurve": "Eğri",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -14394,6 +14394,18 @@ abstract class AppLocalizations {
   /// **'Edit transition'**
   String get videoEditorTransitionButtonSemanticLabel;
 
+  /// Title of the bottom sheet for choosing the loop-restart transition, where the last clip's tail blends into the first clip's head so the video loops seamlessly.
+  ///
+  /// In en, this message translates to:
+  /// **'Loop transition'**
+  String get videoEditorLoopTransitionSheetTitle;
+
+  /// Accessibility label for the button at the end of the timeline that opens the loop-restart transition picker.
+  ///
+  /// In en, this message translates to:
+  /// **'Edit loop transition'**
+  String get videoEditorLoopTransitionButtonSemanticLabel;
+
   /// Section label above the transition duration presets in the transition picker.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -8124,6 +8124,12 @@ class AppLocalizationsAm extends AppLocalizations {
   String get videoEditorTransitionButtonSemanticLabel => 'ሽግግርን አርትዕ';
 
   @override
+  String get videoEditorLoopTransitionSheetTitle => 'የዙር ሽግግር';
+
+  @override
+  String get videoEditorLoopTransitionButtonSemanticLabel => 'የዙር ሽግግርን አርትዕ';
+
+  @override
   String get videoEditorTransitionDuration => 'ቆይታ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -8242,6 +8242,13 @@ class AppLocalizationsAr extends AppLocalizations {
   String get videoEditorTransitionButtonSemanticLabel => 'تعديل الانتقال';
 
   @override
+  String get videoEditorLoopTransitionSheetTitle => 'انتقال التكرار';
+
+  @override
+  String get videoEditorLoopTransitionButtonSemanticLabel =>
+      'تعديل انتقال التكرار';
+
+  @override
   String get videoEditorTransitionDuration => 'المدة';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -8376,6 +8376,13 @@ class AppLocalizationsBg extends AppLocalizations {
       'Редактиране на преход';
 
   @override
+  String get videoEditorLoopTransitionSheetTitle => 'Циклов преход';
+
+  @override
+  String get videoEditorLoopTransitionButtonSemanticLabel =>
+      'Редактиране на циклов преход';
+
+  @override
   String get videoEditorTransitionDuration => 'Продължителност';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -8396,6 +8396,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get videoEditorTransitionButtonSemanticLabel => 'Übergang bearbeiten';
 
   @override
+  String get videoEditorLoopTransitionSheetTitle => 'Loop-Übergang';
+
+  @override
+  String get videoEditorLoopTransitionButtonSemanticLabel =>
+      'Loop-Übergang bearbeiten';
+
+  @override
   String get videoEditorTransitionDuration => 'Dauer';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -8280,6 +8280,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get videoEditorTransitionButtonSemanticLabel => 'Edit transition';
 
   @override
+  String get videoEditorLoopTransitionSheetTitle => 'Loop transition';
+
+  @override
+  String get videoEditorLoopTransitionButtonSemanticLabel =>
+      'Edit loop transition';
+
+  @override
   String get videoEditorTransitionDuration => 'Duration';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -8375,6 +8375,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get videoEditorTransitionButtonSemanticLabel => 'Editar transición';
 
   @override
+  String get videoEditorLoopTransitionSheetTitle => 'Transición de bucle';
+
+  @override
+  String get videoEditorLoopTransitionButtonSemanticLabel =>
+      'Editar transición de bucle';
+
+  @override
   String get videoEditorTransitionDuration => 'Duración';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -8394,6 +8394,13 @@ class AppLocalizationsFil extends AppLocalizations {
       'I-edit ang transisyon';
 
   @override
+  String get videoEditorLoopTransitionSheetTitle => 'Transisyon ng loop';
+
+  @override
+  String get videoEditorLoopTransitionButtonSemanticLabel =>
+      'I-edit ang transisyon ng loop';
+
+  @override
   String get videoEditorTransitionDuration => 'Tagal';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -8416,6 +8416,13 @@ class AppLocalizationsFr extends AppLocalizations {
       'Modifier la transition';
 
   @override
+  String get videoEditorLoopTransitionSheetTitle => 'Transition en boucle';
+
+  @override
+  String get videoEditorLoopTransitionButtonSemanticLabel =>
+      'Modifier la transition en boucle';
+
+  @override
   String get videoEditorTransitionDuration => 'Durée';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -8269,6 +8269,13 @@ class AppLocalizationsId extends AppLocalizations {
   String get videoEditorTransitionButtonSemanticLabel => 'Edit transisi';
 
   @override
+  String get videoEditorLoopTransitionSheetTitle => 'Transisi loop';
+
+  @override
+  String get videoEditorLoopTransitionButtonSemanticLabel =>
+      'Edit transisi loop';
+
+  @override
   String get videoEditorTransitionDuration => 'Durasi';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -8375,6 +8375,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get videoEditorTransitionButtonSemanticLabel => 'Modifica transizione';
 
   @override
+  String get videoEditorLoopTransitionSheetTitle => 'Transizione in loop';
+
+  @override
+  String get videoEditorLoopTransitionButtonSemanticLabel =>
+      'Modifica transizione in loop';
+
+  @override
   String get videoEditorTransitionDuration => 'Durata';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -7959,6 +7959,12 @@ class AppLocalizationsJa extends AppLocalizations {
   String get videoEditorTransitionButtonSemanticLabel => 'トランジションを編集';
 
   @override
+  String get videoEditorLoopTransitionSheetTitle => 'ループトランジション';
+
+  @override
+  String get videoEditorLoopTransitionButtonSemanticLabel => 'ループトランジションを編集';
+
+  @override
   String get videoEditorTransitionDuration => '長さ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -7984,6 +7984,12 @@ class AppLocalizationsKo extends AppLocalizations {
   String get videoEditorTransitionButtonSemanticLabel => '전환 편집';
 
   @override
+  String get videoEditorLoopTransitionSheetTitle => '루프 전환';
+
+  @override
+  String get videoEditorLoopTransitionButtonSemanticLabel => '루프 전환 편집';
+
+  @override
   String get videoEditorTransitionDuration => '길이';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -8332,6 +8332,13 @@ class AppLocalizationsNl extends AppLocalizations {
   String get videoEditorTransitionButtonSemanticLabel => 'Overgang bewerken';
 
   @override
+  String get videoEditorLoopTransitionSheetTitle => 'Loop-overgang';
+
+  @override
+  String get videoEditorLoopTransitionButtonSemanticLabel =>
+      'Loop-overgang bewerken';
+
+  @override
   String get videoEditorTransitionDuration => 'Duur';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -8470,6 +8470,13 @@ class AppLocalizationsPl extends AppLocalizations {
   String get videoEditorTransitionButtonSemanticLabel => 'Edytuj przejście';
 
   @override
+  String get videoEditorLoopTransitionSheetTitle => 'Przejście pętli';
+
+  @override
+  String get videoEditorLoopTransitionButtonSemanticLabel =>
+      'Edytuj przejście pętli';
+
+  @override
   String get videoEditorTransitionDuration => 'Czas trwania';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -8350,6 +8350,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get videoEditorTransitionButtonSemanticLabel => 'Editar transição';
 
   @override
+  String get videoEditorLoopTransitionSheetTitle => 'Transição de loop';
+
+  @override
+  String get videoEditorLoopTransitionButtonSemanticLabel =>
+      'Editar transição de loop';
+
+  @override
   String get videoEditorTransitionDuration => 'Duração';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -8482,6 +8482,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get videoEditorTransitionButtonSemanticLabel => 'Editează tranziția';
 
   @override
+  String get videoEditorLoopTransitionSheetTitle => 'Tranziție în buclă';
+
+  @override
+  String get videoEditorLoopTransitionButtonSemanticLabel =>
+      'Editează tranziția în buclă';
+
+  @override
   String get videoEditorTransitionDuration => 'Durată';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -8296,6 +8296,13 @@ class AppLocalizationsSv extends AppLocalizations {
   String get videoEditorTransitionButtonSemanticLabel => 'Redigera övergång';
 
   @override
+  String get videoEditorLoopTransitionSheetTitle => 'Loopövergång';
+
+  @override
+  String get videoEditorLoopTransitionButtonSemanticLabel =>
+      'Redigera loopövergång';
+
+  @override
   String get videoEditorTransitionDuration => 'Längd';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -8263,6 +8263,13 @@ class AppLocalizationsTr extends AppLocalizations {
   String get videoEditorTransitionButtonSemanticLabel => 'Geçişi düzenle';
 
   @override
+  String get videoEditorLoopTransitionSheetTitle => 'Döngü geçişi';
+
+  @override
+  String get videoEditorLoopTransitionButtonSemanticLabel =>
+      'Döngü geçişini düzenle';
+
+  @override
   String get videoEditorTransitionDuration => 'Süre';
 
   @override

--- a/mobile/lib/models/divine_video_clip.dart
+++ b/mobile/lib/models/divine_video_clip.dart
@@ -96,8 +96,10 @@ class DivineVideoClip {
   /// How this clip transitions into the **next** clip on the timeline
   /// (dissolve, fade-to-black, slide, …), or `null` for a hard cut.
   ///
-  /// Ignored on the last clip (there is no following clip). Drives both the
-  /// live editor preview and the final rendered composition.
+  /// On the **last clip** there is no following clip, so this is the
+  /// loop-restart wrap (`pro_video_editor` ≥ 2.5): it blends the last clip's
+  /// tail into the first clip's head so a looping player restarts seamlessly.
+  /// Drives both the live editor preview and the final rendered composition.
   final ClipTransition? transition;
 
   double get durationInSeconds => duration.inMilliseconds / 1000.0;

--- a/mobile/lib/models/video_editor/transition_geometry.dart
+++ b/mobile/lib/models/video_editor/transition_geometry.dart
@@ -242,8 +242,20 @@ class LoopWrapDisplay {
 
   factory LoopWrapDisplay.fromClips(List<DivineVideoClip> clips) {
     if (clips.isEmpty) return none;
-    final wrap = clampTransitions(clips)[clips.last.id];
-    if (wrap == null) return none;
+    return LoopWrapDisplay.fromClamped(
+      clips,
+      clampTransitions(clips)[clips.last.id],
+    );
+  }
+
+  /// Like [LoopWrapDisplay.fromClips], but takes the already-clamped [wrap]
+  /// (`clampTransitions(clips)[clips.last.id]`) so callers that hold the
+  /// clamped map don't run [clampTransitions] a second time.
+  factory LoopWrapDisplay.fromClamped(
+    List<DivineVideoClip> clips,
+    ClipTransition? wrap,
+  ) {
+    if (clips.isEmpty || wrap == null) return none;
     final consumed = transitionConsumedPerSide(
       clips.last.playbackDuration,
       clips.first.playbackDuration,
@@ -283,8 +295,10 @@ class LoopWrapDisplay {
     return d.isNegative ? Duration.zero : d;
   }
 
-  /// Total display-axis duration: shortened clips plus the seam region. Equals
-  /// the exported output length (overlaps shorten by the blend, dips don't).
+  /// Total display-axis duration: shortened clips plus the seam region. The
+  /// wrap is fully reflected (an overlap wrap shortens the total by its blend,
+  /// a dip doesn't); interior overlaps keep their editor-axis length here,
+  /// exactly as the strip draws them.
   Duration displayTotal(List<DivineVideoClip> clips) {
     var total = Duration.zero;
     for (var i = 0; i < clips.length; i++) {
@@ -320,10 +334,11 @@ class _Blend {
 /// clamp guarantees adjacent blend regions never touch, so the mapping is
 /// strictly monotonic and invertible.
 ///
-/// The loop-restart wrap (the last clip's transition) is deliberately **not**
-/// reflected here: the editor timeline stays the editing space (clips at full
-/// length) and the ruler/playhead map exactly as without a wrap. The wrap only
-/// shortens the exported output, which the native renderer handles.
+/// The loop-restart wrap (the last clip's transition) adds **no blend region**
+/// to the position mapping: its blend sits at the loop point, past the last
+/// clip, so the editor timeline stays the editing space (clips at full length)
+/// and the ruler/playhead map exactly as without a wrap. Like any overlap it
+/// does shorten the export, so [outputDuration] subtracts its blend.
 class TransitionTimelineMap {
   TransitionTimelineMap._(
     this._blends, {
@@ -350,6 +365,16 @@ class TransitionTimelineMap {
       removed += blend;
     }
 
+    // The loop-restart wrap's blend plays at the loop point, past the last
+    // clip, so it shortens the output without adding a blend region to the
+    // position mapping.
+    if (clips.isNotEmpty) {
+      final wrap = clamped[clips.last.id];
+      if (wrap != null && _shortensTimeline(wrap.type)) {
+        removed += wrap.duration;
+      }
+    }
+
     return TransitionTimelineMap._(
       blends,
       editorDuration: editorTotal,
@@ -360,9 +385,9 @@ class TransitionTimelineMap {
   /// Length of the editor timeline — clips laid out at full length.
   final Duration editorDuration;
 
-  /// Length of the rendered output — [editorDuration] minus every interior
-  /// overlap blend. (The loop-restart wrap shortens the export separately,
-  /// native-side, and is not counted here.)
+  /// Length of the rendered output — [editorDuration] minus every overlap
+  /// blend, including the loop-restart wrap's. This is what the final export
+  /// lasts.
   final Duration outputDuration;
 
   final List<_Blend> _blends;
@@ -412,9 +437,9 @@ class TransitionTimelineMap {
 }
 
 /// The duration of the rendered output for [clips] — the sum of clip playback
-/// lengths minus the blend each interior overlap transition removes (after the
-/// no-overlap clamp). Dips don't shorten the timeline, so they don't count, and
-/// neither does the loop-restart wrap (shortened native-side on export only).
+/// lengths minus the blend each overlap transition removes (after the
+/// no-overlap clamp), including the loop-restart wrap's. Dips don't shorten
+/// the timeline, so they don't count.
 ///
 /// This is what the final export lasts, which differs from the editor
 /// timeline length (`ClipEditorState.totalDuration`, clips at full length)

--- a/mobile/lib/models/video_editor/transition_geometry.dart
+++ b/mobile/lib/models/video_editor/transition_geometry.dart
@@ -66,14 +66,24 @@ Duration transitionDurationForConsumed(
 /// and the second half the other). A single transition on a clip is never
 /// reduced.
 ///
-/// Returns `null` for the last clip (no following boundary) and whenever there
-/// is no room for a transition. Keyed by clip id rather than index so it stays
-/// correct even if the render pipeline reorders clips.
+/// The **last clip's transition is the loop-restart wrap** (`pro_video_editor`
+/// ≥ 2.5): it blends the last clip's tail into the first clip's head so a
+/// looping player restarts seamlessly. It is clamped against the room left on
+/// the last clip's tail and the first clip's head after their own internal
+/// transitions — and, on a single clip that is both first and last, so its head
+/// and tail together leave a middle body.
+///
+/// Returns `null` for any boundary (internal or wrap) with no room. Keyed by
+/// clip id rather than index so it stays correct even if the render pipeline
+/// reorders clips.
 Map<String, ClipTransition?> clampTransitions(List<DivineVideoClip> clips) {
   final n = clips.length;
+  if (n == 0) return const {};
 
-  // Per-boundary requested per-side consumption. demand[i] is the boundary
-  // between clip i and clip i+1 (clip i's outgoing transition).
+  // Per-boundary requested per-side consumption. demand[i] is the internal
+  // boundary between clip i and clip i+1 (clip i's outgoing transition); the
+  // last clip has no internal boundary. loopDemand is the wrap boundary between
+  // the last clip's tail and the first clip's head (the same clip when n == 1).
   final demand = List<Duration>.filled(n, Duration.zero);
   for (var i = 0; i < n - 1; i++) {
     final transition = clips[i].transition;
@@ -85,13 +95,23 @@ Map<String, ClipTransition?> clampTransitions(List<DivineVideoClip> clips) {
       );
     }
   }
+  final loopTransition = clips[n - 1].transition;
+  final loopDemand = loopTransition == null
+      ? Duration.zero
+      : transitionConsumedPerSide(
+          clips[n - 1].playbackDuration,
+          clips[0].playbackDuration,
+          loopTransition,
+        );
 
   // Per-clip scale so the head + tail consumption fits the clip's playback
-  // length. A clip touched by only one transition (or none) keeps scale 1.
+  // length. The wrap consumes the first clip's head and the last clip's tail;
+  // on a single clip it consumes both ends of that one clip. A clip touched by
+  // only one transition (or none) keeps scale 1.
   final scale = List<double>.filled(n, 1);
   for (var i = 0; i < n; i++) {
-    final head = i > 0 ? demand[i - 1] : Duration.zero;
-    final tail = i < n - 1 ? demand[i] : Duration.zero;
+    final head = i == 0 ? loopDemand : demand[i - 1];
+    final tail = i == n - 1 ? loopDemand : demand[i];
     final total = head + tail;
     final playback = clips[i].playbackDuration;
     if (total > playback && total > Duration.zero) {
@@ -102,38 +122,180 @@ Map<String, ClipTransition?> clampTransitions(List<DivineVideoClip> clips) {
   // Each boundary is bounded by the tighter scale of the two clips it touches,
   // so neither clip is over-consumed.
   final clamped = <String, ClipTransition?>{};
-  for (var i = 0; i < n; i++) {
-    final transition = clips[i].transition;
-    if (i >= n - 1 || transition == null || demand[i] <= Duration.zero) {
-      clamped[clips[i].id] = null;
-      continue;
-    }
-    final s = scale[i] < scale[i + 1] ? scale[i] : scale[i + 1];
-    final finalConsumed = Duration(
-      microseconds: (demand[i].inMicroseconds * s).round(),
+  for (var i = 0; i < n - 1; i++) {
+    clamped[clips[i].id] = _clampBoundary(
+      transition: clips[i].transition,
+      demand: demand[i],
+      scale: scale[i] < scale[i + 1] ? scale[i] : scale[i + 1],
     );
-    if (finalConsumed <= Duration.zero) {
-      clamped[clips[i].id] = null;
-      continue;
-    }
-    final clampedDuration = transitionDurationForConsumed(
-      finalConsumed,
-      transition.type,
-    );
-    if (clampedDuration < transition.duration) {
-      Log.debug(
-        '✂️ Clamping transition ${transition.duration.inMilliseconds}ms '
-        'to ${clampedDuration.inMilliseconds}ms (avoids overlap on a '
-        'shared clip)',
-        name: _logName,
-        category: .video,
-      );
-      clamped[clips[i].id] = transition.copyWith(duration: clampedDuration);
-    } else {
-      clamped[clips[i].id] = transition;
-    }
   }
+  clamped[clips[n - 1].id] = _clampBoundary(
+    transition: loopTransition,
+    demand: loopDemand,
+    scale: scale[n - 1] < scale[0] ? scale[n - 1] : scale[0],
+  );
   return clamped;
+}
+
+/// Clamps [transition]'s duration to the room its boundary keeps after [scale]
+/// is applied to the requested per-side [demand], logging when it shrinks.
+/// Returns `null` when the boundary has no transition or no room.
+ClipTransition? _clampBoundary({
+  required ClipTransition? transition,
+  required Duration demand,
+  required double scale,
+}) {
+  if (transition == null || demand <= Duration.zero) return null;
+  final finalConsumed = Duration(
+    microseconds: (demand.inMicroseconds * scale).round(),
+  );
+  if (finalConsumed <= Duration.zero) return null;
+  final clampedDuration = transitionDurationForConsumed(
+    finalConsumed,
+    transition.type,
+  );
+  if (clampedDuration < transition.duration) {
+    Log.debug(
+      '✂️ Clamping transition ${transition.duration.inMilliseconds}ms '
+      'to ${clampedDuration.inMilliseconds}ms (avoids overlap on a '
+      'shared clip)',
+      name: _logName,
+      category: .video,
+    );
+    return transition.copyWith(duration: clampedDuration);
+  }
+  return transition;
+}
+
+/// The per-side playback room the loop-restart wrap may consume at the seam
+/// between the last clip's tail and the first clip's head, after those clips'
+/// own internal transitions have taken their share.
+///
+/// On a single clip the wrap carves its head and tail from the *same* clip, so
+/// the two sides split the clip and each may use at most half its playback.
+/// With multiple clips it is the tighter of the last clip's remaining tail and
+/// the first clip's remaining head. Feeds the loop picker's duration ceiling,
+/// mirroring the internal picker's room calculation.
+Duration loopTransitionRoomPerSide(List<DivineVideoClip> clips) {
+  final n = clips.length;
+  if (n == 0) return Duration.zero;
+  final first = clips[0];
+  final last = clips[n - 1];
+  if (n == 1) {
+    return Duration(microseconds: first.playbackDuration.inMicroseconds ~/ 2);
+  }
+
+  // The last clip's head is consumed by its incoming internal transition,
+  // leaving the rest of its tail for the wrap.
+  var tailRoom = last.playbackDuration;
+  final incoming = clips[n - 2].transition;
+  if (incoming != null) {
+    tailRoom -= transitionConsumedPerSide(
+      clips[n - 2].playbackDuration,
+      last.playbackDuration,
+      incoming,
+    );
+  }
+
+  // The first clip's tail is consumed by its outgoing internal transition,
+  // leaving the rest of its head for the wrap.
+  var headRoom = first.playbackDuration;
+  final outgoing = first.transition;
+  if (outgoing != null) {
+    headRoom -= transitionConsumedPerSide(
+      first.playbackDuration,
+      clips[1].playbackDuration,
+      outgoing,
+    );
+  }
+
+  final room = tailRoom < headRoom ? tailRoom : headRoom;
+  return room.isNegative ? Duration.zero : room;
+}
+
+/// Display geometry of the loop-restart wrap — the single source of truth the
+/// timeline strip, the preview player plan and the [SeamTimeline] mapping all
+/// share, so they agree on the same axis.
+///
+/// A loop wrap moves content: the first clip's head and the last clip's tail
+/// live inside the rendered blend seam at the loop point instead of at their
+/// original positions. The timeline therefore draws the first clip starting
+/// [consumedPerSide] later and the last clip ending [consumedPerSide] earlier,
+/// with a [seamDuration]-long blend region appended at the end — making
+/// timeline, preview and export line up 1:1.
+///
+/// Mirrors `TransitionSeamRenderService.computeSeamSpans`: per side an overlap
+/// consumes 2× its duration (solo lead-in/out around the blend) and its seam
+/// plays 1.5× the consumed span; a dip consumes half its duration per side and
+/// its seam plays the full 2× consumed span (dips don't shorten).
+class LoopWrapDisplay {
+  const LoopWrapDisplay._({
+    required this.consumedPerSide,
+    required this.seamDuration,
+  });
+
+  /// No wrap: nothing consumed, no seam region.
+  static const none = LoopWrapDisplay._(
+    consumedPerSide: Duration.zero,
+    seamDuration: Duration.zero,
+  );
+
+  factory LoopWrapDisplay.fromClips(List<DivineVideoClip> clips) {
+    if (clips.isEmpty) return none;
+    final wrap = clampTransitions(clips)[clips.last.id];
+    if (wrap == null) return none;
+    final consumed = transitionConsumedPerSide(
+      clips.last.playbackDuration,
+      clips.first.playbackDuration,
+      wrap,
+    );
+    if (consumed <= Duration.zero) return none;
+    final blend = _isDip(wrap.type)
+        ? Duration.zero
+        : Duration(microseconds: consumed.inMicroseconds ~/ 2);
+    return LoopWrapDisplay._(
+      consumedPerSide: consumed,
+      seamDuration: consumed * 2 - blend,
+    );
+  }
+
+  /// Wall-clock (playback) span the wrap consumes from the first clip's head
+  /// and, equally, from the last clip's tail.
+  final Duration consumedPerSide;
+
+  /// Playback length of the blend seam region appended at the end of the
+  /// timeline (the loop point).
+  final Duration seamDuration;
+
+  bool get isActive => consumedPerSide > Duration.zero;
+
+  /// The span [clip] contributes to the display axis: its playback duration
+  /// minus what the wrap consumed from its head (first clip) and/or tail (last
+  /// clip — the same clip on a single-clip timeline).
+  Duration displayDuration(
+    DivineVideoClip clip, {
+    required bool isFirst,
+    required bool isLast,
+  }) {
+    var d = clip.playbackDuration;
+    if (isFirst) d -= consumedPerSide;
+    if (isLast) d -= consumedPerSide;
+    return d.isNegative ? Duration.zero : d;
+  }
+
+  /// Total display-axis duration: shortened clips plus the seam region. Equals
+  /// the exported output length (overlaps shorten by the blend, dips don't).
+  Duration displayTotal(List<DivineVideoClip> clips) {
+    var total = Duration.zero;
+    for (var i = 0; i < clips.length; i++) {
+      total += displayDuration(
+        clips[i],
+        isFirst: i == 0,
+        isLast: i == clips.length - 1,
+      );
+    }
+    return total + seamDuration;
+  }
 }
 
 /// One overlap blend on the editor axis: the region
@@ -157,6 +319,11 @@ class _Blend {
 /// `duration` of output; positions outside any blend map 1:1. The no-overlap
 /// clamp guarantees adjacent blend regions never touch, so the mapping is
 /// strictly monotonic and invertible.
+///
+/// The loop-restart wrap (the last clip's transition) is deliberately **not**
+/// reflected here: the editor timeline stays the editing space (clips at full
+/// length) and the ruler/playhead map exactly as without a wrap. The wrap only
+/// shortens the exported output, which the native renderer handles.
 class TransitionTimelineMap {
   TransitionTimelineMap._(
     this._blends, {
@@ -193,8 +360,9 @@ class TransitionTimelineMap {
   /// Length of the editor timeline — clips laid out at full length.
   final Duration editorDuration;
 
-  /// Length of the rendered output — [editorDuration] minus every overlap
-  /// blend. This is what the final export lasts.
+  /// Length of the rendered output — [editorDuration] minus every interior
+  /// overlap blend. (The loop-restart wrap shortens the export separately,
+  /// native-side, and is not counted here.)
   final Duration outputDuration;
 
   final List<_Blend> _blends;
@@ -244,8 +412,9 @@ class TransitionTimelineMap {
 }
 
 /// The duration of the rendered output for [clips] — the sum of clip playback
-/// lengths minus the blend each overlap transition removes (after the
-/// no-overlap clamp). Dips don't shorten the timeline, so they don't count.
+/// lengths minus the blend each interior overlap transition removes (after the
+/// no-overlap clamp). Dips don't shorten the timeline, so they don't count, and
+/// neither does the loop-restart wrap (shortened native-side on export only).
 ///
 /// This is what the final export lasts, which differs from the editor
 /// timeline length (`ClipEditorState.totalDuration`, clips at full length)

--- a/mobile/lib/services/video_editor/transition_seam_render_service.dart
+++ b/mobile/lib/services/video_editor/transition_seam_render_service.dart
@@ -396,15 +396,43 @@ class SeamTimeline {
     ClipSpeedRenderService? speedRenders,
   }) {
     final clamped = clampTransitions(clips);
+    final n = clips.length;
+
+    // Loop-restart wrap: the wrap-consumed head of the first clip and tail of
+    // the last clip live in the blend seam at the loop point, so the display
+    // axis (what the timeline draws) excludes them from the clip bodies and
+    // appends the seam region at the end — mirroring [buildSeamAwarePlayerClips]
+    // and [LoopWrapDisplay] so player, mapping and strips share one axis.
+    final wrapDisplay = LoopWrapDisplay.fromClips(clips);
+    final wrapTransition = n > 0 ? clamped[clips[n - 1].id] : null;
+    final wrapSeam = wrapTransition != null && wrapDisplay.isActive
+        ? seams.cached(clips[n - 1], clips[0], wrapTransition)
+        : null;
+    final wrapHeadPb = !wrapDisplay.isActive
+        ? Duration.zero
+        : wrapSeam != null
+        ? clips[0].sourceDurationToPlaybackDuration(wrapSeam.headConsumed)
+        : wrapDisplay.consumedPerSide;
+    final wrapTailPb = !wrapDisplay.isActive
+        ? Duration.zero
+        : wrapSeam != null
+        ? clips[n - 1].sourceDurationToPlaybackDuration(wrapSeam.tailConsumed)
+        : wrapDisplay.consumedPerSide;
+
     var composite = Duration.zero;
     var editor = Duration.zero; // start of the current clip on the editor line
     // Last editor position handed to a segment. Clamping each segment's editor
     // extent to this cursor keeps the axis non-decreasing; it is a no-op
     // whenever clips aren't over-consumed (which the clamp also prevents).
     var editorCursor = Duration.zero;
-    for (var i = 0; i < clips.length; i++) {
+    for (var i = 0; i < n; i++) {
       final clip = clips[i];
-      final clipDuration = clip.playbackDuration;
+      // The wrap-consumed head/tail is cut from the clip's display span, not
+      // offset within it — the axis itself starts at the shifted content.
+      var clipDuration = clip.playbackDuration;
+      if (i == 0) clipDuration -= wrapHeadPb;
+      if (i == n - 1) clipDuration -= wrapTailPb;
+      if (clipDuration.isNegative) clipDuration = Duration.zero;
 
       var headPb = Duration.zero;
       final prevTransition = i > 0 ? clamped[clips[i - 1].id] : null;
@@ -418,7 +446,7 @@ class SeamTimeline {
       TransitionSeam? outgoing;
       var tailPb = Duration.zero;
       final transition = clamped[clip.id];
-      if (i + 1 < clips.length && transition != null) {
+      if (i + 1 < n && transition != null) {
         outgoing = seams.cached(clip, clips[i + 1], transition);
         if (outgoing != null) {
           tailPb = clip.sourceDurationToPlaybackDuration(outgoing.tailConsumed);
@@ -474,6 +502,22 @@ class SeamTimeline {
 
       editor += clipDuration;
     }
+
+    // The wrap seam plays last, previewing the restart blend. On the display
+    // axis it occupies the seam region the timeline draws after the last clip
+    // ([LoopWrapDisplay.seamDuration]); until the seam file lands, playback
+    // simply ends at the bodies' end and the region stays unmapped.
+    if (wrapSeam != null) {
+      final editorStart = _maxDur(editor, editorCursor);
+      _segments.add(
+        _Segment(
+          composite,
+          composite + wrapSeam.duration,
+          editorStart,
+          editorStart + wrapDisplay.seamDuration,
+        ),
+      );
+    }
   }
 
   final List<_Segment> _segments = [];
@@ -504,7 +548,15 @@ class SeamTimeline {
       if (clamped < fromEnd || isLast) {
         final span = fromEnd - fromStart;
         if (span <= Duration.zero) return toStart;
-        final frac = (clamped - fromStart).inMicroseconds / span.inMicroseconds;
+        // Clamp to the segment: a query below the first segment's start (the
+        // loop wrap consumes the first clip's head, so editor 0 falls before the
+        // first body segment) must map to the segment start, never extrapolate
+        // to a negative position that would freeze the player on seek.
+        final frac =
+            ((clamped - fromStart).inMicroseconds / span.inMicroseconds).clamp(
+              0.0,
+              1.0,
+            );
         return toStart +
             Duration(
               microseconds: (frac * (toEnd - toStart).inMicroseconds).round(),
@@ -555,8 +607,22 @@ List<player.VideoClip> buildSeamAwarePlayerClips(
   ClipSpeedRenderService? speedRenders,
 }) {
   final clamped = clampTransitions(clips);
+  final n = clips.length;
+
+  // The last clip's transition is the loop-restart wrap: its rendered seam
+  // blends the last clip's tail into the first clip's head. That head and tail
+  // are consumed *eagerly* — even before the seam file lands — so the display
+  // axis (timeline strips shortened by [LoopWrapDisplay]) never shifts under
+  // the playhead; the seam is appended once rendered and the loop then restarts
+  // seamlessly through the blend, exactly matching the export.
+  final wrapDisplay = LoopWrapDisplay.fromClips(clips);
+  final wrapTransition = n > 0 ? clamped[clips[n - 1].id] : null;
+  final wrapSeam = wrapTransition != null && wrapDisplay.isActive
+      ? seams.cached(clips[n - 1], clips[0], wrapTransition)
+      : null;
+
   final result = <player.VideoClip>[];
-  for (var i = 0; i < clips.length; i++) {
+  for (var i = 0; i < n; i++) {
     final clip = clips[i];
 
     var headConsumed = Duration.zero;
@@ -566,13 +632,23 @@ List<player.VideoClip> buildSeamAwarePlayerClips(
           seams.cached(clips[i - 1], clip, prevTransition)?.headConsumed ??
           Duration.zero;
     }
+    if (i == 0 && wrapDisplay.isActive) {
+      headConsumed +=
+          wrapSeam?.headConsumed ??
+          clip.playbackDurationToSourceDuration(wrapDisplay.consumedPerSide);
+    }
 
     TransitionSeam? outgoingSeam;
     var tailConsumed = Duration.zero;
     final transition = clamped[clip.id];
-    if (i + 1 < clips.length && transition != null) {
+    if (i + 1 < n && transition != null) {
       outgoingSeam = seams.cached(clip, clips[i + 1], transition);
       tailConsumed = outgoingSeam?.tailConsumed ?? Duration.zero;
+    }
+    if (i == n - 1 && wrapDisplay.isActive) {
+      tailConsumed +=
+          wrapSeam?.tailConsumed ??
+          clip.playbackDurationToSourceDuration(wrapDisplay.consumedPerSide);
     }
 
     final bodyStart = clip.trimStart + headConsumed;
@@ -597,6 +673,10 @@ List<player.VideoClip> buildSeamAwarePlayerClips(
     if (outgoingSeam != null) {
       result.add(player.VideoClip.file(outgoingSeam.path));
     }
+  }
+
+  if (wrapSeam != null) {
+    result.add(player.VideoClip.file(wrapSeam.path));
   }
   return result;
 }

--- a/mobile/lib/services/video_editor/transition_seam_render_service.dart
+++ b/mobile/lib/services/video_editor/transition_seam_render_service.dart
@@ -403,8 +403,8 @@ class SeamTimeline {
     // axis (what the timeline draws) excludes them from the clip bodies and
     // appends the seam region at the end — mirroring [buildSeamAwarePlayerClips]
     // and [LoopWrapDisplay] so player, mapping and strips share one axis.
-    final wrapDisplay = LoopWrapDisplay.fromClips(clips);
     final wrapTransition = n > 0 ? clamped[clips[n - 1].id] : null;
+    final wrapDisplay = LoopWrapDisplay.fromClamped(clips, wrapTransition);
     final wrapSeam = wrapTransition != null && wrapDisplay.isActive
         ? seams.cached(clips[n - 1], clips[0], wrapTransition)
         : null;
@@ -615,8 +615,8 @@ List<player.VideoClip> buildSeamAwarePlayerClips(
   // axis (timeline strips shortened by [LoopWrapDisplay]) never shifts under
   // the playhead; the seam is appended once rendered and the loop then restarts
   // seamlessly through the blend, exactly matching the export.
-  final wrapDisplay = LoopWrapDisplay.fromClips(clips);
   final wrapTransition = n > 0 ? clamped[clips[n - 1].id] : null;
+  final wrapDisplay = LoopWrapDisplay.fromClamped(clips, wrapTransition);
   final wrapSeam = wrapTransition != null && wrapDisplay.isActive
       ? seams.cached(clips[n - 1], clips[0], wrapTransition)
       : null;

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -575,7 +575,9 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     // The loop-restart wrap consumes the first clip's head and the last clip's
     // tail eagerly (see buildSeamAwarePlayerClips); those clips stay on live
     // retiming like interior seam-consumed clips.
-    final wrapActive = LoopWrapDisplay.fromClips(clips).isActive;
+    final wrapActive =
+        clips.isNotEmpty &&
+        LoopWrapDisplay.fromClamped(clips, clamped[clips.last.id]).isActive;
     for (var i = 0; i < clips.length; i++) {
       final clip = clips[i];
       // Skip a clip whose body is consumed by a rendered seam on either side:

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -47,6 +47,7 @@ import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timel
 import 'package:openvine/widgets/video_editor/tune_editor/tune_set_timeline_ops.dart';
 import 'package:pro_image_editor/pro_image_editor.dart'
     hide AudioTrack, VideoClip;
+import 'package:pro_video_editor/pro_video_editor.dart' show ClipTransition;
 import 'package:unified_logger/unified_logger.dart';
 
 /// Direction an undo/redo navigation moved, used to bias which way
@@ -532,23 +533,36 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     for (var i = 0; i < clips.length - 1; i++) {
       final transition = clamped[clips[i].id];
       if (transition == null) continue;
-      if (_seamService.cached(clips[i], clips[i + 1], transition) != null) {
-        continue;
-      }
-      // Already counted by an earlier pass whose render is still in flight —
-      // skip so the pending counter (and overlay) is not double-incremented.
-      if (_seamService.isRendering(clips[i], clips[i + 1], transition)) {
-        continue;
-      }
-      _pendingSeamRenders.value++;
-      _seamService
-          .render(clipA: clips[i], clipB: clips[i + 1], transition: transition)
-          .then((seam) {
-            if (!mounted) return;
-            _pendingSeamRenders.value--;
-            if (seam != null) _resyncPlayerClips();
-          });
+      _renderSeam(clips[i], clips[i + 1], transition);
     }
+
+    // Loop-restart wrap: the last clip's transition blends its tail into the
+    // first clip's head (the same clip on a single-clip timeline) so the looping
+    // preview restarts through the blend instead of a hard cut.
+    if (clips.isNotEmpty) {
+      final wrap = clamped[clips.last.id];
+      if (wrap != null) _renderSeam(clips.last, clips.first, wrap);
+    }
+  }
+
+  /// Renders (once) the transition seam blending [clipA]'s tail into [clipB]'s
+  /// head, resyncing the preview when it lands. Idempotent — cached / in-flight
+  /// seams are skipped so the pending counter isn't double-incremented.
+  void _renderSeam(
+    DivineVideoClip clipA,
+    DivineVideoClip clipB,
+    ClipTransition transition,
+  ) {
+    if (_seamService.cached(clipA, clipB, transition) != null) return;
+    if (_seamService.isRendering(clipA, clipB, transition)) return;
+    _pendingSeamRenders.value++;
+    _seamService
+        .render(clipA: clipA, clipB: clipB, transition: transition)
+        .then((seam) {
+          if (!mounted) return;
+          _pendingSeamRenders.value--;
+          if (seam != null) _resyncPlayerClips();
+        });
   }
 
   /// Kicks off background renders of the normal-rate body for any non-1× clip,
@@ -558,6 +572,10 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
   /// live-retimed clip until the swap lands.
   void _ensureSpeedClipsRendered(List<DivineVideoClip> clips) {
     final clamped = clampTransitions(clips);
+    // The loop-restart wrap consumes the first clip's head and the last clip's
+    // tail eagerly (see buildSeamAwarePlayerClips); those clips stay on live
+    // retiming like interior seam-consumed clips.
+    final wrapActive = LoopWrapDisplay.fromClips(clips).isActive;
     for (var i = 0; i < clips.length; i++) {
       final clip = clips[i];
       // Skip a clip whose body is consumed by a rendered seam on either side:
@@ -574,7 +592,8 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
           i + 1 < clips.length &&
           outgoing != null &&
           _seamService.cached(clip, clips[i + 1], outgoing) != null;
-      if (consumedByIncoming || consumedByOutgoing) continue;
+      final consumedByWrap = wrapActive && (i == 0 || i == clips.length - 1);
+      if (consumedByIncoming || consumedByOutgoing || consumedByWrap) continue;
 
       if (_speedRenderService.cached(clip) != null) continue;
       if (_speedRenderService.isRendering(clip)) continue;

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_transition_sheet.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_transition_sheet.dart
@@ -100,11 +100,13 @@ Future<void> editLoopTransition(BuildContext context) async {
 
   final lastClip = clips.last;
   final firstClip = clips.first;
+  final roomPerSide = loopTransitionRoomPerSide(clips);
 
-  // The wrap the neighbours can't constrain: on a single clip the head and tail
-  // split it (half each); otherwise the shorter of the two joined clips.
+  // The room the neighbours can't constrain: on a single clip the head and
+  // tail split it (half each — identical to [roomPerSide], since a lone clip
+  // has no internal transitions); otherwise the shorter of the joined clips.
   final unconstrainedRoom = clips.length == 1
-      ? Duration(microseconds: firstClip.playbackDuration.inMicroseconds ~/ 2)
+      ? roomPerSide
       : (lastClip.playbackDuration < firstClip.playbackDuration
             ? lastClip.playbackDuration
             : firstClip.playbackDuration);
@@ -115,7 +117,7 @@ Future<void> editLoopTransition(BuildContext context) async {
     fromClip: lastClip,
     toClip: firstClip,
     editedClip: lastClip,
-    roomPerSide: loopTransitionRoomPerSide(clips),
+    roomPerSide: roomPerSide,
     unconstrainedRoom: unconstrainedRoom,
     title: context.l10n.videoEditorLoopTransitionSheetTitle,
   );

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_transition_sheet.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_transition_sheet.dart
@@ -59,50 +59,107 @@ const _loopMs = 2800;
 /// [DivineVideoClip.transition] through the editor history.
 ///
 /// A transition describes how a clip flows **into the next** clip, so the
-/// boundary is identified by its left clip; the last clip has no boundary.
+/// boundary is identified by its left clip; the last clip has no internal
+/// boundary — see [editLoopTransition] for its loop-restart wrap.
 Future<void> editClipTransition(
   BuildContext context,
   int leftClipIndex,
 ) async {
-  final bloc = context.read<ClipEditorBloc>();
-  final state = bloc.state;
-  if (leftClipIndex < 0 || leftClipIndex >= state.clips.length - 1) return;
+  final clips = context.read<ClipEditorBloc>().state.clips;
+  if (leftClipIndex < 0 || leftClipIndex >= clips.length - 1) return;
 
-  final clip = state.clips[leftClipIndex];
-  final nextClip = state.clips[leftClipIndex + 1];
-  final editor = VideoEditorScope.of(context).requireEditor;
+  final clip = clips[leftClipIndex];
+  final nextClip = clips[leftClipIndex + 1];
 
   final boundaryShorter = clip.playbackDuration < nextClip.playbackDuration
       ? clip.playbackDuration
       : nextClip.playbackDuration;
-  final roomPerSide = _roomPerSide(state.clips, leftClipIndex);
+
+  await _showTransitionSheet(
+    context,
+    // A transition runs at the boundary: clip A's tail into clip B's head.
+    fromClip: clip,
+    toClip: nextClip,
+    editedClip: clip,
+    roomPerSide: _roomPerSide(clips, leftClipIndex),
+    unconstrainedRoom: boundaryShorter,
+    title: context.l10n.videoEditorTransitionSheetTitle,
+  );
+}
+
+/// Opens the transition picker for the **loop-restart wrap** — the seam where
+/// the last clip's tail dissolves into the first clip's head so a looping
+/// player restarts seamlessly (`pro_video_editor` ≥ 2.5) — then applies the
+/// choice to the last clip's [DivineVideoClip.transition].
+///
+/// On a single-clip timeline the last and first clip are the same, so the wrap
+/// blends that clip's end into its own beginning.
+Future<void> editLoopTransition(BuildContext context) async {
+  final clips = context.read<ClipEditorBloc>().state.clips;
+  if (clips.isEmpty) return;
+
+  final lastClip = clips.last;
+  final firstClip = clips.first;
+
+  // The wrap the neighbours can't constrain: on a single clip the head and tail
+  // split it (half each); otherwise the shorter of the two joined clips.
+  final unconstrainedRoom = clips.length == 1
+      ? Duration(microseconds: firstClip.playbackDuration.inMicroseconds ~/ 2)
+      : (lastClip.playbackDuration < firstClip.playbackDuration
+            ? lastClip.playbackDuration
+            : firstClip.playbackDuration);
+
+  await _showTransitionSheet(
+    context,
+    // The wrap seam: the last clip's tail into the first clip's head.
+    fromClip: lastClip,
+    toClip: firstClip,
+    editedClip: lastClip,
+    roomPerSide: loopTransitionRoomPerSide(clips),
+    unconstrainedRoom: unconstrainedRoom,
+    title: context.l10n.videoEditorLoopTransitionSheetTitle,
+  );
+}
+
+/// Shared picker: previews [fromClip]'s tail flowing into [toClip]'s head, then
+/// applies the chosen transition to [editedClip] through the editor history.
+///
+/// [roomPerSide] is the per-side playback room the transition may consume after
+/// the adjacent clips' own transitions; [unconstrainedRoom] is that room before
+/// any neighbour reduced it, so the picker can hint when it was limited.
+Future<void> _showTransitionSheet(
+  BuildContext context, {
+  required DivineVideoClip fromClip,
+  required DivineVideoClip toClip,
+  required DivineVideoClip editedClip,
+  required Duration roomPerSide,
+  required Duration unconstrainedRoom,
+  required String title,
+}) async {
+  final bloc = context.read<ClipEditorBloc>();
+  final editor = VideoEditorScope.of(context).requireEditor;
 
   final result = await VineBottomSheet.show<({ClipTransition? transition})>(
     context: context,
     expanded: false,
     scrollable: false,
     isScrollControlled: true,
-    title: Text(
-      context.l10n.videoEditorTransitionSheetTitle,
-      style: VineTheme.titleMediumFont(),
-    ),
+    title: Text(title, style: VineTheme.titleMediumFont()),
     body: BlocProvider<TransitionBoundaryCubit>(
-      // A transition runs at the boundary: clip A's tail into clip B's head.
-      // The cubit shows A's ghost frame and B's thumbnail immediately, then
-      // swaps in the exact boundary frames (A at trimEnd, B at trimStart) as
-      // they are extracted fresh.
+      // The cubit shows the outgoing clip's ghost frame and the incoming clip's
+      // thumbnail immediately, then swaps in the exact boundary frames (the
+      // outgoing clip at trimEnd, the incoming at trimStart) as they extract.
       create: (_) => TransitionBoundaryCubit(
-        fromClip: clip,
-        toClip: nextClip,
-        fromPlaceholder: clip.ghostFramePath ?? clip.thumbnailPath,
-        toPlaceholder: nextClip.thumbnailPath,
+        fromClip: fromClip,
+        toClip: toClip,
+        fromPlaceholder: fromClip.ghostFramePath ?? fromClip.thumbnailPath,
+        toPlaceholder: toClip.thumbnailPath,
       ),
       child: TransitionPickerView(
-        // The per-side room a transition at this boundary may use, after the
-        // adjacent clips' own transitions. Overlaps blend both clips at once
-        // (so cap at half the room); dips fade out then in (so up to twice it).
-        // This keeps two transitions from over-consuming a shared clip — which
-        // the native compositor can't render — so they split it instead.
+        // Overlaps blend both clips at once (so cap at half the room); dips fade
+        // out then in (so up to twice it). The room already excludes what the
+        // adjacent clips' own transitions consume, so two transitions never
+        // over-consume a shared clip — which the native compositor can't render.
         overlapMaxMs: _snapDurationMs(
           transitionDurationForConsumed(
             roomPerSide,
@@ -115,8 +172,8 @@ Future<void> editClipTransition(
             ClipTransitionType.fadeToBlack,
           ).inMilliseconds,
         ),
-        limitedByNeighbor: roomPerSide < boundaryShorter,
-        initial: clip.transition,
+        limitedByNeighbor: roomPerSide < unconstrainedRoom,
+        initial: editedClip.transition,
       ),
     ),
   );
@@ -126,17 +183,17 @@ Future<void> editClipTransition(
   final newTransition = result.transition;
   // Re-selecting the current transition is a no-op — avoid a redundant history
   // entry.
-  if (newTransition == clip.transition) return;
+  if (newTransition == editedClip.transition) return;
 
-  final updated = clip.copyWith(
+  final updated = editedClip.copyWith(
     transition: newTransition,
     clearTransition: newTransition == null,
   );
-  final newClips = state.clips
-      .map((c) => c.id == clip.id ? updated : c)
+  final newClips = bloc.state.clips
+      .map((c) => c.id == editedClip.id ? updated : c)
       .toList();
 
-  bloc.add(ClipEditorClipUpdated(clipId: clip.id, clip: updated));
+  bloc.add(ClipEditorClipUpdated(clipId: editedClip.id, clip: updated));
   editor.setClipState(newClips);
 }
 

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
@@ -671,6 +671,7 @@ class _VideoEditorTimelineClipStripState
                   orderedClips: _orderedClips,
                   thumbnails: _thumbnails,
                   layout: layout,
+                  wrap: wrap,
                   dragIndex: _dragIndex,
                   trimmingClipId: widget.trimmingClipId,
                   shouldAnimate: shouldAnimate || volumeAnimating,
@@ -856,6 +857,7 @@ class _NonTrimmingClipPositions extends StatelessWidget {
     required this.orderedClips,
     required this.thumbnails,
     required this.layout,
+    required this.wrap,
     required this.dragIndex,
     required this.trimmingClipId,
     required this.shouldAnimate,
@@ -877,6 +879,13 @@ class _NonTrimmingClipPositions extends StatelessWidget {
   final List<DivineVideoClip> orderedClips;
   final ClipThumbnailManager thumbnails;
   final ({List<double> widths, List<double> offsets, double totalWidth}) layout;
+
+  /// Loop-wrap display geometry (or [LoopWrapDisplay.none]). The first clip's
+  /// head plays inside the blend seam at the loop point, so its thumbnails start
+  /// [LoopWrapDisplay.consumedPerSide] later; the last clip's tail is clipped by
+  /// its shortened [layout] width.
+  final LoopWrapDisplay wrap;
+
   final int? dragIndex;
   final String? trimmingClipId;
   final bool shouldAnimate;
@@ -917,6 +926,14 @@ class _NonTrimmingClipPositions extends StatelessWidget {
                 total: orderedClips.length,
                 clipWidth: layout.widths[i],
                 pixelsPerSecond: pixelsPerSecond,
+                // Shift the first clip's thumbnails past its wrap-consumed head
+                // so they match the shortened strip (and the playhead). Skipped
+                // while reordering, where the tile is a fixed square slot.
+                wrapHeadOffset: !isReordering && wrap.isActive && i == 0
+                    ? wrap.consumedPerSide.inMilliseconds /
+                          1000.0 *
+                          pixelsPerSecond
+                    : 0.0,
                 thumbnailNotifier: thumbnails[orderedClips[i].id],
                 onReorder: onReorder,
                 onTap: onClipTapped,

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
@@ -12,6 +12,7 @@ import 'package:openvine/blocs/video_editor/main_editor/video_editor_main_bloc.d
 import 'package:openvine/constants/video_editor_timeline_constants.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/video_editor/transition_geometry.dart';
 import 'package:openvine/router/app_router.dart';
 import 'package:openvine/services/video_editor/clip_thumbnail_manager.dart';
 import 'package:openvine/services/video_thumbnail_service.dart';
@@ -280,11 +281,25 @@ class _VideoEditorTimelineClipStripState
   /// produce those frames first — giving instant visual coverage.
   Map<String, List<Duration>> _computeSlotTimestamps() {
     final result = <String, List<Duration>>{};
+    final wrap = _wrapDisplay;
 
     for (final clip in widget.clips) {
-      final clipPx = _clipWidth(clip);
-      final trimmedMs = clip.trimmedDuration.inMilliseconds;
-      if (clipPx <= 0 || trimmedMs <= 0) continue;
+      final clipPx = _clipWidth(clip, wrap);
+      // The strip shows the clip's display range: the loop wrap moves the first
+      // clip's head and the last clip's tail into the blend seam at the end, so
+      // their thumbnails start later / end earlier by the consumed span
+      // (converted into this clip's source time).
+      var visibleStart = clip.trimStart;
+      var visibleEnd = clip.duration - clip.trimEnd;
+      if (wrap.isActive) {
+        final consumedSource = clip.playbackDurationToSourceDuration(
+          wrap.consumedPerSide,
+        );
+        if (clip.id == widget.clips.first.id) visibleStart += consumedSource;
+        if (clip.id == widget.clips.last.id) visibleEnd -= consumedSource;
+      }
+      final visibleMs = (visibleEnd - visibleStart).inMilliseconds;
+      if (clipPx <= 0 || visibleMs <= 0) continue;
 
       final slotCount = (clipPx / TimelineConstants.thumbnailWidth)
           .ceil()
@@ -292,7 +307,7 @@ class _VideoEditorTimelineClipStripState
       final timestamps = <Duration>[];
       for (var i = 0; i < slotCount; i++) {
         final centerMs =
-            clip.trimStart.inMilliseconds + trimmedMs * (i + 0.5) / slotCount;
+            visibleStart.inMilliseconds + visibleMs * (i + 0.5) / slotCount;
         timestamps.add(Duration(milliseconds: centerMs.round()));
       }
       result[clip.id] = timestamps;
@@ -301,9 +316,33 @@ class _VideoEditorTimelineClipStripState
     return result;
   }
 
-  double _clipWidth(DivineVideoClip clip) {
-    if (widget.clips.length == 1) return widget.totalWidth;
-    return clip.playbackDurationInSeconds * widget.pixelsPerSecond;
+  /// The loop-wrap display geometry for the current strip order, or
+  /// [LoopWrapDisplay.none] while trimming — trim math maps pixels to durations
+  /// assuming full-length strips, so the wrap shortening is suspended for the
+  /// gesture (like the transition buttons are hidden) and reapplied on release.
+  LoopWrapDisplay get _wrapDisplay => widget.trimmingClipId != null
+      ? LoopWrapDisplay.none
+      : LoopWrapDisplay.fromClips(_orderedClips);
+
+  double _seamRegionWidth(LoopWrapDisplay wrap) =>
+      wrap.seamDuration.inMicroseconds /
+      Duration.microsecondsPerSecond *
+      widget.pixelsPerSecond;
+
+  double _clipWidth(DivineVideoClip clip, LoopWrapDisplay wrap) {
+    if (widget.clips.length == 1) {
+      // The single clip fills the strip minus the loop-blend seam region
+      // appended at the end (widget.totalWidth already spans both).
+      return math.max(0, widget.totalWidth - _seamRegionWidth(wrap));
+    }
+    final display = wrap.displayDuration(
+      clip,
+      isFirst: clip.id == _orderedClips.first.id,
+      isLast: clip.id == _orderedClips.last.id,
+    );
+    return display.inMicroseconds /
+        Duration.microsecondsPerSecond *
+        widget.pixelsPerSecond;
   }
 
   int _clipIndexAtX(double localX) {
@@ -323,10 +362,11 @@ class _VideoEditorTimelineClipStripState
     final fingerX = details.localPosition.dx;
 
     // Find which clip was pressed in the normal layout.
+    final wrap = _wrapDisplay;
     var accX = 0.0;
     var pressedIndex = _orderedClips.length - 1;
     for (var i = 0; i < _orderedClips.length; i++) {
-      final w = _clipWidth(_orderedClips[i]);
+      final w = _clipWidth(_orderedClips[i], wrap);
       if (fingerX < accX + w) {
         pressedIndex = i;
         break;
@@ -335,7 +375,7 @@ class _VideoEditorTimelineClipStripState
     }
 
     // Where in the clip the finger landed (0.0 = left edge, 1.0 = right).
-    final clipW = _clipWidth(_orderedClips[pressedIndex]);
+    final clipW = _clipWidth(_orderedClips[pressedIndex], wrap);
     final fingerInClip = (fingerX - accX).clamp(0.0, clipW);
     final fingerRatio = clipW > 0 ? fingerInClip / clipW : 0.5;
 
@@ -529,19 +569,25 @@ class _VideoEditorTimelineClipStripState
   }
 
   /// Compute clip widths, left offsets and total width in a single pass.
+  ///
+  /// With a loop transition, the total includes the blend seam region appended
+  /// after the last clip (the wrap-consumed head/tail plays there instead of
+  /// inside the clips), so strips, playhead, preview and export share one axis.
   ({List<double> widths, List<double> offsets, double totalWidth})
   _computeLayout() {
+    final wrap = _wrapDisplay;
     final widths = <double>[];
     final offsets = <double>[];
     var x = 0.0;
     for (var i = 0; i < _orderedClips.length; i++) {
-      final w = _clipWidth(_orderedClips[i]);
+      final w = _clipWidth(_orderedClips[i], wrap);
       widths.add(w);
       offsets.add(x);
       x += w + TimelineConstants.clipGap;
     }
-    // Subtract trailing gap.
-    final total = x > 0 ? x - TimelineConstants.clipGap : 0.0;
+    // Subtract trailing gap, then append the loop-blend seam region.
+    var total = x > 0 ? x - TimelineConstants.clipGap : 0.0;
+    total += _seamRegionWidth(wrap);
     return (widths: widths, offsets: offsets, totalWidth: total);
   }
 
@@ -556,6 +602,15 @@ class _VideoEditorTimelineClipStripState
     final totalWidth = _isReordering
         ? _orderedClips.length * reorderSlotStep - gap
         : layout.totalWidth;
+
+    // Reserve a half-button-wide trailing slot so the loop-restart button can
+    // straddle the strip's end edge (centred on the last clip's end) without the
+    // outer Stack's hardEdge clipping its right half. Always reserved when there
+    // are clips so entering/leaving trim/volume/reorder doesn't animate the
+    // strip width.
+    final loopSlotWidth = _orderedClips.isEmpty
+        ? 0.0
+        : _TransitionButtonsLayer._hitWidth / 2;
 
     final shouldAnimate = _isReordering || _isReorderExiting;
 
@@ -598,7 +653,7 @@ class _VideoEditorTimelineClipStripState
           child: AnimatedContainer(
             duration: shouldAnimate || volumeAnimating ? animDuration : .zero,
             curve: animCurve,
-            width: totalWidth,
+            width: totalWidth + loopSlotWidth,
             height: containerHeight,
             child: Stack(
               clipBehavior:
@@ -675,15 +730,37 @@ class _VideoEditorTimelineClipStripState
                     pixelsPerSecond: widget.pixelsPerSecond,
                   ),
 
-                /// Transition buttons on each internal clip boundary. Hidden
-                /// during reorder/trim/volume/multi-select so they never
+                /// Transition buttons on each internal clip boundary, plus the
+                /// loop-blend seam region and the loop-restart button at the
+                /// very end (last clip's tail into the first clip's head).
+                /// Hidden during reorder/trim/volume/multi-select so they never
                 /// overlap those interactions.
                 if (!shouldAnimate &&
                     widget.trimmingClipId == null &&
                     !isVolumeEditMode &&
                     !widget.isMultiSelectMode &&
-                    _orderedClips.length >= 2)
-                  _TransitionButtonsLayer(clips: _orderedClips, layout: layout),
+                    _orderedClips.isNotEmpty) ...[
+                  if (_orderedClips.length >= 2)
+                    _TransitionButtonsLayer(
+                      clips: _orderedClips,
+                      layout: layout,
+                    ),
+                  if (_seamRegionWidth(_wrapDisplay) > 0)
+                    _LoopSeamRegion(
+                      left: layout.totalWidth - _seamRegionWidth(_wrapDisplay),
+                      width: _seamRegionWidth(_wrapDisplay),
+                      // The same frames the transition picker previews: the
+                      // last clip's tail into the first clip's head.
+                      tailFramePath:
+                          _orderedClips.last.ghostFramePath ??
+                          _orderedClips.last.thumbnailPath,
+                      headFramePath: _orderedClips.first.thumbnailPath,
+                    ),
+                  _LoopTransitionButton(
+                    hasTransition: _orderedClips.last.transition != null,
+                    layout: layout,
+                  ),
+                ],
               ],
             ),
           ),
@@ -940,6 +1017,144 @@ class _TransitionButtonsLayer extends StatelessWidget {
             ),
           ),
       ],
+    );
+  }
+}
+
+/// Positions the loop-restart button centred on the last clip's end edge — the
+/// "end" side of the wrap seam where the last clip's tail flows into the first
+/// clip's head so a looping player restarts seamlessly. Straddles the edge like
+/// the between-clip buttons straddle their seams; the strip reserves a
+/// half-button trailing slot so the right half isn't clipped. Shown even for a
+/// single clip, which wraps into itself.
+/// The loop-blend seam region drawn after the last clip: the span where the
+/// last clip's tail dissolves into the first clip's head on restart. Its width
+/// is the seam's real playback length ([LoopWrapDisplay.seamDuration]), so the
+/// playhead traverses it exactly while the blend plays in the preview.
+///
+/// Rendered as the actual blend: the last clip's tail frame cross-fading into
+/// the first clip's head frame along the region — the same frames the
+/// transition picker previews. Falls back to a tinted box when neither frame
+/// resolves.
+class _LoopSeamRegion extends StatelessWidget {
+  const _LoopSeamRegion({
+    required this.left,
+    required this.width,
+    required this.tailFramePath,
+    required this.headFramePath,
+  });
+
+  final double left;
+  final double width;
+
+  /// Last clip's tail frame (ghost frame / thumbnail), fading out.
+  final String? tailFramePath;
+
+  /// First clip's head frame (thumbnail), fading in toward the loop point.
+  final String? headFramePath;
+
+  @override
+  Widget build(BuildContext context) {
+    final fallback = ColoredBox(
+      color: VineTheme.primary.withValues(alpha: 0.18),
+    );
+    final tail = _frame(tailFramePath);
+    final head = _frame(headFramePath);
+    return Positioned(
+      left: left,
+      top: 0,
+      width: width,
+      height: TimelineConstants.thumbnailStripHeight,
+      child: ClipRRect(
+        borderRadius: const BorderRadius.horizontal(
+          right: Radius.circular(TimelineConstants.thumbnailRadius),
+        ),
+        child: ExcludeSemantics(
+          child: Stack(
+            fit: .expand,
+            children: [
+              tail ?? fallback,
+              if (head != null)
+                ShaderMask(
+                  // Only the gradient's alpha matters (dstIn masks the head
+                  // frame in from transparent to opaque across the region).
+                  shaderCallback: (rect) => const LinearGradient(
+                    colors: [Colors.transparent, VineTheme.whiteText],
+                  ).createShader(rect),
+                  blendMode: BlendMode.dstIn,
+                  child: head,
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget? _frame(String? path) {
+    if (path == null) return null;
+    return Image.file(
+      File(path),
+      fit: .cover,
+      gaplessPlayback: true,
+      errorBuilder: (_, _, _) => const SizedBox.shrink(),
+    );
+  }
+}
+
+class _LoopTransitionButton extends StatelessWidget {
+  const _LoopTransitionButton({
+    required this.hasTransition,
+    required this.layout,
+  });
+
+  final bool hasTransition;
+  final ({List<double> widths, List<double> offsets, double totalWidth}) layout;
+
+  @override
+  Widget build(BuildContext context) {
+    final foreground = hasTransition
+        ? VineTheme.primary
+        : VineTheme.secondaryText;
+    final left = math.max(
+      0.0,
+      layout.totalWidth - _TransitionButtonsLayer._hitWidth / 2,
+    );
+    return Positioned(
+      left: left,
+      top:
+          (TimelineConstants.thumbnailStripHeight -
+              _TransitionButtonsLayer._hitHeight) /
+          2,
+      width: _TransitionButtonsLayer._hitWidth,
+      height: _TransitionButtonsLayer._hitHeight,
+      child: Semantics(
+        button: true,
+        label: context.l10n.videoEditorLoopTransitionButtonSemanticLabel,
+        child: GestureDetector(
+          onTap: () => editLoopTransition(context),
+          behavior: HitTestBehavior.opaque,
+          child: Center(
+            child: SizedBox.square(
+              dimension: _TransitionButtonsLayer._visualSize,
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  color: VineTheme.surfaceBackground,
+                  shape: BoxShape.circle,
+                  border: Border.all(color: foreground, width: 1.5),
+                ),
+                child: Center(
+                  child: DivineIcon(
+                    icon: DivineIconName.repeat,
+                    size: 14,
+                    color: foreground,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
@@ -574,8 +574,7 @@ class _VideoEditorTimelineClipStripState
   /// after the last clip (the wrap-consumed head/tail plays there instead of
   /// inside the clips), so strips, playhead, preview and export share one axis.
   ({List<double> widths, List<double> offsets, double totalWidth})
-  _computeLayout() {
-    final wrap = _wrapDisplay;
+  _computeLayout(LoopWrapDisplay wrap) {
     final widths = <double>[];
     final offsets = <double>[];
     var x = 0.0;
@@ -598,7 +597,11 @@ class _VideoEditorTimelineClipStripState
     const animDuration = _animDuration;
     const animCurve = Curves.easeInOut;
 
-    final layout = _computeLayout();
+    // One wrap-display per build: [_wrapDisplay] runs [clampTransitions] on
+    // every call, so compute it once and share it with the layout pass.
+    final wrap = _wrapDisplay;
+    final seamRegionWidth = _seamRegionWidth(wrap);
+    final layout = _computeLayout(wrap);
     final totalWidth = _isReordering
         ? _orderedClips.length * reorderSlotStep - gap
         : layout.totalWidth;
@@ -745,10 +748,10 @@ class _VideoEditorTimelineClipStripState
                       clips: _orderedClips,
                       layout: layout,
                     ),
-                  if (_seamRegionWidth(_wrapDisplay) > 0)
+                  if (seamRegionWidth > 0)
                     _LoopSeamRegion(
-                      left: layout.totalWidth - _seamRegionWidth(_wrapDisplay),
-                      width: _seamRegionWidth(_wrapDisplay),
+                      left: layout.totalWidth - seamRegionWidth,
+                      width: seamRegionWidth,
                       // The same frames the transition picker previews: the
                       // last clip's tail into the first clip's head.
                       tailFramePath:
@@ -1021,12 +1024,6 @@ class _TransitionButtonsLayer extends StatelessWidget {
   }
 }
 
-/// Positions the loop-restart button centred on the last clip's end edge — the
-/// "end" side of the wrap seam where the last clip's tail flows into the first
-/// clip's head so a looping player restarts seamlessly. Straddles the edge like
-/// the between-clip buttons straddle their seams; the strip reserves a
-/// half-button trailing slot so the right half isn't clipped. Shown even for a
-/// single clip, which wraps into itself.
 /// The loop-blend seam region drawn after the last clip: the span where the
 /// last clip's tail dissolves into the first clip's head on restart. Its width
 /// is the seam's real playback length ([LoopWrapDisplay.seamDuration]), so the
@@ -1102,6 +1099,12 @@ class _LoopSeamRegion extends StatelessWidget {
   }
 }
 
+/// Positions the loop-restart button centred on the strip's end edge — the
+/// "end" side of the wrap seam where the last clip's tail flows into the first
+/// clip's head so a looping player restarts seamlessly. Straddles the edge like
+/// the between-clip buttons straddle their seams; the strip reserves a
+/// half-button trailing slot so the right half isn't clipped. Shown even for a
+/// single clip, which wraps into itself.
 class _LoopTransitionButton extends StatelessWidget {
   const _LoopTransitionButton({
     required this.hasTransition,

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_tiles.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_tiles.dart
@@ -230,6 +230,7 @@ class _AccessibleClipTile extends StatelessWidget {
     required this.pixelsPerSecond,
     required this.thumbnailNotifier,
     required this.onReorder,
+    this.wrapHeadOffset = 0,
     this.onTap,
     this.isMultiSelectMode = false,
     this.isSelected = false,
@@ -242,6 +243,10 @@ class _AccessibleClipTile extends StatelessWidget {
   final double pixelsPerSecond;
   final ValueNotifier<List<StripThumbnail>> thumbnailNotifier;
   final void Function(int from, int to) onReorder;
+
+  /// Extra pixels to shift thumbnails left (on top of trim-start) so a loop
+  /// wrap's consumed head is skipped on the first clip. Zero otherwise.
+  final double wrapHeadOffset;
   final ValueChanged<int>? onTap;
   final bool isMultiSelectMode;
   final bool isSelected;
@@ -292,9 +297,10 @@ class _AccessibleClipTile extends StatelessWidget {
               clip.durationInSeconds * pixelsPerSecond * clip._playbackScale,
           trimStartOffset:
               clip.trimStart.inMilliseconds /
-              1000.0 *
-              pixelsPerSecond *
-              clip._playbackScale,
+                  1000.0 *
+                  pixelsPerSecond *
+                  clip._playbackScale +
+              wrapHeadOffset,
           thumbnailNotifier: thumbnailNotifier,
           selectionState: isMultiSelectMode
               ? (isSelected

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart
@@ -10,6 +10,7 @@ import 'package:openvine/extensions/video_editor_history_extensions.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/timeline_overlay_item.dart';
+import 'package:openvine/models/video_editor/transition_geometry.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_timeline_control_bar.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart';
@@ -127,10 +128,18 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
         ? clips[currentClipIndex].id
         : null;
 
-    _totalDuration = totalDuration;
+    // With a loop transition, the display axis differs from the raw clip sum:
+    // the wrap-consumed head/tail plays inside the blend seam region appended
+    // at the end (see [LoopWrapDisplay]). Suspended while trimming, matching
+    // the clip strip. `displayDuration` equals `totalDuration` without a wrap.
+    final wrapDisplay = trimmingClipId != null
+        ? LoopWrapDisplay.none
+        : LoopWrapDisplay.fromClips(clips);
+    final displayDuration = wrapDisplay.displayTotal(clips);
+    _totalDuration = displayDuration;
     final screenWidth = MediaQuery.sizeOf(context).width;
     final halfScreen = screenWidth / 2;
-    final totalWidth = _contentWidth(totalDuration);
+    final totalWidth = _contentWidth(displayDuration);
 
     final hasSelectedOverlay = context.select(
       (TimelineOverlayBloc b) => b.state.selectedItemId != null,
@@ -149,7 +158,9 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
         BlocListener<ClipEditorBloc, ClipEditorState>(
           listenWhen: (prev, curr) => prev.totalDuration != curr.totalDuration,
           listener: (context, state) {
-            _totalDuration = state.totalDuration;
+            _totalDuration = LoopWrapDisplay.fromClips(
+              state.clips,
+            ).displayTotal(state.clips);
             final overlayBloc = context.read<TimelineOverlayBloc>();
             overlayBloc.add(
               TimelineOverlayTotalDurationChanged(state.totalDuration),
@@ -295,7 +306,7 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
                     maxHeight: TimelineConstants.height,
                     child: VideoEditorTimelineInteractiveBody(
                       playheadPosition: _playheadPosition,
-                      totalDuration: totalDuration,
+                      totalDuration: displayDuration,
                       formatPosition: (pos) {
                         final totalSeconds = pos.inMilliseconds / 1000.0;
                         final minutes = totalSeconds ~/ 60;

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart
@@ -158,9 +158,10 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
         BlocListener<ClipEditorBloc, ClipEditorState>(
           listenWhen: (prev, curr) => prev.totalDuration != curr.totalDuration,
           listener: (context, state) {
-            _totalDuration = LoopWrapDisplay.fromClips(
-              state.clips,
-            ).displayTotal(state.clips);
+            // _totalDuration is not updated here: build recomputes it on every
+            // rebuild (all its inputs are in the context.select record above)
+            // and, unlike this listener, correctly suspends the loop-wrap
+            // shortening while a trim gesture is active.
             final overlayBloc = context.read<TimelineOverlayBloc>();
             overlayBloc.add(
               TimelineOverlayTotalDurationChanged(state.totalDuration),

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart
@@ -53,6 +53,11 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
   /// that fire outside the build phase.
   Duration _totalDuration = Duration.zero;
 
+  /// Cached loop-wrap display geometry from the last build (suspended while
+  /// trimming, matching the strip) — used by the scroll/pinch mappings that
+  /// fire outside build so the playhead lines up with the shortened strip.
+  LoopWrapDisplay _wrapDisplay = LoopWrapDisplay.none;
+
   /// Playhead time derived from scroll offset — always matches the visual
   /// playhead regardless of zoom level.
   final _playheadPosition = ValueNotifier<Duration>(Duration.zero);
@@ -137,6 +142,7 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
         : LoopWrapDisplay.fromClips(clips);
     final displayDuration = wrapDisplay.displayTotal(clips);
     _totalDuration = displayDuration;
+    _wrapDisplay = wrapDisplay;
     final screenWidth = MediaQuery.sizeOf(context).width;
     final halfScreen = screenWidth / 2;
     final totalWidth = _contentWidth(displayDuration);
@@ -942,6 +948,7 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
             _scrollController.offset,
             _pixelsPerSecond,
             _totalDuration,
+            wrap: _wrapDisplay,
           )
         : Duration.zero;
 
@@ -952,6 +959,7 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
         clips,
         anchorPosition,
         newPps,
+        wrap: _wrapDisplay,
       );
       _scrollController.jumpTo(
         newOffset.clamp(0, _scrollController.position.maxScrollExtent),
@@ -979,6 +987,7 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
         context.read<ClipEditorBloc>().state.clips,
         position,
         _pixelsPerSecond,
+        wrap: _wrapDisplay,
       );
 
   /// Inverse of [_positionToScrollOffset]: maps a [scrollOffset] back to a
@@ -989,6 +998,7 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
         scrollOffset,
         _pixelsPerSecond,
         _totalDuration,
+        wrap: _wrapDisplay,
       );
 
   void _syncScrollToPosition(Duration position, Duration totalDuration) {

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart
@@ -5,6 +5,7 @@
 import 'package:models/models.dart' show AudioEvent;
 import 'package:openvine/constants/video_editor_timeline_constants.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/video_editor/transition_geometry.dart';
 
 /// Converts a [sourcePosition] inside one untrimmed clip to the matching
 /// composite playback position on the full timeline.
@@ -303,17 +304,29 @@ class _TimelineMarkerAnchor {
 /// Without this correction the scroll target is up to
 /// `(clipsPassedCount × clipGap)` pixels short of the trim-handle
 /// marker's actual visual position.
+/// A loop transition draws the first/last clips shortened by the wrap-consumed
+/// head/tail (see [LoopWrapDisplay]), so the strip's clip boundaries — and the
+/// [TimelineConstants.clipGap]s at them — sit on the display axis. [position] is
+/// already a display-axis position (the playhead comes from
+/// `SeamTimeline.compositeToTimeline`), so pass [wrap] to count gaps at the
+/// display boundaries; otherwise the boundaries fall on the raw-duration axis
+/// and the playhead drifts from the strip by a gap width near each boundary.
 double timelinePositionToScrollOffset(
   List<DivineVideoClip> clips,
   Duration position,
-  double pixelsPerSecond,
-) {
+  double pixelsPerSecond, {
+  LoopWrapDisplay wrap = LoopWrapDisplay.none,
+}) {
   var acc = Duration.zero;
   var gapPixels = 0.0;
   for (var i = 0; i < clips.length; i++) {
-    final clip = clips[i];
-    if (acc + clip.playbackDuration > position) break;
-    acc += clip.playbackDuration;
+    final display = wrap.displayDuration(
+      clips[i],
+      isFirst: i == 0,
+      isLast: i == clips.length - 1,
+    );
+    if (acc + display > position) break;
+    acc += display;
     if (i < clips.length - 1) {
       gapPixels += TimelineConstants.clipGap;
     }
@@ -325,27 +338,35 @@ double timelinePositionToScrollOffset(
 /// position — the exact inverse of [timelinePositionToScrollOffset].
 ///
 /// The result is clamped to `[Duration.zero, totalDuration]`.
+/// Pass [wrap] so the clip boundaries (and their gaps) are measured on the
+/// display axis the strip draws — the returned position is then a display-axis
+/// position, matching what [timelinePositionToScrollOffset] expects and what
+/// `SeamTimeline` produces. Without a loop transition [wrap] is
+/// [LoopWrapDisplay.none] and the mapping is the plain raw-duration one.
 Duration timelineScrollOffsetToPosition(
   List<DivineVideoClip> clips,
   double scrollOffset,
   double pixelsPerSecond,
-  Duration totalDuration,
-) {
+  Duration totalDuration, {
+  LoopWrapDisplay wrap = LoopWrapDisplay.none,
+}) {
   var acc = Duration.zero;
   var gapPixels = 0.0;
   for (var i = 0; i < clips.length; i++) {
-    final clip = clips[i];
+    final display = wrap.displayDuration(
+      clips[i],
+      isFirst: i == 0,
+      isLast: i == clips.length - 1,
+    );
     final clipEndPx =
-        (acc + clip.playbackDuration).inMicroseconds /
-            1_000_000.0 *
-            pixelsPerSecond +
+        (acc + display).inMicroseconds / 1_000_000.0 * pixelsPerSecond +
         gapPixels;
     if (scrollOffset <= clipEndPx) break;
     final gapEndPx = clipEndPx + TimelineConstants.clipGap;
     if (i < clips.length - 1 && scrollOffset < gapEndPx) {
-      return acc + clip.playbackDuration;
+      return acc + display;
     }
-    acc += clip.playbackDuration;
+    acc += display;
     if (i < clips.length - 1) {
       gapPixels += TimelineConstants.clipGap;
     }

--- a/mobile/test/models/video_editor/transition_geometry_test.dart
+++ b/mobile/test/models/video_editor/transition_geometry_test.dart
@@ -119,13 +119,16 @@ void main() {
       playbackSpeed: playbackSpeed,
     );
 
-    test('drops the transition on the last clip (no following boundary)', () {
+    test('keeps the last clip transition as the loop-restart wrap', () {
+      // The last clip's transition is no longer dropped: it wraps the last
+      // clip's tail into the first clip's head. A 500ms dissolve fits two 2s
+      // clips, so it passes through unchanged.
       final clips = [
         clip('a', const Duration(seconds: 2)),
         clip('b', const Duration(seconds: 2), transition: dissolve),
       ];
 
-      expect(clampTransitions(clips)['b'], isNull);
+      expect(clampTransitions(clips)['b'], equals(dissolve));
     });
 
     test('returns null for a clip with no transition', () {
@@ -525,6 +528,235 @@ void main() {
             equals(const Duration(milliseconds: 1500)),
           );
         });
+      });
+    });
+  });
+
+  group('loop-restart wrap', () {
+    DivineVideoClip clip(
+      String id,
+      Duration duration, {
+      ClipTransition? transition,
+    }) => DivineVideoClip(
+      id: id,
+      video: EditorVideo.file('${Directory.systemTemp.path}/$id.mp4'),
+      duration: duration,
+      recordedAt: DateTime(2026),
+      targetAspectRatio: model.AspectRatio.vertical,
+      originalAspectRatio: 9 / 16,
+      transition: transition,
+    );
+
+    group('clampTransitions', () {
+      test('passes an in-bounds single-clip wrap through unchanged', () {
+        // One 4s clip: an 800ms dissolve carves 1.6s head + 1.6s tail, leaving
+        // an 0.8s middle body, so it fits and is not reduced.
+        final wrap = dissolve.copyWith(
+          duration: const Duration(milliseconds: 800),
+        );
+        expect(
+          clampTransitions([
+            clip('a', const Duration(seconds: 4), transition: wrap),
+          ])['a'],
+          equals(wrap),
+        );
+      });
+
+      test('clamps a single-clip wrap that would consume the whole clip', () {
+        // A 1500ms dissolve on a 2s clip wants 2×(1500×2)=6s of a 2s clip; the
+        // head+tail budget caps it to half the clip per side → 500ms.
+        final tooLong = dissolve.copyWith(
+          duration: const Duration(milliseconds: 1500),
+        );
+        expect(
+          clampTransitions([
+            clip('a', const Duration(seconds: 2), transition: tooLong),
+          ])['a']?.duration,
+          equals(const Duration(milliseconds: 500)),
+        );
+      });
+
+      test('passes an in-bounds multi-clip wrap through unchanged', () {
+        // Two 4s clips, no interior transition: a 500ms dissolve carves 1s from
+        // the last clip's tail and 1s from the first clip's head, both fit.
+        final wrap = dissolve.copyWith(
+          duration: const Duration(milliseconds: 500),
+        );
+        final clips = [
+          clip('a', const Duration(seconds: 4)),
+          clip('b', const Duration(seconds: 4), transition: wrap),
+        ];
+
+        expect(clampTransitions(clips)['b'], equals(wrap));
+      });
+    });
+
+    // The loop-restart wrap shortens the exported output native-side only. The
+    // editor↔output map deliberately ignores it, so the ruler and playhead
+    // never go negative or run past the editor timeline.
+    group('does not affect the editor↔output map', () {
+      test('renderedOutputDuration ignores an overlap wrap', () {
+        final wrap = dissolve.copyWith(
+          duration: const Duration(milliseconds: 800),
+        );
+        expect(
+          renderedOutputDuration([
+            clip('a', const Duration(seconds: 4), transition: wrap),
+          ]),
+          equals(const Duration(seconds: 4)),
+        );
+      });
+
+      test('renderedOutputDuration still subtracts an interior blend', () {
+        // Only the interior a→b dissolve (500ms) is removed; the wrap on b is
+        // not: 4s − 0.5s.
+        final t = dissolve.copyWith(
+          duration: const Duration(milliseconds: 500),
+        );
+        final clips = [
+          clip('a', const Duration(seconds: 2), transition: t),
+          clip('b', const Duration(seconds: 2), transition: t),
+        ];
+
+        expect(
+          renderedOutputDuration(clips),
+          equals(const Duration(milliseconds: 3500)),
+        );
+      });
+
+      test('editorToOutputPosition is the identity for a single-clip wrap', () {
+        final wrap = dissolve.copyWith(
+          duration: const Duration(milliseconds: 800),
+        );
+        final clips = [
+          clip('a', const Duration(seconds: 4), transition: wrap),
+        ];
+        expect(
+          editorToOutputPosition(clips, const Duration(seconds: 2)),
+          equals(const Duration(seconds: 2)),
+        );
+        expect(
+          editorToOutputPosition(clips, const Duration(seconds: 4)),
+          equals(const Duration(seconds: 4)),
+        );
+      });
+    });
+
+    group(LoopWrapDisplay, () {
+      test('is none without a loop transition', () {
+        final display = LoopWrapDisplay.fromClips([
+          clip('a', const Duration(seconds: 3)),
+        ]);
+        expect(display.isActive, isFalse);
+        expect(
+          display.displayTotal([clip('a', const Duration(seconds: 3))]),
+          equals(const Duration(seconds: 3)),
+        );
+      });
+
+      test('shortens first head + last tail and appends the overlap seam', () {
+        // 500ms dissolve → 1s consumed per side, seam 2s−1s/2... = 1.5s.
+        final wrap = dissolve.copyWith(
+          duration: const Duration(milliseconds: 500),
+        );
+        final clips = [
+          clip('a', const Duration(seconds: 3)),
+          clip('b', const Duration(seconds: 3), transition: wrap),
+        ];
+        final display = LoopWrapDisplay.fromClips(clips);
+
+        expect(display.consumedPerSide, equals(const Duration(seconds: 1)));
+        expect(
+          display.seamDuration,
+          equals(const Duration(milliseconds: 1500)),
+        );
+        expect(
+          display.displayDuration(clips.first, isFirst: true, isLast: false),
+          equals(const Duration(seconds: 2)),
+        );
+        expect(
+          display.displayDuration(clips.last, isFirst: false, isLast: true),
+          equals(const Duration(seconds: 2)),
+        );
+        // Total = 6s − 2×1s + 1.5s = 5.5s — exactly the export length
+        // (6s − 500ms blend).
+        expect(
+          display.displayTotal(clips),
+          equals(const Duration(milliseconds: 5500)),
+        );
+      });
+
+      test('keeps the total unchanged for a dip wrap', () {
+        // Dips don't shorten the export; consumed head+tail return in full via
+        // the seam region: total stays Σ.
+        final wrap = fadeToBlack.copyWith(
+          duration: const Duration(seconds: 1),
+        );
+        final clips = [
+          clip('a', const Duration(seconds: 3), transition: wrap),
+        ];
+        final display = LoopWrapDisplay.fromClips(clips);
+
+        expect(
+          display.consumedPerSide,
+          equals(const Duration(milliseconds: 500)),
+        );
+        expect(display.seamDuration, equals(const Duration(seconds: 1)));
+        expect(
+          display.displayTotal(clips),
+          equals(const Duration(seconds: 3)),
+        );
+      });
+
+      test('consumes both ends of a single clip', () {
+        final wrap = dissolve.copyWith(
+          duration: const Duration(milliseconds: 250),
+        );
+        final clips = [
+          clip('a', const Duration(seconds: 3), transition: wrap),
+        ];
+        final display = LoopWrapDisplay.fromClips(clips);
+
+        // 250ms dissolve → 500ms per side, both from the same clip.
+        expect(
+          display.displayDuration(clips.first, isFirst: true, isLast: true),
+          equals(const Duration(seconds: 2)),
+        );
+      });
+    });
+
+    group('loopTransitionRoomPerSide', () {
+      test('is half the playback for a single clip', () {
+        expect(
+          loopTransitionRoomPerSide([clip('a', const Duration(seconds: 4))]),
+          equals(const Duration(seconds: 2)),
+        );
+      });
+
+      test('is the shorter of the joined tail and head', () {
+        expect(
+          loopTransitionRoomPerSide([
+            clip('a', const Duration(seconds: 3)),
+            clip('b', const Duration(seconds: 2)),
+          ]),
+          equals(const Duration(seconds: 2)),
+        );
+      });
+
+      test('excludes the neighbours own internal transitions', () {
+        // a→b dissolve (500ms) consumes 1s of b's head, leaving 1s tail for the
+        // wrap; a's own outgoing consumes 1s of its tail, leaving 2s head. The
+        // tighter side (1s) wins.
+        final internal = dissolve.copyWith(
+          duration: const Duration(milliseconds: 500),
+        );
+        expect(
+          loopTransitionRoomPerSide([
+            clip('a', const Duration(seconds: 3), transition: internal),
+            clip('b', const Duration(seconds: 2)),
+          ]),
+          equals(const Duration(seconds: 1)),
+        );
       });
     });
   });

--- a/mobile/test/models/video_editor/transition_geometry_test.dart
+++ b/mobile/test/models/video_editor/transition_geometry_test.dart
@@ -591,13 +591,26 @@ void main() {
       });
     });
 
-    // The loop-restart wrap shortens the exported output native-side only. The
-    // editor↔output map deliberately ignores it, so the ruler and playhead
-    // never go negative or run past the editor timeline.
-    group('does not affect the editor↔output map', () {
-      test('renderedOutputDuration ignores an overlap wrap', () {
+    // The loop-restart wrap's blend plays at the loop point, past the last
+    // clip, so it shortens the output length without adding a blend region to
+    // the position mapping — the ruler and playhead map exactly as without a
+    // wrap and never go negative or run past the editor timeline.
+    group('editor↔output map', () {
+      test('renderedOutputDuration subtracts an overlap wrap blend', () {
         final wrap = dissolve.copyWith(
           duration: const Duration(milliseconds: 800),
+        );
+        expect(
+          renderedOutputDuration([
+            clip('a', const Duration(seconds: 4), transition: wrap),
+          ]),
+          equals(const Duration(milliseconds: 3200)),
+        );
+      });
+
+      test('renderedOutputDuration keeps a dip wrap at full length', () {
+        final wrap = fadeToBlack.copyWith(
+          duration: const Duration(seconds: 1),
         );
         expect(
           renderedOutputDuration([
@@ -607,9 +620,9 @@ void main() {
         );
       });
 
-      test('renderedOutputDuration still subtracts an interior blend', () {
-        // Only the interior a→b dissolve (500ms) is removed; the wrap on b is
-        // not: 4s − 0.5s.
+      test('renderedOutputDuration subtracts interior and wrap blends', () {
+        // The interior a→b dissolve and the wrap on b each remove their 500ms
+        // blend: 4s − 0.5s − 0.5s.
         final t = dissolve.copyWith(
           duration: const Duration(milliseconds: 500),
         );
@@ -620,7 +633,7 @@ void main() {
 
         expect(
           renderedOutputDuration(clips),
-          equals(const Duration(milliseconds: 3500)),
+          equals(const Duration(seconds: 3)),
         );
       });
 

--- a/mobile/test/services/video_editor/transition_seam_render_service_test.dart
+++ b/mobile/test/services/video_editor/transition_seam_render_service_test.dart
@@ -51,6 +51,84 @@ void main() {
       expect(result[1].start, equals(Duration.zero));
     });
 
+    test('consumes the wrap head/tail eagerly before its seam is rendered', () {
+      // The last clip's transition is the loop-restart wrap. Its consumption is
+      // applied even before the seam file lands, so the display axis (timeline
+      // strips) never shifts under the playhead; only the blend itself is
+      // missing until rendered. A 500ms dissolve consumes 2×500ms per side.
+      final clips = [clip('a'), clip('b', transition: dissolve)];
+      final result = buildSeamAwarePlayerClips(
+        clips,
+        TransitionSeamRenderService(),
+      );
+
+      expect(result, hasLength(2));
+      expect(result[0].uri, equals('/tmp/a.mp4'));
+      expect(result[0].start, equals(const Duration(seconds: 1)));
+      expect(result[0].end, equals(const Duration(seconds: 3)));
+      expect(result[1].uri, equals('/tmp/b.mp4'));
+      expect(result[1].start, equals(Duration.zero));
+      expect(result[1].end, equals(const Duration(seconds: 2)));
+    });
+
+    test('consumes the first head + last tail and appends the wrap seam', () {
+      // The wrap seam (keyed last→first) consumes the first clip's head (it
+      // starts later) and the last clip's tail (replaced by the seam), then is
+      // appended so the loop restarts seamlessly through the blend.
+      final clipA = clip('a');
+      final clipB = clip('b', transition: dissolve);
+      final service = TransitionSeamRenderService()
+        ..cacheSeamForTest(
+          clipB,
+          clipA,
+          dissolve,
+          const TransitionSeam(
+            path: '/tmp/wrap.mp4',
+            duration: Duration(milliseconds: 500),
+            tailConsumed: Duration(milliseconds: 500),
+            headConsumed: Duration(milliseconds: 500),
+          ),
+        );
+
+      final result = buildSeamAwarePlayerClips([clipA, clipB], service);
+
+      expect(result, hasLength(3));
+      // First clip: head consumed → starts at 500ms.
+      expect(result[0].uri, equals('/tmp/a.mp4'));
+      expect(result[0].start, equals(const Duration(milliseconds: 500)));
+      expect(result[0].end, equals(const Duration(seconds: 3)));
+      // Last clip: tail consumed → ends at 2500ms.
+      expect(result[1].uri, equals('/tmp/b.mp4'));
+      expect(result[1].start, equals(Duration.zero));
+      expect(result[1].end, equals(const Duration(milliseconds: 2500)));
+      expect(result[2].uri, equals('/tmp/wrap.mp4'));
+    });
+
+    test('wraps a single clip into itself (head + tail into the seam)', () {
+      final only = clip('a', transition: dissolve);
+      final service = TransitionSeamRenderService()
+        ..cacheSeamForTest(
+          only,
+          only,
+          dissolve,
+          const TransitionSeam(
+            path: '/tmp/wrap.mp4',
+            duration: Duration(milliseconds: 500),
+            tailConsumed: Duration(milliseconds: 500),
+            headConsumed: Duration(milliseconds: 500),
+          ),
+        );
+
+      final result = buildSeamAwarePlayerClips([only], service);
+
+      expect(result, hasLength(2));
+      // Middle body: [500ms, 2500ms].
+      expect(result[0].uri, equals('/tmp/a.mp4'));
+      expect(result[0].start, equals(const Duration(milliseconds: 500)));
+      expect(result[0].end, equals(const Duration(milliseconds: 2500)));
+      expect(result[1].uri, equals('/tmp/wrap.mp4'));
+    });
+
     test('splices the rendered seam between trimmed neighbours', () {
       final clipA = clip('a', transition: dissolve);
       final clipB = clip('b');
@@ -587,6 +665,51 @@ void main() {
         );
         previous = mapped;
       }
+    });
+
+    test('a single-clip loop wrap maps bodies 1:1 on the display axis', () {
+      // The display axis excludes the wrap-consumed head/tail (they live in
+      // the seam region the strip draws at the end), so the body maps 1:1 —
+      // playhead X = thumbnail X = preview frame X — and the seam segment
+      // covers the appended region.
+      final only = clip('a', transition: dissolve);
+      final service = TransitionSeamRenderService()
+        ..cacheSeamForTest(
+          only,
+          only,
+          dissolve,
+          const TransitionSeam(
+            path: '/tmp/wrap.mp4',
+            duration: Duration(milliseconds: 800),
+            tailConsumed: Duration(milliseconds: 500),
+            headConsumed: Duration(milliseconds: 500),
+          ),
+        );
+      final timeline = SeamTimeline([only], service);
+
+      // Body (composite [0,2000]) is the identity on the display axis.
+      expect(
+        timeline.compositeToTimeline(Duration.zero),
+        equals(Duration.zero),
+      );
+      expect(
+        timeline.compositeToTimeline(const Duration(seconds: 1)),
+        equals(const Duration(seconds: 1)),
+      );
+      expect(
+        timeline.compositeToTimeline(const Duration(seconds: 2)),
+        equals(const Duration(seconds: 2)),
+      );
+      // The seam plays after the body and maps onto the appended seam region.
+      expect(
+        timeline.compositeToTimeline(const Duration(milliseconds: 2800)),
+        greaterThan(const Duration(seconds: 2)),
+      );
+      // Never seeks negative.
+      expect(
+        timeline.timelineToComposite(Duration.zero),
+        equals(Duration.zero),
+      );
     });
   });
 }

--- a/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
@@ -5,6 +5,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart' show AudioEvent;
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/video_editor/transition_geometry.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 
@@ -33,6 +34,7 @@ DivineVideoClip _clip(
   double? speed,
   Duration trimStart = Duration.zero,
   Duration trimEnd = Duration.zero,
+  ClipTransition? transition,
 }) => DivineVideoClip(
   id: id,
   video: EditorVideo.file('/tmp/$id.mp4'),
@@ -43,6 +45,7 @@ DivineVideoClip _clip(
   playbackSpeed: speed,
   trimStart: trimStart,
   trimEnd: trimEnd,
+  transition: transition,
 );
 
 void main() {
@@ -715,6 +718,101 @@ void main() {
         speedTotal,
       );
       expect(recovered, equals(pos));
+    });
+  });
+
+  // A loop transition draws the first/last clips shortened by the wrap-consumed
+  // head/tail and appends a blend seam at the end (see [LoopWrapDisplay]). The
+  // playhead position is on that display axis, so the scroll mappings must count
+  // clip-gap boundaries on the display axis too — otherwise the playhead drifts
+  // from the drawn strip by a gap width near each boundary.
+  //
+  //   clips: c0 = 4 s, c1 = 4 s with a 500 ms dissolve loop wrap
+  //   → consumed = 1 s per side, display c0 = 3 s, c1 = 3 s, seam = 1.5 s
+  //   display layout @ pps 52, clipGap 1:
+  //     [0…156 px] gap [157…313 px]  seam [313…391 px]  (total 7.5 s → 390 px)
+  group('loop-wrap-aware geometry', () {
+    const dissolve = ClipTransition(type: ClipTransitionType.dissolve);
+    final wrapClips = [
+      _clip('w0', 4),
+      _clip(
+        'w1',
+        4,
+        transition: dissolve.copyWith(
+          duration: const Duration(milliseconds: 500),
+        ),
+      ),
+    ];
+    final wrap = LoopWrapDisplay.fromClips(wrapClips);
+    const displayTotal = Duration(milliseconds: 7500);
+    const clipGap = 1.0;
+
+    test('LoopWrapDisplay carries the expected consumed span', () {
+      expect(wrap.consumedPerSide, equals(const Duration(seconds: 1)));
+      expect(wrap.displayTotal(wrapClips), equals(displayTotal));
+    });
+
+    test('positionToOffset counts the gap on the display boundary', () {
+      // 3.5 s is 0.5 s into c1 on the display axis (c1 starts at display 3 s),
+      // so the gap after c0 is already crossed → +1 gap.
+      const pos = Duration(milliseconds: 3500);
+      expect(
+        timelinePositionToScrollOffset(wrapClips, pos, pps, wrap: wrap),
+        equals(3.5 * pps + clipGap),
+      );
+    });
+
+    test('positionToOffset without the wrap misses the display gap', () {
+      // Without the wrap the raw c0 duration (4 s) still contains 3.5 s, so the
+      // gap is not counted — the drift the wrap parameter fixes.
+      const pos = Duration(milliseconds: 3500);
+      expect(
+        timelinePositionToScrollOffset(wrapClips, pos, pps),
+        equals(3.5 * pps),
+      );
+    });
+
+    test('positionToOffset maps the seam region past every clip gap', () {
+      // 6.5 s is 0.5 s into the seam (bodies end at display 6 s); one gap sits
+      // before it (between c0 and c1).
+      const pos = Duration(milliseconds: 6500);
+      expect(
+        timelinePositionToScrollOffset(wrapClips, pos, pps, wrap: wrap),
+        equals(6.5 * pps + clipGap),
+      );
+    });
+
+    test('offsetToPosition round-trips a display-axis position', () {
+      const pos = Duration(milliseconds: 3500);
+      final offset = timelinePositionToScrollOffset(
+        wrapClips,
+        pos,
+        pps,
+        wrap: wrap,
+      );
+      expect(
+        timelineScrollOffsetToPosition(
+          wrapClips,
+          offset,
+          pps,
+          displayTotal,
+          wrap: wrap,
+        ),
+        equals(pos),
+      );
+    });
+
+    test('offsetToPosition clamps to the shortened display total', () {
+      expect(
+        timelineScrollOffsetToPosition(
+          wrapClips,
+          99999,
+          pps,
+          displayTotal,
+          wrap: wrap,
+        ),
+        equals(displayTotal),
+      );
     });
   });
 


### PR DESCRIPTION
Closes #5981

## What

Adds a **loop transition** to the video editor: a repeat button at the end of the timeline strip opens the existing transition picker for the loop seam — the last clip's tail blending into the first clip's head — so exported vines restart through a dissolve/fade/slide/push/wipe instead of a hard cut. Works for multi-clip timelines and for a single clip (which wraps into itself).

Built on `pro_video_editor` 2.5.0, where a `ClipTransition` on the **last (or only)** `VideoSegment` renders as a seamless wrap into the first segment (bumped from 2.4.0; no API change, behavioral only).

## Why the design looks the way it does

- **Stored on the last clip's `transition` field** — that is exactly what the native renderer reads as the wrap; no new model field, persistence (drafts/library JSON) works unchanged.
- **Trims are never mutated.** A real `trimStart` bump would be consumed twice (once by us, once by the native wrap) and would need un-trimming when the loop is removed. Instead the consumption is *virtual*, derived from the transition.
- **One shared geometry (`LoopWrapDisplay`)** drives strip widths, thumbnail timestamps, timeline width and the preview player plan, so the timeline draws exactly what plays: the first clip starts later by the consumed head, the last ends earlier by the consumed tail, and a blend-seam region (a tail-into-head cross-fade preview) sits at the loop point. Timeline total equals the export length.
- **The wrap shortens the export like any overlap.** An overlap wrap removes its blend from the rendered output, so the header's total length and the ruler both account for it (`TransitionTimelineMap.outputDuration` subtracts the wrap blend). The *position* mapping stays wrap-free — the blend plays at the loop point, past the last clip — so the playhead and ruler ticks map exactly as without a wrap and never go negative or past the editor timeline. Dips don't shorten, so they leave the total unchanged.
- **Eager consumption**: head/tail are consumed before the seam file finishes rendering, so the axis never shifts under the playhead; the blend pops in at the loop point when the background render (existing transition-seam pipeline) lands.
- **`SeamTimeline` maps clip bodies 1:1** (playhead X = thumbnail X = preview frame X) and now clamps instead of extrapolating negative — the extrapolation froze the preview player on seek.
- Wrap display is suspended during trim gestures (like the transition buttons) so trim px↔duration math stays untouched.
- `clampTransitions` now treats the last clip's transition as the wrap boundary and budgets it against the first clip's head / last clip's tail (and both ends of a single clip), sharing the existing no-overlap clamp.

## Known limits

- Layers/audio anchored near the wrap-consumed region can appear shifted by up to the consumed span (bounded by the transition duration) between preview and export.
- Live preview of interior transitions is unchanged; the loop seam uses the same seam-render pipeline and conventions.
- With a loop set, the first/last clip stays on live retiming in the preview when it runs at a non-1× speed (its whole-body speed render is skipped, matching interior seam-consumed clips). Playback speed is still correct — only the background-render optimization is skipped; the export is unaffected.

## Tests

- `transition_geometry_test.dart`: wrap clamping (single/multi clip, against interior neighbours), `LoopWrapDisplay` (consumption, seam length, display totals incl. dip vs overlap), loop room ceiling, and the editor↔output map counting the wrap blend in `renderedOutputDuration` (overlap subtracts, dip doesn't) while keeping the position mapping identity.
- `transition_seam_render_service_test.dart`: eager consumption before the seam lands, seam splice + trim for multi-clip and single-clip wraps, `SeamTimeline` 1:1 body mapping + non-negative seek clamp.
- l10n: 2 new keys (`videoEditorLoopTransitionSheetTitle`, `videoEditorLoopTransitionButtonSemanticLabel`) mirrored into all 17 non-en locales; ARB consistency test green.
- `flutter analyze` clean; the video-editor suites (models + services + widgets) green.

## Manual test plan

1. Single clip + loop dissolve → strip shortens at both ends, blend region appears at the end, preview loops through the blend, thumbnails match preview frames, header total matches the shortened export length.
2. Multi-clip + loop transition, incl. combination with interior transitions (budget splitting).
3. Trim first/last clip while a loop is set (wrap display suspends during the gesture).
4. Export and verify the published vine loops seamlessly in the feed.