### PR TITLE
test(event-router): restore coverage and document unsupported routing kinds

### DIFF
--- a/mobile/lib/services/event_router.dart
+++ b/mobile/lib/services/event_router.dart
@@ -289,6 +289,20 @@ class EventRouter {
     return routeBatch;
   }
 
+  /// Extracts denormalized rows for kinds that have a dedicated table.
+  ///
+  /// Only kind 0 (profiles) is denormalized, into UserProfiles. The other
+  /// routed kinds — 3 (contacts, NIP-02), 6 (repost, NIP-18), 7 (reactions,
+  /// NIP-25), and 34236 (video, NIP-71) — are intentionally raw-cached only
+  /// via [_persistRawEvents] and NOT denormalized here.
+  ///
+  /// No feed-aggregate table exists for them; their surfaced data comes from
+  /// other paths: like/reaction counts from the relay (NIP-45) and
+  /// LikesRepository, the user's own likes from PersonalReactions, follower
+  /// counts from the backend (ProfileStats), and VideoMetrics parsed from the
+  /// video event's own tags during raw caching. The cases stay listed
+  /// explicitly so this "unsupported by design" choice is visible rather than
+  /// an implicit default.
   Future<void> _routeEvent(Event event) async {
     switch (event.kind) {
       case 0:

--- a/mobile/scripts/baseline/future_delayed_tests.txt
+++ b/mobile/scripts/baseline/future_delayed_tests.txt
@@ -34,7 +34,6 @@ test/services/subscription_manager_cache_test.dart
 test/services/video_event_service_deduplication_test.dart
 test/services/video_event_service_pagination_test.dart
 test/services/video_event_service_repost_test.dart
-test/services/video_event_service_with_event_router_test.dart
 test/startup/startup_diagnostics_test.dart
 test/unit/services/video_event_service_force_refresh_test.dart
 test/unit/services/video_event_service_infinite_scroll_test.dart

--- a/mobile/scripts/baseline/skip_tests.txt
+++ b/mobile/scripts/baseline/skip_tests.txt
@@ -60,7 +60,6 @@ test/services/video_event_publisher_native_proof_test.dart
 test/services/video_event_service_deduplication_test.dart
 test/services/video_event_service_replaceable_test.dart
 test/services/video_event_service_repost_test.dart
-test/services/video_event_service_with_event_router_test.dart
 test/tools/future_delayed_detector_test.dart
 test/tools/naming_convention_test.dart
 test/unit/services/classic_vines_priority_test.dart

--- a/mobile/test/services/event_router_test.dart
+++ b/mobile/test/services/event_router_test.dart
@@ -5,6 +5,7 @@ import 'dart:convert';
 
 import 'package:db_client/db_client.dart';
 import 'package:drift/native.dart';
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart';
 import 'package:nostr_sdk/event.dart';
@@ -349,6 +350,107 @@ void main() {
         expect(router.queuedLength, equals(1000));
         expect(router.droppedEventCount, equals(0));
       });
+    });
+
+    group('unsupported routing kinds', () {
+      test('raw-caches kind 3 (contacts) and kind 7 (reactions) without '
+          'denormalizing them', () async {
+        final contacts = Event(pubkeyFor(80), 3, const [], '');
+        final reaction = Event(pubkeyFor(81), 7, const [], '+');
+
+        await flush([contacts, reaction]);
+
+        // Both are stored raw in the events table...
+        expect(await db.nostrEventsDao.getEventById(contacts.id), isNotNull);
+        expect(await db.nostrEventsDao.getEventById(reaction.id), isNotNull);
+        // ...but neither is denormalized: _routeEvent is a no-op for these
+        // kinds, so no profile (or any other derived row) is written.
+        expect(await db.userProfilesDao.getProfile(contacts.pubkey), isNull);
+        expect(await db.userProfilesDao.getProfile(reaction.pubkey), isNull);
+      });
+    });
+
+    group('autoStart ingestion path', () {
+      test('flushes immediately when the batch reaches maxBatchSize', () async {
+        final r = EventRouter(
+          db,
+          config: const EventRouterConfig(maxBatchSize: 3),
+        );
+        addTearDown(r.dispose);
+        final events = [videoEvent(93), videoEvent(94), videoEvent(95)];
+
+        r.handleEvent(events[0]);
+        r.handleEvent(events[1]);
+        // Below the threshold: a flush timer is armed, nothing drained yet.
+        expect(r.queuedLength, equals(2));
+
+        r.handleEvent(events[2]);
+        // Reaching maxBatchSize cancels the timer and drains synchronously
+        // (the batch is dequeued before the first await in _processNextBatch).
+        expect(r.queuedLength, equals(0));
+
+        await pumpEventQueue();
+        for (final event in events) {
+          expect(await db.nostrEventsDao.getEventById(event.id), isNotNull);
+        }
+      });
+
+      test('arms a flush timer that drains the queue on elapse', () {
+        fakeAsync((async) {
+          final r = EventRouter(
+            db,
+            config: const EventRouterConfig(
+              flushDelay: Duration(milliseconds: 20),
+              maxBatchSize: 10,
+            ),
+          );
+
+          r.handleEvent(videoEvent(90));
+          // Timer armed but not yet fired.
+          expect(r.queuedLength, equals(1));
+
+          async.elapse(const Duration(milliseconds: 20));
+          // Timer fired: _takeNextBatch dequeues synchronously, so the queue
+          // is empty even though the DB write completes on the real loop
+          // (asserting queuedLength here needs no DB under the fake clock).
+          expect(r.queuedLength, equals(0));
+
+          r.dispose();
+        });
+      });
+
+      test('persists an enqueued event without a manual drain', () async {
+        final r = EventRouter(
+          db,
+          config: const EventRouterConfig(flushDelay: Duration.zero),
+        );
+        addTearDown(r.dispose);
+        final event = videoEvent(91);
+
+        r.handleEvent(event);
+        // Duration.zero takes the immediate branch; pump the real event loop
+        // so the fire-and-forget persist completes.
+        await pumpEventQueue();
+
+        expect(await db.nostrEventsDao.getEventById(event.id), isNotNull);
+      });
+
+      test(
+        'swallows a persistence error so ingestion is not aborted',
+        () async {
+          // Close the shared database so the DAO throws mid-persist. The group
+          // tearDown closes it again, which drift tolerates.
+          await db.close();
+
+          router.handleEvent(videoEvent(92));
+
+          // drainForTesting must complete without rethrowing, and the batch is
+          // still consumed (the error is caught and logged in _persistBatch).
+          await router.drainForTesting();
+
+          expect(router.queuedLength, equals(0));
+        },
+      );
     });
   });
 }

--- a/mobile/test/services/video_event_service_with_event_router_test.dart
+++ b/mobile/test/services/video_event_service_with_event_router_test.dart
@@ -83,8 +83,11 @@ void main() {
       testDbPath = p.join(tempDir.path, 'test.db');
       db = AppDatabase.test(NativeDatabase(File(testDbPath)));
 
-      // Create EventRouter
-      eventRouter = EventRouter(db);
+      // Create EventRouter (autoStart off so tests drain deterministically)
+      eventRouter = EventRouter(
+        db,
+        config: const EventRouterConfig(autoStart: false),
+      );
 
       // Create mock NostrService
       mockNostrService = MockNostrService();
@@ -110,6 +113,15 @@ void main() {
         await file.delete();
       }
     });
+
+    /// Flushes the mock event stream into the router, then drains it
+    /// deterministically. Replaces wall-clock waits: [pumpEventQueue] lets the
+    /// broadcast-stream listener forward the emitted event into the router's
+    /// queue, then [EventRouter.drainForTesting] persists it.
+    Future<void> settle() async {
+      await pumpEventQueue();
+      await eventRouter.drainForTesting();
+    }
 
     test('exposes the injected EventRouter via eventRouter getter', () {
       expect(videoEventService.eventRouter, same(eventRouter));
@@ -140,8 +152,7 @@ void main() {
       // Emit event via mock NostrService
       mockNostrService.emitEvent(videoEvent);
 
-      // Wait for event processing
-      await Future.delayed(const Duration(milliseconds: 100));
+      await settle();
 
       // Verify event was cached to database via EventRouter
       final cachedEvent = await db.nostrEventsDao.getEventById(
@@ -181,8 +192,7 @@ void main() {
         // Emit profile event via mock NostrService
         mockNostrService.emitEvent(profileEvent);
 
-        // Wait for event processing
-        await Future.delayed(const Duration(milliseconds: 100));
+        await settle();
 
         // Verify event was cached to NostrEvents table
         final cachedEvent = await db.nostrEventsDao.getEventById(
@@ -234,8 +244,7 @@ void main() {
       // Emit contacts event via mock NostrService
       mockNostrService.emitEvent(contactsEvent);
 
-      // Wait for event processing
-      await Future.delayed(const Duration(milliseconds: 100));
+      await settle();
 
       // Verify event was cached to database
       final cachedEvent = await db.nostrEventsDao.getEventById(
@@ -273,8 +282,7 @@ void main() {
       // Emit reaction event via mock NostrService
       mockNostrService.emitEvent(reactionEvent);
 
-      // Wait for event processing
-      await Future.delayed(const Duration(milliseconds: 100));
+      await settle();
 
       // Verify event was cached to database
       final cachedEvent = await db.nostrEventsDao.getEventById(
@@ -307,8 +315,7 @@ void main() {
       // Emit unknown event via mock NostrService
       mockNostrService.emitEvent(unknownEvent);
 
-      // Wait for event processing
-      await Future.delayed(const Duration(milliseconds: 100));
+      await settle();
 
       // Verify event was cached to database
       final cachedEvent = await db.nostrEventsDao.getEventById(
@@ -319,17 +326,21 @@ void main() {
       expect(cachedEvent.content, equals('Unknown kind content'));
     });
 
-    test('Multiple events from same subscription are all cached', () async {
+    test('caches every event from one subscription (distinct authors)', () async {
       // Subscribe to discovery feed
       await videoEventService.subscribeToVideoFeed(
         subscriptionType: SubscriptionType.discovery,
       );
 
-      // Create and emit multiple test events
+      // Distinct pubkeys: one feed subscription carries videos from many
+      // authors, so each event is a distinct addressable coordinate and none
+      // supersede each other. (The original fixture reused a single pubkey with
+      // no d-tag, collapsing all 5 to one coordinate so only the newest
+      // survived the addressable upsert.)
       final events = <Event>[];
-      for (int i = 0; i < 5; i++) {
+      for (var i = 0; i < 5; i++) {
         final event = Event(
-          'abababababababababababababababababababababababababababababababab',
+          '${i + 1}'.padLeft(64, '0'),
           34236,
           [
             ['url', 'https://example.com/video$i.mp4'],
@@ -347,18 +358,13 @@ void main() {
         mockNostrService.emitEvent(event);
       }
 
-      // Wait for all events to process
-      await Future.delayed(const Duration(milliseconds: 200));
+      await settle();
 
-      // Verify all events were cached
-      for (int i = 0; i < 5; i++) {
-        final cachedEvent = await db.nostrEventsDao.getEventById(
-          'event${i}00000000000000000000000000000000000000000000000000000000000',
-        );
-        expect(cachedEvent, isNotNull, reason: 'Event $i should be cached');
+      for (final event in events) {
+        final cachedEvent = await db.nostrEventsDao.getEventById(event.id);
+        expect(cachedEvent, isNotNull, reason: '${event.id} should be cached');
         expect(cachedEvent!.kind, equals(34236));
       }
-      // TODO(any): Fix and re-enable this test
-    }, skip: true);
+    });
   });
 }


### PR DESCRIPTION
## Description

#3345 asked to restore EventRouter test coverage and resolve routing-TODO drift. Investigation found that two of its four acceptance criteria were **already satisfied incidentally** by perf work (#5395, #5406, #5906) that never referenced the issue:

- **AC1 (real enabled tests)** and **AC2 (deterministic flush)** are already met — `event_router_test.dart` has real behaviour tests and `EventRouter` exposes `drainForTesting()` / `drainOneBatchForTesting()`.

This PR closes the two remaining gaps plus approved hardening.

**AC3 — document the unsupported routing kinds.** #5406 stripped the old `// TODO: Future implementation` comments from `_routeEvent`, leaving unexplained bare `break;` for kinds 3/6/7/34236. There is no denormalized table for contacts or reactions from the feed — their surfaced data comes from other paths (relay NIP-45 + `LikesRepository`, `PersonalReactions` for the user's own likes, Funnelcake `ProfileStats` for follower counts, and `VideoMetrics` parsed from the video's own tags during raw caching). The cases are now documented as raw-cached-only by design, with a regression test pinning "kind 3/7 raw-cached but not denormalized".

**AC4 — resolve the skipped integration test.** The disabled test wasn't flaky. Its fixture reused a single pubkey with no `d`-tag, so all 5 kind-34236 events collapsed to one addressable coordinate and only the newest survived the upsert — the "all 5 cached" assertion could never pass. It was bulk-disabled by #759 without diagnosis. Rewritten with distinct pubkeys (a realistic multi-author single-subscription feed) and re-enabled; it now covers a path no other test did — multiple events through one `VideoEventService` subscription all reaching the DB.

**Hardening:**
- Added autoStart-path coverage that was entirely untested (every prior test used `autoStart:false`): immediate `maxBatchSize` flush, `fakeAsync` flush-timer arm, `Duration.zero` persist, and the `_persistBatch` error-swallow.
- Converted the file's five `Future.delayed(100ms)` waits to a deterministic `pumpEventQueue()` + `drainForTesting()` drain.

No runtime behaviour changes — the only app-code change is a doc comment.

Note: the issue's Evidence section is stale — it cites `event_router.dart:93-99` TODOs that #5406 has since deleted.

**Related Issue:** Closes #3345 (part of #4337)

## Out of Scope

A few autoStart branches remain intentionally uncovered and can be a follow-up if wanted: `_enforceQueueBound` visible-drop, `_coalesceReplaceableRouting` keep-newer, and the memory-pressure `shedLowPriority` / `queuedLength` wiring in `main.dart`.

## Verification

- `dart format --output=none --set-exit-if-changed` — clean
- `flutter analyze lib test` — no issues
- `flutter test test/services/event_router_test.dart test/services/video_event_service_with_event_router_test.dart` — 27 passing, including with `--test-randomize-ordering-seed random`

## Type of Change

- [x] 🧹 Code refactor
- [x] 📝 Documentation
