### PR TITLE
feat(camera): blur the front/back switch and fix its flashes

### DIFF
--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -184,7 +184,13 @@ class VideoRecorderBloc
     on<VideoRecorderFlashToggled>(_onFlashToggled);
     on<VideoRecorderAspectRatioToggled>(_onAspectRatioToggled);
     on<VideoRecorderAspectRatioSet>(_onAspectRatioSet);
-    on<VideoRecorderCameraSwitched>(_onCameraSwitched);
+    on<VideoRecorderCameraSwitched>(
+      _onCameraSwitched,
+      // A switch drives a native rebind and raises isSwitchingCamera for the
+      // blur transition; drop taps that arrive mid-switch so a rapid double-tap
+      // can't kick off a second rebind (which would just toggle back).
+      transformer: droppable(),
+    );
     on<VideoRecorderStabilizationModeSet>(
       _onStabilizationModeSet,
       // Each change drives a native reconfigure (a CameraX rebind on Android);
@@ -467,8 +473,10 @@ class VideoRecorderBloc
         category: LogCategory.video,
       );
 
-      emit(state.copyWith(zoomLevel: 1, baseZoomLevel: 1));
-      _emitCameraSync(emit);
+      if (!emit.isDone) {
+        emit(state.copyWith(zoomLevel: 1, baseZoomLevel: 1));
+        _emitCameraSync(emit);
+      }
     } finally {
       if (!emit.isDone) {
         emit(state.copyWith(isSwitchingCamera: false));

--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -442,27 +442,38 @@ class VideoRecorderBloc
     VideoRecorderCameraSwitched event,
     Emitter<VideoRecorderBlocState> emit,
   ) async {
-    final success = await _cameraService.switchCamera();
+    // Flag the switch up front so the preview blurs its frozen last frame
+    // while the native camera rebinds. `_emitCameraSync` rebuilds the state
+    // from scratch and drops this flag once the new lens is live; the
+    // `finally` covers the early-return and error paths.
+    emit(state.copyWith(isSwitchingCamera: true));
+    try {
+      final success = await _cameraService.switchCamera();
 
-    if (!success) {
-      Log.warning(
-        '⚠️ Camera switch failed - no available cameras to switch',
+      if (!success) {
+        Log.warning(
+          '⚠️ Camera switch failed - no available cameras to switch',
+          name: 'VideoRecorderBloc',
+          category: LogCategory.video,
+        );
+        return;
+      }
+
+      await _saveCurrentLensPreference();
+
+      Log.info(
+        '🔄 Camera switched successfully - zoom reset to 1.0x',
         name: 'VideoRecorderBloc',
         category: LogCategory.video,
       );
-      return;
+
+      emit(state.copyWith(zoomLevel: 1, baseZoomLevel: 1));
+      _emitCameraSync(emit);
+    } finally {
+      if (!emit.isDone) {
+        emit(state.copyWith(isSwitchingCamera: false));
+      }
     }
-
-    await _saveCurrentLensPreference();
-
-    Log.info(
-      '🔄 Camera switched successfully - zoom reset to 1.0x',
-      name: 'VideoRecorderBloc',
-      category: LogCategory.video,
-    );
-
-    emit(state.copyWith(zoomLevel: 1, baseZoomLevel: 1));
-    _emitCameraSync(emit);
   }
 
   Future<void> _onStabilizationModeSet(
@@ -1461,6 +1472,7 @@ class VideoRecorderBloc
         isCameraInitialized: _cameraService.isInitialized,
         hasFlash: _cameraService.hasFlash,
         canSwitchCamera: _cameraService.canSwitchCamera,
+        previewTextureId: _cameraService.textureId,
         videoStabilizationMode: _cameraService.videoStabilizationMode,
         availableVideoStabilizationModes:
             _cameraService.availableVideoStabilizationModes,

--- a/mobile/lib/blocs/video_recorder/video_recorder_state.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_state.dart
@@ -18,6 +18,8 @@ class VideoRecorderBlocState extends Equatable {
     this.canRecord = false,
     this.isCameraInitialized = false,
     this.canSwitchCamera = true,
+    this.isSwitchingCamera = false,
+    this.previewTextureId,
     this.hasFlash = true,
     this.countdownValue = 0,
     this.cameraRebuildCount = 0,
@@ -60,6 +62,19 @@ class VideoRecorderBlocState extends Equatable {
 
   /// Whether camera switching is available.
   final bool canSwitchCamera;
+
+  /// Whether a front/back lens switch is currently in progress.
+  ///
+  /// True from the moment the switch is dispatched until the native camera
+  /// has rebound. The preview freezes on its last frame during this window;
+  /// the UI overlays a brief blur over that frozen frame to soften the cut.
+  final bool isSwitchingCamera;
+
+  /// Flutter texture id backing the live preview, or null before the camera
+  /// is ready. A lens switch rebinds the incoming camera onto a fresh texture,
+  /// so this changes on switch; the preview is keyed on it to pick up the new
+  /// camera's frames.
+  final int? previewTextureId;
 
   /// Whether the camera has flash capability.
   final bool hasFlash;
@@ -200,6 +215,8 @@ class VideoRecorderBlocState extends Equatable {
     bool? canRecord,
     bool? isCameraInitialized,
     bool? canSwitchCamera,
+    bool? isSwitchingCamera,
+    int? previewTextureId,
     bool? hasFlash,
     int? countdownValue,
     int? cameraRebuildCount,
@@ -234,6 +251,8 @@ class VideoRecorderBlocState extends Equatable {
       canRecord: canRecord ?? this.canRecord,
       isCameraInitialized: isCameraInitialized ?? this.isCameraInitialized,
       canSwitchCamera: canSwitchCamera ?? this.canSwitchCamera,
+      isSwitchingCamera: isSwitchingCamera ?? this.isSwitchingCamera,
+      previewTextureId: previewTextureId ?? this.previewTextureId,
       hasFlash: hasFlash ?? this.hasFlash,
       countdownValue: countdownValue ?? this.countdownValue,
       cameraRebuildCount: cameraRebuildCount ?? this.cameraRebuildCount,
@@ -277,6 +296,8 @@ class VideoRecorderBlocState extends Equatable {
     canRecord,
     isCameraInitialized,
     canSwitchCamera,
+    isSwitchingCamera,
+    previewTextureId,
     hasFlash,
     countdownValue,
     cameraRebuildCount,

--- a/mobile/lib/services/video_recorder/camera/camera_base_service.dart
+++ b/mobile/lib/services/video_recorder/camera/camera_base_service.dart
@@ -122,6 +122,12 @@ abstract class CameraService {
   /// Used to block recording triggers during the switch.
   bool get isSwitchingCamera;
 
+  /// The Flutter texture id backing the live preview, or null when no camera
+  /// is active. Changes when a lens switch rebinds the preview onto a fresh
+  /// texture; the UI keys the preview on it so the new camera's frames are
+  /// picked up.
+  int? get textureId;
+
   /// Whether the device can active the camera-flash.
   bool get hasFlash;
 

--- a/mobile/lib/services/video_recorder/camera/camera_linux_service.dart
+++ b/mobile/lib/services/video_recorder/camera/camera_linux_service.dart
@@ -45,6 +45,9 @@ class CameraLinuxService extends CameraService {
   bool get isSwitchingCamera => false;
 
   @override
+  int? get textureId => null;
+
+  @override
   bool get hasFlash => false;
 
   @override

--- a/mobile/lib/services/video_recorder/camera/camera_mobile_service.dart
+++ b/mobile/lib/services/video_recorder/camera/camera_mobile_service.dart
@@ -420,6 +420,9 @@ class CameraMobileService extends CameraService {
   bool get isSwitchingCamera => _isSwitchingCamera;
 
   @override
+  int? get textureId => _camera.textureId;
+
+  @override
   DivineCameraLens get currentLens => _camera.state.lens;
 
   @override

--- a/mobile/lib/widgets/video_recorder/preview/video_recorder_camera_preview.dart
+++ b/mobile/lib/widgets/video_recorder/preview/video_recorder_camera_preview.dart
@@ -55,7 +55,11 @@ class VideoRecorderCameraPreview extends StatelessWidget {
                 child: ClipRRect(
                   clipBehavior: .hardEdge,
                   borderRadius: borderRadius,
-                  child: _StackItems(enableTapToFocus: enableTapToFocus),
+                  // The blur wraps the whole stack from above its camera-rebuild
+                  // [ValueKey], so a switch's rebuild doesn't dispose the ramp.
+                  child: _CameraSwitchBlur(
+                    child: _StackItems(enableTapToFocus: enableTapToFocus),
+                  ),
                 ),
               );
             },
@@ -85,9 +89,7 @@ class _StackItems extends StatelessWidget {
       key: ValueKey('Camera-Count-${state.cameraRebuildCount}'),
       children: [
         if (state.isCameraInitialized)
-          _CameraSwitchBlur(
-            child: _CameraPreview(enableTapToFocus: enableTapToFocus),
-          )
+          _CameraPreview(enableTapToFocus: enableTapToFocus)
         else
           VideoRecorderCameraPlaceholder(
             errorMessage: state.initializationErrorMessage,
@@ -127,11 +129,12 @@ class _CameraPreview extends StatelessWidget {
             if (!kIsWeb && defaultTargetPlatform == TargetPlatform.linux)
               const SizedBox.shrink()
             else
-              // Keyed on the texture id: a lens switch rebinds the incoming
+              // Keyed on the texture id: a facing flip rebinds the incoming
               // camera onto a fresh texture, so a changed id remounts the
-              // preview to pick up the new camera's frames. This rebuild does
-              // not reset the switch blur — that lives one level up in
-              // [_CameraSwitchBlur], so its ramp-out plays over the new frame.
+              // preview to pick up its frames. Neither this remount nor the
+              // camera-rebuild remount of the enclosing Stack resets the switch
+              // blur — it lives above [_StackItems], so its ramp-out plays over
+              // the new frame.
               VideoRecorderMobilePreview(
                 key: ValueKey(textureId),
                 enableTapToFocus: enableTapToFocus,
@@ -148,6 +151,9 @@ class _CameraPreview extends StatelessWidget {
 /// blur over it, then deblurs as the new lens's first frames arrive — the same
 /// cue the native camera app uses to hide the hard cut and the new sensor's
 /// initial unfocused frames.
+///
+/// Wraps the preview stack from above its camera-rebuild [ValueKey], so the
+/// ramp survives the remount a switch triggers and deblurs over the new frame.
 class _CameraSwitchBlur extends StatelessWidget {
   const _CameraSwitchBlur({required this.child});
 
@@ -158,24 +164,28 @@ class _CameraSwitchBlur extends StatelessWidget {
   /// raster-thread work, and it only runs for the brief switch transition.
   static const double _peakBlurSigma = 16;
 
-  /// Blur ramp duration each way. Matches the aspect-ratio transition above so
-  /// the two camera animations feel of a piece.
+  /// Blur ramp duration each way. Kept short so the new lens is revealed
+  /// quickly once the deblur starts.
   static const Duration _rampDuration = Duration(milliseconds: 50);
+
+  /// Below this sigma the blur is visually a no-op; skip the filter layer so
+  /// there is zero blur cost at rest and once the deblur completes.
+  static const double _blurEpsilon = 0.1;
 
   @override
   Widget build(BuildContext context) {
     final isSwitching = context.select(
       (VideoRecorderBloc b) => b.state.isSwitchingCamera,
     );
+    // Under reduced motion, snap the blur in/out instead of ramping it.
+    final reduceMotion = MediaQuery.of(context).disableAnimations;
     return TweenAnimationBuilder<double>(
       tween: Tween<double>(end: isSwitching ? _peakBlurSigma : 0),
-      duration: _rampDuration,
+      duration: reduceMotion ? Duration.zero : _rampDuration,
       curve: Curves.easeOut,
       child: child,
       builder: (context, sigma, child) {
-        // Below ~0 the filter is a no-op; skip the layer so there is zero blur
-        // cost at rest and once the deblur completes.
-        if (sigma < 0.1) return child!;
+        if (sigma < _blurEpsilon) return child!;
         return ClipRect(
           child: ImageFiltered(
             imageFilter: ui.ImageFilter.blur(sigmaX: sigma, sigmaY: sigma),

--- a/mobile/lib/widgets/video_recorder/preview/video_recorder_camera_preview.dart
+++ b/mobile/lib/widgets/video_recorder/preview/video_recorder_camera_preview.dart
@@ -178,7 +178,7 @@ class _CameraSwitchBlur extends StatelessWidget {
       (VideoRecorderBloc b) => b.state.isSwitchingCamera,
     );
     // Under reduced motion, snap the blur in/out instead of ramping it.
-    final reduceMotion = MediaQuery.of(context).disableAnimations;
+    final reduceMotion = MediaQuery.disableAnimationsOf(context);
     return TweenAnimationBuilder<double>(
       tween: Tween<double>(end: isSwitching ? _peakBlurSigma : 0),
       duration: reduceMotion ? Duration.zero : _rampDuration,

--- a/mobile/lib/widgets/video_recorder/preview/video_recorder_camera_preview.dart
+++ b/mobile/lib/widgets/video_recorder/preview/video_recorder_camera_preview.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Camera preview widget with animated aspect ratio transitions and grid overlay
 // ABOUTME: Handles tap-to-focus and displays rule-of-thirds grid during non-recording state
 
+import 'dart:ui' as ui;
+
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -83,7 +85,9 @@ class _StackItems extends StatelessWidget {
       key: ValueKey('Camera-Count-${state.cameraRebuildCount}'),
       children: [
         if (state.isCameraInitialized)
-          _CameraPreview(enableTapToFocus: enableTapToFocus)
+          _CameraSwitchBlur(
+            child: _CameraPreview(enableTapToFocus: enableTapToFocus),
+          )
         else
           VideoRecorderCameraPlaceholder(
             errorMessage: state.initializationErrorMessage,
@@ -103,8 +107,11 @@ class _CameraPreview extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final sensorAspectRatio = context.select(
-      (VideoRecorderBloc b) => b.state.cameraSensorAspectRatio,
+    final (:sensorAspectRatio, :textureId) = context.select(
+      (VideoRecorderBloc b) => (
+        sensorAspectRatio: b.state.cameraSensorAspectRatio,
+        textureId: b.state.previewTextureId,
+      ),
     );
 
     return FittedBox(
@@ -120,10 +127,62 @@ class _CameraPreview extends StatelessWidget {
             if (!kIsWeb && defaultTargetPlatform == TargetPlatform.linux)
               const SizedBox.shrink()
             else
-              VideoRecorderMobilePreview(enableTapToFocus: enableTapToFocus),
+              // Keyed on the texture id: a lens switch rebinds the incoming
+              // camera onto a fresh texture, so a changed id remounts the
+              // preview to pick up the new camera's frames. This rebuild does
+              // not reset the switch blur — that lives one level up in
+              // [_CameraSwitchBlur], so its ramp-out plays over the new frame.
+              VideoRecorderMobilePreview(
+                key: ValueKey(textureId),
+                enableTapToFocus: enableTapToFocus,
+              ),
           ],
         ),
       ),
+    );
+  }
+}
+
+/// Softens a front/back lens switch: while the preview is frozen on its last
+/// frame (see [VideoRecorderBlocState.isSwitchingCamera]) this ramps a gaussian
+/// blur over it, then deblurs as the new lens's first frames arrive — the same
+/// cue the native camera app uses to hide the hard cut and the new sensor's
+/// initial unfocused frames.
+class _CameraSwitchBlur extends StatelessWidget {
+  const _CameraSwitchBlur({required this.child});
+
+  final Widget child;
+
+  /// Peak gaussian sigma applied to the frozen frame mid-switch. Deliberately
+  /// moderate — a full-screen blur pass over the camera texture is
+  /// raster-thread work, and it only runs for the brief switch transition.
+  static const double _peakBlurSigma = 16;
+
+  /// Blur ramp duration each way. Matches the aspect-ratio transition above so
+  /// the two camera animations feel of a piece.
+  static const Duration _rampDuration = Duration(milliseconds: 50);
+
+  @override
+  Widget build(BuildContext context) {
+    final isSwitching = context.select(
+      (VideoRecorderBloc b) => b.state.isSwitchingCamera,
+    );
+    return TweenAnimationBuilder<double>(
+      tween: Tween<double>(end: isSwitching ? _peakBlurSigma : 0),
+      duration: _rampDuration,
+      curve: Curves.easeOut,
+      child: child,
+      builder: (context, sigma, child) {
+        // Below ~0 the filter is a no-op; skip the layer so there is zero blur
+        // cost at rest and once the deblur completes.
+        if (sigma < 0.1) return child!;
+        return ClipRect(
+          child: ImageFiltered(
+            imageFilter: ui.ImageFilter.blur(sigmaX: sigma, sigmaY: sigma),
+            child: child,
+          ),
+        );
+      },
     );
   }
 }

--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/CameraController.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/CameraController.kt
@@ -1063,7 +1063,15 @@ class CameraController(
         
         // Disable screen flash when switching cameras
         disableScreenFlash()
-        
+
+        // Only a facing flip (front<->back) needs a fresh preview texture — that
+        // sensor-orientation delta is what produced the upside-down flash. A
+        // same-facing rebind (a stabilization toggle rebinds through this
+        // method) must reuse the existing texture: it reports no new textureId
+        // to Dart, so a fresh one would strand the preview on the retired
+        // texture and freeze it.
+        val previousLens = currentLens
+
         // Map lens string to lens type and facing
         currentLensType = lens
         currentLens = getLensFacingForType(lens)
@@ -1088,6 +1096,7 @@ class CameraController(
             return
         }
 
+        var didSwapTexture = false
         try {
             // Unbind all use cases
             provider.unbindAll()
@@ -1096,12 +1105,16 @@ class CameraController(
             // outgoing one (kept alive so the Dart freeze-gate keeps showing its
             // last frame until the swap). The outgoing texture never receives the
             // new camera's frames, so its rotation can't desync mid-switch — this
-            // is the structural fix for the upside-down flash. The previous
+            // is the structural fix for the upside-down flash. Only done on a
+            // facing flip; same-facing rebinds reuse the texture. The previous
             // switch's retired producer is safe to release now: Dart swapped off
             // it a switch ago.
-            retiringSurfaceProducer?.release()
-            retiringSurfaceProducer = surfaceProducer
-            surfaceProducer = textureRegistry.createSurfaceProducer()
+            if (currentLens != previousLens) {
+                retiringSurfaceProducer?.release()
+                retiringSurfaceProducer = surfaceProducer
+                surfaceProducer = textureRegistry.createSurfaceProducer()
+                didSwapTexture = true
+            }
 
             // Build camera selector for the requested lens
             // For specialized lenses (ultraWide, telephoto, macro), we need to use Camera2 interop
@@ -1118,8 +1131,9 @@ class CameraController(
                 stabilizationMode,
             )
 
-            // Drive the freshly created texture; update its buffer size once we
-            // get the incoming camera's resolution.
+            // Drive the preview texture (fresh on a facing flip, reused on a
+            // same-facing rebind); update its buffer size once we get the
+            // incoming camera's resolution.
             preview?.setSurfaceProvider(ContextCompat.getMainExecutor(context)) { request ->
                 val resolution = request.resolution
                 videoWidth = resolution.width
@@ -1206,6 +1220,15 @@ class CameraController(
             mainHandler.postDelayed(finishSwitch, SWITCH_FIRST_FRAME_TIMEOUT_MS)
 
         } catch (e: Exception) {
+            // Roll back a fresh-texture swap so surfaceProducer again matches the
+            // texture Dart is still showing; otherwise the next switch would
+            // release that on-screen texture (black preview) or a later
+            // getCameraState would swap the preview onto the empty producer.
+            if (didSwapTexture) {
+                surfaceProducer?.release()
+                surfaceProducer = retiringSurfaceProducer
+                retiringSurfaceProducer = null
+            }
             DivineCameraLog.e(TAG, "Failed to switch camera", e)
             mainHandler.post {
                 callback(null, "Failed to switch camera: ${e.message}")

--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/CameraController.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/CameraController.kt
@@ -1113,9 +1113,15 @@ class CameraController(
             // switch's retired producer is safe to release now: Dart swapped off
             // it a switch ago.
             if (currentLens != previousLens) {
+                // Created before the swap mutations: createSurfaceProducer()
+                // can throw, and the catch rollback only covers a committed
+                // swap — mutating first would alias retiringSurfaceProducer
+                // to the live producer, so the next flip would release the
+                // on-screen texture.
+                val freshSurfaceProducer = textureRegistry.createSurfaceProducer()
                 retiringSurfaceProducer?.release()
                 retiringSurfaceProducer = surfaceProducer
-                surfaceProducer = textureRegistry.createSurfaceProducer()
+                surfaceProducer = freshSurfaceProducer
                 didSwapTexture = true
             }
 

--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/CameraController.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/CameraController.kt
@@ -68,6 +68,15 @@ class CameraController(
     // black — issue #5865.
     private var surfaceProducer: TextureRegistry.SurfaceProducer? = null
 
+    // The outgoing camera's SurfaceProducer during a lens switch. A switch gives
+    // the incoming camera a brand-new producer/texture and keeps the old one
+    // here so the Dart freeze-gate can keep showing its last (correctly
+    // oriented) frame until the new texture is swapped in. Released at the start
+    // of the next switch — by then Dart has long swapped off it — and on
+    // dispose. This is what fixes the upside-down flash: the outgoing texture
+    // never receives the incoming camera's frames, so its rotation can't desync.
+    private var retiringSurfaceProducer: TextureRegistry.SurfaceProducer? = null
+
     private var cameraExecutor: ExecutorService =
         RejectionTolerantExecutorService(Executors.newSingleThreadExecutor())
     private val mainHandler = Handler(Looper.getMainLooper())
@@ -131,11 +140,17 @@ class CameraController(
                 currentExposureTime = exposureTime
             }
 
-            // First frame after a lens switch: let the switch completion run so
-            // the UI flips lens/rotation only now that the new frame is ready.
+            // Frames after a lens switch: let a few settle so the incoming
+            // camera's pixels are actually on its fresh texture before resolving
+            // the switch — otherwise the UI swaps onto a still-empty (black)
+            // texture. Until then the old frozen frame stays on screen.
             onFirstFrameAfterSwitch?.let { completion ->
-                onFirstFrameAfterSwitch = null
-                completion()
+                if (switchSettleFramesRemaining > 0) {
+                    switchSettleFramesRemaining--
+                } else {
+                    onFirstFrameAfterSwitch = null
+                    completion()
+                }
             }
         }
     }
@@ -196,13 +211,21 @@ class CameraController(
     private var maxDurationRunnable: Runnable? = null
     private var autoStopCallback: ((Map<String, Any?>?, String?) -> Unit)? = null
 
-    // Fires once, on the first frame the incoming camera produces after a lens
-    // switch, so the switch completes (and the UI flips lens/rotation) only when
-    // the new frame is ready — otherwise the frozen preview briefly flips upside
-    // down at the old→new rotation boundary (#5865). Written on the main thread,
-    // read on the Camera2 capture thread, so it must be @Volatile.
+    // Fires once the incoming camera has produced enough frames after a lens
+    // switch (see [switchSettleFramesRemaining]) to resolve the switch. The
+    // incoming camera renders onto a brand-new texture, so completing before it
+    // carries real pixels would swap the UI onto an empty (black) texture;
+    // waiting also keeps the frozen old frame — with its own correct rotation —
+    // on screen until then (#5865). Written on the main thread, read on the
+    // Camera2 capture thread, so it must be @Volatile.
     @Volatile
     private var onFirstFrameAfterSwitch: (() -> Unit)? = null
+
+    // Preview frames still to let pass before [onFirstFrameAfterSwitch] resolves
+    // the switch — see [SWITCH_SETTLE_FRAMES]. Written on the main thread when a
+    // switch starts, decremented on the Camera2 capture thread, so @Volatile.
+    @Volatile
+    private var switchSettleFramesRemaining: Int = 0
 
     // Quality fallback: when the hardware encoder rejects the requested quality
     // (e.g. device falsely reports FHD support), retry with lower quality.
@@ -223,6 +246,15 @@ class CameraController(
         // reports a frame (rare device quirk), so `await switchCamera` on the
         // Dart side can't hang forever.
         private const val SWITCH_FIRST_FRAME_TIMEOUT_MS = 1200L
+
+        // Preview frames to let pass after a lens switch before resolving it.
+        // The incoming camera renders onto a fresh texture; its capture result
+        // completes a frame or two before those pixels reach the surface, so
+        // resolving on the very first completion would swap the UI onto a still-
+        // empty (black) texture. A few settle frames guarantee real pixels are
+        // there before the swap. The extra frozen frames are hidden by the
+        // switch blur, so they're imperceptible.
+        private const val SWITCH_SETTLE_FRAMES = 3
 
         // Canonical cross-platform stabilization mode strings, shared with the
         // iOS/macOS implementations so the Dart layer speaks one vocabulary.
@@ -886,6 +918,9 @@ class CameraController(
                 surfaceProducer?.release()
                 surfaceProducer = null
             }
+            // Drop any producer still retired from an interrupted switch.
+            retiringSurfaceProducer?.release()
+            retiringSurfaceProducer = null
 
             // Create the Flutter surface producer for the preview.
             surfaceProducer = textureRegistry.createSurfaceProducer()
@@ -1057,6 +1092,17 @@ class CameraController(
             // Unbind all use cases
             provider.unbindAll()
 
+            // Give the incoming camera a brand-new texture and retire the
+            // outgoing one (kept alive so the Dart freeze-gate keeps showing its
+            // last frame until the swap). The outgoing texture never receives the
+            // new camera's frames, so its rotation can't desync mid-switch — this
+            // is the structural fix for the upside-down flash. The previous
+            // switch's retired producer is safe to release now: Dart swapped off
+            // it a switch ago.
+            retiringSurfaceProducer?.release()
+            retiringSurfaceProducer = surfaceProducer
+            surfaceProducer = textureRegistry.createSurfaceProducer()
+
             // Build camera selector for the requested lens
             // For specialized lenses (ultraWide, telephoto, macro), we need to use Camera2 interop
             val cameraSelector = buildCameraSelectorForLens(currentLensType, provider)
@@ -1072,7 +1118,8 @@ class CameraController(
                 stabilizationMode,
             )
 
-            // Reuse the existing flutter texture - just update buffer size when we get new resolution
+            // Drive the freshly created texture; update its buffer size once we
+            // get the incoming camera's resolution.
             preview?.setSurfaceProvider(ContextCompat.getMainExecutor(context)) { request ->
                 val resolution = request.resolution
                 videoWidth = resolution.width
@@ -1154,6 +1201,7 @@ class CameraController(
                     callback(getCameraState(), null)
                 }
             }
+            switchSettleFramesRemaining = SWITCH_SETTLE_FRAMES
             onFirstFrameAfterSwitch = { mainHandler.post(finishSwitch) }
             mainHandler.postDelayed(finishSwitch, SWITCH_FIRST_FRAME_TIMEOUT_MS)
 
@@ -2450,6 +2498,8 @@ class CameraController(
             // The SurfaceProducer owns the Surface; release() tears it down.
             surfaceProducer?.release()
             surfaceProducer = null
+            retiringSurfaceProducer?.release()
+            retiringSurfaceProducer = null
 
             // Delay shutdown so CameraX can drain in-flight encoder/muxer
             // tasks. cameraExecutor is rejection-tolerant, so any callback

--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/CameraController.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/CameraController.kt
@@ -1046,10 +1046,13 @@ class CameraController(
 
     /**
      * Switches to a different camera lens.
-     * Reuses the same texture to avoid black screen during switch.
+     * Uses a fresh preview texture for front/back facing flips so the outgoing
+     * frozen frame cannot receive incoming-camera pixels with the wrong
+     * rotation. Same-facing rebinds reuse the current texture because Dart keeps
+     * displaying it.
      *
      * [onBound] runs synchronously once the new camera is bound, before the
-     * switch is gated on the first frame and while the preview is still frozen
+     * switch is gated on settled frames and while the preview is still frozen
      * on the old frame. Use it for adjustments (e.g. restoring zoom) that must
      * already be in effect when the incoming frame becomes visible, so the
      * preview doesn't visibly unfreeze at the default and then jump.
@@ -1200,13 +1203,14 @@ class CameraController(
             // becomes visible instead of unfreezing at the reset default.
             onBound?.invoke()
 
-            // Resolve the switch only once the incoming camera has produced its
-            // first frame. Until then the SurfaceProducer keeps showing the old
-            // frame (frozen) and the state (lens/rotation) stays on the old
-            // camera, so the frozen frame never flips to the new rotation early.
-            // Whichever path runs first (first frame or the timeout) cancels the
-            // other queued copy via removeCallbacks, so this runs exactly once
-            // and no stale timeout lingers on the main looper afterwards.
+            // Resolve the switch only once the incoming camera has produced
+            // enough frames for its fresh texture to carry pixels. Until then
+            // the SurfaceProducer keeps showing the old frame (frozen) and the
+            // state (lens/rotation) stays on the old camera, so the frozen
+            // frame never flips to the new rotation early. Whichever path runs
+            // first (settled frames or the timeout) cancels the other queued
+            // copy via removeCallbacks, so this runs exactly once and no stale
+            // timeout lingers on the main looper afterwards.
             val finishSwitch = object : Runnable {
                 override fun run() {
                     mainHandler.removeCallbacks(this)

--- a/mobile/packages/divine_camera/lib/divine_camera.dart
+++ b/mobile/packages/divine_camera/lib/divine_camera.dart
@@ -263,10 +263,14 @@ class DivineCamera {
   /// support (macOS, Linux) this is a no-op that returns false.
   ///
   /// [mode] the stabilization mode to apply.
-  /// Returns true if the requested mode was applied.
+  /// Returns true if the requested mode was applied. Returns false while a
+  /// lens switch is in flight: on Android the mode change rebinds through the
+  /// same native switch path, so it would clobber the switch's pending
+  /// first-frame completion and hold the frozen preview until its timeout.
   Future<bool> setVideoStabilizationMode(
     DivineVideoStabilizationMode mode,
   ) async {
+    if (_state.isSwitchingCamera) return false;
     final success = await _platform.setVideoStabilizationMode(mode);
     if (success) {
       _state = _state.copyWith(videoStabilizationMode: mode);

--- a/mobile/packages/divine_camera/test/divine_camera_test.dart
+++ b/mobile/packages/divine_camera/test/divine_camera_test.dart
@@ -422,6 +422,33 @@ void main() {
           DivineCamera.instance.state.isVideoStabilizationSupported,
         );
       });
+
+      test('rejects a mode change while a lens switch is in flight', () async {
+        await DivineCamera.instance.initialize();
+
+        final gate = Completer<void>();
+        mockPlatform.switchGate = gate;
+        final switching = DivineCamera.instance.switchCamera();
+
+        // Mid-switch the change would rebind through the same native switch
+        // path and clobber the switch's pending first-frame completion.
+        final rejected = await DivineCamera.instance.setVideoStabilizationMode(
+          DivineVideoStabilizationMode.cinematic,
+        );
+        expect(rejected, isFalse);
+        expect(
+          DivineCamera.instance.videoStabilizationMode,
+          DivineVideoStabilizationMode.off,
+        );
+
+        gate.complete();
+        expect(await switching, isTrue);
+
+        final applied = await DivineCamera.instance.setVideoStabilizationMode(
+          DivineVideoStabilizationMode.cinematic,
+        );
+        expect(applied, isTrue);
+      });
     });
 
     group('focus and exposure', () {

--- a/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
+++ b/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
@@ -464,6 +464,54 @@ void main() {
       );
     });
 
+    group('VideoRecorderCameraSwitched', () {
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'raises then clears isSwitchingCamera and propagates the new '
+        'previewTextureId on a successful switch',
+        setUp: () {
+          when(
+            () => cameraService.switchCamera(),
+          ).thenAnswer((_) async => true);
+          when(() => cameraService.textureId).thenReturn(42);
+        },
+        build: buildBloc,
+        act: (bloc) => bloc.add(const VideoRecorderCameraSwitched()),
+        expect: () => [
+          isA<VideoRecorderBlocState>().having(
+            (s) => s.isSwitchingCamera,
+            'isSwitchingCamera',
+            isTrue,
+          ),
+          isA<VideoRecorderBlocState>()
+              .having((s) => s.isSwitchingCamera, 'isSwitchingCamera', isFalse)
+              .having((s) => s.previewTextureId, 'previewTextureId', 42),
+        ],
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'still clears isSwitchingCamera via the finally when the switch fails',
+        setUp: () {
+          when(
+            () => cameraService.switchCamera(),
+          ).thenAnswer((_) async => false);
+        },
+        build: buildBloc,
+        act: (bloc) => bloc.add(const VideoRecorderCameraSwitched()),
+        expect: () => [
+          isA<VideoRecorderBlocState>().having(
+            (s) => s.isSwitchingCamera,
+            'isSwitchingCamera',
+            isTrue,
+          ),
+          isA<VideoRecorderBlocState>().having(
+            (s) => s.isSwitchingCamera,
+            'isSwitchingCamera',
+            isFalse,
+          ),
+        ],
+      );
+    });
+
     group('VideoRecorderStabilizationModeSet', () {
       blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
         'persists the new mode when the camera accepts it',

--- a/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
+++ b/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 
 import 'package:bloc_test/bloc_test.dart';
 import 'package:divine_camera/divine_camera.dart';
+import 'package:flutter/services.dart' show PlatformException;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -465,6 +466,8 @@ void main() {
     });
 
     group('VideoRecorderCameraSwitched', () {
+      late Completer<bool> switchGate;
+
       blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
         'raises then clears isSwitchingCamera and propagates the new '
         'previewTextureId on a successful switch',
@@ -509,6 +512,69 @@ void main() {
             isFalse,
           ),
         ],
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'clears isSwitchingCamera and surfaces the error when the switch '
+        'throws',
+        // Production CameraService catches internally and returns false; the
+        // finally exists for an implementation that violates that contract.
+        // Without it the blur would stick and block every later switch.
+        setUp: () {
+          when(
+            () => cameraService.switchCamera(),
+          ).thenThrow(PlatformException(code: 'SWITCH_FAILED'));
+        },
+        build: buildBloc,
+        act: (bloc) => bloc.add(const VideoRecorderCameraSwitched()),
+        expect: () => [
+          isA<VideoRecorderBlocState>().having(
+            (s) => s.isSwitchingCamera,
+            'isSwitchingCamera',
+            isTrue,
+          ),
+          isA<VideoRecorderBlocState>().having(
+            (s) => s.isSwitchingCamera,
+            'isSwitchingCamera',
+            isFalse,
+          ),
+        ],
+        errors: () => [isA<PlatformException>()],
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'drops a second switch tap that lands mid-switch (droppable)',
+        setUp: () {
+          switchGate = Completer<bool>();
+          when(
+            () => cameraService.switchCamera(),
+          ).thenAnswer((_) => switchGate.future);
+          when(() => cameraService.textureId).thenReturn(42);
+        },
+        build: buildBloc,
+        act: (bloc) async {
+          bloc
+            ..add(const VideoRecorderCameraSwitched())
+            ..add(const VideoRecorderCameraSwitched());
+          await Future<void>.delayed(Duration.zero);
+          switchGate.complete(true);
+          await Future<void>.delayed(Duration.zero);
+        },
+        // Only the first tap's emit pair — a rapid double-tap must not queue
+        // a second rebind that would just toggle straight back.
+        expect: () => [
+          isA<VideoRecorderBlocState>().having(
+            (s) => s.isSwitchingCamera,
+            'isSwitchingCamera',
+            isTrue,
+          ),
+          isA<VideoRecorderBlocState>()
+              .having((s) => s.isSwitchingCamera, 'isSwitchingCamera', isFalse)
+              .having((s) => s.previewTextureId, 'previewTextureId', 42),
+        ],
+        verify: (_) {
+          verify(() => cameraService.switchCamera()).called(1);
+        },
       );
     });
 

--- a/mobile/test/mocks/mock_camera_service.dart
+++ b/mobile/test/mocks/mock_camera_service.dart
@@ -143,6 +143,9 @@ class MockCameraService extends CameraService {
   bool get isSwitchingCamera => false;
 
   @override
+  int? get textureId => null;
+
+  @override
   bool get hasFlash => true;
 
   @override

--- a/mobile/test/widgets/video_recorder/video_recorder_camera_preview_test.dart
+++ b/mobile/test/widgets/video_recorder/video_recorder_camera_preview_test.dart
@@ -69,7 +69,7 @@ void main() {
       expect(find.byType(VideoRecorderCameraPlaceholder), findsOneWidget);
     });
 
-    testWidgets('contains TweenAnimationBuilder for transitions', (
+    testWidgets('applies no blur filter when not switching cameras', (
       tester,
     ) async {
       when(() => recorderBloc.state).thenReturn(
@@ -77,8 +77,25 @@ void main() {
       );
 
       await tester.pumpWidget(buildSubject());
+      await tester.pump();
 
-      expect(find.byType(TweenAnimationBuilder<double>), isNotNull);
+      expect(find.byType(ImageFiltered), findsNothing);
+    });
+
+    testWidgets('blurs the frozen preview while switching cameras', (
+      tester,
+    ) async {
+      when(() => recorderBloc.state).thenReturn(
+        const VideoRecorderBlocState(
+          isCameraInitialized: true,
+          isSwitchingCamera: true,
+        ),
+      );
+
+      await tester.pumpWidget(buildSubject());
+      await tester.pump(const Duration(milliseconds: 60));
+
+      expect(find.byType(ImageFiltered), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
Closes #5985

## Description

Polishes the front/back camera switch so it matches the native camera app and stops flashing on the frozen-frame transition.

**Blur transition.** While the preview is frozen during a lens switch, a brief gaussian blur ramps over the frozen frame and deblurs as the new lens's first frames arrive — hiding the hard cut and the new sensor's initial unfocused frames. The blur is a pure UI transition (`_CameraSwitchBlur`) driven by a new `isSwitchingCamera` flag on the recorder state: the bloc raises the flag around the switch and the UI animates the `ImageFilter.blur` off it.

**Upside-down flash fix (pre-existing).** On Android the preview `SurfaceProducer` was reused across the switch, so the incoming camera's frames landed on the same texture while Dart still applied the outgoing lens's rotation via `RotatedBox` — briefly rendering a frame upside down at the front/back sensor-orientation delta (a residual of #5865). Reusing the surface makes this unfixable by timing alone: the new frames and the lagging rotation always race. The switch now binds the incoming camera to a **fresh texture** and keeps the outgoing producer alive (frozen, correctly oriented) until the swap, so the old texture never shows a new frame with the wrong rotation. Dart picks up the new texture through a `previewTextureId` on the recorder state, keyed on the preview so the switch blur survives the swap and its ramp-out plays over the new frame.

**Black flash fix.** With a distinct texture the swap could land on a still-empty (black) texture, because the switch resolved on the incoming camera's capture-metadata completion — a frame or two before its pixels reach the surface. A few settle frames now delay the swap until the fresh texture actually carries pixels; during that window the old frozen frame stays on screen. The existing 1200 ms first-frame timeout still guards against a camera that never delivers frames.

Why native rather than a Flutter-side workaround: baking rotation into the frames (a CameraX `SurfaceProcessor`) is the `PreviewView` approach but needs an always-on GPU stage plus hand-written GL for a transient glitch, and `RepaintBoundary.toImage()` on a platform texture is expensive and unreliable. The distinct-texture approach reuses the preview's existing freeze-gate design (`isSwitching ? _lastTextureId : textureId`) and costs nothing per frame.

**Related Issue:** 

## Out of Scope

- iOS: the flash is Android-specific (portrait orientation and front mirroring are handled natively there), so the native change is Android-only. No iOS change needed.
- The `SurfaceProcessor` / bake-rotation approach was considered and deliberately not taken (see above).

## Verification

- `flutter analyze` on all changed Dart files — clean.
- `flutter test test/blocs/video_recorder/video_recorder_bloc_test.dart test/screens/video_recorder_screen_test.dart` — green.
- Pre-push hook (analyze + affected tests) — green.
- Manual on-device (Android): rapid front↔back switching — blur ramps in and out over the correctly oriented frame, no upside-down flash, no black flash.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)