### PR TITLE
ci(android): upload Google Play release as a draft to unblock the build

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -575,6 +575,12 @@ workflows:
       google_play:
         credentials: $GCLOUD_SERVICE_ACCOUNT_CREDENTIALS
         track: production
+        # Upload as a draft instead of rolling out a release. Rolling out a
+        # production release fails the build until the one-time Play Console
+        # "Foreground service permissions" declaration is completed (required
+        # on every track). A draft upload succeeds; promote it to a live
+        # release in the Play Console after completing that declaration.
+        submit_as_draft: true
 
   macos-build:
     name: macOS Build


### PR DESCRIPTION
Closes #6015

## Context

Progress so far: the Android **build** is fixed — on the Mac mini M4 with the effective Gradle heap (#6011), the APK + AAB build cleanly (the R8/L8 OOM is gone). The build now fails only at the **final publishing step**:

```
Uploaded App Bundle ... to Google Play        ← succeeded
Set new release for ... production track failed.
You must let us know whether your app uses any Foreground Service permissions.
```

## Why this can't be fixed purely in code

Google Play requires a one-time **"Foreground service permissions" declaration** (App content page) before it will roll out a release for any app that ships a `FOREGROUND_SERVICE_*` permission (contributed here via a merged dependency manifest). Per [Play Console Help](https://support.google.com/googleplay/android-developer/answer/13392821) and [this CI/CD writeup](https://dulanwirajith.medium.com/google-play-permissions-declaration-not-showing-heres-how-i-fixed-it-after-a-ci-cd-upload-7f3443224918), this declaration is required on **every track — internal included** — and can only be completed by the account owner in the Play Console. No track switch or API flag removes it.

## Fix

Set `submit_as_draft: true` on the `google_play` publishing block. Codemagic then **uploads the AAB as a draft** rather than rolling out a release — the draft upload succeeds, so the build goes green. The bundle lands on the production track as a draft.

```yaml
publishing:
  google_play:
    credentials: $GCLOUD_SERVICE_ACCOUNT_CREDENTIALS
    track: production
    submit_as_draft: true
```

## One-time manual step (account owner)

To actually ship to users, complete the declaration once: **Play Console → app → Policy → App content → "Foreground service permissions" → Start declaration** (uploading this draft AAB is what surfaces the form). Then promote the draft to a live release. After the declaration is on file, future rollouts work; if you later want CI to auto-roll-out again, we can drop `submit_as_draft`.

## Verification

`codemagic.yaml` parses as valid YAML and `submit_as_draft: true` is set on the android-build `google_play` block. Confirm with a Codemagic run from `fix/android-play-draft-release`.