### PR TITLE
feat(video-editor): save a trimmed clip to the clip library (#5322)

### DIFF
--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
@@ -4,8 +4,10 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:models/models.dart' show AudioEvent;
 import 'package:openvine/constants/video_editor_timeline_constants.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/video_editor/editor_overlay_snapshot.dart';
 import 'package:openvine/observability/reportable_error.dart';
 import 'package:openvine/services/audio_extraction_service.dart';
+import 'package:openvine/services/video_editor/video_editor_clip_library_save_service.dart';
 import 'package:openvine/services/video_editor/video_editor_merge_service.dart';
 import 'package:openvine/services/video_editor/video_editor_reverse_service.dart';
 import 'package:openvine/services/video_editor/video_editor_split_service.dart';
@@ -59,6 +61,27 @@ typedef MergeClipsFn =
       required String renderId,
     });
 
+/// Function signature matching
+/// [VideoEditorClipLibrarySaveService.flattenClipForLibrary], used as an
+/// injectable seam so tests can swap in a pure-Dart fake that does not touch
+/// `path_provider` or `pro_video_editor` plugins.
+typedef FlattenClipForLibraryFn =
+    Future<DivineVideoClip?> Function({
+      required DivineVideoClip clip,
+      required String renderId,
+      EditorOverlaySnapshot? overlays,
+    });
+
+/// Persists an already-flattened clip to the device's clip library, returning
+/// whether it was stored.
+///
+/// Wired by the widget layer to `ClipManagerNotifier.saveClipToLibrary`. The
+/// library lives behind a Riverpod provider this BLoC cannot reach, so the
+/// dependency arrives as a callback — the same transition seam that already
+/// brings the clip list in (see [ClipEditorBloc]).
+typedef SaveClipToLibraryFn =
+    Future<bool> Function({required DivineVideoClip clip});
+
 /// BLoC for managing video clip editor state.
 ///
 /// Owns a local copy of the clip list so that all mutations (add, remove,
@@ -74,11 +97,13 @@ typedef MergeClipsFn =
 class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
   ClipEditorBloc({
     required this.onFinalClipInvalidated,
+    required SaveClipToLibraryFn saveClipToLibrary,
     AudioExtractionService? audioExtractionService,
     SplitClipFn? splitClip,
     ReverseClipFn? reverseClip,
     TransformClipFn? transformClip,
     MergeClipsFn? mergeClips,
+    FlattenClipForLibraryFn? flattenClipForLibrary,
   }) : _audioExtractionService =
            audioExtractionService ?? AudioExtractionService(),
        _splitClip = splitClip ?? VideoEditorSplitService.splitClip,
@@ -86,6 +111,10 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
        _transformClip =
            transformClip ?? VideoEditorTransformService.transformClip,
        _mergeClips = mergeClips ?? VideoEditorMergeService.mergeClips,
+       _flattenClipForLibrary =
+           flattenClipForLibrary ??
+           VideoEditorClipLibrarySaveService.flattenClipForLibrary,
+       _saveClipToLibrary = saveClipToLibrary,
        super(const ClipEditorState()) {
     // Clip data
     on<ClipEditorInitialized>(_onInitialized);
@@ -144,6 +173,12 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
       transformer: droppable(),
     );
 
+    // Save a single clip to the persistent clip library
+    on<ClipEditorSaveClipToLibraryRequested>(
+      _onSaveClipToLibraryRequested,
+      transformer: droppable(),
+    );
+
     // Volume
     on<ClipEditorClipVolumeChanged>(
       _onClipVolumeChanged,
@@ -161,6 +196,8 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
   final ReverseClipFn _reverseClip;
   final TransformClipFn _transformClip;
   final MergeClipsFn _mergeClips;
+  final FlattenClipForLibraryFn _flattenClipForLibrary;
+  final SaveClipToLibraryFn _saveClipToLibrary;
 
   // === CLIP DATA ===
 
@@ -839,6 +876,137 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
         clipsVolumeRevision: state.clipsVolumeRevision + 1,
       ),
     );
+  }
+
+  // === SAVE TO CLIP LIBRARY ===
+
+  /// Re-encodes the requested clip's trim window into its own file and stores
+  /// it in the clip library, leaving the timeline untouched.
+  ///
+  /// `droppable` rather than `sequential`: the Save control is disabled for the
+  /// in-flight clip, so a second event here can only come from a double-tap
+  /// race — queuing it would silently store a duplicate copy.
+  Future<void> _onSaveClipToLibraryRequested(
+    ClipEditorSaveClipToLibraryRequested event,
+    Emitter<ClipEditorState> emit,
+  ) async {
+    final index = state.clips.indexWhere((c) => c.id == event.clipId);
+    if (index == -1) return;
+    final clip = state.clips[index];
+
+    // Overlay windows are authored against the editor timeline — every clip at
+    // its full playback length — so this clip's slice of it starts after every
+    // preceding clip's playbackDuration. Window the overlays down to that slice
+    // and rebase to zero, so the standalone render draws exactly what sat over
+    // this clip, at the right moments (#5322).
+    var clipStart = Duration.zero;
+    for (var i = 0; i < index; i++) {
+      clipStart += state.clips[i].playbackDuration;
+    }
+    final overlays = event.overlays?.windowedTo(
+      start: clipStart,
+      end: clipStart + clip.playbackDuration,
+    );
+
+    // Namespaced from the clip id so it can't collide with a concurrent
+    // reverse render keyed on the same clip id.
+    final renderId = '${clip.id}_clip_library_save';
+
+    Log.info(
+      '💾 Saving clip ${clip.id} to the clip library',
+      name: 'ClipEditorBloc',
+      category: LogCategory.video,
+    );
+
+    emit(
+      state.copyWith(
+        isSavingClipToLibrary: true,
+        savingClipToLibraryClipId: clip.id,
+      ),
+    );
+
+    try {
+      final flattened = await _flattenClipForLibrary(
+        clip: clip,
+        renderId: renderId,
+        overlays: overlays,
+      );
+
+      if (flattened == null) {
+        // Matrix-NO: render cancel/failure surfaces as a null output from
+        // VideoEditorRenderService.renderVideo (Network/IO).
+        emit(
+          state.copyWith(
+            isSavingClipToLibrary: false,
+            clearSavingClipToLibraryClipId: true,
+            lastClipLibrarySave: ClipLibrarySaveFailure(),
+          ),
+        );
+        return;
+      }
+
+      // Reconcile after the async gap: the user can delete the source clip
+      // while the ~15-20s re-encode runs. Saving it anyway would resurrect a
+      // clip they just discarded.
+      if (state.clips.every((c) => c.id != clip.id)) {
+        Log.warning(
+          '⚠️ Library save discarded: clip ${clip.id} no longer exists',
+          name: 'ClipEditorBloc',
+          category: LogCategory.video,
+        );
+        emit(
+          state.copyWith(
+            isSavingClipToLibrary: false,
+            clearSavingClipToLibraryClipId: true,
+            lastClipLibrarySave: ClipLibrarySaveDiscarded(),
+          ),
+        );
+        return;
+      }
+
+      final saved = await _saveClipToLibrary(clip: flattened);
+
+      emit(
+        state.copyWith(
+          isSavingClipToLibrary: false,
+          clearSavingClipToLibraryClipId: true,
+          lastClipLibrarySave: saved
+              ? ClipLibrarySaveSuccess()
+              : ClipLibrarySaveFailure(),
+        ),
+      );
+
+      Log.info(
+        saved
+            ? '✅ Saved clip ${clip.id} to the library as ${flattened.id}'
+            : '❌ Library rejected clip ${flattened.id}',
+        name: 'ClipEditorBloc',
+        category: LogCategory.video,
+      );
+    } catch (e, stackTrace) {
+      final error = switch (e) {
+        StateError() || TypeError() || RangeError() => Reportable(
+          e,
+          context: '_onSaveClipToLibraryRequested',
+        ),
+        _ => e,
+      };
+      addError(error, stackTrace);
+      Log.error(
+        '❌ Failed to save clip to library: $e',
+        name: 'ClipEditorBloc',
+        category: LogCategory.video,
+        error: e,
+        stackTrace: stackTrace,
+      );
+      emit(
+        state.copyWith(
+          isSavingClipToLibrary: false,
+          clearSavingClipToLibraryClipId: true,
+          lastClipLibrarySave: ClipLibrarySaveFailure(),
+        ),
+      );
+    }
   }
 
   // === REVERSE ===

--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
@@ -72,6 +72,17 @@ typedef FlattenClipForLibraryFn =
       EditorOverlaySnapshot? overlays,
     });
 
+/// Function signature matching
+/// [VideoEditorClipLibrarySaveService.cleanupFlattenedClip], the injectable
+/// seam that deletes a flattened clip's documents-dir files when the save
+/// doesn't reach the library, so tests can assert cleanup without touching the
+/// file system.
+typedef CleanupFlattenedClipFn =
+    Future<void> Function(
+      DivineVideoClip flattened, {
+      String? keepThumbnailPath,
+    });
+
 /// Persists an already-flattened clip to the device's clip library, returning
 /// whether it was stored.
 ///
@@ -104,6 +115,7 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
     TransformClipFn? transformClip,
     MergeClipsFn? mergeClips,
     FlattenClipForLibraryFn? flattenClipForLibrary,
+    CleanupFlattenedClipFn? cleanupFlattenedClip,
   }) : _audioExtractionService =
            audioExtractionService ?? AudioExtractionService(),
        _splitClip = splitClip ?? VideoEditorSplitService.splitClip,
@@ -114,6 +126,9 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
        _flattenClipForLibrary =
            flattenClipForLibrary ??
            VideoEditorClipLibrarySaveService.flattenClipForLibrary,
+       _cleanupFlattenedClip =
+           cleanupFlattenedClip ??
+           VideoEditorClipLibrarySaveService.cleanupFlattenedClip,
        _saveClipToLibrary = saveClipToLibrary,
        super(const ClipEditorState()) {
     // Clip data
@@ -197,6 +212,7 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
   final TransformClipFn _transformClip;
   final MergeClipsFn _mergeClips;
   final FlattenClipForLibraryFn _flattenClipForLibrary;
+  final CleanupFlattenedClipFn _cleanupFlattenedClip;
   final SaveClipToLibraryFn _saveClipToLibrary;
 
   // === CLIP DATA ===
@@ -883,9 +899,12 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
   /// Re-encodes the requested clip's trim window into its own file and stores
   /// it in the clip library, leaving the timeline untouched.
   ///
-  /// `droppable` rather than `sequential`: the Save control is disabled for the
-  /// in-flight clip, so a second event here can only come from a double-tap
-  /// race — queuing it would silently store a duplicate copy.
+  /// `droppable` rather than `sequential`: while a save runs the controls
+  /// disable Save on *every* clip (not just the in-flight one), so a second
+  /// event here can only come from a double-tap race in the frame before that
+  /// disable renders — queuing it would silently store a duplicate copy. Only
+  /// one re-encode runs at a time; the user can still select and edit other
+  /// clips, they just can't launch a concurrent save.
   Future<void> _onSaveClipToLibraryRequested(
     ClipEditorSaveClipToLibraryRequested event,
     Emitter<ClipEditorState> emit,
@@ -925,8 +944,13 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
       ),
     );
 
+    // The flattened file lands in the persistent documents dir, so any path
+    // that doesn't hand it to the library must delete it — nothing else ever
+    // reclaims an unreferenced documents-dir file. Held outside the try so the
+    // catch can clean up a file that was rendered before a later step threw.
+    DivineVideoClip? flattened;
     try {
-      final flattened = await _flattenClipForLibrary(
+      flattened = await _flattenClipForLibrary(
         clip: clip,
         renderId: renderId,
         overlays: overlays,
@@ -934,7 +958,8 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
 
       if (flattened == null) {
         // Matrix-NO: render cancel/failure surfaces as a null output from
-        // VideoEditorRenderService.renderVideo (Network/IO).
+        // VideoEditorRenderService.renderVideo (Network/IO). No file was
+        // written, so there is nothing to clean up.
         emit(
           state.copyWith(
             isSavingClipToLibrary: false,
@@ -954,6 +979,10 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
           name: 'ClipEditorBloc',
           category: LogCategory.video,
         );
+        await _cleanupFlattenedClip(
+          flattened,
+          keepThumbnailPath: clip.thumbnailPath,
+        );
         emit(
           state.copyWith(
             isSavingClipToLibrary: false,
@@ -965,6 +994,13 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
       }
 
       final saved = await _saveClipToLibrary(clip: flattened);
+
+      if (!saved) {
+        await _cleanupFlattenedClip(
+          flattened,
+          keepThumbnailPath: clip.thumbnailPath,
+        );
+      }
 
       emit(
         state.copyWith(
@@ -984,6 +1020,12 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
         category: LogCategory.video,
       );
     } catch (e, stackTrace) {
+      if (flattened != null) {
+        await _cleanupFlattenedClip(
+          flattened,
+          keepThumbnailPath: clip.thumbnailPath,
+        );
+      }
       final error = switch (e) {
         StateError() || TypeError() || RangeError() => Reportable(
           e,

--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_event.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_event.dart
@@ -332,3 +332,34 @@ class ClipEditorAllClipsVolumeChanged extends ClipEditorEvent {
   @override
   List<Object?> get props => [volume];
 }
+
+// === SAVE TO CLIP LIBRARY ===
+
+/// Save the clip with [clipId] to the persistent clip library as a standalone
+/// clip, so its trimmed section can be reused in an unrelated project (#5322).
+///
+/// The bloc re-encodes the trim window into its own file and persists it,
+/// emitting a [ClipLibrarySaveResult] one-shot signal for the widget layer to
+/// surface. The timeline is left untouched — this only ever adds a copy to the
+/// library.
+///
+/// [clipId] binds the request to a specific clip, captured at dispatch time so
+/// the save still targets the intended clip if the user selects another one
+/// while the render is running.
+///
+/// [overlays] is the editor's overlay state captured at dispatch time, spanning
+/// the whole composition; the handler windows it down to this clip's slice. The
+/// widget layer captures it because only it can reach the editor — see
+/// `ProImageEditorState.captureOverlaySnapshot`. `null` renders the bare video.
+class ClipEditorSaveClipToLibraryRequested extends ClipEditorEvent {
+  const ClipEditorSaveClipToLibraryRequested({
+    required this.clipId,
+    this.overlays,
+  });
+
+  final String clipId;
+  final EditorOverlaySnapshot? overlays;
+
+  @override
+  List<Object?> get props => [clipId, overlays];
+}

--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_state.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_state.dart
@@ -37,6 +37,9 @@ class ClipEditorState extends Equatable {
     this.mergingRenderId,
     this.lastMergeResult,
     this.lastClipsRemovedResult,
+    this.isSavingClipToLibrary = false,
+    this.savingClipToLibraryClipId,
+    this.lastClipLibrarySave,
   });
 
   /// Local copy of clips managed by this editor session.
@@ -181,6 +184,21 @@ class ClipEditorState extends Equatable {
   /// rebase timeline markers and commit the new clip list to editor history.
   final ClipsRemovedResult? lastClipsRemovedResult;
 
+  /// Whether a save-to-clip-library re-encode is currently running.
+  final bool isSavingClipToLibrary;
+
+  /// Id of the clip being saved to the library.
+  ///
+  /// Non-`null` while [isSavingClipToLibrary] is `true`. Lets the controls
+  /// disable Save for *that* clip only — the user can keep editing, and save,
+  /// other clips while this render runs.
+  final String? savingClipToLibraryClipId;
+
+  /// Last completed save-to-clip-library result.
+  ///
+  /// Consumed by the widget layer to surface a success/failure snackbar.
+  final ClipLibrarySaveResult? lastClipLibrarySave;
+
   /// Total wall-clock duration of all clips (respecting trim and playback speed).
   Duration get totalDuration =>
       clips.fold(Duration.zero, (sum, clip) => sum + clip.playbackDuration);
@@ -223,6 +241,10 @@ class ClipEditorState extends Equatable {
     bool clearMergingRenderId = false,
     ClipMergeResult? lastMergeResult,
     ClipsRemovedResult? lastClipsRemovedResult,
+    bool? isSavingClipToLibrary,
+    String? savingClipToLibraryClipId,
+    bool clearSavingClipToLibraryClipId = false,
+    ClipLibrarySaveResult? lastClipLibrarySave,
   }) {
     return ClipEditorState(
       clips: clips ?? this.clips,
@@ -269,6 +291,12 @@ class ClipEditorState extends Equatable {
       lastMergeResult: lastMergeResult ?? this.lastMergeResult,
       lastClipsRemovedResult:
           lastClipsRemovedResult ?? this.lastClipsRemovedResult,
+      isSavingClipToLibrary:
+          isSavingClipToLibrary ?? this.isSavingClipToLibrary,
+      savingClipToLibraryClipId: clearSavingClipToLibraryClipId
+          ? null
+          : (savingClipToLibraryClipId ?? this.savingClipToLibraryClipId),
+      lastClipLibrarySave: lastClipLibrarySave ?? this.lastClipLibrarySave,
     );
   }
 
@@ -307,6 +335,10 @@ class ClipEditorState extends Equatable {
     identityHashCode(lastMergeResult),
     // Identity-only: each ClipsRemovedResult is a fresh instance per removal.
     identityHashCode(lastClipsRemovedResult),
+    isSavingClipToLibrary,
+    savingClipToLibraryClipId,
+    // Identity-only: each ClipLibrarySaveResult is a fresh instance per save.
+    identityHashCode(lastClipLibrarySave),
   ];
 }
 
@@ -448,3 +480,25 @@ final class ClipsRemovedResult {
 
   final List<DivineVideoClip> previousClips;
 }
+
+// === CLIP LIBRARY SAVE RESULT ===
+
+/// One-shot signal describing the outcome of a save-to-clip-library attempt.
+///
+/// Emitted into [ClipEditorState.lastClipLibrarySave] after each attempt.
+/// Identity-compared so the scaffold [BlocListener] fires exactly once per
+/// attempt even when the same outcome repeats.
+sealed class ClipLibrarySaveResult {}
+
+/// The clip was re-encoded and stored in the library.
+final class ClipLibrarySaveSuccess extends ClipLibrarySaveResult {}
+
+/// The re-encode or the library write failed; widget should show a snackbar.
+final class ClipLibrarySaveFailure extends ClipLibrarySaveResult {}
+
+/// The re-encode finished but the source clip had been removed from the
+/// timeline meanwhile, so the result was dropped.
+///
+/// Silent by design: the user deleted the clip they asked to save, so neither
+/// a success nor a failure snackbar would make sense.
+final class ClipLibrarySaveDiscarded extends ClipLibrarySaveResult {}

--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_state.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_state.dart
@@ -189,9 +189,10 @@ class ClipEditorState extends Equatable {
 
   /// Id of the clip being saved to the library.
   ///
-  /// Non-`null` while [isSavingClipToLibrary] is `true`. Lets the controls
-  /// disable Save for *that* clip only — the user can keep editing, and save,
-  /// other clips while this render runs.
+  /// Non-`null` while [isSavingClipToLibrary] is `true`. Save is disabled on
+  /// every clip while a save runs (only one heavy re-encode at a time); this
+  /// id picks which clip shows the in-flight spinner versus a plain disabled
+  /// button. The user can still select and edit other clips meanwhile.
   final String? savingClipToLibraryClipId;
 
   /// Last completed save-to-clip-library result.

--- a/mobile/lib/extensions/video_editor_extensions.dart
+++ b/mobile/lib/extensions/video_editor_extensions.dart
@@ -37,8 +37,17 @@ extension VideoEditorExtensions on ProImageEditorState {
   ///
   /// Rasterizing the layers costs a frame, so only call this when a render is
   /// actually about to run.
+  ///
+  /// Passes the same `basePixelRatio` the Done/export path uses
+  /// (`configs.imageGeneration.customPixelRatio`, the export-resolution ratio)
+  /// so a layer baked into a saved clip is captured at the same resolution it
+  /// would be in a full export, not the lower device pixel ratio the bare call
+  /// would fall back to. Global transforms are deliberately *not* applied — a
+  /// clip's own geometry is already baked into its file (#5322).
   Future<EditorOverlaySnapshot> captureOverlaySnapshot() async {
-    final capturedLayers = await captureAllLayersWithMeta();
+    final capturedLayers = await captureAllLayersWithMeta(
+      basePixelRatio: configs.imageGeneration.customPixelRatio,
+    );
     return EditorOverlaySnapshot(
       capturedLayers: capturedLayers,
       filterStates: List.of(stateManager.activeFilters),

--- a/mobile/lib/extensions/video_editor_extensions.dart
+++ b/mobile/lib/extensions/video_editor_extensions.dart
@@ -2,6 +2,7 @@ import 'package:models/models.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/extensions/video_editor_history_extensions.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/video_editor/editor_overlay_snapshot.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart';
 import 'package:pro_image_editor/pro_image_editor.dart' hide AudioTrack;
 
@@ -26,6 +27,27 @@ Map<String, dynamic> buildAppendedAudioMeta({
 }
 
 extension VideoEditorExtensions on ProImageEditorState {
+  /// Captures the overlays currently over the composition — layers, colour
+  /// filters, tune adjustments and blur — so they can be baked into a render
+  /// mid-session.
+  ///
+  /// The export path gets the same data handed to it in `CompleteParameters`,
+  /// but only once the user taps Done; anything that renders *during* editing
+  /// (saving a single clip to the library) has to ask for it.
+  ///
+  /// Rasterizing the layers costs a frame, so only call this when a render is
+  /// actually about to run.
+  Future<EditorOverlaySnapshot> captureOverlaySnapshot() async {
+    final capturedLayers = await captureAllLayersWithMeta();
+    return EditorOverlaySnapshot(
+      capturedLayers: capturedLayers,
+      filterStates: List.of(stateManager.activeFilters),
+      tuneAdjustments: List.of(stateManager.activeTuneAdjustments),
+      blur: stateManager.activeBlur,
+      bodySize: sizesManager.bodySize,
+    );
+  }
+
   void setSoundTimeline({
     required int index,
     Duration? startTime,

--- a/mobile/lib/models/video_editor/editor_overlay_snapshot.dart
+++ b/mobile/lib/models/video_editor/editor_overlay_snapshot.dart
@@ -1,0 +1,124 @@
+// ABOUTME: Snapshot of the editor's overlays (layers, filters, tune, blur)
+// ABOUTME: Windows them down to one clip's slice of the editor timeline
+
+import 'dart:ui';
+
+import 'package:pro_image_editor/pro_image_editor.dart';
+
+/// The overlays sitting over the composition at one moment: captured layers
+/// (text / stickers / drawings), colour filters, tune adjustments and blur.
+///
+/// Overlay time windows are authored on the **editor timeline** — every clip at
+/// its full playback length, `sum(clip.playbackDuration)` — which is the same
+/// axis `TransitionTimelineMap` maps from. [windowedTo] slices that axis down to
+/// a single clip so the clip can be rendered on its own with exactly the
+/// overlays that were over it.
+class EditorOverlaySnapshot {
+  const EditorOverlaySnapshot({
+    this.capturedLayers = const [],
+    this.filterStates = const [],
+    this.tuneAdjustments = const [],
+    this.blur = 0,
+    this.bodySize,
+  });
+
+  /// Overlay layers, each already rasterized to bytes.
+  final List<ExportedLayer> capturedLayers;
+
+  /// Colour filters (sepia, noir, …), each with its own time window.
+  final List<FilterState> filterStates;
+
+  /// Tune adjustments (brightness, contrast, …), each with its own window.
+  final List<TuneAdjustmentMatrix> tuneAdjustments;
+
+  /// Blur strength applied to the whole composition. Carries no time window.
+  final double blur;
+
+  /// The editor body size the layers were laid out against. Layer offsets are
+  /// meaningless without it, so the render skips layers when it is `null`.
+  final Size? bodySize;
+
+  /// Whether there is nothing to bake, so the render can skip the overlay pass.
+  bool get isEmpty =>
+      capturedLayers.isEmpty &&
+      filterStates.isEmpty &&
+      tuneAdjustments.isEmpty &&
+      blur == 0;
+
+  /// Returns the overlays visible between [start] and [end] on the editor
+  /// timeline, rebased so the window starts at zero.
+  ///
+  /// Overlays that don't reach into the window are dropped; overlays that only
+  /// partly cover it are clamped to it. A `null` start/end means "unbounded" —
+  /// after windowing every bound is concrete, because an overlay that outlives
+  /// the window still ends where the clip does.
+  ///
+  /// [blur] and [bodySize] carry through untouched: blur has no time window and
+  /// body size is a layout constant, not a timeline value.
+  EditorOverlaySnapshot windowedTo({
+    required Duration start,
+    required Duration end,
+  }) {
+    if (end <= start) {
+      return EditorOverlaySnapshot(blur: blur, bodySize: bodySize);
+    }
+
+    return EditorOverlaySnapshot(
+      capturedLayers: [
+        for (final item in capturedLayers)
+          if (_windowFor(item.layer.startTime, item.layer.endTime, start, end)
+              case final w?)
+            ExportedLayer(
+              // copyWith returns a base Layer, dropping the text/paint subtype.
+              // That is fine — the layer is already rasterized into `bytes`, and
+              // the render only reads offset, time window and animations back
+              // off it. Copying (rather than mutating) matters: Layer.startTime
+              // is mutable and this instance is the editor's live layer.
+              layer: item.layer.copyWith(startTime: w.start, endTime: w.end),
+              bytes: item.bytes,
+              logicalSize: item.logicalSize,
+            ),
+      ],
+      filterStates: [
+        for (final filter in filterStates)
+          if (_windowFor(filter.startTime, filter.endTime, start, end)
+              case final w?)
+            filter.copyWith(startTime: w.start, endTime: w.end),
+      ],
+      tuneAdjustments: [
+        for (final tune in tuneAdjustments)
+          if (_windowFor(tune.startTime, tune.endTime, start, end)
+              case final w?)
+            tune.copyWith(startTime: w.start, endTime: w.end),
+      ],
+      blur: blur,
+      bodySize: bodySize,
+    );
+  }
+
+  /// Intersects an overlay's `[from, to]` window (either side `null` for
+  /// unbounded) with `[windowStart, windowEnd]`, rebased to the window's start.
+  ///
+  /// Returns `null` when the overlay never shows inside the window.
+  static ({Duration start, Duration end})? _windowFor(
+    Duration? from,
+    Duration? to,
+    Duration windowStart,
+    Duration windowEnd,
+  ) {
+    final effectiveFrom = from ?? Duration.zero;
+    // An unbounded end runs to the window's end by definition.
+    final effectiveTo = to ?? windowEnd;
+
+    // Touching the boundary is not overlapping: an overlay that ends exactly
+    // where the clip starts was never over it.
+    if (effectiveFrom >= windowEnd || effectiveTo <= windowStart) return null;
+
+    final clampedFrom = effectiveFrom < windowStart
+        ? windowStart
+        : effectiveFrom;
+    final clampedTo = effectiveTo > windowEnd ? windowEnd : effectiveTo;
+
+    return (start: clampedFrom - windowStart, end: clampedTo - windowStart);
+  }
+}

--- a/mobile/lib/models/video_editor/editor_overlay_snapshot.dart
+++ b/mobile/lib/models/video_editor/editor_overlay_snapshot.dart
@@ -69,12 +69,7 @@ class EditorOverlaySnapshot {
           if (_windowFor(item.layer.startTime, item.layer.endTime, start, end)
               case final w?)
             ExportedLayer(
-              // copyWith returns a base Layer, dropping the text/paint subtype.
-              // That is fine — the layer is already rasterized into `bytes`, and
-              // the render only reads offset, time window and animations back
-              // off it. Copying (rather than mutating) matters: Layer.startTime
-              // is mutable and this instance is the editor's live layer.
-              layer: item.layer.copyWith(startTime: w.start, endTime: w.end),
+              layer: _windowedLayer(item.layer, w),
               bytes: item.bytes,
               logicalSize: item.logicalSize,
             ),
@@ -96,11 +91,60 @@ class EditorOverlaySnapshot {
     );
   }
 
+  /// Copies [layer] onto its clip-local window [w], dropping any enter/leave
+  /// animation whose edge was clamped away.
+  ///
+  /// The copy is safe even though `copyWith` on a concrete layer subtype
+  /// (text/paint/…) returns that same subtype: the visual content already
+  /// travels in the rasterized `bytes`, and the render reads back only base
+  /// `Layer` fields — offset, time window, animations. Copying rather than
+  /// mutating matters because these fields are mutable and the source is the
+  /// editor's live layer.
+  ///
+  /// A layer that reached past the window on a side sat steadily on screen
+  /// there on the timeline — its enter (start clamped) or leave (end clamped)
+  /// played *outside* this clip. Replaying it inside the saved clip would show
+  /// motion that never happened over the clip, so the clamped-away phase (and
+  /// the legacy fade synthesized from [Layer.enterDuration] /
+  /// [Layer.exitDuration]) is dropped.
+  static Layer _windowedLayer(Layer layer, _OverlayWindow w) {
+    final strip = w.startClamped || w.endClamped;
+    final animations = layer.animations.isEmpty || !strip
+        ? layer.animations
+        : [
+            for (final a in layer.animations)
+              if (!_isClampedAway(a.phase, w)) a,
+          ];
+
+    final windowed = layer.copyWith(
+      startTime: w.start,
+      endTime: w.end,
+      animations: animations,
+    );
+    // copyWith can't null a Duration field (it null-coalesces to the old
+    // value), so clear the legacy fade convenience on the fresh copy directly.
+    if (w.startClamped) windowed.enterDuration = null;
+    if (w.endClamped) windowed.exitDuration = null;
+    return windowed;
+  }
+
+  /// Whether an animation of [phase] belongs to time outside the clip and so
+  /// should be dropped. `animateInOut` spans both edges, so it only goes when
+  /// *both* were clamped.
+  static bool _isClampedAway(AnimationPhase phase, _OverlayWindow w) =>
+      (w.startClamped && phase == AnimationPhase.animateIn) ||
+      (w.endClamped && phase == AnimationPhase.animateOut) ||
+      (w.startClamped && w.endClamped && phase == AnimationPhase.animateInOut);
+
   /// Intersects an overlay's `[from, to]` window (either side `null` for
   /// unbounded) with `[windowStart, windowEnd]`, rebased to the window's start.
   ///
+  /// `startClamped` / `endClamped` report whether the overlay reached past that
+  /// edge of the window (or was unbounded there) — i.e. its enter/leave belongs
+  /// to time outside the clip.
+  ///
   /// Returns `null` when the overlay never shows inside the window.
-  static ({Duration start, Duration end})? _windowFor(
+  static _OverlayWindow? _windowFor(
     Duration? from,
     Duration? to,
     Duration windowStart,
@@ -119,6 +163,20 @@ class EditorOverlaySnapshot {
         : effectiveFrom;
     final clampedTo = effectiveTo > windowEnd ? windowEnd : effectiveTo;
 
-    return (start: clampedFrom - windowStart, end: clampedTo - windowStart);
+    return (
+      start: clampedFrom - windowStart,
+      end: clampedTo - windowStart,
+      startClamped: from == null || from < windowStart,
+      endClamped: to == null || to > windowEnd,
+    );
   }
 }
+
+/// A clip-local overlay window plus whether each edge was clamped from a wider
+/// span (so an enter/leave animation on that edge played outside the clip).
+typedef _OverlayWindow = ({
+  Duration start,
+  Duration end,
+  bool startClamped,
+  bool endClamped,
+});

--- a/mobile/lib/screens/video_editor/video_editor_screen.dart
+++ b/mobile/lib/screens/video_editor/video_editor_screen.dart
@@ -141,6 +141,15 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen>
       onPrecacheStickers: _precacheStickers,
     );
     _clipEditorBloc = ClipEditorBloc(
+      // The clip library sits behind a Riverpod provider the BLoC can't reach,
+      // so it arrives as a callback — the same transition seam that brings the
+      // clip list in. `ref` is unsafe once this State unmounts, so bail rather
+      // than let a save that outlived the screen throw "Using ref when
+      // unmounted"; the render is abandoned with the editor session either way.
+      saveClipToLibrary: ({required clip}) async {
+        if (!mounted) return false;
+        return ref.read(clipManagerProvider.notifier).saveClipToLibrary(clip);
+      },
       onFinalClipInvalidated: () {
         // A clip render (reverse / transform) can resolve after this screen is
         // disposed — the user backed out while a long clip was still

--- a/mobile/lib/services/video_editor/video_editor_clip_library_save_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_clip_library_save_service.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Flattens one timeline clip into a standalone file for the clip library
 // ABOUTME: Bakes trim/speed/volume plus the overlays over it into a fresh documents-dir clip
 
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:openvine/models/divine_video_clip.dart';
@@ -37,12 +38,17 @@ class VideoEditorClipLibrarySaveService {
   /// already windowed and rebased to start at zero by
   /// [EditorOverlaySnapshot.windowedTo]. They get baked into the output too, so
   /// the saved clip looks the way it looked on the timeline. Pass `null` (or an
-  /// empty snapshot) to render the bare video.
+  /// empty snapshot) to render the bare video. Only *visual* overlays are baked
+  /// — session audio (background music, voice-over) spans the whole project
+  /// timeline and is deliberately not carried onto a single saved clip.
   ///
   /// [renderId] keys the native progress/cancel stream.
   ///
   /// Returns `null` when the render is cancelled or fails — both already
   /// surface as a `null` output path from [VideoEditorRenderService.renderVideo].
+  /// The returned clip's file lives in the persistent documents dir; if the
+  /// caller does not go on to store it in the library, it must call
+  /// [cleanupFlattenedClip] to avoid leaving an orphan there.
   static Future<DivineVideoClip?> flattenClipForLibrary({
     required DivineVideoClip clip,
     required String renderId,
@@ -88,6 +94,44 @@ class VideoEditorClipLibrarySaveService {
     );
   }
 
+  /// Deletes the files a [flattenClipForLibrary] result left in the documents
+  /// dir when the clip never reached the library — the re-encoded video and,
+  /// when it was freshly extracted, its thumbnail.
+  ///
+  /// The render writes into persistent storage, so nothing reclaims these files
+  /// unless a library row ends up referencing them. Call this on every path
+  /// where the save does not land (render discarded, library write rejected, or
+  /// the save threw) so the documents dir isn't left with permanent orphans.
+  ///
+  /// [keepThumbnailPath] is the source clip's own thumbnail: when frame
+  /// extraction fails, [flattenClipForLibrary] falls back to it, and it is still
+  /// referenced by the live source clip, so it must never be deleted here.
+  static Future<void> cleanupFlattenedClip(
+    DivineVideoClip flattened, {
+    String? keepThumbnailPath,
+  }) async {
+    await _deleteQuietly(flattened.video.file?.path);
+
+    final thumbnailPath = flattened.thumbnailPath;
+    if (thumbnailPath != null && thumbnailPath != keepThumbnailPath) {
+      await _deleteQuietly(thumbnailPath);
+    }
+  }
+
+  static Future<void> _deleteQuietly(String? path) async {
+    if (path == null) return;
+    try {
+      final file = File(path);
+      if (file.existsSync()) await file.delete();
+    } catch (e) {
+      Log.warning(
+        '⚠️ Failed to delete orphaned library-clip file $path: $e',
+        name: 'VideoEditorClipLibrarySaveService',
+        category: LogCategory.video,
+      );
+    }
+  }
+
   /// Wraps [overlays] in the [CompleteParameters] shape the render pipeline
   /// reads, or `null` when there is nothing to bake.
   ///
@@ -106,19 +150,24 @@ class VideoEditorClipLibrarySaveService {
       filterStates: overlays.filterStates,
       tuneAdjustments: overlays.tuneAdjustments,
       bodySize: overlays.bodySize,
-      // The render pipeline reads none of the below for overlays; they are
-      // required constructor args, so they carry inert defaults.
+      // Geometry: the render pipeline *does* read these into its ExportTransform,
+      // so they are deliberately left at identity — a clip's own spatial
+      // transform is already baked into its file, and the aspect-ratio crop
+      // comes from targetAspectRatio in renderVideo. Applying geometry here
+      // would double-transform.
+      rotateTurns: 0,
+      flipX: false,
+      flipY: false,
+      // The render pipeline reads none of the below for an overlay bake; they
+      // are required constructor args, so they carry inert defaults.
       matrixFilterList: const [],
       matrixTuneAdjustmentsList: const [],
       startTime: null,
       endTime: null,
       cropWidth: null,
       cropHeight: null,
-      rotateTurns: 0,
       cropX: null,
       cropY: null,
-      flipX: false,
-      flipY: false,
       image: Uint8List(0),
       isTransformed: false,
       layers: const [],

--- a/mobile/lib/services/video_editor/video_editor_clip_library_save_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_clip_library_save_service.dart
@@ -1,0 +1,152 @@
+// ABOUTME: Flattens one timeline clip into a standalone file for the clip library
+// ABOUTME: Bakes trim/speed/volume plus the overlays over it into a fresh documents-dir clip
+
+import 'dart:typed_data';
+
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/video_editor/editor_overlay_snapshot.dart';
+import 'package:openvine/services/video_editor/video_editor_render_service.dart';
+import 'package:openvine/services/video_thumbnail_service.dart';
+import 'package:pro_image_editor/pro_image_editor.dart' show CompleteParameters;
+import 'package:pro_video_editor/pro_video_editor.dart' show EditorVideo;
+import 'package:unified_logger/unified_logger.dart';
+
+/// Service for saving a single timeline clip to the persistent clip library.
+class VideoEditorClipLibrarySaveService {
+  /// Renders [clip]'s trim window into a standalone file and returns it as a
+  /// fresh [DivineVideoClip] ready to hand to the clip library.
+  ///
+  /// Unlike the editor's own trim-based split (which keeps both halves on the
+  /// shared source file), a library clip must outlive the editing session that
+  /// produced it and be insertable into an unrelated project. So this re-encodes
+  /// rather than carrying a trim window: the output holds *only* the selected
+  /// section, and the returned clip carries no residual trim/speed/volume — the
+  /// [VideoEditorRenderService.renderVideo] pipeline bakes all three in. That is
+  /// what lets the user reuse a moment from a long video without dragging the
+  /// whole source along (#5322).
+  ///
+  /// `reversed` is deliberately dropped rather than copied: a reversed clip's
+  /// `video` already points at reversed content, so the flattened file is
+  /// reversed too and re-flagging it would double-apply on the next render.
+  ///
+  /// The render is uncapped (`maxOutputDuration: null`) because a library clip
+  /// is an intermediate clip the user can still trim, not a final export — the
+  /// same reasoning as `VideoEditorMergeService.mergeClips`.
+  ///
+  /// [overlays] are the layers/filters/tune/blur that were over *this clip*,
+  /// already windowed and rebased to start at zero by
+  /// [EditorOverlaySnapshot.windowedTo]. They get baked into the output too, so
+  /// the saved clip looks the way it looked on the timeline. Pass `null` (or an
+  /// empty snapshot) to render the bare video.
+  ///
+  /// [renderId] keys the native progress/cancel stream.
+  ///
+  /// Returns `null` when the render is cancelled or fails — both already
+  /// surface as a `null` output path from [VideoEditorRenderService.renderVideo].
+  static Future<DivineVideoClip?> flattenClipForLibrary({
+    required DivineVideoClip clip,
+    required String renderId,
+    EditorOverlaySnapshot? overlays,
+  }) async {
+    Log.info(
+      '💾 Flattening clip ${clip.id} for the clip library '
+      '(${overlays?.capturedLayers.length ?? 0} layer(s), '
+      '${overlays?.filterStates.length ?? 0} filter(s))',
+      name: 'VideoEditorClipLibrarySaveService',
+      category: LogCategory.video,
+    );
+
+    // usePersistentStorage writes into the documents dir, which the library
+    // requires: it persists only a basename and resolves it back against
+    // getDocumentsPath(), so a temp-dir file would save and then dangle.
+    final outputPath = await VideoEditorRenderService.renderVideo(
+      // A transition describes a boundary with the *next* clip, which this
+      // render doesn't have — leaving it on would blend the clip into nothing.
+      clips: [clip.copyWith(clearTransition: true)],
+      usePersistentStorage: true,
+      taskId: renderId,
+      maxOutputDuration: null,
+      parameters: _renderParameters(overlays),
+    );
+
+    if (outputPath == null) return null;
+
+    final thumbnail = await _extractThumbnail(outputPath);
+
+    return DivineVideoClip(
+      id: 'clip_library_${DateTime.now().microsecondsSinceEpoch}',
+      video: EditorVideo.file(outputPath),
+      duration: clip.playbackDuration,
+      recordedAt: clip.recordedAt,
+      targetAspectRatio: clip.targetAspectRatio,
+      originalAspectRatio: clip.originalAspectRatio,
+      // Fall back to the source clip's frame when extraction fails; a library
+      // card without any thumbnail is worse than a slightly-off one.
+      thumbnailPath: thumbnail?.path ?? clip.thumbnailPath,
+      thumbnailTimestamp: thumbnail?.timestamp,
+      lensMetadata: clip.lensMetadata,
+    );
+  }
+
+  /// Wraps [overlays] in the [CompleteParameters] shape the render pipeline
+  /// reads, or `null` when there is nothing to bake.
+  ///
+  /// Only the overlay fields are populated. Geometry (crop / rotate / flip) is
+  /// deliberately left at its defaults: a clip's own spatial transform is
+  /// already baked into its file by the transform action, and the aspect-ratio
+  /// crop comes from the clip's `targetAspectRatio` inside `renderVideo`.
+  static CompleteParameters? _renderParameters(
+    EditorOverlaySnapshot? overlays,
+  ) {
+    if (overlays == null || overlays.isEmpty) return null;
+
+    return CompleteParameters(
+      blur: overlays.blur,
+      capturedLayers: overlays.capturedLayers,
+      filterStates: overlays.filterStates,
+      tuneAdjustments: overlays.tuneAdjustments,
+      bodySize: overlays.bodySize,
+      // The render pipeline reads none of the below for overlays; they are
+      // required constructor args, so they carry inert defaults.
+      matrixFilterList: const [],
+      matrixTuneAdjustmentsList: const [],
+      startTime: null,
+      endTime: null,
+      cropWidth: null,
+      cropHeight: null,
+      rotateTurns: 0,
+      cropX: null,
+      cropY: null,
+      flipX: false,
+      flipY: false,
+      image: Uint8List(0),
+      isTransformed: false,
+      layers: const [],
+      originalImageSize: null,
+      temporaryDecodedImageSize: null,
+      editorSize: null,
+    );
+  }
+
+  /// Extracts a representative frame from the freshly rendered [videoPath].
+  ///
+  /// The source clip's own thumbnail can point at a frame the trim window
+  /// excludes, and its timestamp is measured against the source timeline — both
+  /// meaningless for the flattened file, which starts at zero.
+  static Future<ThumbnailFileResult?> _extractThumbnail(
+    String videoPath,
+  ) async {
+    try {
+      return await VideoThumbnailService.extractThumbnail(videoPath: videoPath);
+    } catch (e, stackTrace) {
+      Log.error(
+        '❌ Failed to extract library-clip thumbnail: $e',
+        name: 'VideoEditorClipLibrarySaveService',
+        category: LogCategory.video,
+        error: e,
+        stackTrace: stackTrace,
+      );
+      return null;
+    }
+  }
+}

--- a/mobile/lib/services/video_editor/video_editor_render_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_render_service.dart
@@ -305,6 +305,7 @@ class VideoEditorRenderService {
     model.AspectRatio? aspectRatio,
     CompleteParameters? parameters,
     String? taskId,
+    Duration? maxOutputDuration,
   })?
   renderVideoOverride;
 
@@ -517,6 +518,7 @@ class VideoEditorRenderService {
         aspectRatio: aspectRatio,
         parameters: parameters,
         taskId: taskId,
+        maxOutputDuration: maxOutputDuration,
       );
     }
 

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart
@@ -32,6 +32,7 @@ class _TimelineClipControlsState extends State<TimelineClipControls> {
       clipCount,
       isExtractingAudioCurrentClip,
       isSplittingCurrentClip,
+      isSavingCurrentClipToLibrary,
       isReversed,
     ) = context.select((ClipEditorBloc b) {
       final state = b.state;
@@ -50,6 +51,9 @@ class _TimelineClipControlsState extends State<TimelineClipControls> {
         state.isSplitting &&
             currentClipId != null &&
             state.splittingClipId == currentClipId,
+        state.isSavingClipToLibrary &&
+            currentClipId != null &&
+            state.savingClipToLibraryClipId == currentClipId,
         hasClip && state.clips[index].reversed,
       );
     });
@@ -66,6 +70,8 @@ class _TimelineClipControlsState extends State<TimelineClipControls> {
       onTransform: () => _transformClip(context),
       onExtractAudio: () => _requestExtractAudio(context),
       onReversed: () => _reverseClip(context),
+      onSaveToLibrary: () => _saveClipToLibrary(context),
+      isSavingToLibrary: isSavingCurrentClipToLibrary,
       onMultiSelect: isLastClip ? null : () => _startMultiSelect(context),
       isReversed: isReversed,
       isExtractingAudio: isExtractingAudioCurrentClip,
@@ -188,6 +194,38 @@ class _TimelineClipControlsState extends State<TimelineClipControls> {
       ClipEditorAudioExtractionRequested(
         clipId: state.clips[state.currentClipIndex].id,
         clipTitle: context.l10n.videoEditorClipAudioTitle,
+      ),
+    );
+  }
+
+  Future<void> _saveClipToLibrary(BuildContext context) async {
+    final bloc = context.read<ClipEditorBloc>();
+    final state = bloc.state;
+    if (state.currentClipIndex < 0 ||
+        state.currentClipIndex >= state.clips.length) {
+      return;
+    }
+    final clipId = state.clips[state.currentClipIndex].id;
+
+    // Whatever sits over the clip — text, stickers, drawings, filters, tune,
+    // blur — has to be baked in too, so the saved clip looks the way it looks
+    // on the timeline. Only the editor holds that state, and it hands it over
+    // in CompleteParameters solely on Done, so capture it here; the BLoC then
+    // windows it down to this clip's slice of the timeline.
+    //
+    // No editor means the route is already gone (a gesture that resolved after
+    // the pop). Bail rather than save the bare video: a clip silently missing
+    // the text and filters the user was looking at is worse than no clip.
+    final editor = _editorOrNull(context);
+    if (editor == null) return;
+    final overlays = await editor.captureOverlaySnapshot();
+
+    bloc.add(
+      // Bind the request to this clip so the render still targets the intended
+      // clip even if the selection changes while it runs.
+      ClipEditorSaveClipToLibraryRequested(
+        clipId: clipId,
+        overlays: overlays,
       ),
     );
   }

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart
@@ -33,6 +33,7 @@ class _TimelineClipControlsState extends State<TimelineClipControls> {
       isExtractingAudioCurrentClip,
       isSplittingCurrentClip,
       isSavingCurrentClipToLibrary,
+      isSavingAnyClipToLibrary,
       isReversed,
     ) = context.select((ClipEditorBloc b) {
       final state = b.state;
@@ -43,6 +44,11 @@ class _TimelineClipControlsState extends State<TimelineClipControls> {
       // *this* clip. A split or audio extraction rendering on a different clip
       // (the user can switch clips mid-render) leaves the current clip's
       // actions available.
+      //
+      // Save is the exception: a library re-encode is a heavy render we run one
+      // at a time, so it is disabled on every clip while any save runs. Only
+      // the in-flight clip shows a spinner; the rest show a plain disabled
+      // button, so a tap on another clip's Save can never be silently dropped.
       return (
         state.clips.length,
         state.isExtractingAudio &&
@@ -54,6 +60,7 @@ class _TimelineClipControlsState extends State<TimelineClipControls> {
         state.isSavingClipToLibrary &&
             currentClipId != null &&
             state.savingClipToLibraryClipId == currentClipId,
+        state.isSavingClipToLibrary,
         hasClip && state.clips[index].reversed,
       );
     });
@@ -72,6 +79,7 @@ class _TimelineClipControlsState extends State<TimelineClipControls> {
       onReversed: () => _reverseClip(context),
       onSaveToLibrary: () => _saveClipToLibrary(context),
       isSavingToLibrary: isSavingCurrentClipToLibrary,
+      isSaveToLibraryDisabled: isSavingAnyClipToLibrary,
       onMultiSelect: isLastClip ? null : () => _startMultiSelect(context),
       isReversed: isReversed,
       isExtractingAudio: isExtractingAudioCurrentClip,
@@ -219,6 +227,14 @@ class _TimelineClipControlsState extends State<TimelineClipControls> {
     final editor = _editorOrNull(context);
     if (editor == null) return;
     final overlays = await editor.captureOverlaySnapshot();
+
+    // Capturing the snapshot rasterizes every layer and costs at least a frame,
+    // during which the editor screen can be popped and its bloc closed. Adding
+    // to a closed bloc throws, so bail. Guard on the bloc rather than `mounted`:
+    // leaving edit mode unmounts these controls while the bloc lives on, and
+    // that save should still go through (the scaffold-level listener surfaces
+    // its result).
+    if (bloc.isClosed) return;
 
     bloc.add(
       // Bind the request to this clip so the render still targets the intended

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_controls.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_controls.dart
@@ -18,6 +18,8 @@ class VideoEditorTimelineControls extends StatelessWidget {
     this.onExtractAudio,
     this.isExtractingAudio = false,
     this.isSplitting = false,
+    this.onSaveToLibrary,
+    this.isSavingToLibrary = false,
     this.onMultiSelect,
     this.multiSelectSemanticLabel,
     super.key,
@@ -41,6 +43,12 @@ class VideoEditorTimelineControls extends StatelessWidget {
   /// Split action disabled (rather than removing it) so the control stays in
   /// place instead of confusingly disappearing mid-operation.
   final bool isSplitting;
+
+  /// Saves the active clip to the clip library as a standalone clip.
+  final VoidCallback? onSaveToLibrary;
+
+  /// Whether the active clip is currently being re-encoded for the library.
+  final bool isSavingToLibrary;
   final VoidCallback? onMultiSelect;
 
   /// Overrides the multi-select button's accessibility label. Defaults to the
@@ -154,6 +162,14 @@ class VideoEditorTimelineControls extends StatelessWidget {
                           .videoEditorExtractAudioFromClipSemanticLabel,
                       onPressed: isExtractingAudio ? null : onExtractAudio,
                       isLoading: isExtractingAudio,
+                    ),
+                  if (onSaveToLibrary != null)
+                    _ControlButton(
+                      icon: .save,
+                      label: context.l10n.videoEditorSaveClip,
+                      semanticLabel: context.l10n.videoEditorSaveSelectedClip,
+                      onPressed: isSavingToLibrary ? null : onSaveToLibrary,
+                      isLoading: isSavingToLibrary,
                     ),
                   if (onMultiSelect != null)
                     _ControlButton(

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_controls.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_controls.dart
@@ -20,6 +20,7 @@ class VideoEditorTimelineControls extends StatelessWidget {
     this.isSplitting = false,
     this.onSaveToLibrary,
     this.isSavingToLibrary = false,
+    this.isSaveToLibraryDisabled = false,
     this.onMultiSelect,
     this.multiSelectSemanticLabel,
     super.key,
@@ -48,7 +49,15 @@ class VideoEditorTimelineControls extends StatelessWidget {
   final VoidCallback? onSaveToLibrary;
 
   /// Whether the active clip is currently being re-encoded for the library.
+  /// Shows the Save action as a spinner.
   final bool isSavingToLibrary;
+
+  /// Whether Save should be shown disabled because a library re-encode of some
+  /// (possibly other) clip is already running. Only one save runs at a time, so
+  /// the button is greyed rather than left tappable-but-ignored. Distinct from
+  /// [isSavingToLibrary], which additionally swaps the button for a spinner on
+  /// the clip actually being saved.
+  final bool isSaveToLibraryDisabled;
   final VoidCallback? onMultiSelect;
 
   /// Overrides the multi-select button's accessibility label. Defaults to the
@@ -168,7 +177,9 @@ class VideoEditorTimelineControls extends StatelessWidget {
                       icon: .save,
                       label: context.l10n.videoEditorSaveClip,
                       semanticLabel: context.l10n.videoEditorSaveSelectedClip,
-                      onPressed: isSavingToLibrary ? null : onSaveToLibrary,
+                      onPressed: isSavingToLibrary || isSaveToLibraryDisabled
+                          ? null
+                          : onSaveToLibrary,
                       isLoading: isSavingToLibrary,
                     ),
                   if (onMultiSelect != null)

--- a/mobile/lib/widgets/video_editor/video_editor_scaffold.dart
+++ b/mobile/lib/widgets/video_editor/video_editor_scaffold.dart
@@ -55,7 +55,9 @@ class VideoEditorScaffold extends StatelessWidget {
               child: _ClipMergeResultListener(
                 child: _ClipsRemovedResultListener(
                   child: _AudioExtractionResultListener(
-                    child: _ScaffoldBody(isLoading: isLoading),
+                    child: _ClipLibrarySaveResultListener(
+                      child: _ScaffoldBody(isLoading: isLoading),
+                    ),
                   ),
                 ),
               ),
@@ -403,6 +405,54 @@ class _AudioExtractionResultListener extends StatelessWidget {
     // so undo/redo reverts both the mute and the added track together.
     final updatedTracks = [...editor.stateManager.audioTracks, audioEvent];
     editor.setClipAndAudioState(clips: state.clips, audioTracks: updatedTracks);
+  }
+}
+
+/// Listens to [ClipEditorBloc.state.lastClipLibrarySave] from a widget that
+/// stays mounted for the entire editor session, so the save's outcome still
+/// reaches the user after they leave edit mode or switch clips mid-render.
+///
+/// No history is written: saving to the library copies the clip out of the
+/// session and never mutates the timeline.
+class _ClipLibrarySaveResultListener extends StatelessWidget {
+  const _ClipLibrarySaveResultListener({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<ClipEditorBloc, ClipEditorState>(
+      listenWhen: (prev, curr) =>
+          !identical(prev.lastClipLibrarySave, curr.lastClipLibrarySave) &&
+          curr.lastClipLibrarySave != null,
+      listener: _onClipLibrarySaveResult,
+      child: child,
+    );
+  }
+
+  void _onClipLibrarySaveResult(BuildContext context, ClipEditorState state) {
+    final result = state.lastClipLibrarySave;
+    if (result == null) return;
+
+    switch (result) {
+      case ClipLibrarySaveSuccess():
+        ScaffoldMessenger.of(context).showSnackBar(
+          DivineSnackbarContainer.snackBar(
+            context.l10n.videoEditorClipSavedSuccess,
+          ),
+        );
+      case ClipLibrarySaveDiscarded():
+        // The source clip was deleted while the re-encode ran — the user
+        // discarded what they asked to save, so neither outcome warrants a
+        // snackbar.
+        break;
+      case ClipLibrarySaveFailure():
+        ScaffoldMessenger.of(context).showSnackBar(
+          DivineSnackbarContainer.snackBar(
+            context.l10n.videoEditorClipSaveFailed,
+          ),
+        );
+    }
   }
 }
 

--- a/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
@@ -2,17 +2,22 @@
 // ABOUTME: trimming, and split operations.
 
 import 'dart:async';
+import 'dart:typed_data';
+import 'dart:ui';
 
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/video_editor/editor_overlay_snapshot.dart';
 import 'package:openvine/observability/reportable_error.dart';
 import 'package:openvine/services/audio_extraction_service.dart';
 import 'package:openvine/services/video_editor/video_editor_split_service.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:pro_image_editor/pro_image_editor.dart'
+    show ExportedLayer, Layer;
 import 'package:pro_video_editor/pro_video_editor.dart';
 
 class _MockAudioExtractionService extends Mock
@@ -209,6 +214,38 @@ Future<DivineVideoClip?> _fakeMergeClipsThrow({
   throw StateError('merge boom');
 }
 
+/// Pure-Dart fake of
+/// [VideoEditorClipLibrarySaveService.flattenClipForLibrary]. Returns a fresh
+/// clip carrying no residual trim, as the real re-encode does.
+Future<DivineVideoClip?> _fakeFlattenClipForLibrary({
+  required DivineVideoClip clip,
+  required String renderId,
+  EditorOverlaySnapshot? overlays,
+}) async {
+  return _createClip(
+    id: 'flattened-${clip.id}',
+    duration: clip.playbackDuration,
+  );
+}
+
+/// Fake flatten that fails (render cancelled / null output path).
+Future<DivineVideoClip?> _fakeFlattenClipForLibraryFail({
+  required DivineVideoClip clip,
+  required String renderId,
+  EditorOverlaySnapshot? overlays,
+}) async {
+  return null;
+}
+
+/// Fake flatten that throws — exercises the BLoC's catch / [Reportable] path.
+Future<DivineVideoClip?> _fakeFlattenClipForLibraryThrow({
+  required DivineVideoClip clip,
+  required String renderId,
+  EditorOverlaySnapshot? overlays,
+}) async {
+  throw StateError('flatten boom');
+}
+
 void main() {
   group(ClipEditorBloc, () {
     late List<DivineVideoClip> twoClips;
@@ -243,6 +280,8 @@ void main() {
       ReverseClipFn? reverseClip,
       TransformClipFn? transformClip,
       MergeClipsFn? mergeClips,
+      FlattenClipForLibraryFn? flattenClipForLibrary,
+      SaveClipToLibraryFn? saveClipToLibrary,
     }) {
       return ClipEditorBloc(
         onFinalClipInvalidated: () {},
@@ -251,6 +290,11 @@ void main() {
         reverseClip: reverseClip,
         transformClip: transformClip,
         mergeClips: mergeClips,
+        flattenClipForLibrary: flattenClipForLibrary,
+        // Defaults to "the library rejected it" so a test that never opts in
+        // can't silently pass a save it didn't wire up.
+        saveClipToLibrary:
+            saveClipToLibrary ?? ({required clip}) async => false,
       );
     }
 
@@ -2974,6 +3018,321 @@ void main() {
           );
           expect(bloc.state.isMerging, isFalse);
           expect(bloc.state.isMultiSelectMode, isFalse);
+        },
+      );
+    });
+
+    group('ClipEditorSaveClipToLibraryRequested', () {
+      late List<DivineVideoClip> twoClips;
+      late List<DivineVideoClip> savedToLibrary;
+      late Completer<DivineVideoClip?> flattenCompleter;
+
+      /// Records what the BLoC handed to the library.
+      Future<bool> recordSave({required DivineVideoClip clip}) async {
+        savedToLibrary.add(clip);
+        return true;
+      }
+
+      setUp(() {
+        twoClips = [
+          _createClip(id: 'a', duration: const Duration(seconds: 2)),
+          _createClip(id: 'b', duration: const Duration(seconds: 4)),
+        ];
+        savedToLibrary = [];
+      });
+
+      group('overlay windowing', () {
+        late EditorOverlaySnapshot? forwardedOverlays;
+
+        /// Captures the overlays the BLoC windowed for the render.
+        Future<DivineVideoClip?> recordOverlays({
+          required DivineVideoClip clip,
+          required String renderId,
+          EditorOverlaySnapshot? overlays,
+        }) async {
+          forwardedOverlays = overlays;
+          return _createClip(id: 'flattened-${clip.id}');
+        }
+
+        /// A layer spanning 3s-4s of the editor timeline. Clip 'a' occupies
+        /// 0s-2s and clip 'b' 2s-6s, so this sits over 'b' only — one second in.
+        EditorOverlaySnapshot snapshotWithLayerAt3to4() {
+          return EditorOverlaySnapshot(
+            bodySize: const Size(100, 200),
+            capturedLayers: [
+              ExportedLayer(
+                layer: Layer(
+                  id: 'text',
+                  startTime: const Duration(seconds: 3),
+                  endTime: const Duration(seconds: 4),
+                ),
+                bytes: Uint8List.fromList([1]),
+                logicalSize: const Size(10, 10),
+              ),
+            ],
+          );
+        }
+
+        setUp(() => forwardedOverlays = null);
+
+        blocTest<ClipEditorBloc, ClipEditorState>(
+          'rebases a layer onto the saved clip position on the timeline',
+          build: () => buildBloc(
+            flattenClipForLibrary: recordOverlays,
+            saveClipToLibrary: recordSave,
+          ),
+          seed: () => ClipEditorState(clips: twoClips),
+          act: (bloc) => bloc.add(
+            ClipEditorSaveClipToLibraryRequested(
+              clipId: 'b',
+              overlays: snapshotWithLayerAt3to4(),
+            ),
+          ),
+          verify: (bloc) {
+            // Clip 'b' starts 2s into the composition, so a layer at 3s-4s
+            // must land at 1s-2s of the standalone clip.
+            final layer = forwardedOverlays!.capturedLayers.single.layer;
+            expect(layer.startTime, equals(const Duration(seconds: 1)));
+            expect(layer.endTime, equals(const Duration(seconds: 2)));
+          },
+        );
+
+        blocTest<ClipEditorBloc, ClipEditorState>(
+          'drops a layer that was never over the saved clip',
+          build: () => buildBloc(
+            flattenClipForLibrary: recordOverlays,
+            saveClipToLibrary: recordSave,
+          ),
+          seed: () => ClipEditorState(clips: twoClips),
+          act: (bloc) => bloc.add(
+            ClipEditorSaveClipToLibraryRequested(
+              clipId: 'a',
+              overlays: snapshotWithLayerAt3to4(),
+            ),
+          ),
+          verify: (bloc) {
+            // Clip 'a' is 0s-2s; the layer only shows from 3s.
+            expect(forwardedOverlays!.capturedLayers, isEmpty);
+          },
+        );
+
+        blocTest<ClipEditorBloc, ClipEditorState>(
+          'forwards no overlays when the editor had none to capture',
+          build: () => buildBloc(
+            flattenClipForLibrary: recordOverlays,
+            saveClipToLibrary: recordSave,
+          ),
+          seed: () => ClipEditorState(clips: twoClips),
+          act: (bloc) => bloc.add(
+            const ClipEditorSaveClipToLibraryRequested(clipId: 'a'),
+          ),
+          verify: (bloc) {
+            expect(forwardedOverlays, isNull);
+          },
+        );
+      });
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'stores the flattened clip and emits success',
+        build: () => buildBloc(
+          flattenClipForLibrary: _fakeFlattenClipForLibrary,
+          saveClipToLibrary: recordSave,
+        ),
+        seed: () => ClipEditorState(clips: twoClips),
+        act: (bloc) => bloc.add(
+          const ClipEditorSaveClipToLibraryRequested(clipId: 'a'),
+        ),
+        verify: (bloc) {
+          expect(savedToLibrary.map((c) => c.id), equals(['flattened-a']));
+          expect(bloc.state.lastClipLibrarySave, isA<ClipLibrarySaveSuccess>());
+          expect(bloc.state.isSavingClipToLibrary, isFalse);
+          expect(bloc.state.savingClipToLibraryClipId, isNull);
+        },
+      );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'leaves the timeline untouched — saving only copies to the library',
+        build: () => buildBloc(
+          flattenClipForLibrary: _fakeFlattenClipForLibrary,
+          saveClipToLibrary: recordSave,
+        ),
+        seed: () => ClipEditorState(clips: twoClips, currentClipIndex: 1),
+        act: (bloc) => bloc.add(
+          const ClipEditorSaveClipToLibraryRequested(clipId: 'b'),
+        ),
+        verify: (bloc) {
+          expect(bloc.state.clips.map((c) => c.id), equals(['a', 'b']));
+          expect(bloc.state.currentClipIndex, equals(1));
+        },
+      );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'saves the clip named by the event, not the current selection',
+        build: () => buildBloc(
+          flattenClipForLibrary: _fakeFlattenClipForLibrary,
+          saveClipToLibrary: recordSave,
+        ),
+        seed: () => ClipEditorState(clips: twoClips, currentClipIndex: 1),
+        act: (bloc) => bloc.add(
+          const ClipEditorSaveClipToLibraryRequested(clipId: 'a'),
+        ),
+        verify: (bloc) {
+          expect(savedToLibrary.map((c) => c.id), equals(['flattened-a']));
+        },
+      );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'does nothing when the requested clip does not exist',
+        build: () => buildBloc(
+          flattenClipForLibrary: _fakeFlattenClipForLibrary,
+          saveClipToLibrary: recordSave,
+        ),
+        seed: () => ClipEditorState(clips: twoClips),
+        act: (bloc) => bloc.add(
+          const ClipEditorSaveClipToLibraryRequested(clipId: 'missing'),
+        ),
+        verify: (bloc) {
+          expect(savedToLibrary, isEmpty);
+          expect(bloc.state.lastClipLibrarySave, isNull);
+          expect(bloc.state.isSavingClipToLibrary, isFalse);
+        },
+      );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'emits failure and stores nothing when the re-encode fails',
+        build: () => buildBloc(
+          flattenClipForLibrary: _fakeFlattenClipForLibraryFail,
+          saveClipToLibrary: recordSave,
+        ),
+        seed: () => ClipEditorState(clips: twoClips),
+        act: (bloc) => bloc.add(
+          const ClipEditorSaveClipToLibraryRequested(clipId: 'a'),
+        ),
+        verify: (bloc) {
+          expect(savedToLibrary, isEmpty);
+          expect(bloc.state.lastClipLibrarySave, isA<ClipLibrarySaveFailure>());
+          expect(bloc.state.isSavingClipToLibrary, isFalse);
+        },
+      );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'emits failure when the library rejects the write',
+        build: () => buildBloc(
+          flattenClipForLibrary: _fakeFlattenClipForLibrary,
+          saveClipToLibrary: ({required clip}) async => false,
+        ),
+        seed: () => ClipEditorState(clips: twoClips),
+        act: (bloc) => bloc.add(
+          const ClipEditorSaveClipToLibraryRequested(clipId: 'a'),
+        ),
+        verify: (bloc) {
+          expect(bloc.state.lastClipLibrarySave, isA<ClipLibrarySaveFailure>());
+        },
+      );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'reports the error and emits failure when the re-encode throws',
+        build: () => buildBloc(
+          flattenClipForLibrary: _fakeFlattenClipForLibraryThrow,
+          saveClipToLibrary: recordSave,
+        ),
+        seed: () => ClipEditorState(clips: twoClips),
+        act: (bloc) => bloc.add(
+          const ClipEditorSaveClipToLibraryRequested(clipId: 'a'),
+        ),
+        errors: () => [
+          isA<Reportable<Object>>().having(
+            (r) => r.unwrap(),
+            'unwrap',
+            isA<StateError>(),
+          ),
+        ],
+        verify: (bloc) {
+          expect(savedToLibrary, isEmpty);
+          expect(bloc.state.lastClipLibrarySave, isA<ClipLibrarySaveFailure>());
+          expect(bloc.state.isSavingClipToLibrary, isFalse);
+        },
+      );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'discards the result when the source clip is removed mid-render',
+        build: () => buildBloc(
+          flattenClipForLibrary:
+              ({required clip, required renderId, overlays}) =>
+                  flattenCompleter.future,
+          saveClipToLibrary: recordSave,
+        ),
+        seed: () => ClipEditorState(clips: twoClips),
+        act: (bloc) async {
+          flattenCompleter = Completer<DivineVideoClip?>();
+          bloc.add(const ClipEditorSaveClipToLibraryRequested(clipId: 'a'));
+          // Let the save start (emits isSavingClipToLibrary) and suspend.
+          await Future<void>.delayed(Duration.zero);
+          bloc.add(const ClipEditorClipRemoved('a'));
+          await Future<void>.delayed(Duration.zero);
+          flattenCompleter.complete(
+            _createClip(id: 'flattened-a'),
+          );
+        },
+        verify: (bloc) {
+          // The user deleted the clip they asked to save — storing it anyway
+          // would resurrect it in the library.
+          expect(savedToLibrary, isEmpty);
+          expect(
+            bloc.state.lastClipLibrarySave,
+            isA<ClipLibrarySaveDiscarded>(),
+          );
+          expect(bloc.state.isSavingClipToLibrary, isFalse);
+        },
+      );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'drops a second request while one is in flight (no duplicate copy)',
+        build: () => buildBloc(
+          flattenClipForLibrary:
+              ({required clip, required renderId, overlays}) =>
+                  flattenCompleter.future,
+          saveClipToLibrary: recordSave,
+        ),
+        seed: () => ClipEditorState(clips: twoClips),
+        act: (bloc) async {
+          flattenCompleter = Completer<DivineVideoClip?>();
+          bloc.add(const ClipEditorSaveClipToLibraryRequested(clipId: 'a'));
+          await Future<void>.delayed(Duration.zero);
+          // A double-tap while the first render is still running.
+          bloc.add(const ClipEditorSaveClipToLibraryRequested(clipId: 'a'));
+          await Future<void>.delayed(Duration.zero);
+          flattenCompleter.complete(
+            _createClip(id: 'flattened-a'),
+          );
+          await Future<void>.delayed(Duration.zero);
+        },
+        verify: (bloc) {
+          expect(savedToLibrary.map((c) => c.id), equals(['flattened-a']));
+        },
+      );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'marks the in-flight clip while the re-encode runs',
+        build: () => buildBloc(
+          flattenClipForLibrary:
+              ({required clip, required renderId, overlays}) =>
+                  flattenCompleter.future,
+          saveClipToLibrary: recordSave,
+        ),
+        seed: () => ClipEditorState(clips: twoClips),
+        act: (bloc) async {
+          flattenCompleter = Completer<DivineVideoClip?>();
+          bloc.add(const ClipEditorSaveClipToLibraryRequested(clipId: 'a'));
+          await Future<void>.delayed(Duration.zero);
+          // Assert mid-flight: the controls disable Save for this clip only.
+          expect(bloc.state.isSavingClipToLibrary, isTrue);
+          expect(bloc.state.savingClipToLibraryClipId, equals('a'));
+          flattenCompleter.complete(null);
+        },
+        verify: (bloc) {
+          expect(bloc.state.isSavingClipToLibrary, isFalse);
+          expect(bloc.state.savingClipToLibraryClipId, isNull);
         },
       );
     });

--- a/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
@@ -281,6 +281,7 @@ void main() {
       TransformClipFn? transformClip,
       MergeClipsFn? mergeClips,
       FlattenClipForLibraryFn? flattenClipForLibrary,
+      CleanupFlattenedClipFn? cleanupFlattenedClip,
       SaveClipToLibraryFn? saveClipToLibrary,
     }) {
       return ClipEditorBloc(
@@ -291,6 +292,10 @@ void main() {
         transformClip: transformClip,
         mergeClips: mergeClips,
         flattenClipForLibrary: flattenClipForLibrary,
+        // Defaults to a no-op so tests that don't exercise the non-landing
+        // paths never touch the file system.
+        cleanupFlattenedClip:
+            cleanupFlattenedClip ?? (clip, {keepThumbnailPath}) async {},
         // Defaults to "the library rejected it" so a test that never opts in
         // can't silently pass a save it didn't wire up.
         saveClipToLibrary:
@@ -3325,7 +3330,8 @@ void main() {
           flattenCompleter = Completer<DivineVideoClip?>();
           bloc.add(const ClipEditorSaveClipToLibraryRequested(clipId: 'a'));
           await Future<void>.delayed(Duration.zero);
-          // Assert mid-flight: the controls disable Save for this clip only.
+          // Assert mid-flight: Save is disabled on every clip, and this id
+          // marks which one shows the spinner.
           expect(bloc.state.isSavingClipToLibrary, isTrue);
           expect(bloc.state.savingClipToLibraryClipId, equals('a'));
           flattenCompleter.complete(null);
@@ -3335,6 +3341,102 @@ void main() {
           expect(bloc.state.savingClipToLibraryClipId, isNull);
         },
       );
+
+      group('render id', () {
+        late String? forwardedRenderId;
+
+        setUp(() => forwardedRenderId = null);
+
+        blocTest<ClipEditorBloc, ClipEditorState>(
+          'namespaces the render id so a save cannot cancel a reverse render',
+          build: () => buildBloc(
+            flattenClipForLibrary:
+                ({required clip, required renderId, overlays}) async {
+                  forwardedRenderId = renderId;
+                  return _createClip(id: 'flattened-${clip.id}');
+                },
+            saveClipToLibrary: recordSave,
+          ),
+          seed: () => ClipEditorState(clips: twoClips),
+          act: (bloc) =>
+              bloc.add(const ClipEditorSaveClipToLibraryRequested(clipId: 'a')),
+          verify: (bloc) {
+            // The bare clip id keys the reverse render, which the native layer
+            // cancels on a colliding id — so the save id must be namespaced.
+            expect(forwardedRenderId, equals('a_clip_library_save'));
+          },
+        );
+      });
+
+      group('orphan cleanup', () {
+        late List<DivineVideoClip> cleanedUp;
+
+        /// Records which flattened clips the BLoC asked the service to delete.
+        Future<void> recordCleanup(
+          DivineVideoClip clip, {
+          String? keepThumbnailPath,
+        }) async {
+          cleanedUp.add(clip);
+        }
+
+        setUp(() => cleanedUp = []);
+
+        blocTest<ClipEditorBloc, ClipEditorState>(
+          'deletes the flattened file when the library rejects the write',
+          build: () => buildBloc(
+            flattenClipForLibrary: _fakeFlattenClipForLibrary,
+            cleanupFlattenedClip: recordCleanup,
+            saveClipToLibrary: ({required clip}) async => false,
+          ),
+          seed: () => ClipEditorState(clips: twoClips),
+          act: (bloc) =>
+              bloc.add(const ClipEditorSaveClipToLibraryRequested(clipId: 'a')),
+          verify: (bloc) {
+            // Rejected write leaves a documents-dir file nothing references.
+            expect(cleanedUp.map((c) => c.id), equals(['flattened-a']));
+          },
+        );
+
+        blocTest<ClipEditorBloc, ClipEditorState>(
+          'deletes the flattened file when the source clip was removed',
+          build: () => buildBloc(
+            flattenClipForLibrary:
+                ({required clip, required renderId, overlays}) =>
+                    flattenCompleter.future,
+            cleanupFlattenedClip: recordCleanup,
+            saveClipToLibrary: recordSave,
+          ),
+          seed: () => ClipEditorState(clips: twoClips),
+          act: (bloc) async {
+            flattenCompleter = Completer<DivineVideoClip?>();
+            bloc.add(const ClipEditorSaveClipToLibraryRequested(clipId: 'a'));
+            await Future<void>.delayed(Duration.zero);
+            bloc.add(const ClipEditorClipRemoved('a'));
+            await Future<void>.delayed(Duration.zero);
+            flattenCompleter.complete(_createClip(id: 'flattened-a'));
+          },
+          verify: (bloc) {
+            expect(savedToLibrary, isEmpty);
+            expect(cleanedUp.map((c) => c.id), equals(['flattened-a']));
+          },
+        );
+
+        blocTest<ClipEditorBloc, ClipEditorState>(
+          'keeps the flattened file when the save succeeds',
+          build: () => buildBloc(
+            flattenClipForLibrary: _fakeFlattenClipForLibrary,
+            cleanupFlattenedClip: recordCleanup,
+            saveClipToLibrary: recordSave,
+          ),
+          seed: () => ClipEditorState(clips: twoClips),
+          act: (bloc) =>
+              bloc.add(const ClipEditorSaveClipToLibraryRequested(clipId: 'a')),
+          verify: (bloc) {
+            // Success hands the file to the library, which now references it.
+            expect(cleanedUp, isEmpty);
+          },
+        );
+      });
     });
   });
 }

--- a/mobile/test/models/video_editor/editor_overlay_snapshot_test.dart
+++ b/mobile/test/models/video_editor/editor_overlay_snapshot_test.dart
@@ -1,0 +1,250 @@
+// ABOUTME: Tests for EditorOverlaySnapshot - windowing overlays onto one clip's
+// ABOUTME: slice of the editor timeline.
+
+import 'dart:typed_data';
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/models/video_editor/editor_overlay_snapshot.dart';
+import 'package:pro_image_editor/pro_image_editor.dart';
+
+ExportedLayer _layer({String id = 'l', Duration? start, Duration? end}) {
+  return ExportedLayer(
+    layer: Layer(id: id, startTime: start, endTime: end),
+    bytes: Uint8List.fromList([1, 2, 3]),
+    logicalSize: const Size(10, 10),
+  );
+}
+
+FilterState _filter({String id = 'f', Duration? start, Duration? end}) {
+  return FilterState(
+    id: id,
+    name: id,
+    matrices: [
+      [1.0],
+    ],
+    startTime: start,
+    endTime: end,
+  );
+}
+
+TuneAdjustmentMatrix _tune({String id = 't', Duration? start, Duration? end}) {
+  return TuneAdjustmentMatrix(
+    id: id,
+    value: 1,
+    matrix: const [1.0],
+    startTime: start,
+    endTime: end,
+  );
+}
+
+const _s1 = Duration(seconds: 1);
+const _s2 = Duration(seconds: 2);
+const _s3 = Duration(seconds: 3);
+const _s4 = Duration(seconds: 4);
+const _s5 = Duration(seconds: 5);
+const _s6 = Duration(seconds: 6);
+
+void main() {
+  group(EditorOverlaySnapshot, () {
+    group('isEmpty', () {
+      test('is true with nothing to bake', () {
+        expect(const EditorOverlaySnapshot().isEmpty, isTrue);
+      });
+
+      test('is false when only a blur is set', () {
+        expect(const EditorOverlaySnapshot(blur: 3).isEmpty, isFalse);
+      });
+
+      test('is false when a layer is present', () {
+        expect(
+          EditorOverlaySnapshot(capturedLayers: [_layer()]).isEmpty,
+          isFalse,
+        );
+      });
+    });
+
+    group('windowedTo layers', () {
+      test('keeps a layer inside the window, rebased to zero', () {
+        // Clip occupies 3s-6s; layer sits at 4s-5s over it.
+        final result = EditorOverlaySnapshot(
+          capturedLayers: [_layer(start: _s4, end: _s5)],
+        ).windowedTo(start: _s3, end: _s6);
+
+        expect(result.capturedLayers, hasLength(1));
+        expect(result.capturedLayers.single.layer.startTime, equals(_s1));
+        expect(result.capturedLayers.single.layer.endTime, equals(_s2));
+      });
+
+      test('drops a layer that ends before the window', () {
+        final result = EditorOverlaySnapshot(
+          capturedLayers: [_layer(start: _s1, end: _s2)],
+        ).windowedTo(start: _s3, end: _s6);
+
+        expect(result.capturedLayers, isEmpty);
+      });
+
+      test('drops a layer that starts after the window', () {
+        final result = EditorOverlaySnapshot(
+          capturedLayers: [_layer(start: const Duration(seconds: 7))],
+        ).windowedTo(start: _s3, end: _s6);
+
+        expect(result.capturedLayers, isEmpty);
+      });
+
+      test('drops a layer that only touches the window boundary', () {
+        // Ends exactly where the clip starts — it was never over this clip.
+        final result = EditorOverlaySnapshot(
+          capturedLayers: [_layer(start: _s1, end: _s3)],
+        ).windowedTo(start: _s3, end: _s6);
+
+        expect(result.capturedLayers, isEmpty);
+      });
+
+      test('clamps a layer that starts before the window', () {
+        // Layer runs 1s-4s, clip is 3s-6s → visible for the clip's first second.
+        final result = EditorOverlaySnapshot(
+          capturedLayers: [_layer(start: _s1, end: _s4)],
+        ).windowedTo(start: _s3, end: _s6);
+
+        expect(
+          result.capturedLayers.single.layer.startTime,
+          equals(Duration.zero),
+        );
+        expect(result.capturedLayers.single.layer.endTime, equals(_s1));
+      });
+
+      test('clamps a layer that outlives the window', () {
+        // Layer runs 4s-10s, clip is 3s-6s → visible from 1s to the clip's end.
+        final result = EditorOverlaySnapshot(
+          capturedLayers: [
+            _layer(start: _s4, end: const Duration(seconds: 10)),
+          ],
+        ).windowedTo(start: _s3, end: _s6);
+
+        expect(result.capturedLayers.single.layer.startTime, equals(_s1));
+        expect(result.capturedLayers.single.layer.endTime, equals(_s3));
+      });
+
+      test('binds an unbounded layer to the window', () {
+        // null/null spans the whole composition, so it covers all of the clip.
+        final result = EditorOverlaySnapshot(
+          capturedLayers: [_layer()],
+        ).windowedTo(start: _s3, end: _s6);
+
+        expect(
+          result.capturedLayers.single.layer.startTime,
+          equals(Duration.zero),
+        );
+        expect(result.capturedLayers.single.layer.endTime, equals(_s3));
+      });
+
+      test('carries the rasterized bytes and layout through untouched', () {
+        final source = _layer(start: _s4, end: _s5);
+        final result = EditorOverlaySnapshot(
+          capturedLayers: [source],
+        ).windowedTo(start: _s3, end: _s6);
+
+        expect(result.capturedLayers.single.bytes, same(source.bytes));
+        expect(
+          result.capturedLayers.single.logicalSize,
+          equals(const Size(10, 10)),
+        );
+      });
+
+      test("does not mutate the editor's live layer", () {
+        // Layer.startTime is mutable and this instance belongs to the editor —
+        // rebasing it in place would corrupt the running session.
+        final source = _layer(start: _s4, end: _s5);
+        EditorOverlaySnapshot(
+          capturedLayers: [source],
+        ).windowedTo(start: _s3, end: _s6);
+
+        expect(source.layer.startTime, equals(_s4));
+        expect(source.layer.endTime, equals(_s5));
+      });
+
+      test('keeps only the layers overlapping the window', () {
+        final result = EditorOverlaySnapshot(
+          capturedLayers: [
+            _layer(id: 'before', start: Duration.zero, end: _s1),
+            _layer(id: 'over', start: _s4, end: _s5),
+            _layer(id: 'after', start: const Duration(seconds: 8)),
+          ],
+        ).windowedTo(start: _s3, end: _s6);
+
+        expect(
+          result.capturedLayers.map((l) => l.layer.id),
+          equals(['over']),
+        );
+      });
+    });
+
+    group('windowedTo filters and tune', () {
+      test('windows a filter like a layer', () {
+        final result = EditorOverlaySnapshot(
+          filterStates: [_filter(start: _s4, end: const Duration(seconds: 10))],
+        ).windowedTo(start: _s3, end: _s6);
+
+        expect(result.filterStates.single.startTime, equals(_s1));
+        expect(result.filterStates.single.endTime, equals(_s3));
+      });
+
+      test('drops a filter outside the window', () {
+        final result = EditorOverlaySnapshot(
+          filterStates: [_filter(start: Duration.zero, end: _s1)],
+        ).windowedTo(start: _s3, end: _s6);
+
+        expect(result.filterStates, isEmpty);
+      });
+
+      test('windows a tune adjustment like a layer', () {
+        final result = EditorOverlaySnapshot(
+          tuneAdjustments: [_tune(start: _s1, end: _s4)],
+        ).windowedTo(start: _s3, end: _s6);
+
+        expect(result.tuneAdjustments.single.startTime, equals(Duration.zero));
+        expect(result.tuneAdjustments.single.endTime, equals(_s1));
+      });
+
+      test('drops a tune adjustment outside the window', () {
+        final result = EditorOverlaySnapshot(
+          tuneAdjustments: [
+            _tune(start: const Duration(seconds: 7)),
+          ],
+        ).windowedTo(start: _s3, end: _s6);
+
+        expect(result.tuneAdjustments, isEmpty);
+      });
+    });
+
+    group('windowedTo pass-through', () {
+      test(
+        'carries blur and bodySize through — neither is a timeline value',
+        () {
+          final result = const EditorOverlaySnapshot(
+            blur: 5,
+            bodySize: Size(100, 200),
+          ).windowedTo(start: _s3, end: _s6);
+
+          expect(result.blur, equals(5));
+          expect(result.bodySize, equals(const Size(100, 200)));
+        },
+      );
+
+      test('keeps blur but drops timed overlays for an empty window', () {
+        final result = EditorOverlaySnapshot(
+          capturedLayers: [_layer(start: Duration.zero, end: _s6)],
+          filterStates: [_filter()],
+          blur: 5,
+          bodySize: const Size(100, 200),
+        ).windowedTo(start: _s3, end: _s3);
+
+        expect(result.capturedLayers, isEmpty);
+        expect(result.filterStates, isEmpty);
+        expect(result.blur, equals(5));
+        expect(result.bodySize, equals(const Size(100, 200)));
+      });
+    });
+  });
+}

--- a/mobile/test/models/video_editor/editor_overlay_snapshot_test.dart
+++ b/mobile/test/models/video_editor/editor_overlay_snapshot_test.dart
@@ -16,6 +16,34 @@ ExportedLayer _layer({String id = 'l', Duration? start, Duration? end}) {
   );
 }
 
+ExportedLayer _animatedLayer({
+  String id = 'l',
+  Duration? start,
+  Duration? end,
+  Duration? enterDuration,
+  Duration? exitDuration,
+  List<LayerAnimation> animations = const [],
+}) {
+  return ExportedLayer(
+    layer: Layer(
+      id: id,
+      startTime: start,
+      endTime: end,
+      enterDuration: enterDuration,
+      exitDuration: exitDuration,
+      animations: animations,
+    ),
+    bytes: Uint8List.fromList([1, 2, 3]),
+    logicalSize: const Size(10, 10),
+  );
+}
+
+LayerAnimation _anim(AnimationPhase phase) => LayerAnimation(
+  type: LayerAnimationType.fade,
+  phase: phase,
+  duration: const Duration(milliseconds: 300),
+);
+
 FilterState _filter({String id = 'f', Duration? start, Duration? end}) {
   return FilterState(
     id: id,
@@ -244,6 +272,161 @@ void main() {
         expect(result.filterStates, isEmpty);
         expect(result.blur, equals(5));
         expect(result.bodySize, equals(const Size(100, 200)));
+      });
+    });
+
+    group('windowedTo clamped-edge animations', () {
+      Layer windowedLayer(ExportedLayer source) => EditorOverlaySnapshot(
+        capturedLayers: [source],
+      ).windowedTo(start: _s3, end: _s6).capturedLayers.single.layer;
+
+      test('keeps enter and exit fades for a layer fully inside the clip', () {
+        // 4s-5s sits inside the 3s-6s clip: both edges are the layer's own, so
+        // its fades belong.
+        final layer = windowedLayer(
+          _animatedLayer(
+            start: _s4,
+            end: _s5,
+            enterDuration: const Duration(milliseconds: 200),
+            exitDuration: const Duration(milliseconds: 200),
+          ),
+        );
+
+        expect(layer.enterDuration, equals(const Duration(milliseconds: 200)));
+        expect(layer.exitDuration, equals(const Duration(milliseconds: 200)));
+      });
+
+      test('drops the enter fade when the layer began before the clip', () {
+        // 1s-4s over a 3s-6s clip: the fade-in played at 1s, before the clip.
+        final layer = windowedLayer(
+          _animatedLayer(
+            start: _s1,
+            end: _s4,
+            enterDuration: const Duration(milliseconds: 200),
+            exitDuration: const Duration(milliseconds: 200),
+          ),
+        );
+
+        expect(layer.enterDuration, isNull);
+        // The layer still ends inside the clip, so its exit fade stays.
+        expect(layer.exitDuration, equals(const Duration(milliseconds: 200)));
+      });
+
+      test('drops the exit fade when the layer outlives the clip', () {
+        // 4s-10s over a 3s-6s clip: the fade-out plays at 10s, after the clip.
+        final layer = windowedLayer(
+          _animatedLayer(
+            start: _s4,
+            end: const Duration(seconds: 10),
+            enterDuration: const Duration(milliseconds: 200),
+            exitDuration: const Duration(milliseconds: 200),
+          ),
+        );
+
+        expect(layer.enterDuration, equals(const Duration(milliseconds: 200)));
+        expect(layer.exitDuration, isNull);
+      });
+
+      test('drops both fades for an unbounded layer', () {
+        // null/null spans the whole composition — steadily on screen over the
+        // clip, so neither fade ever played over it.
+        final layer = windowedLayer(
+          _animatedLayer(
+            enterDuration: const Duration(milliseconds: 200),
+            exitDuration: const Duration(milliseconds: 200),
+          ),
+        );
+
+        expect(layer.enterDuration, isNull);
+        expect(layer.exitDuration, isNull);
+      });
+
+      test('drops the animateIn animation when the layer began earlier', () {
+        final layer = windowedLayer(
+          _animatedLayer(
+            start: _s1,
+            end: _s4,
+            animations: [
+              _anim(AnimationPhase.animateIn),
+              _anim(AnimationPhase.animateOut),
+            ],
+          ),
+        );
+
+        expect(
+          layer.animations.map((a) => a.phase),
+          equals([AnimationPhase.animateOut]),
+        );
+      });
+
+      test(
+        'drops the animateOut animation when the layer outlives the clip',
+        () {
+          final layer = windowedLayer(
+            _animatedLayer(
+              start: _s4,
+              end: const Duration(seconds: 10),
+              animations: [
+                _anim(AnimationPhase.animateIn),
+                _anim(AnimationPhase.animateOut),
+              ],
+            ),
+          );
+
+          expect(
+            layer.animations.map((a) => a.phase),
+            equals([AnimationPhase.animateIn]),
+          );
+        },
+      );
+
+      test('drops an animateInOut only when both edges were clamped', () {
+        // Layer 1s-10s spans past both edges of the 3s-6s clip.
+        final bothClamped = windowedLayer(
+          _animatedLayer(
+            start: _s1,
+            end: const Duration(seconds: 10),
+            animations: [_anim(AnimationPhase.animateInOut)],
+          ),
+        );
+        expect(bothClamped.animations, isEmpty);
+
+        // Layer 1s-4s is only clamped at the start, so the inOut phase stays.
+        final oneEdgeClamped = windowedLayer(
+          _animatedLayer(
+            start: _s1,
+            end: _s4,
+            animations: [_anim(AnimationPhase.animateInOut)],
+          ),
+        );
+        expect(
+          oneEdgeClamped.animations.map((a) => a.phase),
+          equals([AnimationPhase.animateInOut]),
+        );
+      });
+
+      test('does not mutate the source layer when stripping animations', () {
+        final source = _animatedLayer(
+          start: _s1,
+          end: const Duration(seconds: 10),
+          enterDuration: const Duration(milliseconds: 200),
+          exitDuration: const Duration(milliseconds: 200),
+          animations: [_anim(AnimationPhase.animateIn)],
+        );
+
+        EditorOverlaySnapshot(
+          capturedLayers: [source],
+        ).windowedTo(start: _s3, end: _s6);
+
+        expect(
+          source.layer.enterDuration,
+          equals(const Duration(milliseconds: 200)),
+        );
+        expect(
+          source.layer.exitDuration,
+          equals(const Duration(milliseconds: 200)),
+        );
+        expect(source.layer.animations, hasLength(1));
       });
     });
   });

--- a/mobile/test/services/video_editor/video_editor_clip_library_save_service_test.dart
+++ b/mobile/test/services/video_editor/video_editor_clip_library_save_service_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Tests for VideoEditorClipLibrarySaveService - flattening one clip
 // ABOUTME: into a standalone library clip via the render pipeline.
 
+import 'dart:io';
 import 'dart:typed_data';
 import 'dart:ui';
 
@@ -356,6 +357,76 @@ void main() {
           );
 
       expect(result, isNull);
+    });
+
+    group('cleanupFlattenedClip', () {
+      late Directory tempDir;
+
+      setUp(
+        () => tempDir = Directory.systemTemp.createTempSync('clip_lib_save'),
+      );
+      tearDown(() {
+        if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+      });
+
+      DivineVideoClip flattenedWith({
+        required String videoPath,
+        String? thumbnailPath,
+      }) {
+        return DivineVideoClip(
+          id: 'clip_library_1',
+          video: EditorVideo.file(videoPath),
+          duration: const Duration(seconds: 2),
+          recordedAt: DateTime(2025),
+          targetAspectRatio: model.AspectRatio.vertical,
+          originalAspectRatio: 9 / 16,
+          thumbnailPath: thumbnailPath,
+        );
+      }
+
+      test(
+        'deletes the rendered video and freshly extracted thumbnail',
+        () async {
+          final video = File('${tempDir.path}/out.mp4')..writeAsBytesSync([1]);
+          final thumb = File('${tempDir.path}/thumb.jpg')
+            ..writeAsBytesSync([1]);
+
+          await VideoEditorClipLibrarySaveService.cleanupFlattenedClip(
+            flattenedWith(videoPath: video.path, thumbnailPath: thumb.path),
+          );
+
+          expect(video.existsSync(), isFalse);
+          expect(thumb.existsSync(), isFalse);
+        },
+      );
+
+      test('keeps a thumbnail it fell back to rather than created', () async {
+        final video = File('${tempDir.path}/out.mp4')..writeAsBytesSync([1]);
+        // Extraction failed, so the flattened clip carries the source clip's
+        // thumbnail — still referenced by the live source clip.
+        final sourceThumb = File('${tempDir.path}/source.jpg')
+          ..writeAsBytesSync([1]);
+
+        await VideoEditorClipLibrarySaveService.cleanupFlattenedClip(
+          flattenedWith(
+            videoPath: video.path,
+            thumbnailPath: sourceThumb.path,
+          ),
+          keepThumbnailPath: sourceThumb.path,
+        );
+
+        expect(video.existsSync(), isFalse);
+        expect(sourceThumb.existsSync(), isTrue);
+      });
+
+      test('tolerates already-missing files', () async {
+        await expectLater(
+          VideoEditorClipLibrarySaveService.cleanupFlattenedClip(
+            flattenedWith(videoPath: '${tempDir.path}/never_written.mp4'),
+          ),
+          completes,
+        );
+      });
     });
   });
 }

--- a/mobile/test/services/video_editor/video_editor_clip_library_save_service_test.dart
+++ b/mobile/test/services/video_editor/video_editor_clip_library_save_service_test.dart
@@ -1,0 +1,361 @@
+// ABOUTME: Tests for VideoEditorClipLibrarySaveService - flattening one clip
+// ABOUTME: into a standalone library clip via the render pipeline.
+
+import 'dart:typed_data';
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart' as model show AspectRatio;
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/video_editor/editor_overlay_snapshot.dart';
+import 'package:openvine/services/video_editor/video_editor_clip_library_save_service.dart';
+import 'package:openvine/services/video_editor/video_editor_render_service.dart';
+import 'package:pro_image_editor/pro_image_editor.dart'
+    show CompleteParameters, ExportedLayer, FilterState, Layer;
+import 'package:pro_video_editor/pro_video_editor.dart';
+
+DivineVideoClip _createClip({
+  String id = 'a',
+  Duration duration = const Duration(seconds: 3),
+  Duration trimStart = Duration.zero,
+  Duration trimEnd = Duration.zero,
+  double? playbackSpeed,
+  bool reversed = false,
+  double volume = 1,
+  String? thumbnailPath,
+}) {
+  return DivineVideoClip(
+    id: id,
+    video: EditorVideo.file('/path/$id.mp4'),
+    duration: duration,
+    recordedAt: DateTime(2025),
+    targetAspectRatio: model.AspectRatio.vertical,
+    originalAspectRatio: 9 / 16,
+    trimStart: trimStart,
+    trimEnd: trimEnd,
+    playbackSpeed: playbackSpeed,
+    reversed: reversed,
+    volume: volume,
+    thumbnailPath: thumbnailPath,
+  );
+}
+
+void main() {
+  group(VideoEditorClipLibrarySaveService, () {
+    tearDown(() {
+      VideoEditorRenderService.renderVideoOverride = null;
+    });
+
+    test(
+      'renders the source clip and returns it as a fresh library clip',
+      () async {
+        List<DivineVideoClip>? forwardedClips;
+        String? forwardedTaskId;
+        bool? forwardedPersistent;
+        VideoEditorRenderService.renderVideoOverride =
+            ({
+              required clips,
+              required usePersistentStorage,
+              aspectRatio,
+              parameters,
+              taskId,
+              maxOutputDuration,
+            }) async {
+              forwardedClips = clips;
+              forwardedTaskId = taskId;
+              forwardedPersistent = usePersistentStorage;
+              return '/documents/divine_1.mp4';
+            };
+
+        final clip = _createClip(trimStart: const Duration(seconds: 2));
+        final result =
+            await VideoEditorClipLibrarySaveService.flattenClipForLibrary(
+              clip: clip,
+              renderId: 'save-1',
+            );
+
+        expect(forwardedClips?.single.id, equals(clip.id));
+        expect(
+          forwardedClips?.single.trimStart,
+          equals(const Duration(seconds: 2)),
+          reason: 'the render must still see the trim window to bake it in',
+        );
+        expect(forwardedTaskId, equals('save-1'));
+        expect(result, isNotNull);
+        expect(result!.video.file?.path, equals('/documents/divine_1.mp4'));
+        expect(result.id, isNot(equals(clip.id)));
+        expect(result.targetAspectRatio, equals(model.AspectRatio.vertical));
+        expect(
+          forwardedPersistent,
+          isTrue,
+          reason:
+              'the library resolves clips against the documents dir, so a '
+              'temp-dir render would save and then dangle',
+        );
+      },
+    );
+
+    test('bakes the edits in rather than carrying them on the clip', () async {
+      VideoEditorRenderService.renderVideoOverride =
+          ({
+            required clips,
+            required usePersistentStorage,
+            aspectRatio,
+            parameters,
+            taskId,
+            maxOutputDuration,
+          }) async => '/documents/divine_1.mp4';
+
+      final result =
+          await VideoEditorClipLibrarySaveService.flattenClipForLibrary(
+            clip: _createClip(
+              duration: const Duration(seconds: 10),
+              trimStart: const Duration(seconds: 2),
+              trimEnd: const Duration(seconds: 3),
+              playbackSpeed: 2,
+              reversed: true,
+              volume: 0.5,
+            ),
+            renderId: 'save-1',
+          );
+
+      // The render pipeline applies trim/speed/volume, and a reversed clip's
+      // file is already reversed — re-flagging any of these would double-apply
+      // them the next time the library clip is rendered.
+      expect(result!.trimStart, equals(Duration.zero));
+      expect(result.trimEnd, equals(Duration.zero));
+      expect(result.playbackSpeed, isNull);
+      expect(result.reversed, isFalse);
+      expect(result.volume, equals(1.0));
+      expect(result.minTrimStart, equals(Duration.zero));
+    });
+
+    test(
+      'sizes the library clip to the trimmed section, not the source',
+      () async {
+        VideoEditorRenderService.renderVideoOverride =
+            ({
+              required clips,
+              required usePersistentStorage,
+              aspectRatio,
+              parameters,
+              taskId,
+              maxOutputDuration,
+            }) async => '/documents/divine_1.mp4';
+
+        // A 10s source trimmed to its middle 5s.
+        final result =
+            await VideoEditorClipLibrarySaveService.flattenClipForLibrary(
+              clip: _createClip(
+                duration: const Duration(seconds: 10),
+                trimStart: const Duration(seconds: 2),
+                trimEnd: const Duration(seconds: 3),
+              ),
+              renderId: 'save-1',
+            );
+
+        expect(result!.duration, equals(const Duration(seconds: 5)));
+      },
+    );
+
+    test('accounts for playback speed in the saved duration', () async {
+      VideoEditorRenderService.renderVideoOverride =
+          ({
+            required clips,
+            required usePersistentStorage,
+            aspectRatio,
+            parameters,
+            taskId,
+            maxOutputDuration,
+          }) async => '/documents/divine_1.mp4';
+
+      // 8s of source at 2x plays back in 4s, which is what lands on disk.
+      final result =
+          await VideoEditorClipLibrarySaveService.flattenClipForLibrary(
+            clip: _createClip(
+              duration: const Duration(seconds: 8),
+              playbackSpeed: 2,
+            ),
+            renderId: 'save-1',
+          );
+
+      expect(result!.duration, equals(const Duration(seconds: 4)));
+    });
+
+    test('renders uncapped so a long section is not truncated', () async {
+      var capWasSet = true;
+      VideoEditorRenderService.renderVideoOverride =
+          ({
+            required clips,
+            required usePersistentStorage,
+            aspectRatio,
+            parameters,
+            taskId,
+            maxOutputDuration,
+          }) async {
+            capWasSet = maxOutputDuration != null;
+            return '/documents/divine_1.mp4';
+          };
+
+      await VideoEditorClipLibrarySaveService.flattenClipForLibrary(
+        clip: _createClip(duration: const Duration(seconds: 10)),
+        renderId: 'save-1',
+      );
+
+      // The whole point of #5322 is reusing e.g. a 10s section of a long
+      // video; the ~6.3s cap belongs to the final export, not to a clip the
+      // user can still trim.
+      expect(
+        capWasSet,
+        isFalse,
+        reason: 'a capped render silently truncates the saved section',
+      );
+    });
+
+    test('keeps the source thumbnail when extraction yields nothing', () async {
+      VideoEditorRenderService.renderVideoOverride =
+          ({
+            required clips,
+            required usePersistentStorage,
+            aspectRatio,
+            parameters,
+            taskId,
+            maxOutputDuration,
+          }) async => '/documents/divine_1.mp4';
+
+      // The rendered file does not exist here, so extraction returns null —
+      // the library card must still get a frame rather than none.
+      final result =
+          await VideoEditorClipLibrarySaveService.flattenClipForLibrary(
+            clip: _createClip(thumbnailPath: '/documents/thumb_a.jpg'),
+            renderId: 'save-1',
+          );
+
+      expect(result!.thumbnailPath, equals('/documents/thumb_a.jpg'));
+    });
+
+    test('bakes the overlays over the clip into the render', () async {
+      CompleteParameters? forwardedParameters;
+      VideoEditorRenderService.renderVideoOverride =
+          ({
+            required clips,
+            required usePersistentStorage,
+            aspectRatio,
+            parameters,
+            taskId,
+            maxOutputDuration,
+          }) async {
+            forwardedParameters = parameters;
+            return '/documents/divine_1.mp4';
+          };
+
+      await VideoEditorClipLibrarySaveService.flattenClipForLibrary(
+        clip: _createClip(),
+        renderId: 'save-1',
+        overlays: EditorOverlaySnapshot(
+          bodySize: const Size(100, 200),
+          blur: 4,
+          capturedLayers: [
+            ExportedLayer(
+              layer: Layer(id: 'text'),
+              bytes: Uint8List.fromList([1]),
+              logicalSize: const Size(10, 10),
+            ),
+          ],
+          filterStates: [
+            FilterState(
+              id: 'sepia',
+              name: 'sepia',
+              matrices: [
+                [1.0],
+              ],
+            ),
+          ],
+        ),
+      );
+
+      // Without bodySize the render silently skips every layer, so it has to
+      // travel with them.
+      expect(forwardedParameters, isNotNull);
+      expect(forwardedParameters!.bodySize, equals(const Size(100, 200)));
+      expect(forwardedParameters!.capturedLayers, hasLength(1));
+      expect(forwardedParameters!.filterStates, hasLength(1));
+      expect(forwardedParameters!.blur, equals(4));
+    });
+
+    test('sends no parameters when there are no overlays', () async {
+      var parametersWereSent = true;
+      VideoEditorRenderService.renderVideoOverride =
+          ({
+            required clips,
+            required usePersistentStorage,
+            aspectRatio,
+            parameters,
+            taskId,
+            maxOutputDuration,
+          }) async {
+            parametersWereSent = parameters != null;
+            return '/documents/divine_1.mp4';
+          };
+
+      await VideoEditorClipLibrarySaveService.flattenClipForLibrary(
+        clip: _createClip(),
+        renderId: 'save-1',
+        overlays: const EditorOverlaySnapshot(bodySize: Size(100, 200)),
+      );
+
+      expect(parametersWereSent, isFalse);
+    });
+
+    test(
+      'drops the transition — it belongs to a boundary this clip lost',
+      () async {
+        List<DivineVideoClip>? forwardedClips;
+        VideoEditorRenderService.renderVideoOverride =
+            ({
+              required clips,
+              required usePersistentStorage,
+              aspectRatio,
+              parameters,
+              taskId,
+              maxOutputDuration,
+            }) async {
+              forwardedClips = clips;
+              return '/documents/divine_1.mp4';
+            };
+
+        final clip = _createClip().copyWith(
+          transition: const ClipTransition(type: ClipTransitionType.dissolve),
+        );
+
+        await VideoEditorClipLibrarySaveService.flattenClipForLibrary(
+          clip: clip,
+          renderId: 'save-1',
+        );
+
+        // Rendering alone, there is no next clip to blend into.
+        expect(forwardedClips?.single.transition, isNull);
+      },
+    );
+
+    test('returns null when the render fails or is cancelled', () async {
+      VideoEditorRenderService.renderVideoOverride =
+          ({
+            required clips,
+            required usePersistentStorage,
+            aspectRatio,
+            parameters,
+            taskId,
+            maxOutputDuration,
+          }) async => null;
+
+      final result =
+          await VideoEditorClipLibrarySaveService.flattenClipForLibrary(
+            clip: _createClip(),
+            renderId: 'save-1',
+          );
+
+      expect(result, isNull);
+    });
+  });
+}

--- a/mobile/test/services/video_editor/video_editor_merge_service_test.dart
+++ b/mobile/test/services/video_editor/video_editor_merge_service_test.dart
@@ -39,6 +39,7 @@ void main() {
             aspectRatio,
             parameters,
             taskId,
+            maxOutputDuration,
           }) async {
             called = true;
             return '/out.mp4';
@@ -66,6 +67,7 @@ void main() {
               aspectRatio,
               parameters,
               taskId,
+              maxOutputDuration,
             }) async {
               forwardedClips = clips;
               forwardedTaskId = taskId;
@@ -96,6 +98,7 @@ void main() {
     );
 
     test('keeps the full merged duration uncapped (no export limit)', () async {
+      var capWasSet = true;
       VideoEditorRenderService.renderVideoOverride =
           ({
             required clips,
@@ -103,7 +106,11 @@ void main() {
             aspectRatio,
             parameters,
             taskId,
-          }) async => '/documents/merged.mp4';
+            maxOutputDuration,
+          }) async {
+            capWasSet = maxOutputDuration != null;
+            return '/documents/merged.mp4';
+          };
 
       // 5s + 5s = 10s, well beyond the ~6.3s final-export cap, which must not
       // truncate an intermediate merged clip.
@@ -116,6 +123,13 @@ void main() {
       );
 
       expect(result!.duration, equals(const Duration(seconds: 10)));
+      expect(
+        capWasSet,
+        isFalse,
+        reason:
+            'the render must be uncapped, or the file is truncated at '
+            'the export limit even though the clip claims the full duration',
+      );
     });
 
     test('accounts for playback speed when summing duration', () async {
@@ -126,6 +140,7 @@ void main() {
             aspectRatio,
             parameters,
             taskId,
+            maxOutputDuration,
           }) async => '/documents/merged.mp4';
 
       // 4s at 2x = 2s playback; 2s at 1x = 2s → 4s total.
@@ -152,6 +167,7 @@ void main() {
             aspectRatio,
             parameters,
             taskId,
+            maxOutputDuration,
           }) async => null;
 
       final result = await VideoEditorMergeService.mergeClips(

--- a/mobile/test/services/video_editor_render_service_test.dart
+++ b/mobile/test/services/video_editor_render_service_test.dart
@@ -210,6 +210,7 @@ void main() {
               aspectRatio,
               parameters,
               taskId,
+              maxOutputDuration,
             }) async {
               expect(usePersistentStorage, isTrue);
               expect(taskId, equals('composite-sequence-test'));

--- a/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls_test.dart
@@ -367,5 +367,61 @@ void main() {
         () => bloc.add(const ClipEditorMultiSelectStarted('clip-1')),
       ).called(1);
     });
+
+    testWidgets('library save is a no-op when the editor scope is gone', (
+      tester,
+    ) async {
+      final controls = await pumpWithMissingEditorScope(tester);
+
+      controls.onSaveToLibrary?.call();
+      await tester.pumpAndSettle();
+
+      // The overlays over the clip can only be read off the editor. With it
+      // gone they are unreachable, and saving the bare video would hand the
+      // user a clip missing the text/filters they were looking at.
+      verifyNever(
+        () => bloc.add(any(that: isA<ClipEditorSaveClipToLibraryRequested>())),
+      );
+    });
+
+    testWidgets('Save shows a spinner while this clip is being saved', (
+      tester,
+    ) async {
+      when(() => bloc.state).thenReturn(
+        ClipEditorState(
+          clips: [clip('clip-1')],
+          isSavingClipToLibrary: true,
+          savingClipToLibraryClipId: 'clip-1',
+        ),
+      );
+
+      await tester.pumpWidget(build());
+
+      final controls = tester.widget<VideoEditorTimelineControls>(
+        find.byType(VideoEditorTimelineControls),
+      );
+      expect(controls.isSavingToLibrary, isTrue);
+    });
+
+    testWidgets('Save stays available while a different clip is saving', (
+      tester,
+    ) async {
+      when(() => bloc.state).thenReturn(
+        ClipEditorState(
+          clips: [clip('clip-1'), clip('clip-2')],
+          currentClipIndex: 1,
+          isSavingClipToLibrary: true,
+          savingClipToLibraryClipId: 'clip-1',
+        ),
+      );
+
+      await tester.pumpWidget(build());
+
+      final controls = tester.widget<VideoEditorTimelineControls>(
+        find.byType(VideoEditorTimelineControls),
+      );
+      expect(controls.onSaveToLibrary, isNotNull);
+      expect(controls.isSavingToLibrary, isFalse);
+    });
   });
 }

--- a/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls_test.dart
@@ -16,8 +16,9 @@ import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_timeline_controls.dart';
-import 'package:pro_image_editor/pro_image_editor.dart'
-    show ProImageEditorState;
+import 'package:pro_image_editor/features/main_editor/services/sizes_manager.dart'
+    show SizesManager;
+import 'package:pro_image_editor/pro_image_editor.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 
 class _MockClipEditorBloc extends MockBloc<ClipEditorEvent, ClipEditorState>
@@ -26,6 +27,16 @@ class _MockClipEditorBloc extends MockBloc<ClipEditorEvent, ClipEditorState>
 class _MockTimelineOverlayBloc
     extends MockBloc<TimelineOverlayEvent, TimelineOverlayState>
     implements TimelineOverlayBloc {}
+
+class _MockProImageEditorState extends Mock implements ProImageEditorState {
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
+      '_MockProImageEditorState';
+}
+
+class _MockStateManager extends Mock implements StateManager {}
+
+class _MockSizesManager extends Mock implements SizesManager {}
 
 void main() {
   group(TimelineClipControls, () {
@@ -41,6 +52,8 @@ void main() {
       when(
         () => bloc.stream,
       ).thenAnswer((_) => const Stream<ClipEditorState>.empty());
+      // The save dispatch guards on `bloc.isClosed` after the capture await.
+      when(() => bloc.isClosed).thenReturn(false);
     });
 
     Widget build() {
@@ -384,6 +397,91 @@ void main() {
       );
     });
 
+    testWidgets(
+      'captures overlays and dispatches a save for the current clip',
+      (tester) async {
+        when(() => bloc.state).thenReturn(
+          ClipEditorState(clips: [clip('clip-1'), clip('clip-2')]),
+        );
+        final overlayBloc = _MockTimelineOverlayBloc();
+        when(() => overlayBloc.state).thenReturn(const TimelineOverlayState());
+        when(
+          () => overlayBloc.stream,
+        ).thenAnswer((_) => const Stream<TimelineOverlayState>.empty());
+
+        final editor = _MockProImageEditorState();
+        final stateManager = _MockStateManager();
+        final sizesManager = _MockSizesManager();
+        when(
+          () => editor.captureAllLayersWithMeta(
+            basePixelRatio: any(named: 'basePixelRatio'),
+          ),
+        ).thenAnswer((_) async => <ExportedLayer>[]);
+        when(() => editor.stateManager).thenReturn(stateManager);
+        when(() => editor.sizesManager).thenReturn(sizesManager);
+        when(() => editor.configs).thenReturn(const ProImageEditorConfigs());
+        when(() => stateManager.activeFilters).thenReturn(const []);
+        when(() => stateManager.activeTuneAdjustments).thenReturn(const []);
+        when(() => stateManager.activeBlur).thenReturn(0);
+        when(() => sizesManager.bodySize).thenReturn(const Size(400, 600));
+
+        await tester.pumpWidget(
+          ProviderScope(
+            child: MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(
+                body: VideoEditorScope(
+                  editorKey: GlobalKey<ProImageEditorState>(),
+                  editorOverride: editor,
+                  removeAreaKey: GlobalKey(),
+                  originalClipAspectRatio: 9 / 16,
+                  bodySizeNotifier: ValueNotifier(const Size(400, 600)),
+                  zoomMatrixNotifier: ValueNotifier(Matrix4.identity()),
+                  fromLibrary: false,
+                  onOpenCamera: () {},
+                  onOpenClipsEditor: () {},
+                  onAddStickers: () {},
+                  onOpenMusicLibrary: () {},
+                  onOpenVoiceOver: () {},
+                  onAddEditTextLayer: ([layer]) async => null,
+                  child: MultiBlocProvider(
+                    providers: [
+                      BlocProvider<ClipEditorBloc>.value(value: bloc),
+                      BlocProvider<TimelineOverlayBloc>.value(
+                        value: overlayBloc,
+                      ),
+                    ],
+                    child: TimelineClipControls(
+                      playheadPosition: ValueNotifier(Duration.zero),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        final controls = tester.widget<VideoEditorTimelineControls>(
+          find.byType(VideoEditorTimelineControls),
+        );
+        controls.onSaveToLibrary!();
+        await tester.pumpAndSettle();
+
+        // The dispatch binds the *current* clip and carries a captured (never
+        // null) overlay snapshot, so a regression that binds the wrong clip or
+        // drops the overlays fails here.
+        final captured = verify(
+          () => bloc.add(
+            captureAny(that: isA<ClipEditorSaveClipToLibraryRequested>()),
+          ),
+        ).captured;
+        final event = captured.single as ClipEditorSaveClipToLibraryRequested;
+        expect(event.clipId, equals('clip-1'));
+        expect(event.overlays, isNotNull);
+      },
+    );
+
     testWidgets('Save shows a spinner while this clip is being saved', (
       tester,
     ) async {
@@ -403,7 +501,7 @@ void main() {
       expect(controls.isSavingToLibrary, isTrue);
     });
 
-    testWidgets('Save stays available while a different clip is saving', (
+    testWidgets('Save is disabled without a spinner while another clip saves', (
       tester,
     ) async {
       when(() => bloc.state).thenReturn(
@@ -420,8 +518,11 @@ void main() {
       final controls = tester.widget<VideoEditorTimelineControls>(
         find.byType(VideoEditorTimelineControls),
       );
-      expect(controls.onSaveToLibrary, isNotNull);
+      // Only one re-encode runs at a time, so Save on clip-2 is greyed rather
+      // than tappable-but-ignored: no spinner (that clip isn't the one saving),
+      // but disabled so the tap can't be silently dropped by the bloc.
       expect(controls.isSavingToLibrary, isFalse);
+      expect(controls.isSaveToLibraryDisabled, isTrue);
     });
   });
 }

--- a/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_controls_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_controls_test.dart
@@ -216,5 +216,76 @@ void main() {
       await tester.pump();
       expect(speedCount, equals(1));
     });
+
+    testWidgets('hides Save when onSaveToLibrary is not provided', (
+      tester,
+    ) async {
+      final l10n = lookupAppLocalizations(const Locale('en'));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: VideoEditorTimelineControls(onDone: () {})),
+        ),
+      );
+
+      expect(find.text(l10n.videoEditorSaveClip), findsNothing);
+    });
+
+    testWidgets('invokes onSaveToLibrary when idle', (tester) async {
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      var saveCount = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: VideoEditorTimelineControls(
+              onSaveToLibrary: () => saveCount++,
+              onDone: () {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text(l10n.videoEditorSaveClip), findsOneWidget);
+      await tester.tap(
+        find.bySemanticsLabel(l10n.videoEditorSaveSelectedClip),
+      );
+      await tester.pump();
+      expect(saveCount, equals(1));
+    });
+
+    testWidgets('swaps Save for a spinner while saving to the library', (
+      tester,
+    ) async {
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      var saveCount = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: VideoEditorTimelineControls(
+              onSaveToLibrary: () => saveCount++,
+              isSavingToLibrary: true,
+              onDone: () {},
+            ),
+          ),
+        ),
+      );
+
+      // The label stays put so the control set doesn't reshuffle mid-render,
+      // but the button is replaced by the spinner and can't be tapped again.
+      expect(find.text(l10n.videoEditorSaveClip), findsOneWidget);
+      expect(
+        find.bySemanticsLabel(l10n.videoEditorSaveSelectedClip),
+        findsNothing,
+      );
+      expect(saveCount, equals(0));
+    });
   });
 }

--- a/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_volume_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_volume_test.dart
@@ -21,7 +21,10 @@ void main() {
     late ValueNotifier<double?> volumePreviewNotifier;
 
     setUp(() {
-      clipBloc = ClipEditorBloc(onFinalClipInvalidated: () {});
+      clipBloc = ClipEditorBloc(
+        onFinalClipInvalidated: () {},
+        saveClipToLibrary: ({required clip}) async => false,
+      );
       overlayBloc = TimelineOverlayBloc();
       volumePreviewNotifier = ValueNotifier<double?>(null);
     });

--- a/mobile/test/widgets/video_editor/video_editor_scaffold_test.dart
+++ b/mobile/test/widgets/video_editor/video_editor_scaffold_test.dart
@@ -314,6 +314,78 @@ void main() {
       },
     );
 
+    testWidgets('shows a snackbar when a clip is saved to the library', (
+      tester,
+    ) async {
+      final clipBloc = _MockClipEditorBloc();
+      final successState = ClipEditorState(
+        lastClipLibrarySave: ClipLibrarySaveSuccess(),
+      );
+
+      when(() => clipBloc.state).thenReturn(const ClipEditorState());
+      whenListen(
+        clipBloc,
+        Stream<ClipEditorState>.fromIterable([successState]),
+        initialState: const ClipEditorState(),
+      );
+
+      await tester.pumpWidget(
+        buildWidget(isLoading: true, clipBlocOverride: clipBloc),
+      );
+      await tester.pump();
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      expect(find.text(l10n.videoEditorClipSavedSuccess), findsOneWidget);
+    });
+
+    testWidgets('shows a snackbar when a clip library save fails', (
+      tester,
+    ) async {
+      final clipBloc = _MockClipEditorBloc();
+      final failureState = ClipEditorState(
+        lastClipLibrarySave: ClipLibrarySaveFailure(),
+      );
+
+      when(() => clipBloc.state).thenReturn(const ClipEditorState());
+      whenListen(
+        clipBloc,
+        Stream<ClipEditorState>.fromIterable([failureState]),
+        initialState: const ClipEditorState(),
+      );
+
+      await tester.pumpWidget(
+        buildWidget(isLoading: true, clipBlocOverride: clipBloc),
+      );
+      await tester.pump();
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      expect(find.text(l10n.videoEditorClipSaveFailed), findsOneWidget);
+    });
+
+    testWidgets(
+      'ignores a discarded clip library save without a snackbar',
+      (tester) async {
+        final clipBloc = _MockClipEditorBloc();
+        final discardedState = ClipEditorState(
+          lastClipLibrarySave: ClipLibrarySaveDiscarded(),
+        );
+
+        when(() => clipBloc.state).thenReturn(const ClipEditorState());
+        whenListen(
+          clipBloc,
+          Stream<ClipEditorState>.fromIterable([discardedState]),
+          initialState: const ClipEditorState(),
+        );
+
+        await tester.pumpWidget(
+          buildWidget(isLoading: true, clipBlocOverride: clipBloc),
+        );
+        await tester.pump();
+
+        expect(find.byType(SnackBar), findsNothing);
+      },
+    );
+
     testWidgets(
       'ignores discarded extraction results without snackbar or history write',
       (tester) async {

--- a/mobile/test/widgets/video_editor/video_editor_scaffold_test.dart
+++ b/mobile/test/widgets/video_editor/video_editor_scaffold_test.dart
@@ -46,7 +46,10 @@ void main() {
       prefs = await SharedPreferences.getInstance();
       mainBloc = VideoEditorMainBloc();
       overlayBloc = TimelineOverlayBloc();
-      clipBloc = ClipEditorBloc(onFinalClipInvalidated: () {});
+      clipBloc = ClipEditorBloc(
+        onFinalClipInvalidated: () {},
+        saveClipToLibrary: ({required clip}) async => false,
+      );
       filterBloc = VideoEditorFilterBloc();
     });
 


### PR DESCRIPTION
## Description

Brings back the editor-side **Save clip** that #3246 removed with the deprecated clip-editor. Selecting a clip on the timeline and tapping Save re-encodes its trimmed section — with its edits and overlays baked in — into a standalone clip in the clip library, so a moment from a long video can be reused in an unrelated project without importing the whole source.

The library plumbing survived the earlier removal (`ClipManagerNotifier.saveClipToLibrary` is still live for the recorder), as did the l10n keys — already translated in all 18 locales and unused since — so no new translation work.

### Re-encode, not a trim-based cut

Unlike the trim-based split in #6134 (both halves share the source file), a library clip has to **outlive** the session that produced it and be dropped into an unrelated project. Sharing the source file would mean carrying a 5-minute video around to reuse ten seconds of it — the opposite of what the issue asks for. So this re-encodes: the output holds only the selected section, and the returned clip carries no residual trim/speed/volume/reverse — the render pipeline bakes all of it in. It runs uncapped (`maxOutputDuration: null`) because the ~6.3s limit belongs to the final export, not to a clip the user can still trim.

### Overlays are baked in too

Whatever sits over the clip — text, stickers, drawings, filters, tune, blur — is baked in, so the saved clip looks the way it looked on the timeline. Overlay time windows are authored against the *editor timeline* and composited onto the whole composition after concat, so `EditorOverlaySnapshot.windowedTo` slices them down to the clip's own span: overlays that never covered it are dropped, overlays that partly covered it are clamped, and the survivors are rebased to start at zero. The editor only hands over `CompleteParameters` on Done, so the widget layer captures the overlay state on demand via a new `ProImageEditorState.captureOverlaySnapshot()`.

A layer at 3s–4s of the timeline, saved from a clip that occupies 2s–6s, lands at 1s–2s of the standalone clip; the same layer, saved from a clip at 0s–2s, is dropped.

### Layering

- `UI` (`TimelineClipControls`) captures the overlay snapshot off the editor and dispatches an event; bails if the editor route is already gone, so a save can never silently drop the text/filters the user was looking at.
- `BLoC` (`ClipEditorBloc`) windows the overlays to the clip's slice, drives the re-encode through injectable seams, and persists via a callback (the library sits behind Riverpod, which the BLoC can't reach — same transition seam that brings the clip list in). Timeline is never mutated.
- `Service` (`VideoEditorClipLibrarySaveService`) flattens one clip to a fresh documents-dir file, closest precedent being `VideoEditorMergeService`.

Also extends the `renderVideoOverride` test seam with `maxOutputDuration`: without it no test can see whether a render is capped, and a lost `maxOutputDuration: null` would silently truncate a saved section at 6.3s — exactly the case the issue is about. It makes the merge service's uncapped guarantee assertable too.

**Related Issue:** Closes #5322 (part of #4341)

## Out of Scope

- The main editor's global crop/rotate/flip is intentionally not re-applied — a clip's own spatial transform is already baked into its file, and the aspect-ratio crop comes from `targetAspectRatio` inside the render; applying geometry twice would be wrong.
- Device verification of the actual re-encode (export + library round-trip) is still pending — see the manual test plan below.

## Verification

- `flutter analyze lib test integration_test` → No issues found
- `flutter test` across `blocs/video_editor`, `widgets/video_editor`, `services/video_editor`, `models/video_editor`, `services/video_editor_render_service_test.dart` → all green (1406)
- `dart format` clean; untested-services floor unchanged
- Windowing math, timeline-position math, the uncapped guarantee, and the null-editor bail each mutation-checked (every guard's test goes red when the guard is removed)

**Manual test plan (pending, needs a device):**
1. Trim a long clip to ~10s → Save clip → confirm the library clip contains only the 10s and its trim handles can't be pulled back open.
2. Put a text layer + filter over **clip 2** of a multi-clip timeline → save clip 2 → the saved clip shows the text at the right second with the filter applied.
3. Save **clip 1** → the same text does **not** appear (it was never over clip 1).
4. Leave the editor mid-re-encode → confirm no crash and the save is abandoned with the session.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
