### PR TITLE
docs: fix stale Linux desktop dependency documentation

### DIFF
--- a/mobile/docs/LINUX_SUPPORT.md
+++ b/mobile/docs/LINUX_SUPPORT.md
@@ -7,9 +7,9 @@ divine-mobile can be built and run on Linux desktop for browsing and watching vi
 | Feature | Status |
 |---------|--------|
 | Browse / discover videos | Works |
-| Watch videos | Works (requires GStreamer) |
+| Watch videos | Works (requires libmpv) |
 | Login / auth (bunker, nsec) | Works |
-| Notifications | Works (requires libnotify) |
+| Notifications | Works (via D-Bus) |
 | Video recording | Not available |
 | Gallery save | Skipped on desktop |
 | Firebase / Crashlytics | Gracefully disabled |
@@ -20,19 +20,23 @@ Install these before building:
 
 ```bash
 # Ubuntu / Debian
-sudo apt install libgtk-3-dev libsecret-1-dev libjsoncpp-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-good libnotify-dev
+sudo apt install libgtk-3-dev libsecret-1-dev libmpv-dev libepoxy-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-good libwebkit2gtk-4.1-dev libasound2-dev
 
 # Fedora
-sudo dnf install gtk3-devel libsecret-devel jsoncpp-devel gstreamer1-devel gstreamer1-plugins-base-devel gstreamer1-plugins-good libnotify-devel
+sudo dnf install gtk3-devel libsecret-devel mpv-devel libepoxy-devel gstreamer1-devel gstreamer1-plugins-base-devel gstreamer1-plugins-good webkit2gtk4.1-devel alsa-lib-devel
 ```
 
 | Package | Used by |
 |---------|---------|
-| `libgtk-3-dev` | Flutter Linux embedding |
-| `libsecret-1-dev` | `flutter_secure_storage` (keychain) |
-| `libjsoncpp-dev` | `flutter_secure_storage` |
-| `gstreamer1.0-*` | `video_player` (video playback) |
-| `libnotify-dev` | `flutter_local_notifications` |
+| `libgtk-3-dev` | Flutter Linux embedding (all plugins) |
+| `libsecret-1-dev` | `flutter_secure_storage_linux` (keychain) |
+| `libmpv-dev` | `media_kit_video` — **video playback** engine (libmpv) |
+| `libepoxy-dev` | `media_kit_video` — GL texture rendering |
+| `libgstreamer1.0-dev`, `libgstreamer-plugins-base1.0-dev` | `pro_video_editor` — video metadata & thumbnail generation (**not** playback) |
+| `libwebkit2gtk-4.1-dev` | `desktop_webview_window` (embedded webview) |
+| `libasound2-dev` | `volume_controller` (system volume via ALSA) |
+
+> **Video playback vs. GStreamer:** playback runs through `media_kit` → **libmpv** (which decodes via FFmpeg, not GStreamer). GStreamer is required only by `pro_video_editor` for metadata extraction and thumbnail generation. `video_player` has no Linux implementation and plays no part on this platform.
 
 ## Building
 


### PR DESCRIPTION
## Description

`mobile/docs/LINUX_SUPPORT.md` documented the Linux video stack incorrectly, and its system-dependency list had drifted. Most visibly, it attributed video playback to `video_player` + GStreamer — but `video_player` has **no Linux implementation** at all, and Linux playback actually runs through `media_kit` → **libmpv** (which decodes via FFmpeg, not GStreamer). GStreamer *is* required on Linux, but by `pro_video_editor` for metadata/thumbnail generation — not playback.

The doc has been wrong since it was created (#1795); the real media_kit/libmpv Linux backend landed later (#4487) without updating it.

### Corrections

Every claim below was verified against each registered Linux plugin's `linux/CMakeLists.txt` (in the pub cache / pub archive) and the Linux plugin registrant.

**Fixed attributions**
- Playback status: `requires GStreamer` → `requires libmpv` (`media_kit_video` links `PkgConfig::mpv`).
- Dependency table: GStreamer re-attributed from `video_player (video playback)` → `pro_video_editor (metadata & thumbnails)`; added an explicit "playback vs. GStreamer" note.
- Notifications status: `requires libnotify` → `via D-Bus` (`flutter_local_notifications_linux` is a pure-Dart D-Bus impl with no native code).

**Removed (stale)**
- `libjsoncpp-dev` — `flutter_secure_storage_linux` dropped its libjsoncpp dependency in 1.2.0 (bundled header-only `nlohmann::json`).
- `libnotify-dev` — no native consumer on Linux (see above).

**Added (required by registered plugins but omitted)**
- `libmpv-dev` — `media_kit_video` playback (`PkgConfig::mpv`).
- `libepoxy-dev` — `media_kit_video` GL texture rendering (`PkgConfig::epoxy`).
- `libwebkit2gtk-4.1-dev` — `desktop_webview_window` (`webkit2gtk-4.1`, **REQUIRED** — the build fails at CMake configure without it).
- `libasound2-dev` — `volume_controller` (`find_package(ALSA REQUIRED)`).

Fedora (`dnf`) equivalents updated to match.

**Related Issue:** Relates to #3637 (this drift was surfaced during that dependency audit).

## Out of Scope

- Any code change — this is documentation only.
- The `audio_session has no Linux backend` limitation note (unverified, left untouched).

## Verification

- Docs-only Markdown change; no Dart touched, so `flutter analyze` / tests are N/A.
- Each dependency mapping was confirmed from the plugin's `linux/CMakeLists.txt`: `media_kit_video-2.0.1` (mpv+epoxy, lines 30–31/57–58), `pro_video_editor-2.6.0` (gstreamer-1.0 + gstreamer-pbutils-1.0 REQUIRED, lines 46–47/51–52), `desktop_webview_window-0.2.3` (webkit2gtk-4.1 REQUIRED, lines 10/27), `volume_controller-3.4.4` (ALSA REQUIRED, line 50), `flutter_secure_storage_linux-1.2.3` (libsecret; CHANGELOG 1.2.0 "Remove and replace libjsoncpp1 dependency").
- Cross-checked against `media_kit`'s official Linux setup (`libmpv-dev`; libmpv decodes via FFmpeg, not GStreamer).
- Not validated by a live `flutter build linux` — cross-compilation from macOS is unsupported (per the doc itself). The corrections are derived from the plugins' declared CMake requirements.

## Type of Change

- [x] 📝 Documentation
