### PR TITLE
fix(categories): fall back to emoji when a category has no bundled SVG

### DIFF
--- a/mobile/lib/screens/category_gallery_screen.dart
+++ b/mobile/lib/screens/category_gallery_screen.dart
@@ -434,25 +434,23 @@ class _CategoryHeaderMascotSlot extends StatelessWidget {
       key: const Key('category-header-mascot-slot'),
       width: 149,
       height: 90,
-      child: visuals.assetPath == null
-          ? const SizedBox.shrink()
-          : OverflowBox(
-              maxWidth: 149,
-              maxHeight: 132,
-              alignment: Alignment.topCenter,
-              child: Transform.translate(
-                offset: const Offset(0, -12),
-                child: Transform.rotate(
-                  angle: 8 * math.pi / 180,
-                  child: CategoryGlyph(
-                    assetPath: visuals.assetPath!,
-                    emoji: emoji,
-                    height: 104,
-                    width: 132,
-                  ),
-                ),
-              ),
+      child: OverflowBox(
+        maxWidth: 149,
+        maxHeight: 132,
+        alignment: Alignment.topCenter,
+        child: Transform.translate(
+          offset: const Offset(0, -12),
+          child: Transform.rotate(
+            angle: 8 * math.pi / 180,
+            child: CategoryGlyph(
+              assetPath: visuals.assetPath,
+              emoji: emoji,
+              height: 104,
+              width: 132,
             ),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/mobile/lib/widgets/categories/category_glyph.dart
+++ b/mobile/lib/widgets/categories/category_glyph.dart
@@ -4,13 +4,16 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 
-/// Renders the SVG at [assetPath], falling back to [emoji] when the asset is
-/// not in the bundle.
+/// Renders the SVG at [assetPath], falling back to [emoji] when no bundled
+/// asset is available.
 ///
 /// Backend category names are an open-ended, uncurated stream (see #2547), so a
-/// name can arrive with no matching `assets/categories/<name>.svg`. flutter_svg
-/// would otherwise throw "Unable to load asset"; here the missing asset routes
-/// to [SvgPicture]'s `errorBuilder` and degrades to the category emoji instead.
+/// name can arrive with no matching `assets/categories/<name>.svg`. Callers pass
+/// a `null` [assetPath] for those (see `CategoryVisuals.forCategory`), and the
+/// emoji is rendered directly without ever asking flutter_svg to load a missing
+/// file — a missing-asset load reports a non-fatal to the zone even though
+/// `errorBuilder` handles the visual (#6116). The `errorBuilder` stays as a
+/// belt-and-suspenders guard for a genuinely corrupt bundled asset.
 class CategoryGlyph extends StatelessWidget {
   const CategoryGlyph({
     required this.assetPath,
@@ -20,10 +23,11 @@ class CategoryGlyph extends StatelessWidget {
     super.key,
   });
 
-  /// The bundled SVG asset path, e.g. `assets/categories/music.svg`.
-  final String assetPath;
+  /// The bundled SVG asset path, e.g. `assets/categories/music.svg`, or `null`
+  /// when no bundled asset exists for the category.
+  final String? assetPath;
 
-  /// The fallback glyph shown when [assetPath] is missing from the bundle.
+  /// The fallback glyph shown when [assetPath] is `null` or fails to load.
   final String emoji;
 
   /// Height for both the SVG and the emoji fallback.
@@ -34,8 +38,12 @@ class CategoryGlyph extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final path = assetPath;
+    if (path == null) {
+      return _EmojiGlyph(emoji: emoji, height: height, width: width);
+    }
     return SvgPicture.asset(
-      assetPath,
+      path,
       height: height,
       width: width,
       errorBuilder: (context, error, stackTrace) =>

--- a/mobile/lib/widgets/categories/category_visuals.dart
+++ b/mobile/lib/widgets/categories/category_visuals.dart
@@ -16,8 +16,9 @@ class CategoryVisuals {
   final String? assetPath;
 
   /// Resolves visuals for any category. Featured categories get custom colors;
-  /// all others cycle through fallback colors and get an SVG asset path derived
-  /// from their name — but only when that asset is actually bundled.
+  /// all others cycle through fallback colors. Every asset path — featured or
+  /// derived from the name — resolves through [bundledAssetBasenames], so it
+  /// only points at an asset that is actually bundled.
   ///
   /// Backend category names are an open-ended, uncurated stream (#2547), so a
   /// name can arrive with no matching `assets/categories/<name>.svg`. In that
@@ -30,24 +31,40 @@ class CategoryVisuals {
     final name = category.name.toLowerCase();
     final featured = _featuredCategoryVisuals[name];
     if (featured != null) {
-      return featured;
+      return CategoryVisuals(
+        backgroundColor: featured.backgroundColor,
+        foregroundColor: featured.foregroundColor,
+        assetPath: _bundledAssetPathOrNull(featured.assetBasename),
+      );
     }
     final fallback =
         _fallbackCategoryVisuals[index % _fallbackCategoryVisuals.length];
-    final assetName = _assetNameAliases[name] ?? name;
     return CategoryVisuals(
       backgroundColor: fallback.backgroundColor,
       foregroundColor: fallback.foregroundColor,
-      assetPath: bundledAssetBasenames.contains(assetName)
-          ? 'assets/categories/$assetName.svg'
-          : null,
+      assetPath: _bundledAssetPathOrNull(_assetNameAliases[name] ?? name),
     );
   }
+
+  static String? _bundledAssetPathOrNull(String basename) =>
+      bundledAssetBasenames.contains(basename)
+      ? 'assets/categories/$basename.svg'
+      : null;
+
+  /// Names of the featured categories, exposed so tests can pin every curated
+  /// asset basename to [bundledAssetBasenames].
+  @visibleForTesting
+  static List<String> get featuredCategoryNames =>
+      _featuredCategoryVisuals.keys.toList();
 
   /// Basenames (without extension) of every SVG bundled under
   /// `assets/categories/`. Used to decide whether a derived asset path points
   /// at a real file before handing it to [CategoryGlyph]. Kept in sync with the
   /// directory by `category_visuals_test.dart`, which fails if the two diverge.
+  ///
+  /// Public only for that drift-guard test; production code goes through
+  /// [forCategory].
+  @visibleForTesting
   static const bundledAssetBasenames = <String>{
     'action',
     'adventure',
@@ -162,46 +179,56 @@ const _assetNameAliases = <String, String>{
   'beverages': 'beverage',
 };
 
-const _featuredCategoryVisuals = <String, CategoryVisuals>{
-  'animals': CategoryVisuals(
+/// Curated colors plus the bundled-SVG basename for a featured category. The
+/// basename resolves through the same [CategoryVisuals.bundledAssetBasenames]
+/// gate as derived names, so a featured entry can never point at a missing
+/// file (#6116).
+typedef _FeaturedVisuals = ({
+  Color backgroundColor,
+  Color foregroundColor,
+  String assetBasename,
+});
+
+const _featuredCategoryVisuals = <String, _FeaturedVisuals>{
+  'animals': (
     backgroundColor: Color(0xFF3E0C1F),
     foregroundColor: Color(0xFFFF7FAF),
-    assetPath: 'assets/categories/animals.svg',
+    assetBasename: 'animals',
   ),
-  'food': CategoryVisuals(
+  'food': (
     backgroundColor: Color(0xFF272F0E),
     foregroundColor: Color(0xFFD2FF40),
-    assetPath: 'assets/categories/food.svg',
+    assetBasename: 'food',
   ),
-  'nature': CategoryVisuals(
+  'nature': (
     backgroundColor: Color(0xFF231557),
     foregroundColor: Color(0xFF8568FF),
-    assetPath: 'assets/categories/nature.svg',
+    assetBasename: 'nature',
   ),
-  'sports': CategoryVisuals(
+  'sports': (
     backgroundColor: Color(0xFF471F10),
     foregroundColor: Color(0xFFFF7640),
-    assetPath: 'assets/categories/sports.svg',
+    assetBasename: 'sports',
   ),
-  'fashion': CategoryVisuals(
+  'fashion': (
     backgroundColor: Color(0xFF0A223C),
     foregroundColor: Color(0xFF34BBF1),
-    assetPath: 'assets/categories/style.svg',
+    assetBasename: 'style',
   ),
-  'music': CategoryVisuals(
+  'music': (
     backgroundColor: Color(0xFF363313),
     foregroundColor: Color(0xFFFFF140),
-    assetPath: 'assets/categories/music.svg',
+    assetBasename: 'music',
   ),
-  'fitness': CategoryVisuals(
+  'fitness': (
     backgroundColor: Color(0xFF2D214D),
     foregroundColor: Color(0xFFA3A9FF),
-    assetPath: 'assets/categories/fitness.svg',
+    assetBasename: 'fitness',
   ),
-  'art': CategoryVisuals(
+  'art': (
     backgroundColor: Color(0xFF471F10),
     foregroundColor: Color(0xFFFF7640),
-    assetPath: 'assets/categories/art.svg',
+    assetBasename: 'art',
   ),
 };
 

--- a/mobile/lib/widgets/categories/category_visuals.dart
+++ b/mobile/lib/widgets/categories/category_visuals.dart
@@ -16,8 +16,16 @@ class CategoryVisuals {
   final String? assetPath;
 
   /// Resolves visuals for any category. Featured categories get custom colors;
-  /// all others cycle through fallback colors. Every category gets an SVG
-  /// asset path derived from its name.
+  /// all others cycle through fallback colors and get an SVG asset path derived
+  /// from their name — but only when that asset is actually bundled.
+  ///
+  /// Backend category names are an open-ended, uncurated stream (#2547), so a
+  /// name can arrive with no matching `assets/categories/<name>.svg`. In that
+  /// case [assetPath] is `null` and callers degrade to the category emoji.
+  /// Resolving to `null` here — rather than pointing at a missing file and
+  /// relying on [CategoryGlyph]'s `errorBuilder` — is what keeps the load from
+  /// ever being attempted: a missing-asset load surfaces the failure to the
+  /// zone as a non-fatal even when `errorBuilder` handles the visual (#6116).
   static CategoryVisuals forCategory(VideoCategory category, int index) {
     final name = category.name.toLowerCase();
     final featured = _featuredCategoryVisuals[name];
@@ -30,9 +38,119 @@ class CategoryVisuals {
     return CategoryVisuals(
       backgroundColor: fallback.backgroundColor,
       foregroundColor: fallback.foregroundColor,
-      assetPath: 'assets/categories/$assetName.svg',
+      assetPath: bundledAssetBasenames.contains(assetName)
+          ? 'assets/categories/$assetName.svg'
+          : null,
     );
   }
+
+  /// Basenames (without extension) of every SVG bundled under
+  /// `assets/categories/`. Used to decide whether a derived asset path points
+  /// at a real file before handing it to [CategoryGlyph]. Kept in sync with the
+  /// directory by `category_visuals_test.dart`, which fails if the two diverge.
+  static const bundledAssetBasenames = <String>{
+    'action',
+    'adventure',
+    'animals',
+    'animation',
+    'architecture',
+    'art',
+    'automotive',
+    'award-show',
+    'awards',
+    'baseball',
+    'basketball',
+    'beauty',
+    'beverage',
+    'cars',
+    'celebration',
+    'celebrities',
+    'celebrity',
+    'cityscape',
+    'comedy',
+    'concert',
+    'cooking',
+    'costume',
+    'crafts',
+    'crime',
+    'culture',
+    'dance',
+    'diy',
+    'drama',
+    'education',
+    'emotional',
+    'emotions',
+    'entertainment',
+    'event',
+    'family',
+    'fans',
+    'fantasy',
+    'fashion',
+    'festival',
+    'film',
+    'fitness',
+    'food',
+    'football',
+    'furniture',
+    'gaming',
+    'golf',
+    'grooming',
+    'guitar',
+    'halloween',
+    'health',
+    'hockey',
+    'holiday',
+    'home',
+    'home-improvement',
+    'horror',
+    'hospital',
+    'humor',
+    'interior-design',
+    'interview',
+    'kids',
+    'lifestyle',
+    'magic',
+    'makeup',
+    'medical',
+    'music',
+    'mystery',
+    'nature',
+    'news',
+    'outdoor',
+    'party',
+    'people',
+    'performance',
+    'pets',
+    'politics',
+    'prank',
+    'pranks',
+    'reality-show',
+    'relationship',
+    'relationships',
+    'romance',
+    'school',
+    'science-fiction',
+    'selfie',
+    'shopping',
+    'skateboarding',
+    'skincare',
+    'soccer',
+    'social-gathering',
+    'social-media',
+    'sports',
+    'style',
+    'talk-show',
+    'technology',
+    'television',
+    'toys',
+    'transportation',
+    'travel',
+    'urban',
+    'violence',
+    'vlog',
+    'vlogging',
+    'wrestling',
+  };
 }
 
 /// Maps backend category slugs onto the bundled SVG asset basename when the two

--- a/mobile/lib/widgets/categories_tab.dart
+++ b/mobile/lib/widgets/categories_tab.dart
@@ -198,19 +198,18 @@ class _CategoryTile extends StatelessWidget {
                     ],
                   ),
                 ),
-                if (visuals.assetPath != null)
-                  PositionedDirectional(
-                    end: 18,
-                    top: 0,
-                    bottom: 0,
-                    child: IgnorePointer(
-                      child: CategoryGlyph(
-                        assetPath: visuals.assetPath!,
-                        emoji: category.emoji,
-                        height: 88,
-                      ),
+                PositionedDirectional(
+                  end: 18,
+                  top: 0,
+                  bottom: 0,
+                  child: IgnorePointer(
+                    child: CategoryGlyph(
+                      assetPath: visuals.assetPath,
+                      emoji: category.emoji,
+                      height: 88,
                     ),
                   ),
+                ),
               ],
             ),
           ),

--- a/mobile/test/widgets/categories/category_glyph_test.dart
+++ b/mobile/test/widgets/categories/category_glyph_test.dart
@@ -1,14 +1,16 @@
 // ABOUTME: Widget tests for CategoryGlyph's SVG-with-emoji-fallback behavior.
-// ABOUTME: Covers the #4398 crash fix: a missing asset degrades to the emoji.
+// ABOUTME: Covers the #4398/#6116 crash fix: a missing asset degrades to emoji.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart' show VideoCategory;
 import 'package:openvine/widgets/categories/category_glyph.dart';
+import 'package:openvine/widgets/categories/category_visuals.dart';
 
 void main() {
   group(CategoryGlyph, () {
-    Widget buildSubject({required String assetPath, required String emoji}) {
+    Widget buildSubject({required String? assetPath, required String emoji}) {
       return MaterialApp(
         home: Scaffold(
           body: Center(
@@ -93,6 +95,36 @@ void main() {
 
       expect(find.byType(SvgPicture), findsOneWidget);
       expect(find.text('🎸'), findsNothing);
+    });
+
+    testWidgets('renders the emoji directly when assetPath is null (#6116)', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildSubject(assetPath: null, emoji: '🥊'));
+      await tester.pumpAndSettle();
+
+      // No SvgPicture is built at all, so flutter_svg never attempts (and never
+      // reports) a missing-asset load.
+      expect(find.byType(SvgPicture), findsNothing);
+      expect(find.text('🥊'), findsOneWidget);
+    });
+
+    testWidgets('an unknown category renders its emoji, not an SVG (#6116)', (
+      tester,
+    ) async {
+      // End-to-end: the exact Crashlytics scenario — a backend category with no
+      // bundled SVG resolves to a null path and degrades to the emoji.
+      const category = VideoCategory(name: 'fighting', videoCount: 42);
+      final visuals = CategoryVisuals.forCategory(category, 0);
+      expect(visuals.assetPath, isNull);
+
+      await tester.pumpWidget(
+        buildSubject(assetPath: visuals.assetPath, emoji: category.emoji),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(SvgPicture), findsNothing);
+      expect(find.text(category.emoji), findsOneWidget);
     });
   });
 }

--- a/mobile/test/widgets/categories/category_visuals_test.dart
+++ b/mobile/test/widgets/categories/category_visuals_test.dart
@@ -96,14 +96,20 @@ void main() {
         expect(CategoryVisuals.bundledAssetBasenames, equals(onDisk));
       });
 
-      test('covers every curated featured asset', () {
-        // Featured categories bypass the bundled-set check, so verify their
-        // hand-picked assets are on disk too.
-        for (final name in const ['animals', 'food', 'nature', 'style']) {
+      test('every featured category resolves a bundled asset', () {
+        // Featured basenames resolve through the same bundled-set gate as
+        // derived names, so a curated asset drifting off disk would silently
+        // demote a flagship category to its emoji — pin all of them here.
+        expect(CategoryVisuals.featuredCategoryNames, isNotEmpty);
+        for (final name in CategoryVisuals.featuredCategoryNames) {
+          final visuals = CategoryVisuals.forCategory(
+            VideoCategory(name: name, videoCount: 1),
+            0,
+          );
           expect(
-            CategoryVisuals.bundledAssetBasenames,
-            contains(name),
-            reason: '$name.svg backs a featured category',
+            visuals.assetPath,
+            isNotNull,
+            reason: '$name is featured but its asset is not bundled',
           );
         }
       });

--- a/mobile/test/widgets/categories/category_visuals_test.dart
+++ b/mobile/test/widgets/categories/category_visuals_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Tests for CategoryVisuals asset-path resolution and aliases.
 // ABOUTME: Locks the #4398 alias map so backend names resolve to bundled SVGs.
 
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart' show VideoCategory;
 import 'package:openvine/widgets/categories/category_visuals.dart';
@@ -34,6 +36,20 @@ void main() {
 
         expect(visuals.assetPath, equals('assets/categories/beverage.svg'));
       });
+
+      test('resolves to null when no SVG is bundled for the slug (#6116)', () {
+        // "fighting" has no assets/categories/fighting.svg; the old code pointed
+        // assetPath at the missing file and let the load throw.
+        final visuals = CategoryVisuals.forCategory(
+          const VideoCategory(name: 'fighting', videoCount: 42),
+          1,
+        );
+
+        expect(visuals.assetPath, isNull);
+        // A missing asset must not cost the category its fallback colors.
+        expect(visuals.backgroundColor, isNotNull);
+        expect(visuals.foregroundColor, isNotNull);
+      });
     });
 
     group('featured categories', () {
@@ -55,6 +71,41 @@ void main() {
         );
 
         expect(visuals.assetPath, equals('assets/categories/style.svg'));
+      });
+    });
+
+    group('bundledAssetBasenames', () {
+      test('stays in sync with the assets/categories/ directory (#6116)', () {
+        // The set is the runtime source of truth for "is this asset bundled?".
+        // If it drifts from disk, forCategory either drops a real asset (ugly
+        // emoji fallback) or points at a missing file (the crash returns), so
+        // pin it to the actual *.svg files here.
+        final onDisk = Directory('assets/categories')
+            .listSync()
+            .whereType<File>()
+            .map((e) => e.uri.pathSegments.last)
+            .where((name) => name.endsWith('.svg'))
+            .map((name) => name.substring(0, name.length - '.svg'.length))
+            .toSet();
+
+        expect(
+          onDisk,
+          isNotEmpty,
+          reason: 'asset directory should not be empty',
+        );
+        expect(CategoryVisuals.bundledAssetBasenames, equals(onDisk));
+      });
+
+      test('covers every curated featured asset', () {
+        // Featured categories bypass the bundled-set check, so verify their
+        // hand-picked assets are on disk too.
+        for (final name in const ['animals', 'food', 'nature', 'style']) {
+          expect(
+            CategoryVisuals.bundledAssetBasenames,
+            contains(name),
+            reason: '$name.svg backs a featured category',
+          );
+        }
       });
     });
   });


### PR DESCRIPTION
## What

Unknown backend category names (e.g. `fighting`) derived an `assetPath` pointing at a missing `assets/categories/<name>.svg`. `CategoryVisuals.forCategory` now resolves `assetPath` to `null` when the derived basename isn't bundled, and `CategoryGlyph` renders the category emoji directly for a `null` path — so `flutter_svg` is never asked to load a file that doesn't exist.

## Why the existing errorBuilder wasn't enough

#4398 already wired an `errorBuilder` on `CategoryGlyph`, and it does render the emoji when the SVG is missing — but the Crashlytics non-fatals kept coming in through 1.0.16. The reason is in `vector_graphics`' `_loadPicture`: it attaches `result.whenComplete(...)` and discards the returned future. On a missing asset, `_loadAssetBytes`'s try/catch handles the awaited subscription (so the `errorBuilder` fires and the UI is fine), but the discarded `whenComplete` future completes with the same error, has no listener, and escalates to the app's `runZonedGuarded` handler → logged as a non-fatal. As long as `SvgPicture.asset` is *asked* to load a missing path, the event fires; `errorBuilder` only fixes the pixels, not the report.

So the fix is to never hand a missing path to `SvgPicture` in the first place. The two call sites' defensive `if (visuals.assetPath != null)` gates were already there but dead (`forCategory` always returned a non-null path) — this wires the intended null path through and keeps the emoji mascot for unknown categories.

Chose the fallback (issue option b) over adding `fighting.svg` (option a): backend category names are an open-ended, uncurated stream, so adding one asset is whack-a-mole — the class fix stops all of them.

## Tests

- `forCategory('fighting')` → `assetPath` is `null`; `CategoryGlyph(null)` renders the emoji with no `SvgPicture`; an end-to-end test pins the exact Crashlytics scenario.
- A drift-guard test asserts `bundledAssetBasenames` equals the actual `assets/categories/*.svg` files on disk, so deleting/adding an SVG without updating the set fails CI instead of quietly reintroducing the crash.

`flutter analyze` clean; the 4 affected test suites pass locally.

Closes #6116