### PR TITLE
fix(comments): clear the stale engine text-input client on sheet dismiss

### DIFF
--- a/mobile/lib/screens/comments/widgets/unfocus_on_sheet_dismiss.dart
+++ b/mobile/lib/screens/comments/widgets/unfocus_on_sheet_dismiss.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 /// Unfocuses the active text field and hides the software keyboard the moment
 /// the enclosing [ModalRoute] begins its dismiss transition.
@@ -84,16 +85,30 @@ class _UnfocusOnSheetDismissState extends State<UnfocusOnSheetDismiss> {
     // entirely — see the class doc.
     if (status == AnimationStatus.reverse ||
         status == AnimationStatus.dismissed) {
-      _dismissKeyboard();
+      _dismissKeyboard(trigger: status.name);
     }
   }
 
-  void _dismissKeyboard() {
+  void _dismissKeyboard({required String trigger}) {
     // A single teardown can surface more than one signal (a pop emits reverse
     // then dismissed); dismiss exactly once so we don't re-send TextInput.hide.
     if (_dismissed) return;
     _dismissed = true;
-    FocusManager.instance.primaryFocus?.unfocus();
+    final primaryFocus = FocusManager.instance.primaryFocus;
+    // Field forensics for the stranded-keyboard reports (#5959, #6007): the
+    // trigger names the dismissal path, and the focus shape distinguishes a
+    // healthy teardown (a focused field node) from the split-brain state
+    // (focus already fell back to a scope, so unfocus() will be silent).
+    Log.info(
+      'Keyboard teardown (trigger=$trigger, focus=${switch (primaryFocus) {
+        null => 'none',
+        FocusScopeNode() => 'scope',
+        FocusNode() => 'node',
+      }}): unfocus + clearClient + hide',
+      name: 'UnfocusOnSheetDismiss',
+      category: LogCategory.ui,
+    );
+    primaryFocus?.unfocus();
     // unfocus() sends nothing over the text-input channel when the framework
     // side of the connection is already gone (platform-initiated teardown
     // during background/resume — see the class doc). clearClient zeroes the
@@ -116,7 +131,7 @@ class _UnfocusOnSheetDismissState extends State<UnfocusOnSheetDismiss> {
     // existed so a generic non-sheet host that never stranded a keyboard
     // doesn't yank global focus / hide another route's keyboard on disposal.
     if (!_dismissed && _animation != null) {
-      _dismissKeyboard();
+      _dismissKeyboard(trigger: 'dispose');
     }
     super.dispose();
   }

--- a/mobile/lib/screens/comments/widgets/unfocus_on_sheet_dismiss.dart
+++ b/mobile/lib/screens/comments/widgets/unfocus_on_sheet_dismiss.dart
@@ -31,6 +31,20 @@ import 'package:flutter/services.dart';
 /// an explicit `TextInput.hide` — which resigns the first responder
 /// engine-side regardless of framework connection state — is sent as well.
 ///
+/// `TextInput.hide` alone is still not enough (#6007): the engine's
+/// `hideTextInput` resigns the first responder but never zeroes
+/// `_textInputClient`, and in the split-brain state the framework never sends
+/// its own `TextInput.clearClient` either. The dismissal then leaves an
+/// in-hierarchy `FlutterTextInputView` whose `canBecomeFirstResponder` is
+/// still `YES` — a session iOS 26 re-presents on its own (observed in #5959
+/// on resume, and stranded over the feed in #6007 with no resume at all). An
+/// explicit `TextInput.clearClient` is therefore sent before the hide — the
+/// engine's own reset order — so every dismissal ends with client 0, first
+/// responder resigned, and the input view removed: nothing left for UIKit to
+/// re-present. In the healthy case both raw messages are no-ops racing the
+/// framework's identical `clearClient` + scheduled hide, and the resign
+/// delegate reports client 0, which the framework's client-id guard drops.
+///
 /// The [dispose] fallback runs only when no route-status change already
 /// dismissed the keyboard and only when there was an enclosing modal route, so
 /// it is scoped to a sheet actually tearing down rather than firing on every
@@ -82,8 +96,14 @@ class _UnfocusOnSheetDismissState extends State<UnfocusOnSheetDismiss> {
     FocusManager.instance.primaryFocus?.unfocus();
     // unfocus() sends nothing over the text-input channel when the framework
     // side of the connection is already gone (platform-initiated teardown
-    // during background/resume — see the class doc). Hide explicitly; this is
-    // a harmless no-op when the keyboard is already down.
+    // during background/resume — see the class doc). clearClient zeroes the
+    // engine's stale client id so the orphaned FlutterTextInputView stops
+    // being re-presentable (#6007); hide then resigns the first responder and
+    // removes the view. Both are harmless no-ops when the keyboard is already
+    // down or the framework connection is healthy.
+    unawaited(
+      SystemChannels.textInput.invokeMethod<void>('TextInput.clearClient'),
+    );
     unawaited(SystemChannels.textInput.invokeMethod<void>('TextInput.hide'));
   }
 

--- a/mobile/test/screens/comments/widgets/unfocus_on_sheet_dismiss_test.dart
+++ b/mobile/test/screens/comments/widgets/unfocus_on_sheet_dismiss_test.dart
@@ -113,6 +113,39 @@ void main() {
     );
 
     testWidgets(
+      'clears the engine-side client on dismiss after the platform closed '
+      'the connection during background/resume',
+      (tester) async {
+        final focusNode = await pumpHostAndOpenSheet(tester);
+        await severConnectionPlatformSide(tester, focusNode);
+
+        // In the split-brain state the framework never sends its own
+        // TextInput.clearClient, and TextInput.hide alone leaves the engine
+        // with a stale client id whose in-hierarchy view iOS 26 can
+        // re-present on its own (#6007). The guard must clear the client
+        // explicitly, and must do so before the hide so the engine removes
+        // the input view during the hide's resign (the engine's own reset
+        // order).
+        tester.testTextInput.log.clear();
+        Navigator.of(tester.element(find.byType(UnfocusOnSheetDismiss))).pop();
+        await tester.pumpAndSettle();
+
+        final teardownCalls = tester.testTextInput.log
+            .map((call) => call.method)
+            .where(
+              (method) =>
+                  method == 'TextInput.clearClient' ||
+                  method == 'TextInput.hide',
+            )
+            .toList();
+        expect(
+          teardownCalls,
+          equals(['TextInput.clearClient', 'TextInput.hide']),
+        );
+      },
+    );
+
+    testWidgets(
       'hides the stranded keyboard when a chrome drag rides the route '
       'controller to its 0.0 clamp without ever reversing',
       (tester) async {


### PR DESCRIPTION
## Description

The keyboard was reported stranded over the home feed again on build 1.0.16+792 / iOS 26.5.1 — after posting a comment and closing the comments sheet, with the sheet's whole life spent in the foreground (no background/resume, unlike #5959).

Root cause, verified against the pinned Flutter 3.44.0 engine (`FlutterTextInputPlugin.mm`):

- `TextInput.hide` (`hideTextInput`) resigns the first responder but **never zeroes `_textInputClient`**.
- `TextInput.clearClient` (`clearTextInputClient`) zeroes the client and removes the input view, but never resigns.
- `canBecomeFirstResponder` returns `_textInputClient != 0` — the engine's only barrier against iOS re-presenting a keyboard by itself.

`UnfocusOnSheetDismiss` (#5961) sends only `TextInput.hide`. In the #5959 split-brain state (framework side of the connection nulled by `onConnectionClosed`, so `unfocus()` produces no channel traffic and the framework never sends its own `clearClient`), the dismissal hides the keyboard but leaves a durable, in-hierarchy `FlutterTextInputView` with a stale client and `canBecomeFirstResponder == YES` — a session iOS 26 re-presents on its own (observed on resume in #5959; stranded over the feed with no resume in the new report). An exhaustive audit found no in-app path that can summon a keyboard on the home feed, so the re-present is OS-initiated; the fix removes the state it needs.

The fix sends `TextInput.clearClient` before the `TextInput.hide` — the engine's own reset order (`resetWithResult:` calls `clearTextInputClient` then `hideTextInput`). Every dismissal now ends with client 0, first responder resigned, and the input view removed from the hierarchy: nothing left for UIKit to re-present. In the healthy case both raw messages are no-ops racing the framework's identical `clearClient` + scheduled hide, and the hide's resign delegate reports client 0, which the framework's client-id guard drops.

The new regression test pins the channel order (`clearClient` before `hide`) in the split-brain state; it fails against the previous implementation (verified by stashing the lib change) and passes with the fix. The remaining five #5961 tests are unchanged and stay green.

Why not "unfocus after tapping send": the keyboard's send key already unfocuses via `EditableText._finalizeEditing`, a healthy-connection teardown already ends clean, and no focus change produces channel traffic once the framework side of the connection is gone — so an extra unfocus cannot clear a stale engine client.

**Related Issue:** Fixes #6007

## Out of Scope

The share, find-people, new-message, and clip-title sheets have focused/autofocused fields but no `UnfocusOnSheetDismiss` guard at all; extending the guard to them is independent of this report and will be proposed separately. Confirming whether TestFlight 792 contains #5961 (Codemagic build 650) is an administrative check tracked in #6007.

## Verification

- `flutter test test/screens/comments/widgets/unfocus_on_sheet_dismiss_test.dart` — 8/8 pass
- New test verified red against the pre-fix implementation (stash lib change → fails, restore → passes)
- `flutter test test/screens/comments/` — 103/103 pass
- `flutter analyze lib test integration_test` — no issues
- `dart format` — no changes

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
