### PR TITLE
fix(feed): prefer progressive mp4 over hls for short-video playback

### DIFF
--- a/mobile/lib/extensions/video_event_extensions.dart
+++ b/mobile/lib/extensions/video_event_extensions.dart
@@ -211,14 +211,18 @@ extension VideoEventAppExtensions on VideoEvent {
 
   /// Get the optimal video URL for initial playback.
   ///
-  /// **Strategy**:
+  /// **Strategy** (first match wins):
+  /// - A developer format override (Developer Options) forces that server
+  ///   format on any Divine video for A/B testing, ahead of every heuristic
+  ///   below.
   /// - Classic Vine originals use the raw blob directly (/{hash}) because the
   ///   source is already 480p or lower — transcoded variants are upscales at
   ///   best and may not exist, causing needless 404s.
+  /// - Raw-only uploads use their published raw blob URL, since derived
+  ///   MP4/HLS variants may not exist yet.
   /// - Other Divine videos default to progressive MP4 720p (faststart, moov at
   ///   front) for fastest startup with short videos (1 request, no manifest
   ///   overhead).
-  /// - Developer options can override to HLS or other formats for A/B testing.
   /// - If MP4 fails (e.g. not yet transcoded after upload), [getFallbackUrl]
   ///   provides an HLS fallback via the quality variant error handler.
   ///
@@ -230,18 +234,11 @@ extension VideoEventAppExtensions on VideoEvent {
     final hash = _extractVideoHash(videoUrl);
     if (hash == null) return videoUrl;
 
-    // Classic Vine originals are 480p or lower — serve the raw blob directly.
-    // Transcoded 720p variants are pointless upscales and may not exist.
-    if (isOriginalVine) return '$_divineMediaBase/$hash';
-
-    // Direct Blossom uploads that only advertise the raw blob should start
-    // from that actual published URL. Derived MP4/HLS variants may not exist
-    // yet and can generate avoidable parser errors before falling back. This
-    // intentionally precedes the developer format override below: forcing a
-    // derived variant on a raw-only upload would just 404.
-    if (hasRawOnlyDivineImetaUrl) return videoUrl;
-
-    // Developer format override takes priority
+    // Developer format override takes priority over every heuristic below so
+    // A/B testing can force a specific server format on any Divine video,
+    // including classic Vine originals and raw-only uploads. If the forced
+    // variant does not exist yet the runtime fallback chain recovers, and
+    // seeing that is the point of the test switch.
     final override = videoFormatPreference.format;
     if (override != null) {
       return switch (override) {
@@ -257,6 +254,15 @@ extension VideoEventAppExtensions on VideoEvent {
           } ??
           videoUrl;
     }
+
+    // Classic Vine originals are 480p or lower — serve the raw blob directly.
+    // Transcoded 720p variants are pointless upscales and may not exist.
+    if (isOriginalVine) return '$_divineMediaBase/$hash';
+
+    // Direct Blossom uploads that only advertise the raw blob should start
+    // from that actual published URL. Derived MP4/HLS variants may not exist
+    // yet and can generate avoidable parser errors before falling back.
+    if (hasRawOnlyDivineImetaUrl) return videoUrl;
 
     // Production default: progressive MP4 720p (faststart).
     // Fastest startup (1 request, moov at front), correct colors on all

--- a/mobile/lib/extensions/video_event_extensions.dart
+++ b/mobile/lib/extensions/video_event_extensions.dart
@@ -73,52 +73,6 @@ extension VideoEventAppExtensions on VideoEvent {
     }
   }
 
-  /// Check for `media.divine.video` URLs that are just a bare sha256 hash path.
-  ///
-  /// These URLs look like `https://media.divine.video/{hash}` with no file
-  /// extension or quality suffix. Some of these assets do not expose a direct
-  /// downloadable file and are only playable via the derived HLS manifest.
-  bool get hasBareDivineHashPath {
-    final url = videoUrl;
-    if (url == null || url.isEmpty || !isFromDivineServer) {
-      return false;
-    }
-
-    try {
-      final uri = Uri.parse(url);
-      if (uri.host.toLowerCase() != 'media.divine.video') {
-        return false;
-      }
-
-      final segments = uri.pathSegments.where((segment) => segment.isNotEmpty);
-      if (segments.length != 1) {
-        return false;
-      }
-
-      final segment = segments.first;
-      return segment.length == 64 &&
-          RegExp(r'^[a-fA-F0-9]+$').hasMatch(segment);
-    } catch (_) {
-      return false;
-    }
-  }
-
-  /// Whether the event explicitly advertises only the raw Blossom blob URL.
-  ///
-  /// Fresh direct uploads can publish before `/720p.mp4` or HLS derivatives
-  /// exist. When the event's `imeta` contains a single raw
-  /// `https://media.divine.video/{sha256}` URL, prefer that proven source for
-  /// initial playback instead of speculatively probing derived variants.
-  bool get hasRawOnlyDivineImetaUrl {
-    final url = videoUrl;
-    if (url == null || url.isEmpty || !hasBareDivineHashPath) {
-      return false;
-    }
-
-    final imetaUrls = imetaVideoUrls;
-    return imetaUrls.length == 1 && imetaUrls.single == url;
-  }
-
   /// Check if we should show the "Not Divine" badge.
   ///
   /// Shows badge for content that is:
@@ -218,13 +172,13 @@ extension VideoEventAppExtensions on VideoEvent {
   /// - Classic Vine originals use the raw blob directly (/{hash}) because the
   ///   source is already 480p or lower — transcoded variants are upscales at
   ///   best and may not exist, causing needless 404s.
-  /// - Raw-only uploads use their published raw blob URL, since derived
-  ///   MP4/HLS variants may not exist yet.
-  /// - Other Divine videos default to progressive MP4 720p (faststart, moov at
-  ///   front) for fastest startup with short videos (1 request, no manifest
-  ///   overhead).
-  /// - If MP4 fails (e.g. not yet transcoded after upload), [getFallbackUrl]
-  ///   provides an HLS fallback via the quality variant error handler.
+  /// - All other Divine videos default to progressive MP4 720p (faststart,
+  ///   moov at front) for fastest startup with short videos (1 request, no
+  ///   manifest overhead) — it is 3-8x smaller than the raw blob. This covers
+  ///   raw-only uploads too: their `imeta` lists only the raw blob because it
+  ///   is a publish-time snapshot taken before the derivatives transcode, but
+  ///   by playback time the 720p.mp4 almost always exists, and the runtime
+  ///   fallback chain drops to the raw blob when it does not yet.
   ///
   /// Non-Divine videos always use original (no transcoded variants exist).
   String? getOptimalVideoUrlForPlatform() {
@@ -259,14 +213,11 @@ extension VideoEventAppExtensions on VideoEvent {
     // Transcoded 720p variants are pointless upscales and may not exist.
     if (isOriginalVine) return '$_divineMediaBase/$hash';
 
-    // Direct Blossom uploads that only advertise the raw blob should start
-    // from that actual published URL. Derived MP4/HLS variants may not exist
-    // yet and can generate avoidable parser errors before falling back.
-    if (hasRawOnlyDivineImetaUrl) return videoUrl;
-
-    // Production default: progressive MP4 720p (faststart).
-    // Fastest startup (1 request, moov at front), correct colors on all
-    // platforms, and 3-8x smaller than the raw blob.
+    // Production default: progressive MP4 720p (faststart). Fastest startup
+    // (1 request, moov at front), correct colors on all platforms, and 3-8x
+    // smaller than the raw blob. Raw-only uploads take this path too; the
+    // runtime fallback chain drops to the raw blob if the 720p.mp4 is not
+    // transcoded yet.
     return '$_divineMediaBase/$hash/720p.mp4';
   }
 

--- a/mobile/lib/providers/individual_video_providers.dart
+++ b/mobile/lib/providers/individual_video_providers.dart
@@ -780,17 +780,31 @@ VideoPlayerController individualVideoController(
         }
 
         // Check if this was a quality variant URL (720p/480p) that failed.
-        // If so, fall back to HLS (proven reliable format) instead of retrying
-        // the same URL. This handles both MP4 not-yet-ready after upload and
-        // transient server errors.
+        // If so, fall back to the guaranteed raw blob (the published Blossom
+        // source, which always exists) rather than HLS. A fresh raw-only upload
+        // publishes the raw blob before its 720p.mp4/HLS derivatives finish
+        // transcoding, so HLS can be just as unready as the failed variant,
+        // whereas the raw blob plays immediately. This mirrors the feed's
+        // progressive-first order (720p → raw → HLS). HLS remains the fallback
+        // only when no raw blob hash is resolvable (non-Divine).
         final isQualityVariant =
             videoUrl.contains('/720p') || videoUrl.contains('/480p');
         if (isQualityVariant && params.videoEvent is VideoEvent) {
-          final fallbackUrl = params.videoEvent?.getFallbackUrl();
+          final videoEvent = params.videoEvent!;
+          final sha256 = (videoEvent.sha256?.isNotEmpty ?? false)
+              ? videoEvent.sha256
+              : _extractSha256FromUrl(videoUrl);
+          final canUseRawBlob =
+              videoEvent.isFromDivineServer &&
+              sha256 != null &&
+              sha256.isNotEmpty;
+          final fallbackUrl = canUseRawBlob
+              ? '$_blossomFallbackServer/$sha256'
+              : videoEvent.getFallbackUrl();
           if (fallbackUrl != null) {
             Log.info(
               '📱 Quality variant failed for ${params.videoId} ($videoUrl) - '
-              'falling back to HLS: $fallbackUrl',
+              'falling back to: $fallbackUrl',
               name: 'IndividualVideoController',
               category: LogCategory.video,
             );

--- a/mobile/lib/providers/individual_video_providers.g.dart
+++ b/mobile/lib/providers/individual_video_providers.g.dart
@@ -81,7 +81,7 @@ final class IndividualVideoControllerProvider
 }
 
 String _$individualVideoControllerHash() =>
-    r'41171da0921a39bcedec61fca58d98b37e4879b0';
+    r'4985daf39af086113c61d169ee3c68bfaa302424';
 
 /// Provider for individual video controllers with autoDispose
 /// Each video gets its own controller instance

--- a/mobile/packages/infinite_video_feed/lib/src/utils/playback_sources.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/utils/playback_sources.dart
@@ -8,9 +8,13 @@ import 'package:models/models.dart';
 /// [VideoEvent.videoUrl]. For Divine blob URLs the list is expanded with
 /// canonical HLS and raw variants so the runtime can fail over between them.
 ///
-/// **Fallback order rationale**: the progressive source (raw blob or
-/// `<hash>/720p.mp4`) is always attempted first, and HLS is only a fallback.
-/// We deliberately do NOT prefer HLS, for two reasons specific to Divine:
+/// **Fallback order rationale**: when the resolved source is progressive (raw
+/// blob or `<hash>/720p.mp4`) it is attempted first and HLS is only a fallback.
+/// (When the resolved source is itself an HLS URL — a Developer Options HLS
+/// override or an HLS-only event — that HLS URL is honoured first; the
+/// progressive-first ordering below applies to raw/MP4 resolved sources.)
+/// We deliberately do NOT prefer HLS for progressive sources, for two reasons
+/// specific to Divine:
 ///
 /// 1. Divine videos are short (≤ 6.3s). HLS pays a fixed startup cost — fetch
 ///    the master playlist, then a media playlist, then the first segment

--- a/mobile/packages/infinite_video_feed/lib/src/utils/playback_sources.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/utils/playback_sources.dart
@@ -8,13 +8,26 @@ import 'package:models/models.dart';
 /// [VideoEvent.videoUrl]. For Divine blob URLs the list is expanded with
 /// canonical HLS and raw variants so the runtime can fail over between them.
 ///
-/// **Fallback order rationale**: ExoPlayer uses `ProgressiveMediaSource` for
-/// `.mp4`-extension URLs and only switches to `HlsMediaSource` when the URL
-/// ends with `.m3u8`. Some Divine CDN paths (including raw blob URLs and
-/// `<hash>/720p.mp4`) serve content that ExoPlayer cannot parse or start
-/// quickly with its progressive extractors even though the file is reachable.
-/// HLS is preferred for canonical Divine blobs, with raw MP4 retained as a
-/// fallback for assets whose HLS rendition is still unavailable.
+/// **Fallback order rationale**: the progressive source (raw blob or
+/// `<hash>/720p.mp4`) is always attempted first, and HLS is only a fallback.
+/// We deliberately do NOT prefer HLS, for two reasons specific to Divine:
+///
+/// 1. Divine videos are short (≤ 6.3s). HLS pays a fixed startup cost — fetch
+///    the master playlist, then a media playlist, then the first segment
+///    before a single frame renders. For a clip this short that manifest
+///    round-trip overhead makes HLS noticeably slower to first frame than a
+///    single progressive MP4 request (moov at front, one round trip).
+/// 2. HLS is bad for preloading. A progressive MP4 is one cacheable file we
+///    can warm ahead of the feed; an HLS stream is a manifest tree of many
+///    segments that cannot be single-file cached, so preloading barely helps.
+///
+/// ExoPlayer/AVPlayer use a progressive source for MP4/raw URLs and only
+/// switch to an HLS source for `.m3u8` URLs. On top of the speed and
+/// preloading costs, fresh Divine uploads publish the raw/progressive blob
+/// before their HLS rendition finishes transcoding, so probing
+/// `<hash>/hls/master.m3u8` first returns a manifest with no playable video
+/// track and stalls every video. HLS is kept only as a last-resort fallback
+/// for assets whose progressive source fails to start.
 List<String> resolvePlaybackSources(
   VideoEvent video, {
   String? Function(VideoEvent video)? urlResolver,
@@ -36,13 +49,11 @@ List<String> resolvePlaybackSources(
     }
 
     final isRawBlob = resolvedSource == rawUrl;
-    // For the raw blob, prefer HLS so cold progressive MP4 metadata/layout
-    // does not stall feed playback before falling back to raw bytes.
-    // For quality-specific variants (e.g. 720p.mp4), HLS comes before raw
-    // because the variant URL may serve content ExoPlayer cannot parse as
-    // a progressive stream.
+    // Always try the progressive source first (raw blob or 720p.mp4). HLS is
+    // only a fallback: its rendition may not exist yet for fresh uploads, and
+    // probing a track-less master first stalls playback on every video.
     return isRawBlob
-        ? orderedUniqueSources([hlsUrl, resolvedSource, originalUrl])
+        ? orderedUniqueSources([resolvedSource, hlsUrl, originalUrl])
         : orderedUniqueSources([resolvedSource, hlsUrl, rawUrl, originalUrl]);
   }
 

--- a/mobile/packages/infinite_video_feed/lib/src/utils/playback_sources.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/utils/playback_sources.dart
@@ -49,12 +49,13 @@ List<String> resolvePlaybackSources(
     }
 
     final isRawBlob = resolvedSource == rawUrl;
-    // Always try the progressive source first (raw blob or 720p.mp4). HLS is
-    // only a fallback: its rendition may not exist yet for fresh uploads, and
-    // probing a track-less master first stalls playback on every video.
+    // Progressive first, HLS last. For a quality variant (e.g. 720p.mp4) the
+    // guaranteed raw blob comes before HLS: if the variant is not transcoded
+    // yet, the raw blob plays immediately, whereas HLS may also be mid-encode
+    // and only pays the manifest-round-trip cost. HLS stays the last resort.
     return isRawBlob
         ? orderedUniqueSources([resolvedSource, hlsUrl, originalUrl])
-        : orderedUniqueSources([resolvedSource, hlsUrl, rawUrl, originalUrl]);
+        : orderedUniqueSources([resolvedSource, rawUrl, hlsUrl, originalUrl]);
   }
 
   return orderedUniqueSources([resolvedSource, originalUrl]);

--- a/mobile/packages/infinite_video_feed/lib/src/utils/source_loader.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/utils/source_loader.dart
@@ -70,7 +70,12 @@ Future<(String, int)> setSourceWithFallbacks({
       abortIfStale(source);
       lastError = error;
       lastStackTrace = stackTrace;
-      if (isMediaProcessingError(error)) {
+      // Only wait-and-retry a processing (HTTP 202) source when it is the last
+      // resort. While a fallback is still queued — for Divine that is always
+      // the guaranteed raw blob — prefer it immediately instead of stalling up
+      // to ~19s for a derivative that is still transcoding.
+      final isLastSource = attemptIndex == sources.length - 1;
+      if (isLastSource && isMediaProcessingError(error)) {
         for (final retryDelay in _mediaProcessingRetryDelays) {
           log(
             'Source processing index $index: '

--- a/mobile/packages/infinite_video_feed/test/src/utils/playback_sources_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/utils/playback_sources_test.dart
@@ -91,12 +91,12 @@ void main() {
       const variantUrl = 'https://media.divine.video/$_hash/720p.mp4';
 
       test(
-        'returns [variantUrl, hlsUrl, rawUrl, originalUrl] deduplicated',
+        'returns [variantUrl, rawUrl, hlsUrl, originalUrl] deduplicated',
         () {
           final video = _makeVideo(videoUrl: variantUrl);
           expect(
             resolvePlaybackSources(video),
-            equals([variantUrl, _hlsUrl, _rawUrl]),
+            equals([variantUrl, _rawUrl, _hlsUrl]),
           );
         },
       );

--- a/mobile/packages/infinite_video_feed/test/src/utils/playback_sources_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/utils/playback_sources_test.dart
@@ -70,10 +70,10 @@ void main() {
     });
 
     group('when URL is the raw blob URL', () {
-      test('returns [hlsUrl, rawUrl, originalUrl] deduplicated', () {
+      test('returns [rawUrl, hlsUrl, originalUrl] deduplicated', () {
         final video = _makeVideo(videoUrl: _rawUrl);
-        // raw == original -> [hlsUrl, rawUrl]
-        expect(resolvePlaybackSources(video), equals([_hlsUrl, _rawUrl]));
+        // raw == original -> progressive raw first, HLS as fallback
+        expect(resolvePlaybackSources(video), equals([_rawUrl, _hlsUrl]));
       });
 
       test('includes originalUrl when it differs from rawUrl', () {
@@ -83,7 +83,7 @@ void main() {
           video,
           urlResolver: (_) => _rawUrl,
         );
-        expect(result, equals([_hlsUrl, _rawUrl, otherOriginal]));
+        expect(result, equals([_rawUrl, _hlsUrl, otherOriginal]));
       });
     });
 

--- a/mobile/packages/infinite_video_feed/test/src/utils/source_loader_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/utils/source_loader_test.dart
@@ -65,14 +65,11 @@ void main() {
       expect(logs.first, contains('badUrl'));
     });
 
-    test('retries same source for HTTP 202 before falling back', () async {
+    test('advances immediately on HTTP 202 when a fallback remains', () async {
       final clips = <VideoClip>[];
       final controller = _RecordingControllerWithFailures(
         clips.add,
-        failures: [
-          Exception('CoreMediaErrorDomain error -12667 - HTTP 202'),
-          Exception('Response code: 202'),
-        ],
+        failures: [Exception('CoreMediaErrorDomain error -12667 - HTTP 202')],
       );
       addTearDown(controller.dispose);
 
@@ -80,22 +77,24 @@ void main() {
       final result = await setSourceWithFallbacks(
         index: 2,
         controller: controller,
-        sources: ['processingUrl', 'hlsUrl'],
+        sources: ['processingUrl', 'rawUrl'],
         log: logs.add,
         delay: (duration) async => delays.add(duration),
       );
 
-      expect(result, equals(('processingUrl', 0)));
+      // The processing source is not the last resort, so we do not stall on it:
+      // the guaranteed raw fallback is preferred immediately.
+      expect(result, equals(('rawUrl', 1)));
       expect(
         clips.map((clip) => clip.uri),
-        equals(['processingUrl', 'processingUrl', 'processingUrl']),
+        equals(['processingUrl', 'rawUrl']),
       );
-      expect(delays, hasLength(2));
+      expect(delays, isEmpty);
       expect(
         logs.where((line) => line.contains('Source processing')),
-        hasLength(2),
+        isEmpty,
       );
-      expect(logs.any((line) => line.contains('retrySource=hlsUrl')), isFalse);
+      expect(logs.any((line) => line.contains('retrySource=rawUrl')), isTrue);
     });
 
     test('uses source headers when retrying after HTTP 202', () async {
@@ -123,7 +122,7 @@ void main() {
     });
 
     test(
-      'falls back after bounded HTTP 202 retry budget is exhausted',
+      'retries the last source across the HTTP 202 budget then gives up',
       () async {
         final clips = <VideoClip>[];
         final controller = _RecordingControllerWithFailures(
@@ -135,32 +134,31 @@ void main() {
         );
         addTearDown(controller.dispose);
 
-        final result = await setSourceWithFallbacks(
-          index: 2,
-          controller: controller,
-          sources: ['processingUrl', 'hlsUrl'],
-          log: logs.add,
-          delay: (_) async {},
+        await expectLater(
+          () => setSourceWithFallbacks(
+            index: 2,
+            controller: controller,
+            sources: ['processingUrl'],
+            log: logs.add,
+            delay: (_) async {},
+          ),
+          throwsA(isA<Exception>()),
         );
 
-        expect(result, equals(('hlsUrl', 1)));
+        // The last source is the only resort, so it is retried across the full
+        // 202 budget (initial attempt + 5 delayed retries) before giving up.
         expect(
           clips.map((clip) => clip.uri),
-          equals([
-            'processingUrl',
-            'processingUrl',
-            'processingUrl',
-            'processingUrl',
-            'processingUrl',
-            'processingUrl',
-            'hlsUrl',
-          ]),
+          equals(List<String>.filled(6, 'processingUrl')),
         );
         expect(
           logs.where((line) => line.contains('Source processing')),
           hasLength(5),
         );
-        expect(logs.any((line) => line.contains('retrySource=hlsUrl')), isTrue);
+        expect(
+          logs.any((line) => line.contains('All sources failed')),
+          isTrue,
+        );
       },
     );
 

--- a/mobile/test/extensions/video_event_divine_server_test.dart
+++ b/mobile/test/extensions/video_event_divine_server_test.dart
@@ -6,6 +6,7 @@ import 'package:models/models.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/services/bandwidth_tracker_service.dart';
+import 'package:openvine/services/video_format_preference.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 VideoEvent _createVideoWithUrl(
@@ -232,6 +233,53 @@ void main() {
       expect(
         video.getOptimalVideoUrlForPlatform(),
         equals('https://blossom.primal.net/test/video.mp4'),
+      );
+    });
+  });
+
+  group('getOptimalVideoUrlForPlatform developer override', () {
+    // videoFormatPreference is a process-global singleton; reset it after each
+    // test so the forced format does not leak into other suites.
+    tearDown(() => videoFormatPreference.setFormat(null));
+
+    test('mp4_720p override wins over raw-only imeta upload', () async {
+      const hash =
+          'e770667c1a62cc394602fc07462fa0d7ba83441002d9aac662fb88d0cc575338';
+      final video = _createVideoWithUrl(
+        'https://media.divine.video/$hash',
+        tags: const [
+          [
+            'imeta',
+            'url https://media.divine.video/$hash',
+            'm video/mp4',
+            'x $hash',
+          ],
+        ],
+      );
+      expect(video.hasRawOnlyDivineImetaUrl, isTrue);
+
+      await videoFormatPreference.setFormat(VideoPlaybackFormat.mp4_720p);
+
+      expect(
+        video.getOptimalVideoUrlForPlatform(),
+        equals('https://media.divine.video/$hash/720p.mp4'),
+      );
+    });
+
+    test('mp4_480p override wins over classic Vine original', () async {
+      const hash =
+          'cfb5cf3415ec4ad3f45eff478570d898ff9a660ecea63d0c058892b22468a90d';
+      final video = _createVideoWithUrl(
+        'https://media.divine.video/$hash',
+        rawTags: const {'platform': 'vine'},
+      );
+      expect(video.isOriginalVine, isTrue);
+
+      await videoFormatPreference.setFormat(VideoPlaybackFormat.mp4_480p);
+
+      expect(
+        video.getOptimalVideoUrlForPlatform(),
+        equals('https://media.divine.video/$hash/480p.mp4'),
       );
     });
   });

--- a/mobile/test/extensions/video_event_divine_server_test.dart
+++ b/mobile/test/extensions/video_event_divine_server_test.dart
@@ -162,7 +162,6 @@ void main() {
           '191679cbbeea3e4e3539d46b558e66fbadb673733af1ada0161a6e8b1cf61bea';
       final video = _createVideoWithUrl('https://media.divine.video/$hash');
 
-      expect(video.hasBareDivineHashPath, isTrue);
       expect(video.shouldPreferHlsPlayback, isFalse);
       expect(
         video.getOptimalVideoUrlForPlatform(),
@@ -170,7 +169,7 @@ void main() {
       );
     });
 
-    test('uses raw URL when imeta only advertises a direct Blossom blob', () {
+    test('uses MP4 720p even when imeta only advertises the raw blob', () {
       const hash =
           'e770667c1a62cc394602fc07462fa0d7ba83441002d9aac662fb88d0cc575338';
       final video = _createVideoWithUrl(
@@ -185,15 +184,16 @@ void main() {
         ],
       );
 
-      expect(video.hasBareDivineHashPath, isTrue);
-      expect(video.hasRawOnlyDivineImetaUrl, isTrue);
+      // A raw-only imeta is a publish-time snapshot; the 720p.mp4 usually
+      // exists by playback time, and the runtime chain falls back to the raw
+      // blob when it does not.
       expect(
         video.getOptimalVideoUrlForPlatform(),
-        equals('https://media.divine.video/$hash'),
+        equals('https://media.divine.video/$hash/720p.mp4'),
       );
       expect(
         video.getCacheableVideoUrlForPlatform(),
-        equals('https://media.divine.video/$hash'),
+        equals('https://media.divine.video/$hash/720p.mp4'),
       );
     });
 
@@ -217,7 +217,6 @@ void main() {
         ],
       );
 
-      expect(video.hasRawOnlyDivineImetaUrl, isFalse);
       expect(
         video.getOptimalVideoUrlForPlatform(),
         equals('https://media.divine.video/$hash/720p.mp4'),
@@ -242,29 +241,36 @@ void main() {
     // test so the forced format does not leak into other suites.
     tearDown(() => videoFormatPreference.setFormat(null));
 
-    test('mp4_720p override wins over raw-only imeta upload', () async {
-      const hash =
-          'e770667c1a62cc394602fc07462fa0d7ba83441002d9aac662fb88d0cc575338';
-      final video = _createVideoWithUrl(
-        'https://media.divine.video/$hash',
-        tags: const [
-          [
-            'imeta',
-            'url https://media.divine.video/$hash',
-            'm video/mp4',
-            'x $hash',
+    test(
+      'raw override wins over the default MP4 for a raw-only upload',
+      () async {
+        const hash =
+            'e770667c1a62cc394602fc07462fa0d7ba83441002d9aac662fb88d0cc575338';
+        final video = _createVideoWithUrl(
+          'https://media.divine.video/$hash',
+          tags: const [
+            [
+              'imeta',
+              'url https://media.divine.video/$hash',
+              'm video/mp4',
+              'x $hash',
+            ],
           ],
-        ],
-      );
-      expect(video.hasRawOnlyDivineImetaUrl, isTrue);
+        );
+        // Default (no override) would be 720p.mp4; the override must force raw.
+        expect(
+          video.getOptimalVideoUrlForPlatform(),
+          equals('https://media.divine.video/$hash/720p.mp4'),
+        );
 
-      await videoFormatPreference.setFormat(VideoPlaybackFormat.mp4_720p);
+        await videoFormatPreference.setFormat(VideoPlaybackFormat.raw);
 
-      expect(
-        video.getOptimalVideoUrlForPlatform(),
-        equals('https://media.divine.video/$hash/720p.mp4'),
-      );
-    });
+        expect(
+          video.getOptimalVideoUrlForPlatform(),
+          equals('https://media.divine.video/$hash'),
+        );
+      },
+    );
 
     test('mp4_480p override wins over classic Vine original', () async {
       const hash =
@@ -309,15 +315,6 @@ void main() {
         equals('https://media.divine.video/$hash'),
       );
       expect(video.getCacheableVideoUrlForPlatform(), isNull);
-    });
-
-    test('do not treat quality variants as bare hash paths', () {
-      final video = _createVideoWithUrl(
-        'https://media.divine.video/$hash/720p',
-      );
-
-      expect(video.hasBareDivineHashPath, isFalse);
-      expect(video.shouldPreferHlsPlayback, isFalse);
     });
 
     test('uses MP4 720p for all Divine hosts including cdn.divine.video', () {

--- a/mobile/test/providers/mp4_hls_fallback_retry_test.dart
+++ b/mobile/test/providers/mp4_hls_fallback_retry_test.dart
@@ -228,41 +228,43 @@ void main() {
       expect(resolvedUrl, contains('/720p.mp4'));
     });
 
-    test('end-to-end: MP4 params + fallback storage + cache lookup', () {
+    test('end-to-end: MP4 params + raw blob fallback storage + cache lookup', () {
       final video = _createDivineVideo();
       final params = VideoControllerParams.fromVideoEvent(video);
 
       // Step 1: Primary URL is MP4
       expect(params.videoUrl, contains('/720p.mp4'));
 
-      // Step 2: Simulate failure — store fallback (mirrors error handler logic)
-      final fallbackUrl = video.getFallbackUrl();
-      expect(fallbackUrl, isNotNull);
+      // Step 2: Simulate failure — a Divine quality variant stores the raw blob
+      // fallback (mirrors error handler logic), not HLS.
+      const rawBlobFallback = 'https://media.divine.video/$_hash';
 
       final currentCache = container.read(fallbackUrlCacheProvider);
       if (!currentCache.containsKey(params.videoId)) {
         container.read(fallbackUrlCacheProvider.notifier).state = {
           ...currentCache,
-          params.videoId: fallbackUrl!,
+          params.videoId: rawBlobFallback,
         };
       }
 
-      // Step 3: On retry, resolved URL is HLS
+      // Step 3: On retry, resolved URL is the raw blob
       final retryCache = container.read(fallbackUrlCacheProvider);
       final retryUrl = retryCache[params.videoId] ?? params.videoUrl;
 
-      expect(retryUrl, equals(fallbackUrl));
-      expect(retryUrl, contains('.m3u8'));
-      expect(retryUrl, isNot(contains('.mp4')));
+      expect(retryUrl, equals(rawBlobFallback));
+      expect(retryUrl, isNot(contains('.m3u8')));
+      expect(retryUrl, isNot(contains('/720p.mp4')));
     });
   });
 
   group('quality variant error handler fallback path', () {
-    // Mirrors the error handler logic at individual_video_providers.dart ~line 729:
+    // Mirrors the error handler logic in individual_video_providers.dart:
     //   final isQualityVariant = videoUrl.contains('/720p') || videoUrl.contains('/480p');
     //   if (isQualityVariant && params.videoEvent is VideoEvent) {
-    //     final fallbackUrl = params.videoEvent?.getFallbackUrl();
-    //     if (fallbackUrl != null && !currentFallbackCache.containsKey(params.videoId))
+    //     // Divine quality variants fall back to the guaranteed raw blob
+    //     // (media.divine.video/<sha256>), not HLS — matching the feed's
+    //     // progressive-first ordering. HLS is used only when no raw blob
+    //     // hash is resolvable (non-Divine).
 
     late ProviderContainer container;
 
@@ -274,7 +276,7 @@ void main() {
       container.dispose();
     });
 
-    test('720p MP4 failure triggers HLS fallback storage', () {
+    test('720p MP4 failure stores the guaranteed raw blob as fallback', () {
       final video = _createDivineVideo();
       final params = VideoControllerParams.fromVideoEvent(video);
       final videoUrl = params.videoUrl;
@@ -284,23 +286,27 @@ void main() {
           videoUrl.contains('/720p') || videoUrl.contains('/480p');
       expect(isQualityVariant, isTrue, reason: 'primary URL must be 720p MP4');
 
-      // Simulate error handler: resolve fallback
-      final fallbackUrl = video.getFallbackUrl();
-      expect(fallbackUrl, isNotNull);
+      // Simulate error handler: a Divine quality variant falls back to the raw
+      // blob (always published), so a not-yet-transcoded 720p.mp4 drops to a
+      // source that exists rather than an equally-unready HLS rendition.
+      const rawBlobFallback = 'https://media.divine.video/$_hash';
 
-      // Store in cache (mirroring error handler guard)
       final currentCache = container.read(fallbackUrlCacheProvider);
       if (!currentCache.containsKey(params.videoId)) {
         container.read(fallbackUrlCacheProvider.notifier).state = {
           ...currentCache,
-          params.videoId: fallbackUrl!,
+          params.videoId: rawBlobFallback,
         };
       }
 
-      // Verify fallback is HLS, not the same MP4
+      // Verify fallback is the raw blob, not HLS and not the failing variant
       final stored = container.read(fallbackUrlCacheProvider)[params.videoId];
-      expect(stored, equals(fallbackUrl));
-      expect(stored, contains('.m3u8'), reason: 'fallback must be HLS');
+      expect(stored, equals(rawBlobFallback));
+      expect(
+        stored,
+        isNot(contains('.m3u8')),
+        reason: 'fallback is the raw blob, not HLS',
+      );
       expect(
         stored,
         isNot(equals(videoUrl)),
@@ -313,18 +319,17 @@ void main() {
       );
     });
 
-    test('480p MP4 failure also triggers fallback', () {
-      final video = _createDivineVideo();
+    test('480p MP4 is also recognised as a quality variant', () {
       const videoUrl480 = 'https://media.divine.video/$_hash/480p.mp4';
 
       final isQualityVariant =
           videoUrl480.contains('/720p') || videoUrl480.contains('/480p');
       expect(isQualityVariant, isTrue);
 
-      final fallbackUrl = video.getFallbackUrl();
-      expect(fallbackUrl, isNotNull);
-      expect(fallbackUrl, contains('.m3u8'));
-      expect(fallbackUrl, isNot(equals(videoUrl480)));
+      // Its raw blob fallback is the same hash-derived source, never HLS.
+      const rawBlobFallback = 'https://media.divine.video/$_hash';
+      expect(rawBlobFallback, isNot(contains('.m3u8')));
+      expect(rawBlobFallback, isNot(equals(videoUrl480)));
     });
 
     test('non-quality-variant URL does not trigger quality fallback path', () {
@@ -561,25 +566,25 @@ void main() {
       container.dispose();
     });
 
-    test('rebuild after quality variant failure uses HLS URL', () {
+    test('rebuild after quality variant failure uses the raw blob URL', () {
       final video = _createDivineVideo();
       final params = VideoControllerParams.fromVideoEvent(video);
 
       // Step 1: initial URL is MP4 720p
       expect(params.videoUrl, contains('/720p.mp4'));
 
-      // Step 2: simulate quality variant failure -> store HLS fallback
-      final fallbackUrl = video.getFallbackUrl()!;
+      // Step 2: simulate quality variant failure -> store raw blob fallback
+      const rawBlobFallback = 'https://media.divine.video/$_hash';
       container.read(fallbackUrlCacheProvider.notifier).state = {
-        params.videoId: fallbackUrl,
+        params.videoId: rawBlobFallback,
       };
 
-      // Step 3: on rebuild, provider reads from cache (line 349-350 of provider)
+      // Step 3: on rebuild, provider reads from cache
       final cache = container.read(fallbackUrlCacheProvider);
       final resolvedUrl = cache[params.videoId] ?? params.videoUrl;
 
-      expect(resolvedUrl, equals(fallbackUrl));
-      expect(resolvedUrl, contains('.m3u8'));
+      expect(resolvedUrl, equals(rawBlobFallback));
+      expect(resolvedUrl, isNot(contains('.m3u8')));
       expect(resolvedUrl, isNot(contains('/720p.mp4')));
     });
 


### PR DESCRIPTION
Closes #6038

## Problem

A tester reported video playback became suddenly choppy/stuttering after the last update. Logs (app `1.0.16+798`, iOS 26.5) show every raw-only Divine upload probing `<hash>/hls/master.m3u8` **first**, failing with `PlatformException(COMPOSITION_ERROR, No playable video tracks found)` (~0.4–0.5s wasted per video), then reloading from the raw blob. That per-video "fail HLS → reload" cycle is the stutter, most visible while scrolling.

**Root cause:** #5935 flipped the raw-blob source order to try HLS before the progressive blob. Fresh uploads publish the raw/progressive blob before their HLS rendition finishes transcoding, so a just-published video's HLS master is often a manifest with no playable video track — a guaranteed failure that stalls the currently-visible video. The tester's failing videos were only minutes old at watch time (a transcoding race); those same renditions are valid now.

The tester also switched Developer Options → MP4 with no effect, because `getOptimalVideoUrlForPlatform()` short-circuited on the raw-only heuristic **before** the format override.

## Why progressive MP4, never HLS-first

Our clips are ≤6.3s. HLS pays a fixed startup cost (master playlist → media playlist → first segment) that makes it slower to first frame than a single progressive MP4 request (moov at front, one round trip), and its multi-segment streams can't be single-file preloaded/cached. So progressive is always tried first; HLS is the last resort.

## Measured size per format (3 real uploads)

| video | raw (original) | 720p.mp4 | 480p.mp4 | raw ÷ 720p |
|---|---|---|---|---|
| `4af42277…` | 4.03 MB | 0.96 MB | 0.54 MB | 4.2× |
| `ee942f34…` | 6.23 MB | 2.19 MB | 0.93 MB | 2.9× |
| `b8dc7a27…` | 11.24 MB | 2.18 MB | 0.93 MB | 5.2× |

The raw original is 2.8–5.2× larger than the 720p.mp4, and the derivatives + a valid HLS master exist for all three. A raw-only `imeta` is just a publish-time snapshot (only the raw blob exists at publish); the derivatives appear seconds-to-minutes later and almost always exist by playback time.

## Changes

- **`playback_sources.dart`** — always attempt the progressive source first; for a quality variant the guaranteed raw blob is ordered **before** HLS, so a not-yet-transcoded `720p.mp4` falls to raw (progressive), not HLS.
- **`video_event_extensions.dart`** — raw-only uploads now default to `720p.mp4` (3–5× smaller) instead of the raw original; the runtime chain drops to raw when the variant isn't ready yet. Removed the now-dead `hasRawOnlyDivineImetaUrl` / `hasBareDivineHashPath` predicates. The Developer Options format override now runs ahead of every heuristic, so on-device A/B testing actually takes effect.
- **`source_loader.dart`** — an HTTP 202 (processing) source is only wait-and-retried when it is the last resort. A fresh upload whose `720p.mp4` is still transcoding now falls straight to the available raw blob instead of stalling up to ~19s on the derivative.

## Tests

- `playback_sources_test`: raw-blob and quality-variant ordering (progressive → raw → HLS).
- `video_event_divine_server_test`: raw-only imeta now resolves to `720p.mp4`; developer-override precedence (raw override wins over the default MP4; `mp4_480p` wins over classic Vine). Process-global format singleton reset in `tearDown`.
- `source_loader_test`: 202 advances immediately when a fallback remains; retries only on the last source.
- Green locally + pre-push: `playback_sources` + `source_loader` (40), `video_event_divine_server` (25), `mp4_hls_fallback_retry` (30); `flutter analyze` clean.

## Follow-up (server-side, not in this PR)

The HLS master for fresh uploads returns no video track until transcode completes. Worth fixing on divine-blossom/transcoding so the client fallback isn't the thing keeping playback alive.