### PR TITLE
chore: Add local Android verifier setup command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -236,6 +236,7 @@ Useful app entry paths from `mobile/`:
 - `./run_dev.sh ios debug`
 - `./run_dev.sh android debug`
 - `./run_dev.sh macos debug`
+- `mise run local_android` - Android emulator against the default local stack
 - `flutter run -d macos`
 - `./build_ios.sh release`
 - `./build_android.sh release`

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Common alternatives from `mobile/`:
 - `./run_dev.sh ios debug`
 - `./run_dev.sh android debug`
 - `./run_dev.sh macos debug`
+- `mise run local_android` - Android emulator against the default local stack
 
 If a build fails from generated code or CocoaPods state, use the targeted scripts first (from `mobile/`):
 

--- a/local_stack/android_sdk.sh
+++ b/local_stack/android_sdk.sh
@@ -66,3 +66,18 @@ detect_x11_display() {
 first_available_avd_name() {
     emulator -list-avds 2>/dev/null | sed -n '1p'
 }
+
+local_stack_has_running_container() {
+    local compose_file="$1"
+    local container_ids
+
+    if ! container_ids="$(docker compose -f "$compose_file" ps --status running -q 2>/dev/null)"; then
+        return 1
+    fi
+
+    [[ -n "$container_ids" ]]
+}
+
+android_emulator_invite_server_url() {
+    printf '%s\n' 'http://10.0.2.2:43004'
+}

--- a/local_stack/profile.sh
+++ b/local_stack/profile.sh
@@ -20,6 +20,7 @@ MERGE_SCRIPT="${SCRIPT_DIR}/merge_logs.py"
 
 # shellcheck source=android_sdk.sh
 source "${SCRIPT_DIR}/android_sdk.sh"
+INVITE_SERVER_URL="$(android_emulator_invite_server_url)"
 
 # --- Ensure DISPLAY is set for emulator (Hyprland/XWayland) ---
 DISPLAY_TO_USE="$(detect_x11_display)"
@@ -56,7 +57,7 @@ echo "Report:     ${REPORT_FILE}" >&2
 echo "" >&2
 
 # --- Verify docker stack is running ---
-if ! docker compose -f "$COMPOSE_FILE" ps --status running -q 2>/dev/null | head -1 | grep -q .; then
+if ! local_stack_has_running_container "$COMPOSE_FILE"; then
     echo "ERROR: Docker stack is not running. Start with: mise run local_up" >&2
     exit 1
 fi
@@ -95,7 +96,7 @@ set +e
 PATH="$HOME/.pub-cache/bin:$PATH" patrol test \
     --target "$TEST_PATH" \
     --dart-define=DEFAULT_ENV=LOCAL \
-    --dart-define=INVITE_SERVER_URL=http://10.0.2.2:43004 \
+    --dart-define=INVITE_SERVER_URL="$INVITE_SERVER_URL" \
     "${PATROL_EXTRA_ARGS[@]}" \
     2>&1 | tee "$APP_LOG"
 TEST_EXIT="${PIPESTATUS[0]}"

--- a/local_stack/run_android_local.sh
+++ b/local_stack/run_android_local.sh
@@ -58,10 +58,34 @@ if [[ -z "$DEVICE" ]]; then
     exit 1
 fi
 
+clear_app_data() {
+    local clear_output
+    local path_output
+
+    if clear_output="$(adb -s "$DEVICE" shell pm clear "$ANDROID_PACKAGE_ID" 2>&1)"; then
+        return 0
+    fi
+
+    if path_output="$(adb -s "$DEVICE" shell pm path "$ANDROID_PACKAGE_ID" 2>&1)"; then
+        echo "ERROR: Failed to clear persisted app data for ${ANDROID_PACKAGE_ID}" >&2
+        printf '%s\n' "$clear_output" >&2
+        exit 1
+    fi
+
+    if [[ -z "$path_output" ]]; then
+        echo "No existing app install found for ${ANDROID_PACKAGE_ID}; continuing with a clean first run" >&2
+        return 0
+    fi
+
+    echo "ERROR: Failed to inspect installed package ${ANDROID_PACKAGE_ID}" >&2
+    printf '%s\n' "$path_output" >&2
+    exit 1
+}
+
 echo "Running Divine against the local stack on Android emulator: ${DEVICE}" >&2
 echo "Invite server: http://10.0.2.2:43004" >&2
 echo "Clearing persisted app data for ${ANDROID_PACKAGE_ID} so LOCAL is deterministic" >&2
-adb -s "$DEVICE" shell pm clear "$ANDROID_PACKAGE_ID" >/dev/null
+clear_app_data
 
 cd "$MOBILE_DIR"
 exec flutter run \

--- a/local_stack/run_android_local.sh
+++ b/local_stack/run_android_local.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Manual Android local-stack runner
+#
+# Usage:
+#   local_stack/run_android_local.sh [device_id] [debug|profile|release]
+#
+# Defaults to the first connected Android device and debug mode.
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MOBILE_DIR="$(cd "${SCRIPT_DIR}/../mobile" && pwd)"
+COMPOSE_FILE="${SCRIPT_DIR}/docker-compose.yml"
+
+# shellcheck source=android_sdk.sh
+source "${SCRIPT_DIR}/android_sdk.sh"
+
+DEVICE_ARG="${1:-}"
+BUILD_MODE="${2:-debug}"
+
+case "$BUILD_MODE" in
+    debug|profile|release) ;;
+    *)
+        echo "ERROR: Unknown build mode: ${BUILD_MODE}" >&2
+        echo "Usage: $0 [device_id] [debug|profile|release]" >&2
+        exit 2
+        ;;
+esac
+
+if ! docker compose -f "$COMPOSE_FILE" ps --status running -q 2>/dev/null | head -1 | grep -q .; then
+    echo "ERROR: Docker stack is not running. Start with: mise run local_up" >&2
+    exit 1
+fi
+
+if ! command -v adb >/dev/null 2>&1; then
+    echo "ERROR: 'adb' not on PATH and Android SDK not found." >&2
+    echo "Set ANDROID_HOME or install the SDK at \$HOME/Android/Sdk (Linux) / \$HOME/Library/Android/sdk (macOS)." >&2
+    exit 1
+fi
+
+if [[ -n "$DEVICE_ARG" ]]; then
+    DEVICE="$DEVICE_ARG"
+else
+    DEVICE="$(adb devices | awk 'NR > 1 && $2 == "device" { print $1; exit }')"
+fi
+
+if [[ -z "$DEVICE" ]]; then
+    echo "ERROR: No Android device connected. Start one with: mise run emulator" >&2
+    exit 1
+fi
+
+echo "Running Divine against the local stack on Android device: ${DEVICE}" >&2
+echo "Invite server: http://10.0.2.2:43004" >&2
+
+cd "$MOBILE_DIR"
+exec flutter run \
+    -d "$DEVICE" \
+    --"$BUILD_MODE" \
+    --dart-define=DEFAULT_ENV=LOCAL \
+    --dart-define=INVITE_SERVER_URL=http://10.0.2.2:43004

--- a/local_stack/run_android_local.sh
+++ b/local_stack/run_android_local.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 # Usage:
 #   local_stack/run_android_local.sh [device_id] [debug|profile|release]
 #
-# Defaults to the first connected Android device and debug mode.
+# Defaults to the first connected Android emulator and debug mode.
 # ---------------------------------------------------------------------------
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -41,17 +41,23 @@ if ! command -v adb >/dev/null 2>&1; then
 fi
 
 if [[ -n "$DEVICE_ARG" ]]; then
+    if [[ "$DEVICE_ARG" != emulator-* ]]; then
+        echo "ERROR: ${DEVICE_ARG} is not an Android emulator." >&2
+        echo "This local-stack command uses Android emulator host URLs. Start one with: mise run emulator" >&2
+        exit 1
+    fi
+
     DEVICE="$DEVICE_ARG"
 else
-    DEVICE="$(adb devices | awk 'NR > 1 && $2 == "device" { print $1; exit }')"
+    DEVICE="$(adb devices | awk 'NR > 1 && $1 ~ /^emulator-/ && $2 == "device" { print $1; exit }')"
 fi
 
 if [[ -z "$DEVICE" ]]; then
-    echo "ERROR: No Android device connected. Start one with: mise run emulator" >&2
+    echo "ERROR: No Android emulator connected. Start one with: mise run emulator" >&2
     exit 1
 fi
 
-echo "Running Divine against the local stack on Android device: ${DEVICE}" >&2
+echo "Running Divine against the local stack on Android emulator: ${DEVICE}" >&2
 echo "Invite server: http://10.0.2.2:43004" >&2
 
 cd "$MOBILE_DIR"

--- a/local_stack/run_android_local.sh
+++ b/local_stack/run_android_local.sh
@@ -17,6 +17,7 @@ ANDROID_PACKAGE_ID="co.openvine.app"
 
 # shellcheck source=android_sdk.sh
 source "${SCRIPT_DIR}/android_sdk.sh"
+INVITE_SERVER_URL="$(android_emulator_invite_server_url)"
 
 DEVICE_ARG="${1:-}"
 BUILD_MODE="${2:-debug}"
@@ -30,7 +31,7 @@ case "$BUILD_MODE" in
         ;;
 esac
 
-if ! docker compose -f "$COMPOSE_FILE" ps --status running -q 2>/dev/null | head -1 | grep -q .; then
+if ! local_stack_has_running_container "$COMPOSE_FILE"; then
     echo "ERROR: Docker stack is not running. Start with: mise run local_up" >&2
     exit 1
 fi
@@ -83,7 +84,7 @@ clear_app_data() {
 }
 
 echo "Running Divine against the local stack on Android emulator: ${DEVICE}" >&2
-echo "Invite server: http://10.0.2.2:43004" >&2
+echo "Invite server: ${INVITE_SERVER_URL}" >&2
 echo "Clearing persisted app data for ${ANDROID_PACKAGE_ID} so LOCAL is deterministic" >&2
 clear_app_data
 
@@ -92,4 +93,4 @@ exec flutter run \
     -d "$DEVICE" \
     --"$BUILD_MODE" \
     --dart-define=DEFAULT_ENV=LOCAL \
-    --dart-define=INVITE_SERVER_URL=http://10.0.2.2:43004
+    --dart-define=INVITE_SERVER_URL="$INVITE_SERVER_URL"

--- a/local_stack/run_android_local.sh
+++ b/local_stack/run_android_local.sh
@@ -13,6 +13,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MOBILE_DIR="$(cd "${SCRIPT_DIR}/../mobile" && pwd)"
 COMPOSE_FILE="${SCRIPT_DIR}/docker-compose.yml"
+ANDROID_PACKAGE_ID="co.openvine.app"
 
 # shellcheck source=android_sdk.sh
 source "${SCRIPT_DIR}/android_sdk.sh"
@@ -59,6 +60,8 @@ fi
 
 echo "Running Divine against the local stack on Android emulator: ${DEVICE}" >&2
 echo "Invite server: http://10.0.2.2:43004" >&2
+echo "Clearing persisted app data for ${ANDROID_PACKAGE_ID} so LOCAL is deterministic" >&2
+adb -s "$DEVICE" shell pm clear "$ANDROID_PACKAGE_ID" >/dev/null
 
 cd "$MOBILE_DIR"
 exec flutter run \

--- a/local_stack/test_android_scripts.sh
+++ b/local_stack/test_android_scripts.sh
@@ -119,7 +119,18 @@ if [[ "${1:-}" == "devices" ]]; then
   exit 0
 fi
 if [[ "${1:-}" == "-s" && "${3:-}" == "shell" && "${4:-}" == "pm" && "${5:-}" == "clear" ]]; then
+  if [[ "${ADB_PM_CLEAR_FAIL:-}" == "1" ]]; then
+    printf '%s\n' Failed >&2
+    exit 1
+  fi
   printf '%s\n' Success
+  exit 0
+fi
+if [[ "${1:-}" == "-s" && "${3:-}" == "shell" && "${4:-}" == "pm" && "${5:-}" == "path" ]]; then
+  if [[ "${ADB_PM_PATH_ABSENT:-}" == "1" ]]; then
+    exit 1
+  fi
+  printf '%s\n' 'package:/data/app/co.openvine.app/base.apk'
   exit 0
 fi
 exit 2
@@ -142,6 +153,33 @@ assert_contains 'shell pm clear co.openvine.app' "$adb_args_file" \
   "local Android runner should clear persisted app data before launching"
 assert_contains 'Clearing persisted app data for co.openvine.app' "${tmp_dir}/emulator-selection.err" \
   "local Android runner should make the deterministic reset visible"
+
+rm -f "$adb_args_file" "$flutter_args_file"
+env ADB_DEVICES_OUTPUT=$'emulator-5554\tdevice\n' ADB_ARGS_FILE="$adb_args_file" \
+  ADB_PM_CLEAR_FAIL=1 ADB_PM_PATH_ABSENT=1 FLUTTER_ARGS_FILE="$flutter_args_file" \
+  PATH="${tmp_dir}/bin:${PATH}" \
+  bash "${SCRIPT_DIR}/run_android_local.sh" >/dev/null 2>"${tmp_dir}/missing-package-reset.err"
+assert_contains '-d emulator-5554' "$flutter_args_file" \
+  "local Android runner should still launch Flutter when no app data exists yet"
+assert_contains '--dart-define=DEFAULT_ENV=LOCAL' "$flutter_args_file" \
+  "missing app data should not bypass the LOCAL dart define"
+assert_contains 'No existing app install found for co.openvine.app' "${tmp_dir}/missing-package-reset.err" \
+  "missing app data should be reported as an idempotent first-run reset"
+
+rm -f "$adb_args_file" "$flutter_args_file"
+set +e
+env ADB_DEVICES_OUTPUT=$'emulator-5554\tdevice\n' ADB_ARGS_FILE="$adb_args_file" \
+  ADB_PM_CLEAR_FAIL=1 FLUTTER_ARGS_FILE="$flutter_args_file" \
+  PATH="${tmp_dir}/bin:${PATH}" \
+  bash "${SCRIPT_DIR}/run_android_local.sh" >/dev/null 2>"${tmp_dir}/clear-failure.err"
+clear_failure_exit=$?
+set -e
+assert_eq "1" "$clear_failure_exit" \
+  "local Android runner should fail when app data exists but cannot be cleared"
+assert_contains 'Failed to clear persisted app data for co.openvine.app' "${tmp_dir}/clear-failure.err" \
+  "clear failure should preserve the underlying hard adb error"
+assert_not_file_exists "$flutter_args_file" \
+  "local Android runner should not launch Flutter after a real app-data clear failure"
 
 rm -f "$adb_args_file" "$flutter_args_file"
 set +e

--- a/local_stack/test_android_scripts.sh
+++ b/local_stack/test_android_scripts.sh
@@ -46,6 +46,17 @@ assert_not_contains() {
   fi
 }
 
+assert_not_file_exists() {
+  local file="$1"
+  local message="$2"
+
+  if [[ -e "$file" ]]; then
+    echo "FAIL: ${message}" >&2
+    echo "  unexpected file: ${file}" >&2
+    exit 1
+  fi
+}
+
 extract_mise_task() {
   local task_name="$1"
   local file="$2"
@@ -90,6 +101,63 @@ chmod +x "${tmp_dir}/bin/emulator"
 PATH="${tmp_dir}/bin:${PATH}"
 assert_eq "Pixel_API_35" "$(first_available_avd_name)" \
   "default AVD should come from emulator -list-avds"
+
+cat > "${tmp_dir}/bin/docker" <<'STUB'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "compose" && "${2:-}" == "-f" && "${4:-}" == "ps" ]]; then
+  printf '%s\n' local-stack-container
+  exit 0
+fi
+exit 2
+STUB
+cat > "${tmp_dir}/bin/adb" <<'STUB'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "devices" ]]; then
+  printf '%s\n' "List of devices attached"
+  printf '%b' "${ADB_DEVICES_OUTPUT:-}"
+  exit 0
+fi
+exit 2
+STUB
+cat > "${tmp_dir}/bin/flutter" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "${FLUTTER_ARGS_FILE:?}"
+STUB
+chmod +x "${tmp_dir}/bin/docker" "${tmp_dir}/bin/adb" "${tmp_dir}/bin/flutter"
+
+flutter_args_file="${tmp_dir}/flutter.args"
+env ADB_DEVICES_OUTPUT=$'R58N1234567\tdevice\nemulator-5554\tdevice\n' \
+  FLUTTER_ARGS_FILE="$flutter_args_file" PATH="${tmp_dir}/bin:${PATH}" \
+  bash "${SCRIPT_DIR}/run_android_local.sh" >/dev/null 2>"${tmp_dir}/emulator-selection.err"
+assert_contains '-d emulator-5554' "$flutter_args_file" \
+  "local Android runner should default to the first emulator instead of a physical device"
+
+rm -f "$flutter_args_file"
+set +e
+env ADB_DEVICES_OUTPUT=$'R58N1234567\tdevice\n' FLUTTER_ARGS_FILE="$flutter_args_file" \
+  PATH="${tmp_dir}/bin:${PATH}" \
+  bash "${SCRIPT_DIR}/run_android_local.sh" >/dev/null 2>"${tmp_dir}/physical-only.err"
+physical_only_exit=$?
+set -e
+assert_eq "1" "$physical_only_exit" \
+  "local Android runner should fail when only a physical Android device is connected"
+assert_contains 'No Android emulator connected' "${tmp_dir}/physical-only.err" \
+  "physical-only failure should explain that an emulator is required"
+assert_not_file_exists "$flutter_args_file" \
+  "local Android runner should not start Flutter for physical-only adb output"
+
+set +e
+env ADB_DEVICES_OUTPUT=$'R58N1234567\tdevice\nemulator-5554\tdevice\n' \
+  FLUTTER_ARGS_FILE="$flutter_args_file" PATH="${tmp_dir}/bin:${PATH}" \
+  bash "${SCRIPT_DIR}/run_android_local.sh" R58N1234567 >/dev/null 2>"${tmp_dir}/explicit-physical.err"
+explicit_physical_exit=$?
+set -e
+assert_eq "1" "$explicit_physical_exit" \
+  "local Android runner should reject an explicit physical Android device"
+assert_contains 'is not an Android emulator' "${tmp_dir}/explicit-physical.err" \
+  "explicit physical-device rejection should explain why the device is invalid"
+assert_not_file_exists "$flutter_args_file" \
+  "local Android runner should not start Flutter for explicit physical devices"
 
 assert_contains 'bash ../local_stack/up.sh' "${REPO_ROOT}/mobile/mise.toml" \
   "mise local_up tasks should delegate to the shared stack launcher"

--- a/local_stack/test_android_scripts.sh
+++ b/local_stack/test_android_scripts.sh
@@ -112,9 +112,14 @@ exit 2
 STUB
 cat > "${tmp_dir}/bin/adb" <<'STUB'
 #!/usr/bin/env bash
+printf '%s\n' "$*" >> "${ADB_ARGS_FILE:-/dev/null}"
 if [[ "${1:-}" == "devices" ]]; then
   printf '%s\n' "List of devices attached"
   printf '%b' "${ADB_DEVICES_OUTPUT:-}"
+  exit 0
+fi
+if [[ "${1:-}" == "-s" && "${3:-}" == "shell" && "${4:-}" == "pm" && "${5:-}" == "clear" ]]; then
+  printf '%s\n' Success
   exit 0
 fi
 exit 2
@@ -125,16 +130,23 @@ printf '%s\n' "$*" > "${FLUTTER_ARGS_FILE:?}"
 STUB
 chmod +x "${tmp_dir}/bin/docker" "${tmp_dir}/bin/adb" "${tmp_dir}/bin/flutter"
 
+adb_args_file="${tmp_dir}/adb.args"
 flutter_args_file="${tmp_dir}/flutter.args"
 env ADB_DEVICES_OUTPUT=$'R58N1234567\tdevice\nemulator-5554\tdevice\n' \
-  FLUTTER_ARGS_FILE="$flutter_args_file" PATH="${tmp_dir}/bin:${PATH}" \
+  ADB_ARGS_FILE="$adb_args_file" FLUTTER_ARGS_FILE="$flutter_args_file" \
+  PATH="${tmp_dir}/bin:${PATH}" \
   bash "${SCRIPT_DIR}/run_android_local.sh" >/dev/null 2>"${tmp_dir}/emulator-selection.err"
 assert_contains '-d emulator-5554' "$flutter_args_file" \
   "local Android runner should default to the first emulator instead of a physical device"
+assert_contains 'shell pm clear co.openvine.app' "$adb_args_file" \
+  "local Android runner should clear persisted app data before launching"
+assert_contains 'Clearing persisted app data for co.openvine.app' "${tmp_dir}/emulator-selection.err" \
+  "local Android runner should make the deterministic reset visible"
 
-rm -f "$flutter_args_file"
+rm -f "$adb_args_file" "$flutter_args_file"
 set +e
-env ADB_DEVICES_OUTPUT=$'R58N1234567\tdevice\n' FLUTTER_ARGS_FILE="$flutter_args_file" \
+env ADB_DEVICES_OUTPUT=$'R58N1234567\tdevice\n' ADB_ARGS_FILE="$adb_args_file" \
+  FLUTTER_ARGS_FILE="$flutter_args_file" \
   PATH="${tmp_dir}/bin:${PATH}" \
   bash "${SCRIPT_DIR}/run_android_local.sh" >/dev/null 2>"${tmp_dir}/physical-only.err"
 physical_only_exit=$?
@@ -148,7 +160,8 @@ assert_not_file_exists "$flutter_args_file" \
 
 set +e
 env ADB_DEVICES_OUTPUT=$'R58N1234567\tdevice\nemulator-5554\tdevice\n' \
-  FLUTTER_ARGS_FILE="$flutter_args_file" PATH="${tmp_dir}/bin:${PATH}" \
+  ADB_ARGS_FILE="$adb_args_file" FLUTTER_ARGS_FILE="$flutter_args_file" \
+  PATH="${tmp_dir}/bin:${PATH}" \
   bash "${SCRIPT_DIR}/run_android_local.sh" R58N1234567 >/dev/null 2>"${tmp_dir}/explicit-physical.err"
 explicit_physical_exit=$?
 set -e

--- a/local_stack/test_android_scripts.sh
+++ b/local_stack/test_android_scripts.sh
@@ -25,7 +25,7 @@ assert_contains() {
   local file="$2"
   local message="$3"
 
-  if ! grep -qF "$needle" "$file"; then
+  if ! grep -qF -- "$needle" "$file"; then
     echo "FAIL: ${message}" >&2
     echo "  missing: ${needle}" >&2
     echo "  file:    ${file}" >&2
@@ -38,7 +38,7 @@ assert_not_contains() {
   local file="$2"
   local message="$3"
 
-  if grep -qF "$needle" "$file"; then
+  if grep -qF -- "$needle" "$file"; then
     echo "FAIL: ${message}" >&2
     echo "  unexpected: ${needle}" >&2
     echo "  file:       ${file}" >&2
@@ -60,7 +60,9 @@ extract_mise_task() {
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT
 local_reset_task="${tmp_dir}/local_reset.mise-task"
+local_android_task="${tmp_dir}/local_android.mise-task"
 extract_mise_task local_reset "${REPO_ROOT}/mobile/mise.toml" > "$local_reset_task"
+extract_mise_task local_android "${REPO_ROOT}/mobile/mise.toml" > "$local_android_task"
 
 mkdir -p "${tmp_dir}/home"
 set +e
@@ -91,6 +93,8 @@ assert_eq "Pixel_API_35" "$(first_available_avd_name)" \
 
 assert_contains 'bash ../local_stack/up.sh' "${REPO_ROOT}/mobile/mise.toml" \
   "mise local_up tasks should delegate to the shared stack launcher"
+assert_contains 'bash ../local_stack/run_android_local.sh' "$local_android_task" \
+  "mise local_android should delegate to the shared local Android runner"
 assert_contains 'docker compose -f ../local_stack/docker-compose.yml down -v' "$local_reset_task" \
   "mise local_reset should wipe local stack volumes before restart"
 assert_contains 'bash ../local_stack/up.sh' "$local_reset_task" \
@@ -103,6 +107,14 @@ assert_contains 'docker compose -f "$COMPOSE_FILE" run --rm e2e-seed' "${SCRIPT_
   "up.sh should run e2e-seed as an explicit lifecycle step"
 assert_contains 'profiles: ["seed"]' "${SCRIPT_DIR}/docker-compose.yml" \
   "e2e-seed should be excluded from default compose up"
+assert_contains 'source "${SCRIPT_DIR}/android_sdk.sh"' "${SCRIPT_DIR}/run_android_local.sh" \
+  "local Android runner should reuse Android SDK discovery"
+assert_contains 'Start with: mise run local_up' "${SCRIPT_DIR}/run_android_local.sh" \
+  "local Android runner should point to the local stack startup task when services are down"
+assert_contains '--dart-define=DEFAULT_ENV=LOCAL' "${SCRIPT_DIR}/run_android_local.sh" \
+  "local Android runner should force the app into LOCAL environment"
+assert_contains '--dart-define=INVITE_SERVER_URL=http://10.0.2.2:43004' "${SCRIPT_DIR}/run_android_local.sh" \
+  "local Android runner should use the Android emulator invite-server URL"
 
 cat > "${tmp_dir}/bin/uname" <<'STUB'
 #!/usr/bin/env bash

--- a/local_stack/test_android_scripts.sh
+++ b/local_stack/test_android_scripts.sh
@@ -101,6 +101,8 @@ chmod +x "${tmp_dir}/bin/emulator"
 PATH="${tmp_dir}/bin:${PATH}"
 assert_eq "Pixel_API_35" "$(first_available_avd_name)" \
   "default AVD should come from emulator -list-avds"
+assert_eq "http://10.0.2.2:43004" "$(android_emulator_invite_server_url)" \
+  "Android emulator invite URL should match the local invite service host port"
 
 cat > "${tmp_dir}/bin/docker" <<'STUB'
 #!/usr/bin/env bash
@@ -149,6 +151,8 @@ env ADB_DEVICES_OUTPUT=$'R58N1234567\tdevice\nemulator-5554\tdevice\n' \
   bash "${SCRIPT_DIR}/run_android_local.sh" >/dev/null 2>"${tmp_dir}/emulator-selection.err"
 assert_contains '-d emulator-5554' "$flutter_args_file" \
   "local Android runner should default to the first emulator instead of a physical device"
+assert_contains '--dart-define=INVITE_SERVER_URL=http://10.0.2.2:43004' "$flutter_args_file" \
+  "local Android runner should pass the Android emulator invite-server URL to Flutter"
 assert_contains 'shell pm clear co.openvine.app' "$adb_args_file" \
   "local Android runner should clear persisted app data before launching"
 assert_contains 'Clearing persisted app data for co.openvine.app' "${tmp_dir}/emulator-selection.err" \
@@ -232,8 +236,14 @@ assert_contains 'Start with: mise run local_up' "${SCRIPT_DIR}/run_android_local
   "local Android runner should point to the local stack startup task when services are down"
 assert_contains '--dart-define=DEFAULT_ENV=LOCAL' "${SCRIPT_DIR}/run_android_local.sh" \
   "local Android runner should force the app into LOCAL environment"
-assert_contains '--dart-define=INVITE_SERVER_URL=http://10.0.2.2:43004' "${SCRIPT_DIR}/run_android_local.sh" \
-  "local Android runner should use the Android emulator invite-server URL"
+assert_contains 'local_stack_has_running_container "$COMPOSE_FILE"' "${SCRIPT_DIR}/run_android_local.sh" \
+  "local Android runner should reuse the shared local stack status check"
+assert_contains 'android_emulator_invite_server_url' "${SCRIPT_DIR}/run_android_local.sh" \
+  "local Android runner should reuse the shared Android emulator invite-server URL"
+assert_contains 'local_stack_has_running_container "$COMPOSE_FILE"' "${SCRIPT_DIR}/profile.sh" \
+  "profile runner should reuse the shared local stack status check"
+assert_contains 'android_emulator_invite_server_url' "${SCRIPT_DIR}/profile.sh" \
+  "profile runner should reuse the shared Android emulator invite-server URL"
 
 cat > "${tmp_dir}/bin/uname" <<'STUB'
 #!/usr/bin/env bash

--- a/mobile/mise.toml
+++ b/mobile/mise.toml
@@ -32,6 +32,10 @@ run = "flutter build apk --debug --dart-define=DEFAULT_ENV=LOCAL"
 description = "Install LOCAL APK on emulator"
 run = "adb install -r build/app/outputs/flutter-apk/app-debug.apk"
 
+[tasks.local_android]
+description = "Run the app on Android against the default local stack"
+run = "bash ../local_stack/run_android_local.sh"
+
 [tasks.local_status]
 description = "Check status of local services"
 run = "docker compose -f ../local_stack/docker-compose.yml ps"


### PR DESCRIPTION
Closes #5990

## Description

Manual Android local-stack checks did not have one supported command.
This change adds `mise run local_android` from `mobile/` so a developer or agent can launch the app against the default local stack with the right Android emulator URLs.
It matters because the app needs both `DEFAULT_ENV=LOCAL` and the local invite-server URL to exercise the local services reliably.

The local-stack behavior lives in a dedicated wrapper instead of `run_dev.sh`.
That keeps normal development runs unchanged while making the local verifier path explicit.

- Added `local_stack/run_android_local.sh` and a `mobile/mise.toml` task.
- Reused the local Android SDK helper and shared the local Docker stack check.
- Shared the Android emulator invite-server URL between local stack scripts.
- Limited the command to Android emulators because `10.0.2.2` is emulator-only.
- Cleared app data before launch so saved environment preferences cannot override LOCAL.
- Treated a missing first-run app install as a clean no-op, while preserving hard failures for real clear errors.
- Documented the command in README and CONTRIBUTING.

## Related Issue

- #5990

## Out of Scope

Physical Android devices are not supported by this command.
They need different host-reachable URLs than the emulator-only `10.0.2.2` addresses.
Patrol E2E flows and generic `run_dev.sh` behavior are unchanged.

## Verification

I tested the script behavior and the full Flutter suite.
I did not manually launch an Android emulator in this session.

- `git -c url.https://github.com/.insteadOf=git@github.com: fetch origin main:refs/remotes/origin/main && git rebase origin/main`
- `bash local_stack/test_android_scripts.sh`
- `bash -n local_stack/android_sdk.sh local_stack/profile.sh local_stack/run_android_local.sh local_stack/test_android_scripts.sh`
- `git diff --check`
- `MISE_TRUSTED_CONFIG_PATHS="$PWD/mise.toml" mise exec -- flutter analyze`
- `MISE_TRUSTED_CONFIG_PATHS="$PWD/mise.toml" mise exec -- flutter test`

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore