### PR TITLE
chore(deps): migrate media_kit_video to pub and harden the c2pa_flutter git pin

### DIFF
--- a/mobile/packages/divine_video_player/pubspec.yaml
+++ b/mobile/packages/divine_video_player/pubspec.yaml
@@ -18,11 +18,7 @@ dependencies:
     sdk: flutter
   media_kit: ^1.2.6
   media_kit_libs_video: ^1.0.7
-  media_kit_video:
-    git:
-      url: https://github.com/divinevideo/media-kit
-      ref: 6b718491261e40ddebf1fe9b880b3d5d30205ee0
-      path: media_kit_video
+  media_kit_video: ^2.0.1
   path_provider: ^2.1.5
   unified_logger:
     path: ../unified_logger

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1446,11 +1446,10 @@ packages:
   media_kit_video:
     dependency: transitive
     description:
-      path: media_kit_video
-      ref: "6b718491261e40ddebf1fe9b880b3d5d30205ee0"
-      resolved-ref: "6b718491261e40ddebf1fe9b880b3d5d30205ee0"
-      url: "https://github.com/divinevideo/media-kit"
-    source: git
+      name: media_kit_video
+      sha256: afaa509e7b7e0bf247557a3a740cde903a52c34ace9810f94500e127bd7b043d
+      url: "https://pub.dev"
+    source: hosted
     version: "2.0.1"
   melos:
     dependency: "direct dev"

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -268,7 +268,7 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "0.0.3"
+      ref: "847d0c0183c9c09946ce321c107decd3fd9f56b2"
       resolved-ref: "847d0c0183c9c09946ce321c107decd3fd9f56b2"
       url: "https://github.com/guardianproject/c2pa-flutter.git"
     source: git

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -131,10 +131,17 @@ dependencies:
   record: ^7.1.0 # Microphone capture for voice-over recording
 
   # Camera and media
+  # c2pa_flutter is intentionally git-pinned: the guardianproject plugin Divine
+  # uses is not published on pub.dev. (pub.dev's same-named package is an
+  # unrelated third-party FFI rewrite — different author, c2pa-rs 0.75.x, no
+  # RemoteSigner.) Pinned by immutable commit (tag 0.0.3) so a moved tag cannot
+  # silently change the build.
+  # TODO(#6166): revert to a pub/version dep if guardianproject publishes
+  # c2pa_flutter to pub.dev.
   c2pa_flutter:
     git:
       url: https://github.com/guardianproject/c2pa-flutter.git
-      ref: 0.0.3
+      ref: 847d0c0183c9c09946ce321c107decd3fd9f56b2 # tag 0.0.3
   divine_camera:
     path: packages/divine_camera
   divine_quick_actions:


### PR DESCRIPTION
## Description

Resolves the two git-pinned dependencies flagged in #3637. They needed opposite remediations, so this is one PR with two clearly-delineated commits.

**1. `media_kit_video` → pub `^2.0.1` (removes the git pin).**
The `divinevideo/media-kit` fork diverged from pub `media_kit_video` 2.0.1 by a single darwin-only patch — an iOS-Simulator software-render rotation crash workaround (upstream media-kit/media-kit#627). Divine routes `media_kit` only on Linux (`kIsWeb || TargetPlatform.linux` in `divine_video_player`); iOS/macOS use native AVFoundation, Android ExoPlayer, Web `HtmlVideoElement`. That darwin path is unreachable on every platform we ship, so the fork carried dead code for us. Pub 2.0.1's Dart/pubspec surface is identical to the fork, so the swap is dependency-graph and behaviour neutral.

**2. `c2pa_flutter` → documented + hardened (stays git-pinned).**
It can't move to pub: the guardianproject plugin we use isn't on pub.dev, and pub.dev's same-named `c2pa_flutter` is an unrelated third-party rewrite (different author, `flutter_rust_bridge` FFI, c2pa-rs 0.75.x, no `RemoteSigner`) our signing services can't consume. `0.0.3` is guardianproject's latest tag. This pins the immutable commit (was the movable `0.0.3` tag) so a moved/force-pushed tag can't silently change the build, and adds a comment explaining the pin. The resolved commit is unchanged.

The systemic "git pins bypass pub.dev scanning" concern is tracked separately in #3655.

**Related Issue:** Closes #3637

## Out of Scope

- De-git-pinning `c2pa_flutter` — blocked upstream; tracked in #6166 (revert to pub if guardianproject publishes).
- Automated git-pin monitoring — #3655.

## Verification

- `flutter pub get` — clean; `media_kit_video` flips git→hosted (pub 2.0.1), `c2pa_flutter` `resolved-ref` unchanged (immutable-SHA relabel only).
- `flutter analyze lib test integration_test` — No issues found.
- `flutter analyze` + `flutter test` in `divine_video_player` — 250 tests pass.
- `flutter test` for c2pa signing / identity-manifest / native-proofmode services — 18 tests pass.

## Type of Change

- [x] ✅ Build configuration change
- [x] 🗑️ Chore
