### PR TITLE
fix(nostr): guard queryEvents against a disposed client's closed pool

### DIFF
--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -588,6 +588,10 @@ class NostrClient {
   /// Then queries via WebSocket and merges results.
   ///
   /// Results from websocket are cached for future queries.
+  ///
+  /// Calling this on a disposed client is a no-op that returns an empty
+  /// list. If the client is disposed while a call is in flight, the
+  /// network query is skipped and only cached results are returned.
   Future<List<Event>> queryEvents(
     List<Filter> filters, {
     String? subscriptionId,

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -637,14 +637,18 @@ class NostrClient {
     // relay's "too many concurrent REQs" limit. `withResource` releases the
     // slot when the (time-bounded) query completes, so it can't leak.
     //
-    // Re-check the pool's own closed state immediately before use (rather
-    // than relying solely on the upfront isDisposed check above): dispose()
-    // can run during the awaits above, and `_queryPool.isClosed` flips
-    // before `_isDisposed` does (dispose() closes the pool first). This
-    // check-then-call has no await between them, so it closes the race
-    // rather than narrowing it. See #5952.
+    // Re-check the pool's own closed state immediately before the query,
+    // independent of `useQueryPool`: dispose() can run during the awaits
+    // above, and `_queryPool.close()` flips `isClosed` before `_isDisposed`
+    // is set (dispose() closes the pool first), so it's a reliable
+    // dispose-in-progress sentinel for both paths. The non-pooled path
+    // (`queryUsers`, `useQueryPool: false`) matters here too: a query that
+    // fell through after `_nostr.close()` would re-open fresh WebSockets to
+    // the NIP-50 search relays and leak temp relays nothing would clean up.
+    // This check-then-call has no await before the query, so it closes the
+    // race rather than narrowing it. See #5952.
     final List<Event> websocketEvents;
-    if (useQueryPool && _queryPool.isClosed) {
+    if (_queryPool.isClosed) {
       websocketEvents = [];
     } else {
       websocketEvents = useQueryPool

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -598,6 +598,13 @@ class NostrClient {
     bool useQueryPool = true,
     Duration timeout = const Duration(seconds: 5),
   }) async {
+    // A disposed client's query pool is closed; querying it is a no-op
+    // rather than an error. This is the common case (checked upfront to
+    // skip pointless cache/reconnect work below) — the narrower re-check
+    // right before `withResource` (see below) closes the residual race
+    // where dispose() runs during the awaits in between. See #5952.
+    if (_isDisposed) return [];
+
     final effectiveTempRelays = _allowedRelays(tempRelays);
     final cacheResults = <Event>[];
 
@@ -629,9 +636,21 @@ class NostrClient {
     // videos → per-item like-count/badge/profile/repost fetches) can't trip a
     // relay's "too many concurrent REQs" limit. `withResource` releases the
     // slot when the (time-bounded) query completes, so it can't leak.
-    final websocketEvents = useQueryPool
-        ? await _queryPool.withResource(runWebSocketQuery)
-        : await runWebSocketQuery();
+    //
+    // Re-check the pool's own closed state immediately before use (rather
+    // than relying solely on the upfront isDisposed check above): dispose()
+    // can run during the awaits above, and `_queryPool.isClosed` flips
+    // before `_isDisposed` does (dispose() closes the pool first). This
+    // check-then-call has no await between them, so it closes the race
+    // rather than narrowing it. See #5952.
+    final List<Event> websocketEvents;
+    if (useQueryPool && _queryPool.isClosed) {
+      websocketEvents = [];
+    } else {
+      websocketEvents = useQueryPool
+          ? await _queryPool.withResource(runWebSocketQuery)
+          : await runWebSocketQuery();
+    }
 
     // Cache websocket results (fire-and-forget)
     if (websocketEvents.isNotEmpty) {

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -1154,6 +1154,30 @@ void main() {
           ),
         ).called(1);
       });
+
+      test(
+        'returns empty list without throwing when client is disposed',
+        () async {
+          final filters = [
+            Filter(kinds: [EventKind.textNote], limit: 10),
+          ];
+          when(() => mockNostr.unsubscribe(any())).thenReturn(null);
+          await client.dispose();
+
+          final result = await client.queryEvents(filters);
+
+          expect(result, isEmpty);
+          verifyNever(
+            () => mockNostr.queryEvents(
+              any(),
+              id: any(named: 'id'),
+              tempRelays: any(named: 'tempRelays'),
+              relayTypes: any(named: 'relayTypes'),
+              sendAfterAuth: any(named: 'sendAfterAuth'),
+            ),
+          );
+        },
+      );
     });
 
     group('fetchEventById', () {

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -1156,15 +1156,144 @@ void main() {
       });
 
       test(
-        'returns empty list without throwing when client is disposed',
+        'returns empty without touching cache or relays when already '
+        'disposed',
         () async {
-          final filters = [
-            Filter(kinds: [EventKind.textNote], limit: 10),
-          ];
+          // The upfront isDisposed early-return: a disposed client must not
+          // read the cache or attempt a reconnect. connectedRelays is empty
+          // so the reconnect branch WOULD fire if the early-return were gone.
+          final mockDbClient = _MockAppDbClient();
+          final mockDatabase = _MockAppDatabase();
+          final dao = _MockNostrEventsDao();
+          when(() => mockDbClient.database).thenReturn(mockDatabase);
+          when(() => mockDatabase.nostrEventsDao).thenReturn(dao);
+          when(
+            () => dao.getEventsByFilter(any()),
+          ).thenAnswer((_) async => <Event>[]);
+          when(() => mockRelayManager.connectedRelays).thenReturn([]);
+          when(
+            mockRelayManager.retryDisconnectedRelays,
+          ).thenAnswer((_) async {});
           when(() => mockNostr.unsubscribe(any())).thenReturn(null);
-          await client.dispose();
 
-          final result = await client.queryEvents(filters);
+          final clientWithCache = NostrClient.forTesting(
+            nostr: mockNostr,
+            relayManager: mockRelayManager,
+            dbClient: mockDbClient,
+          );
+          await clientWithCache.dispose();
+
+          final result = await clientWithCache.queryEvents([
+            Filter(kinds: [EventKind.textNote], limit: 10),
+          ]);
+
+          expect(result, isEmpty);
+          verifyNever(() => dao.getEventsByFilter(any()));
+          verifyNever(mockRelayManager.retryDisconnectedRelays);
+          verifyNever(
+            () => mockNostr.queryEvents(
+              any(),
+              id: any(named: 'id'),
+              tempRelays: any(named: 'tempRelays'),
+              relayTypes: any(named: 'relayTypes'),
+              sendAfterAuth: any(named: 'sendAfterAuth'),
+            ),
+          );
+        },
+      );
+
+      test(
+        'skips the WebSocket query without throwing when dispose races the '
+        'cache read (pooled path)',
+        () async {
+          // Park the query at the cache await, then dispose() mid-flight so
+          // it resumes past the upfront isDisposed check and reaches the
+          // pre-query guard with a closed pool. Deleting that guard makes
+          // this throw "withResource() may not be called on a closed Pool".
+          final mockDbClient = _MockAppDbClient();
+          final mockDatabase = _MockAppDatabase();
+          final dao = _MockNostrEventsDao();
+          when(() => mockDbClient.database).thenReturn(mockDatabase);
+          when(() => mockDatabase.nostrEventsDao).thenReturn(dao);
+
+          final cacheGate = Completer<List<Event>>();
+          when(
+            () => dao.getEventsByFilter(any()),
+          ).thenAnswer((_) => cacheGate.future);
+          when(() => mockNostr.unsubscribe(any())).thenReturn(null);
+
+          final clientWithCache = NostrClient.forTesting(
+            nostr: mockNostr,
+            relayManager: mockRelayManager,
+            dbClient: mockDbClient,
+          );
+
+          final pending = clientWithCache.queryEvents([
+            Filter(kinds: [EventKind.textNote], limit: 10),
+          ]);
+          await pumpEventQueue();
+          // Confirm we actually parked in the race window.
+          verify(() => dao.getEventsByFilter(any())).called(1);
+
+          await clientWithCache.dispose();
+          cacheGate.complete([_createTestEvent(id: 'cached')]);
+
+          final result = await pending;
+
+          // The already-read cache result survives; the network is skipped.
+          expect(result.map((e) => e.id), ['cached']);
+          verifyNever(
+            () => mockNostr.queryEvents(
+              any(),
+              id: any(named: 'id'),
+              tempRelays: any(named: 'tempRelays'),
+              relayTypes: any(named: 'relayTypes'),
+              sendAfterAuth: any(named: 'sendAfterAuth'),
+            ),
+          );
+        },
+      );
+
+      test(
+        'skips the WebSocket query when dispose races the cache read '
+        '(non-pooled useQueryPool: false path)',
+        () async {
+          // Same race for the queryUsers path. With the old
+          // `useQueryPool && _queryPool.isClosed` guard this fell through to
+          // `_nostr.queryEvents` on a closed client, re-opening WebSockets to
+          // the search relays. verifyNever below is what catches that.
+          final mockDbClient = _MockAppDbClient();
+          final mockDatabase = _MockAppDatabase();
+          final dao = _MockNostrEventsDao();
+          when(() => mockDbClient.database).thenReturn(mockDatabase);
+          when(() => mockDatabase.nostrEventsDao).thenReturn(dao);
+
+          final cacheGate = Completer<List<Event>>();
+          when(
+            () => dao.getEventsByFilter(any()),
+          ).thenAnswer((_) => cacheGate.future);
+          when(() => mockNostr.unsubscribe(any())).thenReturn(null);
+
+          final clientWithCache = NostrClient.forTesting(
+            nostr: mockNostr,
+            relayManager: mockRelayManager,
+            dbClient: mockDbClient,
+          );
+
+          final pending = clientWithCache.queryEvents(
+            [
+              Filter(kinds: [EventKind.metadata], search: 'alice', limit: 100),
+            ],
+            tempRelays: const ['wss://search.example.com'],
+            useQueryPool: false,
+          );
+          await pumpEventQueue();
+          verify(() => dao.getEventsByFilter(any())).called(1);
+
+          await clientWithCache.dispose();
+          cacheGate.complete(const []);
+
+          final result = await pending;
 
           expect(result, isEmpty);
           verifyNever(


### PR DESCRIPTION
Closes #5952

## Summary

- #5952 reported `ModerationLabelService.subscribeToLabeler` throwing `Bad state: withResource() may not be called on a closed Pool` at cold start, with moderation labels silently failing to load. Investigation found the crash and permanent-loss case were already fixed by #5596 (merged before #5952 was filed) — the support tickets cited in #5952 are all on a pre-#5596 build.
- What remained: a narrow, transient version of the same logged error that can still fire when `dispose()` races the async work inside `NostrClient.queryEvents` between a caller's readiness check and the actual `_queryPool.withResource` call.
- This PR closes that residual gap: an upfront `isDisposed` check (skips pointless cache/reconnect work on an already-disposed client) plus a re-check of the pool's own `isClosed` state immediately before use, with no `await` in between — closing the race rather than narrowing it, and without needing to catch a `StateError` (avoids the `avoid_catching_errors` lint, and is more precise since it checks the pool's real state rather than inferring it from a caught exception).

## Investigation trail

Full findings, confidence-scored hypotheses, and the considered-and-rejected alternatives (folding into #5638, mobile-side consumption of the `moderation/resolution` namespace) are in the issue thread and this session's brainstorm. Two adjacent findings surfaced during investigation were filed separately, out of scope for this PR:
- `divine-relay-manager#180` — a backend "ban" audit label published without a confirmed enforcement RPC call
- `divine-mobile#6088` — four unrelated NIP-32 parser spec-compliance gaps in `ModerationLabelService`, invisible today since production publishes zero `content-warning` events

## Test plan

- [x] New regression test: `queryEvents` on a disposed client returns `[]` without throwing, and never reaches the underlying WebSocket query
- [x] `flutter test` — full `nostr_client` package (287 tests) and `moderation_label_service_test.dart` (20 tests), all pass
- [x] `flutter analyze lib test integration_test` — clean
- [x] Package coverage: 85.17%, above the 82% `min_coverage` gate
- [x] Pre-commit and pre-push hooks passed