### PR TITLE
fix(list): show a single back button in curated list video mode

### DIFF
--- a/mobile/lib/screens/curated_list_feed_screen.dart
+++ b/mobile/lib/screens/curated_list_feed_screen.dart
@@ -230,6 +230,12 @@ class _CuratedListFeedScreenState extends ConsumerState<CuratedListFeedScreen> {
     );
   }
 
+  void _exitVideoMode() {
+    setState(() {
+      _activeVideoIndex = null;
+    });
+  }
+
   Widget _buildVideoPlayer(List<VideoEvent> videos) {
     if (videos.isEmpty || _activeVideoIndex! >= videos.length) {
       return Center(
@@ -240,20 +246,24 @@ class _CuratedListFeedScreenState extends ConsumerState<CuratedListFeedScreen> {
       );
     }
 
-    // Embedded as this screen's "video mode": the feed's own app-bar back
-    // button returns to the grid instead of popping the whole route, so the
-    // user sees a single back button.
-    return PooledFullscreenVideoFeedScreen(
-      source: VideoListViewSource(videos),
-      feedRepository: StaticFeedRepository(),
-      initialIndex: _activeVideoIndex!,
-      contextTitle: widget.listName,
-      trafficSource: ViewTrafficSource.search,
-      onBack: () {
-        setState(() {
-          _activeVideoIndex = null;
-        });
+    // Embedded as this screen's "video mode": both the feed's own app-bar back
+    // button ([onBack]) and the system back gesture ([PopScope]) return to the
+    // grid instead of popping the whole route, so the user sees a single back
+    // button and hardware back stays consistent with it.
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, _) {
+        if (didPop) return;
+        _exitVideoMode();
       },
+      child: PooledFullscreenVideoFeedScreen(
+        source: VideoListViewSource(videos),
+        feedRepository: StaticFeedRepository(),
+        initialIndex: _activeVideoIndex!,
+        contextTitle: widget.listName,
+        trafficSource: ViewTrafficSource.search,
+        onBack: _exitVideoMode,
+      ),
     );
   }
 

--- a/mobile/lib/screens/curated_list_feed_screen.dart
+++ b/mobile/lib/screens/curated_list_feed_screen.dart
@@ -240,42 +240,20 @@ class _CuratedListFeedScreenState extends ConsumerState<CuratedListFeedScreen> {
       );
     }
 
-    // Use Stack with back button overlay to exit video mode
-    return Stack(
-      children: [
-        PooledFullscreenVideoFeedScreen(
-          source: VideoListViewSource(videos),
-          feedRepository: StaticFeedRepository(),
-          initialIndex: _activeVideoIndex!,
-          contextTitle: widget.listName,
-          trafficSource: ViewTrafficSource.search,
-        ),
-        // Back button overlay to exit video mode
-        PositionedDirectional(
-          top: 50,
-          start: 16,
-          child: SafeArea(
-            child: IconButton(
-              icon: Container(
-                padding: const EdgeInsets.all(8),
-                decoration: const BoxDecoration(
-                  color: VineTheme.scrim50,
-                  shape: BoxShape.circle,
-                ),
-                child: const DivineIcon(
-                  icon: DivineIconName.arrowLeft,
-                  color: VineTheme.whiteText,
-                ),
-              ),
-              onPressed: () {
-                setState(() {
-                  _activeVideoIndex = null;
-                });
-              },
-            ),
-          ),
-        ),
-      ],
+    // Embedded as this screen's "video mode": the feed's own app-bar back
+    // button returns to the grid instead of popping the whole route, so the
+    // user sees a single back button.
+    return PooledFullscreenVideoFeedScreen(
+      source: VideoListViewSource(videos),
+      feedRepository: StaticFeedRepository(),
+      initialIndex: _activeVideoIndex!,
+      contextTitle: widget.listName,
+      trafficSource: ViewTrafficSource.search,
+      onBack: () {
+        setState(() {
+          _activeVideoIndex = null;
+        });
+      },
     );
   }
 

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -163,6 +163,7 @@ class PooledFullscreenVideoFeedScreen extends ConsumerWidget {
     this.autoOpenComments = false,
     this.onPageChanged,
     this.dmReplyContext,
+    this.onBack,
     super.key,
   });
 
@@ -192,6 +193,15 @@ class PooledFullscreenVideoFeedScreen extends ConsumerWidget {
   /// Receives the new feed index. Used by embedded surfaces (e.g. explore,
   /// search) to keep the URL in sync for deep-linking.
   final void Function(int index)? onPageChanged;
+
+  /// Overrides the app-bar back action.
+  ///
+  /// When the fullscreen feed is embedded as a "video mode" of a parent screen
+  /// (e.g. a curated list grid) rather than pushed as its own route, the parent
+  /// passes this to return to its grid instead of popping the whole route — so
+  /// the feed's own app-bar back button is the single back affordance the user
+  /// sees.
+  final VoidCallback? onBack;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -294,6 +304,7 @@ class PooledFullscreenVideoFeedScreen extends ConsumerWidget {
         autoOpenComments: autoOpenComments,
         onPageChanged: onPageChanged,
         dmReplyContext: dmReplyContext,
+        onBack: onBack,
       ),
     );
   }
@@ -314,6 +325,7 @@ class FullscreenFeedContent extends ConsumerStatefulWidget {
     this.autoOpenComments = false,
     this.onPageChanged,
     this.dmReplyContext,
+    this.onBack,
     super.key,
   });
 
@@ -339,6 +351,10 @@ class FullscreenFeedContent extends ConsumerStatefulWidget {
   /// Present when the reel was opened from a DM thread — drives the in-player
   /// reply/reaction bar in the body footer.
   final DmReplyContext? dmReplyContext;
+
+  /// Overrides the app-bar back action when the feed is embedded as a parent
+  /// screen's video mode (see [PooledFullscreenVideoFeedScreen.onBack]).
+  final VoidCallback? onBack;
 
   @override
   ConsumerState<FullscreenFeedContent> createState() =>
@@ -404,6 +420,11 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
   }
 
   void _handleBack(BuildContext context) {
+    final onBack = widget.onBack;
+    if (onBack != null) {
+      onBack();
+      return;
+    }
     if (context.canPop()) {
       context.pop();
       return;

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -627,6 +627,13 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                   prev.status != curr.status &&
                   curr.status == FullscreenFeedStatus.emptyAfterRemoval,
               listener: (context, _) {
+                // Embedded video mode: hand back to the parent (grid) instead
+                // of popping the whole route, matching the app-bar back button.
+                final onBack = widget.onBack;
+                if (onBack != null) {
+                  onBack();
+                  return;
+                }
                 unawaited(Navigator.of(context).maybePop());
               },
             ),

--- a/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
+++ b/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
@@ -241,6 +241,7 @@ void main() {
       String? contextTitle,
       ViewTrafficSource trafficSource = ViewTrafficSource.unknown,
       String? sourceDetail,
+      VoidCallback? onBack,
     }) {
       return MultiBlocProvider(
         providers: [
@@ -254,6 +255,7 @@ void main() {
           contextTitle: contextTitle,
           trafficSource: trafficSource,
           sourceDetail: sourceDetail,
+          onBack: onBack,
         ),
       );
     }
@@ -265,6 +267,7 @@ void main() {
       String? contextTitle,
       ViewTrafficSource trafficSource = ViewTrafficSource.unknown,
       String? sourceDetail,
+      VoidCallback? onBack,
     }) {
       final effectiveState = state ?? const FullscreenFeedState();
       when(() => mockBloc.state).thenReturn(effectiveState);
@@ -278,6 +281,7 @@ void main() {
           contextTitle: contextTitle,
           trafficSource: trafficSource,
           sourceDetail: sourceDetail,
+          onBack: onBack,
         ),
       );
     }
@@ -582,6 +586,131 @@ void main() {
 
           expect(sentinelBuilt, isTrue);
           expect(find.text('home-sentinel'), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'ready-state back button calls onBack instead of popping when the '
+        'feed is embedded as a parent screen video mode',
+        (tester) async {
+          final videos = createTestVideos(count: 1);
+          when(() => mockBloc.state).thenReturn(
+            FullscreenFeedState(
+              status: FullscreenFeedStatus.ready,
+              videos: videos,
+            ),
+          );
+
+          var onBackCalls = 0;
+          var popCount = 0;
+          final observer = _PopCountingObserver(onPop: () => popCount++);
+
+          await tester.pumpWidget(
+            testProviderScope(
+              mockProfileRepository: mockProfileRepository,
+              mockNip05VerificationService: mockNip05VerificationService,
+              child: MaterialApp(
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                navigatorObservers: [observer],
+                home: Builder(
+                  builder: (context) => Scaffold(
+                    body: ElevatedButton(
+                      onPressed: () => Navigator.of(context).push(
+                        MaterialPageRoute<void>(
+                          builder: (_) => buildContent(
+                            contextTitle: 'Embedded',
+                            onBack: () => onBackCalls++,
+                          ),
+                        ),
+                      ),
+                      child: const Text('open'),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          );
+
+          await tester.tap(find.text('open'));
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 400));
+          expect(find.byType(FeedVideos), findsOneWidget);
+
+          tester
+              .widget<DiVineAppBarIconButton>(
+                find.byType(DiVineAppBarIconButton).first,
+              )
+              .onPressed
+              ?.call();
+          await tester.pump();
+
+          expect(onBackCalls, 1);
+          // The app-bar back must NOT pop the route in embedded mode — it
+          // hands control back to the parent grid via onBack.
+          expect(popCount, 0);
+          expect(find.byType(FeedVideos), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'hands back to onBack instead of popping when status becomes '
+        'emptyAfterRemoval in embedded video mode',
+        (tester) async {
+          final videos = createTestVideos(count: 1);
+          final initialState = FullscreenFeedState(
+            status: FullscreenFeedStatus.ready,
+            videos: videos,
+          );
+          final emptyState = FullscreenFeedState(
+            status: FullscreenFeedStatus.emptyAfterRemoval,
+            removedVideoIds: {videos.first.id},
+          );
+          final controller = StreamController<FullscreenFeedState>();
+          addTearDown(controller.close);
+          whenListen(mockBloc, controller.stream, initialState: initialState);
+
+          var onBackCalls = 0;
+          var popCount = 0;
+          final observer = _PopCountingObserver(onPop: () => popCount++);
+
+          await tester.pumpWidget(
+            testProviderScope(
+              mockProfileRepository: mockProfileRepository,
+              mockNip05VerificationService: mockNip05VerificationService,
+              child: MaterialApp(
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                navigatorObservers: [observer],
+                home: Builder(
+                  builder: (context) => Scaffold(
+                    body: ElevatedButton(
+                      onPressed: () => Navigator.of(context).push(
+                        MaterialPageRoute<void>(
+                          builder: (_) => buildContent(
+                            contextTitle: 'Embedded',
+                            onBack: () => onBackCalls++,
+                          ),
+                        ),
+                      ),
+                      child: const Text('open'),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          );
+
+          await tester.tap(find.text('open'));
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 400));
+
+          controller.add(emptyState);
+          await tester.pump();
+
+          expect(onBackCalls, 1);
+          // Auto-empty must return to the parent grid, not pop the route.
+          expect(popCount, 0);
         },
       );
 


### PR DESCRIPTION
Closes #6044

## What

In a curated list, tapping a video opens a fullscreen player. Users saw **two identical back arrows** stacked in the top-left of that video view.

The screen embeds `PooledFullscreenVideoFeedScreen` (which renders its own `DiVineAppBar` back button that pops the whole route) and additionally layered a custom back-arrow overlay on top (which returned to the grid). Two buttons, two different behaviours, same icon in the same spot.

<img width="322" alt="image" src="https://github.com/user-attachments/assets/016dce67-6825-46b3-956e-3b2c4162126e" />


## Fix

- Add an optional `onBack` override to `PooledFullscreenVideoFeedScreen` / `FullscreenFeedContent`. When provided, the feed's own app-bar back button calls it instead of popping the route. Backward compatible — every existing caller keeps the pop-the-route default.
- `CuratedListFeedScreen` now passes `onBack: () => setState(() => _activeVideoIndex = null)` and drops the custom overlay entirely.

Result: a single back button (the standard transparent app bar, which also keeps the list title + settings menu, consistent with every other feed surface), and the intended two-level back is preserved: video → grid → list.

## Why keep return-to-grid instead of just deleting the overlay

This screen is deliberately a two-mode (grid / video) screen, and all three embedded-feed screens keep a "back to parent grid" affordance. So the overlay's *behaviour* was the correct one; the fullscreen feed's own route-popping back button was the redundant one in this embedded context. The fix removes the redundant button while preserving the drill-in navigation model.

## Scope note

`user_list_people_screen.dart` (people lists) and `sound_detail_screen.dart` embed the same fullscreen feed with a similar overlay, but they use a distinct icon (grid / X), so they don't present as "two back buttons". Left untouched to keep this focused on the reported bug — happy to migrate them to the same `onBack` approach in a follow-up if wanted.

## Testing

- `flutter analyze` on both changed files — no issues.
- `flutter test test/screens/curated_list_feed_screen_test.dart` — 8/8 pass.
- `flutter test test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart` + args test — pass (pre-push hook also re-ran these).