### PR TITLE
chore(deps): remove misplaced/unused root dependencies (#3631, #3632)

### DIFF
--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -456,14 +456,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
-  cupertino_icons:
-    dependency: "direct main"
-    description:
-      name: cupertino_icons
-      sha256: ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.8"
   dart_style:
     dependency: transitive
     description:

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -378,7 +378,7 @@ packages:
     source: hosted
     version: "0.6.1+1"
   convert:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: convert
       sha256: b30acd5944035672bc15c6b7a8b47d773e41e2f17de064350988c5d02adb1c68
@@ -1143,7 +1143,7 @@ packages:
     source: hosted
     version: "3.2.2"
   http_parser:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: http_parser
       sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -86,10 +86,6 @@ dependencies:
   flutter:
     sdk: flutter
 
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.8
-
   # Analytics — unified event schema and the single Firebase analytics surface.
   analytics:
 

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -109,7 +109,6 @@ dependencies:
 
   # Networking
   http: ^1.5.0
-  http_parser: ^4.0.2
   web_socket_channel: ^3.0.3
   connectivity_plus: ^7.3.0
   device_info_plus: ^10.1.2
@@ -305,7 +304,6 @@ dependencies:
   video_player_web_hls: ^1.3.0
   firebase_performance: ^0.11.1+4
   firebase_messaging: ^16.1.1
-  convert: ^3.1.2
   audio_session: ^0.2.2
   pro_video_editor: ^2.6.0
   pro_image_editor: ^13.2.0


### PR DESCRIPTION
## Description

Removes three misplaced/unused `direct main` dependencies from root `mobile/pubspec.yaml`. This bundles the still-valid removals from two issues in the same 2026-04-29 dependency audit.

### `cupertino_icons` (#3631)

Leftover `flutter create` boilerplate with no usage anywhere in the app:

- No `CupertinoIcons.*` glyph references (0 hits across `lib`, `test`, `packages`).
- No `package:flutter/cupertino.dart` imports and no Cupertino widgets that render its font.
- The only `Cupertino*`-shaped identifiers in the tree are unrelated: `CupertinoClient` (the `cupertino_http` networking package in `media_cache`) and `GlobalCupertinoLocalizations` (from `flutter_localizations`). `Switch.adaptive` renders `CupertinoSwitch` on iOS, which is custom-painted and uses no icon glyph.

It is a `direct main` leaf with no transitive dependents, so it drops cleanly from the lock.

### `convert` and `http_parser` (#3632)

Both were declared `direct main` at the root, but the app layer (`mobile/lib`, `test`, `integration_test`) imports **neither**. Their only importers are workspace packages that declare their own copies:

- `convert` → used by `nostr_sdk` (declares `^3.1.1`) and `blossom_upload_service` (declares `^3.1.1`).
- `http_parser` → used only by `nostr_sdk` (declares `^4.1.2`).

Because this is a pub workspace, removing the root declarations only reclassifies both `direct main → transitive` at the **identical** resolved version (`convert` 3.1.2, `http_parser` 4.1.2 — same sha256, no downgrade); the packages stay resolved via `nostr_sdk` / `blossom_upload_service`.

> Note: the #3632 issue body's "where used" list is inaccurate — `funnelcake_api_client` uses neither package. The removal conclusion still holds.

**Related Issues:** Closes #3631, Closes #3632

## Out of Scope

- `file_picker` (named in #3631) — **kept**. It was accurate to flag at filing (2026-04-29, declared but unimported), but PR #4503 (2026-05-19) reactivated it: `FilePicker.platform.pickFiles(...)` is now used in `lib/widgets/video_editor/audio_editor/audio_selection_bottom_sheet.dart` (the "import local audio files" feature), so removing it would break the build.
- A general unused-dependency audit / `dependency_validator` CI gate — worth a separate issue to catch future declared-but-unused (and used-but-undeclared) deps, especially since `depend_on_referenced_packages` is disabled in `analysis_options.yaml`, so the analyzer won't flag implicit deps automatically. Out of scope here to keep this focused.

## Verification

- `flutter pub get` → `Got dependencies!`. Lock delta is exactly the `cupertino_icons` block removal plus `convert` / `http_parser` reclassified `direct main → transitive` (versions unchanged). `file_picker` retained.
- `flutter analyze lib test integration_test` → **No issues found!** (also verified clean in `nostr_sdk` and `blossom_upload_service`).
- Diff is two files: `pubspec.yaml` (−6 lines) and `pubspec.lock`.

## Type of Change

- [x] 🗑️ Chore
