### PR TITLE
fix(auth): handle NIP-46 auth_url challenge as non-terminal in nostrconnect pairing

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -1477,7 +1477,6 @@
     "authConnectionCancelledMessage": "ግንኙነቱ ተሰርዟል።",
     "authConnectionFailed": "ግንኙነት አልተሳካም።",
     "authUnknownError": "ያልታወቀ ስህተት ተከስቷል።",
-    "authBunkerRejectedConnection": "ፈራሚ መተግበሪያዎ ግንኙነቱን አልተቀበለም።",
     "authNostrConnectStartFailed": "ፈራሚውን ማግኘት አልተቻለም። ግንኙነትዎን ያረጋግጡ እና እንደገና ይሞክሩ።",
     "authNostrConnectInvalidSession": "ይህ የግንኙነት አገናኝ ከአሁን በኋላ የሚሰራ አይደለም። አዲስ ይጀምሩ።",
     "authNostrConnectSetupFailed": "ጥቂት ቀርቷል — መግባትዎን ማጠናቀቅ አልቻልንም። እንደገና ይሞክሩ።",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -1272,7 +1272,6 @@
     "authConnectionCancelledMessage": "تم إلغاء الاتصال.",
     "authConnectionFailed": "فشل الاتصال",
     "authUnknownError": "حدث خطأ غير معروف.",
-    "authBunkerRejectedConnection": "رفض تطبيق التوقيع الخاص بك الاتصال.",
     "authNostrConnectStartFailed": "تعذّر الوصول إلى تطبيق التوقيع. تحقّق من اتصالك وحاول مرّة أخرى.",
     "authNostrConnectInvalidSession": "لم يعد رابط الاتصال هذا صالحًا. أنشئ رابطًا جديدًا.",
     "authNostrConnectSetupFailed": "اقتربنا — لكن لم نتمكّن من إتمام تسجيل دخولك. حاول مرّة أخرى.",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -1355,7 +1355,6 @@
     "authConnectionCancelledMessage": "Връзката беше прекратена.",
     "authConnectionFailed": "Връзката е неуспешна",
     "authUnknownError": "Възникна неизвестна грешка.",
-    "authBunkerRejectedConnection": "Приложението ти за подписване отказа връзката.",
     "authNostrConnectStartFailed": "Не успяхме да се свържем с приложението за подписване. Провери връзката си и опитай пак.",
     "authNostrConnectInvalidSession": "Тази връзка вече не е валидна. Започни нова.",
     "authNostrConnectSetupFailed": "Почти готово — не успяхме да завършим влизането ти. Опитай пак.",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -1281,7 +1281,6 @@
     "authConnectionCancelledMessage": "Die Verbindung wurde abgebrochen.",
     "authConnectionFailed": "Verbindung fehlgeschlagen",
     "authUnknownError": "Ein unbekannter Fehler ist aufgetreten.",
-    "authBunkerRejectedConnection": "Deine Signer-App hat die Verbindung abgelehnt.",
     "authNostrConnectStartFailed": "Die Signer-App ist nicht erreichbar. Prüf deine Verbindung und versuch es nochmal.",
     "authNostrConnectInvalidSession": "Dieser Verbindungslink ist nicht mehr gültig. Starte einen neuen.",
     "authNostrConnectSetupFailed": "Fast geschafft — wir konnten dich nicht ganz anmelden. Versuch es nochmal.",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -1722,7 +1722,6 @@
   "authConnectionCancelledMessage": "The connection was cancelled.",
   "authConnectionFailed": "Connection failed",
   "authUnknownError": "An unknown error occurred.",
-  "authBunkerRejectedConnection": "Your signer app declined the connection.",
   "authNostrConnectStartFailed": "Couldn't reach the signer. Check your connection and try again.",
   "authNostrConnectInvalidSession": "This connection link is no longer valid. Start a new one.",
   "authNostrConnectSetupFailed": "Almost there — we couldn't finish signing you in. Try again.",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -1285,7 +1285,6 @@
     "authConnectionCancelledMessage": "La conexión fue cancelada.",
     "authConnectionFailed": "Falló la conexión",
     "authUnknownError": "Ocurrió un error desconocido.",
-    "authBunkerRejectedConnection": "Tu app firmante rechazó la conexión.",
     "authNostrConnectStartFailed": "No pudimos contactar con la app firmante. Revisá tu conexión y probá de nuevo.",
     "authNostrConnectInvalidSession": "Este enlace de conexión ya no es válido. Iniciá uno nuevo.",
     "authNostrConnectSetupFailed": "Ya casi — no pudimos completar tu inicio de sesión. Probá de nuevo.",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -826,7 +826,6 @@
     "authConnectionCancelledMessage": "Kinansela ang connection.",
     "authConnectionFailed": "Nabigo ang connection",
     "authUnknownError": "May hindi inaasahang error na nangyari.",
-    "authBunkerRejectedConnection": "Tinanggihan ng iyong signer app ang connection.",
     "authNostrConnectStartFailed": "Hindi maabot ang signer app. Pakitsek ang iyong connection at subukan ulit.",
     "authNostrConnectInvalidSession": "Hindi na valid ang connection link na ito. Magsimula ng bago.",
     "authNostrConnectSetupFailed": "Malapit na — hindi namin natapos ang pag-sign in sa iyo. Subukan ulit.",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -1281,7 +1281,6 @@
     "authConnectionCancelledMessage": "La connexion a été annulée.",
     "authConnectionFailed": "Échec de la connexion",
     "authUnknownError": "Une erreur inconnue est survenue.",
-    "authBunkerRejectedConnection": "Ton app de signature a refusé la connexion.",
     "authNostrConnectStartFailed": "Impossible de joindre l'app de signature. Vérifie ta connexion et réessaie.",
     "authNostrConnectInvalidSession": "Ce lien de connexion n'est plus valide. Génères-en un nouveau.",
     "authNostrConnectSetupFailed": "On y est presque — impossible de finaliser ta connexion. Réessaie.",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -1278,7 +1278,6 @@
     "authConnectionCancelledMessage": "Koneksi dibatalkan.",
     "authConnectionFailed": "Koneksi gagal",
     "authUnknownError": "Terjadi kesalahan yang tidak diketahui.",
-    "authBunkerRejectedConnection": "Aplikasi signer-mu menolak koneksi.",
     "authNostrConnectStartFailed": "Tidak bisa menghubungi signer. Periksa koneksi kamu dan coba lagi.",
     "authNostrConnectInvalidSession": "Tautan koneksi ini sudah tidak valid lagi. Buat yang baru.",
     "authNostrConnectSetupFailed": "Hampir selesai — kami belum berhasil menyelesaikan proses masukmu. Coba lagi.",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -1281,7 +1281,6 @@
     "authConnectionCancelledMessage": "La connessione è stata annullata.",
     "authConnectionFailed": "Connessione fallita",
     "authUnknownError": "Si è verificato un errore sconosciuto.",
-    "authBunkerRejectedConnection": "La tua app signer ha rifiutato la connessione.",
     "authNostrConnectStartFailed": "Impossibile raggiungere il signer. Controlla la connessione e riprova.",
     "authNostrConnectInvalidSession": "Questo link di connessione non è più valido. Avviane uno nuovo.",
     "authNostrConnectSetupFailed": "Ci siamo quasi — non siamo riusciti a completare l'accesso. Riprova.",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -1272,7 +1272,6 @@
     "authConnectionCancelledMessage": "接続はキャンセルされたよ。",
     "authConnectionFailed": "接続がうまくいかなかった",
     "authUnknownError": "不明なエラーが起きた。",
-    "authBunkerRejectedConnection": "署名アプリが接続を拒否したよ。",
     "authNostrConnectStartFailed": "署名アプリにつながらなかった。接続を確認してもう一回試してみて。",
     "authNostrConnectInvalidSession": "この接続リンクはもう使えないよ。新しいリンクで始めてね。",
     "authNostrConnectSetupFailed": "あと少し——サインインを完了できなかったよ。もう一回試してみて。",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -752,7 +752,6 @@
     "authConnectionCancelledMessage": "연결이 취소됐어요.",
     "authConnectionFailed": "연결 실패",
     "authUnknownError": "알 수 없는 오류가 발생했어요.",
-    "authBunkerRejectedConnection": "서명 앱이 연결을 거절했어요.",
     "authNostrConnectStartFailed": "서명 앱에 닿지 못했어요. 연결을 확인하고 다시 시도해주세요.",
     "authNostrConnectInvalidSession": "이 연결 링크는 더 이상 유효하지 않아요. 새로 시작해주세요.",
     "authNostrConnectSetupFailed": "거의 다 왔는데 — 로그인을 마무리하지 못했어요. 다시 시도해주세요.",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -1281,7 +1281,6 @@
     "authConnectionCancelledMessage": "De verbinding is geannuleerd.",
     "authConnectionFailed": "Verbinding mislukt",
     "authUnknownError": "Er is een onbekende fout opgetreden.",
-    "authBunkerRejectedConnection": "Je signer-app heeft de verbinding geweigerd.",
     "authNostrConnectStartFailed": "De signer-app is niet bereikbaar. Controleer je verbinding en probeer het opnieuw.",
     "authNostrConnectInvalidSession": "Deze verbindingslink is niet meer geldig. Start een nieuwe.",
     "authNostrConnectSetupFailed": "Bijna gelukt — we konden het inloggen niet afronden. Probeer het opnieuw.",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -1281,7 +1281,6 @@
     "authConnectionCancelledMessage": "Połączenie zostało anulowane.",
     "authConnectionFailed": "Połączenie nieudane",
     "authUnknownError": "Wystąpił nieznany błąd.",
-    "authBunkerRejectedConnection": "Twoja aplikacja do podpisywania odrzuciła połączenie.",
     "authNostrConnectStartFailed": "Nie udało się połączyć z aplikacją do podpisywania. Sprawdź połączenie i spróbuj ponownie.",
     "authNostrConnectInvalidSession": "Ten link do połączenia jest już nieważny. Utwórz nowy.",
     "authNostrConnectSetupFailed": "Prawie gotowe — nie udało się dokończyć logowania. Spróbuj ponownie.",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -1281,7 +1281,6 @@
     "authConnectionCancelledMessage": "A conexão foi cancelada.",
     "authConnectionFailed": "Falha na conexão",
     "authUnknownError": "Ocorreu um erro desconhecido.",
-    "authBunkerRejectedConnection": "Seu app signer recusou a conexão.",
     "authNostrConnectStartFailed": "Não foi possível alcançar o app signer. Verifique sua conexão e tente novamente.",
     "authNostrConnectInvalidSession": "Este link de conexão não é mais válido. Inicie um novo.",
     "authNostrConnectSetupFailed": "Quase lá — não conseguimos concluir seu acesso. Tente novamente.",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -1281,7 +1281,6 @@
     "authConnectionCancelledMessage": "Conexiunea a fost anulată.",
     "authConnectionFailed": "Conexiunea a eșuat",
     "authUnknownError": "A apărut o eroare necunoscută.",
-    "authBunkerRejectedConnection": "Aplicația ta de semnare a refuzat conexiunea.",
     "authNostrConnectStartFailed": "N-am putut contacta aplicația de semnare. Verifică-ți conexiunea și încearcă din nou.",
     "authNostrConnectInvalidSession": "Acest link de conexiune nu mai e valid. Începe unul nou.",
     "authNostrConnectSetupFailed": "Aproape gata — n-am putut finaliza autentificarea. Încearcă din nou.",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -1281,7 +1281,6 @@
     "authConnectionCancelledMessage": "Anslutningen avbröts.",
     "authConnectionFailed": "Anslutning misslyckades",
     "authUnknownError": "Ett okänt fel uppstod.",
-    "authBunkerRejectedConnection": "Din sign-app nekade anslutningen.",
     "authNostrConnectStartFailed": "Kunde inte nå sign-appen. Kontrollera din anslutning och försök igen.",
     "authNostrConnectInvalidSession": "Den här anslutningslänken är inte längre giltig. Starta en ny.",
     "authNostrConnectSetupFailed": "Nästan klart — vi kunde inte slutföra inloggningen. Försök igen.",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -1278,7 +1278,6 @@
     "authConnectionCancelledMessage": "Bağlantı iptal edildi.",
     "authConnectionFailed": "Bağlantı başarısız",
     "authUnknownError": "Bilinmeyen bir hata oluştu.",
-    "authBunkerRejectedConnection": "İmzalama uygulaman bağlantıyı reddetti.",
     "authNostrConnectStartFailed": "İmzalama uygulamasına ulaşılamadı. Bağlantını kontrol et ve tekrar dene.",
     "authNostrConnectInvalidSession": "Bu bağlantı artık geçerli değil. Yeni bir tane oluştur.",
     "authNostrConnectSetupFailed": "Az kaldı — girişini tamamlayamadık. Tekrar dene.",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -5322,12 +5322,6 @@ abstract class AppLocalizations {
   /// **'An unknown error occurred.'**
   String get authUnknownError;
 
-  /// No description provided for @authBunkerRejectedConnection.
-  ///
-  /// In en, this message translates to:
-  /// **'Your signer app declined the connection.'**
-  String get authBunkerRejectedConnection;
-
   /// No description provided for @authNostrConnectStartFailed.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -2990,9 +2990,6 @@ class AppLocalizationsAm extends AppLocalizations {
   String get authUnknownError => 'ያልታወቀ ስህተት ተከስቷል።';
 
   @override
-  String get authBunkerRejectedConnection => 'ፈራሚ መተግበሪያዎ ግንኙነቱን አልተቀበለም።';
-
-  @override
   String get authNostrConnectStartFailed =>
       'ፈራሚውን ማግኘት አልተቻለም። ግንኙነትዎን ያረጋግጡ እና እንደገና ይሞክሩ።';
 

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -3025,10 +3025,6 @@ class AppLocalizationsAr extends AppLocalizations {
   String get authUnknownError => 'حدث خطأ غير معروف.';
 
   @override
-  String get authBunkerRejectedConnection =>
-      'رفض تطبيق التوقيع الخاص بك الاتصال.';
-
-  @override
   String get authNostrConnectStartFailed =>
       'تعذّر الوصول إلى تطبيق التوقيع. تحقّق من اتصالك وحاول مرّة أخرى.';
 

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -3094,10 +3094,6 @@ class AppLocalizationsBg extends AppLocalizations {
   String get authUnknownError => 'Възникна неизвестна грешка.';
 
   @override
-  String get authBunkerRejectedConnection =>
-      'Приложението ти за подписване отказа връзката.';
-
-  @override
   String get authNostrConnectStartFailed =>
       'Не успяхме да се свържем с приложението за подписване. Провери връзката си и опитай пак.';
 

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -3081,10 +3081,6 @@ class AppLocalizationsDe extends AppLocalizations {
   String get authUnknownError => 'Ein unbekannter Fehler ist aufgetreten.';
 
   @override
-  String get authBunkerRejectedConnection =>
-      'Deine Signer-App hat die Verbindung abgelehnt.';
-
-  @override
   String get authNostrConnectStartFailed =>
       'Die Signer-App ist nicht erreichbar. Prüf deine Verbindung und versuch es nochmal.';
 

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -3045,10 +3045,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get authUnknownError => 'An unknown error occurred.';
 
   @override
-  String get authBunkerRejectedConnection =>
-      'Your signer app declined the connection.';
-
-  @override
   String get authNostrConnectStartFailed =>
       'Couldn\'t reach the signer. Check your connection and try again.';
 

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -3080,10 +3080,6 @@ class AppLocalizationsEs extends AppLocalizations {
   String get authUnknownError => 'Ocurrió un error desconocido.';
 
   @override
-  String get authBunkerRejectedConnection =>
-      'Tu app firmante rechazó la conexión.';
-
-  @override
   String get authNostrConnectStartFailed =>
       'No pudimos contactar con la app firmante. Revisá tu conexión y probá de nuevo.';
 

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -3093,10 +3093,6 @@ class AppLocalizationsFil extends AppLocalizations {
   String get authUnknownError => 'May hindi inaasahang error na nangyari.';
 
   @override
-  String get authBunkerRejectedConnection =>
-      'Tinanggihan ng iyong signer app ang connection.';
-
-  @override
   String get authNostrConnectStartFailed =>
       'Hindi maabot ang signer app. Pakitsek ang iyong connection at subukan ulit.';
 

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -3088,10 +3088,6 @@ class AppLocalizationsFr extends AppLocalizations {
   String get authUnknownError => 'Une erreur inconnue est survenue.';
 
   @override
-  String get authBunkerRejectedConnection =>
-      'Ton app de signature a refusé la connexion.';
-
-  @override
   String get authNostrConnectStartFailed =>
       'Impossible de joindre l\'app de signature. Vérifie ta connexion et réessaie.';
 

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -3021,10 +3021,6 @@ class AppLocalizationsId extends AppLocalizations {
   String get authUnknownError => 'Terjadi kesalahan yang tidak diketahui.';
 
   @override
-  String get authBunkerRejectedConnection =>
-      'Aplikasi signer-mu menolak koneksi.';
-
-  @override
   String get authNostrConnectStartFailed =>
       'Tidak bisa menghubungi signer. Periksa koneksi kamu dan coba lagi.';
 

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -3081,10 +3081,6 @@ class AppLocalizationsIt extends AppLocalizations {
   String get authUnknownError => 'Si è verificato un errore sconosciuto.';
 
   @override
-  String get authBunkerRejectedConnection =>
-      'La tua app signer ha rifiutato la connessione.';
-
-  @override
   String get authNostrConnectStartFailed =>
       'Impossibile raggiungere il signer. Controlla la connessione e riprova.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -2901,9 +2901,6 @@ class AppLocalizationsJa extends AppLocalizations {
   String get authUnknownError => '不明なエラーが起きた。';
 
   @override
-  String get authBunkerRejectedConnection => '署名アプリが接続を拒否したよ。';
-
-  @override
   String get authNostrConnectStartFailed => '署名アプリにつながらなかった。接続を確認してもう一回試してみて。';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -2914,9 +2914,6 @@ class AppLocalizationsKo extends AppLocalizations {
   String get authUnknownError => '알 수 없는 오류가 발생했어요.';
 
   @override
-  String get authBunkerRejectedConnection => '서명 앱이 연결을 거절했어요.';
-
-  @override
   String get authNostrConnectStartFailed =>
       '서명 앱에 닿지 못했어요. 연결을 확인하고 다시 시도해주세요.';
 

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -3061,10 +3061,6 @@ class AppLocalizationsNl extends AppLocalizations {
   String get authUnknownError => 'Er is een onbekende fout opgetreden.';
 
   @override
-  String get authBunkerRejectedConnection =>
-      'Je signer-app heeft de verbinding geweigerd.';
-
-  @override
   String get authNostrConnectStartFailed =>
       'De signer-app is niet bereikbaar. Controleer je verbinding en probeer het opnieuw.';
 

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -3126,10 +3126,6 @@ class AppLocalizationsPl extends AppLocalizations {
   String get authUnknownError => 'Wystąpił nieznany błąd.';
 
   @override
-  String get authBunkerRejectedConnection =>
-      'Twoja aplikacja do podpisywania odrzuciła połączenie.';
-
-  @override
   String get authNostrConnectStartFailed =>
       'Nie udało się połączyć z aplikacją do podpisywania. Sprawdź połączenie i spróbuj ponownie.';
 

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -3072,10 +3072,6 @@ class AppLocalizationsPt extends AppLocalizations {
   String get authUnknownError => 'Ocorreu um erro desconhecido.';
 
   @override
-  String get authBunkerRejectedConnection =>
-      'Seu app signer recusou a conexão.';
-
-  @override
   String get authNostrConnectStartFailed =>
       'Não foi possível alcançar o app signer. Verifique sua conexão e tente novamente.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -3141,10 +3141,6 @@ class AppLocalizationsRo extends AppLocalizations {
   String get authUnknownError => 'A apărut o eroare necunoscută.';
 
   @override
-  String get authBunkerRejectedConnection =>
-      'Aplicația ta de semnare a refuzat conexiunea.';
-
-  @override
   String get authNostrConnectStartFailed =>
       'N-am putut contacta aplicația de semnare. Verifică-ți conexiunea și încearcă din nou.';
 

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -3044,10 +3044,6 @@ class AppLocalizationsSv extends AppLocalizations {
   String get authUnknownError => 'Ett okänt fel uppstod.';
 
   @override
-  String get authBunkerRejectedConnection =>
-      'Din sign-app nekade anslutningen.';
-
-  @override
   String get authNostrConnectStartFailed =>
       'Kunde inte nå sign-appen. Kontrollera din anslutning och försök igen.';
 

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -3030,10 +3030,6 @@ class AppLocalizationsTr extends AppLocalizations {
   String get authUnknownError => 'Bilinmeyen bir hata oluştu.';
 
   @override
-  String get authBunkerRejectedConnection =>
-      'İmzalama uygulaman bağlantıyı reddetti.';
-
-  @override
   String get authNostrConnectStartFailed =>
       'İmzalama uygulamasına ulaşılamadı. Bağlantını kontrol et ve tekrar dene.';
 

--- a/mobile/lib/screens/auth/nostr_connect_screen.dart
+++ b/mobile/lib/screens/auth/nostr_connect_screen.dart
@@ -441,8 +441,6 @@ String resolveNostrConnectFailureMessage(
   NostrConnectFailureReason? reason,
 ) {
   return switch (reason) {
-    NostrConnectFailureReason.bunkerRejected =>
-      l10n.authBunkerRejectedConnection,
     NostrConnectFailureReason.startFailed => l10n.authNostrConnectStartFailed,
     NostrConnectFailureReason.noExpectedSecret =>
       l10n.authNostrConnectInvalidSession,

--- a/mobile/packages/nostr_sdk/lib/nip46/nostr_connect_session.dart
+++ b/mobile/packages/nostr_sdk/lib/nip46/nostr_connect_session.dart
@@ -56,10 +56,6 @@ enum NostrConnectFailureReason {
   /// secret to validate against. Should never happen in practice.
   noExpectedSecret,
 
-  /// The signer set `response.error` — a terminal signer-side error or
-  /// explicit rejection.
-  bunkerRejected,
-
   /// The wait window elapsed without a valid response.
   timedOut,
 
@@ -179,6 +175,26 @@ class NostrConnectSession {
   Timer? _timeoutTimer;
   bool _isClosed = false;
 
+  /// Ids of relay events already processed. Up to 4 relays each deliver
+  /// the same event, and the fixed `since` timestamp replays history on
+  /// every reconnect — skip replays before paying for decryption.
+  /// Bounded by the events received in one short-lived pairing session.
+  final Set<String> _seenEventIds = {};
+
+  /// Response ids of auth challenges already logged, so a signer that
+  /// re-sends its challenge as a fresh event doesn't spam the log.
+  /// Bounded by session lifetime.
+  final Set<String> _seenAuthChallengeIds = {};
+
+  /// The wait window passed to [waitForConnection], kept so the timer can
+  /// be re-armed once when an auth challenge arrives.
+  Duration? _waitTimeout;
+
+  /// Whether the one allowed challenge-triggered timer restart happened.
+  /// Capped at one per session so injected challenges cannot extend the
+  /// wait indefinitely.
+  bool _challengeTimerRestarted = false;
+
   /// The since timestamp used for subscriptions, captured once at session start
   /// so reconnections use the same timestamp.
   int? _subscriptionSinceTimestamp;
@@ -244,16 +260,20 @@ class NostrConnectSession {
 
     _connectionCompleter = Completer<NostrConnectResult?>();
 
-    // Start timeout timer
+    _waitTimeout = timeout;
+    _armTimeoutTimer(timeout);
+
+    return _connectionCompleter!.future;
+  }
+
+  void _armTimeoutTimer(Duration timeout) {
     _timeoutTimer = Timer(timeout, () {
-      if (!_connectionCompleter!.isCompleted) {
+      if (!(_connectionCompleter?.isCompleted ?? true)) {
         logger('[NostrConnectSession] Connection timed out');
         _setState(NostrConnectState.timeout);
         _connectionCompleter!.complete(null);
       }
     });
-
-    return _connectionCompleter!.future;
   }
 
   /// Cancel the session.
@@ -467,6 +487,10 @@ class NostrConnectSession {
   }
 
   Future<void> _handleResponse(Event event) async {
+    if (!_seenEventIds.add(event.id)) {
+      return;
+    }
+
     // Decrypt the response
     final response = await NostrRemoteResponse.decrypt(
       event.content,
@@ -487,10 +511,12 @@ class NostrConnectSession {
 
     // Validate the secret per NIP-46. Accept ONLY an exact match;
     // "ack"/"connect" belong to the bunker:// flow's connect method
-    // and are not valid for nostrconnect://. Non-matching, non-error
-    // responses are dropped silently — treating them as terminal would
-    // let any pubkey on the listening relays DoS pairing by racing
-    // a junk response in front of the legitimate signer's reply.
+    // and are not valid for nostrconnect://. Everything else — junk
+    // responses, signer errors, auth_url challenges — is non-terminal:
+    // the sender is unauthenticated pre-secret, so treating any of it
+    // as terminal would let any pubkey on the listening relays DoS
+    // pairing by racing a junk response in front of the legitimate
+    // signer's reply (matches nostr-tools/NDK pairing behavior).
     final validation = validateConnectResponse(
       response: response,
       expectedSecret: _info?.optionalSecret,
@@ -501,22 +527,34 @@ class NostrConnectSession {
         logger('[NostrConnectSession] No expected secret - cannot validate');
         _failureReason = NostrConnectFailureReason.noExpectedSecret;
         _setState(NostrConnectState.error);
+        _timeoutTimer?.cancel();
         if (_connectionCompleter != null &&
             !_connectionCompleter!.isCompleted) {
           _connectionCompleter!.complete(null);
         }
         return;
 
-      case NostrConnectResponseValidation.rejectedByBunker:
-        logger(
-          '[NostrConnectSession] Bunker rejected connection from '
-          '${event.pubkey}',
-        );
-        _failureReason = NostrConnectFailureReason.bunkerRejected;
-        _setState(NostrConnectState.error);
-        if (_connectionCompleter != null &&
-            !_connectionCompleter!.isCompleted) {
-          _connectionCompleter!.complete(null);
+      case NostrConnectResponseValidation.authChallenge:
+        // The challenge URL in response.error is deliberately not
+        // surfaced, opened, or logged: the sender is unauthenticated
+        // at pairing time, so the URL is attacker-suppliable (#3760).
+        // The signer answers on the same request id once the user
+        // authenticates out-of-band, so keep listening.
+        if (_seenAuthChallengeIds.add(response.id)) {
+          logger(
+            '[NostrConnectSession] Auth challenge from ${event.pubkey}; '
+            'keeping the session listening',
+          );
+        }
+        // Grant extra runway exactly once per session, since out-of-band
+        // approval can be slow. The single restart is deliberately
+        // consumable by any sender: an unauthenticated challenge must
+        // not be able to extend the wait forever.
+        if (!_challengeTimerRestarted && (_timeoutTimer?.isActive ?? false)) {
+          _challengeTimerRestarted = true;
+          _timeoutTimer!.cancel();
+          _armTimeoutTimer(_waitTimeout!);
+          logger('[NostrConnectSession] Wait window restarted once');
         }
         return;
 
@@ -526,12 +564,22 @@ class NostrConnectSession {
         // ever arrives.
         logger(
           '[NostrConnectSession] Ignoring response from ${event.pubkey}: '
-          'result did not match the expected secret',
+          'not a binding response',
         );
         return;
 
       case NostrConnectResponseValidation.match:
-        break; // fall through to the success path below
+        if (_connectionCompleter != null && _connectionCompleter!.isCompleted) {
+          // The wait already ended (timeout or cancel); binding now would
+          // flip the UI to a connected state nobody is waiting on.
+          logger(
+            '[NostrConnectSession] Ignoring late secret match from '
+            '${event.pubkey}: the wait already ended',
+          );
+          return;
+        }
+        // Fall through to the success path below.
+        break;
     }
 
     // Success! Extract remote signer pubkey from the event
@@ -577,19 +625,27 @@ enum NostrConnectResponseValidation {
   /// bind the session.
   match,
 
-  /// `response.error` is set; the signer explicitly rejected the
-  /// connection. Surface a terminal error to the user.
-  rejectedByBunker,
+  /// `response.result` is the literal `auth_url` challenge marker
+  /// (NIP-46 Auth Challenges): the signer wants the user to authenticate
+  /// out-of-band and will answer later on the same request id, so keep
+  /// listening. The challenge URL (carried in `response.error`) is
+  /// deliberately not surfaced, opened, or logged — during
+  /// nostrconnect:// pairing the sender is unauthenticated, so the URL
+  /// is attacker-suppliable (#3760, #5683).
+  authChallenge,
 
   /// Programmer error: the session is missing an expected secret.
   /// Surface a terminal error.
   invalidSession,
 
-  /// `response.result` did not match and `response.error` is empty.
-  /// Drop silently per the policy decision in #3355 — treating this
-  /// as terminal would let any pubkey on the listening relays DoS
-  /// pairing by racing junk responses in front of the legitimate
-  /// signer's reply.
+  /// Anything else: a non-matching `response.result`, or a signer error
+  /// (`response.error` set) that is not an auth challenge. Drop silently
+  /// per #3355/#5683 — the sender is unauthenticated pre-secret, so
+  /// treating errors as terminal would let any pubkey on the listening
+  /// relays DoS pairing by racing junk responses in front of the
+  /// legitimate signer's reply. Matches nostr-tools/NDK pairing
+  /// behavior; the cost is that a genuine signer-side deny waits out
+  /// the timeout instead of failing fast.
   ignore,
 }
 
@@ -604,9 +660,14 @@ NostrConnectResponseValidation validateConnectResponse({
   if (expectedSecret == null || expectedSecret.isEmpty) {
     return NostrConnectResponseValidation.invalidSession;
   }
+  if (response.isAuthChallenge) {
+    return NostrConnectResponseValidation.authChallenge;
+  }
   final error = response.error;
+  // Checked before the secret compare so a response carrying an error
+  // can never bind the session, even if its result matches the secret.
   if (error != null && error.isNotEmpty) {
-    return NostrConnectResponseValidation.rejectedByBunker;
+    return NostrConnectResponseValidation.ignore;
   }
   if (_constantTimeEqual(response.result, expectedSecret)) {
     return NostrConnectResponseValidation.match;

--- a/mobile/packages/nostr_sdk/lib/nip46/nostr_connect_session.dart
+++ b/mobile/packages/nostr_sdk/lib/nip46/nostr_connect_session.dart
@@ -487,6 +487,20 @@ class NostrConnectSession {
   }
 
   Future<void> _handleResponse(Event event) async {
+    // NIP-01 id integrity: an event id is the SHA-256 of its serialized
+    // content, so a tampered relay copy cannot reuse the genuine
+    // response's id without also reproducing its content. Verify before
+    // touching the replay-dedup cache — otherwise an attacker on the
+    // listening relays could reserve the real id with a junk copy that
+    // fails decryption, so the genuine response arriving from another
+    // relay is discarded as a "duplicate" and sign-in times out (#6151).
+    if (!event.isValid) {
+      logger(
+        '[NostrConnectSession] Dropped event from ${event.pubkey}: '
+        'failed id integrity',
+      );
+      return;
+    }
     if (!_seenEventIds.add(event.id)) {
       return;
     }

--- a/mobile/packages/nostr_sdk/lib/nip46/nostr_remote_response.dart
+++ b/mobile/packages/nostr_sdk/lib/nip46/nostr_remote_response.dart
@@ -12,6 +12,13 @@ class NostrRemoteResponse {
 
   NostrRemoteResponse(this.id, this.result, {this.error});
 
+  /// Whether this is a NIP-46 auth challenge: [result] is the literal
+  /// `auth_url` marker and [error] carries the URL the user must visit to
+  /// authenticate out-of-band. The signer answers later on the same request
+  /// id. An `auth_url` marker without a URL is malformed and not a challenge.
+  bool get isAuthChallenge =>
+      result == 'auth_url' && error != null && error!.isNotEmpty;
+
   static Future<NostrRemoteResponse?> decrypt(
     String ciphertext,
     NostrSigner signer,

--- a/mobile/packages/nostr_sdk/test/unit/nostr_connect_session_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/nostr_connect_session_test.dart
@@ -1025,6 +1025,68 @@ void main() {
       );
     });
   });
+
+  group('event id integrity (#6151)', () {
+    test('drops a tampered relay copy that reuses the real response id, so the '
+        'genuine secret still binds instead of being deduped away', () async {
+      final relay = await _TestRelayServer.start();
+      addTearDown(relay.close);
+
+      final logs = <String>[];
+      final session = NostrConnectSession(
+        relays: [relay.url],
+        logger: logs.add,
+      );
+      addTearDown(session.dispose);
+
+      await session.start();
+      final info = session.info!;
+      final secret = info.optionalSecret!;
+      logs.clear();
+
+      final wait = session.waitForConnection(
+        timeout: const Duration(seconds: 5),
+      );
+
+      // The genuine signer's binding response. Its `id` is public relay
+      // metadata that any pubkey on the listening relays can observe.
+      final genuineEvent = await _encryptedResponseEvent(
+        clientPubkey: info.clientPubkey!,
+        result: secret,
+      );
+
+      // An attacker races a copy that reuses the real id but swaps in
+      // junk content that fails NIP-44 decryption. Without the NIP-01
+      // id-integrity guard this copy would reserve the real id in the
+      // replay-dedup cache, and the genuine response arriving next would
+      // be dropped as a "duplicate" — stranding sign-in until timeout.
+      final tamperedEvent = Map<String, dynamic>.from(genuineEvent)
+        ..['content'] = 'not-a-valid-nip44-ciphertext';
+      relay.push(['EVENT', 'sub', tamperedEvent]);
+      await _waitUntil(
+        () => logs.any((line) => line.contains('failed id integrity')),
+      );
+      expect(
+        session.state,
+        equals(NostrConnectState.listening),
+        reason: 'a tampered copy must neither terminate nor bind pairing',
+      );
+
+      // The genuine response, still carrying the real id, must bind: the
+      // tampered copy must not have reserved that id in the dedup cache.
+      relay.push(['EVENT', 'sub', genuineEvent]);
+      final result = await wait;
+
+      expect(
+        result,
+        isNotNull,
+        reason:
+            'the genuine secret must still bind after a tampered copy '
+            'reused its id',
+      );
+      expect(session.state, equals(NostrConnectState.connected));
+    });
+  });
 }
 
 /// Builds a NIP-44-encrypted kind-24133 response event addressed to

--- a/mobile/packages/nostr_sdk/test/unit/nostr_connect_session_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/nostr_connect_session_test.dart
@@ -483,30 +483,25 @@ void main() {
       expect(validation, equals(NostrConnectResponseValidation.ignore));
     });
 
-    test('returns rejectedByBunker when response.error is non-empty', () {
+    test('returns ignore when response.error is non-empty — signer errors are '
+        'non-terminal because the sender is unauthenticated pre-secret', () {
       final validation = validateConnectResponse(
         response: buildResponse('', error: 'user denied'),
         expectedSecret: 's3cret',
       );
-      expect(
-        validation,
-        equals(NostrConnectResponseValidation.rejectedByBunker),
-      );
+      expect(validation, equals(NostrConnectResponseValidation.ignore));
     });
 
-    test('returns rejectedByBunker even when result happens to match — '
-        'an explicit error must always win', () {
+    test('returns ignore even when result happens to match — '
+        'a response carrying an error must never bind the session', () {
       final validation = validateConnectResponse(
         response: buildResponse('s3cret', error: 'user denied'),
         expectedSecret: 's3cret',
       );
-      expect(
-        validation,
-        equals(NostrConnectResponseValidation.rejectedByBunker),
-      );
+      expect(validation, equals(NostrConnectResponseValidation.ignore));
     });
 
-    test('returns rejectedByBunker for auth_url challenge responses', () {
+    test('returns authChallenge for auth_url challenge responses', () {
       final validation = validateConnectResponse(
         response: buildResponse(
           'auth_url',
@@ -514,9 +509,45 @@ void main() {
         ),
         expectedSecret: 's3cret',
       );
+      expect(validation, equals(NostrConnectResponseValidation.authChallenge));
+    });
+
+    test('NostrRemoteResponse.isAuthChallenge requires the auth_url marker '
+        'and a non-empty URL', () {
       expect(
-        validation,
-        equals(NostrConnectResponseValidation.rejectedByBunker),
+        NostrRemoteResponse(
+          'id',
+          'auth_url',
+          error: 'https://example.com/x',
+        ).isAuthChallenge,
+        isTrue,
+      );
+      expect(NostrRemoteResponse('id', 'auth_url').isAuthChallenge, isFalse);
+      expect(
+        NostrRemoteResponse('id', 'auth_url', error: '').isAuthChallenge,
+        isFalse,
+      );
+      expect(
+        NostrRemoteResponse('id', 'ack', error: 'https://x').isAuthChallenge,
+        isFalse,
+      );
+    });
+
+    test('returns ignore for an auth_url result with no challenge URL in '
+        'error — malformed challenges are dropped, not surfaced', () {
+      expect(
+        validateConnectResponse(
+          response: buildResponse('auth_url'),
+          expectedSecret: 's3cret',
+        ),
+        equals(NostrConnectResponseValidation.ignore),
+      );
+      expect(
+        validateConnectResponse(
+          response: buildResponse('auth_url', error: ''),
+          expectedSecret: 's3cret',
+        ),
+        equals(NostrConnectResponseValidation.ignore),
       );
     });
 
@@ -658,7 +689,8 @@ void main() {
       },
     );
 
-    test('reports bunkerRejected when the signer returns an error', () async {
+    test('keeps listening through an injected error response and still binds '
+        'on the real secret (pairing-DoS regression, #5683)', () async {
       final relay = await _TestRelayServer.start();
       addTearDown(relay.close);
 
@@ -667,6 +699,7 @@ void main() {
 
       await session.start();
       final info = session.info!;
+      final secret = info.optionalSecret!;
 
       final wait = session.waitForConnection(
         timeout: const Duration(seconds: 5),
@@ -680,14 +713,32 @@ void main() {
           error: 'user rejected',
         ),
       ]);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(
+        session.state,
+        equals(NostrConnectState.listening),
+        reason: 'an unauthenticated error must not terminate pairing',
+      );
+      expect(session.failureReason, isNull);
+
+      relay.push([
+        'EVENT',
+        'sub',
+        await _encryptedResponseEvent(
+          clientPubkey: info.clientPubkey!,
+          result: secret,
+          requestId: 'real-signer-request-id',
+        ),
+      ]);
       final result = await wait;
 
-      expect(result, isNull);
-      expect(session.state, equals(NostrConnectState.error));
       expect(
-        session.failureReason,
-        equals(NostrConnectFailureReason.bunkerRejected),
+        result,
+        isNotNull,
+        reason: 'the legitimate secret must still bind after the junk error',
       );
+      expect(session.state, equals(NostrConnectState.connected));
     });
 
     test('reports startFailed when no relay can be reached', () async {
@@ -704,6 +755,276 @@ void main() {
       );
     });
   });
+
+  group('auth challenge (non-terminal, #5683)', () {
+    const challengeUrl = 'https://example.com/approve?token=untrusted';
+
+    test('keeps listening through an auth_url challenge, dedupes relay '
+        'replays of the same id, and still binds on the real secret', () async {
+      final relay = await _TestRelayServer.start();
+      addTearDown(relay.close);
+
+      final logs = <String>[];
+      final session = NostrConnectSession(
+        relays: [relay.url],
+        logger: logs.add,
+      );
+      addTearDown(session.dispose);
+
+      await session.start();
+      final info = session.info!;
+      final secret = info.optionalSecret!;
+      logs.clear();
+
+      final wait = session.waitForConnection(
+        timeout: const Duration(seconds: 5),
+      );
+      final challengeEvent = await _encryptedResponseEvent(
+        clientPubkey: info.clientPubkey!,
+        result: 'auth_url',
+        error: challengeUrl,
+        requestId: 'challenge-id',
+      );
+      relay.push(['EVENT', 'sub', challengeEvent]);
+      await _waitUntil(
+        () => logs.any((line) => line.contains('Auth challenge')),
+      );
+
+      expect(
+        session.state,
+        equals(NostrConnectState.listening),
+        reason: 'an auth challenge must not terminate pairing',
+      );
+      expect(session.failureReason, isNull);
+
+      // A relay replay of the identical event and a signer re-send of the
+      // same challenge id as a fresh event must both be deduped.
+      relay.push(['EVENT', 'sub', challengeEvent]);
+      relay.push([
+        'EVENT',
+        'sub',
+        await _encryptedResponseEvent(
+          clientPubkey: info.clientPubkey!,
+          result: 'auth_url',
+          error: challengeUrl,
+          requestId: 'challenge-id',
+        ),
+      ]);
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      expect(
+        logs.where((line) => line.contains('Auth challenge')),
+        hasLength(1),
+        reason: 'a replayed challenge id must be logged once',
+      );
+
+      relay.push([
+        'EVENT',
+        'sub',
+        await _encryptedResponseEvent(
+          clientPubkey: info.clientPubkey!,
+          result: secret,
+          requestId: 'challenge-id',
+        ),
+      ]);
+      final result = await wait;
+
+      expect(
+        result,
+        isNotNull,
+        reason: 'the post-challenge secret on the same id must bind',
+      );
+      expect(session.state, equals(NostrConnectState.connected));
+    });
+
+    test(
+      'restarts the wait window exactly once across multiple challenges',
+      () async {
+        final relay = await _TestRelayServer.start();
+        addTearDown(relay.close);
+
+        final logs = <String>[];
+        final session = NostrConnectSession(
+          relays: [relay.url],
+          logger: logs.add,
+        );
+        addTearDown(session.dispose);
+
+        await session.start();
+        final info = session.info!;
+        logs.clear();
+
+        unawaited(
+          session.waitForConnection(timeout: const Duration(seconds: 5)),
+        );
+        relay.push([
+          'EVENT',
+          'sub',
+          await _encryptedResponseEvent(
+            clientPubkey: info.clientPubkey!,
+            result: 'auth_url',
+            error: challengeUrl,
+            requestId: 'challenge-1',
+          ),
+        ]);
+        relay.push([
+          'EVENT',
+          'sub',
+          await _encryptedResponseEvent(
+            clientPubkey: info.clientPubkey!,
+            result: 'auth_url',
+            error: challengeUrl,
+            requestId: 'challenge-2',
+          ),
+        ]);
+        await _waitUntil(
+          () =>
+              logs.where((line) => line.contains('Auth challenge')).length == 2,
+        );
+
+        expect(
+          logs.where((line) => line.contains('Wait window restarted once')),
+          hasLength(1),
+          reason: 'injected challenges must not extend the wait repeatedly',
+        );
+      },
+    );
+
+    test('extends the deadline once: a challenge mid-wait moves the timeout '
+        'to a full window from the challenge, then still times out', () async {
+      final relay = await _TestRelayServer.start();
+      addTearDown(relay.close);
+
+      final logs = <String>[];
+      final session = NostrConnectSession(
+        relays: [relay.url],
+        logger: logs.add,
+      );
+      addTearDown(session.dispose);
+
+      await session.start();
+      final info = session.info!;
+
+      const timeout = Duration(milliseconds: 1500);
+      const challengeDelay = Duration(milliseconds: 500);
+      final stopwatch = Stopwatch()..start();
+      final wait = session.waitForConnection(timeout: timeout);
+
+      await Future<void>.delayed(challengeDelay);
+      relay.push([
+        'EVENT',
+        'sub',
+        await _encryptedResponseEvent(
+          clientPubkey: info.clientPubkey!,
+          result: 'auth_url',
+          error: challengeUrl,
+        ),
+      ]);
+      // The restart must land while the original window is still open, or
+      // the elapsed-time assertion below would be measuring the wrong thing.
+      await _waitUntil(
+        () => logs.any((line) => line.contains('Wait window restarted once')),
+        timeout: timeout - challengeDelay,
+      );
+
+      final result = await wait;
+      stopwatch.stop();
+
+      expect(result, isNull);
+      expect(session.state, equals(NostrConnectState.timeout));
+      // Lower bound only (slow machines can only make it larger): the
+      // challenge was pushed at >= 500ms and the restarted timer runs a
+      // full 1500ms from there, so completing before ~2000ms means the
+      // original, un-cancelled timer fired instead of the restarted one.
+      expect(
+        stopwatch.elapsedMilliseconds,
+        greaterThanOrEqualTo(1990),
+        reason: 'the restart must extend the deadline, not just re-log',
+      );
+    });
+
+    test('ignores a secret match that arrives after the wait timed out — '
+        'the session must not flip to connected with nobody waiting', () async {
+      final relay = await _TestRelayServer.start();
+      addTearDown(relay.close);
+
+      final logs = <String>[];
+      final session = NostrConnectSession(
+        relays: [relay.url],
+        logger: logs.add,
+      );
+      addTearDown(session.dispose);
+
+      await session.start();
+      final info = session.info!;
+      final secret = info.optionalSecret!;
+
+      final result = await session.waitForConnection(
+        timeout: const Duration(milliseconds: 300),
+      );
+      expect(result, isNull);
+      expect(session.state, equals(NostrConnectState.timeout));
+
+      relay.push([
+        'EVENT',
+        'sub',
+        await _encryptedResponseEvent(
+          clientPubkey: info.clientPubkey!,
+          result: secret,
+        ),
+      ]);
+      await _waitUntil(
+        () => logs.any((line) => line.contains('Ignoring late secret match')),
+      );
+
+      expect(session.state, equals(NostrConnectState.timeout));
+    });
+
+    test('never logs the challenge URL (#3760 redaction contract)', () async {
+      final relay = await _TestRelayServer.start();
+      addTearDown(relay.close);
+
+      final logs = <String>[];
+      final session = NostrConnectSession(
+        relays: [relay.url],
+        logger: logs.add,
+      );
+      addTearDown(session.dispose);
+
+      await session.start();
+      final info = session.info!;
+      logs.clear();
+
+      unawaited(session.waitForConnection(timeout: const Duration(seconds: 5)));
+      relay.push([
+        'EVENT',
+        'sub',
+        await _encryptedResponseEvent(
+          clientPubkey: info.clientPubkey!,
+          result: 'auth_url',
+          error: challengeUrl,
+        ),
+      ]);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      // Guard the guard: the challenge path must actually route through
+      // the injected logger, or the redaction assertion is vacuous.
+      expect(
+        logs.any((line) => line.contains('Auth challenge')),
+        isTrue,
+        reason: 'the challenge path must log via the injected logger',
+      );
+      expect(
+        logs.where(
+          (line) =>
+              line.contains(challengeUrl) ||
+              line.contains('token=untrusted') ||
+              line.contains('example.com'),
+        ),
+        isEmpty,
+        reason: 'the attacker-suppliable challenge URL must never be logged',
+      );
+    });
+  });
 }
 
 /// Builds a NIP-44-encrypted kind-24133 response event addressed to
@@ -714,14 +1035,31 @@ Future<Map<String, dynamic>> _encryptedResponseEvent({
   required String clientPubkey,
   required String result,
   String? error,
+  String requestId = 'test-request-id',
 }) async {
   final signer = LocalNostrSigner(generatePrivateKey());
   final remoteSignerPubkey = (await signer.getPublicKey())!;
-  final response = NostrRemoteResponse('test-request-id', result, error: error);
+  final response = NostrRemoteResponse(requestId, result, error: error);
   final ciphertext = (await response.encrypt(signer, clientPubkey))!;
   return Event(remoteSignerPubkey, EventKind.nostrRemoteSigning, [
     ['p', clientPubkey],
   ], ciphertext).toJson();
+}
+
+/// Polls [condition] until it holds, failing the test after [timeout].
+/// Prefer this over fixed sleeps so slow CI machines cannot flake a
+/// positive assertion; negative assertions still need a bounded delay.
+Future<void> _waitUntil(
+  bool Function() condition, {
+  Duration timeout = const Duration(seconds: 5),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (!condition()) {
+    if (DateTime.now().isAfter(deadline)) {
+      fail('condition not met within $timeout');
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+  }
 }
 
 Future<int> _unusedLoopbackPort() async {

--- a/mobile/test/screens/auth/nostr_connect_failure_message_test.dart
+++ b/mobile/test/screens/auth/nostr_connect_failure_message_test.dart
@@ -21,13 +21,6 @@ void main() {
       expect(
         resolveNostrConnectFailureMessage(
           en,
-          NostrConnectFailureReason.bunkerRejected,
-        ),
-        equals(en.authBunkerRejectedConnection),
-      );
-      expect(
-        resolveNostrConnectFailureMessage(
-          en,
           NostrConnectFailureReason.startFailed,
         ),
         equals(en.authNostrConnectStartFailed),
@@ -80,10 +73,6 @@ void main() {
       final de = lookupAppLocalizations(const Locale('de'));
       // The #3761 keys are now translated in every locale, so German must
       // not resolve to the English source.
-      expect(
-        de.authBunkerRejectedConnection,
-        isNot(equals(en.authBunkerRejectedConnection)),
-      );
       expect(
         de.authNostrConnectSetupFailed,
         isNot(equals(en.authNostrConnectSetupFailed)),

--- a/mobile/test/services/auth/nostr_connect_coordinator_test.dart
+++ b/mobile/test/services/auth/nostr_connect_coordinator_test.dart
@@ -170,7 +170,7 @@ void main() {
         when(() => session.state).thenReturn(NostrConnectState.error);
         when(
           () => session.failureReason,
-        ).thenReturn(NostrConnectFailureReason.bunkerRejected);
+        ).thenReturn(NostrConnectFailureReason.startFailed);
         final coordinator = build();
         await coordinator.initiate();
 
@@ -178,7 +178,7 @@ void main() {
 
         expect(
           result.nostrConnectFailureReason,
-          NostrConnectFailureReason.bunkerRejected,
+          NostrConnectFailureReason.startFailed,
         );
       });
 


### PR DESCRIPTION
## Description

During `nostrconnect://` pairing, `validateConnectResponse` treated any non-empty `response.error` as terminal `rejectedByBunker`. A spec-following signer that answers `connect` with a NIP-46 auth challenge (`{result:"auth_url", error:<URL>}` — nsec.app does this whenever manual confirmation is needed) was therefore misclassified as a rejection: the session died and the user saw the false "Your signer app declined the connection." copy. The same branch let any unauthenticated relay pubkey kill pairing by racing a junk error in front of the legitimate signer's reply.

This PR makes the pairing path match reference-client behavior (nostr-tools `BunkerSigner.fromURI`, NDK `blockUntilReadyNostrConnect`), which resolves only on `result == secret` and treats everything else as non-terminal:

- `auth_url` challenges classify as a new `authChallenge` outcome: the session keeps listening for the real response on the same request id. The challenge URL is deliberately **not** surfaced, opened, or logged — during nostrconnect pairing the sender is unauthenticated (the subscription has no `authors` filter), so the URL is attacker-suppliable; #3760 removed the original pre-secret auth_url handling for exactly this reason and this PR preserves that posture.
- All other pre-secret errors classify as `ignore` (kept **before** the secret compare so an errored response can never bind), which also closes the pairing-DoS above. Trade-off: a genuine signer-side deny (`error:"Not authorized"`, verified in noauth source) now waits out the timeout — whose copy already says "Make sure you approved the connection in your signer app" — instead of showing an instant, attacker-spoofable "declined".
- The wait window restarts **exactly once** on the first challenge (out-of-band approval is slow; the once-cap keeps injected challenges from extending the wait forever).
- Relay replays are deduped on `event.id` before paying for NIP-44 decryption; signer re-sends of the same challenge id are deduped for logging.
- A secret match arriving after the wait already timed out is ignored instead of flipping the session to a `connected` state nobody is waiting on.
- The now-unreachable `rejectedByBunker` / `NostrConnectFailureReason.bunkerRejected` / `authBunkerRejectedConnection` chain is deleted (ARB key removed from all 18 locales, l10n regenerated).
- Shared challenge predicate extracted as `NostrRemoteResponse.isAuthChallenge`; the bunker:// flow's own auth_url handling is intentionally untouched (its sender is authenticated via the `bunker://` URI).

Design/investigation record: multi-round root-cause analysis with cross-repo verification (keycast never emits `auth_url`; nsec.app always surfaces its own in-tab confirm, so never surfacing the URL strands no signer; nsecbunkerd cannot pair via this receive-only flow at all). Full trail in `tasks/findings_5683.md` / `tasks/brainstorm_5683.md` (local, not committed).

**Related Issue:** Closes #5683. Relates to #3761, #3760, #5179.

## Out of Scope

- Surfacing the challenge URL behind a user-gated tap-to-open affordance (follow-up enhancement, needs security sign-off): #6153.
- The same bug class in divine-web (`NConnectSigner`): divinevideo/divine-web#485, and divine-connect: divinevideo/divine-connect#27.
- The bunker:// flow's `auth_url` handling (authenticated sender; unchanged).

## Verification

- `mobile/packages/nostr_sdk`: `flutter test` — 362/362 pass, including new tests: auth_url → `authChallenge` classification, malformed-challenge → `ignore`, pairing-DoS regression (junk error then real secret still binds), challenge keep-listening e2e with replay dedup, restart-once cap, deadline-extension (mutant-verified: removing the timer `cancel()` fails it), late-match-after-timeout, and a #3760-style redaction pin that the challenge URL never reaches logs.
- `mobile`: `flutter analyze lib test integration_test` clean; `flutter test test/screens/auth test/services/auth test/l10n/arb_consistency_test.dart` — 284/284 pass; `dart format` clean; l10n regenerated via gen-l10n.
- Manual verification planned post-merge: live nsec.app pairing (challenge only fires on first-time/unpermissioned connects).

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change) — a genuine signer deny now times out instead of failing fast (deliberate, see Description)
