### PR TITLE
fix(minor-safety): point minor-review endpoints at the relay-manager host

### DIFF
--- a/mobile/lib/config/app_config.dart
+++ b/mobile/lib/config/app_config.dart
@@ -13,6 +13,16 @@ class AppConfig {
     defaultValue: 'https://api.openvine.co',
   );
 
+  /// Moderation API (relay-manager worker). The minor-account-review
+  /// endpoints (/v1/account/moderation-status, /v1/minor-review-cases/*)
+  /// live here, NOT on the main backend host — calling them on
+  /// [backendBaseUrl] 404s and the review gate silently fails open
+  /// (divine-relay-manager#108).
+  static const String moderationApiBaseUrl = String.fromEnvironment(
+    'MODERATION_API_URL',
+    defaultValue: 'https://api-relay-prod.divine.video',
+  );
+
   static const String inviteServerBaseUrl = String.fromEnvironment(
     'INVITE_SERVER_URL',
     defaultValue: 'https://invite.divine.video',
@@ -98,6 +108,7 @@ class AppConfig {
     'environment': environment,
     'backendUrl': backendBaseUrl,
     'mediaApiUrl': mediaApiBaseUrl,
+    'moderationApiUrl': moderationApiBaseUrl,
     'inviteServerUrl': inviteServerBaseUrl,
     'appsDirectoryUrl': appsDirectoryBaseUrl,
     'isDevelopment': isDevelopment,

--- a/mobile/lib/config/app_config.dart
+++ b/mobile/lib/config/app_config.dart
@@ -13,16 +13,6 @@ class AppConfig {
     defaultValue: 'https://api.openvine.co',
   );
 
-  /// Moderation API (relay-manager worker). The minor-account-review
-  /// endpoints (/v1/account/moderation-status, /v1/minor-review-cases/*)
-  /// live here, NOT on the main backend host — calling them on
-  /// [backendBaseUrl] 404s and the review gate silently fails open
-  /// (divine-relay-manager#108).
-  static const String moderationApiBaseUrl = String.fromEnvironment(
-    'MODERATION_API_URL',
-    defaultValue: 'https://api-relay-prod.divine.video',
-  );
-
   static const String inviteServerBaseUrl = String.fromEnvironment(
     'INVITE_SERVER_URL',
     defaultValue: 'https://invite.divine.video',
@@ -108,7 +98,6 @@ class AppConfig {
     'environment': environment,
     'backendUrl': backendBaseUrl,
     'mediaApiUrl': mediaApiBaseUrl,
-    'moderationApiUrl': moderationApiBaseUrl,
     'inviteServerUrl': inviteServerBaseUrl,
     'appsDirectoryUrl': appsDirectoryBaseUrl,
     'isDevelopment': isDevelopment,

--- a/mobile/lib/providers/upload_media_providers.dart
+++ b/mobile/lib/providers/upload_media_providers.dart
@@ -281,11 +281,16 @@ UploadManager uploadManager(Ref ref) {
   return manager;
 }
 
-/// API service depends on auth service
+/// API service depends on auth service and the current environment
+/// (relay-manager URL is env-aware; watching keeps env switches applied)
 @riverpod
 ApiService apiService(Ref ref) {
   final authService = ref.watch(nip98AuthServiceProvider);
-  return ApiService(authService: authService);
+  final environment = ref.watch(currentEnvironmentProvider);
+  return ApiService(
+    authService: authService,
+    relayManagerBaseUrl: environment.relayManagerApiUrl,
+  );
 }
 
 /// Crosspost API client for Bluesky toggle settings

--- a/mobile/lib/providers/upload_media_providers.dart
+++ b/mobile/lib/providers/upload_media_providers.dart
@@ -287,10 +287,15 @@ UploadManager uploadManager(Ref ref) {
 ApiService apiService(Ref ref) {
   final authService = ref.watch(nip98AuthServiceProvider);
   final environment = ref.watch(currentEnvironmentProvider);
-  return ApiService(
+  final service = ApiService(
     authService: authService,
     relayManagerBaseUrl: environment.relayManagerApiUrl,
   );
+  // Close the owned http.Client on rebuild (env switch) — in-flight requests
+  // on the old instance fail over, which switchEnvironment's cache/sub reset
+  // already assumes
+  ref.onDispose(service.dispose);
+  return service;
 }
 
 /// Crosspost API client for Bluesky toggle settings

--- a/mobile/lib/providers/upload_media_providers.g.dart
+++ b/mobile/lib/providers/upload_media_providers.g.dart
@@ -260,7 +260,7 @@ final class ApiServiceProvider
   }
 }
 
-String _$apiServiceHash() => r'0d5060b3cae1aed43e62c2d6084fb31436373665';
+String _$apiServiceHash() => r'f03345aebc453113d4b58bfa22a1e0455a85603d';
 
 /// Crosspost API client for Bluesky toggle settings
 

--- a/mobile/lib/providers/upload_media_providers.g.dart
+++ b/mobile/lib/providers/upload_media_providers.g.dart
@@ -213,17 +213,20 @@ final class UploadManagerProvider
 
 String _$uploadManagerHash() => r'4f30b7e592133c381c01fcf4d55e046d31c3e8c1';
 
-/// API service depends on auth service
+/// API service depends on auth service and the current environment
+/// (relay-manager URL is env-aware; watching keeps env switches applied)
 
 @ProviderFor(apiService)
 final apiServiceProvider = ApiServiceProvider._();
 
-/// API service depends on auth service
+/// API service depends on auth service and the current environment
+/// (relay-manager URL is env-aware; watching keeps env switches applied)
 
 final class ApiServiceProvider
     extends $FunctionalProvider<ApiService, ApiService, ApiService>
     with $Provider<ApiService> {
-  /// API service depends on auth service
+  /// API service depends on auth service and the current environment
+  /// (relay-manager URL is env-aware; watching keeps env switches applied)
   ApiServiceProvider._()
     : super(
         from: null,
@@ -257,7 +260,7 @@ final class ApiServiceProvider
   }
 }
 
-String _$apiServiceHash() => r'a114c5e161b816881b395a10c90d043ef94c8de7';
+String _$apiServiceHash() => r'0d5060b3cae1aed43e62c2d6084fb31436373665';
 
 /// Crosspost API client for Bluesky toggle settings
 

--- a/mobile/lib/services/api_service.dart
+++ b/mobile/lib/services/api_service.dart
@@ -33,6 +33,7 @@ class ApiService {
        _rateLimiter = rateLimiter;
   static String get _baseUrl => AppConfig.backendBaseUrl;
   static String get _mediaBaseUrl => AppConfig.mediaApiBaseUrl;
+  static String get _moderationBaseUrl => AppConfig.moderationApiBaseUrl;
   static const Duration _defaultTimeout = Duration(seconds: 30);
 
   final http.Client _client;
@@ -152,7 +153,7 @@ class ApiService {
     );
 
     try {
-      final uri = Uri.parse('$_baseUrl/v1/account/moderation-status');
+      final uri = Uri.parse('$_moderationBaseUrl/v1/account/moderation-status');
       final response = await _client
           .get(uri, headers: await _getHeaders(url: uri.toString()))
           .timeout(_defaultTimeout);
@@ -187,7 +188,7 @@ class ApiService {
 
     try {
       final uri = Uri.parse(
-        '$_baseUrl/v1/minor-review-cases/$caseId/parent-contact',
+        '$_moderationBaseUrl/v1/minor-review-cases/$caseId/parent-contact',
       );
       final response = await _client
           .post(

--- a/mobile/lib/services/api_service.dart
+++ b/mobile/lib/services/api_service.dart
@@ -25,15 +25,23 @@ class ApiException implements Exception {
 /// REFACTORED: Removed ChangeNotifier - now uses pure state management via Riverpod
 class ApiService {
   ApiService({
+    required String relayManagerBaseUrl,
     http.Client? client,
     Nip98AuthService? authService,
     RateLimiter? rateLimiter,
-  }) : _client = client ?? http.Client(),
+  }) : _relayManagerBaseUrl = relayManagerBaseUrl,
+       _client = client ?? http.Client(),
        _authService = authService,
        _rateLimiter = rateLimiter;
   static String get _baseUrl => AppConfig.backendBaseUrl;
   static String get _mediaBaseUrl => AppConfig.mediaApiBaseUrl;
-  static String get _moderationBaseUrl => AppConfig.moderationApiBaseUrl;
+
+  /// Relay-manager worker base URL (minor-account-review endpoints live
+  /// there, not on the main backend — divine-relay-manager#108). Injected
+  /// from EnvironmentConfig.relayManagerApiUrl so staging/local builds and
+  /// the developer environment switcher never send signed minor-review
+  /// traffic to the production worker.
+  final String _relayManagerBaseUrl;
   static const Duration _defaultTimeout = Duration(seconds: 30);
 
   final http.Client _client;
@@ -153,7 +161,9 @@ class ApiService {
     );
 
     try {
-      final uri = Uri.parse('$_moderationBaseUrl/v1/account/moderation-status');
+      final uri = Uri.parse(
+        '$_relayManagerBaseUrl/v1/account/moderation-status',
+      );
       final response = await _client
           .get(uri, headers: await _getHeaders(url: uri.toString()))
           .timeout(_defaultTimeout);
@@ -188,7 +198,7 @@ class ApiService {
 
     try {
       final uri = Uri.parse(
-        '$_moderationBaseUrl/v1/minor-review-cases/$caseId/parent-contact',
+        '$_relayManagerBaseUrl/v1/minor-review-cases/$caseId/parent-contact',
       );
       final response = await _client
           .post(

--- a/mobile/test/services/api_service_rate_limit_test.dart
+++ b/mobile/test/services/api_service_rate_limit_test.dart
@@ -37,7 +37,11 @@ void main() {
         );
       });
 
-      apiService = ApiService(client: mockClient, rateLimiter: rateLimiter);
+      apiService = ApiService(
+        client: mockClient,
+        rateLimiter: rateLimiter,
+        relayManagerBaseUrl: 'https://api-relay-prod.divine.video',
+      );
 
       // Configure aggressive rate limit for testing
       rateLimiter.configureEndpoint(
@@ -81,7 +85,10 @@ void main() {
       );
 
       // Create ApiService without rate limiter
-      apiService = ApiService(client: mockClient);
+      apiService = ApiService(
+        client: mockClient,
+        relayManagerBaseUrl: 'https://api-relay-prod.divine.video',
+      );
 
       // Act & Assert - Should work normally
       final result = await apiService.requestSignedUpload(

--- a/mobile/test/services/api_service_test.dart
+++ b/mobile/test/services/api_service_test.dart
@@ -25,7 +25,10 @@ void main() {
 
     setUp(() {
       mockClient = MockHttpClient();
-      apiService = ApiService(client: mockClient);
+      apiService = ApiService(
+        client: mockClient,
+        relayManagerBaseUrl: 'https://api-relay-prod.divine.video',
+      );
     });
 
     group('requestSignedUpload', () {
@@ -209,6 +212,39 @@ void main() {
 
           expect(captured.host, 'api-relay-prod.divine.video');
           expect(captured.path, '/v1/account/moderation-status');
+        },
+      );
+
+      test(
+        'minor-review calls follow the injected relay-manager base URL '
+        '(env-aware: staging builds must not hit prod)',
+        () async {
+          final stagingService = ApiService(
+            client: mockClient,
+            relayManagerBaseUrl: 'https://api-relay-staging.divine.video',
+          );
+          final mockResponse = MockResponse();
+          when(() => mockResponse.statusCode).thenReturn(200);
+          when(() => mockResponse.body).thenReturn(
+            jsonEncode({
+              'restriction': {'status': 'active'},
+            }),
+          );
+          when(
+            () => mockClient.get(any(), headers: any(named: 'headers')),
+          ).thenAnswer((_) async => mockResponse);
+
+          await stagingService.getMinorAccountReviewStatus();
+
+          final captured =
+              verify(
+                    () => mockClient.get(
+                      captureAny(),
+                      headers: any(named: 'headers'),
+                    ),
+                  ).captured.single
+                  as Uri;
+          expect(captured.host, 'api-relay-staging.divine.video');
         },
       );
 

--- a/mobile/test/services/api_service_test.dart
+++ b/mobile/test/services/api_service_test.dart
@@ -181,7 +181,8 @@ void main() {
       );
 
       test(
-        'getMinorAccountReviewStatus uses the Divine backend host',
+        'getMinorAccountReviewStatus uses the moderation API host, '
+        'not the main backend (relay-manager#108: backend 404s -> gate inert)',
         () async {
           final mockResponse = MockResponse();
           when(() => mockResponse.statusCode).thenReturn(200);
@@ -206,7 +207,7 @@ void main() {
                   ).captured.single
                   as Uri;
 
-          expect(captured.host, 'api.divine.video');
+          expect(captured.host, 'api-relay-prod.divine.video');
           expect(captured.path, '/v1/account/moderation-status');
         },
       );
@@ -255,13 +256,22 @@ void main() {
             email: 'parent@example.com',
           );
 
-          verify(
-            () => mockClient.post(
-              any(),
-              headers: any(named: 'headers'),
-              body: jsonEncode({'email': 'parent@example.com'}),
-            ),
-          ).called(1);
+          final captured =
+              verify(
+                    () => mockClient.post(
+                      captureAny(),
+                      headers: any(named: 'headers'),
+                      body: jsonEncode({'email': 'parent@example.com'}),
+                    ),
+                  ).captured.single
+                  as Uri;
+
+          // Same host contract as moderation-status (relay-manager#108)
+          expect(captured.host, 'api-relay-prod.divine.video');
+          expect(
+            captured.path,
+            '/v1/minor-review-cases/case-123/parent-contact',
+          );
         },
       );
     });

--- a/mobile/test/services/api_service_test.dart
+++ b/mobile/test/services/api_service_test.dart
@@ -184,7 +184,7 @@ void main() {
       );
 
       test(
-        'getMinorAccountReviewStatus uses the moderation API host, '
+        'getMinorAccountReviewStatus uses the relay-manager host, '
         'not the main backend (relay-manager#108: backend 404s -> gate inert)',
         () async {
           final mockResponse = MockResponse();
@@ -245,6 +245,33 @@ void main() {
                   ).captured.single
                   as Uri;
           expect(captured.host, 'api-relay-staging.divine.video');
+
+          // Both endpoints read the same injected base — pin the POST too
+          when(() => mockResponse.statusCode).thenReturn(204);
+          when(() => mockResponse.body).thenReturn('');
+          when(
+            () => mockClient.post(
+              any(),
+              headers: any(named: 'headers'),
+              body: any(named: 'body'),
+            ),
+          ).thenAnswer((_) async => mockResponse);
+
+          await stagingService.submitMinorAccountReviewParentContact(
+            caseId: 'case-9',
+            email: 'parent@example.com',
+          );
+
+          final posted =
+              verify(
+                    () => mockClient.post(
+                      captureAny(),
+                      headers: any(named: 'headers'),
+                      body: any(named: 'body'),
+                    ),
+                  ).captured.single
+                  as Uri;
+          expect(posted.host, 'api-relay-staging.divine.video');
         },
       );
 


### PR DESCRIPTION
Closes divinevideo/divine-relay-manager#108

## what

the minor-account-review gate has been silently dead in production: the app calls /v1/account/moderation-status and /v1/minor-review-cases/{id}/parent-contact on the main backend host, which 404s them. MinorAccountReviewRepository fails open to active by design, so restricted accounts are never gated and the review/appeal screen is unreachable.

those endpoints live on the relay-manager worker. this PR routes the two calls through EnvironmentConfig.relayManagerApiUrl, the repo's existing env-aware model of that host (local dev worker, api-relay-staging, api-relay-prod), injected into ApiService as a required constructor param and wired through apiServiceProvider from the reactive currentEnvironmentProvider.

## why this shape

- verified live before changing anything: api.divine.video/v1/account/moderation-status is 404 (the host is funnelcake behind GKE nginx, no /v1/account routes), while api-relay-prod.divine.video answers 401 unauthenticated on the exact same path, meaning the worker serves it and just wants NIP-98. only the host was wrong.
- a client-side fix keeps NIP-98 consistent for free: the app signs the URL it calls, and the worker validates the signed URL against the request URL. any server-side proxy would break that validation unless the worker learned the public host.
- reuse over a new config: the first cut added a MODERATION_API_URL dart-define pinned to prod; review caught that the repo already models this host per environment (the Zendesk JWT flow consumes relayManagerApiUrl for NIP-98 calls to the same worker), and a prod pin would have sent staging/local/env-switched builds' signed minor-review traffic into prod D1. the constructor param is required, so no build can silently fall back to the wrong host, which is the exact bug class this PR fixes.

## behavior by environment

- production builds: api-relay-prod, gate goes live (this is the fix).
- staging builds: api-relay-staging. correction from the relay-manager#174 review: the staging worker's /v1 paths bypass CF Access (verified live; devices must reach them), so staging builds exercise the gate end-to-end against staging data. the kDebugMode local override service remains available for simulating gate states without backend setup.
- local stack: the local relay-manager dev worker (which serves these endpoints), so full local QA works.
- developer environment switcher: applies live (provider watches the environment).

## verification

- TDD both rounds: the host-assertion test previously pinned the wrong host (api.divine.video); it now pins api-relay-prod for the prod config, the parent-contact test gained host+path assertions (it previously asserted neither), and an injection test pins that a staging base URL routes to api-relay-staging (env-awareness at the service boundary).
- flutter analyze clean; api_service + rate-limit suites 13/13; minor-review repository/override/providers suites 573 pass; CI green.
- no visual change. the gate's UI already exists and is tested; this makes it reachable.

## notes for release

- the fix only takes effect for builds that ship it. existing installs keep failing open until users update. server-side coverage for old installs is divine-relay-manager#173; a synthetic check so this class of breakage alerts instead of hiding is divine-relay-manager#174.

