### PR TITLE
chore(minor-safety): scrub the dead support-pubkey from bug-report docs

### DIFF
--- a/mobile/docs/BUG_REPORT_SYSTEM_ARCHITECTURE.md
+++ b/mobile/docs/BUG_REPORT_SYSTEM_ARCHITECTURE.md
@@ -395,10 +395,6 @@ class NIP17MessageService {
 
 /// Configuration for bug report system
 class BugReportConfig {
-  /// Divine support pubkey for receiving bug reports
-  static const String supportPubkey =
-      'YOUR_SUPPORT_PUBKEY_HERE'; // TODO: Set actual support pubkey
-
   /// Maximum log entries to include in bug report
   static const int maxLogEntries = 1000;
 

--- a/mobile/docs/CONTENT_MODERATION_POLICY.md
+++ b/mobile/docs/CONTENT_MODERATION_POLICY.md
@@ -89,7 +89,6 @@ This policy is displayed to users in the report dialog.
 **Bug Reports:**
 - In-app bug report system (`lib/services/bug_report_service.dart`)
 - API endpoint: `https://bug-reports.protestnet.workers.dev/api/bug-reports`
-- Nostr support pubkey: `78a5c21b5166dc1474b64ddf7454bf79e6b5d6b4a77148593bf1e866b73c2738`
 
 **Location:**
 - Settings > Support > Report a Bug


### PR DESCRIPTION
Closes #6074

## Summary

Follow-up doc cleanup after #5963 removed the dead `BugReportConfig.supportPubkey` (a personal key with no profile or NIP-05). Drops the two doc references that outlived it:

- `CONTENT_MODERATION_POLICY.md`: removes the personal key that was listed as the "Nostr support pubkey" under published bug-report contacts. Bug reports go via the API + `contact@divine.video`, not a Nostr DM.
- `BUG_REPORT_SYSTEM_ARCHITECTURE.md`: removes the `supportPubkey` field from the `BugReportConfig` code example, since #5963 deleted it from the actual config.

## Motivation

Closes out the residual doc scrub for divinevideo/support-trust-safety#184 (support-identity cleanup; the recorded decision there is moderation-as-support). The historical design-spec mention of the key is left as an accurate record of the migration.

## Testing

Docs-only, no code change.

## Visuals

No visual change.

## Notes

Out of scope here: ~9 test files use the same hex as a generic fixture pubkey (not a support-identity reference, and at least one derives an npub from it). Flagged as an optional test-data hygiene swap, tracked separately.
