### PR TITLE
test(vgv): gate Tier-3/Tier-4 process-globals in the merged isolate

### DIFF
--- a/mobile/scripts/check_process_global_mutations.sh
+++ b/mobile/scripts/check_process_global_mutations.sh
@@ -16,11 +16,16 @@
 #   1. CAPTURE-RESTORE (GLOBALS) — `<Singleton>.instance` and static hooks whose
 #      documented resting value is the *prior runtime value*. Every untagged
 #      *_test.dart that installs one must, within the same file, SNAPSHOT the
-#      original (a `<id> = <Global>` read) and RESTORE it (a `<Global> = <id>`
-#      bare-identifier write, e.g. in tearDown / tearDownAll / addTearDown).
-#      Unlike check_http_overrides_isolation.sh — which rejects even a correct
-#      restore because a nulled HttpOverrides 400-mock is itself the hazard while
-#      the file runs — a within-file restore PASSES here.
+#      original (a `<id> = <Global>` read) and RESTORE it by assigning the global
+#      back that captured value (`<Global> = <origId>`, e.g. in tearDown /
+#      tearDownAll / addTearDown). The restore RHS must be an identifier that
+#      holds the captured original — the snapshot id itself, or a local copied
+#      from it — NOT an arbitrary bare identifier: the dominant install shape is
+#      itself a bare-id write (`Bloc.observer = observer;`) and `<Global> = null`
+#      strands null, so tying the restore to the captured value is what makes the
+#      check real. Unlike check_http_overrides_isolation.sh — which rejects even a
+#      correct restore because a nulled HttpOverrides 400-mock is itself the
+#      hazard while the file runs — a within-file restore PASSES here.
 #
 #   2. RESET-TO-DEFAULT (RESET_TO_DEFAULT_GLOBALS) — top-level debug overrides /
 #      test-injection setters whose documented resting value is a compile-time
@@ -114,17 +119,50 @@ run_scan() {
       if grep -qE "^[[:space:]]*@Tags\([^)]*skip_very_good_optimization" "$f"; then
         continue
       fi
-      # SNAPSHOT: the global appears on the RHS of an assignment (captured local).
+      # SNAPSHOT: identifiers that hold a value READ FROM the global. Seed with
+      # the LHS of every `<id> = <Global>` capture, then grow transitively across
+      # `<id2> = <id1>` copies (a tearDown that promotes the snapshot into a local
+      # before restoring — e.g. WebViewPlatform's non-null-setter guard). Word
+      # boundary `.` is excluded so a `<Global>.instance = <id>` restore line is
+      # never itself mistaken for a copy that adds `instance` to the set.
+      # `|| true` on every grep|sed: under `set -o pipefail` a no-match grep
+      # (exit 1) would otherwise abort the whole scan.
+      local orig_ids
+      orig_ids=$(grep -oE \
+        "[A-Za-z_][A-Za-z0-9_]*[[:space:]]*=[[:space:]]*([A-Za-z_][A-Za-z0-9_]*\.)?${core}([^A-Za-z0-9_]|$)" \
+        <<<"$body" | sed -E 's/[[:space:]]*=.*//' | sort -u || true)
       local has_capture=0
-      if grep -qE "=[[:space:]]*([A-Za-z_][A-Za-z0-9_]*\.)?${core}([^A-Za-z0-9_]|$)" <<<"$body"; then
-        has_capture=1
-      fi
-      # RESTORE: the global assigned a BARE identifier (block `= original;` or
-      # arrow `=> <Global> = original)`), distinguishing a restore from a
-      # `<Global> = SomeFake()` install.
+      if [[ -n "$orig_ids" ]]; then has_capture=1; fi
+
+      local id1 copies grown
+      for _ in 1 2 3 4 5; do
+        grown="$orig_ids"
+        for id1 in $orig_ids; do
+          copies=$(grep -oE \
+            "(^|[^A-Za-z0-9_.])[A-Za-z_][A-Za-z0-9_]*[[:space:]]*=[[:space:]]*${id1}([^A-Za-z0-9_]|$)" \
+            <<<"$body" | sed -E 's/^[^A-Za-z_]*//; s/[[:space:]]*=.*//' || true)
+          if [[ -n "$copies" ]]; then
+            grown=$(printf '%s\n%s\n' "$grown" "$copies" | sort -u)
+          fi
+        done
+        if [[ "$grown" == "$orig_ids" ]]; then break; fi
+        orig_ids="$grown"
+      done
+
+      # RESTORE: `<Global> = <origId>` (block `= origId;` or arrow `=> ... = origId)`)
+      # where <origId> is one of the captured-original identifiers above. Tying the
+      # RHS to a captured value — not any bare identifier — rejects the bare-id
+      # install `<Global> = observer;` and the null-strand `<Global> = null;`, and
+      # excludes null/true/false for free (they can never be a capture LHS).
       local has_restore=0
-      if grep -qE "([A-Za-z_][A-Za-z0-9_]*\.)?${core}[[:space:]]*=[[:space:]]*[A-Za-z_][A-Za-z0-9_]*[[:space:]]*[;)]" <<<"$body"; then
-        has_restore=1
+      if [[ "$has_capture" -eq 1 ]]; then
+        local id_alt
+        id_alt="${orig_ids//$'\n'/|}"
+        if grep -qE \
+          "([A-Za-z_][A-Za-z0-9_]*\.)?${core}[[:space:]]*=[[:space:]]*(${id_alt})[[:space:]]*[;)]" \
+          <<<"$body"; then
+          has_restore=1
+        fi
       fi
       if [[ "$has_capture" -eq 0 || "$has_restore" -eq 0 ]]; then
         rel="${f#"$MOBILE_DIR"/}"
@@ -226,6 +264,41 @@ void main() {
   final prior = Bloc.observer;
   Bloc.observer = MyObserver();
   addTearDown(() => Bloc.observer = prior);
+}
+'
+  _case "bare-id install masquerading as restore (snapshot + install, no real restore) → FAIL" 1 \
+'import "x";
+void main() {
+  final previousObserver = Bloc.observer;
+  Bloc.observer = observer;
+}
+'
+  _case "bare-id install PLUS real restore (models divine_bloc_observer_test) → PASS" 0 \
+'import "x";
+void main() {
+  final previousObserver = Bloc.observer;
+  Bloc.observer = observer;
+  addTearDown(() => Bloc.observer = previousObserver);
+}
+'
+  _case "null strand masquerading as restore (FlutterError.onError = null) → FAIL" 1 \
+'import "x";
+void main() {
+  final originalOnError = FlutterError.onError;
+  FlutterError.onError = (details) {};
+  tearDown(() { FlutterError.onError = null; });
+}
+'
+  _case "restore via copied local inside guard (models nostr WebView tearDown) → PASS" 0 \
+'import "x";
+void main() {
+  WebViewPlatform? originalWebViewPlatform;
+  setUp(() { originalWebViewPlatform = WebViewPlatform.instance; });
+  tearDown(() {
+    final original = originalWebViewPlatform;
+    if (original != null) { WebViewPlatform.instance = original; }
+  });
+  WebViewPlatform.instance = _FakeWebViewPlatform();
 }
 '
   _case "reset-to-default leaker (debugDefaultTargetPlatformOverride, no = null) → FAIL" 1 \

--- a/mobile/scripts/check_process_global_mutations.sh
+++ b/mobile/scripts/check_process_global_mutations.sh
@@ -10,6 +10,9 @@
 # A file is in the merge UNLESS it is tagged @Tags(['skip_very_good_optimization']).
 # Being under test/manual/ does NOT exclude it — only the tag does (the very_good
 # --optimization globber does not honor dart_test.yaml's exclude: test/manual/**).
+# Tag matching is whitespace-normalized so dart-format-wrapped @Tags([...])
+# annotations are honored. A commented-out @Tags line remains ignored by this
+# stricter gate; do not rely on commented annotations as an optimizer escape hatch.
 #
 # Two detection classes, each HARD-ZERO (no baseline, no tolerated debt):
 #
@@ -103,6 +106,13 @@ RESET_TO_DEFAULT_GLOBALS=(
 # Scan target — overridable for --selftest; defaults to the app merged-isolate tree.
 SCAN_DIR="${SCAN_DIR:-$MOBILE_DIR/test}"
 
+is_skip_vgv_tagged() {
+  local f="$1" tag_body tag_flat
+  tag_body=$(grep -vE '^[[:space:]]*//' "$f" || true)
+  tag_flat=$(tr -d '[:space:]' <<<"$tag_body")
+  grep -qE "@Tags\(\[[^]]*['\"]skip_very_good_optimization['\"]" <<<"$tag_flat"
+}
+
 run_scan() {
   local violations="" core files f body def
 
@@ -116,9 +126,9 @@ run_scan() {
       if ! grep -qE "(^|[^A-Za-z0-9_.])([A-Za-z_][A-Za-z0-9_]*\.)?${core}[[:space:]]*=([^=>]|$)" <<<"$body"; then
         continue
       fi
-      # Tagged out of the merge? Line-anchored, whole-file (a @Tags below class
-      # defs / above main() still counts, matching the very_good text-scan).
-      if grep -qE "^[[:space:]]*@Tags\([^)]*skip_very_good_optimization" "$f"; then
+      # Tagged out of the merge? Whole-file and whitespace-normalized, matching
+      # the very_good text-scan shape for dart-format-wrapped @Tags([...]).
+      if is_skip_vgv_tagged "$f"; then
         continue
       fi
       # SNAPSHOT: identifiers that hold a value READ FROM the global. Seed with
@@ -152,17 +162,18 @@ run_scan() {
       done
 
       # RESTORE: `<Global> = <origId>` (block `= origId;`, arrow `=> ... = origId)`,
-      # or dart-format-wrapped trailing-comma `= origId,`) where <origId> is one of
-      # the captured-original identifiers above — hence the `[;,)]` terminator. Tying the
-      # RHS to a captured value — not any bare identifier — rejects the bare-id
-      # install `<Global> = observer;` and the null-strand `<Global> = null;`, and
-      # excludes null/true/false for free (they can never be a capture LHS).
+      # nullable promotion `= origId!`, or dart-format-wrapped trailing-comma
+      # `= origId,`) where <origId> is one of the captured-original identifiers
+      # above. Tying the RHS to a captured value — not any bare identifier —
+      # rejects the bare-id install `<Global> = observer;` and the null-strand
+      # `<Global> = null;`, and excludes null/true/false for free (they can never
+      # be a capture LHS).
       local has_restore=0
       if [[ "$has_capture" -eq 1 ]]; then
         local id_alt
         id_alt="${orig_ids//$'\n'/|}"
         if grep -qE \
-          "([A-Za-z_][A-Za-z0-9_]*\.)?${core}[[:space:]]*=[[:space:]]*(${id_alt})[[:space:]]*[;,)]" \
+          "([A-Za-z_][A-Za-z0-9_]*\.)?${core}[[:space:]]*=[[:space:]]*(${id_alt})!?[[:space:]]*[;,)]" \
           <<<"$body"; then
           has_restore=1
         fi
@@ -187,7 +198,7 @@ run_scan() {
       if ! grep -qE "(^|[^A-Za-z0-9_.])([A-Za-z_][A-Za-z0-9_]*\.)?${core}[[:space:]]*=([^=>]|$)" <<<"$body"; then
         continue
       fi
-      if grep -qE "^[[:space:]]*@Tags\([^)]*skip_very_good_optimization" "$f"; then
+      if is_skip_vgv_tagged "$f"; then
         continue
       fi
       # RESET-TO-DEFAULT present: `<Global> = <default>` (block, arrow, or
@@ -307,6 +318,14 @@ void main() {
   WebViewPlatform.instance = _FakeWebViewPlatform();
 }
 '
+  _case "restore via nullable promotion (= original!) → PASS" 0 \
+'import "x";
+void main() {
+  final original = WebViewPlatform.instance;
+  WebViewPlatform.instance = _FakeWebViewPlatform();
+  addTearDown(() => WebViewPlatform.instance = original!);
+}
+'
   _case "reset-to-default leaker (debugDefaultTargetPlatformOverride, no = null) → FAIL" 1 \
 'import "x";
 void main() { debugDefaultTargetPlatformOverride = TargetPlatform.iOS; }
@@ -355,6 +374,18 @@ void main() {
 @Tags(["skip_very_good_optimization"])
 import "x";
 void main() { debugDefaultTargetPlatformOverride = TargetPlatform.iOS; }
+'
+  _case "multi-line tagged leaker (dart-format-wrapped @Tags) → PASS" 0 \
+'@Tags([
+  "skip_very_good_optimization",
+])
+import "x";
+void main() { Bloc.observer = MyObserver(); }
+'
+  _case "commented-out tag does not exclude a leaker → FAIL" 1 \
+'// @Tags(["skip_very_good_optimization"])
+import "x";
+void main() { Bloc.observer = MyObserver(); }
 '
   _case "commented-out install → PASS" 0 \
 'import "x";

--- a/mobile/scripts/check_process_global_mutations.sh
+++ b/mobile/scripts/check_process_global_mutations.sh
@@ -1,38 +1,57 @@
 #!/usr/bin/env bash
 # Fails CI if a test the very_good optimizer MERGES into the shared isolate
-# installs a process-global platform/package singleton WITHOUT restoring it.
-# An unrestored install persists into every later merged test in the shared
-# isolate, surfacing as an order-dependent failure cross-attributed to an
-# unrelated test. This generalizes the single-global precedent
-# check_http_overrides_isolation.sh (PR #5163) to the class of
-# `<Singleton>.instance` test seams behind the #5159 / #5180 cascades
-# (parent #3137).
+# mutates a process-global WITHOUT restoring it. An unrestored mutation persists
+# into every later merged test in the shared isolate, surfacing as an
+# order-dependent failure cross-attributed to an unrelated test. This generalizes
+# the single-global precedent check_http_overrides_isolation.sh (PR #5163) to the
+# classes of test seams behind the #5159 / #5180 cascades (parent #3137) and the
+# Tier-3/Tier-4 residual (#5185).
 #
 # A file is in the merge UNLESS it is tagged @Tags(['skip_very_good_optimization']).
 # Being under test/manual/ does NOT exclude it — only the tag does (the very_good
 # --optimization globber does not honor dart_test.yaml's exclude: test/manual/**).
 #
-# Policy: HARD-ZERO. Every untagged *_test.dart that installs a candidate global
-# must, within the same file, SNAPSHOT the original (a `<id> = <Global>` read)
-# and RESTORE it (a `<Global> = <id>` write, e.g. in tearDown / tearDownAll).
-# Unlike check_http_overrides_isolation.sh — which rejects even a correct restore
-# because a nulled HttpOverrides 400-mock is itself the hazard while the file
-# runs — a within-file restore PASSES here: for these singletons the tearDown
-# returns the global to its prior value before the next merged file runs.
-# Detection is a grep proxy (it cannot prove the restore is reachable or lives
-# in a tearDown); the snapshot+restore pair is the canonical fix and the tag is
-# the escape hatch for tests that legitimately cannot restore (real plugin /
-# integration tests).
+# Two detection classes, each HARD-ZERO (no baseline, no tolerated debt):
 #
-# Scope: only `<Singleton>.instance` assignments (the class that caused the
-# #5159 cascades). A read of the global, a comment mention, and `==` / `=>` do
-# not match. lib/ is out of scope. Only `*_test.dart` files are scanned, so
+#   1. CAPTURE-RESTORE (GLOBALS) — `<Singleton>.instance` and static hooks whose
+#      documented resting value is the *prior runtime value*. Every untagged
+#      *_test.dart that installs one must, within the same file, SNAPSHOT the
+#      original (a `<id> = <Global>` read) and RESTORE it (a `<Global> = <id>`
+#      bare-identifier write, e.g. in tearDown / tearDownAll / addTearDown).
+#      Unlike check_http_overrides_isolation.sh — which rejects even a correct
+#      restore because a nulled HttpOverrides 400-mock is itself the hazard while
+#      the file runs — a within-file restore PASSES here.
+#
+#   2. RESET-TO-DEFAULT (RESET_TO_DEFAULT_GLOBALS) — top-level debug overrides /
+#      test-injection setters whose documented resting value is a compile-time
+#      DEFAULT LITERAL (all `null` today), so there is no prior to snapshot. A
+#      file that installs a NON-default value must, within the same file, assign
+#      the global back to its default literal (`<Global> = <default>`, block or
+#      `=> <Global> = <default>)` arrow form). No capture is required; a file
+#      whose only assignment IS the default (e.g. a lone `= null`) is harmless
+#      and passes.
+#
+# Detection is a grep proxy for BOTH classes: it cannot prove the restore is
+# reachable or lives in a tearDown (an inline end-of-body reset satisfies the
+# grep but not a mid-test throw). The snapshot+restore / reset-to-default pair is
+# the canonical fix; the tag is the escape hatch for tests that legitimately
+# cannot restore (real plugin / integration tests).
+#
+# Scope: assignments only (a read, a comment mention, `==`, `=>` do not match).
+# lib/ is out of scope. Only `*_test.dart` under mobile/test is scanned, so
 # non-test helpers — e.g. test/test_setup.dart, which installs the suite-wide
-# PathProviderPlatform mock by design — are not flagged. HttpOverrides.global
-# keeps its own dedicated STRICT gate and is intentionally not handled here.
+# PathProviderPlatform mock by design — are not flagged, and packages/*/test
+# (each its own separate merged isolate — issue #5838) is out of scope here.
+# HttpOverrides.global keeps its own dedicated STRICT gate (check_http_overrides_isolation.sh)
+# and is intentionally not handled here.
+#
+# GoogleFonts.config.allowRuntimeFetching is intentionally NOT gated: the shared
+# test harness sets it `false` suite-wide and `false` is the resting value every
+# test wants (benign-monotonic), so an un-restored `= false` is not a hazard.
 #
 # Usage:
 #   bash mobile/scripts/check_process_global_mutations.sh
+#   bash mobile/scripts/check_process_global_mutations.sh --selftest
 #   (run from the repository root or from mobile/)
 set -euo pipefail
 export LC_ALL=C
@@ -40,8 +59,8 @@ export LC_ALL=C
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MOBILE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# Candidate process-global singletons (Tier-2). Extend as new leak classes are
-# found. Each entry is the ERE core, matched after an optional `<prefix>.`.
+# Class 1 — capture-restore globals. Each entry is the ERE core, matched after an
+# optional `<prefix>.`. (Tier-2 `<Singleton>.instance` + Tier-4 static hooks.)
 GLOBALS=(
   'PathProviderPlatform\.instance'
   'ProVideoEditor\.instance'
@@ -49,76 +68,208 @@ GLOBALS=(
   'UrlLauncherPlatform\.instance'
   'VideoPlayerPlatform\.instance'
   'FirebasePlatform\.instance'
+  'FlutterError\.onError'
+  'Bloc\.observer'
 )
 
-violations=""
+# Class 2 — reset-to-default globals, `core:defaultLiteral` (colon-delimited so
+# bash 3.2 — the macOS pre-commit hook — needs no associative arrays). The
+# default literal must be a regex-safe token; all defaults are `null` today.
+#
+# Note: debugDefaultTargetPlatformOverride is also a Flutter *foundation debug
+# var* — in a `testWidgets` test, `debugAssertAllFoundationVarsUnset` (foundation
+# debug.dart) already fails the test at end-of-body if it is left set, so a leak
+# there is loud, not silent, and only an INLINE reset works (that assertion runs
+# before tearDown/addTearDown). This gate still earns its keep for it by covering
+# plain `test()` usage, which has no such framework guard; the other entries
+# below have no framework guard at all.
+RESET_TO_DEFAULT_GLOBALS=(
+  'debugDefaultTargetPlatformOverride:null'
+  'debugImageCacheOverride:null'
+  'debugUsesAppleAppStoreTipPolicyOverride:null'
+  'VideoEditorRenderService\.renderVideoOverride:null'
+  'VideoEditorRenderService\.renderVideoToClipOverride:null'
+  'NativeProofModeService\.proofFileOverride:null'
+  'InfiniteVideoFeed\.debugIsSupportedOverride:null'
+)
 
-for core in "${GLOBALS[@]}"; do
-  # Fast pre-filter: *_test.dart files mentioning the global at all.
-  files=$(grep -rlE --include='*_test.dart' "$core" "$MOBILE_DIR/test" || true)
-  for f in $files; do
-    # Comment-stripped view: drop lines whose first non-blank chars are // or ///
-    # (defends doc-comment install snippets and fully commented-out tests).
-    body=$(grep -vE '^[[:space:]]*//' "$f" || true)
+# Scan target — overridable for --selftest; defaults to the app merged-isolate tree.
+SCAN_DIR="${SCAN_DIR:-$MOBILE_DIR/test}"
 
-    # A real ASSIGNMENT (install or restore): (<prefix>.)?CORE = , where `=` is
-    # not `==` / `=>`. `=` may sit at end-of-line (dart format keeps the LHS
-    # token on its own line for a multi-line RHS).
-    if ! grep -qE "(^|[^A-Za-z0-9_.])([A-Za-z_][A-Za-z0-9_]*\.)?${core}[[:space:]]*=([^=>]|$)" <<<"$body"; then
-      continue
-    fi
+run_scan() {
+  local violations="" core files f body def
 
-    # Tagged out of the merge? Line-anchored so a commented-out (// @Tags(...))
-    # or doc-mention does NOT satisfy the gate — mirrors how the Dart test
-    # runner reads the library annotation.
-    if grep -qE "^[[:space:]]*@Tags\([^)]*skip_very_good_optimization" "$f"; then
-      continue
-    fi
+  # --- Class 1: capture-restore ---
+  for core in "${GLOBALS[@]}"; do
+    files=$(grep -rlE --include='*_test.dart' "$core" "$SCAN_DIR" || true)
+    for f in $files; do
+      body=$(grep -vE '^[[:space:]]*//' "$f" || true)
 
-    # SNAPSHOT (capture-read): the global appears on the RHS of an assignment
-    # (`<id> = <Global>`), i.e. the original was captured into a local.
-    has_capture=0
-    if grep -qE "=[[:space:]]*([A-Za-z_][A-Za-z0-9_]*\.)?${core}([^A-Za-z0-9_]|$)" <<<"$body"; then
-      has_capture=1
-    fi
-
-    # RESTORE (restore-write): the global is assigned a BARE identifier
-    # (`<Global> = original;` block form, or `=> <Global> = original)` arrow
-    # form), which distinguishes a restore from a `<Global> = SomeFake()` install.
-    has_restore=0
-    if grep -qE "([A-Za-z_][A-Za-z0-9_]*\.)?${core}[[:space:]]*=[[:space:]]*[A-Za-z_][A-Za-z0-9_]*[[:space:]]*[;)]" <<<"$body"; then
-      has_restore=1
-    fi
-
-    if [[ "$has_capture" -eq 0 || "$has_restore" -eq 0 ]]; then
-      rel="${f#"$MOBILE_DIR"/}"
-      disp="${core//\\/}"
-      violations="$violations  $rel  ($disp)"$'\n'
-    fi
+      # A real ASSIGNMENT (install or restore): (<prefix>.)?CORE = , not == / =>.
+      if ! grep -qE "(^|[^A-Za-z0-9_.])([A-Za-z_][A-Za-z0-9_]*\.)?${core}[[:space:]]*=([^=>]|$)" <<<"$body"; then
+        continue
+      fi
+      # Tagged out of the merge? Line-anchored, whole-file (a @Tags below class
+      # defs / above main() still counts, matching the very_good text-scan).
+      if grep -qE "^[[:space:]]*@Tags\([^)]*skip_very_good_optimization" "$f"; then
+        continue
+      fi
+      # SNAPSHOT: the global appears on the RHS of an assignment (captured local).
+      local has_capture=0
+      if grep -qE "=[[:space:]]*([A-Za-z_][A-Za-z0-9_]*\.)?${core}([^A-Za-z0-9_]|$)" <<<"$body"; then
+        has_capture=1
+      fi
+      # RESTORE: the global assigned a BARE identifier (block `= original;` or
+      # arrow `=> <Global> = original)`), distinguishing a restore from a
+      # `<Global> = SomeFake()` install.
+      local has_restore=0
+      if grep -qE "([A-Za-z_][A-Za-z0-9_]*\.)?${core}[[:space:]]*=[[:space:]]*[A-Za-z_][A-Za-z0-9_]*[[:space:]]*[;)]" <<<"$body"; then
+        has_restore=1
+      fi
+      if [[ "$has_capture" -eq 0 || "$has_restore" -eq 0 ]]; then
+        rel="${f#"$MOBILE_DIR"/}"
+        disp="${core//\\/}"
+        violations="$violations  $rel  ($disp) [capture-restore]"$'\n'
+      fi
+    done
   done
-done
 
-if [[ -n "$violations" ]]; then
-  echo "FAIL [process_global_mutations]: untagged test installs a process-global"
-  echo "singleton without a within-file restore:"
-  printf '%s' "$violations" | sed '/^$/d'
-  echo ""
-  echo "Installing <Singleton>.instance in a MERGED (untagged) test without"
-  echo "restoring it leaks the fake into every later test in the shared"
-  echo "very_good --optimization isolate, causing order-dependent flakes"
-  echo "(generalizes PR #5163; cascades #5159 / #5180; parent #3137)."
-  echo ""
-  echo "Remediation — pick one:"
-  echo "  (a) Snapshot the original and restore it within the file:"
-  echo "        late <Type> original;"
-  echo "        setUp(() { original = <Global>.instance; <Global>.instance = <fake>; });"
-  echo "        tearDown(() { <Global>.instance = original; });"
-  echo "      (use setUpAll / tearDownAll for a setUpAll install)."
-  echo "  (b) Real-plugin / integration test that cannot restore: tag it so it"
-  echo "      stays out of the merge (annotation BEFORE the first import):"
-  echo "        @Tags(['skip_very_good_optimization', 'integration'])"
-  echo "      then bump mobile/test/vgv_tag_baseline.txt if the tag count rises."
-  exit 1
+  # --- Class 2: reset-to-default ---
+  local entry
+  for entry in "${RESET_TO_DEFAULT_GLOBALS[@]}"; do
+    core="${entry%%:*}"
+    def="${entry##*:}"
+    files=$(grep -rlE --include='*_test.dart' "$core" "$SCAN_DIR" || true)
+    for f in $files; do
+      body=$(grep -vE '^[[:space:]]*//' "$f" || true)
+
+      if ! grep -qE "(^|[^A-Za-z0-9_.])([A-Za-z_][A-Za-z0-9_]*\.)?${core}[[:space:]]*=([^=>]|$)" <<<"$body"; then
+        continue
+      fi
+      if grep -qE "^[[:space:]]*@Tags\([^)]*skip_very_good_optimization" "$f"; then
+        continue
+      fi
+      # RESET-TO-DEFAULT present: `<Global> = <default>` (block or arrow form).
+      local has_default_reset=0
+      if grep -qE "([A-Za-z_][A-Za-z0-9_]*\.)?${core}[[:space:]]*=[[:space:]]*${def}[[:space:]]*[;)]" <<<"$body"; then
+        has_default_reset=1
+      fi
+      # NON-default install present: an assignment line that is NOT a reset to the
+      # default literal (so a file whose only assignment is the default passes).
+      local has_nondefault_install=0
+      if grep -E "(^|[^A-Za-z0-9_.])([A-Za-z_][A-Za-z0-9_]*\.)?${core}[[:space:]]*=([^=>]|$)" <<<"$body" \
+         | grep -qvE "([A-Za-z_][A-Za-z0-9_]*\.)?${core}[[:space:]]*=[[:space:]]*${def}[[:space:]]*[;)]"; then
+        has_nondefault_install=1
+      fi
+      if [[ "$has_nondefault_install" -eq 1 && "$has_default_reset" -eq 0 ]]; then
+        rel="${f#"$MOBILE_DIR"/}"
+        disp="${core//\\/}"
+        violations="$violations  $rel  ($disp) [reset-to-default → $def]"$'\n'
+      fi
+    done
+  done
+
+  if [[ -n "$violations" ]]; then
+    echo "FAIL [process_global_mutations]: untagged merged test mutates a"
+    echo "process-global without a within-file restore:"
+    printf '%s' "$violations" | sed '/^$/d'
+    echo ""
+    echo "Mutating one of these globals in a MERGED (untagged) test without"
+    echo "restoring it leaks the value into every later test in the shared"
+    echo "very_good --optimization isolate, causing order-dependent flakes"
+    echo "(generalizes PR #5163; cascades #5159 / #5180; parent #3137; residual #5185)."
+    echo ""
+    echo "Remediation — pick one:"
+    echo "  (a) [capture-restore] Snapshot the original and restore it in the file:"
+    echo "        late <Type> original;"
+    echo "        setUp(() { original = <Global>; <Global> = <fake>; });"
+    echo "        tearDown(() { <Global> = original; });"
+    echo "  (b) [reset-to-default] Assign the global back to its default in a"
+    echo "      guaranteed-reachable tearDown/addTearDown (NOT an inline end-of-body"
+    echo "      line, which a mid-test throw would skip):"
+    echo "        addTearDown(() => debugDefaultTargetPlatformOverride = null);"
+    echo "  (c) Real-plugin / integration test that cannot restore: tag it so it"
+    echo "      stays out of the merge (annotation BEFORE the first import):"
+    echo "        @Tags(['skip_very_good_optimization', 'integration'])"
+    echo "      then bump mobile/test/vgv_tag_baseline.txt if the tag count rises."
+    return 1
+  fi
+
+  echo "OK: no untagged test leaks a process-global (capture-restore + reset-to-default)."
+  return 0
+}
+
+# --- self-test: run the REAL scan over synthetic fixtures, assert exit codes ---
+run_selftest() {
+  local rc=0 tmp got desc want
+  _case() {
+    desc="$1"; want="$2"; local content="$3"
+    tmp="$(mktemp -d)"
+    printf '%s' "$content" > "$tmp/fixture_test.dart"
+    if SCAN_DIR="$tmp" bash "$0" >/dev/null 2>&1; then got=0; else got=$?; fi
+    rm -rf "$tmp"
+    if [[ "$got" -eq "$want" ]]; then
+      echo "  ok   ($got) $desc"
+    else
+      echo "  FAIL (got $got, want $want) $desc"; rc=1
+    fi
+  }
+
+  echo "self-test:"
+  _case "capture-restore leaker (Bloc.observer install, no restore) → FAIL" 1 \
+'import "x";
+void main() { Bloc.observer = MyObserver(); }
+'
+  _case "capture-restore correct (snapshot + restore) → PASS" 0 \
+'import "x";
+void main() {
+  final prior = Bloc.observer;
+  Bloc.observer = MyObserver();
+  addTearDown(() => Bloc.observer = prior);
+}
+'
+  _case "reset-to-default leaker (debugDefaultTargetPlatformOverride, no = null) → FAIL" 1 \
+'import "x";
+void main() { debugDefaultTargetPlatformOverride = TargetPlatform.iOS; }
+'
+  _case "reset-to-default correct (= null in tearDown) → PASS" 0 \
+'import "x";
+void main() {
+  debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+  tearDown(() { debugDefaultTargetPlatformOverride = null; });
+}
+'
+  _case "reset-to-default arrow form (=> = null)) → PASS" 0 \
+'import "x";
+void main() {
+  debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+  addTearDown(() => debugDefaultTargetPlatformOverride = null);
+}
+'
+  _case "tagged leaker (skip_very_good_optimization, tag below class defs) → PASS" 0 \
+'class _Foo {}
+@Tags(["skip_very_good_optimization"])
+import "x";
+void main() { debugDefaultTargetPlatformOverride = TargetPlatform.iOS; }
+'
+  _case "commented-out install → PASS" 0 \
+'import "x";
+void main() {
+  // debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+  // Bloc.observer = MyObserver();
+}
+'
+  _case "lone default assignment (= null only, no install) → PASS" 0 \
+'import "x";
+void main() { setUp(() { debugDefaultTargetPlatformOverride = null; }); }
+'
+  return $rc
+}
+
+if [[ "${1:-}" == "--selftest" ]]; then
+  run_selftest
+  exit $?
 fi
 
-echo "OK: no untagged test leaks a process-global singleton."
+run_scan
+exit $?

--- a/mobile/scripts/check_process_global_mutations.sh
+++ b/mobile/scripts/check_process_global_mutations.sh
@@ -78,8 +78,9 @@ GLOBALS=(
 )
 
 # Class 2 — reset-to-default globals, `core:defaultLiteral` (colon-delimited so
-# bash 3.2 — the macOS pre-commit hook — needs no associative arrays). The
-# default literal must be a regex-safe token; all defaults are `null` today.
+# bash 3.2 — macOS's default /bin/bash for local runs — needs no associative
+# arrays; CI runs this via mobile_ci.yaml, not a git hook). The default literal
+# must be a regex-safe token; all defaults are `null` today.
 #
 # Note: debugDefaultTargetPlatformOverride is also a Flutter *foundation debug
 # var* — in a `testWidgets` test, `debugAssertAllFoundationVarsUnset` (foundation
@@ -95,6 +96,7 @@ RESET_TO_DEFAULT_GLOBALS=(
   'VideoEditorRenderService\.renderVideoOverride:null'
   'VideoEditorRenderService\.renderVideoToClipOverride:null'
   'NativeProofModeService\.proofFileOverride:null'
+  'NativeProofModeService\.c2paSigningServiceFactoryOverride:null'
   'InfiniteVideoFeed\.debugIsSupportedOverride:null'
 )
 
@@ -149,8 +151,9 @@ run_scan() {
         orig_ids="$grown"
       done
 
-      # RESTORE: `<Global> = <origId>` (block `= origId;` or arrow `=> ... = origId)`)
-      # where <origId> is one of the captured-original identifiers above. Tying the
+      # RESTORE: `<Global> = <origId>` (block `= origId;`, arrow `=> ... = origId)`,
+      # or dart-format-wrapped trailing-comma `= origId,`) where <origId> is one of
+      # the captured-original identifiers above — hence the `[;,)]` terminator. Tying the
       # RHS to a captured value — not any bare identifier — rejects the bare-id
       # install `<Global> = observer;` and the null-strand `<Global> = null;`, and
       # excludes null/true/false for free (they can never be a capture LHS).
@@ -159,7 +162,7 @@ run_scan() {
         local id_alt
         id_alt="${orig_ids//$'\n'/|}"
         if grep -qE \
-          "([A-Za-z_][A-Za-z0-9_]*\.)?${core}[[:space:]]*=[[:space:]]*(${id_alt})[[:space:]]*[;)]" \
+          "([A-Za-z_][A-Za-z0-9_]*\.)?${core}[[:space:]]*=[[:space:]]*(${id_alt})[[:space:]]*[;,)]" \
           <<<"$body"; then
           has_restore=1
         fi
@@ -187,16 +190,17 @@ run_scan() {
       if grep -qE "^[[:space:]]*@Tags\([^)]*skip_very_good_optimization" "$f"; then
         continue
       fi
-      # RESET-TO-DEFAULT present: `<Global> = <default>` (block or arrow form).
+      # RESET-TO-DEFAULT present: `<Global> = <default>` (block, arrow, or
+      # dart-format-wrapped trailing-comma `= <default>,` form — hence `[;,)]`).
       local has_default_reset=0
-      if grep -qE "([A-Za-z_][A-Za-z0-9_]*\.)?${core}[[:space:]]*=[[:space:]]*${def}[[:space:]]*[;)]" <<<"$body"; then
+      if grep -qE "([A-Za-z_][A-Za-z0-9_]*\.)?${core}[[:space:]]*=[[:space:]]*${def}[[:space:]]*[;,)]" <<<"$body"; then
         has_default_reset=1
       fi
       # NON-default install present: an assignment line that is NOT a reset to the
       # default literal (so a file whose only assignment is the default passes).
       local has_nondefault_install=0
       if grep -E "(^|[^A-Za-z0-9_.])([A-Za-z_][A-Za-z0-9_]*\.)?${core}[[:space:]]*=([^=>]|$)" <<<"$body" \
-         | grep -qvE "([A-Za-z_][A-Za-z0-9_]*\.)?${core}[[:space:]]*=[[:space:]]*${def}[[:space:]]*[;)]"; then
+         | grep -qvE "([A-Za-z_][A-Za-z0-9_]*\.)?${core}[[:space:]]*=[[:space:]]*${def}[[:space:]]*[;,)]"; then
         has_nondefault_install=1
       fi
       if [[ "$has_nondefault_install" -eq 1 && "$has_default_reset" -eq 0 ]]; then
@@ -224,8 +228,10 @@ run_scan() {
     echo "        tearDown(() { <Global> = original; });"
     echo "  (b) [reset-to-default] Assign the global back to its default in a"
     echo "      guaranteed-reachable tearDown/addTearDown (NOT an inline end-of-body"
-    echo "      line, which a mid-test throw would skip):"
-    echo "        addTearDown(() => debugDefaultTargetPlatformOverride = null);"
+    echo "      line, which a mid-test throw would skip). NB: a foundation debug var"
+    echo "      like debugDefaultTargetPlatformOverride needs an INLINE reset instead"
+    echo "      under testWidgets (see the header note), so use a plain override here:"
+    echo "        addTearDown(() => InfiniteVideoFeed.debugIsSupportedOverride = null);"
     echo "  (c) Real-plugin / integration test that cannot restore: tag it so it"
     echo "      stays out of the merge (annotation BEFORE the first import):"
     echo "        @Tags(['skip_very_good_optimization', 'integration'])"
@@ -317,6 +323,31 @@ void main() {
 void main() {
   debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
   addTearDown(() => debugDefaultTargetPlatformOverride = null);
+}
+'
+  _case "reset-to-default dart-format-wrapped trailing comma (= null,) → PASS" 0 \
+'import "x";
+void main() {
+  VideoEditorRenderService.renderVideoToClipOverride = _fake;
+  addTearDown(
+    () => VideoEditorRenderService.renderVideoToClipOverride = null,
+  );
+}
+'
+  _case "capture-restore dart-format-wrapped trailing comma (= prior,) → PASS" 0 \
+'import "x";
+void main() {
+  final prior = Bloc.observer;
+  Bloc.observer = _Fake();
+  addTearDown(
+    () => Bloc.observer = prior,
+  );
+}
+'
+  _case "newly-gated sibling c2paSigningServiceFactoryOverride leaker → FAIL" 1 \
+'import "x";
+void main() {
+  NativeProofModeService.c2paSigningServiceFactoryOverride = () => _fake;
 }
 '
   _case "tagged leaker (skip_very_good_optimization, tag below class defs) → PASS" 0 \


### PR DESCRIPTION
## Description

Extends `mobile/scripts/check_process_global_mutations.sh` beyond the six Tier-2 `<Singleton>.instance` seams (#5163/#5186) to the **Tier-3/Tier-4 residual**, so a future untagged test cannot silently leak one of these process-globals into the `very_good --optimization` merged isolate (an order-dependent, seed-dependent flake cross-attributed to an unrelated test).

Two detection classes, both HARD-ZERO (no baseline, no tolerated debt):

- **capture-restore** (appended to `GLOBALS`): `FlutterError.onError`, `Bloc.observer`. Append-only — every current assigner already snapshots the prior value and restores it, so this is zero-retrofit and zero-false-positive against `main`.
- **reset-to-default** (new mode): `debugDefaultTargetPlatformOverride`, `debugImageCacheOverride`, `debugUsesAppleAppStoreTipPolicyOverride`, `VideoEditorRenderService.renderVideoOverride` / `renderVideoToClipOverride`, `NativeProofModeService.proofFileOverride`, `NativeProofModeService.c2paSigningServiceFactoryOverride`, `InfiniteVideoFeed.debugIsSupportedOverride`. These have no prior runtime value to snapshot (the resting value is a compile-time literal, `null`), so a naive `GLOBALS` append would condemn every correct file. The new mode instead flags a file only when it installs a **non-default** value **and** never assigns the global back to its **default literal** within the file.

`GoogleFonts.config.allowRuntimeFetching` is intentionally **not** gated (benign-monotonic: the shared harness sets it `false` suite-wide and `false` is the resting value every test wants).

Adds a `--selftest` branch. No CI wiring change — the `generated-files` job already runs the real-tree scan. The separate `HttpOverrides.global` STRICT gate is left untouched.

**This is a purely preventive gate — the app merged isolate has no genuine leaker today.** Note on `debugDefaultTargetPlatformOverride`: it is a Flutter *foundation debug var*, so in a `testWidgets` test `debugAssertAllFoundationVarsUnset` already fails the test at end-of-body if it is left set (a leak there is loud, not silent, and only an inline reset works — that assertion runs before `tearDown`/`addTearDown`). The gate still earns its keep for it by covering plain `test()` usage (no framework guard); the other reset-to-default globals have no framework guard at all. The gate accepts an inline `= null`, so it is consistent with the required `testWidgets` pattern.

**Related Issue:** Relates to #5185 · Part of #4337

## Out of Scope

- Extending the gate to scan `mobile/packages/*/test` (each package is its own separate merged isolate) — tracked under **#5838**.
- Fixing the currently-latent **package-bundle** `<Platform>.instance` leakers (`divine_camera`, `divine_video_player`, `background_uploader`) — a separate PR targeting `main`.

## Verification

- `bash mobile/scripts/check_process_global_mutations.sh --selftest` → 18/18 fixtures pass, including multi-line `@Tags([...])`, nullable-promotion restores (`original!`), captured-id restore checks, trailing-comma forms, and the C2PA sibling.
- `/bin/bash mobile/scripts/check_process_global_mutations.sh --selftest` → 18/18 fixtures pass under Bash 3.2.57.
- `bash mobile/scripts/check_process_global_mutations.sh` → exit 0 on this branch (zero false-positives across every current capture-restore + reset-to-default assigner).
- Negative proof: injecting an unrestored `Bloc.observer` install and a `debugDefaultTargetPlatformOverride = TargetPlatform.iOS` (no reset) into a scratch untagged test makes the gate FAIL and name both, with class labels; removed after.

## Type of Change

- [x] ✅ Build configuration change
