### PR TITLE
fix(dm): use a bottom sheet instead of a snackbar for failed-send recovery

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -2655,6 +2655,7 @@
     "collaboratorInviteDmBodyUntitled": "በቪዲዮ ላይ እንድትተባበር ተጋብዘሃል፦ {url}\n\nOpen diVine to review and accept.",
     "dmSendBlockedMessage": "You can only message official Divine accounts",
     "dmSendFailedMessage": "መልዕክቱ መላክ አልተሳካም",
+    "dmSendFailedSubtitle": "አሁን እንደገና ላክ ወይም ከውይይቱ ሰርዝ።",
     "dmSendFailedRetry": "እንደገና ይሞክሩ",
     "dmSendPartialMessage": "ተልኳል፣ ግን ወደ ሌሎች መሣሪያዎች አልተመሳሰለም",
     "dmStatusFailed": "መላክ አልተሳካም",

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -2655,7 +2655,7 @@
     "collaboratorInviteDmBodyUntitled": "በቪዲዮ ላይ እንድትተባበር ተጋብዘሃል፦ {url}\n\nOpen diVine to review and accept.",
     "dmSendBlockedMessage": "You can only message official Divine accounts",
     "dmSendFailedMessage": "መልዕክቱ መላክ አልተሳካም",
-    "dmSendFailedSubtitle": "አሁን እንደገና ላክ ወይም ከውይይቱ ሰርዝ።",
+    "dmSendFailedSubtitle": "አሁን እንደገና ላክ ወይም መሞከር አቁም።",
     "dmSendFailedRetry": "እንደገና ይሞክሩ",
     "dmSendPartialMessage": "ተልኳል፣ ግን ወደ ሌሎች መሣሪያዎች አልተመሳሰለም",
     "dmStatusFailed": "መላክ አልተሳካም",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2468,6 +2468,7 @@
     "profileSetupUploadStaged": "تم الرفع — اضغط على حفظ للتطبيق",
     "dmSendBlockedMessage": "You can only message official Divine accounts",
     "dmSendFailedMessage": "تعذّر إرسال الرسالة",
+    "dmSendFailedSubtitle": "أعد إرسالها الآن، أو احذفها من المحادثة.",
     "dmSendFailedRetry": "إعادة المحاولة",
     "dmSendPartialMessage": "أُرسلت، لكنّها لم تُزامَن مع أجهزتك الأخرى",
     "dmStatusFailed": "فشل الإرسال",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2468,7 +2468,7 @@
     "profileSetupUploadStaged": "تم الرفع — اضغط على حفظ للتطبيق",
     "dmSendBlockedMessage": "You can only message official Divine accounts",
     "dmSendFailedMessage": "تعذّر إرسال الرسالة",
-    "dmSendFailedSubtitle": "أعد إرسالها الآن، أو احذفها من المحادثة.",
+    "dmSendFailedSubtitle": "أعد إرسالها الآن، أو أوقف المحاولة.",
     "dmSendFailedRetry": "إعادة المحاولة",
     "dmSendPartialMessage": "أُرسلت، لكنّها لم تُزامَن مع أجهزتك الأخرى",
     "dmStatusFailed": "فشل الإرسال",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -2507,6 +2507,7 @@
     "collaboratorInviteDmBodyUntitled": "Поканени сте да си сътрудничите по видеоклип: {url}\n\nOpen diVine to review and accept.",
     "dmSendBlockedMessage": "You can only message official Divine accounts",
     "dmSendFailedMessage": "Съобщението не мина",
+    "dmSendFailedSubtitle": "Изпрати го отново сега или го изтрий от разговора.",
     "dmSendFailedRetry": "Опитай пак",
     "dmSendPartialMessage": "Изпратено, но не се синхронизира с другите ти устройства",
     "dmStatusFailed": "Изпращането не успя",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -2507,7 +2507,7 @@
     "collaboratorInviteDmBodyUntitled": "Поканени сте да си сътрудничите по видеоклип: {url}\n\nOpen diVine to review and accept.",
     "dmSendBlockedMessage": "You can only message official Divine accounts",
     "dmSendFailedMessage": "Съобщението не мина",
-    "dmSendFailedSubtitle": "Изпрати го отново сега или го изтрий от разговора.",
+    "dmSendFailedSubtitle": "Изпрати го отново сега или спри опитите.",
     "dmSendFailedRetry": "Опитай пак",
     "dmSendPartialMessage": "Изпратено, но не се синхронизира с другите ти устройства",
     "dmStatusFailed": "Изпращането не успя",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2476,7 +2476,7 @@
     "profileSetupUploadStaged": "Hochgeladen – tippe auf Speichern, um zu übernehmen",
     "dmSendBlockedMessage": "You can only message official Divine accounts",
     "dmSendFailedMessage": "Nachricht konnte nicht gesendet werden",
-    "dmSendFailedSubtitle": "Sende sie jetzt erneut oder lösche sie aus der Unterhaltung.",
+    "dmSendFailedSubtitle": "Sende sie jetzt erneut oder versuche es nicht mehr.",
     "dmSendFailedRetry": "Erneut versuchen",
     "dmSendPartialMessage": "Gesendet, aber nicht mit deinen anderen Geräten synchronisiert",
     "dmStatusFailed": "Senden fehlgeschlagen",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2476,6 +2476,7 @@
     "profileSetupUploadStaged": "Hochgeladen – tippe auf Speichern, um zu übernehmen",
     "dmSendBlockedMessage": "You can only message official Divine accounts",
     "dmSendFailedMessage": "Nachricht konnte nicht gesendet werden",
+    "dmSendFailedSubtitle": "Sende sie jetzt erneut oder lösche sie aus der Unterhaltung.",
     "dmSendFailedRetry": "Erneut versuchen",
     "dmSendPartialMessage": "Gesendet, aber nicht mit deinen anderen Geräten synchronisiert",
     "dmStatusFailed": "Senden fehlgeschlagen",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -3140,7 +3140,7 @@
   "@dmSendFailedMessage": {
     "description": "Accessibility announcement text, and the recovery bottom sheet's title, shown in a DM conversation when a send fails (relay error, signer error, network error). The bottom sheet pairs it with `dmSendFailedSubtitle` and the `dmMessageActionRetrySend` / `dmMessageActionCancelSend` actions."
   },
-  "dmSendFailedSubtitle": "Resend it now, or delete it from the conversation.",
+  "dmSendFailedSubtitle": "Resend it now, or stop trying.",
   "@dmSendFailedSubtitle": {
     "description": "Subtitle in the recovery bottom sheet shown when a failed own DM bubble is tapped, below the `dmSendFailedMessage` title."
   },

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -3138,7 +3138,11 @@
   },
   "dmSendFailedMessage": "Message couldn't be sent",
   "@dmSendFailedMessage": {
-    "description": "SnackBar text shown in a DM conversation when a send fails (relay error, signer error, network error). Paired with the retry action `dmSendFailedRetry`."
+    "description": "Accessibility announcement text, and the recovery bottom sheet's title, shown in a DM conversation when a send fails (relay error, signer error, network error). The bottom sheet pairs it with `dmSendFailedSubtitle` and the `dmMessageActionRetrySend` / `dmMessageActionCancelSend` actions."
+  },
+  "dmSendFailedSubtitle": "Resend it now, or delete it from the conversation.",
+  "@dmSendFailedSubtitle": {
+    "description": "Subtitle in the recovery bottom sheet shown when a failed own DM bubble is tapped, below the `dmSendFailedMessage` title."
   },
   "dmSendFailedRetry": "Retry",
   "@dmSendFailedRetry": {
@@ -3190,11 +3194,11 @@
   },
   "dmMessageActionRetrySend": "Resend",
   "@dmMessageActionRetrySend": {
-    "description": "Action in the snackbar shown when a failed own DM bubble is tapped; re-attempts delivery of that queued message."
+    "description": "Primary action in the recovery bottom sheet shown when a failed own DM bubble is tapped; re-attempts delivery of that queued message."
   },
   "dmMessageActionCancelSend": "Stop trying",
   "@dmMessageActionCancelSend": {
-    "description": "Action in the snackbar shown when a failed own DM bubble is tapped; stops retrying the undelivered recipients and keeps the message (and any already-delivered copies). It does not delete the message — long-press delete does that."
+    "description": "Secondary action in the recovery bottom sheet shown when a failed own DM bubble is tapped; gives up on the queued message and removes it."
   },
   "dmReactionAddCustomA11yLabel": "Add custom emoji reaction",
   "@dmReactionAddCustomA11yLabel": {

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2484,7 +2484,7 @@
     "profileSetupUploadStaged": "Subida — toca Guardar para aplicar",
     "dmSendBlockedMessage": "You can only message official Divine accounts",
     "dmSendFailedMessage": "No se pudo enviar el mensaje",
-    "dmSendFailedSubtitle": "Reenvíalo ahora o elimínalo de la conversación.",
+    "dmSendFailedSubtitle": "Reenvíalo ahora o deja de intentarlo.",
     "dmSendFailedRetry": "Reintentar",
     "dmSendPartialMessage": "Enviado, pero no se sincronizó con tus otros dispositivos",
     "dmStatusFailed": "No se pudo enviar",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2484,6 +2484,7 @@
     "profileSetupUploadStaged": "Subida — toca Guardar para aplicar",
     "dmSendBlockedMessage": "You can only message official Divine accounts",
     "dmSendFailedMessage": "No se pudo enviar el mensaje",
+    "dmSendFailedSubtitle": "Reenvíalo ahora o elimínalo de la conversación.",
     "dmSendFailedRetry": "Reintentar",
     "dmSendPartialMessage": "Enviado, pero no se sincronizó con tus otros dispositivos",
     "dmStatusFailed": "No se pudo enviar",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1451,6 +1451,7 @@
     "profileSetupUploadStaged": "Na-upload na — i-tap ang I-save para ilapat",
     "dmSendBlockedMessage": "You can only message official Divine accounts",
     "dmSendFailedMessage": "Hindi naipadala ang message",
+    "dmSendFailedSubtitle": "I-resend ito ngayon, o burahin ito sa usapan.",
     "dmSendFailedRetry": "Subukan ulit",
     "dmSendPartialMessage": "Naipadala, pero hindi nag-sync sa iba mong device",
     "dmStatusFailed": "Nabigong ipadala",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1451,7 +1451,7 @@
     "profileSetupUploadStaged": "Na-upload na — i-tap ang I-save para ilapat",
     "dmSendBlockedMessage": "You can only message official Divine accounts",
     "dmSendFailedMessage": "Hindi naipadala ang message",
-    "dmSendFailedSubtitle": "I-resend ito ngayon, o burahin ito sa usapan.",
+    "dmSendFailedSubtitle": "I-resend ito ngayon, o itigil ang pagsubok.",
     "dmSendFailedRetry": "Subukan ulit",
     "dmSendPartialMessage": "Naipadala, pero hindi nag-sync sa iba mong device",
     "dmStatusFailed": "Nabigong ipadala",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2476,6 +2476,7 @@
     "profileSetupUploadStaged": "Importée — touchez Enregistrer pour appliquer",
     "dmSendBlockedMessage": "You can only message official Divine accounts",
     "dmSendFailedMessage": "Impossible d'envoyer le message",
+    "dmSendFailedSubtitle": "Renvoie-le maintenant, ou supprime-le de la conversation.",
     "dmSendFailedRetry": "Réessayer",
     "dmSendPartialMessage": "Envoyé, mais pas synchronisé avec tes autres appareils",
     "dmStatusFailed": "Échec de l’envoi",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2476,7 +2476,7 @@
     "profileSetupUploadStaged": "Importée — touchez Enregistrer pour appliquer",
     "dmSendBlockedMessage": "You can only message official Divine accounts",
     "dmSendFailedMessage": "Impossible d'envoyer le message",
-    "dmSendFailedSubtitle": "Renvoie-le maintenant, ou supprime-le de la conversation.",
+    "dmSendFailedSubtitle": "Renvoie-le maintenant, ou arrête d'essayer.",
     "dmSendFailedRetry": "Réessayer",
     "dmSendPartialMessage": "Envoyé, mais pas synchronisé avec tes autres appareils",
     "dmStatusFailed": "Échec de l’envoi",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2475,7 +2475,7 @@
     "profileSetupUploadStaged": "Diunggah — ketuk Simpan untuk menerapkan",
     "dmSendBlockedMessage": "You can only message official Divine accounts",
     "dmSendFailedMessage": "Pesan gagal dikirim",
-    "dmSendFailedSubtitle": "Kirim ulang sekarang, atau hapus dari percakapan.",
+    "dmSendFailedSubtitle": "Kirim ulang sekarang, atau berhenti mencoba.",
     "dmSendFailedRetry": "Coba Lagi",
     "dmSendPartialMessage": "Terkirim, tapi tidak tersinkron ke perangkat lainmu",
     "dmStatusFailed": "Gagal mengirim",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2475,6 +2475,7 @@
     "profileSetupUploadStaged": "Diunggah — ketuk Simpan untuk menerapkan",
     "dmSendBlockedMessage": "You can only message official Divine accounts",
     "dmSendFailedMessage": "Pesan gagal dikirim",
+    "dmSendFailedSubtitle": "Kirim ulang sekarang, atau hapus dari percakapan.",
     "dmSendFailedRetry": "Coba Lagi",
     "dmSendPartialMessage": "Terkirim, tapi tidak tersinkron ke perangkat lainmu",
     "dmStatusFailed": "Gagal mengirim",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2476,7 +2476,7 @@
     "profileSetupUploadStaged": "Caricata — tocca Salva per applicare",
     "dmSendBlockedMessage": "You can only message official Divine accounts",
     "dmSendFailedMessage": "Impossibile inviare il messaggio",
-    "dmSendFailedSubtitle": "Invialo di nuovo ora, oppure eliminalo dalla conversazione.",
+    "dmSendFailedSubtitle": "Invialo di nuovo ora, oppure smetti di provare.",
     "dmSendFailedRetry": "Riprova",
     "dmSendPartialMessage": "Inviato, ma non sincronizzato con gli altri tuoi dispositivi",
     "dmStatusFailed": "Invio non riuscito",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2476,6 +2476,7 @@
     "profileSetupUploadStaged": "Caricata — tocca Salva per applicare",
     "dmSendBlockedMessage": "You can only message official Divine accounts",
     "dmSendFailedMessage": "Impossibile inviare il messaggio",
+    "dmSendFailedSubtitle": "Invialo di nuovo ora, oppure eliminalo dalla conversazione.",
     "dmSendFailedRetry": "Riprova",
     "dmSendPartialMessage": "Inviato, ma non sincronizzato con gli altri tuoi dispositivi",
     "dmStatusFailed": "Invio non riuscito",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2468,7 +2468,7 @@
     "profileSetupUploadStaged": "アップロードしたよ — 適用するには「保存」をタップしてね",
     "dmSendBlockedMessage": "You can only message official Divine accounts",
     "dmSendFailedMessage": "メッセージを送信できなかった",
-    "dmSendFailedSubtitle": "今すぐ再送するか、会話から削除してね。",
+    "dmSendFailedSubtitle": "今すぐ再送するか、送信を中止してね。",
     "dmSendFailedRetry": "もう一回",
     "dmSendPartialMessage": "送信したけど、ほかのデバイスには同期できなかった",
     "dmStatusFailed": "送信できなかった",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2468,6 +2468,7 @@
     "profileSetupUploadStaged": "アップロードしたよ — 適用するには「保存」をタップしてね",
     "dmSendBlockedMessage": "You can only message official Divine accounts",
     "dmSendFailedMessage": "メッセージを送信できなかった",
+    "dmSendFailedSubtitle": "今すぐ再送するか、会話から削除してね。",
     "dmSendFailedRetry": "もう一回",
     "dmSendPartialMessage": "送信したけど、ほかのデバイスには同期できなかった",
     "dmStatusFailed": "送信できなかった",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1799,6 +1799,7 @@
     "profileSetupUploadStaged": "업로드됐어요 — 적용하려면 저장을 탭하세요",
     "dmSendBlockedMessage": "You can only message official Divine accounts",
     "dmSendFailedMessage": "메시지를 보내지 못했어요",
+    "dmSendFailedSubtitle": "지금 다시 보내거나 대화에서 삭제하세요.",
     "dmSendFailedRetry": "다시 시도",
     "dmSendPartialMessage": "보냈지만 다른 기기에 동기화되지 않았어요",
     "dmStatusFailed": "보내지 못했어요",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1799,7 +1799,7 @@
     "profileSetupUploadStaged": "업로드됐어요 — 적용하려면 저장을 탭하세요",
     "dmSendBlockedMessage": "You can only message official Divine accounts",
     "dmSendFailedMessage": "메시지를 보내지 못했어요",
-    "dmSendFailedSubtitle": "지금 다시 보내거나 대화에서 삭제하세요.",
+    "dmSendFailedSubtitle": "지금 다시 보내거나 전송을 중단하세요.",
     "dmSendFailedRetry": "다시 시도",
     "dmSendPartialMessage": "보냈지만 다른 기기에 동기화되지 않았어요",
     "dmStatusFailed": "보내지 못했어요",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2476,7 +2476,7 @@
     "profileSetupUploadStaged": "Geüpload — tik op Opslaan om toe te passen",
     "dmSendBlockedMessage": "You can only message official Divine accounts",
     "dmSendFailedMessage": "Bericht kon niet worden verzonden",
-    "dmSendFailedSubtitle": "Verstuur het nu opnieuw, of verwijder het uit het gesprek.",
+    "dmSendFailedSubtitle": "Verstuur het nu opnieuw, of stop met proberen.",
     "dmSendFailedRetry": "Opnieuw",
     "dmSendPartialMessage": "Verzonden, maar niet gesynchroniseerd met je andere apparaten",
     "dmStatusFailed": "Versturen mislukt",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2476,6 +2476,7 @@
     "profileSetupUploadStaged": "Geüpload — tik op Opslaan om toe te passen",
     "dmSendBlockedMessage": "You can only message official Divine accounts",
     "dmSendFailedMessage": "Bericht kon niet worden verzonden",
+    "dmSendFailedSubtitle": "Verstuur het nu opnieuw, of verwijder het uit het gesprek.",
     "dmSendFailedRetry": "Opnieuw",
     "dmSendPartialMessage": "Verzonden, maar niet gesynchroniseerd met je andere apparaten",
     "dmStatusFailed": "Versturen mislukt",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2476,7 +2476,7 @@
     "profileSetupUploadStaged": "Przesłano — dotknij Zapisz, aby zastosować",
     "dmSendBlockedMessage": "You can only message official Divine accounts",
     "dmSendFailedMessage": "Nie udało się wysłać wiadomości",
-    "dmSendFailedSubtitle": "Wyślij ją ponownie teraz albo usuń ją z rozmowy.",
+    "dmSendFailedSubtitle": "Wyślij ją ponownie teraz albo przestań próbować.",
     "dmSendFailedRetry": "Spróbuj ponownie",
     "dmSendPartialMessage": "Wysłano, ale nie zsynchronizowano z twoimi innymi urządzeniami",
     "dmStatusFailed": "Nie udało się wysłać",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2476,6 +2476,7 @@
     "profileSetupUploadStaged": "Przesłano — dotknij Zapisz, aby zastosować",
     "dmSendBlockedMessage": "You can only message official Divine accounts",
     "dmSendFailedMessage": "Nie udało się wysłać wiadomości",
+    "dmSendFailedSubtitle": "Wyślij ją ponownie teraz albo usuń ją z rozmowy.",
     "dmSendFailedRetry": "Spróbuj ponownie",
     "dmSendPartialMessage": "Wysłano, ale nie zsynchronizowano z twoimi innymi urządzeniami",
     "dmStatusFailed": "Nie udało się wysłać",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2476,7 +2476,7 @@
     "profileSetupUploadStaged": "Enviada — toque em Salvar para aplicar",
     "dmSendBlockedMessage": "You can only message official Divine accounts",
     "dmSendFailedMessage": "Falha ao enviar a mensagem",
-    "dmSendFailedSubtitle": "Reenvie agora, ou exclua a mensagem da conversa.",
+    "dmSendFailedSubtitle": "Reenvie agora, ou pare de tentar.",
     "dmSendFailedRetry": "Tentar novamente",
     "dmSendPartialMessage": "Enviado, mas não sincronizou com seus outros dispositivos",
     "dmStatusFailed": "Falha ao enviar",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2476,6 +2476,7 @@
     "profileSetupUploadStaged": "Enviada — toque em Salvar para aplicar",
     "dmSendBlockedMessage": "You can only message official Divine accounts",
     "dmSendFailedMessage": "Falha ao enviar a mensagem",
+    "dmSendFailedSubtitle": "Reenvie agora, ou exclua a mensagem da conversa.",
     "dmSendFailedRetry": "Tentar novamente",
     "dmSendPartialMessage": "Enviado, mas não sincronizou com seus outros dispositivos",
     "dmStatusFailed": "Falha ao enviar",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2476,7 +2476,7 @@
     "profileSetupUploadStaged": "Încărcată — apasă pe Salvează pentru a aplica",
     "dmSendBlockedMessage": "You can only message official Divine accounts",
     "dmSendFailedMessage": "Mesajul nu a putut fi trimis",
-    "dmSendFailedSubtitle": "Retrimite-l acum sau șterge-l din conversație.",
+    "dmSendFailedSubtitle": "Retrimite-l acum sau nu mai încerca.",
     "dmSendFailedRetry": "Reîncearcă",
     "dmSendPartialMessage": "Trimis, dar nu s-a sincronizat cu celelalte dispozitive",
     "dmStatusFailed": "N-am putut trimite",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2476,6 +2476,7 @@
     "profileSetupUploadStaged": "Încărcată — apasă pe Salvează pentru a aplica",
     "dmSendBlockedMessage": "You can only message official Divine accounts",
     "dmSendFailedMessage": "Mesajul nu a putut fi trimis",
+    "dmSendFailedSubtitle": "Retrimite-l acum sau șterge-l din conversație.",
     "dmSendFailedRetry": "Reîncearcă",
     "dmSendPartialMessage": "Trimis, dar nu s-a sincronizat cu celelalte dispozitive",
     "dmStatusFailed": "N-am putut trimite",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2476,7 +2476,7 @@
     "profileSetupUploadStaged": "Uppladdad — tryck på Spara för att tillämpa",
     "dmSendBlockedMessage": "You can only message official Divine accounts",
     "dmSendFailedMessage": "Meddelandet kunde inte skickas",
-    "dmSendFailedSubtitle": "Skicka det igen nu, eller ta bort det från konversationen.",
+    "dmSendFailedSubtitle": "Skicka det igen nu, eller sluta försöka.",
     "dmSendFailedRetry": "Försök igen",
     "dmSendPartialMessage": "Skickat, men inte synkat till dina andra enheter",
     "dmStatusFailed": "Kunde inte skicka",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2476,6 +2476,7 @@
     "profileSetupUploadStaged": "Uppladdad — tryck på Spara för att tillämpa",
     "dmSendBlockedMessage": "You can only message official Divine accounts",
     "dmSendFailedMessage": "Meddelandet kunde inte skickas",
+    "dmSendFailedSubtitle": "Skicka det igen nu, eller ta bort det från konversationen.",
     "dmSendFailedRetry": "Försök igen",
     "dmSendPartialMessage": "Skickat, men inte synkat till dina andra enheter",
     "dmStatusFailed": "Kunde inte skicka",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2475,7 +2475,7 @@
     "profileSetupUploadStaged": "Yüklendi — uygulamak için Kaydet'e dokunun",
     "dmSendBlockedMessage": "You can only message official Divine accounts",
     "dmSendFailedMessage": "Mesaj gönderilemedi",
-    "dmSendFailedSubtitle": "Şimdi tekrar gönder ya da sohbetten sil.",
+    "dmSendFailedSubtitle": "Şimdi tekrar gönder ya da denemeyi durdur.",
     "dmSendFailedRetry": "Tekrar Dene",
     "dmSendPartialMessage": "Gönderildi, ama diğer cihazlarınla eşitlenmedi",
     "dmStatusFailed": "Gönderilemedi",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2475,6 +2475,7 @@
     "profileSetupUploadStaged": "Yüklendi — uygulamak için Kaydet'e dokunun",
     "dmSendBlockedMessage": "You can only message official Divine accounts",
     "dmSendFailedMessage": "Mesaj gönderilemedi",
+    "dmSendFailedSubtitle": "Şimdi tekrar gönder ya da sohbetten sil.",
     "dmSendFailedRetry": "Tekrar Dene",
     "dmSendPartialMessage": "Gönderildi, ama diğer cihazlarınla eşitlenmedi",
     "dmStatusFailed": "Gönderilemedi",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -9708,11 +9708,17 @@ abstract class AppLocalizations {
   /// **'You can only message official Divine accounts'**
   String get dmSendBlockedMessage;
 
-  /// SnackBar text shown in a DM conversation when a send fails (relay error, signer error, network error). Paired with the retry action `dmSendFailedRetry`.
+  /// Accessibility announcement text, and the recovery bottom sheet's title, shown in a DM conversation when a send fails (relay error, signer error, network error). The bottom sheet pairs it with `dmSendFailedSubtitle` and the `dmMessageActionRetrySend` / `dmMessageActionCancelSend` actions.
   ///
   /// In en, this message translates to:
   /// **'Message couldn\'t be sent'**
   String get dmSendFailedMessage;
+
+  /// Subtitle in the recovery bottom sheet shown when a failed own DM bubble is tapped, below the `dmSendFailedMessage` title.
+  ///
+  /// In en, this message translates to:
+  /// **'Resend it now, or delete it from the conversation.'**
+  String get dmSendFailedSubtitle;
 
   /// SnackBarAction button label that retries the failed DM send. Keep short — fits next to the SnackBar message.
   ///
@@ -9786,13 +9792,13 @@ abstract class AppLocalizations {
   /// **'Report'**
   String get dmMessageActionReport;
 
-  /// Action in the snackbar shown when a failed own DM bubble is tapped; re-attempts delivery of that queued message.
+  /// Primary action in the recovery bottom sheet shown when a failed own DM bubble is tapped; re-attempts delivery of that queued message.
   ///
   /// In en, this message translates to:
   /// **'Resend'**
   String get dmMessageActionRetrySend;
 
-  /// Action in the snackbar shown when a failed own DM bubble is tapped; stops retrying the undelivered recipients and keeps the message (and any already-delivered copies). It does not delete the message — long-press delete does that.
+  /// Secondary action in the recovery bottom sheet shown when a failed own DM bubble is tapped; gives up on the queued message and removes it.
   ///
   /// In en, this message translates to:
   /// **'Stop trying'**

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -9717,7 +9717,7 @@ abstract class AppLocalizations {
   /// Subtitle in the recovery bottom sheet shown when a failed own DM bubble is tapped, below the `dmSendFailedMessage` title.
   ///
   /// In en, this message translates to:
-  /// **'Resend it now, or delete it from the conversation.'**
+  /// **'Resend it now, or stop trying.'**
   String get dmSendFailedSubtitle;
 
   /// SnackBarAction button label that retries the failed DM send. Keep short — fits next to the SnackBar message.

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -5432,6 +5432,9 @@ class AppLocalizationsAm extends AppLocalizations {
   String get dmSendFailedMessage => 'መልዕክቱ መላክ አልተሳካም';
 
   @override
+  String get dmSendFailedSubtitle => 'አሁን እንደገና ላክ ወይም ከውይይቱ ሰርዝ።';
+
+  @override
   String get dmSendFailedRetry => 'እንደገና ይሞክሩ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -5432,7 +5432,7 @@ class AppLocalizationsAm extends AppLocalizations {
   String get dmSendFailedMessage => 'መልዕክቱ መላክ አልተሳካም';
 
   @override
-  String get dmSendFailedSubtitle => 'አሁን እንደገና ላክ ወይም ከውይይቱ ሰርዝ።';
+  String get dmSendFailedSubtitle => 'አሁን እንደገና ላክ ወይም መሞከር አቁም።';
 
   @override
   String get dmSendFailedRetry => 'እንደገና ይሞክሩ';

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -5512,6 +5512,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get dmSendFailedMessage => 'تعذّر إرسال الرسالة';
 
   @override
+  String get dmSendFailedSubtitle => 'أعد إرسالها الآن، أو احذفها من المحادثة.';
+
+  @override
   String get dmSendFailedRetry => 'إعادة المحاولة';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -5512,7 +5512,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get dmSendFailedMessage => 'تعذّر إرسال الرسالة';
 
   @override
-  String get dmSendFailedSubtitle => 'أعد إرسالها الآن، أو احذفها من المحادثة.';
+  String get dmSendFailedSubtitle => 'أعد إرسالها الآن، أو أوقف المحاولة.';
 
   @override
   String get dmSendFailedRetry => 'إعادة المحاولة';

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -5597,6 +5597,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get dmSendFailedMessage => 'Съобщението не мина';
 
   @override
+  String get dmSendFailedSubtitle =>
+      'Изпрати го отново сега или го изтрий от разговора.';
+
+  @override
   String get dmSendFailedRetry => 'Опитай пак';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -5597,8 +5597,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get dmSendFailedMessage => 'Съобщението не мина';
 
   @override
-  String get dmSendFailedSubtitle =>
-      'Изпрати го отново сега или го изтрий от разговора.';
+  String get dmSendFailedSubtitle => 'Изпрати го отново сега или спри опитите.';
 
   @override
   String get dmSendFailedRetry => 'Опитай пак';

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -5612,7 +5612,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get dmSendFailedSubtitle =>
-      'Sende sie jetzt erneut oder lösche sie aus der Unterhaltung.';
+      'Sende sie jetzt erneut oder versuche es nicht mehr.';
 
   @override
   String get dmSendFailedRetry => 'Erneut versuchen';

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -5611,6 +5611,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get dmSendFailedMessage => 'Nachricht konnte nicht gesendet werden';
 
   @override
+  String get dmSendFailedSubtitle =>
+      'Sende sie jetzt erneut oder lösche sie aus der Unterhaltung.';
+
+  @override
   String get dmSendFailedRetry => 'Erneut versuchen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -5542,6 +5542,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get dmSendFailedMessage => 'Message couldn\'t be sent';
 
   @override
+  String get dmSendFailedSubtitle =>
+      'Resend it now, or delete it from the conversation.';
+
+  @override
   String get dmSendFailedRetry => 'Retry';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -5542,8 +5542,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get dmSendFailedMessage => 'Message couldn\'t be sent';
 
   @override
-  String get dmSendFailedSubtitle =>
-      'Resend it now, or delete it from the conversation.';
+  String get dmSendFailedSubtitle => 'Resend it now, or stop trying.';
 
   @override
   String get dmSendFailedRetry => 'Retry';

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -5588,6 +5588,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get dmSendFailedMessage => 'No se pudo enviar el mensaje';
 
   @override
+  String get dmSendFailedSubtitle =>
+      'Reenvíalo ahora o elimínalo de la conversación.';
+
+  @override
   String get dmSendFailedRetry => 'Reintentar';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -5588,8 +5588,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get dmSendFailedMessage => 'No se pudo enviar el mensaje';
 
   @override
-  String get dmSendFailedSubtitle =>
-      'Reenvíalo ahora o elimínalo de la conversación.';
+  String get dmSendFailedSubtitle => 'Reenvíalo ahora o deja de intentarlo.';
 
   @override
   String get dmSendFailedRetry => 'Reintentar';

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -5612,7 +5612,7 @@ class AppLocalizationsFil extends AppLocalizations {
 
   @override
   String get dmSendFailedSubtitle =>
-      'I-resend ito ngayon, o burahin ito sa usapan.';
+      'I-resend ito ngayon, o itigil ang pagsubok.';
 
   @override
   String get dmSendFailedRetry => 'Subukan ulit';

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -5611,6 +5611,10 @@ class AppLocalizationsFil extends AppLocalizations {
   String get dmSendFailedMessage => 'Hindi naipadala ang message';
 
   @override
+  String get dmSendFailedSubtitle =>
+      'I-resend ito ngayon, o burahin ito sa usapan.';
+
+  @override
   String get dmSendFailedRetry => 'Subukan ulit';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -5616,6 +5616,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get dmSendFailedMessage => 'Impossible d\'envoyer le message';
 
   @override
+  String get dmSendFailedSubtitle =>
+      'Renvoie-le maintenant, ou supprime-le de la conversation.';
+
+  @override
   String get dmSendFailedRetry => 'Réessayer';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -5617,7 +5617,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get dmSendFailedSubtitle =>
-      'Renvoie-le maintenant, ou supprime-le de la conversation.';
+      'Renvoie-le maintenant, ou arrête d\'essayer.';
 
   @override
   String get dmSendFailedRetry => 'Réessayer';

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -5518,6 +5518,10 @@ class AppLocalizationsId extends AppLocalizations {
   String get dmSendFailedMessage => 'Pesan gagal dikirim';
 
   @override
+  String get dmSendFailedSubtitle =>
+      'Kirim ulang sekarang, atau hapus dari percakapan.';
+
+  @override
   String get dmSendFailedRetry => 'Coba Lagi';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -5519,7 +5519,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get dmSendFailedSubtitle =>
-      'Kirim ulang sekarang, atau hapus dari percakapan.';
+      'Kirim ulang sekarang, atau berhenti mencoba.';
 
   @override
   String get dmSendFailedRetry => 'Coba Lagi';

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -5594,6 +5594,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get dmSendFailedMessage => 'Impossibile inviare il messaggio';
 
   @override
+  String get dmSendFailedSubtitle =>
+      'Invialo di nuovo ora, oppure eliminalo dalla conversazione.';
+
+  @override
   String get dmSendFailedRetry => 'Riprova';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -5595,7 +5595,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get dmSendFailedSubtitle =>
-      'Invialo di nuovo ora, oppure eliminalo dalla conversazione.';
+      'Invialo di nuovo ora, oppure smetti di provare.';
 
   @override
   String get dmSendFailedRetry => 'Riprova';

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -5315,6 +5315,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get dmSendFailedMessage => 'メッセージを送信できなかった';
 
   @override
+  String get dmSendFailedSubtitle => '今すぐ再送するか、会話から削除してね。';
+
+  @override
   String get dmSendFailedRetry => 'もう一回';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -5315,7 +5315,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get dmSendFailedMessage => 'メッセージを送信できなかった';
 
   @override
-  String get dmSendFailedSubtitle => '今すぐ再送するか、会話から削除してね。';
+  String get dmSendFailedSubtitle => '今すぐ再送するか、送信を中止してね。';
 
   @override
   String get dmSendFailedRetry => 'もう一回';

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -5335,7 +5335,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get dmSendFailedMessage => '메시지를 보내지 못했어요';
 
   @override
-  String get dmSendFailedSubtitle => '지금 다시 보내거나 대화에서 삭제하세요.';
+  String get dmSendFailedSubtitle => '지금 다시 보내거나 전송을 중단하세요.';
 
   @override
   String get dmSendFailedRetry => '다시 시도';

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -5335,6 +5335,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get dmSendFailedMessage => '메시지를 보내지 못했어요';
 
   @override
+  String get dmSendFailedSubtitle => '지금 다시 보내거나 대화에서 삭제하세요.';
+
+  @override
   String get dmSendFailedRetry => '다시 시도';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -5571,7 +5571,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get dmSendFailedSubtitle =>
-      'Verstuur het nu opnieuw, of verwijder het uit het gesprek.';
+      'Verstuur het nu opnieuw, of stop met proberen.';
 
   @override
   String get dmSendFailedRetry => 'Opnieuw';

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -5570,6 +5570,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get dmSendFailedMessage => 'Bericht kon niet worden verzonden';
 
   @override
+  String get dmSendFailedSubtitle =>
+      'Verstuur het nu opnieuw, of verwijder het uit het gesprek.';
+
+  @override
   String get dmSendFailedRetry => 'Opnieuw';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -5689,6 +5689,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get dmSendFailedMessage => 'Nie udało się wysłać wiadomości';
 
   @override
+  String get dmSendFailedSubtitle =>
+      'Wyślij ją ponownie teraz albo usuń ją z rozmowy.';
+
+  @override
   String get dmSendFailedRetry => 'Spróbuj ponownie';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -5690,7 +5690,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get dmSendFailedSubtitle =>
-      'Wyślij ją ponownie teraz albo usuń ją z rozmowy.';
+      'Wyślij ją ponownie teraz albo przestań próbować.';
 
   @override
   String get dmSendFailedRetry => 'Spróbuj ponownie';

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -5579,6 +5579,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get dmSendFailedMessage => 'Falha ao enviar a mensagem';
 
   @override
+  String get dmSendFailedSubtitle =>
+      'Reenvie agora, ou exclua a mensagem da conversa.';
+
+  @override
   String get dmSendFailedRetry => 'Tentar novamente';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -5579,8 +5579,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get dmSendFailedMessage => 'Falha ao enviar a mensagem';
 
   @override
-  String get dmSendFailedSubtitle =>
-      'Reenvie agora, ou exclua a mensagem da conversa.';
+  String get dmSendFailedSubtitle => 'Reenvie agora, ou pare de tentar.';
 
   @override
   String get dmSendFailedRetry => 'Tentar novamente';

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -5697,8 +5697,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get dmSendFailedMessage => 'Mesajul nu a putut fi trimis';
 
   @override
-  String get dmSendFailedSubtitle =>
-      'Retrimite-l acum sau șterge-l din conversație.';
+  String get dmSendFailedSubtitle => 'Retrimite-l acum sau nu mai încerca.';
 
   @override
   String get dmSendFailedRetry => 'Reîncearcă';

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -5697,6 +5697,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get dmSendFailedMessage => 'Mesajul nu a putut fi trimis';
 
   @override
+  String get dmSendFailedSubtitle =>
+      'Retrimite-l acum sau șterge-l din conversație.';
+
+  @override
   String get dmSendFailedRetry => 'Reîncearcă';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -5542,6 +5542,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get dmSendFailedMessage => 'Meddelandet kunde inte skickas';
 
   @override
+  String get dmSendFailedSubtitle =>
+      'Skicka det igen nu, eller ta bort det från konversationen.';
+
+  @override
   String get dmSendFailedRetry => 'Försök igen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -5542,8 +5542,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get dmSendFailedMessage => 'Meddelandet kunde inte skickas';
 
   @override
-  String get dmSendFailedSubtitle =>
-      'Skicka det igen nu, eller ta bort det från konversationen.';
+  String get dmSendFailedSubtitle => 'Skicka det igen nu, eller sluta försöka.';
 
   @override
   String get dmSendFailedRetry => 'Försök igen';

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -5525,7 +5525,8 @@ class AppLocalizationsTr extends AppLocalizations {
   String get dmSendFailedMessage => 'Mesaj gönderilemedi';
 
   @override
-  String get dmSendFailedSubtitle => 'Şimdi tekrar gönder ya da sohbetten sil.';
+  String get dmSendFailedSubtitle =>
+      'Şimdi tekrar gönder ya da denemeyi durdur.';
 
   @override
   String get dmSendFailedRetry => 'Tekrar Dene';

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -5525,6 +5525,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get dmSendFailedMessage => 'Mesaj gönderilemedi';
 
   @override
+  String get dmSendFailedSubtitle => 'Şimdi tekrar gönder ya da sohbetten sil.';
+
+  @override
   String get dmSendFailedRetry => 'Tekrar Dene';
 
   @override

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -46,6 +46,10 @@ class ConversationView extends ConsumerStatefulWidget {
   ConsumerState<ConversationView> createState() => _ConversationViewState();
 }
 
+/// The choice made on the recovery bottom sheet opened by
+/// [_ConversationViewState._onFailedMessageTap].
+enum _FailedMessageAction { resend, delete }
+
 class _ConversationViewState extends ConsumerState<ConversationView> {
   Future<void> _onOptions(String otherPubkey, String displayName) async {
     if (otherPubkey.isEmpty) return;
@@ -502,58 +506,31 @@ class _MessageList extends StatelessWidget {
     }
   }
 
-  /// Tapping a failed own bubble surfaces a native divine snackbar offering a
-  /// queue-aware resend or a "Stop trying". Resend replays the batch's FAILED
+  /// Tapping a failed own bubble opens a recovery bottom sheet offering a
+  /// queue-aware resend or a delete. Resend replays the batch's FAILED
   /// row(s) via [ConversationFullSendRecoveryRequested] (a manual retry
   /// bypasses the sweep's retry-count cap) — never the siblings that
-  /// already delivered. "Stop trying" cancels every UNDELIVERED sibling row
-  /// (pending + failed) via [ConversationOutgoingSendCancelled] so the retry
-  /// sweep stops re-driving them; it does NOT delete the persisted bubble
-  /// (long-press delete is the real delete-for-everyone path). Cancelling
-  /// only the failed ones would leave pending siblings for the sweep to
-  /// publish after the user said give up, so all undelivered rows go.
-  /// Delivered-awaiting-self-wrap rows are excluded — those recipients
-  /// already have the message. Both actions are one-shot, dismiss the
-  /// snackbar, and no-op once the bloc is closed (the snackbar can outlive
-  /// the route).
-  void _onFailedMessageTap(BuildContext context, DmMessage message) {
+  /// already delivered. Delete ("cancel send") drops every UNDELIVERED
+  /// sibling row (pending + failed) via [ConversationOutgoingSendCancelled]:
+  /// cancelling only the failed ones left pending siblings for the retry
+  /// sweep to publish after the user said give up. Delivered-awaiting-
+  /// self-wrap rows are excluded — those recipients already have the
+  /// message. The sheet is modal, so both actions are inherently one-shot;
+  /// the bloc is still checked for closure before dispatching, since the
+  /// route (and its bloc) can be torn down while the sheet is open.
+  Future<void> _onFailedMessageTap(
+    BuildContext context,
+    DmMessage message,
+  ) async {
     final l10n = context.l10n;
     final bloc = context.read<ConversationBloc>();
-    final messenger = ScaffoldMessenger.of(context);
     final failedIds = bloc.state.failedSiblingRumorIdsFor(message.id);
     final resendIds = failedIds.isEmpty ? [message.id] : failedIds;
     final undeliveredIds = bloc.state.undeliveredSiblingRumorIdsFor(
       message.id,
     );
     final cancelIds = undeliveredIds.isEmpty ? [message.id] : undeliveredIds;
-    var handled = false;
-    void runOnce(void Function() action) {
-      if (handled || bloc.isClosed) return;
-      handled = true;
-      messenger.hideCurrentSnackBar();
-      action();
-    }
 
-    messenger
-      ..hideCurrentSnackBar()
-      ..showSnackBar(
-        DivineSnackbarContainer.snackBar(
-          l10n.dmSendFailedMessage,
-          error: true,
-          actionLabel: l10n.dmMessageActionRetrySend,
-          onActionPressed: () => runOnce(
-            () => bloc.add(
-              ConversationFullSendRecoveryRequested(rumorIds: resendIds),
-            ),
-          ),
-          secondaryActionLabel: l10n.dmMessageActionCancelSend,
-          onSecondaryActionPressed: () => runOnce(() {
-            for (final id in cancelIds) {
-              bloc.add(ConversationOutgoingSendCancelled(rumorId: id));
-            }
-          }),
-        ),
-      );
     // Per `accessibility.md`, async visible state changes must announce
     // explicitly — same rule as the blocked/partial snackbars in
     // [_onSendOutcome].
@@ -562,6 +539,31 @@ class _MessageList extends StatelessWidget {
       l10n.dmSendFailedMessage,
       Directionality.of(context),
     );
+
+    final action = await VineBottomSheetPrompt.show<_FailedMessageAction>(
+      context: context,
+      sticker: DivineStickerName.alert,
+      title: l10n.dmSendFailedMessage,
+      subtitle: l10n.dmSendFailedSubtitle,
+      primaryButtonText: l10n.dmMessageActionRetrySend,
+      onPrimaryPressed: () =>
+          Navigator.of(context).pop(_FailedMessageAction.resend),
+      secondaryButtonText: l10n.dmMessageActionCancelSend,
+      onSecondaryPressed: () =>
+          Navigator.of(context).pop(_FailedMessageAction.delete),
+    );
+
+    if (bloc.isClosed) return;
+    switch (action) {
+      case _FailedMessageAction.resend:
+        bloc.add(ConversationFullSendRecoveryRequested(rumorIds: resendIds));
+      case _FailedMessageAction.delete:
+        for (final id in cancelIds) {
+          bloc.add(ConversationOutgoingSendCancelled(rumorId: id));
+        }
+      case null:
+        return;
+    }
   }
 
   void _toggleReaction(BuildContext context, DmMessage message, String emoji) {

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -540,11 +540,16 @@ class _MessageList extends StatelessWidget {
       Directionality.of(context),
     );
 
+    // The prompt must stay open until the user picks resend or stop-trying
+    // (#6092): block both barrier-tap and drag-to-dismiss so a stray gesture
+    // can't return null and silently leave the failed send untouched.
     final action = await VineBottomSheetPrompt.show<_FailedMessageAction>(
       context: context,
       sticker: DivineStickerName.alert,
       title: l10n.dmSendFailedMessage,
       subtitle: l10n.dmSendFailedSubtitle,
+      isDismissible: false,
+      enableDrag: false,
       primaryButtonText: l10n.dmMessageActionRetrySend,
       onPrimaryPressed: () =>
           Navigator.of(context).pop(_FailedMessageAction.resend),
@@ -678,8 +683,8 @@ class _MessageList extends StatelessWidget {
             isLastInGroup: isLastInGroup,
             onLongPress: () =>
                 _onMessageLongPress(context, message, isSent, status),
-            // A single tap on a failed own bubble opens the resend/delete
-            // divine snackbar; every other bubble keeps its default tap.
+            // A single tap on a failed own bubble opens the resend/stop-trying
+            // recovery bottom sheet; every other bubble keeps its default tap.
             onTap: isSent && status == DmDeliveryStatus.failed
                 ? () => _onFailedMessageTap(context, message)
                 : null,

--- a/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet_prompt.dart
+++ b/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet_prompt.dart
@@ -108,6 +108,11 @@ class VineBottomSheetPrompt extends StatelessWidget {
   final VoidCallback? onSecondaryPressed;
 
   /// Shows the prompt sheet as a fixed modal bottom sheet.
+  ///
+  /// Set both [isDismissible] and [enableDrag] to false for a prompt that
+  /// must stay open until the user picks an action — [isDismissible] blocks
+  /// barrier taps and [enableDrag] blocks drag-to-dismiss. Setting only one
+  /// leaves the other dismissal path active.
   static Future<T?> show<T>({
     required BuildContext context,
     required DivineStickerName sticker,
@@ -122,12 +127,14 @@ class VineBottomSheetPrompt extends StatelessWidget {
     String? tertiaryButtonText,
     VoidCallback? onTertiaryPressed,
     bool isDismissible = true,
+    bool enableDrag = true,
   }) {
     return VineBottomSheet.show<T>(
       context: context,
       scrollable: false,
       showHeaderDivider: false,
       isDismissible: isDismissible,
+      enableDrag: enableDrag,
       body: VineBottomSheetPrompt(
         sticker: sticker,
         title: title,

--- a/mobile/packages/divine_ui/test/src/bottom_sheet/vine_bottom_sheet_prompt_test.dart
+++ b/mobile/packages/divine_ui/test/src/bottom_sheet/vine_bottom_sheet_prompt_test.dart
@@ -440,6 +440,57 @@ void main() {
 
         expect(find.text('Dismissable'), findsNothing);
       });
+
+      testWidgets(
+        'stays open when isDismissible and enableDrag are false',
+        (tester) async {
+          await tester.pumpWidget(
+            MaterialApp(
+              home: DefaultAssetBundle(
+                bundle: bundle,
+                child: Scaffold(
+                  body: Builder(
+                    builder: (context) => ElevatedButton(
+                      onPressed: () async {
+                        await VineBottomSheetPrompt.show<void>(
+                          context: context,
+                          sticker: DivineStickerName.alert,
+                          title: 'Locked',
+                          subtitle: 'Pick an action',
+                          primaryButtonText: 'OK',
+                          onPrimaryPressed: () {},
+                          secondaryButtonText: 'Cancel',
+                          onSecondaryPressed: () {},
+                          isDismissible: false,
+                          enableDrag: false,
+                        );
+                      },
+                      child: const Text('Show Sheet'),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          );
+
+          await tester.tap(find.text('Show Sheet'));
+          await tester.pumpAndSettle();
+
+          expect(find.text('Locked'), findsOneWidget);
+
+          // A barrier tap above the sheet must not dismiss it.
+          await tester.tapAt(const Offset(10, 10));
+          await tester.pumpAndSettle();
+          expect(find.text('Locked'), findsOneWidget);
+
+          // enableDrag is threaded through to the modal so a downward drag
+          // can't dismiss it either. The framework gates drag-dismissal on
+          // BottomSheet.enableDrag; assert the forwarded flag directly, since
+          // a simulated fling inside the scroll body is gesture-arena-flaky.
+          final sheet = tester.widget<BottomSheet>(find.byType(BottomSheet));
+          expect(sheet.enableDrag, isFalse);
+        },
+      );
     });
   });
 }

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -847,8 +847,8 @@ void main() {
 
     // Send-failure UX (companion to ConversationBloc's clear-optimistic-on-
     // failure behavior). On `SendStatus.failed`, the bloc strips the
-    // optimistic message; the UI's job is to surface a retry SnackBar so
-    // the user knows the send actually failed and has a one-tap recovery.
+    // optimistic message; the UI's job is to surface a retry bottom sheet
+    // so the user knows the send actually failed and has a one-tap recovery.
     // Without this listener, the only visible change would be a brief
     // spinner flicker, and the user would discover the loss only after
     // navigating away and back — the "looks sent, then disappeared" bug.
@@ -857,7 +857,7 @@ void main() {
 
       testWidgets(
         'shows NO toast on a hard failure — the failure is surfaced on the '
-        'bubble (tap → resend/stop-trying), not a snackbar',
+        'bubble (tap → resend/delete bottom sheet), not a snackbar',
         (tester) async {
           // Emit loaded → failed. listenWhen no longer fires for `failed`.
           whenListen(
@@ -949,8 +949,8 @@ void main() {
       );
 
       testWidgets(
-        'tapping a failed bubble opens the divine snackbar; Resend replays '
-        'the row and Stop trying drops it (never a fresh '
+        'tapping a failed bubble opens the recovery bottom sheet; Resend '
+        'replays the row and Delete drops it (never a fresh '
         'ConversationMessageSent)',
         (tester) async {
           final failedRow = OutgoingDm(
@@ -1008,7 +1008,7 @@ void main() {
           );
           await tester.pumpAndSettle();
 
-          // Tap the failed bubble to open the resend/stop-trying snackbar.
+          // Tap the failed bubble to open the resend/delete bottom sheet.
           await tester.tap(find.text(failedSendContent));
           await tester.pumpAndSettle();
 
@@ -1022,7 +1022,7 @@ void main() {
           // Resend replays the existing row via recoverFullSend — never a
           // fresh ConversationMessageSent (no duplicate delivery).
           await tester.tap(find.text(l10n.dmMessageActionRetrySend));
-          await tester.pump();
+          await tester.pumpAndSettle();
           final afterResend = verify(() => mockBloc.add(captureAny())).captured;
           expect(
             afterResend.last,
@@ -1042,7 +1042,7 @@ void main() {
           await tester.tap(find.text(failedSendContent));
           await tester.pumpAndSettle();
           await tester.tap(find.text(l10n.dmMessageActionCancelSend));
-          await tester.pump();
+          await tester.pumpAndSettle();
           final afterDelete = verify(() => mockBloc.add(captureAny())).captured;
           expect(
             afterDelete.last,
@@ -1160,7 +1160,7 @@ void main() {
           await tester.pumpAndSettle();
 
           await tester.tap(find.text(l10n.dmMessageActionRetrySend));
-          await tester.pump();
+          await tester.pumpAndSettle();
           final afterResend = verify(() => mockBloc.add(captureAny())).captured;
           expect(
             afterResend.whereType<ConversationFullSendRecoveryRequested>(),
@@ -1181,7 +1181,7 @@ void main() {
           await tester.tap(find.text(failedSendContent));
           await tester.pumpAndSettle();
           await tester.tap(find.text(l10n.dmMessageActionCancelSend));
-          await tester.pump();
+          await tester.pumpAndSettle();
           final cancelled = verify(() => mockBloc.add(captureAny())).captured
               .whereType<ConversationOutgoingSendCancelled>()
               .map((e) => e.rumorId)


### PR DESCRIPTION
## Description

The failed-DM-send recovery UI (tap a failed own bubble → Resend / Delete
message) was a `DivineSnackbarContainer` SnackBar. Two problems with that,
most visible in longer-string locales like German:

- Layout: the SnackBar is a `Row` with the info text in an `Expanded` and
  the two action buttons taking intrinsic width. Longer action labels (e.g.
  German "Erneut senden" / "Nachricht löschen" vs English "Resend" /
  "Delete message") squeeze the info text into a narrow, wrapped column.
- Timing: SnackBars in this app auto-dismiss after 4s by default, which is
  a bad fit for a prompt that requires reading two options and deciding —
  worse the longer the copy is.

Swapped to `VineBottomSheetPrompt` (the existing prompt-style bottom sheet
already used for confirm/discard flows elsewhere, e.g.
`library_trash_screen.dart`, `video_editor_main_overlay_actions.dart`).
It gives the copy full width and stays open until the user picks an
action. Same bloc events dispatched on each choice
(`ConversationFullSendRecoveryRequested` / `ConversationOutgoingSendCancelled`),
same accessibility announcement, same retry-batch/undelivered-sibling
targeting logic — only the presentation changed.

Added a new `dmSendFailedSubtitle` l10n string (translated into all 18
locales) since the bottom sheet needs a title + subtitle, where the
SnackBar only had a single line of text.

**Related Issue:** Fixes #6092

## Out of Scope

The blocked-message toast and the partial-delivery-retry toast elsewhere
in `_onSendOutcome` are unrelated flows and were intentionally left as
SnackBars (single message + single action, no crowding/timing concern).

## Verification

- `flutter analyze lib test integration_test` — clean
- `flutter test test/screens/inbox/conversation/conversation_view_test.dart` — 33/33 pass (updated for the sheet's animated dismiss instead of the SnackBar's immediate dismiss)
- `flutter test test/l10n/arb_consistency_test.dart` — pass
- `dart format` — clean
- Manually verified on an iPhone 17 Pro Max simulator with the device locale set to German — the bottom sheet renders full-width, readable, no crowding.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
