### PR TITLE
feat(video): emit an inspired-by p-tag so the referenced creator is notifiable

### DIFF
--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -663,10 +663,12 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
   void initFromPublishedVideo(VideoEvent video) {
     _suppressAutosave = true;
 
-    // Strip any appended NIP-27 inspired-by line before displaying
-    // the description in the edit form.
+    // Strip any appended NIP-27 inspired-by line before displaying the
+    // description in the edit form. Empty-caption publishes trim the leading
+    // newlines, so the attribution line can also be the entire content —
+    // mirror the parse regex in VideoEvent.fromNostrEvent.
     var content = video.content;
-    final npubPattern = RegExp(r'\n\nInspired by nostr:npub1[a-z0-9]+$');
+    final npubPattern = RegExp(r'(^|\n\n)Inspired by nostr:npub1[a-z0-9]+\s*$');
     content = content.replaceFirst(npubPattern, '');
 
     state = VideoEditorProviderState(

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -33,6 +33,7 @@ import 'package:openvine/services/upload_manager.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/services/video_thumbnail_service.dart';
 import 'package:openvine/utils/collaborator_tags.dart';
+import 'package:openvine/utils/inspired_by_tags.dart';
 import 'package:openvine/utils/log_tag_sanitizer.dart';
 import 'package:openvine/utils/proofmode_publishing_helpers.dart';
 import 'package:profile_repository/profile_repository.dart';
@@ -1286,6 +1287,25 @@ class VideoEventPublisher {
           inspiredByRelayUrl ?? 'wss://relay.divine.video',
           'mention',
         ]);
+      }
+
+      // p-tag the inspired-by creator(s) so they are notifiable. Added after
+      // the collaborator/mention p-tags so those win dedup and caption
+      // @token resolution keeps matching caption mentions first. Reply
+      // videos never carry inspired-by p-tags: the model hides inspired-by
+      // attribution on replies (VideoEvent.hasInspiredBy) and the edit flow
+      // cannot own the tag there, so emitting one would notify a creator the
+      // video never visibly credits and could never un-credit.
+      if (replyContext == null) {
+        tags.addAll(
+          buildInspiredByPTags(
+            existingTags: tags,
+            addressableId: inspiredByAddressableId,
+            npub: inspiredByNpub,
+            relayHint: inspiredByRelayUrl,
+            selfPubkey: _authService?.currentPublicKeyHex,
+          ),
+        );
       }
 
       var selectedAudioReferenceId = selectedAudioEventId;

--- a/mobile/lib/services/video_metadata_update_service.dart
+++ b/mobile/lib/services/video_metadata_update_service.dart
@@ -13,6 +13,7 @@ import 'package:openvine/services/collaborator_invite_service.dart';
 import 'package:openvine/services/personal_event_cache_service.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/utils/collaborator_tags.dart';
+import 'package:openvine/utils/inspired_by_tags.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Result returned by [VideoMetadataUpdateService.updateVideo].
@@ -81,6 +82,17 @@ bool _isEditRebuiltTag(List<String> tag, {required bool isVideoReply}) {
   if (name == 'p' &&
       tag.length >= 4 &&
       tag[3].toLowerCase() == 'collaborator') {
+    return true;
+  }
+  // Inspired-by p-tags mirror the inspired-by a-tag's lifecycle: owned by
+  // the edit flow on non-reply videos (stripped here, re-emitted from the
+  // editor state) so clearing or changing attribution updates the tag. On a
+  // reply, emission is suppressed too, so preserve verbatim — otherwise the
+  // tag would be dropped with no replacement.
+  if (!isVideoReply &&
+      name == 'p' &&
+      tag.length >= 4 &&
+      tag[3].toLowerCase() == inspiredByPTagMarker) {
     return true;
   }
   // Inspired-by a-tags (publish writes a 'mention' marker, edit writes
@@ -331,6 +343,25 @@ class VideoMetadataUpdateService {
       }
 
       tags.addAll(preservedTags);
+
+      // p-tag the inspired-by creator(s) so they are notifiable. Emitted
+      // after [preservedTags] so preserved caption-mention p-tags win dedup
+      // and @token resolution. Reply-gated like the a-tag above; on a reply
+      // any legacy inspired-by p-tag is preserved verbatim instead. Unlike
+      // the sibling a-tag (which keeps its shipped `relayUrl ?? ''` shape),
+      // the p-tag deliberately falls back to the default relay so a usable
+      // hint always accompanies the notify tag.
+      if (!isVideoReply) {
+        tags.addAll(
+          buildInspiredByPTags(
+            existingTags: tags,
+            addressableId: editorState.inspiredByVideo?.addressableId,
+            npub: editorState.inspiredByNpub,
+            relayHint: editorState.inspiredByVideo?.relayUrl,
+            selfPubkey: _authService.currentPublicKeyHex,
+          ),
+        );
+      }
 
       var content = editorState.description.trim();
       final inspiredByNpub = editorState.inspiredByNpub;

--- a/mobile/lib/utils/inspired_by_tags.dart
+++ b/mobile/lib/utils/inspired_by_tags.dart
@@ -1,0 +1,96 @@
+// ABOUTME: Shared Divine inspired-by p-tag builder and creator resolution
+// ABOUTME: used by both the direct-upload and edit-video publish paths.
+
+import 'package:models/models.dart';
+import 'package:openvine/constants/app_constants.dart';
+import 'package:openvine/utils/npub_hex.dart';
+
+/// Marker on Divine inspired-by `p` tags.
+///
+/// Distinct from `'mention'` so the edit flow can own this tag's lifecycle
+/// without touching caption-mention p-tags, and from `'collaborator'` so no
+/// consumer renders the inspired-by creator as a collaborator.
+const inspiredByPTagMarker = 'inspired-by';
+
+/// Default relay hint embedded in Divine inspired-by p-tags.
+const String inspiredByPTagRelayHint = AppConstants.defaultRelayUrl;
+
+/// Builds the Divine inspired-by-marked `p` tag for [pubkeyHex].
+///
+/// The marker must stay non-empty: funnelcake's collaborator read model
+/// treats a missing p-tag marker as `'collaborator'`.
+List<String> buildInspiredByPTag(String pubkeyHex, {String? relayHint}) {
+  final relay = (relayHint == null || relayHint.isEmpty)
+      ? inspiredByPTagRelayHint
+      : relayHint;
+  return ['p', pubkeyHex, relay, inspiredByPTagMarker];
+}
+
+/// Resolves the inspired-by creator hex pubkeys carried by a publish.
+///
+/// [addressableId] is the `34236:<pubkey>:<dTag>` coordinate of the
+/// inspiring video; [npub] is the NIP-27 person reference. Both can be
+/// present at publish time because the audio-reuse flow auto-populates the
+/// video reference independently of the person picker, so the result can
+/// contain up to two creators.
+///
+/// Malformed coordinates and undecodable npubs are skipped rather than
+/// surfaced — attribution display does not depend on this resolution, and a
+/// p-tag with an invalid value must never be published. Results are
+/// normalized to lowercase hex and deduplicated.
+Set<String> resolveInspiredByCreatorHexes({
+  String? addressableId,
+  String? npub,
+}) {
+  final hexes = <String>{};
+
+  if (addressableId != null) {
+    final candidate = InspiredByInfo(
+      addressableId: addressableId,
+    ).creatorPubkey.trim().toLowerCase();
+    if (NostrHexUtils.isValidPubkey(candidate)) {
+      hexes.add(candidate);
+    }
+  }
+
+  final decoded = npubToHexOrNull(npub)?.trim().toLowerCase();
+  if (decoded != null && NostrHexUtils.isValidPubkey(decoded)) {
+    hexes.add(decoded);
+  }
+
+  return hexes;
+}
+
+/// Builds inspired-by-marked p-tags for the creator(s) referenced by a
+/// publish, so they are notifiable (per NIP-27, a content mention without a
+/// matching p tag does not notify).
+///
+/// Skips the publisher's own pubkey ([selfPubkey] — reusing your own sound
+/// auto-populates the video reference with yourself) and any pubkey already
+/// carried by a `p` tag in [existingTags], so collaborator, caption-mention,
+/// and reply-threading tags keep the single-p-tag-per-pubkey invariant.
+List<List<String>> buildInspiredByPTags({
+  required List<List<String>> existingTags,
+  String? addressableId,
+  String? npub,
+  String? relayHint,
+  String? selfPubkey,
+}) {
+  final hexes = resolveInspiredByCreatorHexes(
+    addressableId: addressableId,
+    npub: npub,
+  );
+  if (hexes.isEmpty) return const [];
+
+  final self = selfPubkey?.trim().toLowerCase();
+  final existing = {
+    for (final tag in existingTags)
+      if (tag.length >= 2 && tag[0] == 'p') tag[1].trim().toLowerCase(),
+  };
+
+  return [
+    for (final hex in hexes)
+      if (hex != self && !existing.contains(hex))
+        buildInspiredByPTag(hex, relayHint: relayHint),
+  ];
+}

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -621,9 +621,12 @@ class VideoEvent {
       rawTags[tagName] = tagValue;
     }
 
-    // Scan content for NIP-27 nostr:npub1... references (Inspired By person)
+    // Resolve the Inspired By person from the trailing NIP-27 attribution
+    // line the publisher appends ("Inspired by nostr:npub1..."). Anchored to
+    // the end of content so an unrelated inline nostr:npub mention earlier in
+    // the caption is never mistaken for attribution.
     String? inspiredByNpub;
-    final npubPattern = RegExp('nostr:(npub1[a-z0-9]+)');
+    final npubPattern = RegExp(r'Inspired by nostr:(npub1[a-z0-9]+)\s*$');
     final npubMatch = npubPattern.firstMatch(event.content);
     if (npubMatch != null) {
       inspiredByNpub = npubMatch.group(1);

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -623,10 +623,14 @@ class VideoEvent {
 
     // Resolve the Inspired By person from the trailing NIP-27 attribution
     // line the publisher appends ("Inspired by nostr:npub1..."). Anchored to
-    // the end of content so an unrelated inline nostr:npub mention earlier in
-    // the caption is never mistaken for attribution.
+    // the end of content and to a preceding blank line (or start of content,
+    // for empty-caption publishes) so a prose nostr:npub mention is never
+    // mistaken for attribution. Keep in sync with the strip regex in
+    // video_editor_provider.dart.
     String? inspiredByNpub;
-    final npubPattern = RegExp(r'Inspired by nostr:(npub1[a-z0-9]+)\s*$');
+    final npubPattern = RegExp(
+      r'(?:^|\n\n)Inspired by nostr:(npub1[a-z0-9]+)\s*$',
+    );
     final npubMatch = npubPattern.firstMatch(event.content);
     if (npubMatch != null) {
       inspiredByNpub = npubMatch.group(1);

--- a/mobile/packages/models/test/src/video_event_parsing_test.dart
+++ b/mobile/packages/models/test/src/video_event_parsing_test.dart
@@ -707,6 +707,67 @@ void main() {
       expect(videoEvent.inspiredByNpub, isNull);
     });
 
+    test('should not treat an inline nostr:npub mention as inspiredByNpub', () {
+      final nostrEvent = Event(
+        authorPubkey,
+        34236,
+        [
+          ['url', 'https://example.com/video.mp4'],
+        ],
+        'Shoutout to nostr:npub1notattribution for the tip!',
+        createdAt: 1757385263,
+      );
+
+      final videoEvent = VideoEvent.fromNostrEvent(nostrEvent);
+
+      expect(videoEvent.inspiredByNpub, isNull);
+    });
+
+    test('should resolve the trailing attribution npub when an inline mention '
+        'appears earlier in content', () {
+      final nostrEvent = Event(
+        authorPubkey,
+        34236,
+        [
+          ['url', 'https://example.com/video.mp4'],
+        ],
+        'Shoutout to nostr:npub1notattribution for the tip!'
+        '\n\nInspired by nostr:npub1realattribution',
+        createdAt: 1757385263,
+      );
+
+      final videoEvent = VideoEvent.fromNostrEvent(nostrEvent);
+
+      expect(
+        videoEvent.inspiredByNpub,
+        equals('npub1realattribution'),
+      );
+    });
+
+    test(
+      'should parse inspiredByNpub when attribution is the whole content',
+      () {
+        // Empty-description publishes trim the leading newlines, so the
+        // attribution line is the entire content.
+        final nostrEvent = Event(
+          authorPubkey,
+          34236,
+          [
+            ['url', 'https://example.com/video.mp4'],
+          ],
+          'Inspired by nostr:npub1onlyattribution',
+          createdAt: 1757385263,
+        );
+
+        final videoEvent = VideoEvent.fromNostrEvent(nostrEvent);
+
+        expect(
+          videoEvent.inspiredByNpub,
+          equals('npub1onlyattribution'),
+        );
+      },
+    );
+
     test('should parse both a-tag and npub content together', () {
       final nostrEvent = Event(
         authorPubkey,

--- a/mobile/packages/models/test/src/video_event_parsing_test.dart
+++ b/mobile/packages/models/test/src/video_event_parsing_test.dart
@@ -681,7 +681,7 @@ void main() {
         [
           ['url', 'https://example.com/video.mp4'],
         ],
-        'Great idea! Inspired by nostr:npub1abc123def456ghi789',
+        'Great idea!\n\nInspired by nostr:npub1abc123def456ghi789',
         createdAt: 1757385263,
       );
 
@@ -722,6 +722,50 @@ void main() {
 
       expect(videoEvent.inspiredByNpub, isNull);
     });
+
+    test(
+      'should not treat a trailing mid-sentence mention as inspiredByNpub',
+      () {
+        // The strip regex in the edit form requires a blank line (or start of
+        // content) before the attribution phrase. Parsing must be equally
+        // strict, or prose like this would set inspiredByNpub without ever
+        // being strippable — duplicating the line and p-tagging the mentioned
+        // person on the next edit-save.
+        final nostrEvent = Event(
+          authorPubkey,
+          34236,
+          [
+            ['url', 'https://example.com/video.mp4'],
+          ],
+          'my remix. Inspired by nostr:npub1prosecreator',
+          createdAt: 1757385263,
+        );
+
+        final videoEvent = VideoEvent.fromNostrEvent(nostrEvent);
+
+        expect(videoEvent.inspiredByNpub, isNull);
+      },
+    );
+
+    test(
+      'should not treat a single-newline-prefixed attribution as '
+      'inspiredByNpub',
+      () {
+        final nostrEvent = Event(
+          authorPubkey,
+          34236,
+          [
+            ['url', 'https://example.com/video.mp4'],
+          ],
+          'my caption\nInspired by nostr:npub1singlenewline',
+          createdAt: 1757385263,
+        );
+
+        final videoEvent = VideoEvent.fromNostrEvent(nostrEvent);
+
+        expect(videoEvent.inspiredByNpub, isNull);
+      },
+    );
 
     test('should resolve the trailing attribution npub when an inline mention '
         'appears earlier in content', () {

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -1107,13 +1107,14 @@ void main() {
     VideoEvent buildVideo({
       List<List<String>> nostrEventTags = const [],
       Map<String, String> rawTags = const {},
+      String content = 'A published clip',
     }) {
       return VideoEvent(
         id: 'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
         pubkey:
             'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
         createdAt: 1778120201,
-        content: 'A published clip',
+        content: content,
         timestamp: DateTime.utc(2026, 5, 7),
         title: 'Published clip',
         videoUrl: 'https://media.divine.video/published.mp4',
@@ -1158,6 +1159,35 @@ void main() {
           .initFromPublishedVideo(buildVideo());
 
       expect(container.read(videoEditorProvider).allowAudioReuse, isFalse);
+    });
+
+    test('strips a trailing inspired-by line from the description', () {
+      container
+          .read(videoEditorProvider.notifier)
+          .initFromPublishedVideo(
+            buildVideo(
+              content: 'A caption\n\nInspired by nostr:npub1someattribution',
+            ),
+          );
+
+      expect(
+        container.read(videoEditorProvider).description,
+        equals('A caption'),
+      );
+    });
+
+    test('strips a whole-content inspired-by line (empty caption publish)', () {
+      // Empty-caption publishes trim the leading newlines, so the
+      // attribution line is the entire content. Before the fix the strip
+      // required a '\n\n' prefix, seeding the edit form with the raw line
+      // and duplicating it on every republish.
+      container
+          .read(videoEditorProvider.notifier)
+          .initFromPublishedVideo(
+            buildVideo(content: 'Inspired by nostr:npub1someattribution'),
+          );
+
+      expect(container.read(videoEditorProvider).description, isEmpty);
     });
   });
 

--- a/mobile/test/services/video_event_publisher_inspired_by_tags_test.dart
+++ b/mobile/test/services/video_event_publisher_inspired_by_tags_test.dart
@@ -1,0 +1,395 @@
+// ABOUTME: Tests the inspired-by p-tags emitted by VideoEventPublisher so the
+// ABOUTME: referenced creator is notifiable, deduped against other p-tags.
+
+import 'package:collection/collection.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/filter.dart';
+import 'package:nostr_sdk/relay/publish_outcome.dart';
+import 'package:openvine/constants/nip71_migration.dart';
+import 'package:openvine/models/pending_upload.dart';
+import 'package:openvine/models/video_reply_context.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/upload_manager.dart';
+import 'package:openvine/services/video_event_publisher.dart';
+import 'package:openvine/services/video_event_service.dart';
+import 'package:openvine/utils/collaborator_tags.dart';
+import 'package:openvine/utils/inspired_by_tags.dart';
+import 'package:openvine/utils/nostr_key_utils.dart';
+
+class _MockUploadManager extends Mock implements UploadManager {}
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockAuthService extends Mock implements AuthService {}
+
+class _MockVideoEventService extends Mock implements VideoEventService {}
+
+class _FakeEvent extends Fake implements Event {}
+
+class _FakeFilter extends Fake implements Filter {}
+
+const _deepEquals = DeepCollectionEquality();
+
+bool _containsTag(List<List<String>> tags, List<String> expected) {
+  return tags.any((tag) => _deepEquals.equals(tag, expected));
+}
+
+int _countPTagsFor(List<List<String>> tags, String pubkey) {
+  return tags
+      .where((tag) => tag.length >= 2 && tag[0] == 'p' && tag[1] == pubkey)
+      .length;
+}
+
+void main() {
+  late _MockUploadManager uploadManager;
+  late _MockNostrClient nostrClient;
+  late _MockAuthService authService;
+  late _MockVideoEventService videoEventService;
+  late VideoEventPublisher publisher;
+  late List<List<String>> capturedTags;
+
+  const testPubkey =
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+  const inspiredCreatorPubkey =
+      'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+  const inspiredPersonPubkey =
+      'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+  const rootAuthorPubkey =
+      'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd';
+
+  const inspiredByAddressableId = '34236:$inspiredCreatorPubkey:source-d-tag';
+
+  setUpAll(() {
+    registerFallbackValue(_FakeEvent());
+    registerFallbackValue(_FakeFilter());
+    registerFallbackValue(<Filter>[]);
+    registerFallbackValue(UploadStatus.pending);
+    registerFallbackValue(Duration.zero);
+  });
+
+  setUp(() {
+    uploadManager = _MockUploadManager();
+    nostrClient = _MockNostrClient();
+    authService = _MockAuthService();
+    videoEventService = _MockVideoEventService();
+    capturedTags = [];
+
+    publisher = VideoEventPublisher(
+      uploadManager: uploadManager,
+      nostrService: nostrClient,
+      authService: authService,
+      videoEventService: videoEventService,
+    );
+
+    when(() => nostrClient.isInitialized).thenReturn(true);
+    when(() => nostrClient.configuredRelayCount).thenReturn(1);
+    when(() => nostrClient.connectedRelayCount).thenReturn(1);
+    when(
+      () => nostrClient.configuredRelays,
+    ).thenReturn(['wss://relay.divine.video']);
+    when(
+      () => nostrClient.connectedRelays,
+    ).thenReturn(['wss://relay.divine.video']);
+    when(() => nostrClient.publicKey).thenReturn('');
+
+    when(() => authService.isAuthenticated).thenReturn(true);
+    when(() => authService.currentPublicKeyHex).thenReturn(testPubkey);
+
+    when(
+      () => uploadManager.updateUploadStatus(
+        any(),
+        any(),
+        nostrEventId: any(named: 'nostrEventId'),
+      ),
+    ).thenAnswer((_) async {});
+  });
+
+  PendingUpload createUpload() {
+    return PendingUpload(
+      id: 'upload-id',
+      localVideoPath: '',
+      nostrPubkey: testPubkey,
+      status: UploadStatus.readyToPublish,
+      createdAt: DateTime.now(),
+      videoId: 'video-id',
+      cdnUrl: 'https://cdn.example.com/video.mp4',
+      fallbackUrl: 'https://cdn.example.com/video.mp4',
+    );
+  }
+
+  void stubSignAndPublish() {
+    late Event publishedEvent;
+
+    when(
+      () => authService.createAndSignEvent(
+        kind: any(named: 'kind'),
+        content: any(named: 'content'),
+        tags: any(named: 'tags'),
+      ),
+    ).thenAnswer((invocation) async {
+      capturedTags = invocation.namedArguments[#tags] as List<List<String>>;
+      publishedEvent = Event(
+        testPubkey,
+        NIP71VideoKinds.getPreferredAddressableKind(),
+        capturedTags,
+        'test content',
+      );
+      return publishedEvent;
+    });
+
+    when(
+      () => nostrClient.publishEventAwaitOk(
+        any(),
+        timeout: any(named: 'timeout'),
+      ),
+    ).thenAnswer(
+      (_) async => PublishOutcome(
+        eventId: publishedEvent.id,
+        acceptedBy: const ['wss://relay.divine.video'],
+        rejectedBy: const {},
+        noResponseFrom: const [],
+      ),
+    );
+    when(
+      () => nostrClient.queryEvents(
+        any(),
+        subscriptionId: any(named: 'subscriptionId'),
+        tempRelays: any(named: 'tempRelays'),
+        relayTypes: any(named: 'relayTypes'),
+        sendAfterAuth: any(named: 'sendAfterAuth'),
+        useCache: any(named: 'useCache'),
+      ),
+    ).thenAnswer((_) async => <Event>[publishedEvent]);
+  }
+
+  test(
+    'emits an inspired-by p-tag alongside the a-tag for a video reference',
+    () async {
+      stubSignAndPublish();
+
+      final result = await publisher.publishDirectUpload(
+        createUpload(),
+        inspiredByAddressableId: inspiredByAddressableId,
+        inspiredByRelayUrl: 'wss://source.relay',
+      );
+
+      expect(result, isTrue);
+      expect(
+        _containsTag(capturedTags, const [
+          'a',
+          inspiredByAddressableId,
+          'wss://source.relay',
+          'mention',
+        ]),
+        isTrue,
+        reason: 'the existing inspired-by a-tag is unchanged',
+      );
+      expect(
+        _containsTag(
+          capturedTags,
+          buildInspiredByPTag(
+            inspiredCreatorPubkey,
+            relayHint: 'wss://source.relay',
+          ),
+        ),
+        isTrue,
+      );
+    },
+  );
+
+  test('emits an inspired-by p-tag for a person (npub) reference', () async {
+    stubSignAndPublish();
+    final npub = NostrKeyUtils.encodePubKey(inspiredPersonPubkey);
+
+    final result = await publisher.publishDirectUpload(
+      createUpload(),
+      inspiredByNpub: npub,
+    );
+
+    expect(result, isTrue);
+    expect(
+      _containsTag(capturedTags, buildInspiredByPTag(inspiredPersonPubkey)),
+      isTrue,
+    );
+  });
+
+  test(
+    'emits p-tags for both creators when video and person co-occur',
+    () async {
+      stubSignAndPublish();
+      final npub = NostrKeyUtils.encodePubKey(inspiredPersonPubkey);
+
+      final result = await publisher.publishDirectUpload(
+        createUpload(),
+        inspiredByAddressableId: inspiredByAddressableId,
+        inspiredByNpub: npub,
+      );
+
+      expect(result, isTrue);
+      expect(_countPTagsFor(capturedTags, inspiredCreatorPubkey), equals(1));
+      expect(_countPTagsFor(capturedTags, inspiredPersonPubkey), equals(1));
+    },
+  );
+
+  test(
+    'emits a single p-tag when video and person reference the same creator',
+    () async {
+      stubSignAndPublish();
+      final npub = NostrKeyUtils.encodePubKey(inspiredCreatorPubkey);
+
+      final result = await publisher.publishDirectUpload(
+        createUpload(),
+        inspiredByAddressableId: inspiredByAddressableId,
+        inspiredByNpub: npub,
+      );
+
+      expect(result, isTrue);
+      expect(_countPTagsFor(capturedTags, inspiredCreatorPubkey), equals(1));
+    },
+  );
+
+  test("skips the p-tag when inspired by the publisher's own video", () async {
+    stubSignAndPublish();
+
+    final result = await publisher.publishDirectUpload(
+      createUpload(),
+      inspiredByAddressableId: '34236:$testPubkey:own-d-tag',
+    );
+
+    expect(result, isTrue);
+    expect(_countPTagsFor(capturedTags, testPubkey), equals(0));
+  });
+
+  test(
+    'keeps the collaborator p-tag when the creator is also a collaborator',
+    () async {
+      stubSignAndPublish();
+
+      final result = await publisher.publishDirectUpload(
+        createUpload(),
+        collaboratorPubkeys: const [inspiredCreatorPubkey],
+        inspiredByAddressableId: inspiredByAddressableId,
+      );
+
+      expect(result, isTrue);
+      expect(
+        _containsTag(
+          capturedTags,
+          buildCollaboratorPTag(inspiredCreatorPubkey),
+        ),
+        isTrue,
+      );
+      expect(
+        _countPTagsFor(capturedTags, inspiredCreatorPubkey),
+        equals(1),
+        reason: 'a collaborator is never double-tagged as inspired-by',
+      );
+    },
+  );
+
+  test(
+    'keeps a single p-tag when the creator is also a caption mention',
+    () async {
+      stubSignAndPublish();
+
+      final result = await publisher.publishDirectUpload(
+        createUpload(),
+        mentionedPubkeys: const [inspiredCreatorPubkey],
+        inspiredByAddressableId: inspiredByAddressableId,
+      );
+
+      expect(result, isTrue);
+      expect(
+        _containsTag(capturedTags, const [
+          'p',
+          inspiredCreatorPubkey,
+          'wss://relay.divine.video',
+          'mention',
+        ]),
+        isTrue,
+        reason: 'the caption-mention p-tag wins dedup',
+      );
+      expect(_countPTagsFor(capturedTags, inspiredCreatorPubkey), equals(1));
+    },
+  );
+
+  test('does not emit inspired-by p-tags on a video reply', () async {
+    stubSignAndPublish();
+    const replyContext = VideoReplyContext(
+      rootEventId:
+          'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+      rootEventKind: 34236,
+      rootAuthorPubkey: rootAuthorPubkey,
+    );
+
+    final result = await publisher.publishDirectUpload(
+      createUpload(),
+      replyContext: replyContext,
+      inspiredByAddressableId: inspiredByAddressableId,
+      inspiredByNpub: NostrKeyUtils.encodePubKey(inspiredPersonPubkey),
+    );
+
+    expect(result, isTrue);
+    expect(
+      capturedTags.any(
+        (tag) =>
+            tag.length >= 4 && tag[0] == 'p' && tag[3] == inspiredByPTagMarker,
+      ),
+      isFalse,
+      reason:
+          'the model hides inspired-by attribution on replies and the '
+          'edit flow cannot own the tag there, so replies never notify',
+    );
+    expect(
+      _countPTagsFor(capturedTags, rootAuthorPubkey),
+      equals(1),
+      reason: 'reply threading p-tags are untouched',
+    );
+  });
+
+  test('emits no inspired-by p-tag without an inspired-by reference', () async {
+    stubSignAndPublish();
+
+    final result = await publisher.publishDirectUpload(createUpload());
+
+    expect(result, isTrue);
+    expect(
+      capturedTags.any(
+        (tag) =>
+            tag.length >= 4 && tag[0] == 'p' && tag[3] == inspiredByPTagMarker,
+      ),
+      isFalse,
+    );
+  });
+
+  test(
+    'publishes without a p-tag when the addressable id is malformed',
+    () async {
+      stubSignAndPublish();
+
+      final result = await publisher.publishDirectUpload(
+        createUpload(),
+        inspiredByAddressableId: '34236:',
+      );
+
+      expect(result, isTrue);
+      expect(
+        capturedTags.any(
+          (tag) =>
+              tag.length >= 4 &&
+              tag[0] == 'p' &&
+              tag[3] == inspiredByPTagMarker,
+        ),
+        isFalse,
+      );
+      expect(
+        capturedTags.any((tag) => tag.length >= 2 && tag[1].isEmpty),
+        isFalse,
+        reason: 'no empty p value is ever published',
+      );
+    },
+  );
+}

--- a/mobile/test/services/video_metadata_update_service_test.dart
+++ b/mobile/test/services/video_metadata_update_service_test.dart
@@ -19,6 +19,7 @@ import 'package:openvine/services/collaborator_invite_service.dart';
 import 'package:openvine/services/personal_event_cache_service.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/services/video_metadata_update_service.dart';
+import 'package:openvine/utils/nostr_key_utils.dart';
 
 import '../helpers/test_provider_overrides.dart';
 
@@ -1100,6 +1101,389 @@ void main() {
           );
         },
       );
+    });
+
+    group('inspired-by p-tag lifecycle', () {
+      const inspiredCreator =
+          'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+      const otherCreator =
+          '2222222222222222222222222222222222222222222222222222222222222222';
+      const inspiredAddressableId = '34236:$inspiredCreator:source-vid';
+      const inspiredPTag = [
+        'p',
+        inspiredCreator,
+        'wss://relay.divine.video',
+        'inspired-by',
+      ];
+
+      List<List<String>> inspiredByPTags() => capturedTags
+          .where(
+            (tag) =>
+                tag.length >= 4 && tag.first == 'p' && tag[3] == 'inspired-by',
+          )
+          .toList();
+
+      test('keeps the p-tag exactly once when re-editing', () async {
+        final video = _testVideo(
+          extraTags: const [
+            [
+              'a',
+              inspiredAddressableId,
+              'wss://relay.divine.video',
+              'inspired-by',
+            ],
+            inspiredPTag,
+          ],
+        );
+
+        final result = await service.updateVideo(
+          originalVideo: video,
+          editorState: VideoEditorProviderState(
+            inspiredByVideo: const InspiredByInfo(
+              addressableId: inspiredAddressableId,
+              relayUrl: 'wss://relay.divine.video',
+            ),
+          ),
+          initialCollaboratorPubkeys: const {},
+        );
+
+        expect(result, isA<VideoUpdateSuccess>());
+        expect(inspiredByPTags(), [equals(inspiredPTag)]);
+      });
+
+      test('mints the p-tag when editing a pre-fix video', () async {
+        final video = _testVideo(
+          extraTags: const [
+            [
+              'a',
+              inspiredAddressableId,
+              'wss://relay.divine.video',
+              'mention',
+            ],
+          ],
+        );
+
+        final result = await service.updateVideo(
+          originalVideo: video,
+          editorState: VideoEditorProviderState(
+            inspiredByVideo: const InspiredByInfo(
+              addressableId: inspiredAddressableId,
+              relayUrl: 'wss://relay.divine.video',
+            ),
+          ),
+          initialCollaboratorPubkeys: const {},
+        );
+
+        expect(result, isA<VideoUpdateSuccess>());
+        expect(inspiredByPTags(), [equals(inspiredPTag)]);
+      });
+
+      test('strips the p-tag when attribution is cleared', () async {
+        final video = _testVideo(
+          extraTags: const [
+            [
+              'a',
+              inspiredAddressableId,
+              'wss://relay.divine.video',
+              'inspired-by',
+            ],
+            inspiredPTag,
+          ],
+        );
+
+        final result = await service.updateVideo(
+          originalVideo: video,
+          editorState: VideoEditorProviderState(),
+          initialCollaboratorPubkeys: const {},
+        );
+
+        expect(result, isA<VideoUpdateSuccess>());
+        expect(inspiredByPTags(), isEmpty);
+      });
+
+      test('re-targets the p-tag when the inspiring creator changes', () async {
+        final video = _testVideo(
+          extraTags: const [
+            [
+              'a',
+              inspiredAddressableId,
+              'wss://relay.divine.video',
+              'inspired-by',
+            ],
+            inspiredPTag,
+          ],
+        );
+
+        final result = await service.updateVideo(
+          originalVideo: video,
+          editorState: VideoEditorProviderState(
+            inspiredByVideo: const InspiredByInfo(
+              addressableId: '34236:$otherCreator:other-vid',
+              relayUrl: 'wss://relay.divine.video',
+            ),
+          ),
+          initialCollaboratorPubkeys: const {},
+        );
+
+        expect(result, isA<VideoUpdateSuccess>());
+        expect(
+          inspiredByPTags(),
+          [
+            equals([
+              'p',
+              otherCreator,
+              'wss://relay.divine.video',
+              'inspired-by',
+            ]),
+          ],
+        );
+      });
+
+      test('emits a p-tag for a person (npub) attribution', () async {
+        final npub = NostrKeyUtils.encodePubKey(inspiredCreator);
+
+        final result = await service.updateVideo(
+          originalVideo: _testVideo(),
+          editorState: VideoEditorProviderState(inspiredByNpub: npub),
+          initialCollaboratorPubkeys: const {},
+        );
+
+        expect(result, isA<VideoUpdateSuccess>());
+        expect(inspiredByPTags(), [equals(inspiredPTag)]);
+      });
+
+      test(
+        'keeps a single collaborator p-tag when the creator is promoted '
+        'to collaborator',
+        () async {
+          final video = _testVideo(
+            extraTags: const [
+              [
+                'a',
+                inspiredAddressableId,
+                'wss://relay.divine.video',
+                'inspired-by',
+              ],
+              inspiredPTag,
+            ],
+          );
+
+          final result = await service.updateVideo(
+            originalVideo: video,
+            editorState: VideoEditorProviderState(
+              collaboratorPubkeys: {inspiredCreator},
+              inspiredByVideo: const InspiredByInfo(
+                addressableId: inspiredAddressableId,
+                relayUrl: 'wss://relay.divine.video',
+              ),
+            ),
+            initialCollaboratorPubkeys: const {inspiredCreator},
+          );
+
+          expect(result, isA<VideoUpdateSuccess>());
+          final pTagsForCreator = capturedTags
+              .where(
+                (tag) =>
+                    tag.length >= 2 &&
+                    tag.first == 'p' &&
+                    tag[1] == inspiredCreator,
+              )
+              .toList();
+          expect(pTagsForCreator, hasLength(1));
+          expect(
+            pTagsForCreator.single,
+            equals([
+              'p',
+              inspiredCreator,
+              'wss://relay.divine.video',
+              'collaborator',
+            ]),
+          );
+        },
+      );
+
+      test(
+        're-mints the inspired-by p-tag when the creator is demoted from '
+        'collaborator',
+        () async {
+          // The original event was produced by a promotion edit: it carries
+          // the collaborator p-tag and no inspired-by p-tag.
+          final promotedVideo = _testVideo(
+            extraTags: const [
+              [
+                'a',
+                inspiredAddressableId,
+                'wss://relay.divine.video',
+                'inspired-by',
+              ],
+              [
+                'p',
+                inspiredCreator,
+                'wss://relay.divine.video',
+                'collaborator',
+              ],
+            ],
+          );
+
+          final result = await service.updateVideo(
+            originalVideo: promotedVideo,
+            editorState: VideoEditorProviderState(
+              inspiredByVideo: const InspiredByInfo(
+                addressableId: inspiredAddressableId,
+                relayUrl: 'wss://relay.divine.video',
+              ),
+            ),
+            initialCollaboratorPubkeys: const {inspiredCreator},
+          );
+
+          expect(result, isA<VideoUpdateSuccess>());
+          expect(inspiredByPTags(), [equals(inspiredPTag)]);
+          expect(
+            capturedTags,
+            isNot(
+              contains(
+                equals([
+                  'p',
+                  inspiredCreator,
+                  'wss://relay.divine.video',
+                  'collaborator',
+                ]),
+              ),
+            ),
+          );
+        },
+      );
+
+      test('never strips caption-mention p-tags', () async {
+        const mentioned =
+            '3333333333333333333333333333333333333333333333333333333333333333';
+        final video = _testVideo(
+          extraTags: const [
+            ['p', mentioned, 'wss://relay.divine.video', 'mention'],
+          ],
+        );
+
+        final result = await service.updateVideo(
+          originalVideo: video,
+          editorState: VideoEditorProviderState(
+            inspiredByVideo: const InspiredByInfo(
+              addressableId: inspiredAddressableId,
+              relayUrl: 'wss://relay.divine.video',
+            ),
+          ),
+          initialCollaboratorPubkeys: const {},
+        );
+
+        expect(result, isA<VideoUpdateSuccess>());
+        expect(
+          capturedTags,
+          contains(
+            equals(['p', mentioned, 'wss://relay.divine.video', 'mention']),
+          ),
+        );
+        expect(inspiredByPTags(), [equals(inspiredPTag)]);
+      });
+
+      test(
+        'does not double-tag a creator who is already a caption mention',
+        () async {
+          final video = _testVideo(
+            extraTags: const [
+              ['p', inspiredCreator, 'wss://relay.divine.video', 'mention'],
+            ],
+          );
+
+          final result = await service.updateVideo(
+            originalVideo: video,
+            editorState: VideoEditorProviderState(
+              inspiredByVideo: const InspiredByInfo(
+                addressableId: inspiredAddressableId,
+                relayUrl: 'wss://relay.divine.video',
+              ),
+            ),
+            initialCollaboratorPubkeys: const {},
+          );
+
+          expect(result, isA<VideoUpdateSuccess>());
+          final pTagsForCreator = capturedTags
+              .where(
+                (tag) =>
+                    tag.length >= 2 &&
+                    tag.first == 'p' &&
+                    tag[1] == inspiredCreator,
+              )
+              .toList();
+          expect(pTagsForCreator, hasLength(1));
+          expect(
+            pTagsForCreator.single,
+            equals([
+              'p',
+              inspiredCreator,
+              'wss://relay.divine.video',
+              'mention',
+            ]),
+          );
+        },
+      );
+
+      test('preserves an inspired-by p-tag verbatim on a video reply', () async {
+        const rootEventId =
+            'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd';
+        const rootAuthorPubkey =
+            'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+        const rootAddressableId = '34236:$rootAuthorPubkey:root-vid';
+        final video = VideoEvent.fromNostrEvent(
+          Event(
+            _ownerPubkey,
+            NIP71VideoKinds.addressableShortVideo,
+            const [
+              ['d', 'video-d-tag'],
+              [
+                'imeta',
+                'url https://cdn.example.com/video.mp4',
+                'm video/mp4',
+              ],
+              ['A', rootAddressableId, ''],
+              ['P', rootAuthorPubkey],
+              ['E', rootEventId, '', rootAuthorPubkey],
+              ['K', '34236'],
+              ['e', rootEventId, '', rootAuthorPubkey],
+              ['p', rootAuthorPubkey],
+              inspiredPTag,
+            ],
+            'Reply video',
+            createdAt: 1757385263,
+          ),
+        );
+        expect(video.isVideoReply, isTrue);
+
+        final result = await service.updateVideo(
+          originalVideo: video,
+          editorState: VideoEditorProviderState(
+            inspiredByVideo: video.inspiredByVideo,
+          ),
+          initialCollaboratorPubkeys: const {},
+        );
+
+        expect(result, isA<VideoUpdateSuccess>());
+        expect(inspiredByPTags(), [equals(inspiredPTag)]);
+      });
+
+      test('does not self-p-tag when inspired by an own video', () async {
+        final result = await service.updateVideo(
+          originalVideo: _testVideo(),
+          editorState: VideoEditorProviderState(
+            inspiredByVideo: const InspiredByInfo(
+              addressableId: '34236:$_ownerPubkey:own-vid',
+              relayUrl: 'wss://relay.divine.video',
+            ),
+          ),
+          initialCollaboratorPubkeys: const {},
+        );
+
+        expect(result, isA<VideoUpdateSuccess>());
+        expect(inspiredByPTags(), isEmpty);
+      });
     });
   });
 }

--- a/mobile/test/utils/inspired_by_tags_test.dart
+++ b/mobile/test/utils/inspired_by_tags_test.dart
@@ -1,0 +1,160 @@
+// ABOUTME: Tests the shared inspired-by p-tag builder and creator resolution
+// ABOUTME: used by the direct-upload and edit-video publish paths.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/utils/inspired_by_tags.dart';
+import 'package:openvine/utils/nostr_key_utils.dart';
+
+void main() {
+  const creatorPubkey =
+      'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+  const otherPubkey =
+      'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+  const selfPubkey =
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+  group('buildInspiredByPTag', () {
+    test('builds the inspired-by-marked p tag with the default relay', () {
+      expect(
+        buildInspiredByPTag(creatorPubkey),
+        equals([
+          'p',
+          creatorPubkey,
+          inspiredByPTagRelayHint,
+          inspiredByPTagMarker,
+        ]),
+      );
+    });
+
+    test('uses the provided relay hint when non-empty', () {
+      expect(
+        buildInspiredByPTag(creatorPubkey, relayHint: 'wss://other.relay'),
+        equals(['p', creatorPubkey, 'wss://other.relay', 'inspired-by']),
+      );
+    });
+
+    test('falls back to the default relay when the hint is empty', () {
+      expect(
+        buildInspiredByPTag(creatorPubkey, relayHint: ''),
+        equals([
+          'p',
+          creatorPubkey,
+          inspiredByPTagRelayHint,
+          inspiredByPTagMarker,
+        ]),
+      );
+    });
+  });
+
+  group('resolveInspiredByCreatorHexes', () {
+    test('resolves the creator from a well-formed addressable id', () {
+      expect(
+        resolveInspiredByCreatorHexes(
+          addressableId: '34236:$creatorPubkey:some-d-tag',
+        ),
+        equals({creatorPubkey}),
+      );
+    });
+
+    test('skips a malformed addressable id', () {
+      expect(resolveInspiredByCreatorHexes(addressableId: '34236:'), isEmpty);
+      expect(
+        resolveInspiredByCreatorHexes(addressableId: 'not-a-coordinate'),
+        isEmpty,
+      );
+      expect(
+        resolveInspiredByCreatorHexes(addressableId: '34236:short-hex:d'),
+        isEmpty,
+      );
+    });
+
+    test('resolves the creator from a valid npub', () {
+      final npub = NostrKeyUtils.encodePubKey(creatorPubkey);
+      expect(
+        resolveInspiredByCreatorHexes(npub: npub),
+        equals({creatorPubkey}),
+      );
+    });
+
+    test('skips an undecodable npub', () {
+      expect(
+        resolveInspiredByCreatorHexes(npub: 'npub1notavalidbech32string'),
+        isEmpty,
+      );
+      expect(resolveInspiredByCreatorHexes(npub: ''), isEmpty);
+      expect(resolveInspiredByCreatorHexes(), isEmpty);
+    });
+
+    test('resolves two distinct creators when both sources are present', () {
+      final npub = NostrKeyUtils.encodePubKey(otherPubkey);
+      expect(
+        resolveInspiredByCreatorHexes(
+          addressableId: '34236:$creatorPubkey:some-d-tag',
+          npub: npub,
+        ),
+        equals({creatorPubkey, otherPubkey}),
+      );
+    });
+
+    test('dedupes when both sources reference the same creator', () {
+      final npub = NostrKeyUtils.encodePubKey(creatorPubkey);
+      expect(
+        resolveInspiredByCreatorHexes(
+          addressableId: '34236:$creatorPubkey:some-d-tag',
+          npub: npub,
+        ),
+        equals({creatorPubkey}),
+      );
+    });
+  });
+
+  group('buildInspiredByPTags', () {
+    test('emits an inspired-by p tag for the resolved creator', () {
+      expect(
+        buildInspiredByPTags(
+          existingTags: const [],
+          addressableId: '34236:$creatorPubkey:some-d-tag',
+          selfPubkey: selfPubkey,
+        ),
+        equals([buildInspiredByPTag(creatorPubkey)]),
+      );
+    });
+
+    test("skips the publisher's own pubkey", () {
+      expect(
+        buildInspiredByPTags(
+          existingTags: const [],
+          addressableId: '34236:$selfPubkey:some-d-tag',
+          selfPubkey: selfPubkey,
+        ),
+        isEmpty,
+      );
+    });
+
+    test('skips a creator already carried by any existing p tag', () {
+      expect(
+        buildInspiredByPTags(
+          existingTags: const [
+            ['p', creatorPubkey, 'wss://relay.divine.video', 'collaborator'],
+          ],
+          addressableId: '34236:$creatorPubkey:some-d-tag',
+          selfPubkey: selfPubkey,
+        ),
+        isEmpty,
+      );
+    });
+
+    test('emits both creators on co-occurring video and person sources', () {
+      final npub = NostrKeyUtils.encodePubKey(otherPubkey);
+      final tags = buildInspiredByPTags(
+        existingTags: const [],
+        addressableId: '34236:$creatorPubkey:some-d-tag',
+        npub: npub,
+        selfPubkey: selfPubkey,
+      );
+      expect(tags, hasLength(2));
+      expect(tags, anyElement(equals(buildInspiredByPTag(creatorPubkey))));
+      expect(tags, anyElement(equals(buildInspiredByPTag(otherPubkey))));
+    });
+  });
+}


### PR DESCRIPTION
## Description

"Inspired by" attribution on kind-34236 videos was display-only: the referenced creator was never `p`-tagged, so no notifier could target them — per NIP-27, a content mention without a matching `p` tag deliberately does **not** notify. Empirically confirmed on the production relay (event `42d1610431a7d3a1afc8420b21e9e98896977feca2031b927b00b30c79e9d684`: content attribution, 0 p-tags).

### Changes

- **`utils/inspired_by_tags.dart` (new)** — shared builder: `['p', <creatorHex>, <relay>, 'inspired-by']`. Marker is distinct from `'mention'` (so the edit flow can own the tag without touching caption-mention p-tags — stripping those is a #6019-class loss) and from `'collaborator'` (so no consumer renders the creator as a collaborator). Resolution reuses `InspiredByInfo.creatorPubkey` + npub decode, validates hex, self-skips (reusing your own sound auto-populates yourself), and dedups against every existing `p` tag (collaborators, caption mentions, reply threading) to keep the single-p-tag-per-pubkey invariant.
- **`video_event_publisher.dart`** — create path emits the p-tag(s) after the collaborator/mention p-tags; handles the person-npub and video-coordinate sources co-occurring (audio-reuse auto-populate bypasses the editor's mutual exclusion, so two distinct creators are possible). **Not emitted on replies**: the model hides inspired-by attribution on replies (`hasInspiredBy` is `!isVideoReply`-gated) and the edit flow cannot own the tag there, so it would notify for invisible, un-clearable attribution.
- **`video_metadata_update_service.dart`** — the edit flow owns the tag's lifecycle exactly like the inspired-by a-tag: `_isEditRebuiltTag` strips `'inspired-by'`-marker p-tags on non-replies and re-emits from editor state. Clearing attribution removes the tag, changing the creator re-targets it, collaborator promotion→demotion re-mints it, and **editing any pre-fix video backfills the missing p-tag**. Caption-mention and reply p-tags are never stripped.
- **`models/video_event.dart`** — anchors the `inspiredByNpub` content parse to the trailing `Inspired by nostr:npub…` line, so an unrelated inline `nostr:npub` mention earlier in a caption is never mis-attributed (previously first-match-anywhere; the edit path re-derives the person p-tag from this value, making the fix load-bearing).
- **`video_editor_provider.dart`** — the edit-form strip regex now also matches whole-content attribution (empty-caption publishes trim the leading newlines), fixing attribution-line duplication on every edit of such videos.

### Backend dependency

The tag is **inert until the backends source kind 34236**: divinevideo/divine-funnelcake#654 (in-app) and divinevideo/divine-push-service#28 (FCM push) — both fan out on p-tags marker-blind, verified. Part of #5938 / epic #4200.

### Known accepted edge

If a foreign client rewrites content so the attribution line is no longer trailing, a subsequent mobile edit drops the p-tag along with the (equally undetected) display attribution — the tag deliberately follows the content-derived attribution determination, and re-picking the person restores it.

**Related Issue:** Closes #6128

## Out of Scope

- Backend sourcing of kind 34236 (funnelcake#654, push-service#28).
- Unifying the pre-existing create/edit a-tag divergences (marker `mention` vs `inspired-by`, relay `?? 'wss://relay.divine.video'` vs `?? ''`) — deliberately untouched; the shipped a-tag shapes are parsed by web/funnelcake.
- A dedicated `inspired_by` notification type (minimal outcome surfaces as a generic mention; #5938 umbrella).

## Verification

- `flutter analyze lib test integration_test` — no issues.
- `flutter test` on all affected suites — 178 passing: new `test/utils/inspired_by_tags_test.dart` (13), new `test/services/video_event_publisher_inspired_by_tags_test.dart` (10, incl. self-skip, co-occurrence, reply no-emit, malformed-coordinate), `video_metadata_update_service_test.dart` (+11 lifecycle: exactly-once, clear-strips, re-target, promote/demote re-mint, pre-fix backfill, reply preservation, caption-mention safety, self-skip, person-npub), `video_editor_provider_test.dart` (+2 strip cases), plus the pre-existing publisher/collaborator/reply suites unchanged and green.
- `mobile/packages/models`: full suite 797 passing (3 new anchored-regex tests).
- Line coverage on all new/changed lines: 100% (new util 21/21; both service blocks fully covered).
- Multi-agent adversarial review at high effort: 3 confirmed correctness findings fixed in this diff (reply-gate asymmetry, whole-content strip, invisible reply attribution), 4 cleanups applied, 1 plausible edge documented above.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
