### PR TITLE
ci(android): set Gradle heap where Codemagic reads it + move to mac_mini_m4

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -109,6 +109,25 @@ definitions:
     - &setup_local_properties
       name: Set up local.properties
       script: echo "flutter.sdk=$FLUTTER_ROOT" > "$CM_BUILD_DIR/mobile/android/local.properties"
+    - &configure_gradle_memory
+      name: Configure Gradle JVM memory
+      script: |
+        # Codemagic does NOT honor org.gradle.jvmargs from the project
+        # gradle.properties (its GRADLE_USER_HOME gradle.properties takes
+        # precedence), so the release build's L8/dex step has been OOMing at
+        # Codemagic's small default heap regardless of what the project file
+        # says. Set the daemon heap where Gradle actually reads it. Sized for
+        # the 16 GB mac_mini_m4, shared with the Kotlin and Dart JVMs; values
+        # appended last win over any Codemagic default in the same file.
+        GRADLE_HOME="${GRADLE_USER_HOME:-$HOME/.gradle}"
+        mkdir -p "$GRADLE_HOME"
+        {
+          echo "org.gradle.jvmargs=-Xmx10g -XX:MaxMetaspaceSize=2g -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError"
+          echo "kotlin.daemon.jvmargs=-Xmx2g"
+          echo "org.gradle.workers.max=4"
+        } >> "$GRADLE_HOME/gradle.properties"
+        echo "Effective $GRADLE_HOME/gradle.properties:"
+        cat "$GRADLE_HOME/gradle.properties"
     - &build_apk
       name: Build Android APK
       script: |
@@ -505,7 +524,9 @@ workflows:
     name: Android Build
     working_directory: mobile
     max_build_duration: 60
-    instance_type: mac_mini_m2
+    # Release R8 + core-library desugaring (L8) is memory-hungry; the 16 GB
+    # M4 gives the Gradle daemon headroom the 12 GB M2 could not.
+    instance_type: mac_mini_m4
     inputs:
       DEFAULT_ENV:
         description: Default environment for fresh app installs
@@ -542,6 +563,7 @@ workflows:
     scripts:
       - *enable_spm
       - *setup_local_properties
+      - *configure_gradle_memory
       - *build_apk
       - *build_aab
       - *publish_github_release

--- a/mobile/android/gradle.properties
+++ b/mobile/android/gradle.properties
@@ -1,18 +1,14 @@
-# Memory is sized for the ~12 GB Codemagic mac_mini_m2 CI container, which
-# co-hosts three JVMs: this Gradle daemon, the Kotlin compile daemon, and the
-# Dart/Flutter tooling. The previous -Xmx8G + 4G metaspace let this daemon
-# alone commit ~12.5 GB — larger than the machine — so once #5789 re-enabled
-# R8 minification (whose whole-program pass drives the heap toward -Xmx) the
-# container over-committed and the daemon died mid-build with
-# `OutOfMemoryError: Java heap space` at l8DexDesugarLibRelease. Keep the sum
-# of the JVM ceilings comfortably under 12 GB; a Flutter release R8/dex pass
-# fits well within a 6 GB heap.
-org.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=1g -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
+# Heap for local / non-Codemagic release builds. NOTE: Codemagic does NOT read
+# org.gradle.jvmargs from this file — its GRADLE_USER_HOME gradle.properties
+# takes precedence — so the CI heap is set in codemagic.yaml's
+# `Configure Gradle JVM memory` step, not here. Keep the two in the same
+# ballpark. Release R8 + core-library desugaring (L8) is memory-hungry.
+org.gradle.jvmargs=-Xmx8g -XX:MaxMetaspaceSize=2g -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 # Bound the Kotlin compile daemon (a separate JVM) so it cannot balloon and
-# starve the Gradle daemon on the shared CI container.
+# starve the Gradle daemon.
 kotlin.daemon.jvmargs=-Xmx2g
-# Cap concurrent Gradle worker actions so peak dexing/desugaring memory on the
-# 8-core CI machine stays within the heap budget above.
+# Cap concurrent Gradle worker actions to keep peak dexing/desugaring memory
+# within the heap budget above.
 org.gradle.workers.max=4
 android.useAndroidX=true
 android.enableJetifier=true


### PR DESCRIPTION
Closes #6012

## Why the previous fix didn't work

PR #5995 tuned `org.gradle.jvmargs` in the **project** `mobile/android/gradle.properties`, but the Android release build kept OOMing at `:app:l8DexDesugarLibRelease` with a **byte-identical** error whether the heap was set to 8G or 6G.

That identical-failure-regardless-of-value is the tell: **Codemagic does not honor `org.gradle.jvmargs` from the project `gradle.properties`.** Its `GRADLE_USER_HOME/gradle.properties` takes precedence, so the Gradle daemon has been running at Codemagic's small default heap the entire time and the project-file value was inert on CI. (Confirmed: [codemagic-ci-cd discussion #2427](https://github.com/orgs/codemagic-ci-cd/discussions/2427).)

## Fix (two parts)

**1. Set the heap where Codemagic actually reads it.** A new `Configure Gradle JVM memory` step in the `android-build` workflow appends the JVM args to `$GRADLE_USER_HOME/gradle.properties` (last-appended key wins over Codemagic's default). It `cat`s the resulting file so the **effective heap is printed in the build log** — so if anything is still off, the next log shows exactly what was applied.

```
org.gradle.jvmargs=-Xmx10g -XX:MaxMetaspaceSize=2g -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
kotlin.daemon.jvmargs=-Xmx2g
org.gradle.workers.max=4
```

**2. Move `android-build` to `mac_mini_m4` (16 GB).** Up from `mac_mini_m2` (12 GB), giving the release R8 + core-library-desugaring (L8) pass real headroom for a 10 GB heap alongside the Kotlin and Dart JVMs. The M4 is also a faster chip. (Only the Android workflow moves; iOS/macOS stay on M2.)

Also corrects the now-misleading comment in the project `gradle.properties` to note Codemagic ignores it and the CI heap lives in `codemagic.yaml`.

## Verification

- `codemagic.yaml` parses as valid YAML; the anchor/alias resolves; the new step is wired before `Build Android APK`; injected shell passes `bash -n`.
- The real confirmation is the **Codemagic Android Build**. **Please run it from branch `fix/android-ci-gradle-heap-effective`.** The build log will now print the effective `gradle.properties` — if it still OOMs, that output tells us whether the heap took effect (mechanism) vs. genuinely needs more (machine), so the next step is unambiguous.

_Requires `mac_mini_m4` to be available on the Codemagic plan (billing enabled)._