### PR TITLE
fix(video-publish): app auto-double-publishes videos on the audio-reuse path

### DIFF
--- a/mobile/lib/providers/video_publish_provider.dart
+++ b/mobile/lib/providers/video_publish_provider.dart
@@ -71,6 +71,13 @@ MentionResolutionService? createVideoPublishMentionResolutionService(
 
 /// Manages video publish screen state including playback and position.
 class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
+  /// Source-draft ids with a publish currently in flight. Lives outside
+  /// [state] because [clearAll] intentionally resets the state ~600ms
+  /// after navigation while the publish future keeps running for 20s+;
+  /// a state-based guard reopens in that window and admits duplicate
+  /// publishes of the same draft (#6018).
+  final Set<String> _inFlightSourceDraftIds = {};
+
   DraftStorageService get _draftService =>
       ref.read(draftStorageServiceProvider);
   CawgVerifierClient get _cawgVerifierClient =>
@@ -322,8 +329,9 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
     BuildContext context,
     DivineVideoDraft draft,
   ) async {
-    // Only block if actively preparing/uploading
-    if (state.publishState == .preparing || state.publishState == .uploading) {
+    final sourceDraftId = draft.sourceDraftId ?? draft.id;
+    if (state.publishState == .preparing ||
+        _inFlightSourceDraftIds.contains(sourceDraftId)) {
       Log.warning(
         '⚠️ Publish already in progress, ignoring duplicate request',
         name: 'VideoPublishNotifier',
@@ -332,6 +340,7 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
       return;
     }
 
+    _inFlightSourceDraftIds.add(sourceDraftId);
     state = state.copyWith(publishState: .preparing);
 
     try {
@@ -501,6 +510,7 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
         stackTrace: stackTrace,
       );
     } finally {
+      _inFlightSourceDraftIds.remove(sourceDraftId);
       Log.info(
         '🏁 Publish process completed',
         name: 'VideoPublishNotifier',

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -200,6 +200,12 @@ class VideoEventPublisher {
   int _totalEventsFailed = 0;
   DateTime? _lastPublishTime;
 
+  /// In-flight direct publishes keyed by the upload's d-tag
+  /// ([PendingUpload.videoId]). Coalesces concurrent
+  /// [publishDirectUpload] calls for the same upload so only one
+  /// addressable event is signed and broadcast (#6018).
+  final Map<String, Future<bool>> _inFlightDirectPublishes = {};
+
   /// The outer timeout that will bound the next call into
   /// [NostrClient.publishEventAwaitOk] inside [_publishEventToNostr], computed
   /// live from [outerPublishTimeoutFor] and the current
@@ -850,6 +856,13 @@ class VideoEventPublisher {
   }
 
   /// Publish a video directly without polling (for direct upload)
+  ///
+  /// Concurrent calls for the same [PendingUpload.videoId] (the
+  /// addressable event's d-tag) are coalesced: the second caller awaits
+  /// the in-flight publish's result instead of signing and broadcasting
+  /// a duplicate event with a fresh id (#6018). The audio-reuse step can
+  /// keep a publish in flight for 20s+, which is the window where the
+  /// duplicates were minted.
   Future<bool> publishDirectUpload(
     PendingUpload upload, {
     int? expirationTimestamp,
@@ -868,7 +881,8 @@ class VideoEventPublisher {
     VideoReplyContext? replyContext,
     bool addReplyToFeed = false,
   }) async {
-    if (upload.videoId == null || upload.cdnUrl == null) {
+    final videoId = upload.videoId;
+    if (videoId == null || upload.cdnUrl == null) {
       Log.error(
         'Cannot publish upload - missing videoId or cdnUrl',
         name: 'VideoEventPublisher',
@@ -877,6 +891,61 @@ class VideoEventPublisher {
       return false;
     }
 
+    final inFlight = _inFlightDirectPublishes[videoId];
+    if (inFlight != null) {
+      Log.warning(
+        'Publish already in flight for video $videoId - awaiting its '
+        'result instead of signing a duplicate event',
+        name: 'VideoEventPublisher',
+        category: LogCategory.video,
+      );
+      return inFlight;
+    }
+
+    final publish = _publishDirectUploadUnlocked(
+      upload,
+      expirationTimestamp: expirationTimestamp,
+      allowAudioReuse: allowAudioReuse,
+      collaboratorPubkeys: collaboratorPubkeys,
+      mentionedPubkeys: mentionedPubkeys,
+      thumbnailTimestamp: thumbnailTimestamp,
+      inspiredByAddressableId: inspiredByAddressableId,
+      inspiredByRelayUrl: inspiredByRelayUrl,
+      inspiredByNpub: inspiredByNpub,
+      selectedAudio: selectedAudio,
+      selectedAudioEventId: selectedAudioEventId,
+      selectedAudioRelay: selectedAudioRelay,
+      language: language,
+      contentWarning: contentWarning,
+      replyContext: replyContext,
+      addReplyToFeed: addReplyToFeed,
+    );
+    _inFlightDirectPublishes[videoId] = publish;
+    try {
+      return await publish;
+    } finally {
+      _inFlightDirectPublishes.remove(videoId);
+    }
+  }
+
+  Future<bool> _publishDirectUploadUnlocked(
+    PendingUpload upload, {
+    int? expirationTimestamp,
+    bool allowAudioReuse = false,
+    List<String> collaboratorPubkeys = const [],
+    List<String> mentionedPubkeys = const [],
+    Duration? thumbnailTimestamp,
+    String? inspiredByAddressableId,
+    String? inspiredByRelayUrl,
+    String? inspiredByNpub,
+    AudioEvent? selectedAudio,
+    String? selectedAudioEventId,
+    String? selectedAudioRelay,
+    String? language,
+    String? contentWarning,
+    VideoReplyContext? replyContext,
+    bool addReplyToFeed = false,
+  }) async {
     // Validate that at least one video URL is a proper HTTP/HTTPS URL
     // This prevents local file paths from being published to Nostr
     final hasValidVideoUrl =

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -928,6 +928,12 @@ class VideoEventPublisher {
     }
   }
 
+  /// Signs and broadcasts the video event. Must only be called from
+  /// [publishDirectUpload], which holds the [_inFlightDirectPublishes]
+  /// coalescing lock (#6018); calling it directly bypasses that lock and
+  /// can mint a duplicate event. Keep this parameter list in lockstep with
+  /// [publishDirectUpload] — every param has a default, so a forgotten
+  /// forward at the call site fails silently rather than at compile time.
   Future<bool> _publishDirectUploadUnlocked(
     PendingUpload upload, {
     int? expirationTimestamp,

--- a/mobile/test/providers/video_publish_provider_test.dart
+++ b/mobile/test/providers/video_publish_provider_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Unit tests for VideoPublishNotifier
 // ABOUTME: Tests state management for video publishing
 
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
@@ -9,15 +10,24 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart' show NativeProofData;
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/divine_video_draft.dart';
 import 'package:openvine/models/video_publish/video_publish_state.dart';
 import 'package:openvine/models/video_reply_context.dart';
+import 'package:openvine/providers/social_providers.dart';
 import 'package:openvine/providers/video_publish_provider.dart';
 import 'package:openvine/screens/video_detail_screen.dart';
 import 'package:openvine/services/cawg_verifier_client.dart';
+import 'package:openvine/services/draft_storage_service.dart';
 import 'package:openvine/services/mention_resolution_service.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:profile_repository/profile_repository.dart';
 
 class MockProfileRepository extends Mock implements ProfileRepository {}
+
+class _MockDraftStorageService extends Mock implements DraftStorageService {}
+
+class _FakeDivineVideoDraft extends Fake implements DivineVideoDraft {}
 
 void main() {
   group('VideoPublishNotifier', () {
@@ -208,5 +218,91 @@ void main() {
       expect(destination.path, VideoDetailScreen.pathForId(rootAddressableId));
       expect(destination.extra.autoOpenComments, isTrue);
     });
+  });
+
+  group('VideoPublishNotifier publishVideo duplicate guard (#6018)', () {
+    setUpAll(() {
+      registerFallbackValue(_FakeDivineVideoDraft());
+    });
+
+    DivineVideoDraft createDraft() {
+      final clip = DivineVideoClip(
+        id: 'clip_1',
+        video: EditorVideo.file('/tmp/test.mp4'),
+        duration: const Duration(seconds: 6),
+        recordedAt: DateTime(2025),
+        originalAspectRatio: 9 / 16,
+        targetAspectRatio: .vertical,
+      );
+      return DivineVideoDraft(
+        id: 'draft_1',
+        clips: [clip],
+        title: 'Plants',
+        description: '',
+        hashtags: const {},
+        selectedApproach: 'camera',
+        createdAt: DateTime(2025),
+        lastModified: DateTime(2025),
+        publishStatus: PublishStatus.draft,
+        publishAttempts: 0,
+        finalRenderedClip: clip,
+        // Creator identity metadata present so publishVideo skips the
+        // proof refresh and suspends on the mocked saveDraft below.
+        proofManifestJson: jsonEncode(
+          const NativeProofData(
+            videoHash: 'abc123',
+            creatorBindingAssertionLabel: 'video.divine.nostr.creator_binding',
+            creatorBindingPayloadJson: '{"version":1}',
+          ).toJson(),
+        ),
+      );
+    }
+
+    testWidgets(
+      'reset during an in-flight publish does not reopen the gate for '
+      'the same source draft',
+      (tester) async {
+        final mockDraftStorage = _MockDraftStorageService();
+        // Never completes - keeps the first publish in flight, like the
+        // 20s+ audio-reuse window in production.
+        final saveDraftGate = Completer<void>();
+        when(
+          () => mockDraftStorage.saveDraft(any()),
+        ).thenAnswer((_) => saveDraftGate.future);
+
+        final container = ProviderContainer(
+          overrides: [
+            draftStorageServiceProvider.overrideWithValue(mockDraftStorage),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: const MaterialApp(home: SizedBox()),
+          ),
+        );
+        final context = tester.element(find.byType(SizedBox));
+        final notifier = container.read(videoPublishProvider.notifier);
+        final draft = createDraft();
+
+        unawaited(notifier.publishVideo(context, draft));
+        await tester.pump();
+        expect(
+          container.read(videoPublishProvider).publishState,
+          VideoPublishState.preparing,
+        );
+
+        // clearAll resets the state ~600ms after navigation while the
+        // publish future is still running - simulate that state wipe.
+        notifier.reset();
+
+        unawaited(notifier.publishVideo(context, draft));
+        await tester.pump();
+
+        verify(() => mockDraftStorage.saveDraft(any())).called(1);
+      },
+    );
   });
 }

--- a/mobile/test/services/video_event_publisher_double_publish_test.dart
+++ b/mobile/test/services/video_event_publisher_double_publish_test.dart
@@ -1,0 +1,291 @@
+// ABOUTME: Regression tests for #6018 - concurrent publishDirectUpload calls
+// ABOUTME: must coalesce into one signed/broadcast addressable video event
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:blossom_upload_service/blossom_upload_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/relay/publish_outcome.dart';
+import 'package:openvine/models/pending_upload.dart';
+import 'package:openvine/services/audio_extraction_service.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/personal_event_cache_service.dart';
+import 'package:openvine/services/upload_manager.dart';
+import 'package:openvine/services/video_event_publisher.dart';
+
+class _MockUploadManager extends Mock implements UploadManager {}
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockAuthService extends Mock implements AuthService {}
+
+class _MockBlossomUploadService extends Mock implements BlossomUploadService {}
+
+class _MockAudioExtractionService extends Mock
+    implements AudioExtractionService {}
+
+class _MockPersonalEventCacheService extends Mock
+    implements PersonalEventCacheService {}
+
+class _FakeEvent extends Fake implements Event {}
+
+void main() {
+  late _MockUploadManager mockUploadManager;
+  late _MockNostrClient mockNostrClient;
+  late _MockAuthService mockAuthService;
+  late _MockBlossomUploadService mockBlossomUploadService;
+  late _MockAudioExtractionService mockAudioExtractionService;
+  late _MockPersonalEventCacheService mockPersonalEventCache;
+  late VideoEventPublisher publisher;
+
+  const testPubkey =
+      '385c3a6ec0b9d57a4330dbd6284989be5bd00e41c535f9ca39b6ae7c521b81cd';
+
+  setUpAll(() {
+    registerFallbackValue(_FakeEvent());
+    registerFallbackValue(UploadStatus.pending);
+    registerFallbackValue(File(''));
+    registerFallbackValue(Duration.zero);
+  });
+
+  setUp(() {
+    mockUploadManager = _MockUploadManager();
+    mockNostrClient = _MockNostrClient();
+    mockAuthService = _MockAuthService();
+    mockBlossomUploadService = _MockBlossomUploadService();
+    mockAudioExtractionService = _MockAudioExtractionService();
+    mockPersonalEventCache = _MockPersonalEventCacheService();
+
+    publisher = VideoEventPublisher(
+      uploadManager: mockUploadManager,
+      nostrService: mockNostrClient,
+      authService: mockAuthService,
+      personalEventCache: mockPersonalEventCache,
+      blossomUploadService: mockBlossomUploadService,
+      audioExtractionService: mockAudioExtractionService,
+    );
+
+    when(() => mockAuthService.isAuthenticated).thenReturn(true);
+    when(() => mockAuthService.currentPublicKeyHex).thenReturn(testPubkey);
+
+    when(() => mockNostrClient.isInitialized).thenReturn(true);
+    when(() => mockNostrClient.configuredRelayCount).thenReturn(1);
+    when(() => mockNostrClient.connectedRelayCount).thenReturn(1);
+    when(
+      () => mockNostrClient.configuredRelays,
+    ).thenReturn(const ['wss://relay.divine.video']);
+    when(
+      () => mockNostrClient.connectedRelays,
+    ).thenReturn(const ['wss://relay.divine.video']);
+    when(() => mockNostrClient.publicKey).thenReturn(testPubkey);
+
+    when(
+      () => mockUploadManager.updateUploadStatus(
+        any(),
+        any(),
+        nostrEventId: any(named: 'nostrEventId'),
+      ),
+    ).thenAnswer((_) async {});
+
+    when(() => mockPersonalEventCache.cacheUserEvent(any())).thenReturn(null);
+    when(() => mockPersonalEventCache.getEventById(any())).thenReturn(null);
+  });
+
+  PendingUpload createUpload() {
+    return PendingUpload(
+      id: 'test-upload-id',
+      localVideoPath: '/tmp/test.mp4',
+      nostrPubkey: testPubkey,
+      status: UploadStatus.readyToPublish,
+      createdAt: DateTime.now(),
+      videoId: 'test-video-id',
+      title: 'Plants',
+      cdnUrl: 'https://cdn.example.com/video.mp4',
+      fallbackUrl: 'https://cdn.example.com/video.mp4',
+    );
+  }
+
+  group('VideoEventPublisher concurrent publishDirectUpload (#6018)', () {
+    test(
+      'second call during a slow failing audio-reuse step reuses the '
+      'in-flight publish instead of signing a duplicate event',
+      () async {
+        // Gate the audio extraction so the first publish is stuck in the
+        // audio-reuse step - the window where production duplicates were
+        // minted. The extraction then fails, matching the observed
+        // signature (allow_audio_reuse=true, no audio e-tag).
+        final audioGate = Completer<void>();
+        when(
+          () => mockAudioExtractionService.extractAudio(
+            videoPath: any(named: 'videoPath'),
+          ),
+        ).thenAnswer((_) async {
+          await audioGate.future;
+          throw const AudioExtractionException('extraction failed');
+        });
+
+        var videoSignCount = 0;
+        final broadcastVideoEvents = <Event>[];
+        when(
+          () => mockAuthService.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer((invocation) async {
+          videoSignCount++;
+          return Event(
+            testPubkey,
+            invocation.namedArguments[#kind] as int,
+            invocation.namedArguments[#tags] as List<List<String>>,
+            'video content',
+            createdAt: 1700000000 + videoSignCount,
+          );
+        });
+        when(
+          () => mockNostrClient.publishEventAwaitOk(
+            any(),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer((invocation) async {
+          final event = invocation.positionalArguments.first as Event;
+          broadcastVideoEvents.add(event);
+          return PublishOutcome(
+            eventId: event.id,
+            acceptedBy: const ['wss://relay.divine.video'],
+            rejectedBy: const {},
+            noResponseFrom: const [],
+          );
+        });
+
+        final upload = createUpload();
+        final firstPublish = publisher.publishDirectUpload(
+          upload,
+          allowAudioReuse: true,
+        );
+        // Let the first call run into the gated audio extraction.
+        await pumpEventQueue();
+
+        final secondPublish = publisher.publishDirectUpload(
+          upload,
+          allowAudioReuse: true,
+        );
+        await pumpEventQueue();
+
+        audioGate.complete();
+        final results = await Future.wait([firstPublish, secondPublish]);
+
+        expect(results, everyElement(isTrue));
+        expect(
+          videoSignCount,
+          equals(1),
+          reason:
+              'a concurrent second publish must not re-sign a fresh '
+              'event with a new id',
+        );
+        expect(
+          broadcastVideoEvents,
+          hasLength(1),
+          reason: 'exactly one kind-34236 event may reach the relays',
+        );
+      },
+    );
+
+    test('publishes again for the same upload once the first publish '
+        'has completed', () async {
+      when(
+        () => mockAuthService.createAndSignEvent(
+          kind: any(named: 'kind'),
+          content: any(named: 'content'),
+          tags: any(named: 'tags'),
+        ),
+      ).thenAnswer(
+        (invocation) async => Event(
+          testPubkey,
+          invocation.namedArguments[#kind] as int,
+          invocation.namedArguments[#tags] as List<List<String>>,
+          'video content',
+        ),
+      );
+      var broadcastCount = 0;
+      when(
+        () => mockNostrClient.publishEventAwaitOk(
+          any(),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer((invocation) async {
+        broadcastCount++;
+        return PublishOutcome(
+          eventId: (invocation.positionalArguments.first as Event).id,
+          acceptedBy: const ['wss://relay.divine.video'],
+          rejectedBy: const {},
+          noResponseFrom: const [],
+        );
+      });
+
+      final upload = createUpload();
+      expect(await publisher.publishDirectUpload(upload), isTrue);
+      expect(
+        await publisher.publishDirectUpload(upload),
+        isTrue,
+        reason: 'sequential re-publish (e.g. an edit) must not be blocked',
+      );
+      expect(broadcastCount, equals(2));
+    });
+
+    test(
+      'concurrent publishes for different uploads are not coalesced',
+      () async {
+        when(
+          () => mockAuthService.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer(
+          (invocation) async => Event(
+            testPubkey,
+            invocation.namedArguments[#kind] as int,
+            invocation.namedArguments[#tags] as List<List<String>>,
+            'video content',
+          ),
+        );
+        final broadcastDTags = <String>[];
+        when(
+          () => mockNostrClient.publishEventAwaitOk(
+            any(),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer((invocation) async {
+          final event = invocation.positionalArguments.first as Event;
+          broadcastDTags.add(
+            event.tags.firstWhere((tag) => tag.first == 'd')[1],
+          );
+          return PublishOutcome(
+            eventId: event.id,
+            acceptedBy: const ['wss://relay.divine.video'],
+            rejectedBy: const {},
+            noResponseFrom: const [],
+          );
+        });
+
+        final results = await Future.wait([
+          publisher.publishDirectUpload(createUpload()),
+          publisher.publishDirectUpload(
+            createUpload().copyWith(videoId: 'other-video-id'),
+          ),
+        ]);
+
+        expect(results, everyElement(isTrue));
+        expect(
+          broadcastDTags,
+          unorderedEquals(['test-video-id', 'other-video-id']),
+        );
+      },
+    );
+  });
+}

--- a/mobile/test/services/video_event_publisher_double_publish_test.dart
+++ b/mobile/test/services/video_event_publisher_double_publish_test.dart
@@ -34,82 +34,86 @@ class _MockPersonalEventCacheService extends Mock
 class _FakeEvent extends Fake implements Event {}
 
 void main() {
-  late _MockUploadManager mockUploadManager;
-  late _MockNostrClient mockNostrClient;
-  late _MockAuthService mockAuthService;
-  late _MockBlossomUploadService mockBlossomUploadService;
-  late _MockAudioExtractionService mockAudioExtractionService;
-  late _MockPersonalEventCacheService mockPersonalEventCache;
-  late VideoEventPublisher publisher;
-
-  const testPubkey =
-      '385c3a6ec0b9d57a4330dbd6284989be5bd00e41c535f9ca39b6ae7c521b81cd';
-
-  setUpAll(() {
-    registerFallbackValue(_FakeEvent());
-    registerFallbackValue(UploadStatus.pending);
-    registerFallbackValue(File(''));
-    registerFallbackValue(Duration.zero);
-  });
-
-  setUp(() {
-    mockUploadManager = _MockUploadManager();
-    mockNostrClient = _MockNostrClient();
-    mockAuthService = _MockAuthService();
-    mockBlossomUploadService = _MockBlossomUploadService();
-    mockAudioExtractionService = _MockAudioExtractionService();
-    mockPersonalEventCache = _MockPersonalEventCacheService();
-
-    publisher = VideoEventPublisher(
-      uploadManager: mockUploadManager,
-      nostrService: mockNostrClient,
-      authService: mockAuthService,
-      personalEventCache: mockPersonalEventCache,
-      blossomUploadService: mockBlossomUploadService,
-      audioExtractionService: mockAudioExtractionService,
-    );
-
-    when(() => mockAuthService.isAuthenticated).thenReturn(true);
-    when(() => mockAuthService.currentPublicKeyHex).thenReturn(testPubkey);
-
-    when(() => mockNostrClient.isInitialized).thenReturn(true);
-    when(() => mockNostrClient.configuredRelayCount).thenReturn(1);
-    when(() => mockNostrClient.connectedRelayCount).thenReturn(1);
-    when(
-      () => mockNostrClient.configuredRelays,
-    ).thenReturn(const ['wss://relay.divine.video']);
-    when(
-      () => mockNostrClient.connectedRelays,
-    ).thenReturn(const ['wss://relay.divine.video']);
-    when(() => mockNostrClient.publicKey).thenReturn(testPubkey);
-
-    when(
-      () => mockUploadManager.updateUploadStatus(
-        any(),
-        any(),
-        nostrEventId: any(named: 'nostrEventId'),
-      ),
-    ).thenAnswer((_) async {});
-
-    when(() => mockPersonalEventCache.cacheUserEvent(any())).thenReturn(null);
-    when(() => mockPersonalEventCache.getEventById(any())).thenReturn(null);
-  });
-
-  PendingUpload createUpload() {
-    return PendingUpload(
-      id: 'test-upload-id',
-      localVideoPath: '/tmp/test.mp4',
-      nostrPubkey: testPubkey,
-      status: UploadStatus.readyToPublish,
-      createdAt: DateTime.now(),
-      videoId: 'test-video-id',
-      title: 'Plants',
-      cdnUrl: 'https://cdn.example.com/video.mp4',
-      fallbackUrl: 'https://cdn.example.com/video.mp4',
-    );
-  }
-
   group('VideoEventPublisher concurrent publishDirectUpload (#6018)', () {
+    late _MockUploadManager mockUploadManager;
+    late _MockNostrClient mockNostrClient;
+    late _MockAuthService mockAuthService;
+    late _MockBlossomUploadService mockBlossomUploadService;
+    late _MockAudioExtractionService mockAudioExtractionService;
+    late _MockPersonalEventCacheService mockPersonalEventCache;
+    late VideoEventPublisher publisher;
+
+    const testPubkey =
+        '385c3a6ec0b9d57a4330dbd6284989be5bd00e41c535f9ca39b6ae7c521b81cd';
+
+    setUpAll(() {
+      registerFallbackValue(_FakeEvent());
+      registerFallbackValue(UploadStatus.pending);
+      registerFallbackValue(File(''));
+      registerFallbackValue(Duration.zero);
+    });
+
+    setUp(() {
+      mockUploadManager = _MockUploadManager();
+      mockNostrClient = _MockNostrClient();
+      mockAuthService = _MockAuthService();
+      mockBlossomUploadService = _MockBlossomUploadService();
+      mockAudioExtractionService = _MockAudioExtractionService();
+      mockPersonalEventCache = _MockPersonalEventCacheService();
+
+      publisher = VideoEventPublisher(
+        uploadManager: mockUploadManager,
+        nostrService: mockNostrClient,
+        authService: mockAuthService,
+        personalEventCache: mockPersonalEventCache,
+        blossomUploadService: mockBlossomUploadService,
+        audioExtractionService: mockAudioExtractionService,
+      );
+
+      when(() => mockAuthService.isAuthenticated).thenReturn(true);
+      when(() => mockAuthService.currentPublicKeyHex).thenReturn(testPubkey);
+
+      when(() => mockNostrClient.isInitialized).thenReturn(true);
+      when(() => mockNostrClient.configuredRelayCount).thenReturn(1);
+      when(() => mockNostrClient.connectedRelayCount).thenReturn(1);
+      when(
+        () => mockNostrClient.configuredRelays,
+      ).thenReturn(const ['wss://relay.divine.video']);
+      when(
+        () => mockNostrClient.connectedRelays,
+      ).thenReturn(const ['wss://relay.divine.video']);
+      when(() => mockNostrClient.publicKey).thenReturn(testPubkey);
+
+      when(
+        () => mockUploadManager.updateUploadStatus(
+          any(),
+          any(),
+          nostrEventId: any(named: 'nostrEventId'),
+        ),
+      ).thenAnswer((_) async {});
+
+      when(() => mockPersonalEventCache.cacheUserEvent(any())).thenReturn(null);
+      when(() => mockPersonalEventCache.getEventById(any())).thenReturn(null);
+    });
+
+    // Only the audio-reuse test needs a non-empty localVideoPath (it gates the
+    // audio-extraction step). The other tests pass '' so publishDirectUpload
+    // skips the thumbnail/blurhash branch and its real pro_video_editor plugin
+    // channel + retry timers.
+    PendingUpload createUpload({String localVideoPath = ''}) {
+      return PendingUpload(
+        id: 'test-upload-id',
+        localVideoPath: localVideoPath,
+        nostrPubkey: testPubkey,
+        status: UploadStatus.readyToPublish,
+        createdAt: DateTime.now(),
+        videoId: 'test-video-id',
+        title: 'Plants',
+        cdnUrl: 'https://cdn.example.com/video.mp4',
+        fallbackUrl: 'https://cdn.example.com/video.mp4',
+      );
+    }
+
     test(
       'second call during a slow failing audio-reuse step reuses the '
       'in-flight publish instead of signing a duplicate event',
@@ -162,7 +166,7 @@ void main() {
           );
         });
 
-        final upload = createUpload();
+        final upload = createUpload(localVideoPath: '/tmp/test.mp4');
         final firstPublish = publisher.publishDirectUpload(
           upload,
           allowAudioReuse: true,


### PR DESCRIPTION
## Description

The app republished some videos a second time automatically: two concurrent `publishDirectUpload` invocations for the same upload each signed and broadcast their own kind-34236 event for the same coordinate. The ~20–25s audio-reuse step sits before both the video signing and the idempotency claim, so during that window neither call could see the other's signed event and both re-signed fresh — two ids, identical content, likes fragmenting across the two versions.

Two changes:

- **`VideoEventPublisher.publishDirectUpload` — in-flight lock keyed by `upload.videoId` (the d-tag).** A concurrent second call awaits the in-flight publish's result instead of signing a duplicate; the lock is released in a `finally`, so sequential re-publishes (real edits) still work. This is the core fix and covers every entry path (editor post, drafts-tab re-tap, background retry), since they all funnel through this method. The issue's suggested "move the idempotency claim before the audio step" is not implementable literally — no event id exists before signing — so the d-tag lock *is* that claim.
- **`VideoPublishNotifier.publishVideo` — defense-in-depth guard on `sourceDraftId`,** held in a private set for the lifetime of the publish future. The previous state-based guard reopened ~600ms after navigation because `clearAll` resets the state while the publish keeps running 20–30s; that's why it lives outside `state`. The dead `.uploading` branch (never assigned anywhere) is removed.

Both regression tests were verified red on unfixed code and green with the fix: the publisher test follows the issue's test plan (second call during a gated, *failing* audio extraction — matching the production signature of `allow_audio_reuse=true` with no audio e-tag — must yield exactly one signed/broadcast event), plus guards that sequential re-publishes and different uploads are not coalesced. The provider test pins that `reset()` during an in-flight publish does not reopen the gate.

**Related Issue:** Closes #6018

## Out of Scope

- Migrating likes already placed on superseded event ids (tracked by the follow-ups referenced in #6018).
- The pre-existing stuck-`.preparing` state when a publish throws before navigation (unrelated latent issue, unchanged behavior).
- Identifying which UI surface fired the second entry (open question in #6018) — the lock makes the answer irrelevant for correctness.

## Verification

- `flutter test test/services/video_event_publisher_double_publish_test.dart` (new, red without fix / green with fix, verified via `git stash`)
- `flutter test test/providers/video_publish_provider_test.dart` (extended, same red/green verification)
- All 12 `video_event_publisher_*` suites, `test/services/video_publish/`, `test/widgets/library/drafts_tab_test.dart` — green
- `flutter analyze lib test integration_test` — no issues
- `dart format` — clean

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore