### PR TITLE
fix(ios): bump connectivity_plus to 7.3.0 to stop background engine crash

### DIFF
--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -357,18 +357,18 @@ packages:
     dependency: "direct main"
     description:
       name: connectivity_plus
-      sha256: "33bae12a398f841c6cda09d1064212957265869104c478e5ad51e2fb26c3973c"
+      sha256: "25cebb79dfe304022550e0c3c893ae051ded07183d2607f7b88473cb3ade33cb"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0"
+    version: "7.3.0"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
       name: connectivity_plus_platform_interface
-      sha256: "42657c1715d48b167930d5f34d00222ac100475f73d10162ddf43e714932f204"
+      sha256: "3c09627c536d22fd24691a905cdd8b14520de69da52c7a97499c8be5284a32ed"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.1.0"
   conventional_commit:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -115,7 +115,7 @@ dependencies:
   http: ^1.5.0
   http_parser: ^4.0.2
   web_socket_channel: ^3.0.3
-  connectivity_plus: ^7.0.0
+  connectivity_plus: ^7.3.0
   device_info_plus: ^10.1.2
   url_launcher: ^6.3.2
   # OAuth: Uses ASWebAuthenticationSession on iOS (Apple's recommended auth flow)


### PR DESCRIPTION
## What

Bumps `connectivity_plus` `^7.0.0` → `^7.3.0`.

## Why

Crashlytics `1b765f14` is a FATAL crash (17 impacted users / 20 events, fresh on 1.0.16, all `processState BACKGROUND`):

```
NSInternalInconsistencyException: Sending a message before the FlutterEngine has been run.
-[FlutterEngine sendOnChannel:message:binaryReply:]
closure #1 in ConnectivityPlusPlugin.connectivityUpdateHandler (ConnectivityPlusPlugin.swift:83)
```

`connectivity_plus` 7.0.0 pushes `NWPathMonitor` connectivity-change events straight onto its `FlutterEventChannel`. When that native callback fires while the app is backgrounded and the FlutterEngine shell has been torn down, `sendOnChannel:` throws an uncaught ObjC exception → the app aborts. This is vendor plugin code but our lifecycle, and it can't be guarded from the Dart side — the crash happens entirely in the native `NWPathMonitor → eventSink` path.

Rather than hand-roll a subscription-teardown workaround, the clean fix is upstream: 7.3.0 ships [#3797](https://github.com/fluttercommunity/plus_plugins/pull/3797), which guards `connectivityUpdateHandler` against `UIApplication.applicationState == .background` before touching the event sink — exactly our crash condition. We also pick up 7.1.0's [#3752](https://github.com/fluttercommunity/plus_plugins/pull/3752) serial-queue fix for a related `NWPathMonitor` race. Setting the floor to `^7.3.0` (not just `pub upgrade`) guarantees a fresh resolve can't land back on an unfixed 7.0.x.

## Scope / safety

- Pure dependency bump — no Dart source changed. The only new API surface is the `ConnectivityResult.satellite` enum case (7.1.0). On iOS/macOS it's always reported *alongside* `mobile` (`[mobile, satellite]`), so `checkNetworkConnectivity` returns `.mobile` via its existing `contains(mobile)` check, and `getNetworkTypeString` falls through the existing `default:` branch. Every stream call site compares against `.none`, so satellite counts as online. `bluetooth`/`other` already exercised these same fallbacks pre-bump, so there's no new unhandled-enum path.
- The upstream guard is iOS-only — matching the iOS-only crash. macOS `NSApplication` doesn't tear down the FlutterEngine shell on backgrounding, so that path was never a crash vector and needs no guard.
- `flutter analyze` on all five connectivity call sites: clean.
- Plugin platform minimums (iOS 12, macOS 10.14) stay below our iOS 16 / macOS 13 targets — no deployment-target change.
- Verified the `.background` guard is present in the resolved 7.3.0 pub-cache source; lock churn is limited to `connectivity_plus` and `connectivity_plus_platform_interface` (`2.0.1` → `2.1.0`).

No Dart regression test: the failure mode is a native ObjC assertion with no Dart-observable surface, so a test here would assert nothing that can fail.

## Test plan

- [ ] iOS build + smoke test (connectivity transitions online/offline still fire relay-pool repair and DM retry).

Closes #6113
