### PR TITLE
fix(video-editor): disable clip Split/Speed while busy instead of hiding them

### DIFF
--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
@@ -116,7 +116,9 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
 
     // Split
     on<ClipEditorOriginalClipReplaced>(_onOriginalClipReplaced);
-    on<ClipEditorSplitRequested>(_onSplitRequested, transformer: droppable());
+    // sequential (not droppable) so a split requested on a different clip while
+    // one is rendering is queued and runs, rather than being silently dropped.
+    on<ClipEditorSplitRequested>(_onSplitRequested, transformer: sequential());
 
     // Trim
     on<ClipEditorTrimUpdated>(_onTrimUpdated, transformer: restartable());
@@ -124,9 +126,11 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
     on<ClipEditorTrimDragEnded>(_onTrimDragEnded);
 
     // Audio extraction
+    // sequential (not droppable) so an extraction requested on a different clip
+    // while one is running is queued and runs, rather than being dropped.
     on<ClipEditorAudioExtractionRequested>(
       _onAudioExtractionRequested,
-      transformer: droppable(),
+      transformer: sequential(),
     );
 
     // Reverse
@@ -510,10 +514,15 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
     Emitter<ClipEditorState> emit,
   ) async {
     final clips = state.clips;
-    if (state.currentClipIndex >= clips.length) return;
+    // Resolve the target from the event (captured at dispatch) so a queued
+    // split still hits the intended clip; fall back to the current selection.
+    final index = event.clipId != null
+        ? clips.indexWhere((c) => c.id == event.clipId)
+        : state.currentClipIndex;
+    if (index < 0 || index >= clips.length) return;
 
-    final selectedClip = clips[state.currentClipIndex];
-    final splitPosition = state.splitPosition;
+    final selectedClip = clips[index];
+    final splitPosition = event.splitPosition ?? state.splitPosition;
 
     // Validate split position before changing state
     if (!VideoEditorSplitService.isValidSplitPosition(
@@ -538,7 +547,13 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
     );
 
     // Stop editing mode
-    emit(state.copyWith(isEditing: false, isSplitting: true));
+    emit(
+      state.copyWith(
+        isEditing: false,
+        isSplitting: true,
+        splittingClipId: selectedClip.id,
+      ),
+    );
 
     ClipSplitFailure? splitFailure;
     String? splitStartClipId;
@@ -654,6 +669,7 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
           state.copyWith(
             clips: rollbackClips,
             isSplitting: false,
+            clearSplittingClipId: true,
             lastSplitFailure: splitFailure,
             clearLastSplit: splitFailure != null,
           ),
@@ -1038,9 +1054,14 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
     Emitter<ClipEditorState> emit,
   ) async {
     final clips = state.clips;
-    if (state.currentClipIndex >= clips.length) return;
+    // Resolve the target from the event (captured at dispatch) so a queued
+    // extraction still hits the intended clip; fall back to current selection.
+    final index = event.clipId != null
+        ? clips.indexWhere((c) => c.id == event.clipId)
+        : state.currentClipIndex;
+    if (index < 0 || index >= clips.length) return;
 
-    final clip = clips[state.currentClipIndex];
+    final clip = clips[index];
     final videoPath = clip.video.file?.path;
     final extractionSpeed = _effectiveAudioExtractionSpeed(clip);
 
@@ -1056,7 +1077,9 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
       return;
     }
 
-    emit(state.copyWith(isExtractingAudio: true));
+    emit(
+      state.copyWith(isExtractingAudio: true, extractingAudioClipId: clip.id),
+    );
 
     try {
       final result = await _audioExtractionService.extractAudio(
@@ -1083,6 +1106,7 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
         emit(
           state.copyWith(
             isExtractingAudio: false,
+            clearExtractingAudioClipId: true,
             lastAudioExtraction: ClipAudioExtractionDiscarded(),
           ),
         );
@@ -1106,6 +1130,7 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
         emit(
           state.copyWith(
             isExtractingAudio: false,
+            clearExtractingAudioClipId: true,
             lastAudioExtraction: ClipAudioExtractionDiscarded(),
           ),
         );
@@ -1153,6 +1178,7 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
         state.copyWith(
           clips: List.unmodifiable(newClips),
           isExtractingAudio: false,
+          clearExtractingAudioClipId: true,
           lastAudioExtraction: ClipAudioExtractionSuccess(
             audioEvent: audioEvent,
           ),
@@ -1172,6 +1198,7 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
       emit(
         state.copyWith(
           isExtractingAudio: false,
+          clearExtractingAudioClipId: true,
           lastAudioExtraction: ClipAudioExtractionFailure(),
         ),
       );
@@ -1190,6 +1217,7 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
       emit(
         state.copyWith(
           isExtractingAudio: false,
+          clearExtractingAudioClipId: true,
           lastAudioExtraction: ClipAudioExtractionFailure(),
         ),
       );

--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
@@ -580,12 +580,31 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
           final clips = state.clips;
           final index = clips.indexWhere((c) => c.id == selectedClip.id);
           if (index == -1) return;
+          // Preserve the user's live selection identity across the insert. The
+          // split may target a clip *before* the currently-selected one (the
+          // user can switch clips while an earlier split renders), and
+          // inserting the tail shifts every later index by one — re-point
+          // currentClipIndex at the same clip so the selection doesn't
+          // silently jump. When the selected clip *is* the split source, its
+          // id is gone (replaced by startClip); keep the index unchanged so it
+          // lands on startClip.
+          final currentIndex = state.currentClipIndex;
+          final selectedClipId =
+              currentIndex >= 0 && currentIndex < clips.length
+              ? clips[currentIndex].id
+              : null;
           final newClips = List<DivineVideoClip>.of(clips)
             ..[index] = startClip
             ..insert(index + 1, endClip);
+          final newSelectedIndex = selectedClipId == null
+              ? currentIndex
+              : newClips.indexWhere((c) => c.id == selectedClipId);
           emit(
             state.copyWith(
               clips: List.unmodifiable(newClips),
+              currentClipIndex: newSelectedIndex >= 0
+                  ? newSelectedIndex
+                  : currentIndex,
               lastSplit: ClipSplitEvent(
                 sourceClipId: selectedClip.id,
                 startClipId: startClip.id,
@@ -1062,6 +1081,21 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
     if (index < 0 || index >= clips.length) return;
 
     final clip = clips[index];
+
+    // Dedupe a queued re-extraction. With sequential(), a second Extract tap
+    // on a clip queues behind the first; once the first mutes the clip, the
+    // second would re-extract and emit another success, adding a duplicate
+    // audio track. Skip when this clip's audio was already extracted and it is
+    // still muted as a result; a manual un-mute (volume > 0) lifts the guard.
+    if (state.extractedAudioClipIds.contains(clip.id) && clip.volume == 0) {
+      Log.info(
+        '🎵 Skipping duplicate audio extraction for clip ${clip.id}',
+        name: 'ClipEditorBloc',
+        category: LogCategory.video,
+      );
+      return;
+    }
+
     final videoPath = clip.video.file?.path;
     final extractionSpeed = _effectiveAudioExtractionSpeed(clip);
 
@@ -1179,6 +1213,10 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
           clips: List.unmodifiable(newClips),
           isExtractingAudio: false,
           clearExtractingAudioClipId: true,
+          extractedAudioClipIds: {
+            ...state.extractedAudioClipIds,
+            currentClip.id,
+          },
           lastAudioExtraction: ClipAudioExtractionSuccess(
             audioEvent: audioEvent,
           ),

--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_event.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_event.dart
@@ -162,11 +162,24 @@ class ClipEditorOriginalClipReplaced extends ClipEditorEvent {
   List<Object?> get props => [sourceClipId, startClip, endClip];
 }
 
-/// Request to split the currently selected clip at the current split position.
+/// Request to split a clip at a split position.
 ///
 /// Validates the split position and stops editing mode before split.
+///
+/// [clipId] and [splitPosition] bind the request to a specific clip and cut
+/// point. They are captured at dispatch time so a queued split (the handler is
+/// `sequential`) still targets the intended clip even if the user selects a
+/// different clip or moves the playhead while an earlier split is rendering.
+/// When omitted, the handler falls back to the current selection and
+/// [ClipEditorState.splitPosition] (used by tests and any legacy caller).
 class ClipEditorSplitRequested extends ClipEditorEvent {
-  const ClipEditorSplitRequested();
+  const ClipEditorSplitRequested({this.clipId, this.splitPosition});
+
+  final String? clipId;
+  final Duration? splitPosition;
+
+  @override
+  List<Object?> get props => [clipId, splitPosition];
 }
 
 // === TRIM ===
@@ -226,13 +239,23 @@ class ClipEditorTrimDragEnded extends ClipEditorEvent {
 ///
 /// [clipTitle] is the l10n-resolved title forwarded to the created
 /// [AudioEvent] so the bloc stays free of Flutter/UI dependencies.
+///
+/// [clipId] binds the request to a specific clip, captured at dispatch time so
+/// a queued extraction (the handler is `sequential`) still targets the intended
+/// clip even if the user selects a different clip while an earlier extraction
+/// is running. When omitted, the handler falls back to the current selection
+/// (used by tests and any legacy caller).
 class ClipEditorAudioExtractionRequested extends ClipEditorEvent {
-  const ClipEditorAudioExtractionRequested({required this.clipTitle});
+  const ClipEditorAudioExtractionRequested({
+    required this.clipTitle,
+    this.clipId,
+  });
 
   final String clipTitle;
+  final String? clipId;
 
   @override
-  List<Object?> get props => [clipTitle];
+  List<Object?> get props => [clipTitle, clipId];
 }
 
 // === REVERSE ===

--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_state.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_state.dart
@@ -20,6 +20,7 @@ class ClipEditorState extends Equatable {
     this.trimmingClipId,
     this.isExtractingAudio = false,
     this.extractingAudioClipId,
+    this.extractedAudioClipIds = const {},
     this.lastAudioExtraction,
     this.isSplitting = false,
     this.splittingClipId,
@@ -94,6 +95,16 @@ class ClipEditorState extends Equatable {
   /// disable audio-dependent actions (Speed) only for the affected clip, so
   /// switching to and operating on a different clip stays unblocked.
   final String? extractingAudioClipId;
+
+  /// IDs of clips whose audio has been extracted (and muted) this session.
+  ///
+  /// Used to dedupe a queued re-extraction: with the `sequential()`
+  /// transformer a second Extract tap on a clip queues behind the first, and
+  /// without this guard the second run would re-mute the already-muted clip
+  /// and emit a second [ClipAudioExtractionSuccess], adding a duplicate audio
+  /// track. A manual un-mute (volume > 0) lifts the guard, so a deliberate
+  /// re-extraction still works.
+  final Set<String> extractedAudioClipIds;
 
   /// Whether a split operation is currently in progress (rendering).
   final bool isSplitting;
@@ -191,6 +202,7 @@ class ClipEditorState extends Equatable {
     bool? isExtractingAudio,
     String? extractingAudioClipId,
     bool clearExtractingAudioClipId = false,
+    Set<String>? extractedAudioClipIds,
     ClipAudioExtractionResult? lastAudioExtraction,
     bool? isSplitting,
     String? splittingClipId,
@@ -230,6 +242,8 @@ class ClipEditorState extends Equatable {
       extractingAudioClipId: clearExtractingAudioClipId
           ? null
           : (extractingAudioClipId ?? this.extractingAudioClipId),
+      extractedAudioClipIds:
+          extractedAudioClipIds ?? this.extractedAudioClipIds,
       lastAudioExtraction: lastAudioExtraction ?? this.lastAudioExtraction,
       isSplitting: isSplitting ?? this.isSplitting,
       splittingClipId: clearSplittingClipId
@@ -272,6 +286,7 @@ class ClipEditorState extends Equatable {
     trimmingClipId,
     isExtractingAudio,
     extractingAudioClipId,
+    extractedAudioClipIds,
     // Identity-only: each ClipAudioExtractionResult is a fresh instance.
     identityHashCode(lastAudioExtraction),
     isSplitting,

--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_state.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_state.dart
@@ -19,8 +19,10 @@ class ClipEditorState extends Equatable {
     this.trimPosition,
     this.trimmingClipId,
     this.isExtractingAudio = false,
+    this.extractingAudioClipId,
     this.lastAudioExtraction,
     this.isSplitting = false,
+    this.splittingClipId,
     this.lastSplitFailure,
     this.isReversing = false,
     this.reversingClipId,
@@ -86,8 +88,21 @@ class ClipEditorState extends Equatable {
   /// Whether an audio extraction operation is currently running.
   final bool isExtractingAudio;
 
+  /// The ID of the clip whose audio is currently being extracted.
+  ///
+  /// Non-`null` while [isExtractingAudio] is `true`. Lets the controls
+  /// disable audio-dependent actions (Speed) only for the affected clip, so
+  /// switching to and operating on a different clip stays unblocked.
+  final String? extractingAudioClipId;
+
   /// Whether a split operation is currently in progress (rendering).
   final bool isSplitting;
+
+  /// The ID of the clip currently being split (rendering).
+  ///
+  /// Non-`null` while [isSplitting] is `true`. Lets the controls disable
+  /// Split only for the affected clip, leaving other clips unblocked.
+  final String? splittingClipId;
 
   /// One-shot signal emitted when a split rendering operation fails.
   ///
@@ -174,8 +189,12 @@ class ClipEditorState extends Equatable {
     String? trimmingClipId,
     bool clearTrimmingClipId = false,
     bool? isExtractingAudio,
+    String? extractingAudioClipId,
+    bool clearExtractingAudioClipId = false,
     ClipAudioExtractionResult? lastAudioExtraction,
     bool? isSplitting,
+    String? splittingClipId,
+    bool clearSplittingClipId = false,
     ClipSplitFailure? lastSplitFailure,
     bool? isReversing,
     String? reversingClipId,
@@ -208,8 +227,14 @@ class ClipEditorState extends Equatable {
           ? null
           : (trimmingClipId ?? this.trimmingClipId),
       isExtractingAudio: isExtractingAudio ?? this.isExtractingAudio,
+      extractingAudioClipId: clearExtractingAudioClipId
+          ? null
+          : (extractingAudioClipId ?? this.extractingAudioClipId),
       lastAudioExtraction: lastAudioExtraction ?? this.lastAudioExtraction,
       isSplitting: isSplitting ?? this.isSplitting,
+      splittingClipId: clearSplittingClipId
+          ? null
+          : (splittingClipId ?? this.splittingClipId),
       lastSplitFailure: lastSplitFailure ?? this.lastSplitFailure,
       isReversing: isReversing ?? this.isReversing,
       reversingClipId: clearReversingClipId
@@ -246,9 +271,11 @@ class ClipEditorState extends Equatable {
     trimPosition,
     trimmingClipId,
     isExtractingAudio,
+    extractingAudioClipId,
     // Identity-only: each ClipAudioExtractionResult is a fresh instance.
     identityHashCode(lastAudioExtraction),
     isSplitting,
+    splittingClipId,
     // Identity-only: each ClipSplitFailure is a fresh instance per failure.
     identityHashCode(lastSplitFailure),
     isReversing,

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart
@@ -28,43 +28,54 @@ class TimelineClipControls extends StatefulWidget {
 class _TimelineClipControlsState extends State<TimelineClipControls> {
   @override
   Widget build(BuildContext context) {
-    final (clipCount, isExtractingAudio, isSplitting) = context.select(
-      (ClipEditorBloc b) => (
-        b.state.clips.length,
-        b.state.isExtractingAudio,
-        b.state.isSplitting,
-      ),
-    );
-    final isLastClip = clipCount <= 1;
-    final isReversed = context.select((ClipEditorBloc b) {
-      final index = b.state.currentClipIndex;
-      final clips = b.state.clips;
-      return index >= 0 && index < clips.length && clips[index].reversed;
+    final (
+      clipCount,
+      isExtractingAudioCurrentClip,
+      isSplittingCurrentClip,
+      isReversed,
+    ) = context.select((ClipEditorBloc b) {
+      final state = b.state;
+      final index = state.currentClipIndex;
+      final hasClip = index >= 0 && index < state.clips.length;
+      final currentClipId = hasClip ? state.clips[index].id : null;
+      // Split and Speed are only disabled when the in-flight operation targets
+      // *this* clip. A split or audio extraction rendering on a different clip
+      // (the user can switch clips mid-render) leaves the current clip's
+      // actions available.
+      return (
+        state.clips.length,
+        state.isExtractingAudio &&
+            currentClipId != null &&
+            state.extractingAudioClipId == currentClipId,
+        state.isSplitting &&
+            currentClipId != null &&
+            state.splittingClipId == currentClipId,
+        hasClip && state.clips[index].reversed,
+      );
     });
+    final isLastClip = clipCount <= 1;
 
     return VideoEditorTimelineControls(
       onDelete: isLastClip ? null : () => _deleteClip(context),
       onDuplicated: () => _duplicateClip(context),
-      onSplit: isSplitting ? null : () => _splitClip(context),
-      onSpeed: isExtractingAudio ? null : () => _setPlaybackSpeed(context),
+      // Split/Speed stay mounted and are shown disabled (not removed) while
+      // busy, so the control set doesn't visibly reshuffle mid-operation.
+      onSplit: () => _splitClip(context),
+      onSpeed: () => _setPlaybackSpeed(context),
+      isSplitting: isSplittingCurrentClip,
       onTransform: () => _transformClip(context),
       onExtractAudio: () => _requestExtractAudio(context),
       onReversed: () => _reverseClip(context),
       onMultiSelect: isLastClip ? null : () => _startMultiSelect(context),
       isReversed: isReversed,
-      isExtractingAudio: isExtractingAudio,
-      // Done is gated while extraction is in flight purely as a UX cue —
-      // the success/failure side effect itself is handled by an editor-
-      // session-level listener in [VideoEditorScaffold], so it survives
-      // even if the user Deletes/Duplicates/Splits the clip (which exits
-      // edit mode and unmounts these controls) before extraction returns.
-      onDone: isExtractingAudio
-          ? null
-          : () {
-              context.read<ClipEditorBloc>().add(
-                const ClipEditorEditingStopped(),
-              );
-            },
+      isExtractingAudio: isExtractingAudioCurrentClip,
+      // Done stays enabled during a render: leaving edit mode is safe because
+      // the extraction/split success/failure side effect is handled by an
+      // editor-session-level listener in [VideoEditorScaffold], so it survives
+      // even after these controls unmount.
+      onDone: () {
+        context.read<ClipEditorBloc>().add(const ClipEditorEditingStopped());
+      },
     );
   }
 
@@ -139,14 +150,21 @@ class _TimelineClipControlsState extends State<TimelineClipControls> {
 
     if (result == null || !mounted) return;
 
-    final updated = clip.copyWith(playbackSpeed: result);
-    final newClips = state.clips
-        .map((c) => c.id == clip.id ? updated : c)
-        .toList();
+    // Re-read state after the async gap: the clip list may have changed while
+    // the sheet was open — e.g. an audio extraction on another clip finished
+    // and muted it, or a reverse/transform render completed. Rebuild from the
+    // current clips (and apply the speed on top of the current clip version)
+    // so this change doesn't clobber those concurrent mutations.
+    final currentClips = bloc.state.clips;
+    final index = currentClips.indexWhere((c) => c.id == clip.id);
+    if (index == -1) return;
+
+    final updated = currentClips[index].copyWith(playbackSpeed: result);
+    final newClips = List.of(currentClips)..[index] = updated;
     // A speed change rescales the clip's playbackDuration, shifting every
     // later clip — rebase markers by source position so they follow.
     final rebasedMarkers = rebaseTimelineMarkersForClipState(
-      oldClips: state.clips,
+      oldClips: currentClips,
       newClips: newClips,
       markers: overlayBloc.state.timelineMarkers,
     );
@@ -158,8 +176,17 @@ class _TimelineClipControlsState extends State<TimelineClipControls> {
   }
 
   void _requestExtractAudio(BuildContext context) {
-    context.read<ClipEditorBloc>().add(
+    final bloc = context.read<ClipEditorBloc>();
+    final state = bloc.state;
+    if (state.currentClipIndex < 0 ||
+        state.currentClipIndex >= state.clips.length) {
+      return;
+    }
+    // Bind the request to this clip so a queued extraction (sequential handler)
+    // still targets the right clip even if the selection changes meanwhile.
+    bloc.add(
       ClipEditorAudioExtractionRequested(
+        clipId: state.clips[state.currentClipIndex].id,
         clipTitle: context.l10n.videoEditorClipAudioTitle,
       ),
     );
@@ -291,9 +318,17 @@ class _TimelineClipControlsState extends State<TimelineClipControls> {
       return;
     }
 
-    // Update the split position and request the split.
+    // Update the split position and request the split. Bind the request to
+    // this clip and cut point so a queued split (sequential handler) still
+    // targets the right clip even if the selection changes while an earlier
+    // split renders.
     bloc
       ..add(ClipEditorSplitPositionChanged(localPosition))
-      ..add(const ClipEditorSplitRequested());
+      ..add(
+        ClipEditorSplitRequested(
+          clipId: selectedClip.id,
+          splitPosition: localPosition,
+        ),
+      );
   }
 }

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_controls.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_controls.dart
@@ -17,6 +17,7 @@ class VideoEditorTimelineControls extends StatelessWidget {
     this.isReversed = false,
     this.onExtractAudio,
     this.isExtractingAudio = false,
+    this.isSplitting = false,
     this.onMultiSelect,
     this.multiSelectSemanticLabel,
     super.key,
@@ -35,6 +36,11 @@ class VideoEditorTimelineControls extends StatelessWidget {
   final bool isReversed;
   final VoidCallback? onExtractAudio;
   final bool isExtractingAudio;
+
+  /// Whether a split of the active clip is currently rendering. Renders the
+  /// Split action disabled (rather than removing it) so the control stays in
+  /// place instead of confusingly disappearing mid-operation.
+  final bool isSplitting;
   final VoidCallback? onMultiSelect;
 
   /// Overrides the multi-select button's accessibility label. Defaults to the
@@ -102,7 +108,7 @@ class VideoEditorTimelineControls extends StatelessWidget {
                       semanticLabel: context
                           .l10n
                           .videoEditorSplitSelectedClipSemanticLabel,
-                      onPressed: onSplit,
+                      onPressed: isSplitting ? null : onSplit,
                     ),
                   if (onAnimate != null)
                     _ControlButton(
@@ -119,7 +125,7 @@ class VideoEditorTimelineControls extends StatelessWidget {
                       label: context.l10n.videoEditorSpeedLabel,
                       semanticLabel:
                           context.l10n.videoEditorSetClipSpeedSemanticLabel,
-                      onPressed: onSpeed,
+                      onPressed: isExtractingAudio ? null : onSpeed,
                     ),
                   if (onTransform != null)
                     _ControlButton(

--- a/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
@@ -604,6 +604,7 @@ void main() {
           isA<ClipEditorState>()
               .having((s) => s.isEditing, 'isEditing', isFalse)
               .having((s) => s.isSplitting, 'isSplitting', isTrue)
+              .having((s) => s.splittingClipId, 'splittingClipId', 'split-me')
               .having((s) => s.isTrimDragging, 'isTrimDragging', isFalse),
           isA<ClipEditorState>()
               .having((s) => s.clips, 'clips', hasLength(2))
@@ -625,8 +626,36 @@ void main() {
               ),
           isA<ClipEditorState>()
               .having((s) => s.clips, 'clips', hasLength(2))
-              .having((s) => s.isSplitting, 'isSplitting', isFalse),
+              .having((s) => s.isSplitting, 'isSplitting', isFalse)
+              .having((s) => s.splittingClipId, 'splittingClipId', isNull),
         ],
+      );
+
+      // A queued split must hit the clip captured at dispatch, not whatever is
+      // selected when the (sequential) handler runs.
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'splits the clip named by the event, not the current selection',
+        build: () => buildBloc(splitClip: _fakeSplitClip),
+        seed: () => ClipEditorState(
+          clips: [
+            _createClip(id: 'a', duration: const Duration(seconds: 4)),
+            _createClip(id: 'b', duration: const Duration(seconds: 4)),
+          ],
+        ),
+        act: (bloc) => bloc.add(
+          const ClipEditorSplitRequested(
+            clipId: 'b',
+            splitPosition: Duration(seconds: 2),
+          ),
+        ),
+        wait: const Duration(milliseconds: 1),
+        verify: (bloc) {
+          final clips = bloc.state.clips;
+          expect(clips, hasLength(3));
+          // 'a' (the selected clip) is untouched; 'b' was split into two.
+          expect(clips.first.id, equals('a'));
+          expect(clips.any((c) => c.id == 'b'), isFalse);
+        },
       );
 
       test('uses state splitPosition for resulting clip durations', () async {
@@ -812,7 +841,7 @@ void main() {
           );
 
           // The split future always resolves now, so isSplitting resets and the
-          // droppable() transformer no longer wedges the next split request.
+          // sequential() transformer runs the next split request in turn.
           bloc
             ..emit(
               bloc.state.copyWith(
@@ -1943,13 +1972,20 @@ void main() {
           const ClipEditorAudioExtractionRequested(clipTitle: 'Test'),
         ),
         expect: () => [
-          isA<ClipEditorState>().having(
-            (s) => s.isExtractingAudio,
-            'isExtractingAudio',
-            isTrue,
-          ),
+          isA<ClipEditorState>()
+              .having((s) => s.isExtractingAudio, 'isExtractingAudio', isTrue)
+              .having(
+                (s) => s.extractingAudioClipId,
+                'extractingAudioClipId',
+                'clip-local',
+              ),
           isA<ClipEditorState>()
               .having((s) => s.isExtractingAudio, 'isExtractingAudio', isFalse)
+              .having(
+                (s) => s.extractingAudioClipId,
+                'extractingAudioClipId',
+                isNull,
+              )
               .having((s) => s.clips.first.volume, 'volume', 0)
               .having(
                 (s) => s.lastAudioExtraction,
@@ -1971,6 +2007,54 @@ void main() {
           verify(
             () => mockService.extractAudio(
               videoPath: '/path/clip-local.mp4',
+              speed: any(named: 'speed'),
+            ),
+          ).called(1);
+        },
+      );
+
+      // A queued extraction must hit the clip captured at dispatch, not
+      // whatever is selected when the (sequential) handler runs.
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'extracts audio from the clip named by the event, not the selection',
+        build: () {
+          when(
+            () => mockService.extractAudio(
+              videoPath: any(named: 'videoPath'),
+              speed: any(named: 'speed'),
+            ),
+          ).thenAnswer(
+            (_) async => const AudioExtractionResult(
+              audioFilePath: '/tmp/audio.m4a',
+              duration: 5,
+              fileSize: 12345,
+              sha256Hash: 'abc123',
+              mimeType: 'audio/mp4',
+            ),
+          );
+          return buildBloc(audioExtractionService: mockService);
+        },
+        seed: () => ClipEditorState(
+          clips: [
+            _createClipWithFile(id: 'a'),
+            _createClipWithFile(id: 'b'),
+          ],
+        ),
+        act: (bloc) => bloc.add(
+          const ClipEditorAudioExtractionRequested(
+            clipId: 'b',
+            clipTitle: 'Test',
+          ),
+        ),
+        wait: const Duration(milliseconds: 1),
+        verify: (bloc) {
+          final clips = bloc.state.clips;
+          // 'b' (named by the event) is muted; 'a' (selected) is untouched.
+          expect(clips.firstWhere((c) => c.id == 'b').volume, equals(0));
+          expect(clips.firstWhere((c) => c.id == 'a').volume, equals(1.0));
+          verify(
+            () => mockService.extractAudio(
+              videoPath: '/path/b.mp4',
               speed: any(named: 'speed'),
             ),
           ).called(1);

--- a/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
@@ -658,6 +658,40 @@ void main() {
         },
       );
 
+      // A queued split on a clip *before* the current selection must not shift
+      // the selection onto a different clip — currentClipIndex follows the same
+      // clip after the inserted tail pushes later indices down.
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'keeps the selection on the same clip when an earlier clip is split',
+        build: () => buildBloc(splitClip: _fakeSplitClip),
+        seed: () => ClipEditorState(
+          currentClipIndex: 2,
+          clips: [
+            _createClip(id: 'a', duration: const Duration(seconds: 4)),
+            _createClip(id: 'b', duration: const Duration(seconds: 4)),
+            _createClip(id: 'c', duration: const Duration(seconds: 4)),
+          ],
+        ),
+        act: (bloc) => bloc.add(
+          const ClipEditorSplitRequested(
+            clipId: 'a',
+            splitPosition: Duration(seconds: 2),
+          ),
+        ),
+        wait: const Duration(milliseconds: 1),
+        verify: (bloc) {
+          final state = bloc.state;
+          // 'a' became two clips, so 'c' moved from index 2 to index 3.
+          expect(state.clips, hasLength(4));
+          expect(state.clips.last.id, equals('c'));
+          // The selection still points at 'c', not the clip now at index 2.
+          expect(
+            state.clips[state.currentClipIndex].id,
+            equals('c'),
+          );
+        },
+      );
+
       test('uses state splitPosition for resulting clip durations', () async {
         final clip = _createClip(id: 'x', duration: const Duration(seconds: 2));
 
@@ -2055,6 +2089,102 @@ void main() {
           verify(
             () => mockService.extractAudio(
               videoPath: '/path/b.mp4',
+              speed: any(named: 'speed'),
+            ),
+          ).called(1);
+        },
+      );
+
+      // Regression: a rapid double-tap of Extract on the same clip enqueues two
+      // requests (sequential handler). The second must be deduped once the
+      // first mutes the clip, so it does not extract again and add a duplicate
+      // audio track.
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'dedupes a queued re-extraction of an already-extracted clip',
+        build: () {
+          when(
+            () => mockService.extractAudio(
+              videoPath: any(named: 'videoPath'),
+              speed: any(named: 'speed'),
+            ),
+          ).thenAnswer(
+            (_) async => const AudioExtractionResult(
+              audioFilePath: '/tmp/audio.m4a',
+              duration: 5,
+              fileSize: 12345,
+              sha256Hash: 'abc123',
+              mimeType: 'audio/mp4',
+            ),
+          );
+          return buildBloc(audioExtractionService: mockService);
+        },
+        seed: () => ClipEditorState(clips: [_createClipWithFile(id: 'b')]),
+        act: (bloc) => bloc
+          ..add(
+            const ClipEditorAudioExtractionRequested(
+              clipId: 'b',
+              clipTitle: 'Test',
+            ),
+          )
+          ..add(
+            const ClipEditorAudioExtractionRequested(
+              clipId: 'b',
+              clipTitle: 'Test',
+            ),
+          ),
+        wait: const Duration(milliseconds: 1),
+        verify: (bloc) {
+          expect(bloc.state.clips.single.volume, equals(0));
+          expect(bloc.state.extractedAudioClipIds, contains('b'));
+          // Extraction ran exactly once despite two queued requests.
+          verify(
+            () => mockService.extractAudio(
+              videoPath: any(named: 'videoPath'),
+              speed: any(named: 'speed'),
+            ),
+          ).called(1);
+        },
+      );
+
+      // A deliberate re-extraction after a manual un-mute must still run — the
+      // dedupe guard is lifted once the clip's volume is restored.
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        're-extracts after the clip is manually un-muted',
+        build: () {
+          when(
+            () => mockService.extractAudio(
+              videoPath: any(named: 'videoPath'),
+              speed: any(named: 'speed'),
+            ),
+          ).thenAnswer(
+            (_) async => const AudioExtractionResult(
+              audioFilePath: '/tmp/audio.m4a',
+              duration: 5,
+              fileSize: 12345,
+              sha256Hash: 'abc123',
+              mimeType: 'audio/mp4',
+            ),
+          );
+          return buildBloc(audioExtractionService: mockService);
+        },
+        seed: () => ClipEditorState(
+          clips: [_createClipWithFile(id: 'b')],
+          extractedAudioClipIds: const {'b'},
+        ),
+        act: (bloc) => bloc.add(
+          const ClipEditorAudioExtractionRequested(
+            clipId: 'b',
+            clipTitle: 'Test',
+          ),
+        ),
+        wait: const Duration(milliseconds: 1),
+        verify: (bloc) {
+          // 'b' seeded at default volume 1.0 (un-muted), so extraction runs
+          // even though it is already in extractedAudioClipIds.
+          expect(bloc.state.clips.single.volume, equals(0));
+          verify(
+            () => mockService.extractAudio(
+              videoPath: any(named: 'videoPath'),
               speed: any(named: 'speed'),
             ),
           ).called(1);

--- a/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls_test.dart
@@ -177,42 +177,116 @@ void main() {
       },
     );
 
-    // Regression test for Fix 2: Done button is disabled while audio
-    // extraction is running so the user cannot dismiss the busy state
-    // mid-flight. The result side effect itself lives on
-    // VideoEditorScaffold and survives even after this widget unmounts.
-    testWidgets(
-      'Done button passes null onDone to controls while isExtractingAudio',
-      (tester) async {
-        when(
-          () => bloc.state,
-        ).thenReturn(const ClipEditorState(isExtractingAudio: true));
-        await tester.pumpWidget(build());
-
-        final controls = tester.widget<VideoEditorTimelineControls>(
-          find.byType(VideoEditorTimelineControls),
-        );
-        expect(
-          controls.onDone,
-          isNull,
-          reason:
-              'onDone must be null while extracting so Done cannot be tapped',
-        );
-      },
-    );
-
-    testWidgets('Speed button is hidden while isExtractingAudio', (
+    // Done stays tappable during a render — leaving edit mode is safe because
+    // the extraction result is committed by an editor-session-level listener
+    // (VideoEditorScaffold) that survives these controls unmounting.
+    testWidgets('Done stays enabled and dispatches stop while extracting', (
       tester,
     ) async {
-      when(
-        () => bloc.state,
-      ).thenReturn(const ClipEditorState(isExtractingAudio: true));
+      when(() => bloc.state).thenReturn(
+        ClipEditorState(
+          clips: [clip('clip-1')],
+          isExtractingAudio: true,
+          extractingAudioClipId: 'clip-1',
+        ),
+      );
       await tester.pumpWidget(build());
 
       final controls = tester.widget<VideoEditorTimelineControls>(
         find.byType(VideoEditorTimelineControls),
       );
-      expect(controls.onSpeed, isNull);
+      expect(controls.onDone, isNotNull);
+
+      await tester.tap(find.byType(DivineIconButton).last);
+      await tester.pump();
+
+      verify(() => bloc.add(const ClipEditorEditingStopped())).called(1);
+    });
+
+    // Regression: the Speed action must stay mounted (disabled), not vanish,
+    // while the *current* clip's audio is extracting — the disappearing
+    // control confused users.
+    testWidgets(
+      "Speed stays mounted and is disabled while the current clip's audio "
+      'extracts',
+      (tester) async {
+        when(() => bloc.state).thenReturn(
+          ClipEditorState(
+            clips: [clip('clip-1'), clip('clip-2')],
+            isExtractingAudio: true,
+            extractingAudioClipId: 'clip-1',
+          ),
+        );
+        await tester.pumpWidget(build());
+
+        final controls = tester.widget<VideoEditorTimelineControls>(
+          find.byType(VideoEditorTimelineControls),
+        );
+        // Action stays wired; the child renders it disabled via
+        // isExtractingAudio.
+        expect(controls.onSpeed, isNotNull);
+        expect(controls.isExtractingAudio, isTrue);
+      },
+    );
+
+    // A render on a *different* clip must not block the current clip's Speed.
+    testWidgets(
+      "Speed stays enabled while a different clip's audio extracts",
+      (tester) async {
+        when(() => bloc.state).thenReturn(
+          ClipEditorState(
+            clips: [clip('clip-1'), clip('clip-2')],
+            currentClipIndex: 1,
+            isExtractingAudio: true,
+            extractingAudioClipId: 'clip-1',
+          ),
+        );
+        await tester.pumpWidget(build());
+
+        final controls = tester.widget<VideoEditorTimelineControls>(
+          find.byType(VideoEditorTimelineControls),
+        );
+        expect(controls.onSpeed, isNotNull);
+        expect(controls.isExtractingAudio, isFalse);
+      },
+    );
+
+    testWidgets('Split stays mounted and is disabled while splitting the '
+        'current clip', (tester) async {
+      when(() => bloc.state).thenReturn(
+        ClipEditorState(
+          clips: [clip('clip-1'), clip('clip-2')],
+          isSplitting: true,
+          splittingClipId: 'clip-1',
+        ),
+      );
+      await tester.pumpWidget(build());
+
+      final controls = tester.widget<VideoEditorTimelineControls>(
+        find.byType(VideoEditorTimelineControls),
+      );
+      expect(controls.onSplit, isNotNull);
+      expect(controls.isSplitting, isTrue);
+    });
+
+    testWidgets('Split stays enabled while a different clip splits', (
+      tester,
+    ) async {
+      when(() => bloc.state).thenReturn(
+        ClipEditorState(
+          clips: [clip('clip-1'), clip('clip-2')],
+          currentClipIndex: 1,
+          isSplitting: true,
+          splittingClipId: 'clip-1',
+        ),
+      );
+      await tester.pumpWidget(build());
+
+      final controls = tester.widget<VideoEditorTimelineControls>(
+        find.byType(VideoEditorTimelineControls),
+      );
+      expect(controls.onSplit, isNotNull);
+      expect(controls.isSplitting, isFalse);
     });
 
     testWidgets('Select button is hidden for a single clip', (tester) async {

--- a/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_controls_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_controls_test.dart
@@ -110,5 +110,111 @@ void main() {
 
       expect(transformCount, equals(1));
     });
+
+    testWidgets('keeps Split mounted but inert while isSplitting', (
+      tester,
+    ) async {
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      var splitCount = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: VideoEditorTimelineControls(
+              onSplit: () => splitCount++,
+              isSplitting: true,
+              onDone: () {},
+            ),
+          ),
+        ),
+      );
+
+      // Still on screen (disabled, not removed)...
+      expect(find.text(l10n.videoEditorSplitLabel), findsOneWidget);
+      // ...but tapping it does nothing.
+      await tester.tap(
+        find.bySemanticsLabel(l10n.videoEditorSplitSelectedClipSemanticLabel),
+      );
+      await tester.pump();
+      expect(splitCount, equals(0));
+    });
+
+    testWidgets('invokes onSplit when not splitting', (tester) async {
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      var splitCount = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: VideoEditorTimelineControls(
+              onSplit: () => splitCount++,
+              onDone: () {},
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(
+        find.bySemanticsLabel(l10n.videoEditorSplitSelectedClipSemanticLabel),
+      );
+      await tester.pump();
+      expect(splitCount, equals(1));
+    });
+
+    testWidgets('keeps Speed mounted but inert while isExtractingAudio', (
+      tester,
+    ) async {
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      var speedCount = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: VideoEditorTimelineControls(
+              onSpeed: () => speedCount++,
+              isExtractingAudio: true,
+              onDone: () {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text(l10n.videoEditorSpeedLabel), findsOneWidget);
+      await tester.tap(
+        find.bySemanticsLabel(l10n.videoEditorSetClipSpeedSemanticLabel),
+      );
+      await tester.pump();
+      expect(speedCount, equals(0));
+    });
+
+    testWidgets('invokes onSpeed when not extracting audio', (tester) async {
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      var speedCount = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: VideoEditorTimelineControls(
+              onSpeed: () => speedCount++,
+              onDone: () {},
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(
+        find.bySemanticsLabel(l10n.videoEditorSetClipSpeedSemanticLabel),
+      );
+      await tester.pump();
+      expect(speedCount, equals(1));
+    });
   });
 }


### PR DESCRIPTION
Closes #6004

## Description

The Split and Speed controls in the clip-editor toolbar were **removed** from the toolbar while a per-clip render (split / audio extraction) was in flight, which users found confusing — the control set visibly reshuffled mid-operation. This shows them **disabled** instead, and scopes the block to the affected clip so a render on a *different* clip no longer disables the current clip's actions.

Key changes:
- Track `splittingClipId` / `extractingAudioClipId` in `ClipEditorState` so the disable is per-clip (following the existing `reversingClipId` / `transformingClipId` pattern).
- Render Split/Speed disabled (not removed) via the shared `VideoEditorTimelineControls`.
- Don't gate **Done** during a render — leaving edit mode is safe because the extraction/split result is committed by a session-level listener in `VideoEditorScaffold`, so it survives these controls unmounting.
- Queue split & audio extraction on other clips (`droppable()` → `sequential()`) instead of silently dropping them. The two events now carry the target clip id (split also the cut position) so a queued op still targets the intended clip even if the selection changes while an earlier render runs.
- Re-read bloc state after the speed bottom sheet closes so a concurrent mute (e.g. an extraction on another clip finishing) isn't clobbered by a stale pre-`await` snapshot.

**Related Issue:** 

## Out of Scope

- True parallelism (running per-clip renders concurrently) — the queue is `sequential` (one native render at a time), matching the current single-render pipeline.
- Two known minor, undo-able edges are intentionally left: a rapid double-tap of Extract on a clip while another render is queued can enqueue a duplicate extraction; and a queued split on a clip *before* the current selection can shift the selection index by one. Fully closing these needs synchronous "pending" tracking (a `Set`-based state), deferred.

## Verification

- `flutter analyze` on the touched `lib`/`test` dirs — no issues.
- `flutter test` for the clip-editor bloc + both timeline-controls widget suites — all green (116 tests), including new regression tests asserting a queued split/extraction targets the clip named by the event, not the current selection.
- Not yet exercised in the running app — opening as a draft for manual verification.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)