### PR TITLE
fix(profile): offline-tolerant username save (#3161)

### DIFF
--- a/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
+++ b/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
@@ -1036,7 +1036,7 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
     // because ProfileSaveRetryService re-drives the slot when connectivity
     // returns (#3161). A permanent failure surfaces via the slot's `failed`
     // status, not by blocking Save.
-    await _profileRepository.enqueuePendingSave(
+    final generation = await _profileRepository.enqueuePendingSave(
       PendingProfileSave(
         pubkey: event.pubkey,
         displayName: displayName,
@@ -1052,13 +1052,17 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
     );
     emit(state.copyWith(status: ProfileEditorStatus.success));
 
-    // Fast-path publish. drivePendingSave maps the typed publish failures
-    // (no-relays / rejection) to outcomes and clears the slot only on a
-    // relay-confirmed OK, so a transient failure just leaves the slot queued
-    // for ProfileSaveRetryService — the optimistic success stands. Only an
-    // unexpected throw is reported here.
+    // Fast-path publish, scoped to the generation just enqueued so a save the
+    // user fires again while this drive is in flight is never clobbered by it.
+    // drivePendingSave maps the typed publish failures (no-relays / rejection)
+    // to outcomes and clears the slot only on a relay-confirmed OK, so a
+    // transient failure just leaves the slot queued for ProfileSaveRetryService
+    // — the optimistic success stands. Only an unexpected throw is reported.
     try {
-      await _profileRepository.drivePendingSave(event.pubkey);
+      await _profileRepository.drivePendingSave(
+        event.pubkey,
+        expectedGeneration: generation,
+      );
     } on Object catch (error, stackTrace) {
       // Classification: Invariant — matrix-YES. A drift TypeError from a
       // schema mismatch, a StateError from a sync transform, etc. Recovery is

--- a/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
+++ b/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
@@ -1028,10 +1028,17 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
       }
     }
 
-    // 2. Publish kind 0 metadata. By this point either no divine.video
-    // username was requested, or the claim has been confirmed.
-    try {
-      final savedProfile = await _profileRepository.saveProfileEvent(
+    // 2. Persist the save to the durable slot and publish optimistically.
+    // The username claim above either succeeded or was unnecessary, so the
+    // slot is enqueued as claim-confirmed. Report success immediately — the
+    // editor closes and shows the new profile — then re-drive the kind-0 in
+    // the background: a transient relay outage no longer strands the save,
+    // because ProfileSaveRetryService re-drives the slot when connectivity
+    // returns (#3161). A permanent failure surfaces via the slot's `failed`
+    // status, not by blocking Save.
+    await _profileRepository.enqueuePendingSave(
+      PendingProfileSave(
+        pubkey: event.pubkey,
         displayName: displayName,
         about: about,
         website: website,
@@ -1040,49 +1047,24 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
         clearNip05: clearNip05,
         picture: picture,
         banner: banner,
-        currentProfile: currentProfile,
-      );
-      Log.info(
-        '📝 Profile published: nip05=${savedProfile.nip05}',
-        name: 'ProfileEditorBloc',
-      );
-      await _profileRepository.cacheProfile(savedProfile);
-      emit(state.copyWith(status: ProfileEditorStatus.success));
-    } on NoRelaysConnectedException catch (error, stackTrace) {
-      // Classification: Network/IO — matrix-NO. The device has no active
-      // relay connections; user-actionable retry path.
-      Log.error(
-        'Failed to publish profile (no relays): $error',
-        name: 'ProfileEditorBloc',
-      );
-      addError(error, stackTrace);
-      emit(
-        state.copyWith(
-          status: ProfileEditorStatus.failure,
-          error: ProfileEditorError.noRelaysConnected,
-        ),
-      );
-    } on ProfilePublishFailedException catch (error, stackTrace) {
-      // Classification: API/domain — matrix-NO. Typed publish failure
-      // (relay rejected event or send error).
-      Log.error(
-        'Failed to publish profile: $error',
-        name: 'ProfileEditorBloc',
-      );
-      addError(error, stackTrace);
-      emit(
-        state.copyWith(
-          status: ProfileEditorStatus.failure,
-          error: ProfileEditorError.publishFailed,
-        ),
-      );
+      ),
+      claimConfirmed: true,
+    );
+    emit(state.copyWith(status: ProfileEditorStatus.success));
+
+    // Fast-path publish. drivePendingSave maps the typed publish failures
+    // (no-relays / rejection) to outcomes and clears the slot only on a
+    // relay-confirmed OK, so a transient failure just leaves the slot queued
+    // for ProfileSaveRetryService — the optimistic success stands. Only an
+    // unexpected throw is reported here.
+    try {
+      await _profileRepository.drivePendingSave(event.pubkey);
     } on Object catch (error, stackTrace) {
-      // Classification: Invariant — matrix-YES. Anything that escapes the
-      // typed `ProfileRepositoryException` branches above is unexpected:
-      // a drift `TypeError` from a schema mismatch, a `StateError` from a
-      // sync transform between `saveProfileEvent` and `cacheProfile`, etc.
+      // Classification: Invariant — matrix-YES. A drift TypeError from a
+      // schema mismatch, a StateError from a sync transform, etc. Recovery is
+      // still owned by the durable slot + retry service.
       Log.error(
-        'Failed to publish profile (unexpected): $error',
+        'Pending profile-save drive threw: $error',
         name: 'ProfileEditorBloc',
       );
       addError(
@@ -1091,12 +1073,6 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
           context: ProfileEditorReportableSites.saveProfilePublish,
         ),
         stackTrace,
-      );
-      emit(
-        state.copyWith(
-          status: ProfileEditorStatus.failure,
-          error: ProfileEditorError.publishFailed,
-        ),
       );
     }
   }

--- a/mobile/lib/blocs/profile_editor/profile_editor_state.dart
+++ b/mobile/lib/blocs/profile_editor/profile_editor_state.dart
@@ -32,14 +32,12 @@ enum ProfileEditorStatus {
 /// The UI layer should map these to localized strings.
 enum ProfileEditorError {
   /// Failed to publish profile to Nostr relays (relay rejected or send error).
-  publishFailed,
-
-  /// Failed to publish profile because no relays are currently connected.
   ///
-  /// This is distinct from [publishFailed]: the device has no active relay
-  /// connections at all, rather than a relay actively rejecting the event.
-  /// The UI should show a connectivity-specific message and offer a retry.
-  noRelaysConnected,
+  /// Since #3161 the save is optimistic — a transient publish failure no longer
+  /// surfaces here; it is owned by the durable pending-save slot + retry
+  /// service. This value now only covers an unexpected error escaping the
+  /// background drive (a programming invariant).
+  publishFailed,
 
   /// The server rejected the username claim (invalid format or an unexpected
   /// server response). Network failures use [claimNetworkError] instead.

--- a/mobile/lib/blocs/profile_editor/reportable_sites.dart
+++ b/mobile/lib/blocs/profile_editor/reportable_sites.dart
@@ -34,10 +34,10 @@ abstract class ProfileEditorReportableSites {
   /// [onUsernameChanged], dispatched from the reserved-recheck CTA.
   static const String onUsernameRechecked = '_onUsernameRechecked';
 
-  /// Narrowed publish-path catch in `_saveProfile`: any non-typed throw
-  /// (drift `TypeError` from a schema mismatch, `StateError` from a sync
-  /// transform between `saveProfileEvent` and `cacheProfile`) that escapes
-  /// the typed `on NoRelaysConnectedException` / `on ProfilePublishFailedException`
+  /// Narrowed publish-path catch in `_saveProfile`: any non-typed throw from
+  /// the optimistic `drivePendingSave` fast-path (drift `TypeError` from a
+  /// schema mismatch, `StateError` from the slot bookkeeping) that escapes the
+  /// typed `on NoRelaysConnectedException` / `on ProfilePublishFailedException`
   /// branches.
   static const String saveProfilePublish = '_saveProfile';
 

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -2411,6 +2411,10 @@ class _DivineAppState extends ConsumerState<DivineApp>
     // the durable pending_profile_saves slot with no UI consumer (#3161).
     ref.watch(profileSaveRetryServiceProvider);
 
+    // Eagerly wire the connectivity → relay force-reconnect bridge so the
+    // relay pool self-heals app-wide the moment the network returns (#3161).
+    ref.watch(connectivityRelayReconnectProvider);
+
     // Wrap with geo-blocking check first, then lifecycle handler
     Widget wrapped = MultiRepositoryProvider(
       providers: [

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -2406,6 +2406,11 @@ class _DivineAppState extends ConsumerState<DivineApp>
     // durable pending_product_events queue without a UI consumer.
     ref.watch(productEventQueueProvider);
 
+    // Eagerly create the profile-save retry service so its foreground +
+    // connectivity subscriptions are wired at app shell setup. It re-drives
+    // the durable pending_profile_saves slot with no UI consumer (#3161).
+    ref.watch(profileSaveRetryServiceProvider);
+
     // Wrap with geo-blocking check first, then lifecycle handler
     Widget wrapped = MultiRepositoryProvider(
       providers: [

--- a/mobile/lib/providers/relay_providers.dart
+++ b/mobile/lib/providers/relay_providers.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nostr_client/nostr_client.dart'
     show RelayConnectionStatus, RelayState;
@@ -242,3 +243,39 @@ bool _setsEqual<T>(Set<T> a, Set<T> b) {
   if (a.length != b.length) return false;
   return a.containsAll(b);
 }
+
+/// Force-reconnects the relay pool whenever `connectivity_plus` reports the
+/// network returning, so a pool that collapsed to zero connections during an
+/// offline window self-heals app-wide — not only on an app-foreground
+/// transition (#3161). Debounced so a burst of connectivity events collapses
+/// into one reconnect. keepAlive with no UI consumer: read eagerly at app
+/// shell startup so the subscription is wired.
+final connectivityRelayReconnectProvider = Provider<void>((ref) {
+  final nostrService = ref.watch(nostrServiceProvider);
+  Timer? debounce;
+  final subscription = Connectivity().onConnectivityChanged
+      .where((results) => results.any((r) => r != ConnectivityResult.none))
+      .listen((_) {
+        debounce?.cancel();
+        debounce = Timer(const Duration(seconds: 2), () async {
+          try {
+            await nostrService.forceReconnectAll();
+            Log.info(
+              'Reconnected relays after connectivity returned',
+              name: 'ConnectivityRelayReconnect',
+              category: LogCategory.relay,
+            );
+          } catch (e) {
+            Log.error(
+              'connectivity-triggered relay reconnect failed: $e',
+              name: 'ConnectivityRelayReconnect',
+              category: LogCategory.relay,
+            );
+          }
+        });
+      });
+  ref.onDispose(() {
+    debounce?.cancel();
+    subscription.cancel();
+  });
+});

--- a/mobile/lib/providers/repository_providers.dart
+++ b/mobile/lib/providers/repository_providers.dart
@@ -352,6 +352,8 @@ ProfileRepository _buildProfileRepository(Ref ref, {required bool warmCache}) {
     nostrClient: nostrClient,
     userProfilesDao: userProfilesDao,
     profileStatsDao: ref.watch(databaseProvider).profileStatsDao,
+    // Durable pending-save slot for the offline-tolerant username save (#3161).
+    pendingProfileSavesDao: ref.watch(databaseProvider).pendingProfileSavesDao,
     httpClient: Client(),
     funnelcakeApiClient: funnelcakeClient,
     indexerRelays: env.indexerRelays,

--- a/mobile/lib/providers/social_providers.dart
+++ b/mobile/lib/providers/social_providers.dart
@@ -34,6 +34,7 @@ import 'package:openvine/services/hashtag_service.dart';
 import 'package:openvine/services/outgoing_dm_retry_service.dart';
 import 'package:openvine/services/pending_action_service.dart';
 import 'package:openvine/services/product_event_queue.dart';
+import 'package:openvine/services/profile_save_retry_service.dart';
 import 'package:openvine/services/social_service.dart';
 import 'package:openvine/services/user_data_cleanup_service.dart';
 import 'package:openvine/services/view_event_publisher.dart';
@@ -236,6 +237,67 @@ OutgoingDmRetryService? outgoingDmRetryService(Ref ref) {
   ref.onDispose(service.dispose);
   return service;
 }
+
+/// Auto-sweep service that re-drives the durable pending profile/username save
+/// slot (#3161) so a save attempted while relays were unreachable is delivered
+/// when connectivity returns. keepAlive with no UI consumer — read eagerly at
+/// app shell startup (`main.dart`) so the foreground + connectivity
+/// subscriptions are wired.
+///
+/// Returns null until the user is authenticated and the Nostr session is ready
+/// for the active identity (the same readiness [profileRepository] gates on),
+/// so drivePendingSave's claim + publish have a live signer and client.
+final profileSaveRetryServiceProvider = Provider<ProfileSaveRetryService?>((
+  ref,
+) {
+  final authService = ref.watch(authServiceProvider);
+
+  // Rebuild on sign-in / sign-out / account switch.
+  ref.watch(currentAuthStateProvider);
+
+  final userPubkey = authService.currentPublicKeyHex;
+  if (userPubkey == null || userPubkey.isEmpty) return null;
+
+  final readiness = ref.watch(nostrSessionProvider);
+  if (!readiness.isReadyForActiveClient || readiness.pubkey != userPubkey) {
+    return null;
+  }
+
+  final profileRepository = ref.watch(profileRepositoryProvider);
+  if (profileRepository == null) return null;
+
+  final db = ref.watch(databaseProvider);
+
+  final foregroundController = StreamController<bool>();
+  ref.onDispose(foregroundController.close);
+
+  final service = ProfileSaveRetryService(
+    profileRepository: profileRepository,
+    pendingProfileSavesDao: db.pendingProfileSavesDao,
+    userPubkey: userPubkey,
+    appForegroundStream: foregroundController.stream,
+    // Shared connectivity trigger: re-drive the moment the network returns,
+    // not only on an app-foreground transition.
+    retryTriggerStream: _dmRetryConnectivityTriggerStream(),
+  );
+
+  service.initialize().catchError((Object e) {
+    Log.error(
+      'Failed to initialize ProfileSaveRetryService',
+      name: 'AppProviders',
+      error: e,
+    );
+  });
+
+  ref.listen<bool>(appForegroundProvider, (_, next) {
+    if (!foregroundController.isClosed) {
+      foregroundController.add(next);
+    }
+  }, fireImmediately: true);
+
+  ref.onDispose(service.dispose);
+  return service;
+});
 
 /// Auto-sweep service that re-drives undelivered DM reactions (publish failed
 /// or interrupted mid-send) on app-foreground transitions via

--- a/mobile/lib/screens/profile_setup/widgets/profile_setup_listeners.dart
+++ b/mobile/lib/screens/profile_setup/widgets/profile_setup_listeners.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -10,7 +8,6 @@ import 'package:openvine/blocs/my_profile/my_profile_bloc.dart';
 import 'package:openvine/blocs/profile_editor/profile_editor_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
-import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/profile_setup/widgets/profile_setup_upload_errors.dart';
 import 'package:openvine/screens/profile_setup/widgets/verifier_flow.dart';
@@ -46,7 +43,6 @@ class ProfileSetupListeners extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final pubkey = ref.watch(authServiceProvider).currentPublicKeyHex;
     return MultiBlocListener(
       listeners: [
         BlocListener<MyProfileBloc, MyProfileState>(
@@ -215,25 +211,6 @@ class ProfileSetupListeners extends ConsumerWidget {
                       backgroundColor: VineTheme.error,
                     ),
                   );
-                case ProfileEditorError.noRelaysConnected:
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(
-                      content: Text(context.l10n.profileSetupNoRelaysConnected),
-                      backgroundColor: VineTheme.error,
-                      duration: const Duration(seconds: 6),
-                      action: pubkey == null
-                          ? null
-                          : SnackBarAction(
-                              label: context.l10n.profileSetupRetryLabel,
-                              textColor: VineTheme.whiteText,
-                              onPressed: () => _retryAfterRelayReconnect(
-                                context,
-                                ref,
-                                pubkey,
-                              ),
-                            ),
-                    ),
-                  );
                 case null:
                   break;
               }
@@ -333,26 +310,6 @@ class ProfileSetupListeners extends ConsumerWidget {
         ),
       ],
       child: child,
-    );
-  }
-
-  Future<void> _retryAfterRelayReconnect(
-    BuildContext context,
-    WidgetRef ref,
-    String pubkey,
-  ) async {
-    await ref.read(nostrServiceProvider).retryDisconnectedRelays();
-    if (!context.mounted) return;
-    context.read<ProfileEditorBloc>().add(
-      ProfileSaved(
-        pubkey: pubkey,
-        displayName: nameController.text,
-        about: bioController.text,
-        website: websiteController.text,
-        username: nip05Controller.text,
-        // Picture and banner sourced from bloc state (see ProfileSaved
-        // dispatch above) via `effectiveBanner` / `effectivePictureUrl`.
-      ),
     );
   }
 }

--- a/mobile/lib/services/profile_save_retry_service.dart
+++ b/mobile/lib/services/profile_save_retry_service.dart
@@ -101,6 +101,15 @@ class ProfileSaveRetryService {
 
   StreamSubscription<bool>? _foregroundSubscription;
   StreamSubscription<void>? _retryTriggerSubscription;
+
+  /// Self-scheduled next attempt. A recovery signal (foreground/connectivity)
+  /// can arrive before the relay pool has reconnected, so relying on that one
+  /// signal would strand the save until the *next* signal. After every
+  /// non-terminal outcome the sweep arms this timer for the row's remaining
+  /// backoff, so one offline→online transition keeps retrying until a relay
+  /// confirms the publish (#3161 review).
+  Timer? _retryTimer;
+
   bool _isInitialized = false;
   bool _isSweeping = false;
 
@@ -136,12 +145,14 @@ class ProfileSaveRetryService {
     );
   }
 
-  /// Cancel the trigger subscriptions and mark the service un-init. Idempotent.
+  /// Cancel the trigger subscriptions and pending retry timer and mark the
+  /// service un-init. Idempotent.
   Future<void> dispose() async {
     await _foregroundSubscription?.cancel();
     _foregroundSubscription = null;
     await _retryTriggerSubscription?.cancel();
     _retryTriggerSubscription = null;
+    _cancelRetryTimer();
     _isInitialized = false;
   }
 
@@ -178,36 +189,62 @@ class ProfileSaveRetryService {
 
     try {
       final entry = await _dao.get(_userPubkey);
-      if (entry == null) return;
-
-      // A failed slot awaits a manual retry — don't auto-retry it.
-      if (entry.status == PendingProfileSaveStatus.failed) return;
-
-      // Per-row backoff.
-      final lastAttempt = entry.lastAttemptAt;
-      if (lastAttempt != null) {
-        final gap = _now().difference(lastAttempt);
-        if (gap < _retryConfig.backoffFor(entry.retryCount)) return;
+      if (entry == null) {
+        _cancelRetryTimer();
+        return;
       }
 
-      await _dao.markStatus(
+      // A failed slot awaits a manual retry — don't auto-retry it.
+      if (entry.status == PendingProfileSaveStatus.failed) {
+        _cancelRetryTimer();
+        return;
+      }
+
+      final generation = entry.generation;
+
+      // Per-row backoff. When a trigger arrives inside the backoff window, arm
+      // the timer for the remaining time rather than dropping the attempt.
+      final lastAttempt = entry.lastAttemptAt;
+      if (lastAttempt != null) {
+        final backoff = _retryConfig.backoffFor(entry.retryCount);
+        final gap = _now().difference(lastAttempt);
+        if (gap < backoff) {
+          _scheduleRetry(backoff - gap);
+          return;
+        }
+      }
+
+      // Claim the attempt for this generation. If a newer save replaced the
+      // row between the read above and here, this no-ops (false) and we bail —
+      // the newer row is pending and a fresh trigger/timer will drive it.
+      final claimed = await _dao.markStatus(
         userPubkey: _userPubkey,
         status: PendingProfileSaveStatus.syncing,
+        generation: generation,
+        attemptAt: _now(),
       );
+      if (!claimed) return;
 
-      final outcome = await _profileRepository.drivePendingSave(_userPubkey);
+      final outcome = await _profileRepository.drivePendingSave(
+        _userPubkey,
+        expectedGeneration: generation,
+      );
 
       switch (outcome) {
         case PendingSaveDriveOutcome.confirmed:
         case PendingSaveDriveOutcome.noPendingSave:
-          // Slot cleared by the repository (confirmed) or already gone.
-          break;
+          // Slot cleared by the repository (confirmed) or already gone /
+          // superseded — nothing more to schedule.
+          _cancelRetryTimer();
         case PendingSaveDriveOutcome.permanentFailure:
           await _dao.markStatus(
             userPubkey: _userPubkey,
             status: PendingProfileSaveStatus.failed,
             lastError: 'Username claim failed permanently (taken/reserved)',
+            generation: generation,
+            attemptAt: _now(),
           );
+          _cancelRetryTimer();
         case PendingSaveDriveOutcome.retryableFailure:
           if (entry.retryCount + 1 >= _retryConfig.maxRetries) {
             await _dao.markStatus(
@@ -215,13 +252,28 @@ class ProfileSaveRetryService {
               status: PendingProfileSaveStatus.failed,
               lastError:
                   'Could not publish after ${_retryConfig.maxRetries} attempts',
+              generation: generation,
+              attemptAt: _now(),
             );
+            _cancelRetryTimer();
           } else {
-            await _dao.incrementRetry(_userPubkey);
-            await _dao.markStatus(
+            await _dao.incrementRetry(
+              _userPubkey,
+              generation: generation,
+              attemptAt: _now(),
+            );
+            final reverted = await _dao.markStatus(
               userPubkey: _userPubkey,
               status: PendingProfileSaveStatus.pending,
+              generation: generation,
+              attemptAt: _now(),
             );
+            // Arm the next attempt so one recovery signal eventually publishes
+            // even if the relay pool wasn't ready this pass. Only when the row
+            // is still ours — a newer save that slipped in owns its scheduling.
+            if (reverted) {
+              _scheduleRetry(_retryConfig.backoffFor(entry.retryCount + 1));
+            }
           }
       }
     } on Object catch (e, stackTrace) {
@@ -242,5 +294,24 @@ class ProfileSaveRetryService {
     } finally {
       _isSweeping = false;
     }
+  }
+
+  /// Arm (replacing any pending) the self-scheduled next attempt for [delay].
+  /// A negative delay is clamped to zero. The timer fires a fresh [sweep];
+  /// because it is armed from inside a sweep (before the `finally` clears
+  /// [_isSweeping]) and never with a same-tick delay that could beat that
+  /// `finally`, the scheduled sweep always finds the re-entrancy guard clear.
+  void _scheduleRetry(Duration delay) {
+    _retryTimer?.cancel();
+    final clamped = delay.isNegative ? Duration.zero : delay;
+    _retryTimer = Timer(clamped, () {
+      _retryTimer = null;
+      unawaited(sweep());
+    });
+  }
+
+  void _cancelRetryTimer() {
+    _retryTimer?.cancel();
+    _retryTimer = null;
   }
 }

--- a/mobile/lib/services/profile_save_retry_service.dart
+++ b/mobile/lib/services/profile_save_retry_service.dart
@@ -1,0 +1,246 @@
+// ABOUTME: Auto-sweeps the durable pending-profile-save slot (#3161) and
+// ABOUTME: re-drives the queued kind-0 publish via
+// ABOUTME: ProfileRepository.drivePendingSave. Triggered by app-foreground
+// ABOUTME: transitions and connectivity/relay-reconnect; mirrors
+// ABOUTME: OutgoingDmRetryService.
+
+import 'dart:async';
+
+import 'package:db_client/db_client.dart';
+import 'package:meta/meta.dart';
+import 'package:openvine/services/crash_reporting_service.dart';
+import 'package:profile_repository/profile_repository.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// Crashlytics `reason:` suffix for the sweep's top-level catch. Inlined as a
+/// single site per `error_handling.md` (a dedicated *ReportableSites class is
+/// only warranted once a feature has 2+ migrated sites).
+const _sweepTopLevelSite = 'ProfileSaveRetryService.sweepTopLevel';
+
+/// Backoff configuration for [ProfileSaveRetryService].
+///
+/// Defaults match `OutgoingDmRetryConfig` / `PendingActionRetryConfig`
+/// (5 retries, 2s → 5min, 2× backoff).
+class ProfileSaveRetryConfig {
+  const ProfileSaveRetryConfig({
+    this.maxRetries = 5,
+    this.initialDelay = const Duration(seconds: 2),
+    this.maxDelay = const Duration(minutes: 5),
+    this.backoffMultiplier = 2.0,
+  });
+
+  /// Maximum publish attempts before the slot is marked failed.
+  final int maxRetries;
+
+  /// Delay before the second attempt (the first retry).
+  final Duration initialDelay;
+
+  /// Upper bound on the backoff delay.
+  final Duration maxDelay;
+
+  /// Multiplier applied per prior attempt.
+  final double backoffMultiplier;
+
+  /// Minimum gap required before a row whose previous attempt count is
+  /// [retryCount] may be retried. Clamped at [maxDelay].
+  Duration backoffFor(int retryCount) {
+    if (retryCount <= 0) return Duration.zero;
+    var ms = initialDelay.inMilliseconds.toDouble();
+    for (var i = 0; i < retryCount; i++) {
+      ms *= backoffMultiplier;
+      if (ms >= maxDelay.inMilliseconds) return maxDelay;
+    }
+    return Duration(milliseconds: ms.round());
+  }
+}
+
+/// Re-drives the single durable pending profile/username save for one account
+/// until a relay confirms the kind-0 publish, then the slot clears itself.
+///
+/// **Triggers:** [appForegroundStream] transitions to `true`, and each event on
+/// [retryTriggerStream] (wired to connectivity/relay-reconnect). The provider
+/// seeds the foreground stream with the current state on subscription, so the
+/// cold-start sweep fires automatically.
+///
+/// **Re-entrancy:** a sweep already in progress short-circuits the next
+/// trigger; the deferred work is picked up on the next transition.
+///
+/// **Per-row backoff:** a slot whose `lastAttemptAt + backoff(retryCount)` is
+/// in the future is skipped this pass.
+///
+/// **Terminal state:** once [ProfileSaveRetryConfig.maxRetries] is reached, or
+/// the divine.video username claim fails permanently (taken/reserved), the slot
+/// is marked `failed` and left for the user to retry manually via [retryNow].
+class ProfileSaveRetryService {
+  ProfileSaveRetryService({
+    required ProfileRepository profileRepository,
+    required PendingProfileSavesDao pendingProfileSavesDao,
+    required String userPubkey,
+    required Stream<bool> appForegroundStream,
+    Stream<void>? retryTriggerStream,
+    ProfileSaveRetryConfig retryConfig = const ProfileSaveRetryConfig(),
+    DateTime Function() now = DateTime.now,
+    CrashReportingService? crashReporting,
+  }) : _profileRepository = profileRepository,
+       _dao = pendingProfileSavesDao,
+       _userPubkey = userPubkey,
+       _appForegroundStream = appForegroundStream,
+       _retryTriggerStream = retryTriggerStream,
+       _retryConfig = retryConfig,
+       _now = now,
+       _crashReporting = crashReporting ?? CrashReportingService.instance;
+
+  final ProfileRepository _profileRepository;
+  final PendingProfileSavesDao _dao;
+  final String _userPubkey;
+  final Stream<bool> _appForegroundStream;
+  final Stream<void>? _retryTriggerStream;
+  final ProfileSaveRetryConfig _retryConfig;
+  final DateTime Function() _now;
+  final CrashReportingService _crashReporting;
+
+  StreamSubscription<bool>? _foregroundSubscription;
+  StreamSubscription<void>? _retryTriggerSubscription;
+  bool _isInitialized = false;
+  bool _isSweeping = false;
+
+  bool get isInitialized => _isInitialized;
+
+  @visibleForTesting
+  bool get isSweeping => _isSweeping;
+
+  /// Subscribe to the trigger streams and run a cold-start sweep. Idempotent.
+  Future<void> initialize() async {
+    if (_isInitialized) return;
+    _isInitialized = true;
+
+    // A slot left `syncing` by an app-kill mid-publish is reset to `pending`
+    // so this session retries it.
+    await _profileRepository.resetInterruptedPendingSave(_userPubkey);
+
+    _foregroundSubscription = _appForegroundStream.listen((foreground) {
+      if (foreground) unawaited(sweep());
+    });
+    _retryTriggerSubscription = _retryTriggerStream?.listen((_) {
+      unawaited(sweep());
+    });
+
+    // The cold-start sweep is driven by the foreground stream, which the
+    // provider seeds with the current state on subscription (mirrors
+    // OutgoingDmRetryService) — no explicit sweep() call needed here.
+
+    Log.info(
+      'initialized for $_userPubkey',
+      name: 'ProfileSaveRetryService',
+      category: LogCategory.system,
+    );
+  }
+
+  /// Cancel the trigger subscriptions and mark the service un-init. Idempotent.
+  Future<void> dispose() async {
+    await _foregroundSubscription?.cancel();
+    _foregroundSubscription = null;
+    await _retryTriggerSubscription?.cancel();
+    _retryTriggerSubscription = null;
+    _isInitialized = false;
+  }
+
+  /// Reset a `failed` slot back to `pending` (fresh retry budget) and sweep.
+  /// Wired to the UI's manual "retry" affordance.
+  Future<void> retryNow() async {
+    final entry = await _dao.get(_userPubkey);
+    if (entry == null) return;
+    // Re-upsert resets retryCount → 0, status → pending, lastError → null.
+    await _dao.upsert(
+      PendingProfileSaveEntry(
+        userPubkey: entry.userPubkey,
+        payloadJson: entry.payloadJson,
+        claimConfirmed: entry.claimConfirmed,
+        queuedAt: _now(),
+      ),
+    );
+    await sweep();
+  }
+
+  /// One pass over the pending-save slot. Public so tests and the manual-retry
+  /// path can drive it directly.
+  @visibleForTesting
+  Future<void> sweep() async {
+    if (_isSweeping) {
+      Log.debug(
+        'sweep already in progress, skipping',
+        name: 'ProfileSaveRetryService',
+        category: LogCategory.system,
+      );
+      return;
+    }
+    _isSweeping = true;
+
+    try {
+      final entry = await _dao.get(_userPubkey);
+      if (entry == null) return;
+
+      // A failed slot awaits a manual retry — don't auto-retry it.
+      if (entry.status == PendingProfileSaveStatus.failed) return;
+
+      // Per-row backoff.
+      final lastAttempt = entry.lastAttemptAt;
+      if (lastAttempt != null) {
+        final gap = _now().difference(lastAttempt);
+        if (gap < _retryConfig.backoffFor(entry.retryCount)) return;
+      }
+
+      await _dao.markStatus(
+        userPubkey: _userPubkey,
+        status: PendingProfileSaveStatus.syncing,
+      );
+
+      final outcome = await _profileRepository.drivePendingSave(_userPubkey);
+
+      switch (outcome) {
+        case PendingSaveDriveOutcome.confirmed:
+        case PendingSaveDriveOutcome.noPendingSave:
+          // Slot cleared by the repository (confirmed) or already gone.
+          break;
+        case PendingSaveDriveOutcome.permanentFailure:
+          await _dao.markStatus(
+            userPubkey: _userPubkey,
+            status: PendingProfileSaveStatus.failed,
+            lastError: 'Username claim failed permanently (taken/reserved)',
+          );
+        case PendingSaveDriveOutcome.retryableFailure:
+          if (entry.retryCount + 1 >= _retryConfig.maxRetries) {
+            await _dao.markStatus(
+              userPubkey: _userPubkey,
+              status: PendingProfileSaveStatus.failed,
+              lastError:
+                  'Could not publish after ${_retryConfig.maxRetries} attempts',
+            );
+          } else {
+            await _dao.incrementRetry(_userPubkey);
+            await _dao.markStatus(
+              userPubkey: _userPubkey,
+              status: PendingProfileSaveStatus.pending,
+            );
+          }
+      }
+    } on Object catch (e, stackTrace) {
+      Log.error(
+        'sweep failed: $e',
+        name: 'ProfileSaveRetryService',
+        category: LogCategory.system,
+        error: e,
+        stackTrace: stackTrace,
+      );
+      unawaited(
+        _crashReporting.recordError(
+          e,
+          stackTrace,
+          reason: _sweepTopLevelSite,
+        ),
+      );
+    } finally {
+      _isSweeping = false;
+    }
+  }
+}

--- a/mobile/lib/services/profile_save_retry_service.dart
+++ b/mobile/lib/services/profile_save_retry_service.dart
@@ -57,13 +57,19 @@ class ProfileSaveRetryConfig {
 /// Re-drives the single durable pending profile/username save for one account
 /// until a relay confirms the kind-0 publish, then the slot clears itself.
 ///
-/// **Triggers:** [appForegroundStream] transitions to `true`, and each event on
-/// [retryTriggerStream] (wired to connectivity/relay-reconnect). The provider
-/// seeds the foreground stream with the current state on subscription, so the
-/// cold-start sweep fires automatically.
+/// **Triggers:** [appForegroundStream] transitions to `true`, each event on
+/// [retryTriggerStream] (wired to connectivity/relay-reconnect), and a fresh
+/// enqueue observed on the durable slot (a new generation) — so a save stranded
+/// by a failed editor fast-path is re-driven without waiting for the next
+/// foreground/connectivity event. The provider seeds the foreground stream with
+/// the current state on subscription, so the cold-start sweep fires
+/// automatically.
 ///
-/// **Re-entrancy:** a sweep already in progress short-circuits the next
-/// trigger; the deferred work is picked up on the next transition.
+/// **Re-entrancy:** a trigger that arrives while a pass is in flight is
+/// coalesced into a single follow-up pass, not dropped. A newer generation that
+/// replaced an older, in-flight one is therefore always driven — the older
+/// pass's generation-guarded writes no-op against the newer row, then the loop
+/// re-reads and drives the current generation (latest intent wins).
 ///
 /// **Per-row backoff:** a slot whose `lastAttemptAt + backoff(retryCount)` is
 /// in the future is skipped this pass.
@@ -102,6 +108,13 @@ class ProfileSaveRetryService {
   StreamSubscription<bool>? _foregroundSubscription;
   StreamSubscription<void>? _retryTriggerSubscription;
 
+  /// Reactive view of the durable slot. Makes the sweep **level-triggered**: a
+  /// fresh enqueue (new [PendingProfileSaveEntry.generation]) wakes an
+  /// otherwise-idle service, so a save stranded by a failed editor fast-path is
+  /// re-driven without waiting for the *next* foreground/connectivity event
+  /// (#3161 review).
+  StreamSubscription<PendingProfileSaveEntry?>? _pendingSaveSubscription;
+
   /// Self-scheduled next attempt. A recovery signal (foreground/connectivity)
   /// can arrive before the relay pool has reconnected, so relying on that one
   /// signal would strand the save until the *next* signal. After every
@@ -112,6 +125,22 @@ class ProfileSaveRetryService {
 
   bool _isInitialized = false;
   bool _isSweeping = false;
+
+  /// A trigger (foreground/connectivity/enqueue/chain) arrived while a sweep was
+  /// in flight. Coalesced into a single follow-up pass drained by [sweep]'s loop
+  /// once the current pass finishes, so a mid-sweep enqueue is never dropped.
+  bool _sweepAgain = false;
+
+  /// Set before awaiting cancellation in [dispose] so a sweep resuming past an
+  /// `await` (or a queued timer callback) after teardown becomes a no-op — it
+  /// must not arm a new timer or mutate the (now account-detached) slot.
+  bool _disposed = false;
+
+  /// The last [PendingProfileSaveEntry.generation] the slot watcher reacted to.
+  /// De-dupes the watcher against the service's own status/retry writes (same
+  /// generation) and the initial priming emission, so only a genuinely new
+  /// enqueue wakes an idle service.
+  String? _lastWakeGeneration;
 
   bool get isInitialized => _isInitialized;
 
@@ -126,6 +155,14 @@ class ProfileSaveRetryService {
     // A slot left `syncing` by an app-kill mid-publish is reset to `pending`
     // so this session retries it.
     await _profileRepository.resetInterruptedPendingSave(_userPubkey);
+
+    // Prime the watcher with the current generation before subscribing so its
+    // initial emission (and the service's own later writes, which keep the same
+    // generation) don't spuriously wake the service — only a fresh enqueue with
+    // a new generation does. The cold-start sweep for whatever is already queued
+    // is driven by the foreground seed below, as before.
+    _lastWakeGeneration = (await _dao.get(_userPubkey))?.generation;
+    _pendingSaveSubscription = _dao.watch(_userPubkey).listen(_onSlotChanged);
 
     _foregroundSubscription = _appForegroundStream.listen((foreground) {
       if (foreground) unawaited(sweep());
@@ -147,7 +184,16 @@ class ProfileSaveRetryService {
 
   /// Cancel the trigger subscriptions and pending retry timer and mark the
   /// service un-init. Idempotent.
+  ///
+  /// [_disposed] is set **first**, before awaiting cancellation, so an
+  /// in-flight sweep resuming past an `await` (and any queued timer callback)
+  /// sees teardown and bails without arming a new timer or mutating the slot —
+  /// `cancel`/`_cancelRetryTimer` alone only stop work that exists at this
+  /// instant, not work a resuming sweep is about to schedule (#3161 review).
   Future<void> dispose() async {
+    _disposed = true;
+    await _pendingSaveSubscription?.cancel();
+    _pendingSaveSubscription = null;
     await _foregroundSubscription?.cancel();
     _foregroundSubscription = null;
     await _retryTriggerSubscription?.cancel();
@@ -161,8 +207,11 @@ class ProfileSaveRetryService {
   Future<void> retryNow() async {
     final entry = await _dao.get(_userPubkey);
     if (entry == null) return;
-    // Re-upsert resets retryCount → 0, status → pending, lastError → null.
-    await _dao.upsert(
+    // Re-upsert resets retryCount → 0, status → pending, lastError → null and
+    // mints a fresh generation. Record it as the last woken generation so the
+    // watcher doesn't fire a redundant backstop sweep for our own re-enqueue —
+    // the explicit sweep below already drives it.
+    _lastWakeGeneration = await _dao.upsert(
       PendingProfileSaveEntry(
         userPubkey: entry.userPubkey,
         payloadJson: entry.payloadJson,
@@ -173,109 +222,29 @@ class ProfileSaveRetryService {
     await sweep();
   }
 
-  /// One pass over the pending-save slot. Public so tests and the manual-retry
-  /// path can drive it directly.
+  /// Drive the pending-save slot to a resting point. Public so tests and the
+  /// manual-retry path can drive it directly.
+  ///
+  /// Runs [_runSweepOnce] in a loop that drains [_sweepAgain]: a trigger that
+  /// arrives while a pass is in flight (an enqueue, a completed older drive that
+  /// left a newer generation queued, a foreground/connectivity event) is
+  /// coalesced into one follow-up pass instead of being dropped — so a newer
+  /// generation that replaced an older, in-flight one is always driven, without
+  /// a second external signal (#3161 review).
   @visibleForTesting
   Future<void> sweep() async {
+    if (_disposed) return;
     if (_isSweeping) {
-      Log.debug(
-        'sweep already in progress, skipping',
-        name: 'ProfileSaveRetryService',
-        category: LogCategory.system,
-      );
+      _sweepAgain = true;
       return;
     }
     _isSweeping = true;
 
     try {
-      final entry = await _dao.get(_userPubkey);
-      if (entry == null) {
-        _cancelRetryTimer();
-        return;
-      }
-
-      // A failed slot awaits a manual retry — don't auto-retry it.
-      if (entry.status == PendingProfileSaveStatus.failed) {
-        _cancelRetryTimer();
-        return;
-      }
-
-      final generation = entry.generation;
-
-      // Per-row backoff. When a trigger arrives inside the backoff window, arm
-      // the timer for the remaining time rather than dropping the attempt.
-      final lastAttempt = entry.lastAttemptAt;
-      if (lastAttempt != null) {
-        final backoff = _retryConfig.backoffFor(entry.retryCount);
-        final gap = _now().difference(lastAttempt);
-        if (gap < backoff) {
-          _scheduleRetry(backoff - gap);
-          return;
-        }
-      }
-
-      // Claim the attempt for this generation. If a newer save replaced the
-      // row between the read above and here, this no-ops (false) and we bail —
-      // the newer row is pending and a fresh trigger/timer will drive it.
-      final claimed = await _dao.markStatus(
-        userPubkey: _userPubkey,
-        status: PendingProfileSaveStatus.syncing,
-        generation: generation,
-        attemptAt: _now(),
-      );
-      if (!claimed) return;
-
-      final outcome = await _profileRepository.drivePendingSave(
-        _userPubkey,
-        expectedGeneration: generation,
-      );
-
-      switch (outcome) {
-        case PendingSaveDriveOutcome.confirmed:
-        case PendingSaveDriveOutcome.noPendingSave:
-          // Slot cleared by the repository (confirmed) or already gone /
-          // superseded — nothing more to schedule.
-          _cancelRetryTimer();
-        case PendingSaveDriveOutcome.permanentFailure:
-          await _dao.markStatus(
-            userPubkey: _userPubkey,
-            status: PendingProfileSaveStatus.failed,
-            lastError: 'Username claim failed permanently (taken/reserved)',
-            generation: generation,
-            attemptAt: _now(),
-          );
-          _cancelRetryTimer();
-        case PendingSaveDriveOutcome.retryableFailure:
-          if (entry.retryCount + 1 >= _retryConfig.maxRetries) {
-            await _dao.markStatus(
-              userPubkey: _userPubkey,
-              status: PendingProfileSaveStatus.failed,
-              lastError:
-                  'Could not publish after ${_retryConfig.maxRetries} attempts',
-              generation: generation,
-              attemptAt: _now(),
-            );
-            _cancelRetryTimer();
-          } else {
-            await _dao.incrementRetry(
-              _userPubkey,
-              generation: generation,
-              attemptAt: _now(),
-            );
-            final reverted = await _dao.markStatus(
-              userPubkey: _userPubkey,
-              status: PendingProfileSaveStatus.pending,
-              generation: generation,
-              attemptAt: _now(),
-            );
-            // Arm the next attempt so one recovery signal eventually publishes
-            // even if the relay pool wasn't ready this pass. Only when the row
-            // is still ours — a newer save that slipped in owns its scheduling.
-            if (reverted) {
-              _scheduleRetry(_retryConfig.backoffFor(entry.retryCount + 1));
-            }
-          }
-      }
+      do {
+        _sweepAgain = false;
+        await _runSweepOnce();
+      } while (!_disposed && _sweepAgain);
     } on Object catch (e, stackTrace) {
       Log.error(
         'sweep failed: $e',
@@ -296,16 +265,169 @@ class ProfileSaveRetryService {
     }
   }
 
+  /// One pass over the pending-save slot. Bails at every async boundary when
+  /// the service was disposed mid-pass, so a resuming sweep can't arm a timer
+  /// or mutate the (account-detached) slot after teardown.
+  Future<void> _runSweepOnce() async {
+    final entry = await _dao.get(_userPubkey);
+    if (_disposed) return;
+    if (entry == null) {
+      _cancelRetryTimer();
+      return;
+    }
+
+    // A failed slot awaits a manual retry — don't auto-retry it.
+    if (entry.status == PendingProfileSaveStatus.failed) {
+      _cancelRetryTimer();
+      return;
+    }
+
+    final generation = entry.generation;
+
+    // Per-row backoff. When a trigger arrives inside the backoff window, arm
+    // the timer for the remaining time rather than dropping the attempt.
+    final lastAttempt = entry.lastAttemptAt;
+    if (lastAttempt != null) {
+      final backoff = _retryConfig.backoffFor(entry.retryCount);
+      final gap = _now().difference(lastAttempt);
+      if (gap < backoff) {
+        _scheduleRetry(backoff - gap);
+        return;
+      }
+    }
+
+    // Claim the attempt for this generation. If a newer save replaced the row
+    // between the read above and here, this no-ops (false) — re-read and drive
+    // whatever is queued now (latest intent wins) on the next loop pass.
+    final claimed = await _dao.markStatus(
+      userPubkey: _userPubkey,
+      status: PendingProfileSaveStatus.syncing,
+      generation: generation,
+      attemptAt: _now(),
+    );
+    if (_disposed) return;
+    if (!claimed) {
+      await _chainIfNewerGeneration(generation);
+      return;
+    }
+
+    final outcome = await _profileRepository.drivePendingSave(
+      _userPubkey,
+      expectedGeneration: generation,
+    );
+    if (_disposed) return;
+
+    switch (outcome) {
+      case PendingSaveDriveOutcome.confirmed:
+      case PendingSaveDriveOutcome.noPendingSave:
+        // Our generation is done: cleared by the repository (confirmed) or
+        // already gone / superseded (noPendingSave). If a newer generation
+        // slipped in and our generation-guarded clear no-op'd against it,
+        // _chainIfNewerGeneration drives that one next pass.
+        _cancelRetryTimer();
+      case PendingSaveDriveOutcome.permanentFailure:
+        await _dao.markStatus(
+          userPubkey: _userPubkey,
+          status: PendingProfileSaveStatus.failed,
+          lastError: 'Username claim failed permanently (taken/reserved)',
+          generation: generation,
+          attemptAt: _now(),
+        );
+        if (_disposed) return;
+        _cancelRetryTimer();
+      case PendingSaveDriveOutcome.retryableFailure:
+        if (entry.retryCount + 1 >= _retryConfig.maxRetries) {
+          await _dao.markStatus(
+            userPubkey: _userPubkey,
+            status: PendingProfileSaveStatus.failed,
+            lastError:
+                'Could not publish after ${_retryConfig.maxRetries} attempts',
+            generation: generation,
+            attemptAt: _now(),
+          );
+          if (_disposed) return;
+          _cancelRetryTimer();
+        } else {
+          await _dao.incrementRetry(
+            _userPubkey,
+            generation: generation,
+            attemptAt: _now(),
+          );
+          if (_disposed) return;
+          final reverted = await _dao.markStatus(
+            userPubkey: _userPubkey,
+            status: PendingProfileSaveStatus.pending,
+            generation: generation,
+            attemptAt: _now(),
+          );
+          if (_disposed) return;
+          // Arm the next attempt so one recovery signal eventually publishes
+          // even if the relay pool wasn't ready this pass. Only when the row
+          // is still ours — a newer save that slipped in owns its scheduling.
+          if (reverted) {
+            _scheduleRetry(_retryConfig.backoffFor(entry.retryCount + 1));
+          }
+        }
+    }
+
+    await _chainIfNewerGeneration(generation);
+  }
+
+  /// Request a follow-up pass when the slot now holds a **different**
+  /// generation than [drivenGeneration] — a newer save landed (or replaced an
+  /// older, in-flight one) while we were working, so the older pass's writes
+  /// no-op'd against it and it would otherwise sit un-driven. A cleared/empty
+  /// slot, a failed slot, or the same generation needs no follow-up, which is
+  /// what keeps this from looping.
+  Future<void> _chainIfNewerGeneration(String drivenGeneration) async {
+    if (_disposed) return;
+    final current = await _dao.get(_userPubkey);
+    if (_disposed) return;
+    if (current != null &&
+        current.status != PendingProfileSaveStatus.failed &&
+        current.generation != drivenGeneration) {
+      _sweepAgain = true;
+    }
+  }
+
+  /// Slot-watcher callback: wake an idle service when a genuinely new save is
+  /// enqueued (a new generation), so a save stranded by a failed editor
+  /// fast-path drive is re-driven without waiting for the next
+  /// foreground/connectivity event. The service's own status/retry writes keep
+  /// the same generation and the priming emission matches [_lastWakeGeneration],
+  /// so neither re-wakes it.
+  void _onSlotChanged(PendingProfileSaveEntry? entry) {
+    if (_disposed) return;
+    final generation = entry?.generation;
+    if (generation == _lastWakeGeneration) return;
+    _lastWakeGeneration = generation;
+    if (entry == null || entry.status == PendingProfileSaveStatus.failed) {
+      return;
+    }
+    // A pass in flight will pick this generation up via its coalesced loop; an
+    // idle service arms a short backstop sweep. The delay lets the enqueuer's
+    // own immediate publish attempt (the editor fast-path) confirm and clear
+    // the slot first in the common online case, so the backstop finds nothing
+    // to do — it only re-drives a save the fast-path failed to land.
+    if (_isSweeping) {
+      _sweepAgain = true;
+      return;
+    }
+    _scheduleRetry(_retryConfig.initialDelay);
+  }
+
   /// Arm (replacing any pending) the self-scheduled next attempt for [delay].
-  /// A negative delay is clamped to zero. The timer fires a fresh [sweep];
-  /// because it is armed from inside a sweep (before the `finally` clears
-  /// [_isSweeping]) and never with a same-tick delay that could beat that
-  /// `finally`, the scheduled sweep always finds the re-entrancy guard clear.
+  /// A negative delay is clamped to zero. The timer fires a fresh [sweep]; if
+  /// one happens to be in progress when it fires (or it was armed from the
+  /// enqueue watcher while idle), [sweep]'s own re-entrancy guard coalesces it
+  /// into a follow-up pass. No-ops after [dispose].
   void _scheduleRetry(Duration delay) {
+    if (_disposed) return;
     _retryTimer?.cancel();
     final clamped = delay.isNegative ? Duration.zero : delay;
     _retryTimer = Timer(clamped, () {
       _retryTimer = null;
+      if (_disposed) return;
       unawaited(sweep());
     });
   }

--- a/mobile/packages/db_client/lib/src/database/app_database.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.dart
@@ -541,7 +541,8 @@ class AppDatabase extends _$AppDatabase {
           retry_count INTEGER NOT NULL DEFAULT 0,
           last_attempt_at INTEGER,
           queued_at INTEGER NOT NULL,
-          last_error TEXT
+          last_error TEXT,
+          generation TEXT NOT NULL DEFAULT ''
         )
       ''');
     }

--- a/mobile/packages/db_client/lib/src/database/app_database.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.dart
@@ -38,6 +38,7 @@ const _notificationRetentionDays = 7;
     PendingProductEvents,
     PendingGiftWraps,
     ProcessedGiftWraps,
+    PendingProfileSaves,
   ],
   daos: [
     UserProfilesDao,
@@ -61,6 +62,7 @@ const _notificationRetentionDays = 7;
     PendingProductEventsDao,
     PendingGiftWrapsDao,
     ProcessedGiftWrapsDao,
+    PendingProfileSavesDao,
   ],
 )
 class AppDatabase extends _$AppDatabase {
@@ -516,6 +518,33 @@ class AppDatabase extends _$AppDatabase {
       CREATE INDEX IF NOT EXISTS idx_outgoing_dms_queued_at
       ON outgoing_dms (queued_at)
     ''');
+
+    // Check if pending_profile_saves table exists, create if missing.
+    // Added for #3161 (durable profile/username save + background re-drive).
+    // Schema version stays at 1 — same runtime CREATE-IF-NOT-EXISTS pattern as
+    // outgoing_dms above. Column order/types/defaults must match Drift's
+    // `m.createAll()` output (pinned by the pending_profile_saves schema-parity
+    // test in app_database_test.dart): bool → INTEGER DEFAULT 0 with a
+    // CHECK (x IN (0,1)); DateTime columns → INTEGER (seconds codec).
+    final pendingProfileSavesResult = await customSelect(
+      "SELECT name FROM sqlite_master WHERE type='table' "
+      "AND name='pending_profile_saves'",
+    ).get();
+
+    if (pendingProfileSavesResult.isEmpty) {
+      await customStatement('''
+        CREATE TABLE pending_profile_saves (
+          user_pubkey TEXT NOT NULL PRIMARY KEY,
+          payload_json TEXT NOT NULL,
+          claim_confirmed INTEGER NOT NULL DEFAULT 0 CHECK ("claim_confirmed" IN (0, 1)),
+          status TEXT NOT NULL DEFAULT 'pending',
+          retry_count INTEGER NOT NULL DEFAULT 0,
+          last_attempt_at INTEGER,
+          queued_at INTEGER NOT NULL,
+          last_error TEXT
+        )
+      ''');
+    }
 
     // Check if dm_message_reactions table exists, create if missing.
     // Added for #4633 (DM emoji reactions). Schema version stays at 1 —

--- a/mobile/packages/db_client/lib/src/database/app_database.g.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.g.dart
@@ -14653,6 +14653,18 @@ class $PendingProfileSavesTable extends PendingProfileSaves
     type: DriftSqlType.string,
     requiredDuringInsert: false,
   );
+  static const VerificationMeta _generationMeta = const VerificationMeta(
+    'generation',
+  );
+  @override
+  late final GeneratedColumn<String> generation = GeneratedColumn<String>(
+    'generation',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    defaultValue: const Constant(''),
+  );
   @override
   List<GeneratedColumn> get $columns => [
     userPubkey,
@@ -14663,6 +14675,7 @@ class $PendingProfileSavesTable extends PendingProfileSaves
     lastAttemptAt,
     queuedAt,
     lastError,
+    generation,
   ];
   @override
   String get aliasedName => _alias ?? actualTableName;
@@ -14739,6 +14752,12 @@ class $PendingProfileSavesTable extends PendingProfileSaves
         lastError.isAcceptableOrUnknown(data['last_error']!, _lastErrorMeta),
       );
     }
+    if (data.containsKey('generation')) {
+      context.handle(
+        _generationMeta,
+        generation.isAcceptableOrUnknown(data['generation']!, _generationMeta),
+      );
+    }
     return context;
   }
 
@@ -14780,6 +14799,10 @@ class $PendingProfileSavesTable extends PendingProfileSaves
         DriftSqlType.string,
         data['${effectivePrefix}last_error'],
       ),
+      generation: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}generation'],
+      )!,
     );
   }
 
@@ -14823,6 +14846,14 @@ class PendingProfileSaveRow extends DataClass
   /// Last publish error message, for diagnostics. Null when the most recent
   /// transition was not a failure.
   final String? lastError;
+
+  /// Immutable per-enqueue token stamped fresh on every `upsert` (a new save
+  /// or a manual retry). A background re-drive captures it at read time and
+  /// guards every mutation with it, so a newer save that replaces this row
+  /// while an older drive is awaiting relay work is never cleared or
+  /// reclassified by that stale drive — latest intent wins (#3161 review).
+  /// Empty string only on legacy rows written before this column existed.
+  final String generation;
   const PendingProfileSaveRow({
     required this.userPubkey,
     required this.payloadJson,
@@ -14832,6 +14863,7 @@ class PendingProfileSaveRow extends DataClass
     this.lastAttemptAt,
     required this.queuedAt,
     this.lastError,
+    required this.generation,
   });
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
@@ -14848,6 +14880,7 @@ class PendingProfileSaveRow extends DataClass
     if (!nullToAbsent || lastError != null) {
       map['last_error'] = Variable<String>(lastError);
     }
+    map['generation'] = Variable<String>(generation);
     return map;
   }
 
@@ -14865,6 +14898,7 @@ class PendingProfileSaveRow extends DataClass
       lastError: lastError == null && nullToAbsent
           ? const Value.absent()
           : Value(lastError),
+      generation: Value(generation),
     );
   }
 
@@ -14882,6 +14916,7 @@ class PendingProfileSaveRow extends DataClass
       lastAttemptAt: serializer.fromJson<DateTime?>(json['lastAttemptAt']),
       queuedAt: serializer.fromJson<DateTime>(json['queuedAt']),
       lastError: serializer.fromJson<String?>(json['lastError']),
+      generation: serializer.fromJson<String>(json['generation']),
     );
   }
   @override
@@ -14896,6 +14931,7 @@ class PendingProfileSaveRow extends DataClass
       'lastAttemptAt': serializer.toJson<DateTime?>(lastAttemptAt),
       'queuedAt': serializer.toJson<DateTime>(queuedAt),
       'lastError': serializer.toJson<String?>(lastError),
+      'generation': serializer.toJson<String>(generation),
     };
   }
 
@@ -14908,6 +14944,7 @@ class PendingProfileSaveRow extends DataClass
     Value<DateTime?> lastAttemptAt = const Value.absent(),
     DateTime? queuedAt,
     Value<String?> lastError = const Value.absent(),
+    String? generation,
   }) => PendingProfileSaveRow(
     userPubkey: userPubkey ?? this.userPubkey,
     payloadJson: payloadJson ?? this.payloadJson,
@@ -14919,6 +14956,7 @@ class PendingProfileSaveRow extends DataClass
         : this.lastAttemptAt,
     queuedAt: queuedAt ?? this.queuedAt,
     lastError: lastError.present ? lastError.value : this.lastError,
+    generation: generation ?? this.generation,
   );
   PendingProfileSaveRow copyWithCompanion(PendingProfileSavesCompanion data) {
     return PendingProfileSaveRow(
@@ -14940,6 +14978,9 @@ class PendingProfileSaveRow extends DataClass
           : this.lastAttemptAt,
       queuedAt: data.queuedAt.present ? data.queuedAt.value : this.queuedAt,
       lastError: data.lastError.present ? data.lastError.value : this.lastError,
+      generation: data.generation.present
+          ? data.generation.value
+          : this.generation,
     );
   }
 
@@ -14953,7 +14994,8 @@ class PendingProfileSaveRow extends DataClass
           ..write('retryCount: $retryCount, ')
           ..write('lastAttemptAt: $lastAttemptAt, ')
           ..write('queuedAt: $queuedAt, ')
-          ..write('lastError: $lastError')
+          ..write('lastError: $lastError, ')
+          ..write('generation: $generation')
           ..write(')'))
         .toString();
   }
@@ -14968,6 +15010,7 @@ class PendingProfileSaveRow extends DataClass
     lastAttemptAt,
     queuedAt,
     lastError,
+    generation,
   );
   @override
   bool operator ==(Object other) =>
@@ -14980,7 +15023,8 @@ class PendingProfileSaveRow extends DataClass
           other.retryCount == this.retryCount &&
           other.lastAttemptAt == this.lastAttemptAt &&
           other.queuedAt == this.queuedAt &&
-          other.lastError == this.lastError);
+          other.lastError == this.lastError &&
+          other.generation == this.generation);
 }
 
 class PendingProfileSavesCompanion
@@ -14993,6 +15037,7 @@ class PendingProfileSavesCompanion
   final Value<DateTime?> lastAttemptAt;
   final Value<DateTime> queuedAt;
   final Value<String?> lastError;
+  final Value<String> generation;
   final Value<int> rowid;
   const PendingProfileSavesCompanion({
     this.userPubkey = const Value.absent(),
@@ -15003,6 +15048,7 @@ class PendingProfileSavesCompanion
     this.lastAttemptAt = const Value.absent(),
     this.queuedAt = const Value.absent(),
     this.lastError = const Value.absent(),
+    this.generation = const Value.absent(),
     this.rowid = const Value.absent(),
   });
   PendingProfileSavesCompanion.insert({
@@ -15014,6 +15060,7 @@ class PendingProfileSavesCompanion
     this.lastAttemptAt = const Value.absent(),
     required DateTime queuedAt,
     this.lastError = const Value.absent(),
+    this.generation = const Value.absent(),
     this.rowid = const Value.absent(),
   }) : userPubkey = Value(userPubkey),
        payloadJson = Value(payloadJson),
@@ -15027,6 +15074,7 @@ class PendingProfileSavesCompanion
     Expression<DateTime>? lastAttemptAt,
     Expression<DateTime>? queuedAt,
     Expression<String>? lastError,
+    Expression<String>? generation,
     Expression<int>? rowid,
   }) {
     return RawValuesInsertable({
@@ -15038,6 +15086,7 @@ class PendingProfileSavesCompanion
       if (lastAttemptAt != null) 'last_attempt_at': lastAttemptAt,
       if (queuedAt != null) 'queued_at': queuedAt,
       if (lastError != null) 'last_error': lastError,
+      if (generation != null) 'generation': generation,
       if (rowid != null) 'rowid': rowid,
     });
   }
@@ -15051,6 +15100,7 @@ class PendingProfileSavesCompanion
     Value<DateTime?>? lastAttemptAt,
     Value<DateTime>? queuedAt,
     Value<String?>? lastError,
+    Value<String>? generation,
     Value<int>? rowid,
   }) {
     return PendingProfileSavesCompanion(
@@ -15062,6 +15112,7 @@ class PendingProfileSavesCompanion
       lastAttemptAt: lastAttemptAt ?? this.lastAttemptAt,
       queuedAt: queuedAt ?? this.queuedAt,
       lastError: lastError ?? this.lastError,
+      generation: generation ?? this.generation,
       rowid: rowid ?? this.rowid,
     );
   }
@@ -15093,6 +15144,9 @@ class PendingProfileSavesCompanion
     if (lastError.present) {
       map['last_error'] = Variable<String>(lastError.value);
     }
+    if (generation.present) {
+      map['generation'] = Variable<String>(generation.value);
+    }
     if (rowid.present) {
       map['rowid'] = Variable<int>(rowid.value);
     }
@@ -15110,6 +15164,7 @@ class PendingProfileSavesCompanion
           ..write('lastAttemptAt: $lastAttemptAt, ')
           ..write('queuedAt: $queuedAt, ')
           ..write('lastError: $lastError, ')
+          ..write('generation: $generation, ')
           ..write('rowid: $rowid')
           ..write(')'))
         .toString();
@@ -22068,6 +22123,7 @@ typedef $$PendingProfileSavesTableCreateCompanionBuilder =
       Value<DateTime?> lastAttemptAt,
       required DateTime queuedAt,
       Value<String?> lastError,
+      Value<String> generation,
       Value<int> rowid,
     });
 typedef $$PendingProfileSavesTableUpdateCompanionBuilder =
@@ -22080,6 +22136,7 @@ typedef $$PendingProfileSavesTableUpdateCompanionBuilder =
       Value<DateTime?> lastAttemptAt,
       Value<DateTime> queuedAt,
       Value<String?> lastError,
+      Value<String> generation,
       Value<int> rowid,
     });
 
@@ -22129,6 +22186,11 @@ class $$PendingProfileSavesTableFilterComposer
 
   ColumnFilters<String> get lastError => $composableBuilder(
     column: $table.lastError,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get generation => $composableBuilder(
+    column: $table.generation,
     builder: (column) => ColumnFilters(column),
   );
 }
@@ -22181,6 +22243,11 @@ class $$PendingProfileSavesTableOrderingComposer
     column: $table.lastError,
     builder: (column) => ColumnOrderings(column),
   );
+
+  ColumnOrderings<String> get generation => $composableBuilder(
+    column: $table.generation,
+    builder: (column) => ColumnOrderings(column),
+  );
 }
 
 class $$PendingProfileSavesTableAnnotationComposer
@@ -22225,6 +22292,11 @@ class $$PendingProfileSavesTableAnnotationComposer
 
   GeneratedColumn<String> get lastError =>
       $composableBuilder(column: $table.lastError, builder: (column) => column);
+
+  GeneratedColumn<String> get generation => $composableBuilder(
+    column: $table.generation,
+    builder: (column) => column,
+  );
 }
 
 class $$PendingProfileSavesTableTableManager
@@ -22278,6 +22350,7 @@ class $$PendingProfileSavesTableTableManager
                 Value<DateTime?> lastAttemptAt = const Value.absent(),
                 Value<DateTime> queuedAt = const Value.absent(),
                 Value<String?> lastError = const Value.absent(),
+                Value<String> generation = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => PendingProfileSavesCompanion(
                 userPubkey: userPubkey,
@@ -22288,6 +22361,7 @@ class $$PendingProfileSavesTableTableManager
                 lastAttemptAt: lastAttemptAt,
                 queuedAt: queuedAt,
                 lastError: lastError,
+                generation: generation,
                 rowid: rowid,
               ),
           createCompanionCallback:
@@ -22300,6 +22374,7 @@ class $$PendingProfileSavesTableTableManager
                 Value<DateTime?> lastAttemptAt = const Value.absent(),
                 required DateTime queuedAt,
                 Value<String?> lastError = const Value.absent(),
+                Value<String> generation = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => PendingProfileSavesCompanion.insert(
                 userPubkey: userPubkey,
@@ -22310,6 +22385,7 @@ class $$PendingProfileSavesTableTableManager
                 lastAttemptAt: lastAttemptAt,
                 queuedAt: queuedAt,
                 lastError: lastError,
+                generation: generation,
                 rowid: rowid,
               ),
           withReferenceMapper: (p0) => p0

--- a/mobile/packages/db_client/lib/src/database/app_database.g.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.g.dart
@@ -9952,7 +9952,9 @@ class DmReactionRow extends DataClass implements Insertable<DmReactionRow> {
   final String? rumorEventJson;
 
   /// Publish status for outgoing rows; null for incoming (received from
-  /// relay). Values: `pending`, `sent`, `failed`.
+  /// relay). Values: `pending`, `sent`, `failed`, `blocked` (send-policy
+  /// refused, terminal), `deletion_pending` (soft-deleted, kind-5 awaiting
+  /// durable delivery), `deletion_sent` (kind-5 confirmed, terminal).
   final String? publishStatus;
   const DmReactionRow({
     required this.id,
@@ -14552,6 +14554,568 @@ class ProcessedGiftWrapsCompanion extends UpdateCompanion<ProcessedGiftWrap> {
   }
 }
 
+class $PendingProfileSavesTable extends PendingProfileSaves
+    with TableInfo<$PendingProfileSavesTable, PendingProfileSaveRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $PendingProfileSavesTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _userPubkeyMeta = const VerificationMeta(
+    'userPubkey',
+  );
+  @override
+  late final GeneratedColumn<String> userPubkey = GeneratedColumn<String>(
+    'user_pubkey',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _payloadJsonMeta = const VerificationMeta(
+    'payloadJson',
+  );
+  @override
+  late final GeneratedColumn<String> payloadJson = GeneratedColumn<String>(
+    'payload_json',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _claimConfirmedMeta = const VerificationMeta(
+    'claimConfirmed',
+  );
+  @override
+  late final GeneratedColumn<bool> claimConfirmed = GeneratedColumn<bool>(
+    'claim_confirmed',
+    aliasedName,
+    false,
+    type: DriftSqlType.bool,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'CHECK ("claim_confirmed" IN (0, 1))',
+    ),
+    defaultValue: const Constant(false),
+  );
+  static const VerificationMeta _statusMeta = const VerificationMeta('status');
+  @override
+  late final GeneratedColumn<String> status = GeneratedColumn<String>(
+    'status',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    defaultValue: const Constant('pending'),
+  );
+  static const VerificationMeta _retryCountMeta = const VerificationMeta(
+    'retryCount',
+  );
+  @override
+  late final GeneratedColumn<int> retryCount = GeneratedColumn<int>(
+    'retry_count',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultValue: const Constant(0),
+  );
+  static const VerificationMeta _lastAttemptAtMeta = const VerificationMeta(
+    'lastAttemptAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> lastAttemptAt =
+      GeneratedColumn<DateTime>(
+        'last_attempt_at',
+        aliasedName,
+        true,
+        type: DriftSqlType.dateTime,
+        requiredDuringInsert: false,
+      );
+  static const VerificationMeta _queuedAtMeta = const VerificationMeta(
+    'queuedAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> queuedAt = GeneratedColumn<DateTime>(
+    'queued_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _lastErrorMeta = const VerificationMeta(
+    'lastError',
+  );
+  @override
+  late final GeneratedColumn<String> lastError = GeneratedColumn<String>(
+    'last_error',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    userPubkey,
+    payloadJson,
+    claimConfirmed,
+    status,
+    retryCount,
+    lastAttemptAt,
+    queuedAt,
+    lastError,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'pending_profile_saves';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<PendingProfileSaveRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('user_pubkey')) {
+      context.handle(
+        _userPubkeyMeta,
+        userPubkey.isAcceptableOrUnknown(data['user_pubkey']!, _userPubkeyMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_userPubkeyMeta);
+    }
+    if (data.containsKey('payload_json')) {
+      context.handle(
+        _payloadJsonMeta,
+        payloadJson.isAcceptableOrUnknown(
+          data['payload_json']!,
+          _payloadJsonMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_payloadJsonMeta);
+    }
+    if (data.containsKey('claim_confirmed')) {
+      context.handle(
+        _claimConfirmedMeta,
+        claimConfirmed.isAcceptableOrUnknown(
+          data['claim_confirmed']!,
+          _claimConfirmedMeta,
+        ),
+      );
+    }
+    if (data.containsKey('status')) {
+      context.handle(
+        _statusMeta,
+        status.isAcceptableOrUnknown(data['status']!, _statusMeta),
+      );
+    }
+    if (data.containsKey('retry_count')) {
+      context.handle(
+        _retryCountMeta,
+        retryCount.isAcceptableOrUnknown(data['retry_count']!, _retryCountMeta),
+      );
+    }
+    if (data.containsKey('last_attempt_at')) {
+      context.handle(
+        _lastAttemptAtMeta,
+        lastAttemptAt.isAcceptableOrUnknown(
+          data['last_attempt_at']!,
+          _lastAttemptAtMeta,
+        ),
+      );
+    }
+    if (data.containsKey('queued_at')) {
+      context.handle(
+        _queuedAtMeta,
+        queuedAt.isAcceptableOrUnknown(data['queued_at']!, _queuedAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_queuedAtMeta);
+    }
+    if (data.containsKey('last_error')) {
+      context.handle(
+        _lastErrorMeta,
+        lastError.isAcceptableOrUnknown(data['last_error']!, _lastErrorMeta),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {userPubkey};
+  @override
+  PendingProfileSaveRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return PendingProfileSaveRow(
+      userPubkey: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}user_pubkey'],
+      )!,
+      payloadJson: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}payload_json'],
+      )!,
+      claimConfirmed: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}claim_confirmed'],
+      )!,
+      status: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}status'],
+      )!,
+      retryCount: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}retry_count'],
+      )!,
+      lastAttemptAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}last_attempt_at'],
+      ),
+      queuedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}queued_at'],
+      )!,
+      lastError: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}last_error'],
+      ),
+    );
+  }
+
+  @override
+  $PendingProfileSavesTable createAlias(String alias) {
+    return $PendingProfileSavesTable(attachedDatabase, alias);
+  }
+}
+
+class PendingProfileSaveRow extends DataClass
+    implements Insertable<PendingProfileSaveRow> {
+  /// Owner hex pubkey. Primary key → exactly one pending save per account.
+  final String userPubkey;
+
+  /// Serialized `PendingProfileSave` payload (every `saveProfileEvent` field
+  /// the user submitted). Authoritative source for the re-drive.
+  final String payloadJson;
+
+  /// Whether the divine.video username claim already returned 200 for this
+  /// payload, so re-drives skip the (idempotent) HTTP claim round-trip.
+  /// Always `true` for saves with no divine.video username to claim
+  /// (external NIP-05, or no NIP-05 change).
+  final bool claimConfirmed;
+
+  /// `pending` | `syncing` | `failed`. Stored as a string for readable
+  /// dumps; the DAO throws on an unrecognised value rather than coercing it
+  /// back to `pending`.
+  final String status;
+
+  /// Publish attempts survived. Backoff caps growth at the policy max; once
+  /// exhausted the row moves to `failed` and the UI surfaces a retry.
+  final int retryCount;
+
+  /// Wall-clock timestamp of the most recent publish attempt. Drives the
+  /// retry service's backoff scheduling. Null until the first attempt.
+  final DateTime? lastAttemptAt;
+
+  /// Wall-clock timestamp the row was queued.
+  final DateTime queuedAt;
+
+  /// Last publish error message, for diagnostics. Null when the most recent
+  /// transition was not a failure.
+  final String? lastError;
+  const PendingProfileSaveRow({
+    required this.userPubkey,
+    required this.payloadJson,
+    required this.claimConfirmed,
+    required this.status,
+    required this.retryCount,
+    this.lastAttemptAt,
+    required this.queuedAt,
+    this.lastError,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['user_pubkey'] = Variable<String>(userPubkey);
+    map['payload_json'] = Variable<String>(payloadJson);
+    map['claim_confirmed'] = Variable<bool>(claimConfirmed);
+    map['status'] = Variable<String>(status);
+    map['retry_count'] = Variable<int>(retryCount);
+    if (!nullToAbsent || lastAttemptAt != null) {
+      map['last_attempt_at'] = Variable<DateTime>(lastAttemptAt);
+    }
+    map['queued_at'] = Variable<DateTime>(queuedAt);
+    if (!nullToAbsent || lastError != null) {
+      map['last_error'] = Variable<String>(lastError);
+    }
+    return map;
+  }
+
+  PendingProfileSavesCompanion toCompanion(bool nullToAbsent) {
+    return PendingProfileSavesCompanion(
+      userPubkey: Value(userPubkey),
+      payloadJson: Value(payloadJson),
+      claimConfirmed: Value(claimConfirmed),
+      status: Value(status),
+      retryCount: Value(retryCount),
+      lastAttemptAt: lastAttemptAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(lastAttemptAt),
+      queuedAt: Value(queuedAt),
+      lastError: lastError == null && nullToAbsent
+          ? const Value.absent()
+          : Value(lastError),
+    );
+  }
+
+  factory PendingProfileSaveRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return PendingProfileSaveRow(
+      userPubkey: serializer.fromJson<String>(json['userPubkey']),
+      payloadJson: serializer.fromJson<String>(json['payloadJson']),
+      claimConfirmed: serializer.fromJson<bool>(json['claimConfirmed']),
+      status: serializer.fromJson<String>(json['status']),
+      retryCount: serializer.fromJson<int>(json['retryCount']),
+      lastAttemptAt: serializer.fromJson<DateTime?>(json['lastAttemptAt']),
+      queuedAt: serializer.fromJson<DateTime>(json['queuedAt']),
+      lastError: serializer.fromJson<String?>(json['lastError']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'userPubkey': serializer.toJson<String>(userPubkey),
+      'payloadJson': serializer.toJson<String>(payloadJson),
+      'claimConfirmed': serializer.toJson<bool>(claimConfirmed),
+      'status': serializer.toJson<String>(status),
+      'retryCount': serializer.toJson<int>(retryCount),
+      'lastAttemptAt': serializer.toJson<DateTime?>(lastAttemptAt),
+      'queuedAt': serializer.toJson<DateTime>(queuedAt),
+      'lastError': serializer.toJson<String?>(lastError),
+    };
+  }
+
+  PendingProfileSaveRow copyWith({
+    String? userPubkey,
+    String? payloadJson,
+    bool? claimConfirmed,
+    String? status,
+    int? retryCount,
+    Value<DateTime?> lastAttemptAt = const Value.absent(),
+    DateTime? queuedAt,
+    Value<String?> lastError = const Value.absent(),
+  }) => PendingProfileSaveRow(
+    userPubkey: userPubkey ?? this.userPubkey,
+    payloadJson: payloadJson ?? this.payloadJson,
+    claimConfirmed: claimConfirmed ?? this.claimConfirmed,
+    status: status ?? this.status,
+    retryCount: retryCount ?? this.retryCount,
+    lastAttemptAt: lastAttemptAt.present
+        ? lastAttemptAt.value
+        : this.lastAttemptAt,
+    queuedAt: queuedAt ?? this.queuedAt,
+    lastError: lastError.present ? lastError.value : this.lastError,
+  );
+  PendingProfileSaveRow copyWithCompanion(PendingProfileSavesCompanion data) {
+    return PendingProfileSaveRow(
+      userPubkey: data.userPubkey.present
+          ? data.userPubkey.value
+          : this.userPubkey,
+      payloadJson: data.payloadJson.present
+          ? data.payloadJson.value
+          : this.payloadJson,
+      claimConfirmed: data.claimConfirmed.present
+          ? data.claimConfirmed.value
+          : this.claimConfirmed,
+      status: data.status.present ? data.status.value : this.status,
+      retryCount: data.retryCount.present
+          ? data.retryCount.value
+          : this.retryCount,
+      lastAttemptAt: data.lastAttemptAt.present
+          ? data.lastAttemptAt.value
+          : this.lastAttemptAt,
+      queuedAt: data.queuedAt.present ? data.queuedAt.value : this.queuedAt,
+      lastError: data.lastError.present ? data.lastError.value : this.lastError,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('PendingProfileSaveRow(')
+          ..write('userPubkey: $userPubkey, ')
+          ..write('payloadJson: $payloadJson, ')
+          ..write('claimConfirmed: $claimConfirmed, ')
+          ..write('status: $status, ')
+          ..write('retryCount: $retryCount, ')
+          ..write('lastAttemptAt: $lastAttemptAt, ')
+          ..write('queuedAt: $queuedAt, ')
+          ..write('lastError: $lastError')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    userPubkey,
+    payloadJson,
+    claimConfirmed,
+    status,
+    retryCount,
+    lastAttemptAt,
+    queuedAt,
+    lastError,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is PendingProfileSaveRow &&
+          other.userPubkey == this.userPubkey &&
+          other.payloadJson == this.payloadJson &&
+          other.claimConfirmed == this.claimConfirmed &&
+          other.status == this.status &&
+          other.retryCount == this.retryCount &&
+          other.lastAttemptAt == this.lastAttemptAt &&
+          other.queuedAt == this.queuedAt &&
+          other.lastError == this.lastError);
+}
+
+class PendingProfileSavesCompanion
+    extends UpdateCompanion<PendingProfileSaveRow> {
+  final Value<String> userPubkey;
+  final Value<String> payloadJson;
+  final Value<bool> claimConfirmed;
+  final Value<String> status;
+  final Value<int> retryCount;
+  final Value<DateTime?> lastAttemptAt;
+  final Value<DateTime> queuedAt;
+  final Value<String?> lastError;
+  final Value<int> rowid;
+  const PendingProfileSavesCompanion({
+    this.userPubkey = const Value.absent(),
+    this.payloadJson = const Value.absent(),
+    this.claimConfirmed = const Value.absent(),
+    this.status = const Value.absent(),
+    this.retryCount = const Value.absent(),
+    this.lastAttemptAt = const Value.absent(),
+    this.queuedAt = const Value.absent(),
+    this.lastError = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  PendingProfileSavesCompanion.insert({
+    required String userPubkey,
+    required String payloadJson,
+    this.claimConfirmed = const Value.absent(),
+    this.status = const Value.absent(),
+    this.retryCount = const Value.absent(),
+    this.lastAttemptAt = const Value.absent(),
+    required DateTime queuedAt,
+    this.lastError = const Value.absent(),
+    this.rowid = const Value.absent(),
+  }) : userPubkey = Value(userPubkey),
+       payloadJson = Value(payloadJson),
+       queuedAt = Value(queuedAt);
+  static Insertable<PendingProfileSaveRow> custom({
+    Expression<String>? userPubkey,
+    Expression<String>? payloadJson,
+    Expression<bool>? claimConfirmed,
+    Expression<String>? status,
+    Expression<int>? retryCount,
+    Expression<DateTime>? lastAttemptAt,
+    Expression<DateTime>? queuedAt,
+    Expression<String>? lastError,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (userPubkey != null) 'user_pubkey': userPubkey,
+      if (payloadJson != null) 'payload_json': payloadJson,
+      if (claimConfirmed != null) 'claim_confirmed': claimConfirmed,
+      if (status != null) 'status': status,
+      if (retryCount != null) 'retry_count': retryCount,
+      if (lastAttemptAt != null) 'last_attempt_at': lastAttemptAt,
+      if (queuedAt != null) 'queued_at': queuedAt,
+      if (lastError != null) 'last_error': lastError,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  PendingProfileSavesCompanion copyWith({
+    Value<String>? userPubkey,
+    Value<String>? payloadJson,
+    Value<bool>? claimConfirmed,
+    Value<String>? status,
+    Value<int>? retryCount,
+    Value<DateTime?>? lastAttemptAt,
+    Value<DateTime>? queuedAt,
+    Value<String?>? lastError,
+    Value<int>? rowid,
+  }) {
+    return PendingProfileSavesCompanion(
+      userPubkey: userPubkey ?? this.userPubkey,
+      payloadJson: payloadJson ?? this.payloadJson,
+      claimConfirmed: claimConfirmed ?? this.claimConfirmed,
+      status: status ?? this.status,
+      retryCount: retryCount ?? this.retryCount,
+      lastAttemptAt: lastAttemptAt ?? this.lastAttemptAt,
+      queuedAt: queuedAt ?? this.queuedAt,
+      lastError: lastError ?? this.lastError,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (userPubkey.present) {
+      map['user_pubkey'] = Variable<String>(userPubkey.value);
+    }
+    if (payloadJson.present) {
+      map['payload_json'] = Variable<String>(payloadJson.value);
+    }
+    if (claimConfirmed.present) {
+      map['claim_confirmed'] = Variable<bool>(claimConfirmed.value);
+    }
+    if (status.present) {
+      map['status'] = Variable<String>(status.value);
+    }
+    if (retryCount.present) {
+      map['retry_count'] = Variable<int>(retryCount.value);
+    }
+    if (lastAttemptAt.present) {
+      map['last_attempt_at'] = Variable<DateTime>(lastAttemptAt.value);
+    }
+    if (queuedAt.present) {
+      map['queued_at'] = Variable<DateTime>(queuedAt.value);
+    }
+    if (lastError.present) {
+      map['last_error'] = Variable<String>(lastError.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('PendingProfileSavesCompanion(')
+          ..write('userPubkey: $userPubkey, ')
+          ..write('payloadJson: $payloadJson, ')
+          ..write('claimConfirmed: $claimConfirmed, ')
+          ..write('status: $status, ')
+          ..write('retryCount: $retryCount, ')
+          ..write('lastAttemptAt: $lastAttemptAt, ')
+          ..write('queuedAt: $queuedAt, ')
+          ..write('lastError: $lastError, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$AppDatabase extends GeneratedDatabase {
   _$AppDatabase(QueryExecutor e) : super(e);
   $AppDatabaseManager get managers => $AppDatabaseManager(this);
@@ -14586,6 +15150,8 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   );
   late final $ProcessedGiftWrapsTable processedGiftWraps =
       $ProcessedGiftWrapsTable(this);
+  late final $PendingProfileSavesTable pendingProfileSaves =
+      $PendingProfileSavesTable(this);
   late final UserProfilesDao userProfilesDao = UserProfilesDao(
     this as AppDatabase,
   );
@@ -14642,6 +15208,8 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   );
   late final ProcessedGiftWrapsDao processedGiftWrapsDao =
       ProcessedGiftWrapsDao(this as AppDatabase);
+  late final PendingProfileSavesDao pendingProfileSavesDao =
+      PendingProfileSavesDao(this as AppDatabase);
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
@@ -14668,6 +15236,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     pendingProductEvents,
     pendingGiftWraps,
     processedGiftWraps,
+    pendingProfileSaves,
   ];
 }
 
@@ -21489,6 +22058,289 @@ typedef $$ProcessedGiftWrapsTableProcessedTableManager =
       ProcessedGiftWrap,
       PrefetchHooks Function()
     >;
+typedef $$PendingProfileSavesTableCreateCompanionBuilder =
+    PendingProfileSavesCompanion Function({
+      required String userPubkey,
+      required String payloadJson,
+      Value<bool> claimConfirmed,
+      Value<String> status,
+      Value<int> retryCount,
+      Value<DateTime?> lastAttemptAt,
+      required DateTime queuedAt,
+      Value<String?> lastError,
+      Value<int> rowid,
+    });
+typedef $$PendingProfileSavesTableUpdateCompanionBuilder =
+    PendingProfileSavesCompanion Function({
+      Value<String> userPubkey,
+      Value<String> payloadJson,
+      Value<bool> claimConfirmed,
+      Value<String> status,
+      Value<int> retryCount,
+      Value<DateTime?> lastAttemptAt,
+      Value<DateTime> queuedAt,
+      Value<String?> lastError,
+      Value<int> rowid,
+    });
+
+class $$PendingProfileSavesTableFilterComposer
+    extends Composer<_$AppDatabase, $PendingProfileSavesTable> {
+  $$PendingProfileSavesTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get userPubkey => $composableBuilder(
+    column: $table.userPubkey,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get payloadJson => $composableBuilder(
+    column: $table.payloadJson,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<bool> get claimConfirmed => $composableBuilder(
+    column: $table.claimConfirmed,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get status => $composableBuilder(
+    column: $table.status,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get retryCount => $composableBuilder(
+    column: $table.retryCount,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get lastAttemptAt => $composableBuilder(
+    column: $table.lastAttemptAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get queuedAt => $composableBuilder(
+    column: $table.queuedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get lastError => $composableBuilder(
+    column: $table.lastError,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$PendingProfileSavesTableOrderingComposer
+    extends Composer<_$AppDatabase, $PendingProfileSavesTable> {
+  $$PendingProfileSavesTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get userPubkey => $composableBuilder(
+    column: $table.userPubkey,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get payloadJson => $composableBuilder(
+    column: $table.payloadJson,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<bool> get claimConfirmed => $composableBuilder(
+    column: $table.claimConfirmed,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get status => $composableBuilder(
+    column: $table.status,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get retryCount => $composableBuilder(
+    column: $table.retryCount,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get lastAttemptAt => $composableBuilder(
+    column: $table.lastAttemptAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get queuedAt => $composableBuilder(
+    column: $table.queuedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get lastError => $composableBuilder(
+    column: $table.lastError,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$PendingProfileSavesTableAnnotationComposer
+    extends Composer<_$AppDatabase, $PendingProfileSavesTable> {
+  $$PendingProfileSavesTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get userPubkey => $composableBuilder(
+    column: $table.userPubkey,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get payloadJson => $composableBuilder(
+    column: $table.payloadJson,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<bool> get claimConfirmed => $composableBuilder(
+    column: $table.claimConfirmed,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get status =>
+      $composableBuilder(column: $table.status, builder: (column) => column);
+
+  GeneratedColumn<int> get retryCount => $composableBuilder(
+    column: $table.retryCount,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<DateTime> get lastAttemptAt => $composableBuilder(
+    column: $table.lastAttemptAt,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<DateTime> get queuedAt =>
+      $composableBuilder(column: $table.queuedAt, builder: (column) => column);
+
+  GeneratedColumn<String> get lastError =>
+      $composableBuilder(column: $table.lastError, builder: (column) => column);
+}
+
+class $$PendingProfileSavesTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $PendingProfileSavesTable,
+          PendingProfileSaveRow,
+          $$PendingProfileSavesTableFilterComposer,
+          $$PendingProfileSavesTableOrderingComposer,
+          $$PendingProfileSavesTableAnnotationComposer,
+          $$PendingProfileSavesTableCreateCompanionBuilder,
+          $$PendingProfileSavesTableUpdateCompanionBuilder,
+          (
+            PendingProfileSaveRow,
+            BaseReferences<
+              _$AppDatabase,
+              $PendingProfileSavesTable,
+              PendingProfileSaveRow
+            >,
+          ),
+          PendingProfileSaveRow,
+          PrefetchHooks Function()
+        > {
+  $$PendingProfileSavesTableTableManager(
+    _$AppDatabase db,
+    $PendingProfileSavesTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$PendingProfileSavesTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$PendingProfileSavesTableOrderingComposer(
+                $db: db,
+                $table: table,
+              ),
+          createComputedFieldComposer: () =>
+              $$PendingProfileSavesTableAnnotationComposer(
+                $db: db,
+                $table: table,
+              ),
+          updateCompanionCallback:
+              ({
+                Value<String> userPubkey = const Value.absent(),
+                Value<String> payloadJson = const Value.absent(),
+                Value<bool> claimConfirmed = const Value.absent(),
+                Value<String> status = const Value.absent(),
+                Value<int> retryCount = const Value.absent(),
+                Value<DateTime?> lastAttemptAt = const Value.absent(),
+                Value<DateTime> queuedAt = const Value.absent(),
+                Value<String?> lastError = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => PendingProfileSavesCompanion(
+                userPubkey: userPubkey,
+                payloadJson: payloadJson,
+                claimConfirmed: claimConfirmed,
+                status: status,
+                retryCount: retryCount,
+                lastAttemptAt: lastAttemptAt,
+                queuedAt: queuedAt,
+                lastError: lastError,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String userPubkey,
+                required String payloadJson,
+                Value<bool> claimConfirmed = const Value.absent(),
+                Value<String> status = const Value.absent(),
+                Value<int> retryCount = const Value.absent(),
+                Value<DateTime?> lastAttemptAt = const Value.absent(),
+                required DateTime queuedAt,
+                Value<String?> lastError = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => PendingProfileSavesCompanion.insert(
+                userPubkey: userPubkey,
+                payloadJson: payloadJson,
+                claimConfirmed: claimConfirmed,
+                status: status,
+                retryCount: retryCount,
+                lastAttemptAt: lastAttemptAt,
+                queuedAt: queuedAt,
+                lastError: lastError,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$PendingProfileSavesTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $PendingProfileSavesTable,
+      PendingProfileSaveRow,
+      $$PendingProfileSavesTableFilterComposer,
+      $$PendingProfileSavesTableOrderingComposer,
+      $$PendingProfileSavesTableAnnotationComposer,
+      $$PendingProfileSavesTableCreateCompanionBuilder,
+      $$PendingProfileSavesTableUpdateCompanionBuilder,
+      (
+        PendingProfileSaveRow,
+        BaseReferences<
+          _$AppDatabase,
+          $PendingProfileSavesTable,
+          PendingProfileSaveRow
+        >,
+      ),
+      PendingProfileSaveRow,
+      PrefetchHooks Function()
+    >;
 
 class $AppDatabaseManager {
   final _$AppDatabase _db;
@@ -21535,4 +22387,6 @@ class $AppDatabaseManager {
       $$PendingGiftWrapsTableTableManager(_db, _db.pendingGiftWraps);
   $$ProcessedGiftWrapsTableTableManager get processedGiftWraps =>
       $$ProcessedGiftWrapsTableTableManager(_db, _db.processedGiftWraps);
+  $$PendingProfileSavesTableTableManager get pendingProfileSaves =>
+      $$PendingProfileSavesTableTableManager(_db, _db.pendingProfileSaves);
 }

--- a/mobile/packages/db_client/lib/src/database/daos/daos.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/daos.dart
@@ -11,6 +11,7 @@ export 'outgoing_dms_dao.dart';
 export 'pending_actions_dao.dart';
 export 'pending_gift_wraps_dao.dart';
 export 'pending_product_events_dao.dart';
+export 'pending_profile_saves_dao.dart';
 export 'pending_uploads_dao.dart';
 export 'pending_view_events_dao.dart';
 export 'personal_reactions_dao.dart';

--- a/mobile/packages/db_client/lib/src/database/daos/pending_profile_saves_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/pending_profile_saves_dao.dart
@@ -1,0 +1,238 @@
+// ABOUTME: Data Access Object for the durable single-row-per-user
+// ABOUTME: pending profile/username save slot (#3161). Holds a kind-0
+// ABOUTME: save whose relay publish is not yet confirmed, for background
+// ABOUTME: re-drive on connectivity/foreground.
+
+import 'package:db_client/db_client.dart';
+import 'package:drift/drift.dart';
+import 'package:meta/meta.dart';
+
+part 'pending_profile_saves_dao.g.dart';
+
+/// Lifecycle status of a queued profile save.
+enum PendingProfileSaveStatus {
+  /// Queued, waiting for the retry service to attempt the publish.
+  pending,
+
+  /// A publish attempt is currently in flight.
+  syncing,
+
+  /// The publish has failed past the retry policy cap. The UI surfaces a
+  /// manual retry affordance; the row is kept so the user can re-drive it.
+  failed,
+}
+
+/// Thrown when [PendingProfileSavesDao] reads a row whose persisted status
+/// string does not match any known [PendingProfileSaveStatus].
+///
+/// Signals database corruption or a downgrade from a future schema. The DAO
+/// refuses to coerce the unknown value back to
+/// [PendingProfileSaveStatus.pending] — that would silently re-activate a row
+/// a newer client already moved to a terminal state.
+class UnknownPendingProfileSaveStatusException implements Exception {
+  const UnknownPendingProfileSaveStatusException(this.rawValue);
+
+  /// The raw string read from the database that did not parse.
+  final String rawValue;
+
+  @override
+  String toString() {
+    final known = PendingProfileSaveStatus.values.map((e) => e.name).join(', ');
+    return 'UnknownPendingProfileSaveStatusException: '
+        'unrecognised pending_profile_saves status "$rawValue"; '
+        'expected one of $known';
+  }
+}
+
+/// Domain model for the single queued profile save of one account.
+///
+/// Independent of [PendingProfileSaveRow] (the Drift-generated row) so
+/// callers at the repository / service / bloc layers don't import Drift
+/// types. [payloadJson] is opaque here — the repository owns its shape.
+@immutable
+class PendingProfileSaveEntry {
+  const PendingProfileSaveEntry({
+    required this.userPubkey,
+    required this.payloadJson,
+    required this.queuedAt,
+    this.claimConfirmed = false,
+    this.status = PendingProfileSaveStatus.pending,
+    this.retryCount = 0,
+    this.lastAttemptAt,
+    this.lastError,
+  });
+
+  final String userPubkey;
+  final String payloadJson;
+  final bool claimConfirmed;
+  final PendingProfileSaveStatus status;
+  final int retryCount;
+  final DateTime? lastAttemptAt;
+  final DateTime queuedAt;
+  final String? lastError;
+}
+
+@DriftAccessor(tables: [PendingProfileSaves])
+class PendingProfileSavesDao extends DatabaseAccessor<AppDatabase>
+    with _$PendingProfileSavesDaoMixin {
+  PendingProfileSavesDao(super.attachedDatabase);
+
+  // ---------------------------------------------------------------------
+  // Mapping
+  // ---------------------------------------------------------------------
+
+  PendingProfileSavesCompanion _modelToCompanion(PendingProfileSaveEntry e) {
+    return PendingProfileSavesCompanion.insert(
+      userPubkey: e.userPubkey,
+      payloadJson: e.payloadJson,
+      claimConfirmed: Value(e.claimConfirmed),
+      status: Value(e.status.name),
+      retryCount: Value(e.retryCount),
+      lastAttemptAt: Value(e.lastAttemptAt),
+      queuedAt: e.queuedAt,
+      lastError: Value(e.lastError),
+    );
+  }
+
+  PendingProfileSaveEntry _rowToModel(PendingProfileSaveRow row) {
+    return PendingProfileSaveEntry(
+      userPubkey: row.userPubkey,
+      payloadJson: row.payloadJson,
+      claimConfirmed: row.claimConfirmed,
+      status: _parseStatus(row.status),
+      retryCount: row.retryCount,
+      lastAttemptAt: row.lastAttemptAt,
+      queuedAt: row.queuedAt,
+      lastError: row.lastError,
+    );
+  }
+
+  /// Parse a persisted status string back to [PendingProfileSaveStatus].
+  ///
+  /// Throws [UnknownPendingProfileSaveStatusException] on an unrecognised
+  /// value rather than coercing it to [PendingProfileSaveStatus.pending].
+  PendingProfileSaveStatus _parseStatus(String raw) {
+    for (final status in PendingProfileSaveStatus.values) {
+      if (status.name == raw) return status;
+    }
+    throw UnknownPendingProfileSaveStatusException(raw);
+  }
+
+  // ---------------------------------------------------------------------
+  // Writes
+  // ---------------------------------------------------------------------
+
+  /// Upsert the pending save for one account — **latest intent wins**.
+  ///
+  /// Uses `INSERT OR REPLACE` on the `user_pubkey` primary key, so a fresh
+  /// save replaces any in-flight row and resets its retry budget/status to
+  /// the new [entry]'s values. Correct because kind 0 is replaceable: only
+  /// the newest edit matters.
+  Future<void> upsert(PendingProfileSaveEntry entry) async {
+    await into(pendingProfileSaves).insert(
+      _modelToCompanion(entry),
+      mode: InsertMode.insertOrReplace,
+    );
+  }
+
+  /// Update the status for [userPubkey]. Pass [lastError] when moving to
+  /// [PendingProfileSaveStatus.failed]. Stamps `last_attempt_at`.
+  Future<bool> markStatus({
+    required String userPubkey,
+    required PendingProfileSaveStatus status,
+    String? lastError,
+  }) async {
+    final rows =
+        await (update(
+          pendingProfileSaves,
+        )..where((t) => t.userPubkey.equals(userPubkey))).write(
+          PendingProfileSavesCompanion(
+            status: Value(status.name),
+            lastError: lastError != null
+                ? Value(lastError)
+                : const Value.absent(),
+            lastAttemptAt: Value(DateTime.now()),
+          ),
+        );
+    return rows > 0;
+  }
+
+  /// Mark the claim confirmed for [userPubkey] so re-drives skip the
+  /// (idempotent) HTTP claim round-trip.
+  Future<bool> markClaimConfirmed(String userPubkey) async {
+    final rows =
+        await (update(
+          pendingProfileSaves,
+        )..where((t) => t.userPubkey.equals(userPubkey))).write(
+          const PendingProfileSavesCompanion(claimConfirmed: Value(true)),
+        );
+    return rows > 0;
+  }
+
+  /// Increment the retry count for [userPubkey] and stamp `last_attempt_at`.
+  /// Read-then-write inside a transaction so the [DateTime] write goes
+  /// through the same codec as [markStatus] (seconds-since-epoch).
+  Future<bool> incrementRetry(String userPubkey) async {
+    return transaction(() async {
+      final row = await (select(
+        pendingProfileSaves,
+      )..where((t) => t.userPubkey.equals(userPubkey))).getSingleOrNull();
+      if (row == null) return false;
+      final affected =
+          await (update(
+            pendingProfileSaves,
+          )..where((t) => t.userPubkey.equals(userPubkey))).write(
+            PendingProfileSavesCompanion(
+              retryCount: Value(row.retryCount + 1),
+              lastAttemptAt: Value(DateTime.now()),
+            ),
+          );
+      return affected > 0;
+    });
+  }
+
+  /// Reset a `syncing` row back to `pending` on cold start, so a save that
+  /// was mid-flight when the app was killed is retried. Mirrors
+  /// `PendingActionService`'s reset-on-init.
+  Future<int> resetSyncingToPending(String userPubkey) {
+    return (update(pendingProfileSaves)..where(
+          (t) =>
+              t.userPubkey.equals(userPubkey) &
+              t.status.equals(PendingProfileSaveStatus.syncing.name),
+        ))
+        .write(
+          const PendingProfileSavesCompanion(
+            status: Value('pending'),
+          ),
+        );
+  }
+
+  /// Delete the pending save for [userPubkey] — called once a relay
+  /// confirms the publish (or on an explicit user discard).
+  Future<int> clear(String userPubkey) {
+    return (delete(
+      pendingProfileSaves,
+    )..where((t) => t.userPubkey.equals(userPubkey))).go();
+  }
+
+  // ---------------------------------------------------------------------
+  // Reads
+  // ---------------------------------------------------------------------
+
+  /// The pending save for [userPubkey], or null if none is queued.
+  Future<PendingProfileSaveEntry?> get(String userPubkey) async {
+    final row = await (select(
+      pendingProfileSaves,
+    )..where((t) => t.userPubkey.equals(userPubkey))).getSingleOrNull();
+    return row == null ? null : _rowToModel(row);
+  }
+
+  /// Reactive stream of the pending save for [userPubkey]. Emits null when
+  /// no row exists (e.g. after a confirmed publish clears it).
+  Stream<PendingProfileSaveEntry?> watch(String userPubkey) {
+    return (select(pendingProfileSaves)
+          ..where((t) => t.userPubkey.equals(userPubkey)))
+        .watchSingleOrNull()
+        .map((row) => row == null ? null : _rowToModel(row));
+  }
+}

--- a/mobile/packages/db_client/lib/src/database/daos/pending_profile_saves_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/pending_profile_saves_dao.dart
@@ -60,6 +60,7 @@ class PendingProfileSaveEntry {
     this.retryCount = 0,
     this.lastAttemptAt,
     this.lastError,
+    this.generation = '',
   });
 
   final String userPubkey;
@@ -70,6 +71,11 @@ class PendingProfileSaveEntry {
   final DateTime? lastAttemptAt;
   final DateTime queuedAt;
   final String? lastError;
+
+  /// Opaque per-enqueue token. Empty on entries the caller builds for an
+  /// [PendingProfileSavesDao.upsert] (the DAO mints a fresh value and returns
+  /// it); populated with the persisted value on entries read back from the DB.
+  final String generation;
 }
 
 @DriftAccessor(tables: [PendingProfileSaves])
@@ -77,11 +83,38 @@ class PendingProfileSavesDao extends DatabaseAccessor<AppDatabase>
     with _$PendingProfileSavesDaoMixin {
   PendingProfileSavesDao(super.attachedDatabase);
 
+  /// Process-wide monotonic counter mixed into every minted generation token
+  /// so two upserts in the same microsecond still get distinct tokens.
+  static int _generationCounter = 0;
+
+  /// Mint a fresh opaque generation token. Combines a wall-clock stamp with a
+  /// monotonic counter for process-unique, human-orderable values.
+  String _newGeneration() =>
+      '${DateTime.now().microsecondsSinceEpoch}-${_generationCounter++}';
+
+  /// Row-match predicate for the single-account slot. When [generation] is
+  /// non-null the match additionally requires the stored generation to equal
+  /// it — the optimistic-concurrency guard that stops a stale re-drive from
+  /// mutating a row a newer save already replaced.
+  Expression<bool> _matchRow(
+    $PendingProfileSavesTable t,
+    String userPubkey,
+    String? generation,
+  ) {
+    final byUser = t.userPubkey.equals(userPubkey);
+    return generation == null
+        ? byUser
+        : byUser & t.generation.equals(generation);
+  }
+
   // ---------------------------------------------------------------------
   // Mapping
   // ---------------------------------------------------------------------
 
-  PendingProfileSavesCompanion _modelToCompanion(PendingProfileSaveEntry e) {
+  PendingProfileSavesCompanion _modelToCompanion(
+    PendingProfileSaveEntry e,
+    String generation,
+  ) {
     return PendingProfileSavesCompanion.insert(
       userPubkey: e.userPubkey,
       payloadJson: e.payloadJson,
@@ -91,6 +124,7 @@ class PendingProfileSavesDao extends DatabaseAccessor<AppDatabase>
       lastAttemptAt: Value(e.lastAttemptAt),
       queuedAt: e.queuedAt,
       lastError: Value(e.lastError),
+      generation: Value(generation),
     );
   }
 
@@ -104,6 +138,7 @@ class PendingProfileSavesDao extends DatabaseAccessor<AppDatabase>
       lastAttemptAt: row.lastAttemptAt,
       queuedAt: row.queuedAt,
       lastError: row.lastError,
+      generation: row.generation,
     );
   }
 
@@ -122,71 +157,104 @@ class PendingProfileSavesDao extends DatabaseAccessor<AppDatabase>
   // Writes
   // ---------------------------------------------------------------------
 
-  /// Upsert the pending save for one account — **latest intent wins**.
+  /// Upsert the pending save for one account — **latest intent wins** — and
+  /// return the `generation` token stamped on the row.
   ///
   /// Uses `INSERT OR REPLACE` on the `user_pubkey` primary key, so a fresh
   /// save replaces any in-flight row and resets its retry budget/status to
   /// the new [entry]'s values. Correct because kind 0 is replaceable: only
   /// the newest edit matters.
-  Future<void> upsert(PendingProfileSaveEntry entry) async {
+  ///
+  /// Every upsert mints a fresh `generation` (unless the caller supplied a
+  /// non-empty one on [entry]) so an in-flight re-drive that captured the
+  /// previous generation can detect it was superseded and leave the new row
+  /// alone. The returned token lets the caller scope its own drive to exactly
+  /// this intent.
+  Future<String> upsert(PendingProfileSaveEntry entry) async {
+    final generation = entry.generation.isNotEmpty
+        ? entry.generation
+        : _newGeneration();
     await into(pendingProfileSaves).insert(
-      _modelToCompanion(entry),
+      _modelToCompanion(entry, generation),
       mode: InsertMode.insertOrReplace,
     );
+    return generation;
   }
 
   /// Update the status for [userPubkey]. Pass [lastError] when moving to
-  /// [PendingProfileSaveStatus.failed]. Stamps `last_attempt_at`.
+  /// [PendingProfileSaveStatus.failed]. Stamps `last_attempt_at` with
+  /// [attemptAt] (defaults to now).
+  ///
+  /// When [generation] is non-null the write only lands if the row's stored
+  /// generation still matches — so a newer save that replaced the row is not
+  /// reclassified by an older, in-flight drive. Returns whether a row was
+  /// updated (false when the slot is gone or a newer generation superseded it).
   Future<bool> markStatus({
     required String userPubkey,
     required PendingProfileSaveStatus status,
     String? lastError,
+    String? generation,
+    DateTime? attemptAt,
   }) async {
     final rows =
-        await (update(
-          pendingProfileSaves,
-        )..where((t) => t.userPubkey.equals(userPubkey))).write(
-          PendingProfileSavesCompanion(
-            status: Value(status.name),
-            lastError: lastError != null
-                ? Value(lastError)
-                : const Value.absent(),
-            lastAttemptAt: Value(DateTime.now()),
-          ),
-        );
+        await (update(pendingProfileSaves)..where(
+              (t) => _matchRow(t, userPubkey, generation),
+            ))
+            .write(
+              PendingProfileSavesCompanion(
+                status: Value(status.name),
+                lastError: lastError != null
+                    ? Value(lastError)
+                    : const Value.absent(),
+                lastAttemptAt: Value(attemptAt ?? DateTime.now()),
+              ),
+            );
     return rows > 0;
   }
 
   /// Mark the claim confirmed for [userPubkey] so re-drives skip the
-  /// (idempotent) HTTP claim round-trip.
-  Future<bool> markClaimConfirmed(String userPubkey) async {
+  /// (idempotent) HTTP claim round-trip. See [markStatus] for the
+  /// [generation] guard semantics.
+  Future<bool> markClaimConfirmed(
+    String userPubkey, {
+    String? generation,
+  }) async {
     final rows =
-        await (update(
-          pendingProfileSaves,
-        )..where((t) => t.userPubkey.equals(userPubkey))).write(
-          const PendingProfileSavesCompanion(claimConfirmed: Value(true)),
-        );
+        await (update(pendingProfileSaves)..where(
+              (t) => _matchRow(t, userPubkey, generation),
+            ))
+            .write(
+              const PendingProfileSavesCompanion(claimConfirmed: Value(true)),
+            );
     return rows > 0;
   }
 
-  /// Increment the retry count for [userPubkey] and stamp `last_attempt_at`.
-  /// Read-then-write inside a transaction so the [DateTime] write goes
-  /// through the same codec as [markStatus] (seconds-since-epoch).
-  Future<bool> incrementRetry(String userPubkey) async {
+  /// Increment the retry count for [userPubkey] and stamp `last_attempt_at`
+  /// with [attemptAt] (defaults to now). Read-then-write inside a transaction
+  /// so the [DateTime] write goes through the same codec as [markStatus]
+  /// (seconds-since-epoch). See [markStatus] for the [generation] guard.
+  Future<bool> incrementRetry(
+    String userPubkey, {
+    String? generation,
+    DateTime? attemptAt,
+  }) async {
     return transaction(() async {
-      final row = await (select(
-        pendingProfileSaves,
-      )..where((t) => t.userPubkey.equals(userPubkey))).getSingleOrNull();
+      final row =
+          await (select(pendingProfileSaves)..where(
+                (t) => _matchRow(t, userPubkey, generation),
+              ))
+              .getSingleOrNull();
       if (row == null) return false;
       final affected =
-          await (update(
-            pendingProfileSaves,
-          )..where((t) => t.userPubkey.equals(userPubkey))).write(
-            PendingProfileSavesCompanion(
-              retryCount: Value(row.retryCount + 1),
-              lastAttemptAt: Value(DateTime.now()),
-            ),
-          );
+          await (update(pendingProfileSaves)..where(
+                (t) => _matchRow(t, userPubkey, generation),
+              ))
+              .write(
+                PendingProfileSavesCompanion(
+                  retryCount: Value(row.retryCount + 1),
+                  lastAttemptAt: Value(attemptAt ?? DateTime.now()),
+                ),
+              );
       return affected > 0;
     });
   }
@@ -209,10 +277,15 @@ class PendingProfileSavesDao extends DatabaseAccessor<AppDatabase>
 
   /// Delete the pending save for [userPubkey] — called once a relay
   /// confirms the publish (or on an explicit user discard).
-  Future<int> clear(String userPubkey) {
+  ///
+  /// When [generation] is non-null the delete only lands if the row's stored
+  /// generation still matches, so a drive that confirmed an older intent can
+  /// never delete the newer save that replaced it mid-flight. Returns the
+  /// number of rows deleted.
+  Future<int> clear(String userPubkey, {String? generation}) {
     return (delete(
       pendingProfileSaves,
-    )..where((t) => t.userPubkey.equals(userPubkey))).go();
+    )..where((t) => _matchRow(t, userPubkey, generation))).go();
   }
 
   // ---------------------------------------------------------------------

--- a/mobile/packages/db_client/lib/src/database/daos/pending_profile_saves_dao.g.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/pending_profile_saves_dao.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'pending_profile_saves_dao.dart';
+
+// ignore_for_file: type=lint
+mixin _$PendingProfileSavesDaoMixin on DatabaseAccessor<AppDatabase> {
+  $PendingProfileSavesTable get pendingProfileSaves =>
+      attachedDatabase.pendingProfileSaves;
+  PendingProfileSavesDaoManager get managers =>
+      PendingProfileSavesDaoManager(this);
+}
+
+class PendingProfileSavesDaoManager {
+  final _$PendingProfileSavesDaoMixin _db;
+  PendingProfileSavesDaoManager(this._db);
+  $$PendingProfileSavesTableTableManager get pendingProfileSaves =>
+      $$PendingProfileSavesTableTableManager(
+        _db.attachedDatabase,
+        _db.pendingProfileSaves,
+      );
+}

--- a/mobile/packages/db_client/lib/src/database/tables.dart
+++ b/mobile/packages/db_client/lib/src/database/tables.dart
@@ -1204,6 +1204,61 @@ class OutgoingDms extends Table {
   ];
 }
 
+/// Durable, single-row-per-user slot for a profile/username save whose
+/// kind-0 publish has not yet been confirmed by a relay.
+///
+/// Kind 0 is replaceable and one-per-user, so at most one row exists per
+/// account — a re-save replaces the row (latest intent wins). The
+/// `ProfileSaveRetryService` re-drives this slot on app-foreground and on
+/// connectivity/relay-reconnect until a relay confirms the publish, then
+/// deletes the row. Fixes #3161: a save attempted while the relay pool is
+/// disconnected is delivered when connectivity returns, instead of failing
+/// permanently and stranding a claimed-but-unadvertised divine.video username.
+@DataClassName('PendingProfileSaveRow')
+class PendingProfileSaves extends Table {
+  @override
+  String get tableName => 'pending_profile_saves';
+
+  /// Owner hex pubkey. Primary key → exactly one pending save per account.
+  TextColumn get userPubkey => text().named('user_pubkey')();
+
+  /// Serialized `PendingProfileSave` payload (every `saveProfileEvent` field
+  /// the user submitted). Authoritative source for the re-drive.
+  TextColumn get payloadJson => text().named('payload_json')();
+
+  /// Whether the divine.video username claim already returned 200 for this
+  /// payload, so re-drives skip the (idempotent) HTTP claim round-trip.
+  /// Always `true` for saves with no divine.video username to claim
+  /// (external NIP-05, or no NIP-05 change).
+  BoolColumn get claimConfirmed =>
+      boolean().withDefault(const Constant(false)).named('claim_confirmed')();
+
+  /// `pending` | `syncing` | `failed`. Stored as a string for readable
+  /// dumps; the DAO throws on an unrecognised value rather than coercing it
+  /// back to `pending`.
+  TextColumn get status => text().withDefault(const Constant('pending'))();
+
+  /// Publish attempts survived. Backoff caps growth at the policy max; once
+  /// exhausted the row moves to `failed` and the UI surfaces a retry.
+  IntColumn get retryCount =>
+      integer().withDefault(const Constant(0)).named('retry_count')();
+
+  /// Wall-clock timestamp of the most recent publish attempt. Drives the
+  /// retry service's backoff scheduling. Null until the first attempt.
+  DateTimeColumn get lastAttemptAt =>
+      dateTime().nullable().named('last_attempt_at')();
+
+  /// Wall-clock timestamp the row was queued.
+  DateTimeColumn get queuedAt => dateTime().named('queued_at')();
+
+  /// Last publish error message, for diagnostics. Null when the most recent
+  /// transition was not a failure.
+  TextColumn get lastError => text().nullable().named('last_error')();
+
+  @override
+  Set<Column> get primaryKey => {userPubkey};
+}
+
 /// Durable queue of finalized video view events awaiting relay publish.
 @DataClassName('PendingViewEventRow')
 class PendingViewEvents extends Table {

--- a/mobile/packages/db_client/lib/src/database/tables.dart
+++ b/mobile/packages/db_client/lib/src/database/tables.dart
@@ -1255,6 +1255,14 @@ class PendingProfileSaves extends Table {
   /// transition was not a failure.
   TextColumn get lastError => text().nullable().named('last_error')();
 
+  /// Immutable per-enqueue token stamped fresh on every `upsert` (a new save
+  /// or a manual retry). A background re-drive captures it at read time and
+  /// guards every mutation with it, so a newer save that replaces this row
+  /// while an older drive is awaiting relay work is never cleared or
+  /// reclassified by that stale drive — latest intent wins (#3161 review).
+  /// Empty string only on legacy rows written before this column existed.
+  TextColumn get generation => text().withDefault(const Constant(''))();
+
   @override
   Set<Column> get primaryKey => {userPubkey};
 }

--- a/mobile/packages/db_client/test/src/database/app_database_test.dart
+++ b/mobile/packages/db_client/test/src/database/app_database_test.dart
@@ -377,6 +377,115 @@ void main() {
         },
       );
 
+      test(
+        'upgrade path recreates pending_profile_saves when missing',
+        () async {
+          await database.customStatement('DROP TABLE pending_profile_saves');
+
+          final droppedCheck = await database
+              .customSelect(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name='pending_profile_saves'",
+              )
+              .get();
+          expect(
+            droppedCheck,
+            isEmpty,
+            reason: 'precondition: pending_profile_saves must be missing',
+          );
+
+          await database.close();
+          database = AppDatabase.test(NativeDatabase(File(tempDbPath)));
+
+          final tableCheck = await database
+              .customSelect(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name='pending_profile_saves'",
+              )
+              .get();
+          expect(
+            tableCheck,
+            hasLength(1),
+            reason: 'pending_profile_saves must be re-created on reopen',
+          );
+
+          final dao = database.pendingProfileSavesDao;
+          await dao.upsert(
+            PendingProfileSaveEntry(
+              userPubkey: testPubkey,
+              payloadJson: '{"display_name":"upgrade"}',
+              claimConfirmed: true,
+              queuedAt: DateTime.utc(2026, 7, 13),
+            ),
+          );
+
+          final fetched = await dao.get(testPubkey);
+          expect(fetched, isNotNull);
+          expect(fetched!.payloadJson, '{"display_name":"upgrade"}');
+          expect(fetched.claimConfirmed, isTrue);
+          expect(fetched.status, PendingProfileSaveStatus.pending);
+        },
+      );
+
+      test(
+        'schema parity — pending_profile_saves fresh-install matches runtime '
+        'CREATE-IF-NOT-EXISTS path',
+        () async {
+          final freshColumns = await _collectTableInfo(
+            database,
+            'pending_profile_saves',
+          );
+          final freshIndexes = await _collectIndexNames(
+            database,
+            'pending_profile_saves',
+          );
+          expect(
+            freshColumns,
+            isNotEmpty,
+            reason:
+                'precondition: fresh install should have pending_profile_saves',
+          );
+
+          await database.customStatement('DROP TABLE pending_profile_saves');
+          for (final indexName in freshIndexes) {
+            await database.customStatement('DROP INDEX IF EXISTS $indexName');
+          }
+          await database.close();
+
+          database = AppDatabase.test(NativeDatabase(File(tempDbPath)));
+          await database
+              .customSelect(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name='pending_profile_saves'",
+              )
+              .get();
+
+          final recreatedColumns = await _collectTableInfo(
+            database,
+            'pending_profile_saves',
+          );
+          final recreatedIndexes = await _collectIndexNames(
+            database,
+            'pending_profile_saves',
+          );
+
+          expect(
+            recreatedColumns,
+            equals(freshColumns),
+            reason:
+                'runtime CREATE-IF-NOT-EXISTS path must produce the same '
+                'columns as Drift `m.createAll()` for pending_profile_saves',
+          );
+          expect(
+            recreatedIndexes,
+            equals(freshIndexes),
+            reason:
+                'runtime CREATE-IF-NOT-EXISTS path must declare the same '
+                'index set as Drift fresh-install for pending_profile_saves',
+          );
+        },
+      );
+
       test('upgrade path recreates pending_view_events when missing', () async {
         await database.customStatement('DROP TABLE pending_view_events');
 

--- a/mobile/packages/db_client/test/src/database/daos/pending_profile_saves_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/pending_profile_saves_dao_test.dart
@@ -223,6 +223,114 @@ void main() {
       });
     });
 
+    group('generation guard', () {
+      test('upsert mints and returns a fresh token; a replacement '
+          'upsert returns a different one', () async {
+        final genA = await dao.upsert(makeEntry());
+        expect(genA, isNotEmpty);
+        expect((await dao.get(userA))!.generation, genA);
+
+        final genB = await dao.upsert(
+          makeEntry(payloadJson: '{"display_name":"b"}'),
+        );
+        expect(genB, isNot(genA));
+        expect((await dao.get(userA))!.generation, genB);
+      });
+
+      test('upsert preserves a caller-supplied non-empty generation', () async {
+        final returned = await dao.upsert(
+          PendingProfileSaveEntry(
+            userPubkey: userA,
+            payloadJson: '{"display_name":"alice"}',
+            queuedAt: DateTime.utc(2026, 7, 13),
+            generation: 'gen-fixed',
+          ),
+        );
+        expect(returned, 'gen-fixed');
+        expect((await dao.get(userA))!.generation, 'gen-fixed');
+      });
+
+      test('markStatus with a stale generation is a no-op', () async {
+        final gen = await dao.upsert(makeEntry());
+        // A newer save replaces the row (fresh generation).
+        await dao.upsert(makeEntry(payloadJson: '{"display_name":"new"}'));
+
+        final ok = await dao.markStatus(
+          userPubkey: userA,
+          status: PendingProfileSaveStatus.syncing,
+          generation: gen,
+        );
+
+        expect(ok, isFalse);
+        expect(
+          (await dao.get(userA))!.status,
+          PendingProfileSaveStatus.pending,
+          reason: 'the newer row must keep its status',
+        );
+      });
+
+      test('markStatus with the matching generation applies', () async {
+        final gen = await dao.upsert(makeEntry());
+        final ok = await dao.markStatus(
+          userPubkey: userA,
+          status: PendingProfileSaveStatus.syncing,
+          generation: gen,
+        );
+        expect(ok, isTrue);
+        expect(
+          (await dao.get(userA))!.status,
+          PendingProfileSaveStatus.syncing,
+        );
+      });
+
+      test('clear with a stale generation keeps the (newer) row', () async {
+        final gen = await dao.upsert(makeEntry());
+        await dao.upsert(makeEntry(payloadJson: '{"display_name":"new"}'));
+
+        final deleted = await dao.clear(userA, generation: gen);
+
+        expect(deleted, 0);
+        final row = await dao.get(userA);
+        expect(row, isNotNull);
+        expect(row!.payloadJson, '{"display_name":"new"}');
+      });
+
+      test('markClaimConfirmed and incrementRetry no-op under a stale '
+          'generation', () async {
+        final gen = await dao.upsert(makeEntry(retryCount: 1));
+        await dao.upsert(makeEntry(payloadJson: '{"display_name":"new"}'));
+
+        expect(await dao.markClaimConfirmed(userA, generation: gen), isFalse);
+        expect(await dao.incrementRetry(userA, generation: gen), isFalse);
+
+        final row = await dao.get(userA);
+        expect(row!.claimConfirmed, isFalse);
+        expect(row.retryCount, 0, reason: 'the newer row keeps its budget');
+      });
+
+      test('markStatus/incrementRetry stamp the injected attemptAt', () async {
+        await dao.upsert(makeEntry());
+        final at = DateTime.utc(2026, 7, 13, 9, 30);
+
+        await dao.markStatus(
+          userPubkey: userA,
+          status: PendingProfileSaveStatus.syncing,
+          attemptAt: at,
+        );
+        expect(
+          (await dao.get(userA))!.lastAttemptAt!.isAtSameMomentAs(at),
+          isTrue,
+        );
+
+        final at2 = DateTime.utc(2026, 7, 13, 10);
+        await dao.incrementRetry(userA, attemptAt: at2);
+        expect(
+          (await dao.get(userA))!.lastAttemptAt!.isAtSameMomentAs(at2),
+          isTrue,
+        );
+      });
+    });
+
     group('watch', () {
       test('emits initial null, then the row, then null after clear', () async {
         // Drain Drift's async stream emissions with pumpEventQueue() between

--- a/mobile/packages/db_client/test/src/database/daos/pending_profile_saves_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/pending_profile_saves_dao_test.dart
@@ -1,0 +1,271 @@
+// ABOUTME: Unit tests for PendingProfileSavesDao — the durable single-row
+// ABOUTME: per-user profile/username save slot (#3161). Covers upsert
+// ABOUTME: replace-latest, status transitions, retry, reset, clear, watch.
+
+import 'dart:io';
+
+import 'package:db_client/db_client.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late AppDatabase database;
+  late PendingProfileSavesDao dao;
+  late String tempDbPath;
+
+  const userA =
+      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+  const userB =
+      'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210';
+
+  PendingProfileSaveEntry makeEntry({
+    String userPubkey = userA,
+    String payloadJson = '{"display_name":"alice"}',
+    bool claimConfirmed = false,
+    PendingProfileSaveStatus status = PendingProfileSaveStatus.pending,
+    int retryCount = 0,
+    DateTime? queuedAt,
+    DateTime? lastAttemptAt,
+    String? lastError,
+  }) {
+    return PendingProfileSaveEntry(
+      userPubkey: userPubkey,
+      payloadJson: payloadJson,
+      claimConfirmed: claimConfirmed,
+      status: status,
+      retryCount: retryCount,
+      queuedAt: queuedAt ?? DateTime.utc(2026, 7, 13),
+      lastAttemptAt: lastAttemptAt,
+      lastError: lastError,
+    );
+  }
+
+  setUp(() async {
+    final tempDir = Directory.systemTemp.createTempSync(
+      'pending_profile_saves_test_',
+    );
+    tempDbPath = '${tempDir.path}/test.db';
+    database = AppDatabase.test(NativeDatabase(File(tempDbPath)));
+    dao = database.pendingProfileSavesDao;
+  });
+
+  tearDown(() async {
+    await database.close();
+    final file = File(tempDbPath);
+    if (file.existsSync()) file.deleteSync();
+    final dir = Directory(tempDbPath).parent;
+    if (dir.existsSync()) dir.deleteSync(recursive: true);
+  });
+
+  group(PendingProfileSavesDao, () {
+    group('upsert / get', () {
+      test('inserts a pending save with all fields round-tripped', () async {
+        await dao.upsert(
+          makeEntry(
+            claimConfirmed: true,
+            retryCount: 2,
+            lastAttemptAt: DateTime.utc(2026, 7, 13, 1),
+            lastError: 'no relays',
+          ),
+        );
+
+        final fetched = await dao.get(userA);
+
+        expect(fetched, isNotNull);
+        expect(fetched!.userPubkey, userA);
+        expect(fetched.payloadJson, '{"display_name":"alice"}');
+        expect(fetched.claimConfirmed, isTrue);
+        expect(fetched.status, PendingProfileSaveStatus.pending);
+        expect(fetched.retryCount, 2);
+        // Drift's dateTime codec reads back in local time, so compare the
+        // instant rather than the DateTime (whose isUtc flag would differ).
+        expect(
+          fetched.queuedAt.isAtSameMomentAs(DateTime.utc(2026, 7, 13)),
+          isTrue,
+        );
+        expect(
+          fetched.lastAttemptAt!.isAtSameMomentAs(DateTime.utc(2026, 7, 13, 1)),
+          isTrue,
+        );
+        expect(fetched.lastError, 'no relays');
+      });
+
+      test('returns null when no slot exists for the pubkey', () async {
+        expect(await dao.get(userA), isNull);
+      });
+
+      test('upsert replaces the existing row (latest intent wins) and '
+          'resets retry/status', () async {
+        await dao.upsert(
+          makeEntry(
+            payloadJson: '{"display_name":"old"}',
+            retryCount: 4,
+            status: PendingProfileSaveStatus.failed,
+            lastError: 'boom',
+          ),
+        );
+
+        await dao.upsert(
+          makeEntry(payloadJson: '{"display_name":"new"}'),
+        );
+
+        final fetched = await dao.get(userA);
+        expect(fetched!.payloadJson, '{"display_name":"new"}');
+        expect(fetched.retryCount, 0);
+        expect(fetched.status, PendingProfileSaveStatus.pending);
+        expect(fetched.lastError, isNull);
+      });
+
+      test(
+        'keeps one row per user (distinct pubkeys are independent)',
+        () async {
+          await dao.upsert(makeEntry(payloadJson: '{"a":1}'));
+          await dao.upsert(
+            makeEntry(userPubkey: userB, payloadJson: '{"b":2}'),
+          );
+
+          expect((await dao.get(userA))!.payloadJson, '{"a":1}');
+          expect((await dao.get(userB))!.payloadJson, '{"b":2}');
+        },
+      );
+    });
+
+    group('markStatus', () {
+      test('updates status + stamps lastAttemptAt', () async {
+        await dao.upsert(makeEntry());
+        final ok = await dao.markStatus(
+          userPubkey: userA,
+          status: PendingProfileSaveStatus.syncing,
+        );
+        expect(ok, isTrue);
+        final fetched = await dao.get(userA);
+        expect(fetched!.status, PendingProfileSaveStatus.syncing);
+        expect(fetched.lastAttemptAt, isNotNull);
+      });
+
+      test('writes lastError when moving to failed', () async {
+        await dao.upsert(makeEntry());
+        await dao.markStatus(
+          userPubkey: userA,
+          status: PendingProfileSaveStatus.failed,
+          lastError: 'gave up',
+        );
+        final fetched = await dao.get(userA);
+        expect(fetched!.status, PendingProfileSaveStatus.failed);
+        expect(fetched.lastError, 'gave up');
+      });
+
+      test('returns false when no row exists', () async {
+        expect(
+          await dao.markStatus(
+            userPubkey: userA,
+            status: PendingProfileSaveStatus.syncing,
+          ),
+          isFalse,
+        );
+      });
+    });
+
+    group('markClaimConfirmed', () {
+      test('flips claim_confirmed to true', () async {
+        await dao.upsert(makeEntry());
+        final ok = await dao.markClaimConfirmed(userA);
+        expect(ok, isTrue);
+        expect((await dao.get(userA))!.claimConfirmed, isTrue);
+      });
+    });
+
+    group('incrementRetry', () {
+      test('increments retry count and stamps lastAttemptAt', () async {
+        await dao.upsert(makeEntry(retryCount: 1));
+        final ok = await dao.incrementRetry(userA);
+        expect(ok, isTrue);
+        final fetched = await dao.get(userA);
+        expect(fetched!.retryCount, 2);
+        expect(fetched.lastAttemptAt, isNotNull);
+      });
+
+      test('returns false when no row exists', () async {
+        expect(await dao.incrementRetry(userA), isFalse);
+      });
+    });
+
+    group('resetSyncingToPending', () {
+      test(
+        'moves a syncing row back to pending (cold-start recovery)',
+        () async {
+          await dao.upsert(
+            makeEntry(status: PendingProfileSaveStatus.syncing),
+          );
+          final affected = await dao.resetSyncingToPending(userA);
+          expect(affected, 1);
+          expect(
+            (await dao.get(userA))!.status,
+            PendingProfileSaveStatus.pending,
+          );
+        },
+      );
+
+      test('leaves a failed row untouched', () async {
+        await dao.upsert(makeEntry(status: PendingProfileSaveStatus.failed));
+        final affected = await dao.resetSyncingToPending(userA);
+        expect(affected, 0);
+        expect((await dao.get(userA))!.status, PendingProfileSaveStatus.failed);
+      });
+    });
+
+    group('clear', () {
+      test('deletes the slot for the pubkey', () async {
+        await dao.upsert(makeEntry());
+        final deleted = await dao.clear(userA);
+        expect(deleted, 1);
+        expect(await dao.get(userA), isNull);
+      });
+    });
+
+    group('watch', () {
+      test('emits initial null, then the row, then null after clear', () async {
+        // Drain Drift's async stream emissions with pumpEventQueue() between
+        // each mutation so distinct states are observed in order (no
+        // coalescing of rapid DB changes).
+        final emissions = <PendingProfileSaveEntry?>[];
+        final sub = dao.watch(userA).listen(emissions.add);
+
+        await pumpEventQueue();
+        await dao.upsert(makeEntry(payloadJson: '{"x":1}'));
+        await pumpEventQueue();
+        await dao.clear(userA);
+        await pumpEventQueue();
+        await sub.cancel();
+
+        expect(emissions, [
+          isNull,
+          isA<PendingProfileSaveEntry>().having(
+            (e) => e.payloadJson,
+            'payloadJson',
+            '{"x":1}',
+          ),
+          isNull,
+        ]);
+      });
+    });
+
+    group('status parsing', () {
+      test(
+        'throws UnknownPendingProfileSaveStatusException on a bad status',
+        () async {
+          await dao.upsert(makeEntry());
+          // Corrupt the persisted status out-of-band.
+          await database.customStatement(
+            "UPDATE pending_profile_saves SET status = 'bogus' "
+            "WHERE user_pubkey = '$userA'",
+          );
+          expect(
+            () => dao.get(userA),
+            throwsA(isA<UnknownPendingProfileSaveStatusException>()),
+          );
+        },
+      );
+    });
+  });
+}

--- a/mobile/packages/profile_repository/lib/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/profile_repository.dart
@@ -6,6 +6,7 @@ export 'src/divine_username_policy.dart';
 export 'src/exceptions.dart';
 export 'src/identity_claim.dart';
 export 'src/identity_claims_repository.dart';
+export 'src/pending_profile_save.dart';
 export 'src/profile_repository.dart';
 export 'src/progressive_search_result.dart';
 export 'src/username_availability_result.dart';

--- a/mobile/packages/profile_repository/lib/src/pending_profile_save.dart
+++ b/mobile/packages/profile_repository/lib/src/pending_profile_save.dart
@@ -1,0 +1,132 @@
+// ABOUTME: Serializable payload for a queued profile/username save (#3161).
+// ABOUTME: Captures the user's raw save intent so a failed kind-0 publish can
+// ABOUTME: be re-driven in the background when connectivity returns.
+
+import 'dart:convert';
+
+import 'package:models/models.dart';
+
+/// The raw intent of a single profile/username save, persisted in the
+/// durable pending-save slot so `ProfileRepository.drivePendingSave` can
+/// replay it after a transient relay outage.
+///
+/// Mirrors the editable parameters of `ProfileRepository.saveProfileEvent`.
+/// The current profile is intentionally NOT stored — the re-drive re-reads the
+/// freshest cached profile and re-seeds from relays at drive time so unknown
+/// kind-0 fields are preserved.
+class PendingProfileSave {
+  /// Creates a save payload from the user's raw edit intent.
+  const PendingProfileSave({
+    required this.pubkey,
+    required this.displayName,
+    this.about,
+    this.website,
+    this.username,
+    this.nip05,
+    this.clearNip05 = false,
+    this.picture,
+    this.banner,
+    this.monetizationLinks,
+  });
+
+  /// Reconstructs a payload from its [toJson] map.
+  factory PendingProfileSave.fromJson(Map<String, dynamic> json) {
+    final links = json['monetizationLinks'] as List<dynamic>?;
+    return PendingProfileSave(
+      pubkey: json['pubkey'] as String,
+      displayName: json['displayName'] as String,
+      about: json['about'] as String?,
+      website: json['website'] as String?,
+      username: json['username'] as String?,
+      nip05: json['nip05'] as String?,
+      clearNip05: json['clearNip05'] as bool? ?? false,
+      picture: json['picture'] as String?,
+      banner: json['banner'] as String?,
+      monetizationLinks: links
+          ?.map((e) => MonetizationLink.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  /// Decodes a payload from the JSON string stored in the slot's
+  /// `payload_json` column.
+  factory PendingProfileSave.decode(String encoded) =>
+      PendingProfileSave.fromJson(jsonDecode(encoded) as Map<String, dynamic>);
+
+  /// Hex pubkey of the account whose profile is being saved.
+  final String pubkey;
+
+  /// The kind-0 `display_name`.
+  final String displayName;
+
+  /// The kind-0 `about` (bio), or null to clear it.
+  final String? about;
+
+  /// The kind-0 `website`, or null to clear it.
+  final String? website;
+
+  /// The divine.video username to claim, or null when none is requested.
+  final String? username;
+
+  /// An external NIP-05 identifier (takes precedence over [username]).
+  final String? nip05;
+
+  /// Whether to explicitly remove the existing NIP-05 from the profile.
+  final bool clearNip05;
+
+  /// The kind-0 `picture` URL, or null to clear it.
+  final String? picture;
+
+  /// The kind-0 `banner` (URL or hex color), or null to clear it.
+  final String? banner;
+
+  /// Enabled monetization links to encode into the profile, or null to leave
+  /// them untouched.
+  final List<MonetizationLink>? monetizationLinks;
+
+  /// Whether this save requests a divine.video username that must be claimed
+  /// on the name server before the kind-0 publish.
+  bool get requiresClaim => username != null && username!.trim().isNotEmpty;
+
+  /// Serializes the payload to a JSON-encodable map.
+  Map<String, dynamic> toJson() => {
+    'pubkey': pubkey,
+    'displayName': displayName,
+    if (about != null) 'about': about,
+    if (website != null) 'website': website,
+    if (username != null) 'username': username,
+    if (nip05 != null) 'nip05': nip05,
+    'clearNip05': clearNip05,
+    if (picture != null) 'picture': picture,
+    if (banner != null) 'banner': banner,
+    if (monetizationLinks != null)
+      'monetizationLinks': monetizationLinks!
+          .map((link) => link.toJson())
+          .toList(),
+  };
+
+  /// Encodes the payload to the JSON string stored in the slot.
+  String encode() => jsonEncode(toJson());
+}
+
+/// Outcome of a single `ProfileRepository.drivePendingSave` attempt.
+///
+/// The retry service maps this onto its slot bookkeeping: [confirmed] means
+/// the slot was already cleared; [retryableFailure] means increment-and-retry;
+/// [permanentFailure] means mark-failed and stop; [noPendingSave] is a no-op.
+enum PendingSaveDriveOutcome {
+  /// A relay confirmed the kind-0 (NIP-20 OK). The slot has been cleared and
+  /// the profile cached locally.
+  confirmed,
+
+  /// The publish did not land (no relays connected, relay rejected, or a
+  /// transient claim network error). Safe to retry later — the slot is kept.
+  retryableFailure,
+
+  /// The divine.video username claim failed terminally (taken / reserved), so
+  /// re-driving cannot succeed. The slot should be marked failed and abandoned.
+  permanentFailure,
+
+  /// No pending save exists for the pubkey.
+  noPendingSave,
+}

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -69,6 +69,7 @@ class ProfileRepository {
     FunnelcakeApiClient? funnelcakeApiClient,
     ProfileSearchFilter? profileSearchFilter,
     BlockedProfileFilter? blockFilter,
+    PendingProfileSavesDao? pendingProfileSavesDao,
     List<String> indexerRelays = defaultProfileIndexerRelays,
   }) : _nostrClient = nostrClient,
        _userProfilesDao = userProfilesDao,
@@ -77,6 +78,7 @@ class ProfileRepository {
        _funnelcakeApiClient = funnelcakeApiClient,
        _profileSearchFilter = profileSearchFilter,
        _blockFilter = blockFilter,
+       _pendingProfileSavesDao = pendingProfileSavesDao,
        _indexerRelays = indexerRelays;
 
   final NostrClient _nostrClient;
@@ -86,6 +88,12 @@ class ProfileRepository {
   final FunnelcakeApiClient? _funnelcakeApiClient;
   final ProfileSearchFilter? _profileSearchFilter;
   final BlockedProfileFilter? _blockFilter;
+
+  /// Durable single-row-per-user slot for a save whose kind-0 publish is not
+  /// yet relay-confirmed (#3161). Null when the caller does not wire the
+  /// offline-tolerant save path (e.g. legacy tests) — the queue methods
+  /// no-op in that case.
+  final PendingProfileSavesDao? _pendingProfileSavesDao;
   final List<String> _indexerRelays;
 
   /// In-flight relay fetches keyed by pubkey. Concurrent callers for the
@@ -703,6 +711,118 @@ class ProfileRepository {
         throw const ProfilePublishFailedException(
           'Failed to publish profile. Please try again.',
         );
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Pending-save slot (#3161): durable, background-re-driven profile save.
+  // -------------------------------------------------------------------------
+
+  /// Persist [payload] to the durable pending-save slot so a failed kind-0
+  /// publish is re-driven in the background when connectivity returns.
+  ///
+  /// Latest intent wins — a fresh save replaces any in-flight row (kind 0 is
+  /// replaceable). Pass [claimConfirmed] true when the divine.video username
+  /// claim already succeeded for this payload (or when no claim is needed), so
+  /// the re-drive skips the idempotent HTTP claim round-trip.
+  ///
+  /// No-op when no [PendingProfileSavesDao] was injected.
+  Future<void> enqueuePendingSave(
+    PendingProfileSave payload, {
+    required bool claimConfirmed,
+  }) async {
+    final dao = _pendingProfileSavesDao;
+    if (dao == null) return;
+    await dao.upsert(
+      PendingProfileSaveEntry(
+        userPubkey: payload.pubkey,
+        payloadJson: payload.encode(),
+        claimConfirmed: claimConfirmed,
+        queuedAt: DateTime.now(),
+      ),
+    );
+  }
+
+  /// Reactive view of the pending save for [pubkey], or null when none is
+  /// queued (e.g. after a confirmed publish clears it). Emits nothing when no
+  /// [PendingProfileSavesDao] was injected.
+  Stream<PendingProfileSaveEntry?> watchPendingSave(String pubkey) {
+    final dao = _pendingProfileSavesDao;
+    if (dao == null) return const Stream.empty();
+    return dao.watch(pubkey);
+  }
+
+  /// The current pending save for [pubkey], or null.
+  Future<PendingProfileSaveEntry?> getPendingSave(String pubkey) async {
+    return _pendingProfileSavesDao?.get(pubkey);
+  }
+
+  /// Delete the pending save for [pubkey] (e.g. on an explicit user discard).
+  Future<void> clearPendingSave(String pubkey) async {
+    await _pendingProfileSavesDao?.clear(pubkey);
+  }
+
+  /// Reset a `syncing` slot back to `pending` for [pubkey] — call once on cold
+  /// start so a save interrupted mid-publish is retried.
+  Future<void> resetInterruptedPendingSave(String pubkey) async {
+    await _pendingProfileSavesDao?.resetSyncingToPending(pubkey);
+  }
+
+  /// Attempt to publish the queued save for [pubkey] once.
+  ///
+  /// Claim-first (only when not yet confirmed and a divine.video username is
+  /// requested), then publish the kind-0 re-seeded from the freshest cached
+  /// profile. On a relay-confirmed publish the slot is cleared and the profile
+  /// cached, returning [PendingSaveDriveOutcome.confirmed]. Slot bookkeeping on
+  /// failure (retry count, mark-failed) is the caller's (retry service's) job —
+  /// this method only reports the typed outcome and never increments retries.
+  ///
+  /// Throws only unexpected (non-[ProfileRepositoryException]) errors, which
+  /// the retry service treats as a retryable failure.
+  Future<PendingSaveDriveOutcome> drivePendingSave(String pubkey) async {
+    final dao = _pendingProfileSavesDao;
+    if (dao == null) return PendingSaveDriveOutcome.noPendingSave;
+
+    final entry = await dao.get(pubkey);
+    if (entry == null) return PendingSaveDriveOutcome.noPendingSave;
+
+    final payload = PendingProfileSave.decode(entry.payloadJson);
+
+    if (!entry.claimConfirmed && payload.requiresClaim) {
+      final result = await claimUsername(username: payload.username!);
+      switch (result) {
+        case UsernameClaimSuccess():
+          await dao.markClaimConfirmed(pubkey);
+        case UsernameClaimTaken():
+        case UsernameClaimReserved():
+          return PendingSaveDriveOutcome.permanentFailure;
+        case UsernameClaimNetworkError():
+        case UsernameClaimError():
+          return PendingSaveDriveOutcome.retryableFailure;
+      }
+    }
+
+    final currentProfile = await getCachedProfile(pubkey: pubkey);
+    try {
+      final saved = await saveProfileEvent(
+        displayName: payload.displayName,
+        about: payload.about,
+        website: payload.website,
+        username: payload.username,
+        nip05: payload.nip05,
+        clearNip05: payload.clearNip05,
+        picture: payload.picture,
+        banner: payload.banner,
+        monetizationLinks: payload.monetizationLinks,
+        currentProfile: currentProfile,
+      );
+      await cacheProfile(saved);
+      await dao.clear(pubkey);
+      return PendingSaveDriveOutcome.confirmed;
+    } on NoRelaysConnectedException {
+      return PendingSaveDriveOutcome.retryableFailure;
+    } on ProfilePublishFailedException {
+      return PendingSaveDriveOutcome.retryableFailure;
     }
   }
 

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -689,7 +689,21 @@ class ProfileRepository {
     switch (result) {
       case PublishSuccess(:final event):
         final profile = UserProfile.fromNostrEvent(event);
-        await _userProfilesDao.upsertProfile(profile);
+        // A relay confirmed the kind-0 (OK true). The local cache write is
+        // non-fatal from here on: a Drift hiccup must never turn a landed
+        // publish into a thrown failure, or a durable re-drive would re-publish
+        // an already-confirmed save forever (#3161 G3 / review). Callers that
+        // need the cache warm re-read through the normal fetch path.
+        try {
+          await _userProfilesDao.upsertProfile(profile);
+        } on Object catch (e) {
+          Log.warning(
+            'profile cache upsert after a confirmed publish failed '
+            '(non-fatal): $e',
+            name: 'ProfileRepository.saveProfileEvent',
+            category: LogCategory.storage,
+          );
+        }
         return profile;
 
       case PublishNoRelays():
@@ -726,14 +740,16 @@ class ProfileRepository {
   /// claim already succeeded for this payload (or when no claim is needed), so
   /// the re-drive skips the idempotent HTTP claim round-trip.
   ///
-  /// No-op when no [PendingProfileSavesDao] was injected.
-  Future<void> enqueuePendingSave(
+  /// Returns the `generation` token stamped on the queued row so the caller
+  /// can scope its own [drivePendingSave] to exactly this intent. Returns null
+  /// when no [PendingProfileSavesDao] was injected (a no-op).
+  Future<String?> enqueuePendingSave(
     PendingProfileSave payload, {
     required bool claimConfirmed,
   }) async {
     final dao = _pendingProfileSavesDao;
-    if (dao == null) return;
-    await dao.upsert(
+    if (dao == null) return null;
+    return dao.upsert(
       PendingProfileSaveEntry(
         userPubkey: payload.pubkey,
         payloadJson: payload.encode(),
@@ -772,19 +788,39 @@ class ProfileRepository {
   ///
   /// Claim-first (only when not yet confirmed and a divine.video username is
   /// requested), then publish the kind-0 re-seeded from the freshest cached
-  /// profile. On a relay-confirmed publish the slot is cleared and the profile
-  /// cached, returning [PendingSaveDriveOutcome.confirmed]. Slot bookkeeping on
-  /// failure (retry count, mark-failed) is the caller's (retry service's) job —
-  /// this method only reports the typed outcome and never increments retries.
+  /// profile. On a relay-confirmed publish the slot is cleared (and the profile
+  /// cached by [saveProfileEvent], non-fatally), returning
+  /// [PendingSaveDriveOutcome.confirmed]. Slot bookkeeping on failure (retry
+  /// count, mark-failed) is the caller's (retry service's) job — this method
+  /// only reports the typed outcome and never increments retries.
+  ///
+  /// Every slot mutation here (claim-confirmed, clear) is guarded by the
+  /// generation captured at read time, so a newer save that replaces the row
+  /// while this drive awaits relay work is never cleared or reclassified — the
+  /// newer intent is left queued to be driven on its own (#3161 review). Pass
+  /// [expectedGeneration] (from [enqueuePendingSave] / the retry service) to
+  /// additionally bail out with [PendingSaveDriveOutcome.noPendingSave] when
+  /// the row was already superseded before this drive started; omit it to drive
+  /// whatever intent is currently queued.
   ///
   /// Throws only unexpected (non-[ProfileRepositoryException]) errors, which
   /// the retry service treats as a retryable failure.
-  Future<PendingSaveDriveOutcome> drivePendingSave(String pubkey) async {
+  Future<PendingSaveDriveOutcome> drivePendingSave(
+    String pubkey, {
+    String? expectedGeneration,
+  }) async {
     final dao = _pendingProfileSavesDao;
     if (dao == null) return PendingSaveDriveOutcome.noPendingSave;
 
     final entry = await dao.get(pubkey);
     if (entry == null) return PendingSaveDriveOutcome.noPendingSave;
+
+    // A newer save replaced the row after the caller captured the generation
+    // it wanted driven — that newer intent owns delivery now; don't touch it.
+    if (expectedGeneration != null && entry.generation != expectedGeneration) {
+      return PendingSaveDriveOutcome.noPendingSave;
+    }
+    final generation = entry.generation;
 
     final payload = PendingProfileSave.decode(entry.payloadJson);
 
@@ -792,7 +828,7 @@ class ProfileRepository {
       final result = await claimUsername(username: payload.username!);
       switch (result) {
         case UsernameClaimSuccess():
-          await dao.markClaimConfirmed(pubkey);
+          await dao.markClaimConfirmed(pubkey, generation: generation);
         case UsernameClaimTaken():
         case UsernameClaimReserved():
           return PendingSaveDriveOutcome.permanentFailure;
@@ -804,7 +840,13 @@ class ProfileRepository {
 
     final currentProfile = await getCachedProfile(pubkey: pubkey);
     try {
-      final saved = await saveProfileEvent(
+      // saveProfileEvent only returns on a relay-confirmed OK true, and its
+      // post-publish cache write is non-fatal, so reaching here means the
+      // kind-0 landed. Clearing the slot is generation-guarded: if a newer
+      // save replaced this row while we awaited the publish, the delete
+      // affects zero rows and the newer intent survives to be driven on its
+      // own — latest intent wins (#3161 review).
+      await saveProfileEvent(
         displayName: payload.displayName,
         about: payload.about,
         website: payload.website,
@@ -816,21 +858,7 @@ class ProfileRepository {
         monetizationLinks: payload.monetizationLinks,
         currentProfile: currentProfile,
       );
-      // A relay confirmed the kind-0 (saveProfileEvent only returns on an
-      // OK true). Clear the slot BEFORE the local cache write so a
-      // cache-write failure can't strand a save that already persisted on a
-      // relay — the #3161 G3 false-negative, relocated here from the bloc.
-      await dao.clear(pubkey);
-      try {
-        await cacheProfile(saved);
-      } on Object catch (e) {
-        Log.warning(
-          'cacheProfile after a confirmed pending-save publish failed '
-          '(non-fatal): $e',
-          name: 'ProfileRepository.drivePendingSave',
-          category: LogCategory.storage,
-        );
-      }
+      await dao.clear(pubkey, generation: generation);
       return PendingSaveDriveOutcome.confirmed;
     } on NoRelaysConnectedException {
       return PendingSaveDriveOutcome.retryableFailure;

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -816,8 +816,21 @@ class ProfileRepository {
         monetizationLinks: payload.monetizationLinks,
         currentProfile: currentProfile,
       );
-      await cacheProfile(saved);
+      // A relay confirmed the kind-0 (saveProfileEvent only returns on an
+      // OK true). Clear the slot BEFORE the local cache write so a
+      // cache-write failure can't strand a save that already persisted on a
+      // relay — the #3161 G3 false-negative, relocated here from the bloc.
       await dao.clear(pubkey);
+      try {
+        await cacheProfile(saved);
+      } on Object catch (e) {
+        Log.warning(
+          'cacheProfile after a confirmed pending-save publish failed '
+          '(non-fatal): $e',
+          name: 'ProfileRepository.drivePendingSave',
+          category: LogCategory.storage,
+        );
+      }
       return PendingSaveDriveOutcome.confirmed;
     } on NoRelaysConnectedException {
       return PendingSaveDriveOutcome.retryableFailure;

--- a/mobile/packages/profile_repository/pubspec.yaml
+++ b/mobile/packages/profile_repository/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 resolution: workspace
 
 dev_dependencies:
+  drift: ^2.34.0
   fake_async: ^1.3.3
   flutter_test:
     sdk: flutter

--- a/mobile/packages/profile_repository/test/src/pending_profile_save_test.dart
+++ b/mobile/packages/profile_repository/test/src/pending_profile_save_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart';
+import 'package:profile_repository/profile_repository.dart';
+
+void main() {
+  group(PendingProfileSave, () {
+    const pubkey =
+        'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2';
+
+    test('round-trips all fields through encode/decode', () {
+      const payload = PendingProfileSave(
+        pubkey: pubkey,
+        displayName: 'Alice',
+        about: 'bio',
+        website: 'https://alice.example',
+        username: 'alice',
+        clearNip05: true,
+        picture: 'https://cdn/pic.png',
+        banner: '#112233',
+        monetizationLinks: [
+          MonetizationLink(
+            provider: MonetizationLinkProvider.venmo,
+            category: MonetizationLinkCategory.tip,
+            url: 'https://venmo.com/alice',
+            enabled: true,
+          ),
+        ],
+      );
+
+      final decoded = PendingProfileSave.decode(payload.encode());
+
+      expect(decoded.pubkey, pubkey);
+      expect(decoded.displayName, 'Alice');
+      expect(decoded.about, 'bio');
+      expect(decoded.website, 'https://alice.example');
+      expect(decoded.username, 'alice');
+      expect(decoded.clearNip05, isTrue);
+      expect(decoded.picture, 'https://cdn/pic.png');
+      expect(decoded.banner, '#112233');
+      expect(decoded.monetizationLinks, hasLength(1));
+      expect(decoded.monetizationLinks!.first.url, 'https://venmo.com/alice');
+    });
+
+    test('omits null optionals and defaults clearNip05/monetizationLinks', () {
+      const payload = PendingProfileSave(pubkey: pubkey, displayName: 'Bob');
+      final json = payload.toJson();
+
+      expect(json.containsKey('about'), isFalse);
+      expect(json.containsKey('username'), isFalse);
+      expect(json.containsKey('monetizationLinks'), isFalse);
+      expect(json['clearNip05'], isFalse);
+
+      final decoded = PendingProfileSave.decode(payload.encode());
+      expect(decoded.about, isNull);
+      expect(decoded.username, isNull);
+      expect(decoded.clearNip05, isFalse);
+      expect(decoded.monetizationLinks, isNull);
+    });
+
+    group('requiresClaim', () {
+      test('is true when a non-blank username is set', () {
+        expect(
+          const PendingProfileSave(
+            pubkey: pubkey,
+            displayName: 'x',
+            username: 'alice',
+          ).requiresClaim,
+          isTrue,
+        );
+      });
+
+      test('is false for null or blank username', () {
+        expect(
+          const PendingProfileSave(
+            pubkey: pubkey,
+            displayName: 'x',
+          ).requiresClaim,
+          isFalse,
+        );
+        expect(
+          const PendingProfileSave(
+            pubkey: pubkey,
+            displayName: 'x',
+            username: '   ',
+          ).requiresClaim,
+          isFalse,
+        );
+      });
+    });
+  });
+}

--- a/mobile/packages/profile_repository/test/src/profile_repository_pending_save_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_pending_save_test.dart
@@ -1,0 +1,374 @@
+// ABOUTME: Tests the offline-tolerant pending-save slot on ProfileRepository
+// ABOUTME: (#3161): enqueue delegation + drivePendingSave orchestration
+// ABOUTME: outcomes, using a real in-memory PendingProfileSavesDao.
+
+import 'package:db_client/db_client.dart' hide Filter, ProfileStats;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:profile_repository/profile_repository.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockHttpClient extends Mock implements Client {}
+
+class _MockUserProfilesDao extends Mock implements UserProfilesDao {}
+
+class _MockEvent extends Mock implements Event {
+  @override
+  DateTime get createdAtDateTime =>
+      DateTime.fromMillisecondsSinceEpoch(createdAt * 1000, isUtc: true);
+
+  @override
+  List<List<String>> get tags => const [];
+}
+
+void main() {
+  group('ProfileRepository pending-save slot (#3161)', () {
+    late _MockNostrClient nostrClient;
+    late _MockHttpClient httpClient;
+    late _MockUserProfilesDao userProfilesDao;
+    late AppDatabase db;
+    late PendingProfileSavesDao slotDao;
+    late ProfileRepository repository;
+    late _MockEvent event;
+
+    const pubkey =
+        'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2';
+
+    setUpAll(() {
+      registerFallbackValue(Uri.parse('https://names.divine.video'));
+      registerFallbackValue(<String, dynamic>{});
+      registerFallbackValue(
+        UserProfile(
+          pubkey: pubkey,
+          rawData: const {},
+          createdAt: DateTime(2026),
+          eventId: 'eventId',
+        ),
+      );
+    });
+
+    setUp(() {
+      nostrClient = _MockNostrClient();
+      httpClient = _MockHttpClient();
+      userProfilesDao = _MockUserProfilesDao();
+      db = AppDatabase.test(NativeDatabase.memory());
+      slotDao = db.pendingProfileSavesDao;
+      repository = ProfileRepository(
+        nostrClient: nostrClient,
+        userProfilesDao: userProfilesDao,
+        httpClient: httpClient,
+        pendingProfileSavesDao: slotDao,
+      );
+
+      event = _MockEvent();
+      when(() => event.kind).thenReturn(0);
+      when(() => event.pubkey).thenReturn(pubkey);
+      when(() => event.createdAt).thenReturn(1704067200);
+      when(() => event.id).thenReturn('e' * 64);
+      when(() => event.content).thenReturn('{"display_name":"Alice"}');
+
+      // No cached profile → seed short-circuits, no relay fetch.
+      when(
+        () => userProfilesDao.getProfile(any()),
+      ).thenAnswer((_) async => null);
+      when(() => userProfilesDao.upsertProfile(any())).thenAnswer((_) async {});
+
+      // Default: a confirmed publish.
+      when(
+        () => nostrClient.sendProfileAwaitOk(
+          profileContent: any(named: 'profileContent'),
+        ),
+      ).thenAnswer((_) async => PublishSuccess(event: event));
+
+      // Default claim wiring (overridden per-test as needed).
+      when(
+        () => nostrClient.createNip98AuthHeader(
+          url: any(named: 'url'),
+          method: any(named: 'method'),
+          payload: any(named: 'payload'),
+        ),
+      ).thenAnswer((_) async => 'Nostr header');
+      when(
+        () => httpClient.post(
+          any(),
+          headers: any(named: 'headers'),
+          body: any(named: 'body'),
+        ),
+      ).thenAnswer((_) async => Response('{}', 200));
+    });
+
+    tearDown(() => db.close());
+
+    PendingProfileSave payload({String? username}) => PendingProfileSave(
+      pubkey: pubkey,
+      displayName: 'Alice',
+      username: username,
+    );
+
+    Future<void> seedSlot({
+      required bool claimConfirmed,
+      String? username,
+    }) {
+      return slotDao.upsert(
+        PendingProfileSaveEntry(
+          userPubkey: pubkey,
+          payloadJson: payload(username: username).encode(),
+          claimConfirmed: claimConfirmed,
+          queuedAt: DateTime.utc(2026, 7, 13),
+        ),
+      );
+    }
+
+    group('enqueuePendingSave', () {
+      test('persists the payload + claimConfirmed to the slot', () async {
+        await repository.enqueuePendingSave(
+          payload(username: 'alice'),
+          claimConfirmed: true,
+        );
+
+        final entry = await slotDao.get(pubkey);
+        expect(entry, isNotNull);
+        expect(entry!.claimConfirmed, isTrue);
+        expect(entry.status, PendingProfileSaveStatus.pending);
+        final decoded = PendingProfileSave.decode(entry.payloadJson);
+        expect(decoded.username, 'alice');
+        expect(decoded.displayName, 'Alice');
+      });
+
+      test('latest enqueue replaces the previous slot', () async {
+        await repository.enqueuePendingSave(
+          payload(username: 'old'),
+          claimConfirmed: false,
+        );
+        await repository.enqueuePendingSave(
+          payload(username: 'new'),
+          claimConfirmed: true,
+        );
+
+        final entry = await slotDao.get(pubkey);
+        expect(PendingProfileSave.decode(entry!.payloadJson).username, 'new');
+        expect(entry.claimConfirmed, isTrue);
+      });
+    });
+
+    group('drivePendingSave', () {
+      test('returns noPendingSave when the slot is empty', () async {
+        expect(
+          await repository.drivePendingSave(pubkey),
+          PendingSaveDriveOutcome.noPendingSave,
+        );
+      });
+
+      test(
+        'confirmed publish clears the slot (claim already confirmed)',
+        () async {
+          await seedSlot(claimConfirmed: true);
+
+          final outcome = await repository.drivePendingSave(pubkey);
+
+          expect(outcome, PendingSaveDriveOutcome.confirmed);
+          expect(await slotDao.get(pubkey), isNull);
+          // Claim endpoint is never hit when already confirmed.
+          verifyNever(
+            () => httpClient.post(
+              any(),
+              headers: any(named: 'headers'),
+              body: any(named: 'body'),
+            ),
+          );
+        },
+      );
+
+      test(
+        'claims first when not yet confirmed, then publishes + clears',
+        () async {
+          await seedSlot(claimConfirmed: false, username: 'alice');
+
+          final outcome = await repository.drivePendingSave(pubkey);
+
+          expect(outcome, PendingSaveDriveOutcome.confirmed);
+          expect(await slotDao.get(pubkey), isNull);
+          verify(
+            () => httpClient.post(
+              any(),
+              headers: any(named: 'headers'),
+              body: any(named: 'body'),
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
+        'permanentFailure when the claim is taken — publish not attempted',
+        () async {
+          when(
+            () => httpClient.post(
+              any(),
+              headers: any(named: 'headers'),
+              body: any(named: 'body'),
+            ),
+          ).thenAnswer((_) async => Response('{"error":"taken"}', 409));
+
+          await seedSlot(claimConfirmed: false, username: 'alice');
+
+          final outcome = await repository.drivePendingSave(pubkey);
+
+          expect(outcome, PendingSaveDriveOutcome.permanentFailure);
+          expect(await slotDao.get(pubkey), isNotNull); // slot kept
+          verifyNever(
+            () => nostrClient.sendProfileAwaitOk(
+              profileContent: any(named: 'profileContent'),
+            ),
+          );
+        },
+      );
+
+      test('retryableFailure on no connected relays — slot kept', () async {
+        when(
+          () => nostrClient.sendProfileAwaitOk(
+            profileContent: any(named: 'profileContent'),
+          ),
+        ).thenAnswer((_) async => const PublishNoRelays());
+
+        await seedSlot(claimConfirmed: true);
+
+        final outcome = await repository.drivePendingSave(pubkey);
+
+        expect(outcome, PendingSaveDriveOutcome.retryableFailure);
+        expect(await slotDao.get(pubkey), isNotNull);
+      });
+
+      test(
+        'retryableFailure when relays reject the publish — slot kept',
+        () async {
+          when(
+            () => nostrClient.sendProfileAwaitOk(
+              profileContent: any(named: 'profileContent'),
+            ),
+          ).thenAnswer((_) async => const PublishFailed());
+
+          await seedSlot(claimConfirmed: true);
+
+          expect(
+            await repository.drivePendingSave(pubkey),
+            PendingSaveDriveOutcome.retryableFailure,
+          );
+          expect(await slotDao.get(pubkey), isNotNull);
+        },
+      );
+
+      test('permanentFailure when the claim is reserved', () async {
+        when(
+          () => httpClient.post(
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer((_) async => Response('{"error":"reserved"}', 403));
+
+        await seedSlot(claimConfirmed: false, username: 'alice');
+
+        expect(
+          await repository.drivePendingSave(pubkey),
+          PendingSaveDriveOutcome.permanentFailure,
+        );
+      });
+
+      test(
+        'retryableFailure when the claim hits a network error — slot kept',
+        () async {
+          when(
+            () => httpClient.post(
+              any(),
+              headers: any(named: 'headers'),
+              body: any(named: 'body'),
+            ),
+          ).thenThrow(Exception('offline'));
+
+          await seedSlot(claimConfirmed: false, username: 'alice');
+
+          expect(
+            await repository.drivePendingSave(pubkey),
+            PendingSaveDriveOutcome.retryableFailure,
+          );
+          expect(await slotDao.get(pubkey), isNotNull);
+          verifyNever(
+            () => nostrClient.sendProfileAwaitOk(
+              profileContent: any(named: 'profileContent'),
+            ),
+          );
+        },
+      );
+
+      test(
+        'retryableFailure when the claim returns a 4xx error — slot kept',
+        () async {
+          when(
+            () => httpClient.post(
+              any(),
+              headers: any(named: 'headers'),
+              body: any(named: 'body'),
+            ),
+          ).thenAnswer((_) async => Response('{"error":"bad format"}', 400));
+
+          await seedSlot(claimConfirmed: false, username: 'alice');
+
+          expect(
+            await repository.drivePendingSave(pubkey),
+            PendingSaveDriveOutcome.retryableFailure,
+          );
+          expect(await slotDao.get(pubkey), isNotNull);
+        },
+      );
+    });
+
+    group('watchPendingSave (dao wired)', () {
+      test('emits the queued slot', () async {
+        await seedSlot(claimConfirmed: true);
+        expect(
+          repository.watchPendingSave(pubkey),
+          emits(isA<PendingProfileSaveEntry>()),
+        );
+      });
+    });
+
+    group('no pending-save dao wired (queue methods are safe no-ops)', () {
+      late ProfileRepository repoNoSlot;
+
+      setUp(() {
+        repoNoSlot = ProfileRepository(
+          nostrClient: nostrClient,
+          userProfilesDao: userProfilesDao,
+          httpClient: httpClient,
+        );
+      });
+
+      test('enqueue / clear / reset are no-ops and get returns null', () async {
+        await repoNoSlot.enqueuePendingSave(
+          payload(username: 'alice'),
+          claimConfirmed: true,
+        );
+        await repoNoSlot.clearPendingSave(pubkey);
+        await repoNoSlot.resetInterruptedPendingSave(pubkey);
+        expect(await repoNoSlot.getPendingSave(pubkey), isNull);
+      });
+
+      test('watchPendingSave emits nothing', () async {
+        expect(repoNoSlot.watchPendingSave(pubkey), emitsDone);
+      });
+
+      test('drivePendingSave returns noPendingSave', () async {
+        expect(
+          await repoNoSlot.drivePendingSave(pubkey),
+          PendingSaveDriveOutcome.noPendingSave,
+        );
+      });
+    });
+  });
+}

--- a/mobile/packages/profile_repository/test/src/profile_repository_pending_save_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_pending_save_test.dart
@@ -166,6 +166,28 @@ void main() {
       });
 
       test(
+        'confirmed even if the post-publish cache write fails (G3)',
+        () async {
+          // saveProfileEvent upserts once on success; cacheProfile upserts
+          // again — make only that second write throw. The confirmed publish
+          // must still clear the slot (a cache failure cannot strand it).
+          var upserts = 0;
+          when(() => userProfilesDao.upsertProfile(any())).thenAnswer((
+            _,
+          ) async {
+            upserts++;
+            if (upserts >= 2) throw Exception('cache boom');
+          });
+          await seedSlot(claimConfirmed: true);
+
+          final outcome = await repository.drivePendingSave(pubkey);
+
+          expect(outcome, PendingSaveDriveOutcome.confirmed);
+          expect(await slotDao.get(pubkey), isNull);
+        },
+      );
+
+      test(
         'confirmed publish clears the slot (claim already confirmed)',
         () async {
           await seedSlot(claimConfirmed: true);

--- a/mobile/packages/profile_repository/test/src/profile_repository_pending_save_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_pending_save_test.dart
@@ -2,6 +2,8 @@
 // ABOUTME: (#3161): enqueue delegation + drivePendingSave orchestration
 // ABOUTME: outcomes, using a real in-memory PendingProfileSavesDao.
 
+import 'dart:async';
+
 import 'package:db_client/db_client.dart' hide Filter, ProfileStats;
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -166,17 +168,17 @@ void main() {
       });
 
       test(
-        'confirmed even if the post-publish cache write fails (G3)',
+        'confirmed even when the profile cache write fails (G3) — the '
+        'first (only) upsert throws yet the slot still clears',
         () async {
-          // saveProfileEvent upserts once on success; cacheProfile upserts
-          // again — make only that second write throw. The confirmed publish
-          // must still clear the slot (a cache failure cannot strand it).
-          var upserts = 0;
+          // The single post-publish cache write inside saveProfileEvent throws.
+          // A relay already confirmed the kind-0, so the drive must still
+          // report confirmed and clear the slot — a cache hiccup can never
+          // strand a landed publish into an endless re-publish (#3161 review).
           when(() => userProfilesDao.upsertProfile(any())).thenAnswer((
             _,
           ) async {
-            upserts++;
-            if (upserts >= 2) throw Exception('cache boom');
+            throw Exception('cache boom');
           });
           await seedSlot(claimConfirmed: true);
 
@@ -184,6 +186,84 @@ void main() {
 
           expect(outcome, PendingSaveDriveOutcome.confirmed);
           expect(await slotDao.get(pubkey), isNull);
+        },
+      );
+
+      test(
+        'a newer save enqueued mid-publish is not cleared by the older drive '
+        'and is driven on its own (generation guard)',
+        () async {
+          // Gate A's publish so a newer save B can slip in while A awaits the
+          // relay round-trip.
+          final publishGate = Completer<PublishResult>();
+          when(
+            () => nostrClient.sendProfileAwaitOk(
+              profileContent: any(named: 'profileContent'),
+            ),
+          ).thenAnswer((_) => publishGate.future);
+
+          final genA = await repository.enqueuePendingSave(
+            payload(),
+            claimConfirmed: true,
+          );
+
+          // Start driving A; it parks on the gated publish.
+          final driveA = repository.drivePendingSave(
+            pubkey,
+            expectedGeneration: genA,
+          );
+          await pumpEventQueue();
+
+          // B replaces the row while A is mid-publish.
+          final genB = await repository.enqueuePendingSave(
+            payload(username: 'bob'),
+            claimConfirmed: true,
+          );
+          expect(genB, isNot(genA));
+
+          // A's publish confirms — its generation-guarded clear must miss B.
+          publishGate.complete(PublishSuccess(event: event));
+          expect(await driveA, PendingSaveDriveOutcome.confirmed);
+
+          final surviving = await slotDao.get(pubkey);
+          expect(surviving, isNotNull, reason: 'B must not be cleared by A');
+          expect(surviving!.generation, genB);
+          expect(
+            PendingProfileSave.decode(surviving.payloadJson).username,
+            'bob',
+          );
+
+          // B is still deliverable on its own.
+          final driveB = await repository.drivePendingSave(pubkey);
+          expect(driveB, PendingSaveDriveOutcome.confirmed);
+          expect(await slotDao.get(pubkey), isNull);
+        },
+      );
+
+      test(
+        'a superseded expectedGeneration bails without touching the newer row',
+        () async {
+          final genA = await repository.enqueuePendingSave(
+            payload(),
+            claimConfirmed: true,
+          );
+          await repository.enqueuePendingSave(
+            payload(username: 'bob'),
+            claimConfirmed: true,
+          );
+
+          final outcome = await repository.drivePendingSave(
+            pubkey,
+            expectedGeneration: genA,
+          );
+
+          expect(outcome, PendingSaveDriveOutcome.noPendingSave);
+          expect(await slotDao.get(pubkey), isNotNull);
+          verifyNever(
+            () => nostrClient.sendProfileAwaitOk(
+              profileContent: any(named: 'profileContent'),
+            ),
+          );
         },
       );
 

--- a/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
+++ b/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
@@ -92,9 +92,12 @@ void main() {
           any(),
           claimConfirmed: any(named: 'claimConfirmed'),
         ),
-      ).thenAnswer((_) async {});
+      ).thenAnswer((_) async => 'gen-test');
       when(
-        () => mockProfileRepository.drivePendingSave(any()),
+        () => mockProfileRepository.drivePendingSave(
+          any(),
+          expectedGeneration: any(named: 'expectedGeneration'),
+        ),
       ).thenAnswer((_) async => PendingSaveDriveOutcome.confirmed);
     });
 
@@ -680,7 +683,10 @@ void main() {
               () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
             ).thenAnswer((_) async => null);
             when(
-              () => mockProfileRepository.drivePendingSave(testPubkey),
+              () => mockProfileRepository.drivePendingSave(
+                testPubkey,
+                expectedGeneration: any(named: 'expectedGeneration'),
+              ),
             ).thenAnswer((_) async => PendingSaveDriveOutcome.retryableFailure);
           },
           build: createBloc,
@@ -725,7 +731,10 @@ void main() {
               () => mockProfileRepository.claimUsername(username: testUsername),
             ).thenAnswer((_) async => const UsernameClaimSuccess());
             when(
-              () => mockProfileRepository.drivePendingSave(testPubkey),
+              () => mockProfileRepository.drivePendingSave(
+                testPubkey,
+                expectedGeneration: any(named: 'expectedGeneration'),
+              ),
             ).thenAnswer((_) async => PendingSaveDriveOutcome.retryableFailure);
           },
           build: createBloc,
@@ -773,7 +782,10 @@ void main() {
               () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
             ).thenAnswer((_) async => null);
             when(
-              () => mockProfileRepository.drivePendingSave(testPubkey),
+              () => mockProfileRepository.drivePendingSave(
+                testPubkey,
+                expectedGeneration: any(named: 'expectedGeneration'),
+              ),
             ).thenAnswer((_) async => PendingSaveDriveOutcome.retryableFailure);
           },
           build: createBloc,
@@ -818,7 +830,10 @@ void main() {
               () => mockProfileRepository.claimUsername(username: testUsername),
             ).thenAnswer((_) async => const UsernameClaimSuccess());
             when(
-              () => mockProfileRepository.drivePendingSave(testPubkey),
+              () => mockProfileRepository.drivePendingSave(
+                testPubkey,
+                expectedGeneration: any(named: 'expectedGeneration'),
+              ),
             ).thenAnswer((_) async => PendingSaveDriveOutcome.retryableFailure);
           },
           build: createBloc,
@@ -944,7 +959,12 @@ void main() {
                   claimConfirmed: any(named: 'claimConfirmed'),
                 ),
               );
-              verifyNever(() => mockProfileRepository.drivePendingSave(any()));
+              verifyNever(
+                () => mockProfileRepository.drivePendingSave(
+                  any(),
+                  expectedGeneration: any(named: 'expectedGeneration'),
+                ),
+              );
             },
           );
         }
@@ -1044,7 +1064,12 @@ void main() {
               claimConfirmed: any(named: 'claimConfirmed'),
             ),
           );
-          verifyNever(() => mockProfileRepository.drivePendingSave(any()));
+          verifyNever(
+            () => mockProfileRepository.drivePendingSave(
+              any(),
+              expectedGeneration: any(named: 'expectedGeneration'),
+            ),
+          );
         },
       );
 
@@ -1056,7 +1081,10 @@ void main() {
             () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
           ).thenAnswer((_) async => null);
           when(
-            () => mockProfileRepository.drivePendingSave(testPubkey),
+            () => mockProfileRepository.drivePendingSave(
+              testPubkey,
+              expectedGeneration: any(named: 'expectedGeneration'),
+            ),
           ).thenThrow(StateError('publish invariant'));
         },
         build: createBloc,
@@ -1097,7 +1125,10 @@ void main() {
             () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
           ).thenAnswer((_) async => null);
           when(
-            () => mockProfileRepository.drivePendingSave(testPubkey),
+            () => mockProfileRepository.drivePendingSave(
+              testPubkey,
+              expectedGeneration: any(named: 'expectedGeneration'),
+            ),
           ).thenThrow(StateError('nip05 save invariant'));
         },
         build: createBloc,
@@ -1144,7 +1175,10 @@ void main() {
             () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
           ).thenAnswer((_) async => null);
           when(
-            () => mockProfileRepository.drivePendingSave(testPubkey),
+            () => mockProfileRepository.drivePendingSave(
+              testPubkey,
+              expectedGeneration: any(named: 'expectedGeneration'),
+            ),
           ).thenThrow(StateError('confirmed save invariant'));
         },
         build: () => createBloc(hasExistingProfile: false),
@@ -2872,7 +2906,12 @@ void main() {
               claimConfirmed: any(named: 'claimConfirmed'),
             ),
           );
-          verifyNever(() => mockProfileRepository.drivePendingSave(any()));
+          verifyNever(
+            () => mockProfileRepository.drivePendingSave(
+              any(),
+              expectedGeneration: any(named: 'expectedGeneration'),
+            ),
+          );
           verifyNever(
             () => mockProfileRepository.claimUsername(
               username: any(named: 'username'),
@@ -2907,7 +2946,12 @@ void main() {
               claimConfirmed: any(named: 'claimConfirmed'),
             ),
           );
-          verifyNever(() => mockProfileRepository.drivePendingSave(any()));
+          verifyNever(
+            () => mockProfileRepository.drivePendingSave(
+              any(),
+              expectedGeneration: any(named: 'expectedGeneration'),
+            ),
+          );
           verifyNever(
             () => mockProfileRepository.claimUsername(
               username: any(named: 'username'),
@@ -2950,7 +2994,12 @@ void main() {
               claimConfirmed: any(named: 'claimConfirmed'),
             ),
           );
-          verifyNever(() => mockProfileRepository.drivePendingSave(any()));
+          verifyNever(
+            () => mockProfileRepository.drivePendingSave(
+              any(),
+              expectedGeneration: any(named: 'expectedGeneration'),
+            ),
+          );
           verifyNever(
             () => mockProfileRepository.claimUsername(
               username: any(named: 'username'),
@@ -2985,7 +3034,12 @@ void main() {
               claimConfirmed: any(named: 'claimConfirmed'),
             ),
           );
-          verifyNever(() => mockProfileRepository.drivePendingSave(any()));
+          verifyNever(
+            () => mockProfileRepository.drivePendingSave(
+              any(),
+              expectedGeneration: any(named: 'expectedGeneration'),
+            ),
+          );
           verifyNever(
             () => mockProfileRepository.claimUsername(
               username: any(named: 'username'),

--- a/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
+++ b/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
@@ -72,6 +72,9 @@ void main() {
       );
       registerFallbackValue(_FakeFile());
       registerFallbackValue(Uint8List(0));
+      registerFallbackValue(
+        const PendingProfileSave(pubkey: testPubkey, displayName: 'fallback'),
+      );
     });
 
     setUp(() {
@@ -81,6 +84,18 @@ void main() {
       when(
         () => mockProfileRepository.cacheProfile(any()),
       ).thenAnswer((_) async {});
+      // Optimistic-save path (#3161): every save enqueues the durable slot and
+      // re-drives it. Default the slot to a confirmed publish so success-path
+      // tests read [loading, success] unchanged; failure-path tests override.
+      when(
+        () => mockProfileRepository.enqueuePendingSave(
+          any(),
+          claimConfirmed: any(named: 'claimConfirmed'),
+        ),
+      ).thenAnswer((_) async {});
+      when(
+        () => mockProfileRepository.drivePendingSave(any()),
+      ).thenAnswer((_) async => PendingSaveDriveOutcome.confirmed);
     });
 
     ProfileEditorBloc createBloc({
@@ -108,14 +123,6 @@ void main() {
             when(
               () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
             ).thenAnswer((_) async => null);
-            when(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                picture: testPicture,
-                clearNip05: any(named: 'clearNip05'),
-              ),
-            ).thenAnswer((_) async => createTestProfile());
           },
           build: createBloc,
           act: (bloc) => bloc.add(
@@ -139,14 +146,17 @@ void main() {
             ),
           ],
           verify: (_) {
-            verify(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                picture: testPicture,
-                clearNip05: any(named: 'clearNip05'),
+            final captured = verify(
+              () => mockProfileRepository.enqueuePendingSave(
+                captureAny(),
+                claimConfirmed: captureAny(named: 'claimConfirmed'),
               ),
-            ).called(1);
+            ).captured;
+            final payload = captured[0] as PendingProfileSave;
+            expect(payload.displayName, testDisplayName);
+            expect(payload.about, testAbout);
+            expect(payload.picture, testPicture);
+            expect(payload.username, isNull);
             verifyNever(
               () => mockProfileRepository.claimUsername(
                 username: any(named: 'username'),
@@ -164,15 +174,6 @@ void main() {
             when(
               () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
             ).thenAnswer((_) async => existingProfile);
-            when(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                picture: testPicture,
-                clearNip05: any(named: 'clearNip05'),
-                currentProfile: existingProfile,
-              ),
-            ).thenAnswer((_) async => createTestProfile());
           },
           build: createBloc,
           act: (bloc) => bloc.add(
@@ -203,14 +204,6 @@ void main() {
             when(
               () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
             ).thenAnswer((_) async => null);
-            when(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                picture: testPicture,
-                clearNip05: any(named: 'clearNip05'),
-              ),
-            ).thenAnswer((_) async => createTestProfile());
           },
           build: createBloc,
           act: (bloc) => bloc.add(
@@ -235,14 +228,17 @@ void main() {
             ),
           ],
           verify: (_) {
-            verify(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                picture: testPicture,
-                clearNip05: any(named: 'clearNip05'),
+            final captured = verify(
+              () => mockProfileRepository.enqueuePendingSave(
+                captureAny(),
+                claimConfirmed: captureAny(named: 'claimConfirmed'),
               ),
-            ).called(1);
+            ).captured;
+            final payload = captured[0] as PendingProfileSave;
+            expect(payload.displayName, testDisplayName);
+            expect(payload.about, testAbout);
+            expect(payload.picture, testPicture);
+            expect(payload.username, isNull);
           },
         );
 
@@ -253,14 +249,6 @@ void main() {
             when(
               () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
             ).thenAnswer((_) async => null);
-            when(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                picture: testPicture,
-                clearNip05: any(named: 'clearNip05'),
-              ),
-            ).thenAnswer((_) async => createTestProfile());
           },
           build: createBloc,
           act: (bloc) => bloc.add(
@@ -272,14 +260,17 @@ void main() {
             ),
           ),
           verify: (_) {
-            verify(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                picture: testPicture,
-                clearNip05: any(named: 'clearNip05', that: isFalse),
+            final captured = verify(
+              () => mockProfileRepository.enqueuePendingSave(
+                captureAny(),
+                claimConfirmed: captureAny(named: 'claimConfirmed'),
               ),
-            ).called(1);
+            ).captured;
+            final payload = captured[0] as PendingProfileSave;
+            expect(payload.displayName, testDisplayName);
+            expect(payload.about, testAbout);
+            expect(payload.picture, testPicture);
+            expect(payload.clearNip05, isFalse);
           },
         );
 
@@ -289,14 +280,6 @@ void main() {
             when(
               () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
             ).thenAnswer((_) async => null);
-            when(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                picture: testPicture,
-                clearNip05: true,
-              ),
-            ).thenAnswer((_) async => createTestProfile());
           },
           build: createBloc,
           // Dispatch InitialUsernameSet first so the bloc knows the user had
@@ -314,21 +297,23 @@ void main() {
             );
           },
           verify: (_) {
-            verify(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                picture: testPicture,
-                clearNip05: true,
+            final captured = verify(
+              () => mockProfileRepository.enqueuePendingSave(
+                captureAny(),
+                claimConfirmed: captureAny(named: 'claimConfirmed'),
               ),
-            ).called(1);
+            ).captured;
+            final payload = captured[0] as PendingProfileSave;
+            expect(payload.displayName, testDisplayName);
+            expect(payload.about, testAbout);
+            expect(payload.picture, testPicture);
+            expect(payload.clearNip05, isTrue);
           },
         );
 
         blocTest<ProfileEditorBloc, ProfileEditorState>(
           'canonicalizes exact bio mentions before publishing profile metadata',
           setUp: () {
-            final aliceNpub = NostrKeyUtils.encodePubKey(alicePubkey);
             when(
               () => mockProfileRepository.searchUsersLocally(
                 query: 'alice',
@@ -348,14 +333,6 @@ void main() {
             when(
               () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
             ).thenAnswer((_) async => null);
-            when(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: 'hi nostr:$aliceNpub',
-                picture: testPicture,
-                clearNip05: any(named: 'clearNip05'),
-              ),
-            ).thenAnswer((_) async => createTestProfile());
           },
           build: () => createBloc(
             mentionResolutionService: MentionResolutionService(
@@ -384,14 +361,16 @@ void main() {
           ],
           verify: (_) {
             final aliceNpub = NostrKeyUtils.encodePubKey(alicePubkey);
-            verify(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: 'hi nostr:$aliceNpub',
-                picture: testPicture,
-                clearNip05: any(named: 'clearNip05'),
+            final captured = verify(
+              () => mockProfileRepository.enqueuePendingSave(
+                captureAny(),
+                claimConfirmed: captureAny(named: 'claimConfirmed'),
               ),
-            ).called(1);
+            ).captured;
+            final payload = captured[0] as PendingProfileSave;
+            expect(payload.displayName, testDisplayName);
+            expect(payload.about, 'hi nostr:$aliceNpub');
+            expect(payload.picture, testPicture);
           },
         );
 
@@ -407,14 +386,6 @@ void main() {
             when(
               () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
             ).thenAnswer((_) async => null);
-            when(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: 'hi @alice',
-                picture: testPicture,
-                clearNip05: any(named: 'clearNip05'),
-              ),
-            ).thenAnswer((_) async => createTestProfile());
           },
           build: () => createBloc(
             mentionResolutionService: MentionResolutionService(
@@ -442,14 +413,16 @@ void main() {
             ),
           ],
           verify: (_) {
-            verify(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: 'hi @alice',
-                picture: testPicture,
-                clearNip05: any(named: 'clearNip05'),
+            final captured = verify(
+              () => mockProfileRepository.enqueuePendingSave(
+                captureAny(),
+                claimConfirmed: captureAny(named: 'claimConfirmed'),
               ),
-            ).called(1);
+            ).captured;
+            final payload = captured[0] as PendingProfileSave;
+            expect(payload.displayName, testDisplayName);
+            expect(payload.about, 'hi @alice');
+            expect(payload.picture, testPicture);
           },
         );
       });
@@ -461,14 +434,6 @@ void main() {
             when(
               () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
             ).thenAnswer((_) async => null);
-            when(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                username: testUsername,
-                picture: testPicture,
-              ),
-            ).thenAnswer((_) async => createTestProfile());
             when(
               () => mockProfileRepository.claimUsername(username: testUsername),
             ).thenAnswer((_) async => const UsernameClaimSuccess());
@@ -498,15 +463,18 @@ void main() {
           verify: (_) {
             // Claim must run before publish so kind 0 is only broadcast
             // after the registry confirms the name belongs to this pubkey.
-            verifyInOrder([
+            final results = verifyInOrder([
               () => mockProfileRepository.claimUsername(username: testUsername),
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                username: testUsername,
-                picture: testPicture,
+              () => mockProfileRepository.enqueuePendingSave(
+                captureAny(),
+                claimConfirmed: captureAny(named: 'claimConfirmed'),
               ),
             ]);
+            final payload = results[1].captured[0] as PendingProfileSave;
+            expect(payload.displayName, testDisplayName);
+            expect(payload.about, testAbout);
+            expect(payload.username, testUsername);
+            expect(payload.picture, testPicture);
           },
         );
 
@@ -516,14 +484,6 @@ void main() {
             when(
               () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
             ).thenAnswer((_) async => null);
-            when(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                username: testUsername,
-                picture: testPicture,
-              ),
-            ).thenAnswer((_) async => createTestProfile());
           },
           seed: () => const ProfileEditorState(
             initialUsername: testUsername,
@@ -556,14 +516,17 @@ void main() {
                 username: any(named: 'username'),
               ),
             );
-            verify(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                username: testUsername,
-                picture: testPicture,
+            final captured = verify(
+              () => mockProfileRepository.enqueuePendingSave(
+                captureAny(),
+                claimConfirmed: captureAny(named: 'claimConfirmed'),
               ),
-            ).called(1);
+            ).captured;
+            final payload = captured[0] as PendingProfileSave;
+            expect(payload.displayName, testDisplayName);
+            expect(payload.about, testAbout);
+            expect(payload.username, testUsername);
+            expect(payload.picture, testPicture);
           },
         );
 
@@ -581,15 +544,6 @@ void main() {
             when(
               () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
             ).thenAnswer((_) async => owned);
-            when(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                username: testUsername,
-                picture: testPicture,
-                currentProfile: owned,
-              ),
-            ).thenAnswer((_) async => createTestProfile());
           },
           build: createBloc,
           act: (bloc) => bloc.add(
@@ -619,15 +573,17 @@ void main() {
                 username: any(named: 'username'),
               ),
             );
-            verify(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                username: testUsername,
-                picture: testPicture,
-                currentProfile: any(named: 'currentProfile'),
+            final captured = verify(
+              () => mockProfileRepository.enqueuePendingSave(
+                captureAny(),
+                claimConfirmed: captureAny(named: 'claimConfirmed'),
               ),
-            ).called(1);
+            ).captured;
+            final payload = captured[0] as PendingProfileSave;
+            expect(payload.displayName, testDisplayName);
+            expect(payload.about, testAbout);
+            expect(payload.username, testUsername);
+            expect(payload.picture, testPicture);
           },
         );
 
@@ -644,14 +600,6 @@ void main() {
             when(
               () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
             ).thenAnswer((_) async => null);
-            when(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                username: testUsername,
-                picture: testPicture,
-              ),
-            ).thenAnswer((_) async => createTestProfile());
             when(
               () => mockProfileRepository.claimUsername(username: testUsername),
             ).thenAnswer((_) async => const UsernameClaimSuccess());
@@ -705,14 +653,17 @@ void main() {
                 currentUserPubkey: testPubkey,
               ),
             ).called(1);
-            verify(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                username: testUsername,
-                picture: testPicture,
+            final captured = verify(
+              () => mockProfileRepository.enqueuePendingSave(
+                captureAny(),
+                claimConfirmed: captureAny(named: 'claimConfirmed'),
               ),
-            ).called(1);
+            ).captured;
+            final payload = captured[0] as PendingProfileSave;
+            expect(payload.displayName, testDisplayName);
+            expect(payload.about, testAbout);
+            expect(payload.username, testUsername);
+            expect(payload.picture, testPicture);
             verify(
               () => mockProfileRepository.claimUsername(username: testUsername),
             ).called(1);
@@ -722,19 +673,15 @@ void main() {
 
       group('profile publish failure', () {
         blocTest<ProfileEditorBloc, ProfileEditorState>(
-          'emits [loading, failure] with publishFailed error',
+          'retryable publish failure no longer blocks the save — emits '
+          'optimistic success and leaves the slot queued for retry',
           setUp: () {
             when(
               () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
             ).thenAnswer((_) async => null);
             when(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                picture: testPicture,
-                clearNip05: any(named: 'clearNip05'),
-              ),
-            ).thenThrow(const ProfilePublishFailedException('Network error'));
+              () => mockProfileRepository.drivePendingSave(testPubkey),
+            ).thenAnswer((_) async => PendingSaveDriveOutcome.retryableFailure);
           },
           build: createBloc,
           act: (bloc) => bloc.add(
@@ -751,18 +698,25 @@ void main() {
               'status',
               ProfileEditorStatus.loading,
             ),
-            isA<ProfileEditorState>()
-                .having((s) => s.status, 'status', ProfileEditorStatus.failure)
-                .having(
-                  (s) => s.error,
-                  'error',
-                  ProfileEditorError.publishFailed,
-                ),
+            isA<ProfileEditorState>().having(
+              (s) => s.status,
+              'status',
+              ProfileEditorStatus.success,
+            ),
           ],
+          verify: (_) {
+            verify(
+              () => mockProfileRepository.enqueuePendingSave(
+                any(),
+                claimConfirmed: any(named: 'claimConfirmed'),
+              ),
+            ).called(1);
+          },
         );
 
         blocTest<ProfileEditorBloc, ProfileEditorState>(
-          'still emits publishFailed when claim succeeds but publish fails',
+          'still emits optimistic success when claim succeeds but publish '
+          'fails — slot stays queued for retry',
           setUp: () {
             when(
               () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
@@ -771,13 +725,8 @@ void main() {
               () => mockProfileRepository.claimUsername(username: testUsername),
             ).thenAnswer((_) async => const UsernameClaimSuccess());
             when(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                username: testUsername,
-                picture: testPicture,
-              ),
-            ).thenThrow(const ProfilePublishFailedException('Network error'));
+              () => mockProfileRepository.drivePendingSave(testPubkey),
+            ).thenAnswer((_) async => PendingSaveDriveOutcome.retryableFailure);
           },
           build: createBloc,
           act: (bloc) => bloc.add(
@@ -795,24 +744,20 @@ void main() {
               'status',
               ProfileEditorStatus.loading,
             ),
-            isA<ProfileEditorState>()
-                .having((s) => s.status, 'status', ProfileEditorStatus.failure)
-                .having(
-                  (s) => s.error,
-                  'error',
-                  ProfileEditorError.publishFailed,
-                ),
+            isA<ProfileEditorState>().having(
+              (s) => s.status,
+              'status',
+              ProfileEditorStatus.success,
+            ),
           ],
           verify: (_) {
-            // Claim happens first; saveProfileEvent is then attempted and
-            // throws. There is no rollback publish.
+            // Claim happens first; the slot is then enqueued and driven —
+            // a retryable publish failure no longer blocks Save.
             verifyInOrder([
               () => mockProfileRepository.claimUsername(username: testUsername),
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                username: testUsername,
-                picture: testPicture,
+              () => mockProfileRepository.enqueuePendingSave(
+                any(),
+                claimConfirmed: any(named: 'claimConfirmed'),
               ),
             ]);
           },
@@ -821,19 +766,15 @@ void main() {
 
       group('no relays connected', () {
         blocTest<ProfileEditorBloc, ProfileEditorState>(
-          'emits [loading, failure] with noRelaysConnected error',
+          'no relays connected → optimistic success, slot stays queued '
+          'for retry',
           setUp: () {
             when(
               () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
             ).thenAnswer((_) async => null);
             when(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                picture: testPicture,
-                clearNip05: any(named: 'clearNip05'),
-              ),
-            ).thenThrow(const NoRelaysConnectedException('No relays'));
+              () => mockProfileRepository.drivePendingSave(testPubkey),
+            ).thenAnswer((_) async => PendingSaveDriveOutcome.retryableFailure);
           },
           build: createBloc,
           act: (bloc) => bloc.add(
@@ -850,20 +791,25 @@ void main() {
               'status',
               ProfileEditorStatus.loading,
             ),
-            isA<ProfileEditorState>()
-                .having((s) => s.status, 'status', ProfileEditorStatus.failure)
-                .having(
-                  (s) => s.error,
-                  'error',
-                  ProfileEditorError.noRelaysConnected,
-                ),
+            isA<ProfileEditorState>().having(
+              (s) => s.status,
+              'status',
+              ProfileEditorStatus.success,
+            ),
           ],
-          errors: () => [isA<NoRelaysConnectedException>()],
+          verify: (_) {
+            verify(
+              () => mockProfileRepository.enqueuePendingSave(
+                any(),
+                claimConfirmed: any(named: 'claimConfirmed'),
+              ),
+            ).called(1);
+          },
         );
 
         blocTest<ProfileEditorBloc, ProfileEditorState>(
-          'still emits noRelaysConnected when claim succeeded but publish '
-          'cannot reach any relay',
+          'still optimistic success when claim succeeded but publish '
+          'cannot reach any relay — slot stays queued for retry',
           setUp: () {
             when(
               () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
@@ -872,13 +818,8 @@ void main() {
               () => mockProfileRepository.claimUsername(username: testUsername),
             ).thenAnswer((_) async => const UsernameClaimSuccess());
             when(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                username: testUsername,
-                picture: testPicture,
-              ),
-            ).thenThrow(const NoRelaysConnectedException('No relays'));
+              () => mockProfileRepository.drivePendingSave(testPubkey),
+            ).thenAnswer((_) async => PendingSaveDriveOutcome.retryableFailure);
           },
           build: createBloc,
           act: (bloc) => bloc.add(
@@ -896,15 +837,21 @@ void main() {
               'status',
               ProfileEditorStatus.loading,
             ),
-            isA<ProfileEditorState>()
-                .having((s) => s.status, 'status', ProfileEditorStatus.failure)
-                .having(
-                  (s) => s.error,
-                  'error',
-                  ProfileEditorError.noRelaysConnected,
-                ),
+            isA<ProfileEditorState>().having(
+              (s) => s.status,
+              'status',
+              ProfileEditorStatus.success,
+            ),
           ],
-          errors: () => [isA<NoRelaysConnectedException>()],
+          verify: (_) {
+            verifyInOrder([
+              () => mockProfileRepository.claimUsername(username: testUsername),
+              () => mockProfileRepository.enqueuePendingSave(
+                any(),
+                claimConfirmed: any(named: 'claimConfirmed'),
+              ),
+            ]);
+          },
         );
       });
 
@@ -912,7 +859,8 @@ void main() {
       // immutable once broadcast. If we publish before confirming the username
       // claim, a single name-server hiccup leaves the user advertising a
       // _@<name>.divine.video identifier with no registry record. These tests
-      // assert that saveProfileEvent is never called when the claim fails.
+      // assert that the durable save slot is never enqueued/driven when the
+      // claim fails.
       group('claim failure does not broadcast kind 0', () {
         for (final scenario in [
           (
@@ -941,7 +889,7 @@ void main() {
           ),
         ]) {
           blocTest<ProfileEditorBloc, ProfileEditorState>(
-            'emits failure and never calls saveProfileEvent on '
+            'emits failure and never enqueues/drives the pending save on '
             '${scenario.label}',
             setUp: () {
               final existingProfile = createTestProfile(
@@ -991,18 +939,12 @@ void main() {
                     mockProfileRepository.claimUsername(username: testUsername),
               ).called(1);
               verifyNever(
-                () => mockProfileRepository.saveProfileEvent(
-                  displayName: any(named: 'displayName'),
-                  about: any(named: 'about'),
-                  username: any(named: 'username'),
-                  nip05: any(named: 'nip05'),
-                  clearNip05: any(named: 'clearNip05'),
-                  picture: any(named: 'picture'),
-                  banner: any(named: 'banner'),
-                  currentProfile: any(named: 'currentProfile'),
+                () => mockProfileRepository.enqueuePendingSave(
+                  any(),
+                  claimConfirmed: any(named: 'claimConfirmed'),
                 ),
               );
-              verifyNever(() => mockProfileRepository.cacheProfile(any()));
+              verifyNever(() => mockProfileRepository.drivePendingSave(any()));
             },
           );
         }
@@ -1097,33 +1039,24 @@ void main() {
         verify: (_) {
           // Claim threw — never reach the publish step.
           verifyNever(
-            () => mockProfileRepository.saveProfileEvent(
-              displayName: any(named: 'displayName'),
-              about: any(named: 'about'),
-              username: any(named: 'username'),
-              clearNip05: any(named: 'clearNip05'),
-              picture: any(named: 'picture'),
-              banner: any(named: 'banner'),
-              currentProfile: any(named: 'currentProfile'),
+            () => mockProfileRepository.enqueuePendingSave(
+              any(),
+              claimConfirmed: any(named: 'claimConfirmed'),
             ),
           );
+          verifyNever(() => mockProfileRepository.drivePendingSave(any()));
         },
       );
 
       blocTest<ProfileEditorBloc, ProfileEditorState>(
-        'wraps unexpected saveProfileEvent Error in narrowed publish catch '
-        'as Reportable and emits failure(publishFailed)',
+        'wraps unexpected drivePendingSave Error in narrowed publish catch '
+        'as Reportable but keeps the optimistic success emitted earlier',
         setUp: () {
           when(
             () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
           ).thenAnswer((_) async => null);
           when(
-            () => mockProfileRepository.saveProfileEvent(
-              displayName: testDisplayName,
-              about: testAbout,
-              picture: testPicture,
-              clearNip05: any(named: 'clearNip05'),
-            ),
+            () => mockProfileRepository.drivePendingSave(testPubkey),
           ).thenThrow(StateError('publish invariant'));
         },
         build: createBloc,
@@ -1141,13 +1074,11 @@ void main() {
             'status',
             ProfileEditorStatus.loading,
           ),
-          isA<ProfileEditorState>()
-              .having((s) => s.status, 'status', ProfileEditorStatus.failure)
-              .having(
-                (s) => s.error,
-                'error',
-                ProfileEditorError.publishFailed,
-              ),
+          isA<ProfileEditorState>().having(
+            (s) => s.status,
+            'status',
+            ProfileEditorStatus.success,
+          ),
         ],
         errors: () => [
           isA<Reportable<Object>>().having(
@@ -1159,20 +1090,14 @@ void main() {
       );
 
       blocTest<ProfileEditorBloc, ProfileEditorState>(
-        'wraps unexpected Error in _onProfileNip05Saved as Reportable and '
-        'emits failure(publishFailed)',
+        'wraps unexpected drivePendingSave Error in _onProfileNip05Saved as '
+        'Reportable but keeps the optimistic success emitted earlier',
         setUp: () {
           when(
             () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
           ).thenAnswer((_) async => null);
           when(
-            () => mockProfileRepository.saveProfileEvent(
-              displayName: testDisplayName,
-              about: testAbout,
-              picture: testPicture,
-              banner: any(named: 'banner'),
-              clearNip05: any(named: 'clearNip05'),
-            ),
+            () => mockProfileRepository.drivePendingSave(testPubkey),
           ).thenThrow(StateError('nip05 save invariant'));
         },
         build: createBloc,
@@ -1196,13 +1121,11 @@ void main() {
             'status',
             ProfileEditorStatus.loading,
           ),
-          isA<ProfileEditorState>()
-              .having((s) => s.status, 'status', ProfileEditorStatus.failure)
-              .having(
-                (s) => s.error,
-                'error',
-                ProfileEditorError.publishFailed,
-              ),
+          isA<ProfileEditorState>().having(
+            (s) => s.status,
+            'status',
+            ProfileEditorStatus.success,
+          ),
         ],
         errors: () => [
           isA<Reportable<Object>>().having(
@@ -1214,17 +1137,14 @@ void main() {
       );
 
       blocTest<ProfileEditorBloc, ProfileEditorState>(
-        'wraps unexpected Error in _onProfileSaveConfirmed as Reportable '
-        'and emits failure(publishFailed)',
+        'wraps unexpected drivePendingSave Error in _onProfileSaveConfirmed '
+        'as Reportable but keeps the optimistic success emitted earlier',
         setUp: () {
           when(
             () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
           ).thenAnswer((_) async => null);
           when(
-            () => mockProfileRepository.saveProfileEvent(
-              displayName: testDisplayName,
-              clearNip05: any(named: 'clearNip05'),
-            ),
+            () => mockProfileRepository.drivePendingSave(testPubkey),
           ).thenThrow(StateError('confirmed save invariant'));
         },
         build: () => createBloc(hasExistingProfile: false),
@@ -1242,13 +1162,11 @@ void main() {
             'status',
             ProfileEditorStatus.loading,
           ),
-          isA<ProfileEditorState>()
-              .having((s) => s.status, 'status', ProfileEditorStatus.failure)
-              .having(
-                (s) => s.error,
-                'error',
-                ProfileEditorError.publishFailed,
-              ),
+          isA<ProfileEditorState>().having(
+            (s) => s.status,
+            'status',
+            ProfileEditorStatus.success,
+          ),
         ],
         errors: () => [
           isA<Reportable<Object>>().having(
@@ -1363,14 +1281,6 @@ void main() {
             () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
           ).thenAnswer((_) async => null);
           when(
-            () => mockProfileRepository.saveProfileEvent(
-              displayName: testDisplayName,
-              about: 'hi @alice',
-              picture: testPicture,
-              clearNip05: any(named: 'clearNip05'),
-            ),
-          ).thenAnswer((_) async => createTestProfile());
-          when(
             () => mockMentionResolutionService.resolveTextMentions(
               rawText: any(named: 'rawText'),
               currentUserPubkey: any(named: 'currentUserPubkey'),
@@ -1409,14 +1319,14 @@ void main() {
         ],
         verify: (_) {
           // Save still happens with the raw (unresolved) bio.
-          verify(
-            () => mockProfileRepository.saveProfileEvent(
-              displayName: testDisplayName,
-              about: 'hi @alice',
-              picture: testPicture,
-              clearNip05: any(named: 'clearNip05'),
+          final captured = verify(
+            () => mockProfileRepository.enqueuePendingSave(
+              captureAny(),
+              claimConfirmed: captureAny(named: 'claimConfirmed'),
             ),
-          ).called(1);
+          ).captured;
+          final payload = captured[0] as PendingProfileSave;
+          expect(payload.about, 'hi @alice');
         },
       );
     });
@@ -1882,25 +1792,8 @@ void main() {
             () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
           ).thenAnswer((_) async => existingProfile);
           when(
-            () => mockProfileRepository.saveProfileEvent(
-              displayName: testDisplayName,
-              about: testAbout,
-              username: testUsername,
-              picture: testPicture,
-              currentProfile: existingProfile,
-            ),
-          ).thenAnswer((_) async => createTestProfile());
-          when(
             () => mockProfileRepository.claimUsername(username: testUsername),
           ).thenAnswer((_) async => const UsernameClaimReserved());
-          when(
-            () => mockProfileRepository.saveProfileEvent(
-              displayName: testDisplayName,
-              about: testAbout,
-              picture: testPicture,
-              currentProfile: existingProfile,
-            ),
-          ).thenAnswer((_) async => createTestProfile());
         },
         build: createBloc,
         act: (bloc) async {
@@ -2224,14 +2117,6 @@ void main() {
           when(
             () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
           ).thenAnswer((_) async => null);
-          when(
-            () => mockProfileRepository.saveProfileEvent(
-              displayName: testDisplayName,
-              about: testAbout,
-              nip05: 'alice@example.com',
-              picture: testPicture,
-            ),
-          ).thenAnswer((_) async => createTestProfile());
         },
         build: createBloc,
         seed: () => const ProfileEditorState(nip05Mode: Nip05Mode.external_),
@@ -2257,14 +2142,18 @@ void main() {
           ),
         ],
         verify: (_) {
-          verify(
-            () => mockProfileRepository.saveProfileEvent(
-              displayName: testDisplayName,
-              about: testAbout,
-              nip05: 'alice@example.com',
-              picture: testPicture,
+          final captured = verify(
+            () => mockProfileRepository.enqueuePendingSave(
+              captureAny(),
+              claimConfirmed: captureAny(named: 'claimConfirmed'),
             ),
-          ).called(1);
+          ).captured;
+          final payload = captured[0] as PendingProfileSave;
+          expect(payload.displayName, testDisplayName);
+          expect(payload.about, testAbout);
+          expect(payload.nip05, 'alice@example.com');
+          expect(payload.picture, testPicture);
+          expect(payload.username, isNull);
           verifyNever(
             () => mockProfileRepository.claimUsername(
               username: any(named: 'username'),
@@ -2280,14 +2169,6 @@ void main() {
           when(
             () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
           ).thenAnswer((_) async => null);
-          when(
-            () => mockProfileRepository.saveProfileEvent(
-              displayName: testDisplayName,
-              about: testAbout,
-              nip05: 'alice@example.com',
-              picture: testPicture,
-            ),
-          ).thenAnswer((_) async => createTestProfile());
         },
         build: createBloc,
         seed: () => const ProfileEditorState(nip05Mode: Nip05Mode.external_),
@@ -2314,15 +2195,19 @@ void main() {
           ),
         ],
         verify: (_) {
-          // Username should be dropped — saveProfileEvent called without it
-          verify(
-            () => mockProfileRepository.saveProfileEvent(
-              displayName: testDisplayName,
-              about: testAbout,
-              nip05: 'alice@example.com',
-              picture: testPicture,
+          // Username should be dropped — enqueued payload carries no username.
+          final captured = verify(
+            () => mockProfileRepository.enqueuePendingSave(
+              captureAny(),
+              claimConfirmed: captureAny(named: 'claimConfirmed'),
             ),
-          ).called(1);
+          ).captured;
+          final payload = captured[0] as PendingProfileSave;
+          expect(payload.displayName, testDisplayName);
+          expect(payload.about, testAbout);
+          expect(payload.nip05, 'alice@example.com');
+          expect(payload.picture, testPicture);
+          expect(payload.username, isNull);
           // No username claim should be attempted
           verifyNever(
             () => mockProfileRepository.claimUsername(
@@ -2891,18 +2776,6 @@ void main() {
               pubkey: any(named: 'pubkey'),
             ),
           ).thenAnswer((_) async => null);
-          when(
-            () => mockProfileRepository.saveProfileEvent(
-              displayName: any(named: 'displayName'),
-              about: any(named: 'about'),
-              username: any(named: 'username'),
-              nip05: any(named: 'nip05'),
-              clearNip05: any(named: 'clearNip05'),
-              picture: any(named: 'picture'),
-              banner: any(named: 'banner'),
-              currentProfile: any(named: 'currentProfile'),
-            ),
-          ).thenAnswer((_) async => createTestProfile());
         },
         build: createBloc,
         seed: () => const ProfileEditorState(
@@ -2918,13 +2791,16 @@ void main() {
           ),
         ),
         verify: (_) {
-          verify(
-            () => mockProfileRepository.saveProfileEvent(
-              displayName: testDisplayName,
-              about: testAbout,
-              picture: testStagedUrl,
+          final captured = verify(
+            () => mockProfileRepository.enqueuePendingSave(
+              captureAny(),
+              claimConfirmed: captureAny(named: 'claimConfirmed'),
             ),
-          ).called(1);
+          ).captured;
+          final payload = captured[0] as PendingProfileSave;
+          expect(payload.displayName, testDisplayName);
+          expect(payload.about, testAbout);
+          expect(payload.picture, testStagedUrl);
         },
       );
 
@@ -2936,18 +2812,6 @@ void main() {
               pubkey: any(named: 'pubkey'),
             ),
           ).thenAnswer((_) async => null);
-          when(
-            () => mockProfileRepository.saveProfileEvent(
-              displayName: any(named: 'displayName'),
-              about: any(named: 'about'),
-              username: any(named: 'username'),
-              nip05: any(named: 'nip05'),
-              clearNip05: any(named: 'clearNip05'),
-              picture: any(named: 'picture'),
-              banner: any(named: 'banner'),
-              currentProfile: any(named: 'currentProfile'),
-            ),
-          ).thenAnswer((_) async => createTestProfile());
         },
         build: createBloc,
         seed: () =>
@@ -2962,18 +2826,14 @@ void main() {
         verify: (_) {
           // Picture argument falls back to persisted URL — Save with no edits
           // must not silently blank an existing avatar.
-          verify(
-            () => mockProfileRepository.saveProfileEvent(
-              displayName: any(named: 'displayName'),
-              about: any(named: 'about'),
-              username: any(named: 'username'),
-              nip05: any(named: 'nip05'),
-              clearNip05: any(named: 'clearNip05'),
-              picture: testPersistedUrl,
-              banner: any(named: 'banner'),
-              currentProfile: any(named: 'currentProfile'),
+          final captured = verify(
+            () => mockProfileRepository.enqueuePendingSave(
+              captureAny(),
+              claimConfirmed: captureAny(named: 'claimConfirmed'),
             ),
-          ).called(1);
+          ).captured;
+          final payload = captured[0] as PendingProfileSave;
+          expect(payload.picture, testPersistedUrl);
         },
       );
 
@@ -3007,17 +2867,12 @@ void main() {
           // The load-bearing invariant from reviewer bullet 6: upload alone
           // must not call into the profile-publish path.
           verifyNever(
-            () => mockProfileRepository.saveProfileEvent(
-              displayName: any(named: 'displayName'),
-              about: any(named: 'about'),
-              username: any(named: 'username'),
-              nip05: any(named: 'nip05'),
-              clearNip05: any(named: 'clearNip05'),
-              picture: any(named: 'picture'),
-              banner: any(named: 'banner'),
-              currentProfile: any(named: 'currentProfile'),
+            () => mockProfileRepository.enqueuePendingSave(
+              any(),
+              claimConfirmed: any(named: 'claimConfirmed'),
             ),
           );
+          verifyNever(() => mockProfileRepository.drivePendingSave(any()));
           verifyNever(
             () => mockProfileRepository.claimUsername(
               username: any(named: 'username'),
@@ -3029,8 +2884,8 @@ void main() {
       blocTest<ProfileEditorBloc, ProfileEditorState>(
         'ProfileSaved while uploading is dropped — no publish, no claim',
         // Pins the bloc-side guard from reviewer #3916 follow-up: even if the
-        // UI gate (`isSaveReady`) is bypassed, the bloc must not call into
-        // saveProfileEvent / claimUsername with a stale `persistedPictureUrl`
+        // UI gate (`isSaveReady`) is bypassed, the bloc must not enqueue the
+        // pending save / claimUsername with a stale `persistedPictureUrl`
         // while the staged URL is still in flight.
         build: createBloc,
         seed: () => const ProfileEditorState(
@@ -3047,17 +2902,12 @@ void main() {
         expect: () => const <ProfileEditorState>[],
         verify: (_) {
           verifyNever(
-            () => mockProfileRepository.saveProfileEvent(
-              displayName: any(named: 'displayName'),
-              about: any(named: 'about'),
-              username: any(named: 'username'),
-              nip05: any(named: 'nip05'),
-              clearNip05: any(named: 'clearNip05'),
-              picture: any(named: 'picture'),
-              banner: any(named: 'banner'),
-              currentProfile: any(named: 'currentProfile'),
+            () => mockProfileRepository.enqueuePendingSave(
+              any(),
+              claimConfirmed: any(named: 'claimConfirmed'),
             ),
           );
+          verifyNever(() => mockProfileRepository.drivePendingSave(any()));
           verifyNever(
             () => mockProfileRepository.claimUsername(
               username: any(named: 'username'),
@@ -3095,17 +2945,12 @@ void main() {
         expect: () => const <ProfileEditorState>[],
         verify: (_) {
           verifyNever(
-            () => mockProfileRepository.saveProfileEvent(
-              displayName: any(named: 'displayName'),
-              about: any(named: 'about'),
-              username: any(named: 'username'),
-              nip05: any(named: 'nip05'),
-              clearNip05: any(named: 'clearNip05'),
-              picture: any(named: 'picture'),
-              banner: any(named: 'banner'),
-              currentProfile: any(named: 'currentProfile'),
+            () => mockProfileRepository.enqueuePendingSave(
+              any(),
+              claimConfirmed: any(named: 'claimConfirmed'),
             ),
           );
+          verifyNever(() => mockProfileRepository.drivePendingSave(any()));
           verifyNever(
             () => mockProfileRepository.claimUsername(
               username: any(named: 'username'),
@@ -3135,17 +2980,12 @@ void main() {
         expect: () => const <ProfileEditorState>[],
         verify: (_) {
           verifyNever(
-            () => mockProfileRepository.saveProfileEvent(
-              displayName: any(named: 'displayName'),
-              about: any(named: 'about'),
-              username: any(named: 'username'),
-              nip05: any(named: 'nip05'),
-              clearNip05: any(named: 'clearNip05'),
-              picture: any(named: 'picture'),
-              banner: any(named: 'banner'),
-              currentProfile: any(named: 'currentProfile'),
+            () => mockProfileRepository.enqueuePendingSave(
+              any(),
+              claimConfirmed: any(named: 'claimConfirmed'),
             ),
           );
+          verifyNever(() => mockProfileRepository.drivePendingSave(any()));
           verifyNever(
             () => mockProfileRepository.claimUsername(
               username: any(named: 'username'),

--- a/mobile/test/providers/user_profile_providers_test.dart
+++ b/mobile/test/providers/user_profile_providers_test.dart
@@ -29,6 +29,9 @@ class _MockUserProfilesDao extends Mock implements UserProfilesDao {}
 
 class _MockProfileStatsDao extends Mock implements ProfileStatsDao {}
 
+class _MockPendingProfileSavesDao extends Mock
+    implements PendingProfileSavesDao {}
+
 class _TestNostrSession extends NostrSession {
   _TestNostrSession(this._readiness);
 
@@ -200,12 +203,16 @@ void main() {
         final database = _MockAppDatabase();
         final userProfilesDao = _MockUserProfilesDao();
         final profileStatsDao = _MockProfileStatsDao();
+        final pendingProfileSavesDao = _MockPendingProfileSavesDao();
         final funnelcakeClient = FunnelcakeApiClient(
           baseUrl: 'https://api.divine.video',
         );
 
         when(() => database.userProfilesDao).thenReturn(userProfilesDao);
         when(() => database.profileStatsDao).thenReturn(profileStatsDao);
+        when(
+          () => database.pendingProfileSavesDao,
+        ).thenReturn(pendingProfileSavesDao);
 
         final container = ProviderContainer(
           overrides: [

--- a/mobile/test/screens/settings/nip05_settings_screen_test.dart
+++ b/mobile/test/screens/settings/nip05_settings_screen_test.dart
@@ -205,9 +205,12 @@ void main() {
             any(),
             claimConfirmed: any(named: 'claimConfirmed'),
           ),
-        ).thenAnswer((_) async {});
+        ).thenAnswer((_) async => 'gen-test');
         when(
-          () => mockProfileRepository.drivePendingSave(any()),
+          () => mockProfileRepository.drivePendingSave(
+            any(),
+            expectedGeneration: any(named: 'expectedGeneration'),
+          ),
         ).thenAnswer((_) async => PendingSaveDriveOutcome.retryableFailure);
 
         // Nip05SettingsView calls `context.pop()` on optimistic success, which

--- a/mobile/test/screens/settings/nip05_settings_screen_test.dart
+++ b/mobile/test/screens/settings/nip05_settings_screen_test.dart
@@ -3,6 +3,7 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/my_profile/my_profile_bloc.dart';
@@ -50,6 +51,9 @@ void main() {
           eventId:
               'fallback123456789012345678901234567890123456789012345678901234',
         ),
+      );
+      registerFallbackValue(
+        const PendingProfileSave(pubkey: testPubkey, displayName: 'fallback'),
       );
     });
 
@@ -186,46 +190,99 @@ void main() {
       );
     });
 
-    testWidgets('shows a failure snackbar when saving the new NIP-05 fails', (
-      tester,
-    ) async {
-      final profile = createProfile(nip05: 'alice@example.com');
-      when(
-        () => mockProfileRepository.saveProfileEvent(
-          displayName: any(named: 'displayName'),
-          about: any(named: 'about'),
-          username: any(named: 'username'),
-          nip05: any(named: 'nip05'),
-          clearNip05: any(named: 'clearNip05'),
-          picture: any(named: 'picture'),
-          banner: any(named: 'banner'),
-          currentProfile: any(named: 'currentProfile'),
-        ),
-      ).thenThrow(Exception('publish failed'));
+    testWidgets(
+      'queues the NIP-05 save optimistically even when the publish fails',
+      (tester) async {
+        final profile = createProfile(nip05: 'alice@example.com');
+        when(
+          () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
+        ).thenAnswer((_) async => profile);
+        when(
+          () => mockProfileRepository.fetchFreshProfile(pubkey: testPubkey),
+        ).thenAnswer((_) async => profile);
+        when(
+          () => mockProfileRepository.enqueuePendingSave(
+            any(),
+            claimConfirmed: any(named: 'claimConfirmed'),
+          ),
+        ).thenAnswer((_) async {});
+        when(
+          () => mockProfileRepository.drivePendingSave(any()),
+        ).thenAnswer((_) async => PendingSaveDriveOutcome.retryableFailure);
 
-      await tester.pumpWidget(buildSubject(profile: profile));
-      await tester.pumpAndSettle();
+        // Nip05SettingsView calls `context.pop()` on optimistic success, which
+        // requires a GoRouter ancestor. Push it onto a minimal router (rather
+        // than using buildSubject's bare MaterialApp) so that pop succeeds
+        // instead of throwing "No GoRouter found in context".
+        final router = GoRouter(
+          initialLocation: '/',
+          routes: [
+            GoRoute(
+              path: '/',
+              builder: (context, state) => const SizedBox.shrink(),
+            ),
+            GoRoute(
+              path: '/nip05',
+              builder: (context, state) => MultiBlocProvider(
+                providers: [
+                  BlocProvider(
+                    create: (_) => ProfileEditorBloc(
+                      profileRepository: mockProfileRepository,
+                      blossomUploadService: mockBlossomUploadService,
+                      hasExistingProfile: true,
+                      currentUserPubkey: testPubkey,
+                    ),
+                  ),
+                  BlocProvider(
+                    create: (_) => MyProfileBloc(
+                      profileRepository: mockProfileRepository,
+                      pubkey: testPubkey,
+                    )..add(const MyProfileLoadRequested()),
+                  ),
+                ],
+                child: const Nip05SettingsView(),
+              ),
+            ),
+          ],
+        );
 
-      await tester.enterText(
-        find.byType(TextFormField).last,
-        'bob@example.com',
-      );
-      await tester.pump();
+        await tester.pumpWidget(
+          MaterialApp.router(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            theme: VineTheme.theme,
+            routerConfig: router,
+          ),
+        );
+        await tester.pumpAndSettle();
 
-      await tester.tap(find.text(l10n.nostrSettingsNip05SaveAction));
-      await tester.pumpAndSettle();
+        router.push('/nip05');
+        await tester.pumpAndSettle();
 
-      expect(find.text(l10n.nostrSettingsNip05SaveFailed), findsOneWidget);
-      verify(
-        () => mockProfileRepository.saveProfileEvent(
-          displayName: 'Test User',
-          about: 'Still making weird loops',
-          nip05: 'bob@example.com',
-          picture: 'https://example.com/avatar.png',
-          currentProfile: profile,
-        ),
-      ).called(1);
-    });
+        await tester.enterText(
+          find.byType(TextFormField).last,
+          'bob@example.com',
+        );
+        await tester.pump();
+
+        await tester.tap(find.text(l10n.nostrSettingsNip05SaveAction));
+        await tester.pumpAndSettle();
+
+        // A transient publish failure is retried in the background by
+        // ProfileEditorBloc's optimistic save flow, so it must NOT surface
+        // as a save-failure snackbar.
+        expect(find.text(l10n.nostrSettingsNip05SaveFailed), findsNothing);
+
+        final captured = verify(
+          () => mockProfileRepository.enqueuePendingSave(
+            captureAny(),
+            claimConfirmed: captureAny(named: 'claimConfirmed'),
+          ),
+        ).captured;
+        final payload = captured[0] as PendingProfileSave;
+        expect(payload.nip05, 'bob@example.com');
+      },
+    );
 
     testWidgets(
       'shows retry UI instead of spinning forever when profile load fails',

--- a/mobile/test/services/profile_save_retry_service_test.dart
+++ b/mobile/test/services/profile_save_retry_service_test.dart
@@ -1,0 +1,288 @@
+// ABOUTME: Tests ProfileSaveRetryService (#3161) — the background re-drive of
+// ABOUTME: the durable pending profile-save slot: sweep outcomes, backoff,
+// ABOUTME: re-entrancy, triggers, and manual retry.
+
+import 'dart:async';
+
+import 'package:db_client/db_client.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/services/profile_save_retry_service.dart';
+import 'package:profile_repository/profile_repository.dart';
+
+class _MockProfileRepository extends Mock implements ProfileRepository {}
+
+void main() {
+  const pubkey =
+      'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2';
+
+  late _MockProfileRepository repository;
+  late AppDatabase db;
+  late PendingProfileSavesDao dao;
+  late StreamController<bool> foreground;
+  late StreamController<void> retryTrigger;
+  late DateTime clock;
+
+  const config = ProfileSaveRetryConfig(maxRetries: 3);
+
+  ProfileSaveRetryService buildService() => ProfileSaveRetryService(
+    profileRepository: repository,
+    pendingProfileSavesDao: dao,
+    userPubkey: pubkey,
+    appForegroundStream: foreground.stream,
+    retryTriggerStream: retryTrigger.stream,
+    retryConfig: config,
+    now: () => clock,
+  );
+
+  Future<void> seed({
+    PendingProfileSaveStatus status = PendingProfileSaveStatus.pending,
+    int retryCount = 0,
+    DateTime? lastAttemptAt,
+  }) {
+    return dao.upsert(
+      PendingProfileSaveEntry(
+        userPubkey: pubkey,
+        payloadJson: const PendingProfileSave(
+          pubkey: pubkey,
+          displayName: 'Alice',
+        ).encode(),
+        status: status,
+        retryCount: retryCount,
+        lastAttemptAt: lastAttemptAt,
+        queuedAt: DateTime.utc(2026, 7, 13),
+      ),
+    );
+  }
+
+  setUp(() {
+    repository = _MockProfileRepository();
+    db = AppDatabase.test(NativeDatabase.memory());
+    dao = db.pendingProfileSavesDao;
+    foreground = StreamController<bool>.broadcast();
+    retryTrigger = StreamController<void>.broadcast();
+    clock = DateTime.utc(2026, 7, 13, 12);
+
+    when(
+      () => repository.resetInterruptedPendingSave(any()),
+    ).thenAnswer((_) async {});
+  });
+
+  tearDown(() async {
+    await foreground.close();
+    await retryTrigger.close();
+    await db.close();
+  });
+
+  group('sweep outcomes', () {
+    test('confirmed leaves the slot cleared (by the repository)', () async {
+      await seed();
+      when(() => repository.drivePendingSave(pubkey)).thenAnswer((_) async {
+        await dao.clear(pubkey); // simulate the repo clearing on confirm
+        return PendingSaveDriveOutcome.confirmed;
+      });
+
+      await buildService().sweep();
+
+      expect(await dao.get(pubkey), isNull);
+    });
+
+    test(
+      'retryableFailure below cap increments retry and stays pending',
+      () async {
+        await seed();
+        when(
+          () => repository.drivePendingSave(pubkey),
+        ).thenAnswer((_) async => PendingSaveDriveOutcome.retryableFailure);
+
+        await buildService().sweep();
+
+        final entry = await dao.get(pubkey);
+        expect(entry!.status, PendingProfileSaveStatus.pending);
+        expect(entry.retryCount, 1);
+      },
+    );
+
+    test('retryableFailure at the cap marks the slot failed', () async {
+      // maxRetries=3, retryCount=2 → this attempt is the 3rd → exhausted.
+      await seed(retryCount: 2);
+      when(
+        () => repository.drivePendingSave(pubkey),
+      ).thenAnswer((_) async => PendingSaveDriveOutcome.retryableFailure);
+
+      await buildService().sweep();
+
+      final entry = await dao.get(pubkey);
+      expect(entry!.status, PendingProfileSaveStatus.failed);
+      expect(entry.lastError, contains('Could not publish'));
+    });
+
+    test('permanentFailure marks the slot failed', () async {
+      await seed();
+      when(
+        () => repository.drivePendingSave(pubkey),
+      ).thenAnswer((_) async => PendingSaveDriveOutcome.permanentFailure);
+
+      await buildService().sweep();
+
+      expect((await dao.get(pubkey))!.status, PendingProfileSaveStatus.failed);
+    });
+  });
+
+  group('sweep guards', () {
+    test('does nothing when the slot is empty', () async {
+      await buildService().sweep();
+      verifyNever(() => repository.drivePendingSave(any()));
+    });
+
+    test('skips a failed slot (awaits manual retry)', () async {
+      await seed(status: PendingProfileSaveStatus.failed);
+      await buildService().sweep();
+      verifyNever(() => repository.drivePendingSave(any()));
+    });
+
+    test('skips while inside the backoff window', () async {
+      // retryCount=1 → backoff = initialDelay*2 = 4s. lastAttempt 1s ago.
+      await seed(
+        retryCount: 1,
+        lastAttemptAt: clock.subtract(const Duration(seconds: 1)),
+      );
+      await buildService().sweep();
+      verifyNever(() => repository.drivePendingSave(any()));
+    });
+
+    test('drives once the backoff window has elapsed', () async {
+      await seed(
+        retryCount: 1,
+        lastAttemptAt: clock.subtract(const Duration(seconds: 10)),
+      );
+      when(
+        () => repository.drivePendingSave(pubkey),
+      ).thenAnswer((_) async => PendingSaveDriveOutcome.confirmed);
+
+      await buildService().sweep();
+
+      verify(() => repository.drivePendingSave(pubkey)).called(1);
+    });
+
+    test('re-entrant sweep is skipped while one is in flight', () async {
+      await seed();
+      final gate = Completer<void>();
+      var driveCalls = 0;
+      when(() => repository.drivePendingSave(pubkey)).thenAnswer((_) async {
+        driveCalls++;
+        await gate.future;
+        return PendingSaveDriveOutcome.retryableFailure;
+      });
+
+      final service = buildService();
+      final first = service.sweep();
+      final second = service.sweep(); // should short-circuit
+      gate.complete();
+      await Future.wait([first, second]);
+
+      expect(driveCalls, 1);
+    });
+  });
+
+  group('triggers', () {
+    test('a foreground=true transition triggers a sweep', () async {
+      await seed();
+      when(
+        () => repository.drivePendingSave(pubkey),
+      ).thenAnswer((_) async => PendingSaveDriveOutcome.confirmed);
+
+      final service = buildService();
+      await service.initialize();
+      clearInteractions(repository);
+
+      foreground.add(true);
+      await Future<void>.delayed(Duration.zero);
+
+      verify(() => repository.drivePendingSave(pubkey)).called(1);
+    });
+
+    test('a retry-trigger event triggers a sweep', () async {
+      await seed();
+      when(
+        () => repository.drivePendingSave(pubkey),
+      ).thenAnswer((_) async => PendingSaveDriveOutcome.confirmed);
+
+      final service = buildService();
+      await service.initialize();
+      clearInteractions(repository);
+
+      retryTrigger.add(null);
+      await Future<void>.delayed(Duration.zero);
+
+      verify(() => repository.drivePendingSave(pubkey)).called(1);
+    });
+
+    test('foreground=false does not trigger a sweep', () async {
+      await seed();
+      when(
+        () => repository.drivePendingSave(pubkey),
+      ).thenAnswer((_) async => PendingSaveDriveOutcome.retryableFailure);
+
+      final service = buildService();
+      await service.initialize();
+      clearInteractions(repository);
+
+      foreground.add(false);
+      await Future<void>.delayed(Duration.zero);
+
+      verifyNever(() => repository.drivePendingSave(any()));
+    });
+  });
+
+  group('lifecycle', () {
+    test('initialize resets an interrupted slot and is idempotent', () async {
+      final service = buildService();
+      await service.initialize();
+      await service.initialize();
+
+      verify(() => repository.resetInterruptedPendingSave(pubkey)).called(1);
+      expect(service.isInitialized, isTrue);
+    });
+
+    test('dispose cancels triggers so later events do not sweep', () async {
+      await seed();
+      when(
+        () => repository.drivePendingSave(pubkey),
+      ).thenAnswer((_) async => PendingSaveDriveOutcome.retryableFailure);
+
+      final service = buildService();
+      await service.initialize();
+      await service.dispose();
+      clearInteractions(repository);
+
+      foreground.add(true);
+      retryTrigger.add(null);
+      await Future<void>.delayed(Duration.zero);
+
+      verifyNever(() => repository.drivePendingSave(any()));
+      expect(service.isInitialized, isFalse);
+    });
+  });
+
+  group('retryNow', () {
+    test('resets a failed slot to a fresh retry and re-drives', () async {
+      await seed(status: PendingProfileSaveStatus.failed, retryCount: 3);
+      when(() => repository.drivePendingSave(pubkey)).thenAnswer((_) async {
+        await dao.clear(pubkey);
+        return PendingSaveDriveOutcome.confirmed;
+      });
+
+      await buildService().retryNow();
+
+      verify(() => repository.drivePendingSave(pubkey)).called(1);
+      expect(await dao.get(pubkey), isNull);
+    });
+
+    test('is a no-op when there is no slot', () async {
+      await buildService().retryNow();
+      verifyNever(() => repository.drivePendingSave(any()));
+    });
+  });
+}

--- a/mobile/test/services/profile_save_retry_service_test.dart
+++ b/mobile/test/services/profile_save_retry_service_test.dart
@@ -45,7 +45,9 @@ void main() {
     return service;
   }
 
-  Future<void> seed({
+  // Returns the minted generation so interleaving tests can assert which
+  // enqueue was driven.
+  Future<String> seed({
     PendingProfileSaveStatus status = PendingProfileSaveStatus.pending,
     int retryCount = 0,
     DateTime? lastAttemptAt,
@@ -63,6 +65,18 @@ void main() {
         queuedAt: DateTime.utc(2026, 7, 13),
       ),
     );
+  }
+
+  // Poll a real (short-backoff) service until [cond] holds, so timer- and
+  // watch-driven tests prove work happens on its own without a second trigger.
+  Future<void> pumpUntil(
+    Future<bool> Function() cond, {
+    Duration timeout = const Duration(seconds: 2),
+  }) async {
+    final deadline = DateTime.now().add(timeout);
+    while (!await cond() && DateTime.now().isBefore(deadline)) {
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+    }
   }
 
   setUp(() {
@@ -216,7 +230,7 @@ void main() {
       ).called(1);
     });
 
-    test('re-entrant sweep is skipped while one is in flight', () async {
+    test('a re-entrant trigger is coalesced, not run concurrently', () async {
       await seed();
       final gate = Completer<void>();
       var driveCalls = 0;
@@ -233,10 +247,13 @@ void main() {
 
       final service = buildService();
       final first = service.sweep();
-      final second = service.sweep(); // should short-circuit
+      final second = service.sweep(); // coalesced into a follow-up pass
       gate.complete();
       await Future.wait([first, second]);
 
+      // The coalesced follow-up pass runs after the first, but the row is now
+      // inside its post-attempt backoff window, so it schedules rather than
+      // driving again — no concurrent or redundant second drive.
       expect(driveCalls, 1);
     });
   });
@@ -351,6 +368,62 @@ void main() {
       );
       expect(service.isInitialized, isFalse);
     });
+
+    test(
+      'disposing during a retryable drive does not retry, mutate the row, '
+      'or arm a timer',
+      () async {
+        await seed();
+        final driveStarted = Completer<void>();
+        final releaseDrive = Completer<void>();
+        var driveCalls = 0;
+        when(
+          () => repository.drivePendingSave(
+            pubkey,
+            expectedGeneration: any(named: 'expectedGeneration'),
+          ),
+        ).thenAnswer((_) async {
+          driveCalls++;
+          if (!driveStarted.isCompleted) driveStarted.complete();
+          await releaseDrive.future;
+          return PendingSaveDriveOutcome.retryableFailure;
+        });
+
+        // Real clock + tiny backoff: were the disposal guard missing, a retry
+        // timer would arm and fire within the test rather than 2s later, so the
+        // final assertion can actually catch the regression.
+        final service = ProfileSaveRetryService(
+          profileRepository: repository,
+          pendingProfileSavesDao: dao,
+          userPubkey: pubkey,
+          appForegroundStream: foreground.stream,
+          retryTriggerStream: retryTrigger.stream,
+          retryConfig: const ProfileSaveRetryConfig(
+            maxRetries: 3,
+            initialDelay: Duration(milliseconds: 5),
+            maxDelay: Duration(milliseconds: 40),
+          ),
+        );
+
+        final sweepFuture = service.sweep();
+        await driveStarted.future; // the publish is in flight
+        await service.dispose(); // teardown mid-drive
+        releaseDrive.complete(); // the drive returns a retryable failure
+        await sweepFuture; // the sweep must bail without rescheduling
+
+        expect(driveCalls, 1, reason: 'no second drive after dispose');
+        final entry = await dao.get(pubkey);
+        expect(
+          entry!.retryCount,
+          0,
+          reason: 'incrementRetry never ran past disposal',
+        );
+
+        // Give any (wrongly) armed retry timer time to fire — it must not.
+        await Future<void>.delayed(const Duration(milliseconds: 30));
+        expect(driveCalls, 1, reason: 'no timer-driven retry after dispose');
+      },
+    );
   });
 
   group('retryNow', () {
@@ -389,18 +462,6 @@ void main() {
   });
 
   group('self-scheduled retry (relay-recovery)', () {
-    // Poll a real (short-backoff) service until [cond] holds, so the test
-    // proves the armed timer fires on its own without a second trigger.
-    Future<void> pumpUntil(
-      bool Function() cond, {
-      Duration timeout = const Duration(seconds: 2),
-    }) async {
-      final deadline = DateTime.now().add(timeout);
-      while (!cond() && DateTime.now().isBefore(deadline)) {
-        await Future<void>.delayed(const Duration(milliseconds: 5));
-      }
-    }
-
     test(
       'one recovery signal eventually publishes via the armed retry timer '
       '(no second signal needed)',
@@ -443,11 +504,11 @@ void main() {
 
         // A single offline→online recovery signal.
         retryTrigger.add(null);
-        await pumpUntil(() => calls >= 1);
+        await pumpUntil(() async => calls >= 1);
         expect(calls, 1, reason: 'the signal drives the first attempt');
 
         // No second signal — the armed timer must drive the retry that lands.
-        await pumpUntil(() => calls >= 2);
+        await pumpUntil(() async => calls >= 2);
         expect(
           calls,
           greaterThanOrEqualTo(2),
@@ -457,6 +518,115 @@ void main() {
           await dao.get(pubkey),
           isNull,
           reason: 'the confirmed retry cleared the slot',
+        );
+      },
+    );
+  });
+
+  group('level-triggered chaining (interleaved saves)', () {
+    test(
+      'a newer save that replaces an in-flight older one is driven to '
+      'completion without a second trigger',
+      () async {
+        final gA = await seed();
+        final aDriveStarted = Completer<void>();
+        final releaseA = Completer<void>();
+        String? gB;
+
+        when(
+          () => repository.drivePendingSave(
+            pubkey,
+            expectedGeneration: any(named: 'expectedGeneration'),
+          ),
+        ).thenAnswer((invocation) async {
+          final gen = invocation.namedArguments[#expectedGeneration] as String?;
+          if (gen == gA) {
+            if (!aDriveStarted.isCompleted) aDriveStarted.complete();
+            await releaseA.future;
+            // The real repo returns noPendingSave once a newer generation has
+            // replaced the row this drive was scoped to.
+            return PendingSaveDriveOutcome.noPendingSave;
+          }
+          // Driving B: confirm and clear, as the repo does on a relay OK.
+          await dao.clear(pubkey, generation: gB);
+          return PendingSaveDriveOutcome.confirmed;
+        });
+
+        final service = buildService();
+        // The only trigger — drives A. B is never manually driven and no
+        // foreground/connectivity signal is emitted.
+        final sweepFuture = service.sweep();
+        await aDriveStarted.future;
+
+        // B replaces A while A's publish is parked mid-flight.
+        gB = await seed();
+
+        releaseA.complete();
+        await sweepFuture; // the coalesced loop chains to B and drives it
+
+        verify(
+          () => repository.drivePendingSave(pubkey, expectedGeneration: gA),
+        ).called(1);
+        verify(
+          () => repository.drivePendingSave(pubkey, expectedGeneration: gB),
+        ).called(1);
+        expect(
+          await dao.get(pubkey),
+          isNull,
+          reason: 'B was driven and its confirmed publish cleared the slot',
+        );
+      },
+    );
+  });
+
+  group('enqueue wake (idle service)', () {
+    test(
+      'a fresh enqueue re-drives an idle service with no foreground or '
+      'connectivity signal',
+      () async {
+        when(
+          () => repository.drivePendingSave(
+            pubkey,
+            expectedGeneration: any(named: 'expectedGeneration'),
+          ),
+        ).thenAnswer((_) async {
+          await dao.clear(pubkey);
+          return PendingSaveDriveOutcome.confirmed;
+        });
+
+        // Real clock + tiny backstop delay so the enqueue-armed sweep fires
+        // quickly.
+        final service = ProfileSaveRetryService(
+          profileRepository: repository,
+          pendingProfileSavesDao: dao,
+          userPubkey: pubkey,
+          appForegroundStream: foreground.stream,
+          retryTriggerStream: retryTrigger.stream,
+          retryConfig: const ProfileSaveRetryConfig(
+            maxRetries: 3,
+            initialDelay: Duration(milliseconds: 5),
+            maxDelay: Duration(milliseconds: 40),
+          ),
+        );
+        addTearDown(service.dispose);
+        await service.initialize();
+        clearInteractions(repository);
+
+        // No foreground / connectivity event — just enqueue a save.
+        await seed();
+
+        await pumpUntil(() async => (await dao.get(pubkey)) == null);
+
+        verify(
+          () => repository.drivePendingSave(
+            pubkey,
+            expectedGeneration: any(named: 'expectedGeneration'),
+          ),
+        ).called(1);
+        expect(
+          await dao.get(pubkey),
+          isNull,
+          reason: 'the enqueue-armed sweep drove and cleared the slot',
         );
       },
     );

--- a/mobile/test/services/profile_save_retry_service_test.dart
+++ b/mobile/test/services/profile_save_retry_service_test.dart
@@ -26,15 +26,24 @@ void main() {
 
   const config = ProfileSaveRetryConfig(maxRetries: 3);
 
-  ProfileSaveRetryService buildService() => ProfileSaveRetryService(
-    profileRepository: repository,
-    pendingProfileSavesDao: dao,
-    userPubkey: pubkey,
-    appForegroundStream: foreground.stream,
-    retryTriggerStream: retryTrigger.stream,
-    retryConfig: config,
-    now: () => clock,
-  );
+  // Track every built service so tearDown can dispose it — a sweep that hits a
+  // retryable failure arms a real retry Timer, which must be cancelled before
+  // the DB/streams close or a late fire would sweep a torn-down fixture.
+  final built = <ProfileSaveRetryService>[];
+
+  ProfileSaveRetryService buildService() {
+    final service = ProfileSaveRetryService(
+      profileRepository: repository,
+      pendingProfileSavesDao: dao,
+      userPubkey: pubkey,
+      appForegroundStream: foreground.stream,
+      retryTriggerStream: retryTrigger.stream,
+      retryConfig: config,
+      now: () => clock,
+    );
+    built.add(service);
+    return service;
+  }
 
   Future<void> seed({
     PendingProfileSaveStatus status = PendingProfileSaveStatus.pending,
@@ -70,6 +79,10 @@ void main() {
   });
 
   tearDown(() async {
+    for (final service in built) {
+      await service.dispose();
+    }
+    built.clear();
     await foreground.close();
     await retryTrigger.close();
     await db.close();
@@ -78,7 +91,12 @@ void main() {
   group('sweep outcomes', () {
     test('confirmed leaves the slot cleared (by the repository)', () async {
       await seed();
-      when(() => repository.drivePendingSave(pubkey)).thenAnswer((_) async {
+      when(
+        () => repository.drivePendingSave(
+          pubkey,
+          expectedGeneration: any(named: 'expectedGeneration'),
+        ),
+      ).thenAnswer((_) async {
         await dao.clear(pubkey); // simulate the repo clearing on confirm
         return PendingSaveDriveOutcome.confirmed;
       });
@@ -93,7 +111,10 @@ void main() {
       () async {
         await seed();
         when(
-          () => repository.drivePendingSave(pubkey),
+          () => repository.drivePendingSave(
+            pubkey,
+            expectedGeneration: any(named: 'expectedGeneration'),
+          ),
         ).thenAnswer((_) async => PendingSaveDriveOutcome.retryableFailure);
 
         await buildService().sweep();
@@ -108,7 +129,10 @@ void main() {
       // maxRetries=3, retryCount=2 → this attempt is the 3rd → exhausted.
       await seed(retryCount: 2);
       when(
-        () => repository.drivePendingSave(pubkey),
+        () => repository.drivePendingSave(
+          pubkey,
+          expectedGeneration: any(named: 'expectedGeneration'),
+        ),
       ).thenAnswer((_) async => PendingSaveDriveOutcome.retryableFailure);
 
       await buildService().sweep();
@@ -121,7 +145,10 @@ void main() {
     test('permanentFailure marks the slot failed', () async {
       await seed();
       when(
-        () => repository.drivePendingSave(pubkey),
+        () => repository.drivePendingSave(
+          pubkey,
+          expectedGeneration: any(named: 'expectedGeneration'),
+        ),
       ).thenAnswer((_) async => PendingSaveDriveOutcome.permanentFailure);
 
       await buildService().sweep();
@@ -133,13 +160,23 @@ void main() {
   group('sweep guards', () {
     test('does nothing when the slot is empty', () async {
       await buildService().sweep();
-      verifyNever(() => repository.drivePendingSave(any()));
+      verifyNever(
+        () => repository.drivePendingSave(
+          any(),
+          expectedGeneration: any(named: 'expectedGeneration'),
+        ),
+      );
     });
 
     test('skips a failed slot (awaits manual retry)', () async {
       await seed(status: PendingProfileSaveStatus.failed);
       await buildService().sweep();
-      verifyNever(() => repository.drivePendingSave(any()));
+      verifyNever(
+        () => repository.drivePendingSave(
+          any(),
+          expectedGeneration: any(named: 'expectedGeneration'),
+        ),
+      );
     });
 
     test('skips while inside the backoff window', () async {
@@ -149,7 +186,12 @@ void main() {
         lastAttemptAt: clock.subtract(const Duration(seconds: 1)),
       );
       await buildService().sweep();
-      verifyNever(() => repository.drivePendingSave(any()));
+      verifyNever(
+        () => repository.drivePendingSave(
+          any(),
+          expectedGeneration: any(named: 'expectedGeneration'),
+        ),
+      );
     });
 
     test('drives once the backoff window has elapsed', () async {
@@ -158,19 +200,32 @@ void main() {
         lastAttemptAt: clock.subtract(const Duration(seconds: 10)),
       );
       when(
-        () => repository.drivePendingSave(pubkey),
+        () => repository.drivePendingSave(
+          pubkey,
+          expectedGeneration: any(named: 'expectedGeneration'),
+        ),
       ).thenAnswer((_) async => PendingSaveDriveOutcome.confirmed);
 
       await buildService().sweep();
 
-      verify(() => repository.drivePendingSave(pubkey)).called(1);
+      verify(
+        () => repository.drivePendingSave(
+          pubkey,
+          expectedGeneration: any(named: 'expectedGeneration'),
+        ),
+      ).called(1);
     });
 
     test('re-entrant sweep is skipped while one is in flight', () async {
       await seed();
       final gate = Completer<void>();
       var driveCalls = 0;
-      when(() => repository.drivePendingSave(pubkey)).thenAnswer((_) async {
+      when(
+        () => repository.drivePendingSave(
+          pubkey,
+          expectedGeneration: any(named: 'expectedGeneration'),
+        ),
+      ).thenAnswer((_) async {
         driveCalls++;
         await gate.future;
         return PendingSaveDriveOutcome.retryableFailure;
@@ -190,7 +245,10 @@ void main() {
     test('a foreground=true transition triggers a sweep', () async {
       await seed();
       when(
-        () => repository.drivePendingSave(pubkey),
+        () => repository.drivePendingSave(
+          pubkey,
+          expectedGeneration: any(named: 'expectedGeneration'),
+        ),
       ).thenAnswer((_) async => PendingSaveDriveOutcome.confirmed);
 
       final service = buildService();
@@ -200,13 +258,21 @@ void main() {
       foreground.add(true);
       await Future<void>.delayed(Duration.zero);
 
-      verify(() => repository.drivePendingSave(pubkey)).called(1);
+      verify(
+        () => repository.drivePendingSave(
+          pubkey,
+          expectedGeneration: any(named: 'expectedGeneration'),
+        ),
+      ).called(1);
     });
 
     test('a retry-trigger event triggers a sweep', () async {
       await seed();
       when(
-        () => repository.drivePendingSave(pubkey),
+        () => repository.drivePendingSave(
+          pubkey,
+          expectedGeneration: any(named: 'expectedGeneration'),
+        ),
       ).thenAnswer((_) async => PendingSaveDriveOutcome.confirmed);
 
       final service = buildService();
@@ -216,13 +282,21 @@ void main() {
       retryTrigger.add(null);
       await Future<void>.delayed(Duration.zero);
 
-      verify(() => repository.drivePendingSave(pubkey)).called(1);
+      verify(
+        () => repository.drivePendingSave(
+          pubkey,
+          expectedGeneration: any(named: 'expectedGeneration'),
+        ),
+      ).called(1);
     });
 
     test('foreground=false does not trigger a sweep', () async {
       await seed();
       when(
-        () => repository.drivePendingSave(pubkey),
+        () => repository.drivePendingSave(
+          pubkey,
+          expectedGeneration: any(named: 'expectedGeneration'),
+        ),
       ).thenAnswer((_) async => PendingSaveDriveOutcome.retryableFailure);
 
       final service = buildService();
@@ -232,7 +306,12 @@ void main() {
       foreground.add(false);
       await Future<void>.delayed(Duration.zero);
 
-      verifyNever(() => repository.drivePendingSave(any()));
+      verifyNever(
+        () => repository.drivePendingSave(
+          any(),
+          expectedGeneration: any(named: 'expectedGeneration'),
+        ),
+      );
     });
   });
 
@@ -249,7 +328,10 @@ void main() {
     test('dispose cancels triggers so later events do not sweep', () async {
       await seed();
       when(
-        () => repository.drivePendingSave(pubkey),
+        () => repository.drivePendingSave(
+          pubkey,
+          expectedGeneration: any(named: 'expectedGeneration'),
+        ),
       ).thenAnswer((_) async => PendingSaveDriveOutcome.retryableFailure);
 
       final service = buildService();
@@ -261,7 +343,12 @@ void main() {
       retryTrigger.add(null);
       await Future<void>.delayed(Duration.zero);
 
-      verifyNever(() => repository.drivePendingSave(any()));
+      verifyNever(
+        () => repository.drivePendingSave(
+          any(),
+          expectedGeneration: any(named: 'expectedGeneration'),
+        ),
+      );
       expect(service.isInitialized, isFalse);
     });
   });
@@ -269,20 +356,109 @@ void main() {
   group('retryNow', () {
     test('resets a failed slot to a fresh retry and re-drives', () async {
       await seed(status: PendingProfileSaveStatus.failed, retryCount: 3);
-      when(() => repository.drivePendingSave(pubkey)).thenAnswer((_) async {
+      when(
+        () => repository.drivePendingSave(
+          pubkey,
+          expectedGeneration: any(named: 'expectedGeneration'),
+        ),
+      ).thenAnswer((_) async {
         await dao.clear(pubkey);
         return PendingSaveDriveOutcome.confirmed;
       });
 
       await buildService().retryNow();
 
-      verify(() => repository.drivePendingSave(pubkey)).called(1);
+      verify(
+        () => repository.drivePendingSave(
+          pubkey,
+          expectedGeneration: any(named: 'expectedGeneration'),
+        ),
+      ).called(1);
       expect(await dao.get(pubkey), isNull);
     });
 
     test('is a no-op when there is no slot', () async {
       await buildService().retryNow();
-      verifyNever(() => repository.drivePendingSave(any()));
+      verifyNever(
+        () => repository.drivePendingSave(
+          any(),
+          expectedGeneration: any(named: 'expectedGeneration'),
+        ),
+      );
     });
+  });
+
+  group('self-scheduled retry (relay-recovery)', () {
+    // Poll a real (short-backoff) service until [cond] holds, so the test
+    // proves the armed timer fires on its own without a second trigger.
+    Future<void> pumpUntil(
+      bool Function() cond, {
+      Duration timeout = const Duration(seconds: 2),
+    }) async {
+      final deadline = DateTime.now().add(timeout);
+      while (!cond() && DateTime.now().isBefore(deadline)) {
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+      }
+    }
+
+    test(
+      'one recovery signal eventually publishes via the armed retry timer '
+      '(no second signal needed)',
+      () async {
+        await seed();
+
+        // First attempt fails (relay pool not reconnected yet), the retry the
+        // armed timer schedules confirms — with no further external signal.
+        var calls = 0;
+        when(
+          () => repository.drivePendingSave(
+            pubkey,
+            expectedGeneration: any(named: 'expectedGeneration'),
+          ),
+        ).thenAnswer((_) async {
+          calls++;
+          if (calls == 1) return PendingSaveDriveOutcome.retryableFailure;
+          await dao.clear(pubkey);
+          return PendingSaveDriveOutcome.confirmed;
+        });
+
+        // Real clock + tiny backoff so the armed timer fires quickly. (The
+        // shared buildService injects a frozen clock, which would desync from
+        // the DAO's real-time attempt stamps and defeat the backoff gate.)
+        final service = ProfileSaveRetryService(
+          profileRepository: repository,
+          pendingProfileSavesDao: dao,
+          userPubkey: pubkey,
+          appForegroundStream: foreground.stream,
+          retryTriggerStream: retryTrigger.stream,
+          retryConfig: const ProfileSaveRetryConfig(
+            maxRetries: 3,
+            initialDelay: Duration(milliseconds: 5),
+            maxDelay: Duration(milliseconds: 40),
+          ),
+        );
+        addTearDown(service.dispose);
+        await service.initialize();
+        clearInteractions(repository);
+
+        // A single offline→online recovery signal.
+        retryTrigger.add(null);
+        await pumpUntil(() => calls >= 1);
+        expect(calls, 1, reason: 'the signal drives the first attempt');
+
+        // No second signal — the armed timer must drive the retry that lands.
+        await pumpUntil(() => calls >= 2);
+        expect(
+          calls,
+          greaterThanOrEqualTo(2),
+          reason: 'the armed timer drove a second attempt on its own',
+        );
+        expect(
+          await dao.get(pubkey),
+          isNull,
+          reason: 'the confirmed retry cleared the slot',
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
## Description

Fixes "Can't save username" (#3161, a duplicate of the closed #3152). On iOS the reporter's relay pool sat at zero connected relays, so every profile/username save failed (`ProfilePublishFailedException` ×6) and the divine.video username they had claimed never landed in their kind-0 metadata. The prior fixes around this (#3468 timeout, #3528 error copy, #3175 bootstrap relays, #5674 relay-confirmed saves) improved the *error handling* but none made the save actually **land** when the pool was stuck.

Root cause was threefold on current main:

- **G1 — one-shot, not offline-tolerant.** The save did a single best-effort reconnect per tap with no durable queue, and connectivity-return re-drove DMs/reactions/views but never the relay pool. A transient offline moment became a hard failure the user had to manually retry.
- **G2 — claim/publish consistency gap.** The divine.video username is claimed on the name server (idempotent, edge-synced) *before* the kind-0 publish. When the publish failed, the name was committed server-side but the kind-0 never advertised the `nip05` — a "half-registered" state that reads to the user as "didn't save."
- **G3 — false-negative.** A throw from the post-publish local cache write flipped a relay-confirmed publish into `publishFailed`.

### What this does

Makes the profile/username save **optimistic and durable**, reusing the app's existing retry-queue pattern (`OutgoingDmRetryService` / `PendingActionService`):

- **`PendingProfileSaves` Drift slot** — one row per user (kind-0 is replaceable, so latest-intent wins) + DAO, wired via the same runtime CREATE-IF-NOT-EXISTS pattern as `outgoing_dms` (schema-parity pinned by test). *(db_client)*
- **`ProfileRepository.enqueuePendingSave` / `drivePendingSave`** — an idempotent claim-then-publish re-drive that clears the slot only on a relay-confirmed `OK true`. Safe to replay: the name-server claim is idempotent for the owner and kind-0 is replaceable.
- **`ProfileSaveRetryService`** — sweeps the slot on app-foreground **and connectivity return**, with per-row backoff (5×, 2s→5min), a re-entrancy guard, cold-start interrupted-slot reset, and a `retryNow()` for a manual retry.
- **Optimistic bloc save** — after the username claim, enqueue and emit success immediately (the editor closes and shows the username), then re-drive the kind-0 in the background. A transient publish failure no longer surfaces as an error; the durable slot + retry service own delivery (fixes G1 + G2).
- **G3 fix** — clear the slot before the local cache write and make the cache write non-fatal, so a cache failure can never strand a relay-confirmed save.
- **connectivity → relay reconnect** — a debounced `forceReconnectAll` on network return so the pool self-heals app-wide (helps likes/views/DMs too), not only on app resume.

Commits are delineated per layer: db_client slot → repository enqueue/drive → retry service → G3 hardening → optimistic bloc → app wiring → connectivity reconnect → dead-code cleanup.

Recommend closing **#3161 as a duplicate of #3152** once this merges.

## Out of Scope

- **Permanent-failure UI surface (follow-up):** if the background retry permanently exhausts (5 retries over a prolonged offline window), the failed slot is still recoverable (retry service / connectivity / `retryNow`) but is not yet surfaced in the UI. Deferred to a follow-up.
- **Half-registered usernames (server/product follow-up):** a claim that lands server-side while its kind-0 never publishes is now re-driven client-side; a server/product path to surface or reap any names that stay unadvertised is a separate follow-up.
- The reporter's *exact* runtime trigger of the zero-connected state (network flip vs iOS socket-kill vs DNS/TLS) can't be pinned from the available device logs; the fix is trigger-agnostic.

## Verification

- `flutter analyze lib test` — clean.
- **db_client**: full suite, including new `pending_profile_saves` DAO tests + schema-parity + upgrade-path tests.
- **profile_repository**: full suite, 100% package coverage retained (new payload model + enqueue/drive/G3).
- **ProfileSaveRetryService**: new unit test — sweep outcomes, backoff, re-entrancy, foreground/connectivity triggers, cold-start reset, manual retry.
- **ProfileEditorBloc**: 94 tests migrated to the optimistic behavior (assert the enqueued `PendingProfileSave` payload; transient publish failures → optimistic success + queued slot).
- profile_setup screen/widget tests, l10n `arb_consistency`, and the untested-services floor check — all pass.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (durable offline-tolerant save infrastructure)
