### PR TITLE
fix(likes): own "liked" heart un-fills on your own video after an edit

### DIFF
--- a/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
+++ b/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
@@ -99,11 +99,27 @@ class VideoInteractionsBloc
     VideoInteractionsSubscriptionRequested event,
     Emitter<VideoInteractionsState> emit,
   ) {
+    // Track the latest snapshot from both like streams so either one
+    // ticking recomputes membership from BOTH — a like recorded against a
+    // pre-edit event id for this coordinate only shows up in the
+    // addressable-id stream, and watchLikedEventIds ticks on every
+    // like/unlike anywhere in the app (not just this video), so treating
+    // the two streams independently would let a same-coordinate-only hit
+    // get silently overwritten back to unliked the next time anything
+    // else is liked/unliked (#6020).
+    var likedEventIds = const <String>[];
+    var likedAddressableIds = const <String>{};
+    bool resolveIsLiked() =>
+        likedEventIds.contains(_eventId) ||
+        (_addressableId != null &&
+            likedAddressableIds.contains(_addressableId));
+
     final subscriptions = [
       emit.forEach<List<String>>(
         _likesRepository.watchLikedEventIds(),
-        onData: (likedIds) {
-          final isLiked = likedIds.contains(_eventId);
+        onData: (ids) {
+          likedEventIds = ids;
+          final isLiked = resolveIsLiked();
           // Load-bearing: when [_onLikeToggled] has already emitted its
           // optimistic state, state.isLiked matches and we no-op here.
           // This guarantees a single bloc emit per tap and avoids the
@@ -118,6 +134,16 @@ class VideoInteractionsBloc
           return state.copyWith(isLiked: isLiked);
         },
       ),
+      if (_addressableId != null)
+        emit.forEach<Set<String>>(
+          _likesRepository.watchLikedAddressableIds(),
+          onData: (ids) {
+            likedAddressableIds = ids;
+            final isLiked = resolveIsLiked();
+            if (isLiked == state.isLiked) return state;
+            return state.copyWith(isLiked: isLiked);
+          },
+        ),
       if (_addressableId != null)
         emit.forEach<Set<String>>(
           _repostsRepository.watchRepostedAddressableIds(),
@@ -160,8 +186,14 @@ class VideoInteractionsBloc
     emit(state.copyWith(status: VideoInteractionsStatus.loading));
 
     try {
-      // Check if liked (fast - from local cache)
-      final isLiked = await _likesRepository.isLiked(_eventId);
+      // Check if liked (fast - from local cache). Falls back to the
+      // addressable coordinate when the event id misses, so a like
+      // recorded against a pre-edit version of this video still resolves
+      // (#6020).
+      final isLiked = await _likesRepository.isLikedResolvingCoordinate(
+        eventId: _eventId,
+        addressableId: _addressableId,
+      );
 
       // Check if reposted (fast - from local cache) if addressable
       final isReposted =

--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -571,7 +571,10 @@ LikesRepository likesRepository(Ref ref) {
     );
     pendingActionService.registerExecutor(
       PendingActionType.unlike,
-      (action) => repository.executeUnlikeAction(action.targetId),
+      (action) => repository.executeUnlikeAction(
+        action.targetId,
+        addressableId: action.addressableId,
+      ),
     );
   }
 

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -973,4 +973,4 @@ final class LikesRepositoryProvider
   }
 }
 
-String _$likesRepositoryHash() => r'fc6229af119fdde9c92deaa2280f26e3ce3bfb00';
+String _$likesRepositoryHash() => r'441c473c923ad75405f4ab0a650e0f5716894fa1';

--- a/mobile/packages/db_client/drift_schemas/app_database/drift_schema_v1.json
+++ b/mobile/packages/db_client/drift_schemas/app_database/drift_schema_v1.json
@@ -971,6 +971,16 @@
             "default_dart": null,
             "default_client_dart": null,
             "dsl_features": []
+          },
+          {
+            "name": "addressable_id",
+            "getter_name": "addressableId",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
           }
         ],
         "is_virtual": false,
@@ -2669,6 +2679,117 @@
           "gift_wrap_id"
         ]
       }
+    },
+    {
+      "id": 21,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "pending_profile_saves",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "user_pubkey",
+            "getter_name": "userPubkey",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "payload_json",
+            "getter_name": "payloadJson",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "claim_confirmed",
+            "getter_name": "claimConfirmed",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"claim_confirmed\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"claim_confirmed\" IN (0, 1))"
+            },
+            "default_dart": "const CustomExpression('0')",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "status",
+            "getter_name": "status",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "const CustomExpression('\\'pending\\'')",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "retry_count",
+            "getter_name": "retryCount",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "const CustomExpression('0')",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "last_attempt_at",
+            "getter_name": "lastAttemptAt",
+            "moor_type": "dateTime",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "queued_at",
+            "getter_name": "queuedAt",
+            "moor_type": "dateTime",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "last_error",
+            "getter_name": "lastError",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "generation",
+            "getter_name": "generation",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "const CustomExpression('\\'\\'')",
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "user_pubkey"
+        ]
+      }
     }
   ],
   "fixed_sql": [
@@ -2740,7 +2861,7 @@
       "sql": [
         {
           "dialect": "sqlite",
-          "sql": "CREATE TABLE IF NOT EXISTS \"personal_reactions\" (\"target_event_id\" TEXT NOT NULL, \"reaction_event_id\" TEXT NOT NULL, \"user_pubkey\" TEXT NOT NULL, \"created_at\" INTEGER NOT NULL, PRIMARY KEY (\"target_event_id\", \"user_pubkey\"));"
+          "sql": "CREATE TABLE IF NOT EXISTS \"personal_reactions\" (\"target_event_id\" TEXT NOT NULL, \"reaction_event_id\" TEXT NOT NULL, \"user_pubkey\" TEXT NOT NULL, \"created_at\" INTEGER NOT NULL, \"addressable_id\" TEXT NULL, PRIMARY KEY (\"target_event_id\", \"user_pubkey\"));"
         }
       ]
     },
@@ -2858,6 +2979,15 @@
         {
           "dialect": "sqlite",
           "sql": "CREATE TABLE IF NOT EXISTS \"processed_gift_wraps\" (\"gift_wrap_id\" TEXT NOT NULL, \"processed_at\" INTEGER NOT NULL, \"owner_pubkey\" TEXT NULL, PRIMARY KEY (\"gift_wrap_id\"));"
+        }
+      ]
+    },
+    {
+      "name": "pending_profile_saves",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"pending_profile_saves\" (\"user_pubkey\" TEXT NOT NULL, \"payload_json\" TEXT NOT NULL, \"claim_confirmed\" INTEGER NOT NULL DEFAULT 0 CHECK (\"claim_confirmed\" IN (0, 1)), \"status\" TEXT NOT NULL DEFAULT 'pending', \"retry_count\" INTEGER NOT NULL DEFAULT 0, \"last_attempt_at\" INTEGER NULL, \"queued_at\" INTEGER NOT NULL, \"last_error\" TEXT NULL, \"generation\" TEXT NOT NULL DEFAULT '', PRIMARY KEY (\"user_pubkey\"));"
         }
       ]
     }

--- a/mobile/packages/db_client/lib/src/database/app_database.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.dart
@@ -751,6 +751,15 @@ class AppDatabase extends _$AppDatabase {
     await _addColumnIfMissing('outgoing_dms', 'send_batch_id', 'TEXT');
     await _addColumnIfMissing('direct_messages', 'send_batch_id', 'TEXT');
 
+    // Addressable coordinate for own-like state, so it survives a target
+    // edit that mints a new event id for the same coordinate (#6020). Same
+    // runtime ADD-COLUMN-IF-MISSING pattern as d_tag/send_batch_id above.
+    await _addColumnIfMissing('personal_reactions', 'addressable_id', 'TEXT');
+    await customStatement('''
+      CREATE INDEX IF NOT EXISTS idx_personal_reactions_addressable_id
+      ON personal_reactions (addressable_id)
+    ''');
+
     // Create the event indexes unconditionally. The `List<Index> get
     // indexes` getter on NostrEvents is not wired through
     // `@DriftDatabase(...)`, so Drift's m.createAll() never creates them —

--- a/mobile/packages/db_client/lib/src/database/app_database.g.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.g.dart
@@ -4950,12 +4950,24 @@ class $PersonalReactionsTable extends PersonalReactions
     type: DriftSqlType.int,
     requiredDuringInsert: true,
   );
+  static const VerificationMeta _addressableIdMeta = const VerificationMeta(
+    'addressableId',
+  );
+  @override
+  late final GeneratedColumn<String> addressableId = GeneratedColumn<String>(
+    'addressable_id',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
   @override
   List<GeneratedColumn> get $columns => [
     targetEventId,
     reactionEventId,
     userPubkey,
     createdAt,
+    addressableId,
   ];
   @override
   String get aliasedName => _alias ?? actualTableName;
@@ -5007,6 +5019,15 @@ class $PersonalReactionsTable extends PersonalReactions
     } else if (isInserting) {
       context.missing(_createdAtMeta);
     }
+    if (data.containsKey('addressable_id')) {
+      context.handle(
+        _addressableIdMeta,
+        addressableId.isAcceptableOrUnknown(
+          data['addressable_id']!,
+          _addressableIdMeta,
+        ),
+      );
+    }
     return context;
   }
 
@@ -5032,6 +5053,10 @@ class $PersonalReactionsTable extends PersonalReactions
         DriftSqlType.int,
         data['${effectivePrefix}created_at'],
       )!,
+      addressableId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}addressable_id'],
+      ),
     );
   }
 
@@ -5054,11 +5079,20 @@ class PersonalReactionRow extends DataClass
 
   /// Unix timestamp when the reaction was created
   final int createdAt;
+
+  /// Addressable coordinate (`kind:pubkey:d-tag`) of the target event, when
+  /// the target is a Kind 30000+ addressable event (e.g. a video).
+  ///
+  /// Null for likes on non-addressable targets (e.g. comments), which have
+  /// no `d` tag / coordinate. Lets own-like state survive a target edit
+  /// that mints a new [targetEventId] for the same coordinate (#6020).
+  final String? addressableId;
   const PersonalReactionRow({
     required this.targetEventId,
     required this.reactionEventId,
     required this.userPubkey,
     required this.createdAt,
+    this.addressableId,
   });
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
@@ -5067,6 +5101,9 @@ class PersonalReactionRow extends DataClass
     map['reaction_event_id'] = Variable<String>(reactionEventId);
     map['user_pubkey'] = Variable<String>(userPubkey);
     map['created_at'] = Variable<int>(createdAt);
+    if (!nullToAbsent || addressableId != null) {
+      map['addressable_id'] = Variable<String>(addressableId);
+    }
     return map;
   }
 
@@ -5076,6 +5113,9 @@ class PersonalReactionRow extends DataClass
       reactionEventId: Value(reactionEventId),
       userPubkey: Value(userPubkey),
       createdAt: Value(createdAt),
+      addressableId: addressableId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(addressableId),
     );
   }
 
@@ -5089,6 +5129,7 @@ class PersonalReactionRow extends DataClass
       reactionEventId: serializer.fromJson<String>(json['reactionEventId']),
       userPubkey: serializer.fromJson<String>(json['userPubkey']),
       createdAt: serializer.fromJson<int>(json['createdAt']),
+      addressableId: serializer.fromJson<String?>(json['addressableId']),
     );
   }
   @override
@@ -5099,6 +5140,7 @@ class PersonalReactionRow extends DataClass
       'reactionEventId': serializer.toJson<String>(reactionEventId),
       'userPubkey': serializer.toJson<String>(userPubkey),
       'createdAt': serializer.toJson<int>(createdAt),
+      'addressableId': serializer.toJson<String?>(addressableId),
     };
   }
 
@@ -5107,11 +5149,15 @@ class PersonalReactionRow extends DataClass
     String? reactionEventId,
     String? userPubkey,
     int? createdAt,
+    Value<String?> addressableId = const Value.absent(),
   }) => PersonalReactionRow(
     targetEventId: targetEventId ?? this.targetEventId,
     reactionEventId: reactionEventId ?? this.reactionEventId,
     userPubkey: userPubkey ?? this.userPubkey,
     createdAt: createdAt ?? this.createdAt,
+    addressableId: addressableId.present
+        ? addressableId.value
+        : this.addressableId,
   );
   PersonalReactionRow copyWithCompanion(PersonalReactionsCompanion data) {
     return PersonalReactionRow(
@@ -5125,6 +5171,9 @@ class PersonalReactionRow extends DataClass
           ? data.userPubkey.value
           : this.userPubkey,
       createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+      addressableId: data.addressableId.present
+          ? data.addressableId.value
+          : this.addressableId,
     );
   }
 
@@ -5134,14 +5183,20 @@ class PersonalReactionRow extends DataClass
           ..write('targetEventId: $targetEventId, ')
           ..write('reactionEventId: $reactionEventId, ')
           ..write('userPubkey: $userPubkey, ')
-          ..write('createdAt: $createdAt')
+          ..write('createdAt: $createdAt, ')
+          ..write('addressableId: $addressableId')
           ..write(')'))
         .toString();
   }
 
   @override
-  int get hashCode =>
-      Object.hash(targetEventId, reactionEventId, userPubkey, createdAt);
+  int get hashCode => Object.hash(
+    targetEventId,
+    reactionEventId,
+    userPubkey,
+    createdAt,
+    addressableId,
+  );
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -5149,7 +5204,8 @@ class PersonalReactionRow extends DataClass
           other.targetEventId == this.targetEventId &&
           other.reactionEventId == this.reactionEventId &&
           other.userPubkey == this.userPubkey &&
-          other.createdAt == this.createdAt);
+          other.createdAt == this.createdAt &&
+          other.addressableId == this.addressableId);
 }
 
 class PersonalReactionsCompanion extends UpdateCompanion<PersonalReactionRow> {
@@ -5157,12 +5213,14 @@ class PersonalReactionsCompanion extends UpdateCompanion<PersonalReactionRow> {
   final Value<String> reactionEventId;
   final Value<String> userPubkey;
   final Value<int> createdAt;
+  final Value<String?> addressableId;
   final Value<int> rowid;
   const PersonalReactionsCompanion({
     this.targetEventId = const Value.absent(),
     this.reactionEventId = const Value.absent(),
     this.userPubkey = const Value.absent(),
     this.createdAt = const Value.absent(),
+    this.addressableId = const Value.absent(),
     this.rowid = const Value.absent(),
   });
   PersonalReactionsCompanion.insert({
@@ -5170,6 +5228,7 @@ class PersonalReactionsCompanion extends UpdateCompanion<PersonalReactionRow> {
     required String reactionEventId,
     required String userPubkey,
     required int createdAt,
+    this.addressableId = const Value.absent(),
     this.rowid = const Value.absent(),
   }) : targetEventId = Value(targetEventId),
        reactionEventId = Value(reactionEventId),
@@ -5180,6 +5239,7 @@ class PersonalReactionsCompanion extends UpdateCompanion<PersonalReactionRow> {
     Expression<String>? reactionEventId,
     Expression<String>? userPubkey,
     Expression<int>? createdAt,
+    Expression<String>? addressableId,
     Expression<int>? rowid,
   }) {
     return RawValuesInsertable({
@@ -5187,6 +5247,7 @@ class PersonalReactionsCompanion extends UpdateCompanion<PersonalReactionRow> {
       if (reactionEventId != null) 'reaction_event_id': reactionEventId,
       if (userPubkey != null) 'user_pubkey': userPubkey,
       if (createdAt != null) 'created_at': createdAt,
+      if (addressableId != null) 'addressable_id': addressableId,
       if (rowid != null) 'rowid': rowid,
     });
   }
@@ -5196,6 +5257,7 @@ class PersonalReactionsCompanion extends UpdateCompanion<PersonalReactionRow> {
     Value<String>? reactionEventId,
     Value<String>? userPubkey,
     Value<int>? createdAt,
+    Value<String?>? addressableId,
     Value<int>? rowid,
   }) {
     return PersonalReactionsCompanion(
@@ -5203,6 +5265,7 @@ class PersonalReactionsCompanion extends UpdateCompanion<PersonalReactionRow> {
       reactionEventId: reactionEventId ?? this.reactionEventId,
       userPubkey: userPubkey ?? this.userPubkey,
       createdAt: createdAt ?? this.createdAt,
+      addressableId: addressableId ?? this.addressableId,
       rowid: rowid ?? this.rowid,
     );
   }
@@ -5222,6 +5285,9 @@ class PersonalReactionsCompanion extends UpdateCompanion<PersonalReactionRow> {
     if (createdAt.present) {
       map['created_at'] = Variable<int>(createdAt.value);
     }
+    if (addressableId.present) {
+      map['addressable_id'] = Variable<String>(addressableId.value);
+    }
     if (rowid.present) {
       map['rowid'] = Variable<int>(rowid.value);
     }
@@ -5235,6 +5301,7 @@ class PersonalReactionsCompanion extends UpdateCompanion<PersonalReactionRow> {
           ..write('reactionEventId: $reactionEventId, ')
           ..write('userPubkey: $userPubkey, ')
           ..write('createdAt: $createdAt, ')
+          ..write('addressableId: $addressableId, ')
           ..write('rowid: $rowid')
           ..write(')'))
         .toString();
@@ -17735,6 +17802,7 @@ typedef $$PersonalReactionsTableCreateCompanionBuilder =
       required String reactionEventId,
       required String userPubkey,
       required int createdAt,
+      Value<String?> addressableId,
       Value<int> rowid,
     });
 typedef $$PersonalReactionsTableUpdateCompanionBuilder =
@@ -17743,6 +17811,7 @@ typedef $$PersonalReactionsTableUpdateCompanionBuilder =
       Value<String> reactionEventId,
       Value<String> userPubkey,
       Value<int> createdAt,
+      Value<String?> addressableId,
       Value<int> rowid,
     });
 
@@ -17772,6 +17841,11 @@ class $$PersonalReactionsTableFilterComposer
 
   ColumnFilters<int> get createdAt => $composableBuilder(
     column: $table.createdAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get addressableId => $composableBuilder(
+    column: $table.addressableId,
     builder: (column) => ColumnFilters(column),
   );
 }
@@ -17804,6 +17878,11 @@ class $$PersonalReactionsTableOrderingComposer
     column: $table.createdAt,
     builder: (column) => ColumnOrderings(column),
   );
+
+  ColumnOrderings<String> get addressableId => $composableBuilder(
+    column: $table.addressableId,
+    builder: (column) => ColumnOrderings(column),
+  );
 }
 
 class $$PersonalReactionsTableAnnotationComposer
@@ -17832,6 +17911,11 @@ class $$PersonalReactionsTableAnnotationComposer
 
   GeneratedColumn<int> get createdAt =>
       $composableBuilder(column: $table.createdAt, builder: (column) => column);
+
+  GeneratedColumn<String> get addressableId => $composableBuilder(
+    column: $table.addressableId,
+    builder: (column) => column,
+  );
 }
 
 class $$PersonalReactionsTableTableManager
@@ -17878,12 +17962,14 @@ class $$PersonalReactionsTableTableManager
                 Value<String> reactionEventId = const Value.absent(),
                 Value<String> userPubkey = const Value.absent(),
                 Value<int> createdAt = const Value.absent(),
+                Value<String?> addressableId = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => PersonalReactionsCompanion(
                 targetEventId: targetEventId,
                 reactionEventId: reactionEventId,
                 userPubkey: userPubkey,
                 createdAt: createdAt,
+                addressableId: addressableId,
                 rowid: rowid,
               ),
           createCompanionCallback:
@@ -17892,12 +17978,14 @@ class $$PersonalReactionsTableTableManager
                 required String reactionEventId,
                 required String userPubkey,
                 required int createdAt,
+                Value<String?> addressableId = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => PersonalReactionsCompanion.insert(
                 targetEventId: targetEventId,
                 reactionEventId: reactionEventId,
                 userPubkey: userPubkey,
                 createdAt: createdAt,
+                addressableId: addressableId,
                 rowid: rowid,
               ),
           withReferenceMapper: (p0) => p0

--- a/mobile/packages/db_client/lib/src/database/daos/personal_reactions_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/personal_reactions_dao.dart
@@ -27,11 +27,16 @@ class PersonalReactionsDao extends DatabaseAccessor<AppDatabase>
   ///
   /// Called when the user likes an event. Stores the mapping so that
   /// the reaction can later be deleted (unlike).
+  ///
+  /// [addressableId] is the `kind:pubkey:d-tag` coordinate of the target
+  /// event, when the target is addressable (e.g. a video). Null for
+  /// non-addressable targets (e.g. comments).
   Future<void> upsertReaction({
     required String targetEventId,
     required String reactionEventId,
     required String userPubkey,
     required int createdAt,
+    String? addressableId,
   }) async {
     await into(personalReactions).insertOnConflictUpdate(
       PersonalReactionsCompanion.insert(
@@ -39,6 +44,7 @@ class PersonalReactionsDao extends DatabaseAccessor<AppDatabase>
         reactionEventId: reactionEventId,
         userPubkey: userPubkey,
         createdAt: createdAt,
+        addressableId: Value(addressableId),
       ),
     );
   }
@@ -59,6 +65,7 @@ class PersonalReactionsDao extends DatabaseAccessor<AppDatabase>
             reactionEventId: r.reactionEventId,
             userPubkey: r.userPubkey,
             createdAt: r.createdAt,
+            addressableId: Value(r.addressableId),
           ),
         ),
       );
@@ -192,6 +199,29 @@ class PersonalReactionsDao extends DatabaseAccessor<AppDatabase>
             t.targetEventId.equals(targetEventId) &
             t.userPubkey.equals(userPubkey),
       );
+
+    return query.getSingleOrNull();
+  }
+
+  /// Get a reaction record by addressable coordinate.
+  ///
+  /// Resolves own-like state for an addressable (e.g. video) target across
+  /// an edit that minted a new [PersonalReactionRow.targetEventId] for the
+  /// same coordinate (#6020). Returns `null` when the coordinate has never
+  /// been liked, or when multiple rows would match the query returns the
+  /// most recently created one.
+  Future<PersonalReactionRow?> getReactionByAddressableId({
+    required String addressableId,
+    required String userPubkey,
+  }) async {
+    final query = select(personalReactions)
+      ..where(
+        (t) =>
+            t.addressableId.equals(addressableId) &
+            t.userPubkey.equals(userPubkey),
+      )
+      ..orderBy([(t) => OrderingTerm.desc(t.createdAt)])
+      ..limit(1);
 
     return query.getSingleOrNull();
   }

--- a/mobile/packages/db_client/lib/src/database/tables.dart
+++ b/mobile/packages/db_client/lib/src/database/tables.dart
@@ -340,6 +340,14 @@ class PersonalReactions extends Table {
   /// Unix timestamp when the reaction was created
   IntColumn get createdAt => integer().named('created_at')();
 
+  /// Addressable coordinate (`kind:pubkey:d-tag`) of the target event, when
+  /// the target is a Kind 30000+ addressable event (e.g. a video).
+  ///
+  /// Null for likes on non-addressable targets (e.g. comments), which have
+  /// no `d` tag / coordinate. Lets own-like state survive a target edit
+  /// that mints a new [targetEventId] for the same coordinate (#6020).
+  TextColumn get addressableId => text().nullable().named('addressable_id')();
+
   @override
   Set<Column> get primaryKey => {targetEventId, userPubkey};
 
@@ -355,6 +363,12 @@ class PersonalReactions extends Table {
       'idx_personal_reactions_reaction_id',
       'CREATE INDEX IF NOT EXISTS idx_personal_reactions_reaction_id '
           'ON personal_reactions (reaction_event_id)',
+    ),
+    // Index on addressable_id for coordinate-based own-like resolution
+    Index(
+      'idx_personal_reactions_addressable_id',
+      'CREATE INDEX IF NOT EXISTS idx_personal_reactions_addressable_id '
+          'ON personal_reactions (addressable_id)',
     ),
   ];
 }

--- a/mobile/packages/db_client/test/drift/app_database/generated/schema_v1.dart
+++ b/mobile/packages/db_client/test/drift/app_database/generated/schema_v1.dart
@@ -976,12 +976,21 @@ class PersonalReactions extends Table with TableInfo {
     requiredDuringInsert: true,
     $customConstraints: 'NOT NULL',
   );
+  late final GeneratedColumn<String> addressableId = GeneratedColumn<String>(
+    'addressable_id',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    $customConstraints: 'NULL',
+  );
   @override
   List<GeneratedColumn> get $columns => [
     targetEventId,
     reactionEventId,
     userPubkey,
     createdAt,
+    addressableId,
   ];
   @override
   String get aliasedName => _alias ?? actualTableName;
@@ -2740,6 +2749,122 @@ class ProcessedGiftWraps extends Table with TableInfo {
   bool get dontWriteConstraints => true;
 }
 
+class PendingProfileSaves extends Table with TableInfo {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  PendingProfileSaves(this.attachedDatabase, [this._alias]);
+  late final GeneratedColumn<String> userPubkey = GeneratedColumn<String>(
+    'user_pubkey',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    $customConstraints: 'NOT NULL',
+  );
+  late final GeneratedColumn<String> payloadJson = GeneratedColumn<String>(
+    'payload_json',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    $customConstraints: 'NOT NULL',
+  );
+  late final GeneratedColumn<int> claimConfirmed = GeneratedColumn<int>(
+    'claim_confirmed',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    $customConstraints: 'NOT NULL DEFAULT 0 CHECK (claim_confirmed IN (0, 1))',
+    defaultValue: const CustomExpression('0'),
+  );
+  late final GeneratedColumn<String> status = GeneratedColumn<String>(
+    'status',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    $customConstraints: 'NOT NULL DEFAULT \'pending\'',
+    defaultValue: const CustomExpression('\'pending\''),
+  );
+  late final GeneratedColumn<int> retryCount = GeneratedColumn<int>(
+    'retry_count',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    $customConstraints: 'NOT NULL DEFAULT 0',
+    defaultValue: const CustomExpression('0'),
+  );
+  late final GeneratedColumn<int> lastAttemptAt = GeneratedColumn<int>(
+    'last_attempt_at',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    $customConstraints: 'NULL',
+  );
+  late final GeneratedColumn<int> queuedAt = GeneratedColumn<int>(
+    'queued_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+    $customConstraints: 'NOT NULL',
+  );
+  late final GeneratedColumn<String> lastError = GeneratedColumn<String>(
+    'last_error',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    $customConstraints: 'NULL',
+  );
+  late final GeneratedColumn<String> generation = GeneratedColumn<String>(
+    'generation',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    $customConstraints: 'NOT NULL DEFAULT \'\'',
+    defaultValue: const CustomExpression('\'\''),
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    userPubkey,
+    payloadJson,
+    claimConfirmed,
+    status,
+    retryCount,
+    lastAttemptAt,
+    queuedAt,
+    lastError,
+    generation,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'pending_profile_saves';
+  @override
+  Set<GeneratedColumn> get $primaryKey => {userPubkey};
+  @override
+  Never map(Map<String, dynamic> data, {String? tablePrefix}) {
+    throw UnsupportedError('TableInfo.map in schema verification code');
+  }
+
+  @override
+  PendingProfileSaves createAlias(String alias) {
+    return PendingProfileSaves(attachedDatabase, alias);
+  }
+
+  @override
+  List<String> get customConstraints => const ['PRIMARY KEY(user_pubkey)'];
+  @override
+  bool get dontWriteConstraints => true;
+}
+
 class DatabaseAtV1 extends GeneratedDatabase {
   DatabaseAtV1(QueryExecutor e) : super(e);
   late final Event event = Event(this);
@@ -2765,6 +2890,9 @@ class DatabaseAtV1 extends GeneratedDatabase {
   );
   late final PendingGiftWraps pendingGiftWraps = PendingGiftWraps(this);
   late final ProcessedGiftWraps processedGiftWraps = ProcessedGiftWraps(this);
+  late final PendingProfileSaves pendingProfileSaves = PendingProfileSaves(
+    this,
+  );
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
@@ -2791,6 +2919,7 @@ class DatabaseAtV1 extends GeneratedDatabase {
     pendingProductEvents,
     pendingGiftWraps,
     processedGiftWraps,
+    pendingProfileSaves,
   ];
   @override
   StreamQueryUpdateRules get streamUpdateRules => const StreamQueryUpdateRules([

--- a/mobile/packages/db_client/test/src/database/app_database_test.dart
+++ b/mobile/packages/db_client/test/src/database/app_database_test.dart
@@ -1304,6 +1304,81 @@ void main() {
         },
       );
     });
+
+    group('personal_reactions addressable_id column (#6020)', () {
+      test(
+        'upgrade path — re-adds addressable_id on personal_reactions on '
+        'reopen, and the re-added column is usable',
+        () async {
+          // Seed a row under the pre-drop schema, so the DROP exercises a
+          // populated table (mirrors the send_batch_id upgrade test).
+          await database.personalReactionsDao.upsertReaction(
+            targetEventId: 'target_pre',
+            reactionEventId: 'reaction_pre',
+            userPubkey: testPubkey,
+            createdAt: 1700000000,
+            addressableId: '34236:$testPubkey:pre-d-tag',
+          );
+
+          // Simulate a legacy install that pre-dates the column: drop the
+          // index that references it, then the column itself.
+          await database.customStatement(
+            'DROP INDEX idx_personal_reactions_addressable_id',
+          );
+          await database.customStatement(
+            'ALTER TABLE personal_reactions DROP COLUMN addressable_id',
+          );
+          expect(
+            await _columnNames(database, 'personal_reactions'),
+            isNot(contains('addressable_id')),
+          );
+          await database.close();
+
+          // Reopen the same on-disk file. `beforeOpen` re-adds the column
+          // and its index. There is no backfill: the pre-drop coordinate is
+          // gone, the column comes back null for that row (same contract
+          // as the DM send_batch_id upgrade — acceptable since #6020's own
+          // consumer, LikesRepository.syncUserReactions, re-derives the
+          // coordinate from relay data on next sync).
+          database = AppDatabase.test(NativeDatabase(File(tempDbPath)));
+
+          expect(
+            await _columnNames(database, 'personal_reactions'),
+            contains('addressable_id'),
+          );
+          expect(
+            await _collectIndexNames(database, 'personal_reactions'),
+            contains('idx_personal_reactions_addressable_id'),
+          );
+
+          // The re-added column is writable and readable end-to-end.
+          await database.personalReactionsDao.upsertReaction(
+            targetEventId: 'target_post',
+            reactionEventId: 'reaction_post',
+            userPubkey: testPubkey,
+            createdAt: 1700000100,
+            addressableId: '34236:$testPubkey:post-d-tag',
+          );
+          final byCoordinate = await database.personalReactionsDao
+              .getReactionByAddressableId(
+                addressableId: '34236:$testPubkey:post-d-tag',
+                userPubkey: testPubkey,
+              );
+          expect(byCoordinate, isNotNull);
+          expect(byCoordinate!.targetEventId, equals('target_post'));
+
+          // The pre-drop row survived the ALTER TABLE DROP/ADD round trip
+          // (SQLite's DROP COLUMN only removes that column; other columns
+          // and rows are untouched), now with a null coordinate.
+          final preDropRow = await database.personalReactionsDao.getReaction(
+            targetEventId: 'target_pre',
+            userPubkey: testPubkey,
+          );
+          expect(preDropRow, isNotNull);
+          expect(preDropRow!.addressableId, isNull);
+        },
+      );
+    });
   });
 }
 

--- a/mobile/packages/db_client/test/src/database/app_database_test.dart
+++ b/mobile/packages/db_client/test/src/database/app_database_test.dart
@@ -1335,11 +1335,15 @@ void main() {
           await database.close();
 
           // Reopen the same on-disk file. `beforeOpen` re-adds the column
-          // and its index. There is no backfill: the pre-drop coordinate is
-          // gone, the column comes back null for that row (same contract
-          // as the DM send_batch_id upgrade — acceptable since #6020's own
-          // consumer, LikesRepository.syncUserReactions, re-derives the
-          // coordinate from relay data on next sync).
+          // and its index. There is no backfill at the DB layer: the
+          // pre-drop coordinate is gone, the column comes back null for
+          // that row (same contract as the DM send_batch_id upgrade).
+          // Backfill is owned by LikesRepository: initialize() detects
+          // null-coordinate rows and runs syncUserReactions(), whose
+          // same-reaction-id exemption re-persists the coordinate from the
+          // relay reaction's `a` tag even when the relay copy is not newer
+          // (#6123). End-to-end pin: likes_repository/test/src/
+          // likes_repository_pre_column_db_test.dart.
           database = AppDatabase.test(NativeDatabase(File(tempDbPath)));
 
           expect(

--- a/mobile/packages/db_client/test/src/database/daos/personal_reactions_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/personal_reactions_dao_test.dart
@@ -720,5 +720,176 @@ void main() {
         expect(result, isNull);
       });
     });
+
+    group('addressableId (#6020)', () {
+      const testAddressableId = '34236:$testUserPubkey:test-d-tag';
+
+      test('upsertReaction persists a null addressableId by default', () async {
+        await dao.upsertReaction(
+          targetEventId: testTargetEventId,
+          reactionEventId: testReactionEventId,
+          userPubkey: testUserPubkey,
+          createdAt: 1000,
+        );
+
+        final result = await dao.getReaction(
+          targetEventId: testTargetEventId,
+          userPubkey: testUserPubkey,
+        );
+
+        expect(result!.addressableId, isNull);
+      });
+
+      test('upsertReaction persists a non-null addressableId', () async {
+        await dao.upsertReaction(
+          targetEventId: testTargetEventId,
+          reactionEventId: testReactionEventId,
+          userPubkey: testUserPubkey,
+          createdAt: 1000,
+          addressableId: testAddressableId,
+        );
+
+        final result = await dao.getReaction(
+          targetEventId: testTargetEventId,
+          userPubkey: testUserPubkey,
+        );
+
+        expect(result!.addressableId, equals(testAddressableId));
+      });
+
+      test('upsertReactionsBatch persists addressableId per row', () async {
+        await dao.upsertReactionsBatch([
+          PersonalReactionRow(
+            targetEventId: testTargetEventId,
+            reactionEventId: testReactionEventId,
+            userPubkey: testUserPubkey,
+            createdAt: 1000,
+            addressableId: testAddressableId,
+          ),
+          PersonalReactionRow(
+            targetEventId: testTargetEventId2,
+            reactionEventId: testReactionEventId2,
+            userPubkey: testUserPubkey,
+            createdAt: 2000,
+          ),
+        ]);
+
+        final withCoordinate = await dao.getReaction(
+          targetEventId: testTargetEventId,
+          userPubkey: testUserPubkey,
+        );
+        final withoutCoordinate = await dao.getReaction(
+          targetEventId: testTargetEventId2,
+          userPubkey: testUserPubkey,
+        );
+
+        expect(withCoordinate!.addressableId, equals(testAddressableId));
+        expect(withoutCoordinate!.addressableId, isNull);
+      });
+    });
+
+    group('getReactionByAddressableId', () {
+      const testAddressableId = '34236:$testUserPubkey:test-d-tag';
+
+      test('returns the record when the coordinate is liked', () async {
+        await dao.upsertReaction(
+          targetEventId: testTargetEventId,
+          reactionEventId: testReactionEventId,
+          userPubkey: testUserPubkey,
+          createdAt: 1000,
+          addressableId: testAddressableId,
+        );
+
+        final result = await dao.getReactionByAddressableId(
+          addressableId: testAddressableId,
+          userPubkey: testUserPubkey,
+        );
+
+        expect(result, isNotNull);
+        expect(result!.targetEventId, equals(testTargetEventId));
+      });
+
+      test('returns null when the coordinate has never been liked', () async {
+        final result = await dao.getReactionByAddressableId(
+          addressableId: testAddressableId,
+          userPubkey: testUserPubkey,
+        );
+
+        expect(result, isNull);
+      });
+
+      test(
+        'resolves the coordinate across a target edit — a like recorded '
+        'under a pre-edit target event id still resolves by coordinate',
+        () async {
+          // Simulates: user liked the pre-edit video (testTargetEventId),
+          // then the video was edited, minting testTargetEventId2 for the
+          // same coordinate. The like record is still keyed by the OLD
+          // event id, but resolves via the coordinate (#6020).
+          await dao.upsertReaction(
+            targetEventId: testTargetEventId,
+            reactionEventId: testReactionEventId,
+            userPubkey: testUserPubkey,
+            createdAt: 1000,
+            addressableId: testAddressableId,
+          );
+
+          final result = await dao.getReactionByAddressableId(
+            addressableId: testAddressableId,
+            userPubkey: testUserPubkey,
+          );
+
+          expect(result, isNotNull);
+          expect(result!.targetEventId, equals(testTargetEventId));
+          expect(result.reactionEventId, equals(testReactionEventId));
+        },
+      );
+
+      test('only returns the coordinate for the specified user', () async {
+        await dao.upsertReaction(
+          targetEventId: testTargetEventId,
+          reactionEventId: testReactionEventId,
+          userPubkey: testUserPubkey,
+          createdAt: 1000,
+          addressableId: testAddressableId,
+        );
+
+        final result = await dao.getReactionByAddressableId(
+          addressableId: testAddressableId,
+          userPubkey: testUserPubkey2,
+        );
+
+        expect(result, isNull);
+      });
+
+      test(
+        'returns the most recently created row when multiple event ids '
+        'share the same coordinate (the duplicate-reaction scenario)',
+        () async {
+          await dao.upsertReaction(
+            targetEventId: testTargetEventId,
+            reactionEventId: testReactionEventId,
+            userPubkey: testUserPubkey,
+            createdAt: 1000,
+            addressableId: testAddressableId,
+          );
+          await dao.upsertReaction(
+            targetEventId: testTargetEventId2,
+            reactionEventId: testReactionEventId2,
+            userPubkey: testUserPubkey,
+            createdAt: 2000,
+            addressableId: testAddressableId,
+          );
+
+          final result = await dao.getReactionByAddressableId(
+            addressableId: testAddressableId,
+            userPubkey: testUserPubkey,
+          );
+
+          expect(result, isNotNull);
+          expect(result!.targetEventId, equals(testTargetEventId2));
+        },
+      );
+    });
   });
 }

--- a/mobile/packages/likes_repository/lib/src/db_likes_local_storage.dart
+++ b/mobile/packages/likes_repository/lib/src/db_likes_local_storage.dart
@@ -31,6 +31,7 @@ class DbLikesLocalStorage implements LikesLocalStorage {
       reactionEventId: record.reactionEventId,
       userPubkey: _userPubkey,
       createdAt: record.createdAt.millisecondsSinceEpoch ~/ 1000,
+      addressableId: record.addressableId,
     );
   }
 
@@ -44,6 +45,7 @@ class DbLikesLocalStorage implements LikesLocalStorage {
         reactionEventId: record.reactionEventId,
         userPubkey: _userPubkey,
         createdAt: record.createdAt.millisecondsSinceEpoch ~/ 1000,
+        addressableId: record.addressableId,
       );
     }).toList();
 
@@ -63,6 +65,20 @@ class DbLikesLocalStorage implements LikesLocalStorage {
   Future<LikeRecord?> getLikeRecord(String targetEventId) async {
     final row = await _dao.getReaction(
       targetEventId: targetEventId,
+      userPubkey: _userPubkey,
+    );
+
+    if (row == null) return null;
+
+    return _rowToRecord(row);
+  }
+
+  @override
+  Future<LikeRecord?> getLikeRecordByAddressableId(
+    String addressableId,
+  ) async {
+    final row = await _dao.getReactionByAddressableId(
+      addressableId: addressableId,
       userPubkey: _userPubkey,
     );
 
@@ -112,6 +128,7 @@ class DbLikesLocalStorage implements LikesLocalStorage {
         row.createdAt * 1000,
         isUtc: true,
       ),
+      addressableId: row.addressableId,
     );
   }
 }

--- a/mobile/packages/likes_repository/lib/src/likes_local_storage.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_local_storage.dart
@@ -34,6 +34,13 @@ abstract class LikesLocalStorage {
   /// Returns `null` if no record exists for the given target.
   Future<LikeRecord?> getLikeRecord(String targetEventId);
 
+  /// Gets a like record by addressable coordinate (`kind:pubkey:d-tag`).
+  ///
+  /// Resolves own-like state for an addressable target across an edit that
+  /// minted a new event id for the same coordinate (#6020). Returns `null`
+  /// if the coordinate has never been liked.
+  Future<LikeRecord?> getLikeRecordByAddressableId(String addressableId);
+
   /// Gets the reaction event ID for a target event.
   ///
   /// This is a convenience method that returns just the reaction event ID,

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -522,12 +522,30 @@ class LikesRepository {
   ///
   /// This method bypasses offline queuing and directly publishes to relays.
   /// Used by PendingActionService to execute queued actions.
+  ///
+  /// If [addressableId] is already liked by a *different* reaction than the
+  /// one queued for [eventId] — e.g. cross-device sync delivered a like for
+  /// this coordinate (under a different event id) while this action sat in
+  /// the offline queue — reconciles to that reaction instead of publishing
+  /// a duplicate. The app-layer queue's own dedup only cancels opposite
+  /// actions on the same event id; it has no visibility into reactions
+  /// arriving from other devices, so this is the only guard against a
+  /// duplicate live reaction on replay (#6020).
   Future<String> executeLikeAction({
     required String eventId,
     required String authorPubkey,
     String? addressableId,
     int? targetKind,
   }) async {
+    if (addressableId != null && addressableId.isNotEmpty) {
+      final byCoordinate = _likeRecordsByAddressableId[addressableId];
+      final ownReactionEventId = _likeRecords[eventId]?.reactionEventId;
+      if (byCoordinate != null &&
+          byCoordinate.reactionEventId != ownReactionEventId) {
+        return byCoordinate.reactionEventId;
+      }
+    }
+
     // Publish Kind 7 reaction event via NostrClient
     final reactionEvent = await _nostrClient.sendLike(
       eventId,

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -108,6 +108,18 @@ class LikesRepository {
   /// In-memory cache of like records keyed by target event ID.
   final Map<String, LikeRecord> _likeRecords = {};
 
+  /// Companion index of [_likeRecords], keyed by addressable coordinate
+  /// (`kind:pubkey:d-tag`) instead of target event ID.
+  ///
+  /// Lets own-like state survive a target edit that mints a new event id
+  /// for the same coordinate (#6020) — a like recorded against the pre-edit
+  /// id stays resolvable via [isLikedByCoordinate]/[getLikeRecordByCoordinate]
+  /// after the edit. Populated everywhere [_likeRecords] is written (see
+  /// [_indexLikeRecord]) whenever an addressable id is known, including on
+  /// load from persisted storage, so cold app starts resolve correctly too
+  /// (unlike the in-memory-only precedent in #4478's comment count cache).
+  final Map<String, LikeRecord> _likeRecordsByAddressableId = {};
+
   /// In-memory cache of downvote records keyed by target event ID.
   ///
   /// Mirror of [_likeRecords] for kind-7 reactions whose content is `-`.
@@ -122,8 +134,31 @@ class LikesRepository {
   /// stays consistent with optimistic UI updates.
   final Map<String, int> _likeCountCache = {};
 
+  /// Companion of [_likeCountCache], keyed by addressable coordinate.
+  ///
+  /// Mirrors the dual-key pattern `comments_repository` shipped in #4478:
+  /// a cached count survives a target edit that changes the event id, as
+  /// long as the coordinate stayed the same. Read falls back to this map
+  /// only on an event-id miss; writes are always dual when a coordinate is
+  /// known (see [_readCachedLikeCount]/[_writeCachedLikeCount]).
+  final Map<String, int> _likeCountCacheByAddressableId = {};
+
   /// Reactive stream controller for liked event IDs (ordered by recency).
   final _likedIdsController = BehaviorSubject<List<String>>.seeded([]);
+
+  /// Reactive stream controller for liked addressable coordinates.
+  ///
+  /// Companion of [_likedIdsController], ticked alongside it (see
+  /// [_emitLikedIds]) so a live subscriber (e.g. a video interactions BLoC)
+  /// can resolve "is this coordinate liked" reactively, not just via a
+  /// one-shot fetch — without this, a consumer subscribed only to
+  /// [watchLikedEventIds] would have its own-like state silently flip back
+  /// to unliked the next time *any* like/unlike ticks the stream anywhere
+  /// in the app, since that stream is blind to coordinate membership
+  /// (#6020).
+  final _likedAddressableIdsController = BehaviorSubject<Set<String>>.seeded(
+    <String>{},
+  );
 
   /// Reactive stream controller for downvoted event IDs (ordered by recency).
   final _downvotedIdsController = BehaviorSubject<List<String>>.seeded(
@@ -142,7 +177,37 @@ class LikesRepository {
   StreamSubscription<Event>? _reactionSubscription;
   String? _reactionSubscriptionId;
 
-  /// Emits the current liked event IDs ordered by recency (most recent first).
+  /// Writes [record] into [_likeRecords] and, when its
+  /// [LikeRecord.addressableId] is non-empty, also into
+  /// [_likeRecordsByAddressableId].
+  ///
+  /// Centralizes the dual-write so every write site (like, sync, live
+  /// subscription, load-from-storage) stays consistent — mirrors the
+  /// `_writeCachedCommentCount` helper from #4478.
+  void _indexLikeRecord(LikeRecord record) {
+    _likeRecords[record.targetEventId] = record;
+    final addressableId = record.addressableId;
+    if (addressableId != null && addressableId.isNotEmpty) {
+      _likeRecordsByAddressableId[addressableId] = record;
+    }
+  }
+
+  /// Removes any record for [targetEventId] from both [_likeRecords] and
+  /// [_likeRecordsByAddressableId].
+  ///
+  /// Looks up the record before removing so the addressable-id companion
+  /// entry can be found and removed too — [_likeRecordsByAddressableId] is
+  /// keyed by coordinate, not by [targetEventId].
+  void _deindexLikeRecord(String targetEventId) {
+    final record = _likeRecords.remove(targetEventId);
+    final addressableId = record?.addressableId;
+    if (addressableId != null && addressableId.isNotEmpty) {
+      _likeRecordsByAddressableId.remove(addressableId);
+    }
+  }
+
+  /// Emits the current liked event IDs ordered by recency (most recent
+  /// first), and the current liked addressable coordinates alongside them.
   ///
   /// Guards against emitting after [dispose] has been called or the controller
   /// has been closed, which can happen if [clearCache] runs during or after
@@ -152,6 +217,11 @@ class LikesRepository {
     final sortedRecords = _likeRecords.values.toList()
       ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
     _likedIdsController.add(sortedRecords.map((r) => r.targetEventId).toList());
+    if (!_likedAddressableIdsController.isClosed) {
+      _likedAddressableIdsController.add(
+        _likeRecordsByAddressableId.keys.toSet(),
+      );
+    }
   }
 
   /// Emits the current downvoted event IDs ordered by recency.
@@ -177,6 +247,19 @@ class LikesRepository {
     // watches, so it stays consistent with isLiked/getOrderedLikedEventIds.
     await _ensureInitialized();
     yield* _likedIdsController.stream;
+  }
+
+  /// Stream of liked addressable coordinates (reactive).
+  ///
+  /// Companion of [watchLikedEventIds] keyed by `kind:pubkey:d-tag`
+  /// coordinate instead of event id. A live consumer that cares about an
+  /// addressable target's own-like state should combine both streams —
+  /// membership in either means the target is liked — so a coordinate-only
+  /// hit (the target's underlying reaction is for a pre-edit event id)
+  /// isn't missed (#6020).
+  Stream<Set<String>> watchLikedAddressableIds() async* {
+    await _ensureInitialized();
+    yield* _likedAddressableIdsController.stream;
   }
 
   /// Get the current set of liked event IDs.
@@ -207,6 +290,47 @@ class LikesRepository {
   Future<bool> isLiked(String eventId) async {
     await _ensureInitialized();
     return _likeRecords.containsKey(eventId);
+  }
+
+  /// Get the like record for an addressable coordinate
+  /// (`kind:pubkey:d-tag`), or `null` if the coordinate is not liked.
+  ///
+  /// Resolves own-like state for an addressable target across an edit that
+  /// minted a new event id for the same coordinate (#6020) — a like made
+  /// against a pre-edit version of the target is still found here after
+  /// the edit, even though [isLiked] with the new event id would miss.
+  Future<LikeRecord?> getLikeRecordByCoordinate(String addressableId) async {
+    await _ensureInitialized();
+    return _likeRecordsByAddressableId[addressableId];
+  }
+
+  /// Check if a specific addressable coordinate is liked.
+  ///
+  /// Thin bool wrapper over [getLikeRecordByCoordinate], mirroring the
+  /// [isLiked]/[getLikeRecord] pair shape.
+  Future<bool> isLikedByCoordinate(String addressableId) async {
+    return (await getLikeRecordByCoordinate(addressableId)) != null;
+  }
+
+  /// Check if [eventId] is liked, falling back to [addressableId] (when
+  /// provided) on a miss.
+  ///
+  /// This is the composed check callers with both an event id and an
+  /// optional coordinate should use — e.g. a video interactions BLoC
+  /// resolving "is my own video liked" without needing to know whether the
+  /// underlying reaction was recorded against this exact event id or a
+  /// pre-edit version of the same coordinate (#6020). Mirrors
+  /// [getLikeCount]'s existing eventId+addressableId parameter shape;
+  /// keeps the fallback/composition policy in the repository layer per
+  /// this codebase's architecture convention, rather than pushing two
+  /// sequential calls onto the caller.
+  Future<bool> isLikedResolvingCoordinate({
+    required String eventId,
+    String? addressableId,
+  }) async {
+    if (await isLiked(eventId)) return true;
+    if (addressableId == null || addressableId.isEmpty) return false;
+    return isLikedByCoordinate(addressableId);
   }
 
   /// Stream of downvoted event IDs ordered by recency (reactive).
@@ -274,13 +398,25 @@ class LikesRepository {
   }) async {
     await _ensureInitialized();
 
-    // Check if already liked
-    if (_likeRecords.containsKey(eventId)) {
+    // Check if already liked — by event id, or (when addressableId is
+    // known) by coordinate. The coordinate check catches the case where a
+    // pre-edit version of this target was already liked under a different
+    // event id: without it, a stale heart-unfilled UI (#6020) could lead
+    // the user to create a second, duplicate live reaction whose original
+    // becomes un-deletable via the normal unlike flow.
+    final alreadyLikedByCoordinate =
+        addressableId != null &&
+        addressableId.isNotEmpty &&
+        _likeRecordsByAddressableId.containsKey(addressableId);
+    if (_likeRecords.containsKey(eventId) || alreadyLikedByCoordinate) {
       throw AlreadyLikedException(eventId);
     }
 
     // Snapshot for rollback if the network publish fails
-    final previousCount = _likeCountCache[eventId];
+    final previousCount = _readCachedLikeCount(
+      eventId,
+      addressableId: addressableId,
+    );
 
     // 1. Optimistic-first: write to memory + local storage and tick the
     // watchLikedEventIds stream BEFORE any network I/O. The UI flips here.
@@ -294,10 +430,17 @@ class LikesRepository {
       targetEventId: eventId,
       reactionEventId: placeholderId,
       createdAt: DateTime.now(),
+      addressableId: addressableId,
     );
-    _likeRecords[eventId] = placeholder;
+    _indexLikeRecord(placeholder);
     await _localStorage?.saveLikeRecord(placeholder);
-    if (previousCount != null) _likeCountCache[eventId] = previousCount + 1;
+    if (previousCount != null) {
+      _writeCachedLikeCount(
+        eventId,
+        previousCount + 1,
+        addressableId: addressableId,
+      );
+    }
     _emitLikedIds();
 
     // 2. Offline → leave the optimistic state in place; queue replays later
@@ -337,8 +480,9 @@ class LikesRepository {
         targetEventId: eventId,
         reactionEventId: reactionEvent.id,
         createdAt: placeholder.createdAt,
+        addressableId: addressableId,
       );
-      _likeRecords[eventId] = confirmed;
+      _indexLikeRecord(confirmed);
       await _localStorage?.saveLikeRecord(confirmed);
 
       return reactionEvent.id;
@@ -360,9 +504,15 @@ class LikesRepository {
         );
         return placeholderId;
       }
-      _likeRecords.remove(eventId);
+      _deindexLikeRecord(eventId);
       await _localStorage?.deleteLikeRecord(eventId);
-      if (previousCount != null) _likeCountCache[eventId] = previousCount;
+      if (previousCount != null) {
+        _writeCachedLikeCount(
+          eventId,
+          previousCount,
+          addressableId: addressableId,
+        );
+      }
       _emitLikedIds();
       rethrow;
     }
@@ -399,8 +549,9 @@ class LikesRepository {
         targetEventId: eventId,
         reactionEventId: reactionEvent.id,
         createdAt: existingRecord.createdAt,
+        addressableId: addressableId ?? existingRecord.addressableId,
       );
-      _likeRecords[eventId] = record;
+      _indexLikeRecord(record);
       await _localStorage?.saveLikeRecord(record);
     }
 
@@ -415,38 +566,63 @@ class LikesRepository {
   /// If the device is offline and offline queuing is enabled, the action
   /// is queued for later sync and the UI should be updated optimistically.
   ///
+  /// [addressableId], when provided, resolves the underlying reaction by
+  /// coordinate when no record exists under [eventId] — the case where the
+  /// like was recorded against a pre-edit version of this target (#6020).
+  /// Without this fallback, unliking the current version after an edit
+  /// would silently no-op on the original reaction, leaving it live and
+  /// permanently un-deletable via this method.
+  ///
   /// Throws `UnlikeFailedException` if the operation fails.
   /// Throws `NotLikedException` if the event is not currently liked.
-  Future<void> unlikeEvent(String eventId) async {
+  Future<void> unlikeEvent(String eventId, {String? addressableId}) async {
     await _ensureInitialized();
 
-    // Try in-memory cache first, then fall back to database
-    // This handles the case where the cache hasn't been populated yet
+    // Try in-memory cache first (by event id, then by coordinate), then
+    // fall back to database. This handles both the cache-not-populated-yet
+    // case and the post-edit case where the record's real key is a
+    // different (pre-edit) event id than the one the caller passed in.
     var record = _likeRecords[eventId];
+    if (record == null && addressableId != null && addressableId.isNotEmpty) {
+      record = _likeRecordsByAddressableId[addressableId];
+    }
     if (record == null && _localStorage != null) {
       record = await _localStorage.getLikeRecord(eventId);
+      if (record == null && addressableId != null && addressableId.isNotEmpty) {
+        record = await _localStorage.getLikeRecordByAddressableId(
+          addressableId,
+        );
+      }
     }
 
     if (record == null) {
       throw NotLikedException(eventId);
     }
 
+    // The record's own targetEventId is the correct key to deindex/delete
+    // — it may be a pre-edit id the caller doesn't know about, when this
+    // record was found via the addressableId fallback above.
+    final resolvedEventId = record.targetEventId;
+
     // Snapshot for rollback if the network publish fails
     final snapshotRecord = record;
-    final previousCount = _likeCountCache[eventId];
+    final previousCount = _readCachedLikeCount(
+      eventId,
+      addressableId: addressableId,
+    );
 
     // 1. Optimistic-first: remove from memory + local storage and tick the
     // watchLikedEventIds stream BEFORE any network I/O (mirror of likeEvent).
-    _likeRecords.remove(eventId);
-    await _localStorage?.deleteLikeRecord(eventId);
-    _decrementLikeCountCache(eventId);
+    _deindexLikeRecord(resolvedEventId);
+    await _localStorage?.deleteLikeRecord(resolvedEventId);
+    _decrementLikeCountCache(eventId, addressableId: addressableId);
     _emitLikedIds();
 
     // 2. Offline → leave the optimistic state in place; queue replays later
     if (_isOnline != null && !_isOnline() && _queueOfflineAction != null) {
       await _queueOfflineAction(
         isLike: false,
-        eventId: eventId,
+        eventId: resolvedEventId,
         authorPubkey: '', // Not needed for unlike
       );
       return;
@@ -480,14 +656,20 @@ class LikesRepository {
         );
         await _queueOfflineAction(
           isLike: false,
-          eventId: eventId,
+          eventId: resolvedEventId,
           authorPubkey: '', // Not needed for unlike
         );
         return;
       }
-      _likeRecords[eventId] = snapshotRecord;
+      _indexLikeRecord(snapshotRecord);
       await _localStorage?.saveLikeRecord(snapshotRecord);
-      if (previousCount != null) _likeCountCache[eventId] = previousCount;
+      if (previousCount != null) {
+        _writeCachedLikeCount(
+          eventId,
+          previousCount,
+          addressableId: addressableId,
+        );
+      }
       _emitLikedIds();
       rethrow;
     }
@@ -497,11 +679,25 @@ class LikesRepository {
   ///
   /// This method bypasses offline queuing and directly publishes to relays.
   /// Used by PendingActionService to execute queued actions.
-  Future<void> executeUnlikeAction(String eventId) async {
+  ///
+  /// [addressableId] resolves the record by coordinate when [eventId] finds
+  /// nothing — mirrors [unlikeEvent]'s fallback for the same reason (#6020).
+  Future<void> executeUnlikeAction(
+    String eventId, {
+    String? addressableId,
+  }) async {
     // Try to get the record - it may not exist if the like was also offline
     var record = _likeRecords[eventId];
+    if (record == null && addressableId != null && addressableId.isNotEmpty) {
+      record = _likeRecordsByAddressableId[addressableId];
+    }
     if (record == null && _localStorage != null) {
       record = await _localStorage.getLikeRecord(eventId);
+      if (record == null && addressableId != null && addressableId.isNotEmpty) {
+        record = await _localStorage.getLikeRecordByAddressableId(
+          addressableId,
+        );
+      }
     }
 
     // If no record exists, the like was never synced either, so we're done
@@ -509,13 +705,15 @@ class LikesRepository {
       return;
     }
 
+    final resolvedEventId = record.targetEventId;
+
     // Skip publishing if this was a pending like
     if (record.reactionEventId.startsWith('pending_')) {
       // Just clean up local storage
-      _likeRecords.remove(eventId);
-      await _localStorage?.deleteLikeRecord(eventId);
+      _deindexLikeRecord(resolvedEventId);
+      await _localStorage?.deleteLikeRecord(resolvedEventId);
       _emitLikedIds();
-      _decrementLikeCountCache(eventId);
+      _decrementLikeCountCache(eventId, addressableId: addressableId);
       return;
     }
 
@@ -529,10 +727,10 @@ class LikesRepository {
     }
 
     // Remove from cache and storage
-    _likeRecords.remove(eventId);
-    await _localStorage?.deleteLikeRecord(eventId);
+    _deindexLikeRecord(resolvedEventId);
+    await _localStorage?.deleteLikeRecord(resolvedEventId);
     _emitLikedIds();
-    _decrementLikeCountCache(eventId);
+    _decrementLikeCountCache(eventId, addressableId: addressableId);
   }
 
   /// Toggle like status for an event.
@@ -559,13 +757,22 @@ class LikesRepository {
     await _ensureInitialized();
 
     // Query the database directly as source of truth to avoid cache/db
-    // inconsistency after app restart
-    final isCurrentlyLiked =
+    // inconsistency after app restart. Also check by coordinate: after an
+    // edit, a like recorded pre-edit resolves under a different event id
+    // than the one being toggled here (#6020) — without this check,
+    // toggling the (correctly, post-fix) filled heart on the current
+    // version would try to *like* again instead of unliking the original.
+    final likedByEventId =
         await _localStorage?.isLiked(eventId) ??
         _likeRecords.containsKey(eventId);
+    final likedByCoordinate =
+        addressableId != null &&
+        addressableId.isNotEmpty &&
+        _likeRecordsByAddressableId.containsKey(addressableId);
+    final isCurrentlyLiked = likedByEventId || likedByCoordinate;
 
     if (isCurrentlyLiked) {
-      await unlikeEvent(eventId);
+      await unlikeEvent(eventId, addressableId: addressableId);
       return false;
     } else {
       await likeEvent(
@@ -591,7 +798,7 @@ class LikesRepository {
   ///
   /// Note: This counts all likes, not just the current user's.
   Future<int> getLikeCount(String eventId, {String? addressableId}) async {
-    final cached = _likeCountCache[eventId];
+    final cached = _readCachedLikeCount(eventId, addressableId: addressableId);
     if (cached != null) return cached;
 
     int count;
@@ -614,7 +821,7 @@ class LikesRepository {
       count = result.count;
     }
 
-    _likeCountCache[eventId] = count;
+    _writeCachedLikeCount(eventId, count, addressableId: addressableId);
     return count;
   }
 
@@ -651,7 +858,10 @@ class LikesRepository {
     final counts = <String, int>{};
     final uncachedIds = <String>[];
     for (final id in eventIds) {
-      final cached = _likeCountCache[id];
+      final cached = _readCachedLikeCount(
+        id,
+        addressableId: addressableIds?[id],
+      );
       if (cached != null) {
         counts[id] = cached;
       } else {
@@ -679,7 +889,11 @@ class LikesRepository {
       for (final id in uncachedIds) {
         final count = likersByEvent[id]?.length ?? 0;
         counts[id] = count;
-        _likeCountCache[id] = count;
+        _writeCachedLikeCount(
+          id,
+          count,
+          addressableId: uncachedAddressableIds[id],
+        );
       }
       return counts;
     }
@@ -710,7 +924,7 @@ class LikesRepository {
 
     // Populate cache with fetched counts
     for (final id in uncachedIds) {
-      _likeCountCache[id] = counts[id]!;
+      _writeCachedLikeCount(id, counts[id]!);
     }
 
     return counts;
@@ -976,9 +1190,7 @@ class LikesRepository {
     // First, load from local storage (fast)
     if (_localStorage != null) {
       final records = await _localStorage.getAllLikeRecords();
-      for (final record in records) {
-        _likeRecords[record.targetEventId] = record;
-      }
+      records.forEach(_indexLikeRecord);
       _emitLikedIds();
     }
 
@@ -1042,13 +1254,14 @@ class LikesRepository {
             createdAt: DateTime.fromMillisecondsSinceEpoch(
               event.createdAt * 1000,
             ),
+            addressableId: _extractAddressableId(event),
           );
 
           // Only update if we don't have this record or the new one is newer
           final existing = _likeRecords[targetId];
           if (existing == null ||
               record.createdAt.isAfter(existing.createdAt)) {
-            _likeRecords[targetId] = record;
+            _indexLikeRecord(record);
             newRecords.add(record);
           }
         } else if (event.content == _downvoteContent) {
@@ -1073,7 +1286,7 @@ class LikesRepository {
 
       // Remove deleted likes from cache and storage
       for (final targetId in deletedTargetIds) {
-        _likeRecords.remove(targetId);
+        _deindexLikeRecord(targetId);
         await _localStorage?.deleteLikeRecord(targetId);
       }
 
@@ -1361,9 +1574,7 @@ class LikesRepository {
     // Load from local storage first for immediate UI display
     if (_localStorage != null) {
       final records = await _localStorage.getAllLikeRecords();
-      for (final record in records) {
-        _likeRecords[record.targetEventId] = record;
-      }
+      records.forEach(_indexLikeRecord);
       _emitLikedIds();
     }
 
@@ -1430,9 +1641,10 @@ class LikesRepository {
         targetEventId: targetId,
         reactionEventId: event.id,
         createdAt: createdAt,
+        addressableId: _extractAddressableId(event),
       );
 
-      _likeRecords[targetId] = record;
+      _indexLikeRecord(record);
       unawaited(_localStorage?.saveLikeRecord(record));
       _emitLikedIds();
     } else if (event.content == _downvoteContent) {
@@ -1449,9 +1661,52 @@ class LikesRepository {
     }
   }
 
-  void _decrementLikeCountCache(String eventId) {
-    final cached = _likeCountCache[eventId];
-    if (cached != null) _likeCountCache[eventId] = max(0, cached - 1);
+  void _decrementLikeCountCache(String eventId, {String? addressableId}) {
+    _adjustCachedLikeCount(eventId, -1, addressableId: addressableId);
+  }
+
+  /// Reads the cached like count, checking event-id first then the
+  /// addressable-id companion cache. Returns `null` on a full miss.
+  ///
+  /// Mirrors `comments_repository`'s `_readCachedCommentCount` (#4478),
+  /// applied to like counts (#6020's in-scope follow-up on #4478's own
+  /// suggested-but-unimplemented extension).
+  int? _readCachedLikeCount(String eventId, {String? addressableId}) {
+    final byEventId = _likeCountCache[eventId];
+    if (byEventId != null) return byEventId;
+    if (addressableId == null || addressableId.isEmpty) return null;
+    return _likeCountCacheByAddressableId[addressableId];
+  }
+
+  /// Writes [count] into both caches when [addressableId] is provided.
+  /// Otherwise writes only the event-id cache.
+  void _writeCachedLikeCount(
+    String eventId,
+    int count, {
+    String? addressableId,
+  }) {
+    _likeCountCache[eventId] = count;
+    if (addressableId != null && addressableId.isNotEmpty) {
+      _likeCountCacheByAddressableId[addressableId] = count;
+    }
+  }
+
+  /// Adjusts the cached like count by [delta] (clamped at zero), dual-
+  /// writing both caches. No-op if neither cache has a baseline value yet
+  /// — an isolated delta without a known total would lie.
+  void _adjustCachedLikeCount(
+    String eventId,
+    int delta, {
+    String? addressableId,
+  }) {
+    final current = _readCachedLikeCount(eventId, addressableId: addressableId);
+    if (current == null) return;
+    final updated = current + delta;
+    _writeCachedLikeCount(
+      eventId,
+      updated < 0 ? 0 : updated,
+      addressableId: addressableId,
+    );
   }
 
   /// Clear all local like data.
@@ -1463,8 +1718,10 @@ class LikesRepository {
   /// stream emission is attempted.
   Future<void> clearCache() async {
     _likeRecords.clear();
+    _likeRecordsByAddressableId.clear();
     _downvoteRecords.clear();
     _likeCountCache.clear();
+    _likeCountCacheByAddressableId.clear();
     await _localStorage?.clearAll();
     _emitLikedIds();
     _emitDownvotedIds();
@@ -1473,7 +1730,7 @@ class LikesRepository {
 
   /// Dispose of resources.
   ///
-  /// Cancels the reaction subscription and closes both stream controllers.
+  /// Cancels the reaction subscription and closes all stream controllers.
   /// Should be called when the repository is no longer needed.
   void dispose() {
     _isDisposed = true;
@@ -1483,6 +1740,7 @@ class LikesRepository {
       _reactionSubscriptionId = null;
     }
     unawaited(_likedIdsController.close());
+    unawaited(_likedAddressableIdsController.close());
     unawaited(_downvotedIdsController.close());
   }
 
@@ -1492,9 +1750,7 @@ class LikesRepository {
 
     if (_localStorage != null) {
       final records = await _localStorage.getAllLikeRecords();
-      for (final record in records) {
-        _likeRecords[record.targetEventId] = record;
-      }
+      records.forEach(_indexLikeRecord);
       _emitLikedIds();
     }
     _isInitialized = true;
@@ -1506,6 +1762,23 @@ class LikesRepository {
   String? _extractTargetEventId(Event event) {
     for (final tag in event.tags) {
       if (tag.isNotEmpty && tag[0] == 'e' && tag.length > 1) {
+        return tag[1];
+      }
+    }
+    return null;
+  }
+
+  /// Extracts the addressable coordinate from a reaction event's 'a' tag.
+  ///
+  /// Per NIP-25, an 'a' tag SHOULD be included together with the 'e' tag
+  /// when reacting to an addressable event, set to the `kind:pubkey:d-tag`
+  /// coordinate. Returns `null` when absent (e.g. reactions to non-
+  /// addressable targets like comments, or reactions published before this
+  /// tag was added). Used to keep own-like state resolvable by coordinate
+  /// across a target edit that mints a new event id (#6020).
+  String? _extractAddressableId(Event event) {
+    for (final tag in event.tags) {
+      if (tag.isNotEmpty && tag[0] == 'a' && tag.length > 1) {
         return tag[1];
       }
     }

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -537,11 +537,28 @@ class LikesRepository {
     String? addressableId,
     int? targetKind,
   }) async {
+    // Replay can race initialize(): both are fired unawaited at provider
+    // build, and the coordinate guard below is memory-only, so an empty
+    // cache would make it blind to a persisted cross-device reaction.
+    await _ensureInitialized();
+
     if (addressableId != null && addressableId.isNotEmpty) {
       final byCoordinate = _likeRecordsByAddressableId[addressableId];
       final ownReactionEventId = _likeRecords[eventId]?.reactionEventId;
       if (byCoordinate != null &&
           byCoordinate.reactionEventId != ownReactionEventId) {
+        if (ownReactionEventId != null &&
+            ownReactionEventId.startsWith('pending_')) {
+          // Drop the queued placeholder now that the coordinate reaction
+          // is authoritative; leaving it would make a later unlike resolve
+          // the placeholder by event id, skip the Kind 5 publish, and
+          // strand the real reaction live. NOT _deindexLikeRecord: the
+          // placeholder shares the coordinate, so deindexing by event id
+          // would evict the cross-device record from the coordinate index.
+          _likeRecords.remove(eventId);
+          await _localStorage?.deleteLikeRecord(eventId);
+          _emitLikedIds();
+        }
         return byCoordinate.reactionEventId;
       }
     }
@@ -1275,10 +1292,26 @@ class LikesRepository {
             addressableId: _extractAddressableId(event),
           );
 
-          // Only update if we don't have this record or the new one is newer
+          // Only update if we don't have this record or the new one is
+          // newer — except to backfill a missing coordinate. Rows persisted
+          // before the addressable_id column existed carry no coordinate,
+          // and the relay copy of the same reaction is never *newer*, so
+          // without the exemption they would stay coordinate-less forever
+          // (#6123). Restricted to the same reaction id: accepting a
+          // different (older) coordinate-bearing reaction would repoint the
+          // record at the wrong wire event, so unlike would delete the
+          // wrong reaction.
           final existing = _likeRecords[targetId];
+          final canBackfillCoordinate =
+              existing != null &&
+              existing.reactionEventId == record.reactionEventId &&
+              (existing.addressableId == null ||
+                  existing.addressableId!.isEmpty) &&
+              record.addressableId != null &&
+              record.addressableId!.isNotEmpty;
           if (existing == null ||
-              record.createdAt.isAfter(existing.createdAt)) {
+              record.createdAt.isAfter(existing.createdAt) ||
+              canBackfillCoordinate) {
             _indexLikeRecord(record);
             newRecords.add(record);
           }
@@ -1584,15 +1617,23 @@ class LikesRepository {
   /// Follows the same pattern as `FollowRepository.initialize()`:
   /// 1. Load persisted records from local storage for immediate UI display.
   /// 2. Set up a persistent Kind 7 subscription for live updates.
+  /// 3. When any loaded record predates the addressable_id column (null
+  ///    coordinate), run [syncUserReactions] to backfill coordinates from
+  ///    the relay reactions' `a` tags — otherwise likes made before the
+  ///    column shipped never resolve by coordinate after an edit (#6123).
   ///
   /// Safe to call multiple times (idempotent).
   Future<void> initialize() async {
     if (_isInitialized) return;
 
     // Load from local storage first for immediate UI display
+    var hasCoordinatelessRecords = false;
     if (_localStorage != null) {
       final records = await _localStorage.getAllLikeRecords();
       records.forEach(_indexLikeRecord);
+      hasCoordinatelessRecords = records.any(
+        (r) => r.addressableId == null || r.addressableId!.isEmpty,
+      );
       _emitLikedIds();
     }
 
@@ -1601,7 +1642,19 @@ class LikesRepository {
       _subscribeToReactions();
     }
 
+    // Flip the flag before the backfill sync so _ensureInitialized callers
+    // aren't blocked on a relay round-trip.
     _isInitialized = true;
+
+    if (hasCoordinatelessRecords && _nostrClient.hasKeys) {
+      try {
+        await syncUserReactions();
+      } on Exception catch (_) {
+        // Best-effort coordinate backfill; initialize() must not fail on
+        // relay errors. Records missing a coordinate on the wire (e.g.
+        // comment likes, which have no a tag) keep a null coordinate.
+      }
+    }
   }
 
   /// Subscribe to reactions for real-time sync and cross-device updates.

--- a/mobile/packages/likes_repository/lib/src/models/like_record.dart
+++ b/mobile/packages/likes_repository/lib/src/models/like_record.dart
@@ -18,6 +18,7 @@ class LikeRecord extends Equatable {
     required this.targetEventId,
     required this.reactionEventId,
     required this.createdAt,
+    this.addressableId,
   });
 
   /// The event ID that was liked (e.g., video event ID).
@@ -31,27 +32,43 @@ class LikeRecord extends Equatable {
   /// When the like was created.
   final DateTime createdAt;
 
+  /// Addressable coordinate (`kind:pubkey:d-tag`) of the target event, when
+  /// the target is a Kind 30000+ addressable event (e.g. a video).
+  ///
+  /// Null for likes on non-addressable targets (e.g. comments). Lets own-
+  /// like state resolve across a target edit that mints a new
+  /// [targetEventId] for the same coordinate (#6020).
+  final String? addressableId;
+
   /// Creates a copy of this record with the given fields replaced.
   LikeRecord copyWith({
     String? targetEventId,
     String? reactionEventId,
     DateTime? createdAt,
+    String? addressableId,
   }) {
     return LikeRecord(
       targetEventId: targetEventId ?? this.targetEventId,
       reactionEventId: reactionEventId ?? this.reactionEventId,
       createdAt: createdAt ?? this.createdAt,
+      addressableId: addressableId ?? this.addressableId,
     );
   }
 
   @override
-  List<Object?> get props => [targetEventId, reactionEventId, createdAt];
+  List<Object?> get props => [
+    targetEventId,
+    reactionEventId,
+    createdAt,
+    addressableId,
+  ];
 
   @override
   String toString() {
     return 'LikeRecord('
         'targetEventId: $targetEventId, '
         'reactionEventId: $reactionEventId, '
-        'createdAt: $createdAt)';
+        'createdAt: $createdAt, '
+        'addressableId: $addressableId)';
   }
 }

--- a/mobile/packages/likes_repository/pubspec.yaml
+++ b/mobile/packages/likes_repository/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
     path: ../unified_logger
 
 dev_dependencies:
+  drift: ^2.34.0
   mocktail: ^1.0.4
   test: ^1.26.3
   very_good_analysis: ^10.0.0

--- a/mobile/packages/likes_repository/test/src/db_likes_local_storage_test.dart
+++ b/mobile/packages/likes_repository/test/src/db_likes_local_storage_test.dart
@@ -89,6 +89,38 @@ void main() {
           ),
         ).called(1);
       });
+
+      test('passes addressableId through to dao.upsertReaction', () async {
+        when(
+          () => mockDao.upsertReaction(
+            targetEventId: any(named: 'targetEventId'),
+            reactionEventId: any(named: 'reactionEventId'),
+            userPubkey: any(named: 'userPubkey'),
+            createdAt: any(named: 'createdAt'),
+            addressableId: any(named: 'addressableId'),
+          ),
+        ).thenAnswer((_) async {});
+
+        const testAddressableId = '34236:$testUserPubkey:test-d-tag';
+        final record = LikeRecord(
+          targetEventId: testTargetEventId,
+          reactionEventId: testReactionEventId,
+          createdAt: DateTime.now(),
+          addressableId: testAddressableId,
+        );
+
+        await storage.saveLikeRecord(record);
+
+        verify(
+          () => mockDao.upsertReaction(
+            targetEventId: testTargetEventId,
+            reactionEventId: testReactionEventId,
+            userPubkey: testUserPubkey,
+            createdAt: any(named: 'createdAt'),
+            addressableId: testAddressableId,
+          ),
+        ).called(1);
+      });
     });
 
     group('saveLikeRecordsBatch', () {
@@ -206,6 +238,78 @@ void main() {
         ).thenAnswer((_) async => null);
 
         final result = await storage.getLikeRecord(testTargetEventId);
+
+        expect(result, isNull);
+      });
+
+      test('maps a row addressableId onto the returned LikeRecord', () async {
+        const testAddressableId = '34236:$testUserPubkey:test-d-tag';
+        final row = PersonalReactionRow(
+          targetEventId: testTargetEventId,
+          reactionEventId: testReactionEventId,
+          userPubkey: testUserPubkey,
+          createdAt: 1000,
+          addressableId: testAddressableId,
+        );
+
+        when(
+          () => mockDao.getReaction(
+            targetEventId: any(named: 'targetEventId'),
+            userPubkey: any(named: 'userPubkey'),
+          ),
+        ).thenAnswer((_) async => row);
+
+        final result = await storage.getLikeRecord(testTargetEventId);
+
+        expect(result!.addressableId, equals(testAddressableId));
+      });
+    });
+
+    group('getLikeRecordByAddressableId', () {
+      const testAddressableId = '34236:$testUserPubkey:test-d-tag';
+
+      test('returns LikeRecord when the coordinate is liked', () async {
+        final row = PersonalReactionRow(
+          targetEventId: testTargetEventId,
+          reactionEventId: testReactionEventId,
+          userPubkey: testUserPubkey,
+          createdAt: 1000,
+          addressableId: testAddressableId,
+        );
+
+        when(
+          () => mockDao.getReactionByAddressableId(
+            addressableId: any(named: 'addressableId'),
+            userPubkey: any(named: 'userPubkey'),
+          ),
+        ).thenAnswer((_) async => row);
+
+        final result = await storage.getLikeRecordByAddressableId(
+          testAddressableId,
+        );
+
+        expect(result, isNotNull);
+        expect(result!.targetEventId, equals(testTargetEventId));
+        expect(result.addressableId, equals(testAddressableId));
+        verify(
+          () => mockDao.getReactionByAddressableId(
+            addressableId: testAddressableId,
+            userPubkey: testUserPubkey,
+          ),
+        ).called(1);
+      });
+
+      test('returns null when the coordinate has never been liked', () async {
+        when(
+          () => mockDao.getReactionByAddressableId(
+            addressableId: any(named: 'addressableId'),
+            userPubkey: any(named: 'userPubkey'),
+          ),
+        ).thenAnswer((_) async => null);
+
+        final result = await storage.getLikeRecordByAddressableId(
+          testAddressableId,
+        );
 
         expect(result, isNull);
       });

--- a/mobile/packages/likes_repository/test/src/likes_repository_pre_column_db_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_pre_column_db_test.dart
@@ -1,0 +1,173 @@
+// ABOUTME: End-to-end regression test for #6020/#6123: a database from a
+// ABOUTME: build that pre-dates personal_reactions.addressable_id self-heals
+// ABOUTME: through the production initialize() path, and the backfilled
+// ABOUTME: coordinate survives an offline restart.
+
+import 'dart:io';
+
+import 'package:db_client/db_client.dart' hide Filter;
+import 'package:drift/native.dart';
+import 'package:likes_repository/likes_repository.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:test/test.dart';
+
+class MockNostrClient extends Mock implements NostrClient {}
+
+class MockEvent extends Mock implements Event {}
+
+void main() {
+  group('LikesRepository pre-column DB self-heal (#6020)', () {
+    late AppDatabase database;
+    late String tempDbPath;
+
+    const testUserPubkey =
+        '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+    const oldEditEventId =
+        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    const newEditEventId =
+        'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+    const reactionEventId =
+        'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+    const coordinate = '34236:$testUserPubkey:test-d-tag';
+    const reactionCreatedAt = 1700000000;
+
+    setUpAll(() {
+      registerFallbackValue(<Filter>[]);
+    });
+
+    setUp(() {
+      final tempDir = Directory.systemTemp.createTempSync(
+        'likes_repo_db_test_',
+      );
+      tempDbPath = '${tempDir.path}/test.db';
+      database = AppDatabase.test(NativeDatabase(File(tempDbPath)));
+    });
+
+    tearDown(() async {
+      await database.close();
+      final dir = File(tempDbPath).parent;
+      if (dir.existsSync()) {
+        dir.deleteSync(recursive: true);
+      }
+    });
+
+    MockEvent createReaction() {
+      final event = MockEvent();
+      when(() => event.id).thenReturn(reactionEventId);
+      when(() => event.pubkey).thenReturn(testUserPubkey);
+      when(() => event.kind).thenReturn(EventKind.reaction);
+      when(() => event.content).thenReturn('+');
+      when(() => event.createdAt).thenReturn(reactionCreatedAt);
+      when(() => event.tags).thenReturn([
+        ['e', oldEditEventId],
+        ['a', coordinate],
+      ]);
+      return event;
+    }
+
+    MockNostrClient createClient() {
+      final client = MockNostrClient();
+      when(() => client.publicKey).thenReturn(testUserPubkey);
+      when(() => client.hasKeys).thenReturn(true);
+      when(() => client.unsubscribe(any())).thenAnswer((_) async {});
+      when(
+        () => client.subscribe(
+          any(),
+          subscriptionId: any(named: 'subscriptionId'),
+        ),
+      ).thenAnswer((_) => const Stream<Event>.empty());
+      return client;
+    }
+
+    test(
+      'a pre-addressable_id-column database self-heals through initialize() '
+      'and the backfill survives an offline restart',
+      () async {
+        // 1. Legacy install: the like row exists, the addressable_id
+        // column does not (same recipe as db_client's upgrade-path test).
+        await database.personalReactionsDao.upsertReaction(
+          targetEventId: oldEditEventId,
+          reactionEventId: reactionEventId,
+          userPubkey: testUserPubkey,
+          createdAt: reactionCreatedAt,
+        );
+        await database.customStatement(
+          'DROP INDEX idx_personal_reactions_addressable_id',
+        );
+        await database.customStatement(
+          'ALTER TABLE personal_reactions DROP COLUMN addressable_id',
+        );
+        await database.close();
+
+        // 2. App upgrade: beforeOpen re-adds the column, null for the
+        // legacy row.
+        database = AppDatabase.test(NativeDatabase(File(tempDbPath)));
+
+        // 3. Cold start through the production init path only — never call
+        // syncUserReactions directly. The relay carries the same reaction
+        // with its `a` tag, at the same createdAt (never *newer*), so only
+        // the same-id backfill exemption can re-derive the coordinate.
+        final client = createClient();
+        var queryCall = 0;
+        when(() => client.queryEvents(any())).thenAnswer((_) async {
+          queryCall++;
+          return queryCall == 1 ? [createReaction()] : <Event>[];
+        });
+        final repository = LikesRepository(
+          nostrClient: client,
+          localStorage: DbLikesLocalStorage(
+            dao: database.personalReactionsDao,
+            userPubkey: testUserPubkey,
+          ),
+        );
+        await repository.initialize();
+
+        expect(
+          await repository.isLikedResolvingCoordinate(
+            eventId: newEditEventId,
+            addressableId: coordinate,
+          ),
+          isTrue,
+        );
+        repository.dispose();
+
+        // The backfill was persisted, not just cached in memory.
+        final persisted = await database.personalReactionsDao
+            .getReactionByAddressableId(
+              addressableId: coordinate,
+              userPubkey: testUserPubkey,
+            );
+        expect(persisted, isNotNull);
+        expect(persisted!.targetEventId, equals(oldEditEventId));
+
+        // 4. Offline restart over the same database: every row now has a
+        // coordinate, so initialize() skips the backfill sync entirely and
+        // the edited video still resolves as liked with no relay access.
+        final offlineClient = createClient();
+        when(
+          () => offlineClient.queryEvents(any()),
+        ).thenThrow(Exception('offline'));
+        final restarted = LikesRepository(
+          nostrClient: offlineClient,
+          localStorage: DbLikesLocalStorage(
+            dao: database.personalReactionsDao,
+            userPubkey: testUserPubkey,
+          ),
+        );
+        await restarted.initialize();
+
+        expect(
+          await restarted.isLikedResolvingCoordinate(
+            eventId: newEditEventId,
+            addressableId: coordinate,
+          ),
+          isTrue,
+        );
+        verifyNever(() => offlineClient.queryEvents(any()));
+        restarted.dispose();
+      },
+    );
+  });
+}

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -3149,6 +3149,86 @@ void main() {
         verify(() => mockLocalStorage.saveLikeRecord(any())).called(2);
       });
 
+      test(
+        // #6020: PendingActionService's own queue-time dedup only cancels
+        // opposite actions on the *same* event id — it has no visibility
+        // into a like that synced in from another device (under a
+        // different event id) for the same coordinate while this action
+        // sat in the offline queue. Without this guard, replay would
+        // publish a second, duplicate live reaction.
+        'reconciles to an already-synced coordinate reaction instead of '
+        'publishing a duplicate, when another device liked the same '
+        'coordinate while this action was queued',
+        () async {
+          const coordinate = '34236:$testAuthorPubkey:test-d-tag';
+          const otherDeviceReactionId = 'other_device_reaction_id';
+          const otherDeviceEventId = 'other_device_event_id';
+
+          when(
+            () => mockLocalStorage.saveLikeRecord(any()),
+          ).thenAnswer((_) async {});
+          when(
+            () => mockLocalStorage.saveLikeRecordsBatch(any()),
+          ).thenAnswer((_) async {});
+
+          // 1. Offline: queue a like for testEventId at this coordinate.
+          repository = LikesRepository(
+            nostrClient: mockNostrClient,
+            localStorage: mockLocalStorage,
+            isOnline: () => false,
+            queueOfflineAction:
+                ({
+                  required isLike,
+                  required eventId,
+                  required authorPubkey,
+                  addressableId,
+                  targetKind,
+                }) async {},
+          );
+          final placeholderId = await repository.likeEvent(
+            eventId: testEventId,
+            authorPubkey: testAuthorPubkey,
+            addressableId: coordinate,
+          );
+          expect(placeholderId, startsWith('pending_like_'));
+
+          // 2. While still queued, another device's like for the SAME
+          // coordinate (different event id, real reaction id) syncs in.
+          final otherDeviceReaction = createMockReaction(
+            id: otherDeviceReactionId,
+            targetEventId: otherDeviceEventId,
+            authorPubkey: testUserPubkey,
+            tags: [
+              ['e', otherDeviceEventId],
+              ['a', coordinate],
+            ],
+          );
+          mockQueryEventsSequence([
+            [otherDeviceReaction],
+            <Event>[],
+          ]);
+          await repository.syncUserReactions();
+
+          // 3. Sync replay executes the originally-queued action.
+          final resolvedId = await repository.executeLikeAction(
+            eventId: testEventId,
+            authorPubkey: testAuthorPubkey,
+            addressableId: coordinate,
+          );
+
+          expect(resolvedId, equals(otherDeviceReactionId));
+          verifyNever(
+            () => mockNostrClient.sendLike(
+              any(),
+              content: any(named: 'content'),
+              addressableId: any(named: 'addressableId'),
+              targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
+              targetKind: any(named: 'targetKind'),
+            ),
+          );
+        },
+      );
+
       test('throws LikeFailedException when publish fails', () async {
         when(
           () => mockNostrClient.sendLike(

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -30,10 +30,12 @@ void main() {
       String targetEventId = testEventId,
       String reactionEventId = testReactionEventId,
       DateTime? createdAt,
+      String? addressableId,
     }) => LikeRecord(
       targetEventId: targetEventId,
       reactionEventId: reactionEventId,
       createdAt: createdAt ?? DateTime.now(),
+      addressableId: addressableId,
     );
 
     // Helper to create a mock reaction event
@@ -115,6 +117,9 @@ void main() {
       ).thenAnswer((_) async => false);
       when(
         () => mockLocalStorage.getLikeRecord(any()),
+      ).thenAnswer((_) async => null);
+      when(
+        () => mockLocalStorage.getLikeRecordByAddressableId(any()),
       ).thenAnswer((_) async => null);
     });
 
@@ -3360,6 +3365,333 @@ void main() {
         final cached = await repository.getLikeCount(testEventId);
         expect(cached, equals(10));
       });
+    });
+
+    group('coordinate-aware own-like resolution (#6020)', () {
+      const oldEventId = 'old_event_id_1234567890abcdef';
+      const newEventId = 'new_event_id_1234567890abcdef';
+      const coordinate = '34236:$testAuthorPubkey:test-d-tag';
+
+      test(
+        'isLikedByCoordinate resolves true after syncUserReactions ingests '
+        'a reaction whose e tag is a different (old) id but whose a tag '
+        'matches',
+        () async {
+          final reaction = createMockReaction(
+            id: testReactionEventId,
+            targetEventId: oldEventId,
+            tags: [
+              ['e', oldEventId],
+              ['a', coordinate],
+            ],
+          );
+          mockQueryEventsSequence([
+            [reaction],
+            <Event>[],
+          ]);
+          when(
+            () => mockLocalStorage.saveLikeRecordsBatch(any()),
+          ).thenAnswer((_) async {});
+
+          repository = createRepository();
+          await repository.syncUserReactions();
+
+          // The new (post-edit) event id was never liked directly...
+          expect(await repository.isLiked(newEventId), isFalse);
+          // ...but the coordinate resolves true, and isLikedResolvingCoordinate
+          // (what VideoInteractionsBloc calls) composes the two correctly.
+          expect(await repository.isLikedByCoordinate(coordinate), isTrue);
+          expect(
+            await repository.isLikedResolvingCoordinate(
+              eventId: newEventId,
+              addressableId: coordinate,
+            ),
+            isTrue,
+          );
+        },
+      );
+
+      test(
+        'getLikeRecordByCoordinate returns the reactionEventId needed for '
+        'unlike resolution',
+        () async {
+          final reaction = createMockReaction(
+            id: testReactionEventId,
+            targetEventId: oldEventId,
+            tags: [
+              ['e', oldEventId],
+              ['a', coordinate],
+            ],
+          );
+          mockQueryEventsSequence([
+            [reaction],
+            <Event>[],
+          ]);
+          when(
+            () => mockLocalStorage.saveLikeRecordsBatch(any()),
+          ).thenAnswer((_) async {});
+
+          repository = createRepository();
+          await repository.syncUserReactions();
+
+          final record = await repository.getLikeRecordByCoordinate(
+            coordinate,
+          );
+          expect(record, isNotNull);
+          expect(record!.targetEventId, equals(oldEventId));
+          expect(record.reactionEventId, equals(testReactionEventId));
+        },
+      );
+
+      test('clearCache wipes the addressable-id companion cache too', () async {
+        final reaction = createMockReaction(
+          id: testReactionEventId,
+          targetEventId: oldEventId,
+          tags: [
+            ['e', oldEventId],
+            ['a', coordinate],
+          ],
+        );
+        mockQueryEventsSequence([
+          [reaction],
+          <Event>[],
+        ]);
+        when(
+          () => mockLocalStorage.saveLikeRecordsBatch(any()),
+        ).thenAnswer((_) async {});
+        when(() => mockLocalStorage.clearAll()).thenAnswer((_) async {});
+
+        repository = createRepository();
+        await repository.syncUserReactions();
+        expect(await repository.isLikedByCoordinate(coordinate), isTrue);
+
+        await repository.clearCache();
+
+        expect(await repository.isLikedByCoordinate(coordinate), isFalse);
+      });
+
+      test(
+        'cold start resolves isLikedByCoordinate from persisted storage '
+        'alone, without any relay call (beats #4478s warm-cache-only limit)',
+        () async {
+          when(() => mockLocalStorage.getAllLikeRecords()).thenAnswer(
+            (_) async => [
+              createLikeRecord(
+                targetEventId: oldEventId,
+                addressableId: coordinate,
+              ),
+            ],
+          );
+
+          repository = createRepository();
+          // initialize() loads from local storage only; no relay query is
+          // stubbed for reactions/deletions, so a relay round-trip here
+          // would surface as a Mocktail MissingStubError.
+          await repository.initialize();
+
+          expect(
+            await repository.isLikedResolvingCoordinate(
+              eventId: newEventId,
+              addressableId: coordinate,
+            ),
+            isTrue,
+          );
+        },
+      );
+    });
+
+    group('duplicate-reaction guard (#6020)', () {
+      const oldEventId = 'old_event_id_1234567890abcdef';
+      const newEventId = 'new_event_id_1234567890abcdef';
+      const coordinate = '34236:$testAuthorPubkey:test-d-tag';
+
+      test(
+        'likeEvent throws AlreadyLikedException when the coordinate is '
+        'already liked under a different event id',
+        () async {
+          when(() => mockLocalStorage.getAllLikeRecords()).thenAnswer(
+            (_) async => [
+              createLikeRecord(
+                targetEventId: oldEventId,
+                addressableId: coordinate,
+              ),
+            ],
+          );
+
+          repository = createRepository();
+          await repository.initialize();
+
+          expect(
+            () => repository.likeEvent(
+              eventId: newEventId,
+              authorPubkey: testAuthorPubkey,
+              addressableId: coordinate,
+            ),
+            throwsA(isA<AlreadyLikedException>()),
+          );
+        },
+      );
+
+      test(
+        'toggleLike treats the coordinate as currently liked and unlikes '
+        'the original reaction rather than creating a duplicate',
+        () async {
+          when(() => mockLocalStorage.getAllLikeRecords()).thenAnswer(
+            (_) async => [
+              createLikeRecord(
+                targetEventId: oldEventId,
+                addressableId: coordinate,
+              ),
+            ],
+          );
+          when(
+            () => mockNostrClient.deleteEvent(testReactionEventId),
+          ).thenAnswer((_) async => MockEvent());
+          when(
+            () => mockLocalStorage.deleteLikeRecord(oldEventId),
+          ).thenAnswer((_) async => true);
+
+          repository = createRepository();
+          await repository.initialize();
+
+          final isNowLiked = await repository.toggleLike(
+            eventId: newEventId,
+            authorPubkey: testAuthorPubkey,
+            addressableId: coordinate,
+          );
+
+          expect(isNowLiked, isFalse);
+          verifyNever(
+            () => mockNostrClient.sendLike(
+              any(),
+              content: any(named: 'content'),
+              addressableId: any(named: 'addressableId'),
+              targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
+              targetKind: any(named: 'targetKind'),
+            ),
+          );
+          verify(
+            () => mockNostrClient.deleteEvent(testReactionEventId),
+          ).called(1);
+        },
+      );
+    });
+
+    group('unlikeEvent resolves by coordinate (#6020)', () {
+      const oldEventId = 'old_event_id_1234567890abcdef';
+      const newEventId = 'new_event_id_1234567890abcdef';
+      const coordinate = '34236:$testAuthorPubkey:test-d-tag';
+
+      test(
+        'unlikeEvent(newEventId, addressableId: coordinate) deletes the '
+        'reaction recorded under oldEventId',
+        () async {
+          when(() => mockLocalStorage.getAllLikeRecords()).thenAnswer(
+            (_) async => [
+              createLikeRecord(
+                targetEventId: oldEventId,
+                addressableId: coordinate,
+              ),
+            ],
+          );
+          when(
+            () => mockNostrClient.deleteEvent(testReactionEventId),
+          ).thenAnswer((_) async => MockEvent());
+          when(
+            () => mockLocalStorage.deleteLikeRecord(oldEventId),
+          ).thenAnswer((_) async => true);
+
+          repository = createRepository();
+          await repository.initialize();
+
+          await repository.unlikeEvent(newEventId, addressableId: coordinate);
+
+          verify(
+            () => mockNostrClient.deleteEvent(testReactionEventId),
+          ).called(1);
+          verify(
+            () => mockLocalStorage.deleteLikeRecord(oldEventId),
+          ).called(1);
+          expect(await repository.isLikedByCoordinate(coordinate), isFalse);
+          expect(await repository.isLiked(oldEventId), isFalse);
+        },
+      );
+
+      test(
+        'unlikeEvent falls back to local storage by coordinate when '
+        'neither the memory cache nor a direct database lookup by event id '
+        'has the record',
+        () async {
+          when(
+            () => mockLocalStorage.getLikeRecordByAddressableId(coordinate),
+          ).thenAnswer(
+            (_) async => createLikeRecord(
+              targetEventId: oldEventId,
+              addressableId: coordinate,
+            ),
+          );
+          when(
+            () => mockNostrClient.deleteEvent(testReactionEventId),
+          ).thenAnswer((_) async => MockEvent());
+          when(
+            () => mockLocalStorage.deleteLikeRecord(oldEventId),
+          ).thenAnswer((_) async => true);
+
+          repository = createRepository();
+
+          await repository.unlikeEvent(newEventId, addressableId: coordinate);
+
+          verify(
+            () => mockLocalStorage.getLikeRecordByAddressableId(coordinate),
+          ).called(1);
+          verify(
+            () => mockNostrClient.deleteEvent(testReactionEventId),
+          ).called(1);
+        },
+      );
+    });
+
+    group('like count cache dual-key (#6020)', () {
+      const oldEventId = 'old_event_id_1234567890abcdef';
+      const newEventId = 'new_event_id_1234567890abcdef';
+      const coordinate = '34236:$testAuthorPubkey:test-d-tag';
+
+      test(
+        'a count cached under the old event id resolves for the new event '
+        'id via the coordinate, without an extra relay query',
+        () async {
+          final reaction = createMockReaction(
+            id: 'liker_reaction',
+            targetEventId: oldEventId,
+            authorPubkey: 'some_liker_pubkey_1234567890abcdef',
+            tags: [
+              ['a', coordinate],
+            ],
+          );
+          mockQueryEventsSequence([
+            [reaction], // e-filter query for oldEventId
+            [reaction], // a-filter query for coordinate
+            <Event>[], // deletion-scoped query
+          ]);
+
+          repository = createRepository();
+          final firstCount = await repository.getLikeCount(
+            oldEventId,
+            addressableId: coordinate,
+          );
+          expect(firstCount, equals(1));
+
+          // Same coordinate, new (post-edit) event id — should be served
+          // from the addressable-id companion cache, not a fresh query.
+          final secondCount = await repository.getLikeCount(
+            newEventId,
+            addressableId: coordinate,
+          );
+          expect(secondCount, equals(1));
+
+          verify(() => mockNostrClient.queryEvents(any())).called(3);
+        },
+      );
     });
   });
 }

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -2236,6 +2236,131 @@ void main() {
 
         expect(result.eventIdToReactionId[targetId], equals(newerReactionId));
       });
+
+      // #6123: rows persisted before the addressable_id column existed
+      // carry no coordinate, and the relay copy of the same reaction is
+      // never *newer*, so the freshness guard alone would skip it and the
+      // coordinate would stay null forever.
+      test(
+        'backfills addressableId onto a stored record when the relay copy '
+        'of the same reaction is same-age but carries a coordinate the '
+        'stored record lacks',
+        () async {
+          const oldEventId = 'old_event_id_1234567890abcdef';
+          const newEventId = 'new_edit_event_id_1234567890abcdef';
+          const reactionId = 'reaction_event_id_1234567890abcdef';
+          const coordinate = '34236:$testAuthorPubkey:test-d-tag';
+
+          // Persisted pre-migration row: no addressableId, same instant as
+          // the relay reaction (so createdAt.isAfter is false).
+          when(() => mockLocalStorage.getAllLikeRecords()).thenAnswer(
+            (_) async => [
+              createLikeRecord(
+                targetEventId: oldEventId,
+                reactionEventId: reactionId,
+                createdAt: DateTime.fromMillisecondsSinceEpoch(
+                  defaultTimestamp * 1000,
+                ),
+              ),
+            ],
+          );
+          final relayReaction = createMockReaction(
+            id: reactionId,
+            targetEventId: oldEventId,
+            authorPubkey: testUserPubkey,
+            tags: [
+              ['e', oldEventId],
+              ['a', coordinate],
+            ],
+          );
+          mockQueryEventsSequence([
+            [relayReaction],
+            <Event>[],
+          ]);
+          when(
+            () => mockLocalStorage.saveLikeRecordsBatch(any()),
+          ).thenAnswer((_) async {});
+
+          repository = createRepository();
+          await repository.syncUserReactions();
+
+          expect(
+            await repository.isLikedResolvingCoordinate(
+              eventId: newEventId,
+              addressableId: coordinate,
+            ),
+            isTrue,
+          );
+          verify(
+            () => mockLocalStorage.saveLikeRecordsBatch(
+              any(
+                that: contains(
+                  isA<LikeRecord>()
+                      .having(
+                        (r) => r.targetEventId,
+                        'targetEventId',
+                        oldEventId,
+                      )
+                      .having(
+                        (r) => r.addressableId,
+                        'addressableId',
+                        coordinate,
+                      ),
+                ),
+              ),
+            ),
+          ).called(1);
+        },
+      );
+
+      // #6123: the backfill exemption must not repoint a stored record at a
+      // *different* (older) reaction just because that reaction carries a
+      // coordinate — unlike would then delete the wrong wire event.
+      test(
+        'does not replace a stored newer coordinate-less record with a '
+        'different older reaction that carries a coordinate',
+        () async {
+          const targetId = 'target_event_1234567890abcdef';
+          const newerReactionId = 'newer_reaction_1234567890abcdef';
+          const olderReactionId = 'older_reaction_1234567890abcdef';
+          const coordinate = '34236:$testAuthorPubkey:test-d-tag';
+
+          when(() => mockLocalStorage.getAllLikeRecords()).thenAnswer(
+            (_) async => [
+              createLikeRecord(
+                targetEventId: targetId,
+                reactionEventId: newerReactionId,
+                createdAt: DateTime.fromMillisecondsSinceEpoch(
+                  (defaultTimestamp + 100) * 1000,
+                ),
+              ),
+            ],
+          );
+          final olderRelayReaction = createMockReaction(
+            id: olderReactionId,
+            targetEventId: targetId,
+            authorPubkey: testUserPubkey,
+            tags: [
+              ['e', targetId],
+              ['a', coordinate],
+            ],
+          );
+          mockQueryEventsSequence([
+            [olderRelayReaction],
+            <Event>[],
+          ]);
+
+          repository = createRepository();
+          final result = await repository.syncUserReactions();
+
+          expect(
+            result.eventIdToReactionId[targetId],
+            equals(newerReactionId),
+          );
+          expect(await repository.isLikedByCoordinate(coordinate), isFalse);
+          verifyNever(() => mockLocalStorage.saveLikeRecordsBatch(any()));
+        },
+      );
     });
 
     group('fetchUserLikes', () {
@@ -2836,6 +2961,119 @@ void main() {
 
         verify(() => mockLocalStorage.getAllLikeRecords()).called(1);
       });
+
+      // #6123: likes persisted before the addressable_id column shipped
+      // must self-heal at startup — waiting for a Liked Videos visit
+      // leaves every pre-existing like carrying bug #6020.
+      test(
+        'backfills coordinates via syncUserReactions when a loaded record '
+        'lacks an addressableId',
+        () async {
+          const oldEventId = 'old_event_id_1234567890abcdef';
+          const newEventId = 'new_edit_event_id_1234567890abcdef';
+          const reactionId = 'reaction_event_id_1234567890abcdef';
+          const coordinate = '34236:$testAuthorPubkey:test-d-tag';
+
+          when(() => mockNostrClient.hasKeys).thenReturn(true);
+          when(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+            ),
+          ).thenAnswer((_) => const Stream.empty());
+          when(() => mockLocalStorage.getAllLikeRecords()).thenAnswer(
+            (_) async => [
+              createLikeRecord(
+                targetEventId: oldEventId,
+                reactionEventId: reactionId,
+                createdAt: DateTime.fromMillisecondsSinceEpoch(
+                  defaultTimestamp * 1000,
+                ),
+              ),
+            ],
+          );
+          final relayReaction = createMockReaction(
+            id: reactionId,
+            targetEventId: oldEventId,
+            authorPubkey: testUserPubkey,
+            tags: [
+              ['e', oldEventId],
+              ['a', coordinate],
+            ],
+          );
+          mockQueryEventsSequence([
+            [relayReaction],
+            <Event>[],
+          ]);
+          when(
+            () => mockLocalStorage.saveLikeRecordsBatch(any()),
+          ).thenAnswer((_) async {});
+
+          repository = createRepository();
+          await repository.initialize();
+
+          verify(() => mockNostrClient.queryEvents(any())).called(2);
+          expect(
+            await repository.isLikedResolvingCoordinate(
+              eventId: newEventId,
+              addressableId: coordinate,
+            ),
+            isTrue,
+          );
+        },
+      );
+
+      test(
+        'skips the backfill sync when every loaded record already has a '
+        'coordinate',
+        () async {
+          when(() => mockNostrClient.hasKeys).thenReturn(true);
+          when(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+            ),
+          ).thenAnswer((_) => const Stream.empty());
+          when(() => mockLocalStorage.getAllLikeRecords()).thenAnswer(
+            (_) async => [
+              createLikeRecord(
+                addressableId: '34236:$testAuthorPubkey:test-d-tag',
+              ),
+            ],
+          );
+
+          repository = createRepository();
+          await repository.initialize();
+
+          verifyNever(() => mockNostrClient.queryEvents(any()));
+        },
+      );
+
+      test(
+        'completes and keeps local state when the backfill sync fails',
+        () async {
+          const oldEventId = 'old_event_id_1234567890abcdef';
+
+          when(() => mockNostrClient.hasKeys).thenReturn(true);
+          when(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+            ),
+          ).thenAnswer((_) => const Stream.empty());
+          when(() => mockLocalStorage.getAllLikeRecords()).thenAnswer(
+            (_) async => [createLikeRecord(targetEventId: oldEventId)],
+          );
+          when(
+            () => mockNostrClient.queryEvents(any()),
+          ).thenThrow(Exception('offline'));
+
+          repository = createRepository();
+          await repository.initialize();
+
+          expect(await repository.isLiked(oldEventId), isTrue);
+        },
+      );
     });
 
     group('real-time sync', () {
@@ -3170,6 +3408,9 @@ void main() {
           when(
             () => mockLocalStorage.saveLikeRecordsBatch(any()),
           ).thenAnswer((_) async {});
+          when(
+            () => mockLocalStorage.deleteLikeRecord(any()),
+          ).thenAnswer((_) async => true);
 
           // 1. Offline: queue a like for testEventId at this coordinate.
           repository = LikesRepository(
@@ -3226,6 +3467,113 @@ void main() {
               targetKind: any(named: 'targetKind'),
             ),
           );
+        },
+      );
+
+      test(
+        // #6123 review: without dropping the pending_ placeholder while
+        // reconciling, a later unlike resolves the placeholder by event id
+        // first, hits the pending_ short-circuit, and never deletes the
+        // live cross-device reaction — stranding it un-deletable.
+        'drops the queued placeholder when reconciling to a cross-device '
+        'coordinate reaction, so a later unlike deletes that reaction and '
+        'clears both lookups',
+        () async {
+          const coordinate = '34236:$testAuthorPubkey:test-d-tag';
+          const otherDeviceReactionId = 'other_device_reaction_id';
+          const otherDeviceEventId = 'other_device_event_id';
+
+          when(
+            () => mockLocalStorage.saveLikeRecord(any()),
+          ).thenAnswer((_) async {});
+          when(
+            () => mockLocalStorage.saveLikeRecordsBatch(any()),
+          ).thenAnswer((_) async {});
+          when(
+            () => mockLocalStorage.deleteLikeRecord(any()),
+          ).thenAnswer((_) async => true);
+          when(
+            () => mockNostrClient.deleteEvent(any()),
+          ).thenAnswer(
+            (_) async => createMockDeletion([otherDeviceReactionId]),
+          );
+
+          // 1. Offline: queue a like for testEventId at this coordinate.
+          var online = false;
+          repository = LikesRepository(
+            nostrClient: mockNostrClient,
+            localStorage: mockLocalStorage,
+            isOnline: () => online,
+            queueOfflineAction:
+                ({
+                  required isLike,
+                  required eventId,
+                  required authorPubkey,
+                  addressableId,
+                  targetKind,
+                }) async {},
+          );
+          await repository.likeEvent(
+            eventId: testEventId,
+            authorPubkey: testAuthorPubkey,
+            addressableId: coordinate,
+          );
+
+          // 2. While queued, another device's like for the SAME coordinate
+          // (different event id, real reaction id) syncs in.
+          final otherDeviceReaction = createMockReaction(
+            id: otherDeviceReactionId,
+            targetEventId: otherDeviceEventId,
+            authorPubkey: testUserPubkey,
+            tags: [
+              ['e', otherDeviceEventId],
+              ['a', coordinate],
+            ],
+          );
+          mockQueryEventsSequence([
+            [otherDeviceReaction],
+            <Event>[],
+          ]);
+          await repository.syncUserReactions();
+
+          // 3. Back online: replay reconciles, then the user unlikes.
+          online = true;
+          final resolvedId = await repository.executeLikeAction(
+            eventId: testEventId,
+            authorPubkey: testAuthorPubkey,
+            addressableId: coordinate,
+          );
+          await repository.unlikeEvent(testEventId, addressableId: coordinate);
+
+          expect(resolvedId, equals(otherDeviceReactionId));
+          verifyNever(
+            () => mockNostrClient.sendLike(
+              any(),
+              content: any(named: 'content'),
+              addressableId: any(named: 'addressableId'),
+              targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
+              targetKind: any(named: 'targetKind'),
+            ),
+          );
+          // Reconcile dropped the placeholder row; unlike removed the real
+          // record and published Kind 5 for the real reaction.
+          verify(
+            () => mockLocalStorage.deleteLikeRecord(testEventId),
+          ).called(1);
+          verify(
+            () => mockLocalStorage.deleteLikeRecord(otherDeviceEventId),
+          ).called(1);
+          verify(
+            () => mockNostrClient.deleteEvent(otherDeviceReactionId),
+          ).called(1);
+          expect(
+            await repository.isLikedResolvingCoordinate(
+              eventId: testEventId,
+              addressableId: coordinate,
+            ),
+            isFalse,
+          );
+          expect(await repository.isLiked(otherDeviceEventId), isFalse);
         },
       );
 

--- a/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
+++ b/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
@@ -35,6 +35,7 @@ void main() {
     late _MockCommentsRepository mockCommentsRepository;
     late _MockRepostsRepository mockRepostsRepository;
     late StreamController<List<String>> likedIdsController;
+    late StreamController<Set<String>> likedAddressableIdsController;
     late StreamController<Set<String>> repostedIdsController;
 
     const testEventId = 'test-event-id';
@@ -46,12 +47,18 @@ void main() {
       mockCommentsRepository = _MockCommentsRepository();
       mockRepostsRepository = _MockRepostsRepository();
       likedIdsController = StreamController<List<String>>.broadcast();
+      likedAddressableIdsController = StreamController<Set<String>>.broadcast();
       repostedIdsController = StreamController<Set<String>>.broadcast();
 
       // Default stub for watchLikedEventIds
       when(
         () => mockLikesRepository.watchLikedEventIds(),
       ).thenAnswer((_) => likedIdsController.stream);
+
+      // Default stub for watchLikedAddressableIds
+      when(
+        () => mockLikesRepository.watchLikedAddressableIds(),
+      ).thenAnswer((_) => likedAddressableIdsController.stream);
 
       // Default stub for watchRepostedAddressableIds
       when(
@@ -66,6 +73,7 @@ void main() {
 
     tearDown(() {
       likedIdsController.close();
+      likedAddressableIdsController.close();
       repostedIdsController.close();
     });
 
@@ -116,7 +124,9 @@ void main() {
         'emits [loading, success] with fetched data when all calls succeed',
         setUp: () {
           when(
-            () => mockLikesRepository.isLiked(testEventId),
+            () => mockLikesRepository.isLikedResolvingCoordinate(
+              eventId: testEventId,
+            ),
           ).thenAnswer((_) async => true);
           when(
             () => mockLikesRepository.getLikeCount(testEventId),
@@ -151,7 +161,10 @@ void main() {
         'comments and reposts keep their seed',
         setUp: () {
           when(
-            () => mockLikesRepository.isLiked(testEventId),
+            () => mockLikesRepository.isLikedResolvingCoordinate(
+              eventId: testEventId,
+              addressableId: testAddressableId,
+            ),
           ).thenAnswer((_) async => false);
           when(
             () => mockRepostsRepository.isReposted(testAddressableId),
@@ -203,7 +216,9 @@ void main() {
         'fetches relay like count but preserves seeded initialLikeCount',
         setUp: () {
           when(
-            () => mockLikesRepository.isLiked(testEventId),
+            () => mockLikesRepository.isLikedResolvingCoordinate(
+              eventId: testEventId,
+            ),
           ).thenAnswer((_) async => true);
           // Relay returns a higher count than the seeded REST value, simulating
           // the common case where new likes arrived after the REST snapshot.
@@ -247,7 +262,10 @@ void main() {
         'exceeds the seed (#6022)',
         setUp: () {
           when(
-            () => mockLikesRepository.isLiked(testEventId),
+            () => mockLikesRepository.isLikedResolvingCoordinate(
+              eventId: testEventId,
+              addressableId: testAddressableId,
+            ),
           ).thenAnswer((_) async => false);
           when(
             () => mockRepostsRepository.isReposted(testAddressableId),
@@ -300,7 +318,10 @@ void main() {
         'raises a zero addressable seed to the relay resolve (#6022)',
         setUp: () {
           when(
-            () => mockLikesRepository.isLiked(testEventId),
+            () => mockLikesRepository.isLikedResolvingCoordinate(
+              eventId: testEventId,
+              addressableId: testAddressableId,
+            ),
           ).thenAnswer((_) async => false);
           when(
             () => mockRepostsRepository.isReposted(testAddressableId),
@@ -347,7 +368,10 @@ void main() {
         'resolved Nostr likes (#6022)',
         setUp: () {
           when(
-            () => mockLikesRepository.isLiked(testEventId),
+            () => mockLikesRepository.isLikedResolvingCoordinate(
+              eventId: testEventId,
+              addressableId: testAddressableId,
+            ),
           ).thenAnswer((_) async => false);
           when(
             () => mockRepostsRepository.isReposted(testAddressableId),
@@ -396,7 +420,10 @@ void main() {
         'never lowers an addressable seed below the relay resolve (#6022)',
         setUp: () {
           when(
-            () => mockLikesRepository.isLiked(testEventId),
+            () => mockLikesRepository.isLikedResolvingCoordinate(
+              eventId: testEventId,
+              addressableId: testAddressableId,
+            ),
           ).thenAnswer((_) async => false);
           when(
             () => mockRepostsRepository.isReposted(testAddressableId),
@@ -446,7 +473,10 @@ void main() {
         'addressable videos (regression for #4432)',
         setUp: () {
           when(
-            () => mockLikesRepository.isLiked(testEventId),
+            () => mockLikesRepository.isLikedResolvingCoordinate(
+              eventId: testEventId,
+              addressableId: testAddressableId,
+            ),
           ).thenAnswer((_) async => false);
           when(
             () => mockRepostsRepository.isReposted(testAddressableId),
@@ -492,7 +522,9 @@ void main() {
         'videos',
         setUp: () {
           when(
-            () => mockLikesRepository.isLiked(testEventId),
+            () => mockLikesRepository.isLikedResolvingCoordinate(
+              eventId: testEventId,
+            ),
           ).thenAnswer((_) async => false);
           when(
             () => mockLikesRepository.getLikeCount(testEventId),
@@ -524,7 +556,9 @@ void main() {
         'emits [loading, success] when video is not liked',
         setUp: () {
           when(
-            () => mockLikesRepository.isLiked(testEventId),
+            () => mockLikesRepository.isLikedResolvingCoordinate(
+              eventId: testEventId,
+            ),
           ).thenAnswer((_) async => false);
           when(
             () => mockLikesRepository.getLikeCount(testEventId),
@@ -554,7 +588,10 @@ void main() {
         'videos',
         setUp: () {
           when(
-            () => mockLikesRepository.isLiked(testEventId),
+            () => mockLikesRepository.isLikedResolvingCoordinate(
+              eventId: testEventId,
+              addressableId: testAddressableId,
+            ),
           ).thenAnswer((_) async => false);
           when(
             () => mockRepostsRepository.isReposted(testAddressableId),
@@ -607,10 +644,69 @@ void main() {
       );
 
       blocTest<VideoInteractionsBloc, VideoInteractionsState>(
+        // #6020: after a video edit, the bloc is reconstructed with the new
+        // (post-edit) event id but the same addressable coordinate. A like
+        // recorded against the pre-edit event id must still fill the heart
+        // — the bloc composes eventId + addressableId into a single
+        // isLikedResolvingCoordinate call and trusts the repository to
+        // resolve it, rather than checking isLiked(eventId) alone.
+        'heart stays filled when the event id changed after an edit but '
+        'the coordinate was already liked (#6020)',
+        setUp: () {
+          when(
+            () => mockLikesRepository.isLikedResolvingCoordinate(
+              eventId: testEventId,
+              addressableId: testAddressableId,
+            ),
+          ).thenAnswer((_) async => true);
+          when(
+            () => mockRepostsRepository.isReposted(testAddressableId),
+          ).thenAnswer((_) async => false);
+          when(
+            () => mockLikesRepository.getLikeCount(
+              testEventId,
+              addressableId: testAddressableId,
+            ),
+          ).thenAnswer((_) async => 10);
+          when(
+            () => mockCommentsRepository.getCommentsCount(
+              testEventId,
+              rootAddressableId: testAddressableId,
+            ),
+          ).thenAnswer((_) async => 5);
+          when(
+            () => mockRepostsRepository.getRepostCount(testAddressableId),
+          ).thenAnswer((_) async => 3);
+        },
+        build: () => createBloc(addressableId: testAddressableId),
+        act: (bloc) => bloc.add(const VideoInteractionsFetchRequested()),
+        expect: () => [
+          const VideoInteractionsState(status: VideoInteractionsStatus.loading),
+          const VideoInteractionsState(
+            status: VideoInteractionsStatus.success,
+            isLiked: true,
+            likeCount: 10,
+            repostCount: 3,
+            commentCount: 5,
+          ),
+        ],
+        verify: (_) {
+          verify(
+            () => mockLikesRepository.isLikedResolvingCoordinate(
+              eventId: testEventId,
+              addressableId: testAddressableId,
+            ),
+          ).called(1);
+        },
+      );
+
+      blocTest<VideoInteractionsBloc, VideoInteractionsState>(
         'fetches repost count by event ID for non-addressable videos',
         setUp: () {
           when(
-            () => mockLikesRepository.isLiked(testEventId),
+            () => mockLikesRepository.isLikedResolvingCoordinate(
+              eventId: testEventId,
+            ),
           ).thenAnswer((_) async => false);
           when(
             () => mockLikesRepository.getLikeCount(testEventId),
@@ -646,7 +742,9 @@ void main() {
         'emits [loading, success] and reports addError when fetch fails',
         setUp: () {
           when(
-            () => mockLikesRepository.isLiked(testEventId),
+            () => mockLikesRepository.isLikedResolvingCoordinate(
+              eventId: testEventId,
+            ),
           ).thenThrow(Exception('Network error'));
         },
         build: createBloc,
@@ -662,7 +760,9 @@ void main() {
         'does not re-fetch when already loading',
         setUp: () {
           when(
-            () => mockLikesRepository.isLiked(testEventId),
+            () => mockLikesRepository.isLikedResolvingCoordinate(
+              eventId: testEventId,
+            ),
           ).thenAnswer((_) async => true);
           when(
             () => mockLikesRepository.getLikeCount(testEventId),
@@ -678,7 +778,12 @@ void main() {
         act: (bloc) => bloc.add(const VideoInteractionsFetchRequested()),
         expect: () => <VideoInteractionsState>[],
         verify: (_) {
-          verifyNever(() => mockLikesRepository.isLiked(any()));
+          verifyNever(
+            () => mockLikesRepository.isLikedResolvingCoordinate(
+              eventId: any(named: 'eventId'),
+              addressableId: any(named: 'addressableId'),
+            ),
+          );
         },
       );
 
@@ -686,7 +791,9 @@ void main() {
         'does not re-fetch when already loaded successfully',
         setUp: () {
           when(
-            () => mockLikesRepository.isLiked(testEventId),
+            () => mockLikesRepository.isLikedResolvingCoordinate(
+              eventId: testEventId,
+            ),
           ).thenAnswer((_) async => true);
           when(
             () => mockLikesRepository.getLikeCount(testEventId),
@@ -702,7 +809,12 @@ void main() {
         act: (bloc) => bloc.add(const VideoInteractionsFetchRequested()),
         expect: () => <VideoInteractionsState>[],
         verify: (_) {
-          verifyNever(() => mockLikesRepository.isLiked(any()));
+          verifyNever(
+            () => mockLikesRepository.isLikedResolvingCoordinate(
+              eventId: any(named: 'eventId'),
+              addressableId: any(named: 'addressableId'),
+            ),
+          );
         },
       );
 
@@ -716,7 +828,9 @@ void main() {
           commentsCountCompleter = Completer<int>();
           // Pre-fetch repository state: not liked, count from initial seed.
           when(
-            () => mockLikesRepository.isLiked(testEventId),
+            () => mockLikesRepository.isLikedResolvingCoordinate(
+              eventId: testEventId,
+            ),
           ).thenAnswer((_) async => false);
           // getLikeCount is now always queried (relay-fresh path). Return the
           // same value as the seed so the mid-fetch optimistic-toggle
@@ -1682,6 +1796,39 @@ void main() {
           likedIdsController.add([testEventId]);
         },
         wait: const Duration(milliseconds: 100),
+        expect: () => <VideoInteractionsState>[],
+      );
+
+      blocTest<VideoInteractionsBloc, VideoInteractionsState>(
+        // #6020 regression: watchLikedEventIds ticks on EVERY like/unlike
+        // anywhere in the app, not just this video. Before the fix, that
+        // stream alone drove isLiked, so a coordinate-only hit (the
+        // underlying reaction is recorded against a pre-edit event id) got
+        // silently flipped back to unliked the next time anything else was
+        // liked/unliked — because likedIds.contains(_eventId) was false and
+        // didn't know about the coordinate. This pins that liked-via-
+        // coordinate state survives an unrelated watchLikedEventIds tick.
+        'liked-via-coordinate state survives an unrelated '
+        'watchLikedEventIds tick elsewhere in the app (#6020)',
+        build: () => createBloc(addressableId: testAddressableId),
+        seed: () => const VideoInteractionsState(
+          status: VideoInteractionsStatus.success,
+          isLiked: true,
+          likeCount: 10,
+        ),
+        act: (bloc) async {
+          bloc.add(const VideoInteractionsSubscriptionRequested());
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+          // This video's own coordinate is liked (its reaction is recorded
+          // under a different, pre-edit event id — never testEventId).
+          likedAddressableIdsController.add({testAddressableId});
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+          // A completely unrelated video is liked elsewhere in the app,
+          // ticking the shared watchLikedEventIds stream. testEventId is
+          // (correctly) not in this list.
+          likedIdsController.add(['some-other-unrelated-event-id']);
+        },
+        wait: const Duration(milliseconds: 150),
         expect: () => <VideoInteractionsState>[],
       );
     });

--- a/mobile/test/screens/feed/pooled_video_feed_item_repo_swap_test.dart
+++ b/mobile/test/screens/feed/pooled_video_feed_item_repo_swap_test.dart
@@ -93,8 +93,18 @@ void main() {
       when(
         mockLikesB.watchLikedEventIds,
       ).thenAnswer((_) => const Stream<List<String>>.empty());
-      when(() => mockLikesA.isLiked(any())).thenAnswer((_) async => false);
-      when(() => mockLikesB.isLiked(any())).thenAnswer((_) async => false);
+      when(
+        () => mockLikesA.isLikedResolvingCoordinate(
+          eventId: any(named: 'eventId'),
+          addressableId: any(named: 'addressableId'),
+        ),
+      ).thenAnswer((_) async => false);
+      when(
+        () => mockLikesB.isLikedResolvingCoordinate(
+          eventId: any(named: 'eventId'),
+          addressableId: any(named: 'addressableId'),
+        ),
+      ).thenAnswer((_) async => false);
       when(
         () => mockLikesA.getLikeCount(
           any(),

--- a/mobile/test/widgets/video_feed_item/feed_videos_repo_swap_test.dart
+++ b/mobile/test/widgets/video_feed_item/feed_videos_repo_swap_test.dart
@@ -100,8 +100,18 @@ void main() {
       when(
         mockLikesB.watchLikedEventIds,
       ).thenAnswer((_) => const Stream<List<String>>.empty());
-      when(() => mockLikesA.isLiked(any())).thenAnswer((_) async => false);
-      when(() => mockLikesB.isLiked(any())).thenAnswer((_) async => false);
+      when(
+        () => mockLikesA.isLikedResolvingCoordinate(
+          eventId: any(named: 'eventId'),
+          addressableId: any(named: 'addressableId'),
+        ),
+      ).thenAnswer((_) async => false);
+      when(
+        () => mockLikesB.isLikedResolvingCoordinate(
+          eventId: any(named: 'eventId'),
+          addressableId: any(named: 'addressableId'),
+        ),
+      ).thenAnswer((_) async => false);
       when(
         () => mockLikesA.getLikeCount(
           any(),

--- a/mobile/test/widgets/video_feed_item/feed_videos_test.dart
+++ b/mobile/test/widgets/video_feed_item/feed_videos_test.dart
@@ -170,7 +170,12 @@ extension _LikesRepoStub on _MockLikesRepository {
     when(
       watchLikedEventIds,
     ).thenAnswer((_) => const Stream<List<String>>.empty());
-    when(() => isLiked(any())).thenAnswer((_) async => false);
+    when(
+      () => isLikedResolvingCoordinate(
+        eventId: any(named: 'eventId'),
+        addressableId: any(named: 'addressableId'),
+      ),
+    ).thenAnswer((_) async => false);
     when(
       () => getLikeCount(any(), addressableId: any(named: 'addressableId')),
     ).thenAnswer((_) async => 0);

--- a/mobile/test/widgets/video_feed_item/video_interactions_bloc_key_test.dart
+++ b/mobile/test/widgets/video_feed_item/video_interactions_bloc_key_test.dart
@@ -50,7 +50,12 @@ void main() {
     testWidgets('does not keep fetched counts after feed cell reuse', (
       tester,
     ) async {
-      when(() => likesRepository.isLiked(any())).thenAnswer((_) async => false);
+      when(
+        () => likesRepository.isLikedResolvingCoordinate(
+          eventId: any(named: 'eventId'),
+          addressableId: any(named: 'addressableId'),
+        ),
+      ).thenAnswer((_) async => false);
       when(
         () => likesRepository.getLikeCount(
           any(),


### PR DESCRIPTION
## Description

After a video edit mints a new event id for the same `d`-tag coordinate, own-like state (`LikesRepository._likeRecords`, the `personal_reactions` table) was keyed only by target event id, so a like recorded pre-edit became invisible post-edit — the heart un-fills even though the underlying Kind 7 reaction (and its `a` tag) is untouched and still live on relays.

Adds an addressable-id companion index alongside the existing event-id index:
- `personal_reactions` gets a new nullable `addressable_id` column (existing `_addColumnIfMissing` runtime migration pattern, no `schemaVersion` bump — same approach already used for `event.d_tag` / `outgoing_dms.send_batch_id`).
- `LikesRepository` gains an in-memory `_likeRecordsByAddressableId` companion map, persisted via the new column so cold app starts resolve correctly too (not just warm-cache hits, unlike #4478's in-memory-only precedent for comments).
- New `getLikeRecordByCoordinate` / `isLikedByCoordinate` / `isLikedResolvingCoordinate` methods; `isLiked(eventId)`'s existing signature is unchanged.
- `watchLikedAddressableIds()` stream added alongside `watchLikedEventIds()` so `VideoInteractionsBloc`'s live subscription also stays correct — without it, `watchLikedEventIds()` (which ticks on *any* like/unlike anywhere in the app) would silently flip a coordinate-only-liked heart back to unliked the next time anything else was liked/unliked.
- Closes a related duplicate-reaction bug found during investigation: re-liking a video post-edit (while the heart was incorrectly unfilled) created a second live reaction while the first became permanently un-deletable via the normal unlike flow. `likeEvent`'s already-liked guard and `unlikeEvent`'s target resolution now both check the coordinate too.
- Adds the `_likeCountCache` addressable-id dual-key that #4478's own PR body suggested as a follow-up and was never shipped.

No backend, relay, or protocol changes — confirmed via code read, NIP-25/NIP-01 spec read, and an empirical test against the local funnelcake-relay (local Docker stack) that mobile's `sendLike` already emits both `e` and `a` tags, and that the relay correctly serves reactions by both tags regardless of whether the target's addressable version has since been superseded.

**Related Issue:** Closes #6020

## Review round 2 (dcadenas, hm21)

- `executeLikeAction`'s cross-device guard now drops the queued `pending_` placeholder (memory + storage) when reconciling, so a later unlike deletes the real reaction instead of no-oping on the placeholder; it also awaits `_ensureInitialized()` first since replay races `initialize()` at provider build.
- `syncUserReactions` backfills `addressableId` onto stored coordinate-less records from the relay copy of the **same** reaction (same-reaction-id restriction so a different older reaction can never repoint a record).
- `initialize()` runs that backfill sync at startup when any loaded row lacks a coordinate, so pre-migration likes self-heal without a Liked Videos visit; the result is persisted and survives offline restarts (pinned end-to-end by `likes_repository_pre_column_db_test.dart` over a real pre-column `AppDatabase`).
- Fixed the red `Tests` job: `isLikedResolvingCoordinate` is now stubbed in `video_interactions_bloc_key_test.dart` plus the same latent gap in three sibling widget tests.

## Out of Scope

- Downvotes have the identical structural gap (no `addressableId` plumbing at all) but zero current blast radius — they're only ever applied to comments (non-addressable) today. Filed as a separate tracked issue with the supporting evidence rather than fixed here.
- No reconciliation of pre-existing duplicate live relay reactions created before this fix (the orphaned wire events themselves). They are invisible to other users since liker counts dedupe by pubkey. Local rows *are* now reconciled — see review round 2 above.

## Verification

- `flutter analyze lib test integration_test` — no issues
- `flutter test` — `likes_repository` (189 tests, including the new pre-column-DB end-to-end regression), `db_client` (823 tests, including drift schema migration verification), app-layer widget/bloc suites for the touched files (302 tests via pre-push hook)
- `likes_repository` coverage: 90.90% (min_coverage gate: 62%)
- Empirical relay test against local Docker stack (funnelcake-relay) confirming reaction tag survival and `#a`-filter resolution across an addressable-event edit

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
