### PR TITLE
fix(blurhash): correct color-tinted decode and reduce DCT ringing

### DIFF
--- a/mobile/packages/blurhash_service/lib/src/blurhash_service.dart
+++ b/mobile/packages/blurhash_service/lib/src/blurhash_service.dart
@@ -3,6 +3,7 @@
 // ABOUTME: Creates compact representations of images
 // for better UX during vine loading
 
+import 'dart:math' as math;
 import 'dart:ui' as ui;
 
 import 'package:blurhash_dart/blurhash_dart.dart' as blurhash_dart;
@@ -22,8 +23,15 @@ String? _generateBlurhashSync(Uint8List imageBytes) {
     image.height,
   );
 
+  // Average (box) interpolation: the default (nearest) picks single source
+  // pixels when downscaling, which skews the encoded colors on high-detail
+  // frames.
   final resized = image.width > BlurhashService._encodeMaxWidth
-      ? img.copyResize(image, width: BlurhashService._encodeMaxWidth)
+      ? img.copyResize(
+          image,
+          width: BlurhashService._encodeMaxWidth,
+          interpolation: img.Interpolation.average,
+        )
       : image;
 
   return blurhash_dart.BlurHash.encode(
@@ -36,19 +44,22 @@ String? _generateBlurhashSync(Uint8List imageBytes) {
 /// Service for generating and decoding Blurhash
 /// placeholders.
 class BlurhashService {
-  /// Components for 9:16 portrait videos (4:7 ≈ 0.57, matches 9:16 ≈ 0.5625).
-  static const int _portraitComponentX = 4;
-  static const int _portraitComponentY = 7;
+  /// Components for 9:16 portrait videos. Kept low on purpose: high counts
+  /// (the previous 4×7) cause visible DCT ringing — dark/bright blobs that
+  /// aren't in the source frame.
+  static const int _portraitComponentX = 3;
+  static const int _portraitComponentY = 4;
 
-  /// Components for 1:1 square and landscape videos (balanced).
-  static const int _squareComponentX = 4;
-  static const int _squareComponentY = 4;
+  /// Components for 1:1 square videos.
+  static const int _squareComponentX = 3;
+  static const int _squareComponentY = 3;
 
   /// Max width used when downscaling before encoding.
   static const int _encodeMaxWidth = 128;
 
-  /// Default punch (contrast) value.
-  static const double defaultPunch = 1;
+  /// Default punch (contrast) value. Below 1 to soften DCT overshoot from
+  /// already-published high-component hashes (see [decodeBlurhash]).
+  static const double defaultPunch = 0.8;
 
   /// Process-wide memo for [decodeBlurhash]. Decoding is a pure function
   /// of (hash, width, height, punch) and runs synchronously on the UI
@@ -63,7 +74,8 @@ class BlurhashService {
   );
 
   /// Returns component counts suited to the image's aspect ratio.
-  /// Supports 9:16 portrait, 1:1 square, and landscape; falls back to portrait.
+  /// Divine only produces 9:16 portrait and 1:1 square videos; anything
+  /// square-or-wider gets square components, tall formats get portrait.
   static (int compX, int compY) _componentsForAspectRatio(
     int width,
     int height,
@@ -72,10 +84,77 @@ class BlurhashService {
       return (_portraitComponentX, _portraitComponentY);
     }
     final ratio = width / height;
-    // Square or landscape: ratio ≥ 0.9 (covers 1:1 and any wider format)
+    // 1:1 square (and any wider format)
     if (ratio >= 0.9) return (_squareComponentX, _squareComponentY);
     // Portrait 9:16 (and any other tall format)
     return (_portraitComponentX, _portraitComponentY);
+  }
+
+  /// Base83 alphabet from the blurhash spec.
+  static const String _base83Chars =
+      '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+      'abcdefghijklmnopqrstuvwxyz'
+      r'#$%*+,-.:;=?@[]^_{|}~';
+
+  static int _decode83(String value, int from, int to) {
+    var result = 0;
+    for (var i = from; i < to; i++) {
+      result = result * 83 + _base83Chars.indexOf(value[i]);
+    }
+    return result;
+  }
+
+  static double _sRgbToLinear(int value) {
+    final v = value / 255.0;
+    if (v <= 0.04045) return v / 12.92;
+    return math.pow((v + 0.055) / 1.055, 2.4).toDouble();
+  }
+
+  static double _signPow(double value, double exp) =>
+      math.pow(value.abs(), exp) * value.sign;
+
+  /// Spec-correct extraction of the DCT components from [blurhash].
+  ///
+  /// blurhash_dart's decodeAc divides with `/` where the spec requires
+  /// integer division, so the quantised red/green values pick up a
+  /// fractional positive shift (up to ~23% of maxAc) while blue stays
+  /// exact — dark regions of grayscale content decode as navy blue.
+  ///
+  /// [punch] scales every AC component uniformly (baked into maxAc).
+  /// Returns `null` when the hash length doesn't match its size flag.
+  static List<List<blurhash_dart.ColorTriplet>>? _decodeComponents(
+    String blurhash, {
+    double punch = 1.0,
+  }) {
+    final sizeFlag = _decode83(blurhash, 0, 1);
+    final numCompX = (sizeFlag % 9) + 1;
+    final numCompY = (sizeFlag ~/ 9) + 1;
+    if (blurhash.length != 4 + 2 * numCompX * numCompY) return null;
+
+    final maxAc = (_decode83(blurhash, 1, 2) + 1) / 166.0 * punch;
+    final dcValue = _decode83(blurhash, 2, 6);
+
+    return List.generate(numCompY, (j) {
+      return List.generate(numCompX, (i) {
+        if (i == 0 && j == 0) {
+          return blurhash_dart.ColorTriplet(
+            _sRgbToLinear(dcValue >> 16),
+            _sRgbToLinear((dcValue >> 8) & 255),
+            _sRgbToLinear(dcValue & 255),
+          );
+        }
+        final index = i + j * numCompX;
+        final value = _decode83(blurhash, 4 + index * 2, 6 + index * 2);
+        final quantR = value ~/ (19 * 19);
+        final quantG = (value ~/ 19) % 19;
+        final quantB = value % 19;
+        return blurhash_dart.ColorTriplet(
+          _signPow((quantR - 9) / 9, 2) * maxAc,
+          _signPow((quantG - 9) / 9, 2) * maxAc,
+          _signPow((quantB - 9) / 9, 2) * maxAc,
+        );
+      });
+    });
   }
 
   /// Generate blurhash from image bytes.
@@ -148,12 +227,16 @@ class BlurhashService {
         return cached;
       }
 
-      // Use real blurhash_dart library to decode
-      final blurHashObject = blurhash_dart.BlurHash.decode(
-        blurhash,
-        punch: punch,
-      );
-      final image = blurHashObject.toImage(width, height);
+      // Extract the DCT components ourselves instead of using
+      // blurhash_dart's BlurHash.decode: its decodeAc misses the spec's
+      // integer division, inflating red/green in every AC component —
+      // grayscale content decodes with a blue/cream tint. Its `punch` is
+      // also broken (skips the first AC row and column).
+      final components = _decodeComponents(blurhash, punch: punch);
+      if (components == null) return null;
+      final image = blurhash_dart.BlurHash.components(
+        components,
+      ).toImage(width, height);
 
       // RGBA pixel data of the decoded image (getBytes already returns a
       // buffer we own — no defensive copy needed)

--- a/mobile/packages/blurhash_service/lib/src/blurhash_service.dart
+++ b/mobile/packages/blurhash_service/lib/src/blurhash_service.dart
@@ -57,8 +57,10 @@ class BlurhashService {
   /// Max width used when downscaling before encoding.
   static const int _encodeMaxWidth = 128;
 
-  /// Default punch (contrast) value. Below 1 to soften DCT overshoot from
-  /// already-published high-component hashes (see [decodeBlurhash]).
+  /// Default punch (contrast) applied to every decoded hash. Kept below 1
+  /// on purpose: the softer look reads better in the feed and it also damps
+  /// the DCT overshoot high-component legacy hashes produce. This is an
+  /// intentional product choice for all placeholders, not only legacy ones.
   static const double defaultPunch = 0.8;
 
   /// Process-wide memo for [decodeBlurhash]. Decoding is a pure function
@@ -96,10 +98,20 @@ class BlurhashService {
       'abcdefghijklmnopqrstuvwxyz'
       r'#$%*+,-.:;=?@[]^_{|}~';
 
+  /// Reverse index of [_base83Chars] for O(1) character lookup (matching
+  /// blurhash_dart's own decode83). [decodeBlurhash] runs synchronously on
+  /// the UI isolate on every cache miss, so a linear `indexOf` scan per
+  /// character would add up.
+  static final Map<String, int> _base83Index = {
+    for (var i = 0; i < _base83Chars.length; i++) _base83Chars[i]: i,
+  };
+
   static int _decode83(String value, int from, int to) {
     var result = 0;
     for (var i = from; i < to; i++) {
-      result = result * 83 + _base83Chars.indexOf(value[i]);
+      // Every char is validated against the base83 alphabet before decode,
+      // so the lookup never misses; `?? 0` only satisfies null-safety.
+      result = result * 83 + (_base83Index[value[i]] ?? 0);
     }
     return result;
   }

--- a/mobile/packages/blurhash_service/lib/src/blurhash_service.dart
+++ b/mobile/packages/blurhash_service/lib/src/blurhash_service.dart
@@ -141,7 +141,16 @@ class BlurhashService {
     final sizeFlag = _decode83(blurhash, 0, 1);
     final numCompX = (sizeFlag % 9) + 1;
     final numCompY = (sizeFlag ~/ 9) + 1;
-    if (blurhash.length != 4 + 2 * numCompX * numCompY) return null;
+    final expectedLength = 4 + 2 * numCompX * numCompY;
+    if (blurhash.length != expectedLength) {
+      Log.error(
+        'Malformed blurhash: length ${blurhash.length} does not match the '
+        'declared ${numCompX}x$numCompY components (expected $expectedLength)',
+        name: 'BlurhashService',
+        category: LogCategory.system,
+      );
+      return null;
+    }
 
     final maxAc = (_decode83(blurhash, 1, 2) + 1) / 166.0 * punch;
     final dcValue = _decode83(blurhash, 2, 6);

--- a/mobile/packages/blurhash_service/lib/src/blurhash_service.dart
+++ b/mobile/packages/blurhash_service/lib/src/blurhash_service.dart
@@ -234,6 +234,9 @@ class BlurhashService {
       // also broken (skips the first AC row and column).
       final components = _decodeComponents(blurhash, punch: punch);
       if (components == null) return null;
+      // BlurHash.components re-encodes the components into a hash string we
+      // discard, but it's the only public components→image path and ~0.1%
+      // of the iDCT in toImage below — not worth reimplementing to avoid.
       final image = blurhash_dart.BlurHash.components(
         components,
       ).toImage(width, height);

--- a/mobile/packages/blurhash_service/test/src/blurhash_service_test.dart
+++ b/mobile/packages/blurhash_service/test/src/blurhash_service_test.dart
@@ -6,6 +6,7 @@ import 'package:blurhash_dart/blurhash_dart.dart' as blurhash_dart;
 import 'package:blurhash_service/blurhash_service.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:image/image.dart' as img;
+import 'package:unified_logger/unified_logger.dart';
 
 /// Creates a solid-colour JPEG with the given [width] and [height].
 Uint8List _makeJpeg({required int width, required int height}) {
@@ -98,6 +99,32 @@ void main() {
       expect(BlurhashService.decodeBlurhash(''), isNull);
       expect(BlurhashService.decodeBlurhash('short'), isNull);
     });
+
+    test(
+      'logs an error when a valid-charset hash has a mismatched length',
+      () async {
+        await LogCaptureService().clearAllLogs();
+
+        // A real hash truncated mid-string: passes the charset/length-floor
+        // check but its length no longer matches its declared component count,
+        // so decoding bails. Corrupt/truncated tags must stay observable.
+        const truncatedHash = 'L6Pj0^jE.AyE_3t7t7R*';
+
+        expect(BlurhashService.decodeBlurhash(truncatedHash), isNull);
+
+        final errors = LogCaptureService()
+            .getRecentLogs(minLevel: LogLevel.error)
+            .where((entry) => entry.name == 'BlurhashService')
+            .toList();
+        expect(
+          errors,
+          isNotEmpty,
+          reason:
+              'a malformed blurhash must emit an error log, not fail '
+              'silently',
+        );
+      },
+    );
 
     test('blurhash data provides gradient', () {
       final testBlurhash = BlurhashService.getDefaultVineBlurhash();

--- a/mobile/packages/blurhash_service/test/src/blurhash_service_test.dart
+++ b/mobile/packages/blurhash_service/test/src/blurhash_service_test.dart
@@ -146,6 +146,84 @@ void main() {
       }
     });
 
+    test('decodes a solid fill back to its source color', () async {
+      // Reference vector: a solid fill carries no AC energy, so every
+      // decoded pixel must round-trip the DC (average) color on all three
+      // channels. The expected values are the source color itself — an
+      // independent reference, not this decoder's own output — so a channel
+      // swap or the old red/green inflation would fail it.
+      const sourceR = 100;
+      const sourceG = 149;
+      const sourceB = 237;
+      final image = img.Image(width: 128, height: 128);
+      img.fill(image, color: img.ColorRgb8(sourceR, sourceG, sourceB));
+      final hash = await BlurhashService.generateBlurhash(
+        Uint8List.fromList(img.encodePng(image)),
+      );
+      expect(hash, isNotNull);
+
+      final data = BlurhashService.decodeBlurhash(hash!, punch: 1);
+      expect(data, isNotNull);
+      final pixels = data!.pixels!;
+      for (var i = 0; i + 3 < pixels.length; i += 4) {
+        expect(
+          (pixels[i] - sourceR).abs(),
+          lessThanOrEqualTo(5),
+          reason: 'red @ ${i ~/ 4}: ${pixels[i]}',
+        );
+        expect(
+          (pixels[i + 1] - sourceG).abs(),
+          lessThanOrEqualTo(5),
+          reason: 'green @ ${i ~/ 4}: ${pixels[i + 1]}',
+        );
+        expect(
+          (pixels[i + 2] - sourceB).abs(),
+          lessThanOrEqualTo(5),
+          reason: 'blue @ ${i ~/ 4}: ${pixels[i + 2]}',
+        );
+      }
+    });
+
+    test(
+      'punch scales AC contrast, including the first component row',
+      () async {
+        // A horizontal gradient concentrates its AC energy in the first
+        // component row (j = 0, i > 0) — exactly the row blurhash_dart's punch
+        // skipped. Our decode bakes punch into every AC term, so a higher
+        // punch must widen the left↔right contrast.
+        final gradient = img.Image(width: 128, height: 128);
+        for (var x = 0; x < gradient.width; x++) {
+          final v = (x / (gradient.width - 1) * 255).round();
+          for (var y = 0; y < gradient.height; y++) {
+            gradient.setPixelRgb(x, y, v, v, v);
+          }
+        }
+        final hash = await BlurhashService.generateBlurhash(
+          Uint8List.fromList(img.encodePng(gradient)),
+        );
+        expect(hash, isNotNull);
+
+        int horizontalContrast(double punch) {
+          final data = BlurhashService.decodeBlurhash(
+            hash!,
+            width: 16,
+            height: 1,
+            punch: punch,
+          )!;
+          final pixels = data.pixels!;
+          final left = pixels[0];
+          final right = pixels[(16 - 1) * 4];
+          return (right - left).abs();
+        }
+
+        expect(
+          horizontalContrast(2),
+          greaterThan(horizontalContrast(1)),
+          reason: 'higher punch must increase AC-driven contrast',
+        );
+      },
+    );
+
     group('generateBlurhash aspect-ratio component selection', () {
       // Blurhash length = 6 + 2 * (compX * compY - 1)
       // Portrait 3×4 → 6 + 2*11 = 28 chars

--- a/mobile/packages/blurhash_service/test/src/blurhash_service_test.dart
+++ b/mobile/packages/blurhash_service/test/src/blurhash_service_test.dart
@@ -114,23 +114,64 @@ void main() {
       expect(data!.isValid, isTrue);
     });
 
+    test('decodes grayscale content without a color tint', () async {
+      // Regression: blurhash_dart's decodeAc misses the spec's integer
+      // division, which inflates red/green in every AC component — a
+      // white→black gradient decoded with navy blue shadows and a cream
+      // top. The spec-correct decode must keep gray pixels gray.
+      final gradient = img.Image(width: 128, height: 227);
+      for (var y = 0; y < gradient.height; y++) {
+        final v = (230 - (y / gradient.height) * 215).round();
+        for (var x = 0; x < gradient.width; x++) {
+          gradient.setPixelRgb(x, y, v, v, v);
+        }
+      }
+      final hash = await BlurhashService.generateBlurhash(
+        Uint8List.fromList(img.encodePng(gradient)),
+      );
+      expect(hash, isNotNull);
+
+      final data = BlurhashService.decodeBlurhash(hash!);
+      expect(data, isNotNull);
+      final pixels = data!.pixels!;
+      for (var i = 0; i + 3 < pixels.length; i += 4) {
+        final r = pixels[i];
+        final g = pixels[i + 1];
+        final b = pixels[i + 2];
+        expect(
+          (r - g).abs() <= 2 && (g - b).abs() <= 2 && (r - b).abs() <= 2,
+          isTrue,
+          reason: 'pixel ${i ~/ 4} is tinted: r=$r g=$g b=$b',
+        );
+      }
+    });
+
     group('generateBlurhash aspect-ratio component selection', () {
       // Blurhash length = 6 + 2 * (compX * compY - 1)
-      // Portrait 4×7 → 6 + 2*27 = 60 chars
-      // Square   4×4 → 6 + 2*15 = 36 chars
+      // Portrait 3×4 → 6 + 2*11 = 28 chars
+      // Square   3×3 → 6 + 2*8  = 22 chars
 
-      test('uses 4×7 components for 9:16 portrait image', () async {
+      test('uses 3×4 components for 9:16 portrait image', () async {
         final bytes = _makeJpeg(width: 90, height: 160);
         final hash = await BlurhashService.generateBlurhash(bytes);
         expect(hash, isNotNull);
-        expect(hash!.length, equals(60));
+        expect(hash!.length, equals(28));
       });
 
-      test('uses 4×4 components for 1:1 square image', () async {
+      test('uses 3×3 components for 1:1 square image', () async {
         final bytes = _makeJpeg(width: 100, height: 100);
         final hash = await BlurhashService.generateBlurhash(bytes);
         expect(hash, isNotNull);
-        expect(hash!.length, equals(36));
+        expect(hash!.length, equals(22));
+      });
+
+      test('falls back to square components for landscape input', () async {
+        // Divine only produces 9:16 and 1:1 videos; wider input (e.g.
+        // imported media) shares the square components.
+        final bytes = _makeJpeg(width: 160, height: 90);
+        final hash = await BlurhashService.generateBlurhash(bytes);
+        expect(hash, isNotNull);
+        expect(hash!.length, equals(22));
       });
 
       test('accepts valid square hashes that do not start with L', () async {
@@ -151,7 +192,7 @@ void main() {
           await thumbnailFile.readAsBytes(),
         );
         expect(hash, isNotNull);
-        expect(hash!.length, equals(60));
+        expect(hash!.length, equals(28));
       });
 
       test('runs encoding in a background isolate '

--- a/mobile/packages/blurhash_service/test/src/blurhash_service_test.dart
+++ b/mobile/packages/blurhash_service/test/src/blurhash_service_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
+import 'package:blurhash_dart/blurhash_dart.dart' as blurhash_dart;
 import 'package:blurhash_service/blurhash_service.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:image/image.dart' as img;
@@ -147,11 +148,13 @@ void main() {
     });
 
     test('decodes a solid fill back to its source color', () async {
-      // Reference vector: a solid fill carries no AC energy, so every
+      // DC reference vector: a solid fill carries no AC energy, so every
       // decoded pixel must round-trip the DC (average) color on all three
       // channels. The expected values are the source color itself — an
       // independent reference, not this decoder's own output — so a channel
-      // swap or the old red/green inflation would fail it.
+      // swap or a broken DC/sRGB round-trip fails it. (The AC division
+      // regression is guarded separately by the grayscale-tint test above;
+      // it can't be pinned here because a solid fill has ~zero AC energy.)
       const sourceR = 100;
       const sourceG = 149;
       const sourceB = 237;
@@ -187,10 +190,16 @@ void main() {
     test(
       'punch scales AC contrast, including the first component row',
       () async {
-        // A horizontal gradient concentrates its AC energy in the first
-        // component row (j = 0, i > 0) — exactly the row blurhash_dart's punch
-        // skipped. Our decode bakes punch into every AC term, so a higher
-        // punch must widen the left↔right contrast.
+        // A pure horizontal gradient puts nearly all of its AC energy in the
+        // first component row (j = 0, i > 0) — exactly the row blurhash_dart's
+        // punch skipped. Our decode bakes punch into maxAc for every AC term,
+        // so the left↔right contrast must scale ~linearly with punch. A plain
+        // `contrast(high) > contrast(low)` check is NOT enough: the upstream
+        // first-row-skip bug still satisfies it via the tiny residual energy
+        // in the punched j > 0 rows (measured 175 vs 173 at punch 1 vs 0.5).
+        // The ratio assertion below fails under that bug (it needs the
+        // dominant first-row AC to actually be scaled): correct decode gives
+        // ~175 vs ~81, the skip bug gives ~175 vs ~173.
         final gradient = img.Image(width: 128, height: 128);
         for (var x = 0; x < gradient.width; x++) {
           final v = (x / (gradient.width - 1) * 255).round();
@@ -207,7 +216,6 @@ void main() {
           final data = BlurhashService.decodeBlurhash(
             hash!,
             width: 16,
-            height: 1,
             punch: punch,
           )!;
           final pixels = data.pixels!;
@@ -216,10 +224,62 @@ void main() {
           return (right - left).abs();
         }
 
+        final softContrast = horizontalContrast(0.5);
+        final fullContrast = horizontalContrast(1);
         expect(
-          horizontalContrast(2),
-          greaterThan(horizontalContrast(1)),
-          reason: 'higher punch must increase AC-driven contrast',
+          fullContrast,
+          greaterThan((softContrast * 1.4).round()),
+          reason:
+              'punch must scale the dominant first-row AC contrast, '
+              'not skip it',
+        );
+      },
+    );
+
+    test(
+      'defaultPunch softens a legacy high-component (4x7) hash',
+      () async {
+        // The PR softens DCT ringing on already-published legacy hashes,
+        // which used 4x7 / 4x4 components. Those hashes are still live and
+        // decode with defaultPunch (0.8), never a punch override, so exercise
+        // that exact path: a 4x7 hash decoded at 0.8 must show a smaller
+        // value spread (less overshoot/ringing) than the same hash at 1.0.
+        final source = img.Image(width: 128, height: 227);
+        for (var y = 0; y < source.height; y++) {
+          for (var x = 0; x < source.width; x++) {
+            final v = ((x ~/ 16) + (y ~/ 16)).isEven ? 245 : 10;
+            source.setPixelRgb(x, y, v, v, v);
+          }
+        }
+        // Encode the legacy shape directly — the service only emits 3x4/3x3
+        // now, so this reproduces a pre-PR production hash. numCompX is
+        // blurhash_dart's default (4); numCompY: 7 makes it the 4x7 shape.
+        final legacyHash = blurhash_dart.BlurHash.encode(
+          source,
+          numCompY: 7,
+        ).hash;
+
+        int valueSpread(double punch) {
+          final data = BlurhashService.decodeBlurhash(
+            legacyHash,
+            punch: punch,
+          )!;
+          final pixels = data.pixels!;
+          var lo = 255;
+          var hi = 0;
+          for (var i = 0; i + 3 < pixels.length; i += 4) {
+            for (var c = 0; c < 3; c++) {
+              lo = lo < pixels[i + c] ? lo : pixels[i + c];
+              hi = hi > pixels[i + c] ? hi : pixels[i + c];
+            }
+          }
+          return hi - lo;
+        }
+
+        expect(
+          valueSpread(BlurhashService.defaultPunch),
+          lessThan(valueSpread(1)),
+          reason: 'defaultPunch must damp legacy-hash contrast/ringing',
         );
       },
     );


### PR DESCRIPTION
Closes #6071

## Description

Blurhash placeholders looked broken, most visibly on 9:16 videos: grayscale/low-chroma content rendered with **navy-blue shadows and a cream cast**, and high-contrast frames showed dark/bright blobs that don't exist in the source.

Two root causes, both verified empirically against a spec-canonical reference implementation (our encoded hashes were byte-identical to canonical full-res reference encodes, which isolated the decode as the visual culprit):

1. **`blurhash_dart`'s `decodeAc` misses the spec's integer division** (`value / (19*19)` instead of `value ~/ (19*19)`). The fractional remainder systematically inflates red/green in every AC component by up to ~23% of maxAc while blue stays exact. A white→black gradient decodes to `r=0 g=0 b=38` at the dark end — that's the blue tint. Fixed by extracting the DCT components ourselves (spec-correct) and reusing only the library's iDCT (`toImage`). This also fixes rendering of already-published hashes from other clients. The library's `punch` parameter is likewise broken (skips the first AC row/column), so punch is applied uniformly via maxAc in our extraction.
2. **Too many DCT components at encode time** (4×7 = 28 for portrait) cause Gibbs ringing — overshoot at contrast edges clamps to black/white blobs. Reduced to 3×4 portrait / 3×3 square (blurhash-recommended range; Divine only produces 9:16 and 1:1 videos). The pre-encode downscale now uses `average` instead of the default `nearest` interpolation, which sampled stray pixels on detailed frames.

## Performance

Fewer DCT components are also a decode-time win. `decodeBlurhash` runs the inverse-DCT synchronously on the UI thread (from `BlurhashDisplay.initState`/`didUpdateWidget`, once per hash then memoized), and that loop scales with component count. Portrait decodes now do ~57% fewer `cos` evaluations (28→12 components, ~57k→~25k per 32×32 decode) and square ~44% (16→9). The new hand-rolled `_decodeComponents` + `BlurHash.components(...).toImage()` path adds only negligible per-cache-miss overhead (a discarded re-encode, `List.generate`, `indexOf` base83 decode — each well under 1% of the iDCT), and the `average` downscale runs off the UI thread in the encode isolate. Net: the decode hot path got cheaper, not more expensive.

Decode punch defaults to 0.8 so legacy high-component hashes (already published in Nostr events, still 4×7) render with softened ringing too. Encode stays fully spec-compatible — web clients decode the same hashes canonically.

**Related Issue:** 

## Out of Scope

- Upstream bug report to `blurhash_dart` (decodeAc integer division + punch skipping first AC row/column).
- The inherent blurhash brightness bias on high-dynamic-range frames (linear-space averaging) — canonical behavior, all clients share it.

## Verification

- `flutter test` in `mobile/packages/blurhash_service` — 40/40, including a new regression test asserting a grayscale gradient decodes without color tint (fails with the library decode: channel diff 38).
- `flutter analyze packages/blurhash_service` — clean.
- Manual side-by-side comparison in-app (picsum images vs. decoded blurhash) across 9:16/1:1 ratios via a temporary debug screen (not part of this PR).

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
