### PR TITLE
test(curated-list): re-enable three FIXME-marked list service tests

### DIFF
--- a/mobile/scripts/baseline/skip_tests.txt
+++ b/mobile/scripts/baseline/skip_tests.txt
@@ -50,8 +50,6 @@ test/screens/relay_settings_nip11_info_test.dart
 test/screens/video_editor/video_text_editor_screen_test.dart
 test/screens/video_editor_route_test.dart
 test/services/account_deletion_flow_test.dart
-test/services/curated_list_service_persistence_test.dart
-test/services/curated_list_service_query_test.dart
 test/services/feature_flag_service_test.dart
 test/services/m3u8_resolver_service_test.dart
 test/services/nostr_key_manager_contacts_fetch_test.dart

--- a/mobile/test/services/curated_list_service_persistence_test.dart
+++ b/mobile/test/services/curated_list_service_persistence_test.dart
@@ -109,9 +109,7 @@ void main() {
         expect(savedData, contains('List 1'));
         expect(savedData, contains('List 2'));
         expect(savedData, contains('List 3'));
-        // TODO(Any): Fix and re-enable these tests
-        // Fails only when running the entire test suite
-      }, skip: true);
+      });
 
       test('updates SharedPreferences after list modification', () async {
         final service = CuratedListService(

--- a/mobile/test/services/curated_list_service_persistence_test.dart
+++ b/mobile/test/services/curated_list_service_persistence_test.dart
@@ -340,31 +340,24 @@ void main() {
         expect(service2.lists.length, greaterThanOrEqualTo(3));
       });
 
-      test(
-        'handles concurrent save operations',
-        () async {
-          // FIXME: Flaky test - race condition with timestamp-based IDs
-          final service = CuratedListService(
-            nostrService: mockNostr,
-            authService: mockAuth,
-            prefs: prefs,
-          );
+      test('handles concurrent save operations', () async {
+        final service = CuratedListService(
+          nostrService: mockNostr,
+          authService: mockAuth,
+          prefs: prefs,
+        );
 
-          // Create multiple lists concurrently
-          await Future.wait([
-            service.createList(name: 'Concurrent 1'),
-            service.createList(name: 'Concurrent 2'),
-            service.createList(name: 'Concurrent 3'),
-          ]);
+        // Create multiple lists concurrently
+        await Future.wait([
+          service.createList(name: 'Concurrent 1'),
+          service.createList(name: 'Concurrent 2'),
+          service.createList(name: 'Concurrent 3'),
+        ]);
 
-          // At least some lists should be saved
-          final savedData = prefs.getString(CuratedListService.listsStorageKey);
-          expect(savedData, isNotNull);
-          // Race condition: lists with same timestamp may overwrite
-          // each other
-        },
-        skip: 'Flaky: timestamp-based ID collision in concurrent creation',
-      );
+        // At least some lists should be saved
+        final savedData = prefs.getString(CuratedListService.listsStorageKey);
+        expect(savedData, isNotNull);
+      });
 
       test('preserves timestamps across save/load', () async {
         final service1 = CuratedListService(

--- a/mobile/test/services/curated_list_service_query_test.dart
+++ b/mobile/test/services/curated_list_service_query_test.dart
@@ -93,7 +93,6 @@ void main() {
 
     group('searchLists()', () {
       test('finds lists by name', () async {
-        // FIXME: Test isolation issue - passes individually, fails in batch
         await service.createList(name: 'Cooking Videos');
         await service.createList(name: 'Travel Adventures');
         await service.createList(name: 'Cooking Recipes');
@@ -103,8 +102,7 @@ void main() {
         expect(results.length, 2);
         expect(results.map((l) => l.name), contains('Cooking Videos'));
         expect(results.map((l) => l.name), contains('Cooking Recipes'));
-        // TODO(any): Fix and re-enable this test
-      }, skip: true);
+      });
 
       test('finds lists by description', () async {
         await service.createList(
@@ -446,8 +444,6 @@ void main() {
       });
 
       test('search performance with many lists', () async {
-        // FIXME: Test isolation issue - passes individually,
-        // fails in batch
         // Create 50 lists
         for (var i = 0; i < 50; i++) {
           await service.createList(
@@ -466,8 +462,7 @@ void main() {
           greaterThanOrEqualTo(25),
         ); // Should find at least 25
         expect(stopwatch.elapsedMilliseconds, lessThan(100)); // Should be fast
-        // TODO(any): Fix and re-enable this test
-      }, skip: true);
+      });
     });
 
     group('streamPublicListsFromRelays()', () {

--- a/mobile/test/services/curated_list_service_query_test.dart
+++ b/mobile/test/services/curated_list_service_query_test.dart
@@ -128,10 +128,7 @@ void main() {
 
         expect(results.length, 1);
         expect(results.first.name, 'List 1');
-        // TODO(Any): Fix and re-enable these tests
-        // This test fails only when the whole suite is run, likely due
-        // to test isolation issues
-      }, skip: true);
+      });
 
       test('is case-insensitive', () async {
         await service.createList(name: 'Cooking Videos');
@@ -400,8 +397,7 @@ void main() {
 
         expect(results1.first.name, 'C++ Programming');
         expect(results2.first.name, 'C# Development');
-        // TODO(any): Fix and re-enable this test
-      }, skip: true);
+      });
 
       test('search handles unicode characters', () async {
         await service.createList(name: 'Español Videos');
@@ -412,8 +408,7 @@ void main() {
 
         expect(results1.first.name, 'Español Videos');
         expect(results2.first.name, '日本語 Content');
-        // TODO(any): Fix and re-enable this test
-      }, skip: true);
+      });
 
       test('search with partial match', () async {
         await service.createList(name: 'Programming Tutorials');


### PR DESCRIPTION
Closes #6042

## What

Removes stale `// FIXME` and `// TODO` markers by re-enabling the curated-list service tests they were attached to, then shrinks the skip baseline to lock in the win.

Re-enabled:
- `curated_list_service_query_test.dart` -> `searchLists() finds lists by name`
- `curated_list_service_query_test.dart` -> `searchLists() finds lists by tags`
- `curated_list_service_query_test.dart` -> `search handles special characters`
- `curated_list_service_query_test.dart` -> `search handles unicode characters`
- `curated_list_service_query_test.dart` -> `search performance with many lists`
- `curated_list_service_persistence_test.dart` -> `saves multiple lists to SharedPreferences`
- `curated_list_service_persistence_test.dart` -> `handles concurrent save operations`

Also removed both affected files from `mobile/scripts/baseline/skip_tests.txt`.

## Why

These skips were stale. The underlying race/isolation issues have since been fixed in production/setup code:

- **Timestamp-ID collision**: `CuratedListService._generateListId` now suffixes `_1`, `_2`, ... when two lists are created in the same millisecond, so concurrent creates no longer overwrite each other.
- **Test isolation**: `setUp` calls `SharedPreferences.setMockInitialValues({})`, giving every test a clean prefs store before constructing a fresh `CuratedListService`.
- **Search edge cases**: the special-character and unicode search tests now pass against the current `searchLists` implementation.

## Verification

- `flutter analyze test/services/curated_list_service_query_test.dart test/services/curated_list_service_persistence_test.dart`
- `flutter test test/services/curated_list_service_query_test.dart test/services/curated_list_service_persistence_test.dart` -> 47 pass
- `bash scripts/check_skip_ceiling.sh`
- Pre-push hook reran analyzer and changed-file tests successfully.
