### PR TITLE
fix(minor-safety): refresh account-state providers on foreground-resume (#185)

### DIFF
--- a/docs/superpowers/specs/2026-07-10-foreground-resume-account-state-refetch-design.md
+++ b/docs/superpowers/specs/2026-07-10-foreground-resume-account-state-refetch-design.md
@@ -1,0 +1,124 @@
+# Foreground-resume account-state refetch (mobile)
+
+Design for the mobile half of divinevideo/support-trust-safety#185, part of
+the protected-minor (13-15) safeguards epic #173. Surfaced during the #176
+DM-restriction review.
+
+## Problem (verified against code)
+
+The two account-state providers are plain `FutureProvider`s that only
+recompute on an auth-state transition (they `ref.watch(currentAuthStateProvider)`)
+or an explicit `ref.invalidate`:
+
+- `protectedMinorStatusProvider` — drives the #176 DM gate + #175 content
+  lock through `isProtectedMinorProvider` / `isDmRestrictedProvider`.
+- `currentMinorAccountReviewStatusProvider` — drives the #174/#175 blocking
+  review gate (the app-router redirect).
+
+`app_lifecycle_handler.dart`'s `AppLifecycleState.resumed` branch already does
+resume work (relay reconnect, notification refresh, perf-tracker reset,
+foreground flag) but touches neither provider. So when account state flips
+**server-side while the app sits idle-authenticated** — a moderator sets or
+clears `verified_minor`, or a review status changes — the client keeps
+enforcing the stale state until the next relaunch or re-auth.
+
+Web already covers this: `useProtectedMinorStatus` sets `staleTime: 0` +
+`refetchOnWindowFocus: true`. This is mobile parity.
+
+Impact fails **open** in the strengthen direction: an account flagged a
+protected minor mid-session keeps DM + adult-content access until relaunch.
+The lift direction (an aged-up teen staying restricted until relaunch) is the
+less-severe tail, and the sticky store intentionally holds protection until a
+positive not-a-minor signal anyway.
+
+## The design nut
+
+Resolving `protectedMinorStatusProvider` can trigger a Keycast token refresh
+via `getSessionOrRefresh()` (a network call + storage write) when the cached
+session is stale — so invalidating on **every** resume would hit Keycast on
+every foreground. The guard is a min-interval TTL: skip the refetch if the
+account state was refreshed within the last N. (In the common case a valid
+session is reused with no refresh; the guard bounds the worst case.)
+
+## Decisions
+
+- **Min-interval: 15 minutes.** This is the strengthen-protection direction,
+  so propagation latency matters; the worst case is bounded (~4 refreshes/hour,
+  and only when the token is actually stale).
+- **Refetch scope: both providers.** The epic frames #185 as hardening the
+  #174 review gate + #175 content lock + #176 DM gate together, and the
+  review-status provider drives the most consequential (suspend/blocking) gate.
+  The review-status provider hits the app's own API, not Keycast, so the only
+  Keycast-cost concern is the protected-minor one, already bounded by the TTL.
+
+## Design
+
+A small pure-Dart coordinator owns the TTL decision; a keep-alive provider
+injects the two invalidations; the existing resume orchestrator calls it.
+
+```dart
+class AccountStateResumeRefresher {
+  AccountStateResumeRefresher({
+    required VoidCallback invalidateProtectedMinorStatus,
+    required VoidCallback invalidateReviewStatus,
+    Duration minInterval = const Duration(minutes: 15),
+    DateTime Function() now = DateTime.now,
+  });
+
+  /// Invalidate both account-state providers on foreground resume, unless the
+  /// account is unauthenticated or the last refresh was within [minInterval].
+  void refreshOnResume({required bool authenticated}) {
+    if (!authenticated) return;
+    final t = _now();
+    if (_lastRefreshedAt != null &&
+        t.difference(_lastRefreshedAt!) < _minInterval) {
+      return;
+    }
+    _lastRefreshedAt = t;
+    _invalidateProtectedMinorStatus();
+    _invalidateReviewStatus();
+  }
+}
+```
+
+- **State:** in-memory `_lastRefreshedAt`. No persistence — a cold start
+  re-auths and refetches anyway.
+- **Provider:** `accountStateResumeRefresherProvider` (plain `Provider`, alive
+  for the container lifetime) wires the two invalidations to
+  `ref.invalidate(protectedMinorStatusProvider)` and
+  `ref.invalidate(currentMinorAccountReviewStatusProvider)`.
+- **Call site:** one line in the `AppLifecycleState.resumed` branch of
+  `app_lifecycle_handler.dart`, alongside the reconnect / notification-refresh
+  work it already orchestrates:
+  ```dart
+  ref.read(accountStateResumeRefresherProvider).refreshOnResume(
+    authenticated: ref.read(authServiceProvider).isAuthenticated,
+  );
+  ```
+
+### Fail-safe
+
+Invalidation drops `protectedMinorStatusProvider` to `AsyncLoading`. Both gate
+providers read the sticky last-known value during reload
+(`store.isProtectedMinorFor` / `store.lastKnownFor`), so a protected minor
+stays protected through the refetch — no flicker-open window. A resume-refetch
+that resolves to unknown/error therefore never reduces protection; it can only
+strengthen it or correctly lift it on a positive not-a-minor signal.
+
+## Test plan
+
+- **Pure-class unit tests** (fake clock, spy invalidators):
+  - first resume refreshes both providers;
+  - a second resume within 15m does not refresh;
+  - a second resume after 15m refreshes again;
+  - unauthenticated never refreshes;
+  - the interval boundary (exactly 15m).
+- **`ProviderContainer` integration test:** the two real providers rebuild on
+  `refreshOnResume` and do not within the interval (build-count spy).
+
+## Out of scope
+
+- The in-app age-review-completion path invalidating the review provider but
+  not `protectedMinorStatusProvider` — a separate narrower miss the issue
+  scopes away from this ticket.
+- #186 (blocked-send terminal in the DM queue drain) — its own PR.

--- a/mobile/lib/services/account_state_resume_refresher.dart
+++ b/mobile/lib/services/account_state_resume_refresher.dart
@@ -31,6 +31,10 @@ class AccountStateResumeRefresher {
   final Duration _minInterval;
   final DateTime Function() _now;
 
+  // Intentionally not keyed by account: an account switch transits a
+  // non-authenticated authState that invalidates the status providers
+  // directly, so this only bounds the resume-triggered refetch, not
+  // switch-time freshness.
   DateTime? _lastRefreshedAt;
 
   /// Invalidate both account-state providers, unless the account is

--- a/mobile/lib/services/account_state_resume_refresher.dart
+++ b/mobile/lib/services/account_state_resume_refresher.dart
@@ -1,0 +1,60 @@
+// ABOUTME: TTL-guarded refetch of the protected-minor account-state providers
+// ABOUTME: on app foreground-resume, so server-side flips are picked up promptly
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:openvine/providers/minor_account_review_providers.dart';
+import 'package:openvine/providers/protected_minor_providers.dart';
+
+/// Refetches the protected-minor safeguards' account-state providers on app
+/// foreground-resume, so a server-side flip that lands while the app sits
+/// idle-authenticated is picked up without waiting for a relaunch or re-auth.
+///
+/// Guarded by [minInterval]: resolving [protectedMinorStatusProvider] can
+/// trigger a Keycast token refresh, so a frequent backgrounder must not force a
+/// refetch on every foreground. Invalidation only ever strengthens protection
+/// or correctly lifts it — the gate providers read the sticky last-known value
+/// during the reload, so a protected minor never flickers open.
+class AccountStateResumeRefresher {
+  AccountStateResumeRefresher({
+    required VoidCallback invalidateProtectedMinorStatus,
+    required VoidCallback invalidateReviewStatus,
+    Duration minInterval = const Duration(minutes: 15),
+    DateTime Function() now = DateTime.now,
+  }) : _invalidateProtectedMinorStatus = invalidateProtectedMinorStatus,
+       _invalidateReviewStatus = invalidateReviewStatus,
+       _minInterval = minInterval,
+       _now = now;
+
+  final VoidCallback _invalidateProtectedMinorStatus;
+  final VoidCallback _invalidateReviewStatus;
+  final Duration _minInterval;
+  final DateTime Function() _now;
+
+  DateTime? _lastRefreshedAt;
+
+  /// Invalidate both account-state providers, unless the account is
+  /// unauthenticated or the last refresh was within [minInterval].
+  void refreshOnResume({required bool authenticated}) {
+    if (!authenticated) return;
+    final now = _now();
+    final last = _lastRefreshedAt;
+    if (last != null && now.difference(last) < _minInterval) return;
+    _lastRefreshedAt = now;
+    _invalidateProtectedMinorStatus();
+    _invalidateReviewStatus();
+  }
+}
+
+/// App-lifetime coordinator wired to invalidate the real account-state
+/// providers. Held alive by the container; the resume handler reads it on each
+/// foreground transition.
+final accountStateResumeRefresherProvider =
+    Provider<AccountStateResumeRefresher>((ref) {
+      return AccountStateResumeRefresher(
+        invalidateProtectedMinorStatus: () =>
+            ref.invalidate(protectedMinorStatusProvider),
+        invalidateReviewStatus: () =>
+            ref.invalidate(currentMinorAccountReviewStatusProvider),
+      );
+    });

--- a/mobile/lib/widgets/app_lifecycle_handler.dart
+++ b/mobile/lib/widgets/app_lifecycle_handler.dart
@@ -14,6 +14,7 @@ import 'package:openvine/providers/app_foreground_provider.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/video_publish_provider.dart';
+import 'package:openvine/services/account_state_resume_refresher.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/background_activity_manager.dart';
 import 'package:openvine/services/video_editor/video_editor_render_service.dart';
@@ -128,6 +129,16 @@ class _AppLifecycleHandlerState extends ConsumerState<AppLifecycleHandler>
               ?.refresh(reason: NotificationRefreshReason.appResume),
         );
         unawaited(context.read<InviteStatusCubit?>()?.load());
+
+        // Refetch protected-minor account state so a server-side flip that
+        // landed while idle-authenticated is picked up on resume, rather than
+        // waiting for the next relaunch or re-auth. TTL-guarded internally so a
+        // frequent backgrounder doesn't hit Keycast on every foreground.
+        ref
+            .read(accountStateResumeRefresherProvider)
+            .refreshOnResume(
+              authenticated: ref.read(authServiceProvider).isAuthenticated,
+            );
 
         // Don't force resume playback. Foreground, route, and overlay gates
         // decide which mounted feed may play.

--- a/mobile/test/services/account_state_resume_refresher_test.dart
+++ b/mobile/test/services/account_state_resume_refresher_test.dart
@@ -1,0 +1,132 @@
+// ABOUTME: Unit tests for AccountStateResumeRefresher TTL-guarded resume refetch
+// ABOUTME: Verifies min-interval gating, auth gating, and both-provider invalidation
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/models/minor_account_review_status.dart';
+import 'package:openvine/models/protected_minor_status.dart';
+import 'package:openvine/providers/minor_account_review_providers.dart';
+import 'package:openvine/providers/protected_minor_providers.dart';
+import 'package:openvine/services/account_state_resume_refresher.dart';
+
+void main() {
+  group(AccountStateResumeRefresher, () {
+    late int protectedMinorInvalidations;
+    late int reviewInvalidations;
+    late DateTime now;
+
+    AccountStateResumeRefresher build({
+      Duration minInterval = const Duration(minutes: 15),
+    }) {
+      return AccountStateResumeRefresher(
+        invalidateProtectedMinorStatus: () => protectedMinorInvalidations++,
+        invalidateReviewStatus: () => reviewInvalidations++,
+        minInterval: minInterval,
+        now: () => now,
+      );
+    }
+
+    setUp(() {
+      protectedMinorInvalidations = 0;
+      reviewInvalidations = 0;
+      now = DateTime(2026, 7, 10, 12);
+    });
+
+    test('refreshes both providers on the first authenticated resume', () {
+      build().refreshOnResume(authenticated: true);
+
+      expect(protectedMinorInvalidations, 1);
+      expect(reviewInvalidations, 1);
+    });
+
+    test('does not refresh when unauthenticated', () {
+      build().refreshOnResume(authenticated: false);
+
+      expect(protectedMinorInvalidations, isZero);
+      expect(reviewInvalidations, isZero);
+    });
+
+    test('skips a second resume within the min-interval', () {
+      final refresher = build();
+
+      refresher.refreshOnResume(authenticated: true);
+      now = now.add(const Duration(minutes: 14, seconds: 59));
+      refresher.refreshOnResume(authenticated: true);
+
+      expect(protectedMinorInvalidations, 1);
+      expect(reviewInvalidations, 1);
+    });
+
+    test('refreshes again once the min-interval has elapsed', () {
+      final refresher = build();
+
+      refresher.refreshOnResume(authenticated: true);
+      now = now.add(const Duration(minutes: 15));
+      refresher.refreshOnResume(authenticated: true);
+
+      expect(protectedMinorInvalidations, 2);
+      expect(reviewInvalidations, 2);
+    });
+
+    test('an unauthenticated resume does not start the interval clock', () {
+      final refresher = build();
+
+      // No-op: must not record a timestamp that would suppress the next
+      // authenticated resume.
+      refresher.refreshOnResume(authenticated: false);
+      now = now.add(const Duration(minutes: 1));
+      refresher.refreshOnResume(authenticated: true);
+
+      expect(protectedMinorInvalidations, 1);
+      expect(reviewInvalidations, 1);
+    });
+  });
+
+  group('accountStateResumeRefresherProvider', () {
+    test(
+      'invalidates the real account-state providers on resume, and the '
+      'interval guard suppresses a rapid second resume',
+      () async {
+        var protectedBuilds = 0;
+        var reviewBuilds = 0;
+        final container = ProviderContainer(
+          overrides: [
+            protectedMinorStatusProvider.overrideWith((ref) async {
+              protectedBuilds++;
+              return ProtectedMinorStatus.notProtected();
+            }),
+            currentMinorAccountReviewStatusProvider.overrideWith((ref) async {
+              reviewBuilds++;
+              return MinorAccountReviewStatus.active();
+            }),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        // First resolution.
+        await container.read(protectedMinorStatusProvider.future);
+        await container.read(currentMinorAccountReviewStatusProvider.future);
+        expect(protectedBuilds, 1);
+        expect(reviewBuilds, 1);
+
+        // Resume invalidates both; re-reading forces the rebuild.
+        container
+            .read(accountStateResumeRefresherProvider)
+            .refreshOnResume(authenticated: true);
+        await container.read(protectedMinorStatusProvider.future);
+        await container.read(currentMinorAccountReviewStatusProvider.future);
+        expect(protectedBuilds, 2);
+        expect(reviewBuilds, 2);
+
+        // A second resume within the 15-minute default is suppressed.
+        container
+            .read(accountStateResumeRefresherProvider)
+            .refreshOnResume(authenticated: true);
+        await container.read(protectedMinorStatusProvider.future);
+        await container.read(currentMinorAccountReviewStatusProvider.future);
+        expect(protectedBuilds, 2);
+        expect(reviewBuilds, 2);
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes #6033

## What this changes

The app decides whether to restrict a protected minor's DMs and lock adult content by reading the account's status from Keycast. Today it only re-reads that status when you sign in or switch accounts. If the status changes on the server while the app is just sitting open and signed in (a moderator flags an account as a protected minor, or an approval comes through), the app keeps using the old status until the next relaunch.

This makes the app re-check the status when it comes back to the foreground, which is what the web app already does when its window regains focus.

## Where

- A new `AccountStateResumeRefresher` (`mobile/lib/services/`) re-fetches the two providers the protections read: `protectedMinorStatusProvider` (the DM and adult-content gates) and `currentMinorAccountReviewStatusProvider` (the review/suspend gate).
- It's called from the existing app-resume handler (`mobile/lib/widgets/app_lifecycle_handler.dart`), alongside the relay reconnect and notification refresh that already run on resume.
- A 15-minute guard means someone who backgrounds and foregrounds a lot doesn't trigger a Keycast check every single time.

## Why it's safe

This can only ever tighten protection or correctly lift it, never open it by mistake. While the re-fetch is in flight the gates keep using the last known answer, so a protected minor never briefly loses their DM or content restriction. A re-fetch that fails (offline, expired token) leaves protection exactly as it was.

## Related

Relates to divinevideo/support-trust-safety#185 (part of epic #173).

## Verification

- New `test/services/account_state_resume_refresher_test.dart`: the 15-minute guard and the signed-out gate, plus a container test proving both providers actually re-fetch on resume and stay put within the interval.
- `flutter analyze` clean; the new service ships with its test (untested-services floor unchanged); no generated code.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
