### PR TITLE
fix(video): bump pro_video_editor to 2.6.0 to fix clip split freeze

### DIFF
--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1808,10 +1808,10 @@ packages:
     dependency: "direct main"
     description:
       name: pro_video_editor
-      sha256: "75ae478fa8e8f8090e72dcad907f5019a3b3c62d19ec69ccd93e97e24329e102"
+      sha256: aa05eb426dc98607dd6f776b4da9a5bb09c80c44e72138d299409d52a38b920d
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.1"
+    version: "2.6.0"
   process:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -311,7 +311,7 @@ dependencies:
   firebase_messaging: ^16.1.1
   convert: ^3.1.2
   audio_session: ^0.2.2
-  pro_video_editor: ^2.5.1
+  pro_video_editor: ^2.6.0
   pro_image_editor: ^13.2.0
   flutter_colorpicker: ^1.1.0
   file_picker: ^10.3.7


### PR DESCRIPTION
Closes #6049

## What

Bumps `pro_video_editor` from 2.5.1 to 2.6.0.



## Why

A user reported the clip editor freezing for ~2 minutes during a split, ending only in a native `Split export timed out after 120s` (`PlatformException(SPLIT_ERROR, …)`). Device logs (iOS 26.5, release) confirmed the split re-encode sat with no forward progress until the plugin's 120s watchdog force-cancelled it.

Root cause, per the 2.6.0 changelog: concurrent split and render re-encodes contended for the shared hardware encoder. On a throttled device a starved session could sit at 0% until the watchdog fired — the reported freeze. The app already guards against degenerate splits (both halves ≥ 30ms) and already wraps the call in its own Dart-side watchdog, so the input was valid; the stall was genuinely inside the native encoder.

## What 2.6.0 changes

- **Encoder gate:** all split/render re-encodes share a process-wide gate so only one runs at a time; the queue wait is counted *before* the watchdog starts, so a legitimately-queued encode never counts as a stall. Passthrough/stream-copy exports stay ungated.
- **Stall watchdog:** an encode that makes no forward progress for `stallTimeout` (split default 12s) is force-cancelled with a diagnostic reason (`half`, `progress`, segment/split/total durations, preset/mime) instead of hanging the full `exportTimeout`. Both timeouts are now tunable on `SplitVideoModel`; defaults apply here, so no app-side wiring is needed.

Secondary benefit: this reduces the memory a wedged export can strand across repeated editor open/close cycles (the reported usage pattern), because a stalled session now releases its encoder slot after 12s instead of holding decoder/encoder buffers for the full 120s.

## Scope

Version bump only — additive API (new `SplitVideoModel` defaults), no call-site changes. `flutter analyze lib` clean.

## Testing

- `flutter pub get` + `flutter analyze lib` pass locally.
- Functional verification (split no longer freezes) needs a device — best reproduced by repeatedly splitting the same clip while speed-renders run, the scenario from the original report. Left as a draft for that on-device check.