### PR TITLE
feat(deep-links): open playlist links in-app via /list/:pubkey/:listId

### DIFF
--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -152,7 +152,10 @@
                 <data android:pathPrefix="/hashtag"/>
                 <data android:pathPrefix="/search"/>
                 <data android:pathPrefix="/invite"/>
-                <data android:pathPrefix="/list"/>
+                <!-- pathPattern, not pathPrefix: a "/list" prefix would also
+                     claim the web's /lists browse page (prefix matching is a
+                     raw string prefix, not segment-aware). -->
+                <data android:pathPattern="/list/.*"/>
                 <data android:pathPrefix="/reset-password"/>
                 <data android:pathPrefix="/verify-email"/>
             </intent-filter>

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -152,6 +152,7 @@
                 <data android:pathPrefix="/hashtag"/>
                 <data android:pathPrefix="/search"/>
                 <data android:pathPrefix="/invite"/>
+                <data android:pathPrefix="/list"/>
                 <data android:pathPrefix="/reset-password"/>
                 <data android:pathPrefix="/verify-email"/>
             </intent-filter>

--- a/mobile/docs/apple-app-site-association
+++ b/mobile/docs/apple-app-site-association
@@ -22,6 +22,10 @@
             "comment": "Search deep links"
           },
           {
+            "/": "/list/*",
+            "comment": "Curated list (playlist) deep links"
+          },
+          {
             "/": "/app/callback",
             "comment": "OAuth callback for Divine app"
           }

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -71,6 +71,8 @@ import 'package:openvine/providers/service_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/router/router.dart';
 import 'package:openvine/screens/auth/welcome_screen.dart';
+import 'package:openvine/screens/curated_list_by_author_screen.dart';
+import 'package:openvine/screens/curated_list_feed_screen.dart';
 import 'package:openvine/screens/explore/explore_screen.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
 import 'package:openvine/screens/hashtag_screen_router.dart';
@@ -431,6 +433,54 @@ SearchDeepLinkNavAction resolveSearchDeepLinkNavAction({
   // Coming from a non-search route — push so back returns to where the user
   // was instead of obliterating the navigation stack.
   return SearchDeepLinkNavAction.push;
+}
+
+/// Describes the router action to take when navigating to a list deep link.
+///
+/// Mirrors [VideoDeepLinkNavAction] and [ProfileDeepLinkNavAction] so list
+/// links get the same nav-stack parity: `push` keeps the previous route (e.g.
+/// home) underneath so back returns there, `go` replaces an existing list
+/// route in-place, and `skip` dedupes a navigation to the route already shown.
+@visibleForTesting
+enum ListDeepLinkNavAction {
+  /// Navigate to the route, keeping the current route in the back stack.
+  push,
+
+  /// Replace the current route in-place (already on a list route).
+  go,
+
+  /// The router is already on the target route with nothing new to do.
+  skip,
+}
+
+/// Determines which router action to take for a list deep-link navigation
+/// given the current router location and the incoming target path.
+///
+/// Mirrors [resolveProfileDeepLinkNavAction]: extracted for testability — the
+/// caller executes the action; this function only decides what it should be.
+///
+/// The "already on a list route" check matches both list route shapes: the
+/// internal `/list/:listId` route reached from Explore/Search and the
+/// web-canonical `/list/:pubkey/:listId` deep-link route.
+@visibleForTesting
+ListDeepLinkNavAction resolveListDeepLinkNavAction({
+  required String currentLocation,
+  required String targetPath,
+}) {
+  if (currentLocation == targetPath) {
+    // Already on the exact target route. Duplicate navigation with nothing new
+    // to do (e.g. GoRouter's universal-link redirect already navigated here, or
+    // getInitialLink + uriLinkStream both fire for the same URL). Safe to skip.
+    return ListDeepLinkNavAction.skip;
+  }
+  if (currentLocation.startsWith('${CuratedListFeedScreen.basePath}/')) {
+    // A different list is already showing — replace it in-place, matching
+    // the video-replaces-video behaviour.
+    return ListDeepLinkNavAction.go;
+  }
+  // Coming from a non-list route — push so back returns to where the user
+  // was instead of obliterating the navigation stack.
+  return ListDeepLinkNavAction.push;
 }
 
 /// Resolves a push/local payload to a [NotificationTapTarget], the event id to
@@ -2085,6 +2135,58 @@ class _DivineAppState extends ConsumerState<DivineApp>
               } else {
                 Log.warning(
                   '⚠️ Search deep link missing search term',
+                  name: 'DeepLinkHandler',
+                  category: LogCategory.ui,
+                );
+              }
+            case DeepLinkType.list:
+              final listPubkey = deepLink.listPubkey;
+              final listId = deepLink.listId;
+              if (listPubkey != null && listId != null) {
+                final targetPath = CuratedListByAuthorScreen.pathFor(
+                  pubkey: listPubkey,
+                  listId: listId,
+                );
+                Log.info(
+                  '📱 Navigating to list: $targetPath',
+                  name: 'DeepLinkHandler',
+                  category: LogCategory.ui,
+                );
+                try {
+                  final action = resolveListDeepLinkNavAction(
+                    currentLocation: currentLocation,
+                    targetPath: targetPath,
+                  );
+                  switch (action) {
+                    case ListDeepLinkNavAction.skip:
+                      // GoRouter's universal-link redirect may have already
+                      // navigated here; skip the duplicate navigation to avoid
+                      // a second navigation frame on the same target.
+                      break;
+                    case ListDeepLinkNavAction.go:
+                      // Another list is already showing — replace it
+                      // in-place instead of stacking it.
+                      router.go(targetPath);
+                    case ListDeepLinkNavAction.push:
+                      // Keep the current route underneath so back returns to
+                      // wherever the user was instead of wiping the stack.
+                      router.push(targetPath);
+                  }
+                  Log.info(
+                    '✅ Navigation completed to: $targetPath',
+                    name: 'DeepLinkHandler',
+                    category: LogCategory.ui,
+                  );
+                } catch (e) {
+                  Log.error(
+                    '❌ Navigation failed: $e',
+                    name: 'DeepLinkHandler',
+                    category: LogCategory.ui,
+                  );
+                }
+              } else {
+                Log.warning(
+                  '⚠️ List deep link missing pubkey or list id',
                   name: 'DeepLinkHandler',
                   category: LogCategory.ui,
                 );

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -2162,21 +2162,31 @@ class _DivineAppState extends ConsumerState<DivineApp>
                       // GoRouter's universal-link redirect may have already
                       // navigated here; skip the duplicate navigation to avoid
                       // a second navigation frame on the same target.
-                      break;
+                      Log.info(
+                        '⏭️ Already on $targetPath — skipping duplicate '
+                        'list navigation',
+                        name: 'DeepLinkHandler',
+                        category: LogCategory.ui,
+                      );
                     case ListDeepLinkNavAction.go:
                       // Another list is already showing — replace it
                       // in-place instead of stacking it.
                       router.go(targetPath);
+                      Log.info(
+                        '✅ Navigation completed to: $targetPath',
+                        name: 'DeepLinkHandler',
+                        category: LogCategory.ui,
+                      );
                     case ListDeepLinkNavAction.push:
                       // Keep the current route underneath so back returns to
                       // wherever the user was instead of wiping the stack.
                       router.push(targetPath);
+                      Log.info(
+                        '✅ Navigation completed to: $targetPath',
+                        name: 'DeepLinkHandler',
+                        category: LogCategory.ui,
+                      );
                   }
-                  Log.info(
-                    '✅ Navigation completed to: $targetPath',
-                    name: 'DeepLinkHandler',
-                    category: LogCategory.ui,
-                  );
                 } catch (e) {
                   Log.error(
                     '❌ Navigation failed: $e',

--- a/mobile/lib/providers/list_providers.dart
+++ b/mobile/lib/providers/list_providers.dart
@@ -219,6 +219,24 @@ Stream<List<CuratedList>> publicListsContainingVideo(
   yield accumulated;
 }
 
+/// Provider that fetches a public curated list (kind 30005) by author +
+/// d-tag for the `/list/:pubkey/:listId` universal-link route.
+///
+/// Unlike [curatedListVideos], this does not require the list to be in
+/// local storage — it resolves from cache + relays, so deep links to lists
+/// the user has never seen still work. Returns `null` when no matching
+/// list event exists.
+@riverpod
+Future<CuratedList?> publicCuratedList(
+  Ref ref, {
+  required String authorPubkey,
+  required String listId,
+}) async {
+  await ref.watch(curatedListsStateProvider.future);
+  final service = ref.read(curatedListsStateProvider.notifier).service;
+  return service?.fetchPublicList(authorPubkey: authorPubkey, listId: listId);
+}
+
 /// Provider that fetches actual VideoEvent objects for a curated list
 /// Streams videos as they are fetched from cache or relays
 @riverpod

--- a/mobile/lib/providers/list_providers.dart
+++ b/mobile/lib/providers/list_providers.dart
@@ -232,8 +232,16 @@ Future<CuratedList?> publicCuratedList(
   required String authorPubkey,
   required String listId,
 }) async {
-  await ref.watch(curatedListsStateProvider.future);
-  final service = ref.read(curatedListsStateProvider.notifier).service;
+  // Depend on the notifier (stable across state emissions), not the state:
+  // CuratedListsState re-emits on every CuratedListService.notifyListeners
+  // (background relay sync, list add/remove), and watching the state future
+  // would re-run this fetch — resetting the deep-link screen to loading —
+  // on every one of those emissions.
+  final notifier = ref.watch(curatedListsStateProvider.notifier);
+  // One-shot await so the service exists on cold-start deep links;
+  // deliberately read, not watch (see above).
+  await ref.read(curatedListsStateProvider.future);
+  final service = notifier.service;
   return service?.fetchPublicList(authorPubkey: authorPubkey, listId: listId);
 }
 

--- a/mobile/lib/providers/list_providers.g.dart
+++ b/mobile/lib/providers/list_providers.g.dart
@@ -579,7 +579,7 @@ final class PublicCuratedListProvider
   }
 }
 
-String _$publicCuratedListHash() => r'cc4d45f0c106db233512993ccd4e9e0ddee9864b';
+String _$publicCuratedListHash() => r'2b8f4915387aa7b0954908543571a9c780921860';
 
 /// Provider that fetches a public curated list (kind 30005) by author +
 /// d-tag for the `/list/:pubkey/:listId` universal-link route.

--- a/mobile/lib/providers/list_providers.g.dart
+++ b/mobile/lib/providers/list_providers.g.dart
@@ -497,6 +497,133 @@ final class PublicListsContainingVideoFamily extends $Family
   String toString() => r'publicListsContainingVideoProvider';
 }
 
+/// Provider that fetches a public curated list (kind 30005) by author +
+/// d-tag for the `/list/:pubkey/:listId` universal-link route.
+///
+/// Unlike [curatedListVideos], this does not require the list to be in
+/// local storage — it resolves from cache + relays, so deep links to lists
+/// the user has never seen still work. Returns `null` when no matching
+/// list event exists.
+
+@ProviderFor(publicCuratedList)
+final publicCuratedListProvider = PublicCuratedListFamily._();
+
+/// Provider that fetches a public curated list (kind 30005) by author +
+/// d-tag for the `/list/:pubkey/:listId` universal-link route.
+///
+/// Unlike [curatedListVideos], this does not require the list to be in
+/// local storage — it resolves from cache + relays, so deep links to lists
+/// the user has never seen still work. Returns `null` when no matching
+/// list event exists.
+
+final class PublicCuratedListProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<CuratedList?>,
+          CuratedList?,
+          FutureOr<CuratedList?>
+        >
+    with $FutureModifier<CuratedList?>, $FutureProvider<CuratedList?> {
+  /// Provider that fetches a public curated list (kind 30005) by author +
+  /// d-tag for the `/list/:pubkey/:listId` universal-link route.
+  ///
+  /// Unlike [curatedListVideos], this does not require the list to be in
+  /// local storage — it resolves from cache + relays, so deep links to lists
+  /// the user has never seen still work. Returns `null` when no matching
+  /// list event exists.
+  PublicCuratedListProvider._({
+    required PublicCuratedListFamily super.from,
+    required ({String authorPubkey, String listId}) super.argument,
+  }) : super(
+         retry: null,
+         name: r'publicCuratedListProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$publicCuratedListHash();
+
+  @override
+  String toString() {
+    return r'publicCuratedListProvider'
+        ''
+        '$argument';
+  }
+
+  @$internal
+  @override
+  $FutureProviderElement<CuratedList?> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<CuratedList?> create(Ref ref) {
+    final argument = this.argument as ({String authorPubkey, String listId});
+    return publicCuratedList(
+      ref,
+      authorPubkey: argument.authorPubkey,
+      listId: argument.listId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is PublicCuratedListProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$publicCuratedListHash() => r'cc4d45f0c106db233512993ccd4e9e0ddee9864b';
+
+/// Provider that fetches a public curated list (kind 30005) by author +
+/// d-tag for the `/list/:pubkey/:listId` universal-link route.
+///
+/// Unlike [curatedListVideos], this does not require the list to be in
+/// local storage — it resolves from cache + relays, so deep links to lists
+/// the user has never seen still work. Returns `null` when no matching
+/// list event exists.
+
+final class PublicCuratedListFamily extends $Family
+    with
+        $FunctionalFamilyOverride<
+          FutureOr<CuratedList?>,
+          ({String authorPubkey, String listId})
+        > {
+  PublicCuratedListFamily._()
+    : super(
+        retry: null,
+        name: r'publicCuratedListProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  /// Provider that fetches a public curated list (kind 30005) by author +
+  /// d-tag for the `/list/:pubkey/:listId` universal-link route.
+  ///
+  /// Unlike [curatedListVideos], this does not require the list to be in
+  /// local storage — it resolves from cache + relays, so deep links to lists
+  /// the user has never seen still work. Returns `null` when no matching
+  /// list event exists.
+
+  PublicCuratedListProvider call({
+    required String authorPubkey,
+    required String listId,
+  }) => PublicCuratedListProvider._(
+    argument: (authorPubkey: authorPubkey, listId: listId),
+    from: this,
+  );
+
+  @override
+  String toString() => r'publicCuratedListProvider';
+}
+
 /// Provider that fetches actual VideoEvent objects for a curated list
 /// Streams videos as they are fetched from cache or relays
 

--- a/mobile/lib/router/providers/page_context_provider.dart
+++ b/mobile/lib/router/providers/page_context_provider.dart
@@ -14,6 +14,7 @@ import 'package:openvine/screens/blossom_settings_screen.dart';
 import 'package:openvine/screens/category_gallery_screen.dart';
 import 'package:openvine/screens/content_filters_screen.dart';
 import 'package:openvine/screens/creator_analytics_screen.dart';
+import 'package:openvine/screens/curated_list_by_author_screen.dart';
 import 'package:openvine/screens/curated_list_feed_screen.dart';
 import 'package:openvine/screens/developer_options_screen.dart';
 import 'package:openvine/screens/discover_lists_screen.dart';
@@ -414,6 +415,16 @@ RouteContext parseRoute(String path) {
       if (segments.length < 2) {
         return const RouteContext(type: RouteType.explore);
       }
+      // Web-canonical deep-link shape /list/:pubkey/:listId — the author
+      // key rides in [RouteContext.npub] so buildRoute can reconstruct the
+      // by-author path instead of collapsing it to /list/:listId.
+      if (segments.length >= 3) {
+        return RouteContext(
+          type: RouteType.curatedList,
+          npub: _safeDecode(segments[1]),
+          listId: _safeDecode(segments[2]),
+        );
+      }
       final listId = _safeDecode(segments[1]);
       return RouteContext(type: RouteType.curatedList, listId: listId);
 
@@ -677,6 +688,13 @@ String buildRoute(RouteContext context) {
       return OtherProfileScreen.pathForNpub(npub);
 
     case RouteType.curatedList:
+      final listAuthor = context.npub;
+      if (listAuthor != null && listAuthor.isNotEmpty) {
+        return CuratedListByAuthorScreen.pathFor(
+          pubkey: listAuthor,
+          listId: context.listId ?? '',
+        );
+      }
       return CuratedListFeedScreen.pathForId(context.listId ?? '');
 
     case RouteType.discoverLists:

--- a/mobile/lib/router/routes/lists_routes.dart
+++ b/mobile/lib/router/routes/lists_routes.dart
@@ -10,6 +10,7 @@ import 'package:openvine/features/people_lists/view/create_people_list_page.dart
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/router/route_error_screen.dart';
 import 'package:openvine/router/routes/route_extras.dart';
+import 'package:openvine/screens/curated_list_by_author_screen.dart';
 import 'package:openvine/screens/curated_list_feed_screen.dart';
 import 'package:openvine/screens/discover_lists_screen.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
@@ -35,6 +36,28 @@ List<RouteBase> listsRoutes(Ref ref) {
           listName: extra?.listName ?? ctx.l10n.routeDefaultListName,
           videoIds: extra?.videoIds,
           authorPubkey: extra?.authorPubkey,
+        );
+      },
+    ),
+
+    // CURATED LIST BY AUTHOR route — web-canonical /list/:pubkey/:listId
+    // universal-link shape. Resolves the list from relays by author + d-tag,
+    // so deep links work for lists that are not in local storage.
+    GoRoute(
+      path: CuratedListByAuthorScreen.path,
+      name: CuratedListByAuthorScreen.routeName,
+      builder: (ctx, st) {
+        final pubkey = st.pathParameters['pubkey'];
+        final listId = st.pathParameters['listId'];
+        if (pubkey == null ||
+            pubkey.isEmpty ||
+            listId == null ||
+            listId.isEmpty) {
+          return RouteErrorScreen(message: ctx.l10n.routeInvalidListId);
+        }
+        return CuratedListByAuthorScreen(
+          authorPubkey: pubkey,
+          listId: listId,
         );
       },
     ),

--- a/mobile/lib/router/universal_link_resolver.dart
+++ b/mobile/lib/router/universal_link_resolver.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Pure resolver from universal-link URIs to internal GoRouter paths
 // ABOUTME: Shared source of truth used by the router redirect and tests
 
+import 'package:openvine/screens/curated_list_by_author_screen.dart';
 import 'package:openvine/screens/hashtag_screen_router.dart';
 import 'package:openvine/screens/profile_screen_router.dart';
 import 'package:openvine/screens/search_results/view/search_results_page.dart';
@@ -42,6 +43,19 @@ String? divineUrlToPushRoute(Uri uri) {
         term,
         requestFocusOnMount: false,
       );
+    case DeepLinkType.list:
+      final listPubkey = deepLink.listPubkey;
+      final listId = deepLink.listId;
+      if (listPubkey == null ||
+          listPubkey.isEmpty ||
+          listId == null ||
+          listId.isEmpty) {
+        return null;
+      }
+      return CuratedListByAuthorScreen.pathFor(
+        pubkey: listPubkey,
+        listId: listId,
+      );
     case DeepLinkType.invite:
     case DeepLinkType.signerCallback:
     case DeepLinkType.unknown:
@@ -78,6 +92,7 @@ String? universalLinkToRouterPath(Uri uri) {
     case DeepLinkType.profile:
     case DeepLinkType.hashtag:
     case DeepLinkType.search:
+    case DeepLinkType.list:
       return route;
   }
 }

--- a/mobile/lib/screens/curated_list_by_author_screen.dart
+++ b/mobile/lib/screens/curated_list_by_author_screen.dart
@@ -9,6 +9,7 @@ import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/list_providers.dart';
 import 'package:openvine/router/route_error_screen.dart';
 import 'package:openvine/screens/curated_list_feed_screen.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 /// Resolves a `/list/:pubkey/:listId` link into [CuratedListFeedScreen].
 ///
@@ -52,6 +53,13 @@ class CuratedListByAuthorScreen extends ConsumerWidget {
     return listAsync.when(
       data: (list) {
         if (list == null) {
+          // Full IDs (never truncated) so a "link won't open" report is
+          // traceable to the exact list.
+          Log.warning(
+            'List deep link resolved to no event: /list/$authorPubkey/$listId',
+            name: 'CuratedListByAuthorScreen',
+            category: LogCategory.ui,
+          );
           return const _ListUnavailableView();
         }
         return CuratedListFeedScreen(
@@ -62,7 +70,17 @@ class CuratedListByAuthorScreen extends ConsumerWidget {
         );
       },
       loading: () => const _ListLoadingView(),
-      error: (error, stackTrace) => const _ListUnavailableView(),
+      error: (error, stackTrace) {
+        // Expected failure (relay unavailable / not found) — not reportable
+        // per the error decision matrix, but logged with full IDs for triage.
+        Log.warning(
+          'Failed to resolve list deep link /list/$authorPubkey/$listId: '
+          '$error',
+          name: 'CuratedListByAuthorScreen',
+          category: LogCategory.ui,
+        );
+        return const _ListUnavailableView();
+      },
     );
   }
 }

--- a/mobile/lib/screens/curated_list_by_author_screen.dart
+++ b/mobile/lib/screens/curated_list_by_author_screen.dart
@@ -4,12 +4,11 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
+import 'package:openvine/extensions/safe_pop_extension.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/list_providers.dart';
 import 'package:openvine/router/route_error_screen.dart';
 import 'package:openvine/screens/curated_list_feed_screen.dart';
-import 'package:openvine/screens/feed/video_feed_page.dart';
 
 /// Resolves a `/list/:pubkey/:listId` link into [CuratedListFeedScreen].
 ///
@@ -28,8 +27,9 @@ class CuratedListByAuthorScreen extends ConsumerWidget {
   /// Route name for this screen.
   static const routeName = 'listByAuthor';
 
-  /// Path for this route.
-  static const path = '/list/:pubkey/:listId';
+  /// Path for this route. Derived from [CuratedListFeedScreen.basePath] so
+  /// the GoRoute pattern and [pathFor] can never diverge.
+  static const path = '${CuratedListFeedScreen.basePath}/:pubkey/:listId';
 
   /// Build path for a list addressed by author + d-tag.
   static String pathFor({required String pubkey, required String listId}) {
@@ -67,16 +67,6 @@ class CuratedListByAuthorScreen extends ConsumerWidget {
   }
 }
 
-/// Leaves the screen; on a cold-start deep link there is no route
-/// underneath, so fall back to the home feed instead of popping.
-void _navigateBack(BuildContext context) {
-  if (context.canPop()) {
-    context.pop();
-  } else {
-    context.go(VideoFeedPage.pathForIndex(0));
-  }
-}
-
 class _ListLoadingView extends StatelessWidget {
   const _ListLoadingView();
 
@@ -87,7 +77,9 @@ class _ListLoadingView extends StatelessWidget {
       appBar: DiVineAppBar(
         title: context.l10n.routeDefaultListName,
         showBackButton: true,
-        onBackPressed: () => _navigateBack(context),
+        // safePop: on a cold-start deep link this is the only route, and a
+        // raw pop would throw GoError.
+        onBackPressed: context.safePop,
       ),
       body: const Center(
         child: CircularProgressIndicator(color: VineTheme.vineGreen),
@@ -105,7 +97,7 @@ class _ListUnavailableView extends StatelessWidget {
       message: context.l10n.curatedListFailedToLoad,
       title: context.l10n.routeDefaultListName,
       showBackButton: true,
-      onBackPressed: () => _navigateBack(context),
+      onBackPressed: context.safePop,
     );
   }
 }

--- a/mobile/lib/screens/curated_list_by_author_screen.dart
+++ b/mobile/lib/screens/curated_list_by_author_screen.dart
@@ -1,0 +1,111 @@
+// ABOUTME: Screen for /list/:pubkey/:listId universal links (web-canonical shape)
+// ABOUTME: Resolves a NIP-51 kind 30005 list by author + d-tag, then shows the list feed
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/list_providers.dart';
+import 'package:openvine/router/route_error_screen.dart';
+import 'package:openvine/screens/curated_list_feed_screen.dart';
+import 'package:openvine/screens/feed/video_feed_page.dart';
+
+/// Resolves a `/list/:pubkey/:listId` link into [CuratedListFeedScreen].
+///
+/// This is the web-canonical public URL shape for NIP-51 kind 30005 lists,
+/// which are addressed by author + d-tag. Unlike the internal
+/// `/list/:listId` route — which relies on route extras and locally stored
+/// lists — this screen fetches the list from relays, so deep links to lists
+/// the user has never seen still open.
+class CuratedListByAuthorScreen extends ConsumerWidget {
+  const CuratedListByAuthorScreen({
+    required this.authorPubkey,
+    required this.listId,
+    super.key,
+  });
+
+  /// Route name for this screen.
+  static const routeName = 'listByAuthor';
+
+  /// Path for this route.
+  static const path = '/list/:pubkey/:listId';
+
+  /// Build path for a list addressed by author + d-tag.
+  static String pathFor({required String pubkey, required String listId}) {
+    return '${CuratedListFeedScreen.basePath}/${Uri.encodeComponent(pubkey)}'
+        '/${Uri.encodeComponent(listId)}';
+  }
+
+  /// Author pubkey (lowercase hex).
+  final String authorPubkey;
+
+  /// List d-tag identifier.
+  final String listId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final listAsync = ref.watch(
+      publicCuratedListProvider(authorPubkey: authorPubkey, listId: listId),
+    );
+
+    return listAsync.when(
+      data: (list) {
+        if (list == null) {
+          return const _ListUnavailableView();
+        }
+        return CuratedListFeedScreen(
+          listId: list.id,
+          listName: list.name,
+          videoIds: list.videoEventIds,
+          authorPubkey: list.pubkey ?? authorPubkey,
+        );
+      },
+      loading: () => const _ListLoadingView(),
+      error: (error, stackTrace) => const _ListUnavailableView(),
+    );
+  }
+}
+
+/// Leaves the screen; on a cold-start deep link there is no route
+/// underneath, so fall back to the home feed instead of popping.
+void _navigateBack(BuildContext context) {
+  if (context.canPop()) {
+    context.pop();
+  } else {
+    context.go(VideoFeedPage.pathForIndex(0));
+  }
+}
+
+class _ListLoadingView extends StatelessWidget {
+  const _ListLoadingView();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: VineTheme.backgroundColor,
+      appBar: DiVineAppBar(
+        title: context.l10n.routeDefaultListName,
+        showBackButton: true,
+        onBackPressed: () => _navigateBack(context),
+      ),
+      body: const Center(
+        child: CircularProgressIndicator(color: VineTheme.vineGreen),
+      ),
+    );
+  }
+}
+
+class _ListUnavailableView extends StatelessWidget {
+  const _ListUnavailableView();
+
+  @override
+  Widget build(BuildContext context) {
+    return RouteErrorScreen(
+      message: context.l10n.curatedListFailedToLoad,
+      title: context.l10n.routeDefaultListName,
+      showBackButton: true,
+      onBackPressed: () => _navigateBack(context),
+    );
+  }
+}

--- a/mobile/lib/screens/curated_list_feed_screen.dart
+++ b/mobile/lib/screens/curated_list_feed_screen.dart
@@ -9,6 +9,7 @@ import 'package:flutter/semantics.dart' show SemanticsService;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide LogCategory;
+import 'package:openvine/extensions/safe_pop_extension.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/list_providers.dart';
@@ -86,7 +87,9 @@ class _CuratedListFeedScreenState extends ConsumerState<CuratedListFeedScreen> {
                 ],
               ),
               showBackButton: true,
-              onBackPressed: context.pop,
+              // safePop: on a cold-start deep link this screen can be the
+              // only route, and a raw pop would throw GoError.
+              onBackPressed: context.safePop,
               // Subscribing to your own list is meaningless — owners only
               // get the overflow menu (delete).
               actions: [if (!_isOwnedList()) _buildSubscribeAction()],

--- a/mobile/lib/services/curated_list_service.dart
+++ b/mobile/lib/services/curated_list_service.dart
@@ -1304,40 +1304,6 @@ class CuratedListService extends ChangeNotifier {
   /// Use [until] to paginate backwards (set to oldest createdAt from previous batch)
   /// Use [limit] to control how many events to request (default: 500)
   /// Use [excludeIds] to skip lists already known (for pagination)
-  /// Fetches a single public curated list (kind 30005) by author + d-tag.
-  ///
-  /// Queries local cache + relays via [NostrClient.queryEvents]. Returns
-  /// `null` when no matching list event is found. Replaceable-event
-  /// semantics: when multiple versions come back (e.g. from different
-  /// relays), the newest one wins.
-  Future<CuratedList?> fetchPublicList({
-    required String authorPubkey,
-    required String listId,
-  }) async {
-    final events = await _nostrService.queryEvents([
-      Filter(
-        kinds: [30005], // NIP-51 curated lists
-        authors: [authorPubkey],
-        d: [listId],
-        limit: 1,
-      ),
-    ]);
-
-    CuratedList? newest;
-    for (final event in events) {
-      final list = _eventToCuratedList(event);
-      // Re-check author + d-tag: queryEvents merges cache results, whose
-      // filter support can be looser than a relay's.
-      if (list == null || list.id != listId || list.pubkey != authorPubkey) {
-        continue;
-      }
-      if (newest == null || list.updatedAt.isAfter(newest.updatedAt)) {
-        newest = list;
-      }
-    }
-    return newest;
-  }
-
   Stream<List<CuratedList>> streamPublicListsFromRelays({
     DateTime? until,
     int limit = 500,
@@ -1425,6 +1391,39 @@ class CuratedListService extends ChangeNotifier {
       name: 'CuratedListService',
       category: LogCategory.system,
     );
+  }
+
+  /// Fetches a single public curated list (kind 30005) by author + d-tag.
+  ///
+  /// Queries local cache + relays via [NostrClient.queryEvents]. Returns
+  /// `null` when no matching list event is found. No result limit is set,
+  /// so a stale cached version and a newer relay version can both arrive —
+  /// the newest one wins. Author + d-tag are re-checked on each result
+  /// because queryEvents merges cache hits, whose filter support can be
+  /// looser than a relay's.
+  Future<CuratedList?> fetchPublicList({
+    required String authorPubkey,
+    required String listId,
+  }) async {
+    final events = await _nostrService.queryEvents([
+      Filter(
+        kinds: [30005], // NIP-51 curated lists
+        authors: [authorPubkey],
+        d: [listId],
+      ),
+    ]);
+
+    CuratedList? newest;
+    for (final event in events) {
+      final list = _eventToCuratedList(event);
+      if (list == null || list.id != listId || list.pubkey != authorPubkey) {
+        continue;
+      }
+      if (newest == null || list.updatedAt.isAfter(newest.updatedAt)) {
+        newest = list;
+      }
+    }
+    return newest;
   }
 
   /// Fetch public curated lists from Nostr relays for discovery (legacy)

--- a/mobile/lib/services/curated_list_service.dart
+++ b/mobile/lib/services/curated_list_service.dart
@@ -1398,9 +1398,10 @@ class CuratedListService extends ChangeNotifier {
   /// Queries local cache + relays via [NostrClient.queryEvents]. Returns
   /// `null` when no matching list event is found. No result limit is set,
   /// so a stale cached version and a newer relay version can both arrive —
-  /// the newest one wins. Author + d-tag are re-checked on each result
-  /// because queryEvents merges cache hits, whose filter support can be
-  /// looser than a relay's.
+  /// the winner follows NIP-01 replaceable/addressable ordering (newer
+  /// `created_at`, lowest event id on a tie; see [_replacesList]). Author +
+  /// d-tag are re-checked on each result because queryEvents merges cache
+  /// hits, whose filter support can be looser than a relay's.
   Future<CuratedList?> fetchPublicList({
     required String authorPubkey,
     required String listId,
@@ -1413,17 +1414,28 @@ class CuratedListService extends ChangeNotifier {
       ),
     ]);
 
-    CuratedList? newest;
+    CuratedList? winner;
     for (final event in events) {
       final list = _eventToCuratedList(event);
       if (list == null || list.id != listId || list.pubkey != authorPubkey) {
         continue;
       }
-      if (newest == null || list.updatedAt.isAfter(newest.updatedAt)) {
-        newest = list;
+      if (winner == null || _replacesList(list, winner)) {
+        winner = list;
       }
     }
-    return newest;
+    return winner;
+  }
+
+  /// NIP-01 replaceable/addressable ordering: a newer `created_at` wins; on an
+  /// equal timestamp the lowest event id (first in lexical order) is retained.
+  bool _replacesList(CuratedList candidate, CuratedList current) {
+    if (candidate.updatedAt.isAfter(current.updatedAt)) return true;
+    if (candidate.updatedAt.isBefore(current.updatedAt)) return false;
+    return (candidate.nostrEventId ?? '').compareTo(
+          current.nostrEventId ?? '',
+        ) <
+        0;
   }
 
   /// Fetch public curated lists from Nostr relays for discovery (legacy)

--- a/mobile/lib/services/curated_list_service.dart
+++ b/mobile/lib/services/curated_list_service.dart
@@ -1304,6 +1304,40 @@ class CuratedListService extends ChangeNotifier {
   /// Use [until] to paginate backwards (set to oldest createdAt from previous batch)
   /// Use [limit] to control how many events to request (default: 500)
   /// Use [excludeIds] to skip lists already known (for pagination)
+  /// Fetches a single public curated list (kind 30005) by author + d-tag.
+  ///
+  /// Queries local cache + relays via [NostrClient.queryEvents]. Returns
+  /// `null` when no matching list event is found. Replaceable-event
+  /// semantics: when multiple versions come back (e.g. from different
+  /// relays), the newest one wins.
+  Future<CuratedList?> fetchPublicList({
+    required String authorPubkey,
+    required String listId,
+  }) async {
+    final events = await _nostrService.queryEvents([
+      Filter(
+        kinds: [30005], // NIP-51 curated lists
+        authors: [authorPubkey],
+        d: [listId],
+        limit: 1,
+      ),
+    ]);
+
+    CuratedList? newest;
+    for (final event in events) {
+      final list = _eventToCuratedList(event);
+      // Re-check author + d-tag: queryEvents merges cache results, whose
+      // filter support can be looser than a relay's.
+      if (list == null || list.id != listId || list.pubkey != authorPubkey) {
+        continue;
+      }
+      if (newest == null || list.updatedAt.isAfter(newest.updatedAt)) {
+        newest = list;
+      }
+    }
+    return newest;
+  }
+
   Stream<List<CuratedList>> streamPublicListsFromRelays({
     DateTime? until,
     int limit = 500,

--- a/mobile/lib/services/deep_link_service.dart
+++ b/mobile/lib/services/deep_link_service.dart
@@ -4,6 +4,7 @@
 import 'dart:async';
 
 import 'package:app_links/app_links.dart';
+import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/utils/sensitive_uri_for_logs.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -14,6 +15,7 @@ enum DeepLinkType {
   hashtag,
   search,
   invite,
+  list,
   signerCallback,
   unknown,
 }
@@ -27,6 +29,8 @@ class DeepLink {
     this.hashtag,
     this.searchTerm,
     this.inviteCode,
+    this.listPubkey,
+    this.listId,
     this.signerCallbackRelay,
     this.index,
     this.autoOpenComments = false,
@@ -43,6 +47,13 @@ class DeepLink {
   final String? hashtag;
   final String? searchTerm;
   final String? inviteCode;
+
+  /// Author pubkey of a `/list/:pubkey/:listId` link, normalized to
+  /// lowercase hex (NIP-51 kind 30005 lists are addressed by author + d-tag).
+  final String? listPubkey;
+
+  /// The d-tag identifier of a `/list/:pubkey/:listId` link.
+  final String? listId;
   final String? signerCallbackRelay;
   final int? index; // Optional video index for feed view
 
@@ -65,6 +76,9 @@ class DeepLink {
         return 'DeepLink(type: search, searchTerm: $searchTerm$indexStr)';
       case DeepLinkType.invite:
         return 'DeepLink(type: invite, inviteCode: $redactedSensitiveLogPlaceholder)';
+      case DeepLinkType.list:
+        return 'DeepLink(type: list, listPubkey: $listPubkey, '
+            'listId: $listId)';
       case DeepLinkType.signerCallback:
         return 'DeepLink(type: signerCallback)';
       case DeepLinkType.unknown:
@@ -256,6 +270,33 @@ class DeepLinkService {
         );
       }
 
+      // Handle /list/{pubkey}/{listId} — NIP-51 kind 30005 curated video
+      // lists, addressed by author + d-tag. The author segment accepts hex
+      // or npub and is normalized to lowercase hex for relay filters.
+      if (pathSegments.length == 3 && pathSegments[0] == 'list') {
+        final listPubkey = _normalizePubkeyToHex(pathSegments[1]);
+        final listId = pathSegments[2];
+        if (listPubkey == null || listId.isEmpty) {
+          Log.warning(
+            'Ignoring list deep link with invalid author or id: '
+            '${_describeUriForLogs(uri)}',
+            name: 'DeepLinkService',
+            category: LogCategory.ui,
+          );
+          return const DeepLink(type: DeepLinkType.unknown);
+        }
+        Log.info(
+          '📱 Parsed list deep link: $listPubkey/$listId',
+          name: 'DeepLinkService',
+          category: LogCategory.ui,
+        );
+        return DeepLink(
+          type: DeepLinkType.list,
+          listPubkey: listPubkey,
+          listId: listId,
+        );
+      }
+
       // Handle /invite/{code} or /invite?code=ABCD-EFGH
       if (pathSegments.isNotEmpty && pathSegments[0] == 'invite') {
         final inviteCode = pathSegments.length > 1
@@ -336,6 +377,27 @@ class DeepLinkService {
       }
     }
 
+    return null;
+  }
+
+  static final _hexPubkeyRegex = RegExp(r'^[a-fA-F0-9]{64}$');
+
+  /// Normalizes an author path segment (64-char hex or `npub1…`) to
+  /// lowercase hex. Returns `null` when the segment is neither.
+  static String? _normalizePubkeyToHex(String segment) {
+    if (_hexPubkeyRegex.hasMatch(segment)) {
+      return segment.toLowerCase();
+    }
+    if (segment.startsWith('npub1')) {
+      try {
+        final decoded = NostrKeyUtils.decode(segment);
+        if (_hexPubkeyRegex.hasMatch(decoded)) {
+          return decoded.toLowerCase();
+        }
+      } catch (_) {
+        // Invalid bech32 — fall through to null.
+      }
+    }
     return null;
   }
 

--- a/mobile/lib/services/deep_link_service.dart
+++ b/mobile/lib/services/deep_link_service.dart
@@ -4,7 +4,7 @@
 import 'dart:async';
 
 import 'package:app_links/app_links.dart';
-import 'package:openvine/utils/nostr_key_utils.dart';
+import 'package:openvine/utils/public_identifier_normalizer.dart';
 import 'package:openvine/utils/sensitive_uri_for_logs.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -271,10 +271,13 @@ class DeepLinkService {
       }
 
       // Handle /list/{pubkey}/{listId} — NIP-51 kind 30005 curated video
-      // lists, addressed by author + d-tag. The author segment accepts hex
-      // or npub and is normalized to lowercase hex for relay filters.
+      // lists, addressed by author + d-tag. The author segment accepts hex,
+      // npub, or nprofile and is normalized to lowercase hex for relay
+      // filters.
       if (pathSegments.length == 3 && pathSegments[0] == 'list') {
-        final listPubkey = _normalizePubkeyToHex(pathSegments[1]);
+        final listPubkey = normalizePublicIdentifier(
+          pathSegments[1],
+        )?.hexPubkey.toLowerCase();
         final listId = pathSegments[2];
         if (listPubkey == null || listId.isEmpty) {
           Log.warning(
@@ -377,27 +380,6 @@ class DeepLinkService {
       }
     }
 
-    return null;
-  }
-
-  static final _hexPubkeyRegex = RegExp(r'^[a-fA-F0-9]{64}$');
-
-  /// Normalizes an author path segment (64-char hex or `npub1…`) to
-  /// lowercase hex. Returns `null` when the segment is neither.
-  static String? _normalizePubkeyToHex(String segment) {
-    if (_hexPubkeyRegex.hasMatch(segment)) {
-      return segment.toLowerCase();
-    }
-    if (segment.startsWith('npub1')) {
-      try {
-        final decoded = NostrKeyUtils.decode(segment);
-        if (_hexPubkeyRegex.hasMatch(decoded)) {
-          return decoded.toLowerCase();
-        }
-      } catch (_) {
-        // Invalid bech32 — fall through to null.
-      }
-    }
     return null;
   }
 

--- a/mobile/test/main_list_deep_link_nav_action_test.dart
+++ b/mobile/test/main_list_deep_link_nav_action_test.dart
@@ -1,0 +1,77 @@
+// ABOUTME: Regression tests for resolveListDeepLinkNavAction routing decision
+// ABOUTME: Verifies list deep links push (keeping the stack), go (replacing
+// ABOUTME: an existing list route), or skip (dedup) instead of always
+// ABOUTME: calling router.go() which would obliterate the navigation stack.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/main.dart' as app;
+import 'package:openvine/screens/curated_list_by_author_screen.dart';
+import 'package:openvine/screens/curated_list_feed_screen.dart';
+
+void main() {
+  const authorPubkey =
+      'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2';
+  final targetPath = CuratedListByAuthorScreen.pathFor(
+    pubkey: authorPubkey,
+    listId: 'my-vines',
+  );
+
+  group('resolveListDeepLinkNavAction', () {
+    test(
+      'returns skip when already on the list — duplicate link event, '
+      'nothing new to do',
+      () {
+        final action = app.resolveListDeepLinkNavAction(
+          currentLocation: targetPath,
+          targetPath: targetPath,
+        );
+        expect(action, equals(app.ListDeepLinkNavAction.skip));
+      },
+    );
+
+    test('returns go when a different deep-linked list is showing', () {
+      const otherPubkey =
+          'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+      final otherPath = CuratedListByAuthorScreen.pathFor(
+        pubkey: otherPubkey,
+        listId: 'other-list',
+      );
+
+      final action = app.resolveListDeepLinkNavAction(
+        currentLocation: otherPath,
+        targetPath: targetPath,
+      );
+      expect(action, equals(app.ListDeepLinkNavAction.go));
+    });
+
+    test(
+      'returns go when an internally opened list (/list/:listId) is showing',
+      () {
+        final internalPath = CuratedListFeedScreen.pathForId('local-list');
+
+        final action = app.resolveListDeepLinkNavAction(
+          currentLocation: internalPath,
+          targetPath: targetPath,
+        );
+        expect(action, equals(app.ListDeepLinkNavAction.go));
+      },
+    );
+
+    test('returns push from a non-list route so back returns there', () {
+      final action = app.resolveListDeepLinkNavAction(
+        currentLocation: '/home/0',
+        targetPath: targetPath,
+      );
+      expect(action, equals(app.ListDeepLinkNavAction.push));
+    });
+
+    test('returns push from the discover-lists route — /discover-lists is '
+        'not under the /list/ prefix', () {
+      final action = app.resolveListDeepLinkNavAction(
+        currentLocation: '/discover-lists',
+        targetPath: targetPath,
+      );
+      expect(action, equals(app.ListDeepLinkNavAction.push));
+    });
+  });
+}

--- a/mobile/test/providers/list_providers_test.dart
+++ b/mobile/test/providers/list_providers_test.dart
@@ -12,6 +12,7 @@ import 'package:openvine/features/feature_flags/providers/feature_flag_providers
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/list_providers.dart';
 import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/curated_list_service.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:people_lists_repository/people_lists_repository.dart';
 
@@ -494,4 +495,75 @@ void main() {
       expect(second, isEmpty);
     });
   });
+
+  group(publicCuratedListProvider, () {
+    test(
+      'fetches once and does not re-run when the lists state re-emits',
+      () async {
+        final mockService = _MockCuratedListService();
+        when(
+          () => mockService.fetchPublicList(
+            authorPubkey: any(named: 'authorPubkey'),
+            listId: any(named: 'listId'),
+          ),
+        ).thenAnswer((_) async => null);
+
+        late _StubCuratedListsState notifier;
+        final container = ProviderContainer(
+          overrides: [
+            curatedListsStateProvider.overrideWith(
+              () => notifier = _StubCuratedListsState(mockService),
+            ),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        final provider = publicCuratedListProvider(
+          authorPubkey: _ownerA,
+          listId: 'my-vines',
+        );
+        final subscription = container.listen(provider, (_, _) {});
+        addTearDown(subscription.close);
+
+        await container.read(provider.future);
+        verify(
+          () => mockService.fetchPublicList(
+            authorPubkey: _ownerA,
+            listId: 'my-vines',
+          ),
+        ).called(1);
+
+        // Background relay sync and list add/remove fire
+        // CuratedListService.notifyListeners, which re-emits the lists
+        // state. The deep-link fetch must not re-run (and reset its screen
+        // to loading) on those emissions.
+        notifier.reEmit();
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        verifyNever(
+          () => mockService.fetchPublicList(
+            authorPubkey: _ownerA,
+            listId: 'my-vines',
+          ),
+        );
+      },
+    );
+  });
+}
+
+class _MockCuratedListService extends Mock implements CuratedListService {}
+
+class _StubCuratedListsState extends CuratedListsState {
+  _StubCuratedListsState(this._mockService);
+
+  final CuratedListService? _mockService;
+
+  @override
+  CuratedListService? get service => _mockService;
+
+  @override
+  Future<List<CuratedList>> build() async => [];
+
+  void reEmit() => state = const AsyncValue.data(<CuratedList>[]);
 }

--- a/mobile/test/router/route_coverage_test.dart
+++ b/mobile/test/router/route_coverage_test.dart
@@ -11,6 +11,8 @@ import 'package:openvine/screens/auth/welcome_screen.dart';
 import 'package:openvine/screens/badges/badges_screen.dart';
 import 'package:openvine/screens/blossom_settings_screen.dart';
 import 'package:openvine/screens/category_gallery_screen.dart';
+import 'package:openvine/screens/curated_list_by_author_screen.dart';
+import 'package:openvine/screens/curated_list_feed_screen.dart';
 import 'package:openvine/screens/explore/explore_screen.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
 import 'package:openvine/screens/hashtag_screen_router.dart';
@@ -591,6 +593,62 @@ void main() {
         expect(context.type, RouteType.hashtag);
         expect(context.hashtag, 'hello world');
       });
+    });
+
+    group('Curated list routes', () {
+      // Both list route shapes must round-trip through
+      // buildRoute(parseRoute()) or routeNormalizationProvider rewrites the
+      // location the instant the screen opens — bouncing the user off it.
+      const authorPubkey =
+          'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2';
+
+      test('/list/:listId parses to RouteType.curatedList', () {
+        final context = parseRoute(CuratedListFeedScreen.pathForId('my-list'));
+        expect(context.type, RouteType.curatedList);
+        expect(context.listId, 'my-list');
+        expect(context.npub, isNull);
+      });
+
+      test('/list/:listId round-trips through buildRoute(parseRoute())', () {
+        final path = CuratedListFeedScreen.pathForId('my-list');
+        expect(buildRoute(parseRoute(path)), path);
+      });
+
+      test(
+        '/list/:pubkey/:listId parses author pubkey and list id separately',
+        () {
+          final path = CuratedListByAuthorScreen.pathFor(
+            pubkey: authorPubkey,
+            listId: 'my-vines',
+          );
+          final context = parseRoute(path);
+          expect(context.type, RouteType.curatedList);
+          expect(context.npub, authorPubkey);
+          expect(context.listId, 'my-vines');
+        },
+      );
+
+      test(
+        '/list/:pubkey/:listId round-trips through buildRoute(parseRoute())',
+        () {
+          final path = CuratedListByAuthorScreen.pathFor(
+            pubkey: authorPubkey,
+            listId: 'my-vines',
+          );
+          expect(buildRoute(parseRoute(path)), path);
+        },
+      );
+
+      test(
+        '/list/:pubkey/:listId with an encoded list id round-trips',
+        () {
+          final path = CuratedListByAuthorScreen.pathFor(
+            pubkey: authorPubkey,
+            listId: 'my favorite vines',
+          );
+          expect(buildRoute(parseRoute(path)), path);
+        },
+      );
     });
   });
 }

--- a/mobile/test/router/universal_link_resolver_test.dart
+++ b/mobile/test/router/universal_link_resolver_test.dart
@@ -39,6 +39,17 @@ void main() {
         isNull,
       );
     });
+
+    test('maps list links to the internal list route', () {
+      const authorPubkey =
+          'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2';
+      expect(
+        divineUrlToPushRoute(
+          Uri.parse('https://divine.video/list/$authorPubkey/my-vines'),
+        ),
+        equals('/list/$authorPubkey/my-vines'),
+      );
+    });
   });
 
   group('universalLinkToRouterPath', () {
@@ -141,6 +152,38 @@ void main() {
             Uri.parse('https://divine.video/profile/$npub/7'),
           ),
           equals('/profile/$npub/7'),
+        );
+      });
+    });
+
+    group('list', () {
+      const authorPubkey =
+          'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2';
+
+      test('maps /list/:pubkey/:listId to the internal list route', () {
+        expect(
+          universalLinkToRouterPath(
+            Uri.parse('https://divine.video/list/$authorPubkey/my-vines'),
+          ),
+          equals('/list/$authorPubkey/my-vines'),
+        );
+      });
+
+      test('preserves URL-encoded list identifiers', () {
+        expect(
+          universalLinkToRouterPath(
+            Uri.parse('https://divine.video/list/$authorPubkey/my%20vines'),
+          ),
+          equals('/list/$authorPubkey/my%20vines'),
+        );
+      });
+
+      test('returns null for /list without a list id', () {
+        expect(
+          universalLinkToRouterPath(
+            Uri.parse('https://divine.video/list/$authorPubkey'),
+          ),
+          isNull,
         );
       });
     });

--- a/mobile/test/screens/curated_list_by_author_screen_test.dart
+++ b/mobile/test/screens/curated_list_by_author_screen_test.dart
@@ -1,0 +1,150 @@
+// ABOUTME: Tests for the /list/:pubkey/:listId deep-link resolver screen.
+// ABOUTME: Verifies loading, resolved-list, and unavailable states.
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart' hide LogCategory;
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/router/route_error_screen.dart';
+import 'package:openvine/screens/curated_list_by_author_screen.dart';
+import 'package:openvine/screens/curated_list_feed_screen.dart';
+import 'package:openvine/services/curated_list_service.dart';
+
+import '../helpers/test_provider_overrides.dart';
+
+class _MockCuratedListService extends Mock implements CuratedListService {}
+
+class _TestCuratedListsState extends CuratedListsState {
+  _TestCuratedListsState(this._mockService);
+
+  final CuratedListService? _mockService;
+
+  @override
+  CuratedListService? get service => _mockService;
+
+  @override
+  Future<List<CuratedList>> build() async => [];
+}
+
+const _authorPubkey =
+    'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2';
+
+void main() {
+  group(CuratedListByAuthorScreen, () {
+    late _MockCuratedListService mockService;
+    final l10n = lookupAppLocalizations(const Locale('en'));
+
+    setUp(() {
+      mockService = _MockCuratedListService();
+      when(() => mockService.isOwnedList(any())).thenReturn(false);
+      when(() => mockService.isSubscribedToList(any())).thenReturn(false);
+    });
+
+    Widget buildSubject() {
+      return ProviderScope(
+        overrides: [
+          ...getStandardTestOverrides(),
+          curatedListsStateProvider.overrideWith(
+            () => _TestCuratedListsState(mockService),
+          ),
+        ],
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: CuratedListByAuthorScreen(
+            authorPubkey: _authorPubkey,
+            listId: 'my-vines',
+          ),
+        ),
+      );
+    }
+
+    testWidgets('renders $CuratedListFeedScreen when the list resolves', (
+      tester,
+    ) async {
+      when(
+        () => mockService.fetchPublicList(
+          authorPubkey: _authorPubkey,
+          listId: 'my-vines',
+        ),
+      ).thenAnswer(
+        (_) async => CuratedList(
+          id: 'my-vines',
+          name: 'My Vines',
+          videoEventIds: const [],
+          pubkey: _authorPubkey,
+          createdAt: DateTime(2026),
+          updatedAt: DateTime(2026),
+        ),
+      );
+
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CuratedListFeedScreen), findsOneWidget);
+      expect(find.text('My Vines'), findsOneWidget);
+    });
+
+    testWidgets('shows the unavailable state when no list is found', (
+      tester,
+    ) async {
+      when(
+        () => mockService.fetchPublicList(
+          authorPubkey: _authorPubkey,
+          listId: 'my-vines',
+        ),
+      ).thenAnswer((_) async => null);
+
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      expect(find.byType(RouteErrorScreen), findsOneWidget);
+      expect(find.text(l10n.curatedListFailedToLoad), findsOneWidget);
+    });
+
+    testWidgets('shows the unavailable state when the fetch fails', (
+      tester,
+    ) async {
+      when(
+        () => mockService.fetchPublicList(
+          authorPubkey: _authorPubkey,
+          listId: 'my-vines',
+        ),
+      ).thenAnswer((_) async => throw Exception('relay unavailable'));
+
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      expect(find.byType(RouteErrorScreen), findsOneWidget);
+      expect(find.text(l10n.curatedListFailedToLoad), findsOneWidget);
+    });
+
+    testWidgets('shows a loading spinner while the list resolves', (
+      tester,
+    ) async {
+      final completer = Completer<CuratedList?>();
+      when(
+        () => mockService.fetchPublicList(
+          authorPubkey: _authorPubkey,
+          listId: 'my-vines',
+        ),
+      ).thenAnswer((_) => completer.future);
+
+      await tester.pumpWidget(buildSubject());
+      await tester.pump();
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+      completer.complete(null);
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.byType(RouteErrorScreen), findsOneWidget);
+    });
+  });
+}

--- a/mobile/test/screens/curated_list_by_author_screen_test.dart
+++ b/mobile/test/screens/curated_list_by_author_screen_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart' hide LogCategory;
+import 'package:openvine/extensions/safe_pop_extension.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/router/route_error_screen.dart';
@@ -15,6 +16,7 @@ import 'package:openvine/screens/curated_list_by_author_screen.dart';
 import 'package:openvine/screens/curated_list_feed_screen.dart';
 import 'package:openvine/services/curated_list_service.dart';
 
+import '../helpers/go_router.dart';
 import '../helpers/test_provider_overrides.dart';
 
 class _MockCuratedListService extends Mock implements CuratedListService {}
@@ -45,7 +47,11 @@ void main() {
       when(() => mockService.isSubscribedToList(any())).thenReturn(false);
     });
 
-    Widget buildSubject() {
+    Widget buildSubject({MockGoRouter? goRouter}) {
+      const screen = CuratedListByAuthorScreen(
+        authorPubkey: _authorPubkey,
+        listId: 'my-vines',
+      );
       return ProviderScope(
         overrides: [
           ...getStandardTestOverrides(),
@@ -53,13 +59,12 @@ void main() {
             () => _TestCuratedListsState(mockService),
           ),
         ],
-        child: const MaterialApp(
+        child: MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
-          home: CuratedListByAuthorScreen(
-            authorPubkey: _authorPubkey,
-            listId: 'my-vines',
-          ),
+          home: goRouter == null
+              ? screen
+              : MockGoRouterProvider(goRouter: goRouter, child: screen),
         ),
       );
     }
@@ -123,6 +128,31 @@ void main() {
       expect(find.byType(RouteErrorScreen), findsOneWidget);
       expect(find.text(l10n.curatedListFailedToLoad), findsOneWidget);
     });
+
+    testWidgets(
+      'unavailable-state back button falls back to the home feed when there '
+      'is nothing to pop (cold-start deep link)',
+      (tester) async {
+        when(
+          () => mockService.fetchPublicList(
+            authorPubkey: _authorPubkey,
+            listId: 'my-vines',
+          ),
+        ).thenAnswer((_) async => null);
+
+        final goRouter = MockGoRouter();
+        when(goRouter.canPop).thenReturn(false);
+        when(() => goRouter.go(any())).thenReturn(null);
+
+        await tester.pumpWidget(buildSubject(goRouter: goRouter));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byTooltip('Back'));
+
+        verify(() => goRouter.go(defaultSafePopFallback)).called(1);
+        verifyNever(() => goRouter.pop<Object?>());
+      },
+    );
 
     testWidgets('shows a loading spinner while the list resolves', (
       tester,

--- a/mobile/test/screens/curated_list_feed_screen_test.dart
+++ b/mobile/test/screens/curated_list_feed_screen_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart' hide LogCategory;
+import 'package:openvine/extensions/safe_pop_extension.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/curated_list_feed_screen.dart';
@@ -92,6 +93,37 @@ void main() {
 
       return app;
     }
+
+    testWidgets('back button pops when the router can pop', (tester) async {
+      final goRouter = MockGoRouter();
+      when(goRouter.canPop).thenReturn(true);
+      when(() => goRouter.pop<Object?>()).thenReturn(null);
+
+      await tester.pumpWidget(buildSubject(goRouter: goRouter));
+      await tester.pump();
+
+      await tester.tap(find.byTooltip('Back'));
+
+      verify(() => goRouter.pop<Object?>()).called(1);
+    });
+
+    testWidgets(
+      'back button falls back to the home feed when there is nothing to pop '
+      '(cold-start deep link)',
+      (tester) async {
+        final goRouter = MockGoRouter();
+        when(goRouter.canPop).thenReturn(false);
+        when(() => goRouter.go(any())).thenReturn(null);
+
+        await tester.pumpWidget(buildSubject(goRouter: goRouter));
+        await tester.pump();
+
+        await tester.tap(find.byTooltip('Back'));
+
+        verify(() => goRouter.go(defaultSafePopFallback)).called(1);
+        verifyNever(() => goRouter.pop<Object?>());
+      },
+    );
 
     testWidgets('shows unfollow list action for subscribed external list', (
       tester,

--- a/mobile/test/services/curated_list_service_fetch_public_test.dart
+++ b/mobile/test/services/curated_list_service_fetch_public_test.dart
@@ -150,6 +150,41 @@ void main() {
       expect(list!.name, equals('New Title'));
     });
 
+    test(
+      'keeps the lowest event id when timestamps tie (NIP-01 replaceable '
+      'ordering)',
+      () async {
+        final idHigh = 'f' * 64;
+        final idLow = '0' * 64;
+        // Returned high-first so a naive strict "isAfter" keeps the wrong one.
+        when(() => mockNostr.queryEvents(any())).thenAnswer(
+          (_) async => [
+            _listEvent(
+              id: idHigh,
+              dTag: 'my-vines',
+              createdAt: 1000,
+              title: 'High',
+            ),
+            _listEvent(
+              id: idLow,
+              dTag: 'my-vines',
+              createdAt: 1000,
+              title: 'Low',
+            ),
+          ],
+        );
+
+        final list = await service.fetchPublicList(
+          authorPubkey: _authorPubkey,
+          listId: 'my-vines',
+        );
+
+        expect(list, isNotNull);
+        expect(list!.name, equals('Low'));
+        expect(list.nostrEventId, equals(idLow));
+      },
+    );
+
     test('ignores events whose d-tag does not match', () async {
       when(() => mockNostr.queryEvents(any())).thenAnswer(
         (_) async => [

--- a/mobile/test/services/curated_list_service_fetch_public_test.dart
+++ b/mobile/test/services/curated_list_service_fetch_public_test.dart
@@ -199,5 +199,34 @@ void main() {
 
       expect(list, isNull);
     });
+
+    test(
+      'ignores an event whose d-tag matches but pubkey does not '
+      '(loose cache hit)',
+      () async {
+        const otherAuthor =
+            'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+        // queryEvents merges cache hits, whose author filtering can be looser
+        // than a relay's — a matching-d-tag, wrong-author event can slip in,
+        // which is exactly why fetchPublicList re-checks the pubkey.
+        when(() => mockNostr.queryEvents(any())).thenAnswer(
+          (_) async => [
+            _listEvent(
+              id: 'event_wrong_author',
+              dTag: 'my-vines',
+              createdAt: 1000,
+              pubkey: otherAuthor,
+            ),
+          ],
+        );
+
+        final list = await service.fetchPublicList(
+          authorPubkey: _authorPubkey,
+          listId: 'my-vines',
+        );
+
+        expect(list, isNull);
+      },
+    );
   });
 }

--- a/mobile/test/services/curated_list_service_fetch_public_test.dart
+++ b/mobile/test/services/curated_list_service_fetch_public_test.dart
@@ -1,0 +1,168 @@
+// ABOUTME: Unit tests for CuratedListService.fetchPublicList
+// ABOUTME: Covers relay fetch by author + d-tag for list deep links
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/filter.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/curated_list_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockAuthService extends Mock implements AuthService {}
+
+const _authorPubkey =
+    'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2';
+const _videoEventId =
+    '1111111111111111111111111111111111111111111111111111111111111111';
+
+Event _listEvent({
+  required String id,
+  required String dTag,
+  required int createdAt,
+  String title = 'My Vines',
+  String pubkey = _authorPubkey,
+}) {
+  return Event.fromJson({
+    'id': id,
+    'pubkey': pubkey,
+    'created_at': createdAt,
+    'kind': 30005,
+    'tags': [
+      ['d', dTag],
+      ['title', title],
+      ['e', _videoEventId],
+    ],
+    'content': '',
+    'sig': 'test_signature',
+  });
+}
+
+void main() {
+  group('CuratedListService.fetchPublicList', () {
+    late CuratedListService service;
+    late _MockNostrClient mockNostr;
+    late _MockAuthService mockAuth;
+    late SharedPreferences prefs;
+
+    setUpAll(() {
+      registerFallbackValue(<Filter>[]);
+    });
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+
+      mockNostr = _MockNostrClient();
+      mockAuth = _MockAuthService();
+      prefs = await SharedPreferences.getInstance();
+
+      when(() => mockAuth.isAuthenticated).thenReturn(true);
+      when(
+        () => mockAuth.currentPublicKeyHex,
+      ).thenReturn('test_pubkey_123456789abcdef');
+
+      service = CuratedListService(
+        nostrService: mockNostr,
+        authService: mockAuth,
+        prefs: prefs,
+      );
+    });
+
+    test('returns the parsed list when a matching event is found', () async {
+      when(() => mockNostr.queryEvents(any())).thenAnswer(
+        (_) async => [
+          _listEvent(id: 'event_1', dTag: 'my-vines', createdAt: 1000),
+        ],
+      );
+
+      final list = await service.fetchPublicList(
+        authorPubkey: _authorPubkey,
+        listId: 'my-vines',
+      );
+
+      expect(list, isNotNull);
+      expect(list!.id, equals('my-vines'));
+      expect(list.name, equals('My Vines'));
+      expect(list.pubkey, equals(_authorPubkey));
+      expect(list.videoEventIds, equals([_videoEventId]));
+    });
+
+    test('queries kind 30005 by author and d-tag', () async {
+      when(
+        () => mockNostr.queryEvents(any()),
+      ).thenAnswer((_) async => <Event>[]);
+
+      await service.fetchPublicList(
+        authorPubkey: _authorPubkey,
+        listId: 'my-vines',
+      );
+
+      final captured =
+          verify(() => mockNostr.queryEvents(captureAny())).captured.single
+              as List<Filter>;
+      expect(captured, hasLength(1));
+      final filter = captured.single;
+      expect(filter.kinds, equals([30005]));
+      expect(filter.authors, equals([_authorPubkey]));
+      expect(filter.d, equals(['my-vines']));
+    });
+
+    test('returns null when no event matches', () async {
+      when(
+        () => mockNostr.queryEvents(any()),
+      ).thenAnswer((_) async => <Event>[]);
+
+      final list = await service.fetchPublicList(
+        authorPubkey: _authorPubkey,
+        listId: 'my-vines',
+      );
+
+      expect(list, isNull);
+    });
+
+    test('picks the newest version of a replaceable event', () async {
+      when(() => mockNostr.queryEvents(any())).thenAnswer(
+        (_) async => [
+          _listEvent(
+            id: 'event_old',
+            dTag: 'my-vines',
+            createdAt: 1000,
+            title: 'Old Title',
+          ),
+          _listEvent(
+            id: 'event_new',
+            dTag: 'my-vines',
+            createdAt: 2000,
+            title: 'New Title',
+          ),
+        ],
+      );
+
+      final list = await service.fetchPublicList(
+        authorPubkey: _authorPubkey,
+        listId: 'my-vines',
+      );
+
+      expect(list, isNotNull);
+      expect(list!.name, equals('New Title'));
+    });
+
+    test('ignores events whose d-tag does not match', () async {
+      when(() => mockNostr.queryEvents(any())).thenAnswer(
+        (_) async => [
+          _listEvent(id: 'event_other', dTag: 'other-list', createdAt: 1000),
+        ],
+      );
+
+      final list = await service.fetchPublicList(
+        authorPubkey: _authorPubkey,
+        listId: 'my-vines',
+      );
+
+      expect(list, isNull);
+    });
+  });
+}

--- a/mobile/test/services/deep_link_service_test.dart
+++ b/mobile/test/services/deep_link_service_test.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Tests video URLs, profile URLs, and unknown URL patterns
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/nip19/nip19_tlv.dart';
 import 'package:openvine/services/deep_link_service.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/utils/sensitive_uri_for_logs.dart';
@@ -253,6 +254,22 @@ void main() {
       test('normalizes npub author to hex', () {
         final npub = NostrKeyUtils.encodePubKey(authorPubkey);
         final url = 'https://divine.video/list/$npub/my-vines';
+
+        final result = DeepLinkService.parseDeepLink(url);
+
+        expect(result.type, equals(DeepLinkType.list));
+        expect(result.listPubkey, equals(authorPubkey));
+        expect(result.listId, equals('my-vines'));
+      });
+
+      test('normalizes nprofile author to hex', () {
+        final nprofile = NIP19Tlv.encodeNprofile(
+          Nprofile(
+            pubkey: authorPubkey,
+            relays: ['wss://relay.divine.video'],
+          ),
+        );
+        final url = 'https://divine.video/list/$nprofile/my-vines';
 
         final result = DeepLinkService.parseDeepLink(url);
 

--- a/mobile/test/services/deep_link_service_test.dart
+++ b/mobile/test/services/deep_link_service_test.dart
@@ -3,6 +3,7 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/services/deep_link_service.dart';
+import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/utils/sensitive_uri_for_logs.dart';
 
 void main() {
@@ -218,6 +219,88 @@ void main() {
         final result = DeepLinkService.parseDeepLink(
           'https://divine.video/invite',
         );
+
+        expect(result.type, equals(DeepLinkType.unknown));
+      });
+    });
+
+    group('List URL Parsing', () {
+      const authorPubkey =
+          'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2';
+
+      test('parses /list/{pubkey}/{listId} with hex pubkey', () {
+        const url = 'https://divine.video/list/$authorPubkey/my-vines';
+
+        final result = DeepLinkService.parseDeepLink(url);
+
+        expect(result.type, equals(DeepLinkType.list));
+        expect(result.listPubkey, equals(authorPubkey));
+        expect(result.listId, equals('my-vines'));
+        expect(result.videoRef, isNull);
+        expect(result.npub, isNull);
+      });
+
+      test('normalizes uppercase hex pubkey to lowercase', () {
+        final url =
+            'https://divine.video/list/${authorPubkey.toUpperCase()}/my-vines';
+
+        final result = DeepLinkService.parseDeepLink(url);
+
+        expect(result.type, equals(DeepLinkType.list));
+        expect(result.listPubkey, equals(authorPubkey));
+      });
+
+      test('normalizes npub author to hex', () {
+        final npub = NostrKeyUtils.encodePubKey(authorPubkey);
+        final url = 'https://divine.video/list/$npub/my-vines';
+
+        final result = DeepLinkService.parseDeepLink(url);
+
+        expect(result.type, equals(DeepLinkType.list));
+        expect(result.listPubkey, equals(authorPubkey));
+        expect(result.listId, equals('my-vines'));
+      });
+
+      test('decodes URL-encoded list identifiers', () {
+        const url =
+            'https://divine.video/list/$authorPubkey/my%20favorite%20vines';
+
+        final result = DeepLinkService.parseDeepLink(url);
+
+        expect(result.type, equals(DeepLinkType.list));
+        expect(result.listId, equals('my favorite vines'));
+      });
+
+      test('rejects list URL without a list id', () {
+        const url = 'https://divine.video/list/$authorPubkey';
+
+        final result = DeepLinkService.parseDeepLink(url);
+
+        expect(result.type, equals(DeepLinkType.unknown));
+        expect(result.listPubkey, isNull);
+        expect(result.listId, isNull);
+      });
+
+      test('rejects bare /list path', () {
+        const url = 'https://divine.video/list';
+
+        final result = DeepLinkService.parseDeepLink(url);
+
+        expect(result.type, equals(DeepLinkType.unknown));
+      });
+
+      test('rejects list URL with an invalid author pubkey', () {
+        const url = 'https://divine.video/list/not-a-pubkey/my-vines';
+
+        final result = DeepLinkService.parseDeepLink(url);
+
+        expect(result.type, equals(DeepLinkType.unknown));
+      });
+
+      test('rejects list URL with extra path segments', () {
+        const url = 'https://divine.video/list/$authorPubkey/my-vines/extra';
+
+        final result = DeepLinkService.parseDeepLink(url);
 
         expect(result.type, equals(DeepLinkType.unknown));
       });
@@ -454,6 +537,20 @@ void main() {
       test('formats video deep link', () {
         const link = DeepLink(type: DeepLinkType.video, videoRef: 'abc');
         expect(link.toString(), equals('DeepLink(type: video, videoRef: abc)'));
+      });
+
+      test('formats list deep link with full untruncated pubkey', () {
+        const pubkey =
+            'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2';
+        const link = DeepLink(
+          type: DeepLinkType.list,
+          listPubkey: pubkey,
+          listId: 'my-vines',
+        );
+        expect(
+          link.toString(),
+          equals('DeepLink(type: list, listPubkey: $pubkey, listId: my-vines)'),
+        );
       });
 
       test('formats profile deep link with index', () {

--- a/mobile/test/services/deep_link_service_test.dart
+++ b/mobile/test/services/deep_link_service_test.dart
@@ -298,6 +298,19 @@ void main() {
         expect(result.listId, isNull);
       });
 
+      test('rejects a 3-segment list URL with an empty list id '
+          '(trailing slash)', () {
+        // A trailing slash yields a 3rd, empty path segment, so this reaches
+        // the parse branch with a valid pubkey and an empty list id — the
+        // isEmpty half of the guard, distinct from the missing-segment case.
+        const url = 'https://divine.video/list/$authorPubkey/';
+
+        final result = DeepLinkService.parseDeepLink(url);
+
+        expect(result.type, equals(DeepLinkType.unknown));
+        expect(result.listId, isNull);
+      });
+
       test('rejects bare /list path', () {
         const url = 'https://divine.video/list';
 


### PR DESCRIPTION
> [!NOTE]
> **Draft / work-in-progress** — staking out the implementation early per #6093. Code + tests are complete and green locally; manual device verification and the divine-web AASA companion PR link are still pending (checklist below).

## Description

Marketing wants playlist links as CTAs, but tapping a `divine.video` playlist link today opens the browser even when the app is installed. This wires `/list/:pubkey/:listId` — the web-canonical shape, since kind 30005 lists are addressed by author + d-tag — into the same Universal Link / App Link handling that video, profile, hashtag, search, and invite already use.

- **Parser**: new `DeepLinkType.list` branch in `deep_link_service.dart`. Accepts a hex or npub author segment and normalizes to lowercase hex (what relay `authors` filters expect). Additive — all existing link types are untouched, pinned by the existing test suites.
- **Routing**: list links flow through `universal_link_resolver.dart` (the #3032 path — router redirect on Android cold start, stream listener otherwise) into a new `/list/:pubkey/:listId` route. Its `CuratedListByAuthorScreen` resolves the list from relays by author + d-tag (`CuratedListService.fetchPublicList`, cache + relay via `queryEvents`, newest-version-wins) and then renders the existing `CuratedListFeedScreen`. This is the piece that makes links work for lists the user has never seen — the internal `/list/:listId` route only knows about locally stored lists plus route extras, so it was not reusable for deep links.
- **Listener nav parity**: `resolveListDeepLinkNavAction` mirrors the video/profile/hashtag/search push/go/skip semantics, so a warm-app link pushes onto the stack (back returns where you were), replaces an already-showing list in place, and dedupes when the router redirect already navigated.
- **Android**: `/list` `pathPrefix` added to the `autoVerify` intent filter.
- **Route normalization**: `parseRoute`/`buildRoute` in `page_context_provider.dart` learned the 3-segment shape. Without this, `routeNormalizationProvider` parsed `/list/<pubkey>/<listId>` as the 2-segment internal route (author pubkey captured as the list id), rebuilt the "canonical" form as `/list/<pubkey>`, and bounced the user off the screen the moment it opened — the same failure mode as the `/settings/storage` and `/invites` regressions the route-coverage test documents. Round-trip tests now pin both list route shapes.

**Cross-repo dependency:** iOS needs the `/list/*` component in the AASA file served by divine-web (divinevideo/divine-web#482). The feature only works end-to-end once **both** are live, and Apple caches AASA per device/CDN, so iOS can lag the web deploy. Android is self-contained in this PR.

Deliberate choices for reviewer eyes:

- Not-found and fetch-error states reuse the existing `curatedListFailedToLoad` copy via `RouteErrorScreen` — no new ARB keys, no translation debt. Distinct "list not found" copy would be a separate product/copy change.
- The list nav-action handler mirrors the four existing deep-link types (video/profile/hashtag/search) verbatim rather than consolidating all five into one generic resolver. Consolidation is a real cleanup but its own reviewed change — it touches every existing deep-link type (including video's `goSameRouteWithComments` special case), so folding it into this feature PR would balloon the blast radius. Deferred deliberately.
- The resolver screen is a thin `ConsumerWidget` in the existing Riverpod lists surface (legacy area per the migration policy), consistent with `CuratedListFeedScreen` / `DiscoverListsScreen`, rather than introducing a one-off BLoC around a single async read.

**Related Issue:** Relates to #6093

## Out of Scope

- In-app "share list" URL minting (mobile has no list-share affordance today; web already generates these URLs).
- Distinct not-found copy (reuses existing localized string, see above).

## Remaining before marking ready

- [x] Code review loop (converged clean over 3 rounds). Fixed: cold-start back-nav crash (safePop), Android `/lists` over-claim (pathPattern), provider re-fetch storm (notifier dep), shared pubkey normalizer (nprofile support), in-repo AASA `/list/*` mirror synced, NIP-01 replaceable tie-break in `fetchPublicList`, and triage logging on unresolved links. Copy reuse for the not-found/error state was a deliberate call (no new ARB key).

- [x] divine-web AASA companion PR: divinevideo/divine-web#482
- [ ] Manual Android emulator pass against a real published kind 30005 list, e.g. "Art of Divine" (156 videos, verified live on `relay.divine.video` and serving on web):
      `adb shell am start -a android.intent.action.VIEW -d "https://divine.video/list/3e911baba55ae247339cf805dd6ff49ad2cd6bee84ac44e088ce66450c49104f/list_1780802850377"`
- [ ] Manual iOS simulator pass (`xcrun simctl openurl`)

## Verification

- `flutter analyze lib test integration_test` — clean
- Targeted suites, all green: `deep_link_service_test`, `universal_link_resolver_test`, `curated_list_service_fetch_public_test` (new), `curated_list_service_{query,crud,stream}_test`, `curated_list_relay_sync_test`, `curated_list_feed_screen_test`, `curated_list_by_author_screen_test` (new), `main_list_deep_link_nav_action_test` (new), `main_{profile,search}_deep_link_nav_action_test`, `deep_link_provider_test`, `people_lists_route_order_test`
- `dart run build_runner build` — regenerated `list_providers.g.dart` committed

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] ✅ Build configuration change
