### PR TITLE
fix(camera): stop zoom sticking at random positions on iOS

### DIFF
--- a/mobile/integration_test/video_recorder/camera_controls_integration_test.dart
+++ b/mobile/integration_test/video_recorder/camera_controls_integration_test.dart
@@ -94,25 +94,33 @@ void main() {
         final maxZoom = cameraService.maxZoomLevel;
 
         final midZoom = (minZoom + maxZoom) / 2;
-        final success = await cameraService.setZoomLevel(midZoom);
+        // setZoomLevel returns the zoom the camera actually applied
+        // (double?, null on failure), not a bool — assert it lands inside
+        // the advertised range.
+        final applied = await cameraService.setZoomLevel(midZoom);
 
-        expect(success, isA<bool>());
+        expect(applied, isNotNull);
+        expect(applied, inInclusiveRange(minZoom, maxZoom));
       });
 
       patrolTest('can set zoom to minimum', ($) async {
         await _grantPermissions($);
         final minZoom = cameraService.minZoomLevel;
-        final success = await cameraService.setZoomLevel(minZoom);
+        final maxZoom = cameraService.maxZoomLevel;
+        final applied = await cameraService.setZoomLevel(minZoom);
 
-        expect(success, isA<bool>());
+        expect(applied, isNotNull);
+        expect(applied, inInclusiveRange(minZoom, maxZoom));
       });
 
       patrolTest('can set zoom to maximum', ($) async {
         await _grantPermissions($);
+        final minZoom = cameraService.minZoomLevel;
         final maxZoom = cameraService.maxZoomLevel;
-        final success = await cameraService.setZoomLevel(maxZoom);
+        final applied = await cameraService.setZoomLevel(maxZoom);
 
-        expect(success, isA<bool>());
+        expect(applied, isNotNull);
+        expect(applied, inInclusiveRange(minZoom, maxZoom));
       });
 
       patrolTest('can smoothly transition zoom levels', ($) async {

--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -1309,6 +1309,12 @@ class VideoRecorderBloc
         snappedTo1x: snapped,
         snapTime: snapTime,
         showZoomIndicator: true,
+        // Re-assert for the whole gesture. A two-finger pinch held stationary
+        // for >1s emits no update, so the auto-hide timer fires while the
+        // pinch is still down and clears isPinchActive. A resumed update must
+        // restore it — otherwise the ruler shows interactive again and
+        // swallows the lower pinch finger.
+        isPinchActive: true,
       ),
     );
     _armZoomIndicatorHideTimer();
@@ -1337,8 +1343,11 @@ class VideoRecorderBloc
     // isPinchActive is cleared as a safety net for the timer-armed paths
     // (a real two-pointer pinch, or a programmatic zoom set): the timer only
     // fires after a full second without gesture activity, so a still-set flag
-    // there means the scale-end callback was lost (e.g. gesture cancelled by
-    // navigation) and would otherwise leave the ruler non-interactive. A pure
+    // there usually means the scale-end callback was lost (e.g. gesture
+    // cancelled by navigation) and would otherwise leave the ruler
+    // non-interactive. Clearing it is safe even when the pinch is in fact
+    // still down (held stationary >1s): _onScaleUpdated re-asserts the flag on
+    // the next update, so the ruler can't turn interactive mid-gesture. A pure
     // one-finger pan arms no timer, so if its scale-end is lost the flag
     // instead self-heals on the next pinch or zoom set.
     emit(state.copyWith(showZoomIndicator: false, isPinchActive: false));

--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -1334,10 +1334,13 @@ class VideoRecorderBloc
     Emitter<VideoRecorderBlocState> emit,
   ) {
     _zoomIndicatorTimer = null;
-    // isPinchActive is cleared as a safety net: the timer only fires after
-    // a full second without gesture activity, so a still-set flag means the
-    // scale-end callback was lost (e.g. gesture cancelled by navigation) and
-    // would otherwise leave the ruler permanently non-interactive.
+    // isPinchActive is cleared as a safety net for the timer-armed paths
+    // (a real two-pointer pinch, or a programmatic zoom set): the timer only
+    // fires after a full second without gesture activity, so a still-set flag
+    // there means the scale-end callback was lost (e.g. gesture cancelled by
+    // navigation) and would otherwise leave the ruler non-interactive. A pure
+    // one-finger pan arms no timer, so if its scale-end is lost the flag
+    // instead self-heals on the next pinch or zoom set.
     emit(state.copyWith(showZoomIndicator: false, isPinchActive: false));
   }
 

--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -215,6 +215,7 @@ class VideoRecorderBloc
     on<VideoRecorderZoomedByLongPress>(_onZoomedByLongPress);
     on<VideoRecorderScaleStarted>(_onScaleStarted);
     on<VideoRecorderScaleUpdated>(_onScaleUpdated);
+    on<VideoRecorderScaleEnded>(_onScaleEnded);
     on<VideoRecorderRecordingLockedForNavigation>(
       _onRecordingLockedForNavigation,
     );
@@ -549,8 +550,8 @@ class VideoRecorderBloc
       return;
     }
 
-    final success = await _cameraService.setZoomLevel(event.value);
-    if (!success) {
+    final appliedZoom = await _cameraService.setZoomLevel(event.value);
+    if (appliedZoom == null) {
       Log.warning(
         '⚠️ Failed to set zoom level to ${event.value}',
         name: 'VideoRecorderBloc',
@@ -558,7 +559,19 @@ class VideoRecorderBloc
       );
       return;
     }
-    emit(state.copyWith(zoomLevel: event.value, showZoomIndicator: true));
+    // Emit what the camera actually applied, never the request: iOS can
+    // silently clamp an in-range request when the available zoom range is
+    // restricted at runtime. Mirroring the refreshed bounds keeps the
+    // ruler's scale honest (it shrinks under a restriction and heals once
+    // the restriction lifts).
+    emit(
+      state.copyWith(
+        zoomLevel: appliedZoom,
+        minZoomLevel: _cameraService.minZoomLevel,
+        maxZoomLevel: _cameraService.maxZoomLevel,
+        showZoomIndicator: true,
+      ),
+    );
     _armZoomIndicatorHideTimer();
   }
 
@@ -1194,25 +1207,49 @@ class VideoRecorderBloc
     VideoRecorderScaleStarted event,
     Emitter<VideoRecorderBlocState> emit,
   ) {
+    // Only a real pinch (two pointers) summons the ruler. A one-pointer
+    // scale start is just a pan and must not flip the ruler interactive —
+    // an invisible, fading-in ruler otherwise swallows the second finger
+    // of the pinch that follows (its opaque hit-test band sits right where
+    // the lower finger lands). isPinchActive additionally blocks the ruler
+    // for the whole gesture, so a second finger landing on the (visible)
+    // ruler still falls through to the preview and completes the pinch.
+    //
     // snapTime is intentionally not reset here: copyWith's null-coalescing
     // semantics make explicit-null a no-op anyway, and the snap-update
     // handler guards every snapTime read with snappedTo1x — which we
     // just cleared. The next snap engagement overwrites snapTime fresh.
+    final isPinch = event.details.pointerCount >= 2;
     emit(
       state.copyWith(
         baseZoomLevel: state.zoomLevel,
         snappedTo1x: false,
         lastRawZoom: state.zoomLevel,
-        showZoomIndicator: true,
+        showZoomIndicator: isPinch ? true : null,
+        isPinchActive: true,
       ),
     );
-    _armZoomIndicatorHideTimer();
+    if (isPinch) _armZoomIndicatorHideTimer();
+  }
+
+  void _onScaleEnded(
+    VideoRecorderScaleEnded event,
+    Emitter<VideoRecorderBlocState> emit,
+  ) {
+    emit(state.copyWith(isPinchActive: false));
   }
 
   Future<void> _onScaleUpdated(
     VideoRecorderScaleUpdated event,
     Emitter<VideoRecorderBlocState> emit,
   ) async {
+    // One-pointer updates with an unchanged scale are pans, not pinches
+    // (a single pointer keeps scale at exactly 1.0; trackpad pinches
+    // report a scale != 1.0). Skipping them keeps plain preview pans from
+    // summoning and re-arming the zoom ruler.
+    if (event.details.pointerCount < 2 && event.details.scale == 1.0) {
+      return;
+    }
     // Multiplicative mapping: the cumulative pinch scale multiplies the zoom
     // captured at gesture start, so the perceived sensitivity is uniform
     // across the whole range (1×→2× feels like 2×→4×). The previous
@@ -1297,7 +1334,11 @@ class VideoRecorderBloc
     Emitter<VideoRecorderBlocState> emit,
   ) {
     _zoomIndicatorTimer = null;
-    emit(state.copyWith(showZoomIndicator: false));
+    // isPinchActive is cleared as a safety net: the timer only fires after
+    // a full second without gesture activity, so a still-set flag means the
+    // scale-end callback was lost (e.g. gesture cancelled by navigation) and
+    // would otherwise leave the ruler permanently non-interactive.
+    emit(state.copyWith(showZoomIndicator: false, isPinchActive: false));
   }
 
   void _onRecordingLockedForNavigation(

--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -1319,7 +1319,16 @@ class VideoRecorderBloc
     );
     _armZoomIndicatorHideTimer();
 
-    if ((state.zoomLevel - clampedZoom).abs() > 0.01) {
+    // Dispatch when the applied zoom actually moved, or when the raw pinch
+    // target pushed past a cached bound even though the clamp pinned it to the
+    // current zoom. The latter re-runs the platform set so its read-back can
+    // widen a stale ceiling a lifted runtime restriction left behind —
+    // otherwise a user pinned at a shrunk max stays capped until they first
+    // pinch back in.
+    final pushedPastBound =
+        newZoom > _cameraService.maxZoomLevel ||
+        newZoom < _cameraService.minZoomLevel;
+    if ((state.zoomLevel - clampedZoom).abs() > 0.01 || pushedPastBound) {
       add(VideoRecorderZoomLevelSet(clampedZoom));
     }
   }

--- a/mobile/lib/blocs/video_recorder/video_recorder_event.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_event.dart
@@ -203,6 +203,12 @@ final class VideoRecorderScaleUpdated extends VideoRecorderEvent {
   List<Object?> get props => [details];
 }
 
+/// Scale gesture on the preview ended (all pointers lifted or the pointer
+/// configuration changed) — releases the zoom ruler's pinch guard.
+final class VideoRecorderScaleEnded extends VideoRecorderEvent {
+  const VideoRecorderScaleEnded();
+}
+
 /// Disposes the camera service so the next route can take over the
 /// AVAudioSession cleanly. The View dispatches this just before
 /// navigating to a screen that owns the camera, after the push

--- a/mobile/lib/blocs/video_recorder/video_recorder_state.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_state.dart
@@ -46,6 +46,7 @@ class VideoRecorderBlocState extends Equatable {
     this.lastRawZoom = 1.0,
     this.snapTime,
     this.showZoomIndicator = false,
+    this.isPinchActive = false,
   });
 
   /// Recorder mode from the camera.
@@ -188,6 +189,14 @@ class VideoRecorderBlocState extends Equatable {
   /// only shows up while the user is actively changing the zoom.
   final bool showZoomIndicator;
 
+  /// True while a scale gesture is in progress on the camera preview.
+  ///
+  /// The zoom ruler stops accepting pointers while this is set, so the
+  /// second finger of a pinch landing on the ruler strip falls through
+  /// to the preview and completes the pinch instead of being swallowed
+  /// by the ruler's drag scrubber.
+  final bool isPinchActive;
+
   /// Whether currently recording.
   bool get isRecording => recordingState == VideoRecorderState.recording;
 
@@ -238,6 +247,7 @@ class VideoRecorderBlocState extends Equatable {
     double? lastRawZoom,
     DateTime? snapTime,
     bool? showZoomIndicator,
+    bool? isPinchActive,
   }) {
     return VideoRecorderBlocState(
       recorderMode: recorderMode ?? this.recorderMode,
@@ -281,6 +291,7 @@ class VideoRecorderBlocState extends Equatable {
       lastRawZoom: lastRawZoom ?? this.lastRawZoom,
       snapTime: snapTime ?? this.snapTime,
       showZoomIndicator: showZoomIndicator ?? this.showZoomIndicator,
+      isPinchActive: isPinchActive ?? this.isPinchActive,
     );
   }
 
@@ -319,5 +330,6 @@ class VideoRecorderBlocState extends Equatable {
     lastRawZoom,
     snapTime,
     showZoomIndicator,
+    isPinchActive,
   ];
 }

--- a/mobile/lib/services/video_recorder/camera/camera_base_service.dart
+++ b/mobile/lib/services/video_recorder/camera/camera_base_service.dart
@@ -69,8 +69,14 @@ abstract class CameraService {
   /// Sets the exposure point in normalized coordinates (0.0-1.0).
   Future<bool> setExposurePoint(Offset offset);
 
-  /// Sets the zoom level. Returns true if successful.
-  Future<bool> setZoomLevel(double value);
+  /// Sets the zoom level.
+  ///
+  /// Returns the zoom level the camera actually applied, or null on
+  /// failure. The applied zoom can be lower than [value] when the OS
+  /// restricts the available zoom range at runtime (iOS clamps such
+  /// requests silently); [minZoomLevel] / [maxZoomLevel] reflect the
+  /// refreshed range after the call.
+  Future<double?> setZoomLevel(double value);
 
   /// Switches between front and back camera. Returns true if successful.
   Future<bool> switchCamera();

--- a/mobile/lib/services/video_recorder/camera/camera_linux_service.dart
+++ b/mobile/lib/services/video_recorder/camera/camera_linux_service.dart
@@ -111,7 +111,7 @@ class CameraLinuxService extends CameraService {
   Future<bool> setExposurePoint(Offset offset) async => false;
 
   @override
-  Future<bool> setZoomLevel(double value) async => false;
+  Future<double?> setZoomLevel(double value) async => null;
 
   @override
   Future<bool> switchCamera() async => false;

--- a/mobile/lib/services/video_recorder/camera/camera_mobile_service.dart
+++ b/mobile/lib/services/video_recorder/camera/camera_mobile_service.dart
@@ -157,8 +157,8 @@ class CameraMobileService extends CameraService {
   }
 
   @override
-  Future<bool> setZoomLevel(double value) async {
-    if (!_isInitialized) return false;
+  Future<double?> setZoomLevel(double value) async {
+    if (!_isInitialized) return null;
     try {
       Log.info(
         '📷 Setting zoom level to $value',
@@ -166,17 +166,25 @@ class CameraMobileService extends CameraService {
         category: .video,
       );
 
-      await _camera.setZoomLevel(
-        value.clamp(_camera.minZoomLevel, _camera.maxZoomLevel),
-      );
-      return true;
+      // DivineCamera clamps the request and returns what the camera
+      // actually applied (which iOS can silently cap below the request).
+      final applied = await _camera.setZoomLevel(value);
+      if (applied != null && (applied - value).abs() > 0.01) {
+        Log.info(
+          '📷 Zoom clamped by platform: requested $value, applied $applied '
+          '(available ${_camera.minZoomLevel}-${_camera.maxZoomLevel})',
+          name: 'CameraMobileService',
+          category: .video,
+        );
+      }
+      return applied;
     } catch (e) {
       Log.error(
         '📷 Failed to set zoom level (unexpected error): $e',
         name: 'CameraMobileService',
         category: .video,
       );
-      return false;
+      return null;
     }
   }
 

--- a/mobile/lib/widgets/video_recorder/preview/video_recorder_mobile_preview.dart
+++ b/mobile/lib/widgets/video_recorder/preview/video_recorder_mobile_preview.dart
@@ -16,6 +16,7 @@ class VideoRecorderMobilePreview extends StatelessWidget {
     return CameraPreviewWidget(
       onScaleStart: (details) => bloc.add(VideoRecorderScaleStarted(details)),
       onScaleUpdate: (details) => bloc.add(VideoRecorderScaleUpdated(details)),
+      onScaleEnd: (details) => bloc.add(const VideoRecorderScaleEnded()),
       onTap: enableTapToFocus
           ? (localPosition, normalizedPosition) {
               // setFocusPoint already combines AF + AE metering.

--- a/mobile/lib/widgets/video_recorder/video_recorder_zoom_indicator.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_zoom_indicator.dart
@@ -20,8 +20,10 @@ import 'package:openvine/l10n/l10n.dart';
 /// major marks (whole factors and the 0.5× stop) with a soft detent and a
 /// haptic tick, matching the pinch's 1× snap. It only accepts pointer events
 /// while [VideoRecorderBlocState.showZoomIndicator] is set (during a pinch and
-/// for a short hold afterwards); the rest of the time it ignores them so the
-/// preview keeps its own gestures.
+/// for a short hold afterwards) and no preview scale gesture is in progress
+/// ([VideoRecorderBlocState.isPinchActive]); the rest of the time it ignores
+/// them so the preview keeps its own gestures and a pinch finger landing on
+/// the ruler still reaches the preview.
 ///
 /// Renders nothing when the active camera exposes no usable zoom range
 /// (single lens / before initialization).
@@ -35,12 +37,14 @@ class VideoRecorderZoomIndicator extends StatelessWidget {
       :minZoomLevel,
       :maxZoomLevel,
       :showZoomIndicator,
+      :isPinchActive,
     ) = context.select(
       (VideoRecorderBloc b) => (
         zoomLevel: b.state.zoomLevel,
         minZoomLevel: b.state.minZoomLevel,
         maxZoomLevel: b.state.maxZoomLevel,
         showZoomIndicator: b.state.showZoomIndicator,
+        isPinchActive: b.state.isPinchActive,
       ),
     );
 
@@ -51,8 +55,11 @@ class VideoRecorderZoomIndicator extends StatelessWidget {
 
     // Only grab pointer events while the ruler is visible, so the preview
     // keeps its pinch / tap / long-press gestures the rest of the time.
+    // While a preview scale gesture is in progress the ruler also lets
+    // pointers through — its opaque full-width band would otherwise swallow
+    // the second finger of a pinch and break the gesture.
     return IgnorePointer(
-      ignoring: !showZoomIndicator,
+      ignoring: !showZoomIndicator || isPinchActive,
       child: ExcludeSemantics(
         excluding: !showZoomIndicator,
         child: AnimatedOpacity(

--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/CameraController.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/CameraController.kt
@@ -1818,11 +1818,15 @@ class CameraController(
      * accepts a virtual zoom level spanning all available back lenses.
      * 1.0 = main at native 1x. Below 1.0 = ultra-wide. Above
      * telephoto ratio = telephoto.
+     *
+     * Returns the applied zoom plus the currently available range as a
+     * map for the platform channel (shared contract with iOS, where the
+     * OS can silently clamp the request), or null on failure.
      */
-    fun setZoomLevel(level: Float): Boolean {
+    fun setZoomLevel(level: Float): Map<String, Double>? {
         // Without auto lens switching, use direct camera zoom
         if (!autoLensSwitchEnabled) {
-            val cam = camera ?: return false
+            val cam = camera ?: return null
             return try {
                 // When auto lens switch is disabled, clamp to 1.0 minimum
                 // to prevent native HAL from switching to ultra-wide on
@@ -1833,10 +1837,10 @@ class CameraController(
                 cam.cameraControl.setZoomRatio(clampedLevel)
                 currentZoom = clampedLevel
                 DivineCameraLog.d(TAG, "Zoom level set: $clampedLevel")
-                true
+                zoomStateMap(clampedLevel, effectiveMin, maxZoom)
             } catch (e: Exception) {
                 DivineCameraLog.e(TAG, "Failed to set zoom level", e)
-                false
+                null
             }
         }
 
@@ -1851,22 +1855,32 @@ class CameraController(
         // Switch lens if needed (skip during recording)
         if (targetLens != currentLensType && !isRecording) {
             autoSwitchToLens(targetLens, nativeZoom)
-            return true
+            return zoomStateMap(clampedVirtual, virtualMinZoom, virtualMaxZoom)
         }
 
         // Same lens: adjust native zoom directly
-        val cam = camera ?: return false
+        val cam = camera ?: return null
         return try {
             val clampedNative =
                 nativeZoom.coerceIn(minZoom, maxZoom)
             cam.cameraControl.setZoomRatio(clampedNative)
             currentZoom = clampedNative
-            true
+            zoomStateMap(clampedVirtual, virtualMinZoom, virtualMaxZoom)
         } catch (e: Exception) {
             DivineCameraLog.e(TAG, "Failed to set zoom level", e)
-            false
+            null
         }
     }
+
+    private fun zoomStateMap(
+        zoom: Float,
+        min: Float,
+        max: Float
+    ): Map<String, Double> = mapOf(
+        "zoomLevel" to zoom.toDouble(),
+        "minZoomLevel" to min.toDouble(),
+        "maxZoomLevel" to max.toDouble()
+    )
 
     /**
      * Sets the requested video stabilization mode.

--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/DivineCameraPlugin.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/DivineCameraPlugin.kt
@@ -324,8 +324,8 @@ class DivineCameraPlugin :
             return
         }
         try {
-            val success = controller.setZoomLevel(level)
-            result.success(success)
+            // Map with the applied zoom + available range, null on failure.
+            result.success(controller.setZoomLevel(level))
         } catch (e: Exception) {
             result.error("ZOOM_ERROR", e.message, null)
         }

--- a/mobile/packages/divine_camera/ios/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/ios/Classes/CameraController.swift
@@ -1737,22 +1737,51 @@ class CameraController: NSObject {
     
     /// Sets the zoom level (user-facing value, e.g. 0.5x, 1.0x, 2.0x).
     /// Internally converts to native videoZoomFactor using nativeToUserZoomScale.
-    func setZoomLevel(level: CGFloat) -> Bool {
-        guard let device = videoDevice else { return false }
-        
-        let clampedLevel = max(minZoom, min(level, maxZoom))
+    ///
+    /// Clamps against the device's *current* min/maxAvailableVideoZoomFactor
+    /// instead of the configure-time snapshot: on virtual devices iOS
+    /// restricts these at runtime (e.g. while recording or with video
+    /// stabilization active) and silently clamps out-of-range assignments
+    /// rather than throwing. The factor is read back after the assignment so
+    /// the returned zoom is what the camera actually applied, never the
+    /// requested value.
+    ///
+    /// Returns the applied zoom plus the live available range as a map for
+    /// the platform channel, or nil when the device rejected the change.
+    func setZoomLevel(level: CGFloat) -> [String: Double]? {
+        guard let device = videoDevice else { return nil }
+
+        // Without auto lens switch the lower bound stays at 1.0 so the
+        // native HAL never switches a virtual device to the ultra-wide,
+        // mirroring updateCameraProperties.
+        var liveMin = device.minAvailableVideoZoomFactor * nativeToUserZoomScale
+        if !autoLensSwitchRequested {
+            liveMin = max(liveMin, 1.0)
+        }
+        let liveMax = device.maxAvailableVideoZoomFactor * nativeToUserZoomScale
+
+        let clampedLevel = max(liveMin, min(level, liveMax))
         // Convert user-facing zoom to native videoZoomFactor
         let nativeZoom = clampedLevel / nativeToUserZoomScale
-        
+
         do {
             try device.lockForConfiguration()
             device.videoZoomFactor = nativeZoom
             device.unlockForConfiguration()
-            currentZoom = clampedLevel
-            return true
         } catch {
-            return false
+            return nil
         }
+
+        currentZoom = device.videoZoomFactor * nativeToUserZoomScale
+        // Keep the stored bounds in sync so getCameraState reports the same
+        // range; refreshed on every set, so it heals when a restriction lifts.
+        minZoom = liveMin
+        maxZoom = liveMax
+        return [
+            "zoomLevel": Double(currentZoom),
+            "minZoomLevel": Double(liveMin),
+            "maxZoomLevel": Double(liveMax),
+        ]
     }
 
     // MARK: - Video Stabilization

--- a/mobile/packages/divine_camera/ios/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/ios/Classes/CameraController.swift
@@ -1220,7 +1220,10 @@ class CameraController: NSObject {
             // lens switching on virtual multi-camera devices.
             nativeToUserZoomScale = 1.0
             minZoom = 1.0
-            maxZoom = device.activeFormat.videoMaxZoomFactor
+            // Use the live available max (mirrors the auto-lens branch and
+            // setZoomLevel) rather than the static format max, so a runtime
+            // restriction that lowers the ceiling isn't briefly over-advertised.
+            maxZoom = device.maxAvailableVideoZoomFactor
         }
         currentZoom = device.videoZoomFactor * nativeToUserZoomScale
         // Front camera has "flash" via screen brightness when feature is enabled

--- a/mobile/packages/divine_camera/ios/Classes/DivineCameraPlugin.swift
+++ b/mobile/packages/divine_camera/ios/Classes/DivineCameraPlugin.swift
@@ -379,8 +379,8 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
             result(Self.cameraError("NOT_INITIALIZED", "Camera not initialized"))
             return
         }
-        let success = controller.setZoomLevel(level: CGFloat(level))
-        result(success)
+        // Map with the applied zoom + live available range, nil on failure.
+        result(controller.setZoomLevel(level: CGFloat(level)))
     }
 
     private func setVideoStabilizationMode(mode: String, result: @escaping FlutterResult) {

--- a/mobile/packages/divine_camera/lib/divine_camera.dart
+++ b/mobile/packages/divine_camera/lib/divine_camera.dart
@@ -18,6 +18,7 @@ export 'src/models/audio_device.dart';
 export 'src/models/camera_lens.dart';
 export 'src/models/camera_lens_metadata.dart';
 export 'src/models/camera_state.dart';
+export 'src/models/camera_zoom_state.dart';
 export 'src/models/flash_mode.dart';
 export 'src/models/photo_capture_result.dart';
 export 'src/models/remote_record_trigger.dart';
@@ -216,15 +217,26 @@ class DivineCamera {
   /// Sets the zoom level.
   ///
   /// [level] the zoom level to set.
-  /// Returns true if successful.
-  Future<bool> setZoomLevel(double level) async {
+  ///
+  /// Returns the zoom level the camera actually applied, or `null` when
+  /// the platform failed to apply it. The applied zoom can be lower than
+  /// [level]: on iOS virtual multi-camera devices the system restricts
+  /// the available zoom range at runtime and silently clamps out-of-range
+  /// assignments, so the platform reads the factor back after setting it.
+  /// The live range reported alongside it replaces [minZoomLevel] /
+  /// [maxZoomLevel], keeping [state] honest in both directions (it heals
+  /// once a runtime restriction lifts).
+  Future<double?> setZoomLevel(double level) async {
     final clampedLevel = level.clamp(_state.minZoomLevel, _state.maxZoomLevel);
-    final success = await _platform.setZoomLevel(clampedLevel);
-    if (success) {
-      _state = _state.copyWith(zoomLevel: clampedLevel);
-      _notifyStateChanged();
-    }
-    return success;
+    final zoom = await _platform.setZoomLevel(clampedLevel);
+    if (zoom == null) return null;
+    _state = _state.copyWith(
+      zoomLevel: zoom.zoomLevel,
+      minZoomLevel: zoom.minZoomLevel,
+      maxZoomLevel: zoom.maxZoomLevel,
+    );
+    _notifyStateChanged();
+    return zoom.zoomLevel;
   }
 
   /// Switches between front and back camera.

--- a/mobile/packages/divine_camera/lib/divine_camera_method_channel.dart
+++ b/mobile/packages/divine_camera/lib/divine_camera_method_channel.dart
@@ -5,6 +5,7 @@ import 'package:divine_camera/divine_camera_platform_interface.dart';
 import 'package:divine_camera/src/models/audio_device.dart';
 import 'package:divine_camera/src/models/camera_lens.dart';
 import 'package:divine_camera/src/models/camera_state.dart';
+import 'package:divine_camera/src/models/camera_zoom_state.dart';
 import 'package:divine_camera/src/models/flash_mode.dart';
 import 'package:divine_camera/src/models/photo_capture_result.dart';
 import 'package:divine_camera/src/models/remote_record_trigger.dart';
@@ -201,11 +202,13 @@ class MethodChannelDivineCamera extends DivineCameraPlatform {
   }
 
   @override
-  Future<bool> setZoomLevel(double level) async {
-    final result = await methodChannel.invokeMethod<bool>('setZoomLevel', {
-      'level': level,
-    });
-    return result ?? false;
+  Future<CameraZoomState?> setZoomLevel(double level) async {
+    final result = await methodChannel.invokeMapMethod<dynamic, dynamic>(
+      'setZoomLevel',
+      {'level': level},
+    );
+    if (result == null) return null;
+    return CameraZoomState.fromMap(result);
   }
 
   @override

--- a/mobile/packages/divine_camera/lib/divine_camera_platform_interface.dart
+++ b/mobile/packages/divine_camera/lib/divine_camera_platform_interface.dart
@@ -5,6 +5,7 @@ import 'package:divine_camera/divine_camera_method_channel.dart';
 import 'package:divine_camera/src/models/audio_device.dart';
 import 'package:divine_camera/src/models/camera_lens.dart';
 import 'package:divine_camera/src/models/camera_state.dart';
+import 'package:divine_camera/src/models/camera_zoom_state.dart';
 import 'package:divine_camera/src/models/flash_mode.dart';
 import 'package:divine_camera/src/models/photo_capture_result.dart';
 import 'package:divine_camera/src/models/remote_record_trigger.dart';
@@ -83,8 +84,13 @@ abstract class DivineCameraPlatform extends PlatformInterface {
   }
 
   /// Sets the zoom level.
-  /// Returns true if successful.
-  Future<bool> setZoomLevel(double level) {
+  ///
+  /// Returns the zoom state the camera actually applied (read back from
+  /// the device, together with the live available zoom range), or `null`
+  /// when the platform failed to apply the zoom. The applied zoom can be
+  /// lower than [level] when the OS restricts the available range at
+  /// runtime — see [CameraZoomState].
+  Future<CameraZoomState?> setZoomLevel(double level) {
     throw UnimplementedError('setZoomLevel() has not been implemented.');
   }
 

--- a/mobile/packages/divine_camera/lib/src/models/camera_zoom_state.dart
+++ b/mobile/packages/divine_camera/lib/src/models/camera_zoom_state.dart
@@ -1,0 +1,43 @@
+// ABOUTME: Zoom state actually applied by the platform camera after a set
+// ABOUTME: Carries the read-back zoom plus the live available zoom range
+
+/// Result of a `setZoomLevel` call: what the camera actually applied.
+///
+/// [zoomLevel] is read back from the device after the assignment rather
+/// than echoing the request — on iOS virtual multi-camera devices the
+/// system restricts `min/maxAvailableVideoZoomFactor` at runtime (e.g.
+/// while recording or with video stabilization active) and silently
+/// clamps out-of-range assignments instead of throwing.
+/// [minZoomLevel] / [maxZoomLevel] carry that live range so callers can
+/// surface honest bounds instead of the configure-time snapshot.
+class CameraZoomState {
+  /// Creates a zoom state.
+  const CameraZoomState({
+    required this.zoomLevel,
+    required this.minZoomLevel,
+    required this.maxZoomLevel,
+  });
+
+  /// Creates a zoom state from a platform channel map.
+  factory CameraZoomState.fromMap(Map<dynamic, dynamic> map) {
+    return CameraZoomState(
+      zoomLevel: (map['zoomLevel'] as num?)?.toDouble() ?? 1.0,
+      minZoomLevel: (map['minZoomLevel'] as num?)?.toDouble() ?? 1.0,
+      maxZoomLevel: (map['maxZoomLevel'] as num?)?.toDouble() ?? 1.0,
+    );
+  }
+
+  /// The zoom level the camera actually applied.
+  final double zoomLevel;
+
+  /// The minimum zoom level currently available on the device.
+  final double minZoomLevel;
+
+  /// The maximum zoom level currently available on the device.
+  final double maxZoomLevel;
+
+  @override
+  String toString() =>
+      'CameraZoomState(zoomLevel: $zoomLevel, '
+      'minZoomLevel: $minZoomLevel, maxZoomLevel: $maxZoomLevel)';
+}

--- a/mobile/packages/divine_camera/lib/src/widgets/camera_preview_widget.dart
+++ b/mobile/packages/divine_camera/lib/src/widgets/camera_preview_widget.dart
@@ -20,6 +20,7 @@ class CameraPreviewWidget extends StatefulWidget {
     this.onTap,
     this.onScaleStart,
     this.onScaleUpdate,
+    this.onScaleEnd,
     this.loadingWidget,
     this.focusIndicatorBuilder,
     super.key,
@@ -46,6 +47,11 @@ class CameraPreviewWidget extends StatefulWidget {
   /// Optional callback when a scale gesture updates (pinch-to-zoom).
   /// Used to handle zoom level changes during the gesture.
   final ValueChanged<ScaleUpdateDetails>? onScaleUpdate;
+
+  /// Optional callback when a scale gesture ends (all pointers lifted or
+  /// the pointer configuration changed). Lets callers track whether a
+  /// preview gesture is currently in progress.
+  final ValueChanged<ScaleEndDetails>? onScaleEnd;
 
   @override
   State<CameraPreviewWidget> createState() => _CameraPreviewWidgetState();
@@ -214,6 +220,7 @@ class _CameraPreviewWidgetState extends State<CameraPreviewWidget> {
               },
               onScaleStart: widget.onScaleStart,
               onScaleUpdate: widget.onScaleUpdate,
+              onScaleEnd: widget.onScaleEnd,
               child: _CameraPreview(
                 constraints: constraints,
                 textureId: textureToShow,

--- a/mobile/packages/divine_camera/macos/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/macos/Classes/CameraController.swift
@@ -593,13 +593,6 @@ class CameraController: NSObject {
         }
     }
 
-    /// Sets the zoom level.
-    func setZoomLevel(level: CGFloat) -> Bool {
-        // videoZoomFactor is unavailable on macOS
-        // macOS cameras do not support programmatic zoom
-        return false
-    }
-
     // MARK: - Preview
 
     /// Pauses the camera preview.

--- a/mobile/packages/divine_camera/macos/Classes/DivineCameraPlugin.swift
+++ b/mobile/packages/divine_camera/macos/Classes/DivineCameraPlugin.swift
@@ -317,12 +317,13 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
     }
 
     private func setZoomLevel(level: Double, result: @escaping FlutterResult) {
-        guard let controller = cameraController else {
+        guard cameraController != nil else {
             result(Self.cameraError("NOT_INITIALIZED", "Camera not initialized"))
             return
         }
-        let success = controller.setZoomLevel(level: CGFloat(level))
-        result(success)
+        // Programmatic zoom is unsupported on macOS cameras; nil signals
+        // failure in the shared channel contract (applied-zoom map or nil).
+        result(nil)
     }
 
     private func switchCamera(lens: String, result: @escaping FlutterResult) {

--- a/mobile/packages/divine_camera/test/divine_camera_method_channel_test.dart
+++ b/mobile/packages/divine_camera/test/divine_camera_method_channel_test.dart
@@ -48,7 +48,11 @@ void main() {
             case 'cancelFocusAndMetering':
               return true;
             case 'setZoomLevel':
-              return true;
+              return {
+                'zoomLevel': args?['level'],
+                'minZoomLevel': 0.5,
+                'maxZoomLevel': 61.875,
+              };
             case 'setVideoStabilizationMode':
               return true;
             case 'switchCamera':
@@ -190,10 +194,13 @@ void main() {
       expect(result, isTrue);
     });
 
-    test('setZoomLevel returns true', () async {
+    test('setZoomLevel returns the applied zoom state', () async {
       final result = await platform.setZoomLevel(2.5);
 
-      expect(result, isTrue);
+      expect(result, isNotNull);
+      expect(result!.zoomLevel, 2.5);
+      expect(result.minZoomLevel, 0.5);
+      expect(result.maxZoomLevel, 61.875);
     });
 
     test('switchCamera returns updated CameraState', () async {
@@ -554,7 +561,7 @@ void main() {
       expect(result, isFalse);
     });
 
-    test('setZoomLevel returns false when result is null', () async {
+    test('setZoomLevel returns null when result is null', () async {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(channel, (methodCall) async {
             if (methodCall.method == 'setZoomLevel') {
@@ -564,7 +571,7 @@ void main() {
           });
 
       final result = await platform.setZoomLevel(2);
-      expect(result, isFalse);
+      expect(result, isNull);
     });
   });
 

--- a/mobile/packages/divine_camera/test/divine_camera_platform_interface_test.dart
+++ b/mobile/packages/divine_camera/test/divine_camera_platform_interface_test.dart
@@ -35,7 +35,8 @@ class TestDivineCameraPlatform extends DivineCameraPlatform
   Future<bool> setExposurePoint(Offset offset) async => true;
 
   @override
-  Future<bool> setZoomLevel(double level) async => true;
+  Future<CameraZoomState?> setZoomLevel(double level) async =>
+      CameraZoomState(zoomLevel: level, minZoomLevel: 1, maxZoomLevel: 10);
 
   @override
   Future<CameraState> switchCamera(DivineCameraLens lens) async =>

--- a/mobile/packages/divine_camera/test/divine_camera_test.dart
+++ b/mobile/packages/divine_camera/test/divine_camera_test.dart
@@ -126,9 +126,23 @@ class MockDivineCameraPlatform
     return true;
   }
 
+  /// When set, [setZoomLevel] reports this value as the currently
+  /// available maximum and clamps the applied zoom to it, simulating an
+  /// OS runtime restriction (iOS silently clamps in that case).
+  double? availableMaxZoomOverride;
+
+  /// When true, [setZoomLevel] fails (returns null).
+  bool failZoom = false;
+
   @override
-  Future<bool> setZoomLevel(double level) async {
-    return level >= 1.0 && level <= 10.0;
+  Future<CameraZoomState?> setZoomLevel(double level) async {
+    if (failZoom) return null;
+    final availableMax = availableMaxZoomOverride ?? _state.maxZoomLevel;
+    return CameraZoomState(
+      zoomLevel: level.clamp(_state.minZoomLevel, availableMax),
+      minZoomLevel: _state.minZoomLevel,
+      maxZoomLevel: availableMax,
+    );
   }
 
   /// When set, [switchCamera] awaits this before completing, so a test can
@@ -528,12 +542,13 @@ void main() {
     });
 
     group('zoom', () {
-      test('sets zoom level successfully', () async {
+      test('sets zoom level and returns the applied value', () async {
         await DivineCamera.instance.initialize();
 
-        final success = await DivineCamera.instance.setZoomLevel(2);
+        final applied = await DivineCamera.instance.setZoomLevel(2);
 
-        expect(success, isTrue);
+        expect(applied, 2.0);
+        expect(DivineCamera.instance.zoomLevel, 2.0);
       });
 
       test('returns minZoomLevel and maxZoomLevel', () async {
@@ -541,6 +556,47 @@ void main() {
 
         expect(DivineCamera.instance.minZoomLevel, 1.0);
         expect(DivineCamera.instance.maxZoomLevel, 10.0);
+      });
+
+      test('returns null and keeps state when the platform fails', () async {
+        await DivineCamera.instance.initialize();
+        mockPlatform.failZoom = true;
+
+        final applied = await DivineCamera.instance.setZoomLevel(2);
+
+        expect(applied, isNull);
+        expect(DivineCamera.instance.zoomLevel, 1.0);
+      });
+
+      test(
+        'adopts the applied zoom and shrunk bounds when the OS restricts '
+        'the available range at runtime',
+        () async {
+          await DivineCamera.instance.initialize();
+          mockPlatform.availableMaxZoomOverride = 5.2;
+
+          final applied = await DivineCamera.instance.setZoomLevel(8);
+
+          expect(applied, 5.2);
+          expect(DivineCamera.instance.zoomLevel, 5.2);
+          expect(DivineCamera.instance.maxZoomLevel, 5.2);
+        },
+      );
+
+      test('heals the bounds once a runtime restriction lifts', () async {
+        await DivineCamera.instance.initialize();
+        mockPlatform.availableMaxZoomOverride = 5.2;
+        await DivineCamera.instance.setZoomLevel(8);
+        mockPlatform.availableMaxZoomOverride = null;
+
+        // The first set after the lift is still pre-clamped to the shrunk
+        // bounds, but the platform reports the widened range back.
+        await DivineCamera.instance.setZoomLevel(4);
+        expect(DivineCamera.instance.maxZoomLevel, 10.0);
+
+        final applied = await DivineCamera.instance.setZoomLevel(8);
+        expect(applied, 8.0);
+        expect(DivineCamera.instance.zoomLevel, 8.0);
       });
     });
 

--- a/mobile/packages/divine_camera/test/models/camera_zoom_state_test.dart
+++ b/mobile/packages/divine_camera/test/models/camera_zoom_state_test.dart
@@ -1,0 +1,54 @@
+import 'package:divine_camera/divine_camera.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group(CameraZoomState, () {
+    group('fromMap', () {
+      test('parses all fields from a platform channel map', () {
+        final state = CameraZoomState.fromMap(const {
+          'zoomLevel': 5.2,
+          'minZoomLevel': 0.5,
+          'maxZoomLevel': 61.875,
+        });
+
+        expect(state.zoomLevel, 5.2);
+        expect(state.minZoomLevel, 0.5);
+        expect(state.maxZoomLevel, 61.875);
+      });
+
+      test('converts integer values to doubles', () {
+        final state = CameraZoomState.fromMap(const {
+          'zoomLevel': 2,
+          'minZoomLevel': 1,
+          'maxZoomLevel': 8,
+        });
+
+        expect(state.zoomLevel, 2.0);
+        expect(state.minZoomLevel, 1.0);
+        expect(state.maxZoomLevel, 8.0);
+      });
+
+      test('falls back to 1.0 for missing fields', () {
+        final state = CameraZoomState.fromMap(const {});
+
+        expect(state.zoomLevel, 1.0);
+        expect(state.minZoomLevel, 1.0);
+        expect(state.maxZoomLevel, 1.0);
+      });
+    });
+
+    test('toString contains all fields', () {
+      const state = CameraZoomState(
+        zoomLevel: 5.2,
+        minZoomLevel: 0.5,
+        maxZoomLevel: 61.875,
+      );
+
+      expect(
+        state.toString(),
+        'CameraZoomState(zoomLevel: 5.2, '
+        'minZoomLevel: 0.5, maxZoomLevel: 61.875)',
+      );
+    });
+  });
+}

--- a/mobile/packages/divine_camera/test/widgets/camera_preview_widget_test.dart
+++ b/mobile/packages/divine_camera/test/widgets/camera_preview_widget_test.dart
@@ -85,7 +85,11 @@ class MockDivineCameraPlatform
   Future<bool> cancelFocusAndMetering() async => true;
 
   @override
-  Future<bool> setZoomLevel(double level) async => true;
+  Future<CameraZoomState?> setZoomLevel(double level) async => CameraZoomState(
+    zoomLevel: level,
+    minZoomLevel: _state.minZoomLevel,
+    maxZoomLevel: _state.maxZoomLevel,
+  );
 
   @override
   Future<bool> setVideoStabilizationMode(
@@ -188,6 +192,7 @@ void main() {
     Widget Function(Offset)? focusIndicatorBuilder,
     ValueChanged<ScaleStartDetails>? onScaleStart,
     ValueChanged<ScaleUpdateDetails>? onScaleUpdate,
+    ValueChanged<ScaleEndDetails>? onScaleEnd,
   }) {
     return MaterialApp(
       home: Scaffold(
@@ -201,6 +206,7 @@ void main() {
             focusIndicatorBuilder: focusIndicatorBuilder,
             onScaleStart: onScaleStart,
             onScaleUpdate: onScaleUpdate,
+            onScaleEnd: onScaleEnd,
           ),
         ),
       ),
@@ -527,6 +533,24 @@ void main() {
         find.byType(GestureDetector),
       );
       expect(gestureDetector.onScaleUpdate, isNotNull);
+    });
+
+    testWidgets('passes onScaleEnd callback to GestureDetector', (
+      tester,
+    ) async {
+      await camera.initialize();
+
+      await tester.pumpWidget(
+        buildTestWidget(
+          onScaleEnd: (details) {},
+        ),
+      );
+
+      // Verify GestureDetector is present and accepts the callback
+      final gestureDetector = tester.widget<GestureDetector>(
+        find.byType(GestureDetector),
+      );
+      expect(gestureDetector.onScaleEnd, isNotNull);
     });
 
     testWidgets('shows last frame during camera switch', (tester) async {

--- a/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
+++ b/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 
 import 'package:bloc_test/bloc_test.dart';
 import 'package:divine_camera/divine_camera.dart';
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter/services.dart' show PlatformException;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -245,6 +246,28 @@ void main() {
         expect(bloc.state.showZoomIndicator, isFalse);
       });
 
+      test(
+        'summons the zoom ruler when a second finger lands mid-pan',
+        () async {
+          final bloc = buildBloc();
+          addTearDown(bloc.close);
+
+          // Pan→pinch escalation: the just-landed second finger reports an
+          // unchanged scale (1.0) but a pointerCount of 2, so the update must
+          // proceed past the one-pointer pan guard and summon the ruler.
+          bloc.add(
+            VideoRecorderScaleStarted(ScaleStartDetails(pointerCount: 1)),
+          );
+          await Future<void>.delayed(Duration.zero);
+          bloc.add(
+            VideoRecorderScaleUpdated(ScaleUpdateDetails(pointerCount: 2)),
+          );
+          await Future<void>.delayed(Duration.zero);
+
+          expect(bloc.state.showZoomIndicator, isTrue);
+        },
+      );
+
       test('shows the zoom ruler when the zoom level is set', () async {
         when(
           () => cameraService.setZoomLevel(any()),
@@ -258,15 +281,28 @@ void main() {
         expect(bloc.state.showZoomIndicator, isTrue);
       });
 
-      test('auto-hides the zoom ruler after the pinch settles', () async {
-        final bloc = buildBloc();
-        addTearDown(bloc.close);
+      test('auto-hides the zoom ruler after the pinch settles', () {
+        // Drive the 1000ms auto-hide timer with fakeAsync instead of racing
+        // wall-clock, which flakes under the merged-isolate CI run.
+        fakeAsync((async) {
+          final bloc = buildBloc();
 
-        bloc.add(VideoRecorderScaleStarted(ScaleStartDetails(pointerCount: 2)));
-        // The auto-hide timer is 1000ms — give it room to fire.
-        await Future<void>.delayed(const Duration(milliseconds: 1100));
+          bloc.add(
+            VideoRecorderScaleStarted(ScaleStartDetails(pointerCount: 2)),
+          );
+          async.flushMicrotasks();
+          expect(bloc.state.showZoomIndicator, isTrue);
 
-        expect(bloc.state.showZoomIndicator, isFalse);
+          async.elapse(const Duration(milliseconds: 1000));
+          async.flushMicrotasks();
+
+          expect(bloc.state.showZoomIndicator, isFalse);
+
+          // Close inside the fake zone: a real-zone teardown would await
+          // microtasks this (now dead) zone can no longer drain and hang.
+          unawaited(bloc.close());
+          async.flushMicrotasks();
+        });
       });
     });
 
@@ -285,16 +321,26 @@ void main() {
       });
 
       test('is cleared by the indicator auto-hide timer as a safety net '
-          'when the scale-end callback is lost', () async {
-        final bloc = buildBloc();
-        addTearDown(bloc.close);
+          'when the scale-end callback is lost', () {
+        fakeAsync((async) {
+          final bloc = buildBloc();
 
-        bloc.add(VideoRecorderScaleStarted(ScaleStartDetails(pointerCount: 2)));
-        // No VideoRecorderScaleEnded — the 1000ms auto-hide timer must
-        // release the guard so the ruler doesn't stay non-interactive.
-        await Future<void>.delayed(const Duration(milliseconds: 1100));
+          bloc.add(
+            VideoRecorderScaleStarted(ScaleStartDetails(pointerCount: 2)),
+          );
+          async.flushMicrotasks();
+          // No VideoRecorderScaleEnded — the 1000ms auto-hide timer must
+          // release the guard so the ruler doesn't stay non-interactive.
+          async.elapse(const Duration(milliseconds: 1000));
+          async.flushMicrotasks();
 
-        expect(bloc.state.isPinchActive, isFalse);
+          expect(bloc.state.isPinchActive, isFalse);
+
+          // Close inside the fake zone: a real-zone teardown would await
+          // microtasks this (now dead) zone can no longer drain and hang.
+          unawaited(bloc.close());
+          async.flushMicrotasks();
+        });
       });
     });
 

--- a/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
+++ b/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
@@ -342,6 +342,37 @@ void main() {
           async.flushMicrotasks();
         });
       });
+
+      test('is re-asserted when a stationary pinch resumes after the timer '
+          'fired mid-gesture', () {
+        fakeAsync((async) {
+          final bloc = buildBloc();
+
+          bloc.add(
+            VideoRecorderScaleStarted(ScaleStartDetails(pointerCount: 2)),
+          );
+          async.flushMicrotasks();
+          // Held stationary >1s: no updates, so the auto-hide timer fires
+          // while the two fingers are still down and clears the guard.
+          async.elapse(const Duration(milliseconds: 1000));
+          async.flushMicrotasks();
+          expect(bloc.state.isPinchActive, isFalse);
+
+          // The pinch resumes (second finger still down, unchanged scale):
+          // the flag must come back so the ruler can't turn interactive and
+          // swallow the lower pinch finger.
+          bloc.add(
+            VideoRecorderScaleUpdated(ScaleUpdateDetails(pointerCount: 2)),
+          );
+          async.flushMicrotasks();
+
+          expect(bloc.state.isPinchActive, isTrue);
+          expect(bloc.state.showZoomIndicator, isTrue);
+
+          unawaited(bloc.close());
+          async.flushMicrotasks();
+        });
+      });
     });
 
     group('pinch-to-zoom snap', () {

--- a/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
+++ b/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
@@ -921,6 +921,45 @@ void main() {
         ],
       );
 
+      test(
+        'heals a stale shrunk ceiling on pinch-out even when the clamp '
+        'pins the zoom to the current level',
+        () async {
+          // The live max was restricted to 2.5 and the user is pinned there.
+          // The restriction has since lifted (live max back to 5.0) but the
+          // service still advertises the stale 2.5 until the next set's
+          // read-back refreshes it. A pinch-out clamps back to 2.5 (== the
+          // current zoom), so the applied zoom doesn't move — the dispatch
+          // must still fire so the ceiling heals on this gesture rather than
+          // staying capped until the user first pinches back in.
+          var healed = false;
+          when(() => cameraService.setZoomLevel(any())).thenAnswer((inv) async {
+            healed = true;
+            return inv.positionalArguments.first as double;
+          });
+          when(
+            () => cameraService.maxZoomLevel,
+          ).thenAnswer((_) => healed ? 5.0 : 2.5);
+
+          final bloc = buildBloc()
+            ..emit(
+              const VideoRecorderBlocState(zoomLevel: 2.5, maxZoomLevel: 2.5),
+            );
+          addTearDown(bloc.close);
+
+          bloc.add(
+            VideoRecorderScaleStarted(ScaleStartDetails(pointerCount: 2)),
+          );
+          await pumpEventQueue();
+          // 2.5 × 1.6 = 4.0 > stale max 2.5, so clampedZoom pins back to 2.5.
+          bloc.add(VideoRecorderScaleUpdated(ScaleUpdateDetails(scale: 1.6)));
+          await pumpEventQueue();
+
+          verify(() => cameraService.setZoomLevel(2.5)).called(1);
+          expect(bloc.state.maxZoomLevel, 5.0);
+        },
+      );
+
       blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
         'no-op when zoom value out of bounds',
         build: buildBloc,

--- a/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
+++ b/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
@@ -222,20 +222,33 @@ void main() {
     });
 
     group('showZoomIndicator', () {
-      test('shows the zoom ruler when a pinch starts', () async {
+      test('shows the zoom ruler when a two-pointer pinch starts', () async {
         final bloc = buildBloc();
         addTearDown(bloc.close);
 
-        bloc.add(VideoRecorderScaleStarted(ScaleStartDetails()));
+        bloc.add(VideoRecorderScaleStarted(ScaleStartDetails(pointerCount: 2)));
         await Future<void>.delayed(Duration.zero);
 
         expect(bloc.state.showZoomIndicator, isTrue);
       });
 
+      test('does not summon the zoom ruler on a one-pointer pan', () async {
+        final bloc = buildBloc();
+        addTearDown(bloc.close);
+
+        bloc.add(VideoRecorderScaleStarted(ScaleStartDetails(pointerCount: 1)));
+        bloc.add(
+          VideoRecorderScaleUpdated(ScaleUpdateDetails(pointerCount: 1)),
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        expect(bloc.state.showZoomIndicator, isFalse);
+      });
+
       test('shows the zoom ruler when the zoom level is set', () async {
         when(
           () => cameraService.setZoomLevel(any()),
-        ).thenAnswer((_) async => true);
+        ).thenAnswer((inv) async => inv.positionalArguments.first as double);
         final bloc = buildBloc();
         addTearDown(bloc.close);
 
@@ -249,7 +262,7 @@ void main() {
         final bloc = buildBloc();
         addTearDown(bloc.close);
 
-        bloc.add(VideoRecorderScaleStarted(ScaleStartDetails()));
+        bloc.add(VideoRecorderScaleStarted(ScaleStartDetails(pointerCount: 2)));
         // The auto-hide timer is 1000ms — give it room to fire.
         await Future<void>.delayed(const Duration(milliseconds: 1100));
 
@@ -257,11 +270,39 @@ void main() {
       });
     });
 
+    group('isPinchActive', () {
+      test('is set while a preview scale gesture is in progress', () async {
+        final bloc = buildBloc();
+        addTearDown(bloc.close);
+
+        bloc.add(VideoRecorderScaleStarted(ScaleStartDetails(pointerCount: 1)));
+        await Future<void>.delayed(Duration.zero);
+        expect(bloc.state.isPinchActive, isTrue);
+
+        bloc.add(const VideoRecorderScaleEnded());
+        await Future<void>.delayed(Duration.zero);
+        expect(bloc.state.isPinchActive, isFalse);
+      });
+
+      test('is cleared by the indicator auto-hide timer as a safety net '
+          'when the scale-end callback is lost', () async {
+        final bloc = buildBloc();
+        addTearDown(bloc.close);
+
+        bloc.add(VideoRecorderScaleStarted(ScaleStartDetails(pointerCount: 2)));
+        // No VideoRecorderScaleEnded — the 1000ms auto-hide timer must
+        // release the guard so the ruler doesn't stay non-interactive.
+        await Future<void>.delayed(const Duration(milliseconds: 1100));
+
+        expect(bloc.state.isPinchActive, isFalse);
+      });
+    });
+
     group('pinch-to-zoom snap', () {
       test('pinching down across the 1× detent snaps zoom to 1.0', () async {
         when(
           () => cameraService.setZoomLevel(any()),
-        ).thenAnswer((_) async => true);
+        ).thenAnswer((inv) async => inv.positionalArguments.first as double);
         final bloc = buildBloc();
         addTearDown(bloc.close);
 
@@ -285,7 +326,7 @@ void main() {
       test('maps zoom multiplicatively as base × pinch scale', () async {
         when(
           () => cameraService.setZoomLevel(any()),
-        ).thenAnswer((_) async => true);
+        ).thenAnswer((inv) async => inv.positionalArguments.first as double);
         final bloc = buildBloc();
         addTearDown(bloc.close);
 
@@ -307,7 +348,7 @@ void main() {
       setUp(() {
         when(
           () => cameraService.setZoomLevel(any()),
-        ).thenAnswer((_) async => true);
+        ).thenAnswer((inv) async => inv.positionalArguments.first as double);
       });
 
       test('a full upward drag reaches the camera max zoom', () async {
@@ -385,7 +426,7 @@ void main() {
       setUp(() {
         when(
           () => cameraService.setZoomLevel(any()),
-        ).thenAnswer((_) async => true);
+        ).thenAnswer((inv) async => inv.positionalArguments.first as double);
       });
 
       test('captures the current zoom as the drag base', () async {
@@ -753,12 +794,53 @@ void main() {
         setUp: () {
           when(
             () => cameraService.setZoomLevel(any()),
-          ).thenAnswer((_) async => true);
+          ).thenAnswer(
+            (inv) async => inv.positionalArguments.first as double,
+          );
         },
         build: buildBloc,
         act: (bloc) => bloc.add(const VideoRecorderZoomLevelSet(2)),
         expect: () => const [
-          VideoRecorderBlocState(zoomLevel: 2, showZoomIndicator: true),
+          VideoRecorderBlocState(
+            zoomLevel: 2,
+            minZoomLevel: 0.5,
+            maxZoomLevel: 5,
+            showZoomIndicator: true,
+          ),
+        ],
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'emits the zoom the camera actually applied — not the request — '
+        'when the OS silently clamps it, and mirrors the shrunk range',
+        setUp: () {
+          // Runtime-restricted camera: requests above 2.5 are applied as
+          // 2.5 (iOS clamps them silently, without an error). The service
+          // getters still report the stale configure-time range (5.0)
+          // until the first set refreshes them to the live range (2.5) —
+          // mirroring how the real service learns of the restriction.
+          var restricted = false;
+          when(() => cameraService.setZoomLevel(any())).thenAnswer((
+            inv,
+          ) async {
+            final requested = inv.positionalArguments.first as double;
+            if (requested <= 2.5) return requested;
+            restricted = true;
+            return 2.5;
+          });
+          when(
+            () => cameraService.maxZoomLevel,
+          ).thenAnswer((_) => restricted ? 2.5 : 5.0);
+        },
+        build: buildBloc,
+        act: (bloc) => bloc.add(const VideoRecorderZoomLevelSet(4)),
+        expect: () => const [
+          VideoRecorderBlocState(
+            zoomLevel: 2.5,
+            minZoomLevel: 0.5,
+            maxZoomLevel: 2.5,
+            showZoomIndicator: true,
+          ),
         ],
       );
 
@@ -777,7 +859,7 @@ void main() {
         setUp: () {
           when(
             () => cameraService.setZoomLevel(any()),
-          ).thenAnswer((_) async => false);
+          ).thenAnswer((_) async => null);
         },
         build: buildBloc,
         act: (bloc) => bloc.add(const VideoRecorderZoomLevelSet(2)),

--- a/mobile/test/mocks/mock_camera_service.dart
+++ b/mobile/test/mocks/mock_camera_service.dart
@@ -62,9 +62,9 @@ class MockCameraService extends CameraService {
   }
 
   @override
-  Future<bool> setZoomLevel(double value) async {
-    zoomLevel = value;
-    return true;
+  Future<double?> setZoomLevel(double value) async {
+    zoomLevel = value.clamp(minZoomLevel, maxZoomLevel);
+    return zoomLevel;
   }
 
   @override

--- a/mobile/test/services/video_recorder/camera/camera_linux_service_test.dart
+++ b/mobile/test/services/video_recorder/camera/camera_linux_service_test.dart
@@ -116,10 +116,10 @@ void main() {
         expect(result, isFalse);
       });
 
-      test('setZoomLevel returns false', () async {
+      test('setZoomLevel returns null (zoom unsupported)', () async {
         final result = await service.setZoomLevel(2);
 
-        expect(result, isFalse);
+        expect(result, isNull);
       });
 
       test('switchCamera returns false', () async {

--- a/mobile/test/widgets/video_recorder/video_recorder_zoom_indicator_test.dart
+++ b/mobile/test/widgets/video_recorder/video_recorder_zoom_indicator_test.dart
@@ -32,6 +32,7 @@ void main() {
       double minZoomLevel = 0.5,
       double maxZoomLevel = 5.0,
       bool showZoomIndicator = true,
+      bool isPinchActive = false,
     }) {
       when(() => bloc.state).thenReturn(
         VideoRecorderBlocState(
@@ -39,6 +40,7 @@ void main() {
           minZoomLevel: minZoomLevel,
           maxZoomLevel: maxZoomLevel,
           showZoomIndicator: showZoomIndicator,
+          isPinchActive: isPinchActive,
           isCameraInitialized: true,
         ),
       );
@@ -394,6 +396,28 @@ void main() {
           () => bloc.add(any(that: isA<VideoRecorderZoomLevelSet>())),
         );
       });
+
+      testWidgets(
+        'does not capture pointers while a preview pinch is in progress',
+        (tester) async {
+          // Regression: the visible ruler used to swallow the second finger
+          // of a pinch with its opaque full-width band, degrading the pinch
+          // into a one-finger no-op plus an unintended ruler scrub.
+          await tester.pumpWidget(buildWidget(isPinchActive: true));
+          await tester.pumpAndSettle();
+
+          await tester.drag(
+            find.byType(VideoRecorderZoomIndicator),
+            const Offset(-110, 0),
+            warnIfMissed: false,
+          );
+          await tester.pumpAndSettle();
+
+          verifyNever(
+            () => bloc.add(any(that: isA<VideoRecorderZoomLevelSet>())),
+          );
+        },
+      );
     });
   });
 }


### PR DESCRIPTION
Closes #6065

## Description

A user reported that on iOS the recorder camera zoom freezes at a seemingly random factor (5.2×, 9.5×, …) that is stable within a session and differs across sessions — zooming out always works, and the ruler read-out keeps climbing to ~30× while the picture stays put. Their logs (iPhone17,3, 1.0.16+804) confirmed two independent root causes:

**1. iOS silently clamps the zoom, and we never noticed.** On virtual multi-camera devices iOS restricts `min/maxAvailableVideoZoomFactor` at runtime (e.g. under video stabilization, which the reporter had on) and *silently clamps* an out-of-range `videoZoomFactor` assignment instead of throwing. Our native setter clamped against a configure-time snapshot (61.875× on their device), never read the factor back, and the Dart layer discarded the success flag — so the app kept emitting the *requested* zoom while the sensor sat at the clamp. Ruler and camera drifted apart.

- Clamp against the device's **live** `min/maxAvailableVideoZoomFactor`, **read `videoZoomFactor` back** after assignment, and return the applied zoom + live range over the platform channel (new `CameraZoomState`).
- `DivineCamera` / `CameraService.setZoomLevel` now return the applied value (`double?`) and mirror the refreshed bounds into bloc state. The ruler stops exactly where the camera does, and its scale shrinks under a restriction and **heals** once it lifts.
- `CameraMobileService` logs a `Zoom clamped by platform: requested X, applied Y` breadcrumb so we can confirm the trigger (stabilization) on device.

**2. The zoom ruler was swallowing the pinch.** The interactive ruler turned pointer-hungry the instant a scale gesture began — its opaque full-width band sits right where the lower pinch finger lands, and it activated even before fading in. A second finger there degraded the pinch into a one-finger no-op *plus* an unintended linear ruler scrub (110px/1.0×, integer detents) — which is exactly the slow crawl visible in the logs (620 sub-0.01 steps, asymptotic integer snapping, never a pinch step).

- Gate ruler interactivity on a new `isPinchActive` flag (set for the whole preview gesture, wired via `onScaleEnd`), so a pinch finger on the ruler falls through to the preview.
- Only summon the ruler on a genuine two-pointer pinch, so a one-finger pan no longer arms the invisible strip.

## Out of Scope

- The linear 110px-per-1.0× ruler scale means the full 0.5→61.9× span needs ~6,700px of drag travel. A logarithmic mapping or a sensible zoom cap is a separate product/UX decision, not included here.
- iOS Swift changes are not built locally (no device build in this environment) — please verify on device.

## Verification

- `flutter analyze lib test integration_test` — clean; `dart format` — no changes
- `divine_camera`: **366 tests green, 100% line coverage** (CI gate), incl. new tests for silent-clamp adoption, bounds healing, `CameraZoomState`, `onScaleEnd`
- App: video-recorder bloc + widget suites green (~380 tests), incl. new regressions — "emits the zoom the camera actually applied when the OS silently clamps it", "does not capture pointers while a preview pinch is in progress", "does not summon the zoom ruler on a one-pointer pan"
- Android Kotlin compiles (`:divine_camera:compileDebugKotlin`, exit 0)
- Pre-push hook (analyze + changed-file tests) green

**Related Issue:**  (reported via Zendesk/logs, no tracked issue)

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)