### PR TITLE
chore(minor-safety): replace personal-key test fixture 78a5c21b with a synthetic pubkey

### DIFF
--- a/mobile/test/helpers/test_pubkeys.dart
+++ b/mobile/test/helpers/test_pubkeys.dart
@@ -1,0 +1,19 @@
+// ABOUTME: Shared synthetic pubkeys for test fixtures.
+// ABOUTME: Never use a real personal key as test data.
+
+/// A clearly-synthetic 64-char hex pubkey for use as a generic fixture
+/// identity in tests (test video author, mock current-user pubkey, and
+/// similar).
+///
+/// Replaces the real personal key that #5963 removed from production code
+/// but which lingered as scattered literals across test files
+/// (#6083 / support-trust-safety#184). `deadbeef` repeated is unmistakably
+/// fake yet a valid lowercase 64-char hex that round-trips through npub
+/// encode/decode.
+const syntheticTestPubkey =
+    'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
+
+/// A second clearly-synthetic pubkey, distinct from [syntheticTestPubkey], for
+/// tests that need two different fixture identities (e.g. "me" vs "not me").
+const syntheticOtherTestPubkey =
+    'cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe';

--- a/mobile/test/router/profile_me_redirect_integration_test.dart
+++ b/mobile/test/router/profile_me_redirect_integration_test.dart
@@ -22,14 +22,15 @@ import 'package:openvine/ui/overlay_policy.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../helpers/test_pubkeys.dart';
+
 void main() {
   group('Profile /me/ Redirect Integration', () {
     testWidgets(
       'should redirect /profile/me/0 to actual user npub and render profile',
       (tester) async {
         // ARRANGE: Create authenticated user with known public key
-        const testUserHex =
-            '78a5c21b5166dc1474b64ddf7454bf79e6b5d6b4a77148593bf1e866b73c2738';
+        const testUserHex = syntheticTestPubkey;
         final testUserNpub = NostrKeyUtils.encodePubKey(testUserHex);
 
         final testVideo = VideoEvent(
@@ -110,8 +111,7 @@ void main() {
       tester,
     ) async {
       // ARRANGE
-      const testUserHex =
-          '78a5c21b5166dc1474b64ddf7454bf79e6b5d6b4a77148593bf1e866b73c2738';
+      const testUserHex = syntheticTestPubkey;
       final testUserNpub = NostrKeyUtils.encodePubKey(testUserHex);
 
       final mockAuthService = _MockAuthService(testUserHex);

--- a/mobile/test/router/profile_me_redirect_test.dart
+++ b/mobile/test/router/profile_me_redirect_test.dart
@@ -12,14 +12,15 @@ import 'package:openvine/screens/profile_screen_router.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 
+import '../helpers/test_pubkeys.dart';
+
 void main() {
   group('Profile /me/ Redirect', () {
     testWidgets('should redirect /profile/me/0 to current user npub', (
       tester,
     ) async {
       // ARRANGE: Create a test user with known public key
-      const testUserHex =
-          '78a5c21b5166dc1474b64ddf7454bf79e6b5d6b4a77148593bf1e866b73c2738';
+      const testUserHex = syntheticTestPubkey;
       final testUserNpub = NostrKeyUtils.encodePubKey(testUserHex);
 
       // Create a mock auth service that returns our test user
@@ -63,8 +64,7 @@ void main() {
       tester,
     ) async {
       // ARRANGE
-      const testUserHex =
-          '78a5c21b5166dc1474b64ddf7454bf79e6b5d6b4a77148593bf1e866b73c2738';
+      const testUserHex = syntheticTestPubkey;
       final testUserNpub = NostrKeyUtils.encodePubKey(testUserHex);
 
       final mockAuthService = _MockAuthService(testUserHex);
@@ -101,10 +101,8 @@ void main() {
 
     testWidgets('should NOT redirect when npub is not "me"', (tester) async {
       // ARRANGE
-      const currentUserHex =
-          '78a5c21b5166dc1474b64ddf7454bf79e6b5d6b4a77148593bf1e866b73c2738';
-      const otherUserHex =
-          'aaaaaa1b5166dc1474b64ddf7454bf79e6b5d6b4a77148593bf1e866b73c2738';
+      const currentUserHex = syntheticTestPubkey;
+      const otherUserHex = syntheticOtherTestPubkey;
       final otherUserNpub = NostrKeyUtils.encodePubKey(otherUserHex);
 
       final mockAuthService = _MockAuthService(currentUserHex);

--- a/mobile/test/router/route_error_routing_test.dart
+++ b/mobile/test/router/route_error_routing_test.dart
@@ -13,6 +13,7 @@ import 'package:openvine/router/router.dart';
 import 'package:openvine/services/auth_service.dart';
 
 import '../helpers/test_provider_overrides.dart';
+import '../helpers/test_pubkeys.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -22,9 +23,7 @@ void main() {
   MockAuthService authenticatedAuth() {
     final mockAuth = createMockAuthService();
     when(() => mockAuth.isAuthenticated).thenReturn(true);
-    when(() => mockAuth.currentPublicKeyHex).thenReturn(
-      '78a5c21b5166dc1474b64ddf7454bf79e6b5d6b4a77148593bf1e866b73c2738',
-    );
+    when(() => mockAuth.currentPublicKeyHex).thenReturn(syntheticTestPubkey);
     when(() => mockAuth.authState).thenReturn(AuthState.authenticated);
     when(
       () => mockAuth.authStateStream,

--- a/mobile/test/screens/profile_setup_relay_confirmation_test.dart
+++ b/mobile/test/screens/profile_setup_relay_confirmation_test.dart
@@ -9,6 +9,8 @@ import 'package:nostr_sdk/event.dart';
 import 'package:openvine/services/auth_service.dart' hide UserProfile;
 import 'package:profile_repository/profile_repository.dart';
 
+import '../helpers/test_pubkeys.dart';
+
 class _MockNostrClient extends Mock implements NostrClient {}
 
 class _MockAuthService extends Mock implements AuthService {}
@@ -50,8 +52,7 @@ void main() {
       mockAuthService = _MockAuthService();
       mockProfileRepository = _MockProfileRepository();
 
-      testPubkey =
-          '78a5c21b5166dc1474b64ddf7454bf79e6b5d6b4a77148593bf1e866b73c2738';
+      testPubkey = syntheticTestPubkey;
       testTimestamp = DateTime.now().millisecondsSinceEpoch ~/ 1000;
 
       // Default mock setup

--- a/mobile/test/services/profile_editing_race_condition_test.dart
+++ b/mobile/test/services/profile_editing_race_condition_test.dart
@@ -7,6 +7,8 @@ import 'package:models/models.dart';
 import 'package:openvine/utils/async_utils.dart';
 import 'package:profile_repository/profile_repository.dart';
 
+import '../helpers/test_pubkeys.dart';
+
 class _MockProfileRepository extends Mock implements ProfileRepository {}
 
 void main() {
@@ -20,8 +22,7 @@ void main() {
 
     setUp(() {
       mockProfileRepository = _MockProfileRepository();
-      testPubkey =
-          '78a5c21b5166dc1474b64ddf7454bf79e6b5d6b4a77148593bf1e866b73c2738';
+      testPubkey = syntheticTestPubkey;
       testEventId = 'test-event-id-123';
       testTimestamp = DateTime.now().millisecondsSinceEpoch ~/ 1000;
 

--- a/mobile/test/unit/models/user_profile_npub_test.dart
+++ b/mobile/test/unit/models/user_profile_npub_test.dart
@@ -6,12 +6,13 @@ import 'package:models/models.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/utils/user_profile_utils.dart';
 
+import '../../helpers/test_pubkeys.dart';
+
 void main() {
   group('UserProfile npub Encoding', () {
     test('should encode pubkey to npub format', () {
       // Valid 64-character hex pubkey
-      const hexPubkey =
-          '78a5c21b5166dc1474b64ddf7454bf79e6b5d6b4a77148593bf1e866b73c2738';
+      const hexPubkey = syntheticTestPubkey;
 
       final profile = UserProfile(
         pubkey: hexPubkey,

--- a/mobile/test/widgets/profile/profile_banner_layer_test.dart
+++ b/mobile/test/widgets/profile/profile_banner_layer_test.dart
@@ -13,11 +13,12 @@ import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/widgets/profile/profile_banner_layer.dart';
 import 'package:openvine/widgets/profile/profile_header_widget.dart';
 
+import '../../helpers/test_pubkeys.dart';
+
 class _MockMyProfileBloc extends MockBloc<MyProfileEvent, MyProfileState>
     implements MyProfileBloc {}
 
-const _testUserHex =
-    '78a5c21b5166dc1474b64ddf7454bf79e6b5d6b4a77148593bf1e866b73c2738';
+const String _testUserHex = syntheticTestPubkey;
 
 UserProfile _profileWithBanner(String? banner) {
   return UserProfile(

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -42,6 +42,7 @@ import 'package:skeletonizer/skeletonizer.dart';
 
 import '../../helpers/go_router.dart';
 import '../../helpers/test_provider_overrides.dart';
+import '../../helpers/test_pubkeys.dart';
 
 class _MockMyProfileBloc extends MockBloc<MyProfileEvent, MyProfileState>
     implements MyProfileBloc {}
@@ -181,8 +182,7 @@ class MockAuthService extends Mock implements AuthService {
   Future<bool> tryRefreshExpiredSession() async => tryRefreshResult;
 }
 
-const testUserHex =
-    '78a5c21b5166dc1474b64ddf7454bf79e6b5d6b4a77148593bf1e866b73c2738';
+const String testUserHex = syntheticTestPubkey;
 const issuerUserHex =
     '4f071cf08328c9d9dbb21f5d9d1e51fe2ecf4e7de5a4e59ecdf356f6a6f49f22';
 const recipientUserHex =
@@ -669,9 +669,7 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        final headerAvatar = tester.widget<UserAvatar>(
-          find.byType(UserAvatar),
-        );
+        final headerAvatar = tester.widget<UserAvatar>(find.byType(UserAvatar));
         expect(headerAvatar.cornerRadius, isNull);
 
         final avatarClip = tester.widget<ClipRRect>(
@@ -922,40 +920,39 @@ void main() {
       expect(find.byKey(const Key('profile-support-button')), findsNothing);
     });
 
-    testWidgets(
-      'hides subscription-only support links on iOS storefronts',
-      (tester) async {
-        debugUsesAppleAppStoreTipPolicyOverride = true;
+    testWidgets('hides subscription-only support links on iOS storefronts', (
+      tester,
+    ) async {
+      debugUsesAppleAppStoreTipPolicyOverride = true;
 
-        final creatorProfile = createTestProfile(
-          displayName: 'Creator',
-          about: 'Creator bio',
-          rawData: {
-            divineMonetizationLinksKey: [
-              const MonetizationLink(
-                provider: MonetizationLinkProvider.patreon,
-                category: MonetizationLinkCategory.subscription,
-                url: 'https://www.patreon.com/creator',
-                enabled: true,
-              ).toJson(),
-            ],
-          },
-        );
+      final creatorProfile = createTestProfile(
+        displayName: 'Creator',
+        about: 'Creator bio',
+        rawData: {
+          divineMonetizationLinksKey: [
+            const MonetizationLink(
+              provider: MonetizationLinkProvider.patreon,
+              category: MonetizationLinkCategory.subscription,
+              url: 'https://www.patreon.com/creator',
+              enabled: true,
+            ).toJson(),
+          ],
+        },
+      );
 
-        await tester.pumpWidget(
-          buildTestWidget(
-            userIdHex: testUserHex,
-            isOwnProfile: false,
-            suppliedProfile: creatorProfile,
-            monetizationLinksEnabled: true,
-          ),
-        );
-        await tester.pumpAndSettle();
+      await tester.pumpWidget(
+        buildTestWidget(
+          userIdHex: testUserHex,
+          isOwnProfile: false,
+          suppliedProfile: creatorProfile,
+          monetizationLinksEnabled: true,
+        ),
+      );
+      await tester.pumpAndSettle();
 
-        expect(find.byKey(const Key('profile-support-button')), findsNothing);
-        expect(find.text('Support'), findsNothing);
-      },
-    );
+      expect(find.byKey(const Key('profile-support-button')), findsNothing);
+      expect(find.text('Support'), findsNothing);
+    });
 
     testWidgets('uses tip affordance copy on iOS storefronts', (tester) async {
       debugUsesAppleAppStoreTipPolicyOverride = true;

--- a/mobile/test/widgets/report_content_dialog_test.dart
+++ b/mobile/test/widgets/report_content_dialog_test.dart
@@ -21,6 +21,7 @@ import 'package:openvine/services/moderation_label_service.dart';
 import 'package:openvine/widgets/report_content_dialog.dart';
 
 import '../helpers/test_provider_overrides.dart';
+import '../helpers/test_pubkeys.dart';
 
 class _MockContentReportingService extends Mock
     implements ContentReportingService {}
@@ -46,7 +47,7 @@ void main() {
 
   setUp(() {
     final testNostrEvent = nostr.Event(
-      '78a5c21b5166dc1474b64ddf7454bf79e6b5d6b4a77148593bf1e866b73c2738',
+      syntheticTestPubkey,
       34236,
       [
         ['d', 'test_video_id'],
@@ -843,9 +844,9 @@ void main() {
       'shows the "Message the moderation team" affordance when signed in',
       (tester) async {
         final mockAuth = createMockAuthService();
-        when(() => mockAuth.currentPublicKeyHex).thenReturn(
-          '78a5c21b5166dc1474b64ddf7454bf79e6b5d6b4a77148593bf1e866b73c2738',
-        );
+        when(
+          () => mockAuth.currentPublicKeyHex,
+        ).thenReturn(syntheticTestPubkey);
 
         await setLargeSurface(tester);
         await openSubmitWithAuth(tester, mockAuth);
@@ -946,8 +947,7 @@ void main() {
 
     const testMessageId =
         'aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa1111bbbb2222';
-    const testSenderPubkey =
-        '78a5c21b5166dc1474b64ddf7454bf79e6b5d6b4a77148593bf1e866b73c2738';
+    const testSenderPubkey = syntheticTestPubkey;
 
     setUp(() {
       mockNostrClient = createMockNostrService();
@@ -1080,8 +1080,7 @@ void main() {
     late _MockDmRepository mockDmRepository;
     late _MockModerationLabelService mockModerationLabelService;
 
-    const testUserPubkey =
-        '78a5c21b5166dc1474b64ddf7454bf79e6b5d6b4a77148593bf1e866b73c2738';
+    const testUserPubkey = syntheticTestPubkey;
 
     setUp(() {
       mockNostrClient = createMockNostrService();


### PR DESCRIPTION
## Summary

After #5963 removed the dead `BugReportConfig.supportPubkey` constant (a real personal key) and #6073 scrubbed its doc references, ~9 test files still used that same hex — `78a5c21b5166dc1474b64ddf7454bf79e6b5d6b4a77148593bf1e866b73c2738` — as a generic fixture identity. Independent string literals, not references to anything removed, so harmless — but they perpetuated a real personal key as test data. This swaps them for clearly-synthetic shared constants. Test-data hygiene only; no runtime code changes.

## What

- New `test/helpers/test_pubkeys.dart` exporting two clearly-synthetic constants: `syntheticTestPubkey` (`deadbeef`×8) and `syntheticOtherTestPubkey` (`cafebabe`×8) — both valid 64-char hex that round-trip through npub encode/decode.
- All 15 occurrences of the full key across the 9 files now reference `syntheticTestPubkey`.
- `profile_me_redirect_test.dart`'s `otherUserHex` "not me" fixture — the real key with only its first 8 chars changed (56 of 64 chars shared) — now uses the distinct `syntheticOtherTestPubkey`.

## The npub caveat

`user_profile_npub_test.dart` doesn't hardcode an npub — it round-trips (`decode(profile.npub) == hexPubkey`), so the swap needs no recomputed expectation. Confirmed no test file hardcodes the old key's npub or any decoded/truncated form.

## Scope note

`profile_header_widget_test.dart` shows a larger diff than the swap alone: it carried pre-existing `dart format` drift on `main` (Dart 3.12 tall-style), and touching it brings the whole file under the format gate — so the reflow is required. The swap there is one import + one constant line; the rest is the unavoidable formatter reflow.

## Testing

- `flutter analyze` clean on all changed files.
- All 9 affected test files green (113 tests, 7 pre-existing skips).
- `dart format` clean; no real-key material remains in `test/`/`lib/`.

## Related

Closes #6083. Part of divinevideo/support-trust-safety#184.
