### PR TITLE
fix(video-editor): keep timeline thumbnails stable across split renders and undo/redo

### DIFF
--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
@@ -611,6 +611,9 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
             duration: clip.duration,
             trimStart: clip.trimStart,
             trimEnd: clip.trimEnd,
+            // The rendered end half's file starts at the split point \u2014 carry
+            // the shift so the thumbnail raster stays recording-anchored.
+            sourceStartOffset: clip.sourceStartOffset,
           );
           emit(state.copyWith(clips: List.unmodifiable(newClips)));
           Log.debug(

--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
@@ -892,6 +892,14 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
         reversedVideoPath = renderedPath ?? currentClip.reversedVideoPath;
       }
 
+      // Un-reversing via render produces a fresh mirror file with no
+      // recording continuity, and any stored sourceStartOffset was
+      // accumulated in reversed-file coordinates (splitting a reversed clip
+      // adds the split position to it) — keeping it would phase-shift the
+      // forward clip's thumbnail raster by a meaningless amount. Zero it so
+      // the raster anchors at the new file's start. Reversing forward →
+      // reversed keeps the offset: it pairs with the forward file cached in
+      // [forwardVideoPath], which the cached un-reverse branch restores.
       final updatedClip = currentClip.copyWith(
         video: reversedVideo,
         trimStart: currentClip.trimEnd,
@@ -899,6 +907,7 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
         reversed: !clip.reversed,
         forwardVideoPath: forwardVideoPath,
         reversedVideoPath: reversedVideoPath,
+        sourceStartOffset: clip.reversed ? Duration.zero : null,
       );
       final newClips = List<DivineVideoClip>.of(currentClips)
         ..[currentIndex] = updatedClip;

--- a/mobile/lib/models/divine_video_clip.dart
+++ b/mobile/lib/models/divine_video_clip.dart
@@ -28,6 +28,7 @@ class DivineVideoClip {
     this.ghostFramePath,
     this.trimStart = Duration.zero,
     this.trimEnd = Duration.zero,
+    this.sourceStartOffset = Duration.zero,
     this.volume = 1,
     this.playbackSpeed,
     this.reversed = false,
@@ -68,6 +69,14 @@ class DivineVideoClip {
 
   /// How much has been trimmed from the end of the clip.
   final Duration trimEnd;
+
+  /// Where this clip's video file starts within the original source
+  /// recording it was cut from. `Duration.zero` for clips whose file *is*
+  /// the original recording; a split render sets it on the end half (its
+  /// file starts at the split point) so downstream consumers — notably the
+  /// timeline thumbnail raster — can stay anchored to the original
+  /// recording's timeline instead of re-anchoring at the new file's zero.
+  final Duration sourceStartOffset;
 
   /// Playback volume for this clip, between 0 (muted) and 1 (full volume).
   final double volume;
@@ -196,6 +205,7 @@ class DivineVideoClip {
     String? ghostFramePath,
     Duration? trimStart,
     Duration? trimEnd,
+    Duration? sourceStartOffset,
     double? volume,
     double? playbackSpeed,
     bool clearPlaybackSpeed = false,
@@ -229,6 +239,7 @@ class DivineVideoClip {
       ghostFramePath: ghostFramePath ?? this.ghostFramePath,
       trimStart: trimStart ?? this.trimStart,
       trimEnd: trimEnd ?? this.trimEnd,
+      sourceStartOffset: sourceStartOffset ?? this.sourceStartOffset,
       volume: volume ?? this.volume,
       playbackSpeed: clearPlaybackSpeed
           ? null
@@ -274,6 +285,8 @@ class DivineVideoClip {
           : null,
       'trimStartMs': trimStart.inMilliseconds,
       'trimEndMs': trimEnd.inMilliseconds,
+      if (sourceStartOffset > Duration.zero)
+        'sourceStartOffsetMs': sourceStartOffset.inMilliseconds,
       'volume': volume,
       if (playbackSpeed != null) 'playbackSpeed': playbackSpeed,
       if (reversed) 'reversed': true,
@@ -353,6 +366,9 @@ class DivineVideoClip {
       ),
       trimStart: Duration(milliseconds: (json['trimStartMs'] as int?) ?? 0),
       trimEnd: Duration(milliseconds: (json['trimEndMs'] as int?) ?? 0),
+      sourceStartOffset: Duration(
+        milliseconds: (json['sourceStartOffsetMs'] as int?) ?? 0,
+      ),
       volume: (json['volume'] as num?)?.toDouble() ?? 1,
       playbackSpeed: (json['playbackSpeed'] as num?)?.toDouble(),
       reversed: (json['reversed'] as bool?) ?? false,

--- a/mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart
@@ -181,14 +181,20 @@ class _VideoMetadataCoverScreenState
           thumbsPerSecond: thumbsPerSecond,
           priorityTimestamps: slotTimestamps,
           batchSize: 10,
-        ).listen((thumbnails) {
-          for (final t in thumbnails) {
-            _allStripThumbnailPaths.add(t.path);
-          }
-          if (mounted) {
-            setState(() => _stripThumbnails = thumbnails);
-          }
-        });
+        ).listen(
+          (thumbnails) {
+            for (final t in thumbnails) {
+              _allStripThumbnailPaths.add(t.path);
+            }
+            if (mounted) {
+              setState(() => _stripThumbnails = thumbnails);
+            }
+          },
+          // A mid-stream extraction failure is already logged by the
+          // service; keep the batches that arrived so the strip stays
+          // usable for cover selection.
+          onError: (Object _, StackTrace _) {},
+        );
   }
 
   Future<void> _seekTo(Duration position) async {

--- a/mobile/lib/services/video_editor/clip_thumbnail_manager.dart
+++ b/mobile/lib/services/video_editor/clip_thumbnail_manager.dart
@@ -53,6 +53,17 @@ class ClipThumbnailManager {
   // zero-based), the same shift is applied here so the frames stay
   // aligned until fresh thumbnails replace them.
   final Map<String, Duration> _pendingRebase = {};
+  // IDs whose subscription has delivered its final batch — the strip is at
+  // full density and only a source-file change warrants re-extraction.
+  final Set<String> _complete = {};
+  // Strips of recently removed clips, kept (files included) for an instant
+  // restore when the same id returns — undo re-adds the pre-split clip,
+  // redo re-adds the split halves. Without this the returning clip starts
+  // with an empty notifier: every slot falls back to the poster frame and
+  // the whole strip re-extracts from scratch. Insertion-ordered for FIFO
+  // eviction.
+  final Map<String, _RetiredStrip> _retired = {};
+  static const _maxRetiredStrips = 8;
 
   /// When true, newly started subscriptions begin paused and existing ones are
   /// held. See [pauseAll].
@@ -76,31 +87,74 @@ class ClipThumbnailManager {
   }) {
     final currentIds = clips.map((c) => c.id).toSet();
 
-    // Remove stale entries.
+    // Retire stale entries — the strip is kept for an instant restore if
+    // the id returns (undo re-adds the pre-split clip, redo the halves).
     final staleIds = _notifiers.keys
         .where((id) => !currentIds.contains(id))
         .toList();
     for (final id in staleIds) {
       _subscriptions.remove(id)?.cancel();
-      _videoPaths.remove(id);
-      _seeded.remove(id);
+      final videoPath = _videoPaths.remove(id);
+      final wasSeeded = _seeded.remove(id);
       _pendingRebase.remove(id);
+      final wasComplete = _complete.remove(id);
       final notifier = _notifiers.remove(id);
-      if (notifier != null) {
-        // Files borrowed by seeded clips (split halves) stay alive; only
-        // files no other notifier references are deleted.
-        _deleteUnreferencedFiles(notifier.value);
-        notifier.dispose();
+      if (notifier == null) continue;
+      final frames = notifier.value;
+      notifier.dispose();
+      // Seeded strips are not retired: their frames are borrowed from the
+      // (retired) source strip and carry a pending rebase that is lost
+      // here — restoring them later would misalign timestamps. The
+      // unreferenced check keeps the borrowed files alive through the
+      // source's retired entry.
+      if (frames.isEmpty || videoPath == null || wasSeeded) {
+        _deleteUnreferencedFiles(frames);
+        continue;
       }
+      _retire(
+        id,
+        _RetiredStrip(
+          videoPath: videoPath,
+          frames: frames,
+          complete: wasComplete,
+        ),
+      );
     }
 
     // Ensure notifiers exist and start (or restart) loading.
     for (final clip in clips) {
-      _notifiers.putIfAbsent(clip.id, () => ValueNotifier(const []));
+      final notifier = _notifiers.putIfAbsent(
+        clip.id,
+        () => ValueNotifier(const []),
+      );
       final newPath = clip.video.file?.path;
-      final currentPath = _videoPaths[clip.id];
       final hasSubscription = _subscriptions.containsKey(clip.id);
       final isSeeded = _seeded.contains(clip.id);
+
+      // Instant restore for a returning clip id (undo/redo): reuse the
+      // retired strip instead of flashing posters and re-extracting.
+      if (!hasSubscription && !isSeeded && notifier.value.isEmpty) {
+        final retired = _retired.remove(clip.id);
+        if (retired != null) {
+          if (newPath != null && newPath == retired.videoPath) {
+            notifier.value = retired.frames;
+            _videoPaths[clip.id] = newPath;
+            if (retired.complete) {
+              _complete.add(clip.id);
+              continue;
+            }
+            // Partial strip (removed mid-extraction): fall through so a
+            // fresh subscription fills the gaps — the restored frames
+            // stay visible as gap-fillers via the batch merge.
+          } else {
+            // Same id but a different source file — the frames would show
+            // stale content, so drop them (borrowed files stay protected).
+            _deleteUnreferencedFiles(retired.frames);
+          }
+        }
+      }
+
+      final currentPath = _videoPaths[clip.id];
 
       if (!hasSubscription) {
         if (isSeeded) {
@@ -109,10 +163,15 @@ class ClipThumbnailManager {
           if (newPath == null || newPath == currentPath) continue;
           // The rendered (trimmed) file path arrived — start the real
           // subscription. The seeded frames stay visible (rebased into
-          // the rendered file's timebase where needed) until the first
-          // fresh batch replaces them; their files are deleted then.
+          // the rendered file's timebase where needed) until fresh
+          // frames cover their spots; their files are deleted then.
           _seeded.remove(clip.id);
           _rebaseThumbnails(clip.id);
+        } else if (_complete.contains(clip.id)) {
+          // Restored from the retired cache at full density — only a
+          // source-file change warrants re-extraction.
+          if (newPath == null || newPath == currentPath) continue;
+          _complete.remove(clip.id);
         }
         _loadThumbnails(
           clip,
@@ -124,7 +183,9 @@ class ClipThumbnailManager {
         // re-rendered to a trimmed file). Restart against the new file
         // but keep the current frames on screen — clearing them here
         // would flash black until the first fresh batch arrives. The old
-        // files are deleted once the new subscription replaces them.
+        // frames are merged out progressively as fresh batches cover
+        // their spots (see [_mergeCarriedFrames]); their files are
+        // deleted as they drop out.
         //
         // Seeded split halves never reach this branch: they carry no
         // subscription until their rendered path arrives via the
@@ -157,7 +218,8 @@ class ClipThumbnailManager {
   /// — that would overwrite these correct frames with the wrong
   /// range. The real subscription starts once the rendered file
   /// path arrives via the path-change branch in [sync]; the seeded
-  /// frames stay visible until its first batch lands.
+  /// frames stay visible as gap-fillers until fresh frames cover
+  /// their spots (see [_mergeCarriedFrames]).
   ///
   /// [rebaseOnPathChange] is subtracted from every seeded timestamp
   /// when the rendered file path arrives. Use it when the rendered
@@ -227,6 +289,7 @@ class ClipThumbnailManager {
     if (videoPath == null) return;
 
     _videoPaths[clip.id] = videoPath;
+    _complete.remove(clip.id);
 
     final outputSize = Size(
       TimelineConstants.thumbnailWidth * devicePixelRatio,
@@ -240,6 +303,16 @@ class ClipThumbnailManager {
                 TimelineConstants.thumbnailWidth)
             .ceil();
 
+    // A carried frame (seeded split frame, pre-restart frame) is kept as a
+    // gap-filler until a fresh frame lands within half the generator's final
+    // frame spacing — at full density every spot is covered, so all carried
+    // frames are pruned by then (the onDone sweep catches any residue).
+    final keepDistance = Duration(
+      milliseconds: (1000 / thumbsPerSecond / 2).round(),
+    );
+    // Latest accumulated fresh batch, for the onDone carried-frame sweep.
+    var latestFresh = const <StripThumbnail>[];
+
     final subscription =
         _generateStripThumbnails(
           videoPath: videoPath,
@@ -248,29 +321,108 @@ class ClipThumbnailManager {
           outputSize: outputSize,
           thumbsPerSecond: thumbsPerSecond,
           priorityTimestamps: priorityTimestamps,
-        ).listen((thumbnails) {
-          final notifier = _notifiers[clip.id];
-          if (notifier == null) return;
-          final replaced = notifier.value;
-          notifier.value = thumbnails;
-          if (replaced.isEmpty) return;
-          // Frames carried over across a restart (seeded split frames,
-          // pre-render frames) are superseded now — delete their files
-          // unless another clip still shows them. Each batch is a
-          // superset of the previous (the generator accumulates), so in
-          // steady state every replaced path is still in [thumbnails];
-          // filtering to the genuinely dropped paths first skips the
-          // cross-notifier scan on every normal accumulation batch.
-          final currentPaths = {for (final thumb in thumbnails) thumb.path};
-          _deleteUnreferencedFiles([
-            for (final thumb in replaced)
-              if (!currentPaths.contains(thumb.path)) thumb,
-          ]);
-        });
+        ).listen(
+          (thumbnails) {
+            latestFresh = thumbnails;
+            final notifier = _notifiers[clip.id];
+            if (notifier == null) return;
+            final replaced = notifier.value;
+            // Merge instead of replacing wholesale: early batches are sparse
+            // (a handful of frames), while the carried frames are dense.
+            // Dropping the carried frames here would collapse the strip to a
+            // few frames + poster fallbacks and visibly reshuffle it while
+            // batches stream in (worst after a split, where the carried
+            // frames already show the correct content).
+            final merged = _mergeCarriedFrames(
+              fresh: thumbnails,
+              previous: replaced,
+              clipDuration: clip.duration,
+              keepDistance: keepDistance,
+            );
+            notifier.value = merged;
+            if (replaced.isEmpty) return;
+            // Delete files of frames that dropped out of the merged strip,
+            // unless another clip still shows them.
+            final currentPaths = {for (final thumb in merged) thumb.path};
+            _deleteUnreferencedFiles([
+              for (final thumb in replaced)
+                if (!currentPaths.contains(thumb.path)) thumb,
+            ]);
+          },
+          onDone: () {
+            final notifier = _notifiers[clip.id];
+            if (notifier == null || latestFresh.isEmpty) return;
+            _complete.add(clip.id);
+            // Long clips cap the generator's frame count, so the final
+            // spacing can exceed [keepDistance] and leave carried frames
+            // behind — sweep them now that the fresh set is complete.
+            final freshPaths = {for (final thumb in latestFresh) thumb.path};
+            final dropped = [
+              for (final thumb in notifier.value)
+                if (!freshPaths.contains(thumb.path)) thumb,
+            ];
+            if (dropped.isEmpty) return;
+            notifier.value = latestFresh;
+            _deleteUnreferencedFiles(dropped);
+          },
+        );
     // If the owner paused while this clip was (re)synced, keep the new
     // subscription paused too so it doesn't start extracting off-screen.
     if (_paused) subscription.pause();
     _subscriptions[clip.id] = subscription;
+  }
+
+  /// Merges carried-over frames into a fresh accumulated batch.
+  ///
+  /// Fresh frames win; a carried frame from [previous] survives only while
+  /// its timestamp is inside the clip and no fresh frame sits within
+  /// [keepDistance] of it. As batches accumulate, fresh frames blanket the
+  /// timeline and the carried set shrinks to empty on its own.
+  static List<StripThumbnail> _mergeCarriedFrames({
+    required List<StripThumbnail> fresh,
+    required List<StripThumbnail> previous,
+    required Duration clipDuration,
+    required Duration keepDistance,
+  }) {
+    if (previous.isEmpty) return fresh;
+    if (fresh.isEmpty) return previous;
+    final freshPaths = {for (final thumb in fresh) thumb.path};
+    final carried = <StripThumbnail>[
+      for (final thumb in previous)
+        if (!freshPaths.contains(thumb.path) &&
+            thumb.timestamp >= Duration.zero &&
+            thumb.timestamp <= clipDuration &&
+            !_hasFrameNear(fresh, thumb.timestamp, keepDistance))
+          thumb,
+    ];
+    if (carried.isEmpty) return fresh;
+    final merged = [...fresh, ...carried]
+      ..sort((a, b) => a.timestamp.compareTo(b.timestamp));
+    return List.unmodifiable(merged);
+  }
+
+  /// Whether [frames] (sorted by timestamp) contains a frame within
+  /// [distance] of [timestamp].
+  static bool _hasFrameNear(
+    List<StripThumbnail> frames,
+    Duration timestamp,
+    Duration distance,
+  ) {
+    var lo = 0;
+    var hi = frames.length;
+    while (lo < hi) {
+      final mid = (lo + hi) ~/ 2;
+      if (frames[mid].timestamp < timestamp) {
+        lo = mid + 1;
+      } else {
+        hi = mid;
+      }
+    }
+    if (lo < frames.length &&
+        (frames[lo].timestamp - timestamp).abs() <= distance) {
+      return true;
+    }
+    return lo > 0 && (timestamp - frames[lo - 1].timestamp).abs() <= distance;
   }
 
   /// Pauses all in-flight thumbnail subscriptions — e.g. while the editor is
@@ -292,15 +444,31 @@ class ClipThumbnailManager {
     }
   }
 
+  /// Parks a removed clip's strip in the retired cache, evicting the
+  /// oldest entries beyond [_maxRetiredStrips]. Evicted files are only
+  /// deleted when nothing else references them.
+  void _retire(String clipId, _RetiredStrip strip) {
+    _retired
+      ..remove(clipId)
+      ..[clipId] = strip;
+    while (_retired.length > _maxRetiredStrips) {
+      final evicted = _retired.remove(_retired.keys.first);
+      if (evicted != null) _deleteUnreferencedFiles(evicted.frames);
+    }
+  }
+
   /// Deletes the files of [thumbnails] that no current notifier value
-  /// references anymore. Seeded clips borrow the source clip's files,
-  /// so a plain delete would pull decoded frames out from under a
-  /// live tile.
+  /// and no retired strip references anymore. Seeded clips borrow the
+  /// source clip's files, so a plain delete would pull decoded frames
+  /// out from under a live tile; retired strips keep borrowing them
+  /// for undo/redo restores.
   void _deleteUnreferencedFiles(List<StripThumbnail> thumbnails) {
     if (thumbnails.isEmpty) return;
     final live = <String>{
       for (final notifier in _notifiers.values)
         for (final thumbnail in notifier.value) thumbnail.path,
+      for (final strip in _retired.values)
+        for (final thumbnail in strip.frames) thumbnail.path,
     };
     for (final thumb in thumbnails) {
       if (live.contains(thumb.path)) continue;
@@ -327,12 +495,36 @@ class ClipThumbnailManager {
       _deleteFiles(notifier.value);
       notifier.dispose();
     }
+    for (final strip in _retired.values) {
+      _deleteFiles(strip.frames);
+    }
     _subscriptions.clear();
     _notifiers.clear();
     _videoPaths.clear();
     _seeded.clear();
     _pendingRebase.clear();
+    _complete.clear();
+    _retired.clear();
   }
+}
+
+/// A removed clip's strip, parked for an instant restore when the same
+/// clip id returns with the same source file (undo/redo).
+class _RetiredStrip {
+  const _RetiredStrip({
+    required this.videoPath,
+    required this.frames,
+    required this.complete,
+  });
+
+  /// Source video path the frames were extracted from (or borrowed for).
+  final String videoPath;
+
+  final List<StripThumbnail> frames;
+
+  /// Whether the strip's subscription had delivered its final batch, i.e.
+  /// the frames are at full density and need no re-extraction on restore.
+  final bool complete;
 }
 
 /// Inclusive-exclusive duration range `[start, end)`.

--- a/mobile/lib/services/video_editor/clip_thumbnail_manager.dart
+++ b/mobile/lib/services/video_editor/clip_thumbnail_manager.dart
@@ -312,6 +312,9 @@ class ClipThumbnailManager {
     );
     // Latest accumulated fresh batch, for the onDone carried-frame sweep.
     var latestFresh = const <StripThumbnail>[];
+    // Set when the generator hits a native extraction failure mid-stream:
+    // the stream errors and closes with only a partial set delivered.
+    var truncated = false;
 
     final subscription =
         _generateStripThumbnails(
@@ -349,9 +352,16 @@ class ClipThumbnailManager {
                 if (!currentPaths.contains(thumb.path)) thumb,
             ]);
           },
+          onError: (Object error, StackTrace stackTrace) {
+            // Already logged by the generator. Marking the truncation is
+            // enough: the onDone below then keeps the carried gap-fillers
+            // and leaves the clip un-complete, so a later retire/restore
+            // starts a fresh subscription that fills the missing frames.
+            truncated = true;
+          },
           onDone: () {
             final notifier = _notifiers[clip.id];
-            if (notifier == null || latestFresh.isEmpty) return;
+            if (notifier == null || truncated || latestFresh.isEmpty) return;
             _complete.add(clip.id);
             // Long clips cap the generator's frame count, so the final
             // spacing can exceed [keepDistance] and leave carried frames

--- a/mobile/lib/services/video_editor/video_editor_split_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_split_service.dart
@@ -104,9 +104,14 @@ class VideoEditorSplitService {
       trimStart: absoluteSplitPos,
       processingCompleter: Completer<bool>(),
     );
+    // The rendered end file starts at the split point, so its zero-based
+    // timeline sits absoluteSplitPos into the source recording. Recording
+    // that shift keeps the timeline thumbnail raster anchored to the
+    // original recording (no visible frame shift when the render lands).
     final renderedEndClip = previewEndClip.copyWith(
       duration: sourceClip.duration - absoluteSplitPos,
       trimStart: Duration.zero,
+      sourceStartOffset: sourceClip.sourceStartOffset + absoluteSplitPos,
     );
 
     final documentsPath = await getDocumentsPath();

--- a/mobile/lib/services/video_thumbnail_service.dart
+++ b/mobile/lib/services/video_thumbnail_service.dart
@@ -545,6 +545,11 @@ class VideoThumbnailService {
   ///
   /// Each yield contains the **accumulated** list so far, allowing the
   /// caller to simply replace its current list on each event.
+  ///
+  /// If native extraction fails mid-stream, the stream emits the error and
+  /// closes. Batches already delivered stay valid, but the set is truncated
+  /// — listeners must not treat a stream that errored as having reached full
+  /// density.
   static Stream<List<StripThumbnail>> generateStripThumbnails({
     required String videoPath,
     required String clipId,
@@ -654,7 +659,11 @@ class VideoThumbnailService {
           name: 'VideoThumbnailService',
           category: LogCategory.video,
         );
-        break;
+        // Surface the failure as a stream error instead of closing the
+        // stream normally — listeners must be able to tell a truncated set
+        // apart from a complete one (a silent close made partial strips
+        // look final and dropped their gap-filler frames).
+        rethrow;
       }
 
       for (var i = 0; i < bytes.length && i < batchTimestamps.length; i++) {

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
@@ -301,13 +301,27 @@ class _VideoEditorTimelineClipStripState
       final visibleMs = (visibleEnd - visibleStart).inMilliseconds;
       if (clipPx <= 0 || visibleMs <= 0) continue;
 
-      final slotCount = (clipPx / TimelineConstants.thumbnailWidth)
-          .ceil()
-          .clamp(1, 1000);
+      // Mirror the tile's recording-anchored slot raster (fixed pitch,
+      // phase-shifted by sourceStartOffset) so the priority frames land on
+      // the exact window centers the visible slots will look up.
+      final speed = clip.playbackSpeed ?? 1.0;
+      final spanMs =
+          TimelineConstants.thumbnailWidth *
+          1000 *
+          (speed > 0 ? speed : 1.0) /
+          widget.pixelsPerSecond;
+      final phaseMs = clip.sourceStartOffset.inMilliseconds % spanMs;
+      final startMs = visibleStart.inMilliseconds;
+      final endMs = visibleEnd.inMilliseconds;
+      final firstSlot = ((startMs + phaseMs) / spanMs).floor();
       final timestamps = <Duration>[];
-      for (var i = 0; i < slotCount; i++) {
-        final centerMs =
-            visibleStart.inMilliseconds + visibleMs * (i + 0.5) / slotCount;
+      for (var m = firstSlot; timestamps.length < 1000; m++) {
+        final slotStartMs = m * spanMs - phaseMs;
+        if (slotStartMs >= endMs) break;
+        final centerMs = (slotStartMs + spanMs / 2).clamp(
+          startMs.toDouble(),
+          endMs.toDouble() - 1,
+        );
         timestamps.add(Duration(milliseconds: centerMs.round()));
       }
       result[clip.id] = timestamps;

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
@@ -310,7 +310,7 @@ class _VideoEditorTimelineClipStripState
           1000 *
           (speed > 0 ? speed : 1.0) /
           widget.pixelsPerSecond;
-      final phaseMs = clip.sourceStartOffset.inMilliseconds % spanMs;
+      final phaseMs = _rasterAnchorOffset(clip).inMilliseconds % spanMs;
       final startMs = visibleStart.inMilliseconds;
       final endMs = visibleEnd.inMilliseconds;
       final firstSlot = ((startMs + phaseMs) / spanMs).floor();

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_tiles.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_tiles.dart
@@ -15,6 +15,16 @@ extension _DivineVideoClipTimelineScale on DivineVideoClip {
   }
 }
 
+/// Raster anchor offset for [clip]'s thumbnail slot grid.
+///
+/// Reversed clips return zero: reversing keeps [DivineVideoClip
+/// .sourceStartOffset] (it survives `copyWith`), but the reversed file is
+/// physically mirrored — there is no recording continuity to preserve, so
+/// the raster stays file-anchored instead of phase-shifting by the stale
+/// offset.
+Duration _rasterAnchorOffset(DivineVideoClip clip) =>
+    clip.reversed ? Duration.zero : clip.sourceStartOffset;
+
 /// How far (in px) the clip's thumbnail slot grid is shifted left so its
 /// grid lines stay glued to the *original recording's* timeline.
 ///
@@ -29,7 +39,7 @@ double _rasterPhasePx(DivineVideoClip clip, double contentWidth) {
   final durationMs = clip.duration.inMilliseconds;
   if (durationMs <= 0 || contentWidth <= 0) return 0;
   final offsetPx =
-      clip.sourceStartOffset.inMilliseconds * contentWidth / durationMs;
+      _rasterAnchorOffset(clip).inMilliseconds * contentWidth / durationMs;
   return offsetPx % TimelineConstants.thumbnailWidth;
 }
 

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_tiles.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_tiles.dart
@@ -15,6 +15,24 @@ extension _DivineVideoClipTimelineScale on DivineVideoClip {
   }
 }
 
+/// How far (in px) the clip's thumbnail slot grid is shifted left so its
+/// grid lines stay glued to the *original recording's* timeline.
+///
+/// A split's rendered end half starts [DivineVideoClip.sourceStartOffset]
+/// into the recording; without this phase the grid would re-anchor at the
+/// new file's zero and every frame in the tile would visibly jump by up to
+/// one slot when the render lands. The same phase shifts the slot windows
+/// (in [_ClipContainer]) and the tile's content translation (in
+/// [_ClipTile]), which together keep each frame's on-screen position
+/// exactly invariant across the preview → rendered swap.
+double _rasterPhasePx(DivineVideoClip clip, double contentWidth) {
+  final durationMs = clip.duration.inMilliseconds;
+  if (durationMs <= 0 || contentWidth <= 0) return 0;
+  final offsetPx =
+      clip.sourceStartOffset.inMilliseconds * contentWidth / durationMs;
+  return offsetPx % TimelineConstants.thumbnailWidth;
+}
+
 class _TrimmableClipTile extends StatefulWidget {
   const _TrimmableClipTile({
     required this.clip,
@@ -346,6 +364,9 @@ class _ClipTile extends StatelessWidget {
           // thumbnail count — never changes during the reorder animation so
           // thumbnails don't swap content while the tile shrinks/grows.
           final displayWidth = math.max(fullWidth, constraints.maxWidth);
+          // Shift content by the raster phase in lockstep with the slot
+          // windows so frames keep their recording-anchored positions.
+          final phasePx = _rasterPhasePx(clip, fullWidth);
           return SizedBox(
             width: displayWidth,
             height: TimelineConstants.thumbnailStripHeight,
@@ -354,7 +375,7 @@ class _ClipTile extends StatelessWidget {
                 maxWidth: double.infinity,
                 alignment: Alignment.centerLeft,
                 child: Transform.translate(
-                  offset: Offset(-trimStartOffset, 0),
+                  offset: Offset(-trimStartOffset - phasePx, 0),
                   child: ValueListenableBuilder<List<StripThumbnail>>(
                     valueListenable: thumbnailNotifier,
                     builder: (context, stripThumbnails, _) {
@@ -466,11 +487,27 @@ class _ClipContainer extends StatelessWidget {
   final List<StripThumbnail> stripThumbnails;
 
   int get _thumbnailCount {
-    final natural = (contentWidth / TimelineConstants.thumbnailWidth).ceil();
+    // The raster phase shifts every slot left, so one extra slot may be
+    // needed to keep the tile's right edge covered.
+    final natural =
+        ((contentWidth + _rasterPhasePx(clip, contentWidth)) /
+                TimelineConstants.thumbnailWidth)
+            .ceil();
     // Keep visual slot count independent from loading progress so the strip
     // does not collapse to a single slot while thumbnails are still streaming in.
     return natural.clamp(1, 1000);
   }
+
+  /// Time (in ms) one [TimelineConstants.thumbnailWidth]-wide slot covers.
+  ///
+  /// The window pitch matches the slot box pitch exactly, so a frame's
+  /// on-screen position is linear in its timestamp — the `duration/count`
+  /// pitch used previously was slightly narrower than a box (ceil rounding),
+  /// drifting frames rightward toward the tile's end.
+  double get _slotSpanMs =>
+      TimelineConstants.thumbnailWidth *
+      clip.duration.inMilliseconds /
+      contentWidth;
 
   /// Maps a visual slot index to a [StripThumbnail] path that falls
   /// within the slot's time range.
@@ -480,15 +517,23 @@ class _ClipContainer extends StatelessWidget {
   /// This guarantees a slot never changes its image once a matching
   /// thumbnail has been loaded — new thumbnails for *other* slots
   /// don't cause a reassignment.
+  ///
+  /// Windows are anchored to the original recording's timeline (shifted by
+  /// the raster phase, see [_rasterPhasePx]), so a split render landing —
+  /// which rebases the clip's file timeline — never re-buckets frames.
   String? _thumbnailForSlot(int slotIndex, int slotCount) {
     if (stripThumbnails.isEmpty) return null;
 
     final durationMs = clip.duration.inMilliseconds;
     if (durationMs <= 0) return stripThumbnails.first.path;
 
-    // Fixed time window for this slot.
-    final slotStartMs = durationMs * slotIndex / slotCount;
-    final slotEndMs = durationMs * (slotIndex + 1) / slotCount;
+    final spanMs = _slotSpanMs;
+    final phaseMs =
+        _rasterPhasePx(clip, contentWidth) * durationMs / contentWidth;
+
+    // Fixed, recording-anchored time window for this slot.
+    final slotStartMs = slotIndex * spanMs - phaseMs;
+    final slotEndMs = (slotIndex + 1) * spanMs - phaseMs;
     final slotCenterMs = (slotStartMs + slotEndMs) / 2;
 
     // Binary search for the first thumbnail at or after slotStartMs.

--- a/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
@@ -1556,6 +1556,76 @@ void main() {
         },
       );
 
+      // Splitting a reversed clip accumulates sourceStartOffset in
+      // reversed-file coordinates and clears both cache paths, so
+      // un-reversing goes through the render path. The fresh forward mirror
+      // has no recording continuity — keeping the stale offset would
+      // phase-shift its thumbnail raster by a meaningless amount.
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'zeroes sourceStartOffset when un-reversing renders a fresh '
+        'forward file',
+        build: () => buildBloc(reverseClip: _fakeReverseClip),
+        seed: () => ClipEditorState(
+          clips: [
+            _createClipWithFile().copyWith(
+              video: EditorVideo.file('/path/clip-local-reversed.mp4'),
+              reversed: true,
+              sourceStartOffset: const Duration(milliseconds: 1300),
+            ),
+          ],
+        ),
+        act: (bloc) => bloc.add(
+          const ClipEditorClipReverseRequested(clipId: 'clip-local'),
+        ),
+        expect: () => [
+          isA<ClipEditorState>().having(
+            (s) => s.isReversing,
+            'isReversing',
+            isTrue,
+          ),
+          isA<ClipEditorState>()
+              .having((s) => s.clips.first.reversed, 'reversed', isFalse)
+              .having(
+                (s) => s.clips.first.sourceStartOffset,
+                'sourceStartOffset',
+                Duration.zero,
+              ),
+        ],
+      );
+
+      // The offset pairs with the forward file cached as forwardVideoPath:
+      // the cached un-reverse branch restores that file with the clip's
+      // current offset, so a forward → reversed render must keep it.
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'keeps sourceStartOffset when reversing a forward clip so the '
+        'cached un-reverse restores the forward file anchored correctly',
+        build: () => buildBloc(reverseClip: _fakeReverseClip),
+        seed: () => ClipEditorState(
+          clips: [
+            _createClipWithFile().copyWith(
+              sourceStartOffset: const Duration(milliseconds: 1300),
+            ),
+          ],
+        ),
+        act: (bloc) => bloc.add(
+          const ClipEditorClipReverseRequested(clipId: 'clip-local'),
+        ),
+        expect: () => [
+          isA<ClipEditorState>().having(
+            (s) => s.isReversing,
+            'isReversing',
+            isTrue,
+          ),
+          isA<ClipEditorState>()
+              .having((s) => s.clips.first.reversed, 'reversed', isTrue)
+              .having(
+                (s) => s.clips.first.sourceStartOffset,
+                'sourceStartOffset',
+                const Duration(milliseconds: 1300),
+              ),
+        ],
+      );
+
       blocTest<ClipEditorBloc, ClipEditorState>(
         'emits failure result and reports unexpected errors when the reverse '
         'render throws',

--- a/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
@@ -142,6 +142,7 @@ Future<void> _fakeSplitClipThenRenderEnd({
   final renderedEndClip = previewEndClip.copyWith(
     duration: sourceClip.duration - absoluteSplitPos,
     trimStart: Duration.zero,
+    sourceStartOffset: sourceClip.sourceStartOffset + absoluteSplitPos,
   );
   onClipsCreated?.call(startClip, previewEndClip);
   onClipRendered?.call(startClip, startClip.video);
@@ -741,6 +742,13 @@ void main() {
           expect(endClip.duration, const Duration(milliseconds: 1500));
           expect(endClip.trimStart, Duration.zero);
           expect(endClip.trimmedDuration, const Duration(milliseconds: 1500));
+          // The rendered end file starts at the split point — the offset
+          // must reach the state clip, or the thumbnail raster re-anchors
+          // and the strip's frames visibly shift when the render lands.
+          expect(
+            endClip.sourceStartOffset,
+            const Duration(milliseconds: 500),
+          );
 
           await bloc.close();
         },

--- a/mobile/test/models/divine_video_clip_test.dart
+++ b/mobile/test/models/divine_video_clip_test.dart
@@ -40,4 +40,41 @@ void main() {
       );
     });
   });
+
+  group('DivineVideoClip.sourceStartOffset', () {
+    test('defaults to zero and survives copyWith', () {
+      final original = clip('/videos/clip.mp4');
+      expect(original.sourceStartOffset, equals(Duration.zero));
+
+      final shifted = original.copyWith(
+        sourceStartOffset: const Duration(seconds: 3),
+      );
+      expect(shifted.sourceStartOffset, equals(const Duration(seconds: 3)));
+
+      // Unrelated copyWith calls (e.g. the render swapping the video file)
+      // must not reset the offset — losing it re-anchors the timeline
+      // thumbnail raster and visibly shifts the strip.
+      final trimmed = shifted.copyWith(trimStart: const Duration(seconds: 1));
+      expect(trimmed.sourceStartOffset, equals(const Duration(seconds: 3)));
+    });
+
+    test('round-trips through JSON and defaults to zero when absent', () {
+      final shifted = clip('/videos/clip.mp4').copyWith(
+        sourceStartOffset: const Duration(milliseconds: 3210),
+      );
+
+      final restored = DivineVideoClip.fromJson(shifted.toJson(), '/videos');
+      expect(
+        restored.sourceStartOffset,
+        equals(const Duration(milliseconds: 3210)),
+      );
+
+      // Old drafts/history entries have no key — must default to zero.
+      final legacy = DivineVideoClip.fromJson(
+        clip('/videos/clip.mp4').toJson(),
+        '/videos',
+      );
+      expect(legacy.sourceStartOffset, equals(Duration.zero));
+    });
+  });
 }

--- a/mobile/test/services/video_editor/clip_thumbnail_manager_test.dart
+++ b/mobile/test/services/video_editor/clip_thumbnail_manager_test.dart
@@ -405,7 +405,8 @@ void main() {
 
       test(
         'keeps seeded frames rebased into the rendered timebase until the '
-        'first fresh batch replaces them, then deletes the borrowed files',
+        'first fresh batch replaces them; the borrowed file survives in the '
+        'retired source strip and restores instantly on undo',
         () async {
           final borrowed = File('${tempDir.path}/borrowed.jpg')
             ..writeAsStringSync('borrowed');
@@ -478,8 +479,9 @@ void main() {
           expect(held.timestamp, equals(const Duration(seconds: 1)));
           expect(borrowed.existsSync(), isTrue);
 
-          // First fresh batch replaces the seeds and deletes the borrowed
-          // file, which no notifier references anymore.
+          // First fresh batch replaces the seed (same timestamp, so the
+          // carried frame is pruned) — but the borrowed file survives: the
+          // retired source strip still references it for an undo restore.
           final fresh = File('${tempDir.path}/fresh.jpg')
             ..writeAsStringSync('fresh');
           controllers[1].add([
@@ -494,8 +496,143 @@ void main() {
             fakeStreamManager['end'].value.single.path,
             equals(fresh.path),
           );
-          expect(borrowed.existsSync(), isFalse);
+          expect(borrowed.existsSync(), isTrue);
           expect(fresh.existsSync(), isTrue);
+
+          // Undo: the source clip id returns with its original file — the
+          // strip is restored instantly from the retired cache, no poster
+          // flash. Its original subscription never completed, so a fresh
+          // one starts to fill the gaps.
+          fakeStreamManager.sync(clips: [sourceClip], devicePixelRatio: 1);
+          final restored = fakeStreamManager['src'].value.single;
+          expect(restored.path, equals(borrowed.path));
+          expect(restored.timestamp, equals(const Duration(seconds: 4)));
+          expect(controllers, hasLength(3));
+        },
+      );
+
+      // Regression for the visible thumbnail shuffle after a split: the
+      // seeded frames are dense (borrowed from the source strip) while the
+      // first fresh batches are sparse. Replacing the seeds wholesale with a
+      // sparse batch collapses the strip to a few frames + poster fallbacks,
+      // so the tile visibly reshuffles while batches stream in. Carried
+      // frames must stay as gap-fillers until fresh frames cover their spot.
+      test(
+        'keeps dense seeded frames as gap-fillers while sparse fresh '
+        'batches stream in, pruning each once a fresh frame lands nearby',
+        () async {
+          final sourceVideoPath = '${tempDir.path}/source.mp4';
+          final renderedVideoPath = '${tempDir.path}/rendered_end.mp4';
+
+          // Dense source strip: one frame per second at 3.5s..9.5s.
+          final borrowedFiles = <File>[];
+          final sourceFrames = <StripThumbnail>[];
+          for (var i = 0; i < 7; i++) {
+            final file = File('${tempDir.path}/borrowed_$i.jpg')
+              ..writeAsStringSync('borrowed_$i');
+            borrowedFiles.add(file);
+            sourceFrames.add(
+              StripThumbnail(
+                path: file.path,
+                timestamp: Duration(milliseconds: 3500 + i * 1000),
+              ),
+            );
+          }
+
+          final sourceClip = _createFileClip(
+            id: 'src',
+            videoPath: sourceVideoPath,
+            seconds: 10,
+          );
+          fakeStreamManager.sync(clips: [sourceClip], devicePixelRatio: 1);
+          fakeStreamManager['src'].value = sourceFrames;
+
+          // Split at 3s: seed the end half, then let the rendered file
+          // arrive so the real subscription starts (seeds rebased by -3s
+          // to 0.5s..6.5s).
+          fakeStreamManager.seedFromSource(
+            sourceClipId: 'src',
+            targetClipId: 'end',
+            sourceRange: const DurationRange(
+              start: Duration(seconds: 3),
+              end: Duration(seconds: 10),
+            ),
+            timestampOffset: Duration.zero,
+            rebaseOnPathChange: const Duration(seconds: 3),
+            currentSourcePath: sourceVideoPath,
+          );
+          final renderedEndClip = _createFileClip(
+            id: 'end',
+            videoPath: renderedVideoPath,
+            seconds: 7,
+          );
+          fakeStreamManager.sync(
+            clips: [renderedEndClip],
+            devicePixelRatio: 1,
+          );
+          expect(controllers, hasLength(2));
+          expect(fakeStreamManager['end'].value, hasLength(7));
+
+          // Sparse first batch: a single fresh frame at 1.5s. Only the
+          // seeded frame at that spot (originally 4.5s) may be replaced —
+          // the other six must stay so the strip keeps its coverage.
+          final fresh1 = File('${tempDir.path}/fresh_1.jpg')
+            ..writeAsStringSync('fresh_1');
+          controllers[1].add([
+            StripThumbnail(
+              path: fresh1.path,
+              timestamp: const Duration(milliseconds: 1500),
+            ),
+          ]);
+          await pumpEventQueue();
+
+          final afterBatch1 = fakeStreamManager['end'].value;
+          expect(afterBatch1, hasLength(7));
+          expect(
+            afterBatch1.map((t) => t.path),
+            contains(fresh1.path),
+          );
+          // Every borrowed file survives — even the displaced seed's — since
+          // the retired source strip still references them for undo.
+          expect(borrowedFiles[1].existsSync(), isTrue);
+          expect(borrowedFiles[0].existsSync(), isTrue);
+          expect(borrowedFiles[6].existsSync(), isTrue);
+          // Timestamps stay sorted for the strip's binary slot search.
+          for (var i = 1; i < afterBatch1.length; i++) {
+            expect(
+              afterBatch1[i].timestamp >= afterBatch1[i - 1].timestamp,
+              isTrue,
+            );
+          }
+
+          // Stream completes: remaining carried frames are pruned so the
+          // final strip holds only fresh frames. The borrowed files stay on
+          // disk — the retired source strip references them for undo.
+          final fresh2 = File('${tempDir.path}/fresh_2.jpg')
+            ..writeAsStringSync('fresh_2');
+          controllers[1].add([
+            StripThumbnail(
+              path: fresh1.path,
+              timestamp: const Duration(milliseconds: 1500),
+            ),
+            StripThumbnail(
+              path: fresh2.path,
+              timestamp: const Duration(milliseconds: 4500),
+            ),
+          ]);
+          await pumpEventQueue();
+          await controllers[1].close();
+          await pumpEventQueue();
+
+          expect(
+            fakeStreamManager['end'].value.map((t) => t.path).toList(),
+            equals([fresh1.path, fresh2.path]),
+          );
+          for (final file in borrowedFiles) {
+            expect(file.existsSync(), isTrue);
+          }
+          expect(fresh1.existsSync(), isTrue);
+          expect(fresh2.existsSync(), isTrue);
         },
       );
 
@@ -577,7 +714,7 @@ void main() {
 
       test(
         'keeps START-half seeds as-is on rendered path arrival (no rebase), '
-        'then the first fresh batch supersedes and deletes them',
+        'then the first fresh batch supersedes them (files kept for undo)',
         () async {
           final borrowed = File('${tempDir.path}/start_borrowed.jpg')
             ..writeAsStringSync('borrowed');
@@ -645,7 +782,8 @@ void main() {
             fakeStreamManager['start'].value.single.path,
             equals(fresh.path),
           );
-          expect(borrowed.existsSync(), isFalse);
+          // The borrowed file survives in the retired source strip for undo.
+          expect(borrowed.existsSync(), isTrue);
           expect(fresh.existsSync(), isTrue);
         },
       );
@@ -699,6 +837,190 @@ void main() {
           );
           fakeStreamManager.sync(clips: [renderedEndClip], devicePixelRatio: 1);
           expect(controllers, hasLength(2));
+        },
+      );
+    });
+
+    group('retired strips', () {
+      late List<StreamController<List<StripThumbnail>>> controllers;
+      late ClipThumbnailManager fakeStreamManager;
+      late Directory tempDir;
+
+      setUp(() {
+        controllers = [];
+        fakeStreamManager = ClipThumbnailManager(
+          stripThumbnailStreamFactory:
+              ({
+                required String videoPath,
+                required String clipId,
+                required Duration duration,
+                required Size outputSize,
+                required int thumbsPerSecond,
+                List<Duration>? priorityTimestamps,
+              }) {
+                final controller = StreamController<List<StripThumbnail>>();
+                controllers.add(controller);
+                return controller.stream;
+              },
+        );
+        tempDir = Directory.systemTemp.createTempSync(
+          'clip_thumbnail_retired_test_',
+        );
+      });
+
+      tearDown(() {
+        fakeStreamManager.dispose();
+        for (final controller in controllers) {
+          unawaited(controller.close());
+        }
+        if (tempDir.existsSync()) {
+          tempDir.deleteSync(recursive: true);
+        }
+      });
+
+      File writeFrame(String name) =>
+          File('${tempDir.path}/$name.jpg')..writeAsStringSync(name);
+
+      test(
+        'restores a complete strip instantly without re-extraction when the '
+        'clip id returns with the same file (undo)',
+        () async {
+          final frame = writeFrame('a_frame');
+          final clipA = _createFileClip(
+            id: 'a',
+            videoPath: '${tempDir.path}/a.mp4',
+          );
+
+          fakeStreamManager.sync(clips: [clipA], devicePixelRatio: 1);
+          controllers.single.add([
+            StripThumbnail(
+              path: frame.path,
+              timestamp: const Duration(seconds: 1),
+            ),
+          ]);
+          await pumpEventQueue();
+          // Stream completes — the strip is at full density.
+          await controllers.single.close();
+          await pumpEventQueue();
+
+          // Clip 'a' is replaced (e.g. by split halves) — its strip retires.
+          final clipB = _createFileClip(
+            id: 'b',
+            videoPath: '${tempDir.path}/b.mp4',
+          );
+          fakeStreamManager.sync(clips: [clipB], devicePixelRatio: 1);
+          expect(frame.existsSync(), isTrue);
+
+          // Undo: 'a' returns with the same file. The strip is restored
+          // instantly and — being complete — no new subscription starts.
+          fakeStreamManager.sync(
+            clips: [clipA, clipB],
+            devicePixelRatio: 1,
+          );
+          expect(
+            fakeStreamManager['a'].value.single.path,
+            equals(frame.path),
+          );
+          expect(controllers, hasLength(2));
+
+          // Subsequent syncs must not re-subscribe either.
+          fakeStreamManager.sync(clips: [clipA, clipB], devicePixelRatio: 1);
+          expect(controllers, hasLength(2));
+        },
+      );
+
+      test(
+        'restores a partial strip and starts a gap-filling subscription',
+        () async {
+          final frame = writeFrame('partial_frame');
+          final clipA = _createFileClip(
+            id: 'a',
+            videoPath: '${tempDir.path}/a.mp4',
+          );
+
+          fakeStreamManager.sync(clips: [clipA], devicePixelRatio: 1);
+          controllers.single.add([
+            StripThumbnail(
+              path: frame.path,
+              timestamp: const Duration(seconds: 1),
+            ),
+          ]);
+          await pumpEventQueue();
+          // Stream still open — the strip is incomplete when 'a' retires.
+
+          fakeStreamManager.sync(clips: [], devicePixelRatio: 1);
+          fakeStreamManager.sync(clips: [clipA], devicePixelRatio: 1);
+
+          // Frames restored instantly, plus a fresh subscription for gaps.
+          expect(
+            fakeStreamManager['a'].value.single.path,
+            equals(frame.path),
+          );
+          expect(controllers, hasLength(2));
+        },
+      );
+
+      test(
+        'drops the retired strip when the id returns with a different file',
+        () async {
+          final frame = writeFrame('stale_frame');
+          final clipA = _createFileClip(
+            id: 'a',
+            videoPath: '${tempDir.path}/a.mp4',
+          );
+
+          fakeStreamManager.sync(clips: [clipA], devicePixelRatio: 1);
+          controllers.single.add([
+            StripThumbnail(
+              path: frame.path,
+              timestamp: const Duration(seconds: 1),
+            ),
+          ]);
+          await pumpEventQueue();
+
+          fakeStreamManager.sync(clips: [], devicePixelRatio: 1);
+
+          // 'a' returns pointing at a different video — the retired frames
+          // would show stale content, so the strip starts cold and the old
+          // frame file is deleted.
+          final swappedA = _createFileClip(
+            id: 'a',
+            videoPath: '${tempDir.path}/a_other.mp4',
+          );
+          fakeStreamManager.sync(clips: [swappedA], devicePixelRatio: 1);
+
+          expect(fakeStreamManager['a'].value, isEmpty);
+          expect(controllers, hasLength(2));
+          expect(frame.existsSync(), isFalse);
+        },
+      );
+
+      test(
+        'evicts the oldest retired strip beyond the cap and deletes its '
+        'unreferenced files',
+        () async {
+          // Retire 9 strips in sequence — one more than the cap of 8.
+          final frames = <File>[];
+          for (var i = 0; i < 9; i++) {
+            final frame = writeFrame('evict_$i');
+            frames.add(frame);
+            final clip = _createFileClip(
+              id: 'clip_$i',
+              videoPath: '${tempDir.path}/clip_$i.mp4',
+            );
+            fakeStreamManager.sync(clips: [clip], devicePixelRatio: 1);
+            fakeStreamManager['clip_$i'].value = [
+              StripThumbnail(path: frame.path, timestamp: Duration.zero),
+            ];
+          }
+          // Retire the 9th strip too.
+          fakeStreamManager.sync(clips: [], devicePixelRatio: 1);
+
+          // The oldest strip fell off the FIFO; the newest 8 survive.
+          expect(frames.first.existsSync(), isFalse);
+          for (final frame in frames.skip(1)) {
+            expect(frame.existsSync(), isTrue);
+          }
         },
       );
     });

--- a/mobile/test/services/video_editor/clip_thumbnail_manager_test.dart
+++ b/mobile/test/services/video_editor/clip_thumbnail_manager_test.dart
@@ -839,6 +839,78 @@ void main() {
           expect(controllers, hasLength(2));
         },
       );
+
+      // Regression: a native extraction failure mid-stream errors the
+      // subscription with only a partial fresh set delivered. That partial
+      // set must not be treated as complete — the carried gap-fillers stay
+      // on screen (and on disk), and a later retire/restore starts a fresh
+      // subscription instead of parking the truncated strip as final.
+      test(
+        'keeps carried gap-fillers and re-extracts on restore when the '
+        'stream is truncated by an extraction error',
+        () async {
+          final dense = [
+            for (var i = 0; i < 4; i++)
+              File('${tempDir.path}/dense_$i.jpg')..writeAsStringSync('d$i'),
+          ];
+          final clip = _createFileClip(
+            id: 'a',
+            videoPath: '${tempDir.path}/a.mp4',
+            seconds: 4,
+          );
+          fakeStreamManager.sync(clips: [clip], devicePixelRatio: 1);
+          controllers.single.add([
+            for (var i = 0; i < 4; i++)
+              StripThumbnail(
+                path: dense[i].path,
+                timestamp: Duration(milliseconds: 500 + i * 1000),
+              ),
+          ]);
+          await pumpEventQueue();
+
+          // The clip's file is re-rendered — a restart carries the dense
+          // frames as gap-fillers while the new extraction streams in.
+          final rerenderedClip = _createFileClip(
+            id: 'a',
+            videoPath: '${tempDir.path}/a_rerendered.mp4',
+            seconds: 4,
+          );
+          fakeStreamManager.sync(clips: [rerenderedClip], devicePixelRatio: 1);
+          expect(controllers, hasLength(2));
+
+          final fresh = File('${tempDir.path}/fresh.jpg')
+            ..writeAsStringSync('fresh');
+          controllers[1].add([
+            StripThumbnail(
+              path: fresh.path,
+              timestamp: const Duration(milliseconds: 500),
+            ),
+          ]);
+          await pumpEventQueue();
+          expect(fakeStreamManager['a'].value, hasLength(4));
+
+          // Decoder failure truncates the stream after the sparse batch.
+          controllers[1].addError(StateError('decoder died'));
+          await controllers[1].close();
+          await pumpEventQueue();
+
+          // The carried gap-fillers survive — the strip must not collapse
+          // to the single fresh frame — and their files stay on disk.
+          final afterError = fakeStreamManager['a'].value;
+          expect(afterError, hasLength(4));
+          expect(afterError.map((t) => t.path), contains(fresh.path));
+          for (final file in dense.skip(1)) {
+            expect(file.existsSync(), isTrue);
+          }
+
+          // Remove and restore: the strip was truncated, not complete, so
+          // a fresh subscription starts to fill the missing frames.
+          fakeStreamManager.sync(clips: [], devicePixelRatio: 1);
+          fakeStreamManager.sync(clips: [rerenderedClip], devicePixelRatio: 1);
+          expect(fakeStreamManager['a'].value, hasLength(4));
+          expect(controllers, hasLength(3));
+        },
+      );
     });
 
     group('retired strips', () {

--- a/mobile/test/services/video_editor/video_editor_split_service_test.dart
+++ b/mobile/test/services/video_editor/video_editor_split_service_test.dart
@@ -402,6 +402,83 @@ void main() {
         expect(renderedClips.length, 2);
       });
 
+      test('anchors the rendered end half to the source recording', () async {
+        final clip = DivineVideoClip(
+          id: 'test-clip',
+          video: EditorVideo.file('/test/video.mp4'),
+          duration: const Duration(seconds: 5),
+          recordedAt: DateTime.now(),
+          targetAspectRatio: model.AspectRatio.square,
+          originalAspectRatio: 9 / 16,
+        );
+
+        final renderedClips = <DivineVideoClip>[];
+        await VideoEditorSplitService.splitClip(
+          sourceClip: clip,
+          splitPosition: const Duration(seconds: 2),
+          onClipsCreated: null,
+          onThumbnailExtracted: null,
+          onClipRendered: (clip, _) => renderedClips.add(clip),
+        );
+
+        // The end half's rendered file starts at the split point, so its
+        // zero-based timeline sits the split position into the recording.
+        // The start half's file still begins at the recording's start.
+        final startClip = renderedClips.singleWhere(
+          (c) => c.id.endsWith('_start'),
+        );
+        final endClip = renderedClips.singleWhere((c) => c.id.endsWith('_end'));
+        expect(startClip.sourceStartOffset, equals(Duration.zero));
+        expect(endClip.sourceStartOffset, equals(const Duration(seconds: 2)));
+      });
+
+      test(
+        'accumulates sourceStartOffset when splitting an already-shifted '
+        'clip (nested split)',
+        () async {
+          // End half of a previous split: its file starts 3 s into the
+          // original recording and is trimmed 1 s at its own start.
+          final clip = DivineVideoClip(
+            id: 'test-clip',
+            video: EditorVideo.file('/test/video.mp4'),
+            duration: const Duration(seconds: 5),
+            recordedAt: DateTime.now(),
+            targetAspectRatio: model.AspectRatio.square,
+            originalAspectRatio: 9 / 16,
+            sourceStartOffset: const Duration(seconds: 3),
+            trimStart: const Duration(seconds: 1),
+          );
+
+          final renderedClips = <DivineVideoClip>[];
+          await VideoEditorSplitService.splitClip(
+            sourceClip: clip,
+            splitPosition: const Duration(milliseconds: 1500),
+            onClipsCreated: null,
+            onThumbnailExtracted: null,
+            onClipRendered: (clip, _) => renderedClips.add(clip),
+          );
+
+          // absoluteSplitPos = trimStart + splitPosition = 2.5 s into this
+          // clip's file, which itself starts 3 s into the recording — the
+          // end half's file starts 5.5 s into the recording. The start
+          // half keeps its file, so its anchor is unchanged.
+          final startClip = renderedClips.singleWhere(
+            (c) => c.id.endsWith('_start'),
+          );
+          final endClip = renderedClips.singleWhere(
+            (c) => c.id.endsWith('_end'),
+          );
+          expect(
+            startClip.sourceStartOffset,
+            equals(const Duration(seconds: 3)),
+          );
+          expect(
+            endClip.sourceStartOffset,
+            equals(const Duration(milliseconds: 5500)),
+          );
+        },
+      );
+
       test('completes processing completers on success', () async {
         final clip = DivineVideoClip(
           id: 'test-clip',

--- a/mobile/test/services/video_thumbnail_service_test.dart
+++ b/mobile/test/services/video_thumbnail_service_test.dart
@@ -297,6 +297,12 @@ void main() {
         'emits delivered batches then the error when extraction fails '
         'mid-stream',
         () async {
+          // In the merged VGV isolate a widget test that tears down while a
+          // strip generator awaits the static batch queue strands it on a
+          // future from its dead FakeAsync zone (see the cover screen
+          // tests); reset it or the first batch below never runs.
+          VideoThumbnailService.resetStripBatchQueueForTesting();
+
           // First batch succeeds, second batch hits a native failure.
           var callCount = 0;
           final fakeJpegBytes = Uint8List.fromList(

--- a/mobile/test/services/video_thumbnail_service_test.dart
+++ b/mobile/test/services/video_thumbnail_service_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Unit tests for video thumbnail extraction service
 // ABOUTME: Tests thumbnail generation, error handling, and edge cases
 
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/services.dart';
@@ -289,6 +290,59 @@ void main() {
         );
         expect(timestamp.inMilliseconds, equals(630)); // 10% of 6300ms
       });
+    });
+
+    group('generateStripThumbnails', () {
+      test(
+        'emits delivered batches then the error when extraction fails '
+        'mid-stream',
+        () async {
+          // First batch succeeds, second batch hits a native failure.
+          var callCount = 0;
+          final fakeJpegBytes = Uint8List.fromList(
+            List<int>.generate(16, (i) => i),
+          );
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+              .setMockMethodCallHandler(channel, (call) async {
+                if (call.method == 'getThumbnails') {
+                  callCount++;
+                  if (callCount > 1) {
+                    throw PlatformException(code: 'DECODER_ERROR');
+                  }
+                  return List<Uint8List>.generate(6, (_) => fakeJpegBytes);
+                }
+                return null;
+              });
+
+          // 12 s at 1 thumb/s with the default batch size of 6 → 2 batches.
+          final batches = <List<StripThumbnail>>[];
+          Object? streamError;
+          final done = Completer<void>();
+          VideoThumbnailService.generateStripThumbnails(
+            videoPath: testVideoPath,
+            clipId: 'clip-truncated',
+            duration: const Duration(seconds: 12),
+            outputSize: const Size(48, 64),
+          ).listen(
+            batches.add,
+            onError: (Object error) => streamError = error,
+            onDone: done.complete,
+          );
+          await done.future;
+
+          // The successful batch was delivered, then the stream errored —
+          // a listener can tell the truncated set apart from a clean close.
+          expect(batches, hasLength(1));
+          expect(batches.single, hasLength(6));
+          expect(streamError, isA<PlatformException>());
+
+          for (final thumbnail in batches.single) {
+            final file = File(thumbnail.path);
+            expect(file.existsSync(), isTrue);
+            file.deleteSync();
+          }
+        },
+      );
     });
   });
 

--- a/mobile/test/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_test.dart
@@ -123,6 +123,19 @@ void main() {
     });
 
     group('raster stability', () {
+      // Strip thumbnails set cacheHeight, so the FileImage is wrapped
+      // in a ResizeImage — unwrap before comparing the file path.
+      bool providerHasPath(ImageProvider provider, String path) {
+        if (provider is ResizeImage) {
+          return providerHasPath(provider.imageProvider, path);
+        }
+        return provider is FileImage && provider.file.path == path;
+      }
+
+      Finder frame(String path) => find.byWidgetPredicate(
+        (w) => w is Image && providerHasPath(w.image, path),
+      );
+
       // Regression for the visible leftward frame shift when a split's end
       // half finishes rendering: the render rebases the clip from source
       // time (trimStart = split point) to file time (trimStart = 0,
@@ -179,19 +192,6 @@ void main() {
           ];
           await tester.pump();
 
-          // Strip thumbnails set cacheHeight, so the FileImage is wrapped
-          // in a ResizeImage — unwrap before comparing the file path.
-          bool providerHasPath(ImageProvider provider, String path) {
-            if (provider is ResizeImage) {
-              return providerHasPath(provider.imageProvider, path);
-            }
-            return provider is FileImage && provider.file.path == path;
-          }
-
-          Finder frame(String path) => find.byWidgetPredicate(
-            (w) => w is Image && providerHasPath(w.image, path),
-          );
-
           final previewX = {
             for (final path in ['/t/f1.jpg', '/t/f2.jpg', '/t/f3.jpg'])
               path: tester.getTopLeft(frame(path)).dx,
@@ -236,6 +236,97 @@ void main() {
                   '${entry.key} must stay at its pre-render x-position — '
                   'a shift means the slot raster re-anchored on the '
                   'rendered file instead of the original recording',
+            );
+          }
+        },
+      );
+
+      // Reversing keeps sourceStartOffset (it survives copyWith), but the
+      // reversed file is physically mirrored — there is no recording
+      // continuity to preserve, so the raster must stay file-anchored
+      // instead of phase-shifting by the stale offset.
+      testWidgets(
+        'ignores sourceStartOffset for reversed clips — their slot raster '
+        'stays file-anchored',
+        (tester) async {
+          final manager = ClipThumbnailManager(
+            stripThumbnailStreamFactory:
+                ({
+                  required String videoPath,
+                  required String clipId,
+                  required Duration duration,
+                  required Size outputSize,
+                  required int thumbsPerSecond,
+                  List<Duration>? priorityTimestamps,
+                }) => const Stream.empty(),
+          );
+          addTearDown(manager.dispose);
+
+          const pps = 100.0;
+          const totalWidth = 170.0;
+          const frames = [
+            StripThumbnail(
+              path: '/t/r1.jpg',
+              timestamp: Duration(milliseconds: 200),
+            ),
+            StripThumbnail(
+              path: '/t/r2.jpg',
+              timestamp: Duration(milliseconds: 700),
+            ),
+            StripThumbnail(
+              path: '/t/r3.jpg',
+              timestamp: Duration(milliseconds: 1200),
+            ),
+          ];
+
+          // File-anchored reference: identical geometry with no offset.
+          final plain = _createTestClip(id: 'end', seconds: 3).copyWith(
+            duration: const Duration(milliseconds: 1700),
+          );
+          await tester.pumpWidget(
+            buildWidget(
+              clips: [plain],
+              totalWidth: totalWidth,
+              pixelsPerSecond: pps,
+              thumbnailManager: manager,
+              scrollable: false,
+            ),
+          );
+          manager['end'].value = frames;
+          await tester.pump();
+
+          final fileAnchoredX = {
+            for (final path in ['/t/r1.jpg', '/t/r2.jpg', '/t/r3.jpg'])
+              path: tester.getTopLeft(frame(path)).dx,
+          };
+
+          // Same clip reversed, carrying the offset of a rendered split end
+          // half — the raster must not move.
+          final reversedEnd = _createTestClip(id: 'end', seconds: 3).copyWith(
+            duration: const Duration(milliseconds: 1700),
+            sourceStartOffset: const Duration(milliseconds: 1300),
+            reversed: true,
+          );
+          await tester.pumpWidget(
+            buildWidget(
+              clips: [reversedEnd],
+              totalWidth: totalWidth,
+              pixelsPerSecond: pps,
+              thumbnailManager: manager,
+              scrollable: false,
+            ),
+          );
+          manager['end'].value = frames;
+          await tester.pump();
+
+          for (final entry in fileAnchoredX.entries) {
+            expect(
+              tester.getTopLeft(frame(entry.key)).dx,
+              moreOrLessEquals(entry.value),
+              reason:
+                  '${entry.key} must sit at its file-anchored position — '
+                  'a shift means the reversed clip still applies the '
+                  'recording-anchored raster phase',
             );
           }
         },

--- a/mobile/test/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_test.dart
@@ -144,6 +144,7 @@ void main() {
                   List<Duration>? priorityTimestamps,
                 }) => const Stream.empty(),
           );
+          addTearDown(manager.dispose);
 
           // Split of a 3 s source at 1.3 s; visible width 1.7 s × 100 px/s.
           const pps = 100.0;

--- a/mobile/test/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_test.dart
@@ -122,6 +122,125 @@ void main() {
       });
     });
 
+    group('raster stability', () {
+      // Regression for the visible leftward frame shift when a split's end
+      // half finishes rendering: the render rebases the clip from source
+      // time (trimStart = split point) to file time (trimStart = 0,
+      // sourceStartOffset = split point). The thumbnail slot raster is
+      // anchored to the original recording via sourceStartOffset, so every
+      // frame must keep its exact on-screen position across that swap.
+      testWidgets(
+        'keeps each frame at the same x-position when the split end half '
+        'swaps from source-timed preview to rebased rendered geometry',
+        (tester) async {
+          final manager = ClipThumbnailManager(
+            stripThumbnailStreamFactory:
+                ({
+                  required String videoPath,
+                  required String clipId,
+                  required Duration duration,
+                  required Size outputSize,
+                  required int thumbsPerSecond,
+                  List<Duration>? priorityTimestamps,
+                }) => const Stream.empty(),
+          );
+
+          // Split of a 3 s source at 1.3 s; visible width 1.7 s × 100 px/s.
+          const pps = 100.0;
+          const totalWidth = 170.0;
+
+          // Preview phase: still source-timed against the source video.
+          final previewEnd = _createTestClip(id: 'end', seconds: 3).copyWith(
+            trimStart: const Duration(milliseconds: 1300),
+          );
+          await tester.pumpWidget(
+            buildWidget(
+              clips: [previewEnd],
+              totalWidth: totalWidth,
+              pixelsPerSecond: pps,
+              thumbnailManager: manager,
+              scrollable: false,
+            ),
+          );
+          manager['end'].value = const [
+            StripThumbnail(
+              path: '/t/f1.jpg',
+              timestamp: Duration(milliseconds: 1500),
+            ),
+            StripThumbnail(
+              path: '/t/f2.jpg',
+              timestamp: Duration(milliseconds: 2000),
+            ),
+            StripThumbnail(
+              path: '/t/f3.jpg',
+              timestamp: Duration(milliseconds: 2500),
+            ),
+          ];
+          await tester.pump();
+
+          // Strip thumbnails set cacheHeight, so the FileImage is wrapped
+          // in a ResizeImage — unwrap before comparing the file path.
+          bool providerHasPath(ImageProvider provider, String path) {
+            if (provider is ResizeImage) {
+              return providerHasPath(provider.imageProvider, path);
+            }
+            return provider is FileImage && provider.file.path == path;
+          }
+
+          Finder frame(String path) => find.byWidgetPredicate(
+            (w) => w is Image && providerHasPath(w.image, path),
+          );
+
+          final previewX = {
+            for (final path in ['/t/f1.jpg', '/t/f2.jpg', '/t/f3.jpg'])
+              path: tester.getTopLeft(frame(path)).dx,
+          };
+
+          // Rendered phase: the file starts at the split point, timestamps
+          // are rebased by -1.3 s and sourceStartOffset records the shift.
+          final renderedEnd = _createTestClip(id: 'end', seconds: 3).copyWith(
+            duration: const Duration(milliseconds: 1700),
+            sourceStartOffset: const Duration(milliseconds: 1300),
+          );
+          await tester.pumpWidget(
+            buildWidget(
+              clips: [renderedEnd],
+              totalWidth: totalWidth,
+              pixelsPerSecond: pps,
+              thumbnailManager: manager,
+              scrollable: false,
+            ),
+          );
+          manager['end'].value = const [
+            StripThumbnail(
+              path: '/t/f1.jpg',
+              timestamp: Duration(milliseconds: 200),
+            ),
+            StripThumbnail(
+              path: '/t/f2.jpg',
+              timestamp: Duration(milliseconds: 700),
+            ),
+            StripThumbnail(
+              path: '/t/f3.jpg',
+              timestamp: Duration(milliseconds: 1200),
+            ),
+          ];
+          await tester.pump();
+
+          for (final entry in previewX.entries) {
+            expect(
+              tester.getTopLeft(frame(entry.key)).dx,
+              moreOrLessEquals(entry.value),
+              reason:
+                  '${entry.key} must stay at its pre-render x-position — '
+                  'a shift means the slot raster re-anchored on the '
+                  'rendered file instead of the original recording',
+            );
+          }
+        },
+      );
+    });
+
     group('layout', () {
       testWidgets('uses correct strip height', (tester) async {
         await tester.pumpWidget(buildWidget());


### PR DESCRIPTION
Closes #6006

## Description

Splitting a clip made the timeline strip visibly fall apart in three ways, all reported from device testing:

1. **Thumbnails reshuffled while the split rendered.** The split halves are seeded with the source clip's dense, correct frames — but as soon as the rendered segment files arrived, the first fresh extraction batch (6 frames) *wholesale-replaced* the dense seeds. Most slots lost their frame, fell back to the poster, and then refilled batch by batch — a multi-second reshuffle.
2. **Undo/redo flashed wrong thumbnails and re-extracted everything.** Removing a clip id deleted its strip (notifier + files) immediately. Undo brought the pre-split clip back to an empty notifier: every slot briefly showed the poster (the clip's first frame) while a full native re-extraction ran.
3. **The end half's frames all jumped left when its render landed.** The render rebases the clip from source time (`trimStart = splitPos`) to file time (`trimStart = 0`), which re-anchored the 48px thumbnail slot raster at the new file's zero — shifting every frame in the tile by up to one slot.

Key changes (one per defect, all in the thumbnail pipeline):

- **Merge instead of replace** (`ClipThumbnailManager._mergeCarriedFrames`): carried frames (seeds, pre-restart frames) survive as gap-fillers until a fresh frame lands within half the final frame spacing; an `onDone` sweep prunes the residue (long clips cap the generator's frame count, so the final spacing can exceed that distance). Files are only deleted once nothing references them.
- **Retired-strip cache**: removed clip ids park their strip (frames + video path + completeness) in a bounded FIFO (8 strips) instead of being deleted. When the id returns with the same file — undo re-adds the pre-split clip, redo the halves — the strip is restored instantly; complete strips skip re-extraction entirely, partial ones start a gap-filling subscription. Seeded-but-unrendered halves are deliberately *not* retired (their timestamps carry an unapplied rebase; restoring them would misalign frames).
- **Recording-anchored slot raster**: new `DivineVideoClip.sourceStartOffset` field records where a clip's file starts inside the original recording. The split service sets it on the rendered end half (`source offset + absoluteSplitPos`, so nested splits accumulate) and the bloc carries it through `onClipRendered`. The tile shifts its slot windows *and* its content translation by `sourceStartOffset mod slotSpan`, which makes each frame's on-screen position mathematically invariant across the preview → rendered swap. Slot windows also move from `duration/count` pitch to a fixed 48px pitch, fixing a pre-existing drift that pushed frames up to ~half a slot right of their true position toward a tile's end.

**Why a model field** rather than view-layer bookkeeping: the offset must survive undo/redo and draft reload (it round-trips through the clip's JSON), accumulate across nested splits, and be inherited by duplicate/trim/transform via `copyWith` — the strip widget's state dies on unmount and can't provide any of that. Old drafts without the key default to zero (unchanged behavior).

## Out of Scope

- The retired cache is capped at 8 strips; undoing further back than that re-extracts (cold start, as before).
- Reversed clips keep a file-anchored raster — their content mirrors anyway, so there is no continuity to preserve.

## Verification

- `flutter analyze` over all changed `lib`/`test` dirs — no issues.
- Full timeline-editor widget suite (364 tests) + manager/model/bloc suites green. New regression tests: batch-merge gap-filling, instant undo/redo restore (complete + partial + different-file + FIFO eviction), `sourceStartOffset` JSON round-trip, offset propagation through the split render, and a widget test asserting pixel-identical frame positions across the preview → rendered geometry swap (red without the fix).
- Device-tested on iOS: undo/redo now restores thumbnails instantly; split no longer reshuffles the strip.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)