### PR TITLE
fix(divine_video_player): prevent SIGABRT from invalid AVVideoComposition

### DIFF
--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
@@ -438,9 +438,19 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             let scaledDuration: CMTime
             if clipSpeed != 1.0, clipSpeed > 0 {
                 let scaledSeconds = CMTimeGetSeconds(clipDuration) / clipSpeed
-                scaledDuration = CMTime(seconds: scaledSeconds, preferredTimescale: 600)
-                let insertedRange = CMTimeRange(start: insertTime, duration: clipDuration)
-                composition.scaleTimeRange(insertedRange, toDuration: scaledDuration)
+                let candidate = CMTime(seconds: scaledSeconds, preferredTimescale: 600)
+                // A pathological playbackSpeed can round the scaled duration to
+                // zero or overflow it to a non-numeric CMTime. Like
+                // setVideoComposition:, scaleTimeRange throws an uncatchable
+                // Objective-C NSInvalidArgumentException on such a duration, so
+                // fall back to the unscaled clip rather than abort the process.
+                if candidate.isNumeric, candidate.seconds > 0 {
+                    scaledDuration = candidate
+                    let insertedRange = CMTimeRange(start: insertTime, duration: clipDuration)
+                    composition.scaleTimeRange(insertedRange, toDuration: candidate)
+                } else {
+                    scaledDuration = clipDuration
+                }
             } else {
                 scaledDuration = clipDuration
             }

--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
@@ -199,13 +199,23 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                 // cycles from video decode/render on weaker devices, showing up
                 // as dropped or stuttering frames during sped-up preview.
                 playerItem.audioTimePitchAlgorithm = .timeDomain
-                if let videoComposition {
-                    playerItem.videoComposition = videoComposition
-                }
-                if let audioMix { playerItem.audioMix = audioMix }
+                // Validate BEFORE assigning. -[AVPlayerItem setVideoComposition:]
+                // throws an Objective-C NSInvalidArgumentException on an invalid
+                // composition (zero render size or zero/invalid frame duration).
+                // That exception is not a Swift Error, so the enclosing do/catch
+                // can't catch it and the process aborts (SIGABRT). Rejecting the
+                // bad values here surfaces the failure as a FlutterError instead.
                 guard (videoComposition?.renderSize ?? composition.naturalSize).isPositive else {
                     throw CompositionError.invalidRenderSize
                 }
+                if let videoComposition {
+                    let frameDuration = videoComposition.frameDuration
+                    guard frameDuration.isNumeric, frameDuration.seconds > 0 else {
+                        throw CompositionError.invalidFrameDuration
+                    }
+                    playerItem.videoComposition = videoComposition
+                }
+                if let audioMix { playerItem.audioMix = audioMix }
                 self.templateItem = playerItem
 
                 let requestedStartPositionMs = (args["startPositionMs"] as? NSNumber)?.int64Value
@@ -401,8 +411,13 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                     let mutableVideoComposition = AVMutableVideoComposition()
                     mutableVideoComposition.renderSize = displaySize
                     mutableVideoComposition.sourceTrackIDForFrameTiming = videoTrack.trackID
-                    if sourceVideoTrack.minFrameDuration.isValid {
-                        mutableVideoComposition.frameDuration = sourceVideoTrack.minFrameDuration
+                    // minFrameDuration can be valid-but-zero on assets without
+                    // frame-timing metadata; a zero frameDuration makes
+                    // setVideoComposition throw. Require a positive duration and
+                    // fall back to 30fps otherwise.
+                    let minFrameDuration = sourceVideoTrack.minFrameDuration
+                    if minFrameDuration.isNumeric, minFrameDuration.seconds > 0 {
+                        mutableVideoComposition.frameDuration = minFrameDuration
                     } else {
                         mutableVideoComposition.frameDuration = CMTime(value: 1, timescale: 30)
                     }
@@ -1196,6 +1211,7 @@ private enum CompositionError: Error, LocalizedError {
     case cannotCreateTrack
     case noPlayableVideoTracks
     case invalidRenderSize
+    case invalidFrameDuration
 
     var errorDescription: String? {
         switch self {
@@ -1205,6 +1221,8 @@ private enum CompositionError: Error, LocalizedError {
             return "No playable video tracks found."
         case .invalidRenderSize:
             return "Video composition has an invalid render size."
+        case .invalidFrameDuration:
+            return "Video composition has an invalid frame duration."
         }
     }
 }

--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
@@ -411,11 +411,16 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                     let mutableVideoComposition = AVMutableVideoComposition()
                     mutableVideoComposition.renderSize = displaySize
                     mutableVideoComposition.sourceTrackIDForFrameTiming = videoTrack.trackID
-                    // minFrameDuration can be valid-but-zero on assets without
-                    // frame-timing metadata; a zero frameDuration makes
-                    // setVideoComposition throw. Require a positive duration and
-                    // fall back to 30fps otherwise.
-                    let minFrameDuration = sourceVideoTrack.minFrameDuration
+                    // iOS 16+ deprecates the synchronous minFrameDuration
+                    // accessor — it returns an undefined value for an un-loaded
+                    // track property — so load it asynchronously like the
+                    // sibling track properties above. Even once loaded it can be
+                    // valid-but-zero on assets without frame-timing metadata, and
+                    // setVideoComposition rejects a zero/non-numeric frameDuration,
+                    // so guard and fall back to 30fps.
+                    let minFrameDuration = try await sourceVideoTrack.load(
+                        .minFrameDuration
+                    )
                     if minFrameDuration.isNumeric, minFrameDuration.seconds > 0 {
                         mutableVideoComposition.frameDuration = minFrameDuration
                     } else {

--- a/mobile/packages/divine_video_player/test/src/apple_composition_guard_contract_test.dart
+++ b/mobile/packages/divine_video_player/test/src/apple_composition_guard_contract_test.dart
@@ -1,0 +1,110 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// -[AVPlayerItem setVideoComposition:] and AVMutableComposition.scaleTimeRange
+/// validate synchronously and raise an Objective-C NSInvalidArgumentException
+/// (not a Swift Error) on a malformed composition. A Swift do/catch cannot
+/// catch that exception, so a bad value aborts the process (SIGABRT) — the
+/// TestFlight crash on 1.0.16 (804). These invariants have no Dart runtime
+/// surface, so they are pinned as a source contract: a future refactor that
+/// drops a guard or moves it after the throwing call keeps the runtime tests
+/// green while restoring the crash, and only this test catches it.
+void main() {
+  group('Apple native composition guard contract', () {
+    test('falls back to 30fps for a non-numeric-positive minFrameDuration', () {
+      final source = _appleSourceFile().readAsStringSync();
+
+      expect(
+        source,
+        contains('minFrameDuration.isNumeric, minFrameDuration.seconds > 0'),
+        reason:
+            'minFrameDuration can be valid-but-zero (or infinite) on assets '
+            'without frame-timing metadata; .isValid alone accepts those and '
+            'setVideoComposition then rejects the zero/non-numeric duration.',
+      );
+      expect(
+        source,
+        contains(
+          'mutableVideoComposition.frameDuration = '
+          'CMTime(value: 1, timescale: 30)',
+        ),
+        reason:
+            'A non-numeric-positive minFrameDuration must fall back to a valid '
+            '30fps frame duration, not be assigned as-is.',
+      );
+    });
+
+    test('validates render size and frame duration before assigning '
+        'videoComposition', () {
+      final source = _appleSourceFile().readAsStringSync();
+
+      final renderSizeGuard = source.indexOf(
+        'throw CompositionError.invalidRenderSize',
+      );
+      final frameDurationGuard = source.indexOf(
+        'throw CompositionError.invalidFrameDuration',
+      );
+      final assignment = source.indexOf(
+        'playerItem.videoComposition = videoComposition',
+      );
+
+      expect(renderSizeGuard, greaterThanOrEqualTo(0));
+      expect(frameDurationGuard, greaterThanOrEqualTo(0));
+      expect(assignment, greaterThanOrEqualTo(0));
+      expect(
+        renderSizeGuard,
+        lessThan(assignment),
+        reason:
+            'The render-size guard must run before setVideoComposition: — the '
+            'crash it prevents happens during the assignment.',
+      );
+      expect(
+        frameDurationGuard,
+        lessThan(assignment),
+        reason:
+            'The frame-duration guard must run before setVideoComposition: — '
+            'the crash it prevents happens during the assignment.',
+      );
+    });
+
+    test('guards scaled duration before scaleTimeRange', () {
+      final source = _appleSourceFile().readAsStringSync();
+
+      final scaledGuard = source.indexOf(
+        'candidate.isNumeric, candidate.seconds > 0',
+      );
+      final scaleCall = source.indexOf('composition.scaleTimeRange');
+
+      expect(scaledGuard, greaterThanOrEqualTo(0));
+      expect(scaleCall, greaterThanOrEqualTo(0));
+      expect(
+        scaledGuard,
+        lessThan(scaleCall),
+        reason:
+            'A pathological playbackSpeed can drive the scaled duration to '
+            'zero or non-numeric; scaleTimeRange raises the same uncatchable '
+            'NSInvalidArgumentException, so it must be guarded first.',
+      );
+    });
+  });
+}
+
+/// The iOS and macOS players share a single Darwin source tree
+/// (`darwin/divine_video_player/Sources/`), so the composition contract
+/// is asserted once.
+File _appleSourceFile() {
+  final packageRelative = File(
+    'darwin/divine_video_player/Sources/divine_video_player/'
+    'DivineVideoPlayerInstance.swift',
+  );
+  if (packageRelative.existsSync()) {
+    return packageRelative;
+  }
+
+  return File(
+    'packages/divine_video_player/'
+    'darwin/divine_video_player/Sources/divine_video_player/'
+    'DivineVideoPlayerInstance.swift',
+  );
+}


### PR DESCRIPTION
Closes #6080

## Description

Fixes a hard crash (`EXC_CRASH` / `SIGABRT`) in the native multi-clip player. Reported via TestFlight feedback on 1.0.16 (804), iPhone 13 mini, iOS 26.5 — the app aborted ~3s after launch.

The crashing frame:

```
2  AVFCore   -[AVPlayerItem setVideoComposition:] + 520
3  Runner    DivineVideoPlayerInstance.handleSetClips … DivineVideoPlayerInstance.swift:203
```

`-[AVPlayerItem setVideoComposition:]` validates the composition synchronously and throws an Objective-C `NSInvalidArgumentException` when it is malformed (zero render size, or zero/invalid frame duration). That NSException is **not** a Swift `Error`, so the enclosing `do/catch` in `handleSetClips` cannot catch it — it propagates uncaught to `std::terminate` → `abort()`. Firebase's `FIRCLSTerminateHandler` logged it.

Two bugs fed the crash, both when the first loaded clip is rotated (so a `videoComposition` is actually built):

1. **Frame duration could be valid-but-zero.** `buildComposition` set `frameDuration = sourceVideoTrack.minFrameDuration` guarded only by `.isValid`. A zero `CMTime` *is* valid (`isValid == true`), and on assets without frame-timing metadata `minFrameDuration` can come back valid-but-zero. `setVideoComposition:` rejects a zero `frameDuration`. Now guarded by `isNumeric && seconds > 0`, falling back to 30fps otherwise. (`minFrameDuration` is also now `await`-loaded like the sibling track properties, since iOS 16+ deprecates the synchronous accessor.)
2. **Render-size validation ran too late.** The `renderSize.isPositive` guard sat *after* the throwing `playerItem.videoComposition = …` assignment, so it could never protect it. Both render-size and frame-duration are now validated *before* the assignment.

A rejected composition now throws a Swift `CompositionError` that the existing `catch` block turns into a `COMPOSITION_ERROR` `FlutterError`, so the failure surfaces to Dart instead of killing the process.

### Same crash class: `scaleTimeRange`

`AVMutableComposition.scaleTimeRange(_:toDuration:)` (used for per-clip playback speed) is a non-`try` AVFoundation call that raises the *same* uncatchable `NSInvalidArgumentException` when `toDuration` is zero or non-numeric — and the enclosing `do/catch` can't catch it either. `playbackSpeed` is normally bounded: it defaults to `1.0` (so the reported single-clip feed playback never scales) and the editor clamps user values to `[0.25, 3.0]` (`VideoEditorConstants.clipSpeedMin`/`clipSpeedMax`) — so this guard is defensive hardening against a future/edge value rather than the trigger of the reported crash. A duration that rounds to zero or overflows to non-numeric is now guarded with `isNumeric && seconds > 0` before the scale, falling back to the unscaled clip rather than aborting.

### Why pure-Swift validation and not an Objective-C `@try/@catch`

Catching the NSException itself would need a separate Objective-C target wired into **both** `Package.swift` (SwiftPM) and the `.podspec` (CocoaPods) with module-map plumbing — build-system surface that can't be verified without a full native build. For this composition shape (single/multi-clip, one instruction, the composition's own track) the only values AVFoundation hard-rejects are render size and frame duration; the instructions are valid by construction. Validating those before assignment removes the crash without touching the build system.

## Testing

- Added `apple_composition_guard_contract_test.dart` — a Swift **source-contract** test, the same pattern as the existing `apple_threading` / `apple_engine_teardown` contract tests in this package. It pins the invariants that have no Dart runtime surface: the render-size and frame-duration guards must precede the `setVideoComposition:` assignment, `minFrameDuration` must fall back to 30fps when not numeric-positive, and the scaled duration must be guarded before `scaleTimeRange`. A refactor that restores the uncaught crash keeps every runtime test green — only this contract test (index-ordering assertions) catches it.
- The package still has no XCTest target, and exercising `setVideoComposition:` validation at runtime realistically needs real video assets, so the guards are pinned structurally rather than through a native unit test.

## Out of Scope

- No Objective-C exception-catching bridge (see rationale above).

## Verification

- `flutter test` (divine_video_player) — all contract tests pass (12/12, including the 3 new composition-guard assertions).
- `flutter analyze lib test` — no issues.
- `swiftc -parse` on the changed file — no syntax errors (full compile runs through Pods since the file imports `Flutter`/`FlutterMacOS`).
- Manual on-device / TestFlight verification of the previously-crashing clip pending.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
