### PR TITLE
fix(audio-attribution): credit the original creator for reused audio

### DIFF
--- a/mobile/lib/models/video_editor/video_editor_provider_state.dart
+++ b/mobile/lib/models/video_editor/video_editor_provider_state.dart
@@ -142,19 +142,27 @@ class VideoEditorProviderState {
   bool get isValidToPost =>
       !metadataLimitReached && !isProcessing && finalRenderedClip != null;
 
-  /// Whether the video's audio comes from a reused or added sound rather than
-  /// the user's own recording.
+  /// Whether the video's audio is reused from *another creator* — a sound the
+  /// user is not entitled to re-offer for reuse.
   ///
-  /// True when a sound is selected (recorder flow) or the editor timeline
-  /// holds an added audio track that is not the video's own clip-anchored
-  /// original sound. In that case "Publish this sound" ([allowAudioReuse])
-  /// does not apply — the audio isn't the user's to offer for reuse, and the
-  /// publisher already skips the reuse tag — so the metadata toggle is
-  /// disabled to match.
+  /// True only when the selected sound (recorder flow) or an added editor
+  /// timeline track references another creator's Nostr event: a reused
+  /// original sound (`video_<eventId>`) or a published Kind 1063, i.e. it has
+  /// an [AudioEvent.attributionEventId]. Bundled "divine" sounds, self-imported
+  /// audio, voice-over takes, and the video's own clip-anchored original sound
+  /// are all the user's own to offer, so they keep the toggle.
+  ///
+  /// In the reused-from-another case "Publish this sound" ([allowAudioReuse])
+  /// is a no-op — the publisher references the source event instead of
+  /// republishing the audio under the reusing user — so the metadata toggle is
+  /// hidden to match.
   bool get reusesExternalAudio {
-    if (selectedSound != null) return true;
+    bool isReusedFromAnotherCreator(AudioEvent audio) =>
+        !audio.isClipAnchoredOriginalSound && audio.attributionEventId != null;
+    final sound = selectedSound;
+    if (sound != null && isReusedFromAnotherCreator(sound)) return true;
     final tracks = editorEditingParameters?.audioTracksFromMeta ?? const [];
-    return tracks.any((track) => !track.isClipAnchoredOriginalSound);
+    return tracks.any(isReusedFromAnotherCreator);
   }
 
   /// Creates a copy of this state with updated fields.

--- a/mobile/lib/models/video_editor/video_editor_provider_state.dart
+++ b/mobile/lib/models/video_editor/video_editor_provider_state.dart
@@ -3,6 +3,7 @@
 
 import 'package:flutter/widgets.dart';
 import 'package:models/models.dart' show AudioEvent, InspiredByInfo;
+import 'package:openvine/extensions/complete_parameters_extensions.dart';
 import 'package:openvine/models/content_label.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/video_metadata/video_metadata_expiration.dart';
@@ -140,6 +141,21 @@ class VideoEditorProviderState {
   /// - Final rendered clip is available
   bool get isValidToPost =>
       !metadataLimitReached && !isProcessing && finalRenderedClip != null;
+
+  /// Whether the video's audio comes from a reused or added sound rather than
+  /// the user's own recording.
+  ///
+  /// True when a sound is selected (recorder flow) or the editor timeline
+  /// holds an added audio track that is not the video's own clip-anchored
+  /// original sound. In that case "Publish this sound" ([allowAudioReuse])
+  /// does not apply — the audio isn't the user's to offer for reuse, and the
+  /// publisher already skips the reuse tag — so the metadata toggle is
+  /// disabled to match.
+  bool get reusesExternalAudio {
+    if (selectedSound != null) return true;
+    final tracks = editorEditingParameters?.audioTracksFromMeta ?? const [];
+    return tracks.any((track) => !track.isClipAnchoredOriginalSound);
+  }
 
   /// Creates a copy of this state with updated fields.
   ///

--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -597,7 +597,17 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
     final old = state.editorEditingParameters;
     if (old != null) {
       final diffs = old.diff(editingParameters);
-      if (diffs.isEmpty) {
+      // `diff` compares the render-time `audioTracks` field, which is empty in
+      // the editor's complete-callback parameters — it is only populated later
+      // in `_buildRenderParameters`. Audio add/remove instead lives in the
+      // `audio` meta key, so compare that too; otherwise a complete whose only
+      // change is audio is invisible here and the snapshot (and the reuse
+      // toggle / publish attribution that read it) go stale (#6057).
+      final audioMetaChanged = !listEquals(
+        old.audioTracksFromMeta,
+        editingParameters.audioTracksFromMeta,
+      );
+      if (diffs.isEmpty && !audioMetaChanged) {
         Log.debug(
           '🎨 Editor editing parameters unchanged - skipping update',
           name: 'VideoEditorNotifier',
@@ -606,7 +616,8 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
         return;
       }
       Log.debug(
-        '🎨 Editor editing parameters changed: ${diffs.join(", ")}',
+        '🎨 Editor editing parameters changed: '
+        '${[...diffs, if (audioMetaChanged) 'audioMeta'].join(", ")}',
         name: 'VideoEditorNotifier',
         category: LogCategory.video,
       );

--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -516,8 +516,14 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
   /// [inspiredByVideo] from the sound's [sourceVideoReference] if not
   /// already set.
   DivineVideoDraft getActiveDraft({bool isAutosave = false, String? draftId}) {
-    // Read selected sound from local state
-    final selectedSound = state.selectedSound;
+    // Read selected sound from local state. The recorder flow sets
+    // [selectedSound]; the editor's "add music" flow instead appends reused
+    // sounds as timeline tracks, so fall back to the first attributable track
+    // for the publish draft. Skipped for autosave to keep draft round-trips
+    // from re-seeding an editor track as the recorder's selected sound.
+    final selectedSound =
+        state.selectedSound ??
+        (isAutosave ? null : _attributionSoundFromEditorTracks());
 
     // Auto-populate inspired-by from selected sound's source video
     var inspiredByVideo = state.inspiredByVideo;
@@ -1210,6 +1216,24 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
   }
 
   // === PRIVATE HELPERS ===
+
+  /// The reused sound to attribute when publishing a video assembled through
+  /// the editor's "add music" flow, which appends sounds as timeline tracks
+  /// rather than setting the recorder's [selectedSound].
+  ///
+  /// Returns the first added track that references a real Nostr event — a
+  /// published or imported Kind 1063 sound, or another video's original sound
+  /// (`video_<eventId>`). Skips the video's own clip-anchored audio, which
+  /// credits no other creator.
+  AudioEvent? _attributionSoundFromEditorTracks() {
+    final tracks =
+        state.editorEditingParameters?.audioTracksFromMeta ?? const [];
+    for (final track in tracks) {
+      if (track.isClipAnchoredOriginalSound) continue;
+      if (track.attributionEventId != null) return track;
+    }
+    return null;
+  }
 
   /// Build render parameters for video export.
   ///

--- a/mobile/lib/screens/sound_detail_screen.dart
+++ b/mobile/lib/screens/sound_detail_screen.dart
@@ -241,7 +241,13 @@ class _SoundDetailScreenState extends ConsumerState<SoundDetailScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final usageCountAsync = ref.watch(soundUsageCountProvider(widget.sound.id));
+    // A reused original sound carries the source video's id behind a `video_`
+    // prefix; query usage/grid by the recovered event id that real reuses tag
+    // in their `["e", <id>, relay, "audio"]` reference, not the synthetic id.
+    final soundEventId = widget.sound.attributionEventId ?? widget.sound.id;
+    final showsSourceVideo =
+        widget.sound.isOriginalSound && widget.sourceVideo != null;
+    final usageCountAsync = ref.watch(soundUsageCountProvider(soundEventId));
 
     return Scaffold(
       backgroundColor: VineTheme.backgroundColor,
@@ -286,7 +292,7 @@ class _SoundDetailScreenState extends ConsumerState<SoundDetailScreen> {
                       ),
                       const SizedBox(width: 8),
                       Text(
-                        widget.sound.isOriginalSound
+                        showsSourceVideo
                             ? context.l10n.soundSourceVideo
                             : context.l10n.soundVideosUsingThisSound,
                         style: const TextStyle(
@@ -299,17 +305,17 @@ class _SoundDetailScreenState extends ConsumerState<SoundDetailScreen> {
                   ),
                 ),
 
-                // Videos grid — for original sounds, show the source video
-                // directly instead of querying by audio event ID
+                // Videos grid — when a source video is on hand (own original
+                // sound), show it directly; otherwise query by the recovered
+                // audio event id.
                 Expanded(
-                  child:
-                      widget.sound.isOriginalSound && widget.sourceVideo != null
+                  child: showsSourceVideo
                       ? _SourceVideoGrid(
                           video: widget.sourceVideo!,
                           onVideoTap: _navigateToVideo,
                         )
                       : _VideosGrid(
-                          audioEventId: widget.sound.id,
+                          audioEventId: soundEventId,
                           onVideoTap: _navigateToVideo,
                         ),
                 ),

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -1326,10 +1326,15 @@ class VideoEventPublisher {
       final hasSelectedAudioEventId =
           selectedAudioReferenceId != null &&
           selectedAudioReferenceId.isNotEmpty;
+      // A reused *original sound* carries the source video's event id behind a
+      // `video_` prefix (and, from the editor timeline, a `-<timestamp>`
+      // uniqueness suffix). Fall back to [AudioEvent.attributionEventId] to
+      // recover the real event id so the reference survives instead of being
+      // dropped and the audio mislabelled as the reusing user's own sound.
       final reusableSelectedAudioEventId =
           NostrHexUtils.isValidEventId(selectedAudioReferenceId)
           ? selectedAudioReferenceId
-          : null;
+          : selectedAudio?.attributionEventId;
       if (hasSelectedAudioEventId && reusableSelectedAudioEventId == null) {
         Log.warning(
           'Skipping selected audio reference because it is not a Nostr event id: '

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
@@ -282,7 +282,14 @@ class _SoundListItem extends ConsumerWidget {
     Navigator.of(context).pop();
     Future<void>.delayed(Duration.zero).then((_) {
       if (!hostContext.mounted) return;
-      hostContext.pushWithVideoPause(SoundDetailScreen.pathForId(audio.id));
+      // Pass the resolved sound via `extra` (like [_OriginalSoundSection]):
+      // a reused original sound's synthetic `video_<id>` id can't be
+      // re-fetched by the detail loader, so without this it dead-ends at
+      // "Sound not found".
+      hostContext.pushWithVideoPause(
+        SoundDetailScreen.pathForId(audio.id),
+        extra: <String, dynamic>{'sound': audio},
+      );
     });
   }
 }

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
@@ -50,8 +50,14 @@ class _SharedAudioSection extends ConsumerWidget {
     return audioAsync.when(
       data: (audio) {
         if (audio == null) {
-          // Audio event not found, fall back to original sound display
-          return _OriginalSoundSection(video: video);
+          // The shared audio event couldn't be resolved (e.g. the source
+          // video isn't reachable by id). This video still reused a sound, so
+          // credit the reused sound's original creator rather than the
+          // reusing user.
+          return _OriginalSoundSection(
+            video: video,
+            reusedCreatorPubkey: _reusedCreatorPubkey,
+          );
         }
         return MetadataSection(
           label: context.l10n.metadataSoundsLabel,
@@ -68,9 +74,20 @@ class _SharedAudioSection extends ConsumerWidget {
           name: 'MetadataSoundsSection',
           category: LogCategory.ui,
         );
-        return _OriginalSoundSection(video: video);
+        return _OriginalSoundSection(
+          video: video,
+          reusedCreatorPubkey: _reusedCreatorPubkey,
+        );
       },
     );
+  }
+
+  /// The reused sound's original creator, carried on the video via its
+  /// inspired-by source (a reused sound auto-populates inspired-by from the
+  /// source video). Null when absent, so the fallback keeps its default.
+  String? get _reusedCreatorPubkey {
+    final pubkey = video.inspiredByVideo?.creatorPubkey;
+    return (pubkey != null && pubkey.isNotEmpty) ? pubkey : null;
   }
 }
 
@@ -78,19 +95,26 @@ class _SharedAudioSection extends ConsumerWidget {
 /// audio. Tapping navigates to [SoundDetailScreen] where the user can
 /// preview and select the sound for recording.
 class _OriginalSoundSection extends ConsumerWidget {
-  const _OriginalSoundSection({required this.video});
+  const _OriginalSoundSection({required this.video, this.reusedCreatorPubkey});
 
   final VideoEvent video;
 
+  /// When set, the audio was reused from another creator (resolved via the
+  /// video's inspired-by source) but the shared audio event couldn't be
+  /// fetched. This pubkey is credited instead of the reusing user.
+  final String? reusedCreatorPubkey;
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final creatorPubkey = reusedCreatorPubkey ?? video.pubkey;
     final creatorProfile = ref
-        .watch(userProfileReactiveProvider(video.pubkey))
+        .watch(userProfileReactiveProvider(creatorPubkey))
         .value;
     final creatorName =
         creatorProfile?.bestDisplayName ??
-        video.authorName ??
-        UserProfile.generatedNameFor(video.pubkey);
+        (reusedCreatorPubkey != null
+            ? UserProfile.defaultDisplayNameFor(creatorPubkey)
+            : video.authorName ?? UserProfile.generatedNameFor(video.pubkey));
 
     return MetadataSection(
       label: context.l10n.metadataSoundsLabel,
@@ -147,10 +171,19 @@ class _OriginalSoundSection extends ConsumerWidget {
       category: LogCategory.ui,
     );
 
-    final syntheticAudio = AudioEvent.fromVideoOriginalSound(
-      video,
-      creatorName: creatorName,
-    );
+    // For a reused sound the attribution belongs to the source video, so build
+    // the sound around the referenced source (credited to its creator) rather
+    // than this video's own audio.
+    final syntheticAudio = reusedCreatorPubkey != null
+        ? AudioEvent(
+            id: 'video_${video.audioEventId ?? video.id}',
+            pubkey: reusedCreatorPubkey!,
+            createdAt: video.createdAt,
+            title: 'Original sound - $creatorName',
+            source: 'Original Sound',
+            sourceVideoReference: video.inspiredByVideo?.addressableId,
+          )
+        : AudioEvent.fromVideoOriginalSound(video, creatorName: creatorName);
 
     // Dismiss the sheet first, then navigate from the root navigator
     // context.

--- a/mobile/lib/widgets/video_metadata/video_metadata_form_fields.dart
+++ b/mobile/lib/widgets/video_metadata/video_metadata_form_fields.dart
@@ -67,6 +67,13 @@ class _VideoMetadataFormFieldsState
 
   @override
   Widget build(BuildContext context) {
+    // Reusing another creator's audio isn't the user's to offer for reuse, and
+    // the publisher skips the reuse tag in that case, so hide the toggle
+    // entirely rather than showing a control that does nothing.
+    final reusesExternalAudio = ref.watch(
+      videoEditorProvider.select((state) => state.reusesExternalAudio),
+    );
+
     return Padding(
       padding: const .symmetric(horizontal: 16),
       child: Column(
@@ -163,7 +170,7 @@ class _VideoMetadataFormFieldsState
           if (widget.enableContentWarning)
             const _InputWrapper(child: VideoMetadataContentWarningSelector()),
 
-          if (widget.enableAudioReuse)
+          if (widget.enableAudioReuse && !reusesExternalAudio)
             const _InputWrapper(child: _VideoMetadataAudioReuseToggle()),
 
           if (widget.enableVideoReply)

--- a/mobile/packages/models/lib/src/audio_event.dart
+++ b/mobile/packages/models/lib/src/audio_event.dart
@@ -3,6 +3,7 @@
 // ABOUTME: parsing audio shared for use in other videos
 
 import 'package:meta/meta.dart';
+import 'package:models/src/nostr_hex_utils.dart';
 import 'package:models/src/video_event.dart';
 import 'package:models/src/vine_sound.dart';
 import 'package:nostr_sdk/event.dart';
@@ -167,9 +168,16 @@ class AudioEvent {
   /// Uses the video URL as the audio source. The audio player can extract
   /// the audio track from video files. The ID is prefixed with `video_`
   /// to distinguish from real Kind 1063 events.
+  ///
+  /// When [creatorName] is provided the [title] reads
+  /// `Original sound - $creatorName`; when omitted the [title] is left null so
+  /// the display can
+  /// resolve the creator from [pubkey] and localize the "Original sound"
+  /// label itself (used when synthesizing attribution for a reused original
+  /// sound, where the reader owns the localization).
   factory AudioEvent.fromVideoOriginalSound(
     VideoEvent video, {
-    required String creatorName,
+    String? creatorName,
   }) {
     return AudioEvent(
       id: 'video_${video.id}',
@@ -177,7 +185,7 @@ class AudioEvent {
       createdAt: video.createdAt,
       url: video.videoUrl,
       duration: video.duration?.toDouble(),
-      title: 'Original sound - $creatorName',
+      title: creatorName == null ? null : 'Original sound - $creatorName',
       source: 'Original Sound',
       sourceVideoReference: '34236:${video.pubkey}:${video.vineId ?? video.id}',
     );
@@ -246,6 +254,29 @@ class AudioEvent {
 
   /// Whether this audio is derived from a video's original sound.
   bool get isOriginalSound => id.startsWith('video_');
+
+  /// The Nostr event id a reusing video should reference in its
+  /// `["e", <id>, <relay>, "audio"]` attribution tag, or `null` when this
+  /// audio has no referenceable Nostr event (bundled sounds, or imported
+  /// audio that hasn't been published yet).
+  ///
+  /// Resolves two id shapes on top of a plain Kind 1063 event id:
+  /// * a reused *original sound*, whose [id] is `video_<eventId>` — the source
+  ///   Kind 34236 video's own event id (see
+  ///   [AudioEvent.fromVideoOriginalSound]); and
+  /// * an editor timeline track, whose id carries a trailing `-<timestamp>`
+  ///   uniqueness suffix so the same sound can be added to the timeline more
+  ///   than once.
+  ///
+  /// Without this the `video_` prefix / timeline suffix make the id fail a
+  /// 32-byte-hex check, the attribution tag is dropped at publish, and the
+  /// reused audio is mislabelled as the reusing user's original sound.
+  String? get attributionEventId {
+    var candidate = isOriginalSound ? id.substring('video_'.length) : id;
+    final suffixed = RegExp(r'^([0-9a-fA-F]{64})-\d+$').firstMatch(candidate);
+    if (suffixed != null) candidate = suffixed.group(1)!;
+    return NostrHexUtils.isValidEventId(candidate) ? candidate : null;
+  }
 
   /// Whether this track is a video's original sound that is still anchored to
   /// one of the editor's clips.

--- a/mobile/packages/models/lib/src/audio_event.dart
+++ b/mobile/packages/models/lib/src/audio_event.dart
@@ -265,16 +265,22 @@ class AudioEvent {
   ///   Kind 34236 video's own event id (see
   ///   [AudioEvent.fromVideoOriginalSound]); and
   /// * an editor timeline track, whose id carries a trailing `-<timestamp>`
-  ///   uniqueness suffix so the same sound can be added to the timeline more
-  ///   than once.
+  ///   uniqueness suffix (and, after a duplicate/split, one or more
+  ///   `_copy_<micros>` suffixes) so the same sound can appear on the
+  ///   timeline more than once.
   ///
   /// Without this the `video_` prefix / timeline suffix make the id fail a
   /// 32-byte-hex check, the attribution tag is dropped at publish, and the
   /// reused audio is mislabelled as the reusing user's original sound.
   String? get attributionEventId {
     var candidate = isOriginalSound ? id.substring('video_'.length) : id;
-    final suffixed = RegExp(r'^([0-9a-fA-F]{64})-\d+$').firstMatch(candidate);
-    if (suffixed != null) candidate = suffixed.group(1)!;
+    // Recover the leading 64-hex event id, dropping any editor-added
+    // uniqueness/duplicate suffixes (`-<timestamp>`, `_copy_<micros>`, or a
+    // chain of them).
+    final base = RegExp(
+      r'^([0-9a-fA-F]{64})(?:[-_].*)?$',
+    ).firstMatch(candidate);
+    if (base != null) candidate = base.group(1)!;
     return NostrHexUtils.isValidEventId(candidate) ? candidate : null;
   }
 

--- a/mobile/packages/models/test/src/audio_event_test.dart
+++ b/mobile/packages/models/test/src/audio_event_test.dart
@@ -420,6 +420,24 @@ void main() {
         );
       });
 
+      test('strips a duplicate/split _copy_ suffix', () {
+        expect(
+          soundWithId(
+            'video_${testHexId}_copy_1700000000000',
+          ).attributionEventId,
+          equals(testHexId),
+        );
+      });
+
+      test('strips a chained timeline + _copy_ suffix', () {
+        expect(
+          soundWithId(
+            'video_$testHexId-1700000000000_copy_1700000000001',
+          ).attributionEventId,
+          equals(testHexId),
+        );
+      });
+
       test('returns null for a bundled sound', () {
         expect(soundWithId('bundled_classic_snare').attributionEventId, isNull);
       });
@@ -503,10 +521,7 @@ void main() {
 
         expect(
           event.resolvedSource,
-          equals((
-            kind: AudioSourceKind.asset,
-            path: 'assets/sounds/bruh.mp3',
-          )),
+          equals((kind: AudioSourceKind.asset, path: 'assets/sounds/bruh.mp3')),
         );
       });
 
@@ -1303,10 +1318,7 @@ void main() {
 
       test('isAnchored reflects anchorClipId presence', () {
         expect(anchored.isAnchored, isTrue);
-        expect(
-          anchored.copyWith(clearAnchorClipId: true).isAnchored,
-          isFalse,
-        );
+        expect(anchored.copyWith(clearAnchorClipId: true).isAnchored, isFalse);
       });
 
       test('copyWith clears the anchor with clearAnchorClipId', () {
@@ -1351,23 +1363,20 @@ void main() {
         expect(event.isClipAnchoredOriginalSound, isTrue);
       });
 
-      test(
-        'is false for an original sound added from another video '
-        '(not anchored)',
-        () {
-          // A network "Original Sound" the user added from the sound browser:
-          // its id is video_-prefixed but it is free-standing, so it keeps its
-          // own volume arc.
-          const event = AudioEvent(
-            id: 'video_source-abc_copy_1',
-            pubkey: testPubkey,
-            createdAt: 1700000000,
-          );
-          expect(event.isOriginalSound, isTrue);
-          expect(event.isAnchored, isFalse);
-          expect(event.isClipAnchoredOriginalSound, isFalse);
-        },
-      );
+      test('is false for an original sound added from another video '
+          '(not anchored)', () {
+        // A network "Original Sound" the user added from the sound browser:
+        // its id is video_-prefixed but it is free-standing, so it keeps its
+        // own volume arc.
+        const event = AudioEvent(
+          id: 'video_source-abc_copy_1',
+          pubkey: testPubkey,
+          createdAt: 1700000000,
+        );
+        expect(event.isOriginalSound, isTrue);
+        expect(event.isAnchored, isFalse);
+        expect(event.isClipAnchoredOriginalSound, isFalse);
+      });
 
       test('is false for a non-original (custom/imported) track', () {
         const event = AudioEvent(

--- a/mobile/packages/models/test/src/audio_event_test.dart
+++ b/mobile/packages/models/test/src/audio_event_test.dart
@@ -371,6 +371,65 @@ void main() {
           equals('34236:$testPubkey:vine-123'),
         );
       });
+
+      test('leaves title null when creatorName is omitted', () {
+        final video = VideoEvent(
+          id: testHexId,
+          pubkey: testPubkey,
+          createdAt: 1700000000,
+          content: 'classic vine',
+          timestamp: DateTime(2026),
+          videoUrl: 'https://example.com/video.mp4',
+          duration: 6,
+          vineId: 'vine-123',
+        );
+
+        final audioEvent = AudioEvent.fromVideoOriginalSound(video);
+
+        expect(audioEvent.title, isNull);
+        expect(audioEvent.pubkey, equals(testPubkey));
+      });
+    });
+
+    group('attributionEventId', () {
+      AudioEvent soundWithId(String id) =>
+          AudioEvent(id: id, pubkey: testPubkey, createdAt: 1700000000);
+
+      test('returns the event id for a plain Kind 1063 sound', () {
+        expect(soundWithId(testHexId).attributionEventId, equals(testHexId));
+      });
+
+      test('strips the video_ prefix for a reused original sound', () {
+        expect(
+          soundWithId('video_$testHexId').attributionEventId,
+          equals(testHexId),
+        );
+      });
+
+      test('strips a trailing editor timeline uniqueness suffix', () {
+        expect(
+          soundWithId('$testHexId-1700000000000').attributionEventId,
+          equals(testHexId),
+        );
+      });
+
+      test('strips both the video_ prefix and the timeline suffix', () {
+        expect(
+          soundWithId('video_$testHexId-1700000000000').attributionEventId,
+          equals(testHexId),
+        );
+      });
+
+      test('returns null for a bundled sound', () {
+        expect(soundWithId('bundled_classic_snare').attributionEventId, isNull);
+      });
+
+      test('returns null for an unpublished imported sound', () {
+        expect(
+          soundWithId('local_import_1700000000000').attributionEventId,
+          isNull,
+        );
+      });
     });
 
     group('fromLocalImport', () {

--- a/mobile/packages/sounds_repository/lib/src/sounds_repository.dart
+++ b/mobile/packages/sounds_repository/lib/src/sounds_repository.dart
@@ -266,12 +266,20 @@ class SoundsRepository {
           _cache[eventId] = audioEvent;
           return audioEvent;
         } on Object catch (e) {
+          // coverage:ignore-start
+          // Defensive net for adversarial relay data. For a video-kind event
+          // `VideoEvent.fromNostrEvent` does not throw (the kind is already
+          // validated by the `isVideoKind` gate above and `Event.tags` is
+          // strictly typed), so this is unreachable in practice; kept to
+          // downgrade a hypothetical parse failure to a warning + null instead
+          // of the outer error + rethrow.
           Log.warning(
             'Failed to synthesize original sound from video $eventId: $e',
             name: 'SoundsRepository',
             category: LogCategory.api,
           );
           return null;
+          // coverage:ignore-end
         }
       }
 

--- a/mobile/packages/sounds_repository/lib/src/sounds_repository.dart
+++ b/mobile/packages/sounds_repository/lib/src/sounds_repository.dart
@@ -6,7 +6,7 @@
 import 'dart:async';
 
 import 'package:models/models.dart'
-    show AudioEvent, NIP71VideoKinds, audioEventKind;
+    show AudioEvent, NIP71VideoKinds, VideoEvent, audioEventKind;
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:rxdart/rxdart.dart';
@@ -244,21 +244,44 @@ class SoundsRepository {
         return null;
       }
 
-      // Verify it's a Kind 1063 event
-      if (event.kind != audioEventKind) {
-        Log.warning(
-          'Event $eventId is not a Kind $audioEventKind audio event '
-          '(got Kind ${event.kind})',
-          name: 'SoundsRepository',
-          category: LogCategory.api,
-        );
-        return null;
+      if (event.kind == audioEventKind) {
+        final audioEvent = AudioEvent.fromNostrEvent(event);
+        _cacheSound(audioEvent);
+        return audioEvent;
       }
 
-      final audioEvent = AudioEvent.fromNostrEvent(event);
-      _cacheSound(audioEvent);
+      // A video's "original sound" is not a standalone Kind 1063 event — it is
+      // the audio track of the source Kind 34236 video. When a reusing video
+      // references that source video as its audio, synthesize the
+      // original-sound attribution so the original creator is credited
+      // instead of the reusing user. Title is left null so the reader
+      // localizes "Original sound" and resolves the creator name from the
+      // synthesized pubkey. Cached under [eventId] directly (not via
+      // [_cacheSound]) so it is not surfaced in the sounds-browser stream.
+      if (NIP71VideoKinds.isVideoKind(event.kind)) {
+        try {
+          final audioEvent = AudioEvent.fromVideoOriginalSound(
+            VideoEvent.fromNostrEvent(event),
+          );
+          _cache[eventId] = audioEvent;
+          return audioEvent;
+        } on Object catch (e) {
+          Log.warning(
+            'Failed to synthesize original sound from video $eventId: $e',
+            name: 'SoundsRepository',
+            category: LogCategory.api,
+          );
+          return null;
+        }
+      }
 
-      return audioEvent;
+      Log.warning(
+        'Event $eventId is not a Kind $audioEventKind audio event '
+        '(got Kind ${event.kind})',
+        name: 'SoundsRepository',
+        category: LogCategory.api,
+      );
+      return null;
     } catch (e) {
       Log.error(
         'Error fetching sound by ID: $e',

--- a/mobile/packages/sounds_repository/test/src/sounds_repository_test.dart
+++ b/mobile/packages/sounds_repository/test/src/sounds_repository_test.dart
@@ -343,6 +343,38 @@ void main() {
 
         expect(sound, isNull);
       });
+
+      test(
+        'synthesizes an original sound crediting the video creator when the '
+        'reference is a Kind 34236 video',
+        () async {
+          final videoEvent = Event.fromJson({
+            'id': testVideoEventId,
+            'pubkey': testPubkey1,
+            'kind': NIP71VideoKinds.addressableShortVideo,
+            'tags': <List<dynamic>>[
+              ['d', 'vine-abc'],
+              ['url', 'https://example.com/video.mp4'],
+            ],
+            'content': 'reused original sound',
+            'created_at': DateTime.now().millisecondsSinceEpoch ~/ 1000,
+            'sig': '',
+          });
+
+          when(
+            () => mockNostrClient.fetchEventById(testVideoEventId),
+          ).thenAnswer((_) async => videoEvent);
+
+          final sound = await repository.fetchSoundById(testVideoEventId);
+
+          expect(sound, isNotNull);
+          // Credits the original video creator, not the reusing user.
+          expect(sound!.pubkey, equals(testPubkey1));
+          expect(sound.isOriginalSound, isTrue);
+          // Title left null so the reader localizes "Original sound".
+          expect(sound.title, isNull);
+        },
+      );
     });
 
     group('getSoundFromCache', () {

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -1772,17 +1772,20 @@ void main() {
       expect(VideoEditorProviderState().reusesExternalAudio, isFalse);
     });
 
-    test('is true when a sound is selected', () {
+    test("is true when another creator's reused sound is selected", () {
       final state = VideoEditorProviderState(selectedSound: sound());
       expect(state.reusesExternalAudio, isTrue);
     });
 
-    test('is true when the editor timeline has an added reused track', () {
-      final state = VideoEditorProviderState(
-        editorEditingParameters: paramsWithTrack(sound()),
-      );
-      expect(state.reusesExternalAudio, isTrue);
-    });
+    test(
+      "is true when the editor timeline has another creator's reused track",
+      () {
+        final state = VideoEditorProviderState(
+          editorEditingParameters: paramsWithTrack(sound()),
+        );
+        expect(state.reusesExternalAudio, isTrue);
+      },
+    );
 
     test(
       "is false when the only track is the video's own clip-anchored sound",
@@ -1793,6 +1796,50 @@ void main() {
         expect(state.reusesExternalAudio, isFalse);
       },
     );
+
+    test('is false when a bundled divine sound is selected', () {
+      final state = VideoEditorProviderState(
+        selectedSound: AudioEvent.fromBundledSound(
+          VineSound(
+            id: 'boom',
+            title: 'Vine Boom',
+            assetPath: 'assets/sounds/vine-boom.mp3',
+            duration: const Duration(seconds: 1),
+          ),
+        ),
+      );
+      expect(state.reusesExternalAudio, isFalse);
+    });
+
+    test('is false when the added track is self-imported audio', () {
+      final state = VideoEditorProviderState(
+        editorEditingParameters: paramsWithTrack(
+          AudioEvent.fromLocalImport(
+            id: 'local_import_1700000000000',
+            filePath: '/tmp/beat.mp3',
+            createdAt: 1700000000,
+            title: 'beat',
+            mimeType: 'audio/mpeg',
+          ),
+        ),
+      );
+      expect(state.reusesExternalAudio, isFalse);
+    });
+
+    test('is false when the added track is a voice-over take', () {
+      final state = VideoEditorProviderState(
+        editorEditingParameters: paramsWithTrack(
+          AudioEvent.fromLocalImport(
+            id: 'local_import_voice_over_1700000000000',
+            filePath: '/tmp/voice.m4a',
+            createdAt: 1700000000,
+            title: 'Take 1',
+            mimeType: 'audio/mp4',
+          ),
+        ),
+      );
+      expect(state.reusesExternalAudio, isFalse);
+    });
   });
 
   group('getActiveDraft audio attribution', () {
@@ -1879,6 +1926,68 @@ void main() {
 
       expect(draft.selectedSound, isNull);
     });
+  });
+
+  group('updateEditorEditingParameters audio-only changes', () {
+    late ProviderContainer container;
+    final sourceVideoId = 'b' * 64;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      container = ProviderContainer(
+        overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+      );
+    });
+
+    tearDown(() {
+      container.dispose();
+    });
+
+    CompleteParameters paramsWithTracks(List<AudioEvent> tracks) =>
+        CompleteParameters.fromMap(<String, dynamic>{}).copyWith(
+          meta: {
+            VideoEditorConstants.audioStateHistoryKey: tracks
+                .map((t) => t.toJson())
+                .toList(),
+          },
+        );
+
+    AudioEvent reusedSound() => AudioEvent(
+      id: 'video_$sourceVideoId',
+      pubkey: 'c' * 64,
+      createdAt: 1700000000,
+    );
+
+    test(
+      'refreshes the snapshot when only the audio meta changes so the reuse '
+      "toggle tracks add/remove of another creator's sound",
+      () {
+        final notifier = container.read(videoEditorProvider.notifier);
+
+        notifier.updateEditorEditingParameters(
+          paramsWithTracks([reusedSound()]),
+        );
+        expect(
+          container.read(videoEditorProvider).reusesExternalAudio,
+          isTrue,
+          reason: 'adding a reused sound must update the snapshot',
+        );
+
+        // Remove the sound. The only change is the audio meta — every render
+        // field CompleteParameters.diff compares (empty audioTracks field
+        // included) is identical, so without the audio-meta check the update
+        // is skipped and the snapshot stays stale.
+        notifier.updateEditorEditingParameters(paramsWithTracks(const []));
+        expect(
+          container.read(videoEditorProvider).reusesExternalAudio,
+          isFalse,
+          reason:
+              'removing the reused sound must refresh the snapshot even though '
+              'diff() sees no change in the render-time audioTracks field',
+        );
+      },
+    );
   });
 
   group('cover thumbnail persistence', () {

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -1751,6 +1751,136 @@ void main() {
     });
   });
 
+  group('VideoEditorProviderState reusesExternalAudio', () {
+    final sourceVideoId = 'b' * 64;
+
+    CompleteParameters paramsWithTrack(AudioEvent track) =>
+        CompleteParameters.fromMap(<String, dynamic>{}).copyWith(
+          meta: {
+            VideoEditorConstants.audioStateHistoryKey: [track.toJson()],
+          },
+        );
+
+    AudioEvent sound({String? anchorClipId}) => AudioEvent(
+      id: 'video_$sourceVideoId',
+      pubkey: 'c' * 64,
+      createdAt: 1700000000,
+      anchorClipId: anchorClipId,
+    );
+
+    test('is false with no selected sound and no editor tracks', () {
+      expect(VideoEditorProviderState().reusesExternalAudio, isFalse);
+    });
+
+    test('is true when a sound is selected', () {
+      final state = VideoEditorProviderState(selectedSound: sound());
+      expect(state.reusesExternalAudio, isTrue);
+    });
+
+    test('is true when the editor timeline has an added reused track', () {
+      final state = VideoEditorProviderState(
+        editorEditingParameters: paramsWithTrack(sound()),
+      );
+      expect(state.reusesExternalAudio, isTrue);
+    });
+
+    test(
+      "is false when the only track is the video's own clip-anchored sound",
+      () {
+        final state = VideoEditorProviderState(
+          editorEditingParameters: paramsWithTrack(sound(anchorClipId: 'c1')),
+        );
+        expect(state.reusesExternalAudio, isFalse);
+      },
+    );
+  });
+
+  group('getActiveDraft audio attribution', () {
+    late ProviderContainer container;
+
+    // A reused original sound added through the editor's "add music" flow —
+    // credited to the source creator, not the reusing user (#6057).
+    final sourceVideoId = 'b' * 64;
+    final sourceCreator = 'c' * 64;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      container = ProviderContainer(
+        overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+      );
+      container
+          .read(clipManagerProvider.notifier)
+          .addClip(
+            limitClipDuration: false,
+            video: EditorVideo.file('/docs/original.mp4'),
+            targetAspectRatio: .vertical,
+            originalAspectRatio: 9 / 16,
+            duration: const Duration(seconds: 2),
+          );
+    });
+
+    tearDown(() {
+      container.dispose();
+    });
+
+    AudioEvent reusedOriginalSound({String? anchorClipId}) => AudioEvent(
+      id: 'video_$sourceVideoId',
+      pubkey: sourceCreator,
+      createdAt: 1700000000,
+      url: 'https://media.divine.video/abc',
+      duration: 6,
+      sourceVideoReference: '34236:$sourceCreator:vine-xyz',
+      anchorClipId: anchorClipId,
+    );
+
+    void seedEditorAudioTrack(AudioEvent track) {
+      final params = CompleteParameters.fromMap(<String, dynamic>{}).copyWith(
+        meta: {
+          VideoEditorConstants.audioStateHistoryKey: [track.toJson()],
+        },
+      );
+      container
+          .read(videoEditorProvider.notifier)
+          .updateEditorEditingParameters(params);
+    }
+
+    test('credits a reused editor timeline sound in the publish draft', () {
+      seedEditorAudioTrack(reusedOriginalSound());
+
+      final draft = container
+          .read(videoEditorProvider.notifier)
+          .getActiveDraft();
+
+      expect(draft.selectedSound?.id, equals('video_$sourceVideoId'));
+      expect(draft.selectedSound?.pubkey, equals(sourceCreator));
+      expect(
+        draft.inspiredByVideo?.addressableId,
+        equals('34236:$sourceCreator:vine-xyz'),
+      );
+    });
+
+    test('does not derive editor-track attribution for autosave', () {
+      seedEditorAudioTrack(reusedOriginalSound());
+
+      final draft = container
+          .read(videoEditorProvider.notifier)
+          .getActiveDraft(isAutosave: true);
+
+      expect(draft.selectedSound, isNull);
+    });
+
+    test("skips the video's own clip-anchored original sound", () {
+      seedEditorAudioTrack(reusedOriginalSound(anchorClipId: 'clip-1'));
+
+      final draft = container
+          .read(videoEditorProvider.notifier)
+          .getActiveDraft();
+
+      expect(draft.selectedSound, isNull);
+    });
+  });
+
   group('cover thumbnail persistence', () {
     late ProviderContainer container;
 

--- a/mobile/test/screens/sound_detail_screen_test.dart
+++ b/mobile/test/screens/sound_detail_screen_test.dart
@@ -690,9 +690,7 @@ void main() {
               videosUsingSoundProvider(
                 testSound.id,
               ).overrideWith((ref) => Future.value(<String>[])),
-              audioPlaybackServiceProvider.overrideWithValue(
-                mockAudioService,
-              ),
+              audioPlaybackServiceProvider.overrideWithValue(mockAudioService),
             ],
           );
           addTearDown(container.dispose);
@@ -797,6 +795,40 @@ void main() {
 
         expect(find.text('Videos using this sound'), findsOneWidget);
         expect(_divineIcon(DivineIconName.videoCamera), findsOneWidget);
+      });
+
+      testWidgets('reused original sound queries usage/grid by recovered id', (
+        tester,
+      ) async {
+        const sourceVideoId =
+            'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
+        final reusedSynth = createTestAudioEvent(
+          id: 'video_$sourceVideoId',
+          title: 'Original sound',
+        );
+        final l10n = lookupAppLocalizations(const Locale('en'));
+
+        await tester.pumpWidget(
+          createTestWidget(
+            child: SoundDetailScreen(sound: reusedSynth),
+            overrides: [
+              // Only the recovered raw id is overridden — a query by the
+              // synthetic `video_` id would miss these entirely.
+              soundUsageCountProvider(
+                sourceVideoId,
+              ).overrideWith((ref) => Future.value(7)),
+              videosUsingSoundProvider(
+                sourceVideoId,
+              ).overrideWith((ref) => Future.value(<String>[])),
+              audioPlaybackServiceProvider.overrideWithValue(mockAudioService),
+            ],
+          ),
+        );
+
+        await tester.pump();
+
+        expect(find.textContaining(l10n.soundVideoCount(7)), findsOneWidget);
+        expect(find.text('Videos using this sound'), findsOneWidget);
       });
 
       testWidgets('shows empty state when no videos', (tester) async {

--- a/mobile/test/services/video_event_publisher_test.dart
+++ b/mobile/test/services/video_event_publisher_test.dart
@@ -621,6 +621,79 @@ void main() {
       );
     });
 
+    group('reused audio attribution', () {
+      // A reused original sound carries the source video's event id behind a
+      // `video_` prefix; the reference must survive so the audio is credited
+      // to the original creator instead of the reusing user (#6057).
+      final sourceVideoId = 'b' * 64;
+      final sourceCreator = 'c' * 64;
+
+      test(
+        'references the source video when reusing an original sound',
+        () async {
+          stubSignAndPublish();
+
+          final reusedSound = AudioEvent(
+            id: 'video_$sourceVideoId',
+            pubkey: sourceCreator,
+            createdAt: 1700000000,
+            sourceVideoReference: '34236:$sourceCreator:vine-xyz',
+          );
+
+          final result = await publisher.publishVideoEvent(
+            upload: createUpload(),
+            selectedAudio: reusedSound,
+            selectedAudioEventId: reusedSound.id,
+            selectedAudioRelay: reusedSound.sourceVideoRelay,
+          );
+
+          expect(result, isTrue);
+          expect(
+            _containsTag(capturedTags, [
+              'e',
+              sourceVideoId,
+              'wss://relay.divine.video',
+              'audio',
+            ]),
+            isTrue,
+          );
+        },
+      );
+
+      test(
+        'recovers the reference from an editor timeline track id',
+        () async {
+          stubSignAndPublish();
+
+          // The editor appends a `-<timestamp>` uniqueness suffix to timeline
+          // track ids; the reference must still resolve to the source video.
+          final reusedTrack = AudioEvent(
+            id: 'video_$sourceVideoId-1700000000000',
+            pubkey: sourceCreator,
+            createdAt: 1700000000,
+            sourceVideoReference: '34236:$sourceCreator:vine-xyz',
+          );
+
+          final result = await publisher.publishVideoEvent(
+            upload: createUpload(),
+            selectedAudio: reusedTrack,
+            selectedAudioEventId: reusedTrack.id,
+          );
+
+          expect(result, isTrue);
+          expect(
+            _containsTag(capturedTags, [
+              'e',
+              sourceVideoId,
+              'wss://relay.divine.video',
+              'audio',
+            ]),
+            isTrue,
+          );
+        },
+      );
+    });
+
     group('local imported audio', () {
       late _MockBlossomUploadService blossomUploadService;
       late _MockSavedSoundsService savedSoundsService;

--- a/mobile/test/widgets/metadata_sounds_section_test.dart
+++ b/mobile/test/widgets/metadata_sounds_section_test.dart
@@ -186,5 +186,61 @@ void main() {
         expect(find.text('Original sound'), findsOneWidget);
       });
     });
+
+    group('Reused sound fallback', () {
+      const reusedCreatorPubkey =
+          'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
+
+      VideoEvent reusedVideo() {
+        final now = DateTime.now();
+        return VideoEvent(
+          id: testVideoId,
+          pubkey: testPubkey,
+          content: 'Reused audio',
+          videoUrl: 'https://example.com/video.mp4',
+          createdAt: now.millisecondsSinceEpoch ~/ 1000,
+          timestamp: now,
+          title: 'Test Video',
+          authorName: 'Jake Lara',
+          audioEventId: testAudioEventId,
+          inspiredByVideo: const InspiredByInfo(
+            addressableId: '34236:$reusedCreatorPubkey:vine-xyz',
+          ),
+        );
+      }
+
+      testWidgets(
+        'credits the source creator when the shared audio is unresolved',
+        (tester) async {
+          await tester.pumpWidget(
+            ProviderScope(
+              overrides: [
+                soundByIdProvider(
+                  testAudioEventId,
+                ).overrideWith((ref) async => null),
+              ],
+              child: MaterialApp(
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                theme: VineTheme.theme,
+                home: Scaffold(
+                  backgroundColor: Colors.black,
+                  body: MetadataSoundsSection(video: reusedVideo()),
+                ),
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          expect(find.text('Original sound'), findsOneWidget);
+          expect(
+            find.text(UserProfile.defaultDisplayNameFor(reusedCreatorPubkey)),
+            findsOneWidget,
+          );
+          // The reusing user's own author name must not be credited.
+          expect(find.text('Jake Lara'), findsNothing);
+        },
+      );
+    });
   });
 }

--- a/mobile/test/widgets/metadata_sounds_section_test.dart
+++ b/mobile/test/widgets/metadata_sounds_section_test.dart
@@ -5,9 +5,11 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:models/models.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/sounds_providers.dart';
+import 'package:openvine/screens/sound_detail_screen.dart';
 import 'package:openvine/widgets/video_feed_item/metadata/metadata_sounds_section.dart';
 
 Finder _divineIcon(DivineIconName name) =>
@@ -239,6 +241,82 @@ void main() {
           );
           // The reusing user's own author name must not be credited.
           expect(find.text('Jake Lara'), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'tapping a resolved reused sound opens the detail (no dead-end)',
+        (tester) async {
+          const sourceVideoId =
+              'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
+          const reusedSynth = AudioEvent(
+            id: 'video_$sourceVideoId',
+            pubkey: reusedCreatorPubkey,
+            createdAt: 1704067200,
+            title: 'Original sound - Source Creator',
+            source: 'Original Sound',
+          );
+
+          final router = GoRouter(
+            initialLocation: '/',
+            routes: [
+              GoRoute(
+                path: '/',
+                builder: (_, _) => const Scaffold(body: Text('HOME')),
+              ),
+              GoRoute(
+                path: '/sheet',
+                builder: (_, _) => Scaffold(
+                  body: MetadataSoundsSection(video: createVideoWithAudio()),
+                ),
+              ),
+              GoRoute(
+                path: SoundDetailScreen.path,
+                name: SoundDetailScreen.routeName,
+                builder: (context, state) {
+                  // Mirrors the real sound route: a resolved sound arrives via
+                  // `extra`; without it the loader re-fetches and dead-ends.
+                  final extra = state.extra;
+                  final sound = extra is Map<String, dynamic>
+                      ? extra['sound'] as AudioEvent?
+                      : null;
+                  return Scaffold(
+                    body: Text(
+                      sound != null ? 'DETAIL ${sound.id}' : 'NOT FOUND',
+                    ),
+                  );
+                },
+              ),
+            ],
+          );
+
+          await tester.pumpWidget(
+            ProviderScope(
+              overrides: [
+                soundByIdProvider(
+                  testAudioEventId,
+                ).overrideWith((ref) async => reusedSynth),
+              ],
+              child: MaterialApp.router(
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                theme: VineTheme.theme,
+                routerConfig: router,
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          router.push('/sheet');
+          await tester.pumpAndSettle();
+
+          expect(find.text('Original sound - Source Creator'), findsOneWidget);
+
+          await tester.tap(find.text('Original sound - Source Creator'));
+          await tester.pumpAndSettle();
+
+          expect(find.text('DETAIL video_$sourceVideoId'), findsOneWidget);
+          expect(find.text('NOT FOUND'), findsNothing);
         },
       );
     });

--- a/mobile/test/widgets/video_metadata/video_metadata_form_fields_test.dart
+++ b/mobile/test/widgets/video_metadata/video_metadata_form_fields_test.dart
@@ -2,6 +2,7 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart' show AudioEvent;
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
 import 'package:openvine/models/video_reply_context.dart';
@@ -225,6 +226,52 @@ void main() {
 
       expect(mockNotifier.lastShareReplyToFeed, isTrue);
       expect(tester.widget<SwitchListTile>(tile).value, isTrue);
+    });
+
+    testWidgets("audio reuse toggle is shown for the user's own audio", (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildWidget());
+      await tester.pumpAndSettle();
+
+      final l10n = AppLocalizations.of(
+        tester.element(find.byType(VideoMetadataFormFields)),
+      );
+      expect(
+        find.widgetWithText(
+          SwitchListTile,
+          l10n.videoMetadataAudioReuseTitle,
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('audio reuse toggle is hidden when reusing external audio', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildWidget(
+          state: VideoEditorProviderState(
+            selectedSound: AudioEvent(
+              id: 'video_${'b' * 64}',
+              pubkey: 'c' * 64,
+              createdAt: 1700000000,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final l10n = AppLocalizations.of(
+        tester.element(find.byType(VideoMetadataFormFields)),
+      );
+      expect(
+        find.widgetWithText(
+          SwitchListTile,
+          l10n.videoMetadataAudioReuseTitle,
+        ),
+        findsNothing,
+      );
     });
   });
 }

--- a/mobile/test/widgets/video_metadata/video_metadata_form_fields_test.dart
+++ b/mobile/test/widgets/video_metadata/video_metadata_form_fields_test.dart
@@ -2,7 +2,7 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:models/models.dart' show AudioEvent;
+import 'package:models/models.dart' show AudioEvent, VineSound;
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
 import 'package:openvine/models/video_reply_context.dart';
@@ -246,16 +246,48 @@ void main() {
       );
     });
 
-    testWidgets('audio reuse toggle is hidden when reusing external audio', (
+    testWidgets(
+      "audio reuse toggle is hidden when reusing another creator's sound",
+      (tester) async {
+        await tester.pumpWidget(
+          buildWidget(
+            state: VideoEditorProviderState(
+              selectedSound: AudioEvent(
+                id: 'video_${'b' * 64}',
+                pubkey: 'c' * 64,
+                createdAt: 1700000000,
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final l10n = AppLocalizations.of(
+          tester.element(find.byType(VideoMetadataFormFields)),
+        );
+        expect(
+          find.widgetWithText(
+            SwitchListTile,
+            l10n.videoMetadataAudioReuseTitle,
+          ),
+          findsNothing,
+        );
+      },
+    );
+
+    testWidgets('audio reuse toggle is shown for a bundled divine sound', (
       tester,
     ) async {
       await tester.pumpWidget(
         buildWidget(
           state: VideoEditorProviderState(
-            selectedSound: AudioEvent(
-              id: 'video_${'b' * 64}',
-              pubkey: 'c' * 64,
-              createdAt: 1700000000,
+            selectedSound: AudioEvent.fromBundledSound(
+              VineSound(
+                id: 'boom',
+                title: 'Vine Boom',
+                assetPath: 'assets/sounds/vine-boom.mp3',
+                duration: const Duration(seconds: 1),
+              ),
             ),
           ),
         ),
@@ -270,7 +302,7 @@ void main() {
           SwitchListTile,
           l10n.videoMetadataAudioReuseTitle,
         ),
-        findsNothing,
+        findsOneWidget,
       );
     });
   });


### PR DESCRIPTION
## Description

Reusing another creator's sound published the new video with **no audio attribution**, so the feed and the metadata "Sounds" section credited the reusing user as the "original sound" creator instead of the original creator.

**Root cause:** a reused *original sound* (the audio of a video, which has no standalone Kind 1063 event) becomes a synthetic `AudioEvent` whose id is `video_<sourceVideoId>`. The publisher gated the audio reference on `NostrHexUtils.isValidEventId`, which rejected the `video_` prefix, so the `["e", …, "audio"]` tag was dropped and the published video carried no attribution — falling through to the "Original sound — @me" display.

### Changes

- **models** — `AudioEvent.attributionEventId` recovers the real Nostr event id behind the `video_` prefix (and the editor timeline's `-<timestamp>` uniqueness suffix), validating it as 32-byte hex; `fromVideoOriginalSound.creatorName` is now optional (null → null title, so the reader localizes "Original sound" and resolves the creator from the pubkey).
- **publisher** — resolves the reused reference via `attributionEventId`, so `["e", <sourceVideoId>, relay, "audio"]` survives. Bundled/imported behavior is unchanged.
- **editor "add music"** — `getActiveDraft` derives the publish attribution from the editor timeline tracks (skipping the video's own clip-anchored audio), so the editor reuse path is covered too, not only the recorder's `selectedSound` path.
- **sounds_repository** — `fetchSoundById` synthesizes a video-backed original sound when the reference resolves to a Kind 34236 video, crediting that video's creator.
- **metadata sheet** — when the shared audio event can't be fetched, the fallback credits the source creator that the video already carries via its inspired-by source (no network fetch) instead of dropping to the reusing user.
- **metadata screen** — "Publish this sound" is hidden entirely when the video reuses external audio: it isn't the user's to offer for reuse, and the publisher already skips the reuse tag in that case, so the toggle was a no-op.

### Why these choices

- **Reference the source video (not a fresh Kind 1063).** Any Kind 1063 the app publishes is signed by the current user, so its `pubkey` is the reusing user — the display would still credit them. The only event owned by the original creator is their Kind 34236 video, so that is what the reference points to, and the display derives the creator from it.
- **Recover the id in the model, not at each call site.** The `video_` prefix and the editor's timeline suffix both break a plain hex check; centralizing that in `attributionEventId` keeps the publisher and the editor-track derivation in sync and unit-testable.
- **Fetch-independent display fallback.** Kind 34236 is addressable, so fetching it by event id can fail on relays that only serve it by address. The metadata sheet therefore credits the creator from the inspired-by source already on the video, which a reused sound auto-populates — so attribution is correct even when the source video isn't reachable by id.

## Out of Scope

- Videos published **before** this change carry no audio-reference tag, so they cannot be credited retroactively (the information isn't in the event) and will continue to show the reusing user for their reused audio.

## Verification

- `flutter analyze` on all changed files and both touched packages — clean.
- New/updated tests, all green:
  - `packages/models` — `attributionEventId` (prefix/suffix/bundled/import cases) and null-`creatorName`.
  - `packages/sounds_repository` — Kind 34236 synthesis in `fetchSoundById`.
  - `video_event_publisher` — reused original sound and editor-suffixed track both write `["e", <sourceVideoId>, relay, "audio"]`.
  - `video_editor_provider` — editor-track attribution in `getActiveDraft` (and skipped on autosave / for clip-anchored own audio); `reusesExternalAudio`.
  - `metadata_sounds_section` — reused fallback credits the source creator, not the reusing user.
  - `video_metadata_form_fields` — "Publish this sound" hidden when reusing external audio.
- Manual test plan: publish a fresh video reusing another creator's sound (recorder "Use Sound" and editor "Add music"), then check the metadata "Sounds" section credits the original creator; a self-recorded original sound still credits you and keeps the toggle.

**Related Issue:** Closes #6057

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
