### PR TITLE
fix(divine_ui): keep DivineButton size constant with or without border

### DIFF
--- a/mobile/packages/divine_ui/lib/src/button/divine_button.dart
+++ b/mobile/packages/divine_ui/lib/src/button/divine_button.dart
@@ -186,6 +186,9 @@ class _DivineButtonContent extends StatelessWidget {
   final bool expanded;
   final bool isLoading;
 
+  /// Thickness of the visible border on bordered [type]s (e.g. secondary).
+  static const double _kBorderWidth = 2;
+
   bool get _isEnabled => onPressed != null && !isLoading;
 
   /// Icon size scales with [size]: tiny uses a smaller 20px icon to fit
@@ -203,22 +206,36 @@ class _DivineButtonContent extends StatelessWidget {
   /// `DivineIconButton`.
   bool get _noLabel => label.isEmpty;
 
+  /// Border thickness that the `Ink` decoration adds around its child.
+  /// It is subtracted back out of the inner padding ([_verticalPadding],
+  /// [_looseHorizontalPadding]) so a bordered button keeps the exact same
+  /// outer bounds — and the same content position — as an unbordered one
+  /// of the same [size]. Without this, a secondary button renders 2px
+  /// larger on every edge than a primary one.
+  double get _borderInset => _borderColor != null ? _kBorderWidth : 0;
+
   /// Vertical inner padding. Fixed per size — it sets the button height
-  /// (32 / 40 / 48px) and never changes with stretch state.
-  double get _verticalPadding => switch (size) {
-    DivineButtonSize.tiny => 6,
-    DivineButtonSize.small => 8,
-    DivineButtonSize.base => 12,
-  };
+  /// (32 / 40 / 48px) and never changes with stretch state. The border
+  /// thickness is subtracted so the total height stays constant across
+  /// bordered and unbordered types (see [_borderInset]).
+  double get _verticalPadding =>
+      switch (size) {
+        DivineButtonSize.tiny => 6,
+        DivineButtonSize.small => 8,
+        DivineButtonSize.base => 12,
+      } -
+      _borderInset;
 
   /// Horizontal inner padding for a content-hugging button (the wider,
   /// visually-balanced inset). A stretched button instead uses
   /// [_verticalPadding] for symmetric insets — see [_AdaptiveButtonPadding].
-  double get _looseHorizontalPadding => switch (size) {
-    DivineButtonSize.tiny => 12,
-    DivineButtonSize.small => 16,
-    DivineButtonSize.base => 24,
-  };
+  double get _looseHorizontalPadding =>
+      switch (size) {
+        DivineButtonSize.tiny => 12,
+        DivineButtonSize.small => 16,
+        DivineButtonSize.base => 24,
+      } -
+      _borderInset;
 
   /// Whether the button always uses the narrower symmetric padding,
   /// regardless of incoming constraints: icon-only buttons (to match
@@ -352,7 +369,7 @@ class _DivineButtonContent extends StatelessWidget {
       color: _backgroundColor,
       borderRadius: BorderRadius.circular(_borderRadius),
       border: _borderColor != null
-          ? Border.all(color: _borderColor!, width: 2)
+          ? Border.all(color: _borderColor!, width: _kBorderWidth)
           : null,
       boxShadow: _isEnabled ? _boxShadow : null,
     );

--- a/mobile/packages/divine_ui/test/src/button/divine_button_test.dart
+++ b/mobile/packages/divine_ui/test/src/button/divine_button_test.dart
@@ -360,6 +360,29 @@ void main() {
       });
 
       testWidgets(
+        'bordered type keeps the same outer size as an unbordered one',
+        (tester) async {
+          // The secondary type draws a 2px border via the Ink decoration,
+          // which the framework adds around its child. The inner padding
+          // compensates so a bordered button does not render larger than an
+          // unbordered one of the same size (regression: secondary was 4px
+          // wider and taller than primary).
+          await tester.pumpWidget(
+            buildTestWidget(onPressed: () {}),
+          );
+          final unbordered = tester.getSize(find.byType(DivineButton));
+
+          await tester.pumpWidget(
+            buildTestWidget(type: DivineButtonType.secondary, onPressed: () {}),
+          );
+          final bordered = tester.getSize(find.byType(DivineButton));
+
+          expect(bordered, equals(unbordered));
+          expect(bordered.height, equals(48));
+        },
+      );
+
+      testWidgets(
         'tiny outer == inner == 32px (no tap-padding inflation)',
         (tester) async {
           await tester.pumpWidget(


### PR DESCRIPTION
Closes #6035

## What

A `DivineButton` with a border (e.g. `secondary`) rendered larger than one without. A `base` secondary button was **52px** instead of **48px** tall (and 4px wider) — 2px extra on every edge. In figma BOTH have a size of 48px and not 52px.

## Why

The border lives in the `Ink` widget's `BoxDecoration`. Flutter adds the border's thickness (`border.dimensions`) as layout inset around the `Ink`'s child, so any bordered type inflates by the stroke width (2px) on each side. With the default `strokeAlignInside`, the stroke is meant to sit *inside* the bounds — but the layout still grew, so bordered and unbordered buttons of the same size no longer matched.

Measured before the fix:
- primary (no border): `112.6 × 48.0`
- secondary (2px border): `116.6 × 52.0`

## Fix

Subtract the border width back out of the inner padding when a border is present (`_borderInset`). Net effect: the `Ink` adds the 2px border, the padding gives 2px back, so:

- **Outer size stays identical** across bordered/unbordered types of the same size (base = 48px, small visible = 40px, tiny = 32px — all independent of border).
- **Content position is unchanged** — the stroke sits in the outer 2px ring of the padding (inside the bounds) and never overlaps the label/icon.

The magic `2` is also extracted into a single `_kBorderWidth` constant used for both the stroke and the compensation.

## Tests

- New regression test: a bordered (`secondary`) button has the exact same outer `Size` as an unbordered one, and `base` height is 48px.
- All 136 `divine_ui` button tests pass; `divine_ui` 100% coverage gate satisfied (no uncovered lines in the changed file).