### PR TITLE
chore: Prevent relay reconnects during Nostr startup

### DIFF
--- a/mobile/lib/providers/nostr_client_provider.dart
+++ b/mobile/lib/providers/nostr_client_provider.dart
@@ -160,22 +160,35 @@ final nostrInitializationInProgressProvider =
     );
 
 class NostrInitializationInProgress extends Notifier<bool> {
-  int _activeAttempts = 0;
+  final Map<NostrClient, int> _attemptsByClient = Map.identity();
 
   @override
   bool build() => false;
 
-  void begin() {
-    _activeAttempts++;
+  bool isClientInitializing(NostrClient client) {
+    return _attemptsByClient.containsKey(client);
+  }
+
+  void begin(NostrClient client) {
+    _attemptsByClient.update(
+      client,
+      (attempts) => attempts + 1,
+      ifAbsent: () => 1,
+    );
     state = true;
   }
 
-  void end() {
+  void end(NostrClient client) {
     if (!ref.mounted) return;
-    assert(_activeAttempts > 0, 'No Nostr initialization attempt is active');
-    if (_activeAttempts == 0) return;
-    _activeAttempts--;
-    state = _activeAttempts > 0;
+    final attempts = _attemptsByClient[client];
+    assert(attempts != null, 'No initialization attempt for this client');
+    if (attempts == null) return;
+    if (attempts == 1) {
+      _attemptsByClient.remove(client);
+    } else {
+      _attemptsByClient[client] = attempts - 1;
+    }
+    state = _attemptsByClient.isNotEmpty;
   }
 }
 
@@ -315,7 +328,7 @@ class NostrService extends _$NostrService {
       final initializationTracker = ref.read(
         nostrInitializationInProgressProvider.notifier,
       );
-      initializationTracker.begin();
+      initializationTracker.begin(client);
       initialization = initializationTracker;
       await _runClientInitialization(
         client,
@@ -356,7 +369,7 @@ class NostrService extends _$NostrService {
       _setSessionIdentityState(pubkey);
       _scheduleInitializationRetry(pubkey);
     } finally {
-      initialization?.end();
+      initialization?.end(client);
     }
   }
 
@@ -459,7 +472,7 @@ class NostrService extends _$NostrService {
       final initializationTracker = ref.read(
         nostrInitializationInProgressProvider.notifier,
       );
-      initializationTracker.begin();
+      initializationTracker.begin(client);
       initialization = initializationTracker;
       await _runClientInitialization(
         client,
@@ -507,7 +520,7 @@ class NostrService extends _$NostrService {
       _setSessionIdentityState(pubkey);
       _scheduleInitializationRetry(pubkey);
     } finally {
-      initialization?.end();
+      initialization?.end(client);
     }
   }
 

--- a/mobile/lib/providers/nostr_client_provider.dart
+++ b/mobile/lib/providers/nostr_client_provider.dart
@@ -310,10 +310,13 @@ class NostrService extends _$NostrService {
     required List<String> userRelayUrls,
     required String source,
   }) async {
-    final initialization = ref.read(
-      nostrInitializationInProgressProvider.notifier,
-    )..begin();
+    NostrInitializationInProgress? initialization;
     try {
+      final initializationTracker = ref.read(
+        nostrInitializationInProgressProvider.notifier,
+      );
+      initializationTracker.begin();
+      initialization = initializationTracker;
       await _runClientInitialization(
         client,
         userRelayUrls,
@@ -353,7 +356,7 @@ class NostrService extends _$NostrService {
       _setSessionIdentityState(pubkey);
       _scheduleInitializationRetry(pubkey);
     } finally {
-      initialization.end();
+      initialization?.end();
     }
   }
 
@@ -361,7 +364,7 @@ class NostrService extends _$NostrService {
     NostrClient client,
     List<String> userRelayUrls, {
     required String source,
-  }) {
+  }) async {
     final timeout = ref.read(nostrInitializationTimeoutProvider);
     final stopwatch = Stopwatch()..start();
     var stage = 'addingUserRelays';
@@ -372,20 +375,20 @@ class NostrService extends _$NostrService {
       category: LogCategory.system,
     );
 
-    return (() async {
-      if (userRelayUrls.isNotEmpty) {
-        final addedRelayCount = await client.addRelays(userRelayUrls);
-        Log.info(
-          '[NostrService] Initialization stage completed: source=$source, '
-          'stage=$stage, addedRelayCount=$addedRelayCount, '
-          'elapsedMs=${stopwatch.elapsedMilliseconds}',
-          name: 'NostrService',
-          category: LogCategory.system,
-        );
-      }
-      stage = 'client.initialize';
-      await client.initializeWithStageObserver(
-        (clientStage) {
+    try {
+      await (() async {
+        if (userRelayUrls.isNotEmpty) {
+          final addedRelayCount = await client.addRelays(userRelayUrls);
+          Log.info(
+            '[NostrService] Initialization stage completed: source=$source, '
+            'stage=$stage, addedRelayCount=$addedRelayCount, '
+            'elapsedMs=${stopwatch.elapsedMilliseconds}',
+            name: 'NostrService',
+            category: LogCategory.system,
+          );
+        }
+        stage = 'client.initialize';
+        client.initializationObserver = (clientStage) {
           stage = 'client.${clientStage.name}';
           Log.debug(
             '[NostrService] Initialization stage started: source=$source, '
@@ -393,25 +396,28 @@ class NostrService extends _$NostrService {
             name: 'NostrService',
             category: LogCategory.system,
           );
+        };
+        await client.initialize();
+        Log.info(
+          '[NostrService] Initialization completed: source=$source, '
+          'elapsedMs=${stopwatch.elapsedMilliseconds}',
+          name: 'NostrService',
+          category: LogCategory.system,
+        );
+      })().timeout(
+        timeout,
+        onTimeout: () {
+          throw TimeoutException(
+            'Nostr client initialization timed out: source=$source, '
+            'stage=$stage, userRelayCount=${userRelayUrls.length}, '
+            'elapsedMs=${stopwatch.elapsedMilliseconds}',
+            timeout,
+          );
         },
       );
-      Log.info(
-        '[NostrService] Initialization completed: source=$source, '
-        'elapsedMs=${stopwatch.elapsedMilliseconds}',
-        name: 'NostrService',
-        category: LogCategory.system,
-      );
-    })().timeout(
-      timeout,
-      onTimeout: () {
-        throw TimeoutException(
-          'Nostr client initialization timed out: source=$source, '
-          'stage=$stage, userRelayCount=${userRelayUrls.length}, '
-          'elapsedMs=${stopwatch.elapsedMilliseconds}',
-          timeout,
-        );
-      },
-    );
+    } finally {
+      client.initializationObserver = null;
+    }
   }
 
   void _scheduleInitializationRetry(String? pubkey) {
@@ -448,10 +454,13 @@ class NostrService extends _$NostrService {
         .toList();
     final client = _createClient(identity);
     final clientGeneration = _nextClientGeneration();
-    final initialization = ref.read(
-      nostrInitializationInProgressProvider.notifier,
-    )..begin();
+    NostrInitializationInProgress? initialization;
     try {
+      final initializationTracker = ref.read(
+        nostrInitializationInProgressProvider.notifier,
+      );
+      initializationTracker.begin();
+      initialization = initializationTracker;
       await _runClientInitialization(
         client,
         userRelayUrls,
@@ -488,6 +497,7 @@ class NostrService extends _$NostrService {
         category: LogCategory.system,
       );
       _disposeClient(client);
+      if (!ref.mounted) return;
       if (!_isActiveIdentity(pubkey, clientGeneration)) {
         return;
       }
@@ -497,7 +507,7 @@ class NostrService extends _$NostrService {
       _setSessionIdentityState(pubkey);
       _scheduleInitializationRetry(pubkey);
     } finally {
-      initialization.end();
+      initialization?.end();
     }
   }
 

--- a/mobile/lib/providers/nostr_client_provider.dart
+++ b/mobile/lib/providers/nostr_client_provider.dart
@@ -280,7 +280,11 @@ class NostrService extends _$NostrService {
     required String source,
   }) async {
     try {
-      await _runClientInitialization(client, userRelayUrls);
+      await _runClientInitialization(
+        client,
+        userRelayUrls,
+        source: source,
+      );
       // The provider can be disposed during the await (e.g. a rapid identity
       // switch rebuilds it, or a test container is torn down mid-init). Reading
       // `ref` after disposal throws, so bail before the ref-backed checks below.
@@ -319,14 +323,59 @@ class NostrService extends _$NostrService {
 
   Future<void> _runClientInitialization(
     NostrClient client,
-    List<String> userRelayUrls,
-  ) {
+    List<String> userRelayUrls, {
+    required String source,
+  }) {
+    final timeout = ref.read(nostrInitializationTimeoutProvider);
+    final stopwatch = Stopwatch()..start();
+    var stage = 'addingUserRelays';
+    Log.info(
+      '[NostrService] Initialization started: source=$source, '
+      'userRelayCount=${userRelayUrls.length}, timeout=$timeout',
+      name: 'NostrService',
+      category: LogCategory.system,
+    );
+
     return (() async {
       if (userRelayUrls.isNotEmpty) {
-        await client.addRelays(userRelayUrls);
+        final addedRelayCount = await client.addRelays(userRelayUrls);
+        Log.info(
+          '[NostrService] Initialization stage completed: source=$source, '
+          'stage=$stage, addedRelayCount=$addedRelayCount, '
+          'elapsedMs=${stopwatch.elapsedMilliseconds}',
+          name: 'NostrService',
+          category: LogCategory.system,
+        );
       }
-      await client.initialize();
-    })().timeout(ref.read(nostrInitializationTimeoutProvider));
+      stage = 'client.initialize';
+      await client.initializeWithStageObserver(
+        (clientStage) {
+          stage = 'client.${clientStage.name}';
+          Log.debug(
+            '[NostrService] Initialization stage started: source=$source, '
+            'stage=$stage, elapsedMs=${stopwatch.elapsedMilliseconds}',
+            name: 'NostrService',
+            category: LogCategory.system,
+          );
+        },
+      );
+      Log.info(
+        '[NostrService] Initialization completed: source=$source, '
+        'elapsedMs=${stopwatch.elapsedMilliseconds}',
+        name: 'NostrService',
+        category: LogCategory.system,
+      );
+    })().timeout(
+      timeout,
+      onTimeout: () {
+        throw TimeoutException(
+          'Nostr client initialization timed out: source=$source, '
+          'stage=$stage, userRelayCount=${userRelayUrls.length}, '
+          'elapsedMs=${stopwatch.elapsedMilliseconds}',
+          timeout,
+        );
+      },
+    );
   }
 
   void _scheduleInitializationRetry(String? pubkey) {
@@ -364,7 +413,11 @@ class NostrService extends _$NostrService {
     final client = _createClient(identity);
     final clientGeneration = _nextClientGeneration();
     try {
-      await _runClientInitialization(client, userRelayUrls);
+      await _runClientInitialization(
+        client,
+        userRelayUrls,
+        source: 'retry',
+      );
       if (!_isActiveIdentity(pubkey, clientGeneration)) {
         _disposeClient(client);
         return;

--- a/mobile/lib/providers/nostr_client_provider.dart
+++ b/mobile/lib/providers/nostr_client_provider.dart
@@ -148,6 +148,37 @@ final nostrInitializationTimeoutProvider = Provider<Duration>(
   (ref) => _nostrInitializationTimeout,
 );
 
+/// Whether one or more app-level Nostr client initialization attempts are
+/// still running.
+///
+/// This deliberately tracks the outer [NostrService] future rather than
+/// [NostrClient.isInitialized], which becomes true as soon as RelayManager
+/// settles and can precede the rest of the service's startup bookkeeping.
+final nostrInitializationInProgressProvider =
+    NotifierProvider<NostrInitializationInProgress, bool>(
+      NostrInitializationInProgress.new,
+    );
+
+class NostrInitializationInProgress extends Notifier<bool> {
+  int _activeAttempts = 0;
+
+  @override
+  bool build() => false;
+
+  void begin() {
+    _activeAttempts++;
+    state = true;
+  }
+
+  void end() {
+    if (!ref.mounted) return;
+    assert(_activeAttempts > 0, 'No Nostr initialization attempt is active');
+    if (_activeAttempts == 0) return;
+    _activeAttempts--;
+    state = _activeAttempts > 0;
+  }
+}
+
 /// Core Nostr service via NostrClient for relay communication
 /// Uses a Notifier to react to auth state changes and recreate the client
 /// when the keyContainer changes (e.g., user signs out and signs in with different keys)
@@ -279,6 +310,9 @@ class NostrService extends _$NostrService {
     required List<String> userRelayUrls,
     required String source,
   }) async {
+    final initialization = ref.read(
+      nostrInitializationInProgressProvider.notifier,
+    )..begin();
     try {
       await _runClientInitialization(
         client,
@@ -318,6 +352,8 @@ class NostrService extends _$NostrService {
       }
       _setSessionIdentityState(pubkey);
       _scheduleInitializationRetry(pubkey);
+    } finally {
+      initialization.end();
     }
   }
 
@@ -412,6 +448,9 @@ class NostrService extends _$NostrService {
         .toList();
     final client = _createClient(identity);
     final clientGeneration = _nextClientGeneration();
+    final initialization = ref.read(
+      nostrInitializationInProgressProvider.notifier,
+    )..begin();
     try {
       await _runClientInitialization(
         client,
@@ -457,6 +496,8 @@ class NostrService extends _$NostrService {
       }
       _setSessionIdentityState(pubkey);
       _scheduleInitializationRetry(pubkey);
+    } finally {
+      initialization.end();
     }
   }
 

--- a/mobile/lib/providers/nostr_client_provider.g.dart
+++ b/mobile/lib/providers/nostr_client_provider.g.dart
@@ -109,7 +109,7 @@ final class NostrServiceProvider
   }
 }
 
-String _$nostrServiceHash() => r'5b9855947a53cf1014fa32b4d22e8cfc94cde47e';
+String _$nostrServiceHash() => r'd7c3f2c2e7d765f85b62b264f403bbfbbc09db82';
 
 /// Core Nostr service via NostrClient for relay communication
 /// Uses a Notifier to react to auth state changes and recreate the client

--- a/mobile/lib/providers/nostr_client_provider.g.dart
+++ b/mobile/lib/providers/nostr_client_provider.g.dart
@@ -109,7 +109,7 @@ final class NostrServiceProvider
   }
 }
 
-String _$nostrServiceHash() => r'094552a0d9b22d465849fd1a83ba334c4ccdd4e6';
+String _$nostrServiceHash() => r'855f39ef1da93983ee63642735c4beb92589e343';
 
 /// Core Nostr service via NostrClient for relay communication
 /// Uses a Notifier to react to auth state changes and recreate the client

--- a/mobile/lib/providers/nostr_client_provider.g.dart
+++ b/mobile/lib/providers/nostr_client_provider.g.dart
@@ -109,7 +109,7 @@ final class NostrServiceProvider
   }
 }
 
-String _$nostrServiceHash() => r'79f3643e74227a0de2d009979fdbbde50a955b3c';
+String _$nostrServiceHash() => r'094552a0d9b22d465849fd1a83ba334c4ccdd4e6';
 
 /// Core Nostr service via NostrClient for relay communication
 /// Uses a Notifier to react to auth state changes and recreate the client

--- a/mobile/lib/providers/nostr_client_provider.g.dart
+++ b/mobile/lib/providers/nostr_client_provider.g.dart
@@ -109,7 +109,7 @@ final class NostrServiceProvider
   }
 }
 
-String _$nostrServiceHash() => r'855f39ef1da93983ee63642735c4beb92589e343';
+String _$nostrServiceHash() => r'5b9855947a53cf1014fa32b4d22e8cfc94cde47e';
 
 /// Core Nostr service via NostrClient for relay communication
 /// Uses a Notifier to react to auth state changes and recreate the client

--- a/mobile/lib/providers/relay_providers.dart
+++ b/mobile/lib/providers/relay_providers.dart
@@ -47,13 +47,12 @@ final _relaySetChangeCoordinatorProvider = Provider<_RelaySetChangeCoordinator>(
 
 class _RelaySetChangeCoordinator {
   Timer? _debounceTimer;
-  NostrClient? _activeClient;
-  VideoEventService? _videoEventService;
-  NostrInitializationInProgress? _initializationTracker;
-  NostrClient? _intentSourceClient;
-  NostrClient? _reconcilingClient;
-  Set<String>? _targetRelaySet;
-  var _resetRequired = false;
+  _RelayClientAttachment? _attachment;
+  _RelayResetTransaction? _pendingTransaction;
+  var _nextAttachmentGeneration = 0;
+  var _nextTransactionVersion = 0;
+  var _operationInProgress = false;
+  var _rescheduleAfterOperation = false;
   var _disposed = false;
 
   void attach({
@@ -61,18 +60,53 @@ class _RelaySetChangeCoordinator {
     required VideoEventService videoEventService,
     required NostrInitializationInProgress initializationTracker,
   }) {
-    _activeClient = client;
-    _videoEventService = videoEventService;
-    _initializationTracker = initializationTracker;
-  }
+    final scope = _RelayIntentScope.fromClient(client);
+    final currentAttachment = _attachment;
+    if (currentAttachment != null &&
+        identical(currentAttachment.client, client)) {
+      _attachment = currentAttachment.copyWith(
+        videoEventService: videoEventService,
+        initializationTracker: initializationTracker,
+      );
+      return;
+    }
 
-  bool isReconciling(NostrClient client) {
-    return identical(_reconcilingClient, client);
+    _attachment = _RelayClientAttachment(
+      client: client,
+      videoEventService: videoEventService,
+      initializationTracker: initializationTracker,
+      scope: scope,
+      generation: ++_nextAttachmentGeneration,
+    );
+
+    final transaction = _pendingTransaction;
+    if (transaction == null) return;
+
+    if (transaction.scope != scope) {
+      Log.info(
+        'Discarding pending relay reset at environment or identity boundary',
+        name: 'RelaySetChangeBridge',
+        category: LogCategory.relay,
+      );
+      _pendingTransaction = null;
+      _debounceTimer?.cancel();
+      _debounceTimer = null;
+      _rescheduleAfterOperation = false;
+      return;
+    }
+
+    if (_operationInProgress) {
+      _rescheduleAfterOperation = true;
+    } else if (!(_debounceTimer?.isActive ?? false)) {
+      _scheduleReset();
+    }
   }
 
   bool isClientInitializing(NostrClient client) {
+    final attachment = _attachment;
     return !client.isInitialized ||
-        (_initializationTracker?.isClientInitializing(client) ?? false);
+        (attachment?.initializationTracker.isClientInitializing(client) ??
+            false);
   }
 
   void recordMembershipChange({
@@ -81,9 +115,17 @@ class _RelaySetChangeCoordinator {
     required Set<String> currentRelaySet,
     required bool changeRequiresReset,
   }) {
-    if (_disposed || isReconciling(client)) return;
+    if (_disposed) return;
+    final attachment = _attachment;
+    if (attachment == null || !identical(attachment.client, client)) return;
 
-    if (!_resetRequired) {
+    var transaction = _pendingTransaction;
+    if (transaction != null && transaction.scope != attachment.scope) {
+      _pendingTransaction = null;
+      transaction = null;
+    }
+
+    if (transaction == null) {
       if (!changeRequiresReset) {
         Log.info(
           'Relay set change originated during active client initialization; '
@@ -94,53 +136,76 @@ class _RelaySetChangeCoordinator {
         );
         return;
       }
-      _resetRequired = true;
-      _intentSourceClient = client;
-      _targetRelaySet = Set.of(currentRelaySet);
-    } else if (identical(_intentSourceClient, client)) {
+      transaction = _RelayResetTransaction(
+        scope: attachment.scope,
+        sourceClient: client,
+        targetRelaySet: Set.of(currentRelaySet),
+        version: ++_nextTransactionVersion,
+      );
+      _pendingTransaction = transaction;
+    } else if (identical(transaction.sourceClient, client)) {
       // Keep the latest complete target from the client where the reset intent
       // originated. Startup-stage changes from that same generation belong to
       // the batch but cannot clear its sticky reset requirement.
-      _targetRelaySet = Set.of(currentRelaySet);
+      _updateTransactionTarget(transaction, currentRelaySet);
     } else if (changeRequiresReset) {
       // A real edit can race with replacement. Merge its delta into the target
       // retained from the previous generation instead of replacing that target
       // with the replacement's potentially stale startup snapshot.
-      final target = _targetRelaySet ?? <String>{};
+      final target = Set.of(transaction.targetRelaySet);
       target
         ..removeAll(previousRelaySet.difference(currentRelaySet))
         ..addAll(currentRelaySet.difference(previousRelaySet));
-      _targetRelaySet = target;
+      _updateTransactionTarget(transaction, target);
     } else {
       // Ignore startup-only membership snapshots from a replacement client.
       // The retained target is reconciled onto it when the debounce fires.
       return;
     }
 
-    _scheduleReset();
+    if (_operationInProgress) {
+      _rescheduleAfterOperation = true;
+    } else {
+      _scheduleReset();
+    }
+  }
+
+  void _updateTransactionTarget(
+    _RelayResetTransaction transaction,
+    Set<String> targetRelaySet,
+  ) {
+    if (_setsEqual(transaction.targetRelaySet, targetRelaySet)) return;
+    transaction
+      ..targetRelaySet = Set.of(targetRelaySet)
+      ..version = ++_nextTransactionVersion
+      ..reconciliationRetryUsed = false;
   }
 
   void _scheduleReset() {
+    if (_disposed || _pendingTransaction == null) return;
     _debounceTimer?.cancel();
     _debounceTimer = Timer(const Duration(seconds: 2), () {
+      _debounceTimer = null;
       unawaited(_performReset());
     });
   }
 
   Future<void> _performReset() async {
-    if (_disposed || !_resetRequired) return;
-
-    final client = _activeClient;
-    final videoEventService = _videoEventService;
-    final targetRelaySet = _targetRelaySet;
-    if (client == null || videoEventService == null || targetRelaySet == null) {
+    if (_disposed || _pendingTransaction == null) return;
+    if (_operationInProgress) {
+      _rescheduleAfterOperation = true;
       return;
     }
 
-    if (isClientInitializing(client)) {
+    final attachment = _attachment;
+    final transaction = _pendingTransaction;
+    if (attachment == null || transaction == null) return;
+
+    if (isClientInitializing(attachment.client)) {
       Log.info(
         'Active client initialization overlaps relay reset debounce; '
-        'deferring forced reconnect (relayCount=${targetRelaySet.length})',
+        'deferring forced reconnect '
+        '(relayCount=${transaction.targetRelaySet.length})',
         name: 'RelaySetChangeBridge',
         category: LogCategory.relay,
       );
@@ -148,15 +213,39 @@ class _RelaySetChangeCoordinator {
       return;
     }
 
-    final sourceClient = _intentSourceClient;
-    _resetRequired = false;
-    _intentSourceClient = null;
-    _targetRelaySet = null;
-    _reconcilingClient = client;
+    final transactionVersion = transaction.version;
+    _operationInProgress = true;
 
     try {
-      if (!identical(sourceClient, client)) {
-        await _reconcileRelaySet(client, targetRelaySet);
+      if (!identical(transaction.sourceClient, attachment.client)) {
+        final reconciliation = await _reconcileRelaySet(
+          attachment: attachment,
+          transaction: transaction,
+          transactionVersion: transactionVersion,
+        );
+        if (reconciliation.status == _RelayReconciliationStatus.superseded) {
+          _rescheduleAfterOperation = _pendingTransaction != null;
+          return;
+        }
+        if (reconciliation.status == _RelayReconciliationStatus.incomplete) {
+          Log.error(
+            'Failed to reconcile replacement relay set: '
+            '${reconciliation.error}',
+            name: 'RelaySetChangeBridge',
+            category: LogCategory.relay,
+          );
+          _handleReconciliationFailure(transaction, transactionVersion);
+          return;
+        }
+      }
+
+      if (!_operationIsCurrent(
+        attachment,
+        transaction,
+        transactionVersion,
+      )) {
+        _rescheduleAfterOperation = _pendingTransaction != null;
+        return;
       }
 
       Log.info(
@@ -166,7 +255,7 @@ class _RelaySetChangeCoordinator {
       );
 
       try {
-        await client.forceReconnectAll();
+        await attachment.client.forceReconnectAll();
         Log.info(
           'Successfully reconnected all relay WebSockets',
           name: 'RelaySetChangeBridge',
@@ -180,42 +269,238 @@ class _RelaySetChangeCoordinator {
         );
       }
 
-      await videoEventService.resetAndResubscribeAll();
+      if (!_operationIsCurrent(
+        attachment,
+        transaction,
+        transactionVersion,
+      )) {
+        _rescheduleAfterOperation = _pendingTransaction != null;
+        return;
+      }
+
+      try {
+        await attachment.videoEventService.resetAndResubscribeAll();
+      } catch (e) {
+        Log.error(
+          'Failed to reset relay-backed feeds: $e',
+          name: 'RelaySetChangeBridge',
+          category: LogCategory.relay,
+        );
+      }
+
+      if (!_operationIsCurrent(
+        attachment,
+        transaction,
+        transactionVersion,
+      )) {
+        _rescheduleAfterOperation = _pendingTransaction != null;
+        return;
+      }
+
+      _pendingTransaction = null;
     } finally {
-      if (identical(_reconcilingClient, client)) {
-        _reconcilingClient = null;
+      _operationInProgress = false;
+      if (_rescheduleAfterOperation && _pendingTransaction != null) {
+        _rescheduleAfterOperation = false;
+        _scheduleReset();
+      } else {
+        _rescheduleAfterOperation = false;
       }
     }
   }
 
-  Future<void> _reconcileRelaySet(
-    NostrClient client,
-    Set<String> targetRelaySet,
-  ) async {
+  Future<_RelayReconciliationResult> _reconcileRelaySet({
+    required _RelayClientAttachment attachment,
+    required _RelayResetTransaction transaction,
+    required int transactionVersion,
+  }) async {
+    final client = attachment.client;
+    final targetRelaySet = Set.of(transaction.targetRelaySet)
+      ..add(client.defaultRelayUrl);
     try {
       final currentRelaySet = client.configuredRelays.toSet();
       final additions = targetRelaySet.difference(currentRelaySet).toList();
       final removals = currentRelaySet.difference(targetRelaySet).toList();
 
       if (additions.isNotEmpty) {
-        await client.addRelays(additions);
+        final addedCount = await client.addRelays(additions);
+        if (!_operationIsCurrent(
+          attachment,
+          transaction,
+          transactionVersion,
+        )) {
+          return const _RelayReconciliationResult.superseded();
+        }
+        if (addedCount != additions.length) {
+          return _RelayReconciliationResult.incomplete(
+            'added $addedCount of ${additions.length} relays',
+          );
+        }
       }
       for (final relay in removals) {
-        await client.removeRelay(relay);
+        final removed = await client.removeRelay(relay);
+        if (!_operationIsCurrent(
+          attachment,
+          transaction,
+          transactionVersion,
+        )) {
+          return const _RelayReconciliationResult.superseded();
+        }
+        if (!removed) {
+          return _RelayReconciliationResult.incomplete(
+            'could not remove relay $relay',
+          );
+        }
       }
+
+      final reconciledRelaySet = client.configuredRelays.toSet();
+      if (!_setsEqual(reconciledRelaySet, targetRelaySet)) {
+        return const _RelayReconciliationResult.incomplete(
+          'configured relay set does not match the target',
+        );
+      }
+      return const _RelayReconciliationResult.complete();
     } catch (e) {
-      Log.error(
-        'Failed to reconcile replacement relay set: $e',
-        name: 'RelaySetChangeBridge',
-        category: LogCategory.relay,
-      );
+      if (!_operationIsCurrent(
+        attachment,
+        transaction,
+        transactionVersion,
+      )) {
+        return const _RelayReconciliationResult.superseded();
+      }
+      return _RelayReconciliationResult.incomplete(e.toString());
     }
+  }
+
+  bool _operationIsCurrent(
+    _RelayClientAttachment attachment,
+    _RelayResetTransaction transaction,
+    int transactionVersion,
+  ) {
+    final currentAttachment = _attachment;
+    return currentAttachment != null &&
+        identical(currentAttachment.client, attachment.client) &&
+        currentAttachment.generation == attachment.generation &&
+        currentAttachment.scope == attachment.scope &&
+        identical(_pendingTransaction, transaction) &&
+        transaction.version == transactionVersion;
+  }
+
+  void _handleReconciliationFailure(
+    _RelayResetTransaction transaction,
+    int transactionVersion,
+  ) {
+    if (!identical(_pendingTransaction, transaction) ||
+        transaction.version != transactionVersion) {
+      _rescheduleAfterOperation = _pendingTransaction != null;
+      return;
+    }
+    if (!transaction.reconciliationRetryUsed) {
+      transaction.reconciliationRetryUsed = true;
+      _rescheduleAfterOperation = true;
+      return;
+    }
+
+    Log.error(
+      'Relay target remains pending after bounded reconciliation retry',
+      name: 'RelaySetChangeBridge',
+      category: LogCategory.relay,
+    );
   }
 
   void dispose() {
     _disposed = true;
     _debounceTimer?.cancel();
   }
+}
+
+class _RelayIntentScope {
+  const _RelayIntentScope({
+    required this.defaultRelayUrl,
+    required this.identityPubkey,
+  });
+
+  factory _RelayIntentScope.fromClient(NostrClient client) {
+    return _RelayIntentScope(
+      defaultRelayUrl: client.defaultRelayUrl,
+      identityPubkey: client.publicKey,
+    );
+  }
+
+  final String defaultRelayUrl;
+  final String identityPubkey;
+
+  @override
+  bool operator ==(Object other) {
+    return other is _RelayIntentScope &&
+        other.defaultRelayUrl == defaultRelayUrl &&
+        other.identityPubkey == identityPubkey;
+  }
+
+  @override
+  int get hashCode => Object.hash(defaultRelayUrl, identityPubkey);
+}
+
+class _RelayClientAttachment {
+  const _RelayClientAttachment({
+    required this.client,
+    required this.videoEventService,
+    required this.initializationTracker,
+    required this.scope,
+    required this.generation,
+  });
+
+  final NostrClient client;
+  final VideoEventService videoEventService;
+  final NostrInitializationInProgress initializationTracker;
+  final _RelayIntentScope scope;
+  final int generation;
+
+  _RelayClientAttachment copyWith({
+    required VideoEventService videoEventService,
+    required NostrInitializationInProgress initializationTracker,
+  }) {
+    return _RelayClientAttachment(
+      client: client,
+      videoEventService: videoEventService,
+      initializationTracker: initializationTracker,
+      scope: scope,
+      generation: generation,
+    );
+  }
+}
+
+class _RelayResetTransaction {
+  _RelayResetTransaction({
+    required this.scope,
+    required this.sourceClient,
+    required this.targetRelaySet,
+    required this.version,
+  });
+
+  final _RelayIntentScope scope;
+  final NostrClient sourceClient;
+  Set<String> targetRelaySet;
+  int version;
+  bool reconciliationRetryUsed = false;
+}
+
+enum _RelayReconciliationStatus { complete, incomplete, superseded }
+
+class _RelayReconciliationResult {
+  const _RelayReconciliationResult.complete()
+    : status = _RelayReconciliationStatus.complete,
+      error = null;
+
+  const _RelayReconciliationResult.incomplete(this.error)
+    : status = _RelayReconciliationStatus.incomplete;
+
+  const _RelayReconciliationResult.superseded()
+    : status = _RelayReconciliationStatus.superseded,
+      error = null;
+
+  final _RelayReconciliationStatus status;
+  final String? error;
 }
 
 /// Connection status service for monitoring network connectivity
@@ -374,10 +659,6 @@ void relaySetChangeBridge(Ref ref) {
 
       final priorRelaySet = previousRelaySet;
       previousRelaySet = currentRelaySet;
-
-      if (coordinator.isReconciling(nostrService)) {
-        return;
-      }
 
       final changeRequiresReset = !coordinator.isClientInitializing(
         nostrService,

--- a/mobile/lib/providers/relay_providers.dart
+++ b/mobile/lib/providers/relay_providers.dart
@@ -7,12 +7,13 @@ import 'dart:async';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nostr_client/nostr_client.dart'
-    show RelayConnectionStatus, RelayState;
+    show NostrClient, RelayConnectionStatus, RelayState;
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/video_providers.dart';
 import 'package:openvine/services/connection_status_service.dart';
 import 'package:openvine/services/relay_capability_service.dart';
 import 'package:openvine/services/relay_statistics_service.dart';
+import 'package:openvine/services/video_event_service.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -33,6 +34,187 @@ class ConfiguredRelayUrls extends Notifier<List<String>> {
 
   void setUrls(List<String> urls) {
     state = List.unmodifiable(urls);
+  }
+}
+
+final _relaySetChangeCoordinatorProvider = Provider<_RelaySetChangeCoordinator>(
+  (ref) {
+    final coordinator = _RelaySetChangeCoordinator();
+    ref.onDispose(coordinator.dispose);
+    return coordinator;
+  },
+);
+
+class _RelaySetChangeCoordinator {
+  Timer? _debounceTimer;
+  NostrClient? _activeClient;
+  VideoEventService? _videoEventService;
+  NostrInitializationInProgress? _initializationTracker;
+  NostrClient? _intentSourceClient;
+  NostrClient? _reconcilingClient;
+  Set<String>? _targetRelaySet;
+  var _resetRequired = false;
+  var _disposed = false;
+
+  void attach({
+    required NostrClient client,
+    required VideoEventService videoEventService,
+    required NostrInitializationInProgress initializationTracker,
+  }) {
+    _activeClient = client;
+    _videoEventService = videoEventService;
+    _initializationTracker = initializationTracker;
+  }
+
+  bool isReconciling(NostrClient client) {
+    return identical(_reconcilingClient, client);
+  }
+
+  bool isClientInitializing(NostrClient client) {
+    return !client.isInitialized ||
+        (_initializationTracker?.isClientInitializing(client) ?? false);
+  }
+
+  void recordMembershipChange({
+    required NostrClient client,
+    required Set<String> previousRelaySet,
+    required Set<String> currentRelaySet,
+    required bool changeRequiresReset,
+  }) {
+    if (_disposed || isReconciling(client)) return;
+
+    if (!_resetRequired) {
+      if (!changeRequiresReset) {
+        Log.info(
+          'Relay set change originated during active client initialization; '
+          'skipping forced reconnect '
+          '(relayCount=${currentRelaySet.length})',
+          name: 'RelaySetChangeBridge',
+          category: LogCategory.relay,
+        );
+        return;
+      }
+      _resetRequired = true;
+      _intentSourceClient = client;
+      _targetRelaySet = Set.of(currentRelaySet);
+    } else if (identical(_intentSourceClient, client)) {
+      // Keep the latest complete target from the client where the reset intent
+      // originated. Startup-stage changes from that same generation belong to
+      // the batch but cannot clear its sticky reset requirement.
+      _targetRelaySet = Set.of(currentRelaySet);
+    } else if (changeRequiresReset) {
+      // A real edit can race with replacement. Merge its delta into the target
+      // retained from the previous generation instead of replacing that target
+      // with the replacement's potentially stale startup snapshot.
+      final target = _targetRelaySet ?? <String>{};
+      target
+        ..removeAll(previousRelaySet.difference(currentRelaySet))
+        ..addAll(currentRelaySet.difference(previousRelaySet));
+      _targetRelaySet = target;
+    } else {
+      // Ignore startup-only membership snapshots from a replacement client.
+      // The retained target is reconciled onto it when the debounce fires.
+      return;
+    }
+
+    _scheduleReset();
+  }
+
+  void _scheduleReset() {
+    _debounceTimer?.cancel();
+    _debounceTimer = Timer(const Duration(seconds: 2), () {
+      unawaited(_performReset());
+    });
+  }
+
+  Future<void> _performReset() async {
+    if (_disposed || !_resetRequired) return;
+
+    final client = _activeClient;
+    final videoEventService = _videoEventService;
+    final targetRelaySet = _targetRelaySet;
+    if (client == null || videoEventService == null || targetRelaySet == null) {
+      return;
+    }
+
+    if (isClientInitializing(client)) {
+      Log.info(
+        'Active client initialization overlaps relay reset debounce; '
+        'deferring forced reconnect (relayCount=${targetRelaySet.length})',
+        name: 'RelaySetChangeBridge',
+        category: LogCategory.relay,
+      );
+      _scheduleReset();
+      return;
+    }
+
+    final sourceClient = _intentSourceClient;
+    _resetRequired = false;
+    _intentSourceClient = null;
+    _targetRelaySet = null;
+    _reconcilingClient = client;
+
+    try {
+      if (!identical(sourceClient, client)) {
+        await _reconcileRelaySet(client, targetRelaySet);
+      }
+
+      Log.info(
+        'Debounce elapsed - forcing WebSocket reconnection and feed reset',
+        name: 'RelaySetChangeBridge',
+        category: LogCategory.relay,
+      );
+
+      try {
+        await client.forceReconnectAll();
+        Log.info(
+          'Successfully reconnected all relay WebSockets',
+          name: 'RelaySetChangeBridge',
+          category: LogCategory.relay,
+        );
+      } catch (e) {
+        Log.error(
+          'Failed to reconnect relays: $e',
+          name: 'RelaySetChangeBridge',
+          category: LogCategory.relay,
+        );
+      }
+
+      await videoEventService.resetAndResubscribeAll();
+    } finally {
+      if (identical(_reconcilingClient, client)) {
+        _reconcilingClient = null;
+      }
+    }
+  }
+
+  Future<void> _reconcileRelaySet(
+    NostrClient client,
+    Set<String> targetRelaySet,
+  ) async {
+    try {
+      final currentRelaySet = client.configuredRelays.toSet();
+      final additions = targetRelaySet.difference(currentRelaySet).toList();
+      final removals = currentRelaySet.difference(targetRelaySet).toList();
+
+      if (additions.isNotEmpty) {
+        await client.addRelays(additions);
+      }
+      for (final relay in removals) {
+        await client.removeRelay(relay);
+      }
+    } catch (e) {
+      Log.error(
+        'Failed to reconcile replacement relay set: $e',
+        name: 'RelaySetChangeBridge',
+        category: LogCategory.relay,
+      );
+    }
+  }
+
+  void dispose() {
+    _disposed = true;
+    _debounceTimer?.cancel();
   }
 }
 
@@ -161,86 +343,18 @@ void relayStatisticsBridge(Ref ref) {
 void relaySetChangeBridge(Ref ref) {
   final nostrService = ref.watch(nostrServiceProvider);
   final videoEventService = ref.watch(videoEventServiceProvider);
+  final coordinator = ref.watch(_relaySetChangeCoordinatorProvider);
 
   Set<String> previousRelaySet = nostrService.relayStatuses.keys.toSet();
-  Timer? debounceTimer;
   var disposed = false;
-  var resetRequired = false;
   final initializationTracker = ref.read(
     nostrInitializationInProgressProvider.notifier,
   );
-
-  bool activeClientIsInitializing() {
-    return !nostrService.isInitialized ||
-        initializationTracker.isClientInitializing(nostrService);
-  }
-
-  void scheduleRelayReset(
-    Set<String> relaySet, {
-    required bool changeRequiresReset,
-  }) {
-    resetRequired = resetRequired || changeRequiresReset;
-    debounceTimer?.cancel();
-    debounceTimer = Timer(const Duration(seconds: 2), () async {
-      if (disposed) return;
-
-      if (!resetRequired) {
-        Log.info(
-          'Relay set change originated during active client initialization; '
-          'skipping forced reconnect (relayCount=${relaySet.length})',
-          name: 'RelaySetChangeBridge',
-          category: LogCategory.relay,
-        );
-        return;
-      }
-
-      if (activeClientIsInitializing()) {
-        Log.info(
-          'Active client initialization overlaps relay reset debounce; '
-          'deferring forced reconnect (relayCount=${relaySet.length})',
-          name: 'RelaySetChangeBridge',
-          category: LogCategory.relay,
-        );
-        scheduleRelayReset(
-          relaySet,
-          changeRequiresReset: false,
-        );
-        return;
-      }
-
-      // Consume this batch's intent before awaiting. A new relay change that
-      // arrives during reconnect starts a distinct debounce batch and must not
-      // be cleared by completion of this one.
-      resetRequired = false;
-
-      Log.info(
-        'Debounce elapsed - forcing WebSocket reconnection and feed reset',
-        name: 'RelaySetChangeBridge',
-        category: LogCategory.relay,
-      );
-
-      // Force reconnect all WebSocket connections. When relays are added or
-      // removed, existing connections can be stale while still reporting as
-      // connected. Reconnecting establishes fresh connections for the new set.
-      try {
-        await nostrService.forceReconnectAll();
-        Log.info(
-          'Successfully reconnected all relay WebSockets',
-          name: 'RelaySetChangeBridge',
-          category: LogCategory.relay,
-        );
-      } catch (e) {
-        Log.error(
-          'Failed to reconnect relays: $e',
-          name: 'RelaySetChangeBridge',
-          category: LogCategory.relay,
-        );
-      }
-
-      // Reset and resubscribe all feeds against the fresh relay connections.
-      videoEventService.resetAndResubscribeAll();
-    });
-  }
+  coordinator.attach(
+    client: nostrService,
+    videoEventService: videoEventService,
+    initializationTracker: initializationTracker,
+  );
 
   void processStatuses(Map<String, RelayConnectionStatus> statuses) {
     ref
@@ -258,13 +372,22 @@ void relaySetChangeBridge(Ref ref) {
         category: LogCategory.relay,
       );
 
+      final priorRelaySet = previousRelaySet;
       previousRelaySet = currentRelaySet;
 
-      final changeRequiresReset = !activeClientIsInitializing();
+      if (coordinator.isReconciling(nostrService)) {
+        return;
+      }
+
+      final changeRequiresReset = !coordinator.isClientInitializing(
+        nostrService,
+      );
 
       // Debounce: collapse rapid changes into a single reset
-      scheduleRelayReset(
-        currentRelaySet,
+      coordinator.recordMembershipChange(
+        client: nostrService,
+        previousRelaySet: priorRelaySet,
+        currentRelaySet: currentRelaySet,
         changeRequiresReset: changeRequiresReset,
       );
     }
@@ -284,7 +407,6 @@ void relaySetChangeBridge(Ref ref) {
 
   ref.onDispose(() {
     disposed = true;
-    debounceTimer?.cancel();
     subscription.cancel();
   });
 }

--- a/mobile/lib/providers/relay_providers.dart
+++ b/mobile/lib/providers/relay_providers.dart
@@ -166,6 +166,67 @@ void relaySetChangeBridge(Ref ref) {
   Timer? debounceTimer;
   var disposed = false;
 
+  void scheduleRelayReset(
+    Set<String> relaySet, {
+    required bool changeObservedDuringInitialization,
+  }) {
+    debounceTimer?.cancel();
+    debounceTimer = Timer(const Duration(seconds: 2), () async {
+      if (disposed) return;
+
+      if (changeObservedDuringInitialization) {
+        Log.info(
+          'Relay set change originated during Nostr initialization; '
+          'skipping forced reconnect (relayCount=${relaySet.length})',
+          name: 'RelaySetChangeBridge',
+          category: LogCategory.relay,
+        );
+        return;
+      }
+
+      if (ref.read(nostrInitializationInProgressProvider)) {
+        Log.info(
+          'Nostr initialization overlaps relay reset debounce; '
+          'deferring forced reconnect (relayCount=${relaySet.length})',
+          name: 'RelaySetChangeBridge',
+          category: LogCategory.relay,
+        );
+        scheduleRelayReset(
+          relaySet,
+          changeObservedDuringInitialization: false,
+        );
+        return;
+      }
+
+      Log.info(
+        'Debounce elapsed - forcing WebSocket reconnection and feed reset',
+        name: 'RelaySetChangeBridge',
+        category: LogCategory.relay,
+      );
+
+      // Force reconnect all WebSocket connections. When relays are added or
+      // removed, existing connections can be stale while still reporting as
+      // connected. Reconnecting establishes fresh connections for the new set.
+      try {
+        await nostrService.forceReconnectAll();
+        Log.info(
+          'Successfully reconnected all relay WebSockets',
+          name: 'RelaySetChangeBridge',
+          category: LogCategory.relay,
+        );
+      } catch (e) {
+        Log.error(
+          'Failed to reconnect relays: $e',
+          name: 'RelaySetChangeBridge',
+          category: LogCategory.relay,
+        );
+      }
+
+      // Reset and resubscribe all feeds against the fresh relay connections.
+      videoEventService.resetAndResubscribeAll();
+    });
+  }
+
   void processStatuses(Map<String, RelayConnectionStatus> statuses) {
     ref
         .read(configuredRelayUrlsProvider.notifier)
@@ -189,49 +250,10 @@ void relaySetChangeBridge(Ref ref) {
           !nostrService.isInitialized;
 
       // Debounce: collapse rapid changes into a single reset
-      debounceTimer?.cancel();
-      debounceTimer = Timer(const Duration(seconds: 2), () async {
-        if (changeObservedDuringInitialization ||
-            ref.read(nostrInitializationInProgressProvider) ||
-            !nostrService.isInitialized) {
-          Log.info(
-            'Relay set change originated during Nostr initialization; '
-            'skipping forced reconnect (relayCount=${currentRelaySet.length})',
-            name: 'RelaySetChangeBridge',
-            category: LogCategory.relay,
-          );
-          return;
-        }
-
-        Log.info(
-          'Debounce elapsed - forcing WebSocket reconnection and feed reset',
-          name: 'RelaySetChangeBridge',
-          category: LogCategory.relay,
-        );
-
-        // CRITICAL FIX: Force reconnect all WebSocket connections
-        // When relays are added/removed, the existing WebSocket connections
-        // can become stale/zombie - showing as "connected" but not responding
-        // to subscription requests. Force disconnect and reconnect all relays
-        // to establish fresh connections.
-        try {
-          await nostrService.forceReconnectAll();
-          Log.info(
-            'Successfully reconnected all relay WebSockets',
-            name: 'RelaySetChangeBridge',
-            category: LogCategory.relay,
-          );
-        } catch (e) {
-          Log.error(
-            'Failed to reconnect relays: $e',
-            name: 'RelaySetChangeBridge',
-            category: LogCategory.relay,
-          );
-        }
-
-        // Now reset and resubscribe all feeds with fresh connections
-        videoEventService.resetAndResubscribeAll();
-      });
+      scheduleRelayReset(
+        currentRelaySet,
+        changeObservedDuringInitialization: changeObservedDuringInitialization,
+      );
     }
   }
 

--- a/mobile/lib/providers/relay_providers.dart
+++ b/mobile/lib/providers/relay_providers.dart
@@ -57,17 +57,23 @@ class _RelaySetChangeCoordinator {
 
   void attach({
     required NostrClient client,
+    required String? identityPubkey,
     required VideoEventService videoEventService,
     required NostrInitializationInProgress initializationTracker,
   }) {
-    final scope = _RelayIntentScope.fromClient(client);
+    final scope = _RelayIntentScope(
+      defaultRelayUrl: client.defaultRelayUrl,
+      identityPubkey: identityPubkey,
+    );
     final currentAttachment = _attachment;
     if (currentAttachment != null &&
         identical(currentAttachment.client, client)) {
       _attachment = currentAttachment.copyWith(
         videoEventService: videoEventService,
         initializationTracker: initializationTracker,
+        scope: scope,
       );
+      _discardPendingTransactionOutside(scope);
       return;
     }
 
@@ -79,27 +85,29 @@ class _RelaySetChangeCoordinator {
       generation: ++_nextAttachmentGeneration,
     );
 
-    final transaction = _pendingTransaction;
-    if (transaction == null) return;
-
-    if (transaction.scope != scope) {
-      Log.info(
-        'Discarding pending relay reset at environment or identity boundary',
-        name: 'RelaySetChangeBridge',
-        category: LogCategory.relay,
-      );
-      _pendingTransaction = null;
-      _debounceTimer?.cancel();
-      _debounceTimer = null;
-      _rescheduleAfterOperation = false;
-      return;
-    }
+    if (_discardPendingTransactionOutside(scope)) return;
 
     if (_operationInProgress) {
       _rescheduleAfterOperation = true;
     } else if (!(_debounceTimer?.isActive ?? false)) {
       _scheduleReset();
     }
+  }
+
+  bool _discardPendingTransactionOutside(_RelayIntentScope scope) {
+    final transaction = _pendingTransaction;
+    if (transaction == null || transaction.scope == scope) return false;
+
+    Log.info(
+      'Discarding pending relay reset at environment or identity boundary',
+      name: 'RelaySetChangeBridge',
+      category: LogCategory.relay,
+    );
+    _pendingTransaction = null;
+    _debounceTimer?.cancel();
+    _debounceTimer = null;
+    _rescheduleAfterOperation = false;
+    return true;
   }
 
   bool isClientInitializing(NostrClient client) {
@@ -420,15 +428,8 @@ class _RelayIntentScope {
     required this.identityPubkey,
   });
 
-  factory _RelayIntentScope.fromClient(NostrClient client) {
-    return _RelayIntentScope(
-      defaultRelayUrl: client.defaultRelayUrl,
-      identityPubkey: client.publicKey,
-    );
-  }
-
   final String defaultRelayUrl;
-  final String identityPubkey;
+  final String? identityPubkey;
 
   @override
   bool operator ==(Object other) {
@@ -459,6 +460,7 @@ class _RelayClientAttachment {
   _RelayClientAttachment copyWith({
     required VideoEventService videoEventService,
     required NostrInitializationInProgress initializationTracker,
+    required _RelayIntentScope scope,
   }) {
     return _RelayClientAttachment(
       client: client,
@@ -635,11 +637,19 @@ void relaySetChangeBridge(Ref ref) {
   final initializationTracker = ref.read(
     nostrInitializationInProgressProvider.notifier,
   );
-  coordinator.attach(
-    client: nostrService,
-    videoEventService: videoEventService,
-    initializationTracker: initializationTracker,
-  );
+  void attachWithIdentity(String? identityPubkey) {
+    coordinator.attach(
+      client: nostrService,
+      identityPubkey: identityPubkey,
+      videoEventService: videoEventService,
+      initializationTracker: initializationTracker,
+    );
+  }
+
+  attachWithIdentity(ref.read(nostrSessionProvider).pubkey);
+  ref.listen<NostrSessionReadiness>(nostrSessionProvider, (_, next) {
+    attachWithIdentity(next.pubkey);
+  });
 
   void processStatuses(Map<String, RelayConnectionStatus> statuses) {
     ref

--- a/mobile/lib/providers/relay_providers.dart
+++ b/mobile/lib/providers/relay_providers.dart
@@ -165,18 +165,28 @@ void relaySetChangeBridge(Ref ref) {
   Set<String> previousRelaySet = nostrService.relayStatuses.keys.toSet();
   Timer? debounceTimer;
   var disposed = false;
+  var resetRequired = false;
+  final initializationTracker = ref.read(
+    nostrInitializationInProgressProvider.notifier,
+  );
+
+  bool activeClientIsInitializing() {
+    return !nostrService.isInitialized ||
+        initializationTracker.isClientInitializing(nostrService);
+  }
 
   void scheduleRelayReset(
     Set<String> relaySet, {
-    required bool changeObservedDuringInitialization,
+    required bool changeRequiresReset,
   }) {
+    resetRequired = resetRequired || changeRequiresReset;
     debounceTimer?.cancel();
     debounceTimer = Timer(const Duration(seconds: 2), () async {
       if (disposed) return;
 
-      if (changeObservedDuringInitialization) {
+      if (!resetRequired) {
         Log.info(
-          'Relay set change originated during Nostr initialization; '
+          'Relay set change originated during active client initialization; '
           'skipping forced reconnect (relayCount=${relaySet.length})',
           name: 'RelaySetChangeBridge',
           category: LogCategory.relay,
@@ -184,19 +194,24 @@ void relaySetChangeBridge(Ref ref) {
         return;
       }
 
-      if (ref.read(nostrInitializationInProgressProvider)) {
+      if (activeClientIsInitializing()) {
         Log.info(
-          'Nostr initialization overlaps relay reset debounce; '
+          'Active client initialization overlaps relay reset debounce; '
           'deferring forced reconnect (relayCount=${relaySet.length})',
           name: 'RelaySetChangeBridge',
           category: LogCategory.relay,
         );
         scheduleRelayReset(
           relaySet,
-          changeObservedDuringInitialization: false,
+          changeRequiresReset: false,
         );
         return;
       }
+
+      // Consume this batch's intent before awaiting. A new relay change that
+      // arrives during reconnect starts a distinct debounce batch and must not
+      // be cleared by completion of this one.
+      resetRequired = false;
 
       Log.info(
         'Debounce elapsed - forcing WebSocket reconnection and feed reset',
@@ -245,14 +260,12 @@ void relaySetChangeBridge(Ref ref) {
 
       previousRelaySet = currentRelaySet;
 
-      final changeObservedDuringInitialization =
-          ref.read(nostrInitializationInProgressProvider) ||
-          !nostrService.isInitialized;
+      final changeRequiresReset = !activeClientIsInitializing();
 
       // Debounce: collapse rapid changes into a single reset
       scheduleRelayReset(
         currentRelaySet,
-        changeObservedDuringInitialization: changeObservedDuringInitialization,
+        changeRequiresReset: changeRequiresReset,
       );
     }
   }

--- a/mobile/lib/providers/relay_providers.dart
+++ b/mobile/lib/providers/relay_providers.dart
@@ -184,12 +184,16 @@ void relaySetChangeBridge(Ref ref) {
 
       previousRelaySet = currentRelaySet;
 
-      final changeObservedDuringInitialization = !nostrService.isInitialized;
+      final changeObservedDuringInitialization =
+          ref.read(nostrInitializationInProgressProvider) ||
+          !nostrService.isInitialized;
 
       // Debounce: collapse rapid changes into a single reset
       debounceTimer?.cancel();
       debounceTimer = Timer(const Duration(seconds: 2), () async {
-        if (changeObservedDuringInitialization || !nostrService.isInitialized) {
+        if (changeObservedDuringInitialization ||
+            ref.read(nostrInitializationInProgressProvider) ||
+            !nostrService.isInitialized) {
           Log.info(
             'Relay set change originated during Nostr initialization; '
             'skipping forced reconnect (relayCount=${currentRelaySet.length})',

--- a/mobile/lib/providers/relay_providers.dart
+++ b/mobile/lib/providers/relay_providers.dart
@@ -187,6 +187,16 @@ void relaySetChangeBridge(Ref ref) {
       // Debounce: collapse rapid changes into a single reset
       debounceTimer?.cancel();
       debounceTimer = Timer(const Duration(seconds: 2), () async {
+        if (!nostrService.isInitialized) {
+          Log.info(
+            'Relay set change settled during Nostr initialization; '
+            'skipping forced reconnect (relayCount=${currentRelaySet.length})',
+            name: 'RelaySetChangeBridge',
+            category: LogCategory.relay,
+          );
+          return;
+        }
+
         Log.info(
           'Debounce elapsed - forcing WebSocket reconnection and feed reset',
           name: 'RelaySetChangeBridge',

--- a/mobile/lib/providers/relay_providers.dart
+++ b/mobile/lib/providers/relay_providers.dart
@@ -184,12 +184,14 @@ void relaySetChangeBridge(Ref ref) {
 
       previousRelaySet = currentRelaySet;
 
+      final changeObservedDuringInitialization = !nostrService.isInitialized;
+
       // Debounce: collapse rapid changes into a single reset
       debounceTimer?.cancel();
       debounceTimer = Timer(const Duration(seconds: 2), () async {
-        if (!nostrService.isInitialized) {
+        if (changeObservedDuringInitialization || !nostrService.isInitialized) {
           Log.info(
-            'Relay set change settled during Nostr initialization; '
+            'Relay set change originated during Nostr initialization; '
             'skipping forced reconnect (relayCount=${currentRelaySet.length})',
             name: 'RelaySetChangeBridge',
             category: LogCategory.relay,

--- a/mobile/lib/providers/relay_providers.g.dart
+++ b/mobile/lib/providers/relay_providers.g.dart
@@ -339,4 +339,4 @@ final class RelaySetChangeBridgeProvider
 }
 
 String _$relaySetChangeBridgeHash() =>
-    r'346c56179b4e9fff0584fd5c6104aa1be080e17e';
+    r'1ca8ca37a8569f683997823d07bcc901e7b76167';

--- a/mobile/lib/providers/relay_providers.g.dart
+++ b/mobile/lib/providers/relay_providers.g.dart
@@ -339,4 +339,4 @@ final class RelaySetChangeBridgeProvider
 }
 
 String _$relaySetChangeBridgeHash() =>
-    r'af52f50afc55efae5d1f71b04e53b2a8623223b7';
+    r'8bede2eaa43817158fa03820fe7d43f07a6bf988';

--- a/mobile/lib/providers/relay_providers.g.dart
+++ b/mobile/lib/providers/relay_providers.g.dart
@@ -339,4 +339,4 @@ final class RelaySetChangeBridgeProvider
 }
 
 String _$relaySetChangeBridgeHash() =>
-    r'63ad4d47de044d9a690a46d51ea225f937ebc393';
+    r'040ec965dd7b50c6428b6e63da2e237a99fc1013';

--- a/mobile/lib/providers/relay_providers.g.dart
+++ b/mobile/lib/providers/relay_providers.g.dart
@@ -339,4 +339,4 @@ final class RelaySetChangeBridgeProvider
 }
 
 String _$relaySetChangeBridgeHash() =>
-    r'8cf7bde9b8d3b0e65a4c22cce90a2d41f17ea513';
+    r'98d21b0e03fa7fea74a6af1ecc971dec320193b6';

--- a/mobile/lib/providers/relay_providers.g.dart
+++ b/mobile/lib/providers/relay_providers.g.dart
@@ -339,4 +339,4 @@ final class RelaySetChangeBridgeProvider
 }
 
 String _$relaySetChangeBridgeHash() =>
-    r'040ec965dd7b50c6428b6e63da2e237a99fc1013';
+    r'8cf7bde9b8d3b0e65a4c22cce90a2d41f17ea513';

--- a/mobile/lib/providers/relay_providers.g.dart
+++ b/mobile/lib/providers/relay_providers.g.dart
@@ -339,4 +339,4 @@ final class RelaySetChangeBridgeProvider
 }
 
 String _$relaySetChangeBridgeHash() =>
-    r'98d21b0e03fa7fea74a6af1ecc971dec320193b6';
+    r'346c56179b4e9fff0584fd5c6104aa1be080e17e';

--- a/mobile/lib/providers/relay_providers.g.dart
+++ b/mobile/lib/providers/relay_providers.g.dart
@@ -339,4 +339,4 @@ final class RelaySetChangeBridgeProvider
 }
 
 String _$relaySetChangeBridgeHash() =>
-    r'1ca8ca37a8569f683997823d07bcc901e7b76167';
+    r'af52f50afc55efae5d1f71b04e53b2a8623223b7';

--- a/mobile/lib/providers/relay_providers.g.dart
+++ b/mobile/lib/providers/relay_providers.g.dart
@@ -339,4 +339,4 @@ final class RelaySetChangeBridgeProvider
 }
 
 String _$relaySetChangeBridgeHash() =>
-    r'a7a24101b27fb9a1722c4e22982bb63ec89c1adb';
+    r'63ad4d47de044d9a690a46d51ea225f937ebc393';

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -446,7 +446,7 @@ class NostrClient {
   void _reportInitializationStage(NostrClientInitializationStage stage) {
     try {
       initializationObserver?.call(stage);
-    } catch (e, st) {
+    } on Object catch (e, st) {
       log(
         'Initialization stage observer failed',
         name: 'NostrClient',

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -31,6 +31,48 @@ abstract class NostrClientStatisticsObserver {
   void onEventSent();
 }
 
+/// A blocking stage within [NostrClient.initialize].
+///
+/// Callers can record these transitions so a startup timeout identifies the
+/// operation that was still pending instead of reporting one opaque failure.
+enum NostrClientInitializationStage {
+  /// Refreshing the cached public key from the active signer.
+  refreshingPublicKey,
+
+  /// Loading persisted, previously verified event identifiers.
+  loadingVerifiedEvents,
+
+  /// Starting the background signature-verification worker.
+  startingVerificationWorker,
+
+  /// Loading relay configuration and establishing relay connections.
+  connectingRelays,
+}
+
+/// Receives initialization stage transitions before their asynchronous work
+/// begins.
+typedef NostrClientInitializationObserver =
+    void Function(NostrClientInitializationStage stage);
+
+final Object _initializationObserverZoneKey = Object();
+
+/// Diagnostic initialization entry point that reports blocking stage changes.
+///
+/// This is an extension instead of an additional parameter on
+/// [NostrClient.initialize] so test doubles and other implementations of
+/// [NostrClient] retain the existing initialization contract.
+extension NostrClientInitializationDiagnostics on NostrClient {
+  /// Runs [NostrClient.initialize] while reporting each stage before it starts.
+  Future<void> initializeWithStageObserver(
+    NostrClientInitializationObserver observer,
+  ) {
+    return runZoned(
+      initialize,
+      zoneValues: {_initializationObserverZoneKey: observer},
+    );
+  }
+}
+
 /// {@template nostr_client}
 /// Abstraction layer for Nostr communication
 ///
@@ -379,15 +421,28 @@ class NostrClient {
   /// On failure, [ready] resolves with the same error so consumers awaiting
   /// readiness fail fast instead of hanging until a wall-clock timeout.
   Future<void> initialize() async {
+    final onStageChanged =
+        Zone.current[_initializationObserverZoneKey]
+            as NostrClientInitializationObserver?;
     try {
       // Signer is the single source of truth for the public key.
+      onStageChanged?.call(
+        NostrClientInitializationStage.refreshingPublicKey,
+      );
       await _nostr.refreshPublicKey();
       // Seed the already-verified set before relays connect, so re-sent
       // events skip re-verification during the cold-start flood.
+      onStageChanged?.call(
+        NostrClientInitializationStage.loadingVerifiedEvents,
+      );
       await _seedVerifiedEventIds();
       // Wire the off-main verify isolate before relays connect, so the fresh
       // verifies during the cold-start flood run off the main isolate (#5863).
+      onStageChanged?.call(
+        NostrClientInitializationStage.startingVerificationWorker,
+      );
       await _maybeStartEventVerifyWorker();
+      onStageChanged?.call(NostrClientInitializationStage.connectingRelays);
       await _relayManager.initialize();
       if (!_readyCompleter.isCompleted) {
         _readyCompleter.complete();

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -50,28 +50,10 @@ enum NostrClientInitializationStage {
 }
 
 /// Receives initialization stage transitions before their asynchronous work
-/// begins.
+/// begins. Implementations are diagnostic only; exceptions are logged and do
+/// not fail client initialization.
 typedef NostrClientInitializationObserver =
     void Function(NostrClientInitializationStage stage);
-
-final Object _initializationObserverZoneKey = Object();
-
-/// Diagnostic initialization entry point that reports blocking stage changes.
-///
-/// This is an extension instead of an additional parameter on
-/// [NostrClient.initialize] so test doubles and other implementations of
-/// [NostrClient] retain the existing initialization contract.
-extension NostrClientInitializationDiagnostics on NostrClient {
-  /// Runs [NostrClient.initialize] while reporting each stage before it starts.
-  Future<void> initializeWithStageObserver(
-    NostrClientInitializationObserver observer,
-  ) {
-    return runZoned(
-      initialize,
-      zoneValues: {_initializationObserverZoneKey: observer},
-    );
-  }
-}
 
 /// {@template nostr_client}
 /// Abstraction layer for Nostr communication
@@ -421,28 +403,27 @@ class NostrClient {
   /// On failure, [ready] resolves with the same error so consumers awaiting
   /// readiness fail fast instead of hanging until a wall-clock timeout.
   Future<void> initialize() async {
-    final onStageChanged =
-        Zone.current[_initializationObserverZoneKey]
-            as NostrClientInitializationObserver?;
     try {
       // Signer is the single source of truth for the public key.
-      onStageChanged?.call(
+      _reportInitializationStage(
         NostrClientInitializationStage.refreshingPublicKey,
       );
       await _nostr.refreshPublicKey();
       // Seed the already-verified set before relays connect, so re-sent
       // events skip re-verification during the cold-start flood.
-      onStageChanged?.call(
+      _reportInitializationStage(
         NostrClientInitializationStage.loadingVerifiedEvents,
       );
       await _seedVerifiedEventIds();
       // Wire the off-main verify isolate before relays connect, so the fresh
       // verifies during the cold-start flood run off the main isolate (#5863).
-      onStageChanged?.call(
+      _reportInitializationStage(
         NostrClientInitializationStage.startingVerificationWorker,
       );
       await _maybeStartEventVerifyWorker();
-      onStageChanged?.call(NostrClientInitializationStage.connectingRelays);
+      _reportInitializationStage(
+        NostrClientInitializationStage.connectingRelays,
+      );
       await _relayManager.initialize();
       if (!_readyCompleter.isCompleted) {
         _readyCompleter.complete();
@@ -452,6 +433,26 @@ class NostrClient {
         _readyCompleter.completeError(e, st);
       }
       rethrow;
+    }
+  }
+
+  /// Optional diagnostic observer for blocking initialization stages.
+  ///
+  /// The owner may clear this while initialization is still pending (for
+  /// example, after applying its own timeout), so asynchronous work does not
+  /// retain a per-attempt callback for the lifetime of the client.
+  NostrClientInitializationObserver? initializationObserver;
+
+  void _reportInitializationStage(NostrClientInitializationStage stage) {
+    try {
+      initializationObserver?.call(stage);
+    } catch (e, st) {
+      log(
+        'Initialization stage observer failed',
+        name: 'NostrClient',
+        error: e,
+        stackTrace: st,
+      );
     }
   }
 

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -3311,6 +3311,24 @@ void main() {
         expect(resolved, isTrue);
       });
 
+      test('initialize reports the stage reached before each await', () async {
+        when(() => mockNostr.refreshPublicKey()).thenAnswer((_) async {});
+        when(() => mockRelayManager.initialize()).thenAnswer((_) async {});
+        final observedStages = <NostrClientInitializationStage>[];
+
+        await client.initializeWithStageObserver(observedStages.add);
+
+        expect(
+          observedStages,
+          equals([
+            NostrClientInitializationStage.refreshingPublicKey,
+            NostrClientInitializationStage.loadingVerifiedEvents,
+            NostrClientInitializationStage.startingVerificationWorker,
+            NostrClientInitializationStage.connectingRelays,
+          ]),
+        );
+      });
+
       test('ready stays resolved on a second initialize() call', () async {
         when(() => mockNostr.refreshPublicKey()).thenAnswer((_) async {});
         when(() => mockRelayManager.initialize()).thenAnswer((_) async {});

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -3315,8 +3315,9 @@ void main() {
         when(() => mockNostr.refreshPublicKey()).thenAnswer((_) async {});
         when(() => mockRelayManager.initialize()).thenAnswer((_) async {});
         final observedStages = <NostrClientInitializationStage>[];
+        client.initializationObserver = observedStages.add;
 
-        await client.initializeWithStageObserver(observedStages.add);
+        await client.initialize();
 
         expect(
           observedStages,
@@ -3327,6 +3328,17 @@ void main() {
             NostrClientInitializationStage.connectingRelays,
           ]),
         );
+      });
+
+      test('a throwing stage observer does not fail initialization', () async {
+        when(() => mockNostr.refreshPublicKey()).thenAnswer((_) async {});
+        when(() => mockRelayManager.initialize()).thenAnswer((_) async {});
+        client.initializationObserver = (_) {
+          throw StateError('diagnostics failed');
+        };
+
+        await expectLater(client.initialize(), completes);
+        await expectLater(client.ready, completes);
       });
 
       test('ready stays resolved on a second initialize() call', () async {

--- a/mobile/test/providers/nostr_service_identity_source_test.dart
+++ b/mobile/test/providers/nostr_service_identity_source_test.dart
@@ -200,6 +200,27 @@ void main() {
   }
 
   group('NostrService uses NostrIdentity as source of truth', () {
+    test('tracks the full outer initialization attempt', () async {
+      final initialize = Completer<void>();
+      factory.initializeCompleters[pubkeyA] = initialize;
+      when(() => mockAuth.currentIdentity).thenReturn(identityA);
+      when(() => mockAuth.currentPublicKeyHex).thenReturn(pubkeyA);
+
+      final container = createContainer();
+      addTearDown(container.dispose);
+
+      container.read(nostrServiceProvider);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(container.read(nostrInitializationInProgressProvider), isTrue);
+
+      initialize.complete();
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(container.read(nostrInitializationInProgressProvider), isFalse);
+    });
+
     test('initialization retry backoff is bounded exponential policy', () {
       final container = ProviderContainer();
       addTearDown(container.dispose);

--- a/mobile/test/providers/nostr_service_identity_source_test.dart
+++ b/mobile/test/providers/nostr_service_identity_source_test.dart
@@ -21,6 +21,7 @@ import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/nostr_signature_verification_preference_service.dart';
 import 'package:openvine/services/relay_discovery_service.dart';
 import 'package:openvine/services/relay_statistics_service.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 class _MockAuthService extends Mock implements AuthService {}
 
@@ -82,8 +83,7 @@ class _RecordingFactory {
     when(
       () => client.publicKey,
     ).thenReturn(pubkey ?? '');
-    // ignore: unnecessary_lambdas
-    when(() => client.initialize()).thenAnswer((_) {
+    when(client.initialize).thenAnswer((_) {
       initializePubkeys.add(pubkey);
       return initializeCompleter?.future ?? Future<void>.value();
     });
@@ -799,6 +799,7 @@ void main() {
     test(
       'timed out startup relay setup retries automatically for same identity',
       () async {
+        final logCountBeforeTest = LogCaptureService().getRecentLogs().length;
         final stalledAddRelays = Completer<void>();
         factory.addRelaysCompleters[pubkeyA] = stalledAddRelays;
         when(() => mockAuth.currentIdentity).thenReturn(identityA);
@@ -819,6 +820,20 @@ void main() {
         expect(factory.callCount, equals(2));
         expect(factory.addRelaysPubkeys, equals([pubkeyA, pubkeyA]));
         expect(factory.initializePubkeys, equals([pubkeyA]));
+        final testLogs = LogCaptureService().getRecentLogs().skip(
+          logCountBeforeTest,
+        );
+        expect(
+          testLogs.any(
+            (entry) =>
+                entry.message.contains('Failed to initialize client') &&
+                entry.message.contains('stage=addingUserRelays'),
+          ),
+          isTrue,
+          reason:
+              'A remote log export must identify addRelays as the stalled '
+              'startup stage.',
+        );
         verify(timedOutClient.dispose).called(1);
         expect(
           container.read(nostrServiceProvider),

--- a/mobile/test/providers/nostr_service_identity_source_test.dart
+++ b/mobile/test/providers/nostr_service_identity_source_test.dart
@@ -130,7 +130,8 @@ void main() {
     return LocalNostrIdentity(keyContainer: keyContainer);
   }
 
-  setUp(() {
+  setUp(() async {
+    await LogCaptureService().clearAllLogs();
     mockAuth = _MockAuthService();
     mockDbClient = _MockAppDbClient();
     mockStats = _MockRelayStatisticsService();
@@ -820,7 +821,6 @@ void main() {
     test(
       'timed out startup relay setup retries automatically for same identity',
       () async {
-        final logCountBeforeTest = LogCaptureService().getRecentLogs().length;
         final stalledAddRelays = Completer<void>();
         factory.addRelaysCompleters[pubkeyA] = stalledAddRelays;
         when(() => mockAuth.currentIdentity).thenReturn(identityA);
@@ -841,9 +841,7 @@ void main() {
         expect(factory.callCount, equals(2));
         expect(factory.addRelaysPubkeys, equals([pubkeyA, pubkeyA]));
         expect(factory.initializePubkeys, equals([pubkeyA]));
-        final testLogs = LogCaptureService().getRecentLogs().skip(
-          logCountBeforeTest,
-        );
+        final testLogs = LogCaptureService().getRecentLogs();
         expect(
           testLogs.any(
             (entry) =>
@@ -1212,6 +1210,33 @@ void main() {
   });
 
   group('disposed-ref guard (#5602 / #5600 regression)', () {
+    test(
+      'does not touch ref when disposed before init microtask runs',
+      () async {
+        when(() => mockAuth.currentIdentity).thenReturn(identityA);
+
+        final errors = <Object>[];
+        await runZonedGuarded(
+          () async {
+            final container = createContainer();
+            container.read(nostrServiceProvider);
+            container.dispose();
+
+            await Future<void>.delayed(Duration.zero);
+            await Future<void>.delayed(Duration.zero);
+          },
+          (error, _) => errors.add(error),
+        );
+
+        expect(
+          errors,
+          isEmpty,
+          reason:
+              'a disposed-ref read leaked before the init try block: $errors',
+        );
+      },
+    );
+
     test('does not touch ref after the container is disposed mid-init '
         '(success path)', () async {
       when(() => mockAuth.currentIdentity).thenReturn(identityA);

--- a/mobile/test/unit/providers/relay_set_change_bridge_test.dart
+++ b/mobile/test/unit/providers/relay_set_change_bridge_test.dart
@@ -30,6 +30,15 @@ class SwappableNostrService extends NostrService {
   }
 }
 
+class TestNostrSession extends NostrSession {
+  TestNostrSession(this.initialReadiness);
+
+  final NostrSessionReadiness initialReadiness;
+
+  @override
+  NostrSessionReadiness build() => initialReadiness;
+}
+
 void main() {
   setUpAll(() {
     registerFallbackValue(<String>[]);
@@ -44,12 +53,18 @@ void main() {
     late MockNostrClient mockNostrClient;
     late MockVideoEventService mockVideoEventService;
     late StreamController<Map<String, RelayConnectionStatus>> statusController;
+    late TestNostrSession testNostrSession;
+    late String clientPublicKey;
 
     setUp(() {
       mockNostrClient = MockNostrClient();
       mockVideoEventService = MockVideoEventService();
       statusController =
           StreamController<Map<String, RelayConnectionStatus>>.broadcast();
+      testNostrSession = TestNostrSession(
+        const NostrSessionReadiness.identityKnown(pubkey: pubkeyA),
+      );
+      clientPublicKey = '';
 
       when(
         () => mockVideoEventService.resetAndResubscribeAll(),
@@ -57,7 +72,7 @@ void main() {
       when(() => mockNostrClient.isInitialized).thenReturn(true);
       when(() => mockNostrClient.forceReconnectAll()).thenAnswer((_) async {});
       when(() => mockNostrClient.defaultRelayUrl).thenReturn(defaultRelay);
-      when(() => mockNostrClient.publicKey).thenReturn(pubkeyA);
+      when(() => mockNostrClient.publicKey).thenAnswer((_) => clientPublicKey);
     });
 
     tearDown(() {
@@ -75,6 +90,7 @@ void main() {
       final container = ProviderContainer(
         overrides: [
           nostrServiceProvider.overrideWithValue(mockNostrClient),
+          nostrSessionProvider.overrideWith(() => testNostrSession),
           videoEventServiceProvider.overrideWithValue(mockVideoEventService),
         ],
       );
@@ -86,7 +102,7 @@ void main() {
 
     void stubClientScope(
       MockNostrClient client, {
-      String pubkey = pubkeyA,
+      String pubkey = '',
       String relay = defaultRelay,
     }) {
       when(() => client.publicKey).thenReturn(pubkey);
@@ -421,7 +437,7 @@ void main() {
       });
     });
 
-    test('carries a pending relay edit onto a replacement client', () {
+    test('keeps a pending relay edit for a same-account retry client', () {
       fakeAsync((async) {
         final replacementClient = MockNostrClient();
         final replacementStatuses =
@@ -429,6 +445,7 @@ void main() {
         const removedRelay = 'wss://relay-old.example.com';
         const addedRelay = 'wss://relay1.example.com';
         final replacementRelays = <String>{defaultRelay, removedRelay};
+        var replacementPublicKey = '';
 
         when(() => mockNostrClient.relayStatuses).thenReturn({
           defaultRelay: RelayConnectionStatus.connected(defaultRelay),
@@ -438,7 +455,12 @@ void main() {
           () => mockNostrClient.relayStatusStream,
         ).thenAnswer((_) => statusController.stream);
         when(() => replacementClient.isInitialized).thenReturn(true);
-        stubClientScope(replacementClient);
+        when(
+          () => replacementClient.publicKey,
+        ).thenAnswer((_) => replacementPublicKey);
+        when(
+          () => replacementClient.defaultRelayUrl,
+        ).thenReturn(defaultRelay);
         when(
           () => replacementClient.relayStatuses,
         ).thenAnswer(
@@ -470,6 +492,7 @@ void main() {
         final container = ProviderContainer(
           overrides: [
             nostrServiceProvider.overrideWith(() => swappableService),
+            nostrSessionProvider.overrideWith(() => testNostrSession),
             videoEventServiceProvider.overrideWithValue(mockVideoEventService),
           ],
         );
@@ -478,6 +501,16 @@ void main() {
           (_, _) {},
           fireImmediately: true,
         );
+
+        expect(mockNostrClient.publicKey, isEmpty);
+        clientPublicKey = pubkeyA;
+        testNostrSession.update(
+          NostrSessionReadiness.nostrReady(
+            pubkey: pubkeyA,
+            client: mockNostrClient,
+          ),
+        );
+        async.flushMicrotasks();
 
         statusController.add({
           defaultRelay: RelayConnectionStatus.connected(defaultRelay),
@@ -488,7 +521,19 @@ void main() {
 
         swappableService.replaceWith(replacementClient);
         async.flushMicrotasks();
-        async.elapse(const Duration(seconds: 1));
+        expect(replacementClient.publicKey, isEmpty);
+        verifyNever(() => replacementClient.addRelays(any()));
+        verifyNever(replacementClient.forceReconnectAll);
+
+        replacementPublicKey = pubkeyA;
+        testNostrSession.update(
+          NostrSessionReadiness.nostrReady(
+            pubkey: pubkeyA,
+            client: replacementClient,
+          ),
+        );
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 2));
         async.flushMicrotasks();
 
         expect(replacementRelays, contains(addedRelay));
@@ -550,6 +595,7 @@ void main() {
         final container = ProviderContainer(
           overrides: [
             nostrServiceProvider.overrideWith(() => swappableService),
+            nostrSessionProvider.overrideWith(() => testNostrSession),
             videoEventServiceProvider.overrideWithValue(mockVideoEventService),
           ],
         );
@@ -589,6 +635,7 @@ void main() {
             StreamController<Map<String, RelayConnectionStatus>>.broadcast();
         const editedRelay = 'wss://user-relay.example.com';
         final replacementRelays = <String>{defaultRelay};
+        var replacementPublicKey = '';
 
         when(() => mockNostrClient.relayStatuses).thenReturn({
           defaultRelay: RelayConnectionStatus.connected(defaultRelay),
@@ -597,7 +644,12 @@ void main() {
           () => mockNostrClient.relayStatusStream,
         ).thenAnswer((_) => statusController.stream);
         when(() => replacementClient.isInitialized).thenReturn(true);
-        stubClientScope(replacementClient, pubkey: pubkeyB);
+        when(
+          () => replacementClient.publicKey,
+        ).thenAnswer((_) => replacementPublicKey);
+        when(
+          () => replacementClient.defaultRelayUrl,
+        ).thenReturn(defaultRelay);
         when(
           () => replacementClient.relayStatuses,
         ).thenAnswer(
@@ -624,6 +676,7 @@ void main() {
         final container = ProviderContainer(
           overrides: [
             nostrServiceProvider.overrideWith(() => swappableService),
+            nostrSessionProvider.overrideWith(() => testNostrSession),
             videoEventServiceProvider.overrideWithValue(mockVideoEventService),
           ],
         );
@@ -633,13 +686,35 @@ void main() {
           fireImmediately: true,
         );
 
+        expect(mockNostrClient.publicKey, isEmpty);
+        clientPublicKey = pubkeyA;
+        testNostrSession.update(
+          NostrSessionReadiness.nostrReady(
+            pubkey: pubkeyA,
+            client: mockNostrClient,
+          ),
+        );
+        async.flushMicrotasks();
+
         statusController.add({
           defaultRelay: RelayConnectionStatus.connected(defaultRelay),
           editedRelay: RelayConnectionStatus.connected(editedRelay),
         });
         async.flushMicrotasks();
         async.elapse(const Duration(seconds: 1));
+
+        testNostrSession.update(
+          const NostrSessionReadiness.tearingDown(pubkey: pubkeyA),
+        );
+        async.flushMicrotasks();
         swappableService.replaceWith(replacementClient);
+        async.flushMicrotasks();
+        expect(replacementClient.publicKey, isEmpty);
+
+        replacementPublicKey = pubkeyB;
+        testNostrSession.update(
+          const NostrSessionReadiness.identityKnown(pubkey: pubkeyB),
+        );
         async.flushMicrotasks();
         async.elapse(const Duration(seconds: 2));
         async.flushMicrotasks();
@@ -701,6 +776,7 @@ void main() {
         final container = ProviderContainer(
           overrides: [
             nostrServiceProvider.overrideWith(() => swappableService),
+            nostrSessionProvider.overrideWith(() => testNostrSession),
             videoEventServiceProvider.overrideWithValue(mockVideoEventService),
           ],
         );
@@ -783,6 +859,7 @@ void main() {
         final container = ProviderContainer(
           overrides: [
             nostrServiceProvider.overrideWith(() => swappableService),
+            nostrSessionProvider.overrideWith(() => testNostrSession),
             videoEventServiceProvider.overrideWithValue(mockVideoEventService),
           ],
         );
@@ -869,6 +946,7 @@ void main() {
         final container = ProviderContainer(
           overrides: [
             nostrServiceProvider.overrideWith(() => swappableService),
+            nostrSessionProvider.overrideWith(() => testNostrSession),
             videoEventServiceProvider.overrideWithValue(mockVideoEventService),
           ],
         );
@@ -950,6 +1028,7 @@ void main() {
         final container = ProviderContainer(
           overrides: [
             nostrServiceProvider.overrideWith(() => swappableService),
+            nostrSessionProvider.overrideWith(() => testNostrSession),
             videoEventServiceProvider.overrideWithValue(mockVideoEventService),
           ],
         );
@@ -1017,6 +1096,7 @@ void main() {
         final container = ProviderContainer(
           overrides: [
             nostrServiceProvider.overrideWith(() => swappableService),
+            nostrSessionProvider.overrideWith(() => testNostrSession),
             videoEventServiceProvider.overrideWithValue(mockVideoEventService),
           ],
         );
@@ -1114,6 +1194,7 @@ void main() {
         final container = ProviderContainer(
           overrides: [
             nostrServiceProvider.overrideWith(() => swappableService),
+            nostrSessionProvider.overrideWith(() => testNostrSession),
             videoEventServiceProvider.overrideWithValue(mockVideoEventService),
           ],
         );

--- a/mobile/test/unit/providers/relay_set_change_bridge_test.dart
+++ b/mobile/test/unit/providers/relay_set_change_bridge_test.dart
@@ -255,5 +255,33 @@ void main() {
         container.dispose();
       });
     });
+
+    test(
+      'does not reconnect when client settles before service initialization',
+      () {
+        fakeAsync((async) {
+          final container = createContainer(initialStatuses: {});
+          container
+              .read(nostrInitializationInProgressProvider.notifier)
+              .begin();
+
+          statusController.add({
+            'wss://relay1.example.com': RelayConnectionStatus.connecting(
+              'wss://relay1.example.com',
+            ),
+          });
+
+          async.flushMicrotasks();
+          async.elapse(const Duration(seconds: 1));
+          container.read(nostrInitializationInProgressProvider.notifier).end();
+          async.elapse(const Duration(seconds: 1));
+          async.flushMicrotasks();
+
+          verifyNever(() => mockNostrClient.forceReconnectAll());
+          verifyNever(() => mockVideoEventService.resetAndResubscribeAll());
+          container.dispose();
+        });
+      },
+    );
   });
 }

--- a/mobile/test/unit/providers/relay_set_change_bridge_test.dart
+++ b/mobile/test/unit/providers/relay_set_change_bridge_test.dart
@@ -103,6 +103,7 @@ void main() {
         async.elapse(const Duration(seconds: 2));
         async.flushMicrotasks();
 
+        verify(() => mockNostrClient.forceReconnectAll()).called(1);
         verify(() => mockVideoEventService.resetAndResubscribeAll()).called(1);
         container.dispose();
       });
@@ -229,9 +230,12 @@ void main() {
       });
     });
 
-    test('does not reconnect while the Nostr client is initializing', () {
+    test('does not reconnect for a change observed during initialization', () {
       fakeAsync((async) {
-        when(() => mockNostrClient.isInitialized).thenReturn(false);
+        var isInitialized = false;
+        when(
+          () => mockNostrClient.isInitialized,
+        ).thenAnswer((_) => isInitialized);
         final container = createContainer(initialStatuses: {});
 
         statusController.add({
@@ -241,7 +245,9 @@ void main() {
         });
 
         async.flushMicrotasks();
-        async.elapse(const Duration(seconds: 2));
+        async.elapse(const Duration(seconds: 1));
+        isInitialized = true;
+        async.elapse(const Duration(seconds: 1));
         async.flushMicrotasks();
 
         verifyNever(() => mockNostrClient.forceReconnectAll());

--- a/mobile/test/unit/providers/relay_set_change_bridge_test.dart
+++ b/mobile/test/unit/providers/relay_set_change_bridge_test.dart
@@ -36,6 +36,11 @@ void main() {
   });
 
   group('relaySetChangeBridge', () {
+    const defaultRelay = 'wss://relay.divine.video';
+    const pubkeyA =
+        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    const pubkeyB =
+        'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
     late MockNostrClient mockNostrClient;
     late MockVideoEventService mockVideoEventService;
     late StreamController<Map<String, RelayConnectionStatus>> statusController;
@@ -51,6 +56,8 @@ void main() {
       ).thenAnswer((_) async {});
       when(() => mockNostrClient.isInitialized).thenReturn(true);
       when(() => mockNostrClient.forceReconnectAll()).thenAnswer((_) async {});
+      when(() => mockNostrClient.defaultRelayUrl).thenReturn(defaultRelay);
+      when(() => mockNostrClient.publicKey).thenReturn(pubkeyA);
     });
 
     tearDown(() {
@@ -75,6 +82,15 @@ void main() {
       // Activate the provider
       container.read(relaySetChangeBridgeProvider);
       return container;
+    }
+
+    void stubClientScope(
+      MockNostrClient client, {
+      String pubkey = pubkeyA,
+      String relay = defaultRelay,
+    }) {
+      when(() => client.publicKey).thenReturn(pubkey);
+      when(() => client.defaultRelayUrl).thenReturn(relay);
     }
 
     test('does not trigger reset on initial activation', () {
@@ -412,15 +428,17 @@ void main() {
             StreamController<Map<String, RelayConnectionStatus>>.broadcast();
         const removedRelay = 'wss://relay-old.example.com';
         const addedRelay = 'wss://relay1.example.com';
-        final replacementRelays = <String>{removedRelay};
+        final replacementRelays = <String>{defaultRelay, removedRelay};
 
         when(() => mockNostrClient.relayStatuses).thenReturn({
+          defaultRelay: RelayConnectionStatus.connected(defaultRelay),
           removedRelay: RelayConnectionStatus.connected(removedRelay),
         });
         when(
           () => mockNostrClient.relayStatusStream,
         ).thenAnswer((_) => statusController.stream);
         when(() => replacementClient.isInitialized).thenReturn(true);
+        stubClientScope(replacementClient);
         when(
           () => replacementClient.relayStatuses,
         ).thenAnswer(
@@ -462,6 +480,7 @@ void main() {
         );
 
         statusController.add({
+          defaultRelay: RelayConnectionStatus.connected(defaultRelay),
           addedRelay: RelayConnectionStatus.connected(addedRelay),
         });
         async.flushMicrotasks();
@@ -473,9 +492,11 @@ void main() {
         async.flushMicrotasks();
 
         expect(replacementRelays, contains(addedRelay));
+        expect(replacementRelays, contains(defaultRelay));
         expect(replacementRelays, isNot(contains(removedRelay)));
         verify(() => replacementClient.addRelays([addedRelay])).called(1);
         verify(() => replacementClient.removeRelay(removedRelay)).called(1);
+        verifyNever(() => replacementClient.removeRelay(defaultRelay));
         verify(replacementClient.forceReconnectAll).called(1);
         verify(() => mockVideoEventService.resetAndResubscribeAll()).called(1);
         verifyNever(() => mockNostrClient.forceReconnectAll());
@@ -483,6 +504,660 @@ void main() {
         bridgeSubscription.close();
         container.dispose();
         replacementStatuses.close();
+      });
+    });
+
+    test('discards a pending relay edit when the environment changes', () {
+      fakeAsync((async) {
+        final replacementClient = MockNostrClient();
+        final replacementStatuses =
+            StreamController<Map<String, RelayConnectionStatus>>.broadcast();
+        const stagingDefault = 'wss://relay.staging.divine.video';
+        const editedRelay = 'wss://user-relay.example.com';
+        final replacementRelays = <String>{stagingDefault};
+
+        when(() => mockNostrClient.relayStatuses).thenReturn({
+          defaultRelay: RelayConnectionStatus.connected(defaultRelay),
+        });
+        when(
+          () => mockNostrClient.relayStatusStream,
+        ).thenAnswer((_) => statusController.stream);
+        when(() => replacementClient.isInitialized).thenReturn(true);
+        stubClientScope(replacementClient, relay: stagingDefault);
+        when(
+          () => replacementClient.relayStatuses,
+        ).thenAnswer(
+          (_) => {
+            for (final relay in replacementRelays)
+              relay: RelayConnectionStatus.connected(relay),
+          },
+        );
+        when(
+          () => replacementClient.relayStatusStream,
+        ).thenAnswer((_) => replacementStatuses.stream);
+        when(
+          () => replacementClient.configuredRelays,
+        ).thenAnswer((_) => replacementRelays.toList());
+        when(
+          () => replacementClient.addRelays(any()),
+        ).thenAnswer((_) async => 1);
+        when(
+          () => replacementClient.removeRelay(any()),
+        ).thenAnswer((_) async => true);
+        when(replacementClient.forceReconnectAll).thenAnswer((_) async {});
+
+        final swappableService = SwappableNostrService(mockNostrClient);
+        final container = ProviderContainer(
+          overrides: [
+            nostrServiceProvider.overrideWith(() => swappableService),
+            videoEventServiceProvider.overrideWithValue(mockVideoEventService),
+          ],
+        );
+        final bridgeSubscription = container.listen<void>(
+          relaySetChangeBridgeProvider,
+          (_, _) {},
+          fireImmediately: true,
+        );
+
+        statusController.add({
+          defaultRelay: RelayConnectionStatus.connected(defaultRelay),
+          editedRelay: RelayConnectionStatus.connected(editedRelay),
+        });
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 1));
+        swappableService.replaceWith(replacementClient);
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 2));
+        async.flushMicrotasks();
+
+        expect(replacementRelays, equals({stagingDefault}));
+        verifyNever(() => replacementClient.addRelays(any()));
+        verifyNever(() => replacementClient.removeRelay(any()));
+        verifyNever(replacementClient.forceReconnectAll);
+        verifyNever(() => mockVideoEventService.resetAndResubscribeAll());
+
+        bridgeSubscription.close();
+        container.dispose();
+        replacementStatuses.close();
+      });
+    });
+
+    test('discards a pending relay edit when the identity changes', () {
+      fakeAsync((async) {
+        final replacementClient = MockNostrClient();
+        final replacementStatuses =
+            StreamController<Map<String, RelayConnectionStatus>>.broadcast();
+        const editedRelay = 'wss://user-relay.example.com';
+        final replacementRelays = <String>{defaultRelay};
+
+        when(() => mockNostrClient.relayStatuses).thenReturn({
+          defaultRelay: RelayConnectionStatus.connected(defaultRelay),
+        });
+        when(
+          () => mockNostrClient.relayStatusStream,
+        ).thenAnswer((_) => statusController.stream);
+        when(() => replacementClient.isInitialized).thenReturn(true);
+        stubClientScope(replacementClient, pubkey: pubkeyB);
+        when(
+          () => replacementClient.relayStatuses,
+        ).thenAnswer(
+          (_) => {
+            for (final relay in replacementRelays)
+              relay: RelayConnectionStatus.connected(relay),
+          },
+        );
+        when(
+          () => replacementClient.relayStatusStream,
+        ).thenAnswer((_) => replacementStatuses.stream);
+        when(
+          () => replacementClient.configuredRelays,
+        ).thenAnswer((_) => replacementRelays.toList());
+        when(
+          () => replacementClient.addRelays(any()),
+        ).thenAnswer((_) async => 1);
+        when(
+          () => replacementClient.removeRelay(any()),
+        ).thenAnswer((_) async => true);
+        when(replacementClient.forceReconnectAll).thenAnswer((_) async {});
+
+        final swappableService = SwappableNostrService(mockNostrClient);
+        final container = ProviderContainer(
+          overrides: [
+            nostrServiceProvider.overrideWith(() => swappableService),
+            videoEventServiceProvider.overrideWithValue(mockVideoEventService),
+          ],
+        );
+        final bridgeSubscription = container.listen<void>(
+          relaySetChangeBridgeProvider,
+          (_, _) {},
+          fireImmediately: true,
+        );
+
+        statusController.add({
+          defaultRelay: RelayConnectionStatus.connected(defaultRelay),
+          editedRelay: RelayConnectionStatus.connected(editedRelay),
+        });
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 1));
+        swappableService.replaceWith(replacementClient);
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 2));
+        async.flushMicrotasks();
+
+        expect(replacementRelays, equals({defaultRelay}));
+        verifyNever(() => replacementClient.addRelays(any()));
+        verifyNever(() => replacementClient.removeRelay(any()));
+        verifyNever(replacementClient.forceReconnectAll);
+        verifyNever(() => mockVideoEventService.resetAndResubscribeAll());
+
+        bridgeSubscription.close();
+        container.dispose();
+        replacementStatuses.close();
+      });
+    });
+
+    test('retries a partial replacement reconciliation before reset', () {
+      fakeAsync((async) {
+        final replacementClient = MockNostrClient();
+        final replacementStatuses =
+            StreamController<Map<String, RelayConnectionStatus>>.broadcast();
+        const editedRelay = 'wss://user-relay.example.com';
+        final replacementRelays = <String>{defaultRelay};
+        var addAttempts = 0;
+
+        when(() => mockNostrClient.relayStatuses).thenReturn({
+          defaultRelay: RelayConnectionStatus.connected(defaultRelay),
+        });
+        when(
+          () => mockNostrClient.relayStatusStream,
+        ).thenAnswer((_) => statusController.stream);
+        when(() => replacementClient.isInitialized).thenReturn(true);
+        stubClientScope(replacementClient);
+        when(
+          () => replacementClient.relayStatuses,
+        ).thenAnswer(
+          (_) => {
+            for (final relay in replacementRelays)
+              relay: RelayConnectionStatus.connected(relay),
+          },
+        );
+        when(
+          () => replacementClient.relayStatusStream,
+        ).thenAnswer((_) => replacementStatuses.stream);
+        when(
+          () => replacementClient.configuredRelays,
+        ).thenAnswer((_) => replacementRelays.toList());
+        when(() => replacementClient.addRelays(any())).thenAnswer((call) async {
+          addAttempts++;
+          if (addAttempts == 1) return 0;
+          replacementRelays.addAll(
+            call.positionalArguments.single as List<String>,
+          );
+          return 1;
+        });
+        when(replacementClient.forceReconnectAll).thenAnswer((_) async {});
+
+        final swappableService = SwappableNostrService(mockNostrClient);
+        final container = ProviderContainer(
+          overrides: [
+            nostrServiceProvider.overrideWith(() => swappableService),
+            videoEventServiceProvider.overrideWithValue(mockVideoEventService),
+          ],
+        );
+        final bridgeSubscription = container.listen<void>(
+          relaySetChangeBridgeProvider,
+          (_, _) {},
+          fireImmediately: true,
+        );
+
+        statusController.add({
+          defaultRelay: RelayConnectionStatus.connected(defaultRelay),
+          editedRelay: RelayConnectionStatus.connected(editedRelay),
+        });
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 1));
+        swappableService.replaceWith(replacementClient);
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 1));
+        async.flushMicrotasks();
+
+        verifyNever(replacementClient.forceReconnectAll);
+        verifyNever(() => mockVideoEventService.resetAndResubscribeAll());
+
+        async.elapse(const Duration(seconds: 2));
+        async.flushMicrotasks();
+
+        expect(replacementRelays, contains(editedRelay));
+        verify(() => replacementClient.addRelays([editedRelay])).called(2);
+        verify(replacementClient.forceReconnectAll).called(1);
+        verify(() => mockVideoEventService.resetAndResubscribeAll()).called(1);
+
+        bridgeSubscription.close();
+        container.dispose();
+        replacementStatuses.close();
+      });
+    });
+
+    test('retries a thrown replacement reconciliation before reset', () {
+      fakeAsync((async) {
+        final replacementClient = MockNostrClient();
+        final replacementStatuses =
+            StreamController<Map<String, RelayConnectionStatus>>.broadcast();
+        const editedRelay = 'wss://user-relay.example.com';
+        final replacementRelays = <String>{defaultRelay};
+        var addAttempts = 0;
+
+        when(() => mockNostrClient.relayStatuses).thenReturn({
+          defaultRelay: RelayConnectionStatus.connected(defaultRelay),
+        });
+        when(
+          () => mockNostrClient.relayStatusStream,
+        ).thenAnswer((_) => statusController.stream);
+        when(() => replacementClient.isInitialized).thenReturn(true);
+        stubClientScope(replacementClient);
+        when(
+          () => replacementClient.relayStatuses,
+        ).thenAnswer(
+          (_) => {
+            for (final relay in replacementRelays)
+              relay: RelayConnectionStatus.connected(relay),
+          },
+        );
+        when(
+          () => replacementClient.relayStatusStream,
+        ).thenAnswer((_) => replacementStatuses.stream);
+        when(
+          () => replacementClient.configuredRelays,
+        ).thenAnswer((_) => replacementRelays.toList());
+        when(() => replacementClient.addRelays(any())).thenAnswer((call) async {
+          addAttempts++;
+          if (addAttempts == 1) throw StateError('storage unavailable');
+          replacementRelays.addAll(
+            call.positionalArguments.single as List<String>,
+          );
+          return 1;
+        });
+        when(replacementClient.forceReconnectAll).thenAnswer((_) async {});
+
+        final swappableService = SwappableNostrService(mockNostrClient);
+        final container = ProviderContainer(
+          overrides: [
+            nostrServiceProvider.overrideWith(() => swappableService),
+            videoEventServiceProvider.overrideWithValue(mockVideoEventService),
+          ],
+        );
+        final bridgeSubscription = container.listen<void>(
+          relaySetChangeBridgeProvider,
+          (_, _) {},
+          fireImmediately: true,
+        );
+
+        statusController.add({
+          defaultRelay: RelayConnectionStatus.connected(defaultRelay),
+          editedRelay: RelayConnectionStatus.connected(editedRelay),
+        });
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 1));
+        swappableService.replaceWith(replacementClient);
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 1));
+        async.flushMicrotasks();
+
+        verifyNever(replacementClient.forceReconnectAll);
+        async.elapse(const Duration(seconds: 2));
+        async.flushMicrotasks();
+
+        verify(() => replacementClient.addRelays([editedRelay])).called(2);
+        verify(replacementClient.forceReconnectAll).called(1);
+        verify(() => mockVideoEventService.resetAndResubscribeAll()).called(1);
+
+        bridgeSubscription.close();
+        container.dispose();
+        replacementStatuses.close();
+      });
+    });
+
+    test('retries a failed relay removal before reset', () {
+      fakeAsync((async) {
+        final replacementClient = MockNostrClient();
+        final replacementStatuses =
+            StreamController<Map<String, RelayConnectionStatus>>.broadcast();
+        const removedRelay = 'wss://relay-old.example.com';
+        const editedRelay = 'wss://user-relay.example.com';
+        final replacementRelays = <String>{defaultRelay, removedRelay};
+        var removeAttempts = 0;
+
+        when(() => mockNostrClient.relayStatuses).thenReturn({
+          defaultRelay: RelayConnectionStatus.connected(defaultRelay),
+          removedRelay: RelayConnectionStatus.connected(removedRelay),
+        });
+        when(
+          () => mockNostrClient.relayStatusStream,
+        ).thenAnswer((_) => statusController.stream);
+        when(() => replacementClient.isInitialized).thenReturn(true);
+        stubClientScope(replacementClient);
+        when(
+          () => replacementClient.relayStatuses,
+        ).thenAnswer(
+          (_) => {
+            for (final relay in replacementRelays)
+              relay: RelayConnectionStatus.connected(relay),
+          },
+        );
+        when(
+          () => replacementClient.relayStatusStream,
+        ).thenAnswer((_) => replacementStatuses.stream);
+        when(
+          () => replacementClient.configuredRelays,
+        ).thenAnswer((_) => replacementRelays.toList());
+        when(() => replacementClient.addRelays(any())).thenAnswer((call) async {
+          replacementRelays.addAll(
+            call.positionalArguments.single as List<String>,
+          );
+          return 1;
+        });
+        when(
+          () => replacementClient.removeRelay(removedRelay),
+        ).thenAnswer((_) async {
+          removeAttempts++;
+          if (removeAttempts == 1) return false;
+          return replacementRelays.remove(removedRelay);
+        });
+        when(replacementClient.forceReconnectAll).thenAnswer((_) async {});
+
+        final swappableService = SwappableNostrService(mockNostrClient);
+        final container = ProviderContainer(
+          overrides: [
+            nostrServiceProvider.overrideWith(() => swappableService),
+            videoEventServiceProvider.overrideWithValue(mockVideoEventService),
+          ],
+        );
+        final bridgeSubscription = container.listen<void>(
+          relaySetChangeBridgeProvider,
+          (_, _) {},
+          fireImmediately: true,
+        );
+
+        statusController.add({
+          defaultRelay: RelayConnectionStatus.connected(defaultRelay),
+          editedRelay: RelayConnectionStatus.connected(editedRelay),
+        });
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 1));
+        swappableService.replaceWith(replacementClient);
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 1));
+        async.flushMicrotasks();
+
+        verifyNever(replacementClient.forceReconnectAll);
+        async.elapse(const Duration(seconds: 2));
+        async.flushMicrotasks();
+
+        expect(replacementRelays, containsAll({defaultRelay, editedRelay}));
+        expect(replacementRelays, isNot(contains(removedRelay)));
+        verify(() => replacementClient.addRelays([editedRelay])).called(1);
+        verify(() => replacementClient.removeRelay(removedRelay)).called(2);
+        verify(replacementClient.forceReconnectAll).called(1);
+        verify(() => mockVideoEventService.resetAndResubscribeAll()).called(1);
+
+        bridgeSubscription.close();
+        container.dispose();
+        replacementStatuses.close();
+      });
+    });
+
+    test('does not retry an ordinary reconnect failure', () {
+      fakeAsync((async) {
+        final replacementClient = MockNostrClient();
+        final replacementStatuses =
+            StreamController<Map<String, RelayConnectionStatus>>.broadcast();
+        const editedRelay = 'wss://user-relay.example.com';
+        final replacementRelays = <String>{defaultRelay};
+
+        when(() => mockNostrClient.relayStatuses).thenReturn({
+          defaultRelay: RelayConnectionStatus.connected(defaultRelay),
+        });
+        when(
+          () => mockNostrClient.relayStatusStream,
+        ).thenAnswer((_) => statusController.stream);
+        when(() => replacementClient.isInitialized).thenReturn(true);
+        stubClientScope(replacementClient);
+        when(
+          () => replacementClient.relayStatuses,
+        ).thenAnswer(
+          (_) => {
+            for (final relay in replacementRelays)
+              relay: RelayConnectionStatus.connected(relay),
+          },
+        );
+        when(
+          () => replacementClient.relayStatusStream,
+        ).thenAnswer((_) => replacementStatuses.stream);
+        when(
+          () => replacementClient.configuredRelays,
+        ).thenAnswer((_) => replacementRelays.toList());
+        when(() => replacementClient.addRelays(any())).thenAnswer((call) async {
+          replacementRelays.addAll(
+            call.positionalArguments.single as List<String>,
+          );
+          return 1;
+        });
+        when(
+          replacementClient.forceReconnectAll,
+        ).thenThrow(StateError('socket unavailable'));
+
+        final swappableService = SwappableNostrService(mockNostrClient);
+        final container = ProviderContainer(
+          overrides: [
+            nostrServiceProvider.overrideWith(() => swappableService),
+            videoEventServiceProvider.overrideWithValue(mockVideoEventService),
+          ],
+        );
+        final bridgeSubscription = container.listen<void>(
+          relaySetChangeBridgeProvider,
+          (_, _) {},
+          fireImmediately: true,
+        );
+
+        statusController.add({
+          defaultRelay: RelayConnectionStatus.connected(defaultRelay),
+          editedRelay: RelayConnectionStatus.connected(editedRelay),
+        });
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 1));
+        swappableService.replaceWith(replacementClient);
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 6));
+        async.flushMicrotasks();
+
+        verify(replacementClient.forceReconnectAll).called(1);
+        verify(() => mockVideoEventService.resetAndResubscribeAll()).called(1);
+
+        bridgeSubscription.close();
+        container.dispose();
+        replacementStatuses.close();
+      });
+    });
+
+    test('bounds retries for a persistently invalid relay target', () {
+      fakeAsync((async) {
+        final replacementClient = MockNostrClient();
+        final replacementStatuses =
+            StreamController<Map<String, RelayConnectionStatus>>.broadcast();
+        const editedRelay = 'wss://invalid-relay.example.com';
+        final replacementRelays = <String>{defaultRelay};
+
+        when(() => mockNostrClient.relayStatuses).thenReturn({
+          defaultRelay: RelayConnectionStatus.connected(defaultRelay),
+        });
+        when(
+          () => mockNostrClient.relayStatusStream,
+        ).thenAnswer((_) => statusController.stream);
+        when(() => replacementClient.isInitialized).thenReturn(true);
+        stubClientScope(replacementClient);
+        when(
+          () => replacementClient.relayStatuses,
+        ).thenAnswer(
+          (_) => {
+            for (final relay in replacementRelays)
+              relay: RelayConnectionStatus.connected(relay),
+          },
+        );
+        when(
+          () => replacementClient.relayStatusStream,
+        ).thenAnswer((_) => replacementStatuses.stream);
+        when(
+          () => replacementClient.configuredRelays,
+        ).thenAnswer((_) => replacementRelays.toList());
+        when(
+          () => replacementClient.addRelays(any()),
+        ).thenAnswer((_) async => 0);
+
+        final swappableService = SwappableNostrService(mockNostrClient);
+        final container = ProviderContainer(
+          overrides: [
+            nostrServiceProvider.overrideWith(() => swappableService),
+            videoEventServiceProvider.overrideWithValue(mockVideoEventService),
+          ],
+        );
+        final bridgeSubscription = container.listen<void>(
+          relaySetChangeBridgeProvider,
+          (_, _) {},
+          fireImmediately: true,
+        );
+
+        statusController.add({
+          defaultRelay: RelayConnectionStatus.connected(defaultRelay),
+          editedRelay: RelayConnectionStatus.connected(editedRelay),
+        });
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 1));
+        swappableService.replaceWith(replacementClient);
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 7));
+        async.flushMicrotasks();
+
+        verify(() => replacementClient.addRelays([editedRelay])).called(2);
+        verifyNever(replacementClient.forceReconnectAll);
+        verifyNever(() => mockVideoEventService.resetAndResubscribeAll());
+
+        bridgeSubscription.close();
+        container.dispose();
+        replacementStatuses.close();
+      });
+    });
+
+    test('moves an in-flight transaction to a newer same-scope client', () {
+      fakeAsync((async) {
+        final firstReplacement = MockNostrClient();
+        final secondReplacement = MockNostrClient();
+        final firstStatuses =
+            StreamController<Map<String, RelayConnectionStatus>>.broadcast();
+        final secondStatuses =
+            StreamController<Map<String, RelayConnectionStatus>>.broadcast();
+        final firstAddGate = Completer<void>();
+        const editedRelay = 'wss://user-relay.example.com';
+        final firstRelays = <String>{defaultRelay};
+        final secondRelays = <String>{defaultRelay};
+
+        when(() => mockNostrClient.relayStatuses).thenReturn({
+          defaultRelay: RelayConnectionStatus.connected(defaultRelay),
+        });
+        when(
+          () => mockNostrClient.relayStatusStream,
+        ).thenAnswer((_) => statusController.stream);
+
+        for (final client in [firstReplacement, secondReplacement]) {
+          when(() => client.isInitialized).thenReturn(true);
+          stubClientScope(client);
+          when(client.forceReconnectAll).thenAnswer((_) async {});
+        }
+        when(
+          () => firstReplacement.relayStatuses,
+        ).thenAnswer(
+          (_) => {
+            for (final relay in firstRelays)
+              relay: RelayConnectionStatus.connected(relay),
+          },
+        );
+        when(
+          () => firstReplacement.relayStatusStream,
+        ).thenAnswer((_) => firstStatuses.stream);
+        when(
+          () => firstReplacement.configuredRelays,
+        ).thenAnswer((_) => firstRelays.toList());
+        when(() => firstReplacement.addRelays(any())).thenAnswer((call) async {
+          await firstAddGate.future;
+          firstRelays.addAll(call.positionalArguments.single as List<String>);
+          return 1;
+        });
+        when(
+          () => secondReplacement.relayStatuses,
+        ).thenAnswer(
+          (_) => {
+            for (final relay in secondRelays)
+              relay: RelayConnectionStatus.connected(relay),
+          },
+        );
+        when(
+          () => secondReplacement.relayStatusStream,
+        ).thenAnswer((_) => secondStatuses.stream);
+        when(
+          () => secondReplacement.configuredRelays,
+        ).thenAnswer((_) => secondRelays.toList());
+        when(() => secondReplacement.addRelays(any())).thenAnswer((call) async {
+          secondRelays.addAll(call.positionalArguments.single as List<String>);
+          return 1;
+        });
+
+        final swappableService = SwappableNostrService(mockNostrClient);
+        final container = ProviderContainer(
+          overrides: [
+            nostrServiceProvider.overrideWith(() => swappableService),
+            videoEventServiceProvider.overrideWithValue(mockVideoEventService),
+          ],
+        );
+        final bridgeSubscription = container.listen<void>(
+          relaySetChangeBridgeProvider,
+          (_, _) {},
+          fireImmediately: true,
+        );
+
+        statusController.add({
+          defaultRelay: RelayConnectionStatus.connected(defaultRelay),
+          editedRelay: RelayConnectionStatus.connected(editedRelay),
+        });
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 1));
+        swappableService.replaceWith(firstReplacement);
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 1));
+        async.flushMicrotasks();
+
+        verify(() => firstReplacement.addRelays([editedRelay])).called(1);
+        swappableService.replaceWith(secondReplacement);
+        async.flushMicrotasks();
+        async.elapse(Duration.zero);
+        firstAddGate.complete();
+        async.flushMicrotasks();
+
+        verifyNever(firstReplacement.forceReconnectAll);
+        verifyNever(secondReplacement.forceReconnectAll);
+        verifyNever(() => mockVideoEventService.resetAndResubscribeAll());
+
+        async.elapse(const Duration(seconds: 2));
+        async.flushMicrotasks();
+
+        expect(secondRelays, contains(editedRelay));
+        verify(() => secondReplacement.addRelays([editedRelay])).called(1);
+        verifyNever(firstReplacement.forceReconnectAll);
+        verify(secondReplacement.forceReconnectAll).called(1);
+        verify(() => mockVideoEventService.resetAndResubscribeAll()).called(1);
+
+        bridgeSubscription.close();
+        container.dispose();
+        firstStatuses.close();
+        secondStatuses.close();
       });
     });
   });

--- a/mobile/test/unit/providers/relay_set_change_bridge_test.dart
+++ b/mobile/test/unit/providers/relay_set_change_bridge_test.dart
@@ -32,6 +32,7 @@ void main() {
       when(
         () => mockVideoEventService.resetAndResubscribeAll(),
       ).thenAnswer((_) async {});
+      when(() => mockNostrClient.isInitialized).thenReturn(true);
       when(() => mockNostrClient.forceReconnectAll()).thenAnswer((_) async {});
     });
 
@@ -224,6 +225,27 @@ void main() {
         async.flushMicrotasks();
 
         verify(() => mockVideoEventService.resetAndResubscribeAll()).called(1);
+        container.dispose();
+      });
+    });
+
+    test('does not reconnect while the Nostr client is initializing', () {
+      fakeAsync((async) {
+        when(() => mockNostrClient.isInitialized).thenReturn(false);
+        final container = createContainer(initialStatuses: {});
+
+        statusController.add({
+          'wss://relay1.example.com': RelayConnectionStatus.connecting(
+            'wss://relay1.example.com',
+          ),
+        });
+
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 2));
+        async.flushMicrotasks();
+
+        verifyNever(() => mockNostrClient.forceReconnectAll());
+        verifyNever(() => mockVideoEventService.resetAndResubscribeAll());
         container.dispose();
       });
     });

--- a/mobile/test/unit/providers/relay_set_change_bridge_test.dart
+++ b/mobile/test/unit/providers/relay_set_change_bridge_test.dart
@@ -17,7 +17,24 @@ class MockNostrClient extends Mock implements NostrClient {}
 
 class MockVideoEventService extends Mock implements VideoEventService {}
 
+class SwappableNostrService extends NostrService {
+  SwappableNostrService(this.initialClient);
+
+  final NostrClient initialClient;
+
+  @override
+  NostrClient build() => initialClient;
+
+  void replaceWith(NostrClient client) {
+    state = client;
+  }
+}
+
 void main() {
+  setUpAll(() {
+    registerFallbackValue(<String>[]);
+  });
+
   group('relaySetChangeBridge', () {
     late MockNostrClient mockNostrClient;
     late MockVideoEventService mockVideoEventService;
@@ -385,6 +402,87 @@ void main() {
         verify(() => mockNostrClient.forceReconnectAll()).called(1);
         verify(() => mockVideoEventService.resetAndResubscribeAll()).called(1);
         container.dispose();
+      });
+    });
+
+    test('carries a pending relay edit onto a replacement client', () {
+      fakeAsync((async) {
+        final replacementClient = MockNostrClient();
+        final replacementStatuses =
+            StreamController<Map<String, RelayConnectionStatus>>.broadcast();
+        const removedRelay = 'wss://relay-old.example.com';
+        const addedRelay = 'wss://relay1.example.com';
+        final replacementRelays = <String>{removedRelay};
+
+        when(() => mockNostrClient.relayStatuses).thenReturn({
+          removedRelay: RelayConnectionStatus.connected(removedRelay),
+        });
+        when(
+          () => mockNostrClient.relayStatusStream,
+        ).thenAnswer((_) => statusController.stream);
+        when(() => replacementClient.isInitialized).thenReturn(true);
+        when(
+          () => replacementClient.relayStatuses,
+        ).thenAnswer(
+          (_) => {
+            for (final relay in replacementRelays)
+              relay: RelayConnectionStatus.connected(relay),
+          },
+        );
+        when(
+          () => replacementClient.relayStatusStream,
+        ).thenAnswer((_) => replacementStatuses.stream);
+        when(
+          () => replacementClient.configuredRelays,
+        ).thenAnswer((_) => replacementRelays.toList());
+        when(() => replacementClient.addRelays(any())).thenAnswer((call) async {
+          final relays = call.positionalArguments.single as List<String>;
+          replacementRelays.addAll(relays);
+          return relays.length;
+        });
+        when(
+          () => replacementClient.removeRelay(any()),
+        ).thenAnswer((call) async {
+          final relay = call.positionalArguments.single as String;
+          return replacementRelays.remove(relay);
+        });
+        when(replacementClient.forceReconnectAll).thenAnswer((_) async {});
+
+        final swappableService = SwappableNostrService(mockNostrClient);
+        final container = ProviderContainer(
+          overrides: [
+            nostrServiceProvider.overrideWith(() => swappableService),
+            videoEventServiceProvider.overrideWithValue(mockVideoEventService),
+          ],
+        );
+        final bridgeSubscription = container.listen<void>(
+          relaySetChangeBridgeProvider,
+          (_, _) {},
+          fireImmediately: true,
+        );
+
+        statusController.add({
+          addedRelay: RelayConnectionStatus.connected(addedRelay),
+        });
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 1));
+
+        swappableService.replaceWith(replacementClient);
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 1));
+        async.flushMicrotasks();
+
+        expect(replacementRelays, contains(addedRelay));
+        expect(replacementRelays, isNot(contains(removedRelay)));
+        verify(() => replacementClient.addRelays([addedRelay])).called(1);
+        verify(() => replacementClient.removeRelay(removedRelay)).called(1);
+        verify(replacementClient.forceReconnectAll).called(1);
+        verify(() => mockVideoEventService.resetAndResubscribeAll()).called(1);
+        verifyNever(() => mockNostrClient.forceReconnectAll());
+
+        bridgeSubscription.close();
+        container.dispose();
+        replacementStatuses.close();
       });
     });
   });

--- a/mobile/test/unit/providers/relay_set_change_bridge_test.dart
+++ b/mobile/test/unit/providers/relay_set_change_bridge_test.dart
@@ -283,5 +283,34 @@ void main() {
         });
       },
     );
+
+    test('defers a healthy relay change while initialization overlaps', () {
+      fakeAsync((async) {
+        final container = createContainer(initialStatuses: {});
+
+        statusController.add({
+          'wss://relay1.example.com': RelayConnectionStatus.connected(
+            'wss://relay1.example.com',
+          ),
+        });
+
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 1));
+        container.read(nostrInitializationInProgressProvider.notifier).begin();
+        async.elapse(const Duration(seconds: 1));
+        async.flushMicrotasks();
+
+        verifyNever(() => mockNostrClient.forceReconnectAll());
+        verifyNever(() => mockVideoEventService.resetAndResubscribeAll());
+
+        container.read(nostrInitializationInProgressProvider.notifier).end();
+        async.elapse(const Duration(seconds: 2));
+        async.flushMicrotasks();
+
+        verify(() => mockNostrClient.forceReconnectAll()).called(1);
+        verify(() => mockVideoEventService.resetAndResubscribeAll()).called(1);
+        container.dispose();
+      });
+    });
   });
 }

--- a/mobile/test/unit/providers/relay_set_change_bridge_test.dart
+++ b/mobile/test/unit/providers/relay_set_change_bridge_test.dart
@@ -263,7 +263,7 @@ void main() {
           final container = createContainer(initialStatuses: {});
           container
               .read(nostrInitializationInProgressProvider.notifier)
-              .begin();
+              .begin(mockNostrClient);
 
           statusController.add({
             'wss://relay1.example.com': RelayConnectionStatus.connecting(
@@ -273,7 +273,9 @@ void main() {
 
           async.flushMicrotasks();
           async.elapse(const Duration(seconds: 1));
-          container.read(nostrInitializationInProgressProvider.notifier).end();
+          container
+              .read(nostrInitializationInProgressProvider.notifier)
+              .end(mockNostrClient);
           async.elapse(const Duration(seconds: 1));
           async.flushMicrotasks();
 
@@ -296,14 +298,87 @@ void main() {
 
         async.flushMicrotasks();
         async.elapse(const Duration(seconds: 1));
-        container.read(nostrInitializationInProgressProvider.notifier).begin();
+        container
+            .read(nostrInitializationInProgressProvider.notifier)
+            .begin(mockNostrClient);
         async.elapse(const Duration(seconds: 1));
         async.flushMicrotasks();
 
         verifyNever(() => mockNostrClient.forceReconnectAll());
         verifyNever(() => mockVideoEventService.resetAndResubscribeAll());
 
-        container.read(nostrInitializationInProgressProvider.notifier).end();
+        container
+            .read(nostrInitializationInProgressProvider.notifier)
+            .end(mockNostrClient);
+        async.elapse(const Duration(seconds: 2));
+        async.flushMicrotasks();
+
+        verify(() => mockNostrClient.forceReconnectAll()).called(1);
+        verify(() => mockVideoEventService.resetAndResubscribeAll()).called(1);
+        container.dispose();
+      });
+    });
+
+    test(
+      'resets for an active-client edit while a replacement initializes',
+      () {
+        fakeAsync((async) {
+          final replacementClient = MockNostrClient();
+          final container = createContainer(initialStatuses: {});
+          container
+              .read(nostrInitializationInProgressProvider.notifier)
+              .begin(replacementClient);
+
+          statusController.add({
+            'wss://relay1.example.com': RelayConnectionStatus.connected(
+              'wss://relay1.example.com',
+            ),
+          });
+
+          async.flushMicrotasks();
+          async.elapse(const Duration(seconds: 2));
+          async.flushMicrotasks();
+
+          verify(() => mockNostrClient.forceReconnectAll()).called(1);
+          verify(
+            () => mockVideoEventService.resetAndResubscribeAll(),
+          ).called(1);
+          container
+              .read(nostrInitializationInProgressProvider.notifier)
+              .end(replacementClient);
+          container.dispose();
+        });
+      },
+    );
+
+    test('keeps reset intent when a startup change joins the debounce', () {
+      fakeAsync((async) {
+        final container = createContainer(initialStatuses: {});
+
+        statusController.add({
+          'wss://relay1.example.com': RelayConnectionStatus.connected(
+            'wss://relay1.example.com',
+          ),
+        });
+        async.flushMicrotasks();
+        async.elapse(const Duration(milliseconds: 500));
+
+        container
+            .read(nostrInitializationInProgressProvider.notifier)
+            .begin(mockNostrClient);
+        statusController.add({
+          'wss://relay1.example.com': RelayConnectionStatus.connected(
+            'wss://relay1.example.com',
+          ),
+          'wss://relay2.example.com': RelayConnectionStatus.connecting(
+            'wss://relay2.example.com',
+          ),
+        });
+        async.flushMicrotasks();
+        container
+            .read(nostrInitializationInProgressProvider.notifier)
+            .end(mockNostrClient);
+
         async.elapse(const Duration(seconds: 2));
         async.flushMicrotasks();
 


### PR DESCRIPTION
Startup relay setup could reconnect every relay a second time and reset feed subscriptions.
This change keeps startup relay changes inside the startup flow, while preserving normal reconnects for relay changes made later.

## Description

The bug came from using the relay manager's ready flag as the full startup boundary.
That flag can turn true before the app-level Nostr initialization attempt finishes.

Relay changes now record whether the full Nostr service initialization is active when the change is observed.
Balanced lifecycle tracking covers initial startup, account changes, retries, and overlapping attempts without clearing early.
Initialization timeouts also report the last blocking stage so future startup failures identify where they stopped.
Post-startup relay changes still reconnect relays and reset feeds after the existing two-second debounce.

**Related Issue:** Closes #6100

## Out of Scope

None.
This does not change relay selection, the debounce duration, or normal post-startup reconnect behavior.

## Verification

The full app suite, package coverage gate, generated files, formatting, and analysis all pass.

- `very_good test --optimization --concurrency=4 --exclude-tags integration --test-randomize-ordering-seed random` (12,090 passed; 310 declared skips)
- `flutter analyze lib test integration_test`
- `flutter test --coverage` in `mobile/packages/nostr_client` (287 passed; 85.44% coverage; 82% required)
- `dart format --output=none --set-exit-if-changed lib test integration_test`
- `dart run build_runner build --delete-conflicting-outputs`
- `flutter gen-l10n`

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore