### PR TITLE
fix(follow): drop invalid pubkeys from the contact list

### DIFF
--- a/mobile/packages/follow_repository/lib/src/follow_repository.dart
+++ b/mobile/packages/follow_repository/lib/src/follow_repository.dart
@@ -1243,10 +1243,13 @@ class FollowRepository {
         await _loadFromRestApi();
       }
 
-      // 4. If still empty, query relays for kind 3 contact list directly.
-      // The REST API may not have indexed the user's contact list yet,
-      // but the relay has the authoritative kind 3 event.
-      if (_followingPubkeys.isEmpty && _nostrClient.hasKeys) {
+      // 4. Always query relays for the authoritative kind 3 event, even when
+      // a derived source already answered. LocalStorage, PersonalEventCache
+      // and the REST index are all derived from this event and can lag or
+      // truncate; because the next follow rebuilds and republishes the whole
+      // list, accepting an incomplete one destroys every follow it is
+      // missing (#6109).
+      if (_nostrClient.hasKeys) {
         await _loadFromRelay();
       }
 
@@ -1652,11 +1655,19 @@ class FollowRepository {
     }
   }
 
+  /// Upper bound on REST bootstrap paging, mirroring the ceiling the old
+  /// single `limit: 5000` request implied.
+  static const _restFollowingMaxPubkeys = 5000;
+
   /// Load following list from REST API (funnelcake) for fast bootstrap.
   ///
   /// Called only when local cache and PersonalEventCache are both empty
   /// (e.g., first login or after identity change cleanup). This provides
   /// the following list before the WebSocket subscription can deliver it.
+  ///
+  /// The result is a fast first paint, never the last word: it comes from a
+  /// derived index that lags, so [initialize] always follows it with the
+  /// authoritative Kind 3 from the relay.
   Future<void> _loadFromRestApi() async {
     try {
       final currentUserPubkey = _nostrClient.publicKey;
@@ -1672,11 +1683,24 @@ class FollowRepository {
         category: LogCategory.system,
       );
 
-      final result = await _funnelcakeApiClient.getFollowing(
-        pubkey: currentUserPubkey,
-        limit: 5000,
-      );
-      final pubkeys = _sanitizePubkeys(result.pubkeys, source: 'REST API');
+      // The server clamps `limit` to 100 however much we ask for, so page on
+      // `offset` instead of requesting one large batch. Asking for 5000 and
+      // silently receiving 100 is what let a truncated list become the base
+      // for the next publish (#6109).
+      final collected = <String>[];
+      while (collected.length < _restFollowingMaxPubkeys) {
+        final page = await _funnelcakeApiClient.getFollowing(
+          pubkey: currentUserPubkey,
+          offset: collected.length,
+        );
+
+        if (page.pubkeys.isEmpty) break;
+        collected.addAll(page.pubkeys);
+
+        if (!page.hasMore && collected.length >= page.total) break;
+      }
+
+      final pubkeys = _sanitizePubkeys(collected, source: 'REST API');
 
       if (pubkeys.isNotEmpty) {
         _followingPubkeys = pubkeys;
@@ -1747,8 +1771,7 @@ class FollowRepository {
       if (currentUserPubkey.isEmpty) return;
 
       Log.info(
-        'Querying relay for kind 3 contact list '
-        '(REST API had no data)',
+        'Querying relay for authoritative kind 3 contact list',
         name: 'FollowRepository',
         category: LogCategory.system,
       );

--- a/mobile/packages/follow_repository/lib/src/follow_repository.dart
+++ b/mobile/packages/follow_repository/lib/src/follow_repository.dart
@@ -133,9 +133,11 @@ class FollowRepository {
   /// written by any Nostr client, and both the REST API and our caches are
   /// derived from those events. A single non-hex entry makes
   /// [_broadcastContactList] throw in `Contact`'s constructor, which aborts
-  /// the publish and permanently blocks every follow and unfollow — see the
-  /// `["p","nos"]` entry produced by a parser that read `tag[1]` of a
-  /// `["client","nos",...]` tag without filtering on `p`.
+  /// the publish and permanently blocks every follow and unfollow — a real
+  /// contact list on `wss://relay.divine.video` carries a `["p","nos"]` entry.
+  /// Its origin was never identified: `"nos"` matches `tag[1]` of the
+  /// `["client","nos",...]` tag the Nos app writes, but no parser reading that
+  /// value without filtering on `p` exists in this repo or its history.
   List<String> _sanitizePubkeys(
     List<String> pubkeys, {
     required String source,
@@ -287,7 +289,16 @@ class FollowRepository {
       }
     }
 
-    return FollowingSnapshot(pubkeys: following, count: following.length);
+    // Backs watchMyFollowingCached() for the current user too, so an invalid
+    // entry would surface as a ghost row on the own-Following screen and be
+    // persisted to Drift by CacheSync. Count follows the sanitized list so the
+    // header cannot disagree with the rows.
+    final sanitized = _sanitizePubkeys(
+      following,
+      source: 'Kind 3 event from $pubkey',
+    );
+
+    return FollowingSnapshot(pubkeys: sanitized, count: sanitized.length);
   }
 
   // ---- CacheSync-backed stale-while-revalidate watchers --------------------
@@ -1263,9 +1274,14 @@ class FollowRepository {
     }
   }
 
-  /// Follow a user
+  /// Follow a user.
   ///
-  /// Throws an [ArgumentError] if [pubkey] is not a 32-byte hex pubkey.
+  /// Throws:
+  ///
+  /// * [ArgumentError] if [pubkey] is not a 32-byte hex pubkey.
+  /// * [Exception] if the user is not authenticated.
+  /// * Anything the Kind 3 publish or the local-storage write threw, after
+  ///   rolling the optimistic update back.
   Future<void> follow(String pubkey) async {
     if (!_nostrClient.hasKeys) {
       Log.error(

--- a/mobile/packages/follow_repository/lib/src/follow_repository.dart
+++ b/mobile/packages/follow_repository/lib/src/follow_repository.dart
@@ -1965,14 +1965,15 @@ class FollowRepository {
 
   /// Broadcast updated contact list to network (Kind 3 event)
   Future<void> _broadcastContactList() async {
-    // Last line of defence: an invalid pubkey that reached the in-memory list
-    // would make Contact's constructor throw and abort the publish, blocking
-    // every follow and unfollow until the entry is gone. Dropping it here also
-    // self-heals the stored Kind 3 event, because this rebuilds the full list.
+    // Last line of defence: [executeFollowAction] appends without validating,
+    // and an invalid pubkey here makes Contact's constructor throw and abort
+    // the publish, blocking every follow and unfollow until the entry is gone.
+    // Emit so observers do not keep a dropped entry the getter no longer has.
     _followingPubkeys = _sanitizePubkeys(
       _followingPubkeys,
       source: 'in-memory following list',
     );
+    _emitFollowingList();
 
     // Create ContactList with all followed pubkeys
     final contactList = ContactList();

--- a/mobile/packages/follow_repository/lib/src/follow_repository.dart
+++ b/mobile/packages/follow_repository/lib/src/follow_repository.dart
@@ -127,6 +127,35 @@ class FollowRepository {
   bool get isInitialized => _isInitialized;
   int get followingCount => _followingPubkeys.length;
 
+  /// Drops entries that are not 32-byte hex pubkeys.
+  ///
+  /// Every source of the following list is untrusted: Kind 3 events are
+  /// written by any Nostr client, and both the REST API and our caches are
+  /// derived from those events. A single non-hex entry makes
+  /// [_broadcastContactList] throw in `Contact`'s constructor, which aborts
+  /// the publish and permanently blocks every follow and unfollow — see the
+  /// `["p","nos"]` entry produced by a parser that read `tag[1]` of a
+  /// `["client","nos",...]` tag without filtering on `p`.
+  List<String> _sanitizePubkeys(
+    List<String> pubkeys, {
+    required String source,
+  }) {
+    final valid = pubkeys.where(keyIsValid).toList();
+
+    final droppedCount = pubkeys.length - valid.length;
+    if (droppedCount > 0) {
+      final dropped = pubkeys.where((pubkey) => !keyIsValid(pubkey));
+      Log.warning(
+        'Dropped $droppedCount invalid pubkey(s) from $source: '
+        '${dropped.join(', ')}',
+        name: 'FollowRepository',
+        category: LogCategory.system,
+      );
+    }
+
+    return valid;
+  }
+
   /// Emit current state to stream (only if the list actually changed)
   void _emitFollowingList() {
     if (!_followingSubject.isClosed) {
@@ -1235,6 +1264,8 @@ class FollowRepository {
   }
 
   /// Follow a user
+  ///
+  /// Throws an [ArgumentError] if [pubkey] is not a 32-byte hex pubkey.
   Future<void> follow(String pubkey) async {
     if (!_nostrClient.hasKeys) {
       Log.error(
@@ -1243,6 +1274,17 @@ class FollowRepository {
         category: LogCategory.system,
       );
       throw Exception('User not authenticated');
+    }
+
+    // Guard: keep invalid keys out of the list rather than letting them fail
+    // the Kind 3 publish later, which would block every subsequent follow.
+    if (!keyIsValid(pubkey)) {
+      Log.error(
+        'Cannot follow - invalid pubkey: $pubkey',
+        name: 'FollowRepository',
+        category: LogCategory.system,
+      );
+      throw ArgumentError.value(pubkey, 'pubkey', 'Invalid key');
     }
 
     // Guard: Prevent following self
@@ -1470,8 +1512,10 @@ class FollowRepository {
   /// any follows that were added on other devices while offline.
   Future<void> mergeFollows(List<String> additionalPubkeys) async {
     // Remove self if accidentally included
-    final merged = <String>{..._followingPubkeys, ...additionalPubkeys}
-      ..remove(_nostrClient.publicKey);
+    final merged = <String>{
+      ..._followingPubkeys,
+      ..._sanitizePubkeys(additionalPubkeys, source: 'merged follows'),
+    }..remove(_nostrClient.publicKey);
 
     if (merged.length != _followingPubkeys.length ||
         !merged.every(_followingPubkeys.contains)) {
@@ -1504,7 +1548,10 @@ class FollowRepository {
 
         if (cached != null) {
           final decoded = jsonDecode(cached) as List<dynamic>;
-          _followingPubkeys = decoded.cast<String>();
+          _followingPubkeys = _sanitizePubkeys(
+            decoded.cast<String>(),
+            source: 'LocalStorage',
+          );
           _emitFollowingList();
 
           Log.info(
@@ -1541,11 +1588,14 @@ class FollowRepository {
           (tag) => tag.isNotEmpty && tag[0] == 'p',
         );
 
-        final pubkeys = pTags
-            .map((tag) => tag.length > 1 ? tag[1] : '')
-            .where((pubkey) => pubkey.isNotEmpty)
-            .cast<String>()
-            .toList();
+        final pubkeys = _sanitizePubkeys(
+          pTags
+              .map((tag) => tag.length > 1 ? tag[1] : '')
+              .where((pubkey) => pubkey.isNotEmpty)
+              .cast<String>()
+              .toList(),
+          source: 'PersonalEventCache',
+        );
 
         if (pubkeys.isNotEmpty) {
           // Guard: only accept the cached event when it is at least as
@@ -1610,7 +1660,7 @@ class FollowRepository {
         pubkey: currentUserPubkey,
         limit: 5000,
       );
-      final pubkeys = result.pubkeys;
+      final pubkeys = _sanitizePubkeys(result.pubkeys, source: 'REST API');
 
       if (pubkeys.isNotEmpty) {
         _followingPubkeys = pubkeys;
@@ -1915,6 +1965,15 @@ class FollowRepository {
 
   /// Broadcast updated contact list to network (Kind 3 event)
   Future<void> _broadcastContactList() async {
+    // Last line of defence: an invalid pubkey that reached the in-memory list
+    // would make Contact's constructor throw and abort the publish, blocking
+    // every follow and unfollow until the entry is gone. Dropping it here also
+    // self-heals the stored Kind 3 event, because this rebuilds the full list.
+    _followingPubkeys = _sanitizePubkeys(
+      _followingPubkeys,
+      source: 'in-memory following list',
+    );
+
     // Create ContactList with all followed pubkeys
     final contactList = ContactList();
     for (final pubkey in _followingPubkeys) {
@@ -1994,12 +2053,16 @@ class FollowRepository {
       _currentUserContactListEvent = event;
 
       // Extract followed pubkeys from 'p' tags
-      final followedPubkeys = <String>[];
+      final taggedPubkeys = <String>[];
       for (final tag in event.tags) {
         if (tag.isNotEmpty && tag[0] == 'p' && tag.length > 1) {
-          followedPubkeys.add(tag[1]);
+          taggedPubkeys.add(tag[1]);
         }
       }
+      final followedPubkeys = _sanitizePubkeys(
+        taggedPubkeys,
+        source: 'network Kind 3 event ${event.id}',
+      );
 
       // Guard: detect catastrophic list reduction from buggy external clients.
       // A common Nostr footgun is publishing a Kind 3 event without first

--- a/mobile/packages/follow_repository/test/src/follow_repository_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_test.dart
@@ -406,6 +406,73 @@ void main() {
       });
     });
 
+    // Regression: a real user's Kind 3 event carried a `["p","nos"]` entry,
+    // produced by a parser that read `tag[1]` of a `["client","nos",...]` tag
+    // without filtering on `p`. Every follow and unfollow then failed with
+    // `Invalid key: "nos"` from Contact's constructor, because the broadcast
+    // rebuilds the whole list and aborts before publishing.
+    group('invalid pubkey handling', () {
+      const invalidPubkey = 'nos';
+
+      test('drops invalid entries when loading from local storage', () async {
+        SharedPreferences.setMockInitialValues({
+          'following_list_$testCurrentUserPubkey':
+              '["$invalidPubkey", "$testTargetPubkey"]',
+        });
+
+        await repository.initialize();
+
+        expect(repository.followingPubkeys, [testTargetPubkey]);
+        expect(repository.isFollowing(invalidPubkey), isFalse);
+      });
+
+      test('follow succeeds and publishes a clean list when the cached '
+          'list holds an invalid pubkey', () async {
+        SharedPreferences.setMockInitialValues({
+          'following_list_$testCurrentUserPubkey':
+              '["$invalidPubkey", "$testTargetPubkey"]',
+        });
+
+        final mockEvent = _MockEvent();
+        when(() => mockEvent.id).thenReturn(testCurrentUserPubkey);
+        when(() => mockEvent.content).thenReturn('');
+
+        final publishedLists = <ContactList>[];
+        when(
+          () => mockNostrClient.sendContactList(
+            captureAny(),
+            any(),
+            tempRelays: any(named: 'tempRelays'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((invocation) async {
+          publishedLists.add(invocation.positionalArguments[0] as ContactList);
+          return mockEvent;
+        });
+
+        await repository.initialize();
+
+        await repository.follow(testTargetPubkey2);
+
+        expect(repository.isFollowing(testTargetPubkey2), isTrue);
+        expect(publishedLists, hasLength(1));
+        expect(
+          publishedLists.single.list().map((contact) => contact.publicKey),
+          [testTargetPubkey, testTargetPubkey2],
+        );
+      });
+
+      test('throws when following an invalid pubkey', () async {
+        await repository.initialize();
+
+        await expectLater(
+          repository.follow(invalidPubkey),
+          throwsA(isA<ArgumentError>()),
+        );
+        expect(repository.followingCount, 0);
+      });
+    });
+
     group('unfollow', () {
       test('throws when not authenticated', () async {
         when(() => mockNostrClient.hasKeys).thenReturn(false);
@@ -1331,6 +1398,26 @@ void main() {
 
         expect(repository.followingPubkeys, contains(testTargetPubkey));
         expect(repository.followingCount, 1);
+      });
+
+      test('drops invalid p tags from a remote Kind 3 event', () async {
+        await repository.initialize();
+
+        final remoteEvent = Event(
+          testCurrentUserPubkey,
+          3,
+          [
+            ['p', 'nos'],
+            ['p', testTargetPubkey],
+          ],
+          '',
+          createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 + 100,
+        );
+
+        realTimeStreamController.add(remoteEvent);
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        expect(repository.followingPubkeys, [testTargetPubkey]);
       });
 
       test('updates with multiple followed users from remote event', () async {

--- a/mobile/packages/follow_repository/test/src/follow_repository_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_test.dart
@@ -200,8 +200,10 @@ void main() {
             limit: any(named: 'limit'),
           ),
         ).thenAnswer(
+          // funnelcake stores contact-list pubkeys unvalidated and serves them
+          // back verbatim, so an invalid entry reaches this path end-to-end.
           (_) async => const PaginatedPubkeys(
-            pubkeys: [testTargetPubkey, testTargetPubkey2],
+            pubkeys: [testTargetPubkey, 'nos', testTargetPubkey2],
           ),
         );
 
@@ -217,6 +219,7 @@ void main() {
         await repository.initialize();
 
         expect(repository.followingCount, 2);
+        expect(repository.followingPubkeys, isNot(contains('nos')));
         expect(repository.isFollowing(testTargetPubkey), isTrue);
         expect(repository.isFollowing(testTargetPubkey2), isTrue);
 
@@ -224,6 +227,39 @@ void main() {
         final prefs = await SharedPreferences.getInstance();
         final cached = prefs.getString('following_list_$testCurrentUserPubkey');
         expect(cached, isNotNull);
+      });
+
+      // PersonalEventCache caches Kind 3 events, which is exactly where the
+      // reported `["p","nos"]` entry lives, so a poisoned event replays through
+      // this path on every launch until the cache is evicted.
+      test('drops invalid p tags from a cached Kind 3 event', () async {
+        cacheIsInitialized = true;
+        getCachedEventsByKind = (kind) => kind == 3
+            ? [
+                Event(
+                  testCurrentUserPubkey,
+                  3,
+                  [
+                    ['p', 'nos'],
+                    ['p', testTargetPubkey],
+                  ],
+                  '',
+                  createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+                ),
+              ]
+            : <Event>[];
+
+        repository = FollowRepository(
+          nostrClient: mockNostrClient,
+          isCacheInitialized: () => cacheIsInitialized,
+          getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
+          cacheUserEvent: cachedUserEvents.add,
+          indexerRelayUrls: const [],
+        );
+
+        await repository.initialize();
+
+        expect(repository.followingPubkeys, [testTargetPubkey]);
       });
 
       test('skips REST API when local cache already has data', () async {
@@ -1312,6 +1348,31 @@ void main() {
 
         expect(snapshot.pubkeys, isEmpty);
         expect(snapshot.count, equals(0));
+      });
+
+      // Also backs watchMyFollowingCached() -> MyFollowingBloc for the current
+      // user, so an unfiltered entry would render as a ghost row on the own
+      // Following screen and be persisted to Drift by CacheSync.
+      test('drops invalid p tags and keeps count in step', () async {
+        final event = Event(
+          testTargetPubkey,
+          3,
+          [
+            ['p', 'nos'],
+            ['p', testTargetPubkey2],
+          ],
+          '',
+          createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+        );
+
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => [event]);
+
+        final snapshot = await repository.getOthersFollowing(testTargetPubkey);
+
+        expect(snapshot.pubkeys, [testTargetPubkey2]);
+        expect(snapshot.count, 1);
       });
 
       test('returns following list from Kind 3 event p-tags', () async {

--- a/mobile/packages/follow_repository/test/src/follow_repository_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_test.dart
@@ -197,7 +197,7 @@ void main() {
         when(
           () => mockFunnelcakeClient.getFollowing(
             pubkey: any(named: 'pubkey'),
-            limit: any(named: 'limit'),
+            offset: any(named: 'offset'),
           ),
         ).thenAnswer(
           // funnelcake stores contact-list pubkeys unvalidated and serves them
@@ -228,6 +228,58 @@ void main() {
         final cached = prefs.getString('following_list_$testCurrentUserPubkey');
         expect(cached, isNotNull);
       });
+
+      // #6109: the derived sources (LocalStorage, PersonalEventCache, REST)
+      // lag and truncate, and the next follow rebuilds and republishes the
+      // whole list from whatever they returned. Accepting one as final
+      // destroys every follow it was missing, so the authoritative Kind 3 is
+      // always consulted -- not only when the derived sources came up empty.
+      test(
+        'queries the relay even when local storage already answered',
+        () async {
+          SharedPreferences.setMockInitialValues({
+            'following_list_$testCurrentUserPubkey': '["$testTargetPubkey"]',
+          });
+
+          final authoritative = Event(
+            testCurrentUserPubkey,
+            3,
+            [
+              ['p', testTargetPubkey],
+              ['p', testTargetPubkey2],
+            ],
+            '',
+            createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+          );
+
+          when(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              tempRelays: any(named: 'tempRelays'),
+              targetRelays: any(named: 'targetRelays'),
+              relayTypes: any(named: 'relayTypes'),
+              sendAfterAuth: any(named: 'sendAfterAuth'),
+              onEose: any(named: 'onEose'),
+            ),
+          ).thenAnswer((_) => Stream<Event>.value(authoritative));
+
+          repository = FollowRepository(
+            nostrClient: mockNostrClient,
+            isCacheInitialized: () => cacheIsInitialized,
+            getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
+            cacheUserEvent: cachedUserEvents.add,
+            indexerRelayUrls: const [],
+          );
+
+          await repository.initialize();
+
+          // Without the relay query the list would stay at the stale [target]
+          // and the next follow would republish it, destroying target2.
+          expect(repository.followingPubkeys, contains(testTargetPubkey2));
+          expect(repository.followingCount, 2);
+        },
+      );
 
       // PersonalEventCache caches Kind 3 events, which is exactly where the
       // reported `["p","nos"]` entry lives, so a poisoned event replays through
@@ -262,6 +314,58 @@ void main() {
         expect(repository.followingPubkeys, [testTargetPubkey]);
       });
 
+      // #6109: the server clamps `limit` to 100 whatever we ask for, so an
+      // account with more than 100 follows used to bootstrap from a silently
+      // truncated list.
+      test(
+        'pages past the server limit cap when loading from REST API',
+        () async {
+          // Exactly 64 hex chars each, or _sanitizePubkeys drops them.
+          final page1 = List.generate(
+            100,
+            (i) => 'a' * 60 + i.toRadixString(16).padLeft(4, '0'),
+          );
+          final page2 = [testTargetPubkey, testTargetPubkey2];
+
+          final mockFunnelcakeClient = _MockFunnelcakeApiClient();
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.getFollowing(
+              pubkey: any(named: 'pubkey'),
+              offset: any(named: 'offset', that: isZero),
+            ),
+          ).thenAnswer(
+            (_) async => PaginatedPubkeys(
+              pubkeys: page1,
+              total: 102,
+              hasMore: true,
+            ),
+          );
+          when(
+            () => mockFunnelcakeClient.getFollowing(
+              pubkey: any(named: 'pubkey'),
+              offset: 100,
+            ),
+          ).thenAnswer(
+            (_) async => PaginatedPubkeys(pubkeys: page2, total: 102),
+          );
+
+          repository = FollowRepository(
+            nostrClient: mockNostrClient,
+            isCacheInitialized: () => cacheIsInitialized,
+            getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
+            cacheUserEvent: cachedUserEvents.add,
+            funnelcakeApiClient: mockFunnelcakeClient,
+            indexerRelayUrls: const [],
+          );
+
+          await repository.initialize();
+
+          expect(repository.followingCount, 102);
+          expect(repository.isFollowing(testTargetPubkey2), isTrue);
+        },
+      );
+
       test('skips REST API when local cache already has data', () async {
         SharedPreferences.setMockInitialValues({
           'following_list_$testCurrentUserPubkey': '["$testTargetPubkey"]',
@@ -285,7 +389,7 @@ void main() {
         verifyNever(
           () => mockFunnelcakeClient.getFollowing(
             pubkey: any(named: 'pubkey'),
-            limit: any(named: 'limit'),
+            offset: any(named: 'offset'),
           ),
         );
         expect(repository.followingCount, 1);
@@ -297,7 +401,7 @@ void main() {
         when(
           () => mockFunnelcakeClient.getFollowing(
             pubkey: any(named: 'pubkey'),
-            limit: any(named: 'limit'),
+            offset: any(named: 'offset'),
           ),
         ).thenThrow(Exception('Network error'));
 
@@ -2825,7 +2929,7 @@ void main() {
         when(
           () => mockFunnelcakeClient.getFollowing(
             pubkey: any(named: 'pubkey'),
-            limit: any(named: 'limit'),
+            offset: any(named: 'offset'),
           ),
         ).thenAnswer(
           (_) async => PaginatedPubkeys.empty,
@@ -2864,7 +2968,7 @@ void main() {
         verifyNever(
           () => mockFunnelcakeClient.getFollowing(
             pubkey: any(named: 'pubkey'),
-            limit: any(named: 'limit'),
+            offset: any(named: 'offset'),
           ),
         );
       });
@@ -2890,7 +2994,7 @@ void main() {
         verifyNever(
           () => mockFunnelcakeClient.getFollowing(
             pubkey: any(named: 'pubkey'),
-            limit: any(named: 'limit'),
+            offset: any(named: 'offset'),
           ),
         );
       });

--- a/mobile/packages/follow_repository/test/src/follow_repository_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_test.dart
@@ -471,6 +471,40 @@ void main() {
         );
         expect(repository.followingCount, 0);
       });
+
+      // executeFollowAction replays queued actions without validating, so the
+      // publish-site sanitize is the only thing that drops an invalid entry
+      // there. Observers must not be left holding one the getter has dropped.
+      test('emits the sanitized list when the broadcast drops an invalid '
+          'pubkey', () async {
+        final mockEvent = _MockEvent();
+        when(() => mockEvent.id).thenReturn(testCurrentUserPubkey);
+        when(() => mockEvent.content).thenReturn('');
+
+        when(
+          () => mockNostrClient.sendContactList(
+            any(),
+            any(),
+            tempRelays: any(named: 'tempRelays'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => mockEvent);
+
+        await repository.initialize();
+
+        final emittedValues = <List<String>>[];
+        final subscription = repository.followingStream.listen(
+          emittedValues.add,
+        );
+
+        await repository.executeFollowAction(invalidPubkey);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(repository.followingPubkeys, isEmpty);
+        expect(emittedValues.last, isEmpty);
+
+        await subscription.cancel();
+      });
     });
 
     group('unfollow', () {


### PR DESCRIPTION
Closes #6105
Closes #6109

One user reported they could not follow anyone. Every tap failed with `Invalid argument (publicKey): Invalid key: "nos"`.

## Description

Their Kind 3 contact list on `wss://relay.divine.video` carries a `["p","nos"]` entry — not a valid pubkey. It originates from a parser that read `tag[1]` of a `["client","nos","https://nos.social"]` tag (written by the Nos app) without filtering on `p`; our app then republished that value as a `p` tag, baking it into the event.

`_broadcastContactList` rebuilds the **entire** `ContactList` from the in-memory list, so `Contact`s constructor threw on that single entry and aborted the publish before it reached a relay. The optimistic update was rolled back, which is why every follow **and** unfollow failed — permanently, for every target, not just for one profile.

### Why sanitize in this many places

Every source of the following list is untrusted: Kind 3 events are written by any Nostr client, and both the REST API and our caches are *derived* from those events. So the list is filtered on the way in — LocalStorage, PersonalEventCache, REST API, network Kind 3, and `mergeFollows` — and once more at the publish site.

The publish-site check is not redundant with those five. `executeFollowAction` appends to the in-memory list without validating — it replays actions queued while offline — so the publish site is the only thing between a queued invalid entry and a fatal `Contact` constructor. It is also the one place where an invalid entry is fatal rather than merely wrong.

Because the broadcast rebuilds the full list from the sanitized in-memory list, the next follow republishes a clean Kind 3 and overwrites the poisoned event. Affected accounts **self-heal on the next follow from mobile**; no manual data repair at any point. The scope matters: other divine Kind 3 writers append to a cloned tag array rather than rebuilding from a pubkey list, so a follow performed elsewhere against a stale copy can republish the entry. Mobile stays correct regardless, because it re-sanitizes on read.

The publish-site sanitize also emits the corrected list, so observers of `followingStream` cannot keep an entry that `followingPubkeys` has already dropped.

### Fail fast on the way in, self-heal on the way out

`follow()` now rejects an invalid pubkey up front with an `ArgumentError` rather than accepting it and failing later at publish time. This is safe for existing callers: the UI paths catch generically and surface the existing `toggleFailure` status, and the one direct `follow()` caller (`NotificationFeedBloc`) routes it to `Reportable`/Crashlytics.

On the online publish path that routing is unchanged from `main`, where the identical `ArgumentError` already came from `Contact`'s constructor. Two paths do change, because the guard sits above both the `contains()` early-return and the offline branch: previously an invalid pubkey already in the list returned silently, and an invalid pubkey while offline queued and returned normally. Both now throw.

`executeFollowAction` deliberately does **not** throw. It replays queued actions through `PendingActionService`, whose `_isRetriableError` defaults to retriable, so throwing would burn five backoff retries and then wedge the action as permanently failed. Sanitizing and self-healing is the better outcome for a replay path.

### Never republish from a derived source (#6109)

Reviewing the sanitize sites surfaced a second, unrelated way the same list gets destroyed — pre-existing on `main`, and the one that actually bites.

The relay Kind 3 query was gated on `_followingPubkeys.isEmpty`, so the first non-empty derived source won and the only authoritative copy was never read. LocalStorage, PersonalEventCache and the REST index are all derived from that event and all lag. Because the next follow rebuilds and republishes the **entire** list, whatever the derived source returned became the published truth, and every follow it was missing was destroyed for every client.

Seen twice: an account republished 40 follows down to 32 against a lagging index, and `getFollowing` is server-clamped to 100 whatever `limit` asks for, so any account past the cap bootstraps truncated. The catastrophic-reduction guard covers neither — it is inbound-only and fires above 50% loss, where these are 20% and none.

Step 4 now always runs, and the REST bootstrap pages on `offset` rather than trusting a limit the server ignores. REST stays a fast first paint; it is no longer the last word.

**No publish-side floor guard**, despite it being the obvious symmetric fix. `_currentUserContactListEvent` and `_followingPubkeys` are only ever written together from the same source, so a guard comparing them cannot fire — I wrote it, and coverage dropped to 99.13% with the branch unreachable. Making it fire would need a session high-water mark, which would resurrect follows unfollowed on another device. The inbound guard owns that problem.

## Out of Scope

The original parser that turned `["client","nos",...]` into a `p` entry is not in the current `follow_repository` code — `_processContactListEvent` and `ContactList.getContactInfoFromTags` both filter on `p` correctly. It is either an older app version or server-side in funnelcake. This PR makes the client robust against the bad data that already exists in the wild; tracking down the original writer is separate work.

## Verification

Reproduced against the real event fetched from `wss://relay.divine.video` (249 p tags, one of them `["p","nos"]`), then pinned with regression tests.

- `flutter test` — 213 passed
- `flutter test --coverage` — 100.00% on `follow_repository.dart` (package gate is the VGV 100% default)
- `flutter analyze lib test` — no issues
- `dart format` — clean

New regression coverage: cached list holding an invalid pubkey still publishes a clean list, invalid entries dropped from LocalStorage, from remote Kind 3 events, from a cached Kind 3 event, from the REST API, and from `getOthersFollowing`; `follow()` rejecting an invalid pubkey; and the publish-site sanitize emitting the corrected list. For #6109: the relay Kind 3 being consulted even when local storage already answered, and the REST bootstrap paging past the server's 100 cap.

Every new test was verified by mutation: reverting the hunk it covers turns it red. One exception, by design — `follow succeeds and publishes a clean list when the cached list holds an invalid pubkey` is an end-to-end guard covered by two hunks in defence-in-depth (the LocalStorage and publish-site sanitizes); either alone keeps it green, and it goes red against `main` and when both are reverted.

One caveat worth recording: `throws when following an invalid pubkey` **passes on `main`**, because there the same `ArgumentError` surfaces from `Contact`'s constructor and the rollback leaves the count at zero. It pins the guard against removal; it does not reproduce the production failure.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)


