### PR TITLE
fix(camera): scope iOS Now Playing session to foreground

### DIFF
--- a/mobile/ios/RunnerTests/RunnerTests.swift
+++ b/mobile/ios/RunnerTests/RunnerTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import WebKit
+import divine_camera
 @testable import Runner
 
 /// Native coverage for the Nostr bridge frame-attestation plugin. The plugin's
@@ -154,5 +155,120 @@ final class WebKitContentControllerIntegrationTests: XCTestCase {
     let installed = contentController.userScripts.first
     XCTAssertEqual(installed?.injectionTime, .atDocumentStart)
     XCTAssertTrue(installed?.isForMainFrameOnly ?? false)
+  }
+}
+
+/// Native coverage for the divine_camera foreground-scoping state machine that
+/// fixes #6090 (a "Recording" media control lingering on the Lock Screen after
+/// the app was backgrounded with the camera open).
+///
+/// `VolumeKeyHandler`'s claim/release of the iOS "Now Playing" session is
+/// entangled with `UIApplication` and `MediaPlayer` singletons and cannot be
+/// exercised from a unit test. The decision logic is extracted into
+/// `MediaSessionScopePolicy` (pure, no UIKit/MediaPlayer) so the transitions can
+/// be verified here — each case pins one edge of the table and fails loudly if
+/// the foreground scoping regresses.
+final class MediaSessionScopePolicyTests: XCTestCase {
+  func testStartsDisabledAndInactive() {
+    let policy = MediaSessionScopePolicy()
+    XCTAssertFalse(policy.isEnabled)
+    XCTAssertFalse(policy.isMediaSessionActive)
+  }
+
+  func testEnableWhileForegroundClaimsSession() {
+    var policy = MediaSessionScopePolicy()
+    XCTAssertTrue(policy.onEnable(appActive: true))
+    XCTAssertTrue(policy.isEnabled)
+    XCTAssertTrue(policy.isMediaSessionActive)
+  }
+
+  func testEnableWhileBackgroundedDefersClaim() {
+    var policy = MediaSessionScopePolicy()
+    XCTAssertFalse(
+      policy.onEnable(appActive: false),
+      "must not claim the session while backgrounded (#6090)"
+    )
+    XCTAssertTrue(policy.isEnabled)
+    XCTAssertFalse(policy.isMediaSessionActive)
+  }
+
+  func testDeferredClaimHappensOnBecomeActive() {
+    var policy = MediaSessionScopePolicy()
+    _ = policy.onEnable(appActive: false)
+    XCTAssertTrue(policy.onBecomeActive())
+    XCTAssertTrue(policy.isMediaSessionActive)
+  }
+
+  func testEnableIsIdempotent() {
+    var policy = MediaSessionScopePolicy()
+    _ = policy.onEnable(appActive: true)
+    XCTAssertFalse(
+      policy.onEnable(appActive: true),
+      "second enable while already enabled is a no-op"
+    )
+    XCTAssertTrue(policy.isMediaSessionActive)
+  }
+
+  func testBackgroundReleasesSessionButStaysEnabled() {
+    var policy = MediaSessionScopePolicy()
+    _ = policy.onEnable(appActive: true)
+    XCTAssertTrue(policy.onEnterBackground())
+    XCTAssertFalse(
+      policy.isMediaSessionActive,
+      "released on background so no control lingers on the Lock Screen (#6090)"
+    )
+    XCTAssertTrue(policy.isEnabled, "still enabled — will re-claim on foreground")
+  }
+
+  func testBackgroundForegroundCycleReclaims() {
+    var policy = MediaSessionScopePolicy()
+    _ = policy.onEnable(appActive: true)
+    _ = policy.onEnterBackground()
+    XCTAssertTrue(policy.onBecomeActive(), "re-claim on unlock")
+    XCTAssertTrue(policy.isMediaSessionActive)
+  }
+
+  func testBecomeActiveIsIdempotentWhenAlreadyActive() {
+    var policy = MediaSessionScopePolicy()
+    _ = policy.onEnable(appActive: true)
+    XCTAssertFalse(
+      policy.onBecomeActive(),
+      "already active — no duplicate claim / re-suppression"
+    )
+    XCTAssertTrue(policy.isMediaSessionActive)
+  }
+
+  func testBecomeActiveDoesNotClaimWhenDisabled() {
+    var policy = MediaSessionScopePolicy()
+    XCTAssertFalse(policy.onBecomeActive())
+    XCTAssertFalse(policy.isMediaSessionActive)
+  }
+
+  func testEnterBackgroundWhenInactiveIsNoOp() {
+    var policy = MediaSessionScopePolicy()
+    _ = policy.onEnable(appActive: false)
+    XCTAssertFalse(policy.onEnterBackground())
+    XCTAssertFalse(policy.isMediaSessionActive)
+  }
+
+  func testDisableReleasesActiveSession() {
+    var policy = MediaSessionScopePolicy()
+    _ = policy.onEnable(appActive: true)
+    XCTAssertTrue(policy.onDisable(), "should release the claimed session")
+    XCTAssertFalse(policy.isEnabled)
+    XCTAssertFalse(policy.isMediaSessionActive)
+  }
+
+  func testDisableWhenInactiveDoesNotRequestRelease() {
+    var policy = MediaSessionScopePolicy()
+    _ = policy.onEnable(appActive: false)
+    XCTAssertFalse(policy.onDisable(), "nothing to release")
+    XCTAssertFalse(policy.isEnabled)
+  }
+
+  func testDisableWhenAlreadyDisabledIsNoOp() {
+    var policy = MediaSessionScopePolicy()
+    XCTAssertFalse(policy.onDisable())
+    XCTAssertFalse(policy.isEnabled)
   }
 }

--- a/mobile/packages/divine_camera/ios/Classes/MediaSessionScopePolicy.swift
+++ b/mobile/packages/divine_camera/ios/Classes/MediaSessionScopePolicy.swift
@@ -1,0 +1,73 @@
+// ABOUTME: Pure state machine deciding when the iOS "Now Playing" session is claimed
+// ABOUTME: Extracted from VolumeKeyHandler so the #6090 foreground-scoping is unit-testable
+
+import Foundation
+
+/// Pure decision logic for scoping the iOS "Now Playing" session
+/// (`MPRemoteCommandCenter` + `MPNowPlayingInfoCenter`) to the foreground.
+///
+/// `VolumeKeyHandler` must register the app as the "Now Playing" app to receive
+/// AirPods/Bluetooth media-button presses, but that registration draws a media
+/// control on the Lock Screen. To stop it lingering after the app is
+/// backgrounded (#6090), the session is claimed only while the handler is
+/// enabled AND the app is foreground-active: released on `didEnterBackground`,
+/// re-claimed on `didBecomeActive`.
+///
+/// That policy is a two-flag state machine which, inside the handler, is
+/// entangled with `UIApplication` and `MediaPlayer` singletons and cannot be
+/// exercised from a unit test. It is extracted here as pure logic — no UIKit, no
+/// MediaPlayer — so the transition table can be verified directly (mirrors
+/// `NostrBridgeAttestationPolicy` in the Runner test target). Each mutating
+/// method returns whether the caller must run the matching native side effect,
+/// keeping the handler a thin performer over these decisions.
+public struct MediaSessionScopePolicy {
+    /// Whether the handler is listening (between `enable()` and `disable()`).
+    public private(set) var isEnabled: Bool
+    /// Whether the Now Playing session is currently claimed.
+    public private(set) var isMediaSessionActive: Bool
+
+    public init(isEnabled: Bool = false, isMediaSessionActive: Bool = false) {
+        self.isEnabled = isEnabled
+        self.isMediaSessionActive = isMediaSessionActive
+    }
+
+    /// The handler was enabled while the app is (`appActive == true`) or is not
+    /// (`false`) foreground-active. Returns `true` if the caller should claim
+    /// the Now Playing session now. Idempotent: a second `onEnable` while
+    /// already enabled is a no-op.
+    public mutating func onEnable(appActive: Bool) -> Bool {
+        guard !isEnabled else { return false }
+        isEnabled = true
+        guard appActive, !isMediaSessionActive else { return false }
+        isMediaSessionActive = true
+        return true
+    }
+
+    /// The handler was disabled. Returns `true` if the caller should release the
+    /// Now Playing session (i.e. it was claimed). No-op if already disabled.
+    public mutating func onDisable() -> Bool {
+        guard isEnabled else { return false }
+        isEnabled = false
+        guard isMediaSessionActive else { return false }
+        isMediaSessionActive = false
+        return true
+    }
+
+    /// The app entered the background. Returns `true` if the caller should
+    /// release the Now Playing session so no control lingers on the Lock
+    /// Screen (#6090).
+    public mutating func onEnterBackground() -> Bool {
+        guard isMediaSessionActive else { return false }
+        isMediaSessionActive = false
+        return true
+    }
+
+    /// The app became foreground-active. Returns `true` if the caller should
+    /// (re)claim the Now Playing session — only while still enabled and not
+    /// already claimed.
+    public mutating func onBecomeActive() -> Bool {
+        guard isEnabled, !isMediaSessionActive else { return false }
+        isMediaSessionActive = true
+        return true
+    }
+}

--- a/mobile/packages/divine_camera/ios/Classes/VolumeKeyHandler.swift
+++ b/mobile/packages/divine_camera/ios/Classes/VolumeKeyHandler.swift
@@ -7,33 +7,47 @@ import UIKit
 
 /// Handles volume button presses and Bluetooth media button events
 /// for remote recording control on iOS.
+///
+/// Receiving AirPods/Bluetooth media-button presses requires becoming the iOS
+/// "Now Playing" app (MPNowPlayingInfoCenter + MPRemoteCommandCenter), which
+/// surfaces a media control (play/pause) on the Lock Screen / Control Center.
+/// To stop that control lingering on the Lock Screen after the app is
+/// backgrounded (#6090), the Now Playing session is scoped to the foreground:
+/// it is released on `didEnterBackground` and re-claimed on `didBecomeActive`
+/// while the handler is enabled. Camera capture is suspended in the background
+/// anyway, so no remote trigger is lost.
 class VolumeKeyHandler: NSObject {
     private var isEnabled = false
     private var volumeKeysEnabled = true  // Can be toggled independently
     private var onTrigger: ((String) -> Void)?
-    
+
     // Volume button detection
     private var volumeView: MPVolumeView?
     private var volumeSlider: UISlider?
     private var lastVolume: Float = 0.5
     private var isObservingVolume = false
-    
+
     // Track volume changes to detect button presses
     private var volumeChangeTimer: Timer?
     private var isInternalVolumeChange = false
-    
+
     // Cooldown after activation to ignore spurious Bluetooth events.
     // Must be long enough to cover delayed events from AirPods/Apple Watch
     // that arrive after audio route changes during camera initialization.
     private var enabledTimestamp: TimeInterval = 0
     private let activationCooldownSeconds: TimeInterval = 3.0
-    
+
     // Debounce between Bluetooth triggers to prevent rapid-fire events
     private var lastBluetoothTriggerTimestamp: TimeInterval = 0
     private let bluetoothDebounceSeconds: TimeInterval = 1.0
-    
+
     // Temporary suppression during camera switch / audio route changes
     private var isSuppressed = false
+
+    // Whether the Now Playing / MPRemoteCommandCenter session is currently
+    // registered. Scoped to the foreground so no media control lingers on the
+    // Lock Screen (#6090).
+    private var isMediaSessionActive = false
 
     // Re-asserts the owning (UI) engine's diagnostics sink before emitting any
     // native-only diagnostic. iOS has no Activity-attachment lifecycle to bind
@@ -47,7 +61,7 @@ class VolumeKeyHandler: NSObject {
         self.onTrigger = onTrigger
         super.init()
     }
-    
+
     /// Enables volume button listening.
     /// Sets up MPRemoteCommandCenter for Bluetooth remotes and volume observation.
     /// Returns true if successfully enabled.
@@ -55,50 +69,47 @@ class VolumeKeyHandler: NSObject {
         if isEnabled {
             return true
         }
-        
+
         // NOTE: We intentionally do NOT configure the audio session here.
         // The camera already configures its own audio session for video recording.
         // Setting .playAndRecord with Bluetooth options causes iOS to trigger
         // "call start/end" sounds on Bluetooth headsets, which is undesirable.
         // MPRemoteCommandCenter and volume KVO work without specific audio session setup.
-        
-        setupRemoteCommandCenter()
+
         setupVolumeObserver()
-        
+
         isEnabled = true
         volumeKeysEnabled = true
-        enabledTimestamp = ProcessInfo.processInfo.systemUptime
-        
-        // Suppress triggers initially to absorb any spurious Bluetooth events
-        // that fire when MPRemoteCommandCenter handlers are first registered.
-        // Connected AirPods/Apple Watch may send play/pause events when they
-        // detect a new "now playing" app.
-        isSuppressed = true
-        DispatchQueue.main.asyncAfter(deadline: .now() + activationCooldownSeconds) { [weak self] in
-            self?.isSuppressed = false
-            // Native-only event (timer callback, no method call): reclaim the
-            // UI engine's diagnostics sink first.
-            self?.reclaimLogSink?()
-            DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Initial suppression ended")
+
+        registerAppLifecycleObservers()
+
+        // Only claim the Now Playing session while the app is foreground-active.
+        // Claiming it in the background would leave a persistent "Recording"
+        // media control on the Lock Screen (#6090); it is (re)claimed on
+        // foreground via appDidBecomeActive.
+        if UIApplication.shared.applicationState == .active {
+            activateMediaSession()
         }
-        DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Enabled (suppressed for \(activationCooldownSeconds)s)")
+
+        DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Enabled")
         return true
     }
-    
+
     /// Disables volume button listening.
     func disable() {
         if !isEnabled {
             return
         }
-        
-        teardownRemoteCommandCenter()
+
+        unregisterAppLifecycleObservers()
+        deactivateMediaSession()
         teardownVolumeObserver()
-        
+
         isEnabled = false
         volumeKeysEnabled = true
         DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Disabled")
     }
-    
+
     /// Enable or disable volume key interception.
     /// When disabled, volume buttons will change system volume instead of triggering recording.
     /// Bluetooth media buttons are NOT affected by this setting.
@@ -106,12 +117,12 @@ class VolumeKeyHandler: NSObject {
         volumeKeysEnabled = enabled
         DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Volume keys \(enabled ? "enabled" : "disabled")")
     }
-    
+
     /// Whether volume key handling is currently enabled.
     func isHandlerEnabled() -> Bool {
         return isEnabled
     }
-    
+
     /// Temporarily suppress all triggers for the given duration.
     ///
     /// Used during camera switch and other operations that cause
@@ -128,18 +139,98 @@ class VolumeKeyHandler: NSObject {
             DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Suppression ended")
         }
     }
-    
+
     /// Cleanup resources.
     func release() {
         disable()
         onTrigger = nil
     }
-    
+
+    // MARK: - App Lifecycle & Media Session Scoping
+
+    /// Claims the iOS "Now Playing" session (MPRemoteCommandCenter +
+    /// MPNowPlayingInfoCenter) so Bluetooth/AirPods media buttons route to us.
+    /// Idempotent. Scoped to the foreground camera session so the media control
+    /// never lingers on the Lock Screen (#6090).
+    private func activateMediaSession() {
+        guard !isMediaSessionActive else { return }
+        setupRemoteCommandCenter()
+        isMediaSessionActive = true
+        enabledTimestamp = ProcessInfo.processInfo.systemUptime
+
+        // Suppress triggers briefly to absorb spurious Bluetooth events that
+        // fire when MPRemoteCommandCenter handlers are (re)registered. Connected
+        // AirPods/Apple Watch may send play/pause when they detect a new
+        // "now playing" app.
+        isSuppressed = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + activationCooldownSeconds) { [weak self] in
+            self?.isSuppressed = false
+            // Native-only event (timer callback, no method call): reclaim the
+            // UI engine's diagnostics sink first.
+            self?.reclaimLogSink?()
+            DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Initial suppression ended")
+        }
+        DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Media session activated (suppressed for \(activationCooldownSeconds)s)")
+    }
+
+    /// Releases the Now Playing session. Idempotent.
+    private func deactivateMediaSession() {
+        guard isMediaSessionActive else { return }
+        teardownRemoteCommandCenter()
+        isMediaSessionActive = false
+        DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Media session deactivated")
+    }
+
+    private func registerAppLifecycleObservers() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(appDidEnterBackground),
+            name: UIApplication.didEnterBackgroundNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(appDidBecomeActive),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
+    }
+
+    private func unregisterAppLifecycleObservers() {
+        NotificationCenter.default.removeObserver(
+            self,
+            name: UIApplication.didEnterBackgroundNotification,
+            object: nil
+        )
+        NotificationCenter.default.removeObserver(
+            self,
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
+    }
+
+    /// Releases the Now Playing session when the app backgrounds so no media
+    /// control lingers on the Lock Screen (#6090). Camera capture is suspended
+    /// in the background anyway, so no remote trigger is lost.
+    @objc private func appDidEnterBackground() {
+        deactivateMediaSession()
+    }
+
+    /// Re-claims the Now Playing session on return to the foreground so
+    /// Bluetooth/AirPods media buttons keep controlling recording.
+    @objc private func appDidBecomeActive() {
+        // Native-only event (notification, no method call): reclaim the UI
+        // engine's diagnostics sink first.
+        reclaimLogSink?()
+        guard isEnabled else { return }
+        activateMediaSession()
+    }
+
     // MARK: - Remote Command Center (Bluetooth remotes/earbuds)
-    
+
     private func setupRemoteCommandCenter() {
         let commandCenter = MPRemoteCommandCenter.shared()
-        
+
         // Play/Pause toggle (most common on Bluetooth headphones)
         commandCenter.togglePlayPauseCommand.addTarget { [weak self] _ in
             self?.reclaimLogSink?()
@@ -163,32 +254,32 @@ class VolumeKeyHandler: NSObject {
             self?.handleBluetoothTrigger()
             return .success
         }
-        
+
         // Enable the commands
         commandCenter.togglePlayPauseCommand.isEnabled = true
         commandCenter.playCommand.isEnabled = true
         commandCenter.pauseCommand.isEnabled = true
-        
+
         // Set up now playing info to make remote commands work
         var nowPlayingInfo = [String: Any]()
         nowPlayingInfo[MPMediaItemPropertyTitle] = "Recording"
         nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate] = 1.0
         MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
-        
+
         DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Remote command center configured")
     }
-    
+
     private func teardownRemoteCommandCenter() {
         let commandCenter = MPRemoteCommandCenter.shared()
         commandCenter.togglePlayPauseCommand.removeTarget(nil)
         commandCenter.playCommand.removeTarget(nil)
         commandCenter.pauseCommand.removeTarget(nil)
-        
+
         MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
     }
-    
+
     // MARK: - Bluetooth Trigger Handling
-    
+
     /// Handles a Bluetooth remote trigger with cooldown and debounce protection.
     ///
     /// Filters out:
@@ -197,61 +288,65 @@ class VolumeKeyHandler: NSObject {
     /// - Rapid-fire duplicate events (debounce)
     private func handleBluetoothTrigger() {
         let now = ProcessInfo.processInfo.systemUptime
-        
+
         // Check suppression (camera switch in progress)
         if isSuppressed {
             DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Bluetooth trigger ignored - suppressed")
             return
         }
-        
+
         // Check activation cooldown
         let timeSinceEnabled = now - enabledTimestamp
         if timeSinceEnabled < activationCooldownSeconds {
             DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Bluetooth trigger ignored - within \(String(format: "%.0f", activationCooldownSeconds * 1000))ms activation cooldown (\(String(format: "%.0f", timeSinceEnabled * 1000))ms since enabled)")
             return
         }
-        
+
         // Check debounce between triggers
         let timeSinceLastTrigger = now - lastBluetoothTriggerTimestamp
         if timeSinceLastTrigger < bluetoothDebounceSeconds {
             DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Bluetooth trigger ignored - debounce (\(String(format: "%.0f", timeSinceLastTrigger * 1000))ms since last)")
             return
         }
-        
+
         lastBluetoothTriggerTimestamp = now
         DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Bluetooth trigger accepted")
-        
+
         // Refresh now playing info so iOS keeps routing remote events to us.
         // Without this, audio session changes during recording start/stop can
         // cause iOS to disassociate our app from MPNowPlayingInfoCenter,
         // making AirPods stop sending events to our command handlers.
         refreshNowPlayingInfo()
-        
+
         onTrigger?("bluetooth")
     }
-    
+
     /// Refreshes MPNowPlayingInfoCenter to keep our app as the active
     /// "now playing" app. Without this, iOS may stop routing AirPods/Apple
     /// Watch button presses to our MPRemoteCommandCenter handlers after
     /// audio session changes (e.g. recording start/stop).
     private func refreshNowPlayingInfo() {
+        // Only meaningful while the media session is active (foreground). If a
+        // stray trigger arrives while backgrounded, don't re-create the Now
+        // Playing entry — that would resurrect the Lock Screen control (#6090).
+        guard isMediaSessionActive else { return }
         var nowPlayingInfo = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [String: Any]()
         nowPlayingInfo[MPMediaItemPropertyTitle] = "Recording"
         nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate] = 1.0
         MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
     }
-    
+
     // MARK: - Volume Button Detection
-    
+
     private func setupVolumeObserver() {
         // Get current volume
         lastVolume = AVAudioSession.sharedInstance().outputVolume
-        
+
         // Create a hidden MPVolumeView to prevent the system volume HUD from appearing
         let volumeView = MPVolumeView(frame: CGRect(x: -100, y: -100, width: 1, height: 1))
         volumeView.showsRouteButton = false
         volumeView.showsVolumeSlider = true
-        
+
         // Find the volume slider within the view
         for subview in volumeView.subviews {
             if let slider = subview as? UISlider {
@@ -259,13 +354,13 @@ class VolumeKeyHandler: NSObject {
                 break
             }
         }
-        
+
         // Add to window to receive events
         if let window = UIApplication.shared.windows.first {
             window.addSubview(volumeView)
             self.volumeView = volumeView
         }
-        
+
         // Observe volume changes via KVO
         AVAudioSession.sharedInstance().addObserver(
             self,
@@ -274,21 +369,21 @@ class VolumeKeyHandler: NSObject {
             context: nil
         )
         isObservingVolume = true
-        
+
         DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Volume observer configured")
     }
-    
+
     private func teardownVolumeObserver() {
         if isObservingVolume {
             AVAudioSession.sharedInstance().removeObserver(self, forKeyPath: "outputVolume")
             isObservingVolume = false
         }
-        
+
         volumeView?.removeFromSuperview()
         volumeView = nil
         volumeSlider = nil
     }
-    
+
     override func observeValue(
         forKeyPath keyPath: String?,
         of object: Any?,
@@ -313,13 +408,13 @@ class VolumeKeyHandler: NSObject {
             if newValue > oldValue {
                 DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Volume up button pressed")
                 onTrigger?("volumeUp")
-                
+
                 // Restore volume to prevent actual volume change
                 restoreVolume(to: oldValue)
             } else if newValue < oldValue {
                 DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Volume down button pressed")
                 onTrigger?("volumeDown")
-                
+
                 // Restore volume to prevent actual volume change
                 restoreVolume(to: oldValue)
             }
@@ -330,15 +425,15 @@ class VolumeKeyHandler: NSObject {
         }
         // If volume keys are disabled, let the volume change through (don't restore)
     }
-    
+
     /// Restores the volume to the previous level to prevent actual volume changes
     private func restoreVolume(to level: Float) {
         isInternalVolumeChange = true
-        
+
         // Use the hidden slider to set volume without showing the HUD
         DispatchQueue.main.async { [weak self] in
             self?.volumeSlider?.setValue(level, animated: false)
-            
+
             // Reset the flag after a short delay
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                 self?.isInternalVolumeChange = false

--- a/mobile/packages/divine_camera/ios/Classes/VolumeKeyHandler.swift
+++ b/mobile/packages/divine_camera/ios/Classes/VolumeKeyHandler.swift
@@ -17,7 +17,6 @@ import UIKit
 /// while the handler is enabled. Camera capture is suspended in the background
 /// anyway, so no remote trigger is lost.
 class VolumeKeyHandler: NSObject {
-    private var isEnabled = false
     private var volumeKeysEnabled = true  // Can be toggled independently
     private var onTrigger: ((String) -> Void)?
 
@@ -44,10 +43,11 @@ class VolumeKeyHandler: NSObject {
     // Temporary suppression during camera switch / audio route changes
     private var isSuppressed = false
 
-    // Whether the Now Playing / MPRemoteCommandCenter session is currently
-    // registered. Scoped to the foreground so no media control lingers on the
-    // Lock Screen (#6090).
-    private var isMediaSessionActive = false
+    // Foreground-scoping state machine for the Now Playing session (#6090). Owns
+    // both the enabled flag and whether the MPRemoteCommandCenter session is
+    // registered, extracted as pure logic so the transition table is
+    // unit-testable. See MediaSessionScopePolicy.
+    private var scope = MediaSessionScopePolicy()
 
     // Re-asserts the owning (UI) engine's diagnostics sink before emitting any
     // native-only diagnostic. iOS has no Activity-attachment lifecycle to bind
@@ -66,7 +66,7 @@ class VolumeKeyHandler: NSObject {
     /// Sets up MPRemoteCommandCenter for Bluetooth remotes and volume observation.
     /// Returns true if successfully enabled.
     func enable() -> Bool {
-        if isEnabled {
+        if scope.isEnabled {
             return true
         }
 
@@ -78,7 +78,6 @@ class VolumeKeyHandler: NSObject {
 
         setupVolumeObserver()
 
-        isEnabled = true
         volumeKeysEnabled = true
 
         registerAppLifecycleObservers()
@@ -87,8 +86,9 @@ class VolumeKeyHandler: NSObject {
         // Claiming it in the background would leave a persistent "Recording"
         // media control on the Lock Screen (#6090); it is (re)claimed on
         // foreground via appDidBecomeActive.
-        if UIApplication.shared.applicationState == .active {
-            activateMediaSession()
+        let appActive = UIApplication.shared.applicationState == .active
+        if scope.onEnable(appActive: appActive) {
+            performActivateMediaSession()
         }
 
         DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Enabled")
@@ -97,15 +97,16 @@ class VolumeKeyHandler: NSObject {
 
     /// Disables volume button listening.
     func disable() {
-        if !isEnabled {
+        if !scope.isEnabled {
             return
         }
 
         unregisterAppLifecycleObservers()
-        deactivateMediaSession()
+        if scope.onDisable() {
+            performDeactivateMediaSession()
+        }
         teardownVolumeObserver()
 
-        isEnabled = false
         volumeKeysEnabled = true
         DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Disabled")
     }
@@ -120,7 +121,7 @@ class VolumeKeyHandler: NSObject {
 
     /// Whether volume key handling is currently enabled.
     func isHandlerEnabled() -> Bool {
-        return isEnabled
+        return scope.isEnabled
     }
 
     /// Temporarily suppress all triggers for the given duration.
@@ -150,12 +151,11 @@ class VolumeKeyHandler: NSObject {
 
     /// Claims the iOS "Now Playing" session (MPRemoteCommandCenter +
     /// MPNowPlayingInfoCenter) so Bluetooth/AirPods media buttons route to us.
-    /// Idempotent. Scoped to the foreground camera session so the media control
-    /// never lingers on the Lock Screen (#6090).
-    private func activateMediaSession() {
-        guard !isMediaSessionActive else { return }
+    /// Scoped to the foreground camera session so the media control never
+    /// lingers on the Lock Screen (#6090). Callers gate this on `scope`; the
+    /// performer itself is unconditional.
+    private func performActivateMediaSession() {
         setupRemoteCommandCenter()
-        isMediaSessionActive = true
         enabledTimestamp = ProcessInfo.processInfo.systemUptime
 
         // Suppress triggers briefly to absorb spurious Bluetooth events that
@@ -173,11 +173,10 @@ class VolumeKeyHandler: NSObject {
         DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Media session activated (suppressed for \(activationCooldownSeconds)s)")
     }
 
-    /// Releases the Now Playing session. Idempotent.
-    private func deactivateMediaSession() {
-        guard isMediaSessionActive else { return }
+    /// Releases the Now Playing session. Callers gate this on `scope`; the
+    /// performer itself is unconditional.
+    private func performDeactivateMediaSession() {
         teardownRemoteCommandCenter()
-        isMediaSessionActive = false
         DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Media session deactivated")
     }
 
@@ -213,7 +212,9 @@ class VolumeKeyHandler: NSObject {
     /// control lingers on the Lock Screen (#6090). Camera capture is suspended
     /// in the background anyway, so no remote trigger is lost.
     @objc private func appDidEnterBackground() {
-        deactivateMediaSession()
+        if scope.onEnterBackground() {
+            performDeactivateMediaSession()
+        }
     }
 
     /// Re-claims the Now Playing session on return to the foreground so
@@ -222,8 +223,9 @@ class VolumeKeyHandler: NSObject {
         // Native-only event (notification, no method call): reclaim the UI
         // engine's diagnostics sink first.
         reclaimLogSink?()
-        guard isEnabled else { return }
-        activateMediaSession()
+        if scope.onBecomeActive() {
+            performActivateMediaSession()
+        }
     }
 
     // MARK: - Remote Command Center (Bluetooth remotes/earbuds)
@@ -329,7 +331,7 @@ class VolumeKeyHandler: NSObject {
         // Only meaningful while the media session is active (foreground). If a
         // stray trigger arrives while backgrounded, don't re-create the Now
         // Playing entry — that would resurrect the Lock Screen control (#6090).
-        guard isMediaSessionActive else { return }
+        guard scope.isMediaSessionActive else { return }
         var nowPlayingInfo = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [String: Any]()
         nowPlayingInfo[MPMediaItemPropertyTitle] = "Recording"
         nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate] = 1.0
@@ -404,7 +406,7 @@ class VolumeKeyHandler: NSObject {
         // and this is an external change.
         // The isSuppressed check prevents audio route changes during camera
         // switch from being misinterpreted as volume button presses.
-        if !isInternalVolumeChange && isEnabled && volumeKeysEnabled && !isSuppressed {
+        if !isInternalVolumeChange && scope.isEnabled && volumeKeysEnabled && !isSuppressed {
             if newValue > oldValue {
                 DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Volume up button pressed")
                 onTrigger?("volumeUp")

--- a/mobile/packages/divine_camera/ios/Classes/VolumeKeyHandler.swift
+++ b/mobile/packages/divine_camera/ios/Classes/VolumeKeyHandler.swift
@@ -180,6 +180,11 @@ class VolumeKeyHandler: NSObject {
         DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Media session deactivated")
     }
 
+    /// Assumes a single enabled handler per process: AppDelegate registers the
+    /// plugin on both the UI engine and the background notification-action
+    /// engine, so two instances exist and a second `enable()` would add a
+    /// duplicate set of observers here. Dormant while only the UI engine drives
+    /// the camera; revisit if the background isolate ever enables remote record.
     private func registerAppLifecycleObservers() {
         NotificationCenter.default.addObserver(
             self,


### PR DESCRIPTION
## Description

Fixes the iOS "recording widget" from #6090: a **"Recording" media control with play/pause** that showed on the Lock Screen where users expected only the camera quick-action button.

The reported control is **not** the home-screen `CameraQuickActionWidget` (which only draws the camera button). It is the iOS **Now Playing** media control. To receive AirPods/Bluetooth media-button presses for hands-free remote recording, `VolumeKeyHandler` registers the app as the "Now Playing" app (`MPNowPlayingInfoCenter` title `"Recording"` + `MPRemoteCommandCenter` play/pause). iOS surfaces that as a media control on the Lock Screen / Control Center, and it lingered after the app was backgrounded because the session was only torn down when the recorder screen was disposed — not when the app went to the background with the camera still open.

**Fix:** scope the Now Playing session to the foreground camera session instead of dropping Bluetooth support.

- Claim the session (`MPRemoteCommandCenter` + `nowPlayingInfo`) only while the app is foreground-active.
- Release it on `didEnterBackground` and re-claim it on `didBecomeActive` while remote-record control is enabled.

The app has no `audio` background mode, so it suspends on lock and `didEnterBackground` fires reliably — the "Recording" control can no longer appear on the Lock Screen. Bluetooth/volume remote recording keeps working in the foreground, where recording actually happens (you cannot record while backgrounded, so no trigger is lost).

**Why keep the media session rather than remove it?** Receiving AirPods/Bluetooth media buttons on iOS *requires* being the "Now Playing" app, which is exactly what draws the control — there is no API to get those events invisibly. Users rely on the Bluetooth remote, so foreground-scoping is the correct trade-off.

**Related Issue:** Closes #6090

## Out of Scope

- Android is unaffected — it uses `MediaSessionCompat` and keeps full Bluetooth remote-record support; the cross-platform `RemoteRecordTrigger.bluetooth` path is untouched.
- One unavoidable iOS residual: while you are actively in the camera and swipe down Control Center, a media tile still shows there (never on the Lock Screen). iOS provides no way to receive media-button events without a visible Now Playing surface.

## Tests

- The claim/release decision is extracted into a pure, dependency-free `MediaSessionScopePolicy` (no UIKit/MediaPlayer), mirroring the existing `NostrBridgeAttestationPolicy` precedent in `RunnerTests`. `VolumeKeyHandler` is rewired to delegate its `isEnabled` / `isMediaSessionActive` state to it — **behavior-preserving**: activate/deactivate become unconditional performers gated by the policy's return values, and every lifecycle transition maps 1:1 to the previous inline logic.
- `MediaSessionScopePolicyTests` (in `mobile/ios/RunnerTests/RunnerTests.swift`, importing `divine_camera`) pins the full transition table, including the two #6090 invariants that would previously have been untested: "do not claim the session while backgrounded" and "release it on background so no control lingers on the Lock Screen".
- **Why not a Dart test?** The Now Playing behavior is a native-only side effect (`MPNowPlayingInfoCenter` claim/release driven by app-lifecycle notifications) with no Dart-observable signal — a method-channel test would only assert the outbound `setRemoteRecordControlEnabled` call, which this change does not touch, so it could not fail on a regression (coverage theatre).
- **CI note:** iOS Swift XCTests are not run in CI (the `divine_camera` workflow runs Dart + Android unit tests only), so these are a local-only regression guard, consistent with the existing `RunnerTests` targets. Execute them by running the `RunnerTests` scheme in Xcode.

## Verification

- iOS-native change plus a Swift test; no Dart changed, so no analyzer/coverage/Dart-test impact (pre-push hook confirmed "No Dart files changed").
- `xcrun swiftc -typecheck` of the policy + handler against the iOS SDK passes with 0 errors (only pre-existing `showsRouteButton` / `windows` deprecation warnings on untouched lines).
- Manual on-device (iOS):
  - Open camera, lock phone → no "Recording" media control on the Lock Screen.
  - AirPods/Bluetooth button toggles recording in the camera.
  - Volume buttons toggle recording.
  - Lock → unlock → Bluetooth still works (session re-claimed).

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
