### PR TITLE
fix: Show background upload notification immediately (no FGS deferral)

### DIFF
--- a/mobile/packages/background_uploader/android/src/main/kotlin/co/openvine/background_uploader/BackgroundUploadService.kt
+++ b/mobile/packages/background_uploader/android/src/main/kotlin/co/openvine/background_uploader/BackgroundUploadService.kt
@@ -284,11 +284,17 @@ class BackgroundUploadService : Service() {
       @Suppress("DEPRECATION")
       Notification.Builder(this)
     }
-    return builder
+    builder
       .setContentTitle(notificationTitle)
       .setSmallIcon(android.R.drawable.stat_sys_upload)
       .setOngoing(true)
-      .build()
+    // Show the upload notification immediately instead of letting the system
+    // defer it up to ~10s (Android 12+ FGS notification deferral), which would
+    // otherwise hide it for most of a short upload.
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+      builder.setForegroundServiceBehavior(Notification.FOREGROUND_SERVICE_IMMEDIATE)
+    }
+    return builder.build()
   }
 
   private fun createNotificationChannel() {


### PR DESCRIPTION
## Description

Android can delay foreground-service notifications for about 10 seconds on Android 12+.
That meant a short background video upload could finish before users clearly saw the “Uploading video” notification.
This change asks Android to show the data-sync foreground-service notification immediately while keeping the existing service type and notification lifecycle.

The root cause was in native notification construction.
The service called `startForeground()` promptly, but the notification did not set Android's immediate foreground-service behavior.
The fix applies `Notification.FOREGROUND_SERVICE_IMMEDIATE` only on Android 12+.

**Related Issue:** Closes #6031

## Out of Scope

This does not override denied notification permission, disabled channels, or user notification settings.
Those still control whether Android can display the notification.

## Verification

The change was verified with app lint, app tests, package tests, and an Android debug build.

- `cd mobile && flutter analyze`
- `cd mobile && flutter test`
- `cd mobile/packages/background_uploader && flutter test`
- `cd mobile && flutter build apk --debug`

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore