### PR TITLE
fix(likes): floor the addressable like count against the relay resolve (#6022)

### DIFF
--- a/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
+++ b/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
@@ -21,7 +21,9 @@ part 'video_interactions_state.dart';
 ///
 /// This bloc is created per-VideoFeedItem and manages:
 /// - Like status (from LikesRepository)
-/// - Like count (from seeded feed payload, or relay fallback when unseeded)
+/// - Like count (seeded feed payload; for addressable videos floored up to the
+///   archival + relay-resolved Nostr count so a stale/zero seed can be raised
+///   but never lowered, #6022)
 /// - Repost status (from RepostsRepository)
 /// - Repost count (from seeded feed payload, or relay fallback when unseeded)
 /// - Comment count (from seeded feed payload, or relay fallback when unseeded)

--- a/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
+++ b/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Handles like/repost status and counts per video item
 
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:comments_repository/comments_repository.dart';
 import 'package:equatable/equatable.dart';
@@ -37,6 +38,7 @@ class VideoInteractionsBloc
     required RepostsRepository repostsRepository,
     String? addressableId,
     int? initialLikeCount,
+    int? archivedLikeCount,
     int? initialCommentCount,
     int? initialRepostCount,
     bool includeVideoReplies = false,
@@ -46,6 +48,7 @@ class VideoInteractionsBloc
        _commentsRepository = commentsRepository,
        _repostsRepository = repostsRepository,
        _addressableId = addressableId,
+       _archivedLikeCount = archivedLikeCount,
        _includeVideoReplies = includeVideoReplies,
        super(
          VideoInteractionsState(
@@ -82,6 +85,12 @@ class VideoInteractionsBloc
   /// Addressable ID for repost operations (format: `kind:pubkey:d-tag`).
   /// Null if the video doesn't have a d-tag (non-addressable event).
   final String? _addressableId;
+
+  /// Archival (classic Vine) like count baseline, kept separate from the
+  /// live Nostr count so the addressable like floor (#6022) can raise only
+  /// the Nostr portion without letting the archival number mask newly
+  /// resolved Nostr likes. Null when there is no archival baseline.
+  final int? _archivedLikeCount;
 
   /// Subscribe to liked/reposted IDs changes and update status reactively.
   Future<void> _onSubscriptionRequested(
@@ -188,11 +197,18 @@ class VideoInteractionsBloc
       final fetchedCommentCount = results[1];
       final fetchedRepostCount = results[2];
 
-      // Feed/Funnelcake counts remain the display baseline pending the
-      // canonical stats decision tracked in #5751. The fallback count is useful
-      // when there is no seed, but should not replace a count already rendered
-      // from the video payload.
-      final likeCount = preFetchLikeCount ?? fetchedLikeCount;
+      // #6022: floor the Nostr like count against the addressable relay
+      // resolve so a stale/zero funnelcake seed can be raised by the cleaner
+      // distinct-liker count, but never lowered. Addressable-only — the
+      // non-addressable getLikeCount is a raw, unfiltered tally that must not
+      // raise the count. originalLikes (archival) is kept out of the floor so
+      // it can't mask newly resolved Nostr likes.
+      final likeCount = _addressableId != null
+          ? math.max(
+              preFetchLikeCount ?? 0,
+              (_archivedLikeCount ?? 0) + fetchedLikeCount,
+            )
+          : preFetchLikeCount ?? fetchedLikeCount;
       final commentCount = preFetchCommentCount ?? fetchedCommentCount;
       final repostCount = preFetchRepostCount ?? fetchedRepostCount;
 

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -50,6 +50,8 @@ import 'package:openvine/utils/log_tag_sanitizer.dart';
 import 'package:profile_repository/profile_repository.dart';
 import 'package:unified_logger/unified_logger.dart';
 import 'package:video_event_cache/video_event_cache.dart';
+import 'package:videos_repository/videos_repository.dart'
+    show mergeNullableEngagementMax;
 
 /// Pagination state for tracking cursor position and loading status per subscription
 class PaginationState {
@@ -4876,8 +4878,17 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
 
     final videoEvent = eventList[index];
 
-    // Update the video with the like count
-    final updatedVideo = videoEvent.copyWith(nostrLikeCount: likeCount);
+    // #6022: max-merge instead of direct-replace so a later, lower re-fetch
+    // can't lower an already-applied bucket count. Bounded — these buckets are
+    // relay-parsed and start with a null nostrLikeCount, so this normally
+    // applies null->N on first fetch. Aligns with the #3384
+    // mergeNullableEngagementMax policy used by the profile enrichment paths.
+    final updatedVideo = videoEvent.copyWith(
+      nostrLikeCount: mergeNullableEngagementMax(
+        videoEvent.nostrLikeCount,
+        likeCount,
+      ),
+    );
     eventList[index] = updatedVideo;
 
     // Also update in keyed buckets if applicable
@@ -5855,6 +5866,15 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   Future<void> flushPendingLikeCountBatchForTesting() {
     return _executeLikeCountBatchFetch();
   }
+
+  /// Apply a resolved like count to a cached video, bypassing the batch and
+  /// debounce, to exercise the max-merge semantics of [_applyLikeCountToVideo].
+  @visibleForTesting
+  bool applyLikeCountForTesting(
+    String videoId,
+    int likeCount,
+    SubscriptionType subscriptionType,
+  ) => _applyLikeCountToVideo(videoId, likeCount, subscriptionType);
 
   /// Run automatic diagnostics when feed fails to load events
   /// This logs relay status, connection info, and tests direct queries to help debug

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -50,8 +50,6 @@ import 'package:openvine/utils/log_tag_sanitizer.dart';
 import 'package:profile_repository/profile_repository.dart';
 import 'package:unified_logger/unified_logger.dart';
 import 'package:video_event_cache/video_event_cache.dart';
-import 'package:videos_repository/videos_repository.dart'
-    show mergeNullableEngagementMax;
 
 /// Pagination state for tracking cursor position and loading status per subscription
 class PaginationState {
@@ -4878,17 +4876,20 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
 
     final videoEvent = eventList[index];
 
-    // #6022: max-merge instead of direct-replace so a later, lower re-fetch
-    // can't lower an already-applied bucket count. Bounded — these buckets are
-    // relay-parsed and start with a null nostrLikeCount, so this normally
-    // applies null->N on first fetch. Aligns with the #3384
-    // mergeNullableEngagementMax policy used by the profile enrichment paths.
-    final updatedVideo = videoEvent.copyWith(
-      nostrLikeCount: mergeNullableEngagementMax(
-        videoEvent.nostrLikeCount,
-        likeCount,
-      ),
-    );
+    // Direct-replace, not max-merge: unlike the archival originalLikes /
+    // originalLoops / originalComments / originalReposts fields (fixed
+    // values baked into event tags, safe to merge with #3384's
+    // mergeNullableEngagementMax), nostrLikeCount is a live relay-derived
+    // count that legitimately decreases — e.g. after the user's own unlike
+    // decrements LikesRepository's count cache, or a reaction is deleted.
+    // A max-merge here would ratchet this cache's value up across every
+    // future re-application (this video re-entering another subscription
+    // bucket, a later batch, etc.) and permanently block that self-
+    // correction. #6022's addressable floor doesn't need protection at this
+    // layer: it's already a correctly-scoped, one-time comparison in
+    // VideoInteractionsBloc._onFetchRequested between the feed seed and a
+    // fresh relay resolve, independent of this cache (#6102 review).
+    final updatedVideo = videoEvent.copyWith(nostrLikeCount: likeCount);
     eventList[index] = updatedVideo;
 
     // Also update in keyed buckets if applicable
@@ -5868,7 +5869,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   }
 
   /// Apply a resolved like count to a cached video, bypassing the batch and
-  /// debounce, to exercise the max-merge semantics of [_applyLikeCountToVideo].
+  /// debounce, to exercise [_applyLikeCountToVideo] directly.
   @visibleForTesting
   bool applyLikeCountForTesting(
     String videoId,

--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -705,6 +705,7 @@ class __OverlayState extends ConsumerState<_Overlay> {
                     repostsRepository: repostsRepository,
                     addressableId: addressableId,
                     initialLikeCount: liveLikeCountSeed(video),
+                    archivedLikeCount: video.originalLikes,
                     initialCommentCount: liveCommentCountSeed(video),
                     initialRepostCount: liveRepostCountSeed(video),
                   )

--- a/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
+++ b/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
@@ -389,8 +389,10 @@ void main() {
       );
 
       blocTest<VideoInteractionsBloc, VideoInteractionsState>(
-        // #6022: the floor never lowers. A non-zero addressable relay resolve
-        // below the seed leaves the seed intact.
+        // #6022: guards the seed-dominant branch — when the seed already
+        // exceeds the archival + relay-resolved Nostr count, a non-zero relay
+        // resolve below it leaves the seed intact (the raise direction is
+        // covered by the tests above).
         'never lowers an addressable seed below the relay resolve (#6022)',
         setUp: () {
           when(

--- a/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
+++ b/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
@@ -72,6 +72,7 @@ void main() {
     VideoInteractionsBloc createBloc({
       String? addressableId,
       int? initialLikeCount,
+      int? archivedLikeCount,
       int? initialCommentCount,
       int? initialRepostCount,
     }) => VideoInteractionsBloc(
@@ -82,6 +83,7 @@ void main() {
       repostsRepository: mockRepostsRepository,
       addressableId: addressableId,
       initialLikeCount: initialLikeCount,
+      archivedLikeCount: archivedLikeCount,
       initialCommentCount: initialCommentCount,
       initialRepostCount: initialRepostCount,
     );
@@ -141,7 +143,12 @@ void main() {
       );
 
       blocTest<VideoInteractionsBloc, VideoInteractionsState>(
-        'does not overwrite seeded engagement counts with relay counts',
+        // #6022: the like floor is addressable + likes-ONLY. The clean
+        // addressable relay resolve raises the like count above the seed, but
+        // comment and repost counts are NOT floored — their higher relay
+        // values must not overwrite the seeded display counts.
+        'floors only the like count up to the addressable relay resolve; '
+        'comments and reposts keep their seed',
         setUp: () {
           when(
             () => mockLikesRepository.isLiked(testEventId),
@@ -181,55 +188,7 @@ void main() {
           ),
           const VideoInteractionsState(
             status: VideoInteractionsStatus.success,
-            likeCount: 1,
-            commentCount: 0,
-            repostCount: 0,
-          ),
-        ],
-      );
-
-      blocTest<VideoInteractionsBloc, VideoInteractionsState>(
-        'preserves pasted payload counts when relay returns bogus 100/20',
-        setUp: () {
-          when(
-            () => mockLikesRepository.isLiked(testEventId),
-          ).thenAnswer((_) async => false);
-          when(
-            () => mockRepostsRepository.isReposted(testAddressableId),
-          ).thenAnswer((_) async => false);
-          when(
-            () => mockLikesRepository.getLikeCount(
-              testEventId,
-              addressableId: testAddressableId,
-            ),
-          ).thenAnswer((_) async => 100);
-          when(
-            () => mockCommentsRepository.getCommentsCount(
-              testEventId,
-              rootAddressableId: testAddressableId,
-            ),
-          ).thenAnswer((_) async => 0);
-          when(
-            () => mockRepostsRepository.getRepostCount(testAddressableId),
-          ).thenAnswer((_) async => 20);
-        },
-        build: () => createBloc(
-          addressableId: testAddressableId,
-          initialLikeCount: 2,
-          initialCommentCount: 0,
-          initialRepostCount: 0,
-        ),
-        act: (bloc) => bloc.add(const VideoInteractionsFetchRequested()),
-        expect: () => [
-          const VideoInteractionsState(
-            status: VideoInteractionsStatus.loading,
-            likeCount: 2,
-            commentCount: 0,
-            repostCount: 0,
-          ),
-          const VideoInteractionsState(
-            status: VideoInteractionsStatus.success,
-            likeCount: 2,
+            likeCount: 100,
             commentCount: 0,
             repostCount: 0,
           ),
@@ -279,12 +238,13 @@ void main() {
       );
 
       blocTest<VideoInteractionsBloc, VideoInteractionsState>(
-        // Companion to the non-addressable case above: production feed items
-        // for Kind 34236 videos pass both eventId and addressableId to
-        // getLikeCount(), so the relay query still fires but the pre-seeded
-        // count remains the display source of truth.
-        'fetches relay like count with addressableId but preserves seeded '
-        'initialLikeCount',
+        // #6022: for addressable (Kind 34236) videos, getLikeCount resolves the
+        // clean distinct-liker set. When that resolve exceeds the funnelcake
+        // seed (e.g. the seed undercounts due to ingestion lag), the floor
+        // raises the displayed count to the relay value. It only ever raises,
+        // never lowers (see the relay-0 regression tests below).
+        'raises the addressable like count to the relay resolve when it '
+        'exceeds the seed (#6022)',
         setUp: () {
           when(
             () => mockLikesRepository.isLiked(testEventId),
@@ -318,7 +278,7 @@ void main() {
           ),
           const VideoInteractionsState(
             status: VideoInteractionsStatus.success,
-            likeCount: 50,
+            likeCount: 75,
             repostCount: 2,
             commentCount: 3,
           ),
@@ -331,6 +291,145 @@ void main() {
             ),
           ).called(1);
         },
+      );
+
+      blocTest<VideoInteractionsBloc, VideoInteractionsState>(
+        // #6022 case A: funnelcake returned reactions:0 so the seed is 0 (not
+        // null). The old `seed ?? fetched` kept 0 and hid real relay likes; the
+        // floor raises a zero addressable seed to the relay resolve.
+        'raises a zero addressable seed to the relay resolve (#6022)',
+        setUp: () {
+          when(
+            () => mockLikesRepository.isLiked(testEventId),
+          ).thenAnswer((_) async => false);
+          when(
+            () => mockRepostsRepository.isReposted(testAddressableId),
+          ).thenAnswer((_) async => false);
+          when(
+            () => mockLikesRepository.getLikeCount(
+              testEventId,
+              addressableId: testAddressableId,
+            ),
+          ).thenAnswer((_) async => 8);
+          when(
+            () => mockCommentsRepository.getCommentsCount(
+              testEventId,
+              rootAddressableId: testAddressableId,
+            ),
+          ).thenAnswer((_) async => 0);
+          when(
+            () => mockRepostsRepository.getRepostCount(testAddressableId),
+          ).thenAnswer((_) async => 0);
+        },
+        build: () =>
+            createBloc(addressableId: testAddressableId, initialLikeCount: 0),
+        act: (bloc) => bloc.add(const VideoInteractionsFetchRequested()),
+        expect: () => [
+          const VideoInteractionsState(
+            status: VideoInteractionsStatus.loading,
+            likeCount: 0,
+          ),
+          const VideoInteractionsState(
+            status: VideoInteractionsStatus.success,
+            likeCount: 8,
+            repostCount: 0,
+            commentCount: 0,
+          ),
+        ],
+      );
+
+      blocTest<VideoInteractionsBloc, VideoInteractionsState>(
+        // #6022 D3: the floor keeps the archival (classic Vine) baseline out of
+        // the Nostr floor. Seed 102 = 100 archival + 2 Nostr; the relay resolves
+        // 5 Nostr likes. A whole-seed max would keep 102 and MISS the extra
+        // Nostr likes; the Nostr-portion floor yields 100 + max(2, 5) = 105.
+        'keeps archival likes out of the Nostr floor and surfaces newly '
+        'resolved Nostr likes (#6022)',
+        setUp: () {
+          when(
+            () => mockLikesRepository.isLiked(testEventId),
+          ).thenAnswer((_) async => false);
+          when(
+            () => mockRepostsRepository.isReposted(testAddressableId),
+          ).thenAnswer((_) async => false);
+          when(
+            () => mockLikesRepository.getLikeCount(
+              testEventId,
+              addressableId: testAddressableId,
+            ),
+          ).thenAnswer((_) async => 5);
+          when(
+            () => mockCommentsRepository.getCommentsCount(
+              testEventId,
+              rootAddressableId: testAddressableId,
+            ),
+          ).thenAnswer((_) async => 0);
+          when(
+            () => mockRepostsRepository.getRepostCount(testAddressableId),
+          ).thenAnswer((_) async => 0);
+        },
+        build: () => createBloc(
+          addressableId: testAddressableId,
+          initialLikeCount: 102,
+          archivedLikeCount: 100,
+        ),
+        act: (bloc) => bloc.add(const VideoInteractionsFetchRequested()),
+        expect: () => [
+          const VideoInteractionsState(
+            status: VideoInteractionsStatus.loading,
+            likeCount: 102,
+          ),
+          const VideoInteractionsState(
+            status: VideoInteractionsStatus.success,
+            likeCount: 105,
+            repostCount: 0,
+            commentCount: 0,
+          ),
+        ],
+      );
+
+      blocTest<VideoInteractionsBloc, VideoInteractionsState>(
+        // #6022: the floor never lowers. A non-zero addressable relay resolve
+        // below the seed leaves the seed intact.
+        'never lowers an addressable seed below the relay resolve (#6022)',
+        setUp: () {
+          when(
+            () => mockLikesRepository.isLiked(testEventId),
+          ).thenAnswer((_) async => false);
+          when(
+            () => mockRepostsRepository.isReposted(testAddressableId),
+          ).thenAnswer((_) async => false);
+          when(
+            () => mockLikesRepository.getLikeCount(
+              testEventId,
+              addressableId: testAddressableId,
+            ),
+          ).thenAnswer((_) async => 40);
+          when(
+            () => mockCommentsRepository.getCommentsCount(
+              testEventId,
+              rootAddressableId: testAddressableId,
+            ),
+          ).thenAnswer((_) async => 0);
+          when(
+            () => mockRepostsRepository.getRepostCount(testAddressableId),
+          ).thenAnswer((_) async => 0);
+        },
+        build: () =>
+            createBloc(addressableId: testAddressableId, initialLikeCount: 100),
+        act: (bloc) => bloc.add(const VideoInteractionsFetchRequested()),
+        expect: () => [
+          const VideoInteractionsState(
+            status: VideoInteractionsStatus.loading,
+            likeCount: 100,
+          ),
+          const VideoInteractionsState(
+            status: VideoInteractionsStatus.success,
+            likeCount: 100,
+            repostCount: 0,
+            commentCount: 0,
+          ),
+        ],
       );
 
       blocTest<VideoInteractionsBloc, VideoInteractionsState>(

--- a/mobile/test/services/video_event_service_like_count_addressable_test.dart
+++ b/mobile/test/services/video_event_service_like_count_addressable_test.dart
@@ -143,6 +143,47 @@ void main() {
     );
 
     test(
+      '_applyLikeCountToVideo max-merges and never lowers a cached count (#6022)',
+      () async {
+        final event = makeEvent('merge-vine');
+        service.handleEventForTesting(event, SubscriptionType.discovery);
+        final video = VideoEvent.fromNostrEvent(event);
+
+        int? cachedLikeCount() => service.discoveryVideos
+            .firstWhere((v) => v.id == video.id)
+            .nostrLikeCount;
+
+        // First resolve applies null -> 10.
+        expect(
+          service.applyLikeCountForTesting(
+            video.id,
+            10,
+            SubscriptionType.discovery,
+          ),
+          isTrue,
+        );
+        expect(cachedLikeCount(), 10);
+
+        // A later, lower resolve must NOT lower the cached count (max-merge,
+        // not the old direct-replace which would drop it to 4).
+        service.applyLikeCountForTesting(
+          video.id,
+          4,
+          SubscriptionType.discovery,
+        );
+        expect(cachedLikeCount(), 10);
+
+        // A higher resolve still raises it.
+        service.applyLikeCountForTesting(
+          video.id,
+          15,
+          SubscriptionType.discovery,
+        );
+        expect(cachedLikeCount(), 15);
+      },
+    );
+
+    test(
       'non-addressable videos are omitted from the addressableIds batch map',
       () async {
         final addressableEvent = makeEvent('addressable-vine');

--- a/mobile/test/services/video_event_service_like_count_addressable_test.dart
+++ b/mobile/test/services/video_event_service_like_count_addressable_test.dart
@@ -143,7 +143,8 @@ void main() {
     );
 
     test(
-      '_applyLikeCountToVideo max-merges and never lowers a cached count (#6022)',
+      '_applyLikeCountToVideo direct-replaces the cached count, including '
+      'lowering it (#6102 review)',
       () async {
         final event = makeEvent('merge-vine');
         service.handleEventForTesting(event, SubscriptionType.discovery);
@@ -164,14 +165,19 @@ void main() {
         );
         expect(cachedLikeCount(), 10);
 
-        // A later, lower resolve must NOT lower the cached count (max-merge,
-        // not the old direct-replace which would drop it to 4).
+        // A later, lower resolve DOES lower the cached count — nostrLikeCount
+        // is a live relay-derived count that legitimately decreases (e.g.
+        // after the user's own unlike decrements LikesRepository's count
+        // cache, or a reaction is deleted), so a max-merge floor here would
+        // wrongly freeze it at the session high. #6022's addressable floor
+        // is applied once, in VideoInteractionsBloc._onFetchRequested,
+        // independent of this cache.
         service.applyLikeCountForTesting(
           video.id,
           4,
           SubscriptionType.discovery,
         );
-        expect(cachedLikeCount(), 10);
+        expect(cachedLikeCount(), 4);
 
         // A higher resolve still raises it.
         service.applyLikeCountForTesting(


### PR DESCRIPTION
## Description

The displayed like count seeded `preFetchLikeCount ?? fetchedLikeCount`, which makes a present funnelcake seed win outright — a floor **and** a ceiling. Two real gaps hid behind that on addressable videos:

- a `reactions:0` seed zeroed a real relay count, and
- a seed that undercounts (funnelcake ingestion/merge lag) could never be corrected upward by the cleaner #5748 distinct-liker resolve.

This replaces the combine in `VideoInteractionsBloc` with an **addressable-gated, Nostr-portion floor**: `max(seed, originalLikes + fetchedNostr)`.

- **Only ever raises, never lowers** — so it preserves the #568 / #4432 edit-recovery (the funnelcake coordinate-union seed stays the base).
- **Addressable-only** — the non-addressable `getLikeCount` is a raw, unfiltered relay tally (counts downvotes / duplicate reactors / deleted reactions), so it must not raise the count; that path keeps the current `??`.
- **Keeps the archival Vine baseline (`originalLikes`) out of the Nostr floor** so a large archival number can't mask newly resolved Nostr likes. `originalLikes` is threaded into the bloc as `archivedLikeCount`.

Also switches `VideoEventService._applyLikeCountToVideo` from direct-replace to `mergeNullableEngagementMax`, so a later, lower re-fetch can't lower an already-applied hashtag/profile bucket count — aligning it with the #3384 policy the profile enrichment paths already use (bounded: these buckets start `null`, so this normally applies `null → N` on first fetch).

**Deliberate behavior change:** for an addressable video, a higher clean relay resolve now *raises* the seed instead of being discarded. This was chosen over #5751's resolved-wins direction, which would regress #4432 post-#568 (the mobile relay resolve only e-filters the current event id and misses superseded-id likes on edited videos). A `max()` floor cannot pull down funnelcake's *spurious* inflation (downvotes / duplicates / deletions) — that stays a backend concern (funnelcake #626) and the floor never makes the displayed number worse than today.

**Related Issue:** Closes #6022

## Out of Scope

- funnelcake `stats.reactions` spurious-inflation correction (funnelcake #626)
- `originalLikes` archival-vs-Nostr reconciliation
- the "Liked by" list undercount of pre-a-tag e-only reactions (#4432 R4)
- comments/reposts (this is likes-only)

## Verification

- `flutter analyze lib test` — no issues
- `flutter test test/blocs/video_interactions/video_interactions_bloc_test.dart test/services/video_event_service_like_count_addressable_test.dart` — all pass
- Regression sweep: full `video_event_service` suite, `video_feed_bloc`, pooled/hashtag feed screen tests, `list_providers` — all pass
- Pre-push hook (analyze + changed-file tests) — pass

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
