### PR TITLE
fix(dm): treat a blocked DM send as terminal in the queue drain (#186)

### DIFF
--- a/docs/superpowers/specs/2026-07-10-dm-blocked-send-terminal-drain-design.md
+++ b/docs/superpowers/specs/2026-07-10-dm-blocked-send-terminal-drain-design.md
@@ -27,24 +27,25 @@ ever delivered to a non-approved recipient. This is purely a reliability /
 efficiency wart: wasted retry round-trips plus a permanently-`failed` row that
 never resolves.
 
-`recoverFullSend` is the single drain entry for both 1:1 and group rows (the
-retry sweep funnels every `recipientWrapStatus == failed` row through it), so
-there is one fix site.
+`recoverFullSend` is the drain entry for under-budget failed rows and stale
+pending rows in both 1:1 and group sends. Rows that already exhausted their
+retry budget remain outside these queries and are not cleaned up by this PR.
 
 ## Decision
 
 **Delete the row** on a blocked result, rather than adding a distinct
 non-retriable `OutgoingWrapStatus.blocked` state. Deleting reuses the existing
-`deleteById` (already the terminal path the user's "Cancel send" uses), needs
+`deleteById` (already the terminal path after full delivery), needs
 no Drift schema migration (the `_parseStatus` fail-loud downgrade contract
 makes a new enum value a heavier, higher-blast-radius change), and the failed
-bubble simply disappears, cancel-like. A policy block is a permanent decision,
-not a transient error, and this is a no-safety-impact wart, so the proportionate
-fix is to drop the doomed row.
+bubble simply disappears. A confirmed policy block is terminal, not a transient
+error, and this is a no-safety-impact wart, so the proportionate fix is to drop
+the doomed row. Fail-closed denials caused only by unresolved/loading account
+state are ordinary retryable failures and keep the queue row.
 
 ## Design
 
-Two files, one logical fix ("blocked is terminal" end-to-end):
+One logical fix ("confirmed blocked is terminal" end-to-end):
 
 **1. `dm_repository.dart` — `recoverFullSend` else branch.** Branch on
 `result.blocked` before the transient-failure path:
@@ -64,7 +65,9 @@ Two files, one logical fix ("blocked is terminal" end-to-end):
 `_finalizeAfterRecipientBlocked` deletes via `deleteById`, logs, and swallows /
 reports on error without rethrowing — matching `_finalizeAfterRecipientFailure`'s
 non-rethrow posture (the caller still returns the blocked result). If the delete
-somehow fails, the row stays `failed` and self-heals on a later sweep.
+somehow fails, the row stays `failed` or `pending` and is retried on a later
+sweep. A persistent delete failure can therefore re-run the gate each sweep;
+that implies a broken database and does not publish any wrap.
 
 **2. `outgoing_dm_retry_service.dart` — State B dispatch.** After
 `recoverFullSend`, the current `else` calls `incrementRetry` and counts
@@ -78,10 +81,12 @@ failed. This keeps "blocked is terminal" true end-to-end.
 
 - **dm_repository:** a queued row (`recipientWrapStatus == failed`) whose
   recipient is now non-approved, with `sendRumor` stubbed to return
-  `NIP17SendResult.blocked(...)` → `recoverFullSend` deletes the row
-  (`getById` returns `null`), does not mark it `failed`, and returns a blocked
-  result. Confirm the row is absent from `getRetryableForOwner` afterward (no
-  loop).
+  `NIP17SendResult.blocked(...)` → `recoverFullSend` calls `deleteById`, does
+  not mark it `failed`, and returns a blocked result. DAO deletion semantics
+  are covered by the DAO suite.
+- **Unknown-state regression:** a fail-closed denial with no trusted live or
+  persisted protected-minor verdict is classified as temporary; `sendRumor`
+  returns an ordinary failure so the queue row remains retryable.
 - **Regression guard:** a transient `NIP17SendResult.failure(...)` still marks
   both wraps `failed` and leaves the row retryable (unchanged path).
 - **outgoing_dm_retry_service:** a sweep over a row that drains to blocked

--- a/docs/superpowers/specs/2026-07-10-dm-blocked-send-terminal-drain-design.md
+++ b/docs/superpowers/specs/2026-07-10-dm-blocked-send-terminal-drain-design.md
@@ -1,0 +1,96 @@
+# Blocked DM send is terminal in the queue drain (mobile)
+
+Design for divinevideo/support-trust-safety#186, part of the protected-minor
+(13-15) safeguards epic #173. Surfaced during the #176 DM-restriction review.
+Low priority, **no safety impact**.
+
+## Problem (verified against code)
+
+The durable outbound-DM queue drain treats a policy-blocked send the same as a
+transient failure. In `DmRepository.recoverFullSend` (dm_repository package),
+`sendRumor` returns a `NIP17SendResult`; `result.success` is `false` for a
+`NIP17SendResult.blocked(...)` (blocked is a `NIP17SendFailure` subtype), so it
+falls into the `else` branch → `_finalizeAfterRecipientFailure` → both wraps
+marked `failed`. The retry sweep (`OutgoingDmRetryService`, State B) then
+re-attempts the row on every pass until `retryCount` reaches `maxRetries`,
+after which the row lingers permanently as a dead `failed` bubble.
+
+### Why it is not a safety issue
+
+Both `sendMessage` and `sendGroupMessage` pre-gate at `canSendTo` and return
+`.blocked` **before enqueuing**, so a blocked row never originates at initial
+send. A blocked row only arises when a row was enqueued while sending was
+allowed, then the policy flipped before the drain replayed it (sender became a
+protected minor, or an official recipient's approval was revoked). On replay,
+`sendRumor`'s choke point re-evaluates the policy and re-blocks — nothing is
+ever delivered to a non-approved recipient. This is purely a reliability /
+efficiency wart: wasted retry round-trips plus a permanently-`failed` row that
+never resolves.
+
+`recoverFullSend` is the single drain entry for both 1:1 and group rows (the
+retry sweep funnels every `recipientWrapStatus == failed` row through it), so
+there is one fix site.
+
+## Decision
+
+**Delete the row** on a blocked result, rather than adding a distinct
+non-retriable `OutgoingWrapStatus.blocked` state. Deleting reuses the existing
+`deleteById` (already the terminal path the user's "Cancel send" uses), needs
+no Drift schema migration (the `_parseStatus` fail-loud downgrade contract
+makes a new enum value a heavier, higher-blast-radius change), and the failed
+bubble simply disappears, cancel-like. A policy block is a permanent decision,
+not a transient error, and this is a no-safety-impact wart, so the proportionate
+fix is to drop the doomed row.
+
+## Design
+
+Two files, one logical fix ("blocked is terminal" end-to-end):
+
+**1. `dm_repository.dart` — `recoverFullSend` else branch.** Branch on
+`result.blocked` before the transient-failure path:
+
+```dart
+} else if (result.blocked) {
+  await _finalizeAfterRecipientBlocked(outgoingDao: dao, rumorId: rumorId);
+} else {
+  await _finalizeAfterRecipientFailure(
+    outgoingDao: dao,
+    rumorId: rumorId,
+    errorMessage: result.error ?? 'Unknown publish failure',
+  );
+}
+```
+
+`_finalizeAfterRecipientBlocked` deletes via `deleteById`, logs, and swallows /
+reports on error without rethrowing — matching `_finalizeAfterRecipientFailure`'s
+non-rethrow posture (the caller still returns the blocked result). If the delete
+somehow fails, the row stays `failed` and self-heals on a later sweep.
+
+**2. `outgoing_dm_retry_service.dart` — State B dispatch.** After
+`recoverFullSend`, the current `else` calls `incrementRetry` and counts
+`failedFullSend++`. A deleted row makes `incrementRetry` a harmless no-op
+(returns `false` on a missing row), but it is a wasted DB call and mis-counts a
+terminal block as a failure. Add an `else if (result.blocked)` that treats the
+row as terminal: skip `incrementRetry`, and count it as terminal rather than
+failed. This keeps "blocked is terminal" true end-to-end.
+
+## Test plan
+
+- **dm_repository:** a queued row (`recipientWrapStatus == failed`) whose
+  recipient is now non-approved, with `sendRumor` stubbed to return
+  `NIP17SendResult.blocked(...)` → `recoverFullSend` deletes the row
+  (`getById` returns `null`), does not mark it `failed`, and returns a blocked
+  result. Confirm the row is absent from `getRetryableForOwner` afterward (no
+  loop).
+- **Regression guard:** a transient `NIP17SendResult.failure(...)` still marks
+  both wraps `failed` and leaves the row retryable (unchanged path).
+- **outgoing_dm_retry_service:** a sweep over a row that drains to blocked
+  drops the row and does not call `incrementRetry` / count it as a retry
+  failure.
+
+## Out of scope
+
+- The initial-send race where a policy flip mid-`sendGroupMessage` loop yields a
+  per-recipient blocked result that gets marked retryable: vanishingly narrow,
+  and it self-heals through the drain fix above on the next sweep.
+- #185 (foreground-resume account-state refetch) — its own PR.

--- a/docs/superpowers/specs/2026-07-10-dm-blocked-send-terminal-drain-design.md
+++ b/docs/superpowers/specs/2026-07-10-dm-blocked-send-terminal-drain-design.md
@@ -77,6 +77,19 @@ terminal block as a failure. Add an `else if (result.blocked)` that treats the
 row as terminal: skip `incrementRetry`, and count it as terminal rather than
 failed. This keeps "blocked is terminal" true end-to-end.
 
+**3. `dm_repository.dart` — `retryPendingCollaboratorInvites`.** The third
+`recoverFullSend` caller (the collaborator-invite banner + video-publish
+retry) routed a `blocked` result through its generic `else`, counting a
+just-deleted terminal row into `failureCount`. That surfaced as a misleading
+"still needs to send" snackbar, and — for a row a concurrent sweep had
+already removed — reported the expected `ArgumentError` race to Crashlytics.
+Add an `else if (result.blocked)` that tallies a separate `blockedCount`
+(excluded from `failureCount`), and treat the row-missing `ArgumentError`
+as an expected race: skip it without reporting, mirroring
+`OutgoingDmRetryService`'s dispatch-error policy. A new
+`profileCollaboratorInviteBlockedResult` string tells the user the
+collaborator can't receive invites instead of implying a pending retry.
+
 ## Test plan
 
 - **dm_repository:** a queued row (`recipientWrapStatus == failed`) whose
@@ -92,6 +105,11 @@ failed. This keeps "blocked is terminal" true end-to-end.
 - **outgoing_dm_retry_service:** a sweep over a row that drains to blocked
   drops the row and does not call `incrementRetry` / count it as a retry
   failure.
+- **collaborator-invite recovery:** `retryPendingCollaboratorInvites` counts a
+  `blocked` result as terminal (`blockedCount`, not `failureCount`) with no
+  Crashlytics report, and skips a row removed by a concurrent sweep
+  (`ArgumentError`) without reporting it. The UI helpers surface the blocked
+  message apart from "still needs to send" and "all sent".
 
 ## Out of scope
 

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -4201,6 +4201,8 @@
     "profileCollaboratorInviteRetryUnavailable": "የተባባሪ ግብዣ እንደገና መሞከር አሁን አይገኝም።",
     "profileCollaboratorInviteRetryResult": "{count, plural, =0{የተባባሪ ግብዣዎች ተልከዋል።} =1{1 የተባባሪ ግብዣ አሁንም መላክ ይፈልጋል።} other{{count} የተባባሪ ግብዣዎች አሁንም መላክ ይፈልጋሉ።}}",
     "@profileCollaboratorInviteRetryResult": {"placeholders": {"count": {"type": "int"}}},
+    "profileCollaboratorInviteBlockedResult": "{count, plural, =1{1 ተባባሪ ግብዣ መቀበል አይችልም።} other{{count} ተባባሪዎች ግብዣ መቀበል አይችሉም።}}",
+    "@profileCollaboratorInviteBlockedResult": {"placeholders": {"count": {"type": "int"}}},
     "videoErrorAdultContentHidden": "የአዋቂዎች ይዘት ጠፍቷል። በቅንብሮች → የይዘት ማጣሪያዎች ውስጥ ማብራት ይችላሉ።",
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "ቪዲዮ መጫን አልተሳካም፦ {error}",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -4076,6 +4076,8 @@
     "profileCollaboratorInviteRetryUnavailable": "إعادة محاولة دعوة التعاون غير متاحة الآن.",
     "profileCollaboratorInviteRetryResult": "{count, plural, =0{تم إرسال دعوات التعاون.} one{دعوة تعاون واحدة ما زالت بحاجة للإرسال.} two{دعوتا تعاون ما زالتا بحاجة للإرسال.} few{{count} دعوات تعاون ما زالت بحاجة للإرسال.} many{{count} دعوة تعاون ما زالت بحاجة للإرسال.} other{{count} دعوة تعاون ما زالت بحاجة للإرسال.}}",
     "@profileCollaboratorInviteRetryResult": {"placeholders": {"count": {"type": "int"}}},
+    "profileCollaboratorInviteBlockedResult": "{count, plural, one{متعاون واحد لا يمكنه استقبال الدعوات.} two{متعاونان لا يمكنهما استقبال الدعوات.} few{{count} متعاونين لا يمكنهم استقبال الدعوات.} many{{count} متعاونًا لا يمكنه استقبال الدعوات.} other{{count} متعاون لا يمكنه استقبال الدعوات.}}",
+    "@profileCollaboratorInviteBlockedResult": {"placeholders": {"count": {"type": "int"}}},
     "videoErrorAdultContentHidden": "المحتوى للبالغين مُعطَّل. يمكنك تفعيله من الإعدادات ← مرشّحات المحتوى.",
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "فشل تحميل الفيديو: {error}",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -4207,6 +4207,8 @@
     "profileCollaboratorInviteRetryUnavailable": "Повторното изпращане на покани за сътрудници не е налично в момента.",
     "profileCollaboratorInviteRetryResult": "{count, plural, =0{Поканите за сътрудници са изпратени.} =1{1 покана за сътрудник още чака да бъде изпратена.} other{{count} покани за сътрудници още чакат да бъдат изпратени.}}",
     "@profileCollaboratorInviteRetryResult": {"placeholders": {"count": {"type": "int"}}},
+    "profileCollaboratorInviteBlockedResult": "{count, plural, =1{1 сътрудник не може да получава покани.} other{{count} сътрудници не могат да получават покани.}}",
+    "@profileCollaboratorInviteBlockedResult": {"placeholders": {"count": {"type": "int"}}},
     "videoErrorAdultContentHidden": "Съдържанието за възрастни е изключено. Можеш да го включиш от Настройки → Филтри за съдържание.",
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "Неуспешно зареждане на видеото: {error}",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -4076,6 +4076,8 @@
     "profileCollaboratorInviteRetryUnavailable": "Das erneute Senden der Mitwirkenden-Einladung ist gerade nicht möglich.",
     "profileCollaboratorInviteRetryResult": "{count, plural, =0{Mitwirkenden-Einladungen gesendet.} =1{1 Mitwirkenden-Einladung muss noch gesendet werden.} other{{count} Mitwirkenden-Einladungen müssen noch gesendet werden.}}",
     "@profileCollaboratorInviteRetryResult": {"placeholders": {"count": {"type": "int"}}},
+    "profileCollaboratorInviteBlockedResult": "{count, plural, =1{1 Mitwirkender kann keine Einladungen empfangen.} other{{count} Mitwirkende können keine Einladungen empfangen.}}",
+    "@profileCollaboratorInviteBlockedResult": {"placeholders": {"count": {"type": "int"}}},
     "videoErrorAdultContentHidden": "Inhalte für Erwachsene sind ausgeschaltet. Du kannst sie unter Einstellungen → Inhaltsfilter aktivieren.",
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "Video konnte nicht geladen werden: {error}",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -237,6 +237,15 @@
       }
     }
   },
+  "profileCollaboratorInviteBlockedResult": "{count, plural, =1{1 collaborator can't receive invites.} other{{count} collaborators can't receive invites.}}",
+  "@profileCollaboratorInviteBlockedResult": {
+    "description": "Shown after retrying queued collaborator invites when some were terminally dropped because the collaborator is not an approved DM recipient (a confirmed #176 protected-minor policy block). The invite can never be delivered, so it is reported separately from invites that still need to send.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "profileFollowerCountUsers": "{count} users",
   "@profileFollowerCountUsers": {
     "placeholders": {

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -4076,6 +4076,8 @@
     "profileCollaboratorInviteRetryUnavailable": "El reintento de invitaciones de colaborador no está disponible ahora mismo.",
     "profileCollaboratorInviteRetryResult": "{count, plural, =0{Invitaciones de colaborador enviadas.} =1{Falta enviar 1 invitación de colaborador.} other{Faltan enviar {count} invitaciones de colaborador.}}",
     "@profileCollaboratorInviteRetryResult": {"placeholders": {"count": {"type": "int"}}},
+    "profileCollaboratorInviteBlockedResult": "{count, plural, =1{1 colaborador no puede recibir invitaciones.} other{{count} colaboradores no pueden recibir invitaciones.}}",
+    "@profileCollaboratorInviteBlockedResult": {"placeholders": {"count": {"type": "int"}}},
     "videoErrorAdultContentHidden": "El contenido para adultos está desactivado. Podés activarlo en Ajustes → Filtros de contenido.",
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "Error al cargar el video: {error}",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -2659,6 +2659,8 @@
     "profileCollaboratorInviteRetryUnavailable": "Hindi available ngayon ang pag-retry ng collaborator invite.",
     "profileCollaboratorInviteRetryResult": "{count, plural, =0{Naipadala na ang mga collaborator invite.} =1{1 collaborator invite ang kailangan pang ipadala.} other{{count} collaborator invite ang kailangan pang ipadala.}}",
     "@profileCollaboratorInviteRetryResult": {"placeholders": {"count": {"type": "int"}}},
+    "profileCollaboratorInviteBlockedResult": "{count, plural, =1{1 collaborator ang hindi makakatanggap ng mga invite.} other{{count} collaborator ang hindi makakatanggap ng mga invite.}}",
+    "@profileCollaboratorInviteBlockedResult": {"placeholders": {"count": {"type": "int"}}},
     "videoErrorAdultContentHidden": "Naka-off ang adult content. Puwede mong i-on sa Settings → Content Filters.",
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "Hindi ma-load ang video: {error}",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -4076,6 +4076,8 @@
     "profileCollaboratorInviteRetryUnavailable": "Le renvoi des invitations de collaborateur est indisponible pour le moment.",
     "profileCollaboratorInviteRetryResult": "{count, plural, =0{Invitations de collaborateur envoyées.} =1{1 invitation de collaborateur reste à envoyer.} other{{count} invitations de collaborateur restent à envoyer.}}",
     "@profileCollaboratorInviteRetryResult": {"placeholders": {"count": {"type": "int"}}},
+    "profileCollaboratorInviteBlockedResult": "{count, plural, =1{1 collaborateur ne peut pas être invité.} other{{count} collaborateurs ne peuvent pas être invités.}}",
+    "@profileCollaboratorInviteBlockedResult": {"placeholders": {"count": {"type": "int"}}},
     "videoErrorAdultContentHidden": "Le contenu pour adultes est désactivé. Tu peux l'activer dans Réglages → Filtres de contenu.",
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "Échec du chargement de la vidéo : {error}",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -4076,6 +4076,8 @@
     "profileCollaboratorInviteRetryUnavailable": "Kirim ulang undangan kolaborator sedang tidak tersedia saat ini.",
     "profileCollaboratorInviteRetryResult": "{count, plural, =0{Undangan kolaborator terkirim.} =1{1 undangan kolaborator masih perlu dikirim.} other{{count} undangan kolaborator masih perlu dikirim.}}",
     "@profileCollaboratorInviteRetryResult": {"placeholders": {"count": {"type": "int"}}},
+    "profileCollaboratorInviteBlockedResult": "{count, plural, =1{1 kolaborator tidak bisa menerima undangan.} other{{count} kolaborator tidak bisa menerima undangan.}}",
+    "@profileCollaboratorInviteBlockedResult": {"placeholders": {"count": {"type": "int"}}},
     "videoErrorAdultContentHidden": "Konten dewasa sedang dimatikan. Kamu bisa mengaktifkannya di Pengaturan → Filter Konten.",
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "Gagal memuat video: {error}",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -4076,6 +4076,8 @@
     "profileCollaboratorInviteRetryUnavailable": "Il nuovo invio degli inviti a collaborare non è disponibile al momento.",
     "profileCollaboratorInviteRetryResult": "{count, plural, =0{Inviti a collaborare inviati.} =1{1 invito a collaborare deve ancora essere inviato.} other{{count} inviti a collaborare devono ancora essere inviati.}}",
     "@profileCollaboratorInviteRetryResult": {"placeholders": {"count": {"type": "int"}}},
+    "profileCollaboratorInviteBlockedResult": "{count, plural, =1{1 collaboratore non può ricevere inviti.} other{{count} collaboratori non possono ricevere inviti.}}",
+    "@profileCollaboratorInviteBlockedResult": {"placeholders": {"count": {"type": "int"}}},
     "videoErrorAdultContentHidden": "I contenuti per adulti sono disattivati. Puoi attivarli in Impostazioni → Filtri contenuti.",
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "Impossibile caricare il video: {error}",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -4076,6 +4076,8 @@
     "profileCollaboratorInviteRetryUnavailable": "今はコラボ招待の再送信ができないよ。",
     "profileCollaboratorInviteRetryResult": "{count, plural, =0{コラボの招待を送信したよ。} =1{コラボの招待が1件まだ送信されてないよ。} other{コラボの招待が{count}件まだ送信されてないよ。}}",
     "@profileCollaboratorInviteRetryResult": {"placeholders": {"count": {"type": "int"}}},
+    "profileCollaboratorInviteBlockedResult": "{count, plural, =1{コラボ相手1人が招待を受け取れないよ。} other{コラボ相手{count}人が招待を受け取れないよ。}}",
+    "@profileCollaboratorInviteBlockedResult": {"placeholders": {"count": {"type": "int"}}},
     "videoErrorAdultContentHidden": "アダルトコンテンツはオフになってるよ。[設定]→[コンテンツフィルター]でオンにできるよ。",
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "動画の読み込みに失敗したよ: {error}",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -3400,6 +3400,8 @@
     "profileCollaboratorInviteRetryUnavailable": "지금은 콜라보 초대를 다시 보낼 수 없어요.",
     "profileCollaboratorInviteRetryResult": "{count, plural, =0{콜라보 초대를 보냈어요.} =1{보내야 할 콜라보 초대가 1건 남아 있어요.} other{보내야 할 콜라보 초대가 {count}건 남아 있어요.}}",
     "@profileCollaboratorInviteRetryResult": {"placeholders": {"count": {"type": "int"}}},
+    "profileCollaboratorInviteBlockedResult": "{count, plural, =1{콜라보 상대 1명이 초대를 받을 수 없어요.} other{콜라보 상대 {count}명이 초대를 받을 수 없어요.}}",
+    "@profileCollaboratorInviteBlockedResult": {"placeholders": {"count": {"type": "int"}}},
     "videoErrorAdultContentHidden": "성인 콘텐츠가 꺼져 있어요. 설정 → 콘텐츠 필터에서 켤 수 있어요.",
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "영상을 불러오지 못했어요: {error}",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -4076,6 +4076,8 @@
     "profileCollaboratorInviteRetryUnavailable": "Opnieuw proberen van samenwerkingsuitnodiging is nu niet beschikbaar.",
     "profileCollaboratorInviteRetryResult": "{count, plural, =0{Samenwerkingsuitnodigingen verzonden.} =1{1 samenwerkingsuitnodiging moet nog verzonden worden.} other{{count} samenwerkingsuitnodigingen moeten nog verzonden worden.}}",
     "@profileCollaboratorInviteRetryResult": {"placeholders": {"count": {"type": "int"}}},
+    "profileCollaboratorInviteBlockedResult": "{count, plural, =1{1 samenwerker kan geen uitnodigingen ontvangen.} other{{count} samenwerkers kunnen geen uitnodigingen ontvangen.}}",
+    "@profileCollaboratorInviteBlockedResult": {"placeholders": {"count": {"type": "int"}}},
     "videoErrorAdultContentHidden": "Inhoud voor volwassenen staat uit. Je kunt dit aanzetten via Instellingen → Inhoudsfilters.",
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "Video laden mislukt: {error}",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -4076,6 +4076,8 @@
     "profileCollaboratorInviteRetryUnavailable": "Ponawianie zaproszenia dla współtwórcy jest teraz niedostępne.",
     "profileCollaboratorInviteRetryResult": "{count, plural, =0{Zaproszenia dla współtwórców wysłane.} =1{1 zaproszenie dla współtwórcy wciąż czeka na wysłanie.} few{{count} zaproszenia dla współtwórców wciąż czekają na wysłanie.} many{{count} zaproszeń dla współtwórców wciąż czeka na wysłanie.} other{{count} zaproszenia dla współtwórców wciąż czeka na wysłanie.}}",
     "@profileCollaboratorInviteRetryResult": {"placeholders": {"count": {"type": "int"}}},
+    "profileCollaboratorInviteBlockedResult": "{count, plural, =1{1 współtwórca nie może otrzymywać zaproszeń.} few{{count} współtwórcy nie mogą otrzymywać zaproszeń.} many{{count} współtwórców nie może otrzymywać zaproszeń.} other{{count} współtwórcy nie może otrzymywać zaproszeń.}}",
+    "@profileCollaboratorInviteBlockedResult": {"placeholders": {"count": {"type": "int"}}},
     "videoErrorAdultContentHidden": "Treści dla dorosłych są wyłączone. Możesz je włączyć w Ustawienia → Filtry treści.",
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "Nie udało się wczytać filmu: {error}",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -4076,6 +4076,8 @@
     "profileCollaboratorInviteRetryUnavailable": "Não é possível reenviar o convite de colaborador agora.",
     "profileCollaboratorInviteRetryResult": "{count, plural, =0{Convites de colaborador enviados.} =1{1 convite de colaborador ainda precisa ser enviado.} other{{count} convites de colaborador ainda precisam ser enviados.}}",
     "@profileCollaboratorInviteRetryResult": {"placeholders": {"count": {"type": "int"}}},
+    "profileCollaboratorInviteBlockedResult": "{count, plural, =1{1 colaborador não pode receber convites.} other{{count} colaboradores não podem receber convites.}}",
+    "@profileCollaboratorInviteBlockedResult": {"placeholders": {"count": {"type": "int"}}},
     "videoErrorAdultContentHidden": "O conteúdo adulto está desativado. Você pode ativá-lo em Configurações → Filtros de conteúdo.",
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "Falha ao carregar o vídeo: {error}",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -4076,6 +4076,8 @@
     "profileCollaboratorInviteRetryUnavailable": "Reîncercarea invitației de colaborator nu e disponibilă acum.",
     "profileCollaboratorInviteRetryResult": "{count, plural, =0{Invitațiile de colaborator au fost trimise.} =1{1 invitație de colaborator încă trebuie trimisă.} few{{count} invitații de colaborator încă trebuie trimise.} other{{count} de invitații de colaborator încă trebuie trimise.}}",
     "@profileCollaboratorInviteRetryResult": {"placeholders": {"count": {"type": "int"}}},
+    "profileCollaboratorInviteBlockedResult": "{count, plural, =1{1 colaborator nu poate primi invitații.} few{{count} colaboratori nu pot primi invitații.} other{{count} de colaboratori nu pot primi invitații.}}",
+    "@profileCollaboratorInviteBlockedResult": {"placeholders": {"count": {"type": "int"}}},
     "videoErrorAdultContentHidden": "Conținutul pentru adulți este dezactivat. Îl poți activa în Setări → Filtre de conținut.",
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "N-am putut încărca videoclipul: {error}",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -4076,6 +4076,8 @@
     "profileCollaboratorInviteRetryUnavailable": "Det går inte att skicka samarbetsinbjudan igen just nu.",
     "profileCollaboratorInviteRetryResult": "{count, plural, =0{Samarbetsinbjudningar skickade.} =1{1 samarbetsinbjudan behöver fortfarande skickas.} other{{count} samarbetsinbjudningar behöver fortfarande skickas.}}",
     "@profileCollaboratorInviteRetryResult": {"placeholders": {"count": {"type": "int"}}},
+    "profileCollaboratorInviteBlockedResult": "{count, plural, =1{1 samarbetspartner kan inte ta emot inbjudningar.} other{{count} samarbetspartner kan inte ta emot inbjudningar.}}",
+    "@profileCollaboratorInviteBlockedResult": {"placeholders": {"count": {"type": "int"}}},
     "videoErrorAdultContentHidden": "Innehåll för vuxna är avstängt. Du kan slå på det i Inställningar → Innehållsfilter.",
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "Kunde inte läsa in videon: {error}",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -4076,6 +4076,8 @@
     "profileCollaboratorInviteRetryUnavailable": "İş birlikçi davetini tekrar deneme şu anda kullanılamıyor.",
     "profileCollaboratorInviteRetryResult": "{count, plural, =0{İş birlikçi davetleri gönderildi.} =1{1 iş birlikçi daveti hâlâ gönderilmeyi bekliyor.} other{{count} iş birlikçi daveti hâlâ gönderilmeyi bekliyor.}}",
     "@profileCollaboratorInviteRetryResult": {"placeholders": {"count": {"type": "int"}}},
+    "profileCollaboratorInviteBlockedResult": "{count, plural, =1{1 iş birlikçi davet alamıyor.} other{{count} iş birlikçi davet alamıyor.}}",
+    "@profileCollaboratorInviteBlockedResult": {"placeholders": {"count": {"type": "int"}}},
     "videoErrorAdultContentHidden": "Yetişkin içeriği kapalı. Ayarlar → İçerik Filtreleri'nden açabilirsin.",
     "@videoErrorAdultContentHidden": {"description": "Snackbar shown when an age-verified viewer taps Verify age on an age-restricted video but their Content Filters keep adult content hidden. The remedy is opting in via Settings → Content Filters, not re-verifying age."},
     "videoDetailLoadError": "Video yüklenemedi: {error}",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -820,6 +820,12 @@ abstract class AppLocalizations {
   /// **'{count, plural, =0{Collaborator invites sent.} =1{1 collaborator invite still needs to send.} other{{count} collaborator invites still need to send.}}'**
   String profileCollaboratorInviteRetryResult(int count);
 
+  /// Shown after retrying queued collaborator invites when some were terminally dropped because the collaborator is not an approved DM recipient (a confirmed #176 protected-minor policy block). The invite can never be delivered, so it is reported separately from invites that still need to send.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 collaborator can\'t receive invites.} other{{count} collaborators can\'t receive invites.}}'**
+  String profileCollaboratorInviteBlockedResult(int count);
+
   /// No description provided for @profileFollowerCountUsers.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -422,6 +422,17 @@ class AppLocalizationsAm extends AppLocalizations {
   }
 
   @override
+  String profileCollaboratorInviteBlockedResult(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count ተባባሪዎች ግብዣ መቀበል አይችሉም።',
+      one: '1 ተባባሪ ግብዣ መቀበል አይችልም።',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String profileFollowerCountUsers(int count) {
     return '$count ተጠቃሚዎች';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -426,6 +426,20 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String profileCollaboratorInviteBlockedResult(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count متعاون لا يمكنه استقبال الدعوات.',
+      many: '$count متعاونًا لا يمكنه استقبال الدعوات.',
+      few: '$count متعاونين لا يمكنهم استقبال الدعوات.',
+      two: 'متعاونان لا يمكنهما استقبال الدعوات.',
+      one: 'متعاون واحد لا يمكنه استقبال الدعوات.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String profileFollowerCountUsers(int count) {
     return '$count مستخدم';
   }

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -435,6 +435,17 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
+  String profileCollaboratorInviteBlockedResult(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count сътрудници не могат да получават покани.',
+      one: '1 сътрудник не може да получава покани.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String profileFollowerCountUsers(int count) {
     return '$count потребители';
   }

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -435,6 +435,17 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String profileCollaboratorInviteBlockedResult(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count Mitwirkende können keine Einladungen empfangen.',
+      one: '1 Mitwirkender kann keine Einladungen empfangen.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String profileFollowerCountUsers(int count) {
     return '$count Nutzer';
   }

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -431,6 +431,17 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String profileCollaboratorInviteBlockedResult(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count collaborators can\'t receive invites.',
+      one: '1 collaborator can\'t receive invites.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String profileFollowerCountUsers(int count) {
     return '$count users';
   }

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -437,6 +437,17 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String profileCollaboratorInviteBlockedResult(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count colaboradores no pueden recibir invitaciones.',
+      one: '1 colaborador no puede recibir invitaciones.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String profileFollowerCountUsers(int count) {
     return '$count usuarios';
   }

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -434,6 +434,17 @@ class AppLocalizationsFil extends AppLocalizations {
   }
 
   @override
+  String profileCollaboratorInviteBlockedResult(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count collaborator ang hindi makakatanggap ng mga invite.',
+      one: '1 collaborator ang hindi makakatanggap ng mga invite.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String profileFollowerCountUsers(int count) {
     return '$count user';
   }

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -441,6 +441,17 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String profileCollaboratorInviteBlockedResult(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count collaborateurs ne peuvent pas être invités.',
+      one: '1 collaborateur ne peut pas être invité.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String profileFollowerCountUsers(int count) {
     return '$count utilisateurs';
   }

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -413,6 +413,17 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
+  String profileCollaboratorInviteBlockedResult(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count kolaborator tidak bisa menerima undangan.',
+      one: '1 kolaborator tidak bisa menerima undangan.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String profileFollowerCountUsers(int count) {
     return '$count pengguna';
   }

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -436,6 +436,17 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String profileCollaboratorInviteBlockedResult(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count collaboratori non possono ricevere inviti.',
+      one: '1 collaboratore non può ricevere inviti.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String profileFollowerCountUsers(int count) {
     return '$count utenti';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -397,6 +397,17 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
+  String profileCollaboratorInviteBlockedResult(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'コラボ相手$count人が招待を受け取れないよ。',
+      one: 'コラボ相手1人が招待を受け取れないよ。',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String profileFollowerCountUsers(int count) {
     return '$count人';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -399,6 +399,17 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
+  String profileCollaboratorInviteBlockedResult(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '콜라보 상대 $count명이 초대를 받을 수 없어요.',
+      one: '콜라보 상대 1명이 초대를 받을 수 없어요.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String profileFollowerCountUsers(int count) {
     return '사용자 $count명';
   }

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -436,6 +436,17 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String profileCollaboratorInviteBlockedResult(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count samenwerkers kunnen geen uitnodigingen ontvangen.',
+      one: '1 samenwerker kan geen uitnodigingen ontvangen.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String profileFollowerCountUsers(int count) {
     return '$count gebruikers';
   }

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -437,6 +437,19 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
+  String profileCollaboratorInviteBlockedResult(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count współtwórcy nie może otrzymywać zaproszeń.',
+      many: '$count współtwórców nie może otrzymywać zaproszeń.',
+      few: '$count współtwórcy nie mogą otrzymywać zaproszeń.',
+      one: '1 współtwórca nie może otrzymywać zaproszeń.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String profileFollowerCountUsers(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -438,6 +438,17 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String profileCollaboratorInviteBlockedResult(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count colaboradores não podem receber convites.',
+      one: '1 colaborador não pode receber convites.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String profileFollowerCountUsers(int count) {
     return '$count usuários';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -450,6 +450,18 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String profileCollaboratorInviteBlockedResult(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count de colaboratori nu pot primi invitații.',
+      few: '$count colaboratori nu pot primi invitații.',
+      one: '1 colaborator nu poate primi invitații.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String profileFollowerCountUsers(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -421,6 +421,17 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String profileCollaboratorInviteBlockedResult(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count samarbetspartner kan inte ta emot inbjudningar.',
+      one: '1 samarbetspartner kan inte ta emot inbjudningar.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String profileFollowerCountUsers(int count) {
     return '$count användare';
   }

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -413,6 +413,17 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
+  String profileCollaboratorInviteBlockedResult(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count iş birlikçi davet alamıyor.',
+      one: '1 iş birlikçi davet alamıyor.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String profileFollowerCountUsers(int count) {
     return '$count kullanıcı';
   }

--- a/mobile/lib/providers/official_accounts_providers.dart
+++ b/mobile/lib/providers/official_accounts_providers.dart
@@ -2,7 +2,8 @@
 // ABOUTME: the discriminated NIP-05 resolver, the pin ∩ NIP-05 gate service, and
 // ABOUTME: the DmSendPolicy that NIP17MessageService consults on every send.
 
-import 'package:dm_repository/dm_repository.dart' show DmSendPolicy;
+import 'package:dm_repository/dm_repository.dart'
+    show DmSendPolicy, DmSendPolicyDecision;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/blocs/dm/conversation_list/protected_minor_inbox_gate.dart';
 import 'package:openvine/blocs/dm/conversation_list/protected_minor_inbox_gate_impl.dart';
@@ -31,13 +32,21 @@ final officialAccountsServiceProvider = Provider<OfficialAccountsService>((
 /// restricted user may only send to an account currently approved by
 /// [OfficialAccountsService] (pin ∩ live NIP-05). Reads state at call time
 /// (send-time) so the decision is fresh: a mid-session approval/revocation
-/// takes effect on the next send without rebuilding.
+/// takes effect on the next send without rebuilding. An unknown/loading
+/// protected-minor status still denies the send, but marks the denial temporary
+/// so a durable queue row is retained until Keycast provides a trusted verdict.
 final dmSendPolicyProvider = Provider<DmSendPolicy>((ref) {
   return (String recipientPubkey) async {
-    if (!ref.read(isDmRestrictedProvider)) return true;
-    return ref
+    if (!ref.read(isDmRestrictedProvider)) {
+      return DmSendPolicyDecision.allowed;
+    }
+    final approved = await ref
         .read(officialAccountsServiceProvider)
         .isApprovedMinorDmRecipient(recipientPubkey);
+    if (approved) return DmSendPolicyDecision.allowed;
+    return ref.read(hasConfirmedDmRestrictionProvider)
+        ? DmSendPolicyDecision.terminallyBlocked
+        : DmSendPolicyDecision.temporarilyBlocked;
   };
 });
 

--- a/mobile/lib/providers/protected_minor_providers.dart
+++ b/mobile/lib/providers/protected_minor_providers.dart
@@ -176,6 +176,22 @@ final isDmRestrictedProvider = Provider<bool>((ref) {
   return store.lastKnownFor(pubkey) ?? true;
 });
 
+/// Whether the current DM restriction comes from a confirmed protected-minor
+/// verdict rather than the fail-closed unknown/loading fallback.
+final hasConfirmedDmRestrictionProvider = Provider<bool>((ref) {
+  final authState = ref.watch(currentAuthStateProvider);
+  final pubkey = ref.watch(authServiceProvider).currentPublicKeyHex;
+  final store = ref.watch(protectedMinorStickyStoreProvider);
+  final live = ref.watch(protectedMinorStatusProvider);
+  final trusted = trustedProtectedMinorStatus(
+    authenticated: authState == AuthState.authenticated,
+    live: live,
+  );
+  if (trusted?.kind == ProtectedMinorStatusKind.protected) return true;
+  if (trusted?.kind == ProtectedMinorStatusKind.notProtected) return false;
+  return store.lastKnownFor(pubkey) == true;
+});
+
 /// The #182 key-management seam — gates nsec export ("copy private key") and
 /// key import/change (swapping the account to a self-held key) for protected
 /// minors.

--- a/mobile/lib/providers/video_publish_provider.dart
+++ b/mobile/lib/providers/video_publish_provider.dart
@@ -5,6 +5,8 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:dm_repository/dm_repository.dart'
+    show CollaboratorInviteRetrySummary;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -316,6 +318,25 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
     return l10n.videoPublishCollaboratorInviteWarning(failedCount);
   }
 
+  /// Picks the snackbar line for a finished collaborator-invite retry.
+  ///
+  /// Transient failures (still queued) take priority; a confirmed #176 policy
+  /// block is terminal and reported apart from "still needs to send"; otherwise
+  /// every invite was delivered.
+  @visibleForTesting
+  String collaboratorInviteRetryResultMessage(
+    AppLocalizations l10n,
+    CollaboratorInviteRetrySummary summary,
+  ) {
+    if (summary.failureCount > 0) {
+      return collaboratorInviteWarningMessage(l10n, summary.failureCount);
+    }
+    if (summary.blockedCount > 0) {
+      return l10n.profileCollaboratorInviteBlockedResult(summary.blockedCount);
+    }
+    return l10n.profileCollaboratorInviteRetryResult(0);
+  }
+
   /// Publishes the video with ProofMode attestation and navigates to
   /// profile on success.
   Future<void> publishVideo(
@@ -563,13 +584,10 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
         (warning) => warning.collaboratorPubkey,
       ),
     );
+    final message = collaboratorInviteRetryResultMessage(l10n, summary);
     messenger.showSnackBar(
       SnackBar(
-        content: Text(
-          summary.failureCount == 0
-              ? l10n.profileCollaboratorInviteRetryResult(0)
-              : collaboratorInviteWarningMessage(l10n, summary.failureCount),
-        ),
+        content: Text(message),
         behavior: SnackBarBehavior.floating,
       ),
     );

--- a/mobile/lib/services/outgoing_dm_retry_service.dart
+++ b/mobile/lib/services/outgoing_dm_retry_service.dart
@@ -316,6 +316,7 @@ class OutgoingDmRetryService {
       // duplicates if both wire copies eventually land.
       var processedInterrupted = 0;
       var failedInterrupted = 0;
+      var blockedInterrupted = 0;
       var skippedInterruptedTooYoung = 0;
       if (!abortedNotReady) {
         final processedIds = retryable.map((r) => r.id).toSet();
@@ -355,6 +356,10 @@ class OutgoingDmRetryService {
             );
             if (result.success) {
               processedInterrupted++;
+            } else if (result.blocked) {
+              // Terminal, same as the failed-send arm: recoverFullSend
+              // deleted the row for a #176 policy block, so don't re-arm it.
+              blockedInterrupted++;
             } else {
               await _dao.incrementRetry(row.id);
               failedInterrupted++;
@@ -405,6 +410,7 @@ class OutgoingDmRetryService {
         'full-send-blocked=$blockedFullSend '
         'interrupted-recovered=$processedInterrupted '
         'interrupted-failed=$failedInterrupted '
+        'interrupted-blocked=$blockedInterrupted '
         'skipped-backoff=$skippedBackoff '
         'skipped-interrupted-too-young=$skippedInterruptedTooYoung '
         'aborted-not-ready=$abortedNotReady',

--- a/mobile/lib/services/outgoing_dm_retry_service.dart
+++ b/mobile/lib/services/outgoing_dm_retry_service.dart
@@ -159,6 +159,7 @@ class OutgoingDmRetryService {
       var failedSelfWrap = 0;
       var processedFullSend = 0;
       var failedFullSend = 0;
+      var blockedFullSend = 0;
       var skippedBackoff = 0;
       var abortedNotReady = false;
 
@@ -259,6 +260,12 @@ class OutgoingDmRetryService {
               // way the row exits the recipient-failed filter, so
               // skip incrementRetry.
               processedFullSend++;
+            } else if (result.blocked) {
+              // recoverFullSend deleted the row: a #176 policy block is
+              // terminal, not transient. Don't bump the retry counter (the
+              // row is gone and the gate would refuse every retry anyway),
+              // and count it as terminal rather than a failure.
+              blockedFullSend++;
             } else {
               // Publish failed again. recoverFullSend already
               // re-marked both wraps failed with the new error via
@@ -395,6 +402,7 @@ class OutgoingDmRetryService {
         'self-wrap-failed=$failedSelfWrap '
         'full-send-recovered=$processedFullSend '
         'full-send-failed=$failedFullSend '
+        'full-send-blocked=$blockedFullSend '
         'interrupted-recovered=$processedInterrupted '
         'interrupted-failed=$failedInterrupted '
         'skipped-backoff=$skippedBackoff '

--- a/mobile/lib/widgets/profile/pending_collaborator_invite_banner_cubit.dart
+++ b/mobile/lib/widgets/profile/pending_collaborator_invite_banner_cubit.dart
@@ -16,26 +16,41 @@ class PendingCollaboratorInviteBannerState extends Equatable {
     this.isRetrying = false,
     this.feedback = PendingCollaboratorInviteBannerFeedback.none,
     this.remainingInviteCount = 0,
+    this.blockedInviteCount = 0,
   });
 
   final bool isRetrying;
   final PendingCollaboratorInviteBannerFeedback feedback;
+
+  /// Invites that failed transiently and remain queued for a later retry.
   final int remainingInviteCount;
+
+  /// Invites terminally dropped because the collaborator cannot receive DMs
+  /// (a confirmed #176 policy block). Their queue rows are deleted, so they
+  /// are surfaced apart from [remainingInviteCount].
+  final int blockedInviteCount;
 
   PendingCollaboratorInviteBannerState copyWith({
     bool? isRetrying,
     PendingCollaboratorInviteBannerFeedback? feedback,
     int? remainingInviteCount,
+    int? blockedInviteCount,
   }) {
     return PendingCollaboratorInviteBannerState(
       isRetrying: isRetrying ?? this.isRetrying,
       feedback: feedback ?? this.feedback,
       remainingInviteCount: remainingInviteCount ?? this.remainingInviteCount,
+      blockedInviteCount: blockedInviteCount ?? this.blockedInviteCount,
     );
   }
 
   @override
-  List<Object?> get props => [isRetrying, feedback, remainingInviteCount];
+  List<Object?> get props => [
+    isRetrying,
+    feedback,
+    remainingInviteCount,
+    blockedInviteCount,
+  ];
 }
 
 class PendingCollaboratorInviteBannerCubit
@@ -72,6 +87,7 @@ class PendingCollaboratorInviteBannerCubit
         isRetrying: false,
         feedback: PendingCollaboratorInviteBannerFeedback.retryCompleted,
         remainingInviteCount: summary.failureCount,
+        blockedInviteCount: summary.blockedCount,
       ),
     );
   }

--- a/mobile/lib/widgets/profile/profile_videos_grid.dart
+++ b/mobile/lib/widgets/profile/profile_videos_grid.dart
@@ -504,9 +504,14 @@ class _PendingCollaboratorInviteBanner extends ConsumerWidget {
                 PendingCollaboratorInviteBannerFeedback.retryUnavailable =>
                   l10n.profileCollaboratorInviteRetryUnavailable,
                 PendingCollaboratorInviteBannerFeedback.retryCompleted =>
-                  l10n.profileCollaboratorInviteRetryResult(
-                    state.remainingInviteCount,
-                  ),
+                  state.remainingInviteCount == 0 &&
+                          state.blockedInviteCount > 0
+                      ? l10n.profileCollaboratorInviteBlockedResult(
+                          state.blockedInviteCount,
+                        )
+                      : l10n.profileCollaboratorInviteRetryResult(
+                          state.remainingInviteCount,
+                        ),
                 PendingCollaboratorInviteBannerFeedback.none => null,
               };
               if (message == null) return;

--- a/mobile/packages/dm_repository/lib/src/collaborator_invite_recovery.dart
+++ b/mobile/packages/dm_repository/lib/src/collaborator_invite_recovery.dart
@@ -220,6 +220,7 @@ class CollaboratorInviteRetrySummary extends Equatable {
     required this.attemptedCount,
     required this.successCount,
     required this.failureCount,
+    this.blockedCount = 0,
   });
 
   /// Number of invites considered for retry.
@@ -228,14 +229,27 @@ class CollaboratorInviteRetrySummary extends Equatable {
   /// Number of invites successfully recovered.
   final int successCount;
 
-  /// Number of invites that still failed.
+  /// Number of invites that failed transiently and remain queued for a later
+  /// retry. Excludes [blockedCount]: a confirmed #176 policy block is terminal,
+  /// not "still needs to send".
   final int failureCount;
+
+  /// Number of invites terminally dropped because the recipient is not an
+  /// approved DM recipient (a confirmed #176 policy block). The queue rows are
+  /// deleted and are never retryable, so they are surfaced apart from
+  /// [failureCount].
+  final int blockedCount;
 
   /// Whether every attempted recovery succeeded.
   bool get allSucceeded => attemptedCount == successCount;
 
   @override
-  List<Object?> get props => [attemptedCount, successCount, failureCount];
+  List<Object?> get props => [
+    attemptedCount,
+    successCount,
+    failureCount,
+    blockedCount,
+  ];
 }
 
 /// Parses collaborator-invite metadata from a rumor event.

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -3193,6 +3193,11 @@ class DmRepository {
         // surfaces only as a sender-side gap until the self-wrap
         // arrives via the receive pipeline.
       }
+    } else if (result.blocked) {
+      // A #176 policy block is a permanent decision, not a transient error:
+      // drop the row so the retry sweep stops re-attempting a send the gate
+      // refuses every time. The recipient never received anything.
+      await _finalizeAfterRecipientBlocked(outgoingDao: dao, rumorId: rumorId);
     } else {
       await _finalizeAfterRecipientFailure(
         outgoingDao: dao,
@@ -3392,6 +3397,33 @@ class DmRepository {
       );
       // Don't rethrow — caller already gets the failure result. The
       // queue row stays retryable and the next sweep can pick it up.
+    }
+  }
+
+  /// Apply the terminal queue-row transition for a policy-blocked (#176)
+  /// recipient publish. Unlike [_finalizeAfterRecipientFailure], a block is
+  /// permanent — the send gate refuses every retry — so the row is deleted
+  /// rather than left retryable. Non-rethrowing to match the failure path: the
+  /// caller still returns the blocked result. A failed delete leaves the row
+  /// [OutgoingWrapStatus.failed], which self-heals on a later sweep.
+  Future<void> _finalizeAfterRecipientBlocked({
+    required OutgoingDmsDao outgoingDao,
+    required String rumorId,
+  }) async {
+    try {
+      await outgoingDao.deleteById(rumorId);
+    } on Object catch (e, stackTrace) {
+      Log.error(
+        'Failed to delete blocked outgoing_dms row $rumorId: $e',
+        category: LogCategory.system,
+        error: e,
+        stackTrace: stackTrace,
+      );
+      _errorReporter?.call(
+        e,
+        stackTrace,
+        site: DmRepositoryReportableSites.finalizeAfterRecipientBlocked,
+      );
     }
   }
 

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -3194,9 +3194,9 @@ class DmRepository {
         // arrives via the receive pipeline.
       }
     } else if (result.blocked) {
-      // A #176 policy block is a permanent decision, not a transient error:
+      // A confirmed #176 policy block is terminal, not a transient error:
       // drop the row so the retry sweep stops re-attempting a send the gate
-      // refuses every time. The recipient never received anything.
+      // refuses every time. This attempt delivered nothing.
       await _finalizeAfterRecipientBlocked(outgoingDao: dao, rumorId: rumorId);
     } else {
       await _finalizeAfterRecipientFailure(
@@ -3402,7 +3402,7 @@ class DmRepository {
 
   /// Apply the terminal queue-row transition for a policy-blocked (#176)
   /// recipient publish. Unlike [_finalizeAfterRecipientFailure], a block is
-  /// permanent — the send gate refuses every retry — so the row is deleted
+  /// terminal — the send gate refuses every retry — so the row is deleted
   /// rather than left retryable. Non-rethrowing to match the failure path: the
   /// caller still returns the blocked result. A failed delete leaves the row in
   /// place (still `failed` or `pending`, depending on the drain arm), which

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -3277,13 +3277,28 @@ class DmRepository {
 
     var attempted = 0;
     var success = 0;
+    var blocked = 0;
+    var failure = 0;
     for (final invite in matchingInvites) {
       attempted++;
       try {
         final result = await recoverFullSend(rumorId: invite.rumorId);
         if (result.success) {
           success++;
+        } else if (result.blocked) {
+          // A confirmed #176 policy block is terminal: recoverFullSend already
+          // deleted the row, so the invite is neither delivered nor retryable.
+          // Count it apart from transient failures so the banner does not
+          // report a dropped row as "still needs to send".
+          blocked++;
+          Log.warning(
+            'Collaborator invite blocked by policy for rumor '
+            '${invite.rumorId} (recipient=${invite.collaboratorPubkey}, '
+            'video=${invite.videoAddress}); row dropped',
+            category: LogCategory.system,
+          );
         } else {
+          failure++;
           Log.warning(
             'Collaborator invite retry failed for rumor ${invite.rumorId} '
             '(recipient=${invite.collaboratorPubkey}, '
@@ -3292,6 +3307,20 @@ class DmRepository {
           );
         }
       } on Object catch (error, stackTrace) {
+        if (error is ArgumentError) {
+          // recoverFullSend throws ArgumentError when the queue row is missing
+          // or owned by another account. A concurrent drain sweep
+          // recovering/deleting the row between the banner's read and this
+          // retry is an expected race, not a defect — terminal for this
+          // invite, so skip it without a Crashlytics report (mirrors
+          // OutgoingDmRetryService's dispatch-error policy).
+          Log.warning(
+            'Skipping collaborator invite ${invite.rumorId}: $error',
+            category: LogCategory.system,
+          );
+          continue;
+        }
+        failure++;
         Log.error(
           'Collaborator invite retry threw for rumor ${invite.rumorId} '
           '(recipient=${invite.collaboratorPubkey}, '
@@ -3312,7 +3341,8 @@ class DmRepository {
     return CollaboratorInviteRetrySummary(
       attemptedCount: attempted,
       successCount: success,
-      failureCount: attempted - success,
+      failureCount: failure,
+      blockedCount: blocked,
     );
   }
 

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -3404,8 +3404,9 @@ class DmRepository {
   /// recipient publish. Unlike [_finalizeAfterRecipientFailure], a block is
   /// permanent — the send gate refuses every retry — so the row is deleted
   /// rather than left retryable. Non-rethrowing to match the failure path: the
-  /// caller still returns the blocked result. A failed delete leaves the row
-  /// [OutgoingWrapStatus.failed], which self-heals on a later sweep.
+  /// caller still returns the blocked result. A failed delete leaves the row in
+  /// place (still `failed` or `pending`, depending on the drain arm), which
+  /// self-heals on a later sweep — the gate re-blocks and re-drops it.
   Future<void> _finalizeAfterRecipientBlocked({
     required OutgoingDmsDao outgoingDao,
     required String rumorId,

--- a/mobile/packages/dm_repository/lib/src/dm_repository_reportable_sites.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository_reportable_sites.dart
@@ -37,6 +37,12 @@ abstract class DmRepositoryReportableSites {
   static const String finalizeAfterRecipientFailure =
       'finalizeAfterRecipientFailure';
 
+  /// `_finalizeAfterRecipientBlocked`: deleting the terminally-blocked
+  /// queue row threw. Caller already has the blocked result; the row
+  /// stays failed and self-heals on a later sweep.
+  static const String finalizeAfterRecipientBlocked =
+      'finalizeAfterRecipientBlocked';
+
   /// `retryPendingCollaboratorInvites*`: `recoverFullSend` threw while
   /// replaying a queued collaborator invite row.
   static const String retryPendingCollaboratorInviteUnexpectedThrow =

--- a/mobile/packages/dm_repository/lib/src/dm_repository_reportable_sites.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository_reportable_sites.dart
@@ -43,8 +43,10 @@ abstract class DmRepositoryReportableSites {
   static const String finalizeAfterRecipientBlocked =
       'finalizeAfterRecipientBlocked';
 
-  /// `retryPendingCollaboratorInvites*`: `recoverFullSend` threw while
-  /// replaying a queued collaborator invite row.
+  /// `retryPendingCollaboratorInvites*`: `recoverFullSend` threw an
+  /// unexpected error while replaying a queued collaborator invite row.
+  /// The expected `ArgumentError` race (row deleted by a concurrent drain
+  /// sweep, or a foreign-owner row) is skipped and does NOT report here.
   static const String retryPendingCollaboratorInviteUnexpectedThrow =
       'retryPendingCollaboratorInvite.unexpectedThrow';
 

--- a/mobile/packages/dm_repository/lib/src/dm_repository_reportable_sites.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository_reportable_sites.dart
@@ -39,7 +39,7 @@ abstract class DmRepositoryReportableSites {
 
   /// `_finalizeAfterRecipientBlocked`: deleting the terminally-blocked
   /// queue row threw. Caller already has the blocked result; the row
-  /// stays failed and self-heals on a later sweep.
+  /// stays failed or pending and self-heals on a later sweep.
   static const String finalizeAfterRecipientBlocked =
       'finalizeAfterRecipientBlocked';
 

--- a/mobile/packages/dm_repository/lib/src/dm_send_policy.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_send_policy.dart
@@ -2,14 +2,31 @@
 // ABOUTME: DM package can't reach app state (Riverpod), so the protected-minor
 // ABOUTME: decision is injected as a policy the send primitives consult.
 
+/// Result of evaluating the outbound-DM policy for one recipient.
+enum DmSendPolicyDecision {
+  /// The send may proceed.
+  allowed,
+
+  /// Fail closed for now, but the missing account-state verdict may resolve.
+  temporarilyBlocked,
+
+  /// A confirmed protected-minor policy blocks this recipient.
+  terminallyBlocked,
+}
+
 /// Decides whether the current sender may deliver a DM to [recipientPubkey].
 ///
 /// The default is [allowAllDmSendPolicy]; the app injects a policy that blocks
 /// a protected minor from DMing anyone outside the approved official set. It is
 /// consulted at the lowest send primitive so every publisher (direct, group
-/// fan-out, drain replay, reactions, file) is covered at one seam.
-typedef DmSendPolicy = Future<bool> Function(String recipientPubkey);
+/// fan-out, drain replay, reactions, file) is covered at one seam. Temporary
+/// fail-closed denials remain distinguishable from confirmed terminal blocks,
+/// so a cold-start queue drain cannot delete a legitimate queued send.
+typedef DmSendPolicy =
+    Future<DmSendPolicyDecision> Function(String recipientPubkey);
 
 /// Default policy: no restriction. Preserves existing behavior wherever no
 /// policy is injected.
-Future<bool> allowAllDmSendPolicy(String recipientPubkey) async => true;
+Future<DmSendPolicyDecision> allowAllDmSendPolicy(
+  String recipientPubkey,
+) async => DmSendPolicyDecision.allowed;

--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -87,8 +87,8 @@ class NIP17MessageService {
   /// any per-recipient send. The per-send gate in [sendRumor] remains the
   /// authoritative choke point (covers the drain replay); this is the earlier,
   /// cheaper check.
-  Future<bool> canSendTo(String recipientPubkey) =>
-      _sendPolicy(recipientPubkey);
+  Future<bool> canSendTo(String recipientPubkey) async =>
+      await _sendPolicy(recipientPubkey) == DmSendPolicyDecision.allowed;
 
   /// Builds a single NIP-17 gift wrap for [receiverPublicKey] from
   /// [rumorEvent].
@@ -275,11 +275,17 @@ class NIP17MessageService {
       // recipient outside the approved official set. Checked before any wrap
       // build or publish, so a blocked send leaks no metadata to relays and
       // performs no signing work.
-      if (!await _sendPolicy(recipientPubkey)) {
+      final policyDecision = await _sendPolicy(recipientPubkey);
+      if (policyDecision != DmSendPolicyDecision.allowed) {
         Log.info(
           'NIP-17 send blocked by policy for recipient',
           category: LogCategory.system,
         );
+        if (policyDecision == DmSendPolicyDecision.temporarilyBlocked) {
+          return const NIP17SendResult.failure(
+            'temporarily blocked: protected-minor status unresolved',
+          );
+        }
         return const NIP17SendResult.blocked(
           'blocked: recipient not permitted by send policy',
         );

--- a/mobile/packages/dm_repository/test/src/collaborator_invite_recovery_test.dart
+++ b/mobile/packages/dm_repository/test/src/collaborator_invite_recovery_test.dart
@@ -588,6 +588,101 @@ void main() {
       );
     },
   );
+
+  test(
+    'retryPendingCollaboratorInvites counts a confirmed policy block as '
+    'terminal, not a retryable failure',
+    () async {
+      recoverFullSendHandler = (rumorId) async {
+        if (rumorId == 'blocked-b') {
+          return const NIP17SendResult.blocked(
+            'blocked: recipient not permitted by send policy',
+          );
+        }
+        return NIP17SendResult.success(
+          rumorEventId: rumorId,
+          messageEventId: 'wrap:$rumorId',
+          recipientPubkey: _collaboratorA,
+        );
+      };
+
+      final summary = await repository.retryPendingCollaboratorInvites([
+        _toPendingInvite(
+          _inviteRow(
+            id: 'target-a',
+            collaboratorPubkey: _collaboratorA,
+            recipient: OutgoingWrapStatus.failed,
+            self: OutgoingWrapStatus.failed,
+          ),
+        ),
+        _toPendingInvite(
+          _inviteRow(
+            id: 'blocked-b',
+            collaboratorPubkey: _collaboratorB,
+            recipient: OutgoingWrapStatus.failed,
+            self: OutgoingWrapStatus.failed,
+          ),
+        ),
+      ]);
+
+      expect(summary.attemptedCount, 2);
+      expect(summary.successCount, 1);
+      expect(summary.blockedCount, 1);
+      // A terminal block is neither delivered nor retryable, so it must not
+      // inflate the "still needs to send" failure count...
+      expect(summary.failureCount, 0);
+      // ...and it is an expected outcome, not a crash to report.
+      expect(reportedErrors, isEmpty);
+    },
+  );
+
+  test(
+    'retryPendingCollaboratorInvites skips a row removed by a concurrent '
+    'sweep without reporting it',
+    () async {
+      recoverFullSendHandler = (rumorId) async {
+        if (rumorId == 'raced') {
+          throw ArgumentError.value(
+            rumorId,
+            'rumorId',
+            'no queued outgoing DM with this id',
+          );
+        }
+        return NIP17SendResult.success(
+          rumorEventId: rumorId,
+          messageEventId: 'wrap:$rumorId',
+          recipientPubkey: _collaboratorA,
+        );
+      };
+
+      final summary = await repository.retryPendingCollaboratorInvites([
+        _toPendingInvite(
+          _inviteRow(
+            id: 'target-a',
+            collaboratorPubkey: _collaboratorA,
+            recipient: OutgoingWrapStatus.failed,
+            self: OutgoingWrapStatus.failed,
+          ),
+        ),
+        _toPendingInvite(
+          _inviteRow(
+            id: 'raced',
+            collaboratorPubkey: _collaboratorB,
+            recipient: OutgoingWrapStatus.failed,
+            self: OutgoingWrapStatus.failed,
+          ),
+        ),
+      ]);
+
+      expect(summary.attemptedCount, 2);
+      expect(summary.successCount, 1);
+      // The raced row is terminal for this invite but not a retryable
+      // failure, and the expected race must not reach Crashlytics.
+      expect(summary.failureCount, 0);
+      expect(summary.blockedCount, 0);
+      expect(reportedErrors, isEmpty);
+    },
+  );
 }
 
 PendingCollaboratorInvite _toPendingInvite(OutgoingDm row) {

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -14237,6 +14237,11 @@ void main() {
           // and re-dropped on the next sweep.
           expect(result.blocked, isTrue);
           verify(() => mockOutgoingDmsDao.deleteById(_rumorEventId)).called(1);
+          expect(reporterCalls, hasLength(1));
+          expect(
+            reporterCalls.single.site,
+            DmRepositoryReportableSites.finalizeAfterRecipientBlocked,
+          );
         },
       );
 

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -14177,6 +14177,66 @@ void main() {
               lastError: any(named: 'lastError'),
             ),
           );
+          // A blocked send never reached the recipient, so nothing is
+          // persisted to direct_messages (the insert rides only the success
+          // branch's transaction).
+          verifyNever(
+            () => mockDirectMessagesDao.insertMessage(
+              id: any(named: 'id'),
+              conversationId: any(named: 'conversationId'),
+              senderPubkey: any(named: 'senderPubkey'),
+              content: any(named: 'content'),
+              createdAt: any(named: 'createdAt'),
+              giftWrapId: any(named: 'giftWrapId'),
+              messageKind: any(named: 'messageKind'),
+              replyToId: any(named: 'replyToId'),
+              subject: any(named: 'subject'),
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              tagsJson: any(named: 'tagsJson'),
+            ),
+          );
+        },
+      );
+
+      test(
+        'on a blocked send: when deleteById throws, swallows the error and '
+        'still returns the blocked result (row self-heals on a later sweep)',
+        () async {
+          when(
+            () => mockOutgoingDmsDao.getById(_rumorEventId),
+          ).thenAnswer((_) async => queuedRow());
+          stubSendRumor(
+            (_, _) async => const NIP17SendResult.blocked(
+              'blocked: recipient not permitted by send policy',
+            ),
+          );
+          when(
+            () => mockOutgoingDmsDao.deleteById(_rumorEventId),
+          ).thenThrow(Exception('drift busy'));
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          final result = await repository.recoverFullSend(
+            rumorId: _rumorEventId,
+          );
+
+          // The delete failed, but the caller still gets the blocked result
+          // and the drain does not throw; the still-present row is re-blocked
+          // and re-dropped on the next sweep.
+          expect(result.blocked, isTrue);
+          verify(() => mockOutgoingDmsDao.deleteById(_rumorEventId)).called(1);
         },
       );
 

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -14136,6 +14136,51 @@ void main() {
       );
 
       test(
+        'on a blocked send: deletes the queue row instead of marking it '
+        'failed, so the drain stops re-attempting a policy-blocked send',
+        () async {
+          when(
+            () => mockOutgoingDmsDao.getById(_rumorEventId),
+          ).thenAnswer((_) async => queuedRow());
+          stubSendRumor(
+            (_, _) async => const NIP17SendResult.blocked(
+              'blocked: recipient not permitted by send policy',
+            ),
+          );
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          final result = await repository.recoverFullSend(
+            rumorId: _rumorEventId,
+          );
+
+          // A policy block is terminal, not a transient failure.
+          expect(result.success, isFalse);
+          expect(result.blocked, isTrue);
+          // The row is dropped so the retry sweep can never pick it up again.
+          verify(() => mockOutgoingDmsDao.deleteById(_rumorEventId)).called(1);
+          verifyNever(
+            () => mockOutgoingDmsDao.markRecipientWrapStatus(
+              id: any(named: 'id'),
+              status: any(named: 'status'),
+              eventId: any(named: 'eventId'),
+              lastError: any(named: 'lastError'),
+            ),
+          );
+          verifyNever(
+            () => mockOutgoingDmsDao.markSelfWrapStatus(
+              id: any(named: 'id'),
+              status: any(named: 'status'),
+              eventId: any(named: 'eventId'),
+              lastError: any(named: 'lastError'),
+            ),
+          );
+        },
+      );
+
+      test(
         'idempotent: when recipient_wrap_status is already sent, '
         'defers to recoverSelfWrap and never republishes the recipient '
         'wrap',

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -23,7 +23,12 @@ class _FakeEvent extends Fake implements Event {}
 
 /// Denies every recipient — stands in for a protected minor's policy where the
 /// counterparty is not in the approved official set.
-Future<bool> _denyAllPolicy(String recipientPubkey) async => false;
+Future<DmSendPolicyDecision> _denyAllPolicy(String recipientPubkey) async =>
+    DmSendPolicyDecision.terminallyBlocked;
+
+Future<DmSendPolicyDecision> _temporarilyDenyPolicy(
+  String recipientPubkey,
+) async => DmSendPolicyDecision.temporarilyBlocked;
 
 /// A local-key signer that advertises the isolate-offload capability,
 /// delegating all crypto to a real [LocalNostrSigner]. Used to exercise the
@@ -145,6 +150,31 @@ void main() {
 
           expect(await service.canSendTo(_recipientPubkey), isTrue);
           expect(await blocked.canSendTo(_recipientPubkey), isFalse);
+        },
+      );
+
+      test(
+        'temporary fail-closed policy denial stays retryable in the drain',
+        () async {
+          final temporarilyBlocked = NIP17MessageService(
+            signer: LocalNostrSigner(_testPrivateKey),
+            senderPublicKey: _testPublicKey,
+            nostrService: mockNostrClient,
+            sendPolicy: _temporarilyDenyPolicy,
+          );
+          final rumor = temporarilyBlocked.buildRumor(
+            recipientPubkey: _recipientPubkey,
+            content: 'wait for account state',
+          );
+
+          final result = await temporarilyBlocked.sendRumor(
+            rumorEvent: rumor,
+            recipientPubkey: _recipientPubkey,
+          );
+
+          expect(result.success, isFalse);
+          expect(result.blocked, isFalse);
+          verifyNever(() => mockNostrClient.publishEvent(any()));
         },
       );
 

--- a/mobile/test/providers/dm_send_policy_test.dart
+++ b/mobile/test/providers/dm_send_policy_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:dm_repository/dm_repository.dart' show DmSendPolicyDecision;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -36,6 +37,7 @@ void main() {
       ProviderContainer(
         overrides: [
           isDmRestrictedProvider.overrideWithValue(isRestricted),
+          hasConfirmedDmRestrictionProvider.overrideWithValue(isRestricted),
           officialAccountsServiceProvider.overrideWithValue(officials),
         ],
       );
@@ -46,7 +48,7 @@ void main() {
       final container = containerWith(isRestricted: false);
       final policy = container.read(dmSendPolicyProvider);
 
-      expect(await policy(strangerHex), isTrue);
+      expect(await policy(strangerHex), DmSendPolicyDecision.allowed);
       verifyNever(() => officials.isApprovedMinorDmRecipient(any()));
     },
   );
@@ -58,7 +60,7 @@ void main() {
     final container = containerWith(isRestricted: true);
     final policy = container.read(dmSendPolicyProvider);
 
-    expect(await policy(hqHex), isTrue);
+    expect(await policy(hqHex), DmSendPolicyDecision.allowed);
   });
 
   test('a restricted user may not send to a non-approved recipient', () async {
@@ -68,7 +70,10 @@ void main() {
     final container = containerWith(isRestricted: true);
     final policy = container.read(dmSendPolicyProvider);
 
-    expect(await policy(strangerHex), isFalse);
+    expect(
+      await policy(strangerHex),
+      DmSendPolicyDecision.terminallyBlocked,
+    );
   });
 
   test(
@@ -108,13 +113,46 @@ void main() {
 
       expect(
         await policy(strangerHex),
-        isFalse,
+        DmSendPolicyDecision.temporarilyBlocked,
         reason: 'unresolved + never-seen must restrict (fail closed)',
       );
       expect(
         await policy(hqHex),
-        isTrue,
+        DmSendPolicyDecision.allowed,
         reason: 'a pinned approved official stays reachable while restricted',
+      );
+    },
+  );
+
+  test(
+    'unresolved fail-closed denial is temporary, not a terminal policy block',
+    () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final authService = _MockAuthService();
+      when(() => authService.currentPublicKeyHex).thenReturn('a' * 64);
+      when(
+        () => officials.isApprovedMinorDmRecipient(strangerHex),
+      ).thenAnswer((_) async => false);
+
+      final container = ProviderContainer(
+        overrides: [
+          currentAuthStateProvider.overrideWithValue(AuthState.authenticated),
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          authServiceProvider.overrideWithValue(authService),
+          protectedMinorStatusProvider.overrideWith(
+            (ref) => Completer<ProtectedMinorStatus>().future,
+          ),
+          officialAccountsServiceProvider.overrideWithValue(officials),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final decision = await container.read(dmSendPolicyProvider)(strangerHex);
+
+      expect(
+        decision,
+        DmSendPolicyDecision.temporarilyBlocked,
       );
     },
   );

--- a/mobile/test/providers/video_publish_provider_test.dart
+++ b/mobile/test/providers/video_publish_provider_test.dart
@@ -3,6 +3,8 @@
 
 import 'dart:convert';
 
+import 'package:dm_repository/dm_repository.dart'
+    show CollaboratorInviteRetrySummary;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -137,6 +139,61 @@ void main() {
       expect(
         notifier.collaboratorInviteWarningMessage(l10n, 2),
         l10n.videoPublishCollaboratorInviteWarning(2),
+      );
+    });
+
+    test(
+      'collaborator invite retry message prioritizes transient failures',
+      () {
+        final l10n = lookupAppLocalizations(const Locale('en'));
+
+        expect(
+          notifier.collaboratorInviteRetryResultMessage(
+            l10n,
+            const CollaboratorInviteRetrySummary(
+              attemptedCount: 3,
+              successCount: 1,
+              failureCount: 1,
+              blockedCount: 1,
+            ),
+          ),
+          l10n.videoPublishCollaboratorInviteWarning(1),
+        );
+      },
+    );
+
+    test('collaborator invite retry message reports terminal blocks apart '
+        'from failures', () {
+      final l10n = lookupAppLocalizations(const Locale('en'));
+
+      expect(
+        notifier.collaboratorInviteRetryResultMessage(
+          l10n,
+          const CollaboratorInviteRetrySummary(
+            attemptedCount: 1,
+            successCount: 0,
+            failureCount: 0,
+            blockedCount: 1,
+          ),
+        ),
+        l10n.profileCollaboratorInviteBlockedResult(1),
+      );
+    });
+
+    test('collaborator invite retry message reads as sent when all '
+        'delivered', () {
+      final l10n = lookupAppLocalizations(const Locale('en'));
+
+      expect(
+        notifier.collaboratorInviteRetryResultMessage(
+          l10n,
+          const CollaboratorInviteRetrySummary(
+            attemptedCount: 2,
+            successCount: 2,
+            failureCount: 0,
+          ),
+        ),
+        l10n.profileCollaboratorInviteRetryResult(0),
       );
     });
 

--- a/mobile/test/services/outgoing_dm_retry_service_test.dart
+++ b/mobile/test/services/outgoing_dm_retry_service_test.dart
@@ -991,6 +991,36 @@ void main() {
       );
 
       test(
+        'blocked interrupted-send drain is terminal: no incrementRetry',
+        () async {
+          final now = DateTime.utc(2026, 5, 10, 12);
+          final stalePending = _row(
+            id: 'interrupted-blocked',
+            recipient: OutgoingWrapStatus.pending,
+            self: OutgoingWrapStatus.pending,
+            queuedAt: now.subtract(const Duration(minutes: 5)),
+          );
+          when(
+            () => dao.getStillPendingForOwner(any()),
+          ).thenAnswer((_) async => [stalePending]);
+          when(
+            () => dmRepository.recoverFullSend(rumorId: any(named: 'rumorId')),
+          ).thenAnswer(
+            (_) async => const NIP17SendResult.blocked('blocked by policy'),
+          );
+
+          await buildService(now: () => now).sweep();
+
+          verify(
+            () => dmRepository.recoverFullSend(rumorId: 'interrupted-blocked'),
+          ).called(1);
+          // recoverFullSend already deleted the row; a policy block is
+          // terminal, so the interrupted arm must not re-arm it.
+          verifyNever(() => dao.incrementRetry(any()));
+        },
+      );
+
+      test(
         'skips a pending row younger than initialDelay (in-flight send '
         'might still complete in-process)',
         () async {

--- a/mobile/test/services/outgoing_dm_retry_service_test.dart
+++ b/mobile/test/services/outgoing_dm_retry_service_test.dart
@@ -271,6 +271,39 @@ void main() {
         },
       );
 
+      test(
+        'recoverFullSend blocked path is terminal: no incrementRetry',
+        () async {
+          final row = _row(
+            id: 'rumor2c',
+            recipient: OutgoingWrapStatus.failed,
+            self: OutgoingWrapStatus.failed,
+            retryCount: 1,
+            lastAttemptAt: DateTime.utc(2025),
+          );
+          when(
+            () => dao.getRetryableForOwner(
+              ownerPubkey: any(named: 'ownerPubkey'),
+              maxRetries: any(named: 'maxRetries'),
+            ),
+          ).thenAnswer((_) async => [row]);
+          when(
+            () => dmRepository.recoverFullSend(rumorId: any(named: 'rumorId')),
+          ).thenAnswer(
+            (_) async => const NIP17SendResult.blocked('blocked by policy'),
+          );
+
+          await buildService().sweep();
+
+          verify(
+            () => dmRepository.recoverFullSend(rumorId: 'rumor2c'),
+          ).called(1);
+          // A policy block is terminal: recoverFullSend already dropped the
+          // row, so the sweep must not re-arm it with a retry bump.
+          verifyNever(() => dao.incrementRetry(any()));
+        },
+      );
+
       test('publish-failure path bumps incrementRetry once', () async {
         final row = _row(
           id: 'rumor3',

--- a/mobile/test/widgets/profile/profile_videos_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_videos_grid_test.dart
@@ -518,6 +518,63 @@ void main() {
           findsOneWidget,
         );
       });
+
+      testWidgets('retry banner surfaces a blocked message when a '
+          'collaborator cannot receive invites', (tester) async {
+        when(() => mockAuth.currentPublicKeyHex).thenReturn(_ownPubkey);
+        when(
+          () => mockDmRepository.retryPendingCollaboratorInvites(any()),
+        ).thenAnswer(
+          (_) async => const CollaboratorInviteRetrySummary(
+            attemptedCount: 1,
+            successCount: 0,
+            failureCount: 0,
+            blockedCount: 1,
+          ),
+        );
+        final pendingInviteGroups = [
+          PendingCollaboratorInviteGroup(
+            creatorPubkey: _ownPubkey,
+            videoAddress: '34236:$_ownPubkey:video-1',
+            invites: [
+              PendingCollaboratorInvite(
+                rumorId: 'rumor-1',
+                collaboratorPubkey: _otherPubkey,
+                creatorPubkey: _ownPubkey,
+                videoAddress: '34236:$_ownPubkey:video-1',
+                recipientWrapStatus: OutgoingWrapStatus.failed,
+                selfWrapStatus: OutgoingWrapStatus.failed,
+                retryCount: 1,
+                queuedAt: DateTime.utc(2026, 5, 22, 13),
+              ),
+            ],
+          ),
+        ];
+
+        await tester.pumpWidget(
+          buildSubject(
+            userIdHex: _ownPubkey,
+            videos: _createTestVideos(pubkey: _ownPubkey),
+            pendingInviteGroups: pendingInviteGroups,
+          ),
+        );
+        await tester.pump();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.tap(find.text(l10n.profileCollaboratorInviteRetryAction));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        expect(
+          find.text(l10n.profileCollaboratorInviteBlockedResult(1)),
+          findsOneWidget,
+        );
+        // A blocked-only batch must not read as "all invites sent".
+        expect(
+          find.text(l10n.profileCollaboratorInviteRetryResult(0)),
+          findsNothing,
+        );
+      });
     });
 
     group('background uploads', () {


### PR DESCRIPTION
## What this changes

When a protected minor is blocked from sending a DM (the #176 restriction), the app's outbound-message queue treated that block like a temporary network failure: it kept the message queued and retried it over and over, even though the block is permanent and every retry is refused. The message ended up stuck as "failed" forever.

This makes a blocked send final: the queue drops the message instead of retrying it.

## Why it's safe

A blocked message can never reach anyone. Both the one-to-one and group send paths already check the policy before a message is ever queued, so a message only ends up blocked-on-retry when it was queued while sending was allowed and the policy changed afterward (the sender became a protected minor, or a recipient's approval was revoked). The send is re-checked and re-blocked on every attempt regardless. This is a reliability cleanup, not a security fix.

## Where

- `recoverFullSend` (`mobile/packages/dm_repository/`): on a blocked result, delete the queued message (the same thing the user's "Cancel send" does) instead of marking it as a retryable failure.
- The retry sweep (`mobile/lib/services/outgoing_dm_retry_service.dart`): both places it drains the queue now treat a blocked result as final, so neither keeps bumping the retry counter on a message that's already gone.

## Related

Relates to divinevideo/support-trust-safety#186 (part of epic #173).

## Verification

- New tests in `dm_repository` (a blocked message is deleted and nothing is written to the chat history; a delete failure is handled without crashing) and in the retry service (both drain paths treat a blocked send as final, with no retry). Each was checked to fail if the fix is removed.
- Full `dm_repository` suite green; that package's line coverage is 93.42%, above its 93% floor. No database migration, no generated code. `flutter analyze` clean.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
