### PR TITLE
fix(video_editor): instant trim-based clip split + guard teardown races

### DIFF
--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
@@ -169,6 +169,23 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
     ClipEditorInitialized event,
     Emitter<ClipEditorState> emit,
   ) {
+    // While a split is in flight (including splits still queued behind it),
+    // this bloc owns the clip list optimistically — the split has already
+    // inserted its result, but the editor-history round-trip that drives the
+    // canvas re-sync still reflects the pre-split state. Applying that stale
+    // snapshot here wipes the just-applied (queued) split, which then never
+    // appears. Defer: the post-split reconcile re-syncs once isSplitting
+    // clears. The canvas guards its dispatch on the same condition; this is
+    // the matching guard for any other re-init source.
+    if (state.isSplitting) {
+      Log.debug(
+        '📋 Ignoring clip re-init during in-flight split '
+        '(${event.clips.length} clip(s))',
+        name: 'ClipEditorBloc',
+        category: LogCategory.video,
+      );
+      return;
+    }
     Log.debug(
       '📋 Initialized with ${event.clips.length} clip(s)',
       name: 'ClipEditorBloc',
@@ -658,6 +675,12 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
         },
       );
 
+      // onFinalClipInvalidated reaches into the editor screen that owns this
+      // bloc. A long split (a full clip re-encode, ~15-20s) can land after the
+      // user backs out — bloc.close() lets this in-flight handler run to
+      // completion, so `emit.isDone` is still false here. The screen callback
+      // itself must guard on `mounted`; the bloc can't detect the torn-down
+      // screen from this side.
       onFinalClipInvalidated.call();
 
       Log.info(
@@ -728,8 +751,11 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
 
     final clip = state.clips[index];
     final maxTrim = clip.duration - TimelineConstants.minTrimDuration;
-    final clampedStart = event.trimStart < Duration.zero
-        ? Duration.zero
+    // A trim-based split's end half carries a source floor so its start handle
+    // can't be dragged back before the split into the start half's frames.
+    final minStart = clip.minTrimStart;
+    final clampedStart = event.trimStart < minStart
+        ? minStart
         : event.trimStart > maxTrim - clip.trimEnd
         ? maxTrim - clip.trimEnd
         : event.trimStart;

--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
@@ -31,8 +31,6 @@ typedef SplitClipFn =
       onClipsCreated,
       required void Function(DivineVideoClip clip, String thumbnailPath)?
       onThumbnailExtracted,
-      required void Function(DivineVideoClip clip, EditorVideo video)?
-      onClipRendered,
     });
 
 /// Function signature matching [VideoEditorReverseService.reverseClip], used as
@@ -94,6 +92,7 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
     on<ClipEditorClipRemoved>(_onClipRemoved);
     on<ClipEditorClipInserted>(_onClipInserted);
     on<ClipEditorClipUpdated>(_onClipUpdated);
+    on<ClipEditorClipThumbnailUpdated>(_onClipThumbnailUpdated);
 
     // Clip selection
     on<ClipEditorClipSelected>(_onClipSelected);
@@ -237,6 +236,21 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
 
     final newClips = List<DivineVideoClip>.of(state.clips)
       ..[index] = event.clip;
+
+    emit(state.copyWith(clips: List.unmodifiable(newClips)));
+  }
+
+  void _onClipThumbnailUpdated(
+    ClipEditorClipThumbnailUpdated event,
+    Emitter<ClipEditorState> emit,
+  ) {
+    final index = state.clips.indexWhere((c) => c.id == event.clipId);
+    if (index == -1) return;
+
+    final newClips = List<DivineVideoClip>.of(state.clips)
+      ..[index] = state.clips[index].copyWith(
+        thumbnailPath: event.thumbnailPath,
+      );
 
     emit(state.copyWith(clips: List.unmodifiable(newClips)));
   }
@@ -578,10 +592,9 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
     try {
       // Emit directly from callbacks instead of dispatching events.
       // Cross-event-type handlers run concurrently in BLoC, which
-      // caused a race where ClipEditorClipUpdated (rendered video
-      // file) was processed before ClipEditorOriginalClipReplaced
-      // had inserted the new clip ids — the index lookup failed and
-      // the clips kept pointing at the original source video.
+      // caused a race where a follow-up clip update was processed before
+      // the new clip ids were inserted — the index lookup failed and the
+      // clips kept pointing at the original source video.
       await _splitClip(
         sourceClip: selectedClip,
         splitPosition: splitPosition,
@@ -589,10 +602,9 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
           splitStartClipId = startClip.id;
           splitEndClipId = endClip.id;
 
-          // splitClip awaits a single native split (plus the parallel
-          // thumbnail). If the bloc is closed mid-split (user navigates
-          // away from the editor), the late callbacks fire on a done
-          // emitter — guard each one.
+          // The background thumbnail callback can fire after the bloc is
+          // closed (user navigates away from the editor) — guard each one
+          // against a done emitter.
           if (emit.isDone) return;
           final clips = state.clips;
           final index = clips.indexWhere((c) => c.id == selectedClip.id);
@@ -641,46 +653,24 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
           );
         },
         onThumbnailExtracted: (clip, thumbnailPath) {
-          if (emit.isDone) return;
-          final clips = state.clips;
-          final index = clips.indexWhere((c) => c.id == clip.id);
-          if (index == -1) return;
-          final newClips = List<DivineVideoClip>.of(clips);
-          newClips[index] = newClips[index].copyWith(
-            thumbnailPath: thumbnailPath,
-          );
-          emit(state.copyWith(clips: List.unmodifiable(newClips)));
-        },
-        onClipRendered: (clip, video) {
-          if (emit.isDone) return;
-          final clips = state.clips;
-          final index = clips.indexWhere((c) => c.id == clip.id);
-          if (index == -1) return;
-          final newClips = List<DivineVideoClip>.of(clips);
-          newClips[index] = newClips[index].copyWith(
-            video: video,
-            duration: clip.duration,
-            trimStart: clip.trimStart,
-            trimEnd: clip.trimEnd,
-            // The rendered end half's file starts at the split point \u2014 carry
-            // the shift so the thumbnail raster stays recording-anchored.
-            sourceStartOffset: clip.sourceStartOffset,
-          );
-          emit(state.copyWith(clips: List.unmodifiable(newClips)));
-          Log.debug(
-            '\u2705 Clip rendered: ${clip.id}',
-            name: 'ClipEditorBloc',
-            category: LogCategory.video,
+          // The thumbnail decode is fire-and-forget, so it lands after this
+          // split handler completes and its emitter is done. Dispatch a fresh
+          // event so the poster still updates (unless the bloc was closed).
+          if (isClosed) return;
+          add(
+            ClipEditorClipThumbnailUpdated(
+              clipId: clip.id,
+              thumbnailPath: thumbnailPath,
+            ),
           );
         },
       );
 
       // onFinalClipInvalidated reaches into the editor screen that owns this
-      // bloc. A long split (a full clip re-encode, ~15-20s) can land after the
-      // user backs out — bloc.close() lets this in-flight handler run to
-      // completion, so `emit.isDone` is still false here. The screen callback
-      // itself must guard on `mounted`; the bloc can't detect the torn-down
-      // screen from this side.
+      // bloc. The trim-based split is instant, but the same callback also
+      // guards long clip renders elsewhere (reverse / transform, ~15-20s) that
+      // can land after the user backs out — the screen callback must guard on
+      // `mounted`; the bloc can't detect the torn-down screen from this side.
       onFinalClipInvalidated.call();
 
       Log.info(
@@ -689,8 +679,7 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
         category: LogCategory.video,
       );
     } catch (e, stackTrace) {
-      // Matrix-NO: rethrown FFmpeg render exceptions, RenderCanceledException
-      // (user nav-away mid-render), and file IO. ArgumentError from
+      // Matrix-NO: rethrown render exceptions and file IO. ArgumentError from
       // VideoEditorSplitService is pre-validated by isValidSplitPosition at
       // line 259 above and cannot reach this catch.
       addError(e, stackTrace);
@@ -753,11 +742,17 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
     final maxTrim = clip.duration - TimelineConstants.minTrimDuration;
     // A trim-based split's end half carries a source floor so its start handle
     // can't be dragged back before the split into the start half's frames.
+    // The upper bound can dip below that floor when the visible span is shorter
+    // than minTrimDuration (the split guard allows a 30ms half); keep the floor
+    // authoritative so the clamp can never emit a trimStart below it.
     final minStart = clip.minTrimStart;
+    final maxStart = (maxTrim - clip.trimEnd) < minStart
+        ? minStart
+        : maxTrim - clip.trimEnd;
     final clampedStart = event.trimStart < minStart
         ? minStart
-        : event.trimStart > maxTrim - clip.trimEnd
-        ? maxTrim - clip.trimEnd
+        : event.trimStart > maxStart
+        ? maxStart
         : event.trimStart;
     final clampedEnd = event.trimEnd < Duration.zero
         ? Duration.zero
@@ -934,18 +929,28 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
 
       final currentClip = currentClips[currentIndex];
 
-      // The render input (`videoPath`) holds content in the clip's current
-      // direction (`clip.reversed`); the render output (`reversedVideo`) holds
-      // the opposite. Assign each to its matching cache slot so the branch is
-      // also correct when the input is already reversed — e.g. a duplicate or
-      // split of a reversed clip, which preserves `reversed` but clears both
-      // cache paths. Mapping by output direction instead would store forward
-      // content as the reversed path (and vice versa), making every later
-      // cached toggle play the wrong direction.
+      // The reverse bakes the clip's visible window, so the result is a
+      // standalone clip: its file is exactly the window reversed. Reset trims,
+      // set [duration] to the window length, and clear the split floor — the
+      // reversed file holds only this clip's frames, so there is no sibling to
+      // guard and no capped-duration mismatch (the old trimStart/trimEnd swap
+      // was only valid when duration == real file length).
       final renderedPath = reversedVideo.file?.path;
+      final reversedDuration = clip.trimmedDuration;
+
+      // The swap-based cached toggle only round-trips when the forward clip
+      // spanned its whole file (trims zero); a windowed clip re-renders on
+      // toggle instead. The render input (`videoPath`) holds content in the
+      // clip's current direction, the output (`reversedVideo`) the opposite, so
+      // map each to its matching cache slot.
+      final keepCache =
+          clip.trimStart == Duration.zero && clip.trimEnd == Duration.zero;
       final String? forwardVideoPath;
       final String? reversedVideoPath;
-      if (clip.reversed) {
+      if (!keepCache) {
+        forwardVideoPath = null;
+        reversedVideoPath = null;
+      } else if (clip.reversed) {
         forwardVideoPath = renderedPath ?? currentClip.forwardVideoPath;
         reversedVideoPath = currentClip.reversedVideoPath ?? videoPath;
       } else {
@@ -953,22 +958,18 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
         reversedVideoPath = renderedPath ?? currentClip.reversedVideoPath;
       }
 
-      // Un-reversing via render produces a fresh mirror file with no
-      // recording continuity, and any stored sourceStartOffset was
-      // accumulated in reversed-file coordinates (splitting a reversed clip
-      // adds the split position to it) — keeping it would phase-shift the
-      // forward clip's thumbnail raster by a meaningless amount. Zero it so
-      // the raster anchors at the new file's start. Reversing forward →
-      // reversed keeps the offset: it pairs with the forward file cached in
-      // [forwardVideoPath], which the cached un-reverse branch restores.
       final updatedClip = currentClip.copyWith(
         video: reversedVideo,
-        trimStart: currentClip.trimEnd,
-        trimEnd: currentClip.trimStart,
+        trimStart: Duration.zero,
+        trimEnd: Duration.zero,
+        duration: reversedDuration,
+        minTrimStart: Duration.zero,
+        sourceStartOffset: Duration.zero,
         reversed: !clip.reversed,
         forwardVideoPath: forwardVideoPath,
         reversedVideoPath: reversedVideoPath,
-        sourceStartOffset: clip.reversed ? Duration.zero : null,
+        clearForwardVideoPath: forwardVideoPath == null,
+        clearReversedVideoPath: reversedVideoPath == null,
       );
       final newClips = List<DivineVideoClip>.of(currentClips)
         ..[currentIndex] = updatedClip;

--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_event.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_event.dart
@@ -55,6 +55,23 @@ class ClipEditorClipUpdated extends ClipEditorEvent {
   List<Object?> get props => [clipId, clip];
 }
 
+/// Refreshes a clip's representative thumbnail once a background extraction
+/// lands. Dispatched (not emitted from a captured handler) because the split's
+/// thumbnail decode completes after the split handler has already finished, so
+/// its emitter is done.
+class ClipEditorClipThumbnailUpdated extends ClipEditorEvent {
+  const ClipEditorClipThumbnailUpdated({
+    required this.clipId,
+    required this.thumbnailPath,
+  });
+
+  final String clipId;
+  final String thumbnailPath;
+
+  @override
+  List<Object?> get props => [clipId, thumbnailPath];
+}
+
 // === CLIP SELECTION ===
 
 /// Select a clip by its index in the clip list.

--- a/mobile/lib/models/clip_manager_state.dart
+++ b/mobile/lib/models/clip_manager_state.dart
@@ -87,7 +87,7 @@ class ClipManagerState {
 
   /// Total combined duration of all clips.
   Duration get totalDuration {
-    return clips.fold(Duration.zero, (sum, clip) => sum + clip.duration);
+    return clips.fold(Duration.zero, (sum, clip) => sum + clip.budgetDuration);
   }
 
   /// Remaining recording time available before reaching max duration.

--- a/mobile/lib/models/divine_video_clip.dart
+++ b/mobile/lib/models/divine_video_clip.dart
@@ -130,6 +130,19 @@ class DivineVideoClip {
     return result.isNegative ? Duration.zero : result;
   }
 
+  /// The span of source recording time this clip contributes to the total
+  /// recording budget.
+  ///
+  /// Equal to [duration] for a normal clip. A trim-based split's end half keeps
+  /// the full source [duration] but shares its file with the start half, so the
+  /// region before the split ([minTrimStart]) is already counted by the start
+  /// half — subtract it here so summing clips doesn't double-count the split
+  /// region against the recording cap.
+  Duration get budgetDuration {
+    final result = duration - minTrimStart;
+    return result.isNegative ? Duration.zero : result;
+  }
+
   /// Effective duration in seconds after trimming.
   double get trimmedDurationInSeconds =>
       trimmedDuration.inMilliseconds / 1000.0;

--- a/mobile/lib/models/divine_video_clip.dart
+++ b/mobile/lib/models/divine_video_clip.dart
@@ -29,6 +29,7 @@ class DivineVideoClip {
     this.trimStart = Duration.zero,
     this.trimEnd = Duration.zero,
     this.sourceStartOffset = Duration.zero,
+    this.minTrimStart = Duration.zero,
     this.volume = 1,
     this.playbackSpeed,
     this.reversed = false,
@@ -77,6 +78,16 @@ class DivineVideoClip {
   /// timeline thumbnail raster — can stay anchored to the original
   /// recording's timeline instead of re-anchoring at the new file's zero.
   final Duration sourceStartOffset;
+
+  /// The lowest [trimStart] this clip may be trimmed back to — its floor within
+  /// the source file.
+  ///
+  /// `Duration.zero` for normal clips. A trim-based split (which cuts a clip
+  /// into two clips that share the *same* source file rather than re-encoding
+  /// two separate files) sets it on the end half to the split point, so the
+  /// end half's left trim handle can't be dragged back before the split into
+  /// the start half's frames.
+  final Duration minTrimStart;
 
   /// Playback volume for this clip, between 0 (muted) and 1 (full volume).
   final double volume;
@@ -206,6 +217,7 @@ class DivineVideoClip {
     Duration? trimStart,
     Duration? trimEnd,
     Duration? sourceStartOffset,
+    Duration? minTrimStart,
     double? volume,
     double? playbackSpeed,
     bool clearPlaybackSpeed = false,
@@ -240,6 +252,7 @@ class DivineVideoClip {
       trimStart: trimStart ?? this.trimStart,
       trimEnd: trimEnd ?? this.trimEnd,
       sourceStartOffset: sourceStartOffset ?? this.sourceStartOffset,
+      minTrimStart: minTrimStart ?? this.minTrimStart,
       volume: volume ?? this.volume,
       playbackSpeed: clearPlaybackSpeed
           ? null
@@ -287,6 +300,8 @@ class DivineVideoClip {
       'trimEndMs': trimEnd.inMilliseconds,
       if (sourceStartOffset > Duration.zero)
         'sourceStartOffsetMs': sourceStartOffset.inMilliseconds,
+      if (minTrimStart > Duration.zero)
+        'minTrimStartMs': minTrimStart.inMilliseconds,
       'volume': volume,
       if (playbackSpeed != null) 'playbackSpeed': playbackSpeed,
       if (reversed) 'reversed': true,
@@ -368,6 +383,9 @@ class DivineVideoClip {
       trimEnd: Duration(milliseconds: (json['trimEndMs'] as int?) ?? 0),
       sourceStartOffset: Duration(
         milliseconds: (json['sourceStartOffsetMs'] as int?) ?? 0,
+      ),
+      minTrimStart: Duration(
+        milliseconds: (json['minTrimStartMs'] as int?) ?? 0,
       ),
       volume: (json['volume'] as num?)?.toDouble() ?? 1,
       playbackSpeed: (json['playbackSpeed'] as num?)?.toDouble(),

--- a/mobile/lib/providers/clip_manager_provider.dart
+++ b/mobile/lib/providers/clip_manager_provider.dart
@@ -60,7 +60,7 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
   Duration get totalDuration {
     return _clips.fold<Duration>(
       Duration.zero,
-      (sum, clip) => sum + clip.duration,
+      (sum, clip) => sum + clip.budgetDuration,
     );
   }
 

--- a/mobile/lib/screens/video_editor/video_editor_screen.dart
+++ b/mobile/lib/screens/video_editor/video_editor_screen.dart
@@ -142,6 +142,12 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen>
     );
     _clipEditorBloc = ClipEditorBloc(
       onFinalClipInvalidated: () {
+        // A clip render (split / reverse / transform) can resolve after this
+        // screen is disposed — the user backed out while a long clip was still
+        // re-encoding (~15-20s). Both `ref` and `_editor` are unsafe to touch
+        // once the State is unmounted, so bail before either is used;
+        // otherwise `ref.read` throws "Using ref when unmounted".
+        if (!mounted) return;
         ref.read(videoEditorProvider.notifier).invalidateFinalRenderedClip();
 
         if (_editor != null) {

--- a/mobile/lib/screens/video_editor/video_editor_screen.dart
+++ b/mobile/lib/screens/video_editor/video_editor_screen.dart
@@ -142,8 +142,8 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen>
     );
     _clipEditorBloc = ClipEditorBloc(
       onFinalClipInvalidated: () {
-        // A clip render (split / reverse / transform) can resolve after this
-        // screen is disposed — the user backed out while a long clip was still
+        // A clip render (reverse / transform) can resolve after this screen is
+        // disposed — the user backed out while a long clip was still
         // re-encoding (~15-20s). Both `ref` and `_editor` are unsafe to touch
         // once the State is unmounted, so bail before either is used;
         // otherwise `ref.read` throws "Using ref when unmounted".

--- a/mobile/lib/services/video_editor/clip_thumbnail_manager.dart
+++ b/mobile/lib/services/video_editor/clip_thumbnail_manager.dart
@@ -41,18 +41,12 @@ class ClipThumbnailManager {
   // thumbnail generation against the new file.
   final Map<String, String> _videoPaths = {};
   // IDs whose notifier has been pre-populated from another clip's
-  // thumbnails (e.g. split). For these we suppress auto-loading until
-  // the rendered file path arrives — otherwise the seeded frames would
-  // be immediately overwritten by a fresh subscription against the
-  // (still un-trimmed) source video.
+  // thumbnails (a trim-based split borrows the source clip's frames so the
+  // new halves show correct content immediately). Cleared on the next
+  // [sync], which starts the real subscription against the (shared) source
+  // file; until then the flag protects the borrowed frames from being
+  // retired as if they were the clip's own.
   final Set<String> _seeded = {};
-  // Timestamp shift to apply to a seeded clip's thumbnails when its
-  // rendered file path arrives. Seeded frames are kept in the *current*
-  // clip's timebase so they display immediately; when the rendered file
-  // rebases the clip's timeline (split end half: source-time →
-  // zero-based), the same shift is applied here so the frames stay
-  // aligned until fresh thumbnails replace them.
-  final Map<String, Duration> _pendingRebase = {};
   // IDs whose subscription has delivered its final batch — the strip is at
   // full density and only a source-file change warrants re-extraction.
   final Set<String> _complete = {};
@@ -96,7 +90,6 @@ class ClipThumbnailManager {
       _subscriptions.remove(id)?.cancel();
       final videoPath = _videoPaths.remove(id);
       final wasSeeded = _seeded.remove(id);
-      _pendingRebase.remove(id);
       final wasComplete = _complete.remove(id);
       final notifier = _notifiers.remove(id);
       if (notifier == null) continue;
@@ -158,15 +151,14 @@ class ClipThumbnailManager {
 
       if (!hasSubscription) {
         if (isSeeded) {
-          // Skip auto-loading for seeded clips — their notifier already
-          // shows the right frames borrowed from the source clip.
-          if (newPath == null || newPath == currentPath) continue;
-          // The rendered (trimmed) file path arrived — start the real
-          // subscription. The seeded frames stay visible (rebased into
-          // the rendered file's timebase where needed) until fresh
-          // frames cover their spots; their files are deleted then.
+          // A trim-based split half already points at its final (shared
+          // source) file — no rendered-file swap is coming. Start the real
+          // subscription now against that file so the strip can fill new
+          // slots on zoom/scroll; the seeded frames stay visible as
+          // gap-fillers until fresh frames cover them (see
+          // [_mergeCarriedFrames]). Waiting for a path change would freeze
+          // the strip at its seeded density forever.
           _seeded.remove(clip.id);
-          _rebaseThumbnails(clip.id);
         } else if (_complete.contains(clip.id)) {
           // Restored from the retired cache at full density — only a
           // source-file change warrants re-extraction.
@@ -187,10 +179,8 @@ class ClipThumbnailManager {
         // their spots (see [_mergeCarriedFrames]); their files are
         // deleted as they drop out.
         //
-        // Seeded split halves never reach this branch: they carry no
-        // subscription until their rendered path arrives via the
-        // !hasSubscription branch above, which is where _seeded and any
-        // pending rebase are consumed.
+        // A reversed / transformed clip lands here: its file swaps to the
+        // rendered output, so the subscription restarts against the new file.
         _subscriptions.remove(clip.id)?.cancel();
         _loadThumbnails(
           clip,
@@ -213,30 +203,21 @@ class ClipThumbnailManager {
   /// decode that flashes black. Cleanup protects borrowed files: they
   /// are only deleted once no notifier references them anymore.
   ///
-  /// The clip is marked as "seeded" so [sync] will not auto-load a
-  /// fresh subscription against the still-un-trimmed source video
-  /// — that would overwrite these correct frames with the wrong
-  /// range. The real subscription starts once the rendered file
-  /// path arrives via the path-change branch in [sync]; the seeded
-  /// frames stay visible as gap-fillers until fresh frames cover
-  /// their spots (see [_mergeCarriedFrames]).
+  /// The clip is marked as "seeded" so the very next [sync] starts the real
+  /// subscription against [currentSourcePath] (the shared source file a
+  /// trim-based split keeps) while these borrowed frames stay visible as
+  /// gap-fillers until fresh frames cover their spots (see
+  /// [_mergeCarriedFrames]).
   ///
-  /// [rebaseOnPathChange] is subtracted from every seeded timestamp
-  /// when the rendered file path arrives. Use it when the rendered
-  /// file rebases the clip's timeline (split end half: the preview
-  /// clip is source-timed, the rendered file starts at zero).
-  ///
-  /// [currentSourcePath] is the video path the target clip currently
-  /// points at (typically the source video). Recording it lets
-  /// [sync] detect when the rendered file path arrives and swap the
-  /// subscription.
+  /// [currentSourcePath] is the video path the target clip currently points
+  /// at — for a trim-based split this is the shared source file, which is
+  /// also the file the real subscription extracts from.
   void seedFromSource({
     required String sourceClipId,
     required String targetClipId,
     required DurationRange sourceRange,
     required String currentSourcePath,
     Duration? timestampOffset,
-    Duration rebaseOnPathChange = Duration.zero,
   }) {
     final source = _notifiers[sourceClipId];
     if (source == null) return;
@@ -257,27 +238,6 @@ class ClipThumbnailManager {
     notifier.value = seeded;
     _videoPaths[targetClipId] = currentSourcePath;
     _seeded.add(targetClipId);
-    if (rebaseOnPathChange == Duration.zero) {
-      _pendingRebase.remove(targetClipId);
-    } else {
-      _pendingRebase[targetClipId] = rebaseOnPathChange;
-    }
-  }
-
-  /// Applies the pending timestamp rebase recorded by [seedFromSource]
-  /// when the clip's rendered file path arrives.
-  void _rebaseThumbnails(String clipId) {
-    final shift = _pendingRebase.remove(clipId);
-    if (shift == null || shift == Duration.zero) return;
-    final notifier = _notifiers[clipId];
-    if (notifier == null) return;
-    notifier.value = List.unmodifiable([
-      for (final thumbnail in notifier.value)
-        StripThumbnail(
-          path: thumbnail.path,
-          timestamp: thumbnail.timestamp - shift,
-        ),
-    ]);
   }
 
   void _loadThumbnails(
@@ -512,7 +472,6 @@ class ClipThumbnailManager {
     _notifiers.clear();
     _videoPaths.clear();
     _seeded.clear();
-    _pendingRebase.clear();
     _complete.clear();
     _retired.clear();
   }

--- a/mobile/lib/services/video_editor/video_editor_render_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_render_service.dart
@@ -238,12 +238,6 @@ class VideoEditorRenderService {
 
   static const _logName = 'VideoEditorRenderService';
 
-  /// Defense-in-depth Dart-side cap on a single native split. The native split
-  /// already carries its own watchdog; this guards against an unexpected
-  /// Dart-side hang so a stalled split can never wedge the caller's loading
-  /// state (#4801).
-  static const Duration _splitWatchdogTimeout = Duration(seconds: 150);
-
   static final _compositeProgressController =
       StreamController<ProgressModel>.broadcast();
   static final Map<String, Object> _activeNativeRenderTokens =
@@ -1149,67 +1143,6 @@ class VideoEditorRenderService {
     } finally {
       if (identical(_activeNativeRenderTokens[task.id], token)) {
         _activeNativeRenderTokens.remove(task.id);
-      }
-    }
-  }
-
-  /// Splits [inputPath] into two files at [splitPosition] using the dedicated
-  /// frame-accurate `pro_video_editor` split primitive.
-  ///
-  /// Unlike [renderNativeVideoToFile], this does not run the full render
-  /// compositor (no effects, overlays or audio mixing), so it is considerably
-  /// faster and far less likely to stall. The task is tracked in
-  /// [_activeNativeRenderTokens] so a lifecycle-detach [cancelActiveNativeTasks]
-  /// also cancels an in-flight split.
-  ///
-  /// Returns the two output paths as `[startOutputPath, endOutputPath]`.
-  ///
-  /// Throws [RenderCanceledException] when cancelled — including when the
-  /// defensive [_splitWatchdogTimeout] fires — so callers can treat an
-  /// unexpected stall exactly like a user cancel.
-  static Future<List<String>> splitNativeVideoToFile({
-    required String inputPath,
-    required Duration splitPosition,
-    required String startOutputPath,
-    required String endOutputPath,
-    bool enableAudio = true,
-    NativeLogLevel? nativeLogLevel = NativeLogLevel.warning,
-  }) async {
-    final model = SplitVideoModel(
-      video: EditorVideo.file(inputPath),
-      splitPosition: splitPosition,
-      startOutputPath: startOutputPath,
-      endOutputPath: endOutputPath,
-      enableAudio: enableAudio,
-    );
-    final token = Object();
-    _activeNativeRenderTokens[model.id] = token;
-    try {
-      final outputPaths = await ProVideoEditor.instance
-          .splitVideo(model, nativeLogLevel: nativeLogLevel)
-          .timeout(
-            _splitWatchdogTimeout,
-            onTimeout: () {
-              // The native split has its own watchdog; if the Dart Future still
-              // never completes, cancel the native task and surface a cancel so
-              // the caller's loading state can never get stuck (#4801).
-              unawaited(cancelTask(model.id));
-              throw const RenderCanceledException();
-            },
-          );
-      final missingOutputPath = outputPaths.where((path) {
-        return path.isEmpty || !File(path).existsSync();
-      }).firstOrNull;
-      if (missingOutputPath != null) {
-        throw StateError(
-          'Native split completed without creating output file: '
-          '$missingOutputPath',
-        );
-      }
-      return outputPaths;
-    } finally {
-      if (identical(_activeNativeRenderTokens[model.id], token)) {
-        _activeNativeRenderTokens.remove(model.id);
       }
     }
   }

--- a/mobile/lib/services/video_editor/video_editor_reverse_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_reverse_service.dart
@@ -9,10 +9,16 @@ import 'package:unified_logger/unified_logger.dart';
 
 /// Service for rendering a reversed clip to a new local file.
 class VideoEditorReverseService {
-  /// Renders the full clip in reverse.
+  /// Renders the clip's **visible window** `[trimStart, duration - trimEnd]`
+  /// in reverse to a standalone file.
   ///
-  /// Callers keep trim bounds in state and derive the visible segment from the
-  /// reversed source file instead of baking the trim into the output file.
+  /// The window is baked into the output — the reversed file is exactly the
+  /// visible segment reversed, so the caller treats the result as a standalone
+  /// clip (trims reset, floor cleared). This is required for a trim-based split
+  /// half, whose source file is shared with its sibling: reversing the whole
+  /// file and keeping metadata trims would expose the sibling's frames because
+  /// the split half's `duration` no longer equals the real file length. For an
+  /// untrimmed clip the window is the whole file, so the output is unchanged.
   static Future<EditorVideo> reverseClip({
     required DivineVideoClip sourceClip,
     required String renderId,
@@ -48,6 +54,11 @@ class VideoEditorReverseService {
         );
       }
 
+      // Bake the visible window into the reversed output: select
+      // [trimStart, duration - trimEnd] on the source, then reverse it. For an
+      // untrimmed clip this is the whole file, so the output is unchanged.
+      final windowStart = sourceClip.trimStart;
+      final windowEnd = sourceClip.duration - sourceClip.trimEnd;
       await VideoEditorRenderService.renderNativeVideoToFile(
         outputPath,
         VideoRenderData(
@@ -55,6 +66,8 @@ class VideoEditorReverseService {
           videoSegments: [
             VideoSegment(
               video: EditorVideo.file(inputPath),
+              startTime: windowStart == Duration.zero ? null : windowStart,
+              endTime: windowEnd,
               reverseVideo: true,
             ),
           ],

--- a/mobile/lib/services/video_editor/video_editor_split_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_split_service.dart
@@ -5,17 +5,15 @@ import 'dart:async';
 
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/services/video_thumbnail_service.dart';
-import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Service for splitting video clips into two separate segments
 class VideoEditorSplitService {
   static const minClipDuration = Duration(milliseconds: 30);
 
-  /// Defensive cap on awaiting the preview thumbnail after the split settles.
-  /// The native thumbnail decode has no watchdog of its own; without this a
-  /// stalled decode would hold [splitClip] open and re-wedge the editor's
-  /// loading state exactly like the render stall did (#4801).
+  /// Defensive cap on the background preview-thumbnail decode. The decode runs
+  /// fire-and-forget (it never blocks the split), so this only bounds the
+  /// orphaned work if a native decode stalls (#4801).
   static const _thumbnailWatchdogTimeout = Duration(seconds: 30);
 
   /// Validates if the split position is valid for the given clip.
@@ -41,8 +39,9 @@ class VideoEditorSplitService {
   /// * `FileCleanupService` only deletes a file no clip/draft still references,
   ///   so a shared source file is never deleted out from under a sibling half.
   ///
-  /// [onClipRendered] is unused here (kept for the injectable [ClipEditorBloc]
-  /// seam signature) — there is nothing to render.
+  /// The end half's representative thumbnail is refreshed in the background
+  /// (fire-and-forget) so the cut stays instant; [onThumbnailExtracted] fires
+  /// once it lands.
   ///
   /// Throws [ArgumentError] if the split position is invalid.
   static Future<void> splitClip({
@@ -52,8 +51,6 @@ class VideoEditorSplitService {
     onClipsCreated,
     required void Function(DivineVideoClip clip, String thumbnailPath)?
     onThumbnailExtracted,
-    required void Function(DivineVideoClip clip, EditorVideo video)?
-    onClipRendered,
   }) async {
     if (!isValidSplitPosition(sourceClip, splitPosition)) {
       Log.error(
@@ -102,21 +99,24 @@ class VideoEditorSplitService {
 
     onClipsCreated?.call(startClip, endClip);
 
-    // Refresh the end half's representative thumbnail to its new first frame
-    // (the split point). Owns its error handling; on failure the end half keeps
-    // the inherited thumbnail. Bounded so a stalled native decode can't hold
-    // the split open (#4801).
-    await _extractThumbnailForClip(
-      sourceClip,
-      absoluteSplitPos,
-      endClip,
-      onThumbnailExtracted,
-    ).timeout(_thumbnailWatchdogTimeout, onTimeout: () {});
-
     Log.info(
       '✅ Split complete (trim-based) — 2 clips from ${sourceClip.id}',
       name: 'VideoEditorSplitService',
       category: .video,
+    );
+
+    // Refresh the end half's representative thumbnail to its new first frame
+    // (the split point) in the background, so the split itself is instant and
+    // the editor's loading state clears immediately. Owns its error handling;
+    // on failure the end half keeps the inherited thumbnail. Bounded so a
+    // stalled native decode can't leak (#4801).
+    unawaited(
+      _extractThumbnailForClip(
+        sourceClip,
+        absoluteSplitPos,
+        endClip,
+        onThumbnailExtracted,
+      ).timeout(_thumbnailWatchdogTimeout, onTimeout: () {}),
     );
   }
 

--- a/mobile/lib/services/video_editor/video_editor_split_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_split_service.dart
@@ -1,13 +1,10 @@
-// ABOUTME: Service for splitting video clips into separate segments
-// ABOUTME: Handles video rendering, thumbnail extraction, and progress tracking via Completers
+// ABOUTME: Service for splitting a clip into two trim-based halves (no re-encode)
+// ABOUTME: Both halves share the source file; only their trim windows differ
 
 import 'dart:async';
 
 import 'package:openvine/models/divine_video_clip.dart';
-import 'package:openvine/services/video_editor/video_editor_render_service.dart';
 import 'package:openvine/services/video_thumbnail_service.dart';
-import 'package:openvine/utils/path_resolver.dart';
-import 'package:path/path.dart' as p;
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -33,16 +30,21 @@ class VideoEditorSplitService {
         clip.trimmedDuration - splitPosition >= minClipDuration;
   }
 
-  /// Splits a clip at the specified position.
+  /// Splits a clip at the specified position — a pure trim-based cut.
   ///
-  /// This method:
-  /// 1. Creates two new clip objects with completers for tracking processing
-  /// 2. Generates output paths in the documents directory
-  /// 3. Calls onClipsCreated callback to add clips to UI BEFORE rendering
-  /// 4. Extracts the end clip's thumbnail in parallel with the split
-  /// 5. Cuts the source into both halves with a single frame-accurate split
+  /// Both halves keep the **same** source video; only their trim windows
+  /// differ, so there is **no re-encode** and the cut is instant. This is safe
+  /// because:
+  /// * the export already clips each clip to its `[trimStart, trimEnd]` window
+  ///   (`VideoEditorRenderService._normalizeClipsToAspectRatio`), so two clips
+  ///   on one file each export their own segment, and
+  /// * `FileCleanupService` only deletes a file no clip/draft still references,
+  ///   so a shared source file is never deleted out from under a sibling half.
   ///
-  /// Throws if the split fails/cancels or the split position is invalid.
+  /// [onClipRendered] is unused here (kept for the injectable [ClipEditorBloc]
+  /// seam signature) — there is nothing to render.
+  ///
+  /// Throws [ArgumentError] if the split position is invalid.
   static Future<void> splitClip({
     required DivineVideoClip sourceClip,
     required Duration splitPosition,
@@ -68,138 +70,54 @@ class VideoEditorSplitService {
     }
 
     // splitPosition is relative to the trimmed clip (0 to trimmedDuration).
-    // Convert to an absolute position within the full clip for rendering.
+    // Convert to an absolute position within the source file.
     final absoluteSplitPos = sourceClip.trimStart + splitPosition;
 
     Log.info(
-      '✂️ Starting clip split at ${splitPosition.inSeconds}s '
-      '(absolute: ${absoluteSplitPos.inSeconds}s, '
-      'total: ${sourceClip.duration.inSeconds}s)',
+      '✂️ Splitting clip ${sourceClip.id} at ${splitPosition.inSeconds}s '
+      '(absolute: ${absoluteSplitPos.inSeconds}s) — trim-based, no re-encode',
       name: 'VideoEditorSplitService',
       category: .video,
     );
 
-    final timestamp = DateTime.now();
-    final timestampMs = timestamp.microsecondsSinceEpoch;
-    final startClipId = '${timestampMs}_start';
-    final endClipId = '${timestampMs}_end';
+    final timestampMs = DateTime.now().microsecondsSinceEpoch;
 
-    // Start clip: keeps the original trimStart, no trimEnd needed
-    // (the split point is the new end). The split point is a hard cut, so the
-    // start half drops the source clip's outgoing transition — only the end
-    // half inherits it (it now owns the boundary into the following clip).
+    // Start half: source start → split point. [duration] caps the visible end
+    // at the split, and it drops the source's outgoing transition — only the
+    // end half (which now owns the boundary into the next clip) keeps it.
     final startClip = sourceClip.copyWith(
-      id: startClipId,
+      id: '${timestampMs}_start',
       duration: absoluteSplitPos,
       trimEnd: Duration.zero,
-      processingCompleter: Completer<bool>(),
       clearTransition: true,
     );
-    // End clip preview: while rendering, this still points at the original
-    // source video, so keep source-time trimStart at the split point. It keeps
-    // the source clip's transition into the next clip.
-    final previewEndClip = sourceClip.copyWith(
-      id: endClipId,
-      duration: sourceClip.duration,
+    // End half: split point → source end. [minTrimStart] pins its left trim
+    // handle at the split so it can't be dragged back into the start half's
+    // frames (both halves share the same source file).
+    final endClip = sourceClip.copyWith(
+      id: '${timestampMs}_end',
       trimStart: absoluteSplitPos,
-      processingCompleter: Completer<bool>(),
-    );
-    // The rendered end file starts at the split point, so its zero-based
-    // timeline sits absoluteSplitPos into the source recording. Recording
-    // that shift keeps the timeline thumbnail raster anchored to the
-    // original recording (no visible frame shift when the render lands).
-    final renderedEndClip = previewEndClip.copyWith(
-      duration: sourceClip.duration - absoluteSplitPos,
-      trimStart: Duration.zero,
-      sourceStartOffset: sourceClip.sourceStartOffset + absoluteSplitPos,
+      minTrimStart: absoluteSplitPos,
     );
 
-    final documentsPath = await getDocumentsPath();
-    // startClipId / endClipId already carry the `_start` / `_end` suffix, so
-    // the filename is just `<id>.mp4` — appending another suffix produced the
-    // doubled `_start_start.mp4` / `_end_end.mp4` names.
-    final startClipPath = p.join(documentsPath, '$startClipId.mp4');
-    final endClipPath = p.join(documentsPath, '$endClipId.mp4');
+    onClipsCreated?.call(startClip, endClip);
 
-    Log.debug(
-      '📁 Created split clips - Start: ${splitPosition.inSeconds}s, '
-      'End: ${previewEndClip.trimmedDuration.inSeconds}s',
-      name: 'VideoEditorSplitService',
-      category: .video,
-    );
-
-    // Notify that clips are created (so they can be added to UI before
-    // rendering)
-    onClipsCreated?.call(startClip, previewEndClip);
-
-    // Extract the preview thumbnail for the end clip in parallel with the
-    // split, so the preview frame can appear while the re-encode runs. It owns
-    // its error handling internally, so awaiting it later never throws.
-    final thumbnailFuture = _extractThumbnailForClip(
+    // Refresh the end half's representative thumbnail to its new first frame
+    // (the split point). Owns its error handling; on failure the end half keeps
+    // the inherited thumbnail. Bounded so a stalled native decode can't hold
+    // the split open (#4801).
+    await _extractThumbnailForClip(
       sourceClip,
       absoluteSplitPos,
-      previewEndClip,
+      endClip,
       onThumbnailExtracted,
-    );
+    ).timeout(_thumbnailWatchdogTimeout, onTimeout: () {});
 
-    Log.debug(
-      '🎬 Splitting source clip at absolute ${absoluteSplitPos.inSeconds}s',
+    Log.info(
+      '✅ Split complete (trim-based) — 2 clips from ${sourceClip.id}',
       name: 'VideoEditorSplitService',
       category: .video,
     );
-
-    // One frame-accurate native split instead of two full render passes. The
-    // two halves are exactly the previous segment renders: start covers the
-    // source from 0 → split, end covers split → end. Unlike the render
-    // pipeline, this primitive cannot hang (per-export watchdog + Dart-side
-    // timeout), so a stalled export can never wedge the editor again (#4801).
-    try {
-      final outPaths = await VideoEditorRenderService.splitNativeVideoToFile(
-        inputPath: await sourceClip.video.safeFilePath(),
-        splitPosition: absoluteSplitPos,
-        startOutputPath: startClipPath,
-        endOutputPath: endClipPath,
-      );
-
-      startClip.processingCompleter?.complete(true);
-      onClipRendered?.call(startClip, EditorVideo.file(outPaths[0]));
-
-      renderedEndClip.processingCompleter?.complete(true);
-      onClipRendered?.call(renderedEndClip, EditorVideo.file(outPaths[1]));
-
-      Log.info(
-        '✅ Split complete - created 2 clips from ${sourceClip.id}',
-        name: 'VideoEditorSplitService',
-        category: .video,
-      );
-    } on RenderCanceledException {
-      Log.info(
-        '🚫 Split cancelled for ${sourceClip.id}',
-        name: 'VideoEditorSplitService',
-        category: .video,
-      );
-      startClip.processingCompleter?.complete(false);
-      renderedEndClip.processingCompleter?.complete(false);
-      rethrow;
-    } catch (e) {
-      Log.error(
-        '❌ Split failed for ${sourceClip.id}: $e',
-        name: 'VideoEditorSplitService',
-        category: .video,
-      );
-      startClip.processingCompleter?.complete(false);
-      renderedEndClip.processingCompleter?.complete(false);
-      rethrow;
-    } finally {
-      // Bound the wait so a stalled native thumbnail decode can't hold
-      // splitClip open and re-wedge the editor (#4801). The thumbnail owns its
-      // error handling internally, so this await only ever completes or times
-      // out — it never throws.
-      await thumbnailFuture.timeout(
-        _thumbnailWatchdogTimeout,
-        onTimeout: () {},
-      );
-    }
   }
 
   /// Extract a thumbnail for the split clip at the specified timestamp.

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -1422,6 +1422,15 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
         return;
       }
 
+      // A split (and any split still queued behind it) drives the clip list
+      // optimistically in ClipEditorBloc, one step ahead of the editor
+      // history. This snapshot reflects the *previous* split's committed
+      // state; mirroring it back now would overwrite the just-applied split —
+      // a queued split then silently vanishes and never appears. Skip while a
+      // split is in flight; the reconcile that runs once isSplitting clears
+      // mirrors the settled clip list to both the clip manager and the bloc.
+      if (context.read<ClipEditorBloc>().state.isSplitting) return;
+
       // Only update if clips actually changed to avoid unnecessary rebuilds
       // and autosave triggers. DivineVideoClip uses reference equality, so
       // we compare the editable properties explicitly.

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -111,9 +111,48 @@ class VideoEditorCanvas extends StatelessWidget {
     if (previous.isSplitting && current.isSplitting) return false;
     if (previous.isSplitting && !current.isSplitting) return true;
 
+    // A background thumbnail refresh (e.g. after a split) changes only the
+    // clip's poster path, which the player composition doesn't use — skip the
+    // redundant reload.
+    if (_onlyThumbnailPathsChanged(previous.clips, current.clips)) return false;
+
     return !current.isTrimDragging &&
         !previous.isTrimDragging &&
         previous.clips != current.clips;
+  }
+
+  /// Whether [current] differs from [previous] *only* in clip thumbnail paths.
+  ///
+  /// Conservative: any difference in a composition-relevant field (video,
+  /// trims, duration, volume, speed, transition, …) returns `false`, so the
+  /// player still reloads for real edits.
+  static bool _onlyThumbnailPathsChanged(
+    List<DivineVideoClip> previous,
+    List<DivineVideoClip> current,
+  ) {
+    if (identical(previous, current) || previous.length != current.length) {
+      return false;
+    }
+    var anyThumbnailDiff = false;
+    for (var i = 0; i < previous.length; i++) {
+      final a = previous[i];
+      final b = current[i];
+      if (a.id != b.id ||
+          a.video != b.video ||
+          a.trimStart != b.trimStart ||
+          a.trimEnd != b.trimEnd ||
+          a.duration != b.duration ||
+          a.minTrimStart != b.minTrimStart ||
+          a.volume != b.volume ||
+          a.playbackSpeed != b.playbackSpeed ||
+          a.reversed != b.reversed ||
+          a.sourceStartOffset != b.sourceStartOffset ||
+          a.transition != b.transition) {
+        return false;
+      }
+      if (a.thumbnailPath != b.thumbnailPath) anyThumbnailDiff = true;
+    }
+    return anyThumbnailDiff;
   }
 
   @visibleForTesting

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
@@ -257,9 +257,9 @@ class _VideoEditorTimelineClipStripState
       timestampOffset: Duration.zero,
       currentSourcePath: sourcePath,
     );
-    // The end half previews the un-trimmed source video (trimStart at the
-    // split point), so its seeds stay source-timed for now. The rendered
-    // file starts at zero, so the same shift is applied on path change.
+    // The end half keeps the shared source file with trimStart at the split
+    // point, so its seeds stay source-timed — the real subscription extracts
+    // from the same file at the same source timestamps.
     _thumbnails.seedFromSource(
       sourceClipId: split.sourceClipId,
       targetClipId: split.endClipId,
@@ -268,7 +268,6 @@ class _VideoEditorTimelineClipStripState
         end: split.sourceDuration - split.sourceTrimEnd,
       ),
       timestampOffset: Duration.zero,
-      rebaseOnPathChange: split.absoluteSplitPosition,
       currentSourcePath: endClip.video.file?.path ?? sourcePath,
     );
   }

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_tiles.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_tiles.dart
@@ -111,13 +111,16 @@ class _TrimmableClipTileState extends State<_TrimmableClipTile> {
     final trimEnd = _dragTrimEnd ?? clip.trimEnd;
     var newTrimStart = (_dragTrimStart ?? clip.trimStart) + _dxToDuration(dx);
 
+    // A trim-based split's end half floors its start handle at the split point
+    // so it can't be dragged back into the start half's frames.
+    final minTrimStart = clip.minTrimStart;
     final maxTrimStart =
         clip.duration - trimEnd - TimelineConstants.minTrimDuration;
 
     var atLimit = false;
 
-    if (newTrimStart <= Duration.zero) {
-      newTrimStart = Duration.zero;
+    if (newTrimStart <= minTrimStart) {
+      newTrimStart = minTrimStart;
       atLimit = true;
     } else if (newTrimStart >= maxTrimStart) {
       newTrimStart = maxTrimStart;

--- a/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
@@ -99,8 +99,6 @@ Future<void> _fakeSplitClip({
   onClipsCreated,
   required void Function(DivineVideoClip clip, String thumbnailPath)?
   onThumbnailExtracted,
-  required void Function(DivineVideoClip clip, EditorVideo video)?
-  onClipRendered,
 }) async {
   final absoluteSplitPos = sourceClip.trimStart + splitPosition;
   final timestampMs = DateTime.now().microsecondsSinceEpoch;
@@ -109,44 +107,12 @@ Future<void> _fakeSplitClip({
     duration: absoluteSplitPos,
     trimEnd: Duration.zero,
   );
-  final previewEndClip = sourceClip.copyWith(
+  final endClip = sourceClip.copyWith(
     id: '${timestampMs}_end',
-    duration: sourceClip.duration,
     trimStart: absoluteSplitPos,
+    minTrimStart: absoluteSplitPos,
   );
-  onClipsCreated?.call(startClip, previewEndClip);
-}
-
-Future<void> _fakeSplitClipThenRenderEnd({
-  required DivineVideoClip sourceClip,
-  required Duration splitPosition,
-  required void Function(DivineVideoClip startClip, DivineVideoClip endClip)?
-  onClipsCreated,
-  required void Function(DivineVideoClip clip, String thumbnailPath)?
-  onThumbnailExtracted,
-  required void Function(DivineVideoClip clip, EditorVideo video)?
-  onClipRendered,
-}) async {
-  final absoluteSplitPos = sourceClip.trimStart + splitPosition;
-  final timestampMs = DateTime.now().microsecondsSinceEpoch;
-  final startClip = sourceClip.copyWith(
-    id: '${timestampMs}_start',
-    duration: absoluteSplitPos,
-    trimEnd: Duration.zero,
-  );
-  final previewEndClip = sourceClip.copyWith(
-    id: '${timestampMs}_end',
-    duration: sourceClip.duration,
-    trimStart: absoluteSplitPos,
-  );
-  final renderedEndClip = previewEndClip.copyWith(
-    duration: sourceClip.duration - absoluteSplitPos,
-    trimStart: Duration.zero,
-    sourceStartOffset: sourceClip.sourceStartOffset + absoluteSplitPos,
-  );
-  onClipsCreated?.call(startClip, previewEndClip);
-  onClipRendered?.call(startClip, startClip.video);
-  onClipRendered?.call(renderedEndClip, renderedEndClip.video);
+  onClipsCreated?.call(startClip, endClip);
 }
 
 Future<void> _fakeSplitClipThenFail({
@@ -156,17 +122,47 @@ Future<void> _fakeSplitClipThenFail({
   onClipsCreated,
   required void Function(DivineVideoClip clip, String thumbnailPath)?
   onThumbnailExtracted,
-  required void Function(DivineVideoClip clip, EditorVideo video)?
-  onClipRendered,
 }) async {
   await _fakeSplitClip(
     sourceClip: sourceClip,
     splitPosition: splitPosition,
     onClipsCreated: onClipsCreated,
     onThumbnailExtracted: onThumbnailExtracted,
-    onClipRendered: onClipRendered,
   );
   throw StateError('render failed');
+}
+
+/// Fake split that mirrors the real service: it returns immediately and fires
+/// the thumbnail fire-and-forget, so [onThumbnailExtracted] lands *after* the
+/// split handler completes (its emitter is done).
+Future<void> _fakeSplitClipThenLateThumbnail({
+  required DivineVideoClip sourceClip,
+  required Duration splitPosition,
+  required void Function(DivineVideoClip startClip, DivineVideoClip endClip)?
+  onClipsCreated,
+  required void Function(DivineVideoClip clip, String thumbnailPath)?
+  onThumbnailExtracted,
+}) async {
+  final absoluteSplitPos = sourceClip.trimStart + splitPosition;
+  final ts = DateTime.now().microsecondsSinceEpoch;
+  final endClip = sourceClip.copyWith(
+    id: '${ts}_end',
+    trimStart: absoluteSplitPos,
+    minTrimStart: absoluteSplitPos,
+  );
+  onClipsCreated?.call(
+    sourceClip.copyWith(
+      id: '${ts}_start',
+      duration: absoluteSplitPos,
+      trimEnd: Duration.zero,
+    ),
+    endClip,
+  );
+  unawaited(
+    Future<void>.microtask(
+      () => onThumbnailExtracted?.call(endClip, '/thumbs/end.jpg'),
+    ),
+  );
 }
 
 Future<EditorVideo> _fakeReverseClip({
@@ -780,43 +776,6 @@ void main() {
         ],
       );
 
-      test(
-        'applies rendered clip timing after split render completes',
-        () async {
-          final clip = _createClip(
-            id: 'x',
-            duration: const Duration(seconds: 2),
-          );
-
-          final bloc = buildBloc(splitClip: _fakeSplitClipThenRenderEnd);
-
-          bloc.emit(
-            ClipEditorState(
-              clips: [clip],
-              isEditing: true,
-              splitPosition: const Duration(milliseconds: 500),
-            ),
-          );
-
-          bloc.add(const ClipEditorSplitRequested());
-          await bloc.stream.firstWhere((state) => !state.isSplitting);
-
-          final endClip = bloc.state.clips.last;
-          expect(endClip.duration, const Duration(milliseconds: 1500));
-          expect(endClip.trimStart, Duration.zero);
-          expect(endClip.trimmedDuration, const Duration(milliseconds: 1500));
-          // The rendered end file starts at the split point — the offset
-          // must reach the state clip, or the thumbnail raster re-anchors
-          // and the strip's frames visibly shift when the render lands.
-          expect(
-            endClip.sourceStartOffset,
-            const Duration(milliseconds: 500),
-          );
-
-          await bloc.close();
-        },
-      );
-
       blocTest<ClipEditorBloc, ClipEditorState>(
         'rolls back created split clips when render fails',
         build: () => buildBloc(splitClip: _fakeSplitClipThenFail),
@@ -904,6 +863,40 @@ void main() {
         },
       );
 
+      // The split's thumbnail decode is fire-and-forget, so it lands after the
+      // split handler completes. It must still update the poster via a fresh
+      // event rather than a done emitter (otherwise the refresh is dropped).
+      test(
+        'applies the background thumbnail after the split completes',
+        () async {
+          final bloc = buildBloc(splitClip: _fakeSplitClipThenLateThumbnail);
+          bloc.emit(
+            ClipEditorState(
+              clips: [
+                _createClip(id: 'source', duration: const Duration(seconds: 4)),
+              ],
+              isEditing: true,
+              splitPosition: const Duration(seconds: 2),
+            ),
+          );
+
+          bloc.add(const ClipEditorSplitRequested());
+          // The fire-and-forget thumbnail lands after the split settles and
+          // must still reach the poster (the old done-emitter path dropped it,
+          // which would leave this firstWhere waiting forever).
+          await bloc.stream.firstWhere(
+            (s) =>
+                !s.isSplitting &&
+                s.clips.length == 2 &&
+                s.clips.last.thumbnailPath == '/thumbs/end.jpg',
+          );
+          expect(bloc.state.clips.last.thumbnailPath, '/thumbs/end.jpg');
+          expect(bloc.state.isSplitting, isFalse);
+
+          await bloc.close();
+        },
+      );
+
       // Regression: a queued split silently vanished because the editor→bloc
       // re-sync (ClipEditorInitialized, dispatched by the canvas after the
       // previous split committed) carried a stale pre-split snapshot and
@@ -924,8 +917,6 @@ void main() {
             onClipsCreated,
             required void Function(DivineVideoClip clip, String thumbnailPath)?
             onThumbnailExtracted,
-            required void Function(DivineVideoClip clip, EditorVideo video)?
-            onClipRendered,
           }) async {
             final absoluteSplitPos = sourceClip.trimStart + splitPosition;
             final ts = DateTime.now().microsecondsSinceEpoch;
@@ -937,8 +928,8 @@ void main() {
               ),
               sourceClip.copyWith(
                 id: '${ts}_end',
-                duration: sourceClip.duration,
                 trimStart: absoluteSplitPos,
+                minTrimStart: absoluteSplitPos,
               ),
             );
             await gate.future;
@@ -1270,6 +1261,43 @@ void main() {
         ],
       );
 
+      // Regression: the split guard allows a 40ms half, but the upper trim
+      // bound (duration - minTrimDuration - trimEnd) then dips below the
+      // minTrimStart floor. The floor must stay authoritative so the clamp
+      // never emits a trimStart below it (which would show the sibling's
+      // frames).
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'never emits a trimStart below the floor for a sub-60ms end half',
+        build: buildBloc,
+        seed: () => ClipEditorState(
+          clips: [
+            _createClip(
+              id: 'tiny-end',
+              duration: const Duration(seconds: 2),
+            ).copyWith(
+              trimStart: const Duration(milliseconds: 1970),
+              minTrimStart: const Duration(milliseconds: 1970),
+            ),
+          ],
+        ),
+        act: (bloc) => bloc.add(
+          const ClipEditorTrimUpdated(
+            clipId: 'tiny-end',
+            isStart: true,
+            trimStart: Duration(milliseconds: 1980),
+            trimEnd: Duration.zero,
+          ),
+        ),
+        expect: () => [
+          isA<ClipEditorState>().having(
+            (s) =>
+                s.clips.first.trimStart >= const Duration(milliseconds: 1970),
+            'trimStart stays at/above the floor',
+            isTrue,
+          ),
+        ],
+      );
+
       blocTest<ClipEditorBloc, ClipEditorState>(
         'updates totalDuration to reflect trimmed clips',
         build: buildBloc,
@@ -1528,8 +1556,12 @@ void main() {
         ],
       );
 
+      // A trimmed clip (5s, trimmed 1s/0.5s → 3.5s visible) bakes into a
+      // standalone reversed clip: trims reset, duration becomes the window
+      // length, the split floor clears, and — because the forward clip was
+      // trimmed — the swap-based cache is dropped so the toggle re-renders.
       blocTest<ClipEditorBloc, ClipEditorState>(
-        'renders reversed clip, swaps trim bounds, and toggles reversed flag',
+        'bakes the visible window into a standalone reversed clip',
         build: () => buildBloc(reverseClip: _fakeReverseClip),
         seed: () => ClipEditorState(clips: [_createClipWithFile()]),
         act: (bloc) => bloc.add(
@@ -1550,27 +1582,32 @@ void main() {
               .having(
                 (s) => s.clips.first.trimStart,
                 'trimStart',
-                const Duration(milliseconds: 500),
+                Duration.zero,
               )
               .having(
                 (s) => s.clips.first.trimEnd,
                 'trimEnd',
-                const Duration(seconds: 1),
+                Duration.zero,
+              )
+              .having(
+                (s) => s.clips.first.minTrimStart,
+                'minTrimStart',
+                Duration.zero,
               )
               .having(
                 (s) => s.clips.first.duration,
                 'duration',
-                const Duration(seconds: 5),
+                const Duration(milliseconds: 3500),
               )
               .having(
                 (s) => s.clips.first.forwardVideoPath,
                 'forwardVideoPath',
-                '/path/clip-local.mp4',
+                isNull,
               )
               .having(
                 (s) => s.clips.first.reversedVideoPath,
                 'reversedVideoPath',
-                '/reversed/clip-local_clip-local.mp4',
+                isNull,
               )
               .having(
                 (s) => s.lastReverseResult,
@@ -1584,6 +1621,56 @@ void main() {
             equals('/reversed/clip-local_clip-local.mp4'),
           );
         },
+      );
+
+      // Regression for the critical reverse×split bug: a split end half
+      // (shares the source file, floored at the split) must reverse into a
+      // standalone clip — floor cleared, trims reset — so it can never expose
+      // the sibling start half's frames in preview or export.
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'reversing a split end half clears the floor and produces a '
+        'standalone clip',
+        build: () => buildBloc(reverseClip: _fakeReverseClip),
+        seed: () => ClipEditorState(
+          clips: [
+            _createClipWithFile(
+              trimStart: const Duration(seconds: 2),
+              trimEnd: Duration.zero,
+            ).copyWith(minTrimStart: const Duration(seconds: 2)),
+          ],
+        ),
+        act: (bloc) => bloc.add(
+          const ClipEditorClipReverseRequested(clipId: 'clip-local'),
+        ),
+        expect: () => [
+          isA<ClipEditorState>().having(
+            (s) => s.isReversing,
+            'isReversing',
+            isTrue,
+          ),
+          isA<ClipEditorState>()
+              .having((s) => s.clips.first.reversed, 'reversed', isTrue)
+              .having(
+                (s) => s.clips.first.trimStart,
+                'trimStart',
+                Duration.zero,
+              )
+              .having(
+                (s) => s.clips.first.minTrimStart,
+                'minTrimStart (floor cleared)',
+                Duration.zero,
+              )
+              .having(
+                (s) => s.clips.first.duration,
+                'duration is the visible window',
+                const Duration(seconds: 3),
+              )
+              .having(
+                (s) => s.clips.first.forwardVideoPath,
+                'forwardVideoPath (cache cleared)',
+                isNull,
+              ),
+        ],
       );
 
       blocTest<ClipEditorBloc, ClipEditorState>(
@@ -1681,11 +1768,14 @@ void main() {
       // would invert both and make later cached toggles play the wrong way.
       blocTest<ClipEditorBloc, ClipEditorState>(
         'caches forward/reversed paths in the correct direction when fresh '
-        'rendering a reversed clip with no cache (duplicate of reversed)',
+        'rendering an untrimmed reversed clip with no cache',
         build: () => buildBloc(reverseClip: _fakeReverseClip),
         seed: () => ClipEditorState(
           clips: [
-            _createClipWithFile().copyWith(
+            _createClipWithFile(
+              trimStart: Duration.zero,
+              trimEnd: Duration.zero,
+            ).copyWith(
               video: EditorVideo.file('/path/clip-local-reversed.mp4'),
               reversed: true,
             ),
@@ -1764,12 +1854,12 @@ void main() {
         ],
       );
 
-      // The offset pairs with the forward file cached as forwardVideoPath:
-      // the cached un-reverse branch restores that file with the clip's
-      // current offset, so a forward → reversed render must keep it.
+      // The baked reversed file starts at zero, so a forward → reversed render
+      // drops any prior sourceStartOffset too — the standalone reversed clip
+      // anchors its thumbnail raster at the new file's start.
       blocTest<ClipEditorBloc, ClipEditorState>(
-        'keeps sourceStartOffset when reversing a forward clip so the '
-        'cached un-reverse restores the forward file anchored correctly',
+        'zeroes sourceStartOffset when reversing a forward clip into a '
+        'baked standalone file',
         build: () => buildBloc(reverseClip: _fakeReverseClip),
         seed: () => ClipEditorState(
           clips: [
@@ -1792,7 +1882,7 @@ void main() {
               .having(
                 (s) => s.clips.first.sourceStartOffset,
                 'sourceStartOffset',
-                const Duration(milliseconds: 1300),
+                Duration.zero,
               ),
         ],
       );

--- a/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
@@ -904,6 +904,81 @@ void main() {
         },
       );
 
+      // Regression: a queued split silently vanished because the editor→bloc
+      // re-sync (ClipEditorInitialized, dispatched by the canvas after the
+      // previous split committed) carried a stale pre-split snapshot and
+      // overwrote the just-applied split. While a split is in flight the bloc
+      // owns the clip list, so a re-init must be ignored.
+      test(
+        'ignores ClipEditorInitialized while a split is in flight',
+        () async {
+          final gate = Completer<void>();
+
+          Future<void> gatedSplit({
+            required DivineVideoClip sourceClip,
+            required Duration splitPosition,
+            required void Function(
+              DivineVideoClip startClip,
+              DivineVideoClip endClip,
+            )?
+            onClipsCreated,
+            required void Function(DivineVideoClip clip, String thumbnailPath)?
+            onThumbnailExtracted,
+            required void Function(DivineVideoClip clip, EditorVideo video)?
+            onClipRendered,
+          }) async {
+            final absoluteSplitPos = sourceClip.trimStart + splitPosition;
+            final ts = DateTime.now().microsecondsSinceEpoch;
+            onClipsCreated?.call(
+              sourceClip.copyWith(
+                id: '${ts}_start',
+                duration: absoluteSplitPos,
+                trimEnd: Duration.zero,
+              ),
+              sourceClip.copyWith(
+                id: '${ts}_end',
+                duration: sourceClip.duration,
+                trimStart: absoluteSplitPos,
+              ),
+            );
+            await gate.future;
+          }
+
+          final bloc = buildBloc(splitClip: gatedSplit);
+          bloc.emit(
+            ClipEditorState(
+              clips: [
+                _createClip(id: 'source', duration: const Duration(seconds: 4)),
+              ],
+              isEditing: true,
+              splitPosition: const Duration(seconds: 2),
+            ),
+          );
+
+          bloc.add(const ClipEditorSplitRequested());
+          await bloc.stream.firstWhere(
+            (s) => s.clips.length == 2 && s.isSplitting,
+          );
+
+          // A stale editor re-sync lands mid-split — it would revert to 1 clip.
+          bloc.add(
+            ClipEditorInitialized([
+              _createClip(id: 'stale', duration: const Duration(seconds: 4)),
+            ]),
+          );
+          await pumpEventQueue();
+
+          // The in-flight split's clips are preserved; the stale snapshot is
+          // ignored.
+          expect(bloc.state.clips, hasLength(2));
+          expect(bloc.state.isSplitting, isTrue);
+
+          gate.complete();
+          await pumpEventQueue();
+          await bloc.close();
+        },
+      );
+
       test('validates using VideoEditorSplitService.isValidSplitPosition', () {
         final clip = _createClip(duration: const Duration(seconds: 2));
 
@@ -1160,6 +1235,39 @@ void main() {
           ),
         ),
         expect: () => <ClipEditorState>[],
+      );
+
+      // A trim-based split's end half floors trimStart at the split point so
+      // its left handle can't be dragged back into the start half's frames.
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'clamps trimStart to the clip minTrimStart floor',
+        build: buildBloc,
+        seed: () => ClipEditorState(
+          clips: [
+            _createClip(
+              id: 'end-half',
+              duration: const Duration(seconds: 5),
+            ).copyWith(
+              trimStart: const Duration(seconds: 2),
+              minTrimStart: const Duration(seconds: 2),
+            ),
+          ],
+        ),
+        act: (bloc) => bloc.add(
+          const ClipEditorTrimUpdated(
+            clipId: 'end-half',
+            isStart: true,
+            trimStart: Duration(milliseconds: 500),
+            trimEnd: Duration.zero,
+          ),
+        ),
+        expect: () => [
+          isA<ClipEditorState>().having(
+            (s) => s.clips.first.trimStart,
+            'clamped trimStart',
+            const Duration(seconds: 2),
+          ),
+        ],
       );
 
       blocTest<ClipEditorBloc, ClipEditorState>(

--- a/mobile/test/models/divine_video_clip_test.dart
+++ b/mobile/test/models/divine_video_clip_test.dart
@@ -77,4 +77,39 @@ void main() {
       expect(legacy.sourceStartOffset, equals(Duration.zero));
     });
   });
+
+  group('DivineVideoClip.minTrimStart', () {
+    test('defaults to zero and survives copyWith', () {
+      final original = clip('/videos/clip.mp4');
+      expect(original.minTrimStart, equals(Duration.zero));
+
+      final floored = original.copyWith(
+        minTrimStart: const Duration(seconds: 2),
+      );
+      expect(floored.minTrimStart, equals(const Duration(seconds: 2)));
+
+      // An unrelated copyWith (e.g. a later trim) must keep the floor.
+      final trimmed = floored.copyWith(trimStart: const Duration(seconds: 3));
+      expect(trimmed.minTrimStart, equals(const Duration(seconds: 2)));
+    });
+
+    test('round-trips through JSON and defaults to zero when absent', () {
+      final floored = clip('/videos/clip.mp4').copyWith(
+        minTrimStart: const Duration(milliseconds: 2500),
+      );
+
+      final restored = DivineVideoClip.fromJson(floored.toJson(), '/videos');
+      expect(
+        restored.minTrimStart,
+        equals(const Duration(milliseconds: 2500)),
+      );
+
+      // Old drafts/history entries have no key — must default to zero.
+      final legacy = DivineVideoClip.fromJson(
+        clip('/videos/clip.mp4').toJson(),
+        '/videos',
+      );
+      expect(legacy.minTrimStart, equals(Duration.zero));
+    });
+  });
 }

--- a/mobile/test/models/divine_video_clip_test.dart
+++ b/mobile/test/models/divine_video_clip_test.dart
@@ -112,4 +112,32 @@ void main() {
       expect(legacy.minTrimStart, equals(Duration.zero));
     });
   });
+
+  group('DivineVideoClip.budgetDuration', () {
+    test('equals duration for a normal clip', () {
+      expect(
+        clip('/videos/clip.mp4').budgetDuration,
+        equals(const Duration(seconds: 5)),
+      );
+    });
+
+    test('subtracts minTrimStart so a split end half is not double-counted', () {
+      // A 5s clip split at 2s: start half [0,2s], end half [2s,5s] on the same
+      // file with minTrimStart 2s. Summing budgetDuration must recover the
+      // original 5s, not 2s + 5s = 7s.
+      final startHalf = clip('/videos/clip.mp4').copyWith(
+        duration: const Duration(seconds: 2),
+      );
+      final endHalf = clip('/videos/clip.mp4').copyWith(
+        trimStart: const Duration(seconds: 2),
+        minTrimStart: const Duration(seconds: 2),
+      );
+      expect(startHalf.budgetDuration, equals(const Duration(seconds: 2)));
+      expect(endHalf.budgetDuration, equals(const Duration(seconds: 3)));
+      expect(
+        startHalf.budgetDuration + endHalf.budgetDuration,
+        equals(const Duration(seconds: 5)),
+      );
+    });
+  });
 }

--- a/mobile/test/services/video_editor/clip_thumbnail_manager_test.dart
+++ b/mobile/test/services/video_editor/clip_thumbnail_manager_test.dart
@@ -278,6 +278,31 @@ void main() {
             ..writeAsStringSync('unborrowed-thumbnail');
           final sourceVideoPath = '${tempDir.path}/source.mp4';
 
+          // The seeded target starts a real subscription on the next sync, so
+          // use a fake stream factory to keep that off the native extractor.
+          final controllers = <StreamController<List<StripThumbnail>>>[];
+          final manager = ClipThumbnailManager(
+            stripThumbnailStreamFactory:
+                ({
+                  required String videoPath,
+                  required String clipId,
+                  required Duration duration,
+                  required Size outputSize,
+                  required int thumbsPerSecond,
+                  List<Duration>? priorityTimestamps,
+                }) {
+                  final controller = StreamController<List<StripThumbnail>>();
+                  controllers.add(controller);
+                  return controller.stream;
+                },
+          );
+          addTearDown(() {
+            manager.dispose();
+            for (final controller in controllers) {
+              unawaited(controller.close());
+            }
+          });
+
           final sourceClip = _createTestClip(id: 'src', seconds: 4);
           final targetClip = _createFileClip(
             id: 'tgt',
@@ -366,7 +391,7 @@ void main() {
       });
     });
 
-    group('rendered path arrival', () {
+    group('seeded split half subscription', () {
       late List<StreamController<List<StripThumbnail>>> controllers;
       late ClipThumbnailManager fakeStreamManager;
       late Directory tempDir;
@@ -404,14 +429,12 @@ void main() {
       });
 
       test(
-        'keeps seeded frames rebased into the rendered timebase until the '
-        'first fresh batch replaces them; the borrowed file survives in the '
-        'retired source strip and restores instantly on undo',
+        'starts the real subscription on the next sync against the shared '
+        'source file, holding source-timed seeds until the first fresh batch',
         () async {
           final borrowed = File('${tempDir.path}/borrowed.jpg')
             ..writeAsStringSync('borrowed');
           final sourceVideoPath = '${tempDir.path}/source.mp4';
-          final renderedVideoPath = '${tempDir.path}/rendered_end.mp4';
 
           final sourceClip = _createFileClip(
             id: 'src',
@@ -426,8 +449,8 @@ void main() {
             ),
           ];
 
-          // Split at 3 s: the end half previews the source video, so its
-          // seeds stay source-timed; the rendered file starts at zero.
+          // Split at 3 s: a trim-based split, so the end half keeps the shared
+          // source file; its seeds stay source-timed (no rebase).
           fakeStreamManager.seedFromSource(
             sourceClipId: 'src',
             targetClipId: 'end',
@@ -436,7 +459,6 @@ void main() {
               end: Duration(seconds: 10),
             ),
             timestampOffset: Duration.zero,
-            rebaseOnPathChange: const Duration(seconds: 3),
             currentSourcePath: sourceVideoPath,
           );
           expect(
@@ -444,50 +466,31 @@ void main() {
             equals(const Duration(seconds: 4)),
           );
 
-          // Source replaced by the preview end half — no new subscription
-          // while the clip still points at the source video.
-          final previewEndClip = _createFileClip(
+          // The very next sync starts the real subscription against the shared
+          // source file — no rendered-file swap is coming, so waiting for one
+          // would freeze the strip at its seeded density forever. The seeded
+          // frame stays visible, source-timed.
+          final endClip = _createFileClip(
             id: 'end',
             videoPath: sourceVideoPath,
             seconds: 10,
           );
-          fakeStreamManager.sync(
-            clips: [previewEndClip],
-            devicePixelRatio: 1,
-          );
-          expect(controllers, hasLength(1));
-          expect(
-            fakeStreamManager['end'].value.single.timestamp,
-            equals(const Duration(seconds: 4)),
-          );
-
-          // Rendered file arrives: the real subscription starts, the
-          // seeded frame stays visible and is rebased to the rendered
-          // file's zero-based timeline.
-          final renderedEndClip = _createFileClip(
-            id: 'end',
-            videoPath: renderedVideoPath,
-            seconds: 7,
-          );
-          fakeStreamManager.sync(
-            clips: [renderedEndClip],
-            devicePixelRatio: 1,
-          );
+          fakeStreamManager.sync(clips: [endClip], devicePixelRatio: 1);
           expect(controllers, hasLength(2));
           final held = fakeStreamManager['end'].value.single;
           expect(held.path, equals(borrowed.path));
-          expect(held.timestamp, equals(const Duration(seconds: 1)));
+          expect(held.timestamp, equals(const Duration(seconds: 4)));
           expect(borrowed.existsSync(), isTrue);
 
           // First fresh batch replaces the seed (same timestamp, so the
-          // carried frame is pruned) — but the borrowed file survives: the
-          // retired source strip still references it for an undo restore.
+          // carried frame is pruned) — the borrowed file survives in the
+          // retired source strip for an undo restore.
           final fresh = File('${tempDir.path}/fresh.jpg')
             ..writeAsStringSync('fresh');
           controllers[1].add([
             StripThumbnail(
               path: fresh.path,
-              timestamp: const Duration(seconds: 1),
+              timestamp: const Duration(seconds: 4),
             ),
           ]);
           await pumpEventQueue();
@@ -498,16 +501,6 @@ void main() {
           );
           expect(borrowed.existsSync(), isTrue);
           expect(fresh.existsSync(), isTrue);
-
-          // Undo: the source clip id returns with its original file — the
-          // strip is restored instantly from the retired cache, no poster
-          // flash. Its original subscription never completed, so a fresh
-          // one starts to fill the gaps.
-          fakeStreamManager.sync(clips: [sourceClip], devicePixelRatio: 1);
-          final restored = fakeStreamManager['src'].value.single;
-          expect(restored.path, equals(borrowed.path));
-          expect(restored.timestamp, equals(const Duration(seconds: 4)));
-          expect(controllers, hasLength(3));
         },
       );
 
@@ -522,7 +515,6 @@ void main() {
         'batches stream in, pruning each once a fresh frame lands nearby',
         () async {
           final sourceVideoPath = '${tempDir.path}/source.mp4';
-          final renderedVideoPath = '${tempDir.path}/rendered_end.mp4';
 
           // Dense source strip: one frame per second at 3.5s..9.5s.
           final borrowedFiles = <File>[];
@@ -547,9 +539,9 @@ void main() {
           fakeStreamManager.sync(clips: [sourceClip], devicePixelRatio: 1);
           fakeStreamManager['src'].value = sourceFrames;
 
-          // Split at 3s: seed the end half, then let the rendered file
-          // arrive so the real subscription starts (seeds rebased by -3s
-          // to 0.5s..6.5s).
+          // Split at 3s: seed the end half, then the next sync starts the real
+          // subscription against the shared source file. Seeds stay
+          // source-timed at 3.5s..9.5s (no rebase).
           fakeStreamManager.seedFromSource(
             sourceClipId: 'src',
             targetClipId: 'end',
@@ -558,30 +550,26 @@ void main() {
               end: Duration(seconds: 10),
             ),
             timestampOffset: Duration.zero,
-            rebaseOnPathChange: const Duration(seconds: 3),
             currentSourcePath: sourceVideoPath,
           );
-          final renderedEndClip = _createFileClip(
+          final endClip = _createFileClip(
             id: 'end',
-            videoPath: renderedVideoPath,
-            seconds: 7,
+            videoPath: sourceVideoPath,
+            seconds: 10,
           );
-          fakeStreamManager.sync(
-            clips: [renderedEndClip],
-            devicePixelRatio: 1,
-          );
+          fakeStreamManager.sync(clips: [endClip], devicePixelRatio: 1);
           expect(controllers, hasLength(2));
           expect(fakeStreamManager['end'].value, hasLength(7));
 
-          // Sparse first batch: a single fresh frame at 1.5s. Only the
-          // seeded frame at that spot (originally 4.5s) may be replaced —
-          // the other six must stay so the strip keeps its coverage.
+          // Sparse first batch: a single fresh frame at 4.5s (source-timed).
+          // Only the seeded frame at that spot may be replaced — the other
+          // six must stay so the strip keeps its coverage.
           final fresh1 = File('${tempDir.path}/fresh_1.jpg')
             ..writeAsStringSync('fresh_1');
           controllers[1].add([
             StripThumbnail(
               path: fresh1.path,
-              timestamp: const Duration(milliseconds: 1500),
+              timestamp: const Duration(milliseconds: 4500),
             ),
           ]);
           await pumpEventQueue();
@@ -613,11 +601,11 @@ void main() {
           controllers[1].add([
             StripThumbnail(
               path: fresh1.path,
-              timestamp: const Duration(milliseconds: 1500),
+              timestamp: const Duration(milliseconds: 4500),
             ),
             StripThumbnail(
               path: fresh2.path,
-              timestamp: const Duration(milliseconds: 4500),
+              timestamp: const Duration(milliseconds: 7500),
             ),
           ]);
           await pumpEventQueue();
@@ -713,13 +701,12 @@ void main() {
       );
 
       test(
-        'keeps START-half seeds as-is on rendered path arrival (no rebase), '
-        'then the first fresh batch supersedes them (files kept for undo)',
+        'START half: seeds held source-timed, subscription starts on the '
+        'next sync, first fresh batch supersedes the seed (files kept for undo)',
         () async {
           final borrowed = File('${tempDir.path}/start_borrowed.jpg')
             ..writeAsStringSync('borrowed');
           final sourceVideoPath = '${tempDir.path}/source.mp4';
-          final renderedVideoPath = '${tempDir.path}/rendered_start.mp4';
 
           final sourceClip = _createFileClip(
             id: 'src',
@@ -734,9 +721,8 @@ void main() {
             ),
           ];
 
-          // Split at 3 s: the start half already begins at zero, so the
-          // rendered file needs no rebase (rebaseOnPathChange stays zero)
-          // and the seed keeps its source-timed timestamp verbatim.
+          // Split at 3 s: the start half keeps the shared source file and
+          // begins at zero, so the seed keeps its source-timed timestamp.
           fakeStreamManager.seedFromSource(
             sourceClipId: 'src',
             targetClipId: 'start',
@@ -752,16 +738,13 @@ void main() {
             equals(const Duration(seconds: 1)),
           );
 
-          // Rendered file arrives: a real subscription starts and the seed
-          // is held unchanged (no rebase branch runs for the start half).
-          final renderedStartClip = _createFileClip(
+          // The next sync starts the real subscription against the shared
+          // source file; the seed is held unchanged (source-timed).
+          final startClip = _createFileClip(
             id: 'start',
-            videoPath: renderedVideoPath,
+            videoPath: sourceVideoPath,
           );
-          fakeStreamManager.sync(
-            clips: [renderedStartClip],
-            devicePixelRatio: 1,
-          );
+          fakeStreamManager.sync(clips: [startClip], devicePixelRatio: 1);
           expect(controllers, hasLength(2));
           final held = fakeStreamManager['start'].value.single;
           expect(held.path, equals(borrowed.path));
@@ -789,11 +772,10 @@ void main() {
       );
 
       test(
-        'marks the target seeded and suppresses the source-video load when '
-        'the source has no thumbnails yet, then loads on rendered path arrival',
+        'seeds the target empty when the source has no thumbnails yet, then '
+        'still starts the subscription on the next sync',
         () async {
           final sourceVideoPath = '${tempDir.path}/empty_source.mp4';
-          final renderedVideoPath = '${tempDir.path}/empty_rendered.mp4';
 
           final sourceClip = _createFileClip(
             id: 'src',
@@ -804,9 +786,7 @@ void main() {
           expect(controllers, hasLength(1));
 
           // Source frames haven't been extracted yet — seeding is
-          // best-effort: the target is created empty but still marked
-          // seeded so [sync] does not spin up a subscription against the
-          // un-trimmed source video.
+          // best-effort: the target is created empty but still marked seeded.
           fakeStreamManager.seedFromSource(
             sourceClipId: 'src',
             targetClipId: 'end',
@@ -815,27 +795,18 @@ void main() {
               end: Duration(seconds: 10),
             ),
             timestampOffset: Duration.zero,
-            rebaseOnPathChange: const Duration(seconds: 3),
             currentSourcePath: sourceVideoPath,
           );
           expect(fakeStreamManager['end'].value, isEmpty);
 
-          final previewEndClip = _createFileClip(
+          // The next sync starts the real subscription against the shared
+          // source file even though the seed was empty.
+          final endClip = _createFileClip(
             id: 'end',
             videoPath: sourceVideoPath,
             seconds: 10,
           );
-          fakeStreamManager.sync(clips: [previewEndClip], devicePixelRatio: 1);
-          // No new subscription while the clip still points at the source.
-          expect(controllers, hasLength(1));
-
-          // Rendered file arrives — now the real subscription starts.
-          final renderedEndClip = _createFileClip(
-            id: 'end',
-            videoPath: renderedVideoPath,
-            seconds: 7,
-          );
-          fakeStreamManager.sync(clips: [renderedEndClip], devicePixelRatio: 1);
+          fakeStreamManager.sync(clips: [endClip], devicePixelRatio: 1);
           expect(controllers, hasLength(2));
         },
       );

--- a/mobile/test/services/video_editor/video_editor_reverse_service_test.dart
+++ b/mobile/test/services/video_editor/video_editor_reverse_service_test.dart
@@ -106,7 +106,7 @@ void main() {
   });
 
   group('VideoEditorReverseService', () {
-    test('renders the source clip as a reversed video segment', () async {
+    test('reverses the whole file for an untrimmed clip', () async {
       final inputPath = path.join(tempDir.path, 'source.mp4');
       final sourceClip = _clip(id: 'clip-1', inputPath: inputPath);
 
@@ -129,9 +129,35 @@ void main() {
 
       final segment = renderData.videoSegments!.single;
       expect(segment.reverseVideo, isTrue);
+      // Untrimmed clip: the window is the whole file, so no start offset and
+      // the end is the full duration.
       expect(segment.startTime, isNull);
-      expect(segment.endTime, isNull);
+      expect(segment.endTime, const Duration(seconds: 6));
       expect(await segment.video.safeFilePath(), inputPath);
+    });
+
+    test('bakes only the visible window for a windowed clip', () async {
+      final inputPath = path.join(tempDir.path, 'source.mp4');
+      // A split end half: shares the source file, trimmed 2s–5s of 6s.
+      final sourceClip = _clip(
+        id: 'end-half',
+        inputPath: inputPath,
+        trimStart: const Duration(seconds: 2),
+        trimEnd: const Duration(seconds: 1),
+        minTrimStart: const Duration(seconds: 2),
+      );
+
+      await VideoEditorReverseService.reverseClip(
+        sourceClip: sourceClip,
+        renderId: 'reverse-render-window',
+      );
+
+      final segment = proVideoEditor.renderedData.single.videoSegments!.single;
+      expect(segment.reverseVideo, isTrue);
+      // Only [trimStart, duration - trimEnd] = [2s, 5s] is reversed, so the
+      // sibling start half's frames ([0, 2s]) can never leak into the output.
+      expect(segment.startTime, const Duration(seconds: 2));
+      expect(segment.endTime, const Duration(seconds: 5));
     });
 
     test(
@@ -225,6 +251,9 @@ void main() {
 DivineVideoClip _clip({
   required String id,
   required String inputPath,
+  Duration trimStart = Duration.zero,
+  Duration trimEnd = Duration.zero,
+  Duration minTrimStart = Duration.zero,
 }) {
   return DivineVideoClip(
     id: id,
@@ -233,5 +262,8 @@ DivineVideoClip _clip({
     recordedAt: DateTime(2026, 6, 10, 12),
     targetAspectRatio: model.AspectRatio.vertical,
     originalAspectRatio: 9 / 16,
+    trimStart: trimStart,
+    trimEnd: trimEnd,
+    minTrimStart: minTrimStart,
   );
 }

--- a/mobile/test/services/video_editor/video_editor_split_service_test.dart
+++ b/mobile/test/services/video_editor/video_editor_split_service_test.dart
@@ -27,8 +27,8 @@ class MockPathProviderPlatform extends Fake
 }
 
 class MockProVideoEditor extends ProVideoEditor {
-  bool shouldThrowError = false;
-  bool createOutputFiles = true;
+  /// Records any native split request. A trim-based split must never issue
+  /// one, so this stays empty — a non-empty list means a re-encode regressed.
   final List<SplitVideoModel> splitRequests = [];
 
   @override
@@ -41,19 +41,7 @@ class MockProVideoEditor extends ProVideoEditor {
     SplitVideoModel value, {
     NativeLogLevel? nativeLogLevel,
   }) async {
-    if (shouldThrowError) {
-      throw Exception('Split failed');
-    }
     splitRequests.add(value);
-    // Simulate a frame-accurate split producing two files.
-    if (createOutputFiles) {
-      for (final outputPath in [value.startOutputPath, value.endOutputPath]) {
-        final file = File(outputPath);
-        file.parent.createSync(recursive: true);
-        file.writeAsBytesSync([0]);
-      }
-    }
-    await Future<void>.delayed(const Duration(milliseconds: 10));
     return [value.startOutputPath, value.endOutputPath];
   }
 }
@@ -231,7 +219,6 @@ void main() {
             splitPosition: const Duration(milliseconds: 10),
             onClipsCreated: null,
             onThumbnailExtracted: null,
-            onClipRendered: null,
           ),
           throwsArgumentError,
         );
@@ -251,7 +238,6 @@ void main() {
               end = e;
             },
             onThumbnailExtracted: null,
-            onClipRendered: null,
           );
 
           // Nothing is re-encoded; both halves keep the source file.
@@ -273,7 +259,6 @@ void main() {
             end = e;
           },
           onThumbnailExtracted: null,
-          onClipRendered: null,
         );
 
         // Start half: [0, 2s], its duration caps the visible end at the split.
@@ -294,29 +279,12 @@ void main() {
           splitPosition: const Duration(seconds: 2),
           onClipsCreated: (_, e) => end = e,
           onThumbnailExtracted: null,
-          onClipRendered: null,
         );
 
         // So its left trim handle can't be dragged back before the split into
         // the start half's frames.
         expect(end!.minTrimStart, const Duration(seconds: 2));
       });
-
-      test(
-        'does not render anything (onClipRendered is never called)',
-        () async {
-          final clip = _clip(duration: const Duration(seconds: 5));
-          var rendered = 0;
-          await VideoEditorSplitService.splitClip(
-            sourceClip: clip,
-            splitPosition: const Duration(seconds: 2),
-            onClipsCreated: null,
-            onThumbnailExtracted: null,
-            onClipRendered: (_, _) => rendered++,
-          );
-          expect(rendered, isZero);
-        },
-      );
 
       test('splits a trimmed clip at the correct absolute position', () async {
         // 10s clip trimmed to 3s–8s (trimmedDuration = 5s), split 2s in.
@@ -335,7 +303,6 @@ void main() {
             end = e;
           },
           onThumbnailExtracted: null,
-          onClipRendered: null,
         );
 
         // Absolute split = trimStart(3) + 2 = 5s.
@@ -371,7 +338,6 @@ void main() {
             end = e;
           },
           onThumbnailExtracted: null,
-          onClipRendered: null,
         );
 
         // The split point (A1 → A2) is a hard cut; A2 → B keeps the boundary.
@@ -388,7 +354,6 @@ void main() {
           splitPosition: const Duration(seconds: 2),
           onClipsCreated: (_, e) => firstEnd = e,
           onThumbnailExtracted: null,
-          onClipRendered: null,
         );
 
         // Split the end half 1s in → absolute 3s.
@@ -402,7 +367,6 @@ void main() {
             secondEnd = e;
           },
           onThumbnailExtracted: null,
-          onClipRendered: null,
         );
 
         // New start half inherits the first end's floor (2s), capped at 3s.
@@ -425,7 +389,6 @@ void main() {
           splitPosition: const Duration(seconds: 2),
           onClipsCreated: (_, e) => end1 = e,
           onThumbnailExtracted: null,
-          onClipRendered: null,
         );
         await Future<void>.delayed(const Duration(milliseconds: 2));
         await VideoEditorSplitService.splitClip(
@@ -433,7 +396,6 @@ void main() {
           splitPosition: const Duration(seconds: 2),
           onClipsCreated: (_, e) => end2 = e,
           onThumbnailExtracted: null,
-          onClipRendered: null,
         );
         expect(end1!.id, isNot(equals(end2!.id)));
       });

--- a/mobile/test/services/video_editor/video_editor_split_service_test.dart
+++ b/mobile/test/services/video_editor/video_editor_split_service_test.dart
@@ -58,6 +58,26 @@ class MockProVideoEditor extends ProVideoEditor {
   }
 }
 
+DivineVideoClip _clip({
+  required Duration duration,
+  String id = 'test-clip',
+  Duration trimStart = Duration.zero,
+  Duration trimEnd = Duration.zero,
+  ClipTransition? transition,
+}) {
+  return DivineVideoClip(
+    id: id,
+    video: EditorVideo.file('/test/video.mp4'),
+    duration: duration,
+    recordedAt: DateTime(2024),
+    targetAspectRatio: model.AspectRatio.square,
+    originalAspectRatio: 9 / 16,
+    trimStart: trimStart,
+    trimEnd: trimEnd,
+    transition: transition,
+  );
+}
+
 // Permanent: swaps PathProviderPlatform.instance and ProVideoEditor.instance;
 // keep isolated until VideoEditorSplitService accepts injected dependencies.
 @Tags(['skip_very_good_optimization'])
@@ -204,15 +224,7 @@ void main() {
 
     group('splitClip', () {
       test('throws ArgumentError for invalid split position', () async {
-        final clip = DivineVideoClip(
-          id: 'test-clip',
-          video: EditorVideo.file('/test/video.mp4'),
-          duration: const Duration(seconds: 1),
-          recordedAt: DateTime.now(),
-          targetAspectRatio: model.AspectRatio.square,
-          originalAspectRatio: 9 / 16,
-        );
-
+        final clip = _clip(duration: const Duration(seconds: 1));
         expect(
           () => VideoEditorSplitService.splitClip(
             sourceClip: clip,
@@ -225,505 +237,205 @@ void main() {
         );
       });
 
-      test('creates two clips with correct durations', () async {
-        final clip = DivineVideoClip(
-          id: 'test-clip',
-          video: EditorVideo.file('/test/video.mp4'),
-          duration: const Duration(seconds: 5),
-          recordedAt: DateTime.now(),
-          targetAspectRatio: model.AspectRatio.square,
-          originalAspectRatio: 9 / 16,
-        );
-
-        DivineVideoClip? capturedStartClip;
-        DivineVideoClip? capturedEndClip;
-
-        await VideoEditorSplitService.splitClip(
-          sourceClip: clip,
-          splitPosition: const Duration(seconds: 2),
-          onClipsCreated: (start, end) {
-            capturedStartClip = start;
-            capturedEndClip = end;
-          },
-          onThumbnailExtracted: null,
-          onClipRendered: null,
-        );
-
-        expect(capturedStartClip, isNotNull);
-        expect(capturedEndClip, isNotNull);
-        expect(capturedStartClip!.duration, const Duration(seconds: 2));
-        expect(capturedEndClip!.duration, const Duration(seconds: 5));
-        expect(capturedEndClip!.trimStart, const Duration(seconds: 2));
-        expect(capturedEndClip!.trimmedDuration, const Duration(seconds: 3));
-      });
-
-      test('calls onClipsCreated before rendering', () async {
-        final clip = DivineVideoClip(
-          id: 'test-clip',
-          video: EditorVideo.file('/test/video.mp4'),
-          duration: const Duration(seconds: 5),
-          recordedAt: DateTime.now(),
-          targetAspectRatio: model.AspectRatio.square,
-          originalAspectRatio: 9 / 16,
-        );
-
-        var onClipsCreatedCalled = false;
-        var onClipRenderedCalled = false;
-        var clipsCreatedFirst = false;
-
-        await VideoEditorSplitService.splitClip(
-          sourceClip: clip,
-          splitPosition: const Duration(seconds: 2),
-          onClipsCreated: (start, end) {
-            onClipsCreatedCalled = true;
-            if (!onClipRenderedCalled) {
-              clipsCreatedFirst = true;
-            }
-          },
-          onThumbnailExtracted: null,
-          onClipRendered: (clip, video) {
-            onClipRenderedCalled = true;
-          },
-        );
-
-        expect(onClipsCreatedCalled, isTrue);
-        expect(clipsCreatedFirst, isTrue);
-      });
-
-      test('cuts the source with a single frame-accurate split', () async {
-        final clip = DivineVideoClip(
-          id: 'test-clip',
-          video: EditorVideo.file('/test/video.mp4'),
-          duration: const Duration(seconds: 5),
-          recordedAt: DateTime.now(),
-          targetAspectRatio: model.AspectRatio.square,
-          originalAspectRatio: 9 / 16,
-        );
-
-        await VideoEditorSplitService.splitClip(
-          sourceClip: clip,
-          splitPosition: const Duration(seconds: 2),
-          onClipsCreated: null,
-          onThumbnailExtracted: null,
-          onClipRendered: null,
-        );
-
-        // A single native split replaces the two full render passes.
-        expect(mockProVideoEditor.splitRequests, hasLength(1));
-        final request = mockProVideoEditor.splitRequests.single;
-        expect(request.splitPosition, const Duration(seconds: 2));
-        expect(request.startOutputPath, contains('_start.mp4'));
-        expect(request.endOutputPath, contains('_end.mp4'));
-        expect(request.startOutputPath, isNot(request.endOutputPath));
-      });
-
-      test('reports both halves as two distinct output files', () async {
-        final clip = DivineVideoClip(
-          id: 'test-clip',
-          video: EditorVideo.file('/test/video.mp4'),
-          duration: const Duration(seconds: 5),
-          recordedAt: DateTime.now(),
-          targetAspectRatio: model.AspectRatio.square,
-          originalAspectRatio: 9 / 16,
-        );
-
-        final renderedVideos = <EditorVideo>[];
-        await VideoEditorSplitService.splitClip(
-          sourceClip: clip,
-          splitPosition: const Duration(seconds: 2),
-          onClipsCreated: null,
-          onThumbnailExtracted: null,
-          onClipRendered: (clip, video) => renderedVideos.add(video),
-        );
-        expect(renderedVideos, hasLength(2));
-        final paths = renderedVideos.map((v) => v.file?.path).toList();
-        expect(paths.any((p) => p?.contains('_start.mp4') ?? false), isTrue);
-        expect(paths.any((p) => p?.contains('_end.mp4') ?? false), isTrue);
-        expect(paths.first, isNot(paths.last));
-
-        // Regression: the clip id already ends in `_start` / `_end`, so the
-        // filename must not double that suffix (`_start_start.mp4`).
-        final request = mockProVideoEditor.splitRequests.single;
-        expect(request.startOutputPath, isNot(contains('_start_start')));
-        expect(request.endOutputPath, isNot(contains('_end_end')));
-      });
-
-      test('a second split immediately afterwards still works', () async {
-        final clip = DivineVideoClip(
-          id: 'test-clip',
-          video: EditorVideo.file('/test/video.mp4'),
-          duration: const Duration(seconds: 5),
-          recordedAt: DateTime.now(),
-          targetAspectRatio: model.AspectRatio.square,
-          originalAspectRatio: 9 / 16,
-        );
-
-        Future<int> runSplit() async {
-          var renderedCount = 0;
-          await VideoEditorSplitService.splitClip(
-            sourceClip: clip,
-            splitPosition: const Duration(seconds: 2),
-            onClipsCreated: null,
-            onThumbnailExtracted: null,
-            onClipRendered: (_, _) => renderedCount++,
-          );
-          return renderedCount;
-        }
-
-        // Regression for #4801: the split future always completes, so a
-        // back-to-back split is never silently dropped.
-        expect(await runSplit(), 2);
-        expect(await runSplit(), 2);
-        expect(mockProVideoEditor.splitRequests, hasLength(2));
-      });
-
-      test('calls onClipRendered for both clips', () async {
-        final clip = DivineVideoClip(
-          id: 'test-clip',
-          video: EditorVideo.file('/test/video.mp4'),
-          duration: const Duration(seconds: 5),
-          recordedAt: DateTime.now(),
-          targetAspectRatio: model.AspectRatio.square,
-          originalAspectRatio: 9 / 16,
-        );
-
-        final renderedClips = <DivineVideoClip>[];
-
-        await VideoEditorSplitService.splitClip(
-          sourceClip: clip,
-          splitPosition: const Duration(seconds: 2),
-          onClipsCreated: null,
-          onThumbnailExtracted: null,
-          onClipRendered: (clip, video) {
-            renderedClips.add(clip);
-          },
-        );
-
-        expect(renderedClips.length, 2);
-      });
-
-      test('anchors the rendered end half to the source recording', () async {
-        final clip = DivineVideoClip(
-          id: 'test-clip',
-          video: EditorVideo.file('/test/video.mp4'),
-          duration: const Duration(seconds: 5),
-          recordedAt: DateTime.now(),
-          targetAspectRatio: model.AspectRatio.square,
-          originalAspectRatio: 9 / 16,
-        );
-
-        final renderedClips = <DivineVideoClip>[];
-        await VideoEditorSplitService.splitClip(
-          sourceClip: clip,
-          splitPosition: const Duration(seconds: 2),
-          onClipsCreated: null,
-          onThumbnailExtracted: null,
-          onClipRendered: (clip, _) => renderedClips.add(clip),
-        );
-
-        // The end half's rendered file starts at the split point, so its
-        // zero-based timeline sits the split position into the recording.
-        // The start half's file still begins at the recording's start.
-        final startClip = renderedClips.singleWhere(
-          (c) => c.id.endsWith('_start'),
-        );
-        final endClip = renderedClips.singleWhere((c) => c.id.endsWith('_end'));
-        expect(startClip.sourceStartOffset, equals(Duration.zero));
-        expect(endClip.sourceStartOffset, equals(const Duration(seconds: 2)));
-      });
-
       test(
-        'accumulates sourceStartOffset when splitting an already-shifted '
-        'clip (nested split)',
+        'creates two halves that share the source video (no re-encode)',
         () async {
-          // End half of a previous split: its file starts 3 s into the
-          // original recording and is trimmed 1 s at its own start.
-          final clip = DivineVideoClip(
-            id: 'test-clip',
-            video: EditorVideo.file('/test/video.mp4'),
-            duration: const Duration(seconds: 5),
-            recordedAt: DateTime.now(),
-            targetAspectRatio: model.AspectRatio.square,
-            originalAspectRatio: 9 / 16,
-            sourceStartOffset: const Duration(seconds: 3),
-            trimStart: const Duration(seconds: 1),
-          );
-
-          final renderedClips = <DivineVideoClip>[];
-          await VideoEditorSplitService.splitClip(
-            sourceClip: clip,
-            splitPosition: const Duration(milliseconds: 1500),
-            onClipsCreated: null,
-            onThumbnailExtracted: null,
-            onClipRendered: (clip, _) => renderedClips.add(clip),
-          );
-
-          // absoluteSplitPos = trimStart + splitPosition = 2.5 s into this
-          // clip's file, which itself starts 3 s into the recording — the
-          // end half's file starts 5.5 s into the recording. The start
-          // half keeps its file, so its anchor is unchanged.
-          final startClip = renderedClips.singleWhere(
-            (c) => c.id.endsWith('_start'),
-          );
-          final endClip = renderedClips.singleWhere(
-            (c) => c.id.endsWith('_end'),
-          );
-          expect(
-            startClip.sourceStartOffset,
-            equals(const Duration(seconds: 3)),
-          );
-          expect(
-            endClip.sourceStartOffset,
-            equals(const Duration(milliseconds: 5500)),
-          );
-        },
-      );
-
-      test('completes processing completers on success', () async {
-        final clip = DivineVideoClip(
-          id: 'test-clip',
-          video: EditorVideo.file('/test/video.mp4'),
-          duration: const Duration(seconds: 5),
-          recordedAt: DateTime.now(),
-          targetAspectRatio: model.AspectRatio.square,
-          originalAspectRatio: 9 / 16,
-        );
-
-        DivineVideoClip? capturedStartClip;
-        DivineVideoClip? capturedEndClip;
-
-        await VideoEditorSplitService.splitClip(
-          sourceClip: clip,
-          splitPosition: const Duration(seconds: 2),
-          onClipsCreated: (start, end) {
-            capturedStartClip = start;
-            capturedEndClip = end;
-          },
-          onThumbnailExtracted: null,
-          onClipRendered: null,
-        );
-
-        expect(capturedStartClip!.processingCompleter?.isCompleted, isTrue);
-        expect(capturedEndClip!.processingCompleter?.isCompleted, isTrue);
-
-        final startSuccess =
-            await capturedStartClip!.processingCompleter!.future;
-        final endSuccess = await capturedEndClip!.processingCompleter!.future;
-
-        expect(startSuccess, isTrue);
-        expect(endSuccess, isTrue);
-      });
-
-      test('completes processing completers on failure', () async {
-        mockProVideoEditor.shouldThrowError = true;
-
-        final clip = DivineVideoClip(
-          id: 'test-clip',
-          video: EditorVideo.file('/test/video.mp4'),
-          duration: const Duration(seconds: 5),
-          recordedAt: DateTime.now(),
-          targetAspectRatio: model.AspectRatio.square,
-          originalAspectRatio: 9 / 16,
-        );
-
-        try {
+          final clip = _clip(duration: const Duration(seconds: 5));
+          DivineVideoClip? start;
+          DivineVideoClip? end;
           await VideoEditorSplitService.splitClip(
             sourceClip: clip,
             splitPosition: const Duration(seconds: 2),
-            onClipsCreated: null,
+            onClipsCreated: (s, e) {
+              start = s;
+              end = e;
+            },
             onThumbnailExtracted: null,
             onClipRendered: null,
           );
-          fail('Should have thrown exception');
-        } catch (e) {
-          expect(e, isException);
-        }
-      });
 
-      test(
-        'does not report rendered clips when output files are missing',
-        () async {
-          mockProVideoEditor.createOutputFiles = false;
-
-          final clip = DivineVideoClip(
-            id: 'test-clip',
-            video: EditorVideo.file('/test/video.mp4'),
-            duration: const Duration(seconds: 5),
-            recordedAt: DateTime.now(),
-            targetAspectRatio: model.AspectRatio.square,
-            originalAspectRatio: 9 / 16,
-          );
-
-          final renderedClips = <DivineVideoClip>[];
-
-          await expectLater(
-            VideoEditorSplitService.splitClip(
-              sourceClip: clip,
-              splitPosition: const Duration(seconds: 2),
-              onClipsCreated: (_, _) {},
-              onThumbnailExtracted: null,
-              onClipRendered: (renderedClip, _) {
-                renderedClips.add(renderedClip);
-              },
-            ),
-            throwsStateError,
-          );
-
-          expect(renderedClips, isEmpty);
+          // Nothing is re-encoded; both halves keep the source file.
+          expect(mockProVideoEditor.splitRequests, isEmpty);
+          expect(start!.video.file?.path, clip.video.file?.path);
+          expect(end!.video.file?.path, clip.video.file?.path);
         },
       );
 
-      test('generates unique IDs for split clips', () async {
-        final clip = DivineVideoClip(
-          id: 'original-clip',
-          video: EditorVideo.file('/test/video.mp4'),
-          duration: const Duration(seconds: 5),
-          recordedAt: DateTime.now(),
-          targetAspectRatio: model.AspectRatio.square,
-          originalAspectRatio: 9 / 16,
-        );
-
-        DivineVideoClip? endClip1;
-        DivineVideoClip? endClip2;
-
+      test('start half is capped at the split; end half starts at it', () async {
+        final clip = _clip(duration: const Duration(seconds: 5));
+        DivineVideoClip? start;
+        DivineVideoClip? end;
         await VideoEditorSplitService.splitClip(
           sourceClip: clip,
           splitPosition: const Duration(seconds: 2),
-          onClipsCreated: (_, end) => endClip1 = end,
-          onThumbnailExtracted: null,
-          onClipRendered: null,
-        );
-
-        // Wait a bit to ensure different timestamp
-        await Future<void>.delayed(const Duration(milliseconds: 2));
-
-        await VideoEditorSplitService.splitClip(
-          sourceClip: clip,
-          splitPosition: const Duration(seconds: 2),
-          onClipsCreated: (_, end) => endClip2 = end,
-          onThumbnailExtracted: null,
-          onClipRendered: null,
-        );
-
-        expect(endClip1!.id, isNot(equals(endClip2!.id)));
-      });
-
-      test('splits trimmed clip at correct absolute position', () async {
-        // 10s clip trimmed to show 3s–8s (trimmedDuration = 5s)
-        final clip = DivineVideoClip(
-          id: 'trimmed-clip',
-          video: EditorVideo.file('/test/video.mp4'),
-          duration: const Duration(seconds: 10),
-          recordedAt: DateTime.now(),
-          targetAspectRatio: model.AspectRatio.square,
-          originalAspectRatio: 9 / 16,
-          trimStart: const Duration(seconds: 3),
-          trimEnd: const Duration(seconds: 2),
-        );
-
-        DivineVideoClip? capturedStartClip;
-        DivineVideoClip? capturedEndClip;
-
-        await VideoEditorSplitService.splitClip(
-          sourceClip: clip,
-          // Split at 2s into the trimmed clip (absolute 5s)
-          splitPosition: const Duration(seconds: 2),
-          onClipsCreated: (start, end) {
-            capturedStartClip = start;
-            capturedEndClip = end;
+          onClipsCreated: (s, e) {
+            start = s;
+            end = e;
           },
           onThumbnailExtracted: null,
           onClipRendered: null,
         );
 
-        expect(capturedStartClip, isNotNull);
-        expect(capturedEndClip, isNotNull);
+        // Start half: [0, 2s], its duration caps the visible end at the split.
+        expect(start!.duration, const Duration(seconds: 2));
+        expect(start!.trimEnd, Duration.zero);
+        expect(start!.trimmedDuration, const Duration(seconds: 2));
+        // End half: [2s, 5s] on the full-length source.
+        expect(end!.duration, const Duration(seconds: 5));
+        expect(end!.trimStart, const Duration(seconds: 2));
+        expect(end!.trimmedDuration, const Duration(seconds: 3));
+      });
 
-        // Start clip: 0–5s (absolute), trimStart=3s, trimEnd=0
-        // trimmedDuration = 5 - 3 = 2s ✓
-        expect(capturedStartClip!.duration, const Duration(seconds: 5));
-        expect(capturedStartClip!.trimStart, const Duration(seconds: 3));
-        expect(capturedStartClip!.trimEnd, Duration.zero);
-        expect(capturedStartClip!.trimmedDuration, const Duration(seconds: 2));
+      test('end half carries a source floor at the split point', () async {
+        final clip = _clip(duration: const Duration(seconds: 5));
+        DivineVideoClip? end;
+        await VideoEditorSplitService.splitClip(
+          sourceClip: clip,
+          splitPosition: const Duration(seconds: 2),
+          onClipsCreated: (_, e) => end = e,
+          onThumbnailExtracted: null,
+          onClipRendered: null,
+        );
 
-        // Preview end clip still points at the original source while the
-        // rendered end file is being produced, so trimStart is absolute.
-        // trimmedDuration = 10 - 5 - 2 = 3s ✓
-        expect(capturedEndClip!.duration, const Duration(seconds: 10));
-        expect(capturedEndClip!.trimStart, const Duration(seconds: 5));
-        expect(capturedEndClip!.trimEnd, const Duration(seconds: 2));
-        expect(capturedEndClip!.trimmedDuration, const Duration(seconds: 3));
+        // So its left trim handle can't be dragged back before the split into
+        // the start half's frames.
+        expect(end!.minTrimStart, const Duration(seconds: 2));
+      });
 
-        // Total trimmedDuration preserved: 2 + 3 = 5s
+      test(
+        'does not render anything (onClipRendered is never called)',
+        () async {
+          final clip = _clip(duration: const Duration(seconds: 5));
+          var rendered = 0;
+          await VideoEditorSplitService.splitClip(
+            sourceClip: clip,
+            splitPosition: const Duration(seconds: 2),
+            onClipsCreated: null,
+            onThumbnailExtracted: null,
+            onClipRendered: (_, _) => rendered++,
+          );
+          expect(rendered, isZero);
+        },
+      );
+
+      test('splits a trimmed clip at the correct absolute position', () async {
+        // 10s clip trimmed to 3s–8s (trimmedDuration = 5s), split 2s in.
+        final clip = _clip(
+          duration: const Duration(seconds: 10),
+          trimStart: const Duration(seconds: 3),
+          trimEnd: const Duration(seconds: 2),
+        );
+        DivineVideoClip? start;
+        DivineVideoClip? end;
+        await VideoEditorSplitService.splitClip(
+          sourceClip: clip,
+          splitPosition: const Duration(seconds: 2),
+          onClipsCreated: (s, e) {
+            start = s;
+            end = e;
+          },
+          onThumbnailExtracted: null,
+          onClipRendered: null,
+        );
+
+        // Absolute split = trimStart(3) + 2 = 5s.
+        expect(start!.duration, const Duration(seconds: 5));
+        expect(start!.trimStart, const Duration(seconds: 3));
+        expect(start!.trimEnd, Duration.zero);
+        expect(start!.trimmedDuration, const Duration(seconds: 2));
+        expect(end!.duration, const Duration(seconds: 10));
+        expect(end!.trimStart, const Duration(seconds: 5));
+        expect(end!.trimEnd, const Duration(seconds: 2));
+        expect(end!.minTrimStart, const Duration(seconds: 5));
+        expect(end!.trimmedDuration, const Duration(seconds: 3));
+        // Total trimmed duration preserved: 2 + 3 = 5s.
         expect(
-          capturedStartClip!.trimmedDuration + capturedEndClip!.trimmedDuration,
+          start!.trimmedDuration + end!.trimmedDuration,
           clip.trimmedDuration,
         );
       });
 
       test('start half drops the transition; end half keeps it', () async {
         const dissolve = ClipTransition(type: ClipTransitionType.dissolve);
-        // Source clip A → B carries the dissolve into the next clip.
-        final clip = DivineVideoClip(
-          id: 'test-clip',
-          video: EditorVideo.file('/test/video.mp4'),
+        final clip = _clip(
           duration: const Duration(seconds: 5),
-          recordedAt: DateTime.now(),
-          targetAspectRatio: model.AspectRatio.square,
-          originalAspectRatio: 9 / 16,
           transition: dissolve,
         );
-
-        DivineVideoClip? capturedStartClip;
-        DivineVideoClip? capturedEndClip;
-
+        DivineVideoClip? start;
+        DivineVideoClip? end;
         await VideoEditorSplitService.splitClip(
           sourceClip: clip,
           splitPosition: const Duration(seconds: 2),
-          onClipsCreated: (start, end) {
-            capturedStartClip = start;
-            capturedEndClip = end;
+          onClipsCreated: (s, e) {
+            start = s;
+            end = e;
           },
           onThumbnailExtracted: null,
           onClipRendered: null,
         );
 
-        // The split point (A1 → A2) is a hard cut.
-        expect(capturedStartClip!.transition, isNull);
-        // A2 → B keeps the original boundary.
-        expect(capturedEndClip!.transition, equals(dissolve));
+        // The split point (A1 → A2) is a hard cut; A2 → B keeps the boundary.
+        expect(start!.transition, isNull);
+        expect(end!.transition, equals(dissolve));
       });
 
-      test('reports rendered end clip with trimStart reset to zero', () async {
-        final clip = DivineVideoClip(
-          id: 'trimmed-clip',
-          video: EditorVideo.file('/test/video.mp4'),
-          duration: const Duration(seconds: 10),
-          recordedAt: DateTime.now(),
-          targetAspectRatio: model.AspectRatio.square,
-          originalAspectRatio: 9 / 16,
-          trimStart: const Duration(seconds: 3),
-          trimEnd: const Duration(seconds: 2),
-        );
-
-        final renderedClips = <DivineVideoClip>[];
-
+      test('re-splitting the end half floors it at the new split', () async {
+        // First split at 2s of a 5s clip → end half [2s, 5s], floor 2s.
+        final clip = _clip(duration: const Duration(seconds: 5));
+        DivineVideoClip? firstEnd;
         await VideoEditorSplitService.splitClip(
           sourceClip: clip,
           splitPosition: const Duration(seconds: 2),
-          onClipsCreated: null,
+          onClipsCreated: (_, e) => firstEnd = e,
           onThumbnailExtracted: null,
-          onClipRendered: (clip, video) => renderedClips.add(clip),
+          onClipRendered: null,
         );
 
-        final endClip = renderedClips.singleWhere(
-          (clip) => clip.id.endsWith('_end'),
+        // Split the end half 1s in → absolute 3s.
+        DivineVideoClip? secondStart;
+        DivineVideoClip? secondEnd;
+        await VideoEditorSplitService.splitClip(
+          sourceClip: firstEnd!,
+          splitPosition: const Duration(seconds: 1),
+          onClipsCreated: (s, e) {
+            secondStart = s;
+            secondEnd = e;
+          },
+          onThumbnailExtracted: null,
+          onClipRendered: null,
         );
 
-        expect(endClip.duration, const Duration(seconds: 5));
-        expect(endClip.trimStart, Duration.zero);
-        expect(endClip.trimEnd, const Duration(seconds: 2));
-        expect(endClip.trimmedDuration, const Duration(seconds: 3));
+        // New start half inherits the first end's floor (2s), capped at 3s.
+        expect(secondStart!.duration, const Duration(seconds: 3));
+        expect(secondStart!.minTrimStart, const Duration(seconds: 2));
+        // New end half is floored at the new split (3s).
+        expect(secondEnd!.trimStart, const Duration(seconds: 3));
+        expect(secondEnd!.minTrimStart, const Duration(seconds: 3));
+      });
+
+      test('generates unique IDs for split clips', () async {
+        final clip = _clip(
+          id: 'original-clip',
+          duration: const Duration(seconds: 5),
+        );
+        DivineVideoClip? end1;
+        DivineVideoClip? end2;
+        await VideoEditorSplitService.splitClip(
+          sourceClip: clip,
+          splitPosition: const Duration(seconds: 2),
+          onClipsCreated: (_, e) => end1 = e,
+          onThumbnailExtracted: null,
+          onClipRendered: null,
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 2));
+        await VideoEditorSplitService.splitClip(
+          sourceClip: clip,
+          splitPosition: const Duration(seconds: 2),
+          onClipsCreated: (_, e) => end2 = e,
+          onThumbnailExtracted: null,
+          onClipRendered: null,
+        );
+        expect(end1!.id, isNot(equals(end2!.id)));
       });
     });
   });

--- a/mobile/test/services/video_editor_render_service_test.dart
+++ b/mobile/test/services/video_editor_render_service_test.dart
@@ -18,9 +18,7 @@ import '../mocks/mock_path_provider_platform.dart';
 class _ProgressProVideoEditor extends ProVideoEditor {
   final _progressController = StreamController<ProgressModel>.broadcast();
   final renderStarts = StreamController<VideoRenderData>.broadcast();
-  final splitStarts = StreamController<SplitVideoModel>.broadcast();
   final _pendingRenders = <_PendingRender>[];
-  final _pendingSplits = <_PendingSplit>[];
   final cancelCalls = <String>[];
 
   @override
@@ -51,18 +49,6 @@ class _ProgressProVideoEditor extends ProVideoEditor {
   }
 
   @override
-  Future<List<String>> splitVideo(
-    SplitVideoModel value, {
-    NativeLogLevel? nativeLogLevel,
-  }) async {
-    final pending = _PendingSplit(model: value);
-    _pendingSplits.add(pending);
-    splitStarts.add(value);
-    await pending.completer.future;
-    return [value.startOutputPath, value.endOutputPath];
-  }
-
-  @override
   Future<void> cancel(String taskId) async {
     cancelCalls.add(taskId);
     final matchingRender = _pendingRenders.where(
@@ -70,14 +56,6 @@ class _ProgressProVideoEditor extends ProVideoEditor {
     );
     if (matchingRender.isNotEmpty) {
       matchingRender.first.completer.completeError(
-        const RenderCanceledException(),
-      );
-    }
-    final matchingSplit = _pendingSplits.where(
-      (pending) => pending.model.id == taskId && !pending.completer.isCompleted,
-    );
-    if (matchingSplit.isNotEmpty) {
-      matchingSplit.first.completer.completeError(
         const RenderCanceledException(),
       );
     }
@@ -102,7 +80,6 @@ class _ProgressProVideoEditor extends ProVideoEditor {
   Future<void> dispose() async {
     await _progressController.close();
     await renderStarts.close();
-    await splitStarts.close();
   }
 }
 
@@ -143,13 +120,6 @@ class _ImmediateRenderProVideoEditor extends ProVideoEditor {
   Future<void> cancel(String taskId) async {
     cancelCalls.add(taskId);
   }
-}
-
-class _PendingSplit {
-  _PendingSplit({required this.model});
-
-  final SplitVideoModel model;
-  final completer = Completer<void>();
 }
 
 Future<void> _flushStreamEvents() => Future<void>.delayed(Duration.zero);

--- a/mobile/test/services/video_editor_render_service_test.dart
+++ b/mobile/test/services/video_editor_render_service_test.dart
@@ -5,7 +5,6 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:ui';
 
-import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart' as model;
 import 'package:openvine/models/divine_video_clip.dart';
@@ -411,55 +410,6 @@ void main() {
 
       await secondCancellation;
       expect(VideoEditorRenderService.activeNativeTaskIdsForTesting, isEmpty);
-    });
-
-    test('tracks a native split and cancels it on teardown', () async {
-      final splitStarted = proVideoEditor.splitStarts.stream.first;
-      final splitFuture = VideoEditorRenderService.splitNativeVideoToFile(
-        inputPath: '${Directory.systemTemp.path}/source.mp4',
-        splitPosition: const Duration(seconds: 1),
-        startOutputPath: '${Directory.systemTemp.path}/start.mp4',
-        endOutputPath: '${Directory.systemTemp.path}/end.mp4',
-      );
-
-      final startedModel = await splitStarted;
-      expect(
-        VideoEditorRenderService.activeNativeTaskIdsForTesting,
-        contains(startedModel.id),
-      );
-
-      final splitCancellation = expectLater(
-        splitFuture,
-        throwsA(isA<RenderCanceledException>()),
-      );
-      await VideoEditorRenderService.cancelActiveNativeTasks();
-
-      expect(proVideoEditor.cancelCalls, contains(startedModel.id));
-      await splitCancellation;
-      expect(VideoEditorRenderService.activeNativeTaskIdsForTesting, isEmpty);
-    });
-
-    test('watchdog converts a hung native split into a cancel (#4801)', () {
-      fakeAsync((async) {
-        Object? caughtError;
-        VideoEditorRenderService.splitNativeVideoToFile(
-          inputPath: '${Directory.systemTemp.path}/source.mp4',
-          splitPosition: const Duration(seconds: 1),
-          startOutputPath: '${Directory.systemTemp.path}/start.mp4',
-          endOutputPath: '${Directory.systemTemp.path}/end.mp4',
-        ).catchError((Object error) {
-          caughtError = error;
-          return <String>[];
-        });
-
-        // The native split never completes; advance past the Dart-side
-        // watchdog so the timeout fires and surfaces a cancel.
-        async.elapse(const Duration(seconds: 151));
-
-        expect(caughtError, isA<RenderCanceledException>());
-        expect(proVideoEditor.cancelCalls, hasLength(1));
-        expect(VideoEditorRenderService.activeNativeTaskIdsForTesting, isEmpty);
-      });
     });
   });
 

--- a/mobile/test/widgets/video_editor/main_editor/video_editor_canvas_test.dart
+++ b/mobile/test/widgets/video_editor/main_editor/video_editor_canvas_test.dart
@@ -192,6 +192,39 @@ void main() {
         isTrue,
       );
     });
+
+    test('skips a thumbnail-only change (poster refresh after a split)', () {
+      final clip = _createClip(id: 'end');
+
+      expect(
+        VideoEditorCanvas.shouldSyncPlayerForClipStateChange(
+          previous: ClipEditorState(clips: [clip]),
+          current: ClipEditorState(
+            clips: [clip.copyWith(thumbnailPath: '/thumbs/end.jpg')],
+          ),
+        ),
+        isFalse,
+      );
+    });
+
+    test('still syncs when a trim changes alongside the thumbnail', () {
+      final clip = _createClip(id: 'end');
+
+      expect(
+        VideoEditorCanvas.shouldSyncPlayerForClipStateChange(
+          previous: ClipEditorState(clips: [clip]),
+          current: ClipEditorState(
+            clips: [
+              clip.copyWith(
+                thumbnailPath: '/thumbs/end.jpg',
+                trimStart: const Duration(seconds: 1),
+              ),
+            ],
+          ),
+        ),
+        isTrue,
+      );
+    });
   });
 
   group('VideoEditorCanvas.shouldAcceptPlayerReport', () {


### PR DESCRIPTION
Closes #6135

## Description

Splitting a clip in the video editor no longer re-encodes. A split is now a **pure trim-based metadata cut**: both halves keep the **same source file** with adjacent trim windows, so it is **instant** instead of a ~15–20 s native re-encode.

This started from a report that the **Split ("trim") control becomes unavailable / greys out for ~30 s after a couple of cuts** on a long clip. The ~30 s turned out to be the native re-encode (`pro_video_editor` `splitVideo`), whose duration is proportional to clip length. Investigating it surfaced two additional editor-teardown races, fixed here as well.

Three clearly separate changes:

**1. Trim-based split (no re-encode) — the headline**
- `splitClip` now produces two clips that share the source file: start half `[0, split]` (its `duration` caps the visible end at the split), end half `[split, end]`.
- New `DivineVideoClip.minTrimStart` (a source floor, serialized as `minTrimStartMs`) pins the end half's left trim handle at the split so it can't be dragged back into the start half's frames — the separate re-encoded file used to enforce that implicitly.
- Safe because the export already clips each clip to its `[trimStart, trimEnd]` window (`renderVideo._normalizeClipsToAspectRatio`) and `FileCleanupService` only deletes a file no clip/draft still references.
- Removes the now-dead native `splitNativeVideoToFile` primitive and its tests.

**2. Guard the final-clip callback against a disposed editor**
A long render can resolve after the user backs out of the editor. `onFinalClipInvalidated` then touched the disposed screen's Riverpod `ref` and threw `Using "ref" when a widget … has been unmounted`, and the split was lost. It now bails when the screen is unmounted.

**3. Don't let a stale editor re-sync clobber an in-flight split**
When a split was tapped while another was still rendering, the canvas's editor→bloc clip re-sync could carry the previous (stale) snapshot and overwrite the just-applied split, which then silently vanished. The canvas re-sync and `_onInitialized` now skip while `isSplitting`.

## Out of Scope

- On-device verification (see below) — I can't run it here.
- Any change to `pro_video_editor` itself (the split primitive is simply no longer used).

## Verification

- `flutter analyze lib test` — clean.
- Targeted tests: `video_editor_split_service_test` (trim-based, source floor, re-split, transition), `divine_video_clip_test` (`minTrimStart` JSON round-trip + copyWith), `clip_editor_bloc_test` (trim clamp + stale-re-sync guard), `video_editor_render_service_test`.


## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 🧹 Code refactor

**Related Issue:**