### PR TITLE
fix(cache): bound runaway on-disk storage growth

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -118,6 +118,7 @@ import 'package:openvine/utils/video_controller_cleanup.dart';
 import 'package:openvine/widgets/app_lifecycle_handler.dart';
 import 'package:openvine/widgets/geo_blocking_gate.dart';
 import 'package:openvine/widgets/upload_failure_sheet.dart';
+import 'package:openvine/widgets/vine_cached_image.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:permissions_service/permissions_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -1454,6 +1455,10 @@ Future<void> _initializeVideoCacheManifest() async {
     task: () async {
       try {
         await initializeMediaCache();
+        // Trim the image cache back under its byte budget too (unawaited so
+        // it never blocks startup). The video cache is handled inside
+        // initializeMediaCache().
+        unawaited(openVineImageCache.enforceCacheLimits());
       } catch (e) {
         Log.error(
           '[STARTUP] Video cache initialization failed: $e',

--- a/mobile/lib/services/openvine_media_cache.dart
+++ b/mobile/lib/services/openvine_media_cache.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Video file cache singleton using media_cache package
 // ABOUTME: Replaces video_cache_manager.dart with cleaner abstraction
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:media_cache/media_cache.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -42,10 +44,14 @@ MediaCacheManager mediaCache(Ref ref) => openVineMediaCache;
 
 /// Initialize video file cache on app startup.
 ///
-/// Loads the in-memory manifest for synchronous cache lookups.
+/// Loads the in-memory manifest for synchronous cache lookups, then kicks off
+/// a background pass that reclaims leaked cache files and trims the directory
+/// back under its byte budget (see [MediaCacheManager.enforceCacheLimits]).
+/// The trim runs unawaited so it never blocks startup.
 /// Call this in main.dart after WidgetsFlutterBinding.ensureInitialized().
 /// Skipped on web where file-based caching is not available.
 Future<void> initializeMediaCache() async {
   if (kIsWeb) return;
   await openVineMediaCache.initialize();
+  unawaited(openVineMediaCache.enforceCacheLimits());
 }

--- a/mobile/lib/services/video_editor/transition_seam_render_service.dart
+++ b/mobile/lib/services/video_editor/transition_seam_render_service.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Renders the short transition "seam" between two adjacent clips so
 // ABOUTME: the preview can play it as a plain clip instead of compositing live.
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -55,6 +56,25 @@ class TransitionSeam {
 /// guarantees no clip is consumed by transitions on both sides at once, so the
 /// preview matches the export and a middle clip is never replayed.
 class TransitionSeamRenderService {
+  /// [documentsDirectoryProvider] and [maxSeamCacheBytes] are injectable for
+  /// tests; in production the directory resolves to the app documents folder
+  /// that holds persisted seams and the budget defaults to 200 MB.
+  TransitionSeamRenderService({
+    @visibleForTesting Future<Directory> Function()? documentsDirectoryProvider,
+    @visibleForTesting int maxSeamCacheBytes = _defaultMaxSeamCacheBytes,
+  }) : _documentsDirectoryProvider =
+           documentsDirectoryProvider ?? getApplicationDocumentsDirectory,
+       _maxSeamCacheBytes = maxSeamCacheBytes;
+
+  /// Default upper bound on the total size of the persisted
+  /// `transition_seams/` directory. Seam files are individually small, but
+  /// every distinct trim/transition tweak mints a new one, so without a cap
+  /// the directory grows without limit across editor sessions.
+  static const int _defaultMaxSeamCacheBytes = 200 * 1024 * 1024;
+
+  final Future<Directory> Function() _documentsDirectoryProvider;
+  final int _maxSeamCacheBytes;
+
   final _cache = <String, TransitionSeam>{};
   final _inFlight = <String, Future<TransitionSeam?>>{};
 
@@ -350,21 +370,66 @@ class TransitionSeamRenderService {
 
   /// Deterministic on-disk path for a seam, keyed by [key] so the same clip
   /// pair + trims + transition reuse the rendered file across editor sessions
-  /// (like thumbnails). Only the in-memory cache is dropped on [clear]; the
-  /// files persist for reuse.
+  /// (like thumbnails). Files persist for reuse, bounded on [clear] by
+  /// [enforceSeamCacheLimit].
   Future<String> _persistentSeamPath(String key) async {
-    final dir = await getApplicationDocumentsDirectory();
-    final seamDir = Directory('${dir.path}/transition_seams');
-    if (!seamDir.existsSync()) seamDir.createSync(recursive: true);
+    final seamDir = await _seamDirectory();
     final hash = sha256.convert(utf8.encode(key)).toString();
     return '${seamDir.path}/$hash.mp4';
   }
 
-  /// Drops the in-memory cache (e.g. when the editor closes). On-disk seams
-  /// stay for the next session.
+  Future<Directory> _seamDirectory() async {
+    final dir = await _documentsDirectoryProvider();
+    final seamDir = Directory('${dir.path}/transition_seams');
+    if (!seamDir.existsSync()) seamDir.createSync(recursive: true);
+    return seamDir;
+  }
+
+  /// Drops the in-memory cache (e.g. when the editor closes) and kicks off a
+  /// best-effort trim of the persisted seam directory (unawaited so it never
+  /// blocks editor teardown). Recent seams survive for cross-session reuse.
   void clear() {
     _cache.clear();
     _version++;
+    unawaited(enforceSeamCacheLimit());
+  }
+
+  /// Trims the persisted `transition_seams/` directory back under
+  /// [_maxSeamCacheBytes], deleting least-recently-modified seams first so the
+  /// current project's freshly-rendered seams survive for reuse. Every
+  /// distinct trim/transition tweak mints a new seam file, so without this the
+  /// directory grows without bound across sessions. Best-effort: never throws.
+  Future<void> enforceSeamCacheLimit() async {
+    try {
+      final seamDir = await _seamDirectory();
+      final entries = <({File file, int size, DateTime modified})>[];
+      var total = 0;
+      for (final entity in seamDir.listSync(followLinks: false)) {
+        if (entity is! File) continue;
+        final stat = entity.statSync();
+        if (stat.type == FileSystemEntityType.notFound) continue;
+        total += stat.size;
+        entries.add((file: entity, size: stat.size, modified: stat.modified));
+      }
+      if (total <= _maxSeamCacheBytes) return;
+
+      entries.sort((a, b) => a.modified.compareTo(b.modified));
+      for (final entry in entries) {
+        if (total <= _maxSeamCacheBytes) break;
+        try {
+          entry.file.deleteSync();
+          total -= entry.size;
+        } on Object {
+          // Best-effort; a file we cannot delete is retried on the next close.
+        }
+      }
+    } on Object catch (error) {
+      Log.warning(
+        'TransitionSeamRenderService: seam cache trim failed: $error',
+        name: 'TransitionSeamRenderService',
+        category: LogCategory.video,
+      );
+    }
   }
 
   /// Seeds the cache directly so [buildSeamAwarePlayerClips] can be exercised

--- a/mobile/lib/services/video_editor/transition_seam_render_service.dart
+++ b/mobile/lib/services/video_editor/transition_seam_render_service.dart
@@ -233,6 +233,13 @@ class TransitionSeamRenderService {
         await _deleteQuietly(path);
         return null;
       }
+      try {
+        // The trim in enforceSeamCacheLimit evicts by mtime; touch the file
+        // so a seam being actively reused isn't the first eviction candidate.
+        File(path).setLastModifiedSync(DateTime.now());
+      } on Object {
+        // Best-effort LRU touch; reuse must not fail because of it.
+      }
       return TransitionSeam(
         path: path,
         duration: metadata.duration,
@@ -424,6 +431,10 @@ class TransitionSeamRenderService {
         if (total <= _maxSeamCacheBytes) break;
         try {
           await entry.file.delete();
+          total -= entry.size;
+        } on PathNotFoundException {
+          // An overlapping trim already removed it; its bytes are off disk
+          // either way, so count them to avoid over-evicting newer seams.
           total -= entry.size;
         } on Object {
           // Best-effort; a file we cannot delete is retried on the next close.

--- a/mobile/lib/services/video_editor/transition_seam_render_service.dart
+++ b/mobile/lib/services/video_editor/transition_seam_render_service.dart
@@ -399,12 +399,18 @@ class TransitionSeamRenderService {
   /// current project's freshly-rendered seams survive for reuse. Every
   /// distinct trim/transition tweak mints a new seam file, so without this the
   /// directory grows without bound across sessions. Best-effort: never throws.
+  ///
+  /// I/O is asynchronous — the directory is walked with a `Directory.list()`
+  /// stream and files are removed with `File.delete()` so the event loop
+  /// yields between entries instead of the whole trim blocking the isolate on
+  /// editor teardown. Cheap metadata reads stay synchronous (`statSync`) per
+  /// `avoid_slow_async_io`.
   Future<void> enforceSeamCacheLimit() async {
     try {
       final seamDir = await _seamDirectory();
       final entries = <({File file, int size, DateTime modified})>[];
       var total = 0;
-      for (final entity in seamDir.listSync(followLinks: false)) {
+      await for (final entity in seamDir.list(followLinks: false)) {
         if (entity is! File) continue;
         final stat = entity.statSync();
         if (stat.type == FileSystemEntityType.notFound) continue;
@@ -417,7 +423,7 @@ class TransitionSeamRenderService {
       for (final entry in entries) {
         if (total <= _maxSeamCacheBytes) break;
         try {
-          entry.file.deleteSync();
+          await entry.file.delete();
           total -= entry.size;
         } on Object {
           // Best-effort; a file we cannot delete is retried on the next close.

--- a/mobile/lib/services/watermark_download_service.dart
+++ b/mobile/lib/services/watermark_download_service.dart
@@ -397,6 +397,10 @@ class WatermarkDownloadService {
   }) async {
     try {
       final tempDir = await getTemporaryDirectory();
+      // Each save keeps its render only until the share sheet closes; clearing
+      // leftovers here bounds the temp directory to the single in-progress
+      // render instead of leaking one full-size video per save.
+      deleteStaleWatermarkRenders(tempDir);
       final outputPath =
           '${tempDir.path}/watermarked_${DateTime.now().microsecondsSinceEpoch}.mp4';
 
@@ -425,6 +429,29 @@ class WatermarkDownloadService {
         category: LogCategory.video,
       );
       return null;
+    }
+  }
+
+  /// Deletes leftover `watermarked_*.mp4` renders in [tempDir] from previous
+  /// saves. Called before each new render so at most one watermark temp file
+  /// exists at a time. Best-effort: never throws.
+  @visibleForTesting
+  void deleteStaleWatermarkRenders(Directory tempDir) {
+    try {
+      for (final entity in tempDir.listSync(followLinks: false)) {
+        if (entity is! File) continue;
+        final name = p.basename(entity.path);
+        if (!name.startsWith('watermarked_') || !name.endsWith('.mp4')) {
+          continue;
+        }
+        try {
+          entity.deleteSync();
+        } on Object {
+          // Best-effort; a file we cannot delete is retried on the next save.
+        }
+      }
+    } on Object {
+      // Best-effort; a listing failure must not block the render.
     }
   }
 }

--- a/mobile/lib/services/watermark_download_service.dart
+++ b/mobile/lib/services/watermark_download_service.dart
@@ -397,9 +397,6 @@ class WatermarkDownloadService {
   }) async {
     try {
       final tempDir = await getTemporaryDirectory();
-      // Each save keeps its render only until the share sheet closes; clearing
-      // leftovers here bounds the temp directory to the single in-progress
-      // render instead of leaking one full-size video per save.
       deleteStaleWatermarkRenders(tempDir);
       final outputPath =
           '${tempDir.path}/watermarked_${DateTime.now().microsecondsSinceEpoch}.mp4';
@@ -432,11 +429,20 @@ class WatermarkDownloadService {
     }
   }
 
+  /// Renders older than this are safe to delete: no in-flight save can still
+  /// own them. A save whose progress sheet was dismissed keeps rendering in
+  /// the background, and a completed save's file may still be handed to the
+  /// platform share sheet — both live far shorter than this window.
+  static const _staleRenderAge = Duration(hours: 1);
+
   /// Deletes leftover `watermarked_*.mp4` renders in [tempDir] from previous
-  /// saves. Called before each new render so at most one watermark temp file
-  /// exists at a time. Best-effort: never throws.
+  /// saves that are older than [_staleRenderAge]. Called before each new
+  /// render so the temp directory stays bounded to roughly the last hour of
+  /// renders instead of leaking one full-size video per save.
+  /// Best-effort: never throws.
   @visibleForTesting
   void deleteStaleWatermarkRenders(Directory tempDir) {
+    final cutoff = DateTime.now().subtract(_staleRenderAge);
     try {
       for (final entity in tempDir.listSync(followLinks: false)) {
         if (entity is! File) continue;
@@ -445,6 +451,7 @@ class WatermarkDownloadService {
           continue;
         }
         try {
+          if (entity.statSync().modified.isAfter(cutoff)) continue;
           entity.deleteSync();
         } on Object {
           // Best-effort; a file we cannot delete is retried on the next save.

--- a/mobile/packages/media_cache/lib/src/media_cache_manager.dart
+++ b/mobile/packages/media_cache/lib/src/media_cache_manager.dart
@@ -13,6 +13,22 @@ import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
 import 'package:unified_logger/unified_logger.dart';
 
+/// Filenames written by [MediaCacheManager] end with
+/// `_<microseconds>_<seq><ext>` (see `_relativePathFor`). Reclamation only
+/// deletes *untracked* files matching this shape, so externally-managed files
+/// that share the cache directory — e.g. bundled seed media keyed by raw event
+/// id, or the alias manifest — are never removed.
+final RegExp _managedCacheFilePattern = RegExp(r'_\d+_\d+\.[A-Za-z0-9]+$');
+
+/// Number of successful downloads between throttled in-session
+/// [MediaCacheManager.enforceCacheLimits] passes.
+const int _downloadsPerSweep = 25;
+
+/// Minimum wall-clock gap between throttled in-session
+/// [MediaCacheManager.enforceCacheLimits] passes, so heavy scrolling cannot
+/// trigger back-to-back directory scans.
+const Duration _minSweepInterval = Duration(seconds: 60);
+
 /// {@template media_cache_config}
 /// Configuration for [MediaCacheManager].
 ///
@@ -24,6 +40,7 @@ class MediaCacheConfig {
     required this.cacheKey,
     this.stalePeriod = const Duration(days: 14),
     this.maxNrOfCacheObjects = 200,
+    this.maxCacheSizeBytes,
     this.connectionTimeout = const Duration(seconds: 15),
     this.idleTimeout = const Duration(seconds: 30),
     this.maxConnectionsPerHost = 6,
@@ -36,6 +53,8 @@ class MediaCacheConfig {
   ///
   /// - Longer stale period (30 days)
   /// - More cache objects (1000)
+  /// - Total on-disk budget of 2 GB, enforced by
+  ///   [MediaCacheManager.enforceCacheLimits]
   /// - Longer timeouts for large downloads
   /// - Sync manifest enabled for instant playback
   const MediaCacheConfig.video({required String cacheKey})
@@ -43,6 +62,7 @@ class MediaCacheConfig {
         cacheKey: cacheKey,
         stalePeriod: const Duration(days: 30),
         maxNrOfCacheObjects: 1000,
+        maxCacheSizeBytes: 2 * 1024 * 1024 * 1024,
         connectionTimeout: const Duration(seconds: 30),
         idleTimeout: const Duration(minutes: 2),
         maxConnectionsPerHost: 4,
@@ -59,6 +79,8 @@ class MediaCacheConfig {
   ///
   /// - Shorter stale period (7 days)
   /// - Fewer cache objects (200)
+  /// - Total on-disk budget of 256 MB, enforced by
+  ///   [MediaCacheManager.enforceCacheLimits]
   /// - Shorter timeouts for smaller downloads
   /// - No sync manifest needed
   const MediaCacheConfig.image({required String cacheKey})
@@ -66,6 +88,7 @@ class MediaCacheConfig {
         cacheKey: cacheKey,
         stalePeriod: const Duration(days: 7),
         maxNrOfCacheObjects: 200,
+        maxCacheSizeBytes: 256 * 1024 * 1024,
         connectionTimeout: const Duration(seconds: 10),
         idleTimeout: const Duration(seconds: 30),
         // Tuning choice (not a measured optimum): raised from 6 → 20 to
@@ -86,6 +109,16 @@ class MediaCacheConfig {
 
   /// Maximum number of objects to keep in cache.
   final int maxNrOfCacheObjects;
+
+  /// Maximum total size of the on-disk cache directory, in bytes.
+  ///
+  /// `flutter_cache_manager` only bounds the cache by *object count*
+  /// ([maxNrOfCacheObjects]); for media where individual files span
+  /// kilobytes to tens of megabytes, a count limit lets the directory grow
+  /// to many gigabytes. When set, [MediaCacheManager.enforceCacheLimits]
+  /// evicts least-recently-used files until the directory is back under this
+  /// budget. `null` disables byte-based eviction (count limit only).
+  final int? maxCacheSizeBytes;
 
   /// Timeout for establishing HTTP connections.
   ///
@@ -291,6 +324,26 @@ class MediaCacheManager extends CacheManager {
   /// Monotonic counter to disambiguate filenames written within the same
   /// millisecond when the same key is downloaded repeatedly.
   int _downloadSeq = 0;
+
+  /// Relative filenames currently being written by an in-flight download.
+  ///
+  /// [enforceCacheLimits] skips these so a reclamation pass never deletes a
+  /// file mid-download (the file exists on disk before its cache-store row
+  /// is written).
+  final Set<String> _inFlightRelativePaths = {};
+
+  /// Successful downloads since the last [enforceCacheLimits] pass. Drives
+  /// the throttled in-session sweep so the directory stays bounded without
+  /// running a full reconciliation after every single download.
+  int _downloadsSinceSweep = 0;
+
+  /// Guards against overlapping [enforceCacheLimits] runs.
+  bool _sweepInProgress = false;
+
+  /// When the last [enforceCacheLimits] pass started. Drives the time-based
+  /// throttle so back-to-back sweeps cannot pile up during heavy scrolling.
+  /// Seeded to the epoch so the first pass is never throttled.
+  DateTime _lastSweepAt = DateTime.fromMillisecondsSinceEpoch(0);
 
   /// In-memory manifest for synchronous lookups.
   /// Maps cache key to file path.
@@ -698,6 +751,9 @@ class MediaCacheManager extends CacheManager {
     }
 
     final relativePath = _relativePathFor(key, url);
+    // Shield the not-yet-registered file from a concurrent reclamation pass
+    // (added before the file exists, removed once the download settles).
+    _inFlightRelativePaths.add(relativePath);
     final completer = Completer<CancellableDownloadResult>();
     // Register before the async download starts so any concurrent caller
     // (cacheFile or another cacheFileCancellable) for the same key joins
@@ -749,6 +805,7 @@ class MediaCacheManager extends CacheManager {
               }
             }
           }
+          _downloadsSinceSweep++;
         }
         if (!completer.isCompleted) completer.complete(downloadResult);
       } on Object catch (error) {
@@ -762,6 +819,8 @@ class MediaCacheManager extends CacheManager {
         }
       } finally {
         _pendingCacheOperations.remove(key);
+        _inFlightRelativePaths.remove(relativePath);
+        _maybeEnforceCacheLimits();
       }
     }
 
@@ -831,6 +890,139 @@ class MediaCacheManager extends CacheManager {
       // Fall through to default.
     }
     return _config.defaultExtension;
+  }
+
+  /// Runs a throttled [enforceCacheLimits] pass once enough downloads have
+  /// accumulated since the last run, keeping the directory bounded during a
+  /// long session without sweeping after every single download.
+  void _maybeEnforceCacheLimits() {
+    if (_downloadsSinceSweep < _downloadsPerSweep) return;
+    _downloadsSinceSweep = 0;
+    unawaited(enforceCacheLimits());
+  }
+
+  /// Reclaims leaked cache files and enforces
+  /// [MediaCacheConfig.maxCacheSizeBytes].
+  ///
+  /// Two passes, both safe to run at any time and never throwing:
+  ///
+  /// 1. **Reclamation** — deletes files in the cache directory that the cache
+  ///    store no longer tracks but that match [_managedCacheFilePattern].
+  ///    `flutter_cache_manager` drops database rows on eviction without
+  ///    reliably deleting the underlying file for this on-disk layout, so
+  ///    evicted and superseded downloads pile up as untracked orphans; this
+  ///    pass removes them. Files that do not match the pattern (bundled seed
+  ///    media, the alias manifest) are left untouched.
+  /// 2. **Byte eviction** — when [MediaCacheConfig.maxCacheSizeBytes] is set,
+  ///    deletes the least-recently-used tracked files until the directory is
+  ///    back under budget, removing both the file and its store row.
+  ///
+  /// Safe to call at startup and repeatedly; overlapping calls are ignored and
+  /// calls within [_minSweepInterval] of the previous pass are skipped.
+  ///
+  /// I/O is intentionally asynchronous: the directory is walked with a
+  /// `Directory.list()` stream and files are removed with `File.delete()` so
+  /// the event loop yields between entries instead of the whole sweep blocking
+  /// the isolate. Cheap metadata reads stay synchronous (`statSync`) per
+  /// `avoid_slow_async_io` — the async variants of those add more overhead
+  /// than they save.
+  Future<void> enforceCacheLimits() async {
+    if (_isClosed || _sweepInProgress) return;
+    if (DateTime.now().difference(_lastSweepAt) < _minSweepInterval) return;
+    _sweepInProgress = true;
+    _lastSweepAt = DateTime.now();
+    try {
+      final repo = _repoOverride ?? config.repo;
+      if (!await repo.open()) return;
+      final objects = await repo.getAllObjects();
+      final baseDir = await _resolveBaseCacheDir();
+
+      final trackedNames = {for (final object in objects) object.relativePath};
+      await _reclaimOrphanedFiles(baseDir, trackedNames);
+
+      final budget = _config.maxCacheSizeBytes;
+      if (budget != null) {
+        await _evictToByteBudget(baseDir, objects, budget, repo);
+      }
+    } on Object catch (error) {
+      Log.warning(
+        'MediaCacheManager: enforceCacheLimits failed: $error',
+        name: 'MediaCache',
+        category: LogCategory.video,
+      );
+    } finally {
+      _sweepInProgress = false;
+    }
+  }
+
+  Future<void> _reclaimOrphanedFiles(
+    String baseDir,
+    Set<String> trackedNames,
+  ) async {
+    final dir = Directory(baseDir);
+    if (!dir.existsSync()) return;
+    // `Directory.list()` yields between entries, so a large reclamation pass
+    // does not block the isolate the way a `listSync()` loop would.
+    await for (final entity in dir.list(followLinks: false)) {
+      if (entity is! File) continue;
+      final name = path.basename(entity.path);
+      if (trackedNames.contains(name)) continue;
+      if (_inFlightRelativePaths.contains(name)) continue;
+      if (!_managedCacheFilePattern.hasMatch(name)) continue;
+      await _deleteFile(entity);
+    }
+  }
+
+  Future<void> _evictToByteBudget(
+    String baseDir,
+    List<CacheObject> objects,
+    int budget,
+    CacheInfoRepository repo,
+  ) async {
+    final entries = <_TrackedCacheFile>[];
+    var total = 0;
+    for (final object in objects) {
+      final file = File(path.join(baseDir, object.relativePath));
+      final stat = file.statSync();
+      if (stat.type == FileSystemEntityType.notFound) continue;
+      total += stat.size;
+      entries.add(
+        _TrackedCacheFile(
+          object: object,
+          file: file,
+          size: stat.size,
+          lastUsed: object.touched ?? stat.modified,
+        ),
+      );
+    }
+    if (total <= budget) return;
+
+    // Least-recently-used first so hot items survive the trim.
+    entries.sort((a, b) => a.lastUsed.compareTo(b.lastUsed));
+    final removedIds = <int>[];
+    for (final entry in entries) {
+      if (total <= budget) break;
+      await _deleteFile(entry.file);
+      total -= entry.size;
+      final id = entry.object.id;
+      if (id != null) removedIds.add(id);
+      _cacheManifest.remove(entry.object.key);
+    }
+    if (removedIds.isNotEmpty) {
+      await repo.deleteAll(removedIds);
+    }
+  }
+
+  /// Deletes [file] asynchronously (best-effort, never throwing). Async so the
+  /// blocking unlink runs off the isolate's main thread and the surrounding
+  /// loop yields between deletions. No existence pre-check: a missing file
+  /// throws [PathNotFoundException], which is swallowed like any other error.
+  Future<void> _deleteFile(File file) async {
+    try {
+      await file.delete();
+    } on Object catch (_) {
+      // Best-effort; anything left behind is retried on the next pass.
+    }
   }
 
   /// Checks if a file is cached (async version).
@@ -953,6 +1145,7 @@ class MediaCacheManager extends CacheManager {
       'manifestSize': _cacheManifest.length,
       'manifestInitialized': _manifestInitialized,
       'maxObjects': _config.maxNrOfCacheObjects,
+      'maxCacheSizeBytes': _config.maxCacheSizeBytes,
       'stalePeriodDays': _config.stalePeriod.inDays,
       'syncManifestEnabled': _config.enableSyncManifest,
       ...metrics.toMap(),
@@ -1005,6 +1198,22 @@ class MediaCacheManager extends CacheManager {
     _fileServiceClient?.close();
     await super.dispose();
   }
+}
+
+/// A tracked cache file paired with its on-disk size and last-used time,
+/// used to order least-recently-used eviction during byte-budget trimming.
+class _TrackedCacheFile {
+  _TrackedCacheFile({
+    required this.object,
+    required this.file,
+    required this.size,
+    required this.lastUsed,
+  });
+
+  final CacheObject object;
+  final File file;
+  final int size;
+  final DateTime lastUsed;
 }
 
 /// Bridges a deferred [Future] (which performs async setup before the real

--- a/mobile/packages/media_cache/lib/src/media_cache_manager.dart
+++ b/mobile/packages/media_cache/lib/src/media_cache_manager.dart
@@ -116,8 +116,9 @@ class MediaCacheConfig {
   /// ([maxNrOfCacheObjects]); for media where individual files span
   /// kilobytes to tens of megabytes, a count limit lets the directory grow
   /// to many gigabytes. When set, [MediaCacheManager.enforceCacheLimits]
-  /// evicts least-recently-used files until the directory is back under this
-  /// budget. `null` disables byte-based eviction (count limit only).
+  /// evicts the oldest files first — ordered by the store's last-touch time,
+  /// falling back to file mtime when it is unset — until the directory is back
+  /// under this budget. `null` disables byte-based eviction (count limit only).
   final int? maxCacheSizeBytes;
 
   /// Timeout for establishing HTTP connections.
@@ -906,16 +907,21 @@ class MediaCacheManager extends CacheManager {
   ///
   /// Two passes, both safe to run at any time and never throwing:
   ///
-  /// 1. **Reclamation** — deletes files in the cache directory that the cache
-  ///    store no longer tracks but that match [_managedCacheFilePattern].
-  ///    `flutter_cache_manager` drops database rows on eviction without
-  ///    reliably deleting the underlying file for this on-disk layout, so
-  ///    evicted and superseded downloads pile up as untracked orphans; this
-  ///    pass removes them. Files that do not match the pattern (bundled seed
-  ///    media, the alias manifest) are left untouched.
+  /// 1. **Reclamation** — deletes files in the cache directory that neither the
+  ///    cache store nor the sync manifest still tracks and that match
+  ///    [_managedCacheFilePattern]. `flutter_cache_manager` drops database rows
+  ///    on eviction without reliably deleting the underlying file for this
+  ///    on-disk layout, so evicted and superseded downloads pile up as
+  ///    untracked orphans; this pass removes them. Files still referenced by
+  ///    the manifest (live entries the store's object cap has demoted), files
+  ///    that do not match the pattern (bundled seed media, the alias manifest),
+  ///    and in-flight downloads are left untouched.
   /// 2. **Byte eviction** — when [MediaCacheConfig.maxCacheSizeBytes] is set,
-  ///    deletes the least-recently-used tracked files until the directory is
-  ///    back under budget, removing both the file and its store row.
+  ///    deletes the oldest tracked files first (ordered by the store's
+  ///    last-touch time, falling back to file mtime) until the directory is
+  ///    back under budget, removing both the file and its store row. Note the
+  ///    sync-manifest read path does not refresh `touched`, so in practice
+  ///    this trims by download age rather than true last-access.
   ///
   /// Safe to call at startup and repeatedly; overlapping calls are ignored and
   /// calls within [_minSweepInterval] of the previous pass are skipped.
@@ -930,7 +936,6 @@ class MediaCacheManager extends CacheManager {
     if (_isClosed || _sweepInProgress) return;
     if (DateTime.now().difference(_lastSweepAt) < _minSweepInterval) return;
     _sweepInProgress = true;
-    _lastSweepAt = DateTime.now();
     try {
       final repo = _repoOverride ?? config.repo;
       if (!await repo.open()) return;
@@ -952,6 +957,9 @@ class MediaCacheManager extends CacheManager {
       );
     } finally {
       _sweepInProgress = false;
+      // Measure the throttle window from completion, not start, so a slow
+      // sweep can't immediately re-trigger back-to-back and monopolise I/O.
+      _lastSweepAt = DateTime.now();
     }
   }
 
@@ -961,12 +969,23 @@ class MediaCacheManager extends CacheManager {
   ) async {
     final dir = Directory(baseDir);
     if (!dir.existsSync()) return;
+    // Files the sync manifest still points at are live cache entries — even
+    // when flutter_cache_manager has dropped their row from its capped store
+    // (its object cap is far smaller than the manifest can grow). Treating
+    // those as orphans deletes files getCachedFileSync is actively serving,
+    // which forces an immediate re-download that re-populates the manifest and
+    // triggers the next sweep — a churn storm that reads as constant jank.
+    // Protect anything the manifest references.
+    final manifestNames = {
+      for (final filePath in _cacheManifest.values) path.basename(filePath),
+    };
     // `Directory.list()` yields between entries, so a large reclamation pass
     // does not block the isolate the way a `listSync()` loop would.
     await for (final entity in dir.list(followLinks: false)) {
       if (entity is! File) continue;
       final name = path.basename(entity.path);
       if (trackedNames.contains(name)) continue;
+      if (manifestNames.contains(name)) continue;
       if (_inFlightRelativePaths.contains(name)) continue;
       if (!_managedCacheFilePattern.hasMatch(name)) continue;
       await _deleteFile(entity);
@@ -997,7 +1016,7 @@ class MediaCacheManager extends CacheManager {
     }
     if (total <= budget) return;
 
-    // Least-recently-used first so hot items survive the trim.
+    // Oldest first (last-touch time, else file mtime) so newer items survive.
     entries.sort((a, b) => a.lastUsed.compareTo(b.lastUsed));
     final removedIds = <int>[];
     for (final entry in entries) {
@@ -1200,8 +1219,9 @@ class MediaCacheManager extends CacheManager {
   }
 }
 
-/// A tracked cache file paired with its on-disk size and last-used time,
-/// used to order least-recently-used eviction during byte-budget trimming.
+/// A tracked cache file paired with its on-disk size and recency signal
+/// ([lastUsed] = the store's `touched` time, or file mtime when unset), used
+/// to order oldest-first eviction during byte-budget trimming.
 class _TrackedCacheFile {
   _TrackedCacheFile({
     required this.object,

--- a/mobile/packages/media_cache/lib/src/media_cache_manager.dart
+++ b/mobile/packages/media_cache/lib/src/media_cache_manager.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:clock/clock.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:http/io_client.dart';
@@ -15,10 +16,31 @@ import 'package:unified_logger/unified_logger.dart';
 
 /// Filenames written by [MediaCacheManager] end with
 /// `_<microseconds>_<seq><ext>` (see `_relativePathFor`). Reclamation only
-/// deletes *untracked* files matching this shape, so externally-managed files
-/// that share the cache directory — e.g. bundled seed media keyed by raw event
-/// id, or the alias manifest — are never removed.
+/// deletes *untracked* files matching this shape or
+/// [_webHelperCacheFilePattern], so externally-managed files that share the
+/// cache directory — e.g. bundled seed media keyed by raw event id, or the
+/// alias manifest — are never removed.
 final RegExp _managedCacheFilePattern = RegExp(r'_\d+_\d+\.[A-Za-z0-9]+$');
+
+/// Filenames written by `flutter_cache_manager`'s WebHelper — the path behind
+/// the inherited [CacheManager.downloadFile] / [CacheManager.getSingleFile] —
+/// are `<uuid-v1><ext>` (and `<uuid-v1>.file` for not-modified responses).
+/// Its eviction never deletes these files for this on-disk layout (it resolves
+/// the relative path against the process CWD), so they orphan just like the
+/// cancellable path's files. Cannot collide with seed media (raw hex event
+/// ids have no dashes) or the alias manifest.
+final RegExp _webHelperCacheFilePattern = RegExp(
+  '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}'
+  r'-[0-9a-fA-F]{12}\.[A-Za-z0-9]+$',
+);
+
+/// Untracked files younger than this are never reclaimed. Covers the window
+/// where a download settled after the sweep's snapshots were taken (its store
+/// row and manifest entry land after the snapshot but before the walk reaches
+/// the file), and WebHelper's in-flight writes, which carry no in-flight
+/// shield at all. A real orphan is simply picked up by a later sweep once it
+/// has aged past the window.
+const Duration _reclamationFreshnessWindow = Duration(minutes: 5);
 
 /// Number of successful downloads between throttled in-session
 /// [MediaCacheManager.enforceCacheLimits] passes.
@@ -898,6 +920,13 @@ class MediaCacheManager extends CacheManager {
   /// long session without sweeping after every single download.
   void _maybeEnforceCacheLimits() {
     if (_downloadsSinceSweep < _downloadsPerSweep) return;
+    // Keep the counter while a sweep would be skipped anyway (one is already
+    // running, or the throttle window is still open) so these downloads count
+    // toward the next eligible pass instead of being consumed silently.
+    if (_sweepInProgress ||
+        clock.now().difference(_lastSweepAt) < _minSweepInterval) {
+      return;
+    }
     _downloadsSinceSweep = 0;
     unawaited(enforceCacheLimits());
   }
@@ -909,13 +938,15 @@ class MediaCacheManager extends CacheManager {
   ///
   /// 1. **Reclamation** — deletes files in the cache directory that neither the
   ///    cache store nor the sync manifest still tracks and that match
-  ///    [_managedCacheFilePattern]. `flutter_cache_manager` drops database rows
-  ///    on eviction without reliably deleting the underlying file for this
-  ///    on-disk layout, so evicted and superseded downloads pile up as
-  ///    untracked orphans; this pass removes them. Files still referenced by
-  ///    the manifest (live entries the store's object cap has demoted), files
-  ///    that do not match the pattern (bundled seed media, the alias manifest),
-  ///    and in-flight downloads are left untouched.
+  ///    [_managedCacheFilePattern] or [_webHelperCacheFilePattern].
+  ///    `flutter_cache_manager` drops database rows on eviction without
+  ///    reliably deleting the underlying file for this on-disk layout, so
+  ///    evicted and superseded downloads pile up as untracked orphans; this
+  ///    pass removes them. Files still referenced by the manifest (live
+  ///    entries the store's object cap has demoted), files that match neither
+  ///    pattern (bundled seed media, the alias manifest), in-flight
+  ///    downloads, and files written within [_reclamationFreshnessWindow]
+  ///    are left untouched.
   /// 2. **Byte eviction** — when [MediaCacheConfig.maxCacheSizeBytes] is set,
   ///    deletes the oldest tracked files first (ordered by the store's
   ///    last-touch time, falling back to file mtime) until the directory is
@@ -934,11 +965,13 @@ class MediaCacheManager extends CacheManager {
   /// than they save.
   Future<void> enforceCacheLimits() async {
     if (_isClosed || _sweepInProgress) return;
-    if (DateTime.now().difference(_lastSweepAt) < _minSweepInterval) return;
+    if (clock.now().difference(_lastSweepAt) < _minSweepInterval) return;
     _sweepInProgress = true;
+    var repoOpened = false;
     try {
       final repo = _repoOverride ?? config.repo;
       if (!await repo.open()) return;
+      repoOpened = true;
       final objects = await repo.getAllObjects();
       final baseDir = await _resolveBaseCacheDir();
 
@@ -959,7 +992,9 @@ class MediaCacheManager extends CacheManager {
       _sweepInProgress = false;
       // Measure the throttle window from completion, not start, so a slow
       // sweep can't immediately re-trigger back-to-back and monopolise I/O.
-      _lastSweepAt = DateTime.now();
+      // Only stamped for passes that got past open(): a failed repository
+      // open (e.g. cold start) must not throttle out the retry.
+      if (repoOpened) _lastSweepAt = clock.now();
     }
   }
 
@@ -979,6 +1014,7 @@ class MediaCacheManager extends CacheManager {
     final manifestNames = {
       for (final filePath in _cacheManifest.values) path.basename(filePath),
     };
+    final freshnessCutoff = clock.now().subtract(_reclamationFreshnessWindow);
     // `Directory.list()` yields between entries, so a large reclamation pass
     // does not block the isolate the way a `listSync()` loop would.
     await for (final entity in dir.list(followLinks: false)) {
@@ -987,7 +1023,15 @@ class MediaCacheManager extends CacheManager {
       if (trackedNames.contains(name)) continue;
       if (manifestNames.contains(name)) continue;
       if (_inFlightRelativePaths.contains(name)) continue;
-      if (!_managedCacheFilePattern.hasMatch(name)) continue;
+      if (!_managedCacheFilePattern.hasMatch(name) &&
+          !_webHelperCacheFilePattern.hasMatch(name)) {
+        continue;
+      }
+      // Freshness guard (see [_reclamationFreshnessWindow]): a download that
+      // settled after the snapshots above were taken is untracked here yet
+      // fully live, and WebHelper's in-flight writes have no shield entry.
+      // Both carry a fresh mtime, so recently-written files stay untouched.
+      if (entity.statSync().modified.isAfter(freshnessCutoff)) continue;
       await _deleteFile(entity);
     }
   }

--- a/mobile/packages/media_cache/pubspec.yaml
+++ b/mobile/packages/media_cache/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
   flutter: ^3.41.1
 
 dependencies:
+  clock: ^1.1.2
   cronet_http: ^1.8.0
   cupertino_http: ^3.0.2
   file: ^7.0.0

--- a/mobile/packages/media_cache/test/src/enforce_cache_limits_test.dart
+++ b/mobile/packages/media_cache/test/src/enforce_cache_limits_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:clock/clock.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:media_cache/media_cache.dart';
@@ -49,9 +50,18 @@ void main() {
       return (manager, dir);
     }
 
-    File writeFile(Directory dir, String name, int bytes) {
+    // Files are written with an old mtime by default so they sit outside the
+    // reclamation freshness window — leaked orphans in the wild are old.
+    // Pass [modified] to model a freshly-written file.
+    File writeFile(
+      Directory dir,
+      String name,
+      int bytes, {
+      DateTime? modified,
+    }) {
       return File('${dir.path}/$name')
-        ..writeAsBytesSync(List<int>.filled(bytes, 0));
+        ..writeAsBytesSync(List<int>.filled(bytes, 0))
+        ..setLastModifiedSync(modified ?? DateTime(2020));
     }
 
     CacheObject obj(String relativePath, {int? id, DateTime? touched}) {
@@ -87,6 +97,68 @@ void main() {
       expect(seedThumb.existsSync(), isTrue, reason: 'seed thumbnail kept');
       expect(aliases.existsSync(), isTrue, reason: 'alias manifest kept');
       expect(nested.existsSync(), isTrue, reason: 'subdirectory kept');
+    });
+
+    test('reclaims aged uuid-named orphans from the inherited '
+        'downloadFile path', () async {
+      final (manager, dir) = build();
+      final uuidVideo = writeFile(
+        dir,
+        '1b4e28ba-2fa1-11d2-883f-0016d3cca427.mp4',
+        10,
+      );
+      final uuidPartial = writeFile(
+        dir,
+        '5c0e8de0-4f9a-11ee-a3b2-0242ac120002.file',
+        10,
+      );
+      final seedVideo = writeFile(dir, 'a1b2c3d4e5f6', 10);
+
+      when(repo.getAllObjects).thenAnswer((_) async => []);
+
+      await manager.enforceCacheLimits();
+
+      expect(uuidVideo.existsSync(), isFalse, reason: 'uuid orphan removed');
+      expect(
+        uuidPartial.existsSync(),
+        isFalse,
+        reason: 'uuid .file orphan removed',
+      );
+      expect(seedVideo.existsSync(), isTrue, reason: 'seed video kept');
+    });
+
+    test('leaves freshly-written untracked files for a later sweep', () async {
+      final (manager, dir) = build();
+      final freshManaged = writeFile(
+        dir,
+        'vid_key_300_3.mp4',
+        10,
+        modified: DateTime.now(),
+      );
+      final freshUuid = writeFile(
+        dir,
+        '1b4e28ba-2fa1-11d2-883f-0016d3cca427.jpg',
+        10,
+        modified: DateTime.now(),
+      );
+      when(repo.getAllObjects).thenAnswer((_) async => []);
+
+      await manager.enforceCacheLimits();
+
+      expect(
+        freshManaged.existsSync(),
+        isTrue,
+        reason:
+            'a file inside the freshness window may be a download that '
+            'settled after the sweep snapshots were taken',
+      );
+      expect(
+        freshUuid.existsSync(),
+        isTrue,
+        reason:
+            'WebHelper writes carry no in-flight shield; freshness is '
+            'their only protection',
+      );
     });
 
     test('evicts least-recently-used tracked files until under '
@@ -174,6 +246,28 @@ void main() {
 
       expect(orphan.existsSync(), isTrue);
       verifyNever(repo.getAllObjects);
+    });
+
+    test('does not throttle the retry after a failed repository '
+        'open', () async {
+      when(repo.open).thenAnswer((_) async => false);
+      final (manager, dir) = build();
+      final orphan = writeFile(dir, 'x_1_1.mp4', 10);
+
+      await manager.enforceCacheLimits();
+      expect(orphan.existsSync(), isTrue, reason: 'first pass could not run');
+
+      when(repo.open).thenAnswer((_) async => true);
+      when(repo.getAllObjects).thenAnswer((_) async => []);
+      await manager.enforceCacheLimits();
+
+      expect(
+        orphan.existsSync(),
+        isFalse,
+        reason:
+            'a pass that never opened the repo must not start the '
+            'throttle window',
+      );
     });
 
     test('swallows repository errors without throwing', () async {
@@ -264,6 +358,9 @@ void main() {
       downloader.downloads.single.completeWith(target);
       await op.file;
       expect(target.existsSync(), isTrue);
+      // Age the file past the freshness window so this test pins the
+      // manifest protection, not the freshness guard.
+      target.setLastModifiedSync(DateTime(2020));
 
       await manager.enforceCacheLimits();
 
@@ -272,6 +369,45 @@ void main() {
         isTrue,
         reason: 'a manifest-referenced file must survive reclamation',
       );
+    });
+
+    test('keeps a file a stalled in-flight download is still '
+        'writing', () async {
+      final downloader = FakeCancellableDownloader();
+      final cacheKey = 'inflight_${DateTime.now().microsecondsSinceEpoch}';
+      Directory('$testTempPath/$cacheKey').createSync(recursive: true);
+      when(repo.getAllObjects).thenAnswer((_) async => []);
+      when(() => repo.updateOrInsert(any())).thenAnswer((_) async => 0);
+
+      final manager = MediaCacheManager(
+        config: MediaCacheConfig(cacheKey: cacheKey, enableSyncManifest: true),
+        repoOverride: repo,
+        downloaderOverride: downloader,
+      );
+
+      final op = manager.cacheFileCancellable(
+        'https://example.com/v.mp4',
+        key: 'k',
+      );
+      for (var i = 0; i < 400 && downloader.downloads.isEmpty; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 1));
+      }
+      // A long-stalled download: partial bytes on disk with an old mtime, so
+      // only the in-flight shield (not the freshness guard) protects it.
+      final target = downloader.downloads.single.targetFile
+        ..writeAsBytesSync(const [1, 2, 3])
+        ..setLastModifiedSync(DateTime(2020));
+
+      await manager.enforceCacheLimits();
+
+      expect(
+        target.existsSync(),
+        isTrue,
+        reason: 'an in-flight download must never be reclaimed',
+      );
+
+      downloader.downloads.single.completeWith(target);
+      await op.file;
     });
 
     test('runs a throttled sweep after enough downloads', () async {
@@ -310,6 +446,84 @@ void main() {
 
       verify(repo.getAllObjects).called(greaterThanOrEqualTo(1));
       sourceDir.deleteSync(recursive: true);
+    });
+
+    test('retains the download counter while the sweep is '
+        'throttled', () async {
+      var offset = Duration.zero;
+      await withClock(Clock(() => DateTime.now().add(offset)), () async {
+        final downloader = FakeCancellableDownloader();
+        final cacheKey = 'counter_${DateTime.now().microsecondsSinceEpoch}';
+        Directory('$testTempPath/$cacheKey').createSync(recursive: true);
+        var sweeps = 0;
+        when(repo.getAllObjects).thenAnswer((_) async {
+          sweeps++;
+          return [];
+        });
+        when(() => repo.updateOrInsert(any())).thenAnswer((_) async => 0);
+
+        final manager = MediaCacheManager(
+          config: MediaCacheConfig(
+            cacheKey: cacheKey,
+            enableSyncManifest: true,
+          ),
+          repoOverride: repo,
+          downloaderOverride: downloader,
+        );
+
+        final sourceDir = Directory.systemTemp.createTempSync('counter_src_');
+        addTearDown(() => sourceDir.deleteSync(recursive: true));
+        final file = File('${sourceDir.path}/v.mp4')
+          ..writeAsBytesSync(const [1, 2, 3]);
+
+        Future<void> drive(int from, int count) async {
+          final ops = [
+            for (var i = from; i < from + count; i++)
+              manager.cacheFileCancellable(
+                'https://example.com/v$i.mp4',
+                key: 'k$i',
+              ),
+          ];
+          for (
+            var i = 0;
+            i < 400 && downloader.downloads.length < from + count;
+            i++
+          ) {
+            await Future<void>.delayed(const Duration(milliseconds: 1));
+          }
+          for (final download in downloader.downloads.sublist(from)) {
+            download.completeWith(file);
+          }
+          await Future.wait(ops.map((op) => op.file));
+        }
+
+        await drive(0, 25);
+        for (var i = 0; i < 400 && sweeps < 1; i++) {
+          await Future<void>.delayed(const Duration(milliseconds: 1));
+        }
+        expect(sweeps, 1, reason: 'first batch triggers a sweep');
+        // Let the sweep finish so _lastSweepAt is stamped.
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+
+        // A second full batch inside the throttle window: no sweep runs, but
+        // the counter must be retained instead of consumed.
+        await drive(25, 25);
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+        expect(sweeps, 1, reason: 'second batch is throttled');
+
+        // Once the window has passed, the retained counter means a single
+        // further download is enough to trigger the deferred sweep.
+        offset += const Duration(minutes: 2);
+        await drive(50, 1);
+        for (var i = 0; i < 400 && sweeps < 2; i++) {
+          await Future<void>.delayed(const Duration(milliseconds: 1));
+        }
+        expect(
+          sweeps,
+          2,
+          reason: 'throttled downloads still count toward the next pass',
+        );
+      });
     });
 
     test('reports the byte budget via getCacheStats', () {

--- a/mobile/packages/media_cache/test/src/enforce_cache_limits_test.dart
+++ b/mobile/packages/media_cache/test/src/enforce_cache_limits_test.dart
@@ -236,6 +236,44 @@ void main() {
       verify(repo.getAllObjects).called(1);
     });
 
+    test('does not reclaim files still referenced by the sync '
+        'manifest', () async {
+      final downloader = FakeCancellableDownloader();
+      final cacheKey = 'manifest_${DateTime.now().microsecondsSinceEpoch}';
+      Directory('$testTempPath/$cacheKey').createSync(recursive: true);
+      when(() => repo.updateOrInsert(any())).thenAnswer((_) async => 0);
+      // The store reports nothing — as if flutter_cache_manager demoted the
+      // row past its object cap while the file stays live in the manifest.
+      when(repo.getAllObjects).thenAnswer((_) async => []);
+
+      final manager = MediaCacheManager(
+        config: MediaCacheConfig(cacheKey: cacheKey, enableSyncManifest: true),
+        repoOverride: repo,
+        downloaderOverride: downloader,
+      );
+
+      final op = manager.cacheFileCancellable(
+        'https://example.com/v.mp4',
+        key: 'k',
+      );
+      for (var i = 0; i < 400 && downloader.downloads.isEmpty; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 1));
+      }
+      final target = downloader.downloads.single.targetFile
+        ..writeAsBytesSync(const [1, 2, 3]);
+      downloader.downloads.single.completeWith(target);
+      await op.file;
+      expect(target.existsSync(), isTrue);
+
+      await manager.enforceCacheLimits();
+
+      expect(
+        target.existsSync(),
+        isTrue,
+        reason: 'a manifest-referenced file must survive reclamation',
+      );
+    });
+
     test('runs a throttled sweep after enough downloads', () async {
       final downloader = FakeCancellableDownloader();
       final cacheKey = 'throttle_${DateTime.now().microsecondsSinceEpoch}';

--- a/mobile/packages/media_cache/test/src/enforce_cache_limits_test.dart
+++ b/mobile/packages/media_cache/test/src/enforce_cache_limits_test.dart
@@ -1,0 +1,282 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:media_cache/media_cache.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'helpers/mocks.dart';
+import 'helpers/test_helpers.dart';
+
+void main() {
+  setUpTestEnvironment();
+
+  group('MediaCacheManager.enforceCacheLimits', () {
+    late MockCacheInfoRepository repo;
+
+    setUpAll(() async {
+      await setUpTestDirectories();
+      registerFallbackValue(<int>[]);
+      registerFallbackValue(
+        CacheObject('u', relativePath: 'r', validTill: DateTime(2099)),
+      );
+    });
+
+    tearDownAll(() async {
+      await tearDownTestDirectories();
+    });
+
+    setUp(() {
+      repo = MockCacheInfoRepository();
+      when(repo.open).thenAnswer((_) async => true);
+      when(repo.close).thenAnswer((_) async => true);
+      when(() => repo.deleteAll(any())).thenAnswer((_) async => 0);
+    });
+
+    (MediaCacheManager, Directory) build({int? maxCacheSizeBytes}) {
+      final cacheKey = 'enforce_${DateTime.now().microsecondsSinceEpoch}';
+      final dir = Directory('$testTempPath/$cacheKey')
+        ..createSync(recursive: true);
+      final manager = MediaCacheManager(
+        config: MediaCacheConfig(
+          cacheKey: cacheKey,
+          enableSyncManifest: true,
+          maxCacheSizeBytes: maxCacheSizeBytes,
+        ),
+        repoOverride: repo,
+      );
+      return (manager, dir);
+    }
+
+    File writeFile(Directory dir, String name, int bytes) {
+      return File('${dir.path}/$name')
+        ..writeAsBytesSync(List<int>.filled(bytes, 0));
+    }
+
+    CacheObject obj(String relativePath, {int? id, DateTime? touched}) {
+      return CacheObject(
+        'https://example.com/$relativePath',
+        key: 'key_$relativePath',
+        relativePath: relativePath,
+        validTill: DateTime(2099),
+        id: id,
+        touched: touched,
+      );
+    }
+
+    test('reclaims untracked managed-pattern files, keeps everything '
+        'else', () async {
+      final (manager, dir) = build();
+      final tracked = writeFile(dir, 'vid_key_100_1.mp4', 10);
+      final orphan = writeFile(dir, 'vid_key_200_2.mp4', 10);
+      final seedVideo = writeFile(dir, 'a1b2c3d4e5f6', 10);
+      final seedThumb = writeFile(dir, 'thumbnail_a1b2c3.jpg', 10);
+      final aliases = writeFile(dir, 'aliases.json', 10);
+      final nested = Directory('${dir.path}/nested')..createSync();
+
+      when(repo.getAllObjects).thenAnswer(
+        (_) async => [obj('vid_key_100_1.mp4', id: 1)],
+      );
+
+      await manager.enforceCacheLimits();
+
+      expect(orphan.existsSync(), isFalse, reason: 'untracked orphan removed');
+      expect(tracked.existsSync(), isTrue, reason: 'tracked file kept');
+      expect(seedVideo.existsSync(), isTrue, reason: 'seed video kept');
+      expect(seedThumb.existsSync(), isTrue, reason: 'seed thumbnail kept');
+      expect(aliases.existsSync(), isTrue, reason: 'alias manifest kept');
+      expect(nested.existsSync(), isTrue, reason: 'subdirectory kept');
+    });
+
+    test('evicts least-recently-used tracked files until under '
+        'budget', () async {
+      final (manager, dir) = build(maxCacheSizeBytes: 100);
+      final oldest = writeFile(dir, 'a_1_1.mp4', 60);
+      final middle = writeFile(dir, 'b_2_2.mp4', 60);
+      final newest = writeFile(dir, 'c_3_3.mp4', 60);
+
+      when(repo.getAllObjects).thenAnswer(
+        (_) async => [
+          obj('a_1_1.mp4', id: 1, touched: DateTime(2020)),
+          obj('b_2_2.mp4', id: 2, touched: DateTime(2020, 1, 2)),
+          obj('c_3_3.mp4', id: 3, touched: DateTime(2020, 1, 3)),
+        ],
+      );
+
+      await manager.enforceCacheLimits();
+
+      // 180 bytes > 100: drop oldest (→120), still over, drop middle (→60).
+      expect(oldest.existsSync(), isFalse);
+      expect(middle.existsSync(), isFalse);
+      expect(newest.existsSync(), isTrue);
+
+      final captured =
+          verify(() => repo.deleteAll(captureAny())).captured.single as List;
+      expect(captured, containsAll(<int>[1, 2]));
+      expect(captured, isNot(contains(3)));
+    });
+
+    test('does not evict when total size is within budget', () async {
+      final (manager, dir) = build(maxCacheSizeBytes: 1000);
+      final file = writeFile(dir, 'a_1_1.mp4', 60);
+
+      when(repo.getAllObjects).thenAnswer(
+        (_) async => [obj('a_1_1.mp4', id: 1, touched: DateTime(2020))],
+      );
+
+      await manager.enforceCacheLimits();
+
+      expect(file.existsSync(), isTrue);
+      verifyNever(() => repo.deleteAll(any()));
+    });
+
+    test('skips tracked objects whose file is missing on disk', () async {
+      final (manager, dir) = build(maxCacheSizeBytes: 50);
+      final present = writeFile(dir, 'present_2_2.mp4', 60);
+
+      when(repo.getAllObjects).thenAnswer(
+        (_) async => [
+          obj('missing_9_9.mp4', id: 1, touched: DateTime(2020)),
+          obj('present_2_2.mp4', id: 2, touched: DateTime(2020, 1, 2)),
+        ],
+      );
+
+      await manager.enforceCacheLimits();
+
+      expect(present.existsSync(), isFalse);
+      final captured =
+          verify(() => repo.deleteAll(captureAny())).captured.single as List;
+      expect(captured, equals(<int>[2]));
+    });
+
+    test('evicts files whose object has no id without calling '
+        'deleteAll', () async {
+      final (manager, dir) = build(maxCacheSizeBytes: 50);
+      final file = writeFile(dir, 'a_1_1.mp4', 60);
+
+      when(repo.getAllObjects).thenAnswer(
+        (_) async => [obj('a_1_1.mp4', touched: DateTime(2020))],
+      );
+
+      await manager.enforceCacheLimits();
+
+      expect(file.existsSync(), isFalse);
+      verifyNever(() => repo.deleteAll(any()));
+    });
+
+    test('does nothing when the repository fails to open', () async {
+      when(repo.open).thenAnswer((_) async => false);
+      final (manager, dir) = build();
+      final orphan = writeFile(dir, 'x_1_1.mp4', 10);
+
+      await manager.enforceCacheLimits();
+
+      expect(orphan.existsSync(), isTrue);
+      verifyNever(repo.getAllObjects);
+    });
+
+    test('swallows repository errors without throwing', () async {
+      final (manager, _) = build();
+      when(repo.getAllObjects).thenThrow(Exception('boom'));
+
+      await expectLater(manager.enforceCacheLimits(), completes);
+    });
+
+    test('is a no-op after the manager is closed', () async {
+      when(repo.getAllObjects).thenAnswer((_) async => []);
+      final (manager, dir) = build();
+      await runZonedGuarded(() async {
+        try {
+          await manager.close();
+        } on Object catch (_) {}
+      }, (_, _) {});
+      final orphan = writeFile(dir, 'x_1_1.mp4', 10);
+
+      await manager.enforceCacheLimits();
+
+      expect(orphan.existsSync(), isTrue);
+      verifyNever(repo.getAllObjects);
+    });
+
+    test('ignores an overlapping call while a sweep is in progress', () async {
+      final gate = Completer<List<CacheObject>>();
+      when(repo.getAllObjects).thenAnswer((_) => gate.future);
+      final (manager, dir) = build();
+      final orphan = writeFile(dir, 'x_1_1.mp4', 10);
+
+      final first = manager.enforceCacheLimits();
+      // Second call sees _sweepInProgress and returns immediately.
+      await manager.enforceCacheLimits();
+      expect(orphan.existsSync(), isTrue, reason: 'first sweep still parked');
+
+      gate.complete([]);
+      await first;
+
+      expect(orphan.existsSync(), isFalse);
+      verify(repo.getAllObjects).called(1);
+    });
+
+    test('skips a second pass within the throttle window', () async {
+      when(repo.getAllObjects).thenAnswer((_) async => []);
+      final (manager, dir) = build();
+      final firstOrphan = writeFile(dir, 'a_1_1.mp4', 10);
+
+      await manager.enforceCacheLimits();
+      expect(firstOrphan.existsSync(), isFalse, reason: 'first pass ran');
+
+      final secondOrphan = writeFile(dir, 'b_2_2.mp4', 10);
+      await manager.enforceCacheLimits();
+
+      expect(
+        secondOrphan.existsSync(),
+        isTrue,
+        reason: 'second pass throttled within the interval',
+      );
+      verify(repo.getAllObjects).called(1);
+    });
+
+    test('runs a throttled sweep after enough downloads', () async {
+      final downloader = FakeCancellableDownloader();
+      final cacheKey = 'throttle_${DateTime.now().microsecondsSinceEpoch}';
+      Directory('$testTempPath/$cacheKey').createSync(recursive: true);
+      when(repo.getAllObjects).thenAnswer((_) async => []);
+      when(() => repo.updateOrInsert(any())).thenAnswer((_) async => 0);
+
+      final manager = MediaCacheManager(
+        config: MediaCacheConfig(cacheKey: cacheKey, enableSyncManifest: true),
+        repoOverride: repo,
+        downloaderOverride: downloader,
+      );
+
+      final sourceDir = Directory.systemTemp.createTempSync('throttle_src_');
+      final file = File('${sourceDir.path}/v.mp4')
+        ..writeAsBytesSync(const [1, 2, 3]);
+
+      final ops = [
+        for (var i = 0; i < 25; i++)
+          manager.cacheFileCancellable(
+            'https://example.com/v$i.mp4',
+            key: 'k$i',
+          ),
+      ];
+
+      for (var i = 0; i < 400 && downloader.downloads.length < 25; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 1));
+      }
+      for (final download in downloader.downloads) {
+        download.completeWith(file);
+      }
+      await Future.wait(ops.map((op) => op.file));
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+
+      verify(repo.getAllObjects).called(greaterThanOrEqualTo(1));
+      sourceDir.deleteSync(recursive: true);
+    });
+
+    test('reports the byte budget via getCacheStats', () {
+      final (manager, _) = build(maxCacheSizeBytes: 4096);
+      expect(manager.getCacheStats()['maxCacheSizeBytes'], 4096);
+    });
+  });
+}

--- a/mobile/test/services/video_editor/transition_seam_render_service_test.dart
+++ b/mobile/test/services/video_editor/transition_seam_render_service_test.dart
@@ -712,4 +712,61 @@ void main() {
       );
     });
   });
+
+  group('enforceSeamCacheLimit', () {
+    late Directory tempRoot;
+
+    setUp(() {
+      tempRoot = Directory.systemTemp.createTempSync('seam_cache_test_');
+    });
+
+    tearDown(() {
+      if (tempRoot.existsSync()) tempRoot.deleteSync(recursive: true);
+    });
+
+    TransitionSeamRenderService serviceWithBudget(int budget) =>
+        TransitionSeamRenderService(
+          documentsDirectoryProvider: () async => tempRoot,
+          maxSeamCacheBytes: budget,
+        );
+
+    Future<File> seam(String name, int bytes, DateTime modified) async {
+      final dir = Directory('${tempRoot.path}/transition_seams')
+        ..createSync(recursive: true);
+      final file = File('${dir.path}/$name')
+        ..writeAsBytesSync(List<int>.filled(bytes, 0));
+      await file.setLastModified(modified);
+      return file;
+    }
+
+    test('deletes least-recently-modified seams beyond the budget', () async {
+      final oldest = await seam('old.mp4', 60, DateTime(2020));
+      final middle = await seam('mid.mp4', 60, DateTime(2020, 1, 2));
+      final newest = await seam('new.mp4', 60, DateTime(2020, 1, 3));
+
+      await serviceWithBudget(100).enforceSeamCacheLimit();
+
+      // 180 bytes > 100: drop oldest (→120), still over, drop middle (→60).
+      expect(oldest.existsSync(), isFalse);
+      expect(middle.existsSync(), isFalse);
+      expect(newest.existsSync(), isTrue);
+    });
+
+    test('keeps every seam when the directory is within budget', () async {
+      final a = await seam('a.mp4', 40, DateTime(2020));
+      final b = await seam('b.mp4', 40, DateTime(2020, 1, 2));
+
+      await serviceWithBudget(1000).enforceSeamCacheLimit();
+
+      expect(a.existsSync(), isTrue);
+      expect(b.existsSync(), isTrue);
+    });
+
+    test('does not throw when the seam directory is empty', () async {
+      await expectLater(
+        serviceWithBudget(100).enforceSeamCacheLimit(),
+        completes,
+      );
+    });
+  });
 }

--- a/mobile/test/services/video_editor/transition_seam_render_service_test.dart
+++ b/mobile/test/services/video_editor/transition_seam_render_service_test.dart
@@ -762,11 +762,33 @@ void main() {
       expect(b.existsSync(), isTrue);
     });
 
-    test('does not throw when the seam directory is empty', () async {
-      await expectLater(
-        serviceWithBudget(100).enforceSeamCacheLimit(),
-        completes,
+    test('completes when the documents directory cannot be '
+        'resolved', () async {
+      final service = TransitionSeamRenderService(
+        documentsDirectoryProvider: () async =>
+            throw const FileSystemException('unavailable'),
+        maxSeamCacheBytes: 100,
       );
+
+      await expectLater(service.enforceSeamCacheLimit(), completes);
+    });
+
+    test('clear() kicks off a trim of the persisted seam '
+        'directory', () async {
+      final oldest = await seam('old.mp4', 60, DateTime(2020));
+      final newest = await seam('new.mp4', 60, DateTime(2020, 1, 2));
+
+      serviceWithBudget(100).clear();
+
+      // The trim is unawaited by design (it must not block editor teardown);
+      // poll until it lands.
+      for (var i = 0; i < 400 && oldest.existsSync(); i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 1));
+      }
+
+      // 120 bytes > 100: drop oldest (→60), newest survives.
+      expect(oldest.existsSync(), isFalse);
+      expect(newest.existsSync(), isTrue);
     });
   });
 }

--- a/mobile/test/services/watermark_download_service_test.dart
+++ b/mobile/test/services/watermark_download_service_test.dart
@@ -177,6 +177,43 @@ void main() {
       expect(service, isA<WatermarkDownloadService>());
     });
 
+    group('deleteStaleWatermarkRenders', () {
+      late Directory tempDir;
+
+      setUp(() {
+        tempDir = Directory.systemTemp.createTempSync('watermark_stale_test_');
+      });
+
+      tearDown(() {
+        if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+      });
+
+      test('removes only stale watermark renders', () {
+        final stale1 = File('${tempDir.path}/watermarked_111.mp4')
+          ..writeAsStringSync('a');
+        final stale2 = File('${tempDir.path}/watermarked_222.mp4')
+          ..writeAsStringSync('b');
+        final unrelatedVideo = File('${tempDir.path}/merged_333.mp4')
+          ..writeAsStringSync('c');
+        final unrelatedImage = File('${tempDir.path}/watermarked_444.jpg')
+          ..writeAsStringSync('d');
+
+        service.deleteStaleWatermarkRenders(tempDir);
+
+        expect(stale1.existsSync(), isFalse);
+        expect(stale2.existsSync(), isFalse);
+        expect(unrelatedVideo.existsSync(), isTrue);
+        expect(unrelatedImage.existsSync(), isTrue);
+      });
+
+      test('does not throw when the directory is empty', () {
+        expect(
+          () => service.deleteStaleWatermarkRenders(tempDir),
+          returnsNormally,
+        );
+      });
+    });
+
     group('downloadOriginal', () {
       test('saves a cached video file successfully', () async {
         final tempDir = await Directory.systemTemp.createTemp(

--- a/mobile/test/services/watermark_download_service_test.dart
+++ b/mobile/test/services/watermark_download_service_test.dart
@@ -188,15 +188,20 @@ void main() {
         if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
       });
 
-      test('removes only stale watermark renders', () {
+      test('removes only aged watermark renders', () {
+        final oldMtime = DateTime.now().subtract(const Duration(hours: 2));
         final stale1 = File('${tempDir.path}/watermarked_111.mp4')
-          ..writeAsStringSync('a');
+          ..writeAsStringSync('a')
+          ..setLastModifiedSync(oldMtime);
         final stale2 = File('${tempDir.path}/watermarked_222.mp4')
-          ..writeAsStringSync('b');
+          ..writeAsStringSync('b')
+          ..setLastModifiedSync(oldMtime);
         final unrelatedVideo = File('${tempDir.path}/merged_333.mp4')
-          ..writeAsStringSync('c');
+          ..writeAsStringSync('c')
+          ..setLastModifiedSync(oldMtime);
         final unrelatedImage = File('${tempDir.path}/watermarked_444.jpg')
-          ..writeAsStringSync('d');
+          ..writeAsStringSync('d')
+          ..setLastModifiedSync(oldMtime);
 
         service.deleteStaleWatermarkRenders(tempDir);
 
@@ -206,9 +211,22 @@ void main() {
         expect(unrelatedImage.existsSync(), isTrue);
       });
 
-      test('does not throw when the directory is empty', () {
+      test('keeps renders younger than the stale window', () {
+        // A dismissed save can still be rendering into this file, and a
+        // completed save's file may still be presented in the share sheet.
+        final recent = File('${tempDir.path}/watermarked_555.mp4')
+          ..writeAsStringSync('e');
+
+        service.deleteStaleWatermarkRenders(tempDir);
+
+        expect(recent.existsSync(), isTrue);
+      });
+
+      test('does not throw when the directory does not exist', () {
+        final missing = Directory('${tempDir.path}/missing');
+
         expect(
-          () => service.deleteStaleWatermarkRenders(tempDir),
+          () => service.deleteStaleWatermarkRenders(missing),
           returnsNormally,
         );
       });


### PR DESCRIPTION
Closes #5987

## Problem

Users reported the app's on-disk footprint climbing very quickly to ~10 GB. Investigation traced this to caches and temp renders that grow without an effective byte bound.

## Root cause

- **Feed/media cache has no byte cap.** `flutter_cache_manager` only bounds by *object count* (video cache = 1000 objects), so 1000 short videos = 5–20 GB is "within limits".
- **`flutter_cache_manager`'s own file deletion is unreliable for this layout.** Its eviction drops the DB row but resolves the file via a bare relative path, so the underlying file is left on disk. Evicted + re-downloaded files therefore accumulate as **untracked orphans** the count limit can never reclaim — this is the dominant contributor.
- **Transition-seam cache grew unbounded.** Every distinct trim/transition tweak mints a new persisted seam file under `transition_seams/`; `clear()` only dropped the in-memory map.
- **Watermark temp renders leaked.** Each "save with watermark" wrote `watermarked_<ts>.mp4` to temp and never deleted it.

## What changed

**1. Media cache — byte budget + orphan reclamation (`media_cache` package)**
- New `MediaCacheConfig.maxCacheSizeBytes` (video **2 GB**, image **256 MB**).
- New `MediaCacheManager.enforceCacheLimits()`:
  - **Reclamation** — deletes cache-dir files the store no longer tracks. Scoped to our download filename shape (`..._<micros>_<seq>.<ext>`) so externally-managed files in the same directory (bundled **seed media**, the alias manifest) are never touched.
  - **Byte eviction** — removes least-recently-used tracked files (file + store row) until under budget.
- Wired at startup for both the video and image caches, plus a throttled in-session sweep so long sessions stay bounded.
- **Performance:** I/O is async (`Directory.list()` / `File.delete()`) so a large sweep yields instead of freezing the isolate; cheap metadata stays `statSync` per `avoid_slow_async_io`. A 60 s throttle prevents back-to-back sweeps during heavy scrolling.

**2. Transition-seam cache** — 200 MB LRU (by mtime) trim on editor close; recent seams survive for cross-session reuse. Export does not read these files, so trimming is safe.

**3. Watermark temp renders** — stale `watermarked_*.mp4` deleted before each new render, so at most one exists at a time (the file only needs to outlive the save until its share sheet closes).

## Deliberately deferred

`merged_*.mp4` in `upload_manager.dart` is only a rare fallback path ("clips should be pre-merged") with a complex upload/retry lifecycle where the path is referenced by retries. Not worth the regression risk here; better as a focused follow-up.

## Testing

- `media_cache`: 188 tests green, `media_cache_manager.dart` at **100%** line coverage, package total **98.70%** (≥ 98 % gate). New `enforce_cache_limits_test.dart` covers reclamation, byte eviction, throttle, and edge cases.
- Seam + watermark: new tests for the LRU trim and stale-render cleanup; suites green.
- `flutter analyze` clean across all touched files.

> Note: local `flutter test` here intermittently hit a corrupted `sqlite3mc` native-asset download (env/network), unrelated to this change; runs above used an equivalent build.