### PR TITLE
fix(dm): classify Keycast verified_minor policy-denial (403) as terminal, not retryable

### DIFF
--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -2876,6 +2876,15 @@ class DmRepository {
         // Don't rethrow — the message was published successfully.
         // Local persistence failure is a degraded state, not a send failure.
       }
+    } else if (result.blocked && outgoingDao != null) {
+      // A policy block is terminal, not a transient failure: drop the queue
+      // row so the sweep stops re-driving a send the gate refuses every time
+      // (no doomed Resend bubble). Mirrors sendGroupMessage's per-recipient
+      // classification and the drain's blocked arm.
+      await _finalizeAfterRecipientBlocked(
+        outgoingDao: outgoingDao,
+        rumorId: rumor.id,
+      );
     } else if (result.retryablePending && outgoingDao != null) {
       // Soft-unconfirmed: the recipient frame was written but no NIP-20 OK
       // arrived (and no explicit rejection). Keep the row pending — it
@@ -2900,17 +2909,15 @@ class DmRepository {
         rumorId: rumor.id,
         errorMessage: result.error ?? 'Unknown publish failure',
       );
-      // A blocked send never enqueues a bubble, but a failed/pending one
-      // did — make sure a brand-new thread is visible so the user can find
-      // the red bubble to retry or delete it.
-      if (!result.blocked) {
-        await _ensureConversationVisibleAfterSendFailure(
-          conversationId: conversationId,
-          participants: participants,
-          isGroup: false,
-          content: content,
-        );
-      }
+      // Make a brand-new thread visible so the user can find the red bubble
+      // to retry or delete it. A blocked result is handled terminally above
+      // and never reaches here.
+      await _ensureConversationVisibleAfterSendFailure(
+        conversationId: conversationId,
+        participants: participants,
+        isGroup: false,
+        content: content,
+      );
     }
 
     return result;

--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -60,6 +60,13 @@ typedef IsolateGiftWrapBatchBuilder =
 /// connectivity in keep their prior classification behavior.
 typedef OfflineProbe = Future<bool> Function();
 
+/// Body marker Keycast returns (with HTTP 403) only for the verified_minor DM
+/// containment gate. Suspended accounts return "Account restricted" and token
+/// failures are 401 with their own refresh path, so matching this exact marker
+/// terminalizes a policy refusal while leaving transient errors retryable.
+/// Mirrors `MINOR_DM_DENIED_MSG` in divinevideo/keycast.
+const _minorDmPolicyDenialMarker = 'Operation denied by policy';
+
 /// Service for sending encrypted private messages using NIP-17 gift wrapping.
 ///
 /// Accepts any [NostrSigner] implementation, supporting both local key
@@ -580,6 +587,17 @@ class NIP17MessageService {
         error: e,
         stackTrace: stackTrace,
       );
+      if (e.toString().contains(_minorDmPolicyDenialMarker)) {
+        // Keycast's server-side verified_minor gate refused to sign or encrypt
+        // this DM. That is a permanent policy decision, not a transient error,
+        // so terminalize it (blocked) rather than returning a retryable failure
+        // the drain would re-attempt until maxRetries and Resend would
+        // deterministically re-fail. The blocked → terminal drain path already
+        // exists (#6028); this routes the server refusal into it.
+        return const NIP17SendResult.blocked(
+          'blocked: recipient not permitted by send policy',
+        );
+      }
       return NIP17SendResult.failure('Failed to send message: $e');
     }
   }

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -12974,6 +12974,79 @@ void main() {
       );
 
       test(
+        'a server-side policy block after enqueue drops the row, '
+        'not marks it failed (#6067)',
+        () async {
+          // The client canSendTo gate passed — the block is server-side and
+          // the client did not predict it — so the row is enqueued and sent,
+          // then Keycast refuses with a 403 that sendRumor classifies as
+          // blocked. A policy block is terminal, so the row must be dropped
+          // (no doomed Resend bubble), the same as the group and drain arms.
+          stubSendRumor(
+            (_, _) async => const NIP17SendResult.blocked(
+              'blocked: recipient not permitted by send policy',
+            ),
+          );
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          final result = await repository.sendMessage(
+            recipientPubkey: _validPubkeyB,
+            content: 'blocked after enqueue',
+          );
+
+          expect(result.blocked, isTrue);
+
+          final captured = verify(
+            () => mockOutgoingDmsDao.enqueue(captureAny()),
+          ).captured;
+          final enqueued = captured.single as OutgoingDm;
+
+          // Terminal: the row is deleted, never marked failed/retryable
+          // (which would leave a doomed red Resend bubble).
+          verify(
+            () => mockOutgoingDmsDao.deleteById(enqueued.id),
+          ).called(1);
+          verifyNever(
+            () => mockOutgoingDmsDao.markRecipientWrapStatus(
+              id: any(named: 'id'),
+              status: OutgoingWrapStatus.failed,
+              lastError: any(named: 'lastError'),
+            ),
+          );
+          // The recipient received nothing, so no direct_messages row.
+          verifyNever(
+            () => mockDirectMessagesDao.insertMessage(
+              id: any(named: 'id'),
+              conversationId: any(named: 'conversationId'),
+              senderPubkey: any(named: 'senderPubkey'),
+              content: any(named: 'content'),
+              createdAt: any(named: 'createdAt'),
+              giftWrapId: any(named: 'giftWrapId'),
+              messageKind: any(named: 'messageKind'),
+              replyToId: any(named: 'replyToId'),
+              subject: any(named: 'subject'),
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              tagsJson: any(named: 'tagsJson'),
+              sendBatchId: any(named: 'sendBatchId'),
+            ),
+          );
+        },
+      );
+
+      test(
         'on partial delivery: persists locally, keeps the queue row, '
         'marks recipient sent, and marks self failed',
         () async {

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -23,6 +23,21 @@ class _MockNostrSigner extends Mock implements NostrSigner {}
 
 class _FakeEvent extends Fake implements Event {}
 
+/// Reproduces the `toString()` shape of `keycast_flutter`'s `RpcException`
+/// (`'RpcException: <message>'`) so the policy-denial classification test
+/// exercises the real Keycast 403 surface, not a generic `Exception`.
+/// `dm_repository` cannot depend on `keycast_flutter`, so this pins the
+/// cross-package error-body contract locally: if Keycast's wording drifts,
+/// the marker in `nip17_message_service.dart` must be updated in lockstep.
+class _RpcExceptionDouble implements Exception {
+  _RpcExceptionDouble(this.message);
+
+  final String message;
+
+  @override
+  String toString() => 'RpcException: $message';
+}
+
 /// Denies every recipient — stands in for a protected minor's policy where the
 /// counterparty is not in the approved official set.
 Future<DmSendPolicyDecision> _denyAllPolicy(String recipientPubkey) async =>
@@ -198,6 +213,69 @@ void main() {
 
         expect(result.success, isTrue);
       });
+    });
+
+    group('Keycast policy-denial classification (#6067)', () {
+      test(
+        'a 403 "operation denied by policy" refusal terminalizes as blocked',
+        () async {
+          // Keycast's server-side verified_minor gate refuses to sign/encrypt
+          // and surfaces as an RpcException whose 403 body carries this
+          // marker. A remote signer is not isolate-capable, so sendRumor's
+          // _buildWrap goes straight to the injected main-isolate builder;
+          // LocalNostrSigner stands in for that not-isolate-capable signer,
+          // and the builder raises the refusal. The real RpcException string
+          // shape is reproduced so the substring match is tested against the
+          // Keycast surface, not a generic Exception.
+          final refusing = NIP17MessageService(
+            signer: LocalNostrSigner(_testPrivateKey),
+            senderPublicKey: _testPublicKey,
+            nostrService: mockNostrClient,
+            giftWrapBuilder: (_, _, _) async => throw _RpcExceptionDouble(
+              'HTTP 403: {"error":"Operation denied by policy"}',
+            ),
+          );
+          final rumor = refusing.buildRumor(
+            recipientPubkey: _recipientPubkey,
+            content: 'should terminalize, not retry',
+          );
+
+          final result = await refusing.sendRumor(
+            rumorEvent: rumor,
+            recipientPubkey: _recipientPubkey,
+          );
+
+          expect(result.blocked, isTrue);
+          expect(result.success, isFalse);
+          expect(result.retryablePending, isFalse);
+          verifyNever(() => mockNostrClient.publishEvent(any()));
+        },
+      );
+
+      test(
+        'a non-policy send error stays a plain failure, not blocked',
+        () async {
+          final failing = NIP17MessageService(
+            signer: LocalNostrSigner(_testPrivateKey),
+            senderPublicKey: _testPublicKey,
+            nostrService: mockNostrClient,
+            giftWrapBuilder: (_, _, _) async =>
+                throw _RpcExceptionDouble('HTTP 503: relay unavailable'),
+          );
+          final rumor = failing.buildRumor(
+            recipientPubkey: _recipientPubkey,
+            content: 'transient failure',
+          );
+
+          final result = await failing.sendRumor(
+            rumorEvent: rumor,
+            recipientPubkey: _recipientPubkey,
+          );
+
+          expect(result.success, isFalse);
+          expect(result.blocked, isFalse);
+        },
+      );
     });
 
     group('sendRumor relay targeting', () {


### PR DESCRIPTION
## Summary

Classifies a Keycast verified_minor policy-denial (HTTP 403 "Operation denied by policy") as a terminal `blocked` send in `sendRumor`, instead of the generic retryable failure, and wires the terminal handling into the one send arm that lacked it.

## Motivation

Once Keycast's server-side verified_minor DM containment (divinevideo/keycast#284) is on prod, a protected minor's DM to a non-approved recipient is refused at the signer with a 403. Today that lands in the generic catch as a retryable failure, so the drain re-attempts until maxRetries and Resend deterministically re-fails. No leak (Keycast refuses to sign, nothing publishes), but it wastes the retry budget and leaves a doomed Resend button. This is the server-refusal sibling of the client-predicted block handled in #6028.

`sendRumor` is the single recipient-delivering choke point, so classifying there covers direct, group fan-out, drain replay, and reaction sends. Keying on the specific marker (not any 403) keeps transient failures retryable: suspended accounts return "Account restricted" and token issues are 401 with their own refresh path.

The group, drain, and reaction arms already terminalize a `blocked` result (drop the queue row). The 1:1 `sendMessage` live path did not — a post-enqueue block fell into the failed/retryable branch, leaving a doomed red Resend bubble the sweep re-drives once before dropping it. This adds the terminal `blocked` arm to `sendMessage`, mirroring `sendGroupMessage`.

## Related issue

Closes #6067. Part of divinevideo/support-trust-safety#173.

## Testing

- New tests: a 403 terminalizes as `blocked` with no publish; a non-policy error stays a plain failure; a 1:1 `sendMessage` that 403s after enqueue drops the row instead of marking it failed. The classification tests throw an `RpcException`-shaped double reproducing keycast_flutter's toString, so the marker is tested against the real Keycast 403 surface.
- dm_repository suite: 510 pass; coverage 93.56% (gate 93). analyze + format clean.

## Visuals

No visual change.

## Notes

Rebased onto #6046 after it merged. The marker string match is the quick version; a structured Keycast error code is the cleaner long-term option, noted in #6067.
