### PR TITLE
feat(video_editor): draw each clip's waveform over its thumbnails

### DIFF
--- a/mobile/lib/constants/video_editor_timeline_constants.dart
+++ b/mobile/lib/constants/video_editor_timeline_constants.dart
@@ -90,6 +90,39 @@ abstract class TimelineConstants {
   /// Bar width for the compact sound-overlay waveform.
   static const double soundWaveformBarWidth = 1;
 
+  // --- Clip waveform overlay ---
+
+  /// Bar width of the waveform drawn over a clip's thumbnails.
+  static const double clipWaveformBarWidth = 1;
+
+  /// Gap between the bars of the waveform drawn over a clip's thumbnails.
+  static const double clipWaveformBarSpacing = 1;
+
+  /// Height of the waveform band along a clip's bottom edge. Roughly a third
+  /// of the strip, so the frames above stay readable.
+  static const double clipWaveformBandHeight = 22;
+
+  /// Opacity of the waveform drawn over a clip's thumbnails — legible over
+  /// both bright and dark frames without competing with them.
+  static const double clipWaveformOpacity = 0.55;
+
+  /// Headroom multiplier for clip-waveform bars, so a peak at full amplitude
+  /// stops just short of the band's top edge.
+  static const double clipWaveformGain = 0.9;
+
+  /// Lower bound for the per-clip waveform normalizer. A clip whose loudest
+  /// sample sits below this stays quiet on screen rather than being stretched
+  /// to full scale — the difference between "quiet" and "silent" survives.
+  static const double clipWaveformNormalizerFloor = 0.2;
+
+  /// Exponent applied to the normalized amplitude. Below 1 it lifts the quiet
+  /// body of the signal toward the peaks; 1 would be a linear (near-flat) band.
+  static const double clipWaveformCurve = 0.6;
+
+  /// Baseline height of a clip-waveform bar. Keeps a continuous line visible
+  /// through silence and at zero volume.
+  static const double clipWaveformMinBarHeight = 1;
+
   /// Vertical gap between overlay rows within a strip.
   static const double overlayRowGap = 6;
 

--- a/mobile/lib/models/video_editor/clip_waveform.dart
+++ b/mobile/lib/models/video_editor/clip_waveform.dart
@@ -1,0 +1,38 @@
+// ABOUTME: A video clip's audio waveform, reduced to one peak per sample.
+// ABOUTME: Produced by ClipWaveformManager, drawn by the timeline clip strip.
+
+import 'package:flutter/foundation.dart';
+
+/// A clip's audio waveform, reduced to one peak per sample.
+@immutable
+class ClipWaveform {
+  const ClipWaveform({
+    required this.peaks,
+    required this.duration,
+    required this.peak,
+  });
+
+  /// A waveform with no samples — used for clips whose file carries no
+  /// readable audio track.
+  const ClipWaveform.empty()
+    : peaks = const [],
+      duration = Duration.zero,
+      peak = 0;
+
+  /// Peak amplitude (0..1) per sample, spanning [duration] of the source file.
+  ///
+  /// Stereo sources are merged to the louder channel per sample: the strip
+  /// draws a single band, so a per-channel split would only halve the detail.
+  final List<double> peaks;
+
+  /// Span of audio [peaks] covers. Can be shorter than the clip's video
+  /// duration when the audio track ends early.
+  final Duration duration;
+
+  /// The loudest sample in [peaks]. Real recordings rarely approach full scale,
+  /// so the strip normalizes against this instead of against 1.0 — otherwise a
+  /// perfectly audible clip draws as a barely-there ripple.
+  final double peak;
+
+  bool get isEmpty => peaks.isEmpty || duration <= Duration.zero;
+}

--- a/mobile/lib/services/video_editor/clip_waveform_manager.dart
+++ b/mobile/lib/services/video_editor/clip_waveform_manager.dart
@@ -27,14 +27,19 @@ class ClipWaveformManager {
   ClipWaveformManager({ClipWaveformExtractor? extractor})
     : _extract = extractor ?? _extractWithProVideoEditor;
 
-  /// Sample density for extraction. At the timeline's maximum zoom a bar
-  /// covers ~2px, so 200 samples/second still resolves more detail than the
-  /// strip can draw — at ~8KB per minute of audio.
+  /// Sample density for extraction. 200 samples/second resolves every bar the
+  /// strip can draw below ~400px/s of zoom, and stays within a few KB per clip
+  /// at the recorder's 6.3s cap.
   static const WaveformResolution _resolution = WaveformResolution.high;
 
   /// Cached waveforms retained after their clip is gone, so undo/redo does not
   /// re-extract. Insertion-ordered for FIFO eviction.
   static const _maxCachedWaveforms = 32;
+
+  /// Extraction attempts per file before a repeatedly failing one is given up
+  /// on as bandless. Bounded so a `sync` storm (every trim-drag frame) can't
+  /// retry forever.
+  static const _maxExtractionAttempts = 3;
 
   static Future<WaveformData> _extractWithProVideoEditor(String videoPath) {
     return ProVideoEditor.instance.getWaveform(
@@ -56,6 +61,9 @@ class ClipWaveformManager {
 
   final Map<String, ClipWaveform> _cache = {};
   final Set<String> _inFlight = {};
+
+  /// Consecutive transient extraction failures per file path.
+  final Map<String, int> _failures = {};
 
   /// Serializes extractions — the strip's thumbnail generator and the editor
   /// preview already compete for the same hardware decoders.
@@ -117,7 +125,13 @@ class ClipWaveformManager {
       if (_disposed || !_isReferenced(path)) return;
       final data = await _extract(path);
       if (_disposed) return;
+      _failures.remove(path);
       _publish(path, _reduce(data));
+    } on AudioNoTrackException {
+      if (_disposed) return;
+      // Cache the miss: the file carries no audio track, so retrying could
+      // never draw bars. The strip just renders none.
+      _publish(path, const ClipWaveform.empty());
     } catch (e) {
       Log.warning(
         'Failed to extract clip waveform: $e',
@@ -125,12 +139,24 @@ class ClipWaveformManager {
         category: LogCategory.video,
       );
       if (_disposed) return;
-      // Cache the miss: a file without a readable audio track would otherwise
-      // be retried on every sync. The strip just renders no bars.
-      _publish(path, const ClipWaveform.empty());
+      _onTransientFailure(path);
     } finally {
       _inFlight.remove(path);
     }
+  }
+
+  /// Reopens [path] for extraction after a failure that isn't "no audio track"
+  /// — a decoder busy under render contention says nothing about the file, and
+  /// caching it as bandless would blank the clip for the rest of the session.
+  /// Releasing the clips' resolved path lets the next [sync] re-extract.
+  void _onTransientFailure(String path) {
+    final attempts = (_failures[path] ?? 0) + 1;
+    _failures[path] = attempts;
+    if (attempts >= _maxExtractionAttempts) {
+      _publish(path, const ClipWaveform.empty());
+      return;
+    }
+    _paths.removeWhere((_, resolved) => resolved == path);
   }
 
   /// Whether any clip still points at [path]. A clip removed while its
@@ -172,5 +198,6 @@ class ClipWaveformManager {
     _paths.clear();
     _cache.clear();
     _inFlight.clear();
+    _failures.clear();
   }
 }

--- a/mobile/lib/services/video_editor/clip_waveform_manager.dart
+++ b/mobile/lib/services/video_editor/clip_waveform_manager.dart
@@ -37,9 +37,13 @@ class ClipWaveformManager {
   static const _maxCachedWaveforms = 32;
 
   /// Extraction attempts per file before a repeatedly failing one is given up
-  /// on as bandless. Bounded so a `sync` storm (every trim-drag frame) can't
-  /// retry forever.
+  /// on as bandless.
   static const _maxExtractionAttempts = 3;
+
+  /// Delay before a transiently failed extraction is retried. Long enough for
+  /// the decoder contention it usually signals — a render, the strip's own
+  /// thumbnail pass — to clear, rather than re-queuing into the same jam.
+  static const _retryDelay = Duration(seconds: 2);
 
   static Future<WaveformData> _extractWithProVideoEditor(String videoPath) {
     return ProVideoEditor.instance.getWaveform(
@@ -64,6 +68,9 @@ class ClipWaveformManager {
 
   /// Consecutive transient extraction failures per file path.
   final Map<String, int> _failures = {};
+
+  /// Pending retries per file path, so dispose can cancel them.
+  final Map<String, Timer> _retryTimers = {};
 
   /// Serializes extractions — the strip's thumbnail generator and the editor
   /// preview already compete for the same hardware decoders.
@@ -145,10 +152,14 @@ class ClipWaveformManager {
     }
   }
 
-  /// Reopens [path] for extraction after a failure that isn't "no audio track"
-  /// — a decoder busy under render contention says nothing about the file, and
-  /// caching it as bandless would blank the clip for the rest of the session.
-  /// Releasing the clips' resolved path lets the next [sync] re-extract.
+  /// Schedules a retry after a failure that isn't "no audio track" — a decoder
+  /// busy under render contention says nothing about the file, and caching it
+  /// as bandless would blank the clip for the rest of the session.
+  ///
+  /// The retry owns its own timer rather than waiting for the next [sync]:
+  /// contention peaks when the editor opens, and nothing guarantees another
+  /// sync afterwards — the strip only re-syncs when its widget updates, so an
+  /// idle timeline would keep the clip bandless indefinitely.
   void _onTransientFailure(String path) {
     final attempts = (_failures[path] ?? 0) + 1;
     _failures[path] = attempts;
@@ -156,7 +167,12 @@ class ClipWaveformManager {
       _publish(path, const ClipWaveform.empty());
       return;
     }
-    _paths.removeWhere((_, resolved) => resolved == path);
+    _retryTimers[path]?.cancel();
+    _retryTimers[path] = Timer(_retryDelay, () {
+      _retryTimers.remove(path);
+      if (_disposed || !_isReferenced(path)) return;
+      _enqueue(path);
+    });
   }
 
   /// Whether any clip still points at [path]. A clip removed while its
@@ -191,6 +207,10 @@ class ClipWaveformManager {
   /// Disposes every notifier and stops publishing queued extractions.
   void dispose() {
     _disposed = true;
+    for (final timer in _retryTimers.values) {
+      timer.cancel();
+    }
+    _retryTimers.clear();
     for (final notifier in _notifiers.values) {
       notifier.dispose();
     }

--- a/mobile/lib/services/video_editor/clip_waveform_manager.dart
+++ b/mobile/lib/services/video_editor/clip_waveform_manager.dart
@@ -7,6 +7,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/video_editor/clip_waveform.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -15,40 +16,6 @@ import 'package:unified_logger/unified_logger.dart';
 /// Injectable so tests can assert the manager's caching and lifecycle without
 /// invoking the native extractor.
 typedef ClipWaveformExtractor = Future<WaveformData> Function(String videoPath);
-
-/// A clip's audio waveform, reduced to one peak per sample.
-@immutable
-class ClipWaveform {
-  const ClipWaveform({
-    required this.peaks,
-    required this.duration,
-    required this.peak,
-  });
-
-  /// A waveform with no samples — used for clips whose file carries no
-  /// readable audio track.
-  const ClipWaveform.empty()
-    : peaks = const [],
-      duration = Duration.zero,
-      peak = 0;
-
-  /// Peak amplitude (0..1) per sample, spanning [duration] of the source file.
-  ///
-  /// Stereo sources are merged to the louder channel per sample: the strip
-  /// draws a single band, so a per-channel split would only halve the detail.
-  final List<double> peaks;
-
-  /// The loudest sample in [peaks]. Real recordings rarely approach full scale,
-  /// so the strip normalizes against this instead of against 1.0 — otherwise a
-  /// perfectly audible clip draws as a barely-there ripple.
-  final double peak;
-
-  /// Span of audio [peaks] covers. Can be shorter than the clip's video
-  /// duration when the audio track ends early.
-  final Duration duration;
-
-  bool get isEmpty => peaks.isEmpty || duration <= Duration.zero;
-}
 
 /// Manages waveform extraction for the clips currently on the timeline.
 ///

--- a/mobile/lib/services/video_editor/clip_waveform_manager.dart
+++ b/mobile/lib/services/video_editor/clip_waveform_manager.dart
@@ -192,7 +192,9 @@ class ClipWaveformManager {
   ClipWaveform _reduce(WaveformData data) {
     final left = data.leftChannel;
     final right = data.rightChannel;
-    final peaks = List<double>.filled(left.length, 0);
+    // Float32 throughout: the source channels already are, so storing the
+    // reduced peaks as boxed doubles would quadruple the cache for no detail.
+    final peaks = Float32List(left.length);
     var peak = 0.0;
     for (var i = 0; i < left.length; i++) {
       final l = left[i].abs();

--- a/mobile/lib/services/video_editor/clip_waveform_manager.dart
+++ b/mobile/lib/services/video_editor/clip_waveform_manager.dart
@@ -120,9 +120,30 @@ class ClipWaveformManager {
       // clearing here would blink the bars away on every re-render swap.
       _enqueue(path);
     }
+
+    _forgetUnreferencedFailures();
+  }
+
+  /// Drops the retry state of files no clip points at anymore.
+  ///
+  /// Without this a tally outlives its clip: two failures, an undo, and the
+  /// clip's first fresh failure on re-add would hit the cap and blank the
+  /// band — a permanent verdict from one attempt. It also bounds the maps.
+  void _forgetUnreferencedFailures() {
+    _failures.removeWhere((path, _) => !_isReferenced(path));
+    _retryTimers.removeWhere((path, timer) {
+      if (_isReferenced(path)) return false;
+      timer.cancel();
+      return true;
+    });
   }
 
   void _enqueue(String path) {
+    // A retry armed before a sibling clip resolved the same file would
+    // otherwise re-decode it — a wasted pass under the very contention
+    // [_queue] exists to avoid, and one that can fail its way to blanking a
+    // band already on screen.
+    if (_cache.containsKey(path)) return;
     if (!_inFlight.add(path)) return;
     _queue = _queue.then((_) => _extractFor(path));
   }
@@ -180,6 +201,8 @@ class ClipWaveformManager {
   bool _isReferenced(String path) => _paths.values.contains(path);
 
   void _publish(String path, ClipWaveform waveform) {
+    // Whatever a pending retry was going to fetch, this settles it.
+    _retryTimers.remove(path)?.cancel();
     _cache[path] = waveform;
     if (_cache.length > _maxCachedWaveforms) {
       _cache.remove(_cache.keys.first);

--- a/mobile/lib/services/video_editor/clip_waveform_manager.dart
+++ b/mobile/lib/services/video_editor/clip_waveform_manager.dart
@@ -1,0 +1,209 @@
+// ABOUTME: Extracts and caches per-clip audio waveforms for the timeline strip.
+// ABOUTME: One notifier per clip; extractions are shared per source file.
+
+import 'dart:async';
+import 'dart:io';
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart';
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// Extracts waveform data for the video file at [videoPath].
+///
+/// Injectable so tests can assert the manager's caching and lifecycle without
+/// invoking the native extractor.
+typedef ClipWaveformExtractor = Future<WaveformData> Function(String videoPath);
+
+/// A clip's audio waveform, reduced to one peak per sample.
+@immutable
+class ClipWaveform {
+  const ClipWaveform({
+    required this.peaks,
+    required this.duration,
+    required this.peak,
+  });
+
+  /// A waveform with no samples — used for clips whose file carries no
+  /// readable audio track.
+  const ClipWaveform.empty()
+    : peaks = const [],
+      duration = Duration.zero,
+      peak = 0;
+
+  /// Peak amplitude (0..1) per sample, spanning [duration] of the source file.
+  ///
+  /// Stereo sources are merged to the louder channel per sample: the strip
+  /// draws a single band, so a per-channel split would only halve the detail.
+  final List<double> peaks;
+
+  /// The loudest sample in [peaks]. Real recordings rarely approach full scale,
+  /// so the strip normalizes against this instead of against 1.0 — otherwise a
+  /// perfectly audible clip draws as a barely-there ripple.
+  final double peak;
+
+  /// Span of audio [peaks] covers. Can be shorter than the clip's video
+  /// duration when the audio track ends early.
+  final Duration duration;
+
+  bool get isEmpty => peaks.isEmpty || duration <= Duration.zero;
+}
+
+/// Manages waveform extraction for the clips currently on the timeline.
+///
+/// Each clip gets an independent [ValueNotifier] so only the affected tile
+/// repaints when its waveform arrives. Extractions are keyed by source file
+/// path, so the two halves of a trim-based split — which share one file —
+/// resolve from a single pass, and undo/redo restores hit the cache.
+class ClipWaveformManager {
+  ClipWaveformManager({ClipWaveformExtractor? extractor})
+    : _extract = extractor ?? _extractWithProVideoEditor;
+
+  /// Sample density for extraction. At the timeline's maximum zoom a bar
+  /// covers ~2px, so 200 samples/second still resolves more detail than the
+  /// strip can draw — at ~8KB per minute of audio.
+  static const WaveformResolution _resolution = WaveformResolution.high;
+
+  /// Cached waveforms retained after their clip is gone, so undo/redo does not
+  /// re-extract. Insertion-ordered for FIFO eviction.
+  static const _maxCachedWaveforms = 32;
+
+  static Future<WaveformData> _extractWithProVideoEditor(String videoPath) {
+    return ProVideoEditor.instance.getWaveform(
+      WaveformConfigs(
+        video: EditorVideo.file(File(videoPath)),
+        resolution: _resolution,
+      ),
+    );
+  }
+
+  final ClipWaveformExtractor _extract;
+
+  final Map<String, ValueNotifier<ClipWaveform?>> _notifiers = {};
+
+  /// Source file path each clip's current waveform was resolved against.
+  /// A change means the clip was re-rendered (split, speed, reverse) and its
+  /// waveform has to be re-extracted.
+  final Map<String, String> _paths = {};
+
+  final Map<String, ClipWaveform> _cache = {};
+  final Set<String> _inFlight = {};
+
+  /// Serializes extractions — the strip's thumbnail generator and the editor
+  /// preview already compete for the same hardware decoders.
+  Future<void> _queue = Future<void>.value();
+
+  bool _disposed = false;
+
+  /// Returns the waveform notifier for [clipId].
+  ValueNotifier<ClipWaveform?> operator [](String clipId) =>
+      _notifiers[clipId]!;
+
+  /// Syncs waveforms with the current clip list — starts extraction for new
+  /// clips and for clips whose source file changed, and cleans up removed ones.
+  void sync({required List<DivineVideoClip> clips}) {
+    if (_disposed) return;
+
+    final currentIds = clips.map((c) => c.id).toSet();
+    for (final id in _notifiers.keys.toList()) {
+      if (currentIds.contains(id)) continue;
+      _notifiers.remove(id)?.dispose();
+      _paths.remove(id);
+    }
+
+    for (final clip in clips) {
+      final notifier = _notifiers.putIfAbsent(
+        clip.id,
+        () => ValueNotifier(null),
+      );
+
+      final path = clip.video.file?.path;
+      if (path == null) {
+        // A clip whose source file isn't resolved yet (e.g. still rendering).
+        _paths.remove(clip.id);
+        notifier.value = null;
+        continue;
+      }
+
+      if (_paths[clip.id] == path) continue;
+      _paths[clip.id] = path;
+
+      final cached = _cache[path];
+      if (cached != null) {
+        notifier.value = cached;
+        continue;
+      }
+      // The previous waveform stays on screen until the new one lands —
+      // clearing here would blink the bars away on every re-render swap.
+      _enqueue(path);
+    }
+  }
+
+  void _enqueue(String path) {
+    if (!_inFlight.add(path)) return;
+    _queue = _queue.then((_) => _extractFor(path));
+  }
+
+  Future<void> _extractFor(String path) async {
+    try {
+      if (_disposed || !_isReferenced(path)) return;
+      final data = await _extract(path);
+      if (_disposed) return;
+      _publish(path, _reduce(data));
+    } catch (e) {
+      Log.warning(
+        'Failed to extract clip waveform: $e',
+        name: 'ClipWaveformManager',
+        category: LogCategory.video,
+      );
+      if (_disposed) return;
+      // Cache the miss: a file without a readable audio track would otherwise
+      // be retried on every sync. The strip just renders no bars.
+      _publish(path, const ClipWaveform.empty());
+    } finally {
+      _inFlight.remove(path);
+    }
+  }
+
+  /// Whether any clip still points at [path]. A clip removed while its
+  /// extraction was queued has nothing left to render.
+  bool _isReferenced(String path) => _paths.values.contains(path);
+
+  void _publish(String path, ClipWaveform waveform) {
+    _cache[path] = waveform;
+    if (_cache.length > _maxCachedWaveforms) {
+      _cache.remove(_cache.keys.first);
+    }
+    for (final entry in _paths.entries) {
+      if (entry.value == path) _notifiers[entry.key]?.value = waveform;
+    }
+  }
+
+  ClipWaveform _reduce(WaveformData data) {
+    final left = data.leftChannel;
+    final right = data.rightChannel;
+    final peaks = List<double>.filled(left.length, 0);
+    var peak = 0.0;
+    for (var i = 0; i < left.length; i++) {
+      final l = left[i].abs();
+      final r = right != null && i < right.length ? right[i].abs() : l;
+      final sample = math.max(l, r).clamp(0.0, 1.0);
+      peaks[i] = sample;
+      peak = math.max(peak, sample);
+    }
+    return ClipWaveform(peaks: peaks, duration: data.duration, peak: peak);
+  }
+
+  /// Disposes every notifier and stops publishing queued extractions.
+  void dispose() {
+    _disposed = true;
+    for (final notifier in _notifiers.values) {
+      notifier.dispose();
+    }
+    _notifiers.clear();
+    _paths.clear();
+    _cache.clear();
+    _inFlight.clear();
+  }
+}

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/clip_waveform_overlay.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/clip_waveform_overlay.dart
@@ -1,0 +1,153 @@
+// ABOUTME: Translucent waveform band drawn over a timeline clip's thumbnails.
+// ABOUTME: Bars grow up from the clip's bottom edge and scale with clip volume.
+
+import 'dart:math' as math;
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:openvine/constants/video_editor_timeline_constants.dart';
+import 'package:openvine/services/video_editor/clip_waveform_manager.dart';
+
+/// The clip's audio waveform, drawn translucently over its thumbnails.
+///
+/// Sized and positioned by the caller to span the clip's *full source*
+/// duration, so the bars stay glued to the frames as the tile is trimmed,
+/// zoomed, or scrolled.
+class ClipWaveformOverlay extends StatelessWidget {
+  const ClipWaveformOverlay({
+    required this.waveform,
+    required this.clipDuration,
+    required this.volume,
+    super.key,
+  });
+
+  final ClipWaveform waveform;
+
+  /// Duration of the clip's source file — the span [waveform] is stretched
+  /// across the overlay's width against.
+  final Duration clipDuration;
+
+  /// The clip's volume. Scales the bar heights, so muting flattens the band
+  /// to its baseline instead of leaving a misleading loud waveform.
+  final double volume;
+
+  @override
+  Widget build(BuildContext context) {
+    if (waveform.isEmpty) return const SizedBox.shrink();
+
+    return ExcludeSemantics(
+      child: IgnorePointer(
+        child: RepaintBoundary(
+          child: CustomPaint(
+            size: Size.infinite,
+            painter: ClipWaveformPainter(
+              waveform: waveform,
+              clipDuration: clipDuration,
+              volume: volume,
+              color: VineTheme.whiteText.withValues(
+                alpha: TimelineConstants.clipWaveformOpacity,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Paints [waveform] as bottom-anchored bars across the full paint width.
+@visibleForTesting
+class ClipWaveformPainter extends CustomPainter {
+  const ClipWaveformPainter({
+    required this.waveform,
+    required this.clipDuration,
+    required this.volume,
+    required this.color,
+  });
+
+  final ClipWaveform waveform;
+  final Duration clipDuration;
+  final double volume;
+  final Color color;
+
+  static const double _barStep =
+      TimelineConstants.clipWaveformBarWidth +
+      TimelineConstants.clipWaveformBarSpacing;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final clipMs = clipDuration.inMilliseconds;
+    if (waveform.isEmpty || clipMs <= 0 || size.width <= 0) return;
+
+    // An audio track that ends before the video does covers only the leading
+    // part of the tile; anything past it stays bare rather than stretching the
+    // samples over silence.
+    final audioFraction = (waveform.duration.inMilliseconds / clipMs).clamp(
+      0.0,
+      1.0,
+    );
+    final bandWidth = size.width * audioFraction;
+    final barCount = (bandWidth / _barStep).floor();
+    if (barCount <= 0) return;
+
+    final band = math.min(
+      TimelineConstants.clipWaveformBandHeight,
+      size.height,
+    );
+    final paint = Paint()..color = color;
+    final peaks = waveform.peaks;
+
+    // Normalize against the clip's own loudest sample, so a quietly recorded
+    // clip still fills the band. The floor keeps near-silence flat instead of
+    // amplifying room noise into a convincing-looking waveform.
+    final normalizer = math.max(
+      waveform.peak,
+      TimelineConstants.clipWaveformNormalizerFloor,
+    );
+
+    for (var i = 0; i < barCount; i++) {
+      // Peak across every sample the bar covers — averaging (or point
+      // sampling) would alias transients away at low zoom, where one bar
+      // spans dozens of samples.
+      final from = (i * peaks.length ~/ barCount).clamp(0, peaks.length - 1);
+      final to = math.max(from + 1, (i + 1) * peaks.length ~/ barCount);
+      var amplitude = 0.0;
+      for (var s = from; s < to && s < peaks.length; s++) {
+        amplitude = math.max(amplitude, peaks[s]);
+      }
+
+      // Compress the normalized amplitude: audio spends most of its time far
+      // below its peak, so a linear band reads as a flat line with occasional
+      // spikes. The curve lifts the body without flattening the transients.
+      final scaled = math.pow(
+        (amplitude / normalizer).clamp(0.0, 1.0),
+        TimelineConstants.clipWaveformCurve,
+      );
+
+      final height =
+          (scaled * volume * band * TimelineConstants.clipWaveformGain).clamp(
+            TimelineConstants.clipWaveformMinBarHeight,
+            band,
+          );
+      canvas.drawRRect(
+        RRect.fromRectAndRadius(
+          Rect.fromLTWH(
+            i * _barStep,
+            size.height - height,
+            TimelineConstants.clipWaveformBarWidth,
+            height,
+          ),
+          const Radius.circular(TimelineConstants.clipWaveformBarWidth / 2),
+        ),
+        paint,
+      );
+    }
+  }
+
+  @override
+  bool shouldRepaint(ClipWaveformPainter oldDelegate) =>
+      oldDelegate.waveform != waveform ||
+      oldDelegate.clipDuration != clipDuration ||
+      oldDelegate.volume != volume ||
+      oldDelegate.color != color;
+}

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/clip_waveform_overlay.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/clip_waveform_overlay.dart
@@ -23,8 +23,10 @@ class ClipWaveformOverlay extends StatelessWidget {
 
   final ClipWaveform waveform;
 
-  /// Duration of the clip's source file — the span [waveform] is stretched
-  /// across the overlay's width against.
+  /// The clip's own duration — the span the overlay's width represents.
+  ///
+  /// Not necessarily the source file's length: a trim-based split's start half
+  /// is rebased to the split point while still sharing the full-length file.
   final Duration clipDuration;
 
   /// The clip's volume. Scales the bar heights, so muting flattens the band
@@ -79,16 +81,16 @@ class ClipWaveformPainter extends CustomPainter {
     final clipMs = clipDuration.inMilliseconds;
     if (waveform.isEmpty || clipMs <= 0 || size.width <= 0) return;
 
-    // An audio track that ends before the video does covers only the leading
-    // part of the tile; anything past it stays bare rather than stretching the
-    // samples over silence.
-    final audioFraction = (waveform.duration.inMilliseconds / clipMs).clamp(
-      0.0,
-      1.0,
-    );
-    final bandWidth = size.width * audioFraction;
+    // Bars map straight from clip time, so the band spans the audio's own
+    // length rather than being fitted to the tile. Shorter audio leaves the
+    // remainder bare instead of stretching over silence; longer audio — a
+    // trim-based split's start half keeps the whole source file — runs past
+    // the tile and is culled, instead of squeezing the later halves' sound
+    // under these frames.
+    final bandWidth = size.width * waveform.duration.inMilliseconds / clipMs;
     final barCount = (bandWidth / _barStep).floor();
-    if (barCount <= 0) return;
+    final visibleBarCount = math.min(barCount, (size.width / _barStep).floor());
+    if (visibleBarCount <= 0) return;
 
     final band = math.min(
       TimelineConstants.clipWaveformBandHeight,
@@ -105,10 +107,11 @@ class ClipWaveformPainter extends CustomPainter {
       TimelineConstants.clipWaveformNormalizerFloor,
     );
 
-    for (var i = 0; i < barCount; i++) {
+    for (var i = 0; i < visibleBarCount; i++) {
       // Peak across every sample the bar covers — averaging (or point
       // sampling) would alias transients away at low zoom, where one bar
-      // spans dozens of samples.
+      // spans dozens of samples. Indexed against the audio's full bar span,
+      // so a bar keeps its timestamp regardless of where the tile ends.
       final from = (i * peaks.length ~/ barCount).clamp(0, peaks.length - 1);
       final to = math.max(from + 1, (i + 1) * peaks.length ~/ barCount);
       var amplitude = 0.0;

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/clip_waveform_overlay.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/clip_waveform_overlay.dart
@@ -6,7 +6,7 @@ import 'dart:math' as math;
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:openvine/constants/video_editor_timeline_constants.dart';
-import 'package:openvine/services/video_editor/clip_waveform_manager.dart';
+import 'package:openvine/models/video_editor/clip_waveform.dart';
 
 /// The clip's audio waveform, drawn translucently over its thumbnails.
 ///

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/clip_waveform_overlay.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/clip_waveform_overlay.dart
@@ -99,9 +99,14 @@ class ClipWaveformPainter extends CustomPainter {
     final paint = Paint()..color = color;
     final peaks = waveform.peaks;
 
-    // Normalize against the clip's own loudest sample, so a quietly recorded
-    // clip still fills the band. The floor keeps near-silence flat instead of
-    // amplifying room noise into a convincing-looking waveform.
+    // Normalize against the source file's loudest sample, so a quietly
+    // recorded clip still fills the band. The floor keeps near-silence flat
+    // instead of amplifying room noise into a convincing-looking waveform.
+    //
+    // A trim-based split's halves share one file, hence one normalizer: each
+    // half is drawn relative to the whole recording rather than to its own
+    // loudest moment, so splitting a clip never restyles the bars on either
+    // side of the cut.
     final normalizer = math.max(
       waveform.peak,
       TimelineConstants.clipWaveformNormalizerFloor,

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
@@ -874,7 +874,9 @@ class _TrimmingClipPositions extends StatelessWidget {
                 clipWidth: layout.widths[i],
                 pixelsPerSecond: pixelsPerSecond,
                 thumbnailNotifier: thumbnails[orderedClips[i].id],
-                waveformNotifier: waveforms[orderedClips[i].id],
+                waveformNotifier: isReordering
+                    ? null
+                    : waveforms[orderedClips[i].id],
                 onTrimChanged: onTrimChanged,
                 onTrimDragChanged: onTrimDragChanged,
                 trimExpand: trimExpand,
@@ -971,7 +973,10 @@ class _NonTrimmingClipPositions extends StatelessWidget {
                           pixelsPerSecond
                     : 0.0,
                 thumbnailNotifier: thumbnails[orderedClips[i].id],
-                waveformNotifier: waveforms[orderedClips[i].id],
+                // Every tile is a 64px badge mid-drag — no room for a band.
+                waveformNotifier: isReordering
+                    ? null
+                    : waveforms[orderedClips[i].id],
                 onReorder: onReorder,
                 onTap: onClipTapped,
                 isMultiSelectMode: isMultiSelectMode,

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
@@ -15,9 +15,11 @@ import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/video_editor/transition_geometry.dart';
 import 'package:openvine/router/app_router.dart';
 import 'package:openvine/services/video_editor/clip_thumbnail_manager.dart';
+import 'package:openvine/services/video_editor/clip_waveform_manager.dart';
 import 'package:openvine/services/video_thumbnail_service.dart';
 import 'package:openvine/utils/mounted_post_frame.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_transition_sheet.dart';
+import 'package:openvine/widgets/video_editor/timeline_editor/strips/clip_waveform_overlay.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/strips/timeline_trim_handles.dart';
 
 part 'video_editor_timeline_clip_strip_tiles.dart';
@@ -50,6 +52,7 @@ class VideoEditorTimelineClipStrip extends StatefulWidget {
     this.isMultiSelectMode = false,
     this.selectedClipIds = const {},
     @visibleForTesting this.thumbnailManager,
+    @visibleForTesting this.waveformManager,
     super.key,
   });
 
@@ -71,6 +74,11 @@ class VideoEditorTimelineClipStrip extends StatefulWidget {
   /// native thumbnail extractor.
   @visibleForTesting
   final ClipThumbnailManager? thumbnailManager;
+
+  /// Test seam for asserting the clip waveform overlay without invoking the
+  /// native waveform extractor.
+  @visibleForTesting
+  final ClipWaveformManager? waveformManager;
 
   /// When `true` the user is scrolling or pinch-zooming — long press
   /// must not start a reorder drag.
@@ -131,6 +139,10 @@ class _VideoEditorTimelineClipStripState
   /// clip tile rebuilds, not the entire strip.
   late final ClipThumbnailManager _thumbnails;
 
+  /// Audio waveforms keyed by clip ID, drawn over each tile's thumbnails.
+  /// Independent notifiers for the same reason as [_thumbnails].
+  late final ClipWaveformManager _waveforms;
+
   /// Identity of the last split event we already seeded thumbnails
   /// for. Used to ensure each split is processed exactly once.
   ClipSplitEvent? _lastSeededSplit;
@@ -158,6 +170,7 @@ class _VideoEditorTimelineClipStripState
   void initState() {
     super.initState();
     _thumbnails = widget.thumbnailManager ?? ClipThumbnailManager();
+    _waveforms = widget.waveformManager ?? ClipWaveformManager();
     _reorderAnimController = AnimationController(
       vsync: this,
       duration: _animDuration,
@@ -202,6 +215,7 @@ class _VideoEditorTimelineClipStripState
     _volumeExitTimer?.cancel();
     _reorderAnimController.dispose();
     _thumbnails.dispose();
+    _waveforms.dispose();
     super.dispose();
   }
 
@@ -218,6 +232,7 @@ class _VideoEditorTimelineClipStripState
       devicePixelRatio: MediaQuery.devicePixelRatioOf(context),
       priorityTimestamps: _cachedSlotTimestamps,
     );
+    _waveforms.sync(clips: clips);
   }
 
   /// Seeds the new clips' thumbnail notifiers from the source clip's
@@ -683,6 +698,7 @@ class _VideoEditorTimelineClipStripState
                 _NonTrimmingClipPositions(
                   orderedClips: _orderedClips,
                   thumbnails: _thumbnails,
+                  waveforms: _waveforms,
                   layout: layout,
                   wrap: wrap,
                   dragIndex: _dragIndex,
@@ -709,6 +725,7 @@ class _VideoEditorTimelineClipStripState
                 _TrimmingClipPositions(
                   orderedClips: _orderedClips,
                   thumbnails: _thumbnails,
+                  waveforms: _waveforms,
                   layout: layout,
                   dragIndex: _dragIndex,
                   trimmingClipId: widget.trimmingClipId,
@@ -791,6 +808,7 @@ class _TrimmingClipPositions extends StatelessWidget {
   const _TrimmingClipPositions({
     required this.orderedClips,
     required this.thumbnails,
+    required this.waveforms,
     required this.layout,
     required this.dragIndex,
     required this.trimmingClipId,
@@ -812,6 +830,7 @@ class _TrimmingClipPositions extends StatelessWidget {
 
   final List<DivineVideoClip> orderedClips;
   final ClipThumbnailManager thumbnails;
+  final ClipWaveformManager waveforms;
   final ({List<double> widths, List<double> offsets, double totalWidth}) layout;
   final int? dragIndex;
   final String? trimmingClipId;
@@ -854,6 +873,7 @@ class _TrimmingClipPositions extends StatelessWidget {
                 clipWidth: layout.widths[i],
                 pixelsPerSecond: pixelsPerSecond,
                 thumbnailNotifier: thumbnails[orderedClips[i].id],
+                waveformNotifier: waveforms[orderedClips[i].id],
                 onTrimChanged: onTrimChanged,
                 onTrimDragChanged: onTrimDragChanged,
                 trimExpand: trimExpand,
@@ -869,6 +889,7 @@ class _NonTrimmingClipPositions extends StatelessWidget {
   const _NonTrimmingClipPositions({
     required this.orderedClips,
     required this.thumbnails,
+    required this.waveforms,
     required this.layout,
     required this.wrap,
     required this.dragIndex,
@@ -891,6 +912,7 @@ class _NonTrimmingClipPositions extends StatelessWidget {
 
   final List<DivineVideoClip> orderedClips;
   final ClipThumbnailManager thumbnails;
+  final ClipWaveformManager waveforms;
   final ({List<double> widths, List<double> offsets, double totalWidth}) layout;
 
   /// Loop-wrap display geometry (or [LoopWrapDisplay.none]). The first clip's
@@ -948,6 +970,7 @@ class _NonTrimmingClipPositions extends StatelessWidget {
                           pixelsPerSecond
                     : 0.0,
                 thumbnailNotifier: thumbnails[orderedClips[i].id],
+                waveformNotifier: waveforms[orderedClips[i].id],
                 onReorder: onReorder,
                 onTap: onClipTapped,
                 isMultiSelectMode: isMultiSelectMode,

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
@@ -12,6 +12,7 @@ import 'package:openvine/blocs/video_editor/main_editor/video_editor_main_bloc.d
 import 'package:openvine/constants/video_editor_timeline_constants.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/video_editor/clip_waveform.dart';
 import 'package:openvine/models/video_editor/transition_geometry.dart';
 import 'package:openvine/router/app_router.dart';
 import 'package:openvine/services/video_editor/clip_thumbnail_manager.dart';

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_tiles.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_tiles.dart
@@ -426,10 +426,15 @@ class _ClipTile extends StatelessWidget {
                         // straight from clip time, so it starts at the phase.
                         // Both then ride the same translate, which keeps the
                         // bars glued to the frames through trim and zoom.
+                        //
+                        // Width is the clip's natural width, not displayWidth:
+                        // the band's px-per-second must stay the frames' one,
+                        // and displayWidth inflates to the slot while a reorder
+                        // animates a sub-slot-width clip back to size.
                         Positioned(
                           left: phasePx,
                           top: 0,
-                          width: displayWidth,
+                          width: fullWidth,
                           height: TimelineConstants.thumbnailStripHeight,
                           child: _ClipWaveformLayer(
                             clip: clip,

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_tiles.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_tiles.dart
@@ -60,7 +60,9 @@ class _TrimmableClipTile extends StatefulWidget {
   final double clipWidth;
   final double pixelsPerSecond;
   final ValueNotifier<List<StripThumbnail>> thumbnailNotifier;
-  final ValueNotifier<ClipWaveform?> waveformNotifier;
+
+  /// Null while the strip is in a reorder drag — see [_ClipTile].
+  final ValueNotifier<ClipWaveform?>? waveformNotifier;
   final ClipTrimCallback? onTrimChanged;
   final ValueChanged<bool>? onTrimDragChanged;
   final VoidCallback? onTap;
@@ -277,7 +279,9 @@ class _AccessibleClipTile extends StatelessWidget {
   final double clipWidth;
   final double pixelsPerSecond;
   final ValueNotifier<List<StripThumbnail>> thumbnailNotifier;
-  final ValueNotifier<ClipWaveform?> waveformNotifier;
+
+  /// Null while the strip is in a reorder drag — see [_ClipTile].
+  final ValueNotifier<ClipWaveform?>? waveformNotifier;
   final void Function(int from, int to) onReorder;
 
   /// Extra pixels to shift thumbnails left (on top of trim-start) so a loop
@@ -367,8 +371,8 @@ class _ClipTile extends StatelessWidget {
   final double fullWidth;
   final ValueNotifier<List<StripThumbnail>> thumbnailNotifier;
 
-  /// The clip's audio waveform, drawn over the thumbnails. Null while the tile
-  /// is a reorder-drag badge, where the shrunk slot has no room for it.
+  /// The clip's audio waveform, drawn over the thumbnails. Null during a
+  /// reorder drag, where every tile shrinks to a badge with no room for it.
   final ValueNotifier<ClipWaveform?>? waveformNotifier;
 
   /// Pixel offset from the left to shift thumbnails for trim-start.

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_tiles.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_tiles.dart
@@ -49,6 +49,7 @@ class _TrimmableClipTile extends StatefulWidget {
     required this.clipWidth,
     required this.pixelsPerSecond,
     required this.thumbnailNotifier,
+    required this.waveformNotifier,
     this.onTrimChanged,
     this.onTrimDragChanged,
     this.onTap,
@@ -59,6 +60,7 @@ class _TrimmableClipTile extends StatefulWidget {
   final double clipWidth;
   final double pixelsPerSecond;
   final ValueNotifier<List<StripThumbnail>> thumbnailNotifier;
+  final ValueNotifier<ClipWaveform?> waveformNotifier;
   final ClipTrimCallback? onTrimChanged;
   final ValueChanged<bool>? onTrimDragChanged;
   final VoidCallback? onTap;
@@ -203,6 +205,7 @@ class _TrimmableClipTileState extends State<_TrimmableClipTile> {
                   widget.pixelsPerSecond *
                   widget.clip._playbackScale,
               thumbnailNotifier: widget.thumbnailNotifier,
+              waveformNotifier: widget.waveformNotifier,
             ),
           ),
         ),
@@ -260,6 +263,7 @@ class _AccessibleClipTile extends StatelessWidget {
     required this.clipWidth,
     required this.pixelsPerSecond,
     required this.thumbnailNotifier,
+    required this.waveformNotifier,
     required this.onReorder,
     this.wrapHeadOffset = 0,
     this.onTap,
@@ -273,6 +277,7 @@ class _AccessibleClipTile extends StatelessWidget {
   final double clipWidth;
   final double pixelsPerSecond;
   final ValueNotifier<List<StripThumbnail>> thumbnailNotifier;
+  final ValueNotifier<ClipWaveform?> waveformNotifier;
   final void Function(int from, int to) onReorder;
 
   /// Extra pixels to shift thumbnails left (on top of trim-start) so a loop
@@ -333,6 +338,7 @@ class _AccessibleClipTile extends StatelessWidget {
                   clip._playbackScale +
               wrapHeadOffset,
           thumbnailNotifier: thumbnailNotifier,
+          waveformNotifier: waveformNotifier,
           selectionState: isMultiSelectMode
               ? (isSelected
                     ? _ClipSelectionState.selected
@@ -352,6 +358,7 @@ class _ClipTile extends StatelessWidget {
     required this.clip,
     required this.fullWidth,
     required this.thumbnailNotifier,
+    this.waveformNotifier,
     this.trimStartOffset = 0,
     this.selectionState = _ClipSelectionState.none,
   });
@@ -359,6 +366,10 @@ class _ClipTile extends StatelessWidget {
   final DivineVideoClip clip;
   final double fullWidth;
   final ValueNotifier<List<StripThumbnail>> thumbnailNotifier;
+
+  /// The clip's audio waveform, drawn over the thumbnails. Null while the tile
+  /// is a reorder-drag badge, where the shrunk slot has no room for it.
+  final ValueNotifier<ClipWaveform?>? waveformNotifier;
 
   /// Pixel offset from the left to shift thumbnails for trim-start.
   final double trimStartOffset;
@@ -389,16 +400,39 @@ class _ClipTile extends StatelessWidget {
                 alignment: Alignment.centerLeft,
                 child: Transform.translate(
                   offset: Offset(-trimStartOffset - phasePx, 0),
-                  child: ValueListenableBuilder<List<StripThumbnail>>(
-                    valueListenable: thumbnailNotifier,
-                    builder: (context, stripThumbnails, _) {
-                      return _ClipContainer(
-                        clip: clip,
-                        displayWidth: displayWidth,
-                        contentWidth: fullWidth,
-                        stripThumbnails: stripThumbnails,
-                      );
-                    },
+                  child: Stack(
+                    // The enclosing ClipRect already trims the tile to its
+                    // visible box — a second clip layer here buys nothing.
+                    clipBehavior: .none,
+                    children: [
+                      ValueListenableBuilder<List<StripThumbnail>>(
+                        valueListenable: thumbnailNotifier,
+                        builder: (context, stripThumbnails, _) {
+                          return _ClipContainer(
+                            clip: clip,
+                            displayWidth: displayWidth,
+                            contentWidth: fullWidth,
+                            stripThumbnails: stripThumbnails,
+                          );
+                        },
+                      ),
+                      if (waveformNotifier != null)
+                        // The thumbnail row starts one raster phase before the
+                        // clip's zero (see [_rasterPhasePx]); the waveform maps
+                        // straight from clip time, so it starts at the phase.
+                        // Both then ride the same translate, which keeps the
+                        // bars glued to the frames through trim and zoom.
+                        Positioned(
+                          left: phasePx,
+                          top: 0,
+                          width: displayWidth,
+                          height: TimelineConstants.thumbnailStripHeight,
+                          child: _ClipWaveformLayer(
+                            clip: clip,
+                            waveformNotifier: waveformNotifier!,
+                          ),
+                        ),
+                    ],
                   ),
                 ),
               ),
@@ -420,6 +454,33 @@ class _ClipTile extends StatelessWidget {
           ),
         ),
       ],
+    );
+  }
+}
+
+/// Repaints the clip's waveform band on its own, so an arriving waveform never
+/// rebuilds the thumbnail row next to it.
+class _ClipWaveformLayer extends StatelessWidget {
+  const _ClipWaveformLayer({
+    required this.clip,
+    required this.waveformNotifier,
+  });
+
+  final DivineVideoClip clip;
+  final ValueNotifier<ClipWaveform?> waveformNotifier;
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<ClipWaveform?>(
+      valueListenable: waveformNotifier,
+      builder: (context, waveform, _) {
+        if (waveform == null) return const SizedBox.shrink();
+        return ClipWaveformOverlay(
+          waveform: waveform,
+          clipDuration: clip.duration,
+          volume: clip.volume,
+        );
+      },
     );
   }
 }

--- a/mobile/test/services/video_editor/clip_waveform_manager_test.dart
+++ b/mobile/test/services/video_editor/clip_waveform_manager_test.dart
@@ -1,0 +1,236 @@
+// ABOUTME: Unit tests for ClipWaveformManager.
+// ABOUTME: Validates notifier lifecycle, per-path extraction reuse, and errors.
+
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart' as model;
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/services/video_editor/clip_waveform_manager.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
+
+void main() {
+  group(ClipWaveformManager, () {
+    late List<String> extractedPaths;
+    late ClipWaveformManager manager;
+
+    setUp(() {
+      extractedPaths = [];
+      manager = ClipWaveformManager(
+        extractor: (path) async {
+          extractedPaths.add(path);
+          return _waveform(left: [0.5, 1], right: [0.25, 0.75]);
+        },
+      );
+    });
+
+    tearDown(() => manager.dispose());
+
+    test('publishes the extracted waveform to the clip notifier', () async {
+      manager.sync(
+        clips: [_clip(id: 'a', path: '/tmp/a.mp4')],
+      );
+      await pumpEventQueue();
+
+      expect(manager['a'].value?.duration, equals(const Duration(seconds: 2)));
+    });
+
+    test('reduces stereo channels to the louder peak per sample', () async {
+      manager.sync(
+        clips: [_clip(id: 'a', path: '/tmp/a.mp4')],
+      );
+      await pumpEventQueue();
+
+      // left [0.5, 1] vs right [0.25, 0.75] — the left channel wins both.
+      expect(manager['a'].value?.peaks, equals([0.5, 1.0]));
+    });
+
+    test('reports the loudest sample as the peak', () async {
+      final quiet = ClipWaveformManager(
+        extractor: (_) async => _waveform(left: [0.1, 0.3, 0.2]),
+      );
+      addTearDown(quiet.dispose);
+
+      quiet.sync(
+        clips: [_clip(id: 'a', path: '/tmp/quiet.mp4')],
+      );
+      await pumpEventQueue();
+
+      // The strip normalizes the band against this, so a quiet clip is still
+      // drawn at full height.
+      expect(quiet['a'].value?.peak, closeTo(0.3, 0.0001));
+    });
+
+    test('extracts once for two clips sharing a source file', () async {
+      // The two halves of a trim-based split point at the same file.
+      manager.sync(
+        clips: [
+          _clip(id: 'start', path: '/tmp/source.mp4'),
+          _clip(id: 'end', path: '/tmp/source.mp4'),
+        ],
+      );
+      await pumpEventQueue();
+
+      expect(extractedPaths, equals(['/tmp/source.mp4']));
+      expect(manager['start'].value, isNotNull);
+      expect(manager['end'].value, isNotNull);
+    });
+
+    test('re-extracts when a clip is re-rendered to a new file', () async {
+      manager.sync(
+        clips: [_clip(id: 'a', path: '/tmp/a.mp4')],
+      );
+      await pumpEventQueue();
+
+      manager.sync(
+        clips: [_clip(id: 'a', path: '/tmp/a_reversed.mp4')],
+      );
+      await pumpEventQueue();
+
+      expect(extractedPaths, equals(['/tmp/a.mp4', '/tmp/a_reversed.mp4']));
+    });
+
+    test('keeps the old waveform visible until the new one lands', () async {
+      manager.sync(
+        clips: [_clip(id: 'a', path: '/tmp/a.mp4')],
+      );
+      await pumpEventQueue();
+      final previous = manager['a'].value;
+
+      manager.sync(
+        clips: [_clip(id: 'a', path: '/tmp/a_reversed.mp4')],
+      );
+
+      expect(manager['a'].value, same(previous));
+    });
+
+    test('serves a cached waveform without re-extracting', () async {
+      manager.sync(
+        clips: [_clip(id: 'a', path: '/tmp/a.mp4')],
+      );
+      await pumpEventQueue();
+
+      // Undo/redo re-adds the clip under a fresh sync.
+      manager.sync(
+        clips: [_clip(id: 'b', path: '/tmp/b.mp4')],
+      );
+      await pumpEventQueue();
+      manager.sync(
+        clips: [_clip(id: 'a', path: '/tmp/a.mp4')],
+      );
+      await pumpEventQueue();
+
+      expect(extractedPaths, equals(['/tmp/a.mp4', '/tmp/b.mp4']));
+      expect(manager['a'].value, isNotNull);
+    });
+
+    test('leaves a clip without a source file alone', () async {
+      manager.sync(clips: [_clipWithoutFile(id: 'pending')]);
+      await pumpEventQueue();
+
+      expect(extractedPaths, isEmpty);
+      expect(manager['pending'].value, isNull);
+    });
+
+    test('removes notifiers for clips that are gone', () async {
+      manager.sync(
+        clips: [
+          _clip(id: 'a', path: '/tmp/a.mp4'),
+          _clip(id: 'b', path: '/tmp/b.mp4'),
+        ],
+      );
+
+      manager.sync(
+        clips: [_clip(id: 'a', path: '/tmp/a.mp4')],
+      );
+
+      expect(() => manager['b'], throwsA(isA<TypeError>()));
+    });
+
+    test('publishes an empty waveform when extraction fails', () async {
+      final failing = ClipWaveformManager(
+        extractor: (path) async => throw Exception('no audio track'),
+      );
+      addTearDown(failing.dispose);
+
+      failing.sync(
+        clips: [_clip(id: 'a', path: '/tmp/silent.mp4')],
+      );
+      await pumpEventQueue();
+
+      expect(failing['a'].value?.isEmpty, isTrue);
+    });
+
+    test('does not retry a file whose extraction failed', () async {
+      var calls = 0;
+      final failing = ClipWaveformManager(
+        extractor: (path) async {
+          calls++;
+          throw Exception('no audio track');
+        },
+      );
+      addTearDown(failing.dispose);
+
+      failing.sync(
+        clips: [_clip(id: 'a', path: '/tmp/silent.mp4')],
+      );
+      await pumpEventQueue();
+      failing.sync(
+        clips: [_clip(id: 'b', path: '/tmp/silent.mp4')],
+      );
+      await pumpEventQueue();
+
+      expect(calls, equals(1));
+    });
+
+    test(
+      'drops a result whose clip left the timeline mid-extraction',
+      () async {
+        manager
+          ..sync(
+            clips: [_clip(id: 'a', path: '/tmp/a.mp4')],
+          )
+          ..sync(clips: []);
+        await pumpEventQueue();
+
+        expect(extractedPaths, isEmpty);
+      },
+    );
+  });
+}
+
+WaveformData _waveform({
+  required List<double> left,
+  List<double>? right,
+  Duration duration = const Duration(seconds: 2),
+}) {
+  return WaveformData(
+    leftChannel: Float32List.fromList(left),
+    rightChannel: right == null ? null : Float32List.fromList(right),
+    sampleRate: 44100,
+    duration: duration,
+    samplesPerSecond: 200,
+  );
+}
+
+DivineVideoClip _clip({required String id, required String path}) {
+  return DivineVideoClip(
+    id: id,
+    video: EditorVideo.file(path),
+    duration: const Duration(seconds: 2),
+    recordedAt: DateTime(2025),
+    originalAspectRatio: 9 / 16,
+    targetAspectRatio: model.AspectRatio.vertical,
+  );
+}
+
+DivineVideoClip _clipWithoutFile({required String id}) {
+  return DivineVideoClip(
+    id: id,
+    video: EditorVideo.network('https://example.com/pending.mp4'),
+    duration: const Duration(seconds: 2),
+    recordedAt: DateTime(2025),
+    originalAspectRatio: 9 / 16,
+    targetAspectRatio: model.AspectRatio.vertical,
+  );
+}

--- a/mobile/test/services/video_editor/clip_waveform_manager_test.dart
+++ b/mobile/test/services/video_editor/clip_waveform_manager_test.dart
@@ -301,6 +301,108 @@ void main() {
       });
     });
 
+    test('publishes the waveform when a retry succeeds', () {
+      fakeAsync((async) {
+        var failNext = true;
+        final recovering = ClipWaveformManager(
+          extractor: (path) async {
+            if (failNext) {
+              failNext = false;
+              throw Exception('decoder busy');
+            }
+            return _waveform(left: [0.5, 1]);
+          },
+        );
+
+        recovering.sync(
+          clips: [_clip(id: 'a', path: '/tmp/a.mp4')],
+        );
+        async.flushMicrotasks();
+        expect(recovering['a'].value, isNull);
+
+        // The retry's whole point: the band lands once the hiccup clears.
+        async.elapse(const Duration(seconds: 2));
+        expect(recovering['a'].value?.peaks, equals([0.5, 1.0]));
+
+        recovering.dispose();
+      });
+    });
+
+    test('drops a pending retry once the path is cached', () {
+      fakeAsync((async) {
+        var calls = 0;
+        var failNext = true;
+        final flaky = ClipWaveformManager(
+          extractor: (path) async {
+            calls++;
+            if (failNext) {
+              failNext = false;
+              throw Exception('decoder busy');
+            }
+            return _waveform(left: [1]);
+          },
+        );
+
+        flaky.sync(
+          clips: [_clip(id: 'a', path: '/tmp/p.mp4')],
+        );
+        async.flushMicrotasks();
+        expect(calls, equals(1));
+
+        // A split sibling on the same file resolves it while the retry is
+        // still armed, so the retry has nothing left to fetch.
+        flaky.sync(
+          clips: [
+            _clip(id: 'a', path: '/tmp/p.mp4'),
+            _clip(id: 'b', path: '/tmp/p.mp4'),
+          ],
+        );
+        async.flushMicrotasks();
+        expect(calls, equals(2));
+        expect(flaky['a'].value?.isEmpty, isFalse);
+
+        // Re-decoding a file already on screen would burn a decoder pass
+        // under exactly the contention the queue exists to avoid.
+        async.elapse(const Duration(seconds: 5));
+        expect(calls, equals(2));
+
+        flaky.dispose();
+      });
+    });
+
+    test('gives a re-added clip a fresh set of attempts', () {
+      fakeAsync((async) {
+        var calls = 0;
+        final failing = ClipWaveformManager(
+          extractor: (path) async {
+            calls++;
+            throw Exception('decoder busy');
+          },
+        );
+
+        failing.sync(
+          clips: [_clip(id: 'a', path: '/tmp/a.mp4')],
+        );
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 2));
+        expect(calls, equals(2));
+
+        failing.sync(clips: []);
+        async.elapse(const Duration(seconds: 5));
+
+        // Undo brings the clip back. It must not inherit the old tally and
+        // give up after a single fresh attempt.
+        failing.sync(
+          clips: [_clip(id: 'a', path: '/tmp/a.mp4')],
+        );
+        async.flushMicrotasks();
+        expect(calls, equals(3));
+        expect(failing['a'].value, isNull);
+
+        failing.dispose();
+      });
+    });
+
     test('skips extraction for a path no clip references anymore', () async {
       manager
         ..sync(

--- a/mobile/test/services/video_editor/clip_waveform_manager_test.dart
+++ b/mobile/test/services/video_editor/clip_waveform_manager_test.dart
@@ -147,40 +147,90 @@ void main() {
       expect(() => manager['b'], throwsA(isA<TypeError>()));
     });
 
-    test('publishes an empty waveform when extraction fails', () async {
-      final failing = ClipWaveformManager(
-        extractor: (path) async => throw Exception('no audio track'),
-      );
-      addTearDown(failing.dispose);
+    test(
+      'publishes an empty waveform for a file with no audio track',
+      () async {
+        final silent = ClipWaveformManager(
+          extractor: (path) async => throw const AudioNoTrackException(),
+        );
+        addTearDown(silent.dispose);
 
-      failing.sync(
-        clips: [_clip(id: 'a', path: '/tmp/silent.mp4')],
-      );
-      await pumpEventQueue();
+        silent.sync(
+          clips: [_clip(id: 'a', path: '/tmp/silent.mp4')],
+        );
+        await pumpEventQueue();
 
-      expect(failing['a'].value?.isEmpty, isTrue);
-    });
+        expect(silent['a'].value?.isEmpty, isTrue);
+      },
+    );
 
-    test('does not retry a file whose extraction failed', () async {
+    test('does not retry a file that has no audio track', () async {
       var calls = 0;
-      final failing = ClipWaveformManager(
+      final silent = ClipWaveformManager(
         extractor: (path) async {
           calls++;
-          throw Exception('no audio track');
+          throw const AudioNoTrackException();
         },
       );
-      addTearDown(failing.dispose);
+      addTearDown(silent.dispose);
 
-      failing.sync(
+      silent.sync(
         clips: [_clip(id: 'a', path: '/tmp/silent.mp4')],
       );
       await pumpEventQueue();
-      failing.sync(
+      // Another clip resolving to the same file must serve the cached miss.
+      silent.sync(
         clips: [_clip(id: 'b', path: '/tmp/silent.mp4')],
       );
       await pumpEventQueue();
 
       expect(calls, equals(1));
+    });
+
+    test('retries a transient extraction failure on the next sync', () async {
+      var calls = 0;
+      final failing = ClipWaveformManager(
+        extractor: (path) async {
+          calls++;
+          throw Exception('decoder busy');
+        },
+      );
+      addTearDown(failing.dispose);
+
+      failing.sync(
+        clips: [_clip(id: 'a', path: '/tmp/a.mp4')],
+      );
+      await pumpEventQueue();
+      failing.sync(
+        clips: [_clip(id: 'a', path: '/tmp/a.mp4')],
+      );
+      await pumpEventQueue();
+
+      // A decoder busy under render contention says nothing about the file —
+      // caching it as bandless would blank the clip for the whole session.
+      expect(calls, equals(2));
+    });
+
+    test('gives up on a file that keeps failing', () async {
+      var calls = 0;
+      final failing = ClipWaveformManager(
+        extractor: (path) async {
+          calls++;
+          throw Exception('decoder busy');
+        },
+      );
+      addTearDown(failing.dispose);
+
+      // A sync storm — the strip re-syncs on every trim-drag frame.
+      for (var i = 0; i < 6; i++) {
+        failing.sync(
+          clips: [_clip(id: 'a', path: '/tmp/a.mp4')],
+        );
+        await pumpEventQueue();
+      }
+
+      expect(calls, equals(3));
+      expect(failing['a'].value?.isEmpty, isTrue);
     });
 
     test(

--- a/mobile/test/services/video_editor/clip_waveform_manager_test.dart
+++ b/mobile/test/services/video_editor/clip_waveform_manager_test.dart
@@ -1,8 +1,10 @@
 // ABOUTME: Unit tests for ClipWaveformManager.
 // ABOUTME: Validates notifier lifecycle, per-path extraction reuse, and errors.
 
+import 'dart:async';
 import 'dart:typed_data';
 
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart' as model;
 import 'package:openvine/models/divine_video_clip.dart';
@@ -187,65 +189,128 @@ void main() {
       expect(calls, equals(1));
     });
 
-    test('retries a transient extraction failure on the next sync', () async {
-      var calls = 0;
-      final failing = ClipWaveformManager(
-        extractor: (path) async {
-          calls++;
-          throw Exception('decoder busy');
-        },
-      );
-      addTearDown(failing.dispose);
+    test('retries a transient extraction failure without a further sync', () {
+      fakeAsync((async) {
+        var calls = 0;
+        final failing = ClipWaveformManager(
+          extractor: (path) async {
+            calls++;
+            throw Exception('decoder busy');
+          },
+        );
 
-      failing.sync(
-        clips: [_clip(id: 'a', path: '/tmp/a.mp4')],
-      );
-      await pumpEventQueue();
-      failing.sync(
-        clips: [_clip(id: 'a', path: '/tmp/a.mp4')],
-      );
-      await pumpEventQueue();
-
-      // A decoder busy under render contention says nothing about the file —
-      // caching it as bandless would blank the clip for the whole session.
-      expect(calls, equals(2));
-    });
-
-    test('gives up on a file that keeps failing', () async {
-      var calls = 0;
-      final failing = ClipWaveformManager(
-        extractor: (path) async {
-          calls++;
-          throw Exception('decoder busy');
-        },
-      );
-      addTearDown(failing.dispose);
-
-      // A sync storm — the strip re-syncs on every trim-drag frame.
-      for (var i = 0; i < 6; i++) {
         failing.sync(
           clips: [_clip(id: 'a', path: '/tmp/a.mp4')],
         );
-        await pumpEventQueue();
-      }
+        async.flushMicrotasks();
+        expect(calls, equals(1));
 
-      expect(calls, equals(3));
-      expect(failing['a'].value?.isEmpty, isTrue);
+        // A decoder busy under render contention says nothing about the file —
+        // caching it as bandless would blank the clip for the whole session.
+        // Contention peaks as the editor opens, and the strip only re-syncs
+        // when its widget updates: an idle timeline owes us no second sync.
+        async.elapse(const Duration(seconds: 2));
+        expect(calls, equals(2));
+
+        failing.dispose();
+      });
     });
 
-    test(
-      'drops a result whose clip left the timeline mid-extraction',
-      () async {
-        manager
-          ..sync(
-            clips: [_clip(id: 'a', path: '/tmp/a.mp4')],
-          )
-          ..sync(clips: []);
-        await pumpEventQueue();
+    test('gives up on a file that keeps failing', () {
+      fakeAsync((async) {
+        var calls = 0;
+        final failing = ClipWaveformManager(
+          extractor: (path) async {
+            calls++;
+            throw Exception('decoder busy');
+          },
+        );
 
-        expect(extractedPaths, isEmpty);
-      },
-    );
+        failing.sync(
+          clips: [_clip(id: 'a', path: '/tmp/a.mp4')],
+        );
+        async.elapse(const Duration(minutes: 1));
+
+        expect(calls, equals(3));
+        expect(failing['a'].value?.isEmpty, isTrue);
+
+        failing.dispose();
+      });
+    });
+
+    test('stops retrying once its clip leaves the timeline', () {
+      fakeAsync((async) {
+        var calls = 0;
+        final failing = ClipWaveformManager(
+          extractor: (path) async {
+            calls++;
+            throw Exception('decoder busy');
+          },
+        );
+
+        failing.sync(
+          clips: [_clip(id: 'a', path: '/tmp/a.mp4')],
+        );
+        async.flushMicrotasks();
+        expect(calls, equals(1));
+
+        failing.sync(clips: []);
+        async.elapse(const Duration(minutes: 1));
+
+        // Nothing left to draw the bars on.
+        expect(calls, equals(1));
+
+        failing.dispose();
+      });
+    });
+
+    test('extracts one file at a time', () {
+      fakeAsync((async) {
+        final gates = <String, Completer<WaveformData>>{
+          '/tmp/a.mp4': Completer<WaveformData>(),
+          '/tmp/b.mp4': Completer<WaveformData>(),
+        };
+        final started = <String>[];
+        final serial = ClipWaveformManager(
+          extractor: (path) {
+            started.add(path);
+            return gates[path]!.future;
+          },
+        );
+
+        serial.sync(
+          clips: [
+            _clip(id: 'a', path: '/tmp/a.mp4'),
+            _clip(id: 'b', path: '/tmp/b.mp4'),
+          ],
+        );
+        async.flushMicrotasks();
+
+        // The strip's thumbnail generator and the editor preview already
+        // compete for the same hardware decoders — the second file waits.
+        expect(started, equals(['/tmp/a.mp4']));
+
+        gates['/tmp/a.mp4']!.complete(_waveform(left: [1]));
+        async.flushMicrotasks();
+
+        expect(started, equals(['/tmp/a.mp4', '/tmp/b.mp4']));
+
+        gates['/tmp/b.mp4']!.complete(_waveform(left: [1]));
+        async.flushMicrotasks();
+        serial.dispose();
+      });
+    });
+
+    test('skips extraction for a path no clip references anymore', () async {
+      manager
+        ..sync(
+          clips: [_clip(id: 'a', path: '/tmp/a.mp4')],
+        )
+        ..sync(clips: []);
+      await pumpEventQueue();
+
+      expect(extractedPaths, isEmpty);
+    });
   });
 }
 

--- a/mobile/test/widgets/video_editor/timeline_editor/strips/clip_waveform_overlay_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/strips/clip_waveform_overlay_test.dart
@@ -1,0 +1,156 @@
+// ABOUTME: Widget tests for the clip waveform overlay and its painter.
+// ABOUTME: Validates bottom anchoring, volume scaling, and short-audio bounds.
+
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/constants/video_editor_timeline_constants.dart';
+import 'package:openvine/services/video_editor/clip_waveform_manager.dart';
+import 'package:openvine/widgets/video_editor/timeline_editor/strips/clip_waveform_overlay.dart';
+
+void main() {
+  group(ClipWaveformOverlay, () {
+    const height = TimelineConstants.thumbnailStripHeight;
+    const width = 100.0;
+    const barStep =
+        TimelineConstants.clipWaveformBarWidth +
+        TimelineConstants.clipWaveformBarSpacing;
+    const band = TimelineConstants.clipWaveformBandHeight;
+
+    Future<void> pumpOverlay(
+      WidgetTester tester, {
+      required ClipWaveform waveform,
+      double volume = 1,
+      Duration clipDuration = const Duration(seconds: 2),
+    }) {
+      return tester.pumpWidget(
+        MaterialApp(
+          home: Center(
+            child: SizedBox(
+              width: width,
+              height: height,
+              child: ClipWaveformOverlay(
+                waveform: waveform,
+                clipDuration: clipDuration,
+                volume: volume,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    final waveformPaint = find.byWidgetPredicate(
+      (w) => w is CustomPaint && w.painter is ClipWaveformPainter,
+    );
+
+    RenderObject overlayRender(WidgetTester tester) =>
+        tester.renderObject(waveformPaint);
+
+    /// The leftmost bar at [barHeight], grown up from the bottom edge.
+    RRect firstBar(double barHeight) => RRect.fromRectAndRadius(
+      Rect.fromLTWH(
+        0,
+        height - barHeight,
+        TimelineConstants.clipWaveformBarWidth,
+        barHeight,
+      ),
+      const Radius.circular(TimelineConstants.clipWaveformBarWidth / 2),
+    );
+
+    /// A bar at the band's ceiling — what the clip's own loudest sample draws.
+    final fullBandBar = firstBar(band * TimelineConstants.clipWaveformGain);
+
+    testWidgets('draws a bar per step, anchored to the bottom edge', (
+      tester,
+    ) async {
+      await pumpOverlay(tester, waveform: _waveform(peaks: [1, 1, 1, 1]));
+
+      expect(overlayRender(tester), paints..rrect(rrect: fullBandBar));
+      expect(
+        overlayRender(tester),
+        paintsExactlyCountTimes(#drawRRect, width ~/ barStep),
+      );
+    });
+
+    testWidgets('fills the band for a quietly recorded clip', (tester) async {
+      // Real recordings peak well below full scale — mapped linearly they draw
+      // as a barely visible ripple, so the band normalizes per clip.
+      await pumpOverlay(tester, waveform: _waveform(peaks: [0.3, 0.3, 0.3]));
+
+      expect(overlayRender(tester), paints..rrect(rrect: fullBandBar));
+    });
+
+    testWidgets('keeps a near-silent clip below the band', (tester) async {
+      await pumpOverlay(tester, waveform: _waveform(peaks: [0.02, 0.02, 0.02]));
+
+      expect(overlayRender(tester), isNot(paints..rrect(rrect: fullBandBar)));
+    });
+
+    testWidgets('scales bar heights with the clip volume', (tester) async {
+      await pumpOverlay(
+        tester,
+        waveform: _waveform(peaks: [1, 1, 1, 1]),
+        volume: 0.5,
+      );
+
+      expect(
+        overlayRender(tester),
+        paints..rrect(
+          rrect: firstBar(band * TimelineConstants.clipWaveformGain * 0.5),
+        ),
+      );
+    });
+
+    testWidgets('flattens to the baseline for a muted clip', (tester) async {
+      await pumpOverlay(
+        tester,
+        waveform: _waveform(peaks: [1, 1, 1, 1]),
+        volume: 0,
+      );
+
+      expect(
+        overlayRender(tester),
+        paints..rrect(
+          rrect: firstBar(TimelineConstants.clipWaveformMinBarHeight),
+        ),
+      );
+    });
+
+    testWidgets('stops at the audio track end when it ends before the video', (
+      tester,
+    ) async {
+      await pumpOverlay(
+        tester,
+        waveform: _waveform(
+          peaks: [1, 1],
+          duration: const Duration(seconds: 1),
+        ),
+      );
+
+      // The clip runs 2s, its audio 1s — only half the width gets bars.
+      expect(
+        overlayRender(tester),
+        paintsExactlyCountTimes(#drawRRect, width ~/ barStep ~/ 2),
+      );
+    });
+
+    testWidgets('renders nothing for a file without an audio track', (
+      tester,
+    ) async {
+      await pumpOverlay(tester, waveform: const ClipWaveform.empty());
+
+      expect(waveformPaint, findsNothing);
+    });
+  });
+}
+
+ClipWaveform _waveform({
+  required List<double> peaks,
+  Duration duration = const Duration(seconds: 2),
+}) => ClipWaveform(
+  peaks: peaks,
+  duration: duration,
+  peak: peaks.reduce(math.max),
+);

--- a/mobile/test/widgets/video_editor/timeline_editor/strips/clip_waveform_overlay_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/strips/clip_waveform_overlay_test.dart
@@ -6,7 +6,7 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/constants/video_editor_timeline_constants.dart';
-import 'package:openvine/services/video_editor/clip_waveform_manager.dart';
+import 'package:openvine/models/video_editor/clip_waveform.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/strips/clip_waveform_overlay.dart';
 
 void main() {

--- a/mobile/test/widgets/video_editor/timeline_editor/strips/clip_waveform_overlay_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/strips/clip_waveform_overlay_test.dart
@@ -48,16 +48,19 @@ void main() {
     RenderObject overlayRender(WidgetTester tester) =>
         tester.renderObject(waveformPaint);
 
-    /// The leftmost bar at [barHeight], grown up from the bottom edge.
-    RRect firstBar(double barHeight) => RRect.fromRectAndRadius(
+    /// The bar at [index] with [barHeight], grown up from the bottom edge.
+    RRect barAt(int index, double barHeight) => RRect.fromRectAndRadius(
       Rect.fromLTWH(
-        0,
+        index * barStep,
         height - barHeight,
         TimelineConstants.clipWaveformBarWidth,
         barHeight,
       ),
       const Radius.circular(TimelineConstants.clipWaveformBarWidth / 2),
     );
+
+    /// The leftmost bar at [barHeight], grown up from the bottom edge.
+    RRect firstBar(double barHeight) => barAt(0, barHeight);
 
     /// A bar at the band's ceiling — what the clip's own loudest sample draws.
     final fullBandBar = firstBar(band * TimelineConstants.clipWaveformGain);
@@ -85,7 +88,18 @@ void main() {
     testWidgets('keeps a near-silent clip below the band', (tester) async {
       await pumpOverlay(tester, waveform: _waveform(peaks: [0.02, 0.02, 0.02]));
 
+      // Quiet, but still audible-looking: the floor holds the band down
+      // without collapsing it to the silent baseline or hiding it outright.
+      expect(overlayRender(tester), paints..rrect());
       expect(overlayRender(tester), isNot(paints..rrect(rrect: fullBandBar)));
+      expect(
+        overlayRender(tester),
+        isNot(
+          paints..rrect(
+            rrect: firstBar(TimelineConstants.clipWaveformMinBarHeight),
+          ),
+        ),
+      );
     });
 
     testWidgets('scales bar heights with the clip volume', (tester) async {
@@ -133,6 +147,37 @@ void main() {
       expect(
         overlayRender(tester),
         paintsExactlyCountTimes(#drawRRect, width ~/ barStep ~/ 2),
+      );
+    });
+
+    testWidgets("draws only the clip's own share of a longer audio track", (
+      tester,
+    ) async {
+      // A trim-based split rebases the start half's duration to the split
+      // point while it keeps sharing the full-length source file, so its
+      // waveform outlasts it 4:1 here.
+      await pumpOverlay(
+        tester,
+        waveform: _waveform(
+          peaks: [1, 0, 0, 0],
+          duration: const Duration(seconds: 4),
+        ),
+        clipDuration: const Duration(seconds: 1),
+      );
+
+      // The loud first quarter is this clip's entire span, so every bar —
+      // right up to the tile's edge — stays at the ceiling. Fitting all four
+      // samples into the tile instead would drop the band to the baseline
+      // after a few bars, drawing the later halves' sound under these frames.
+      const gain = TimelineConstants.clipWaveformGain;
+      final ceilingBars = paints;
+      for (var i = 0; i < width ~/ barStep; i++) {
+        ceilingBars.rrect(rrect: barAt(i, band * gain));
+      }
+      expect(overlayRender(tester), ceilingBars);
+      expect(
+        overlayRender(tester),
+        paintsExactlyCountTimes(#drawRRect, width ~/ barStep),
       );
     });
 

--- a/mobile/test/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_test.dart
@@ -1,6 +1,9 @@
 // ABOUTME: Widget tests for VideoEditorTimelineClipStrip.
 // ABOUTME: Validates clip rendering, layout, reorder gesture, and accessibility.
 
+import 'dart:async';
+import 'dart:typed_data';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -14,7 +17,9 @@ import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/router/app_router.dart';
 import 'package:openvine/services/video_editor/clip_thumbnail_manager.dart';
+import 'package:openvine/services/video_editor/clip_waveform_manager.dart';
 import 'package:openvine/services/video_thumbnail_service.dart';
+import 'package:openvine/widgets/video_editor/timeline_editor/strips/clip_waveform_overlay.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/strips/timeline_trim_handles.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
@@ -47,6 +52,7 @@ void main() {
       ValueChanged<List<DivineVideoClip>>? onReorder,
       ValueChanged<bool>? onReorderChanged,
       ClipThumbnailManager? thumbnailManager,
+      ClipWaveformManager? waveformManager,
       String? trimmingClipId,
       ClipTrimCallback? onTrimChanged,
       ValueChanged<bool>? onTrimDragChanged,
@@ -72,6 +78,7 @@ void main() {
         onTrimChanged: onTrimChanged,
         onTrimDragChanged: onTrimDragChanged,
         thumbnailManager: thumbnailManager,
+        waveformManager: waveformManager,
       );
 
       return MaterialApp(
@@ -119,6 +126,50 @@ void main() {
         await tester.pumpWidget(buildWidget(clips: clips, totalWidth: 400));
 
         expect(find.byType(ClipRRect), findsOneWidget);
+      });
+
+      testWidgets('draws each clip its own waveform band', (tester) async {
+        await tester.pumpWidget(
+          buildWidget(
+            waveformManager: ClipWaveformManager(
+              extractor: (_) async => WaveformData(
+                leftChannel: Float32List.fromList([0.5, 1, 0.5]),
+                sampleRate: 44100,
+                duration: const Duration(seconds: 3),
+                samplesPerSecond: 200,
+              ),
+            ),
+          ),
+        );
+        // Let the queued extraction resolve and publish.
+        await tester.pump();
+
+        expect(
+          find.byWidgetPredicate(
+            (w) => w is CustomPaint && w.painter is ClipWaveformPainter,
+          ),
+          findsNWidgets(2),
+        );
+      });
+
+      testWidgets('draws no waveform band before extraction lands', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildWidget(
+            waveformManager: ClipWaveformManager(
+              extractor: (_) => Completer<WaveformData>().future,
+            ),
+          ),
+        );
+        await tester.pump();
+
+        expect(
+          find.byWidgetPredicate(
+            (w) => w is CustomPaint && w.painter is ClipWaveformPainter,
+          ),
+          findsNothing,
+        );
       });
     });
 

--- a/mobile/test/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_test.dart
@@ -100,6 +100,19 @@ void main() {
       );
     }
 
+    final waveformBands = find.byWidgetPredicate(
+      (w) => w is CustomPaint && w.painter is ClipWaveformPainter,
+    );
+
+    ClipWaveformManager buildWaveformManager() => ClipWaveformManager(
+      extractor: (_) async => WaveformData(
+        leftChannel: Float32List.fromList([0.5, 1, 0.5]),
+        sampleRate: 44100,
+        duration: const Duration(seconds: 3),
+        samplesPerSecond: 200,
+      ),
+    );
+
     group('renders', () {
       testWidgets('renders $VideoEditorTimelineClipStrip', (tester) async {
         await tester.pumpWidget(buildWidget());
@@ -130,26 +143,12 @@ void main() {
 
       testWidgets('draws each clip its own waveform band', (tester) async {
         await tester.pumpWidget(
-          buildWidget(
-            waveformManager: ClipWaveformManager(
-              extractor: (_) async => WaveformData(
-                leftChannel: Float32List.fromList([0.5, 1, 0.5]),
-                sampleRate: 44100,
-                duration: const Duration(seconds: 3),
-                samplesPerSecond: 200,
-              ),
-            ),
-          ),
+          buildWidget(waveformManager: buildWaveformManager()),
         );
         // Let the queued extraction resolve and publish.
         await tester.pump();
 
-        expect(
-          find.byWidgetPredicate(
-            (w) => w is CustomPaint && w.painter is ClipWaveformPainter,
-          ),
-          findsNWidgets(2),
-        );
+        expect(waveformBands, findsNWidgets(2));
       });
 
       testWidgets('draws no waveform band before extraction lands', (
@@ -164,12 +163,34 @@ void main() {
         );
         await tester.pump();
 
-        expect(
-          find.byWidgetPredicate(
-            (w) => w is CustomPaint && w.painter is ClipWaveformPainter,
-          ),
-          findsNothing,
+        expect(waveformBands, findsNothing);
+      });
+
+      testWidgets('hides every waveform band during a reorder drag', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildWidget(waveformManager: buildWaveformManager()),
         );
+        await tester.pump();
+        expect(waveformBands, findsNWidgets(2));
+
+        // Hold the press — a plain longPress releases it, ending the drag
+        // before the badges are ever on screen.
+        final gesture = await tester.startGesture(
+          tester.getCenter(find.byType(VideoEditorTimelineClipStrip)),
+        );
+        await tester.pump(const Duration(seconds: 1));
+        await tester.pumpAndSettle();
+
+        // Every tile — not just the picked-up one — shrinks to a 64px badge,
+        // whose window of frames a full-clip band no longer lines up with.
+        expect(waveformBands, findsNothing);
+
+        await gesture.up();
+        await tester.pumpAndSettle();
+
+        expect(waveformBands, findsNWidgets(2));
       });
     });
 
@@ -185,6 +206,66 @@ void main() {
 
       Finder frame(String path) => find.byWidgetPredicate(
         (w) => w is Image && providerHasPath(w.image, path),
+      );
+
+      // The band is indexed from clip zero while the thumbnail row starts one
+      // raster phase earlier, so the overlay carries a +phase offset inside
+      // the tile's shared translate. Get either term wrong — drop the phase,
+      // flip its sign, or lift the band out of the translate — and the bars
+      // drift against the frames on every trimmed or split clip.
+      testWidgets(
+        'anchors the waveform band to clip zero: tracking trim-start, but '
+        'not the thumbnail raster phase',
+        (tester) async {
+          final waveforms = ClipWaveformManager(
+            extractor: (_) async => WaveformData(
+              leftChannel: Float32List.fromList([0.5, 1, 0.5]),
+              sampleRate: 44100,
+              duration: const Duration(seconds: 3),
+              samplesPerSecond: 200,
+            ),
+          );
+          addTearDown(waveforms.dispose);
+
+          // 3 s of content at 100 px/s → 300 px wide. sourceStartOffset 1.3 s
+          // puts the recording-anchored slot grid 130 px in, leaving a 34 px
+          // phase (130 % 48) that shifts the frames but not the band.
+          final clip =
+              _createTestClip(
+                id: 'clip1',
+                seconds: 3,
+                trimStartMs: 500,
+              ).copyWith(
+                sourceStartOffset: const Duration(milliseconds: 1300),
+              );
+
+          await tester.pumpWidget(
+            buildWidget(
+              clips: [clip],
+              pixelsPerSecond: 100,
+              waveformManager: waveforms,
+              scrollable: false,
+            ),
+          );
+          await tester.pump();
+
+          final tileLeft = tester.getTopLeft(find.byType(ClipRRect)).dx;
+          final bandLeft = tester
+              .getTopLeft(
+                find.byWidgetPredicate(
+                  (w) => w is CustomPaint && w.painter is ClipWaveformPainter,
+                ),
+              )
+              .dx;
+
+          expect(
+            bandLeft,
+            moreOrLessEquals(tileLeft - 50),
+            reason:
+                'the band must sit exactly trim-start (0.5 s → 50 px) left '
+                'of the tile — no raster phase, which belongs to the frames',
+          );
+        },
       );
 
       // Regression for the visible leftward frame shift when a split's end

--- a/mobile/test/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_test.dart
@@ -151,6 +151,66 @@ void main() {
         expect(waveformBands, findsNWidgets(2));
       });
 
+      // The tile forwards the clip's volume and duration into the band. Both
+      // are one-liners in _ClipWaveformLayer, and matching on the painter's
+      // type alone lets either be dropped or crossed with the waveform's own
+      // values without a test noticing.
+      testWidgets('flattens the band of a muted clip to its baseline', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildWidget(
+            clips: [_createTestClip(id: 'muted', seconds: 3, volume: 0)],
+            pixelsPerSecond: 100,
+            waveformManager: buildWaveformManager(),
+            scrollable: false,
+          ),
+        );
+        await tester.pump();
+
+        const baseline = TimelineConstants.clipWaveformMinBarHeight;
+        expect(
+          tester.renderObject(waveformBands),
+          paints..rrect(
+            rrect: RRect.fromRectAndRadius(
+              const Rect.fromLTWH(
+                0,
+                TimelineConstants.thumbnailStripHeight - baseline,
+                TimelineConstants.clipWaveformBarWidth,
+                baseline,
+              ),
+              const Radius.circular(
+                TimelineConstants.clipWaveformBarWidth / 2,
+              ),
+            ),
+          ),
+        );
+      });
+
+      testWidgets('spans the band over the clip duration, not the audio one', (
+        tester,
+      ) async {
+        // A 4s clip against the 3s waveform the manager hands back: the bars
+        // must cover the audio's own 3s of the tile and leave the rest bare.
+        await tester.pumpWidget(
+          buildWidget(
+            clips: [_createTestClip(id: 'long', seconds: 4)],
+            pixelsPerSecond: 100,
+            waveformManager: buildWaveformManager(),
+            scrollable: false,
+          ),
+        );
+        await tester.pump();
+
+        const barStep =
+            TimelineConstants.clipWaveformBarWidth +
+            TimelineConstants.clipWaveformBarSpacing;
+        expect(
+          tester.renderObject(waveformBands),
+          paintsExactlyCountTimes(#drawRRect, (3 * 100 / barStep).floor()),
+        );
+      });
+
       testWidgets('draws no waveform band before extraction lands', (
         tester,
       ) async {
@@ -1075,6 +1135,7 @@ DivineVideoClip _createTestClip({
   int trimStartMs = 0,
   int trimEndMs = 0,
   String? thumbnailPath,
+  double volume = 1,
 }) {
   return DivineVideoClip(
     id: id,
@@ -1086,5 +1147,6 @@ DivineVideoClip _createTestClip({
     trimStart: Duration(milliseconds: trimStartMs),
     trimEnd: Duration(milliseconds: trimEndMs),
     thumbnailPath: thumbnailPath,
+    volume: volume,
   );
 }


### PR DESCRIPTION
Closes #6150

## Description

Clip tiles in the timeline showed frames only — to see where a clip is loud or silent you had to open the sound strip. Each video clip now draws its own audio as a translucent waveform band along the tile's bottom edge.

**How it lines up:** the band rides the same translate as the thumbnail row (offset by the raster phase, since the row starts one phase before the clip's zero), so the bars stay glued to the frames through trim, zoom and scroll instead of drifting against them.

Bars map straight from clip time rather than being fitted to the tile: the band spans the audio's own length, and whatever runs past the tile is culled. That matters for a trim-based split's start half, which is rebased to the split point while still sharing the full-length file — fitting its waveform to the tile would draw the end half's sound under the start half's frames.

**Why extraction is keyed by file path, not clip id:** the two halves of a trim-based split share one source file, so they resolve from a single pass; undo/redo restores hit the cache (FIFO, 32 entries — a few KB each). Extractions are serialized because the strip's thumbnail generator and the editor preview already compete for the same hardware decoders. A file with no audio track (the typed `AudioNoTrackException`) caches the miss, since a retry could never draw bars. Other failures don't cache — a decoder busy under render contention says nothing about the file — and get bounded retries across syncs, bounded because `sync` runs on every trim-drag frame.

**Why the bars are normalized + curved, not linear:** real recordings peak well below full scale, so mapping raw amplitude onto a 22px band drew an almost flat line. Bars normalize against the clip's own loudest sample, and a compressive exponent lifts the quiet body of the signal — audio spends most of its time far below its peak, so normalization alone would still read as a flat line with occasional spikes. A floor on the normalizer keeps near-silence from being stretched to full height; true silence stays a flat baseline.

**Volume-aware:** bar heights scale with `clip.volume`, so muting flattens the band to its baseline instead of leaving a loud-looking waveform behind. The band is hidden during a reorder drag, where the tile shrinks to a 64px badge.

Tuning knobs live in `TimelineConstants`: `clipWaveformCurve` (1.0 = linear), `clipWaveformNormalizerFloor`, `clipWaveformBandHeight`, `clipWaveformOpacity`.

**Related Issue:** 

## Out of Scope

- The sound overlay strip's own waveform keeps its existing linear scaling — this PR does not touch it.
- Stop-motion clips: `DivineVideoClip.video` is non-nullable on `main`, so there is nothing to handle here yet. When the stop-motion branch lands and makes it nullable, `ClipWaveformManager.sync` needs its null branch back (frames carry no audio file).

## Verification

- `flutter analyze lib test` — clean
- `flutter test test/widgets/video_editor/timeline_editor/strips/ test/services/video_editor/clip_waveform_manager_test.dart` — 98 passing
- `check_untested_services_floor.sh` — no new entries
- New coverage: 14 unit tests for the manager (per-path sharing, re-extract on source change, cache, no-audio miss, transient retry + give-up, peak) and 8 painter tests via the `paints` matcher (bottom anchoring, per-step bars, volume scaling, mute baseline, quiet-clip fill, near-silence floor, short audio track, over-long audio track), plus 3 wiring tests in the strip (band per clip, none before extraction, none mid-reorder) and one pinning the band's alignment to trim-start against the raster phase.
- Each new test was checked to fail against the pre-fix code, not just to pass after it.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
