### PR TITLE
fix(video-editor): preserve allow_audio_reuse when editing cached videos

### DIFF
--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -652,16 +652,11 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
     final npubPattern = RegExp(r'\n\nInspired by nostr:npub1[a-z0-9]+$');
     content = content.replaceFirst(npubPattern, '');
 
-    final allowAudioReuse = video.nostrEventTags.any(
-      (tag) =>
-          tag.isNotEmpty &&
-          tag[0] == 'allow_audio_reuse' &&
-          tag.length > 1 &&
-          tag[1] == 'true',
-    );
-
     state = VideoEditorProviderState(
-      allowAudioReuse: allowAudioReuse,
+      // Sourced via VideoEvent.allowAudioReuse so the toggle seeds ON even when
+      // the event was rehydrated from a JSON cache that drops nostrEventTags
+      // (the value is recovered from the persisted rawTags fallback).
+      allowAudioReuse: video.allowAudioReuse,
       title: video.title ?? '',
       description: content,
       tags: video.hashtags.toSet(),

--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -653,9 +653,7 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
     content = content.replaceFirst(npubPattern, '');
 
     state = VideoEditorProviderState(
-      // Sourced via VideoEvent.allowAudioReuse so the toggle seeds ON even when
-      // the event was rehydrated from a JSON cache that drops nostrEventTags
-      // (the value is recovered from the persisted rawTags fallback).
+      // Getter falls back to rawTags so the toggle survives a cache round-trip.
       allowAudioReuse: video.allowAudioReuse,
       title: video.title ?? '',
       description: content,

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -878,6 +878,16 @@ class VideoEvent {
     return pubkeys;
   }
 
+  /// Whether the creator marked this video's audio as reusable.
+  ///
+  /// Reads the editor-owned `allow_audio_reuse` marker. Prefers
+  /// [nostrEventTags] but falls back to [rawTags], so the flag survives a
+  /// JSON-cache round-trip — [nostrEventTags] is intentionally not persisted
+  /// through `toJson`/`fromJson`, but [rawTags] is, which keeps the edit form
+  /// from seeding the toggle `false` on a cache-rehydrated video.
+  bool get allowAudioReuse =>
+      _firstNostrTagValue('allow_audio_reuse') == 'true';
+
   /// Whether this video has any content warnings.
   bool get hasContentWarning => contentWarningLabels.isNotEmpty;
 

--- a/mobile/packages/models/test/src/video_event_allow_audio_reuse_test.dart
+++ b/mobile/packages/models/test/src/video_event_allow_audio_reuse_test.dart
@@ -1,0 +1,78 @@
+// ABOUTME: Tests for the allow_audio_reuse marker derivation on video events,
+// ABOUTME: including recovery from rawTags after a JSON-cache round-trip.
+
+import 'package:models/models.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('VideoEvent.allowAudioReuse', () {
+    Event buildEvent({required bool withMarker}) {
+      return Event(
+        'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+        34236,
+        [
+          const ['d', 'audio-reuse-d-tag'],
+          const ['url', 'https://media.divine.video/reuse.mp4'],
+          if (withMarker) const ['allow_audio_reuse', 'true'],
+        ],
+        'Audio reuse video',
+        createdAt: 1778120201,
+      );
+    }
+
+    test('is true when the live event carries the marker', () {
+      final video = VideoEvent.fromNostrEvent(buildEvent(withMarker: true));
+
+      expect(video.allowAudioReuse, isTrue);
+    });
+
+    test('is false when the live event omits the marker', () {
+      final video = VideoEvent.fromNostrEvent(buildEvent(withMarker: false));
+
+      expect(video.allowAudioReuse, isFalse);
+    });
+
+    test('survives a JSON-cache round-trip that drops nostrEventTags', () {
+      final original = VideoEvent.fromNostrEvent(buildEvent(withMarker: true));
+
+      final restored = VideoEvent.fromJson(original.toJson());
+
+      // Regression guard: the cache path drops nostrEventTags but preserves
+      // rawTags, so the marker must still be recoverable.
+      expect(restored.nostrEventTags, isEmpty);
+      expect(restored.allowAudioReuse, isTrue);
+    });
+
+    test('is true from a rawTags-only cached event', () {
+      final video = VideoEvent(
+        id: 'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
+        pubkey:
+            'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+        createdAt: 1778120201,
+        content: '',
+        timestamp: DateTime.utc(2026, 5, 7),
+        title: 'Audio reuse video',
+        videoUrl: 'https://media.divine.video/reuse.mp4',
+        rawTags: const {'allow_audio_reuse': 'true'},
+      );
+
+      expect(video.allowAudioReuse, isTrue);
+    });
+
+    test('is false from a cached event without the marker', () {
+      final video = VideoEvent(
+        id: 'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
+        pubkey:
+            'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+        createdAt: 1778120201,
+        content: '',
+        timestamp: DateTime.utc(2026, 5, 7),
+        title: 'Audio reuse video',
+        videoUrl: 'https://media.divine.video/reuse.mp4',
+      );
+
+      expect(video.allowAudioReuse, isFalse);
+    });
+  });
+}

--- a/mobile/packages/models/test/src/video_event_allow_audio_reuse_test.dart
+++ b/mobile/packages/models/test/src/video_event_allow_audio_reuse_test.dart
@@ -33,6 +33,27 @@ void main() {
       expect(video.allowAudioReuse, isFalse);
     });
 
+    test('prefers the live marker over a divergent rawTags value', () {
+      final video = VideoEvent(
+        id: 'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
+        pubkey:
+            'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+        createdAt: 1778120201,
+        content: '',
+        timestamp: DateTime.utc(2026, 5, 7),
+        title: 'Audio reuse video',
+        videoUrl: 'https://media.divine.video/reuse.mp4',
+        nostrEventTags: const [
+          ['allow_audio_reuse', 'false'],
+        ],
+        rawTags: const {'allow_audio_reuse': 'true'},
+      );
+
+      // Live tags win over rawTags. A future reorder of the lookup that
+      // consulted rawTags first would flip this to true and fail here.
+      expect(video.allowAudioReuse, isFalse);
+    });
+
     test('survives a JSON-cache round-trip that drops nostrEventTags', () {
       final original = VideoEvent.fromNostrEvent(buildEvent(withMarker: true));
 

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -1123,6 +1123,9 @@ void main() {
     }
 
     test('seeds allowAudioReuse from live nostrEventTags', () {
+      // rawTags is intentionally left empty so this isolates the live-tag
+      // source: if the live-path scan regressed, there is no fallback to
+      // mask it and the toggle would seed false.
       container
           .read(videoEditorProvider.notifier)
           .initFromPublishedVideo(
@@ -1130,7 +1133,6 @@ void main() {
               nostrEventTags: const [
                 ['allow_audio_reuse', 'true'],
               ],
-              rawTags: const {'allow_audio_reuse': 'true'},
             ),
           );
 

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -1089,6 +1089,76 @@ void main() {
     });
   });
 
+  group('initFromPublishedVideo', () {
+    late ProviderContainer container;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      container = ProviderContainer(
+        overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+      );
+    });
+
+    tearDown(() {
+      container.dispose();
+    });
+
+    VideoEvent buildVideo({
+      List<List<String>> nostrEventTags = const [],
+      Map<String, String> rawTags = const {},
+    }) {
+      return VideoEvent(
+        id: 'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
+        pubkey:
+            'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+        createdAt: 1778120201,
+        content: 'A published clip',
+        timestamp: DateTime.utc(2026, 5, 7),
+        title: 'Published clip',
+        videoUrl: 'https://media.divine.video/published.mp4',
+        nostrEventTags: nostrEventTags,
+        rawTags: rawTags,
+      );
+    }
+
+    test('seeds allowAudioReuse from live nostrEventTags', () {
+      container
+          .read(videoEditorProvider.notifier)
+          .initFromPublishedVideo(
+            buildVideo(
+              nostrEventTags: const [
+                ['allow_audio_reuse', 'true'],
+              ],
+              rawTags: const {'allow_audio_reuse': 'true'},
+            ),
+          );
+
+      expect(container.read(videoEditorProvider).allowAudioReuse, isTrue);
+    });
+
+    test('seeds allowAudioReuse from rawTags when the event was '
+        'rehydrated from cache (nostrEventTags dropped)', () {
+      container
+          .read(videoEditorProvider.notifier)
+          .initFromPublishedVideo(
+            buildVideo(rawTags: const {'allow_audio_reuse': 'true'}),
+          );
+
+      // Regression (#6045): before the fix this seeded false because the
+      // cache path drops nostrEventTags, so a save would strip the marker.
+      expect(container.read(videoEditorProvider).allowAudioReuse, isTrue);
+    });
+
+    test('leaves allowAudioReuse off when the marker is absent', () {
+      container
+          .read(videoEditorProvider.notifier)
+          .initFromPublishedVideo(buildVideo());
+
+      expect(container.read(videoEditorProvider).allowAudioReuse, isFalse);
+    });
+  });
+
   group('VideoEditorProviderState', () {
     group('isValidToPost', () {
       test('returns false when finalRenderedClip is null', () {


### PR DESCRIPTION
## What

Editing a published video could silently drop the `allow_audio_reuse` marker when the `VideoEvent` had been rehydrated from the JSON cache.

`VideoEditorNotifier.initFromPublishedVideo` seeded the toggle from `video.nostrEventTags`, but `nostrEventTags` is intentionally **not** persisted through `VideoEvent.toJson`/`fromJson`. So on any cached or prefetched edit path, `nostrEventTags` was empty and the toggle seeded `false` — even for a video the creator had marked reusable. Saving without touching the toggle then stripped `['allow_audio_reuse', 'true']` from the republished event.

## Why this approach

The issue suggested either recovering the raw event from `PersonalEventCacheService` or adding a dedicated persisted field. Both are heavier than needed: `rawTags` **is** already persisted through the cache round-trip, so the marker is recoverable from data we already keep.

This PR adds a `VideoEvent.allowAudioReuse` getter that reads the marker via the existing `_firstNostrTagValue` helper, which prefers live `nostrEventTags` and falls back to `rawTags`. The editor now seeds its toggle from that getter instead of scanning `nostrEventTags` directly. The derivation lives on the model where it belongs, and no new persisted state or cache-service coupling is introduced.

## Changes

- `packages/models`: add `VideoEvent.allowAudioReuse` getter (live-tag preferred, `rawTags` fallback).
- `video_editor_provider`: source the edit toggle from `video.allowAudioReuse`.
- Tests: model-level round-trip regression coverage + `initFromPublishedVideo` regression tests for the cache-rehydrated path.

## Testing

- `flutter test packages/models/test/src/video_event_allow_audio_reuse_test.dart` — 5 passing
- `flutter test test/providers/video_editor_provider_test.dart` — all passing (incl. 3 new `initFromPublishedVideo` cases)
- `flutter analyze` on changed files — clean

Closes #6045
