### PR TITLE
docs: sync vendored brand guidelines (about.divine.video enrichment)

### DIFF
--- a/brand-guidelines/AGENT_QUICK_REFERENCE.md
+++ b/brand-guidelines/AGENT_QUICK_REFERENCE.md
@@ -62,7 +62,8 @@ Divine is a decentralized short-form video app reviving Vine's 6-second format, 
 - **User ownership**: Your content, your data, your feed. Built on Nostr where you own everything.
 - **Joy scrolling**: Trade doom scrolling for delight. Quick bursts of real human creativity.
 - **Community-built**: Open source, decentralized, built with and for the community.
-- **Vine nostalgia**: 2.1 million archived Vines brought back to life. The golden days of the internet, reimagined.
+- **Vine nostalgia**: 2.1 million archived Vines brought back to life, preserved by ArchiveTeam and the Internet Archive. The golden days of the internet, reimagined.
+- **Independent project**: Divine has no affiliation with Vine or X/Twitter. It's a separate, open-source app on Nostr that gives archived Internet Archive videos a new home and enables new six-second creation. Keep this clear in external copy.
 
 ---
 

--- a/brand-guidelines/BRAND_DNA.md
+++ b/brand-guidelines/BRAND_DNA.md
@@ -44,8 +44,27 @@ When people arrive, we want the feeling to be simple: Welcome Home.
 - Agency over your feed and followers
 - Your content and data stay yours
 - Space to play and experiment
-- Access to 2.1 million archived Vine videos from the original era
+- Access to 2.1 million archived Vines from the original era, preserved by ArchiveTeam and the Internet Archive
 - A place that feels like arrival, not conversion
+
+---
+
+## Mission
+
+Divine's mission is to kick-start a movement to brighten the world by creating a playground for human creativity and connection. Divine will:
+
+- Preserve digital creative legacy
+- Prevent content loss due to corporate decisions
+- Empower creators through decentralized technology
+- Give users agency over their content and feed
+
+---
+
+## The Vine Archive
+
+Between 2013 and 2017, Vine let creators share six-second videos capturing spontaneous moments of creativity. When Twitter shut Vine down, millions of those videos were at risk of being lost. Divine has restored **2.1 million** of them, drawn from the preservation work of [ArchiveTeam](https://archiveteam.org) and the [Internet Archive](https://archive.org), giving these authentic pre-AI-era videos a new home on the decentralized web. We're committed to restoring creator ownership and attribution wherever possible.
+
+**Positioning note (keep this straight in all external copy):** Divine is an independent short-form video app with no affiliation to X (formerly Twitter) or the original Vine platform. It's a separate project built on open-source technology and the Nostr protocol -- it preserves archived videos from the Internet Archive and enables new six-second video creation using similar creative constraints.
 
 ---
 

--- a/brand-guidelines/README.md
+++ b/brand-guidelines/README.md
@@ -30,3 +30,4 @@ Always write the brand name as **Divine** — capital D, lowercase rest. Do **no
 Translated from:
 - `Divine-Brand_Guidelines_2026.pdf` (visual identity, 53 pages)
 - `divine-brand.pdf` (brand DNA & tone of voice, 41 pages)
+- [about.divine.video](https://about.divine.video) (official story, mission, and archive provenance)

--- a/brand-guidelines/VISUAL_IDENTITY.md
+++ b/brand-guidelines/VISUAL_IDENTITY.md
@@ -12,6 +12,8 @@ The Divine logotype is the most recognizable aspect of the brand. It is built on
 
 **The brand name is always written "Divine."** Standard capitalization: capital D, lowercase rest. Never write it as "DiVine" or "diVine" — any stylized capitalization of the "V" belongs to the logotype artwork only and must never appear in body copy, headings, UI text, code comments, docs, or anywhere the name is set as text.
 
+The stylized "V" in the logotype is a nod to the name's origin — "di-Vine," meaning "from Vine." That origin story lives in the mark and in brand storytelling, but it never changes how the name is spelled in text: always **Divine**.
+
 ### Safe Space
 Always leave at least the x-height of the typography as free space around the logo on all sides.
 


### PR DESCRIPTION
Closes #6000

Syncs the vendored brand docs to canonical brand-guidelines: adds archive provenance (ArchiveTeam + Internet Archive), the official mission, the independence/positioning note, and the logotype etymology.

🤖 Generated with [Claude Code](https://claude.com/claude-code)