### PR TITLE
chore(cache-sync): add MigrationStrategy + wipe legacy key residue

### DIFF
--- a/mobile/packages/cache_sync/MIGRATIONS.md
+++ b/mobile/packages/cache_sync/MIGRATIONS.md
@@ -1,0 +1,70 @@
+# cache_sync Database Migrations
+
+`cache_sync` persists cache entries in a single Drift table (`CacheEntries`) in
+a local, unencrypted SQLite file (`cache_sync.db`). It is a **disposable
+cache** — nothing here is a source of truth. Schema and data changes are
+handled through Drift's [`MigrationStrategy`](https://drift.simonbinder.eu/docs/advanced-features/migrations/).
+
+## Current schema version
+
+**Version 1** — see `lib/src/cache_database.dart`.
+
+| Version | Change |
+|---------|--------|
+| 1 | Initial `CacheEntries` table (#4251). |
+
+`cache_database.dart` declares an explicit `MigrationStrategy` (currently just
+`onCreate: createAll`). This is the deliberate anchor point for the first real
+migration; the recipes below describe how to add one.
+
+> **#4382 note:** #4382 evaluated a v1 → v2 data-only migration to delete the
+> short-lived legacy `my_followers_${pubkey}` / `my_following_${pubkey}` rows
+> that `follow_repository` wrote between #4251 and #4361 (before RFC #4244's
+> `${pubkey}:operation` key shape landed). That cohort never reached a tagged
+> native release — the first release containing `cache_sync` already shipped
+> the colon-scoped shape — so no data migration was shipped. The colon-scoped
+> key shape is instead guarded by a `follow_repository` regression test that
+> fails if a key builder ever re-emits the legacy prefix.
+
+## How migrations run
+
+`MigrationStrategy.onUpgrade(m, from, to)` fires **once per existing install**
+when the stored `user_version` is below `schemaVersion`. Fresh installs run
+`onCreate` (which calls `createAll()`) and never run `onUpgrade`.
+
+Because `onUpgrade` never re-runs once `user_version` reaches the target, each
+step must be self-contained: a step that ships incomplete cannot be corrected
+in place — it requires a *further* version bump with a new step.
+
+## Adding a future migration
+
+### Data-only change (delete/rewrite rows, no schema change)
+
+1. Bump `schemaVersion` in `lib/src/cache_database.dart`.
+2. Extend `onUpgrade` with a guarded block for the new step, e.g.
+   `if (from < 2) { … }`. Keep each step idempotent and gated on `from`.
+3. Create `test/cache_migration_test.dart` with a test following the two-phase
+   pattern: open at the new version to create the schema, seed rows, stamp the
+   DB back to the previous `user_version`, close, then reopen so `onUpgrade`
+   runs — and assert the data effect. Use the `NativeDatabase.opened` shared
+   in-memory connection idiom (`closeUnderlyingOnClose: false`) so table and
+   data survive the drift close between phases. The test must be able to fail:
+   seed a row that is *present at the lower version* and assert it is
+   deleted/rewritten, not one inserted after the upgrade hook could touch it.
+4. Run `dart run build_runner build` and confirm `cache_database.g.dart` is
+   unchanged (a data-only bump does not regenerate it).
+
+### Schema-shape change (add/alter/drop a column or table)
+
+This package does not yet ship generated schema snapshots. The first
+schema-shape change should introduce them so migrations can be verified
+against exported schemas (mirroring `db_client`):
+
+1. Edit the table in `lib/src/cache_entries_table.dart`, then bump
+   `schemaVersion` in `lib/src/cache_database.dart`.
+2. `dart run build_runner build` to regenerate `cache_database.g.dart`.
+3. `dart run drift_dev make-migrations` — this uses the `schema_dir` /
+   `test_dir` already declared in `build.yaml` to write
+   `drift_schemas/cache_database/drift_schema_v*.json`,
+   `cache_database.steps.dart`, and generated migration-test helpers.
+4. Implement the step in `onUpgrade` and add migration tests.

--- a/mobile/packages/cache_sync/lib/src/cache_database.dart
+++ b/mobile/packages/cache_sync/lib/src/cache_database.dart
@@ -15,4 +15,15 @@ class CacheDatabase extends _$CacheDatabase {
 
   @override
   int get schemaVersion => 1;
+
+  /// Migration strategy for the cache store.
+  ///
+  /// `cache_sync` is a disposable local cache with a single [CacheEntries]
+  /// table and no schema-shape migration yet. This is the explicit anchor
+  /// point for the first real migration; see `MIGRATIONS.md` for the
+  /// versioning path and the #4382 decision not to ship a legacy-key-residue
+  /// data delete.
+  @override
+  MigrationStrategy get migration =>
+      MigrationStrategy(onCreate: (m) => m.createAll());
 }

--- a/mobile/packages/cache_sync/test/fake_cache_dao.dart
+++ b/mobile/packages/cache_sync/test/fake_cache_dao.dart
@@ -68,6 +68,9 @@ class FakeCacheDao implements CacheDao {
   /// Number of stored entries (for assertions).
   int get length => _store.length;
 
+  /// All stored cache keys (for assertions on key shape).
+  Iterable<String> get keys => _store.keys;
+
   /// Raw payload access without TTL check (for assertions).
   String? rawRead(String key) => _store[key]?.payload;
 }

--- a/mobile/packages/follow_repository/test/src/follow_repository_cached_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_cached_test.dart
@@ -513,4 +513,117 @@ void main() {
       expect(events[0].data.pubkeys, ['fresh']);
     });
   });
+
+  group('cache key shape guardrail (#4382 re-orphan prevention)', () {
+    // follow_repository was the sole cache_sync key-writer that ever used the
+    // orphan-prone legacy `operation_${pubkey}` underscore shape (between #4251
+    // and #4361, before RFC #4244's `${pubkey}:operation` colon shape landed).
+    // Those keys did not start with the pubkey, so invalidatePrefix(pubkey)
+    // never reached them, and with no TTL they were never re-read. These tests
+    // fail loudly if any key builder ever re-emits one of those legacy
+    // prefixes, which would silently re-introduce that orphan-prone shape.
+    //
+    // All four current builders are covered — my_followers_, my_following_,
+    // others_followers_, others_following_ — so the guard has no 2-of-4 blind
+    // spot.
+    void expectNoLegacyPrefixedKey() {
+      const legacyPrefixes = [
+        'my_followers_',
+        'my_following_',
+        'others_followers_',
+        'others_following_',
+      ];
+      expect(
+        dao.keys.every(
+          (k) => legacyPrefixes.every((prefix) => !k.startsWith(prefix)),
+        ),
+        isTrue,
+        reason:
+            'follow_repository cache keys must use the RFC #4244 '
+            'pubkey-prefixed "pubkey:operation" shape, never the legacy '
+            '"operation_pubkey" shape (#4382).',
+      );
+    }
+
+    test(
+      'watchMyFollowersCached writes a colon-scoped key, not legacy',
+      () async {
+        final repo = _TestableFollowRepository(
+          nostrClient: mockNostrClient,
+          myFollowersResult: const ['a'],
+          myFollowerCountResult: 1,
+          myFollowingStream: const Stream.empty(),
+          othersFollowersResult: const [],
+          othersFollowingResult: const FollowingSnapshot(pubkeys: [], count: 0),
+        );
+
+        await repo.watchMyFollowersCached().take(1).toList();
+
+        expect(dao.rawRead('current-user:my_followers'), isNotNull);
+        expect(dao.keys, isNotEmpty);
+        expectNoLegacyPrefixedKey();
+      },
+    );
+
+    test(
+      'watchMyFollowingCached writes a colon-scoped key, not legacy',
+      () async {
+        final repo = _TestableFollowRepository(
+          nostrClient: mockNostrClient,
+          myFollowingStream: const Stream.empty(),
+          othersFollowersResult: const [],
+          othersFollowingResult: const FollowingSnapshot(
+            pubkeys: ['a'],
+            count: 1,
+          ),
+        );
+
+        await repo.watchMyFollowingCached().take(1).toList();
+
+        expect(dao.rawRead('current-user:my_following'), isNotNull);
+        expect(dao.keys, isNotEmpty);
+        expectNoLegacyPrefixedKey();
+      },
+    );
+
+    test(
+      'watchOthersFollowersCached writes a colon-scoped key, not legacy',
+      () async {
+        final repo = _TestableFollowRepository(
+          nostrClient: mockNostrClient,
+          myFollowingStream: const Stream.empty(),
+          othersFollowersResult: const ['a'],
+          othersFollowerCountResult: 1,
+          othersFollowingResult: const FollowingSnapshot(pubkeys: [], count: 0),
+        );
+
+        await repo.watchOthersFollowersCached('target').take(1).toList();
+
+        expect(dao.rawRead('target:others_followers'), isNotNull);
+        expect(dao.keys, isNotEmpty);
+        expectNoLegacyPrefixedKey();
+      },
+    );
+
+    test(
+      'watchOthersFollowingCached writes a colon-scoped key, not legacy',
+      () async {
+        final repo = _TestableFollowRepository(
+          nostrClient: mockNostrClient,
+          myFollowingStream: const Stream.empty(),
+          othersFollowersResult: const [],
+          othersFollowingResult: const FollowingSnapshot(
+            pubkeys: ['a'],
+            count: 1,
+          ),
+        );
+
+        await repo.watchOthersFollowingCached('target').take(1).toList();
+
+        expect(dao.rawRead('target:others_following'), isNotNull);
+        expect(dao.keys, isNotEmpty);
+        expectNoLegacyPrefixedKey();
+      },
+    );
+  });
 }


### PR DESCRIPTION
Closes #4382

## Description

`cache_sync` shipped with `schemaVersion` pinned at 1 and **no** `MigrationStrategy`. #4382 asked for the migration + version-bump pattern so future schema/data changes have a deterministic path.

This lands that groundwork:

- **`CacheDatabase` gets an explicit `MigrationStrategy`** (`onCreate: createAll`) as the anchor point for the first real migration. `schemaVersion` stays at **1** — there is no data/schema change to bump for.
- **`MIGRATIONS.md`** documents the versioning path, with separate recipes for a data-only change and a schema-shape change (the latter noting the `make-migrations` / schema-snapshot machinery to introduce at the first real schema change).
- **A `follow_repository` regression guardrail** fails if any of the four cached key builders (`my_followers_`, `my_following_`, `others_followers_`, `others_following_`) ever re-emits the orphan-prone legacy underscore prefix, instead of the RFC #4244 `${pubkey}:operation` colon shape.

## Why no data DELETE (changed from the first revision)

The first revision added a v1 → v2 `onUpgrade` that deleted the short-lived legacy `my_followers_${pubkey}` / `my_following_${pubkey}` rows `follow_repository` wrote between #4251 and #4361.

Per review (thanks @hm21): that residue **never reached a tagged native release** — the first release containing `cache_sync` already shipped the colon-scoped shape from #4361 — so the DELETE would clean nothing on real devices. It has been dropped. The invariant it was meant to protect (never regress to the underscore shape) is now guarded at the source by the `follow_repository` test above, which also closes the 2-of-4-prefixes blind spot the review flagged.

## Out of Scope / Split Out

- The pre-existing upload-manager recovery-sweep flake fix that was bundled in the first revision has been moved to its own test-only PR: **#6193**.
- Full drift schema-snapshot + generated migration-test infrastructure — deferred to the first real schema-shape change (documented in `MIGRATIONS.md`).

## Verification

Ran from `mobile/`:

- `flutter analyze packages/cache_sync packages/follow_repository` — **No issues found**
- `cache_sync`: `flutter test --coverage` — **83/83 pass**, 100% line coverage on non-generated sources (the package's VGV gate; the new `migration` getter + `onCreate` are covered by existing DB opens)
- `follow_repository`: `flutter test --coverage` — **217/217 pass**, 100% coverage
- `build_runner` regen confirmed a no-op for `cache_database.g.dart` (`schemaVersion` / `MigrationStrategy` are hand-written overrides, not generated)

## Type of Change

- [x] 🧹 Code refactor
- [x] 📝 Documentation
