### PR TITLE
feat(router): fade-upwards transition for camera and library flows

### DIFF
--- a/mobile/lib/router/fade_upwards_page.dart
+++ b/mobile/lib/router/fade_upwards_page.dart
@@ -1,0 +1,27 @@
+// ABOUTME: Shared CustomTransitionPage with the classic fade-upwards
+// ABOUTME: transition (pre-Pie Android) for modal creation/library flows
+
+import 'package:flutter/widgets.dart';
+import 'package:go_router/go_router.dart';
+
+/// Wraps [child] in a page that fades in while sliding up the last
+/// quarter — the classic pre-Pie Android transition.
+///
+/// Pass `state.pageKey` from the route's `pageBuilder` as [key].
+CustomTransitionPage<void> fadeUpwardsPage({
+  required LocalKey key,
+  required Widget child,
+}) {
+  return CustomTransitionPage<void>(
+    key: key,
+    child: child,
+    transitionsBuilder: (context, animation, secondaryAnimation, child) =>
+        const FadeUpwardsPageTransitionsBuilder().buildTransitions<void>(
+          null,
+          context,
+          animation,
+          secondaryAnimation,
+          child,
+        ),
+  );
+}

--- a/mobile/lib/router/fade_upwards_page.dart
+++ b/mobile/lib/router/fade_upwards_page.dart
@@ -7,13 +7,22 @@ import 'package:go_router/go_router.dart';
 /// Wraps [child] in a page that fades in while sliding up the last
 /// quarter — the classic pre-Pie Android transition.
 ///
-/// Pass `state.pageKey` from the route's `pageBuilder` as [key].
+/// Mirrors go_router's default page metadata (`name`, `arguments`,
+/// `restorationId`) from [state] so root-navigator observers such as
+/// `PageLoadObserver` keep resolving a real route name instead of
+/// `unknown_route`. Call it from a route's `pageBuilder`.
 CustomTransitionPage<void> fadeUpwardsPage({
-  required LocalKey key,
+  required GoRouterState state,
   required Widget child,
 }) {
   return CustomTransitionPage<void>(
-    key: key,
+    key: state.pageKey,
+    name: state.name ?? state.path,
+    arguments: <String, String>{
+      ...state.pathParameters,
+      ...state.uri.queryParameters,
+    },
+    restorationId: state.pageKey.value,
     child: child,
     transitionsBuilder: (context, animation, secondaryAnimation, child) =>
         const FadeUpwardsPageTransitionsBuilder().buildTransitions<void>(

--- a/mobile/lib/router/routes/library_routes.dart
+++ b/mobile/lib/router/routes/library_routes.dart
@@ -11,13 +11,13 @@ List<RouteBase> libraryRoutes() {
       path: LibraryScreen.draftsPath,
       name: LibraryScreen.draftsRouteName,
       pageBuilder: (_, state) =>
-          fadeUpwardsPage(key: state.pageKey, child: const LibraryScreen()),
+          fadeUpwardsPage(state: state, child: const LibraryScreen()),
     ),
     GoRoute(
       path: LibraryScreen.clipsPath,
       name: LibraryScreen.clipsRouteName,
       pageBuilder: (_, state) => fadeUpwardsPage(
-        key: state.pageKey,
+        state: state,
         child: const LibraryScreen(initialTabIndex: 1),
       ),
     ),
@@ -25,7 +25,7 @@ List<RouteBase> libraryRoutes() {
       path: LibraryScreen.clipsOnlyPath,
       name: LibraryScreen.clipsOnlyRouteName,
       pageBuilder: (_, state) => fadeUpwardsPage(
-        key: state.pageKey,
+        state: state,
         child: const LibraryScreen(tabsMode: LibraryTabsMode.clipsOnly),
       ),
     ),
@@ -33,7 +33,7 @@ List<RouteBase> libraryRoutes() {
       path: LibraryScreen.soundsPath,
       name: LibraryScreen.soundsRouteName,
       pageBuilder: (_, state) => fadeUpwardsPage(
-        key: state.pageKey,
+        state: state,
         child: const LibraryScreen(initialTabIndex: 2),
       ),
     ),

--- a/mobile/lib/router/routes/library_routes.dart
+++ b/mobile/lib/router/routes/library_routes.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Split from app_router.dart (#4508)
 
 import 'package:go_router/go_router.dart';
+import 'package:openvine/router/fade_upwards_page.dart';
 import 'package:openvine/screens/library_screen.dart';
 
 List<RouteBase> libraryRoutes() {
@@ -9,23 +10,32 @@ List<RouteBase> libraryRoutes() {
     GoRoute(
       path: LibraryScreen.draftsPath,
       name: LibraryScreen.draftsRouteName,
-      builder: (_, _) => const LibraryScreen(),
+      pageBuilder: (_, state) =>
+          fadeUpwardsPage(key: state.pageKey, child: const LibraryScreen()),
     ),
     GoRoute(
       path: LibraryScreen.clipsPath,
       name: LibraryScreen.clipsRouteName,
-      builder: (_, _) => const LibraryScreen(initialTabIndex: 1),
+      pageBuilder: (_, state) => fadeUpwardsPage(
+        key: state.pageKey,
+        child: const LibraryScreen(initialTabIndex: 1),
+      ),
     ),
     GoRoute(
       path: LibraryScreen.clipsOnlyPath,
       name: LibraryScreen.clipsOnlyRouteName,
-      builder: (_, _) =>
-          const LibraryScreen(tabsMode: LibraryTabsMode.clipsOnly),
+      pageBuilder: (_, state) => fadeUpwardsPage(
+        key: state.pageKey,
+        child: const LibraryScreen(tabsMode: LibraryTabsMode.clipsOnly),
+      ),
     ),
     GoRoute(
       path: LibraryScreen.soundsPath,
       name: LibraryScreen.soundsRouteName,
-      builder: (_, _) => const LibraryScreen(initialTabIndex: 2),
+      pageBuilder: (_, state) => fadeUpwardsPage(
+        key: state.pageKey,
+        child: const LibraryScreen(initialTabIndex: 2),
+      ),
     ),
   ];
 }

--- a/mobile/lib/router/routes/video_routes.dart
+++ b/mobile/lib/router/routes/video_routes.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' show AudioEvent, VideoEvent;
 import 'package:openvine/blocs/video_engagement/video_engagement_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/router/fade_upwards_page.dart';
 import 'package:openvine/router/navigator_keys.dart';
 import 'package:openvine/router/pooled_fullscreen_feed_route.dart';
 import 'package:openvine/router/route_error_screen.dart';
@@ -26,7 +27,12 @@ List<RouteBase> videoRoutes() {
     GoRoute(
       path: VideoRecorderScreen.path,
       name: VideoRecorderScreen.routeName,
-      builder: (_, _) => const VideoRecorderRoute(),
+      // The recorder is a modal creation mode, not the next screen in a
+      // flow — open it with the fade-upwards transition.
+      pageBuilder: (_, state) => fadeUpwardsPage(
+        key: state.pageKey,
+        child: const VideoRecorderRoute(),
+      ),
     ),
     GoRoute(
       path: CreatorAnalyticsScreen.path,

--- a/mobile/lib/router/routes/video_routes.dart
+++ b/mobile/lib/router/routes/video_routes.dart
@@ -30,7 +30,7 @@ List<RouteBase> videoRoutes() {
       // The recorder is a modal creation mode, not the next screen in a
       // flow — open it with the fade-upwards transition.
       pageBuilder: (_, state) => fadeUpwardsPage(
-        key: state.pageKey,
+        state: state,
         child: const VideoRecorderRoute(),
       ),
     ),

--- a/mobile/lib/widgets/video_recorder/video_recorder_camera_placeholder.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_camera_placeholder.dart
@@ -1,10 +1,15 @@
 // ABOUTME: Fallback placeholder widget displayed when camera is unavailable
-// ABOUTME: Shows idle icon or error message when camera initialization fails
+// ABOUTME: Plain dark surface while initializing, icon + message on error
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 
-/// Fallback preview widget for when camera is not available
+/// Fallback preview widget for when camera is not available.
+///
+/// While the camera is still initializing (no [errorMessage]) this is a
+/// plain dark surface — flashing an icon for the split second before the
+/// preview arrives looks broken. The icon and message only appear when
+/// initialization actually failed.
 class VideoRecorderCameraPlaceholder extends StatelessWidget {
   /// Creates a camera placeholder widget.
   const VideoRecorderCameraPlaceholder({super.key, this.errorMessage});
@@ -16,33 +21,31 @@ class VideoRecorderCameraPlaceholder extends StatelessWidget {
   Widget build(BuildContext context) {
     return ColoredBox(
       color: const Color(0xFF141414),
-      child: Center(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(
-              errorMessage != null
-                  ? Icons.videocam_off_rounded
-                  : Icons.videocam_rounded,
-              size: 56,
-              color: VineTheme.onSurfaceVariant,
-            ),
-            if (errorMessage != null) ...[
-              const SizedBox(height: 16),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 32),
-                child: Text(
-                  errorMessage!,
-                  textAlign: TextAlign.center,
-                  style: VineTheme.bodyMediumFont(
+      child: errorMessage == null
+          ? null
+          : Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                spacing: 16,
+                children: [
+                  const Icon(
+                    Icons.videocam_off_rounded,
+                    size: 56,
                     color: VineTheme.onSurfaceVariant,
                   ),
-                ),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 32),
+                    child: Text(
+                      errorMessage!,
+                      textAlign: TextAlign.center,
+                      style: VineTheme.bodyMediumFont(
+                        color: VineTheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ),
+                ],
               ),
-            ],
-          ],
-        ),
-      ),
+            ),
     );
   }
 }

--- a/mobile/test/router/fade_upwards_page_test.dart
+++ b/mobile/test/router/fade_upwards_page_test.dart
@@ -1,0 +1,95 @@
+// ABOUTME: Pins that fadeUpwardsPage carries go_router page metadata
+// ABOUTME: Regression test for PageLoadObserver reporting unknown_route
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:openvine/router/fade_upwards_page.dart';
+
+class _FakeGoRouterState extends Fake implements GoRouterState {
+  _FakeGoRouterState({
+    required this.pageKey,
+    this.name,
+    this.path,
+    this.pathParameters = const {},
+    Uri? uri,
+  }) : uri = uri ?? Uri.parse('/');
+
+  @override
+  final ValueKey<String> pageKey;
+
+  @override
+  final String? name;
+
+  @override
+  final String? path;
+
+  @override
+  final Map<String, String> pathParameters;
+
+  @override
+  final Uri uri;
+}
+
+void main() {
+  group('fadeUpwardsPage', () {
+    test('is a CustomTransitionPage (keeps the fade-upwards transition)', () {
+      final page = fadeUpwardsPage(
+        state: _FakeGoRouterState(
+          pageKey: const ValueKey('video-recorder'),
+          name: 'video-recorder',
+          path: '/video-recorder',
+        ),
+        child: const SizedBox.shrink(),
+      );
+
+      expect(page, isA<CustomTransitionPage<void>>());
+      expect(page.key, const ValueKey('video-recorder'));
+    });
+
+    test('carries the route name and restorationId so root-navigator '
+        'observers resolve a real surface, not unknown_route', () {
+      // A nameless CustomTransitionPage makes route.settings.name null,
+      // which PageLoadObserver maps to `unknown_route` — the regression
+      // this pins. See #5983.
+      final page = fadeUpwardsPage(
+        state: _FakeGoRouterState(
+          pageKey: const ValueKey('video-recorder'),
+          name: 'video-recorder',
+          path: '/video-recorder',
+        ),
+        child: const SizedBox.shrink(),
+      );
+
+      expect(page.name, 'video-recorder');
+      expect(page.restorationId, 'video-recorder');
+    });
+
+    test('falls back to the route path when the route has no name', () {
+      final page = fadeUpwardsPage(
+        state: _FakeGoRouterState(
+          pageKey: const ValueKey('/drafts'),
+          path: '/drafts',
+        ),
+        child: const SizedBox.shrink(),
+      );
+
+      expect(page.name, '/drafts');
+    });
+
+    test('merges path and query parameters into arguments', () {
+      final page = fadeUpwardsPage(
+        state: _FakeGoRouterState(
+          pageKey: const ValueKey('clips'),
+          name: 'clips',
+          path: '/clips',
+          pathParameters: const {'id': '42'},
+          uri: Uri.parse('/clips?tab=recent'),
+        ),
+        child: const SizedBox.shrink(),
+      );
+
+      expect(page.arguments, {'id': '42', 'tab': 'recent'});
+    });
+  });
+}

--- a/mobile/test/widgets/video_recorder/video_recorder_camera_placeholder_test.dart
+++ b/mobile/test/widgets/video_recorder/video_recorder_camera_placeholder_test.dart
@@ -22,7 +22,7 @@ void main() {
       expect(find.byType(VideoRecorderCameraPlaceholder), findsOneWidget);
     });
 
-    testWidgets('shows videocam icon when no error', (tester) async {
+    testWidgets('shows no icon while initializing (no error)', (tester) async {
       await tester.pumpWidget(
         const MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -31,8 +31,7 @@ void main() {
         ),
       );
 
-      expect(find.byIcon(Icons.videocam_rounded), findsOneWidget);
-      expect(find.byIcon(Icons.videocam_off_rounded), findsNothing);
+      expect(find.byType(Icon), findsNothing);
     });
 
     testWidgets('shows videocam_off icon when error message provided', (
@@ -51,7 +50,6 @@ void main() {
       );
 
       expect(find.byIcon(Icons.videocam_off_rounded), findsOneWidget);
-      expect(find.byIcon(Icons.videocam_rounded), findsNothing);
     });
 
     testWidgets('displays error message text when provided', (tester) async {


### PR DESCRIPTION
Closes #5983

## Summary

Opening the video recorder used the default horizontal push transition, which reads as "next screen in a flow" — but the recorder is a modal creation mode. It now opens with the classic fade-upwards transition (fade in + slide up the last quarter, the pre-Pie Android look that TikTok/Instagram also use for their camera). The library routes get the same transition since they are entered from the same creation context (profile library button, capture bottom bar, upload-failure sheet, clips picker).

- New shared `fadeUpwardsPage()` helper in `lib/router/fade_upwards_page.dart` that delegates to the SDK's `FadeUpwardsPageTransitionsBuilder` instead of hand-rolling curves, so we inherit the exact reference timing/curves and keep the two route files duplication-free.
- Recorder route and all four library routes (drafts / clips / clips-only / sounds) use the helper via `pageBuilder`.
- The camera init placeholder no longer flashes a `videocam` icon for the split second before the preview arrives — that read as a broken state. While initializing it is now a plain dark surface (the camera simply "turns on"); the icon + message remain for the actual init-error case.

## Test plan

- `flutter analyze` clean on the touched files.
- Router suites (`route_coverage`, `all_routes`, `app_router`) and the recorder placeholder/preview widget tests pass (251 tests).
- Manually verified on device: recorder open/close plays the fade-upwards transition in both directions, library opens the same way, no icon flash during camera init.