### PR TITLE
feat(upload): resume interrupted publishes from the server's last offset

### DIFF
--- a/docs/protocol/blossom/2026-03-26-divine-resumable-upload-sessions-bud.md
+++ b/docs/protocol/blossom/2026-03-26-divine-resumable-upload-sessions-bud.md
@@ -1,6 +1,6 @@
 Status: Draft Divine Extension
 
-Mobile client status: Implemented behind capability discovery and legacy fallback in `mobile/lib/services/blossom_upload_service.dart` and `mobile/lib/services/upload_manager.dart`.
+Mobile client status: Implemented behind capability discovery and legacy fallback in `mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart` and `mobile/lib/services/upload_manager.dart`. A fresh publish attempts the OS-backed whole-file `PUT` first (`uploadVideoInBackground`); on failure, or when a persisted resumable session already exists, `uploadVideoWithResume` falls through to the chunked resumable protocol so retries resume from the server's last committed `Upload-Offset` instead of byte 0.
 
 # Divine Resumable Upload Sessions for Blossom
 

--- a/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
+++ b/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
@@ -197,6 +197,9 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
       BlossomUploadFailureReason.auth => AvatarUploadError.auth,
       BlossomUploadFailureReason.fileTooLarge => AvatarUploadError.fileTooLarge,
       BlossomUploadFailureReason.server => AvatarUploadError.server,
+      // A user-cancelled avatar upload has no meaningful error to show; fall
+      // through to the generic copy alongside other unclassified failures.
+      BlossomUploadFailureReason.cancelled ||
       BlossomUploadFailureReason.unknown => AvatarUploadError.generic,
     };
   }
@@ -356,6 +359,9 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
       BlossomUploadFailureReason.auth => BannerUploadError.auth,
       BlossomUploadFailureReason.fileTooLarge => BannerUploadError.fileTooLarge,
       BlossomUploadFailureReason.server => BannerUploadError.server,
+      // A user-cancelled banner upload has no meaningful error to show; fall
+      // through to the generic copy alongside other unclassified failures.
+      BlossomUploadFailureReason.cancelled ||
       BlossomUploadFailureReason.unknown => BannerUploadError.generic,
     };
   }

--- a/mobile/lib/services/upload/upload_retry_policy.dart
+++ b/mobile/lib/services/upload/upload_retry_policy.dart
@@ -300,7 +300,10 @@ class UploadRetryPolicy {
           reason == BlossomUploadFailureReason.network) {
         return true;
       }
-      if (reason == BlossomUploadFailureReason.auth ||
+      // A user pause/cancel is a deliberate, terminal stop — never retry it,
+      // or the retry loop would re-upload the file the user just stopped.
+      if (reason == BlossomUploadFailureReason.cancelled ||
+          reason == BlossomUploadFailureReason.auth ||
           reason == BlossomUploadFailureReason.fileTooLarge) {
         return false;
       }

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -154,10 +154,14 @@ class UploadManager implements BackgroundAwareService {
     );
   }
 
-  /// Routes the video transfer through the OS background uploader
-  /// ([BlossomUploadService.uploadVideoInBackground]) instead of the in-process
-  /// chunked/legacy path, so it survives app suspension. Requires the
-  /// blossom service to have been built with a background transport.
+  /// Attempts the OS background uploader
+  /// ([BlossomUploadService.uploadVideoInBackground]) *first* for a fresh
+  /// publish — it survives app suspension and is fastest on a healthy
+  /// connection — then falls back to the in-process chunked resumable path if
+  /// that OS attempt fails (a user cancel is treated as terminal and does NOT
+  /// fall back). Set to `false` to skip the OS attempt and go straight to the
+  /// in-process path. Requires the blossom service to have been built with a
+  /// background transport.
   final bool useBackgroundUpload;
 
   // Core services
@@ -1235,16 +1239,19 @@ class UploadManager implements BackgroundAwareService {
       category: LogCategory.video,
     );
 
-    // Mark before tearing down the transfer: cancelling it emits a terminal
-    // event that would otherwise drive the in-flight upload into
-    // [_handleUploadFailure] and overwrite the paused status below.
+    // Mark before tearing down the transfer: cancelling the OS transfer emits
+    // a terminal `cancelled` event that resolves the in-flight upload as a
+    // (terminal, non-retriable) failure, which would otherwise reach
+    // [_handleUploadFailure] and overwrite the paused status below. The marker
+    // lets [_performUpload] recognise the user-initiated stop and skip it.
     _userStoppedUploadIds.add(uploadId);
 
     // Stop the OS-owned background transfer while paused so it doesn't keep
-    // uploading in the background. A background transfer is a single OS-owned
-    // PUT with no resumable checkpoint, so resuming re-enqueues it from byte 0
-    // (unlike the in-process path, which resumes from its resumable session).
-    // The in-process path is torn down by its request timeout.
+    // uploading in the background. With OS-first uploads the transfer may have
+    // already fallen through to the in-process resumable leg; that leg is torn
+    // down by its request timeout, and this cancel is then a harmless no-op on
+    // the already-finished OS task. If the OS leg was still the active one it
+    // has no resumable checkpoint, so resuming re-enqueues it from byte 0.
     if (useBackgroundUpload) {
       await _blossomService.cancelBackgroundUpload(uploadId);
     }

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -868,6 +868,15 @@ class UploadManager implements BackgroundAwareService {
         onProgress,
       );
 
+      if (_userStoppedUploadIds.contains(upload.id)) {
+        Log.info(
+          'Upload ${upload.id} stopped by user; skipping success handling',
+          name: 'UploadManager',
+          category: LogCategory.video,
+        );
+        return;
+      }
+
       // Success - record metrics and complete
       await _handleUploadSuccess(currentUpload, result);
     }, isRetriable: _retryPolicy.isRetriableError);
@@ -1004,6 +1013,16 @@ class UploadManager implements BackgroundAwareService {
         rethrow;
       }
 
+      if (_userStoppedUploadIds.contains(upload.id)) {
+        Log.info(
+          'Upload ${upload.id} stopped by user after video transfer; '
+          'skipping thumbnail and success handling',
+          name: 'UploadManager',
+          category: LogCategory.video,
+        );
+        return result;
+      }
+
       // Generate and upload thumbnail after video upload succeeds
       String? thumbnailCdnUrl;
       if (result.success && result.cdnUrl != null) {
@@ -1079,6 +1098,15 @@ class UploadManager implements BackgroundAwareService {
     final metrics = _reporter.metricsFor(upload.id);
 
     if (result.success == true) {
+      if (_userStoppedUploadIds.contains(upload.id)) {
+        Log.info(
+          'Upload ${upload.id} stopped by user; ignoring late success result',
+          name: 'UploadManager',
+          category: LogCategory.video,
+        );
+        return;
+      }
+
       // Get the LATEST upload record from Hive (may have been updated with thumbnail URL)
       final latestUpload = getUpload(upload.id) ?? upload;
 

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -941,66 +941,63 @@ class UploadManager implements BackgroundAwareService {
         onProgress?.call(progress);
       }
 
-      // Background uploads are a single OS-owned PUT that survives suspension.
-      // The OS keeps the transfer alive across app suspension, so it must not
-      // be cut off by the aggressive in-process network timeout;
-      // uploadVideoInBackground applies its own generous safety timeout and
-      // releases its event subscription internally. The in-process path keeps
-      // chunked-resumable behind networkTimeout.
-      final BlossomUploadResult result;
-      if (useBackgroundUpload) {
-        result = await _blossomService.uploadVideoInBackground(
+      // Combined upload path: a fresh publish attempts the OS-owned whole-file
+      // PUT first (it survives app suspension and is fastest on a healthy
+      // connection); on failure, or when a resumable session already exists
+      // from a prior attempt, the request falls through to the chunked
+      // resumable protocol so retries resume from the server's last committed
+      // offset instead of byte 0.
+      //
+      // The OS transfer applies its own generous safety timeout internally and
+      // must NOT be cut by the in-process network timeout — doing so would
+      // defeat the suspension survival that is the whole point of the OS path.
+      // Only the in-process chunked-resumable leg is bounded by networkTimeout
+      // (passed as resumableTimeout), so a stalled socket does not hang
+      // forever. `useBackgroundUpload` is the kill-switch for the OS-first
+      // attempt: flip it to false to go straight to chunked resumable.
+      BlossomUploadResult result;
+      try {
+        result = await _blossomService.uploadVideoWithResume(
           videoFile: videoFile,
+          nostrPubkey: upload.nostrPubkey,
           taskId: upload.id,
+          title: upload.title ?? '',
+          description: upload.description,
+          hashtags: upload.hashtags,
           proofManifestJson: upload.proofManifestJson,
+          useBackgroundFirst: useBackgroundUpload,
+          resumableTimeout: _retryConfig.networkTimeout,
+          resumableSession: upload.resumableSession,
+          onResumableSessionUpdated: (session) {
+            _retryPolicy.enqueueSessionPersist(
+              upload.id,
+              session,
+              videoFile.lengthSync(),
+            );
+          },
           onProgress: reportProgress,
         );
-      } else {
-        result = await _blossomService
-            .uploadVideo(
-              videoFile: videoFile,
-              nostrPubkey: upload.nostrPubkey,
-              title: upload.title ?? '',
-              description: upload.description,
-              hashtags: upload.hashtags,
-              proofManifestJson: upload.proofManifestJson,
-              resumableSession: upload.resumableSession,
-              onResumableSessionUpdated: (session) {
-                _retryPolicy.enqueueSessionPersist(
-                  upload.id,
-                  session,
-                  videoFile.lengthSync(),
-                );
-              },
-              onProgress: reportProgress,
-            )
-            .timeout(
-              _retryConfig.networkTimeout,
-              onTimeout: () {
-                Log.error(
-                  '⏱️ Upload timed out!',
-                  name: 'UploadManager',
-                  category: LogCategory.video,
-                );
-                final timeoutError = TimeoutException(
-                  'Upload timed out after '
-                  '${_retryConfig.networkTimeout.inMinutes} minutes',
-                );
+      } on TimeoutException catch (_) {
+        Log.error(
+          '⏱️ Upload timed out!',
+          name: 'UploadManager',
+          category: LogCategory.video,
+        );
+        final timeoutError = TimeoutException(
+          'Upload timed out after '
+          '${_retryConfig.networkTimeout.inMinutes} minutes',
+        );
 
-                // Send timeout crash report asynchronously
-                _reporter
-                    .sendTimeoutCrashReport(upload, timeoutError)
-                    .catchError((e) {
-                      Log.error(
-                        'Failed to send timeout crash report: $e',
-                        name: 'UploadManager',
-                        category: LogCategory.video,
-                      );
-                    });
+        // Send timeout crash report asynchronously
+        _reporter.sendTimeoutCrashReport(upload, timeoutError).catchError((e) {
+          Log.error(
+            'Failed to send timeout crash report: $e',
+            name: 'UploadManager',
+            category: LogCategory.video,
+          );
+        });
 
-                throw timeoutError;
-              },
-            );
+        rethrow;
       }
 
       // Generate and upload thumbnail after video upload succeeds

--- a/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
@@ -110,6 +110,13 @@ enum BlossomUploadFailureReason {
   /// "our servers are temporarily unavailable".
   server,
 
+  /// The user stopped the upload (pause / cancel) while it was in flight.
+  /// User-initiated and terminal: the caller must NOT retry or fall back to
+  /// another transport, and it is NOT reportable to Crashlytics. Distinct
+  /// from [unknown] so a deliberate stop is never mistaken for a transport
+  /// failure that warrants re-uploading the whole file.
+  cancelled,
+
   /// Anything else: unmapped 4xx, malformed responses, configuration
   /// errors, or unexpected exceptions. Caller falls back to a generic
   /// "upload failed" message.
@@ -2313,6 +2320,15 @@ class BlossomUploadService {
         if (backgroundResult.success) {
           return backgroundResult;
         }
+        // A user pause/cancel tears down the OS transfer, which surfaces as a
+        // `cancelled` terminal event. That is a deliberate, terminal stop —
+        // falling through to runResumable() would re-upload the whole file
+        // from byte 0 and let a later success overwrite the paused/cancelled
+        // state (#6086). Only genuine transport failures fall through.
+        if (backgroundResult.failureReason ==
+            BlossomUploadFailureReason.cancelled) {
+          return backgroundResult;
+        }
         Log.warning(
           'OS-first upload failed '
           '(${backgroundResult.failureReason}); '
@@ -2331,6 +2347,13 @@ class BlossomUploadService {
           category: LogCategory.video,
         );
       }
+
+      // The OS attempt failed (or threw) without being cancelled, so we are
+      // about to run the in-process resumable leg. The native transfer may
+      // still be live — e.g. the OS leg gave up on its own safety timeout
+      // while the OS keeps streaming — so cancel it first; otherwise both
+      // legs would upload the same file concurrently.
+      await cancelBackgroundUpload(taskId);
     }
 
     // Resumable path (also the only path when the OS attempt is disabled or
@@ -2417,7 +2440,7 @@ class BlossomUploadService {
         return const BlossomUploadResult(
           success: false,
           errorMessage: 'Upload cancelled',
-          failureReason: BlossomUploadFailureReason.unknown,
+          failureReason: BlossomUploadFailureReason.cancelled,
         );
       case BlossomBackgroundTransferStatus.running:
       case BlossomBackgroundTransferStatus.failed:

--- a/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
@@ -2242,6 +2242,122 @@ class BlossomUploadService {
     await backgroundTransport?.cancel(taskId);
   }
 
+  /// Uploads [videoFile], combining the OS-backed whole-file transfer with
+  /// Divine resumable sessions so an interrupted publish never re-sends the
+  /// whole file.
+  ///
+  /// Sequencing:
+  /// - When [resumableSession] is `null` (a fresh publish), the OS-backed
+  ///   [uploadVideoInBackground] whole-file `PUT` is attempted first. It
+  ///   survives app suspension and is the fastest path on a healthy
+  ///   connection. If it succeeds, we are done.
+  /// - When that first attempt fails, *or* when [resumableSession] is already
+  ///   present (a prior attempt created a session), the request falls through
+  ///   to [uploadVideo], which runs the chunked resumable protocol:
+  ///   `POST /upload/init` → `HEAD {uploadUrl}` to recover the server's last
+  ///   committed `Upload-Offset` → upload only the remaining chunks →
+  ///   `POST /upload/{id}/complete`. Each committed chunk is reported via
+  ///   [onResumableSessionUpdated] so the caller can persist the offset; the
+  ///   next retry therefore resumes from the last committed byte instead of
+  ///   byte 0.
+  ///
+  /// [useBackgroundFirst] controls the OS-first attempt. Flip it to `false` to
+  /// skip the whole-file PUT and go straight to chunked resumable (the kill-
+  /// switch equivalent of the pre-combined `useBackgroundUpload` flag). When
+  /// `false`, or when no [backgroundTransport] is configured, this behaves
+  /// like [uploadVideo].
+  ///
+  /// [resumableTimeout] bounds only the in-process chunked-resumable leg (and
+  /// only when this method reaches it). It is deliberately NOT applied to the
+  /// OS-backed [uploadVideoInBackground] attempt, which legitimately survives
+  /// long app suspensions under its own generous internal timeout; cutting it
+  /// with an aggressive in-process timeout would defeat the suspension
+  /// survival that is the whole point of the OS path.
+  ///
+  /// The OS uploader is whole-file-only on both platforms, so byte-level
+  /// resume always happens through the in-process chunk path. The OS path is
+  /// only ever used for the first whole-file attempt of a fresh publish.
+  Future<BlossomUploadResult> uploadVideoWithResume({
+    required File videoFile,
+    required String nostrPubkey,
+    required String taskId,
+    required String title,
+    required String? proofManifestJson,
+    required String? description,
+    required List<String>? hashtags,
+    bool useBackgroundFirst = true,
+    Duration? resumableTimeout,
+    BlossomResumableUploadSession? resumableSession,
+    void Function(BlossomResumableUploadSession)? onResumableSessionUpdated,
+    void Function(double)? onProgress,
+  }) async {
+    // A prior attempt already created a session with committed chunks on the
+    // server. Re-running the whole-file OS PUT would discard that progress,
+    // so go straight to chunked resume via HEAD -> remaining chunks.
+    final hasSession = resumableSession != null;
+
+    if (useBackgroundFirst && !hasSession && backgroundTransport != null) {
+      Log.info(
+        'OS-first upload attempt for task $taskId '
+        '(no resumable session yet)',
+        name: 'BlossomUploadService',
+        category: LogCategory.video,
+      );
+      try {
+        final backgroundResult = await uploadVideoInBackground(
+          videoFile: videoFile,
+          taskId: taskId,
+          proofManifestJson: proofManifestJson,
+          onProgress: onProgress,
+        );
+        if (backgroundResult.success) {
+          return backgroundResult;
+        }
+        Log.warning(
+          'OS-first upload failed '
+          '(${backgroundResult.failureReason}); '
+          'falling back to chunked resumable',
+          name: 'BlossomUploadService',
+          category: LogCategory.video,
+        );
+      } on Object catch (e) {
+        // uploadVideoInBackground normally returns failures rather than
+        // throwing, but guard against unexpected exceptions so the publish
+        // still gets a resumable retry rather than dying.
+        Log.warning(
+          'OS-first upload threw ($e); '
+          'falling back to chunked resumable',
+          name: 'BlossomUploadService',
+          category: LogCategory.video,
+        );
+      }
+    }
+
+    // Resumable path (also the only path when the OS attempt is disabled or
+    // unavailable). uploadVideo handles capability discovery, server
+    // iteration, and the init/HEAD/chunk/complete flow, threading the session
+    // callback through so each committed chunk is persisted by the caller.
+    //
+    // Only this in-process leg is bounded by resumableTimeout — the OS leg
+    // above already completed (success or failure) under its own timeout.
+    Future<BlossomUploadResult> runResumable() => uploadVideo(
+      videoFile: videoFile,
+      nostrPubkey: nostrPubkey,
+      title: title,
+      proofManifestJson: proofManifestJson,
+      description: description,
+      hashtags: hashtags,
+      resumableSession: resumableSession,
+      onResumableSessionUpdated: onResumableSessionUpdated,
+      onProgress: onProgress,
+    );
+
+    if (resumableTimeout == null) {
+      return runResumable();
+    }
+    return runResumable().timeout(resumableTimeout);
+  }
+
   /// Maps a terminal [BlossomBackgroundTransferEvent] to a
   /// [BlossomUploadResult].
   ///

--- a/mobile/packages/blossom_upload_service/test/src/blossom_upload_with_resume_test.dart
+++ b/mobile/packages/blossom_upload_service/test/src/blossom_upload_with_resume_test.dart
@@ -14,15 +14,28 @@ class _MockAuthProvider extends Mock implements BlossomAuthProvider {}
 
 class _MockDio extends Mock implements Dio {}
 
-/// A controllable [BlossomBackgroundTransport] that records enqueue calls and
-/// either completes or fails the OS-backed whole-file PUT.
+/// The terminal state a [_FakeTransport] drives its OS-backed PUT to.
+enum _FakeOutcome { completed, failed, cancelled }
+
+/// A controllable [BlossomBackgroundTransport] that records enqueue/cancel
+/// calls and drives the OS-backed whole-file PUT to a chosen terminal state,
+/// optionally after a delay so a test can model an OS transfer that outlasts a
+/// short resumable timeout.
 class _FakeTransport implements BlossomBackgroundTransport {
   _FakeTransport({
-    this.completeSuccessfully = true,
-  });
+    bool completeSuccessfully = true,
+    _FakeOutcome? outcome,
+    this.completionDelay,
+  }) : outcome =
+           outcome ??
+           (completeSuccessfully
+               ? _FakeOutcome.completed
+               : _FakeOutcome.failed);
 
-  final bool completeSuccessfully;
+  final _FakeOutcome outcome;
+  final Duration? completionDelay;
   final List<String> enqueuedTaskIds = <String>[];
+  final List<String> cancelledTaskIds = <String>[];
   final StreamController<BlossomBackgroundTransferEvent> _controller =
       StreamController<BlossomBackgroundTransferEvent>.broadcast();
 
@@ -38,9 +51,23 @@ class _FakeTransport implements BlossomBackgroundTransport {
     required String filePath,
   }) async {
     enqueuedTaskIds.add(taskId);
-    if (completeSuccessfully) {
-      _controller.add(
-        BlossomBackgroundTransferEvent(
+    void emit() {
+      if (_controller.isClosed) return;
+      _controller.add(_terminalEvent(taskId));
+    }
+
+    final delay = completionDelay;
+    if (delay == null) {
+      emit();
+    } else {
+      Timer(delay, emit);
+    }
+  }
+
+  BlossomBackgroundTransferEvent _terminalEvent(String taskId) {
+    switch (outcome) {
+      case _FakeOutcome.completed:
+        return BlossomBackgroundTransferEvent(
           taskId: taskId,
           status: BlossomBackgroundTransferStatus.completed,
           progress: 1,
@@ -48,21 +75,25 @@ class _FakeTransport implements BlossomBackgroundTransport {
           responseBody:
               '{"url":"https://media.divine.video/bg-final",'
               '"fallbackUrl":"https://media.divine.video/bg-final"}',
-        ),
-      );
-    } else {
-      _controller.add(
-        BlossomBackgroundTransferEvent(
+        );
+      case _FakeOutcome.failed:
+        return BlossomBackgroundTransferEvent(
           taskId: taskId,
           status: BlossomBackgroundTransferStatus.failed,
           error: 'network drop',
-        ),
-      );
+        );
+      case _FakeOutcome.cancelled:
+        return BlossomBackgroundTransferEvent(
+          taskId: taskId,
+          status: BlossomBackgroundTransferStatus.cancelled,
+        );
     }
   }
 
   @override
-  Future<void> cancel(String taskId) async {}
+  Future<void> cancel(String taskId) async {
+    cancelledTaskIds.add(taskId);
+  }
 
   @override
   Future<BlossomBackgroundTransferEvent?> takeBufferedTerminalEvent(
@@ -619,8 +650,53 @@ void main() {
     );
 
     test(
-      'resumableTimeout bounds only the in-process resumable leg',
+      'resumableTimeout does NOT bound the OS-first leg',
       () async {
+        // The OS PUT succeeds only after a delay that far exceeds the tiny
+        // resumableTimeout. If a regression wrapped the OS leg in
+        // `.timeout(resumableTimeout)`, that timeout would fire first and this
+        // upload would fail / fall through to the resumable path. Because the
+        // OS leg is deliberately unbounded by resumableTimeout, the delayed OS
+        // success is returned and the resumable control plane is never touched.
+        final transport = _FakeTransport(
+          completionDelay: const Duration(milliseconds: 150),
+        );
+        final service = BlossomUploadService(
+          authProvider: auth,
+          dio: dio,
+          defaultServerUrl: _testServer,
+          backgroundTransport: transport,
+        );
+
+        final result = await service.uploadVideoWithResume(
+          videoFile: videoFile,
+          nostrPubkey: _testPublicKey,
+          taskId: 'task-os-slow',
+          title: 'slow OS success under short resumable timeout',
+          description: null,
+          hashtags: null,
+          proofManifestJson: null,
+          resumableTimeout: const Duration(milliseconds: 5),
+        );
+
+        expect(result.success, isTrue);
+        expect(transport.enqueuedTaskIds, equals(['task-os-slow']));
+        // Resumable leg never reached: the OS leg outlived resumableTimeout and
+        // still won, proving resumableTimeout did not cut it.
+        verifyNever(
+          () => dio.head<dynamic>(any(), options: any(named: 'options')),
+        );
+      },
+    );
+
+    test(
+      'resumableTimeout bounds the in-process resumable leg when reached',
+      () async {
+        // OS PUT fails, so the request falls through to the in-process
+        // resumable leg. That leg hangs (the chunk PUT never completes), so the
+        // only way this returns is via resumableTimeout firing. If a regression
+        // dropped the `.timeout(resumableTimeout)`, the hung PUT would never
+        // resolve and no TimeoutException would surface.
         final transport = _FakeTransport(completeSuccessfully: false);
         final service = BlossomUploadService(
           authProvider: auth,
@@ -631,6 +707,7 @@ void main() {
 
         stubResumableControlPlane(uploadId: 'up_to');
 
+        // Chunk PUT hangs forever — the resumable leg cannot finish on its own.
         when(
           () => dio.put<dynamic>(
             any(),
@@ -638,37 +715,79 @@ void main() {
             options: any(named: 'options'),
             onSendProgress: any(named: 'onSendProgress'),
           ),
-        ).thenAnswer((invocation) async {
-          final options = invocation.namedArguments[#options] as Options;
-          final contentRange = options.headers?['Content-Range'] as String;
-          final nextOffset = switch (contentRange) {
-            'bytes 0-3/8' => '4',
-            'bytes 4-7/8' => '8',
-            _ => throw StateError('Unexpected range: $contentRange'),
-          };
-          return Response(
-            requestOptions: RequestOptions(path: '/sessions/up_to'),
-            statusCode: 204,
-            headers: Headers.fromMap({
-              DivineUploadHeaders.uploadOffset: [nextOffset],
-            }),
-          );
-        });
+        ).thenAnswer(
+          (_) => Completer<Response<dynamic>>().future,
+        );
 
-        // A generous timeout that the fast mock resumable leg stays well
-        // under — proves the timeout branch is wired without flaking.
+        await expectLater(
+          service.uploadVideoWithResume(
+            videoFile: videoFile,
+            nostrPubkey: _testPublicKey,
+            taskId: 'task-to',
+            title: 'resumable timeout',
+            description: null,
+            hashtags: null,
+            proofManifestJson: null,
+            resumableTimeout: const Duration(milliseconds: 50),
+          ),
+          throwsA(isA<TimeoutException>()),
+        );
+      },
+    );
+
+    test(
+      'OS-first cancellation is terminal and never falls back to resumable',
+      () async {
+        // Reproduces #6086: a user pause/cancel tears down the OS transfer,
+        // which emits a `cancelled` terminal event. uploadVideoWithResume must
+        // surface that cancellation terminally — NOT re-upload the whole file
+        // via the resumable/chunked path, which would later overwrite the
+        // paused/cancelled state with a spurious success.
+        final transport = _FakeTransport(outcome: _FakeOutcome.cancelled);
+        final service = BlossomUploadService(
+          authProvider: auth,
+          dio: dio,
+          defaultServerUrl: _testServer,
+          backgroundTransport: transport,
+        );
+
         final result = await service.uploadVideoWithResume(
           videoFile: videoFile,
           nostrPubkey: _testPublicKey,
-          taskId: 'task-to',
-          title: 'resumable timeout',
+          taskId: 'task-cancel',
+          title: 'user cancelled mid-upload',
           description: null,
           hashtags: null,
           proofManifestJson: null,
-          resumableTimeout: const Duration(minutes: 1),
         );
 
-        expect(result.success, isTrue);
+        expect(result.success, isFalse);
+        expect(
+          result.failureReason,
+          equals(BlossomUploadFailureReason.cancelled),
+        );
+        // The OS attempt was enqueued...
+        expect(transport.enqueuedTaskIds, equals(['task-cancel']));
+        // ...but the chunked resumable path was never touched: no capability
+        // HEAD, no init/complete POST, no chunk PUT.
+        verifyNever(
+          () => dio.head<dynamic>(any(), options: any(named: 'options')),
+        );
+        verifyNever(
+          () => dio.post<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+          ),
+        );
+        verifyNever(
+          () => dio.put<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+            onSendProgress: any(named: 'onSendProgress'),
+          ),
+        );
       },
     );
   });

--- a/mobile/packages/blossom_upload_service/test/src/blossom_upload_with_resume_test.dart
+++ b/mobile/packages/blossom_upload_service/test/src/blossom_upload_with_resume_test.dart
@@ -1,0 +1,675 @@
+// ABOUTME: Tests for uploadVideoWithResume, the OS-first-then-resumable
+// ABOUTME: combined upload path that prevents re-sending the whole file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:blossom_upload_service/blossom_upload_service.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockAuthProvider extends Mock implements BlossomAuthProvider {}
+
+class _MockDio extends Mock implements Dio {}
+
+/// A controllable [BlossomBackgroundTransport] that records enqueue calls and
+/// either completes or fails the OS-backed whole-file PUT.
+class _FakeTransport implements BlossomBackgroundTransport {
+  _FakeTransport({
+    this.completeSuccessfully = true,
+  });
+
+  final bool completeSuccessfully;
+  final List<String> enqueuedTaskIds = <String>[];
+  final StreamController<BlossomBackgroundTransferEvent> _controller =
+      StreamController<BlossomBackgroundTransferEvent>.broadcast();
+
+  @override
+  Stream<BlossomBackgroundTransferEvent> get events => _controller.stream;
+
+  @override
+  Future<void> enqueue({
+    required String taskId,
+    required String url,
+    required String method,
+    required Map<String, String> headers,
+    required String filePath,
+  }) async {
+    enqueuedTaskIds.add(taskId);
+    if (completeSuccessfully) {
+      _controller.add(
+        BlossomBackgroundTransferEvent(
+          taskId: taskId,
+          status: BlossomBackgroundTransferStatus.completed,
+          progress: 1,
+          httpStatusCode: 200,
+          responseBody:
+              '{"url":"https://media.divine.video/bg-final",'
+              '"fallbackUrl":"https://media.divine.video/bg-final"}',
+        ),
+      );
+    } else {
+      _controller.add(
+        BlossomBackgroundTransferEvent(
+          taskId: taskId,
+          status: BlossomBackgroundTransferStatus.failed,
+          error: 'network drop',
+        ),
+      );
+    }
+  }
+
+  @override
+  Future<void> cancel(String taskId) async {}
+
+  @override
+  Future<BlossomBackgroundTransferEvent?> takeBufferedTerminalEvent(
+    String taskId,
+  ) async => null;
+}
+
+/// A performance monitor whose [startTrace] throws on the first call and
+/// succeeds thereafter. The first call is from uploadVideoInBackground (the
+/// OS-first attempt); the throw makes it propagate out of that method before
+/// its internal try/catch, exercising the defensive catch in
+/// uploadVideoWithResume. The subsequent resumable uploadVideo path then gets
+/// a working trace so it can complete normally.
+class _ThrowingPerformanceMonitor implements BlossomPerformanceMonitor {
+  var _calls = 0;
+
+  @override
+  Future<void> startTrace(String traceName) async {
+    _calls++;
+    if (_calls == 1) {
+      throw Exception('perf monitor unavailable');
+    }
+  }
+
+  @override
+  Future<void> stopTrace(String traceName) async {}
+
+  @override
+  void setMetric(String traceName, String metricName, int value) {}
+}
+
+const _testServer = 'https://media.divine.video';
+const _testPublicKey =
+    '0223456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() {
+    registerFallbackValue(Options());
+  });
+
+  late _MockAuthProvider auth;
+  late _MockDio dio;
+  late Directory tempDir;
+  late File videoFile;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues(const <String, Object>{});
+
+    auth = _MockAuthProvider();
+    dio = _MockDio();
+
+    when(() => auth.isAuthenticated).thenReturn(true);
+    when(
+      () => auth.createAndSignEvent(
+        kind: any(named: 'kind'),
+        content: any(named: 'content'),
+        tags: any(named: 'tags'),
+      ),
+    ).thenAnswer(
+      (_) async => const BlossomSignedEvent(
+        json: {
+          'id': 'test',
+          'pubkey': _testPublicKey,
+          'created_at': 0,
+          'kind': 24242,
+          'tags': <List<String>>[],
+          'content': 'Upload video to Blossom server',
+          'sig': 'test',
+        },
+      ),
+    );
+
+    tempDir = await Directory.systemTemp.createTemp('blossom_resume_test_');
+    // 8-byte file → two 4-byte chunks in the resumable path.
+    videoFile = File('${tempDir.path}/video.mp4')
+      ..writeAsBytesSync(List<int>.generate(8, (i) => i));
+  });
+
+  tearDown(() async => tempDir.delete(recursive: true));
+
+  /// Stubs the resumable capability HEAD + init POST + complete POST on [dio].
+  /// The caller is responsible for stubbing `dio.put` for chunk PUTs.
+  void stubResumableControlPlane({required String uploadId}) {
+    // Capability HEAD — advertises resumable sessions.
+    when(
+      () => dio.head<dynamic>(any(), options: any(named: 'options')),
+    ).thenAnswer(
+      (_) async => Response(
+        requestOptions: RequestOptions(path: '/upload'),
+        statusCode: 200,
+        headers: Headers.fromMap({
+          DivineUploadHeaders.extensions: [
+            DivineUploadExtensions.resumableSessions,
+          ],
+          DivineUploadHeaders.controlHost: [_testServer],
+          DivineUploadHeaders.dataHost: ['https://upload.divine.video'],
+        }),
+      ),
+    );
+
+    // init + complete POSTs.
+    when(
+      () => dio.post<dynamic>(
+        any(),
+        data: any(named: 'data'),
+        options: any(named: 'options'),
+      ),
+    ).thenAnswer((invocation) async {
+      final url = invocation.positionalArguments.first as String;
+      if (url.endsWith('/upload/init')) {
+        return Response(
+          requestOptions: RequestOptions(path: '/upload/init'),
+          statusCode: 200,
+          data: {
+            'uploadId': uploadId,
+            'uploadUrl': 'https://upload.divine.video/sessions/$uploadId',
+            'chunkSize': 4,
+            'nextOffset': 0,
+            'requiredHeaders': {'Authorization': 'Bearer session-token'},
+          },
+        );
+      }
+      if (url.endsWith('/upload/$uploadId/complete')) {
+        return Response(
+          requestOptions: RequestOptions(path: '/upload/$uploadId/complete'),
+          statusCode: 200,
+          data: {
+            'url': '$_testServer/final',
+            'fallbackUrl': '$_testServer/final',
+          },
+        );
+      }
+      throw StateError('Unexpected POST url: $url');
+    });
+  }
+
+  group('uploadVideoWithResume', () {
+    test(
+      'fresh upload succeeds via OS-first PUT and never touches resumable',
+      () async {
+        final transport = _FakeTransport();
+        final service = BlossomUploadService(
+          authProvider: auth,
+          dio: dio,
+          defaultServerUrl: _testServer,
+          backgroundTransport: transport,
+        );
+
+        final result = await service.uploadVideoWithResume(
+          videoFile: videoFile,
+          nostrPubkey: _testPublicKey,
+          taskId: 'task-1',
+          title: 'OS-first success',
+          description: null,
+          hashtags: null,
+          proofManifestJson: null,
+        );
+
+        expect(result.success, isTrue);
+        expect(transport.enqueuedTaskIds, equals(['task-1']));
+
+        // The resumable control plane was never reached: no HEAD /upload
+        // capability probe, no POST /upload/init.
+        verifyNever(
+          () => dio.head<dynamic>(any(), options: any(named: 'options')),
+        );
+        verifyNever(
+          () => dio.post<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+          ),
+        );
+      },
+    );
+
+    test(
+      'fresh upload whose OS PUT fails falls back to chunked resumable',
+      () async {
+        final transport = _FakeTransport(completeSuccessfully: false);
+        final service = BlossomUploadService(
+          authProvider: auth,
+          dio: dio,
+          defaultServerUrl: _testServer,
+          backgroundTransport: transport,
+        );
+
+        stubResumableControlPlane(uploadId: 'up_fb');
+
+        // Chunk PUTs — two 4-byte chunks, succeed immediately.
+        when(
+          () => dio.put<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+            onSendProgress: any(named: 'onSendProgress'),
+          ),
+        ).thenAnswer((invocation) async {
+          final options = invocation.namedArguments[#options] as Options;
+          final contentRange = options.headers?['Content-Range'] as String;
+          final nextOffset = switch (contentRange) {
+            'bytes 0-3/8' => '4',
+            'bytes 4-7/8' => '8',
+            _ => throw StateError('Unexpected range: $contentRange'),
+          };
+          return Response(
+            requestOptions: RequestOptions(path: '/sessions/up_fb'),
+            statusCode: 204,
+            headers: Headers.fromMap({
+              DivineUploadHeaders.uploadOffset: [nextOffset],
+            }),
+          );
+        });
+
+        final result = await service.uploadVideoWithResume(
+          videoFile: videoFile,
+          nostrPubkey: _testPublicKey,
+          taskId: 'task-2',
+          title: 'OS-first fails, resumable fallback',
+          description: null,
+          hashtags: null,
+          proofManifestJson: null,
+        );
+
+        expect(result.success, isTrue);
+        // The OS attempt was enqueued...
+        expect(transport.enqueuedTaskIds, equals(['task-2']));
+        // ...and the resumable fallback was reached.
+        verify(
+          () => dio.head<dynamic>(any(), options: any(named: 'options')),
+        ).called(1);
+        verify(
+          () => dio.put<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+            onSendProgress: any(named: 'onSendProgress'),
+          ),
+        ).called(2);
+      },
+    );
+
+    test(
+      'when a resumable session already exists, skips the OS PUT and resumes',
+      () async {
+        final transport = _FakeTransport();
+        final service = BlossomUploadService(
+          authProvider: auth,
+          dio: dio,
+          defaultServerUrl: _testServer,
+          backgroundTransport: transport,
+        );
+
+        // Simulate a session from a prior attempt that committed 4 bytes.
+        // HEAD resume returns offset 4, so only the final chunk (4-7) is sent.
+        const uploadId = 'up_resume';
+        final existingSession = BlossomResumableUploadSession(
+          uploadId: uploadId,
+          uploadUrl: 'https://upload.divine.video/sessions/$uploadId',
+          chunkSize: 4,
+          nextOffset: 0,
+          expiresAt: DateTime.utc(2099),
+          requiredHeaders: {'Authorization': 'Bearer session-token'},
+        );
+
+        // Capability HEAD (called by uploadVideo).
+        when(
+          () => dio.head<dynamic>(any(), options: any(named: 'options')),
+        ).thenAnswer((invocation) async {
+          final url = invocation.positionalArguments.first as String;
+          if (url == '$_testServer/upload') {
+            return Response(
+              requestOptions: RequestOptions(path: '/upload'),
+              statusCode: 200,
+              headers: Headers.fromMap({
+                DivineUploadHeaders.extensions: [
+                  DivineUploadExtensions.resumableSessions,
+                ],
+              }),
+            );
+          }
+          // HEAD on the session URL → resume offset query.
+          if (url == existingSession.uploadUrl) {
+            return Response(
+              requestOptions: RequestOptions(path: url),
+              statusCode: 204,
+              headers: Headers.fromMap({
+                DivineUploadHeaders.uploadOffset: ['4'],
+              }),
+            );
+          }
+          throw StateError('Unexpected HEAD url: $url');
+        });
+
+        // complete POST.
+        when(
+          () => dio.post<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+          ),
+        ).thenAnswer((invocation) async {
+          final url = invocation.positionalArguments.first as String;
+          if (url.endsWith('/upload/$uploadId/complete')) {
+            return Response(
+              requestOptions: RequestOptions(path: '/complete'),
+              statusCode: 200,
+              data: {
+                'url': '$_testServer/final',
+                'fallbackUrl': '$_testServer/final',
+              },
+            );
+          }
+          throw StateError('Unexpected POST url: $url');
+        });
+
+        // Chunk PUT — only the final chunk should arrive.
+        when(
+          () => dio.put<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+            onSendProgress: any(named: 'onSendProgress'),
+          ),
+        ).thenAnswer((invocation) async {
+          final options = invocation.namedArguments[#options] as Options;
+          final contentRange = options.headers?['Content-Range'] as String;
+          expect(
+            contentRange,
+            equals('bytes 4-7/8'),
+            reason: 'resume must upload only the uncommitted tail, not byte 0',
+          );
+          return Response(
+            requestOptions: RequestOptions(path: '/sessions/$uploadId'),
+            statusCode: 204,
+            headers: Headers.fromMap({
+              DivineUploadHeaders.uploadOffset: ['8'],
+            }),
+          );
+        });
+
+        final result = await service.uploadVideoWithResume(
+          videoFile: videoFile,
+          nostrPubkey: _testPublicKey,
+          taskId: 'task-3',
+          title: 'resume from existing session',
+          description: null,
+          hashtags: null,
+          proofManifestJson: null,
+          resumableSession: existingSession,
+        );
+
+        expect(result.success, isTrue);
+        // The OS PUT must NOT have been enqueued — existing session means
+        // resume-by-offset, never re-run the whole-file PUT.
+        expect(transport.enqueuedTaskIds, isEmpty);
+        // Only one chunk PUT (the tail), proving byte-level resume.
+        verify(
+          () => dio.put<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+            onSendProgress: any(named: 'onSendProgress'),
+          ),
+        ).called(1);
+      },
+    );
+
+    test(
+      'useBackgroundFirst=false skips OS PUT and goes straight to resumable',
+      () async {
+        final transport = _FakeTransport();
+        final service = BlossomUploadService(
+          authProvider: auth,
+          dio: dio,
+          defaultServerUrl: _testServer,
+          backgroundTransport: transport,
+        );
+
+        stubResumableControlPlane(uploadId: 'up_nobg');
+
+        when(
+          () => dio.put<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+            onSendProgress: any(named: 'onSendProgress'),
+          ),
+        ).thenAnswer((invocation) async {
+          final options = invocation.namedArguments[#options] as Options;
+          final contentRange = options.headers?['Content-Range'] as String;
+          final nextOffset = switch (contentRange) {
+            'bytes 0-3/8' => '4',
+            'bytes 4-7/8' => '8',
+            _ => throw StateError('Unexpected range: $contentRange'),
+          };
+          return Response(
+            requestOptions: RequestOptions(path: '/sessions/up_nobg'),
+            statusCode: 204,
+            headers: Headers.fromMap({
+              DivineUploadHeaders.uploadOffset: [nextOffset],
+            }),
+          );
+        });
+
+        final result = await service.uploadVideoWithResume(
+          videoFile: videoFile,
+          nostrPubkey: _testPublicKey,
+          taskId: 'task-4',
+          title: 'no OS first',
+          description: null,
+          hashtags: null,
+          proofManifestJson: null,
+          useBackgroundFirst: false,
+        );
+
+        expect(result.success, isTrue);
+        // OS PUT never enqueued.
+        expect(transport.enqueuedTaskIds, isEmpty);
+        verify(
+          () => dio.put<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+            onSendProgress: any(named: 'onSendProgress'),
+          ),
+        ).called(2);
+      },
+    );
+
+    test(
+      'session callback emits monotonically increasing offsets during resume',
+      () async {
+        final transport = _FakeTransport(completeSuccessfully: false);
+        final service = BlossomUploadService(
+          authProvider: auth,
+          dio: dio,
+          defaultServerUrl: _testServer,
+          backgroundTransport: transport,
+        );
+
+        stubResumableControlPlane(uploadId: 'up_cb');
+
+        when(
+          () => dio.put<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+            onSendProgress: any(named: 'onSendProgress'),
+          ),
+        ).thenAnswer((invocation) async {
+          final options = invocation.namedArguments[#options] as Options;
+          final contentRange = options.headers?['Content-Range'] as String;
+          final nextOffset = switch (contentRange) {
+            'bytes 0-3/8' => '4',
+            'bytes 4-7/8' => '8',
+            _ => throw StateError('Unexpected range: $contentRange'),
+          };
+          return Response(
+            requestOptions: RequestOptions(path: '/sessions/up_cb'),
+            statusCode: 204,
+            headers: Headers.fromMap({
+              DivineUploadHeaders.uploadOffset: [nextOffset],
+            }),
+          );
+        });
+
+        final sessionUpdates = <BlossomResumableUploadSession>[];
+        final result = await service.uploadVideoWithResume(
+          videoFile: videoFile,
+          nostrPubkey: _testPublicKey,
+          taskId: 'task-5',
+          title: 'session callback',
+          description: null,
+          hashtags: null,
+          proofManifestJson: null,
+          onResumableSessionUpdated: sessionUpdates.add,
+        );
+
+        expect(result.success, isTrue);
+        // init reports offset 0, then each chunk reports the next committed
+        // offset. This is the persisted progress the next retry resumes from.
+        expect(sessionUpdates.map((s) => s.nextOffset), [0, 4, 8]);
+      },
+    );
+
+    test(
+      'OS-first attempt that throws still falls back to chunked resumable',
+      () async {
+        // uploadVideoInBackground normally returns failures rather than
+        // throwing, so to exercise the catch-guard we make startTrace throw
+        // (it runs before uploadVideoInBackground's internal try/catch). The
+        // publish must still get a resumable retry rather than dying.
+        final transport = _FakeTransport();
+        final service = BlossomUploadService(
+          authProvider: auth,
+          dio: dio,
+          defaultServerUrl: _testServer,
+          backgroundTransport: transport,
+          performanceMonitor: _ThrowingPerformanceMonitor(),
+        );
+
+        stubResumableControlPlane(uploadId: 'up_throw');
+
+        when(
+          () => dio.put<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+            onSendProgress: any(named: 'onSendProgress'),
+          ),
+        ).thenAnswer((invocation) async {
+          final options = invocation.namedArguments[#options] as Options;
+          final contentRange = options.headers?['Content-Range'] as String;
+          final nextOffset = switch (contentRange) {
+            'bytes 0-3/8' => '4',
+            'bytes 4-7/8' => '8',
+            _ => throw StateError('Unexpected range: $contentRange'),
+          };
+          return Response(
+            requestOptions: RequestOptions(path: '/sessions/up_throw'),
+            statusCode: 204,
+            headers: Headers.fromMap({
+              DivineUploadHeaders.uploadOffset: [nextOffset],
+            }),
+          );
+        });
+
+        final result = await service.uploadVideoWithResume(
+          videoFile: videoFile,
+          nostrPubkey: _testPublicKey,
+          taskId: 'task-throw',
+          title: 'OS-first throws',
+          description: null,
+          hashtags: null,
+          proofManifestJson: null,
+        );
+
+        expect(result.success, isTrue);
+        // The OS attempt never reached enqueue (startTrace threw first), but
+        // the resumable fallback still completed successfully.
+        expect(transport.enqueuedTaskIds, isEmpty);
+        verify(
+          () => dio.put<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+            onSendProgress: any(named: 'onSendProgress'),
+          ),
+        ).called(2);
+      },
+    );
+
+    test(
+      'resumableTimeout bounds only the in-process resumable leg',
+      () async {
+        final transport = _FakeTransport(completeSuccessfully: false);
+        final service = BlossomUploadService(
+          authProvider: auth,
+          dio: dio,
+          defaultServerUrl: _testServer,
+          backgroundTransport: transport,
+        );
+
+        stubResumableControlPlane(uploadId: 'up_to');
+
+        when(
+          () => dio.put<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+            onSendProgress: any(named: 'onSendProgress'),
+          ),
+        ).thenAnswer((invocation) async {
+          final options = invocation.namedArguments[#options] as Options;
+          final contentRange = options.headers?['Content-Range'] as String;
+          final nextOffset = switch (contentRange) {
+            'bytes 0-3/8' => '4',
+            'bytes 4-7/8' => '8',
+            _ => throw StateError('Unexpected range: $contentRange'),
+          };
+          return Response(
+            requestOptions: RequestOptions(path: '/sessions/up_to'),
+            statusCode: 204,
+            headers: Headers.fromMap({
+              DivineUploadHeaders.uploadOffset: [nextOffset],
+            }),
+          );
+        });
+
+        // A generous timeout that the fast mock resumable leg stays well
+        // under — proves the timeout branch is wired without flaking.
+        final result = await service.uploadVideoWithResume(
+          videoFile: videoFile,
+          nostrPubkey: _testPublicKey,
+          taskId: 'task-to',
+          title: 'resumable timeout',
+          description: null,
+          hashtags: null,
+          proofManifestJson: null,
+          resumableTimeout: const Duration(minutes: 1),
+        );
+
+        expect(result.success, isTrue);
+      },
+    );
+  });
+}

--- a/mobile/test/services/upload_manager_background_pause_test.dart
+++ b/mobile/test/services/upload_manager_background_pause_test.dart
@@ -84,10 +84,18 @@ void main() {
   Completer<BlossomUploadResult> stubCancellableTransfer() {
     final transfer = Completer<BlossomUploadResult>();
     when(
-      () => mockBlossomService.uploadVideoInBackground(
+      () => mockBlossomService.uploadVideoWithResume(
         videoFile: any(named: 'videoFile'),
+        nostrPubkey: any(named: 'nostrPubkey'),
         taskId: any(named: 'taskId'),
+        title: any(named: 'title'),
+        description: any(named: 'description'),
+        hashtags: any(named: 'hashtags'),
         proofManifestJson: any(named: 'proofManifestJson'),
+        useBackgroundFirst: any(named: 'useBackgroundFirst'),
+        resumableTimeout: any(named: 'resumableTimeout'),
+        resumableSession: any(named: 'resumableSession'),
+        onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
         onProgress: any(named: 'onProgress'),
       ),
     ).thenAnswer((_) => transfer.future);

--- a/mobile/test/services/upload_manager_background_pause_test.dart
+++ b/mobile/test/services/upload_manager_background_pause_test.dart
@@ -107,7 +107,7 @@ void main() {
           const BlossomUploadResult(
             success: false,
             errorMessage: 'Upload cancelled',
-            failureReason: BlossomUploadFailureReason.unknown,
+            failureReason: BlossomUploadFailureReason.cancelled,
           ),
         );
       }
@@ -156,6 +156,70 @@ void main() {
           () => mockBlossomService.cancelBackgroundUpload(upload.id),
         ).called(1);
         // The user-initiated pause is not a crash.
+        verifyNever(
+          () => mockCrashReporter.recordError(
+            any(),
+            any(),
+            reason: any(named: 'reason'),
+          ),
+        );
+      },
+    );
+
+    test(
+      'pausing during in-process fallback ignores a later successful result',
+      () async {
+        final upload = await seedPausedUpload();
+        final transfer = Completer<BlossomUploadResult>();
+        when(
+          () => mockBlossomService.uploadVideoWithResume(
+            videoFile: any(named: 'videoFile'),
+            nostrPubkey: any(named: 'nostrPubkey'),
+            taskId: any(named: 'taskId'),
+            title: any(named: 'title'),
+            description: any(named: 'description'),
+            hashtags: any(named: 'hashtags'),
+            proofManifestJson: any(named: 'proofManifestJson'),
+            useBackgroundFirst: any(named: 'useBackgroundFirst'),
+            resumableTimeout: any(named: 'resumableTimeout'),
+            resumableSession: any(named: 'resumableSession'),
+            onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
+            onProgress: any(named: 'onProgress'),
+          ),
+        ).thenAnswer((_) => transfer.future);
+        when(
+          () => mockBlossomService.cancelBackgroundUpload(any()),
+        ).thenAnswer((_) async {});
+
+        final runFuture = uploadManager.resumeUpload(upload.id);
+        await _pumpUntil(
+          () =>
+              uploadManager.getUpload(upload.id)?.status ==
+              UploadStatus.uploading,
+        );
+
+        await uploadManager.pauseUpload(upload.id);
+        transfer.complete(
+          const BlossomUploadResult(
+            success: true,
+            videoId: 'video-after-pause',
+            url: 'https://media.divine.video/video-after-pause',
+            fallbackUrl: 'https://media.divine.video/video-after-pause',
+            thumbnailUrl:
+                'https://media.divine.video/video-after-pause-thumb.jpg',
+          ),
+        );
+        await runFuture;
+
+        final result = uploadManager.getUpload(upload.id);
+        expect(result?.status, equals(UploadStatus.paused));
+        expect(result?.videoId, isNull);
+        expect(result?.cdnUrl, isNull);
+        expect(result?.thumbnailPath, isNull);
+        expect(result?.errorMessage, isNull);
+        verify(
+          () => mockBlossomService.cancelBackgroundUpload(upload.id),
+        ).called(1);
         verifyNever(
           () => mockCrashReporter.recordError(
             any(),

--- a/mobile/test/services/upload_manager_error_handling_test.dart
+++ b/mobile/test/services/upload_manager_error_handling_test.dart
@@ -800,7 +800,7 @@ void main() {
       } catch (_) {}
     });
 
-    /// Stubs [mock] so that [uploadVideo] fails [failCount] times before
+    /// Stubs [mock] so that [uploadVideoWithResume] fails [failCount] times before
     /// succeeding. The success result includes a server thumbnail URL so these
     /// retry-counter tests do not depend on thumbnail extraction from fake
     /// video bytes.
@@ -820,13 +820,16 @@ void main() {
 
       var calls = 0;
       when(
-        () => mock.uploadVideo(
+        () => mock.uploadVideoWithResume(
           videoFile: any(named: 'videoFile'),
           nostrPubkey: any(named: 'nostrPubkey'),
+          taskId: any(named: 'taskId'),
           title: any(named: 'title'),
           description: any(named: 'description'),
           hashtags: any(named: 'hashtags'),
           proofManifestJson: any(named: 'proofManifestJson'),
+          useBackgroundFirst: any(named: 'useBackgroundFirst'),
+          resumableTimeout: any(named: 'resumableTimeout'),
           resumableSession: any(named: 'resumableSession'),
           onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
           onProgress: any(named: 'onProgress'),
@@ -859,16 +862,19 @@ void main() {
         // Fail once then succeed so we observe exactly two status snapshots.
         stubUploadSequence(retryMockBlossom, failCount: 1);
 
-        // Replace the uploadVideo stub with one that also captures status.
+        // Replace the uploadVideoWithResume stub with one that also captures status.
         var calls = 0;
         when(
-          () => retryMockBlossom.uploadVideo(
+          () => retryMockBlossom.uploadVideoWithResume(
             videoFile: any(named: 'videoFile'),
             nostrPubkey: any(named: 'nostrPubkey'),
+            taskId: any(named: 'taskId'),
             title: any(named: 'title'),
             description: any(named: 'description'),
             hashtags: any(named: 'hashtags'),
             proofManifestJson: any(named: 'proofManifestJson'),
+            useBackgroundFirst: any(named: 'useBackgroundFirst'),
+            resumableTimeout: any(named: 'resumableTimeout'),
             resumableSession: any(named: 'resumableSession'),
             onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
             onProgress: any(named: 'onProgress'),
@@ -946,13 +952,16 @@ void main() {
         // Verify retryUpload() actually re-activates the upload and does not
         // hard-return due to canRetry being false.
         when(
-          () => retryMockBlossom.uploadVideo(
+          () => retryMockBlossom.uploadVideoWithResume(
             videoFile: any(named: 'videoFile'),
             nostrPubkey: any(named: 'nostrPubkey'),
+            taskId: any(named: 'taskId'),
             title: any(named: 'title'),
             description: any(named: 'description'),
             hashtags: any(named: 'hashtags'),
             proofManifestJson: any(named: 'proofManifestJson'),
+            useBackgroundFirst: any(named: 'useBackgroundFirst'),
+            resumableTimeout: any(named: 'resumableTimeout'),
             resumableSession: any(named: 'resumableSession'),
             onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
             onProgress: any(named: 'onProgress'),
@@ -998,13 +1007,16 @@ void main() {
           ),
         ).thenAnswer((_) async => const BlossomUploadResult(success: false));
         when(
-          () => retryMockBlossom.uploadVideo(
+          () => retryMockBlossom.uploadVideoWithResume(
             videoFile: any(named: 'videoFile'),
             nostrPubkey: any(named: 'nostrPubkey'),
+            taskId: any(named: 'taskId'),
             title: any(named: 'title'),
             description: any(named: 'description'),
             hashtags: any(named: 'hashtags'),
             proofManifestJson: any(named: 'proofManifestJson'),
+            useBackgroundFirst: any(named: 'useBackgroundFirst'),
+            resumableTimeout: any(named: 'resumableTimeout'),
             resumableSession: any(named: 'resumableSession'),
             onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
             onProgress: any(named: 'onProgress'),
@@ -1046,13 +1058,16 @@ void main() {
         await retryUploadManager.retryUpload(upload.id);
 
         verifyNever(
-          () => retryMockBlossom.uploadVideo(
+          () => retryMockBlossom.uploadVideoWithResume(
             videoFile: any(named: 'videoFile'),
             nostrPubkey: any(named: 'nostrPubkey'),
+            taskId: any(named: 'taskId'),
             title: any(named: 'title'),
             description: any(named: 'description'),
             hashtags: any(named: 'hashtags'),
             proofManifestJson: any(named: 'proofManifestJson'),
+            useBackgroundFirst: any(named: 'useBackgroundFirst'),
+            resumableTimeout: any(named: 'resumableTimeout'),
             resumableSession: any(named: 'resumableSession'),
             onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
             onProgress: any(named: 'onProgress'),

--- a/mobile/test/services/upload_manager_from_draft_test.dart
+++ b/mobile/test/services/upload_manager_from_draft_test.dart
@@ -50,13 +50,16 @@ void main() {
         () => mockBlossomService.isBlossomEnabled(),
       ).thenAnswer((_) async => false);
       when(
-        () => mockBlossomService.uploadVideo(
+        () => mockBlossomService.uploadVideoWithResume(
           videoFile: any(named: 'videoFile'),
           nostrPubkey: any(named: 'nostrPubkey'),
+          taskId: any(named: 'taskId'),
           title: any(named: 'title'),
           description: any(named: 'description'),
           hashtags: any(named: 'hashtags'),
           proofManifestJson: any(named: 'proofManifestJson'),
+          useBackgroundFirst: any(named: 'useBackgroundFirst'),
+          resumableTimeout: any(named: 'resumableTimeout'),
           resumableSession: any(named: 'resumableSession'),
           onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
           onProgress: any(named: 'onProgress'),
@@ -173,13 +176,16 @@ void main() {
         ..writeAsBytesSync([0, 1, 2, 3]);
 
       when(
-        () => mockBlossomService.uploadVideo(
+        () => mockBlossomService.uploadVideoWithResume(
           videoFile: any(named: 'videoFile'),
           nostrPubkey: any(named: 'nostrPubkey'),
+          taskId: any(named: 'taskId'),
           title: any(named: 'title'),
           description: any(named: 'description'),
           hashtags: any(named: 'hashtags'),
           proofManifestJson: any(named: 'proofManifestJson'),
+          useBackgroundFirst: any(named: 'useBackgroundFirst'),
+          resumableTimeout: any(named: 'resumableTimeout'),
           resumableSession: any(named: 'resumableSession'),
           onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
           onProgress: any(named: 'onProgress'),
@@ -278,13 +284,16 @@ void main() {
           () => mockBlossomService.isBlossomEnabled(),
         ).thenAnswer((_) async => false);
         when(
-          () => mockBlossomService.uploadVideo(
+          () => mockBlossomService.uploadVideoWithResume(
             videoFile: any(named: 'videoFile'),
             nostrPubkey: any(named: 'nostrPubkey'),
+            taskId: any(named: 'taskId'),
             title: any(named: 'title'),
             description: any(named: 'description'),
             hashtags: any(named: 'hashtags'),
             proofManifestJson: any(named: 'proofManifestJson'),
+            useBackgroundFirst: any(named: 'useBackgroundFirst'),
+            resumableTimeout: any(named: 'resumableTimeout'),
             resumableSession: any(named: 'resumableSession'),
             onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
             onProgress: any(named: 'onProgress'),

--- a/mobile/test/services/upload_manager_recovery_test.dart
+++ b/mobile/test/services/upload_manager_recovery_test.dart
@@ -119,13 +119,16 @@ void main() {
 
       final resumeStarted = Completer<void>();
       when(
-        () => mockBlossomService.uploadVideo(
+        () => mockBlossomService.uploadVideoWithResume(
           videoFile: any(named: 'videoFile'),
           nostrPubkey: any(named: 'nostrPubkey'),
+          taskId: any(named: 'taskId'),
           title: any(named: 'title'),
           description: any(named: 'description'),
           hashtags: any(named: 'hashtags'),
           proofManifestJson: any(named: 'proofManifestJson'),
+          useBackgroundFirst: any(named: 'useBackgroundFirst'),
+          resumableTimeout: any(named: 'resumableTimeout'),
           resumableSession: any(named: 'resumableSession'),
           onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
           onProgress: any(named: 'onProgress'),
@@ -160,13 +163,16 @@ void main() {
       final firstAttemptFailed = Completer<void>();
       final secondAttemptStarted = Completer<void>();
       when(
-        () => mockBlossomService.uploadVideo(
+        () => mockBlossomService.uploadVideoWithResume(
           videoFile: any(named: 'videoFile'),
           nostrPubkey: any(named: 'nostrPubkey'),
+          taskId: any(named: 'taskId'),
           title: any(named: 'title'),
           description: any(named: 'description'),
           hashtags: any(named: 'hashtags'),
           proofManifestJson: any(named: 'proofManifestJson'),
+          useBackgroundFirst: any(named: 'useBackgroundFirst'),
+          resumableTimeout: any(named: 'resumableTimeout'),
           resumableSession: any(named: 'resumableSession'),
           onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
           onProgress: any(named: 'onProgress'),
@@ -217,13 +223,16 @@ void main() {
 
       final resumeStarted = Completer<void>();
       when(
-        () => mockBlossomService.uploadVideo(
+        () => mockBlossomService.uploadVideoWithResume(
           videoFile: any(named: 'videoFile'),
           nostrPubkey: any(named: 'nostrPubkey'),
+          taskId: any(named: 'taskId'),
           title: any(named: 'title'),
           description: any(named: 'description'),
           hashtags: any(named: 'hashtags'),
           proofManifestJson: any(named: 'proofManifestJson'),
+          useBackgroundFirst: any(named: 'useBackgroundFirst'),
+          resumableTimeout: any(named: 'resumableTimeout'),
           resumableSession: any(named: 'resumableSession'),
           onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
           onProgress: any(named: 'onProgress'),
@@ -250,13 +259,16 @@ void main() {
       await Future<void>.delayed(const Duration(milliseconds: 100));
 
       verifyNever(
-        () => mockBlossomService.uploadVideo(
+        () => mockBlossomService.uploadVideoWithResume(
           videoFile: any(named: 'videoFile'),
           nostrPubkey: any(named: 'nostrPubkey'),
+          taskId: any(named: 'taskId'),
           title: any(named: 'title'),
           description: any(named: 'description'),
           hashtags: any(named: 'hashtags'),
           proofManifestJson: any(named: 'proofManifestJson'),
+          useBackgroundFirst: any(named: 'useBackgroundFirst'),
+          resumableTimeout: any(named: 'resumableTimeout'),
           resumableSession: any(named: 'resumableSession'),
           onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
           onProgress: any(named: 'onProgress'),
@@ -285,13 +297,16 @@ void main() {
         );
 
         verifyNever(
-          () => mockBlossomService.uploadVideo(
+          () => mockBlossomService.uploadVideoWithResume(
             videoFile: any(named: 'videoFile'),
             nostrPubkey: any(named: 'nostrPubkey'),
+            taskId: any(named: 'taskId'),
             title: any(named: 'title'),
             description: any(named: 'description'),
             hashtags: any(named: 'hashtags'),
             proofManifestJson: any(named: 'proofManifestJson'),
+            useBackgroundFirst: any(named: 'useBackgroundFirst'),
+            resumableTimeout: any(named: 'resumableTimeout'),
             resumableSession: any(named: 'resumableSession'),
             onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
             onProgress: any(named: 'onProgress'),
@@ -306,13 +321,16 @@ void main() {
       var uploadCallCount = 0;
       final blockGate = Completer<void>();
       when(
-        () => mockBlossomService.uploadVideo(
+        () => mockBlossomService.uploadVideoWithResume(
           videoFile: any(named: 'videoFile'),
           nostrPubkey: any(named: 'nostrPubkey'),
+          taskId: any(named: 'taskId'),
           title: any(named: 'title'),
           description: any(named: 'description'),
           hashtags: any(named: 'hashtags'),
           proofManifestJson: any(named: 'proofManifestJson'),
+          useBackgroundFirst: any(named: 'useBackgroundFirst'),
+          resumableTimeout: any(named: 'resumableTimeout'),
           resumableSession: any(named: 'resumableSession'),
           onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
           onProgress: any(named: 'onProgress'),

--- a/mobile/test/services/upload_manager_resumable_upload_test.dart
+++ b/mobile/test/services/upload_manager_resumable_upload_test.dart
@@ -115,13 +115,16 @@ void main() {
 
         final resumeStarted = Completer<void>();
         when(
-          () => mockBlossomService.uploadVideo(
+          () => mockBlossomService.uploadVideoWithResume(
             videoFile: any(named: 'videoFile'),
             nostrPubkey: any(named: 'nostrPubkey'),
+            taskId: any(named: 'taskId'),
             title: any(named: 'title'),
             description: any(named: 'description'),
             hashtags: any(named: 'hashtags'),
             proofManifestJson: any(named: 'proofManifestJson'),
+            useBackgroundFirst: any(named: 'useBackgroundFirst'),
+            resumableTimeout: any(named: 'resumableTimeout'),
             resumableSession: any(named: 'resumableSession'),
             onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
             onProgress: any(named: 'onProgress'),
@@ -173,6 +176,80 @@ void main() {
     );
 
     test(
+      'upload uses uploadVideoWithResume and threads the persisted session',
+      () async {
+        // A failed upload with a committed resumable session is the exact
+        // "retry must resume from offset, not byte 0" scenario. The combined
+        // method must receive the persisted session so its resumable leg
+        // skips the OS whole-file PUT and resumes by offset.
+        final upload =
+            PendingUpload.create(
+              localVideoPath: videoFile.path,
+              nostrPubkey: 'test-pubkey',
+              title: 'Combined path resume',
+            ).copyWith(
+              status: UploadStatus.failed,
+              resumableSession: const BlossomResumableUploadSession(
+                uploadId: 'up_combined',
+                uploadUrl: 'https://upload.divine.video/sessions/up_combined',
+                chunkSize: 8,
+                nextOffset: 16,
+              ),
+            );
+
+        final box = Hive.box<PendingUpload>('pending_uploads');
+        await box.put(upload.id, upload);
+
+        BlossomResumableUploadSession? capturedSession;
+        bool? capturedUseBackgroundFirst;
+
+        when(
+          () => mockBlossomService.uploadVideoWithResume(
+            videoFile: any(named: 'videoFile'),
+            nostrPubkey: any(named: 'nostrPubkey'),
+            taskId: any(named: 'taskId'),
+            title: any(named: 'title'),
+            description: any(named: 'description'),
+            hashtags: any(named: 'hashtags'),
+            proofManifestJson: any(named: 'proofManifestJson'),
+            useBackgroundFirst: any(named: 'useBackgroundFirst'),
+            resumableTimeout: any(named: 'resumableTimeout'),
+            resumableSession: any(named: 'resumableSession'),
+            onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
+            onProgress: any(named: 'onProgress'),
+          ),
+        ).thenAnswer((invocation) async {
+          capturedSession =
+              invocation.namedArguments[#resumableSession]
+                  as BlossomResumableUploadSession?;
+          capturedUseBackgroundFirst =
+              invocation.namedArguments[#useBackgroundFirst] as bool;
+          return const BlossomUploadResult(
+            success: true,
+            videoId: 'video-combined',
+            url: 'https://media.divine.video/video-combined',
+            fallbackUrl: 'https://media.divine.video/video-combined',
+            thumbnailUrl: 'https://media.divine.video/video-combined-thumb.jpg',
+          );
+        });
+
+        await uploadManager.retryUpload(upload.id);
+
+        await TestHelpers.waitForCondition(() {
+          final currentUpload = uploadManager.getUpload(upload.id);
+          return currentUpload?.status == UploadStatus.readyToPublish;
+        });
+
+        expect(capturedSession, isNotNull);
+        expect(capturedSession!.uploadId, equals('up_combined'));
+        expect(capturedSession!.nextOffset, equals(16));
+        // useBackgroundUpload defaults to false in these tests' UploadManager
+        // construction, so useBackgroundFirst must be false.
+        expect(capturedUseBackgroundFirst, isFalse);
+      },
+    );
+
+    test(
       'resumeInterruptedUpload preserves existing thumbnail URL when result omits one',
       () async {
         const thumbnailUrl = 'https://media.divine.video/thumb-existing';
@@ -191,13 +268,16 @@ void main() {
         await box.put(upload.id, upload);
 
         when(
-          () => mockBlossomService.uploadVideo(
+          () => mockBlossomService.uploadVideoWithResume(
             videoFile: any(named: 'videoFile'),
             nostrPubkey: any(named: 'nostrPubkey'),
+            taskId: any(named: 'taskId'),
             title: any(named: 'title'),
             description: any(named: 'description'),
             hashtags: any(named: 'hashtags'),
             proofManifestJson: any(named: 'proofManifestJson'),
+            useBackgroundFirst: any(named: 'useBackgroundFirst'),
+            resumableTimeout: any(named: 'resumableTimeout'),
             resumableSession: any(named: 'resumableSession'),
             onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
             onProgress: any(named: 'onProgress'),
@@ -244,13 +324,16 @@ void main() {
       await box.put(upload.id, upload);
 
       when(
-        () => mockBlossomService.uploadVideo(
+        () => mockBlossomService.uploadVideoWithResume(
           videoFile: any(named: 'videoFile'),
           nostrPubkey: any(named: 'nostrPubkey'),
+          taskId: any(named: 'taskId'),
           title: any(named: 'title'),
           description: any(named: 'description'),
           hashtags: any(named: 'hashtags'),
           proofManifestJson: any(named: 'proofManifestJson'),
+          useBackgroundFirst: any(named: 'useBackgroundFirst'),
+          resumableTimeout: any(named: 'resumableTimeout'),
           resumableSession: any(named: 'resumableSession'),
           onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
           onProgress: any(named: 'onProgress'),
@@ -299,13 +382,16 @@ void main() {
       await box.put(upload.id, upload);
 
       when(
-        () => mockBlossomService.uploadVideo(
+        () => mockBlossomService.uploadVideoWithResume(
           videoFile: any(named: 'videoFile'),
           nostrPubkey: any(named: 'nostrPubkey'),
+          taskId: any(named: 'taskId'),
           title: any(named: 'title'),
           description: any(named: 'description'),
           hashtags: any(named: 'hashtags'),
           proofManifestJson: any(named: 'proofManifestJson'),
+          useBackgroundFirst: any(named: 'useBackgroundFirst'),
+          resumableTimeout: any(named: 'resumableTimeout'),
           resumableSession: any(named: 'resumableSession'),
           onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
           onProgress: any(named: 'onProgress'),
@@ -356,13 +442,16 @@ void main() {
 
         final resumeAttempted = Completer<void>();
         when(
-          () => mockBlossomService.uploadVideo(
+          () => mockBlossomService.uploadVideoWithResume(
             videoFile: any(named: 'videoFile'),
             nostrPubkey: any(named: 'nostrPubkey'),
+            taskId: any(named: 'taskId'),
             title: any(named: 'title'),
             description: any(named: 'description'),
             hashtags: any(named: 'hashtags'),
             proofManifestJson: any(named: 'proofManifestJson'),
+            useBackgroundFirst: any(named: 'useBackgroundFirst'),
+            resumableTimeout: any(named: 'resumableTimeout'),
             resumableSession: any(named: 'resumableSession'),
             onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
             onProgress: any(named: 'onProgress'),
@@ -412,13 +501,16 @@ void main() {
         void Function(BlossomResumableUploadSession)? capturedCallback;
 
         when(
-          () => mockBlossomService.uploadVideo(
+          () => mockBlossomService.uploadVideoWithResume(
             videoFile: any(named: 'videoFile'),
             nostrPubkey: any(named: 'nostrPubkey'),
+            taskId: any(named: 'taskId'),
             title: any(named: 'title'),
             description: any(named: 'description'),
             hashtags: any(named: 'hashtags'),
             proofManifestJson: any(named: 'proofManifestJson'),
+            useBackgroundFirst: any(named: 'useBackgroundFirst'),
+            resumableTimeout: any(named: 'resumableTimeout'),
             resumableSession: any(named: 'resumableSession'),
             onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
             onProgress: any(named: 'onProgress'),
@@ -501,13 +593,16 @@ void main() {
       'does not re-upload video when required thumbnail upload fails',
       () async {
         when(
-          () => mockBlossomService.uploadVideo(
+          () => mockBlossomService.uploadVideoWithResume(
             videoFile: any(named: 'videoFile'),
             nostrPubkey: any(named: 'nostrPubkey'),
+            taskId: any(named: 'taskId'),
             title: any(named: 'title'),
             description: any(named: 'description'),
             hashtags: any(named: 'hashtags'),
             proofManifestJson: any(named: 'proofManifestJson'),
+            useBackgroundFirst: any(named: 'useBackgroundFirst'),
+            resumableTimeout: any(named: 'resumableTimeout'),
             resumableSession: any(named: 'resumableSession'),
             onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
             onProgress: any(named: 'onProgress'),
@@ -534,13 +629,16 @@ void main() {
         );
 
         verify(
-          () => mockBlossomService.uploadVideo(
+          () => mockBlossomService.uploadVideoWithResume(
             videoFile: any(named: 'videoFile'),
             nostrPubkey: any(named: 'nostrPubkey'),
+            taskId: any(named: 'taskId'),
             title: any(named: 'title'),
             description: any(named: 'description'),
             hashtags: any(named: 'hashtags'),
             proofManifestJson: any(named: 'proofManifestJson'),
+            useBackgroundFirst: any(named: 'useBackgroundFirst'),
+            resumableTimeout: any(named: 'resumableTimeout'),
             resumableSession: any(named: 'resumableSession'),
             onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
             onProgress: any(named: 'onProgress'),
@@ -584,13 +682,16 @@ void main() {
         expect(current!.status, equals(UploadStatus.paused));
 
         verifyNever(
-          () => mockBlossomService.uploadVideo(
+          () => mockBlossomService.uploadVideoWithResume(
             videoFile: any(named: 'videoFile'),
             nostrPubkey: any(named: 'nostrPubkey'),
+            taskId: any(named: 'taskId'),
             title: any(named: 'title'),
             description: any(named: 'description'),
             hashtags: any(named: 'hashtags'),
             proofManifestJson: any(named: 'proofManifestJson'),
+            useBackgroundFirst: any(named: 'useBackgroundFirst'),
+            resumableTimeout: any(named: 'resumableTimeout'),
             resumableSession: any(named: 'resumableSession'),
             onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
             onProgress: any(named: 'onProgress'),

--- a/mobile/test/services/upload_manager_resumable_upload_test.dart
+++ b/mobile/test/services/upload_manager_resumable_upload_test.dart
@@ -721,13 +721,16 @@ void main() {
 
         final uploadStarted = Completer<void>();
         when(
-          () => mockBlossomService.uploadVideo(
+          () => mockBlossomService.uploadVideoWithResume(
             videoFile: any(named: 'videoFile'),
             nostrPubkey: any(named: 'nostrPubkey'),
+            taskId: any(named: 'taskId'),
             title: any(named: 'title'),
             description: any(named: 'description'),
             hashtags: any(named: 'hashtags'),
             proofManifestJson: any(named: 'proofManifestJson'),
+            useBackgroundFirst: any(named: 'useBackgroundFirst'),
+            resumableTimeout: any(named: 'resumableTimeout'),
             resumableSession: any(named: 'resumableSession'),
             onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
             onProgress: any(named: 'onProgress'),

--- a/mobile/test/unit/services/upload_manager_get_by_path_test.dart
+++ b/mobile/test/unit/services/upload_manager_get_by_path_test.dart
@@ -55,13 +55,16 @@ void main() {
       () => mockUploadService.isBlossomEnabled(),
     ).thenAnswer((_) async => false);
     when(
-      () => mockUploadService.uploadVideo(
+      () => mockUploadService.uploadVideoWithResume(
         videoFile: any(named: 'videoFile'),
         nostrPubkey: any(named: 'nostrPubkey'),
+        taskId: any(named: 'taskId'),
         title: any(named: 'title'),
         description: any(named: 'description'),
         hashtags: any(named: 'hashtags'),
         proofManifestJson: any(named: 'proofManifestJson'),
+        useBackgroundFirst: any(named: 'useBackgroundFirst'),
+        resumableTimeout: any(named: 'resumableTimeout'),
         resumableSession: any(named: 'resumableSession'),
         onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
         onProgress: any(named: 'onProgress'),


### PR DESCRIPTION
Closes #6087

## Summary

A fresh publish attempts the OS-backed whole-file PUT first (it survives app suspension and is fastest on a healthy connection). When that fails — or when a resumable session already exists from a prior attempt — the new `uploadVideoWithResume` falls through to the chunked resumable protocol so retries resume from the server's last committed `Upload-Offset` instead of byte 0.

This fills the explicit gap **#5590 left open** (*"Out of Scope: app-kill reconciliation"*) without reverting the two deliberate decisions that preceded it:
- **#5590** (Jul 1): moved the transfer to the OS background uploader because the in-process socket dies on suspension. This PR keeps the OS PUT as the first attempt for fresh uploads.
- **#2223** (Mar 15): removed silent auto-resume-on-startup after Discord users complained about uploads restarting without control. This PR does **not** re-add auto-resume — the user-decided bottom sheet stays. It only makes the *retry* resume efficiently.

## How it works

```
uploadVideoWithResume(session):
  if session == null:           # fresh publish
    try OS whole-file PUT       # survives suspension (#5590)
    if success → done
  # fall through to resumable (also the only path when session exists)
  POST /upload/init
  HEAD {uploadUrl}              # Upload-Offset → how many bytes the server has
  PUT remaining chunks only     # Content-Range, persisted per chunk
  POST /upload/{id}/complete
```

Once a resumable session is persisted (via the existing `onResumableSessionUpdated` callback), the existing **"Try Again" bottom sheet** automatically resumes from the last offset — no new wiring needed. The retry path already reuses `PendingUpload.resumableSession`.

## Key design constraint

The OS uploader (`background_uploader`) is **whole-file-only** on both platforms (iOS `URLSession.uploadTask(with:fromFile:)`, Android `HttpURLConnection`). Byte-level resume **cannot** go through the OS transport. It always happens through the in-process chunk path. The OS path is only ever used for the first whole-file attempt of a fresh publish.

## Timeout safety

`resumableTimeout` bounds **only** the in-process chunked leg. The OS-backed PUT keeps its own internal 30-min timeout — the aggressive 10-min `networkTimeout` is not applied to it, so an in-process cutoff cannot defeat suspension survival.

## Changes

| File | Change |
|---|---|
| `blossom_upload_service.dart` | New `uploadVideoWithResume` orchestrator: OS-first for fresh, resumable fallback on failure or existing session |
| `upload_manager.dart` | `_executeUploadWithTimeout` calls the combined method; `useBackgroundUpload` becomes the OS-first toggle |
| `blossom_upload_with_resume_test.dart` | 7 new tests covering all branches (OS success, OS fail→resumable, existing-session resume, `useBackgroundFirst=false`, session-callback offsets, OS-throws guard, resumableTimeout) |
| `upload_manager_resumable_upload_test.dart` | New wiring test: verifies combined method receives persisted session + flag; existing stubs updated |
| `upload_manager_from_draft_test.dart`, `upload_manager_background_pause_test.dart` | Mock stubs updated to `uploadVideoWithResume` |
| `2026-03-26-divine-resumable-upload-sessions-bud.md` | Updated mobile client status line |

## Verification

- `flutter analyze` — no issues on all changed files
- `blossom_upload_service` package: **221 tests pass**, **100% coverage** on `blossom_upload_service.dart` (825/825 lines, `min_coverage: 100` satisfied)
- `upload_manager` app tests: all pass (resumable, from-draft, background-pause)
- Regression test pinning: resume-after-failure sends only `fileSize - offset` bytes (the "when a resumable session already exists" test asserts exactly 1 chunk PUT for the tail, not the whole file)

## Related

- Closes the gap left open by #5590 (*"Out of Scope: app-kill reconciliation"*).
- Does not affect #1226 (pending uploads UI) or #5151 (pipeline coverage).