### PR TITLE
docs: sync vendored brand guidelines with canonical

### DIFF
--- a/brand-guidelines/AGENT_QUICK_REFERENCE.md
+++ b/brand-guidelines/AGENT_QUICK_REFERENCE.md
@@ -4,6 +4,12 @@ Use this as a fast lookup when writing copy, designing UI, or making product dec
 
 ---
 
+## Brand Name (read first)
+
+Always write the name as **Divine** — capital D, lowercase rest. Never "DiVine" or "diVine" in text. The stylized "V" only exists in the logotype artwork, never in written copy, UI, docs, or code.
+
+---
+
 ## One-Line Summary
 
 Divine is a decentralized short-form video app reviving Vine's 6-second format, built on Nostr, championing human creativity over AI slop.
@@ -51,11 +57,12 @@ Divine is a decentralized short-form video app reviving Vine's 6-second format, 
 
 ## Key Messages
 
+- **Welcome Home**: our arrival greeting for people coming to Divine or returning to it. It signals inclusion, belonging, and a human place to land on the internet.
 - **No AI slop**: Human-made content only. We detect and remove machine-generated content.
 - **User ownership**: Your content, your data, your feed. Built on Nostr where you own everything.
 - **Joy scrolling**: Trade doom scrolling for delight. Quick bursts of real human creativity.
 - **Community-built**: Open source, decentralized, built with and for the community.
-- **Vine nostalgia**: 100,000+ archived Vines brought back to life. The golden days of the internet, reimagined.
+- **Vine nostalgia**: 2.1 million archived Vines brought back to life. The golden days of the internet, reimagined.
 
 ---
 
@@ -92,6 +99,7 @@ Secondary accent colors: Yellow `#FFF140`, Lime `#D2FF40`, Pink `#FF7FAF`, Orang
 
 ## Taglines / Phrases to Use
 
+- "Welcome Home"
 - "Life in Loops"
 - "Live, Love, Loop"
 - "Your playground for human creativity"

--- a/brand-guidelines/BRAND_DNA.md
+++ b/brand-guidelines/BRAND_DNA.md
@@ -23,6 +23,7 @@ Then social media grew darker. It got hateful and heavier. It learned how to div
 At Divine, we say: fuck that.
 
 We want you to own what you make. Choose what you see. Trade doom scrolling for joy scrolling. Trade keyboard wars for a playground of human creativity. Crack the algorithm open and make it work for you. Bring your weird unfiltered self. Chances are you'll find someone just like you. Together, we'll put the power of creativity back in human hands.
+When people arrive, we want the feeling to be simple: Welcome Home.
 
 ---
 
@@ -43,7 +44,8 @@ We want you to own what you make. Choose what you see. Trade doom scrolling for 
 - Agency over your feed and followers
 - Your content and data stay yours
 - Space to play and experiment
-- Access to 100,000+ archived Vine videos from the original era
+- Access to 2.1 million archived Vine videos from the original era
+- A place that feels like arrival, not conversion
 
 ---
 

--- a/brand-guidelines/README.md
+++ b/brand-guidelines/README.md
@@ -2,6 +2,10 @@
 
 Brand guidelines for Divine, translated from the official brand PDFs (January 2026).
 
+## Brand Name
+
+Always write the brand name as **Divine** — capital D, lowercase rest. Do **not** write it as "DiVine" or "diVine" in any text (copy, headings, UI, docs, code, commit messages). The stylized capital "V" is a feature of the logotype artwork only and never carries into written text.
+
 ## Files
 
 | File | Purpose |

--- a/brand-guidelines/TONE_OF_VOICE.md
+++ b/brand-guidelines/TONE_OF_VOICE.md
@@ -57,7 +57,7 @@ We have three tone of voice principles that shape how we sound. They ensure cons
 | Instead of | Try |
 |------------|-----|
 | "Vine Revisited - A Return to the Halcyon Days of the Internet" | "Our Divine right to AI-free, human-made creativity" |
-| "Divine includes access to more than 100,000 archived Vine videos and lets people create their own six-second looping videos. We are aiming to provide an experience that is free of AI-generated content." | "We've brought back to life 100,000 Vines from the original archives. At Divine, we want everyone to show up as they are to our human-made, no-slop playground." |
+| "Divine includes access to more than 2.1 million archived Vine videos and lets people create their own six-second looping videos. We are aiming to provide an experience that is free of AI-generated content." | "We've brought back to life 2.1 million Vines from the original archives. At Divine, we want everyone to show up as they are to our human-made, no-slop playground." |
 
 ---
 
@@ -80,6 +80,10 @@ We have three tone of voice principles that shape how we sound. They ensure cons
 - Unnecessary disclaimers or legalese in user-facing copy
 - Calling AI-generated content "creative" -- this is a human creativity space
 - Sounding polished or sterile -- a little rough around the edges is on brand
+
+### Arrival Language
+
+When someone is arriving for the first time or coming back, use "Welcome Home" as the default greeting if the copy needs to feel warm, direct, and inclusive.
 
 ### Tone Dial by Context
 

--- a/brand-guidelines/VISUAL_IDENTITY.md
+++ b/brand-guidelines/VISUAL_IDENTITY.md
@@ -7,7 +7,10 @@ The Divine logotype is the most recognizable aspect of the brand. It is built on
 ### Versions
 - **Primary**: Green and Dark Green
 - **On images**: Dark Green or White versions are permitted, provided strong contrast is maintained
-- The name is always written as "Divine" (capital D, lowercase remainder)
+
+### Brand Name
+
+**The brand name is always written "Divine."** Standard capitalization: capital D, lowercase rest. Never write it as "DiVine" or "diVine" — any stylized capitalization of the "V" belongs to the logotype artwork only and must never appear in body copy, headings, UI text, code comments, docs, or anywhere the name is set as text.
 
 ### Safe Space
 Always leave at least the x-height of the typography as free space around the logo on all sides.


### PR DESCRIPTION
Closes #5998

The `brand-guidelines/` copy vendored in this repo was stale. Syncs it to the canonical [brand-guidelines](https://github.com/divinevideo/brand-guidelines):

- **Divine** spelling (was `diVine`) + the explicit brand-name rule
- Vine archive count **100,000+ → 2.1 million**

🤖 Generated with [Claude Code](https://claude.com/claude-code)