### PR TITLE
fix(feed): ignore double-tap-to-like on your own video

### DIFF
--- a/mobile/lib/widgets/video_feed_item/double_tap_like_helpers.dart
+++ b/mobile/lib/widgets/video_feed_item/double_tap_like_helpers.dart
@@ -1,0 +1,37 @@
+// ABOUTME: Pure decision helper for the double-tap-to-like gesture on feed
+// ABOUTME: videos. Keeps the "you can't like your own video" rule testable in
+// ABOUTME: isolation from the FeedVideos overlay widget.
+
+/// The action a double-tap on a feed video should trigger.
+enum DoubleTapLikeAction {
+  /// Do nothing: the viewer owns the video (you can't like your own video), or
+  /// a content warning is still blocking interaction.
+  ignore,
+
+  /// Play the heart animation without changing the like state — the video is
+  /// already liked, so a double-tap re-affirms rather than unliking.
+  animateOnly,
+
+  /// Toggle the like on and play the heart animation.
+  likeAndAnimate,
+}
+
+/// Decides how a double-tap on a feed video should behave.
+///
+/// Mirrors the like button's rule that the owner cannot like their own video
+/// (see `LikeActionButton`): on the owner's own video the gesture is a no-op.
+/// A content warning that still blocks the video also suppresses the gesture.
+/// Otherwise an unliked video is liked; an already-liked video only replays the
+/// heart animation, because double-tap never unlikes.
+DoubleTapLikeAction resolveDoubleTapLikeAction({
+  required bool isOwnVideo,
+  required bool contentWarningBlocking,
+  required bool alreadyLiked,
+}) {
+  if (isOwnVideo || contentWarningBlocking) {
+    return DoubleTapLikeAction.ignore;
+  }
+  return alreadyLiked
+      ? DoubleTapLikeAction.animateOnly
+      : DoubleTapLikeAction.likeAndAnimate;
+}

--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -33,6 +33,7 @@ import 'package:openvine/widgets/divine_video_metrics_tracker.dart';
 import 'package:openvine/widgets/video_feed_item/blurred_video_backdrop.dart';
 import 'package:openvine/widgets/video_feed_item/content_warning_helpers.dart';
 import 'package:openvine/widgets/video_feed_item/double_tap_heart_overlay.dart';
+import 'package:openvine/widgets/video_feed_item/double_tap_like_helpers.dart';
 import 'package:openvine/widgets/video_feed_item/live_engagement_counts.dart';
 import 'package:openvine/widgets/video_feed_item/moderated_content_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/paused_video_overlay.dart';
@@ -512,20 +513,32 @@ class __OverlayState extends ConsumerState<_Overlay> {
     super.dispose();
   }
 
-  void _handleDoubleTapLike(BuildContext context, TapDownDetails details) {
-    final showWarning = shouldShowContentWarningOverlay(
-      contentWarningLabels: widget.video.contentWarningLabels,
-      warnLabels: widget.video.warnLabels,
-    );
-    if (showWarning && !widget.contentWarningRevealed) return;
+  void _handleDoubleTapLike(
+    BuildContext context,
+    TapDownDetails details, {
+    required bool isOwnVideo,
+  }) {
+    final contentWarningBlocking =
+        shouldShowContentWarningOverlay(
+          contentWarningLabels: widget.video.contentWarningLabels,
+          warnLabels: widget.video.warnLabels,
+        ) &&
+        !widget.contentWarningRevealed;
 
     final bloc = context.read<VideoInteractionsBloc>();
-    final state = bloc.state;
-    if (!state.isLiked) {
+    final action = resolveDoubleTapLikeAction(
+      isOwnVideo: isOwnVideo,
+      contentWarningBlocking: contentWarningBlocking,
+      alreadyLiked: bloc.state.isLiked,
+    );
+
+    if (action == DoubleTapLikeAction.ignore) return;
+
+    if (action == DoubleTapLikeAction.likeAndAnimate) {
       bloc.add(const VideoInteractionsLikeToggled());
     }
 
-    // Always show heart animation at tap position (even if already liked)
+    // Show heart animation at tap position (also when already liked).
     _heartTrigger.value = (
       offset: details.localPosition,
       id: ++_heartTriggerId,
@@ -721,7 +734,11 @@ class __OverlayState extends ConsumerState<_Overlay> {
                     behavior: .translucent,
                     onTap: interactiveReady ? _handlePlayerTap : null,
                     onDoubleTapDown: interactiveReady
-                        ? (details) => _handleDoubleTapLike(context, details)
+                        ? (details) => _handleDoubleTapLike(
+                            context,
+                            details,
+                            isOwnVideo: isOwnVideo,
+                          )
                         : null,
                     child: Stack(
                       children: [

--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -729,7 +729,7 @@ class __OverlayState extends ConsumerState<_Overlay> {
                 return Semantics(
                   button: true,
                   label: context.l10n.videoPlayerPlayVideo,
-                  hint: context.l10n.videoPlayerTapHint,
+                  hint: isOwnVideo ? null : context.l10n.videoPlayerTapHint,
                   child: GestureDetector(
                     behavior: .translucent,
                     onTap: interactiveReady ? _handlePlayerTap : null,

--- a/mobile/test/widgets/video_feed_item/double_tap_like_helpers_test.dart
+++ b/mobile/test/widgets/video_feed_item/double_tap_like_helpers_test.dart
@@ -1,0 +1,71 @@
+// ABOUTME: Tests for resolveDoubleTapLikeAction — the pure decision behind the
+// ABOUTME: double-tap-to-like gesture, including the "can't like your own
+// ABOUTME: video" guard that the like button already enforces.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/widgets/video_feed_item/double_tap_like_helpers.dart';
+
+void main() {
+  group('resolveDoubleTapLikeAction', () {
+    test(
+      'likes and animates when a not-yet-liked other video is double-tapped',
+      () {
+        final action = resolveDoubleTapLikeAction(
+          isOwnVideo: false,
+          contentWarningBlocking: false,
+          alreadyLiked: false,
+        );
+
+        expect(action, DoubleTapLikeAction.likeAndAnimate);
+      },
+    );
+
+    test('only animates when an already-liked video is double-tapped', () {
+      // Double-tap must never unlike, so an already-liked video just replays
+      // the heart animation.
+      final action = resolveDoubleTapLikeAction(
+        isOwnVideo: false,
+        contentWarningBlocking: false,
+        alreadyLiked: true,
+      );
+
+      expect(action, DoubleTapLikeAction.animateOnly);
+    });
+
+    test("ignores the gesture on the viewer's own video", () {
+      // Regression guard: double-tapping your own video (e.g. from your
+      // profile) must not like it — mirrors LikeActionButton.
+      final action = resolveDoubleTapLikeAction(
+        isOwnVideo: true,
+        contentWarningBlocking: false,
+        alreadyLiked: false,
+      );
+
+      expect(action, DoubleTapLikeAction.ignore);
+    });
+
+    test('ignores own video that already carries a self-like', () {
+      // Real data, not hypothetical: the pre-fix bug published self-likes, and
+      // other Nostr clients can too. Pins that the own-video guard is checked
+      // before alreadyLiked — animateOnly here would replay the heart on the
+      // owner's own video.
+      final action = resolveDoubleTapLikeAction(
+        isOwnVideo: true,
+        contentWarningBlocking: false,
+        alreadyLiked: true,
+      );
+
+      expect(action, DoubleTapLikeAction.ignore);
+    });
+
+    test('ignores the gesture while a content warning is blocking', () {
+      final action = resolveDoubleTapLikeAction(
+        isOwnVideo: false,
+        contentWarningBlocking: true,
+        alreadyLiked: false,
+      );
+
+      expect(action, DoubleTapLikeAction.ignore);
+    });
+  });
+}

--- a/mobile/test/widgets/video_feed_item/feed_videos_test.dart
+++ b/mobile/test/widgets/video_feed_item/feed_videos_test.dart
@@ -213,9 +213,12 @@ List _buildOverrides({
   LikesRepository? likesRepository,
   CommentsRepository? commentsRepository,
   RepostsRepository? repostsRepository,
+  MockAuthService? authService,
 }) {
   return [
-    ...getStandardTestOverrides(mockAuthService: createMockAuthService()),
+    ...getStandardTestOverrides(
+      mockAuthService: authService ?? createMockAuthService(),
+    ),
     analyticsServiceProvider.overrideWithValue(_NoopAnalyticsService()),
     seenVideosServiceProvider.overrideWithValue(_NoopSeenVideosService()),
     connectionStatusServiceProvider.overrideWithValue(
@@ -253,6 +256,7 @@ Future<void> _pumpFeedVideos(
   _MockLikesRepository? likesRepository,
   _MockCommentsRepository? commentsRepository,
   _MockRepostsRepository? repostsRepository,
+  MockAuthService? authService,
   bool isActive = true,
   bool appForeground = true,
   bool hasMore = false,
@@ -277,6 +281,7 @@ Future<void> _pumpFeedVideos(
       likesRepository: likesRepository,
       commentsRepository: commentsRepository,
       repostsRepository: repostsRepository,
+      authService: authService,
     ).cast(),
   );
   container.read(appForegroundProvider.notifier).setForeground(appForeground);
@@ -675,6 +680,39 @@ void main() {
         final semanticsNode = tester.getSemantics(surfaceFinder);
         expect(semanticsNode.flagsCollection.isButton, isTrue);
         expect(semanticsNode.hint, equals(l10n.videoPlayerTapHint));
+      } finally {
+        semantics.dispose();
+      }
+    });
+
+    testWidgets('omits double-tap-like semantics hint on own video', (
+      tester,
+    ) async {
+      final semantics = tester.ensureSemantics();
+      try {
+        InfiniteVideoFeed.debugIsSupportedOverride = true;
+
+        final video = _makeVideo();
+        final authService = createMockAuthService();
+        when(() => authService.currentPublicKeyHex).thenReturn(video.pubkey);
+        final cubit = _MockVideoPlaybackStatusCubit()
+          ..stub(PlaybackStatus.ready, video.id);
+
+        await _pumpFeedVideos(
+          tester,
+          videos: [video],
+          videoPlaybackStatusCubit: cubit,
+          authService: authService,
+        );
+        await tester.pump(const Duration(seconds: 4));
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        final surfaceFinder = find.bySemanticsLabel(l10n.videoPlayerPlayVideo);
+
+        expect(surfaceFinder, findsOneWidget);
+        final semanticsNode = tester.getSemantics(surfaceFinder);
+        expect(semanticsNode.flagsCollection.isButton, isTrue);
+        expect(semanticsNode.hint, isEmpty);
       } finally {
         semantics.dispose();
       }


### PR DESCRIPTION
Closes #6170

## What

Double-tapping your **own** video no longer likes it. Previously, viewing your own video in your profile (or anywhere in the feed) and double-tapping registered a like.

The player semantics hint also no longer tells assistive-tech users to double-tap to like on their own videos, because that gesture is now intentionally ignored there.

## Why

The profile fullscreen viewer reuses the shared `FeedVideos` overlay — there is no separate profile player. The like button already enforces "you can't like your own video" (`isOwnVideo` → it opens the likers list instead of toggling), but the double-tap gesture handler never consulted `isOwnVideo`, so it bypassed that rule. Since it's the same widget, the bug reproduced from the profile as well as the main feed.

The decision is extracted into a pure `resolveDoubleTapLikeAction(...)` helper (mirroring the existing `content_warning_helpers.dart` pattern) so the rule is:

- **own video** → ignore (no like, no heart animation), consistent with the like button
- **content warning still blocking** → ignore
- **already liked** → replay the heart animation only (double-tap never unlikes)
- **otherwise** → like + animate

## Testing

The double-tap gesture lives only in the interactive overlay, which requires a real video controller with a rendered first frame — the widget-test harness disables that (`debugIsSupportedOverride = false`), which is why this gesture had no widget coverage. The extracted helper is the clean, can-fail seam: `double_tap_like_helpers_test.dart` covers the own-video regression plus every other branch. If the `isOwnVideo` guard were removed, the test goes red.

- `flutter test test/widgets/video_feed_item/double_tap_like_helpers_test.dart test/widgets/video_feed_item/feed_videos_test.dart` — 22/22 green
- `flutter analyze` — clean
