### PR TITLE
test(packages): stop leaked platform singletons across merged isolates

### DIFF
--- a/mobile/packages/background_uploader/test/background_uploader_method_channel_test.dart
+++ b/mobile/packages/background_uploader/test/background_uploader_method_channel_test.dart
@@ -6,11 +6,16 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  final platform = MethodChannelBackgroundUploader();
+  // Constructed per test: the constructor installs this instance as the
+  // channel's incoming-call handler (last one wins process-wide), so a
+  // file-level instance loses the handler to any sibling suite that reads
+  // BackgroundUploaderPlatform.instance in the merged-isolate bundle.
+  late MethodChannelBackgroundUploader platform;
   const channel = MethodChannel('background_uploader');
   final calls = <MethodCall>[];
 
   setUp(() {
+    platform = MethodChannelBackgroundUploader();
     calls.clear();
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(channel, (methodCall) async {

--- a/mobile/packages/background_uploader/test/background_uploader_test.dart
+++ b/mobile/packages/background_uploader/test/background_uploader_test.dart
@@ -1,3 +1,10 @@
+// Tagged for its own isolate: this suite installs a fake
+// BackgroundUploaderPlatform.instance, and its only non-fake restore constructs
+// the real MethodChannelBackgroundUploader, which claims the plugin channel and
+// conflicts with background_uploader_method_channel_test in the merged run.
+@Tags(['skip_very_good_optimization'])
+library;
+
 import 'dart:async';
 
 import 'package:background_uploader/background_uploader.dart';

--- a/mobile/packages/background_uploader/test/background_uploader_test.dart
+++ b/mobile/packages/background_uploader/test/background_uploader_test.dart
@@ -1,10 +1,3 @@
-// Tagged for its own isolate: this suite installs a fake
-// BackgroundUploaderPlatform.instance, and its only non-fake restore constructs
-// the real MethodChannelBackgroundUploader, which claims the plugin channel and
-// conflicts with background_uploader_method_channel_test in the merged run.
-@Tags(['skip_very_good_optimization'])
-library;
-
 import 'dart:async';
 
 import 'package:background_uploader/background_uploader.dart';
@@ -56,6 +49,19 @@ class _FakeBackgroundUploaderPlatform extends BackgroundUploaderPlatform
 }
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // Swapping in the fake below reassigns the process-global
+  // BackgroundUploaderPlatform.instance. Capture the real default up front and
+  // restore it after every test so the fake cannot strand a sibling suite in
+  // the merged-isolate (very_good --optimization) run. Reading the getter here
+  // reuses the already-lazily-constructed default; it does not build a new one.
+  final initialPlatform = BackgroundUploaderPlatform.instance;
+
+  tearDown(() {
+    BackgroundUploaderPlatform.instance = initialPlatform;
+  });
+
   group('BackgroundUploader.enqueue validation', () {
     late _FakeBackgroundUploaderPlatform fake;
 

--- a/mobile/packages/background_uploader/test/background_uploader_test.dart
+++ b/mobile/packages/background_uploader/test/background_uploader_test.dart
@@ -54,8 +54,9 @@ void main() {
   // Swapping in the fake below reassigns the process-global
   // BackgroundUploaderPlatform.instance. Capture the real default up front and
   // restore it after every test so the fake cannot strand a sibling suite in
-  // the merged-isolate (very_good --optimization) run. Reading the getter here
-  // reuses the already-lazily-constructed default; it does not build a new one.
+  // the merged-isolate (very_good --optimization) run. Reading the getter may
+  // force lazy construction of the real default, whose constructor claims the
+  // background_uploader channel handler.
   final initialPlatform = BackgroundUploaderPlatform.instance;
 
   tearDown(() {

--- a/mobile/packages/divine_camera/test/divine_camera_platform_interface_test.dart
+++ b/mobile/packages/divine_camera/test/divine_camera_platform_interface_test.dart
@@ -89,6 +89,8 @@ void main() {
     });
 
     test('instance setter accepts valid implementation', () {
+      final initialPlatform = DivineCameraPlatform.instance;
+      addTearDown(() => DivineCameraPlatform.instance = initialPlatform);
       final testPlatform = TestDivineCameraPlatform();
       DivineCameraPlatform.instance = testPlatform;
       expect(DivineCameraPlatform.instance, testPlatform);

--- a/mobile/packages/divine_camera/test/divine_camera_test.dart
+++ b/mobile/packages/divine_camera/test/divine_camera_test.dart
@@ -274,6 +274,9 @@ void main() {
     tearDown(() async {
       // Reset DivineCamera singleton state between tests
       await DivineCamera.instance.dispose();
+      // Restore the process-global platform singleton so the mock does not
+      // leak into later files in the package's merged isolate.
+      DivineCameraPlatform.instance = initialPlatform;
     });
 
     test('getPlatformVersion returns expected value', () async {
@@ -1364,6 +1367,9 @@ void main() {
     tearDown(() async {
       // Reset DivineCamera singleton state between tests
       await DivineCamera.instance.dispose();
+      // Restore the process-global platform singleton so the mock does not
+      // leak into later files in the package's merged isolate.
+      DivineCameraPlatform.instance = initialPlatform;
     });
 
     test('onRecordingAutoStopped callback is invoked', () async {

--- a/mobile/packages/divine_camera/test/widgets/camera_preview_widget_test.dart
+++ b/mobile/packages/divine_camera/test/widgets/camera_preview_widget_test.dart
@@ -170,6 +170,7 @@ class _RotatedPreviewMock extends MockDivineCameraPlatform {
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  final initialPlatform = DivineCameraPlatform.instance;
   late MockDivineCameraPlatform mockPlatform;
 
   setUp(() async {
@@ -177,6 +178,12 @@ void main() {
     DivineCameraPlatform.instance = mockPlatform;
     // Reset singleton state
     await DivineCamera.instance.dispose();
+  });
+
+  tearDown(() {
+    // Restore the process-global platform singleton so the mock does not
+    // leak into later files in the package's merged isolate.
+    DivineCameraPlatform.instance = initialPlatform;
   });
 
   final camera = DivineCamera.instance;

--- a/mobile/packages/divine_video_player/test/src/audio_track_test.dart
+++ b/mobile/packages/divine_video_player/test/src/audio_track_test.dart
@@ -130,13 +130,19 @@ void main() {
 
     group('asset', () {
       late Directory tempDir;
+      late PathProviderPlatform originalPathProvider;
 
       setUp(() async {
+        originalPathProvider = PathProviderPlatform.instance;
         tempDir = await Directory.systemTemp.createTemp('audio_track_test_');
         PathProviderPlatform.instance = _FakePathProvider(tempDir.path);
       });
 
       tearDown(() async {
+        // Restore the process-global platform singleton so the fake (whose
+        // temp dir is about to be deleted) does not leak into later files in
+        // the package's merged isolate.
+        PathProviderPlatform.instance = originalPathProvider;
         if (tempDir.existsSync()) {
           await tempDir.delete(recursive: true);
         }
@@ -172,13 +178,19 @@ void main() {
 
     group('memory', () {
       late Directory tempDir;
+      late PathProviderPlatform originalPathProvider;
 
       setUp(() async {
+        originalPathProvider = PathProviderPlatform.instance;
         tempDir = await Directory.systemTemp.createTemp('audio_track_test_');
         PathProviderPlatform.instance = _FakePathProvider(tempDir.path);
       });
 
       tearDown(() async {
+        // Restore the process-global platform singleton so the fake (whose
+        // temp dir is about to be deleted) does not leak into later files in
+        // the package's merged isolate.
+        PathProviderPlatform.instance = originalPathProvider;
         if (tempDir.existsSync()) {
           await tempDir.delete(recursive: true);
         }

--- a/mobile/packages/divine_video_player/test/src/video_clip_test.dart
+++ b/mobile/packages/divine_video_player/test/src/video_clip_test.dart
@@ -151,13 +151,19 @@ void main() {
 
     group('asset', () {
       late Directory tempDir;
+      late PathProviderPlatform originalPathProvider;
 
       setUp(() async {
+        originalPathProvider = PathProviderPlatform.instance;
         tempDir = await Directory.systemTemp.createTemp('video_clip_test_');
         PathProviderPlatform.instance = _FakePathProvider(tempDir.path);
       });
 
       tearDown(() async {
+        // Restore the process-global platform singleton so the fake (whose
+        // temp dir is about to be deleted) does not leak into later files in
+        // the package's merged isolate.
+        PathProviderPlatform.instance = originalPathProvider;
         if (tempDir.existsSync()) {
           await tempDir.delete(recursive: true);
         }
@@ -184,13 +190,19 @@ void main() {
 
     group('memory', () {
       late Directory tempDir;
+      late PathProviderPlatform originalPathProvider;
 
       setUp(() async {
+        originalPathProvider = PathProviderPlatform.instance;
         tempDir = await Directory.systemTemp.createTemp('video_clip_test_');
         PathProviderPlatform.instance = _FakePathProvider(tempDir.path);
       });
 
       tearDown(() async {
+        // Restore the process-global platform singleton so the fake (whose
+        // temp dir is about to be deleted) does not leak into later files in
+        // the package's merged isolate.
+        PathProviderPlatform.instance = originalPathProvider;
         if (tempDir.existsSync()) {
           await tempDir.delete(recursive: true);
         }


### PR DESCRIPTION
## Description

The #5185 open-ended census (over `mobile/packages/*/test`, the #5838 axis) found six untagged package tests that install a process-global `<Platform>.instance` without restoring it, stranding the fake/mock into every later file in that package's `very_good --optimization` merged isolate — a **latent, seed-dependent** contamination (green today only because no later file reads the leaked global in a triggering order). The existing `check_process_global_mutations.sh` gate scans only `mobile/test`, so packages are unguarded.

**Fixes (capture the prior instance, restore in a guaranteed-reachable tearDown):**
- `divine_camera` (`DivineCameraPlatform.instance`):
  - `divine_camera_platform_interface_test.dart` — capture + `addTearDown` (also makes the file order-independent).
  - `divine_camera_test.dart` — restore in both group `tearDown`s (they previously only `dispose()`d the facade).
  - `widgets/camera_preview_widget_test.dart` — top-level `tearDown` restore.
- `divine_video_player` (`PathProviderPlatform.instance`):
  - `audio_track_test.dart`, `video_clip_test.dart` — capture + restore in the group `tearDown`s (which previously only deleted the temp dir).
- `background_uploader` (`BackgroundUploaderPlatform.instance`):
  - `background_uploader_test.dart` — capture the real default up front + top-level `tearDown` restore.
  - `background_uploader_method_channel_test.dart` — construct the real `MethodChannelBackgroundUploader` **per test in `setUp`** (was file-level). Capturing the default in the sibling reuses (and forces the lazy construction of) the singleton, whose constructor claims the `background_uploader` channel's incoming handler; per-test construction re-claims it so this suite's stream/buffer tests stay green. This is the identical MethodChannel-in-constructor shape already shipped on `main` in `divine_quick_actions`, restored the same way rather than tag-isolated.

**Related Issue:** Relates to #5838 (per-package merged-isolate guard) · surfaced by #5185

## Out of Scope

- Building a package-scanning gate (extend `check_process_global_mutations.sh` to `packages/*/test`) — that's **#5838**. This PR removes the current instances; #5838 prevents new ones.

## Verification

- Each affected package's `very_good test --optimization` passes across ordering seeds `1`, `12345`, `98765` (`background_uploader` additionally checked on `99999`, `424242`, and `random`).
- For `background_uploader`, leaving the sibling `_method_channel_test` at its old file-level construction fails its stream + buffered-terminal tests **deterministically** (handler steal), confirming the coupled per-test-construction change is required rather than assumed.
- Standalone `flutter test` passes for every changed file.
- `flutter analyze` clean on all changed files.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
