### PR TITLE
docs: rewrite README to reflect current state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,42 @@
-# Divine
+# Divine Mobile
 
-Status: Current
-Validated against: repo structure, `mobile/pubspec.yaml`, active build scripts, and current settings/support flows on 2026-03-19.
+Divine is a decentralized short-form video app that revives Vine's 6-second looping format — human-made content only, no AI slop. This repository holds the Flutter app for iOS, Android, macOS, and web, the shared workspace packages that power it, and the launch and engineering documentation needed to ship to the App Store, Play Console, and Zapstore. The app is built on Nostr, so people keep ownership of their content, followers, and username.
 
-Divine is a decentralized short-form video app reviving Vine's 6-second format, built on Nostr — human-made content only, no AI slop. This repository contains the Flutter mobile app, the shared workspace packages that power it, and the launch and engineering documentation needed to ship P1 to the App Store and Play Console.
+## Features
 
-## Current Milestone
+- Record, edit, and share 6-second looping videos with an in-app camera and video editor (multi-clip timeline, draw layers, beat markers, subtitles, voice-over).
+- An infinite home feed with swipe-based tuning ("more/less like this"), plus explore, hashtag, category, and curated-list discovery.
+- Social graph and engagement over Nostr: follows, likes, reposts, NIP-22 comments, direct messages, and notifications.
+- Content ownership and portability — your keys, your posts, your follower graph — with hardware-backed key storage and NIP-46 remote signing (`bunker://` / Keycast) for people who want to keep keys off the device.
+- Media hosting on Blossom, with HLS playback for Divine-hosted blobs.
+- Content provenance via C2PA / ProofMode and identity verification through `verifier.divine.video`.
+- Creator analytics, monetization surfaces, people lists, and feature flags.
+- Safety and compliance flows: content filters, blocklists and mutes, geo-blocking, and minor-account review.
+- Localized into 18 languages.
 
-P1 launch means the app is ready to submit to the App Store for review and to cut the matching Android release candidate. The launch-critical documentation lives in [docs/P1_LAUNCH_HUB.md](docs/P1_LAUNCH_HUB.md).
+## Architecture
 
-## Repository Map
+Most application code lives under `mobile/`. The Flutter entry points are `mobile/lib/main.dart` and `mobile/lib/router/app_router.dart` (routing uses `go_router`). App screens and feature wiring sit in `mobile/lib/`; the repo is a Melos workspace whose shared logic lives in packages under `mobile/packages/`.
 
-- `mobile/` - Flutter app, platform projects, scripts, tests, and package workspace.
-- `mobile/packages/` - Shared packages for repositories, models, Nostr clients, UI, media, auth, and utilities.
-- `docs/` - Canonical repository docs, release docs, and the historical archive index.
-- `mobile/docs/` - Product, protocol, testing, and mobile-specific implementation docs.
-## Getting Started
+New feature work follows the layered flow `UI -> BLoC/Cubit -> Repository -> Client`. State management is mid-migration: `flutter_bloc` (BLoC/Cubit) is the target for new UI state, while `flutter_riverpod` remains as legacy compatibility glue. See `docs/STATE_MANAGEMENT.md` and `docs/BLOC_UI_MIGRATION_PRD.md`. Divine is dark-mode only; shared components and theme primitives come from `mobile/packages/divine_ui`.
+
+The workspace is organized into around 75 packages, grouped roughly as:
+
+- `mobile/packages/*_repository/` — data-access and feature repositories (feed, videos, comments, follow, profile, notifications, and more).
+- `mobile/packages/*_client/` and `mobile/packages/*_api_client/` — API and platform client boundaries (for example `verifier_client`, `funnelcake_api_client`, `invite_api_client`).
+- `mobile/packages/models/` — shared model types and generated serialization.
+- `mobile/packages/nostr_*` — Nostr SDK, client, key management, and app-bridge behavior (`nostr_sdk`, `nostr_client`, `nostr_key_manager`, `nostr_app_bridge_repository`).
+- `mobile/packages/divine_camera/`, `mobile/packages/divine_video_player/`, `mobile/packages/media_cache/` — capture, playback, and caching.
+- `mobile/packages/blossom_upload_service/`, `mobile/packages/background_uploader/` — media upload, including OS-backed uploads that survive app suspension.
+- `mobile/packages/keycast_flutter/` — NIP-46 remote signing integration.
+
+How it fits the Divine platform: the app speaks to Nostr relays for the social graph and events, stores and serves media through Blossom, supports Keycast-style remote signers over NIP-46, and verifies identity against `verifier.divine.video`. Persistence is local via Drift (SQLite, at-rest encrypted) and Hive. Firebase provides Crashlytics, push messaging, performance monitoring, and analytics. Code-push updates use Shorebird.
+
+Generated code (Riverpod, Freezed, JSON serialization, Drift, Hive, mocks) is produced by `build_runner` and committed; regenerate after touching any generator input.
+
+## Getting started
+
+Requirements: Flutter `^3.44.0` and the Dart SDK `^3.12.0`. The pinned toolchain version is in `mobile/mise.toml` (Flutter 3.44.0). All Flutter commands run from `mobile/`.
 
 ```bash
 cd mobile
@@ -23,35 +44,21 @@ flutter pub get
 flutter run -d <device>
 ```
 
-From `mobile/`, common alternatives:
+Common alternatives from `mobile/`:
 
 - `./run_dev.sh ios debug`
 - `./run_dev.sh android debug`
 - `./run_dev.sh macos debug`
 
-If a build fails from generated code or pod state, use the targeted scripts first from `mobile/`:
+If a build fails from generated code or CocoaPods state, use the targeted scripts first (from `mobile/`):
 
 - `./build_ios.sh debug --codegen && ./run_dev.sh ios debug`
 - `./build_ios.sh debug --pod-reset && ./run_dev.sh ios debug`
 - `./build_macos.sh debug --codegen && ./run_dev.sh macos debug`
-- `./build_macos.sh debug --pod-reset && ./run_dev.sh macos debug`
 
-For local cache resets from `mobile/`:
+For local cache resets from `mobile/`: `./clear_cache.sh` or `./clear_cache.sh --full`. See `docs/BUILD_SPEED_CHECKLIST.md` for the decision flow.
 
-- `./clear_cache.sh`
-- `./clear_cache.sh --full`
-
-See [docs/BUILD_SPEED_CHECKLIST.md](docs/BUILD_SPEED_CHECKLIST.md) for the decision flow.
-
-## Canonical Docs
-
-- [CONTRIBUTING.md](CONTRIBUTING.md) - setup, workflow, verification, and PR expectations
-- [docs/README.md](docs/README.md) - documentation map and source-of-truth guide
-- [docs/P1_LAUNCH_HUB.md](docs/P1_LAUNCH_HUB.md) - launch-critical release, review, and compliance docs
-- [docs/STATE_MANAGEMENT.md](docs/STATE_MANAGEMENT.md) - current state-management direction
-- [docs/BLOC_UI_MIGRATION_PRD.md](docs/BLOC_UI_MIGRATION_PRD.md) - migration policy and rationale
-
-## Daily Development
+### Daily development
 
 From `mobile/`:
 
@@ -61,24 +68,59 @@ flutter analyze
 flutter test
 ```
 
-If you touch codegen-backed sources such as Riverpod, Freezed, JSON serialization, Drift, or mocks:
+If you touch codegen-backed sources (Riverpod, Freezed, JSON serialization, Drift, Hive, or mocks):
 
 ```bash
 dart run build_runner build --delete-conflicting-outputs
 ```
 
-## Release And Submission
+### Local stack
 
-Use these docs instead of older deployment notes:
+A Docker-based local stack (relay, Keycast, Blossom, and supporting services) lives in `local_stack/` and is driven through `mise` tasks from `mobile/`: `mise run local_up`, `mise run local_status`, `mise run local_down`, and `mise run e2e_test`. The stack speaks cleartext to loopback hosts (`10.0.2.2`, `localhost`, `127.0.0.1`) so both the Android emulator and iOS Simulator work against it out of the box. See `AGENTS.md` for the full workflow.
 
-- [docs/RELEASE_CHECKLIST.md](docs/RELEASE_CHECKLIST.md)
-- [docs/APP_STORE_REVIEW_DOSSIER.md](docs/APP_STORE_REVIEW_DOSSIER.md)
-- [mobile/docs/APPLE_REVIEW_RESPONSE.md](mobile/docs/APPLE_REVIEW_RESPONSE.md)
-- [mobile/docs/ENCRYPTION_EXPORT_COMPLIANCE.md](mobile/docs/ENCRYPTION_EXPORT_COMPLIANCE.md)
+## Configuration
 
-## Documentation Policy
+Runtime environment is selected at build time with `--dart-define=DEFAULT_ENV=<env>`, defaulting to `PRODUCTION`. Supported values (see `mobile/lib/models/environment_config.dart`) are `POC`, `STAGING`, `TEST`, `PRODUCTION`, and `LOCAL`; each maps to one relay URL and API base URL (production API is `https://api.divine.video`). For example, `mise run local_build` builds a debug APK with `DEFAULT_ENV=LOCAL`.
 
-If a doc conflicts with current code, tests, or the focused current docs above, trust the implementation first. Older plans, migration notes, and postmortems are preserved for context and tracked from [docs/archive/README.md](docs/archive/README.md).
+Additional `--dart-define` values wire up optional services, supplied by the run/build scripts and CI:
+
+- `ZENDESK_URL`, `ZENDESK_APP_ID`, `ZENDESK_CLIENT_ID`, `ZENDESK_API_TOKEN` — in-app support.
+- `PROOFMODE_SIGNING_SERVER_ENDPOINT`, `PROOFMODE_SIGNING_SERVER_TOKEN` — ProofMode attestation.
+
+Keep credentials out of the repo. The Firebase surface is configured through generated `firebase_options.dart` and platform config files.
+
+## Building & release
+
+Signed store builds run on Codemagic (`codemagic.yaml`); GitHub Actions (`.github/workflows/`) runs CI. The main app CI workflow is `mobile_ci.yaml`, alongside per-package workflows and web preview/production deploy workflows.
+
+Codemagic workflows and their publishing targets:
+
+- iOS build — `flutter build ipa --release`, published to App Store Connect (TestFlight / App Store); dSYMs uploaded to Firebase Crashlytics.
+- Android build — `flutter build appbundle --release` (and split-per-ABI APKs), published to Google Play.
+- macOS build — packaged as a DMG and published to a GitHub Release.
+- E2E smoke tests — Maestro flows on iOS Simulator and Android emulator.
+
+Additional distribution paths:
+
+- Zapstore — the arm64 release APK, described by `zapstore.yaml` (MPL-2.0). Publishing is done manually with `zsp`; see the Zapstore notes in `AGENTS.md`.
+- Web — the Flutter web build deploys to Cloudflare (`mobile/deploy-web.sh`, `.github/workflows/mobile_web_production_deploy.yml`).
+- Shorebird — over-the-air code-push patches, configured in `mobile/shorebird.yaml`.
+
+The launch-critical release, review, and compliance docs live in `docs/P1_LAUNCH_HUB.md`, with `docs/RELEASE_CHECKLIST.md` and `docs/APP_STORE_REVIEW_DOSSIER.md` for the submission path.
+
+## Documentation
+
+- `CONTRIBUTING.md` — setup, workflow, verification, and PR expectations.
+- `AGENTS.md` — repository guidelines, workflow, and verification rules.
+- `docs/README.md` — documentation map and source-of-truth guide.
+- `docs/ARCHITECTURE.md` — system architecture.
+- `SERVICE-INVENTORY.md` — lightweight repo inventory.
+
+If a doc conflicts with current code, tests, or the focused docs above, trust the implementation first. Older plans, migration notes, and postmortems are preserved in `docs/archive/`.
+
+## License
+
+Mozilla Public License 2.0. See `LICENSE`.
 
 ---
 


### PR DESCRIPTION
Closes #6002

Rewrites `README.md` to accurately reflect the current state of the divine-mobile codebase, verified against the repo rather than the prior thinner version.

## What changed
- Added a **Features** section grounded in `mobile/lib/screens/`, `mobile/lib/features/`, and workspace packages (camera + video editor, tuned infinite feed, discovery, Nostr social graph, Keycast/NIP-46 remote signing, Blossom media + HLS, C2PA/ProofMode provenance, `verifier.divine.video` identity, creator analytics/monetization, safety/minor-account flows, 18 locales).
- Added an **Architecture** section: `mobile/` layout, `go_router` entry points, the `UI -> BLoC/Cubit -> Repository -> Client` flow and the Riverpod→BLoC migration, the ~75-package Melos workspace grouped by role, and how the app fits the Divine platform (Nostr relays, Blossom, Keycast, verifier, Drift/Hive persistence, Firebase, Shorebird).
- Rewrote **Getting started** with the real Flutter/`mise`/script commands and the `local_stack/` Docker workflow, and kept the accurate daily-development and codegen notes.
- Added **Configuration** documenting `--dart-define=DEFAULT_ENV` (`POC`/`STAGING`/`TEST`/`PRODUCTION`/`LOCAL`, default `PRODUCTION`) from `mobile/lib/models/environment_config.dart`, plus the Zendesk and ProofMode dart-defines.
- Added **Building & release** describing the real path: Codemagic signed builds → App Store Connect, Google Play (AAB), macOS DMG via GitHub Release, Maestro E2E; GitHub Actions CI; plus Zapstore (arm64 APK), Cloudflare web deploy, and Shorebird code push.
- Retitled to `# Divine Mobile`, added a License section (MPL-2.0), and kept the Divine brand footer.

## Verified against
`README.md`, `mobile/pubspec.yaml`, `mobile/mise.toml`, `mobile/lib/` (screens, features, `main.dart`, router, `models/environment_config.dart`), `AGENTS.md`, `SERVICE-INVENTORY.md`, `codemagic.yaml`, `.github/workflows/`, `zapstore.yaml`, `mobile/shorebird.yaml`, `LICENSE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)