### PR TITLE
fix(feed): guard ref-after-await in ClassicVinesTab._refreshClassics

### DIFF
--- a/mobile/lib/widgets/classic_vines_tab.dart
+++ b/mobile/lib/widgets/classic_vines_tab.dart
@@ -142,8 +142,14 @@ class _ClassicVinesTabState extends ConsumerState<ClassicVinesTab> {
   Future<void> _refreshClassics() async {
     ref.read(funnelcakeAvailableProvider.notifier).refresh();
     await ref.read(funnelcakeAvailableProvider.future);
+    // The widget can be disposed during any of these awaits (e.g. the Explore
+    // TabController settling on another tab, or navigating away) while a
+    // throttled-network refresh is still in flight. Using `ref` after that
+    // throws a StateError, so bail out once unmounted. See issue #6157.
+    if (!mounted) return;
     ref.invalidate(classicVinesAvailableProvider);
     await ref.read(classicVinesAvailableProvider.future);
+    if (!mounted) return;
     await ref.read(classicVinesFeedProvider.notifier).refresh();
   }
 }

--- a/mobile/test/widgets/classic_vines_tab_test.dart
+++ b/mobile/test/widgets/classic_vines_tab_test.dart
@@ -1,0 +1,99 @@
+// Regression test for issue #6157: ClassicVinesTab._refreshClassics used `ref`
+// after `await` gaps without a `mounted` guard. If the tab was disposed while a
+// throttled-network refresh was still in flight, the resumed refresh called
+// `ref.invalidate` on the unmounted widget and threw
+// `Bad state: Using "ref" when a widget ... has been unmounted is unsafe`.
+//
+// This drives the REAL ClassicVinesTab: its empty/unavailable auto-refresh fires
+// `_refreshClassics`, which is then held mid-`await` on a gated funnelcake future.
+// The tree is disposed, then the future is completed so `_refreshClassics` resumes
+// on a disposed widget. Without the guard this fails with the StateError above
+// (flutter_test surfaces the unhandled async error); with the guard the refresh
+// returns cleanly.
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/classic_vines_provider.dart';
+import 'package:openvine/providers/curation_providers.dart';
+import 'package:openvine/state/video_feed_state.dart';
+import 'package:openvine/widgets/classic_vines_tab.dart';
+
+// A funnelcake future the test controls, so it can dispose the widget while
+// `_refreshClassics` is suspended on `await ref.read(funnelcakeAvailableProvider.future)`.
+late Completer<bool> availabilityGate;
+int funnelcakeBuildCount = 0;
+
+class _ControlledFunnelcakeAvailable extends FunnelcakeAvailable {
+  @override
+  Future<bool> build() async {
+    funnelcakeBuildCount++;
+    // First build resolves false so ClassicVinesTab renders its unavailable
+    // state, whose autoRefresh fires _refreshClassics. Once _refreshClassics
+    // calls refresh() -> invalidateSelf, the next build stays pending on the
+    // gate, holding the widget in the disposal-vulnerable await.
+    if (funnelcakeBuildCount == 1) return false;
+    return availabilityGate.future;
+  }
+}
+
+class _EmptyClassicVinesFeed extends ClassicVinesFeed {
+  @override
+  Future<VideoFeedState> build() async =>
+      const VideoFeedState(videos: [], hasMoreContent: false);
+}
+
+Widget _host() => ProviderScope(
+  overrides: [
+    funnelcakeAvailableProvider.overrideWith(
+      _ControlledFunnelcakeAvailable.new,
+    ),
+    classicVinesFeedProvider.overrideWith(_EmptyClassicVinesFeed.new),
+  ],
+  child: const MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Scaffold(body: ClassicVinesTab()),
+  ),
+);
+
+void main() {
+  testWidgets(
+    'ClassicVinesTab does not throw when disposed mid-refresh (#6157)',
+    (tester) async {
+      availabilityGate = Completer<bool>();
+      funnelcakeBuildCount = 0;
+
+      await tester.pumpWidget(_host());
+      // Resolve providers, render the unavailable state, then run the post-frame
+      // autoRefresh -> _refreshClassics -> funnelcake refresh() -> await the
+      // (now gated, pending) funnelcake future.
+      for (var i = 0; i < 6; i++) {
+        await tester.pump(const Duration(milliseconds: 10));
+      }
+
+      // The refresh must actually be in flight: _refreshClassics invalidated
+      // funnelcake, triggering a second (pending) build.
+      expect(
+        funnelcakeBuildCount,
+        greaterThanOrEqualTo(2),
+        reason: '_refreshClassics should have re-invalidated funnelcake',
+      );
+
+      // Dispose the tree while _refreshClassics is suspended on the future.
+      await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+
+      // Completing the future resumes _refreshClassics after the widget is gone.
+      // Without the mounted guard, ref.invalidate throws an unhandled StateError
+      // that flutter_test surfaces as a test failure; with it, the refresh bails.
+      availabilityGate.complete(false);
+      await tester.pump(const Duration(milliseconds: 10));
+      await tester.pump(const Duration(milliseconds: 10));
+
+      expect(tester.takeException(), isNull);
+    },
+  );
+}


### PR DESCRIPTION
## Description

`ClassicVinesTab._refreshClassics` used `ref` (invalidate/read) after each `await`
gap without a `mounted` guard. If the tab was disposed while a refresh was still in
flight — the Explore `TabController` settling on another tab, navigating away, or a
slow/throttled-network refresh outstanding at teardown — the resumed refresh called
`ref.invalidate` on the unmounted widget and threw:

```
Bad state: Using "ref" when a widget is about to or has been unmounted is unsafe.
#0  ConsumerStatefulElement._assertNotDisposed (flutter_riverpod/…/consumer.dart:471:7)
#1  ConsumerStatefulElement.invalidate         (flutter_riverpod/…/consumer.dart:569:5)
#2  _ClassicVinesTabState._refreshClassics      (openvine/widgets/classic_vines_tab.dart:145:9)
<asynchronous suspension>
```

This flaked `integration_test/perf/feed_ttff_test.dart` — the fresh-user flow lands on
Explore Popular, where `ClassicVinesTab` auto-mounts with an empty classics feed and
self-refreshes — and in release builds surfaced as an unhandled async `StateError`
reported via `runZonedGuarded`.

The fix guards each `ref` use after an `await` with `if (!mounted) return;`, the
established pattern used across the app. `_refreshClassics` was introduced unguarded in
#3701 and had no test coverage.

**Related Issue:** Closes #6157

## Out of Scope

None.

## Verification

- `flutter analyze lib/widgets/classic_vines_tab.dart test/widgets/classic_vines_tab_test.dart` — clean.
- New regression test `test/widgets/classic_vines_tab_test.dart` drives the real
  `ClassicVinesTab`, disposes it while a refresh is in flight, and asserts no
  `StateError`. It consistently fails without the guard and passes with it across
  repeated runs.
- Pre-commit hook (format + analyze) passed.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
