### PR TITLE
fix(trust-safety): log moderation-pubkey pin divergence + ignore NIP-05 redirects (#4948)

### DIFF
--- a/mobile/lib/services/moderation_label_service.dart
+++ b/mobile/lib/services/moderation_label_service.dart
@@ -582,16 +582,27 @@ class ModerationLabelService {
     });
   }
 
+  /// Canonical form of a labeler identity: lowercase hex, no surrounding
+  /// whitespace.
+  ///
+  /// NIP-05 mandates lowercase hex and event authors arrive lowercase on the
+  /// wire, so canonicalizing at the two points that produce an identity keeps
+  /// [_divineModerationPubkey], [_subscribedLabelers] and the pin comparison on
+  /// one form. Without it a non-lowercase answer would read as identical to the
+  /// pin yet fail to match the labeler's own events in the subscription filter.
+  static String _normalizedPubkey(String pubkey) => pubkey.trim().toLowerCase();
+
   /// Resolve the Divine moderation pubkey via cached value or NIP-05 lookup.
   ///
   /// Strategy: SharedPreferences cache (24h TTL) → NIP-05 → fallback constant.
+  /// Every path returns a [_normalizedPubkey].
   Future<String> _resolveModerationPubkey(SharedPreferences prefs) async {
     // Check cached resolution
-    final cachedPubkey = prefs.getString(_resolvedPubkeyKey);
+    final cachedPubkey = _normalizedPubkey(
+      prefs.getString(_resolvedPubkeyKey) ?? '',
+    );
     final cachedAtStr = prefs.getString(_resolvedAtKey);
-    if (cachedPubkey != null &&
-        cachedPubkey.isNotEmpty &&
-        cachedAtStr != null) {
+    if (cachedPubkey.isNotEmpty && cachedAtStr != null) {
       final cachedAt = DateTime.tryParse(cachedAtStr);
       if (cachedAt != null &&
           DateTime.now().difference(cachedAt) < _resolvedPubkeyTtl) {
@@ -602,15 +613,16 @@ class ModerationLabelService {
     // Resolve via NIP-05
     try {
       final resolved = await Nip05Validor.getPubkey(divineModerationNip05);
-      if (resolved != null && resolved.isNotEmpty) {
-        await prefs.setString(_resolvedPubkeyKey, resolved);
+      final normalized = _normalizedPubkey(resolved ?? '');
+      if (normalized.isNotEmpty) {
+        await prefs.setString(_resolvedPubkeyKey, normalized);
         await prefs.setString(_resolvedAtKey, DateTime.now().toIso8601String());
         Log.info(
-          'Resolved moderation pubkey via NIP-05: $resolved',
+          'Resolved moderation pubkey via NIP-05: $normalized',
           name: 'ModerationLabelService',
           category: LogCategory.system,
         );
-        return resolved;
+        return normalized;
       }
     } catch (e) {
       Log.warning(
@@ -621,15 +633,17 @@ class ModerationLabelService {
     }
 
     // Use stale cache if available, otherwise fallback
-    if (cachedPubkey != null && cachedPubkey.isNotEmpty) {
+    if (cachedPubkey.isNotEmpty) {
       return cachedPubkey;
     }
     return fallbackModerationPubkeyHex;
   }
 
   String _cachedModerationPubkey(SharedPreferences prefs) {
-    final cachedPubkey = prefs.getString(_resolvedPubkeyKey);
-    if (cachedPubkey != null && cachedPubkey.isNotEmpty) {
+    final cachedPubkey = _normalizedPubkey(
+      prefs.getString(_resolvedPubkeyKey) ?? '',
+    );
+    if (cachedPubkey.isNotEmpty) {
       return cachedPubkey;
     }
     return fallbackModerationPubkeyHex;
@@ -638,7 +652,8 @@ class ModerationLabelService {
   /// Adopt [pubkey] as the moderation labeler identity.
   ///
   /// Every path that settles on an identity funnels through here so the pin
-  /// check cannot be bypassed by adding a new resolution source.
+  /// check cannot be bypassed by adding a new resolution source. [pubkey] is
+  /// expected canonical — both producers return a [_normalizedPubkey].
   void _adoptModerationPubkey(String pubkey) {
     _divineModerationPubkey = pubkey;
     _warnIfPinMismatch(pubkey);
@@ -650,8 +665,12 @@ class ModerationLabelService {
   /// indistinguishable from an intended rotation in the logs. Fires once per
   /// adoption, so a steady divergence costs one line per session rather than
   /// one per read.
+  ///
+  /// Both sides are canonical here — [adoptedPubkey] via [_normalizedPubkey]
+  /// and the pin as a lowercase constant — so a case-only variant of the pin
+  /// stays silent rather than crying wolf.
   void _warnIfPinMismatch(String adoptedPubkey) {
-    if (adoptedPubkey.trim().toLowerCase() == fallbackModerationPubkeyHex) {
+    if (adoptedPubkey == fallbackModerationPubkeyHex) {
       return;
     }
     Log.warning(

--- a/mobile/lib/services/moderation_label_service.dart
+++ b/mobile/lib/services/moderation_label_service.dart
@@ -115,7 +115,7 @@ class ModerationLabelService {
   /// Cache TTL for NIP-05 resolved pubkey (24 hours).
   static const Duration _resolvedPubkeyTtl = Duration(hours: 24);
 
-  /// Resolved Divine moderation pubkey (NIP-05 → cache → fallback).
+  /// Resolved Divine moderation pubkey (cache → NIP-05 → fallback).
   String _divineModerationPubkey = fallbackModerationPubkeyHex;
 
   /// The current Divine moderation pubkey (resolved via NIP-05 or fallback).
@@ -190,7 +190,7 @@ class ModerationLabelService {
     try {
       // Use cache or fallback only. Remote NIP-05 refresh happens from
       // initialize(), which is called only from relay-ready paths.
-      _divineModerationPubkey = _cachedModerationPubkey(_prefs);
+      _adoptModerationPubkey(_cachedModerationPubkey(_prefs));
 
       final saved = _prefs.getStringList(_subscribedLabelersKey);
       if (saved != null) {
@@ -635,12 +635,41 @@ class ModerationLabelService {
     return fallbackModerationPubkeyHex;
   }
 
+  /// Adopt [pubkey] as the moderation labeler identity.
+  ///
+  /// Every path that settles on an identity funnels through here so the pin
+  /// check cannot be bypassed by adding a new resolution source.
+  void _adoptModerationPubkey(String pubkey) {
+    _divineModerationPubkey = pubkey;
+    _warnIfPinMismatch(pubkey);
+  }
+
+  /// Advisory only: NIP-05 stays authoritative for the labeler identity
+  /// (#4948 tier 1), so a divergence from the shipped pin is logged, never
+  /// overridden. Without this, a hostile repoint of [divineModerationNip05] is
+  /// indistinguishable from an intended rotation in the logs. Fires once per
+  /// adoption, so a steady divergence costs one line per session rather than
+  /// one per read.
+  void _warnIfPinMismatch(String adoptedPubkey) {
+    if (adoptedPubkey.trim().toLowerCase() == fallbackModerationPubkeyHex) {
+      return;
+    }
+    Log.warning(
+      'Moderation pubkey diverges from the key pinned in this build: '
+      'adopted $adoptedPubkey, pinned $fallbackModerationPubkeyHex. '
+      'Expected after an intended rotation; otherwise investigate '
+      '$divineModerationNip05 for an unauthorized repoint.',
+      name: 'ModerationLabelService',
+      category: LogCategory.system,
+    );
+  }
+
   Future<void> _refreshModerationPubkey() async {
     final previousPubkey = _divineModerationPubkey;
     final resolvedPubkey = await _resolveModerationPubkey(_prefs);
     if (resolvedPubkey == previousPubkey) return;
 
-    _divineModerationPubkey = resolvedPubkey;
+    _adoptModerationPubkey(resolvedPubkey);
     _subscribedLabelers.remove(previousPubkey);
     _subscribedLabelers.add(resolvedPubkey);
     await _saveSubscribedLabelers();

--- a/mobile/lib/services/nip05_resolver.dart
+++ b/mobile/lib/services/nip05_resolver.dart
@@ -72,12 +72,15 @@ class Nip05Resolver {
               // redirect and fetchers MUST ignore redirects. Following a 30x is
               // a spurious-APPROVE vector — a MITM or misconfigured origin could
               // bounce the lookup to an attacker host that returns the expected
-              // key for a burner. Do not follow. With Dio's default
-              // validateStatus (2xx only), the unfollowed 3xx fails validation
-              // and throws DioException.badResponse, which _fetchRaw's catch
-              // maps to networkError (no signal). The explicit 3xx guard in
-              // _fetchRaw is defense-in-depth for a future validateStatus that
-              // might accept 3xx as a Response.
+              // key for a burner. Do not follow.
+              //
+              // These flags only bind on dart:io, where the unfollowed 3xx
+              // fails the default validateStatus (2xx only) and throws
+              // DioException.badResponse into _fetchRaw's catch. On Flutter web
+              // dio delegates to XMLHttpRequest, which follows a 30x in the
+              // browser and never reads them — the lookup lands on the redirect
+              // target's 200. _fetchRaw's isRedirect guard is what enforces the
+              // constraint there.
               followRedirects: false,
               maxRedirects: 0,
             ),
@@ -123,12 +126,18 @@ class Nip05Resolver {
       final res = await _dio.get(
         'https://$domain/.well-known/nostr.json?name=$name',
       );
-      // Defense-in-depth for redirects (NIP-05 requires ignoring them). In
-      // production this branch is NOT the one that rejects a 3xx: Dio's default
-      // validateStatus (2xx only) makes an unfollowed 302 throw badResponse,
-      // handled in the DioException catch below. This guard only matters if a
-      // future validateStatus is widened to surface a 3xx as a Response — then a
-      // redirect body still can't resolve to matched.
+      // The only redirect signal that survives every transport. On web a
+      // browser-followed 30x arrives as a 200 flagged isRedirect, so
+      // followRedirects: false never sees it and the default validateStatus
+      // accepts it; without this the redirect target's body would resolve to
+      // matched. On dart:io the 3xx has already thrown into the catch below,
+      // making this a no-op there.
+      if (res.isRedirect) {
+        return const _RawResolution(_RawKind.networkError);
+      }
+      // Defense-in-depth on dart:io: unreachable with the default 2xx
+      // validateStatus, but if it is ever widened to surface a 3xx as a
+      // Response, a redirect body still can't resolve to matched.
       final status = res.statusCode ?? 0;
       if (status >= 300 && status < 400) {
         return const _RawResolution(_RawKind.networkError);
@@ -145,8 +154,9 @@ class Nip05Resolver {
     } on DioException catch (e) {
       // A 404 is an affirmative "this name is not here"; anything else
       // (an unfollowed 3xx redirect, timeout, offline, 5xx, connection reset)
-      // carries no signal. The 3xx lands here because the default validateStatus
-      // (2xx only) rejects it — this is the real redirect-rejection path.
+      // carries no signal. On dart:io an unfollowed 3xx lands here because the
+      // default validateStatus (2xx only) rejects it; on web the browser
+      // follows it instead and the isRedirect guard above catches it.
       if (e.response?.statusCode == 404) {
         return const _RawResolution(_RawKind.absent);
       }

--- a/mobile/packages/nostr_sdk/lib/nip05/nip05_validor.dart
+++ b/mobile/packages/nostr_sdk/lib/nip05/nip05_validor.dart
@@ -6,7 +6,24 @@ import 'package:dio/dio.dart';
 class Nip05Validor {
   static final Map<String, int> _checking = {};
 
-  static var dio = Dio();
+  /// Bounds a slow or hostile origin. Without it a stalled read hangs the
+  /// caller for Dio's default (no timeout at all).
+  static const Duration _timeout = Duration(seconds: 5);
+
+  /// NIP-05 "Security Constraints": the `.well-known/nostr.json` endpoint MUST
+  /// NOT return HTTP redirects, and fetchers MUST ignore any it returns.
+  /// Following a 30x is a spurious-verify vector — a MITM or a misconfigured
+  /// origin can bounce the lookup to a host that answers with an attacker's
+  /// key. Dio's default `validateStatus` accepts 2xx only, so an unfollowed 3xx
+  /// throws and [getPubkey] yields null rather than a redirected key.
+  static var dio = Dio(
+    BaseOptions(
+      connectTimeout: _timeout,
+      receiveTimeout: _timeout,
+      followRedirects: false,
+      maxRedirects: 0,
+    ),
+  );
 
   static Future<bool?> valid(String nip05Address, String pubkey) async {
     if (_checking[nip05Address] != null) {

--- a/mobile/packages/nostr_sdk/lib/nip05/nip05_validor.dart
+++ b/mobile/packages/nostr_sdk/lib/nip05/nip05_validor.dart
@@ -14,8 +14,14 @@ class Nip05Validor {
   /// NOT return HTTP redirects, and fetchers MUST ignore any it returns.
   /// Following a 30x is a spurious-verify vector — a MITM or a misconfigured
   /// origin can bounce the lookup to a host that answers with an attacker's
-  /// key. Dio's default `validateStatus` accepts 2xx only, so an unfollowed 3xx
-  /// throws and [getPubkey] yields null rather than a redirected key.
+  /// key.
+  ///
+  /// These flags only bind on `dart:io` (dio's IOHttpClientAdapter forwards
+  /// them to [HttpClientRequest]). On Flutter web dio delegates to
+  /// XMLHttpRequest, which follows a 30x in the browser and never reads them —
+  /// the lookup lands on the redirect target's 200, which the default
+  /// `validateStatus` accepts. [getPubkey]'s `isRedirect` check is what
+  /// actually enforces the constraint there.
   static var dio = Dio(
     BaseOptions(
       connectTimeout: _timeout,
@@ -59,6 +65,13 @@ class Nip05Validor {
     var url = "https://$address/.well-known/nostr.json?name=$name";
     try {
       var response = await dio.get(url);
+      // The only redirect signal that survives every transport. On web a
+      // browser-followed 30x arrives as a 200 flagged `isRedirect`, so
+      // `followRedirects: false` never sees it; on `dart:io` the 3xx has
+      // already thrown, making this a no-op there.
+      if (response.isRedirect) {
+        return null;
+      }
       if (response.data != null) {
         var map = response.data;
         if (map is String) {

--- a/mobile/packages/nostr_sdk/test/nip05/nip05_validor_test.dart
+++ b/mobile/packages/nostr_sdk/test/nip05/nip05_validor_test.dart
@@ -29,13 +29,15 @@ class _RecordingAdapter implements HttpClientAdapter {
   void close({bool force = false}) {}
 }
 
-ResponseBody _json(String body, int status) => ResponseBody.fromString(
-  body,
-  status,
-  headers: {
-    Headers.contentTypeHeader: [Headers.jsonContentType],
-  },
-);
+ResponseBody _json(String body, int status, {bool isRedirect = false}) =>
+    ResponseBody.fromString(
+      body,
+      status,
+      isRedirect: isRedirect,
+      headers: {
+        Headers.contentTypeHeader: [Headers.jsonContentType],
+      },
+    );
 
 void main() {
   group(Nip05Validor, () {
@@ -88,9 +90,10 @@ void main() {
         );
       });
 
-      // The assertion that actually enforces the spec constraint. A real
-      // adapter follows a 30x when these flags say to; a fake never does, so
-      // asserting on the outcome alone would pass even with redirects enabled.
+      // Pins the `dart:io` half of the constraint: only IOHttpClientAdapter
+      // reads these flags, and a fake never follows a 30x, so asserting on the
+      // outcome alone would pass even with redirects enabled. The web half is
+      // pinned by 'yields null when a browser-followed redirect answers 200'.
       test('disables redirects, per NIP-05 Security Constraints', () async {
         final adapter = install(
           () => _json('{"names":{"bob":"$pubkey"}}', 200),
@@ -125,6 +128,23 @@ void main() {
         expect(await Nip05Validor.getPubkey('bob@example.com'), isNull);
       });
 
+      // Flutter web ships to app.divine.video. There dio delegates to
+      // XMLHttpRequest, which follows a 30x transparently and never reads
+      // `followRedirects`; dio_web_adapter reports the redirect target's 200
+      // with `isRedirect: true`, which the default validateStatus accepts.
+      // Only the explicit check keeps the redirect target's key out.
+      test(
+        'yields null when a browser-followed redirect answers 200',
+        () async {
+          install(
+            () =>
+                _json('{"names":{"bob":"${'e' * 64}"}}', 200, isRedirect: true),
+          );
+
+          expect(await Nip05Validor.getPubkey('bob@example.com'), isNull);
+        },
+      );
+
       test('yields null when the name is absent from the directory', () async {
         install(() => _json('{"names":{}}', 200));
 
@@ -147,6 +167,16 @@ void main() {
 
       test('is false when the directory maps a different key', () async {
         install(() => _json('{"names":{"bob":"${'a' * 64}"}}', 200));
+
+        expect(await Nip05Validor.valid('bob@example.com', pubkey), isFalse);
+      });
+
+      // The redirect target answers with the *claimed* key, so without the
+      // isRedirect check a bounced lookup verifies an impostor's badge.
+      test('is false when a browser-followed redirect answers 200', () async {
+        install(
+          () => _json('{"names":{"bob":"$pubkey"}}', 200, isRedirect: true),
+        );
 
         expect(await Nip05Validor.valid('bob@example.com', pubkey), isFalse);
       });

--- a/mobile/packages/nostr_sdk/test/nip05/nip05_validor_test.dart
+++ b/mobile/packages/nostr_sdk/test/nip05/nip05_validor_test.dart
@@ -1,0 +1,155 @@
+// ABOUTME: Tests the NIP-05 lookup hardening in Nip05Validor.
+// ABOUTME: NIP-05 "Security Constraints" require fetchers to ignore redirects.
+
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/nip05/nip05_validor.dart';
+
+/// Captures the [RequestOptions] Dio hands the transport, and replies with a
+/// canned response instead of reaching the network.
+class _RecordingAdapter implements HttpClientAdapter {
+  _RecordingAdapter(this._respond);
+
+  final ResponseBody Function() _respond;
+  final List<RequestOptions> requests = [];
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    requests.add(options);
+    return _respond();
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+ResponseBody _json(String body, int status) => ResponseBody.fromString(
+  body,
+  status,
+  headers: {
+    Headers.contentTypeHeader: [Headers.jsonContentType],
+  },
+);
+
+void main() {
+  group(Nip05Validor, () {
+    const pubkey =
+        'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
+
+    late HttpClientAdapter originalAdapter;
+
+    setUp(() {
+      originalAdapter = Nip05Validor.dio.httpClientAdapter;
+    });
+
+    tearDown(() {
+      Nip05Validor.dio.httpClientAdapter = originalAdapter;
+    });
+
+    _RecordingAdapter install(ResponseBody Function() respond) {
+      final adapter = _RecordingAdapter(respond);
+      Nip05Validor.dio.httpClientAdapter = adapter;
+      return adapter;
+    }
+
+    group('getPubkey', () {
+      test('returns the mapped pubkey for a well-formed nostr.json', () async {
+        install(() => _json('{"names":{"bob":"$pubkey"}}', 200));
+
+        expect(await Nip05Validor.getPubkey('bob@example.com'), pubkey);
+      });
+
+      test('queries the name as a query string, per NIP-05', () async {
+        final adapter = install(
+          () => _json('{"names":{"bob":"$pubkey"}}', 200),
+        );
+
+        await Nip05Validor.getPubkey('bob@example.com');
+
+        expect(
+          adapter.requests.single.uri.toString(),
+          'https://example.com/.well-known/nostr.json?name=bob',
+        );
+      });
+
+      test('treats a bare domain as the root `_` identifier', () async {
+        final adapter = install(() => _json('{"names":{"_":"$pubkey"}}', 200));
+
+        expect(await Nip05Validor.getPubkey('example.com'), pubkey);
+        expect(
+          adapter.requests.single.uri.toString(),
+          'https://example.com/.well-known/nostr.json?name=_',
+        );
+      });
+
+      // The assertion that actually enforces the spec constraint. A real
+      // adapter follows a 30x when these flags say to; a fake never does, so
+      // asserting on the outcome alone would pass even with redirects enabled.
+      test('disables redirects, per NIP-05 Security Constraints', () async {
+        final adapter = install(
+          () => _json('{"names":{"bob":"$pubkey"}}', 200),
+        );
+
+        await Nip05Validor.getPubkey('bob@example.com');
+
+        expect(adapter.requests.single.followRedirects, isFalse);
+        expect(adapter.requests.single.maxRedirects, 0);
+      });
+
+      test('bounds the lookup with connect and receive timeouts', () async {
+        final adapter = install(
+          () => _json('{"names":{"bob":"$pubkey"}}', 200),
+        );
+
+        await Nip05Validor.getPubkey('bob@example.com');
+
+        expect(
+          adapter.requests.single.connectTimeout,
+          const Duration(seconds: 5),
+        );
+        expect(
+          adapter.requests.single.receiveTimeout,
+          const Duration(seconds: 5),
+        );
+      });
+
+      test('yields null when the endpoint answers with a redirect', () async {
+        install(() => _json('', 302));
+
+        expect(await Nip05Validor.getPubkey('bob@example.com'), isNull);
+      });
+
+      test('yields null when the name is absent from the directory', () async {
+        install(() => _json('{"names":{}}', 200));
+
+        expect(await Nip05Validor.getPubkey('bob@example.com'), isNull);
+      });
+
+      test('yields null when the origin errors', () async {
+        install(() => _json('nope', 500));
+
+        expect(await Nip05Validor.getPubkey('bob@example.com'), isNull);
+      });
+    });
+
+    group('valid', () {
+      test('is true when the directory maps the name to the pubkey', () async {
+        install(() => _json('{"names":{"bob":"$pubkey"}}', 200));
+
+        expect(await Nip05Validor.valid('bob@example.com', pubkey), isTrue);
+      });
+
+      test('is false when the directory maps a different key', () async {
+        install(() => _json('{"names":{"bob":"${'a' * 64}"}}', 200));
+
+        expect(await Nip05Validor.valid('bob@example.com', pubkey), isFalse);
+      });
+    });
+  });
+}

--- a/mobile/test/services/moderation_label_service_test.dart
+++ b/mobile/test/services/moderation_label_service_test.dart
@@ -163,6 +163,22 @@ void main() {
       );
     });
 
+    test('canonicalizes a persisted key that differs only by case', () async {
+      await mockPrefs.setString(resolvedPubkeyPrefsKey, pin.toUpperCase());
+
+      final service = buildService();
+      await service.ensureLoaded();
+
+      expect(
+        service.divineModerationPubkeyHex,
+        pin,
+        reason:
+            'the adopted identity feeds the subscription filter, and event '
+            'authors are lowercase on the wire — storing the uppercase form '
+            'would silently match no events',
+      );
+    });
+
     test('warns when NIP-05 resolves to a key that is not the pin', () async {
       Nip05Validor.dio.httpClientAdapter = _FakeNip05Adapter(
         '{"names":{"moderation":"$divergentKey"}}',

--- a/mobile/test/services/moderation_label_service_test.dart
+++ b/mobile/test/services/moderation_label_service_test.dart
@@ -2,21 +2,50 @@
 // ABOUTME: Validates Kind 1985 label parsing including AI confidence metadata
 
 import 'dart:async';
+import 'dart:typed_data';
 
+import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/filter.dart';
+import 'package:nostr_sdk/nip05/nip05_validor.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/moderation_label_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+import '../helpers/test_pubkeys.dart';
 
 class _MockNostrClient extends Mock implements NostrClient {}
 
 class _MockAuthService extends Mock implements AuthService {}
 
 class _FakeFilter extends Fake implements Filter {}
+
+/// Serves a canned `nostr.json` so the NIP-05 leg resolves without a network.
+class _FakeNip05Adapter implements HttpClientAdapter {
+  _FakeNip05Adapter(this._body);
+
+  final String _body;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async => ResponseBody.fromString(
+    _body,
+    200,
+    headers: {
+      Headers.contentTypeHeader: [Headers.jsonContentType],
+    },
+  );
+
+  @override
+  void close({bool force = false}) {}
+}
 
 /// Fake event for testing label processing.
 class _FakeLabelEvent extends Fake implements Event {
@@ -49,6 +78,106 @@ void main() {
       authService: mockAuthService,
       sharedPreferences: mockPrefs,
     );
+  });
+
+  group('pinned-key mismatch logging (#4948 tier 1)', () {
+    const pin = ModerationLabelService.fallbackModerationPubkeyHex;
+    const divergentKey = syntheticTestPubkey;
+    const resolvedPubkeyPrefsKey = 'divine_moderation_resolved_pubkey';
+
+    late LogCaptureService logCapture;
+    late HttpClientAdapter originalAdapter;
+
+    setUp(() async {
+      logCapture = LogCaptureService();
+      await logCapture.clearAllLogs();
+      originalAdapter = Nip05Validor.dio.httpClientAdapter;
+    });
+
+    tearDown(() async {
+      // Restore the shared static adapter: an unrestored swap would strand
+      // every later suite in the merged isolate on this fake.
+      Nip05Validor.dio.httpClientAdapter = originalAdapter;
+      await logCapture.clearAllLogs();
+    });
+
+    ModerationLabelService buildService({bool canQueryRelays = false}) =>
+        ModerationLabelService(
+          nostrClient: mockNostrClient,
+          authService: mockAuthService,
+          sharedPreferences: mockPrefs,
+          canQueryRelays: () => canQueryRelays,
+        );
+
+    List<String> pinWarnings() => logCapture
+        .getRecentLogs(minLevel: LogLevel.warning)
+        .map((entry) => entry.message)
+        .where((message) => message.contains('diverges from the key pinned'))
+        .toList();
+
+    test('stays silent when the adopted key is the pinned key', () async {
+      final service = buildService();
+
+      await service.ensureLoaded();
+
+      expect(service.divineModerationPubkeyHex, pin);
+      expect(pinWarnings(), isEmpty);
+    });
+
+    test('warns when a persisted key diverges from the pin', () async {
+      await mockPrefs.setString(resolvedPubkeyPrefsKey, divergentKey);
+      final service = buildService();
+
+      await service.ensureLoaded();
+
+      expect(
+        service.divineModerationPubkeyHex,
+        divergentKey,
+        reason:
+            'tier 1 keeps NIP-05 authoritative; the warning is advisory '
+            'and must not change which key is trusted',
+      );
+      expect(pinWarnings(), hasLength(1));
+    });
+
+    test('names both keys in full so the warning is actionable', () async {
+      await mockPrefs.setString(resolvedPubkeyPrefsKey, divergentKey);
+
+      await buildService().ensureLoaded();
+
+      expect(pinWarnings().single, contains(divergentKey));
+      expect(pinWarnings().single, contains(pin));
+    });
+
+    test('does not warn when a persisted key differs only by case', () async {
+      await mockPrefs.setString(resolvedPubkeyPrefsKey, pin.toUpperCase());
+
+      await buildService().ensureLoaded();
+
+      expect(
+        pinWarnings(),
+        isEmpty,
+        reason:
+            'NIP-05 mandates lowercase hex, but an uppercase answer is '
+            'the same identity — warning on it would cry wolf',
+      );
+    });
+
+    test('warns when NIP-05 resolves to a key that is not the pin', () async {
+      Nip05Validor.dio.httpClientAdapter = _FakeNip05Adapter(
+        '{"names":{"moderation":"$divergentKey"}}',
+      );
+      when(
+        () => mockNostrClient.queryEvents(any()),
+      ).thenAnswer((_) async => <Event>[]);
+      final service = buildService(canQueryRelays: true);
+
+      await service.initialize();
+
+      expect(service.divineModerationPubkeyHex, divergentKey);
+      expect(pinWarnings(), hasLength(1));
+      expect(pinWarnings().single, contains(divergentKey));
+    });
   });
 
   group(ModerationLabelService, () {

--- a/mobile/test/services/nip05_resolver_test.dart
+++ b/mobile/test/services/nip05_resolver_test.dart
@@ -24,9 +24,14 @@ void main() {
     resolver = Nip05Resolver(dio: dio);
   });
 
-  Response<dynamic> jsonResponse(Object? body, {int status = 200}) => Response(
+  Response<dynamic> jsonResponse(
+    Object? body, {
+    int status = 200,
+    bool isRedirect = false,
+  }) => Response(
     statusCode: status,
     data: body,
+    isRedirect: isRedirect,
     requestOptions: RequestOptions(),
   );
 
@@ -108,6 +113,28 @@ void main() {
         (_) async => jsonResponse({
           'names': {'_': hqHex},
         }, status: 302),
+      );
+
+      final result = await resolver.resolve('_@divinehq.divine.video', hqHex);
+
+      expect(result.kind, Nip05ResolutionKind.networkError);
+    },
+  );
+
+  // The web shape, and the one the two cases above cannot catch. Flutter web
+  // ships to app.divine.video, where dio delegates to XMLHttpRequest: the
+  // browser follows the 30x itself and never reads followRedirects, so the
+  // redirect target's 200 passes the default validateStatus. The body carries
+  // the *expected* key, so without the isRedirect guard a bounced lookup
+  // approves a burner for the protected-minor DM gate.
+  test(
+    'redirect the browser followed (200 flagged isRedirect) -> networkError, '
+    'never approves',
+    () async {
+      when(() => dio.get(any())).thenAnswer(
+        (_) async => jsonResponse({
+          'names': {'_': hqHex},
+        }, isRedirect: true),
       );
 
       final result = await resolver.resolve('_@divinehq.divine.video', hqHex);


### PR DESCRIPTION
## Description

Tier-1 controls from the #4948 decision, on the moderation NIP-05 path. The decision (2026-07-07) split the trust model into two tiers. Tier 2 (the protected-minor DM gate) shipped in #5754. Tier 1 shipped nothing — this covers the client-side pieces of it, plus a web gap that review surfaced in both NIP-05 lookup paths.

**1. Advisory mismatch logging** (`feat` commit)

Tier 1 keeps NIP-05 authoritative for the labeler identity, accepting that a name-server or DNS redirect can point clients at an attacker's key for up to the 24h cache TTL. The decision paired that acceptance with advisory mismatch logging so the redirect is at least *observable*. It never landed.

Until now a hostile repoint of `moderation@divine.video` was indistinguishable from an intended rotation. The only signals were an unconditional info line naming the resolved key, and `Updated moderation labeler from A to B`, which compares against the previously adopted key — never against the pin. A first-ever resolve that already diverged produced no signal at all.

Every adoption now funnels through `_adoptModerationPubkey`, so the check can't be bypassed by adding a resolution source later, and a divergence from the key shipped in this build logs a warning. **Advisory only — NIP-05 still wins.** No behavior change, per the decision. Both keys are logged in full (never truncate Nostr IDs).

**2. NIP-05 redirect + timeout hardening** (`fix` commit)

NIP-05's Security Constraints are explicit: the `.well-known/nostr.json` endpoint MUST NOT return HTTP redirects, and **fetchers MUST ignore any it returns**. `Nip05Validor` built a bare `Dio()` and issued a plain `get()`, inheriting Dio's defaults of `followRedirects: true`, `maxRedirects: 5`, and no timeout at all.

Following a 30x is a spurious-verify vector: a MITM or misconfigured origin can bounce the lookup to a host that answers with an attacker's key, which the moderation path then caches for 24h and subscribes to as the labeler.

Also corrects the field comment that described the resolution order as `NIP-05 → cache → fallback`. It is **cache-first**, as `_resolveModerationPubkey`'s own doc says — and that stale comment is what put the inverted order into the issue's decision text.

**3. The same redirect refusal, on Flutter web** (`fix` commits — from @dcadenas's review)

`followRedirects: false` does not do what (2) claimed on web, and neither did the equivalent guard already shipped in the #176 resolver. Both are now fixed.

`followRedirects` / `maxRedirects` are read in exactly one place in the whole dio stack — `io_adapter.dart:138-139`. `dio_web_adapter` never reads them: on web the request goes through `XMLHttpRequest`, which follows a 30x in the browser with no opt-out. The lookup lands on the redirect target's **200**, which the default `validateStatus` accepts. This repo ships web to production at `app.divine.video` on every merge to main, and both `Nip05Validor` callers (moderation labeler resolution, user badge verification) are reachable there with no `kIsWeb` gating.

`Response.isRedirect` is the only redirect signal that survives every transport — the web adapter sets it from `options.uri != xhr.responseURL` — so both lookups now guard on it before reading the body. No-op on `dart:io`, where the unfollowed 3xx has already thrown.

`Nip05Resolver` (#176 protected-minor DM gate, shipped in #5754) carried the identical inert guard: its `status >= 300 && status < 400` check never fires on web because the status is 200. That one is the spurious-**APPROVE** its own comment warns about — a burner claiming an official identifier can bounce the lookup to a host that echoes the expected key and resolve to `matched`. Pre-existing, not introduced here, but folded in rather than deferred: same control, same one-line remedy, and this PR previously cited that resolver as the already-correct reference for redirect refusal — a claim that did not hold on web. The comments in both files that asserted the `validateStatus` story have been corrected to say which platform they actually describe.

**4. Canonical labeler identity** (`refactor` commit — from @mbradley's review note)

`_adoptModerationPubkey` stored the raw pubkey while `_warnIfPinMismatch` compared the normalized form, so an uppercase answer would be warn-silent yet fail to match lowercase event authors in the subscription filter. Both producers now return a canonical key, so the identity, the subscription set and the pin comparison agree. No live bug — NIP-05 mandates lowercase hex.

**Related Issue:** Relates to #4948, #5177

## Reviewer notes

- **Blast radius is deliberate.** User NIP-05 verification runs through the same `getPubkey`, so a third-party host that answers the well-known with a redirect now fails to verify — on native *and* web. That's the spec-mandated outcome for a non-compliant endpoint, not a regression.
- **Known narrow tradeoff on web.** The web adapter derives `isRedirect` by string-comparing `options.uri` against `xhr.responseURL`, so an IDN NIP-05 domain (`bob@münchen.de`) reads as a phantom redirect: Dart serializes the host percent-encoded, the browser punycodes it. Those identifiers already fail on native — `dart:io` hands the percent-encoded host straight to DNS — so the guard brings web to parity rather than regressing a working case, and it fails closed (unverified badge). Flagging it so nobody debugs an intermittent web "unverified" from scratch. The moderation caller is a hardcoded ASCII constant and is unaffected.
- **Expected benign warning.** A user whose cache still holds the legacy pubkey (pre-rotation) gets one warning at load; the NIP-05 refresh then adopts the current key and it stops. That's informative — it means they were subscribed to a dead labeler.
- Live state is currently clean: `moderation@divine.video` resolves to exactly `8fd5eb6d8f362163bc00a5ab6b4a3167dbf32d00ec4efdbcf43b3c9514433b7e`, the pinned constant. This is detection for the first repoint, not a response to a live divergence.

## Out of Scope

Tracked from the #4948 audit, not addressed here:

- **divine-web is still hardcoded** (`videoVerification.ts:8-9`, no NIP-05 resolver). Keys are byte-identical today so there's no live split, but web can't follow a rotation — meaning the clients diverge exactly when a repoint is used as the revocation lever. Highest-risk remaining Tier-1 item.
- **Widening this warning to web** and to telemetry rather than logs alone.
- **Team-side `nostr.json` monitoring** and a **repoint-to-burner revocation runbook** (ops, support-trust-safety). The runbook is load-bearing: the Tier-2 resolver documents that `networkError` is adversary-selectable, so a repoint is the only suppression-proof revocation lever.
- **TLS cert pinning** for divine.video (open item 2). Redirect refusal closes a cheaper slice of the same class.
- **Recording the Tier-1 decision durably** — it exists only in a GitHub comment.

## Verification

- `flutter analyze lib test` (mobile) — No issues found
- `flutter analyze lib test` (nostr_sdk) — No issues found
- `dart format --set-exit-if-changed` on all 6 files — 0 changed
- `flutter test test/services/moderation_label_service_test.dart` — 26 passed
- `flutter test test/services/nip05_resolver_test.dart` — 16 passed
- `flutter test` (nostr_sdk package) — 355 passed
- `flutter test test/services/ --test-randomize-ordering-seed random` — 3060 passed, confirming the static-`dio` adapter swap restores cleanly and doesn't strand the merged isolate
- `check_process_global_mutations.sh`, `check_shared_channel_overrides.sh`, `check_http_overrides_isolation.sh`, `check_untested_services_floor.sh` — all pass
- **Mutation-tested every new control** — each new test was confirmed to fail when its control is removed. For the web guards the failure is the vulnerability itself: without them `getPubkey` returns the redirect target's key, `valid()` verifies an impostor's badge, and `Nip05Resolver` returns `matched` instead of `networkError`.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
