### PR TITLE
test(integration): exception-safe ErrorWidget.builder/onError restores (#5839)

### DIFF
--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -99,6 +99,8 @@ jobs:
         run: bash scripts/check_http_overrides_isolation.sh
       - name: 🧬 Verify no untagged test leaks a process-global singleton
         run: bash scripts/check_process_global_mutations.sh
+      - name: 🧯 Verify integration_test error-handler restores are exception-safe
+        run: bash scripts/check_integration_test_error_restore_safety.sh
       - name: 🔌 Verify no new raw shared-channel installs (heal-and-blame ratchet)
         run: |
           # LIST ratchet vs origin/main (fails closed if the base baseline can't

--- a/mobile/integration_test/auth/auth_journey_test.dart
+++ b/mobile/integration_test/auth/auth_journey_test.dart
@@ -32,7 +32,9 @@ void main() {
         final l10n = lookupAppLocalizations(const Locale('en'));
         // ── Setup: suppress non-critical errors ──
         final originalOnError = suppressSetStateErrors();
+        addTearDown(() => restoreErrorHandler(originalOnError));
         final originalErrorBuilder = saveErrorWidgetBuilder();
+        addTearDown(() => restoreErrorWidgetBuilder(originalErrorBuilder));
 
         // Pre-enable semantics so the handle is disposed at the right time.
         // find.bySemanticsLabel() calls ensureSemantics() implicitly; if we
@@ -790,7 +792,8 @@ void main() {
         // Drain pending errors before restoring handlers.
         semanticsHandle.dispose();
         drainAsyncErrors(tester);
-        restoreErrorHandler(originalOnError);
+        // Inline restore is required by the framework's end-of-body
+        // ErrorWidget.builder check; the addTearDown above covers throws.
         restoreErrorWidgetBuilder(originalErrorBuilder);
       },
       timeout: const Timeout(Duration(minutes: 7)),

--- a/mobile/integration_test/auth/follow_reopen_persistence_test.dart
+++ b/mobile/integration_test/auth/follow_reopen_persistence_test.dart
@@ -24,7 +24,9 @@ void main() {
         const password = 'TestPass123!';
 
         final originalOnError = suppressSetStateErrors();
+        addTearDown(() => restoreErrorHandler(originalOnError));
         final originalErrorBuilder = saveErrorWidgetBuilder();
+        addTearDown(() => restoreErrorWidgetBuilder(originalErrorBuilder));
         final semanticsHandle = tester.ensureSemantics();
 
         launchAppGuarded(app.main);
@@ -127,7 +129,8 @@ void main() {
 
         semanticsHandle.dispose();
         drainAsyncErrors(tester);
-        restoreErrorHandler(originalOnError);
+        // Inline restore is required by the framework's end-of-body
+        // ErrorWidget.builder check; the addTearDown above covers throws.
         restoreErrorWidgetBuilder(originalErrorBuilder);
       },
       timeout: const Timeout(Duration(minutes: 4)),

--- a/mobile/integration_test/auth/key_management_export_test.dart
+++ b/mobile/integration_test/auth/key_management_export_test.dart
@@ -26,7 +26,9 @@ void main() {
       ($) async {
         final tester = $.tester;
         final originalOnError = suppressSetStateErrors();
+        addTearDown(() => restoreErrorHandler(originalOnError));
         final originalErrorBuilder = saveErrorWidgetBuilder();
+        addTearDown(() => restoreErrorWidgetBuilder(originalErrorBuilder));
         final semanticsHandle = tester.ensureSemantics();
 
         launchAppGuarded(app.main);
@@ -105,7 +107,8 @@ void main() {
 
         semanticsHandle.dispose();
         drainAsyncErrors(tester);
-        restoreErrorHandler(originalOnError);
+        // Inline restore is required by the framework's end-of-body
+        // ErrorWidget.builder check; the addTearDown above covers throws.
         restoreErrorWidgetBuilder(originalErrorBuilder);
       },
       timeout: const Timeout(Duration(minutes: 5)),

--- a/mobile/integration_test/auth/multi_account_switch_test.dart
+++ b/mobile/integration_test/auth/multi_account_switch_test.dart
@@ -41,7 +41,9 @@ void main() {
         final tester = $.tester;
 
         final originalOnError = suppressSetStateErrors();
+        addTearDown(() => restoreErrorHandler(originalOnError));
         final originalErrorBuilder = saveErrorWidgetBuilder();
+        addTearDown(() => restoreErrorWidgetBuilder(originalErrorBuilder));
         final semanticsHandle = tester.ensureSemantics();
 
         launchAppGuarded(app.main);
@@ -181,7 +183,8 @@ void main() {
 
         semanticsHandle.dispose();
         drainAsyncErrors(tester);
-        restoreErrorHandler(originalOnError);
+        // Inline restore is required by the framework's end-of-body
+        // ErrorWidget.builder check; the addTearDown above covers throws.
         restoreErrorWidgetBuilder(originalErrorBuilder);
       },
       timeout: const Timeout(Duration(minutes: 5)),
@@ -193,7 +196,9 @@ void main() {
         final tester = $.tester;
 
         final originalOnError = suppressSetStateErrors();
+        addTearDown(() => restoreErrorHandler(originalOnError));
         final originalErrorBuilder = saveErrorWidgetBuilder();
+        addTearDown(() => restoreErrorWidgetBuilder(originalErrorBuilder));
         final semanticsHandle = tester.ensureSemantics();
 
         launchAppGuarded(app.main);
@@ -303,7 +308,8 @@ void main() {
 
         semanticsHandle.dispose();
         drainAsyncErrors(tester);
-        restoreErrorHandler(originalOnError);
+        // Inline restore is required by the framework's end-of-body
+        // ErrorWidget.builder check; the addTearDown above covers throws.
         restoreErrorWidgetBuilder(originalErrorBuilder);
       },
       timeout: const Timeout(Duration(minutes: 5)),

--- a/mobile/integration_test/auth/repro_log1_test.dart
+++ b/mobile/integration_test/auth/repro_log1_test.dart
@@ -26,7 +26,9 @@ void main() {
 
         // ── Setup ──
         final originalOnError = suppressSetStateErrors();
+        addTearDown(() => restoreErrorHandler(originalOnError));
         final originalErrorBuilder = saveErrorWidgetBuilder();
+        addTearDown(() => restoreErrorWidgetBuilder(originalErrorBuilder));
         final semanticsHandle = tester.ensureSemantics();
 
         launchAppGuarded(app.main);
@@ -169,7 +171,8 @@ void main() {
         // ── Cleanup ──
         semanticsHandle.dispose();
         drainAsyncErrors(tester);
-        restoreErrorHandler(originalOnError);
+        // Inline restore is required by the framework's end-of-body
+        // ErrorWidget.builder check; the addTearDown above covers throws.
         restoreErrorWidgetBuilder(originalErrorBuilder);
       },
       timeout: const Timeout(Duration(minutes: 5)),

--- a/mobile/integration_test/auth/repro_log2_delete_test.dart
+++ b/mobile/integration_test/auth/repro_log2_delete_test.dart
@@ -96,7 +96,9 @@ void main() {
       ($) async {
         final tester = $.tester;
         final originalOnError = suppressSetStateErrors();
+        addTearDown(() => restoreErrorHandler(originalOnError));
         final originalErrorBuilder = saveErrorWidgetBuilder();
+        addTearDown(() => restoreErrorWidgetBuilder(originalErrorBuilder));
         final semanticsHandle = tester.ensureSemantics();
 
         // Pre-register B so we can login without polling
@@ -258,7 +260,8 @@ void main() {
 
         semanticsHandle.dispose();
         drainAsyncErrors(tester);
-        restoreErrorHandler(originalOnError);
+        // Inline restore is required by the framework's end-of-body
+        // ErrorWidget.builder check; the addTearDown above covers throws.
         restoreErrorWidgetBuilder(originalErrorBuilder);
       },
       timeout: const Timeout(Duration(minutes: 5)),
@@ -273,7 +276,9 @@ void main() {
       ($) async {
         final tester = $.tester;
         final originalOnError = suppressSetStateErrors();
+        addTearDown(() => restoreErrorHandler(originalOnError));
         final originalErrorBuilder = saveErrorWidgetBuilder();
+        addTearDown(() => restoreErrorWidgetBuilder(originalErrorBuilder));
         final semanticsHandle = tester.ensureSemantics();
 
         // Use unique emails for this test case
@@ -436,7 +441,8 @@ void main() {
 
         semanticsHandle.dispose();
         drainAsyncErrors(tester);
-        restoreErrorHandler(originalOnError);
+        // Inline restore is required by the framework's end-of-body
+        // ErrorWidget.builder check; the addTearDown above covers throws.
         restoreErrorWidgetBuilder(originalErrorBuilder);
       },
       timeout: const Timeout(Duration(minutes: 5)),
@@ -458,7 +464,9 @@ void main() {
       ($) async {
         final tester = $.tester;
         final originalOnError = suppressSetStateErrors();
+        addTearDown(() => restoreErrorHandler(originalOnError));
         final originalErrorBuilder = saveErrorWidgetBuilder();
+        addTearDown(() => restoreErrorWidgetBuilder(originalErrorBuilder));
         final semanticsHandle = tester.ensureSemantics();
 
         launchAppGuarded(app.main);
@@ -565,7 +573,8 @@ void main() {
 
         semanticsHandle.dispose();
         drainAsyncErrors(tester);
-        restoreErrorHandler(originalOnError);
+        // Inline restore is required by the framework's end-of-body
+        // ErrorWidget.builder check; the addTearDown above covers throws.
         restoreErrorWidgetBuilder(originalErrorBuilder);
       },
       timeout: const Timeout(Duration(minutes: 3)),

--- a/mobile/integration_test/auth/secure_account_test.dart
+++ b/mobile/integration_test/auth/secure_account_test.dart
@@ -30,7 +30,9 @@ void main() {
 
         // ── Setup ──
         final originalOnError = suppressSetStateErrors();
+        addTearDown(() => restoreErrorHandler(originalOnError));
         final originalErrorBuilder = saveErrorWidgetBuilder();
+        addTearDown(() => restoreErrorWidgetBuilder(originalErrorBuilder));
         final semanticsHandle = tester.ensureSemantics();
 
         launchAppGuarded(app.main);
@@ -208,7 +210,8 @@ void main() {
         // ── Cleanup ──
         semanticsHandle.dispose();
         drainAsyncErrors(tester);
-        restoreErrorHandler(originalOnError);
+        // Inline restore is required by the framework's end-of-body
+        // ErrorWidget.builder check; the addTearDown above covers throws.
         restoreErrorWidgetBuilder(originalErrorBuilder);
       },
       timeout: const Timeout(Duration(minutes: 5)),

--- a/mobile/integration_test/auth/session_expired_banner_test.dart
+++ b/mobile/integration_test/auth/session_expired_banner_test.dart
@@ -30,7 +30,9 @@ void main() {
         final tester = $.tester;
         // ── Setup ──
         final originalOnError = suppressSetStateErrors();
+        addTearDown(() => restoreErrorHandler(originalOnError));
         final originalErrorBuilder = saveErrorWidgetBuilder();
+        addTearDown(() => restoreErrorWidgetBuilder(originalErrorBuilder));
         final semanticsHandle = tester.ensureSemantics();
 
         launchAppGuarded(app.main);
@@ -224,7 +226,8 @@ void main() {
 
         semanticsHandle.dispose();
         drainAsyncErrors(tester);
-        restoreErrorHandler(originalOnError);
+        // Inline restore is required by the framework's end-of-body
+        // ErrorWidget.builder check; the addTearDown above covers throws.
         restoreErrorWidgetBuilder(originalErrorBuilder);
       },
       timeout: const Timeout(Duration(minutes: 5)),

--- a/mobile/integration_test/auth/session_expiry_test.dart
+++ b/mobile/integration_test/auth/session_expiry_test.dart
@@ -28,7 +28,9 @@ void main() {
         final tester = $.tester;
         // ── Setup ──
         final originalOnError = suppressSetStateErrors();
+        addTearDown(() => restoreErrorHandler(originalOnError));
         final originalErrorBuilder = saveErrorWidgetBuilder();
+        addTearDown(() => restoreErrorWidgetBuilder(originalErrorBuilder));
 
         // Pre-enable semantics so the handle is disposed at the right time.
         // Android instrumentation can enable semantics after the framework
@@ -192,7 +194,8 @@ void main() {
 
         semanticsHandle.dispose();
         drainAsyncErrors(tester);
-        restoreErrorHandler(originalOnError);
+        // Inline restore is required by the framework's end-of-body
+        // ErrorWidget.builder check; the addTearDown above covers throws.
         restoreErrorWidgetBuilder(originalErrorBuilder);
       },
       timeout: const Timeout(Duration(minutes: 5)),

--- a/mobile/integration_test/auth/signup_validation_test.dart
+++ b/mobile/integration_test/auth/signup_validation_test.dart
@@ -2,7 +2,6 @@
 // ABOUTME: Requires: local Docker stack running (mise run local_up).
 
 import 'package:divine_ui/divine_ui.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/main.dart' as app;
 import 'package:patrol/patrol.dart';
@@ -17,7 +16,9 @@ void main() {
       ($) async {
         final tester = $.tester;
         final originalOnError = suppressSetStateErrors();
+        addTearDown(() => restoreErrorHandler(originalOnError));
         final originalErrorBuilder = saveErrorWidgetBuilder();
+        addTearDown(() => restoreErrorWidgetBuilder(originalErrorBuilder));
 
         launchAppGuarded(app.main);
         await tester.pumpAndSettle(const Duration(seconds: 3));
@@ -50,8 +51,9 @@ void main() {
         expect(find.text('Complete your registration'), findsNothing);
 
         drainAsyncErrors(tester);
+        // Inline restore is required by the framework's end-of-body
+        // ErrorWidget.builder check; the addTearDown above covers throws.
         restoreErrorWidgetBuilder(originalErrorBuilder);
-        FlutterError.onError = originalOnError;
       },
       timeout: const Timeout(Duration(minutes: 2)),
     );

--- a/mobile/integration_test/auth/token_refresh_test.dart
+++ b/mobile/integration_test/auth/token_refresh_test.dart
@@ -28,7 +28,9 @@ void main() {
         final tester = $.tester;
         // ── Setup ──
         final originalOnError = suppressSetStateErrors();
+        addTearDown(() => restoreErrorHandler(originalOnError));
         final originalErrorBuilder = saveErrorWidgetBuilder();
+        addTearDown(() => restoreErrorWidgetBuilder(originalErrorBuilder));
         final semanticsHandle = tester.ensureSemantics();
 
         // Launch the full app (LOCAL env via --dart-define)
@@ -319,7 +321,8 @@ void main() {
         // Cleanup
         semanticsHandle.dispose();
         drainAsyncErrors(tester);
-        restoreErrorHandler(originalOnError);
+        // Inline restore is required by the framework's end-of-body
+        // ErrorWidget.builder check; the addTearDown above covers throws.
         restoreErrorWidgetBuilder(originalErrorBuilder);
       },
       timeout: const Timeout(Duration(minutes: 3)),

--- a/mobile/integration_test/auth/user_journey_test.dart
+++ b/mobile/integration_test/auth/user_journey_test.dart
@@ -26,7 +26,9 @@ void main() {
       ($) async {
         final tester = $.tester;
         final originalOnError = suppressSetStateErrors();
+        addTearDown(() => restoreErrorHandler(originalOnError));
         final originalErrorBuilder = saveErrorWidgetBuilder();
+        addTearDown(() => restoreErrorWidgetBuilder(originalErrorBuilder));
         final semanticsHandle = tester.ensureSemantics();
 
         launchAppGuarded(app.main);
@@ -501,7 +503,8 @@ void main() {
 
         semanticsHandle.dispose();
         drainAsyncErrors(tester);
-        restoreErrorHandler(originalOnError);
+        // Inline restore is required by the framework's end-of-body
+        // ErrorWidget.builder check; the addTearDown above covers throws.
         restoreErrorWidgetBuilder(originalErrorBuilder);
       },
       timeout: const Timeout(Duration(minutes: 8)),

--- a/mobile/integration_test/e2e/c2pa_init_test.dart
+++ b/mobile/integration_test/e2e/c2pa_init_test.dart
@@ -17,7 +17,9 @@ void main() {
     patrolTest('C2PA hardware signer creates cert file on emulator', ($) async {
       final tester = $.tester;
       final originalOnError = suppressSetStateErrors();
+      addTearDown(() => restoreErrorHandler(originalOnError));
       final originalErrorBuilder = saveErrorWidgetBuilder();
+      addTearDown(() => restoreErrorWidgetBuilder(originalErrorBuilder));
 
       final appDir = await getApplicationDocumentsDirectory();
       final certFile = File('${appDir.path}/c2pa_signing_divine.cert');
@@ -63,8 +65,9 @@ void main() {
         reason: 'Cert file should contain a valid PEM certificate',
       );
 
+      // Inline restore is required by the framework's end-of-body
+      // ErrorWidget.builder check; the addTearDown above covers throws.
       restoreErrorWidgetBuilder(originalErrorBuilder);
-      restoreErrorHandler(originalOnError);
       drainAsyncErrors(tester);
     });
   });

--- a/mobile/integration_test/e2e/deleted_video_visible_to_other_users_test.dart
+++ b/mobile/integration_test/e2e/deleted_video_visible_to_other_users_test.dart
@@ -27,7 +27,9 @@ void main() {
       ($) async {
         final tester = $.tester;
         final originalOnError = suppressSetStateErrors();
+        addTearDown(() => restoreErrorHandler(originalOnError));
         final originalErrorBuilder = saveErrorWidgetBuilder();
+        addTearDown(() => restoreErrorWidgetBuilder(originalErrorBuilder));
 
         // ── Phase 1: Seed relay with User A's profile and video ──
         logPhase('── Phase 1: Seed User A profile + video on relay ──');
@@ -217,7 +219,8 @@ void main() {
 
         // ── Cleanup ──
         drainAsyncErrors(tester);
-        restoreErrorHandler(originalOnError);
+        // Inline restore is required by the framework's end-of-body
+        // ErrorWidget.builder check; the addTearDown above covers throws.
         restoreErrorWidgetBuilder(originalErrorBuilder);
       },
       timeout: const Timeout(Duration(minutes: 5)),

--- a/mobile/integration_test/e2e/dm_optimistic_survives_watch_race_test.dart
+++ b/mobile/integration_test/e2e/dm_optimistic_survives_watch_race_test.dart
@@ -57,7 +57,9 @@ void main() {
       ($) async {
         final tester = $.tester;
         final originalOnError = suppressSetStateErrors();
+        addTearDown(() => restoreErrorHandler(originalOnError));
         final originalErrorBuilder = saveErrorWidgetBuilder();
+        addTearDown(() => restoreErrorWidgetBuilder(originalErrorBuilder));
 
         // ── Phase 1: Pre-publish recipient profile ──
         //
@@ -267,7 +269,8 @@ void main() {
 
         // ── Cleanup ──
         drainAsyncErrors(tester);
-        restoreErrorHandler(originalOnError);
+        // Inline restore is required by the framework's end-of-body
+        // ErrorWidget.builder check; the addTearDown above covers throws.
         restoreErrorWidgetBuilder(originalErrorBuilder);
       },
       timeout: const Timeout(Duration(minutes: 5)),

--- a/mobile/integration_test/e2e/video_creation_flow_test.dart
+++ b/mobile/integration_test/e2e/video_creation_flow_test.dart
@@ -19,6 +19,7 @@ void main() {
         final originalOnError = suppressSetStateErrors();
         addTearDown(() => restoreErrorHandler(originalOnError));
         final originalErrorBuilder = saveErrorWidgetBuilder();
+        addTearDown(() => restoreErrorWidgetBuilder(originalErrorBuilder));
 
         // Launch app in guarded zone to catch external relay errors
         launchAppGuarded(app.main);
@@ -61,6 +62,8 @@ void main() {
 
         await pumpUntilSettled(tester, maxSeconds: 3);
         drainAsyncErrors(tester);
+        // Inline restore is required by the framework's end-of-body
+        // ErrorWidget.builder check; the addTearDown above covers throws.
         restoreErrorWidgetBuilder(originalErrorBuilder);
       },
       timeout: const Timeout(Duration(minutes: 2)),

--- a/mobile/integration_test/lifecycle/app_background_test.dart
+++ b/mobile/integration_test/lifecycle/app_background_test.dart
@@ -16,7 +16,9 @@ void main() {
         final tester = $.tester;
 
         final originalOnError = suppressSetStateErrors();
+        addTearDown(() => restoreErrorHandler(originalOnError));
         final originalErrorBuilder = saveErrorWidgetBuilder();
+        addTearDown(() => restoreErrorWidgetBuilder(originalErrorBuilder));
 
         launchAppGuarded(app.main);
         await tester.pumpAndSettle(const Duration(seconds: 3));
@@ -49,7 +51,8 @@ void main() {
         );
 
         drainAsyncErrors(tester);
-        restoreErrorHandler(originalOnError);
+        // Inline restore is required by the framework's end-of-body
+        // ErrorWidget.builder check; the addTearDown above covers throws.
         restoreErrorWidgetBuilder(originalErrorBuilder);
       },
       timeout: const Timeout(Duration(minutes: 2)),

--- a/mobile/integration_test/perf/feed_ttff_test.dart
+++ b/mobile/integration_test/perf/feed_ttff_test.dart
@@ -14,7 +14,9 @@ void main() {
   patrolTest('feed TTFF under throttled network', ($) async {
     final tester = $.tester;
     final originalOnError = suppressSetStateErrors();
+    addTearDown(() => restoreErrorHandler(originalOnError));
     final originalErrorBuilder = saveErrorWidgetBuilder();
+    addTearDown(() => restoreErrorWidgetBuilder(originalErrorBuilder));
 
     launchAppGuarded(app.main);
     await tester.pumpAndSettle(const Duration(seconds: 3));
@@ -71,8 +73,9 @@ void main() {
     logPhase('perf: scroll_complete');
 
     // --- Cleanup ---
+    // Inline restore is required by the framework's end-of-body
+    // ErrorWidget.builder check; the addTearDown above covers throws.
     restoreErrorWidgetBuilder(originalErrorBuilder);
-    restoreErrorHandler(originalOnError);
     drainAsyncErrors(tester);
   });
 }

--- a/mobile/integration_test/thumbnail_integration_test.dart
+++ b/mobile/integration_test/thumbnail_integration_test.dart
@@ -16,14 +16,16 @@ import 'package:patrol/patrol.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:unified_logger/unified_logger.dart';
 
+import 'helpers/test_setup.dart';
+
 void main() {
   group('Thumbnail Integration Tests', () {
     patrolTest(
       'Record video and generate thumbnail end-to-end',
       ($) async {
         final tester = $.tester;
-        // Save ErrorWidget.builder to restore at end of test
-        final originalErrorWidgetBuilder = ErrorWidget.builder;
+        final originalErrorBuilder = saveErrorWidgetBuilder();
+        addTearDown(() => restoreErrorWidgetBuilder(originalErrorBuilder));
 
         Log.debug('🎬 Starting real thumbnail integration test...');
 
@@ -184,15 +186,16 @@ void main() {
 
         Log.debug('\n🎉 Thumbnail integration test completed!');
 
-        // Restore ErrorWidget.builder before test ends to avoid framework assertion
-        ErrorWidget.builder = originalErrorWidgetBuilder;
+        // Inline restore is required by the framework's end-of-body
+        // ErrorWidget.builder check; the addTearDown above covers throws.
+        restoreErrorWidgetBuilder(originalErrorBuilder);
       },
       timeout: const Timeout(Duration(minutes: 2)),
     );
 
     patrolTest('Test upload manager thumbnail integration', ($) async {
-      // Save ErrorWidget.builder to restore at end of test
-      final originalErrorWidgetBuilder = ErrorWidget.builder;
+      final originalErrorBuilder = saveErrorWidgetBuilder();
+      addTearDown(() => restoreErrorWidgetBuilder(originalErrorBuilder));
 
       Log.debug('\n📋 Testing UploadManager thumbnail integration...');
 
@@ -233,8 +236,9 @@ void main() {
 
       Log.debug('🎉 UploadManager thumbnail integration test passed!');
 
-      // Restore ErrorWidget.builder before test ends to avoid framework assertion
-      ErrorWidget.builder = originalErrorWidgetBuilder;
+      // Inline restore is required by the framework's end-of-body
+      // ErrorWidget.builder check; the addTearDown above covers throws.
+      restoreErrorWidgetBuilder(originalErrorBuilder);
     });
   });
 }

--- a/mobile/scripts/check_integration_test_error_restore_safety.sh
+++ b/mobile/scripts/check_integration_test_error_restore_safety.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Fails CI if an integration_test suite restores ErrorWidget.builder or
+# FlutterError.onError in an exception-UNSAFE way (#5839).
+#
+# The integration_test files (mobile/integration_test) override ErrorWidget.builder
+# and FlutterError.onError per test and must restore them so an early `expect`
+# failure cannot leak the override into a later test in the same file. The
+# correct, exception-safe shape uses the test_setup helpers plus addTearDown:
+#
+#   final originalOnError = suppressSetStateErrors();
+#   addTearDown(() => restoreErrorHandler(originalOnError));      // onError: teardown-only
+#   final originalErrorBuilder = saveErrorWidgetBuilder();
+#   addTearDown(() => restoreErrorWidgetBuilder(originalErrorBuilder));  // builder: suspenders
+#   ...
+#   restoreErrorWidgetBuilder(originalErrorBuilder);             // builder: inline belt
+#
+# ErrorWidget.builder MUST also be restored inline: flutter_test's
+# _verifyErrorWidgetBuilderUnset runs at end-of-body BEFORE addTearDown, so an
+# addTearDown-only builder restore fails the happy path. See
+# test/integration_test_error_restore_contract_test.dart for the pinned contract.
+#
+# Policy (presence-based, scoped to mobile/integration_test):
+#   Rule 1 — no raw `ErrorWidget.builder =` / `FlutterError.onError =`
+#            assignments outside helpers/ (use the test_setup helpers instead).
+#   Rule 2 — a file that calls saveErrorWidgetBuilder() must contain an
+#            addTearDown restoring the builder; a file that calls
+#            suppressSetStateErrors() must contain an addTearDown restoring
+#            onError. (This catches a save/suppress with no exception-safe
+#            teardown. The inline builder belt is required by the framework and
+#            enforced by the contract test above, not by this script.)
+#
+# Allowlist: integration_test/helpers/** (defines the raw ops the helpers wrap).
+# The non-patrol contract test lives under mobile/test/ and is out of scope here.
+#
+# Usage:
+#   bash mobile/scripts/check_integration_test_error_restore_safety.sh
+#   (run from the repository root or from mobile/)
+set -euo pipefail
+export LC_ALL=C
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MOBILE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+IT_DIR="$MOBILE_DIR/integration_test"
+
+if [[ ! -d "$IT_DIR" ]]; then
+  echo "check_integration_test_error_restore_safety: no integration_test dir; skipping."
+  exit 0
+fi
+
+fail=0
+
+# All .dart under integration_test except the helpers/ allowlist. Word-splitting
+# is safe: integration_test paths contain no spaces (matches the convention in
+# the sibling check_*.sh guards, and keeps this portable to macOS bash 3.2).
+files=$(find "$IT_DIR" -name '*.dart' -not -path "$IT_DIR/helpers/*" | sort)
+
+for f in $files; do
+  rel="${f#"$MOBILE_DIR"/}"
+
+  # Rule 1: raw assignments (single '=', not '==') are banned outside helpers/.
+  if grep -nE '(ErrorWidget\.builder|FlutterError\.onError)[[:space:]]*=([^=]|$)' "$f" \
+    >/dev/null 2>&1; then
+    echo "✗ $rel: raw ErrorWidget.builder / FlutterError.onError assignment."
+    grep -nE '(ErrorWidget\.builder|FlutterError\.onError)[[:space:]]*=([^=]|$)' "$f" \
+      | sed 's/^/    /'
+    echo "    → use saveErrorWidgetBuilder()/restoreErrorWidgetBuilder()/"
+    echo "      suppressSetStateErrors()/restoreErrorHandler() from helpers/test_setup.dart."
+    fail=1
+  fi
+
+  # Rule 2a: saveErrorWidgetBuilder() requires an addTearDown restoring it.
+  if grep -q 'saveErrorWidgetBuilder(' "$f" \
+    && ! grep -Eq 'addTearDown\(.*restoreErrorWidgetBuilder' "$f"; then
+    echo "✗ $rel: calls saveErrorWidgetBuilder() but has no"
+    echo "    addTearDown(() => restoreErrorWidgetBuilder(...)) — restore leaks on a throw."
+    fail=1
+  fi
+
+  # Rule 2b: suppressSetStateErrors() requires an addTearDown restoring onError.
+  if grep -q 'suppressSetStateErrors(' "$f" \
+    && ! grep -Eq 'addTearDown\(.*restoreErrorHandler' "$f"; then
+    echo "✗ $rel: calls suppressSetStateErrors() but has no"
+    echo "    addTearDown(() => restoreErrorHandler(...)) — restore leaks on a throw."
+    fail=1
+  fi
+done
+
+if [[ "$fail" -ne 0 ]]; then
+  echo ""
+  echo "Exception-unsafe error-handler restore(s) in integration_test (#5839)."
+  echo "See test/integration_test_error_restore_contract_test.dart for the pattern."
+  exit 1
+fi
+
+echo "✓ integration_test error-handler restores are exception-safe."

--- a/mobile/test/integration_test_error_restore_contract_test.dart
+++ b/mobile/test/integration_test_error_restore_contract_test.dart
@@ -1,0 +1,72 @@
+// ABOUTME: Pins the framework contract behind #5839's belt-and-suspenders
+// ABOUTME: pattern for ErrorWidget.builder / FlutterError.onError restores.
+//
+// The integration_test suites (mobile/integration_test) save ErrorWidget.builder
+// and FlutterError.onError at the start of each test and restore them so an
+// early `expect` failure cannot leak the override into a later test in the same
+// file. #5839 made those restores exception-safe. The correct shape is
+// ASYMMETRIC, and this test encodes why:
+//
+//   * ErrorWidget.builder MUST be restored INLINE before the body ends.
+//     flutter_test's `_verifyErrorWidgetBuilderUnset` runs at end-of-body,
+//     BEFORE any `addTearDown` callback, and fails the test with
+//     "The value of ErrorWidget.builder was changed by the test." So an
+//     addTearDown-only restore breaks the happy path. The integration tests
+//     ALSO register an addTearDown restore (the "suspenders") so the throw
+//     path is covered — addTearDown runs regardless of test outcome.
+//   * FlutterError.onError may be restored via addTearDown ONLY, because the
+//     binding resets it to its pre-test value in postTest() after every test.
+//
+// It is impossible to demonstrate the *failing* case (addTearDown-only builder
+// restore) from a PASSING test: on the happy path the framework verify fails
+// the test, and on the throw path the uncaught throw fails the test. That is
+// exactly the constraint this pattern works around, so this file pins the
+// POSITIVE contract instead. If a future refactor drops the inline
+// ErrorWidget.builder restore, the first test below fails loudly.
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('integration_test error-handler restore contract (#5839)', () {
+    testWidgets(
+      'belt-and-suspenders: inline ErrorWidget.builder restore satisfies the '
+      'end-of-body framework verify',
+      (tester) async {
+        final originalBuilder = ErrorWidget.builder;
+        // Suspenders: covers the throw path (runs even if the body throws).
+        addTearDown(() => ErrorWidget.builder = originalBuilder);
+
+        // Simulate what app.main() does: install a custom error widget builder.
+        ErrorWidget.builder = (details) => const SizedBox.shrink();
+        await tester.pumpWidget(const SizedBox());
+
+        // Belt: the INLINE restore is what keeps the framework's end-of-body
+        // _verifyErrorWidgetBuilderUnset happy. Removing this line makes this
+        // test fail with "The value of ErrorWidget.builder was changed by the
+        // test." — which is the regression #5839 guards against.
+        ErrorWidget.builder = originalBuilder;
+
+        expect(ErrorWidget.builder, same(originalBuilder));
+      },
+    );
+
+    testWidgets(
+      'FlutterError.onError may be restored via addTearDown only (no inline '
+      'restore needed) — the binding resets it per test',
+      (tester) async {
+        final originalOnError = FlutterError.onError;
+        // No inline restore: the throw-safe teardown is sufficient for onError
+        // because the binding resets FlutterError.onError in postTest().
+        addTearDown(() => FlutterError.onError = originalOnError);
+
+        FlutterError.onError = (details) {};
+        await tester.pumpWidget(const SizedBox());
+
+        // Reaching here without the framework failing the test is the proof:
+        // unlike ErrorWidget.builder, a still-overridden onError at end-of-body
+        // does not trip a verify. The override is distinct from the original.
+        expect(FlutterError.onError, isNot(same(originalOnError)));
+      },
+    );
+  });
+}

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -252,6 +252,26 @@ if [ -n "$CHANGED_SERVICE_FILES" ] || [ -n "$CHANGED_TEST_FILES" ]; then
     echo ""
 fi
 
+# Exception-safe error-handler restores in integration_test (mirrors CI's
+# check_integration_test_error_restore_safety.sh, #5839). Trigger on any
+# added/modified/deleted mobile/integration_test/*.dart so unrelated pushes are
+# not slowed.
+CHANGED_IT_FILES=$(git -C "$REPO_ROOT" diff --name-only "$BASE_BRANCH"...HEAD 2>/dev/null \
+    | grep -E '^mobile/integration_test/.*\.dart$' || true)
+if [ -n "$CHANGED_IT_FILES" ]; then
+    echo "integration_test file(s) changed; checking error-handler restore safety..."
+    if ! bash "$REPO_ROOT/mobile/scripts/check_integration_test_error_restore_safety.sh"; then
+        echo ""
+        echo "Exception-unsafe ErrorWidget.builder/FlutterError.onError restore in"
+        echo "integration_test (#5839). Restore onError via addTearDown; restore"
+        echo "ErrorWidget.builder BOTH inline (framework verify) AND via addTearDown"
+        echo "(throw path). See test/integration_test_error_restore_contract_test.dart."
+        exit 1
+    fi
+    echo "integration_test error-handler restore safety OK"
+    echo ""
+fi
+
 # Package CI floor (mirrors CI's check_package_ci_floor.sh). Every package
 # under mobile/packages must ship its own analysis_options.yaml and a
 # per-package workflow (exceptions live in the shrink-only baseline). Trigger


### PR DESCRIPTION
## Description

The ~19 `mobile/integration_test` suites saved `ErrorWidget.builder` and
`FlutterError.onError` at test-body start and restored them **inline at the end
of the body**. If an earlier `expect` threw, the restore never ran, leaking the
override into a later test in the same file. Follow-up carved out of #5755's
"Out of Scope".

The correct fix is **asymmetric**, because of a framework constraint:

- **`ErrorWidget.builder` must be restored inline.** flutter_test's
  `_verifyErrorWidgetBuilderUnset` runs at end-of-body **before** any
  `addTearDown` callback (and is skipped once the body has already thrown), so an
  `addTearDown`-only builder restore fails the happy path with *"The value of
  ErrorWidget.builder was changed by the test."* (verified empirically). The
  tests therefore keep the inline restore (the "belt") **and** add an
  `addTearDown` restore (the "suspenders") that covers the throw path.
- **`FlutterError.onError` moves to `addTearDown` (teardown-only).** The binding
  resets `onError` per test in `postTest()`, so a leak there is already harmless;
  this matches the already-shipped `video_creation_flow_test.dart`.

Changes:

- Belt-and-suspenders conversion across the 19 files (16 standard; plus
  `signup_validation`'s raw `FlutterError.onError =` and `thumbnail`'s raw
  `ErrorWidget.builder =` normalized to the `test_setup` helpers).
- **Regression test** (`test/integration_test_error_restore_contract_test.dart`,
  non-patrol so it runs in the normal suite) pinning the contract — it fails if
  the inline builder restore is ever dropped.
- **CI guard** (`scripts/check_integration_test_error_restore_safety.sh`, wired
  into `mobile_ci.yaml` + the pre-push hook): bans raw `ErrorWidget.builder=` /
  `FlutterError.onError=` outside `helpers/`, and requires an `addTearDown`
  restore wherever `saveErrorWidgetBuilder()` / `suppressSetStateErrors()` is
  used.

Note on impact: within-file blast radius only (integration_test runs one isolate
per file), and the `ErrorWidget.builder` leak is self-neutralizing (the framework
re-baselines per test and `app.main` re-installs its builder), so this lands as
test hygiene + regression-proofing rather than a fix for an observed failure.

**Related Issue:** Closes #5839

## Out of Scope

- The `mobile/integration_test` patrol lane itself (patrol hard-gates plain
  `flutter test`; standing up the `patrol test` lane is #4239).
- A **pre-existing app race** surfaced while verifying:
  `_ClassicVinesTabState._refreshClassics` (`lib/widgets/classic_vines_tab.dart:145`)
  calls `ref.invalidate` after the widget is disposed, which makes
  `perf/feed_ttff_test.dart` flaky under throttled-network teardown timing.
  Unrelated to this change (it flakes on `origin/main` too) — worth its own issue.
- A pre-existing bash-3.2 `PATROL_EXTRA_ARGS[@]: unbound variable` bug in
  `local_stack/profile.sh`.

## Verification

- `flutter analyze lib test integration_test` → No issues found (all 19 compile).
- `dart format` → 0 changes.
- Regression test → 2/2 pass (also green in the pre-push hook).
- Guard → passes on the converted tree; fails on all three violation types
  (raw assignment / save-without-teardown / suppress-without-teardown).
- **Full backend-backed patrol run** (Android emulator + live `local_stack`):
  `patrol test --target integration_test/auth/signup_validation_test.dart
  --dart-define=DEFAULT_ENV=LOCAL` → `All tests passed!` — exercises the
  raw-onError→helper normalization + belt-and-suspenders end-to-end.
- Standard-pattern live run (`perf/feed_ttff_test.dart`): passes on retry on both
  this branch and `origin/main`; the intermittent failure is the pre-existing
  ref-after-dispose race noted in Out of Scope, not this change.

## Type of Change

- [x] 🧹 Code refactor
- [x] ✅ Build configuration change
