### PR TITLE
build(android): right-size Gradle/Kotlin JVM memory for the CI machine

### DIFF
--- a/mobile/android/gradle.properties
+++ b/mobile/android/gradle.properties
@@ -1,4 +1,19 @@
-org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
+# Memory is sized for the ~12 GB Codemagic mac_mini_m2 CI container, which
+# co-hosts three JVMs: this Gradle daemon, the Kotlin compile daemon, and the
+# Dart/Flutter tooling. The previous -Xmx8G + 4G metaspace let this daemon
+# alone commit ~12.5 GB — larger than the machine — so once #5789 re-enabled
+# R8 minification (whose whole-program pass drives the heap toward -Xmx) the
+# container over-committed and the daemon died mid-build with
+# `OutOfMemoryError: Java heap space` at l8DexDesugarLibRelease. Keep the sum
+# of the JVM ceilings comfortably under 12 GB; a Flutter release R8/dex pass
+# fits well within a 6 GB heap.
+org.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=1g -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
+# Bound the Kotlin compile daemon (a separate JVM) so it cannot balloon and
+# starve the Gradle daemon on the shared CI container.
+kotlin.daemon.jvmargs=-Xmx2g
+# Cap concurrent Gradle worker actions so peak dexing/desugaring memory on the
+# 8-core CI machine stays within the heap budget above.
+org.gradle.workers.max=4
 android.useAndroidX=true
 android.enableJetifier=true
 # Allow duplicate classes from java-opentimestamps fat JAR


### PR DESCRIPTION
Closes #5996

## Problem

The **Android release build on Codemagic fails** at `:app:l8DexDesugarLibRelease` with:

```
Exception in thread "Daemon client event forwarder" java.lang.OutOfMemoryError: Java heap space
Execution failed for task ':app:l8DexDesugarLibRelease'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.L8DexWorkAction
   > Compilation failed to complete
```

(Build `6a4fd04779ead39c5953b24b`, index 181, commit `671a705`.)

## Root cause

The CI machine is a Codemagic `mac_mini_m2` with **~12 GB RAM**, and it co-hosts three JVMs during an Android build: the **Gradle daemon**, the **Kotlin compile daemon**, and the **Dart/Flutter tooling**.

The Gradle daemon was configured with `-Xmx8G -XX:MaxMetaspaceSize=4G`, letting that **single JVM commit up to ~12.5 GB — larger than the whole machine** — before the other two JVMs are even counted.

This latent misconfiguration only started failing after **#5789 re-enabled R8 minification** (Jul 5). R8's whole-program analysis drives the Gradle heap up toward `-Xmx`; combined with the co-resident Kotlin daemon and Dart tooling on a 12 GB box, the container over-commits and the daemon dies. It dies at the *lightweight* `l8DexDesugarLibRelease` task rather than at R8 minify itself — the tell that this is machine-wide memory pressure, not L8 genuinely needing 8 GB.

## Fix

Right-size the JVM memory so the sum of the ceilings fits comfortably within 12 GB:

| Setting | Before | After |
|---|---|---|
| Gradle daemon heap | `-Xmx8G` | `-Xmx6g` |
| Gradle metaspace cap | `4G` | `1g` |
| Kotlin compile daemon | unbounded | `-Xmx2g` |
| Concurrent Gradle workers | unbounded | `4` |

A Flutter release R8/dex pass fits well within a 6 GB heap, so this keeps ample headroom while eliminating the over-commit.

## Verification

- This is a `gradle.properties`-only change (no Dart, no generated code) — all JVM-arg / property syntax is standard and valid.
- It **cannot be meaningfully validated locally**: reproducing the failure requires a full Android **release** build (the R8 + L8 path) on a memory-constrained machine, which is exactly the Codemagic build. The real confirmation is a green Android Build on Codemagic.

**Please re-run the Android Build workflow on Codemagic from this branch to confirm.**