### PR TITLE
feat(profile): read NIP-39 claims from kind 10011 and persist verification cache (#3936)

### DIFF
--- a/mobile/lib/blocs/my_profile/my_profile_bloc.dart
+++ b/mobile/lib/blocs/my_profile/my_profile_bloc.dart
@@ -270,32 +270,21 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
       freshTags = await _profileRepository.freshIdentityTags(
         pubkey: profile.pubkey,
         kind0Tags: profile.rawTags,
-        kind0CreatedAt: profile.createdAt.millisecondsSinceEpoch ~/ 1000,
       );
     } on Exception catch (e, stackTrace) {
-      // Source-cache write failure — verify against the kind-0 tags we have.
+      // Source-cache write failure — resolve against the kind-0 tags we have.
       addError(e, stackTrace);
       freshTags = profile.rawTags;
     }
     if (isClosed) return;
-    final freshClaims = IdentityClaimsRepository.parseClaims(
-      profile.pubkey,
-      freshTags,
-    );
 
-    // Snapshot fresh and covering every current claim → skip the verifier.
-    if (cached != null && cached.isFresh) {
-      final verifiedSet = cached.claims.toSet();
-      if (freshClaims.every(verifiedSet.contains)) {
-        _emitClaims(emit, profile.pubkey, freshClaims);
-        return;
-      }
-    }
-
+    // The repository owns the skip-or-verify (stale-while-revalidate)
+    // decision; the bloc just renders whatever it resolves to (#3936).
     try {
-      final claims = await repo.verifiedClaims(
+      final claims = await repo.resolveClaims(
         pubkey: profile.pubkey,
-        tags: freshTags,
+        freshTags: freshTags,
+        cached: cached,
       );
       if (isClosed) return;
       _emitClaims(emit, profile.pubkey, claims);

--- a/mobile/lib/blocs/my_profile/my_profile_bloc.dart
+++ b/mobile/lib/blocs/my_profile/my_profile_bloc.dart
@@ -243,35 +243,84 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
       return;
     }
 
+    // Instant path (#3936): cached claims source ∩ persisted verdict
+    // snapshot renders chips without any network round-trip.
+    CachedVerifiedClaims? cached;
+    try {
+      final cachedTags = await _profileRepository.cachedIdentityTags(
+        profile.pubkey,
+      );
+      if (isClosed) return;
+      cached = await repo.cachedVerifiedClaims(
+        pubkey: profile.pubkey,
+        tags: cachedTags ?? profile.rawTags,
+      );
+      if (isClosed) return;
+      if (cached != null) {
+        _emitClaims(emit, profile.pubkey, cached.claims);
+      }
+    } on Exception catch (e, stackTrace) {
+      // Cache read failure — degrade straight to the network path.
+      addError(e, stackTrace);
+    }
+
+    // Refresh the claims source: kind 10011 wins, kind-0 tags fall back.
+    List<List<String>> freshTags;
+    try {
+      freshTags = await _profileRepository.freshIdentityTags(
+        pubkey: profile.pubkey,
+        kind0Tags: profile.rawTags,
+        kind0CreatedAt: profile.createdAt.millisecondsSinceEpoch ~/ 1000,
+      );
+    } on Exception catch (e, stackTrace) {
+      // Source-cache write failure — verify against the kind-0 tags we have.
+      addError(e, stackTrace);
+      freshTags = profile.rawTags;
+    }
+    if (isClosed) return;
+    final freshClaims = IdentityClaimsRepository.parseClaims(
+      profile.pubkey,
+      freshTags,
+    );
+
+    // Snapshot fresh and covering every current claim → skip the verifier.
+    if (cached != null && cached.isFresh) {
+      final verifiedSet = cached.claims.toSet();
+      if (freshClaims.every(verifiedSet.contains)) {
+        _emitClaims(emit, profile.pubkey, freshClaims);
+        return;
+      }
+    }
+
     try {
       final claims = await repo.verifiedClaims(
         pubkey: profile.pubkey,
-        tags: profile.rawTags,
+        tags: freshTags,
       );
       if (isClosed) return;
-      // State may have changed mid-await; re-check before emitting.
-      final latest = state;
-      if (latest is MyProfileLoaded &&
-          latest.profile.pubkey == profile.pubkey) {
-        emit(latest.copyWith(verifiedClaims: claims));
-      } else if (latest is MyProfileUpdated &&
-          latest.profile.pubkey == profile.pubkey) {
-        emit(latest.copyWith(verifiedClaims: claims));
-      }
+      _emitClaims(emit, profile.pubkey, claims);
     } on Exception catch (e, stackTrace) {
       // Verifier failures are expected (network/4xx/5xx/timeout). Per
-      // .claude/rules/error_handling.md they are NOT Reportable. Surface as
-      // empty list rather than blocking the UI.
+      // .claude/rules/error_handling.md they are NOT Reportable. Keep the
+      // last-known-good claims instead of erasing rendered chips.
       addError(e, stackTrace);
-      if (isClosed) return;
-      final latest = state;
-      if (latest is MyProfileLoaded &&
-          latest.profile.pubkey == profile.pubkey) {
-        emit(latest.copyWith(verifiedClaims: const []));
-      } else if (latest is MyProfileUpdated &&
-          latest.profile.pubkey == profile.pubkey) {
-        emit(latest.copyWith(verifiedClaims: const []));
-      }
+    }
+  }
+
+  /// Emits [claims] onto the latest state when it still shows
+  /// [profilePubkey]'s profile. State may have changed mid-await, so the
+  /// check runs at emit time.
+  void _emitClaims(
+    Emitter<MyProfileState> emit,
+    String profilePubkey,
+    List<IdentityClaim> claims,
+  ) {
+    final latest = state;
+    if (latest is MyProfileLoaded && latest.profile.pubkey == profilePubkey) {
+      emit(latest.copyWith(verifiedClaims: claims));
+    } else if (latest is MyProfileUpdated &&
+        latest.profile.pubkey == profilePubkey) {
+      emit(latest.copyWith(verifiedClaims: claims));
     }
   }
 

--- a/mobile/lib/blocs/my_profile/my_profile_bloc.dart
+++ b/mobile/lib/blocs/my_profile/my_profile_bloc.dart
@@ -52,12 +52,17 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
       pubkey: pubkey,
     );
     if (isClosed) return;
+    // Carry claims through the reload so chips do not vanish and re-pop
+    // while the verifier revalidates (#3936). Read AFTER the await so an
+    // authoritative claims resolve landing during the cache read is not
+    // clobbered by a stale capture.
+    final currentClaims = _claimsFromState(state);
     emit(
       MyProfileLoading(
         profile: cachedProfile,
         extractedUsername: cachedProfile?.divineUsername,
         externalNip05: cachedProfile?.externalNip05,
-        verifiedClaims: _claimsFromState(state),
+        verifiedClaims: currentClaims,
       ),
     );
 
@@ -68,6 +73,7 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
       );
       if (isClosed) return;
 
+      final latestClaims = _claimsFromState(state);
       if (freshProfile != null) {
         emit(
           MyProfileLoaded(
@@ -75,6 +81,7 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
             isFresh: true,
             extractedUsername: freshProfile.divineUsername,
             externalNip05: freshProfile.externalNip05,
+            verifiedClaims: latestClaims,
           ),
         );
         add(const VerifiedClaimsRequested());
@@ -85,6 +92,7 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
             isFresh: false,
             extractedUsername: cachedProfile.divineUsername,
             externalNip05: cachedProfile.externalNip05,
+            verifiedClaims: latestClaims,
           ),
         );
         add(const VerifiedClaimsRequested());
@@ -100,6 +108,7 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
             isFresh: false,
             extractedUsername: cachedProfile.divineUsername,
             externalNip05: cachedProfile.externalNip05,
+            verifiedClaims: _claimsFromState(state),
           ),
         );
         add(const VerifiedClaimsRequested());
@@ -126,6 +135,7 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
         profile: cachedProfile,
         extractedUsername: cachedProfile?.divineUsername,
         externalNip05: cachedProfile?.externalNip05,
+        verifiedClaims: _claimsFromState(state),
       ),
     );
 
@@ -135,10 +145,13 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
         if (isClosed) return state;
         if (profile != null) {
           add(const VerifiedClaimsRequested());
+          // Carry claims through the stream tick so chips do not blank
+          // while the verifier revalidates (#3936).
           return MyProfileUpdated(
             profile: profile,
             extractedUsername: profile.divineUsername,
             externalNip05: profile.externalNip05,
+            verifiedClaims: _claimsFromState(state),
           );
         }
         final currentProfile = _profileFromState(state);
@@ -260,7 +273,7 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
       );
       if (isClosed) return;
       if (cached != null) {
-        _emitClaims(emit, profile.pubkey, cached.claims);
+        _emitClaims(emit, profile.pubkey, cached.claims, authoritative: false);
       }
     } on Exception catch (e, stackTrace) {
       // Cache read failure — degrade straight to the network path.
@@ -275,22 +288,28 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
         kind0Tags: profile.rawTags,
       );
     } on Exception catch (e, stackTrace) {
-      // Source-cache write failure — resolve against the kind-0 tags we have.
+      // Degraded claims source (cache I/O failure). Resolving against the
+      // kind-0 fallback could authoritatively clear chips for a profile
+      // whose claims live in kind 10011, so keep last-known-good and let
+      // the next revalidation tick retry.
       addError(e, stackTrace);
-      freshTags = profile.rawTags;
+      return;
     }
     if (isClosed) return;
 
     // The repository owns the skip-or-verify (stale-while-revalidate)
-    // decision; the bloc just renders whatever it resolves to (#3936).
+    // decision; the bloc just renders whatever it resolves to (#3936). The
+    // currently-rendered claims ride along so a rate-limited (inconclusive)
+    // outcome cannot clear visible chips.
     try {
       final claims = await repo.resolveClaims(
         pubkey: profile.pubkey,
         freshTags: freshTags,
         cached: cached,
+        renderedClaims: _claimsFromState(state),
       );
       if (isClosed) return;
-      _emitClaims(emit, profile.pubkey, claims);
+      _emitClaims(emit, profile.pubkey, claims, authoritative: true);
     } on Exception catch (e, stackTrace) {
       // Verifier failures are expected (network/4xx/5xx/timeout). Per
       // .claude/rules/error_handling.md they are NOT Reportable. Keep the
@@ -302,19 +321,53 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
   /// Emits [claims] onto the latest state when it still shows
   /// [profilePubkey]'s profile. State may have changed mid-await, so the
   /// check runs at emit time.
+  ///
+  /// A non-[authoritative] emit (the instant cache path) may only add
+  /// chips: it is unioned with the rendered set, so a reduced or empty
+  /// snapshot intersection never clears claims the verifier has not
+  /// negatively confirmed. Only the authoritative resolve path replaces
+  /// the rendered set outright.
   void _emitClaims(
     Emitter<MyProfileState> emit,
     String profilePubkey,
-    List<IdentityClaim> claims,
-  ) {
+    List<IdentityClaim> claims, {
+    required bool authoritative,
+  }) {
     final latest = state;
     if (latest is MyProfileLoaded && latest.profile.pubkey == profilePubkey) {
-      emit(latest.copyWith(verifiedClaims: claims));
+      final next = authoritative
+          ? claims
+          : _withRenderedPreserved(claims, latest.verifiedClaims);
+      emit(latest.copyWith(verifiedClaims: next));
     } else if (latest is MyProfileUpdated &&
         latest.profile.pubkey == profilePubkey) {
-      emit(latest.copyWith(verifiedClaims: claims));
+      final next = authoritative
+          ? claims
+          : _withRenderedPreserved(claims, latest.verifiedClaims);
+      emit(latest.copyWith(verifiedClaims: next));
     }
   }
+
+  /// Rendered-first union keyed on case-insensitive `platform:identity`:
+  /// order-stable (no chip reorder churn across revalidation ticks, and
+  /// the steady-state result is deep-equal to [rendered] so the emit is
+  /// Equatable-suppressed) and dedup-safe across casing or proof drift.
+  List<IdentityClaim> _withRenderedPreserved(
+    List<IdentityClaim> incoming,
+    List<IdentityClaim> rendered,
+  ) {
+    if (rendered.isEmpty) return incoming;
+    final renderedKeys = {for (final claim in rendered) _identityKeyOf(claim)};
+    return [
+      ...rendered,
+      ...incoming.where(
+        (claim) => !renderedKeys.contains(_identityKeyOf(claim)),
+      ),
+    ];
+  }
+
+  String _identityKeyOf(IdentityClaim claim) =>
+      '${claim.platform.toLowerCase()}:${claim.identity.toLowerCase()}';
 
   UserProfile? _profileFromState(MyProfileState state) {
     final profile = switch (state) {
@@ -327,13 +380,18 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
   }
 
   List<IdentityClaim> _claimsFromState(MyProfileState state) {
+    // A null Loading profile just means no cached profile row yet — the
+    // carried claims are still this bloc's own-[pubkey] claims, so they
+    // must survive the guard.
     final claims = switch (state) {
       MyProfileLoaded(:final profile, :final verifiedClaims) =>
         profile.pubkey == pubkey ? verifiedClaims : const <IdentityClaim>[],
       MyProfileUpdated(:final profile, :final verifiedClaims) =>
         profile.pubkey == pubkey ? verifiedClaims : const <IdentityClaim>[],
       MyProfileLoading(:final profile, :final verifiedClaims) =>
-        profile?.pubkey == pubkey ? verifiedClaims : const <IdentityClaim>[],
+        profile == null || profile.pubkey == pubkey
+            ? verifiedClaims
+            : const <IdentityClaim>[],
       _ => const <IdentityClaim>[],
     };
     return claims;

--- a/mobile/lib/blocs/my_profile/my_profile_bloc.dart
+++ b/mobile/lib/blocs/my_profile/my_profile_bloc.dart
@@ -31,7 +31,10 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
       _onRefreshRequested,
       transformer: sequential(),
     );
-    on<VerifiedClaimsRequested>(_onVerifiedClaimsRequested);
+    on<VerifiedClaimsRequested>(
+      _onVerifiedClaimsRequested,
+      transformer: restartable(),
+    );
   }
 
   final ProfileRepository _profileRepository;

--- a/mobile/lib/blocs/my_profile/my_profile_state.dart
+++ b/mobile/lib/blocs/my_profile/my_profile_state.dart
@@ -87,8 +87,10 @@ final class MyProfileLoaded extends MyProfileState {
   /// Null if the NIP-05 is a divine.video/openvine.co domain or not set.
   final String? externalNip05;
 
-  /// Verifier-confirmed NIP-39 identity claims for this profile. Empty until
-  /// [VerifiedClaimsRequested] resolves; stays empty if the verifier fails.
+  /// Verifier-confirmed NIP-39 identity claims for this profile. Carried
+  /// over from the previous state while [VerifiedClaimsRequested]
+  /// revalidates; kept at last-known-good when the verifier fails or
+  /// rate-limits, and cleared only by a confirmed negative resolve.
   final List<IdentityClaim> verifiedClaims;
 
   /// Returns a copy of this state with the given fields replaced.

--- a/mobile/lib/blocs/other_profile/other_profile_bloc.dart
+++ b/mobile/lib/blocs/other_profile/other_profile_bloc.dart
@@ -76,7 +76,17 @@ class OtherProfileBloc extends Bloc<OtherProfileEvent, OtherProfileState> {
       pubkey: pubkey,
     );
     if (isClosed) return;
-    emit(OtherProfileLoading(profile: cachedProfile));
+    // Carry claims through the reload so chips do not vanish and re-pop
+    // while the verifier revalidates (#3936). Read AFTER the await so an
+    // authoritative claims resolve landing during the cache read is not
+    // clobbered by a stale capture.
+    final currentClaims = _claimsFromState(state);
+    emit(
+      OtherProfileLoading(
+        profile: cachedProfile,
+        verifiedClaims: currentClaims,
+      ),
+    );
 
     try {
       final freshProfile = await _profileRepository.fetchFreshProfile(
@@ -84,11 +94,24 @@ class OtherProfileBloc extends Bloc<OtherProfileEvent, OtherProfileState> {
         requireRawKind0: _requireRawKind0,
       );
       if (isClosed) return;
+      final latestClaims = _claimsFromState(state);
       if (freshProfile != null) {
-        emit(OtherProfileLoaded(profile: freshProfile, isFresh: true));
+        emit(
+          OtherProfileLoaded(
+            profile: freshProfile,
+            isFresh: true,
+            verifiedClaims: latestClaims,
+          ),
+        );
         add(const VerifiedClaimsRequested());
       } else if (cachedProfile != null) {
-        emit(OtherProfileLoaded(profile: cachedProfile, isFresh: false));
+        emit(
+          OtherProfileLoaded(
+            profile: cachedProfile,
+            isFresh: false,
+            verifiedClaims: latestClaims,
+          ),
+        );
         add(const VerifiedClaimsRequested());
       } else {
         emit(
@@ -98,7 +121,13 @@ class OtherProfileBloc extends Bloc<OtherProfileEvent, OtherProfileState> {
     } catch (e) {
       if (isClosed) return;
       if (cachedProfile != null) {
-        emit(OtherProfileLoaded(profile: cachedProfile, isFresh: false));
+        emit(
+          OtherProfileLoaded(
+            profile: cachedProfile,
+            isFresh: false,
+            verifiedClaims: _claimsFromState(state),
+          ),
+        );
         add(const VerifiedClaimsRequested());
       } else {
         emit(
@@ -199,7 +228,7 @@ class OtherProfileBloc extends Bloc<OtherProfileEvent, OtherProfileState> {
       );
       if (isClosed) return;
       if (cached != null) {
-        _emitClaims(emit, profile.pubkey, cached.claims);
+        _emitClaims(emit, profile.pubkey, cached.claims, authoritative: false);
       }
     } on Exception catch (e, stackTrace) {
       // Cache read failure — degrade straight to the network path.
@@ -214,22 +243,28 @@ class OtherProfileBloc extends Bloc<OtherProfileEvent, OtherProfileState> {
         kind0Tags: profile.rawTags,
       );
     } on Exception catch (e, stackTrace) {
-      // Source-cache write failure — resolve against the kind-0 tags we have.
+      // Degraded claims source (cache I/O failure). Resolving against the
+      // kind-0 fallback could authoritatively clear chips for a profile
+      // whose claims live in kind 10011, so keep last-known-good and let
+      // the next revalidation tick retry.
       addError(e, stackTrace);
-      freshTags = profile.rawTags;
+      return;
     }
     if (isClosed) return;
 
     // The repository owns the skip-or-verify (stale-while-revalidate)
-    // decision; the bloc just renders whatever it resolves to (#3936).
+    // decision; the bloc just renders whatever it resolves to (#3936). The
+    // currently-rendered claims ride along so a rate-limited (inconclusive)
+    // outcome cannot clear visible chips.
     try {
       final claims = await repo.resolveClaims(
         pubkey: profile.pubkey,
         freshTags: freshTags,
         cached: cached,
+        renderedClaims: _claimsFromState(state),
       );
       if (isClosed) return;
-      _emitClaims(emit, profile.pubkey, claims);
+      _emitClaims(emit, profile.pubkey, claims, authoritative: true);
     } on Exception catch (e, stackTrace) {
       // Verifier failures are expected (network/4xx/5xx/timeout). Per
       // .claude/rules/error_handling.md they are NOT Reportable. Keep the
@@ -241,17 +276,48 @@ class OtherProfileBloc extends Bloc<OtherProfileEvent, OtherProfileState> {
   /// Emits [claims] onto the latest state when it still shows
   /// [profilePubkey]'s profile. State may have changed mid-await, so the
   /// check runs at emit time.
+  ///
+  /// A non-[authoritative] emit (the instant cache path) may only add
+  /// chips: it is unioned with the rendered set, so a reduced or empty
+  /// snapshot intersection never clears claims the verifier has not
+  /// negatively confirmed. Only the authoritative resolve path replaces
+  /// the rendered set outright.
   void _emitClaims(
     Emitter<OtherProfileState> emit,
     String profilePubkey,
-    List<IdentityClaim> claims,
-  ) {
+    List<IdentityClaim> claims, {
+    required bool authoritative,
+  }) {
     final latest = state;
     if (latest is OtherProfileLoaded &&
         latest.profile.pubkey == profilePubkey) {
-      emit(latest.copyWith(verifiedClaims: claims));
+      final next = authoritative
+          ? claims
+          : _withRenderedPreserved(claims, latest.verifiedClaims);
+      emit(latest.copyWith(verifiedClaims: next));
     }
   }
+
+  /// Rendered-first union keyed on case-insensitive `platform:identity`:
+  /// order-stable (no chip reorder churn across revalidation ticks, and
+  /// the steady-state result is deep-equal to [rendered] so the emit is
+  /// Equatable-suppressed) and dedup-safe across casing or proof drift.
+  List<IdentityClaim> _withRenderedPreserved(
+    List<IdentityClaim> incoming,
+    List<IdentityClaim> rendered,
+  ) {
+    if (rendered.isEmpty) return incoming;
+    final renderedKeys = {for (final claim in rendered) _identityKeyOf(claim)};
+    return [
+      ...rendered,
+      ...incoming.where(
+        (claim) => !renderedKeys.contains(_identityKeyOf(claim)),
+      ),
+    ];
+  }
+
+  String _identityKeyOf(IdentityClaim claim) =>
+      '${claim.platform.toLowerCase()}:${claim.identity.toLowerCase()}';
 
   List<IdentityClaim> _claimsFromState(OtherProfileState state) {
     return switch (state) {

--- a/mobile/lib/blocs/other_profile/other_profile_bloc.dart
+++ b/mobile/lib/blocs/other_profile/other_profile_bloc.dart
@@ -1,6 +1,7 @@
 // ABOUTME: BLoC for viewing another user's profile
 // ABOUTME: Implements cache+fresh pattern and block/unblock actions
 
+import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -44,7 +45,10 @@ class OtherProfileBloc extends Bloc<OtherProfileEvent, OtherProfileState> {
     on<OtherProfileRefreshRequested>(_onRefreshRequested);
     on<OtherProfileBlockRequested>(_onBlockRequested);
     on<OtherProfileUnblockRequested>(_onUnblockRequested);
-    on<VerifiedClaimsRequested>(_onVerifiedClaimsRequested);
+    on<VerifiedClaimsRequested>(
+      _onVerifiedClaimsRequested,
+      transformer: restartable(),
+    );
   }
 
   final ProfileRepository _profileRepository;

--- a/mobile/lib/blocs/other_profile/other_profile_bloc.dart
+++ b/mobile/lib/blocs/other_profile/other_profile_bloc.dart
@@ -116,7 +116,15 @@ class OtherProfileBloc extends Bloc<OtherProfileEvent, OtherProfileState> {
       OtherProfileLoaded(:final profile) => profile,
       OtherProfileError(:final profile) => profile,
     };
-    emit(OtherProfileLoading(profile: currentProfile));
+    // Carry claims through the refresh so chips do not vanish and re-pop
+    // after the round-trip (#3936).
+    final currentClaims = _claimsFromState(state);
+    emit(
+      OtherProfileLoading(
+        profile: currentProfile,
+        verifiedClaims: currentClaims,
+      ),
+    );
 
     try {
       final freshProfile = await _profileRepository.fetchFreshProfile(
@@ -125,7 +133,13 @@ class OtherProfileBloc extends Bloc<OtherProfileEvent, OtherProfileState> {
       );
       if (isClosed) return;
       if (freshProfile != null) {
-        emit(OtherProfileLoaded(profile: freshProfile, isFresh: true));
+        emit(
+          OtherProfileLoaded(
+            profile: freshProfile,
+            isFresh: true,
+            verifiedClaims: currentClaims,
+          ),
+        );
         add(const VerifiedClaimsRequested());
       } else {
         emit(
@@ -138,7 +152,13 @@ class OtherProfileBloc extends Bloc<OtherProfileEvent, OtherProfileState> {
     } catch (e) {
       if (isClosed) return;
       if (currentProfile != null) {
-        emit(OtherProfileLoaded(profile: currentProfile, isFresh: false));
+        emit(
+          OtherProfileLoaded(
+            profile: currentProfile,
+            isFresh: false,
+            verifiedClaims: currentClaims,
+          ),
+        );
         add(const VerifiedClaimsRequested());
       } else {
         emit(
@@ -161,28 +181,91 @@ class OtherProfileBloc extends Bloc<OtherProfileEvent, OtherProfileState> {
     if (current is! OtherProfileLoaded) return;
     final profile = current.profile;
 
+    // Instant path (#3936): cached claims source ∩ persisted verdict
+    // snapshot renders chips without any network round-trip.
+    CachedVerifiedClaims? cached;
+    try {
+      final cachedTags = await _profileRepository.cachedIdentityTags(
+        profile.pubkey,
+      );
+      if (isClosed) return;
+      cached = await repo.cachedVerifiedClaims(
+        pubkey: profile.pubkey,
+        tags: cachedTags ?? profile.rawTags,
+      );
+      if (isClosed) return;
+      if (cached != null) {
+        _emitClaims(emit, profile.pubkey, cached.claims);
+      }
+    } on Exception catch (e, stackTrace) {
+      // Cache read failure — degrade straight to the network path.
+      addError(e, stackTrace);
+    }
+
+    // Refresh the claims source: kind 10011 wins, kind-0 tags fall back.
+    List<List<String>> freshTags;
+    try {
+      freshTags = await _profileRepository.freshIdentityTags(
+        pubkey: profile.pubkey,
+        kind0Tags: profile.rawTags,
+        kind0CreatedAt: profile.createdAt.millisecondsSinceEpoch ~/ 1000,
+      );
+    } on Exception catch (e, stackTrace) {
+      // Source-cache write failure — verify against the kind-0 tags we have.
+      addError(e, stackTrace);
+      freshTags = profile.rawTags;
+    }
+    if (isClosed) return;
+    final freshClaims = IdentityClaimsRepository.parseClaims(
+      profile.pubkey,
+      freshTags,
+    );
+
+    // Snapshot fresh and covering every current claim → skip the verifier.
+    if (cached != null && cached.isFresh) {
+      final verifiedSet = cached.claims.toSet();
+      if (freshClaims.every(verifiedSet.contains)) {
+        _emitClaims(emit, profile.pubkey, freshClaims);
+        return;
+      }
+    }
+
     try {
       final claims = await repo.verifiedClaims(
         pubkey: profile.pubkey,
-        tags: profile.rawTags,
+        tags: freshTags,
       );
       if (isClosed) return;
-      final latest = state;
-      if (latest is OtherProfileLoaded &&
-          latest.profile.pubkey == profile.pubkey) {
-        emit(latest.copyWith(verifiedClaims: claims));
-      }
+      _emitClaims(emit, profile.pubkey, claims);
     } on Exception catch (e, stackTrace) {
       // Verifier failures are expected (network/4xx/5xx/timeout). Per
-      // .claude/rules/error_handling.md they are NOT Reportable.
+      // .claude/rules/error_handling.md they are NOT Reportable. Keep the
+      // last-known-good claims instead of erasing rendered chips.
       addError(e, stackTrace);
-      if (isClosed) return;
-      final latest = state;
-      if (latest is OtherProfileLoaded &&
-          latest.profile.pubkey == profile.pubkey) {
-        emit(latest.copyWith(verifiedClaims: const []));
-      }
     }
+  }
+
+  /// Emits [claims] onto the latest state when it still shows
+  /// [profilePubkey]'s profile. State may have changed mid-await, so the
+  /// check runs at emit time.
+  void _emitClaims(
+    Emitter<OtherProfileState> emit,
+    String profilePubkey,
+    List<IdentityClaim> claims,
+  ) {
+    final latest = state;
+    if (latest is OtherProfileLoaded &&
+        latest.profile.pubkey == profilePubkey) {
+      emit(latest.copyWith(verifiedClaims: claims));
+    }
+  }
+
+  List<IdentityClaim> _claimsFromState(OtherProfileState state) {
+    return switch (state) {
+      OtherProfileLoaded(:final verifiedClaims) => verifiedClaims,
+      OtherProfileLoading(:final verifiedClaims) => verifiedClaims,
+      _ => const [],
+    };
   }
 
   Future<void> _onBlockRequested(

--- a/mobile/lib/blocs/other_profile/other_profile_bloc.dart
+++ b/mobile/lib/blocs/other_profile/other_profile_bloc.dart
@@ -208,32 +208,21 @@ class OtherProfileBloc extends Bloc<OtherProfileEvent, OtherProfileState> {
       freshTags = await _profileRepository.freshIdentityTags(
         pubkey: profile.pubkey,
         kind0Tags: profile.rawTags,
-        kind0CreatedAt: profile.createdAt.millisecondsSinceEpoch ~/ 1000,
       );
     } on Exception catch (e, stackTrace) {
-      // Source-cache write failure — verify against the kind-0 tags we have.
+      // Source-cache write failure — resolve against the kind-0 tags we have.
       addError(e, stackTrace);
       freshTags = profile.rawTags;
     }
     if (isClosed) return;
-    final freshClaims = IdentityClaimsRepository.parseClaims(
-      profile.pubkey,
-      freshTags,
-    );
 
-    // Snapshot fresh and covering every current claim → skip the verifier.
-    if (cached != null && cached.isFresh) {
-      final verifiedSet = cached.claims.toSet();
-      if (freshClaims.every(verifiedSet.contains)) {
-        _emitClaims(emit, profile.pubkey, freshClaims);
-        return;
-      }
-    }
-
+    // The repository owns the skip-or-verify (stale-while-revalidate)
+    // decision; the bloc just renders whatever it resolves to (#3936).
     try {
-      final claims = await repo.verifiedClaims(
+      final claims = await repo.resolveClaims(
         pubkey: profile.pubkey,
-        tags: freshTags,
+        freshTags: freshTags,
+        cached: cached,
       );
       if (isClosed) return;
       _emitClaims(emit, profile.pubkey, claims);

--- a/mobile/lib/blocs/other_profile/other_profile_state.dart
+++ b/mobile/lib/blocs/other_profile/other_profile_state.dart
@@ -27,14 +27,18 @@ final class OtherProfileInitial extends OtherProfileState {
 
 /// Loading state - may contain cached profile while fetching fresh.
 final class OtherProfileLoading extends OtherProfileState {
-  const OtherProfileLoading({this.profile});
+  const OtherProfileLoading({this.profile, this.verifiedClaims = const []});
 
   /// Cached profile to display while loading fresh data.
   /// Null if no cached profile exists.
   final UserProfile? profile;
 
+  /// Claims carried over from the previous state so chips do not vanish
+  /// during a refresh (#3936).
+  final List<IdentityClaim> verifiedClaims;
+
   @override
-  List<Object?> get props => [profile];
+  List<Object?> get props => [profile, verifiedClaims];
 }
 
 /// Successfully loaded profile state.

--- a/mobile/lib/blocs/other_profile/other_profile_state.dart
+++ b/mobile/lib/blocs/other_profile/other_profile_state.dart
@@ -56,8 +56,10 @@ final class OtherProfileLoaded extends OtherProfileState {
   /// or loaded from cache (false).
   final bool isFresh;
 
-  /// Verifier-confirmed NIP-39 identity claims for this profile. Empty until
-  /// [VerifiedClaimsRequested] resolves; stays empty if the verifier fails.
+  /// Verifier-confirmed NIP-39 identity claims for this profile. Carried
+  /// over from the previous state while [VerifiedClaimsRequested]
+  /// revalidates; kept at last-known-good when the verifier fails or
+  /// rate-limits, and cleared only by a confirmed negative resolve.
   final List<IdentityClaim> verifiedClaims;
 
   /// Returns a copy of this state with the given fields replaced.

--- a/mobile/lib/providers/auth_providers.dart
+++ b/mobile/lib/providers/auth_providers.dart
@@ -13,6 +13,7 @@ import 'package:nostr_key_manager/nostr_key_manager.dart';
 import 'package:openvine/models/auth_rpc_capability.dart';
 import 'package:openvine/models/environment_config.dart';
 import 'package:openvine/models/known_account.dart';
+import 'package:openvine/providers/database_provider.dart';
 import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/repository_providers.dart';
@@ -403,11 +404,16 @@ VerifierClient verifierClient(Ref ref) {
 }
 
 /// Provider for [IdentityClaimsRepository] composing the verifier client
-/// with NIP-39 i tag parsing.
+/// with NIP-39 i tag parsing and the persistent verdict cache (#3936).
 @Riverpod(keepAlive: true)
 IdentityClaimsRepository identityClaimsRepository(Ref ref) {
   return IdentityClaimsRepository(
     verifierClient: ref.watch(verifierClientProvider),
+    identityVerificationsDao: ref
+        .watch(
+          databaseProvider,
+        )
+        .identityVerificationsDao,
   );
 }
 

--- a/mobile/lib/providers/auth_providers.g.dart
+++ b/mobile/lib/providers/auth_providers.g.dart
@@ -740,13 +740,13 @@ final class VerifierClientProvider
 String _$verifierClientHash() => r'1d6966c5483814cd7fa203e7e9e198dc5c9c232d';
 
 /// Provider for [IdentityClaimsRepository] composing the verifier client
-/// with NIP-39 i tag parsing.
+/// with NIP-39 i tag parsing and the persistent verdict cache (#3936).
 
 @ProviderFor(identityClaimsRepository)
 final identityClaimsRepositoryProvider = IdentityClaimsRepositoryProvider._();
 
 /// Provider for [IdentityClaimsRepository] composing the verifier client
-/// with NIP-39 i tag parsing.
+/// with NIP-39 i tag parsing and the persistent verdict cache (#3936).
 
 final class IdentityClaimsRepositoryProvider
     extends
@@ -757,7 +757,7 @@ final class IdentityClaimsRepositoryProvider
         >
     with $Provider<IdentityClaimsRepository> {
   /// Provider for [IdentityClaimsRepository] composing the verifier client
-  /// with NIP-39 i tag parsing.
+  /// with NIP-39 i tag parsing and the persistent verdict cache (#3936).
   IdentityClaimsRepositoryProvider._()
     : super(
         from: null,
@@ -793,7 +793,7 @@ final class IdentityClaimsRepositoryProvider
 }
 
 String _$identityClaimsRepositoryHash() =>
-    r'451c65b551cddcf8cf2ef3d23ac862ab0ae1441d';
+    r'105116da1cf679bd06838f6fbfc290832057a8ec';
 
 /// NIP-98 authentication service
 

--- a/mobile/lib/providers/repository_providers.dart
+++ b/mobile/lib/providers/repository_providers.dart
@@ -354,6 +354,8 @@ ProfileRepository _buildProfileRepository(Ref ref, {required bool warmCache}) {
     profileStatsDao: ref.watch(databaseProvider).profileStatsDao,
     // Durable pending-save slot for the offline-tolerant username save (#3161).
     pendingProfileSavesDao: ref.watch(databaseProvider).pendingProfileSavesDao,
+    // NIP-39 identity-claims source cache (#3936).
+    identityEventsDao: ref.watch(databaseProvider).identityEventsDao,
     httpClient: Client(),
     funnelcakeApiClient: funnelcakeClient,
     indexerRelays: env.indexerRelays,

--- a/mobile/lib/providers/social_providers.dart
+++ b/mobile/lib/providers/social_providers.dart
@@ -660,6 +660,10 @@ UserDataCleanupService userDataCleanupService(Ref ref) {
         // after its DM data is cleared. See #5452.
         await db.processedGiftWrapsDao.clearAll();
         await db.notificationsDao.clearAll();
+        // Issue #3936 requires the NIP-39 identity caches to clear on logout
+        // and account switches rather than persisting across identities.
+        await db.identityEventsDao.clearAll();
+        await db.identityVerificationsDao.clearAll();
         // Clear DM sync cursors so the next login triggers a full re-fetch
         // from relays instead of using stale `since:` boundaries.
         await DmSyncState(prefs).clearAll();

--- a/mobile/lib/providers/social_providers.g.dart
+++ b/mobile/lib/providers/social_providers.g.dart
@@ -626,7 +626,7 @@ final class UserDataCleanupServiceProvider
 }
 
 String _$userDataCleanupServiceHash() =>
-    r'dc580b907d795153456bd68fc2fb107593e550cd';
+    r'ab20ad875bfa6b1b69b269f77754c57bc4e85dfb';
 
 /// Hashtag service depends on Video event service and cache service
 

--- a/mobile/lib/widgets/profile/profile_header_identity.dart
+++ b/mobile/lib/widgets/profile/profile_header_identity.dart
@@ -402,6 +402,7 @@ class _VerifiedAccountsBlock extends StatelessWidget {
       return context.select<OtherProfileBloc, List<IdentityClaim>>((bloc) {
         final state = bloc.state;
         if (state is OtherProfileLoaded) return state.verifiedClaims;
+        if (state is OtherProfileLoading) return state.verifiedClaims;
         return const [];
       });
     } on ProviderNotFoundException {

--- a/mobile/packages/db_client/drift_schemas/app_database/drift_schema_v1.json
+++ b/mobile/packages/db_client/drift_schemas/app_database/drift_schema_v1.json
@@ -2790,6 +2790,120 @@
           "user_pubkey"
         ]
       }
+    },
+    {
+      "id": 22,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "identity_events",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "pubkey",
+            "getter_name": "pubkey",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "tags_json",
+            "getter_name": "tagsJson",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "source_kind",
+            "getter_name": "sourceKind",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "event_created_at",
+            "getter_name": "eventCreatedAt",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "fetched_at",
+            "getter_name": "fetchedAt",
+            "moor_type": "dateTime",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "pubkey"
+        ]
+      }
+    },
+    {
+      "id": 23,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "identity_verifications",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "pubkey",
+            "getter_name": "pubkey",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "verified_claims_json",
+            "getter_name": "verifiedClaimsJson",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "checked_at_floor",
+            "getter_name": "checkedAtFloor",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "pubkey"
+        ]
+      }
     }
   ],
   "fixed_sql": [
@@ -2988,6 +3102,24 @@
         {
           "dialect": "sqlite",
           "sql": "CREATE TABLE IF NOT EXISTS \"pending_profile_saves\" (\"user_pubkey\" TEXT NOT NULL, \"payload_json\" TEXT NOT NULL, \"claim_confirmed\" INTEGER NOT NULL DEFAULT 0 CHECK (\"claim_confirmed\" IN (0, 1)), \"status\" TEXT NOT NULL DEFAULT 'pending', \"retry_count\" INTEGER NOT NULL DEFAULT 0, \"last_attempt_at\" INTEGER NULL, \"queued_at\" INTEGER NOT NULL, \"last_error\" TEXT NULL, \"generation\" TEXT NOT NULL DEFAULT '', PRIMARY KEY (\"user_pubkey\"));"
+        }
+      ]
+    },
+    {
+      "name": "identity_events",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"identity_events\" (\"pubkey\" TEXT NOT NULL, \"tags_json\" TEXT NOT NULL, \"source_kind\" INTEGER NOT NULL, \"event_created_at\" INTEGER NOT NULL, \"fetched_at\" INTEGER NOT NULL, PRIMARY KEY (\"pubkey\"));"
+        }
+      ]
+    },
+    {
+      "name": "identity_verifications",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"identity_verifications\" (\"pubkey\" TEXT NOT NULL, \"verified_claims_json\" TEXT NOT NULL, \"checked_at_floor\" INTEGER NOT NULL, PRIMARY KEY (\"pubkey\"));"
         }
       ]
     }

--- a/mobile/packages/db_client/drift_schemas/app_database/drift_schema_v1.json
+++ b/mobile/packages/db_client/drift_schemas/app_database/drift_schema_v1.json
@@ -2828,26 +2828,6 @@
             "default_dart": null,
             "default_client_dart": null,
             "dsl_features": []
-          },
-          {
-            "name": "event_created_at",
-            "getter_name": "eventCreatedAt",
-            "moor_type": "int",
-            "nullable": false,
-            "customConstraints": null,
-            "default_dart": null,
-            "default_client_dart": null,
-            "dsl_features": []
-          },
-          {
-            "name": "fetched_at",
-            "getter_name": "fetchedAt",
-            "moor_type": "dateTime",
-            "nullable": false,
-            "customConstraints": null,
-            "default_dart": null,
-            "default_client_dart": null,
-            "dsl_features": []
           }
         ],
         "is_virtual": false,
@@ -3110,7 +3090,7 @@
       "sql": [
         {
           "dialect": "sqlite",
-          "sql": "CREATE TABLE IF NOT EXISTS \"identity_events\" (\"pubkey\" TEXT NOT NULL, \"tags_json\" TEXT NOT NULL, \"source_kind\" INTEGER NOT NULL, \"event_created_at\" INTEGER NOT NULL, \"fetched_at\" INTEGER NOT NULL, PRIMARY KEY (\"pubkey\"));"
+          "sql": "CREATE TABLE IF NOT EXISTS \"identity_events\" (\"pubkey\" TEXT NOT NULL, \"tags_json\" TEXT NOT NULL, \"source_kind\" INTEGER NOT NULL, PRIMARY KEY (\"pubkey\"));"
         }
       ]
     },

--- a/mobile/packages/db_client/lib/src/database/app_database.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.dart
@@ -747,7 +747,7 @@ class AppDatabase extends _$AppDatabase {
     // Schema version stays at 1 — same runtime CREATE-IF-NOT-EXISTS pattern
     // as processed_gift_wraps above. Column order/types must match Drift's
     // m.createAll() output (pinned by the schema-parity tests in
-    // app_database_test.dart); DateTime columns → INTEGER (seconds codec).
+    // app_database_test.dart).
     final identityEventsResult = await customSelect(
       "SELECT name FROM sqlite_master WHERE type='table' "
       "AND name='identity_events'",
@@ -758,9 +758,7 @@ class AppDatabase extends _$AppDatabase {
         CREATE TABLE identity_events (
           pubkey TEXT NOT NULL PRIMARY KEY,
           tags_json TEXT NOT NULL,
-          source_kind INTEGER NOT NULL,
-          event_created_at INTEGER NOT NULL,
-          fetched_at INTEGER NOT NULL
+          source_kind INTEGER NOT NULL
         )
       ''');
     }

--- a/mobile/packages/db_client/lib/src/database/app_database.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.dart
@@ -39,6 +39,8 @@ const _notificationRetentionDays = 7;
     PendingGiftWraps,
     ProcessedGiftWraps,
     PendingProfileSaves,
+    IdentityEvents,
+    IdentityVerifications,
   ],
   daos: [
     UserProfilesDao,
@@ -63,6 +65,8 @@ const _notificationRetentionDays = 7;
     PendingGiftWrapsDao,
     ProcessedGiftWrapsDao,
     PendingProfileSavesDao,
+    IdentityEventsDao,
+    IdentityVerificationsDao,
   ],
 )
 class AppDatabase extends _$AppDatabase {
@@ -734,6 +738,47 @@ class AppDatabase extends _$AppDatabase {
           processed_at INTEGER NOT NULL,
           owner_pubkey TEXT,
           PRIMARY KEY (gift_wrap_id)
+        )
+      ''');
+    }
+
+    // Check if identity_events table exists, create if missing.
+    // Added for #3936 (NIP-39 kind-10011 source + verification cache).
+    // Schema version stays at 1 — same runtime CREATE-IF-NOT-EXISTS pattern
+    // as processed_gift_wraps above. Column order/types must match Drift's
+    // m.createAll() output (pinned by the schema-parity tests in
+    // app_database_test.dart); DateTime columns → INTEGER (seconds codec).
+    final identityEventsResult = await customSelect(
+      "SELECT name FROM sqlite_master WHERE type='table' "
+      "AND name='identity_events'",
+    ).get();
+
+    if (identityEventsResult.isEmpty) {
+      await customStatement('''
+        CREATE TABLE identity_events (
+          pubkey TEXT NOT NULL PRIMARY KEY,
+          tags_json TEXT NOT NULL,
+          source_kind INTEGER NOT NULL,
+          event_created_at INTEGER NOT NULL,
+          fetched_at INTEGER NOT NULL
+        )
+      ''');
+    }
+
+    // Check if identity_verifications table exists, create if missing.
+    // Added for #3936 — same pattern as identity_events above. No index:
+    // the only access is a primary-key lookup on pubkey.
+    final identityVerificationsResult = await customSelect(
+      "SELECT name FROM sqlite_master WHERE type='table' "
+      "AND name='identity_verifications'",
+    ).get();
+
+    if (identityVerificationsResult.isEmpty) {
+      await customStatement('''
+        CREATE TABLE identity_verifications (
+          pubkey TEXT NOT NULL PRIMARY KEY,
+          verified_claims_json TEXT NOT NULL,
+          checked_at_floor INTEGER NOT NULL
         )
       ''');
     }

--- a/mobile/packages/db_client/lib/src/database/app_database.g.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.g.dart
@@ -15399,36 +15399,8 @@ class $IdentityEventsTable extends IdentityEvents
     type: DriftSqlType.int,
     requiredDuringInsert: true,
   );
-  static const VerificationMeta _eventCreatedAtMeta = const VerificationMeta(
-    'eventCreatedAt',
-  );
   @override
-  late final GeneratedColumn<int> eventCreatedAt = GeneratedColumn<int>(
-    'event_created_at',
-    aliasedName,
-    false,
-    type: DriftSqlType.int,
-    requiredDuringInsert: true,
-  );
-  static const VerificationMeta _fetchedAtMeta = const VerificationMeta(
-    'fetchedAt',
-  );
-  @override
-  late final GeneratedColumn<DateTime> fetchedAt = GeneratedColumn<DateTime>(
-    'fetched_at',
-    aliasedName,
-    false,
-    type: DriftSqlType.dateTime,
-    requiredDuringInsert: true,
-  );
-  @override
-  List<GeneratedColumn> get $columns => [
-    pubkey,
-    tagsJson,
-    sourceKind,
-    eventCreatedAt,
-    fetchedAt,
-  ];
+  List<GeneratedColumn> get $columns => [pubkey, tagsJson, sourceKind];
   @override
   String get aliasedName => _alias ?? actualTableName;
   @override
@@ -15465,25 +15437,6 @@ class $IdentityEventsTable extends IdentityEvents
     } else if (isInserting) {
       context.missing(_sourceKindMeta);
     }
-    if (data.containsKey('event_created_at')) {
-      context.handle(
-        _eventCreatedAtMeta,
-        eventCreatedAt.isAcceptableOrUnknown(
-          data['event_created_at']!,
-          _eventCreatedAtMeta,
-        ),
-      );
-    } else if (isInserting) {
-      context.missing(_eventCreatedAtMeta);
-    }
-    if (data.containsKey('fetched_at')) {
-      context.handle(
-        _fetchedAtMeta,
-        fetchedAt.isAcceptableOrUnknown(data['fetched_at']!, _fetchedAtMeta),
-      );
-    } else if (isInserting) {
-      context.missing(_fetchedAtMeta);
-    }
     return context;
   }
 
@@ -15505,14 +15458,6 @@ class $IdentityEventsTable extends IdentityEvents
         DriftSqlType.int,
         data['${effectivePrefix}source_kind'],
       )!,
-      eventCreatedAt: attachedDatabase.typeMapping.read(
-        DriftSqlType.int,
-        data['${effectivePrefix}event_created_at'],
-      )!,
-      fetchedAt: attachedDatabase.typeMapping.read(
-        DriftSqlType.dateTime,
-        data['${effectivePrefix}fetched_at'],
-      )!,
     );
   }
 
@@ -15533,19 +15478,10 @@ class IdentityEventRow extends DataClass
   /// Which event kind the tags came from: 10011 (current spec) or 0
   /// (legacy fallback).
   final int sourceKind;
-
-  /// `created_at` of the source event (unix seconds), used to keep the
-  /// newest event when relays disagree.
-  final int eventCreatedAt;
-
-  /// When this row was last written from a relay fetch.
-  final DateTime fetchedAt;
   const IdentityEventRow({
     required this.pubkey,
     required this.tagsJson,
     required this.sourceKind,
-    required this.eventCreatedAt,
-    required this.fetchedAt,
   });
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
@@ -15553,8 +15489,6 @@ class IdentityEventRow extends DataClass
     map['pubkey'] = Variable<String>(pubkey);
     map['tags_json'] = Variable<String>(tagsJson);
     map['source_kind'] = Variable<int>(sourceKind);
-    map['event_created_at'] = Variable<int>(eventCreatedAt);
-    map['fetched_at'] = Variable<DateTime>(fetchedAt);
     return map;
   }
 
@@ -15563,8 +15497,6 @@ class IdentityEventRow extends DataClass
       pubkey: Value(pubkey),
       tagsJson: Value(tagsJson),
       sourceKind: Value(sourceKind),
-      eventCreatedAt: Value(eventCreatedAt),
-      fetchedAt: Value(fetchedAt),
     );
   }
 
@@ -15577,8 +15509,6 @@ class IdentityEventRow extends DataClass
       pubkey: serializer.fromJson<String>(json['pubkey']),
       tagsJson: serializer.fromJson<String>(json['tagsJson']),
       sourceKind: serializer.fromJson<int>(json['sourceKind']),
-      eventCreatedAt: serializer.fromJson<int>(json['eventCreatedAt']),
-      fetchedAt: serializer.fromJson<DateTime>(json['fetchedAt']),
     );
   }
   @override
@@ -15588,8 +15518,6 @@ class IdentityEventRow extends DataClass
       'pubkey': serializer.toJson<String>(pubkey),
       'tagsJson': serializer.toJson<String>(tagsJson),
       'sourceKind': serializer.toJson<int>(sourceKind),
-      'eventCreatedAt': serializer.toJson<int>(eventCreatedAt),
-      'fetchedAt': serializer.toJson<DateTime>(fetchedAt),
     };
   }
 
@@ -15597,14 +15525,10 @@ class IdentityEventRow extends DataClass
     String? pubkey,
     String? tagsJson,
     int? sourceKind,
-    int? eventCreatedAt,
-    DateTime? fetchedAt,
   }) => IdentityEventRow(
     pubkey: pubkey ?? this.pubkey,
     tagsJson: tagsJson ?? this.tagsJson,
     sourceKind: sourceKind ?? this.sourceKind,
-    eventCreatedAt: eventCreatedAt ?? this.eventCreatedAt,
-    fetchedAt: fetchedAt ?? this.fetchedAt,
   );
   IdentityEventRow copyWithCompanion(IdentityEventsCompanion data) {
     return IdentityEventRow(
@@ -15613,10 +15537,6 @@ class IdentityEventRow extends DataClass
       sourceKind: data.sourceKind.present
           ? data.sourceKind.value
           : this.sourceKind,
-      eventCreatedAt: data.eventCreatedAt.present
-          ? data.eventCreatedAt.value
-          : this.eventCreatedAt,
-      fetchedAt: data.fetchedAt.present ? data.fetchedAt.value : this.fetchedAt,
     );
   }
 
@@ -15625,68 +15545,51 @@ class IdentityEventRow extends DataClass
     return (StringBuffer('IdentityEventRow(')
           ..write('pubkey: $pubkey, ')
           ..write('tagsJson: $tagsJson, ')
-          ..write('sourceKind: $sourceKind, ')
-          ..write('eventCreatedAt: $eventCreatedAt, ')
-          ..write('fetchedAt: $fetchedAt')
+          ..write('sourceKind: $sourceKind')
           ..write(')'))
         .toString();
   }
 
   @override
-  int get hashCode =>
-      Object.hash(pubkey, tagsJson, sourceKind, eventCreatedAt, fetchedAt);
+  int get hashCode => Object.hash(pubkey, tagsJson, sourceKind);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       (other is IdentityEventRow &&
           other.pubkey == this.pubkey &&
           other.tagsJson == this.tagsJson &&
-          other.sourceKind == this.sourceKind &&
-          other.eventCreatedAt == this.eventCreatedAt &&
-          other.fetchedAt == this.fetchedAt);
+          other.sourceKind == this.sourceKind);
 }
 
 class IdentityEventsCompanion extends UpdateCompanion<IdentityEventRow> {
   final Value<String> pubkey;
   final Value<String> tagsJson;
   final Value<int> sourceKind;
-  final Value<int> eventCreatedAt;
-  final Value<DateTime> fetchedAt;
   final Value<int> rowid;
   const IdentityEventsCompanion({
     this.pubkey = const Value.absent(),
     this.tagsJson = const Value.absent(),
     this.sourceKind = const Value.absent(),
-    this.eventCreatedAt = const Value.absent(),
-    this.fetchedAt = const Value.absent(),
     this.rowid = const Value.absent(),
   });
   IdentityEventsCompanion.insert({
     required String pubkey,
     required String tagsJson,
     required int sourceKind,
-    required int eventCreatedAt,
-    required DateTime fetchedAt,
     this.rowid = const Value.absent(),
   }) : pubkey = Value(pubkey),
        tagsJson = Value(tagsJson),
-       sourceKind = Value(sourceKind),
-       eventCreatedAt = Value(eventCreatedAt),
-       fetchedAt = Value(fetchedAt);
+       sourceKind = Value(sourceKind);
   static Insertable<IdentityEventRow> custom({
     Expression<String>? pubkey,
     Expression<String>? tagsJson,
     Expression<int>? sourceKind,
-    Expression<int>? eventCreatedAt,
-    Expression<DateTime>? fetchedAt,
     Expression<int>? rowid,
   }) {
     return RawValuesInsertable({
       if (pubkey != null) 'pubkey': pubkey,
       if (tagsJson != null) 'tags_json': tagsJson,
       if (sourceKind != null) 'source_kind': sourceKind,
-      if (eventCreatedAt != null) 'event_created_at': eventCreatedAt,
-      if (fetchedAt != null) 'fetched_at': fetchedAt,
       if (rowid != null) 'rowid': rowid,
     });
   }
@@ -15695,16 +15598,12 @@ class IdentityEventsCompanion extends UpdateCompanion<IdentityEventRow> {
     Value<String>? pubkey,
     Value<String>? tagsJson,
     Value<int>? sourceKind,
-    Value<int>? eventCreatedAt,
-    Value<DateTime>? fetchedAt,
     Value<int>? rowid,
   }) {
     return IdentityEventsCompanion(
       pubkey: pubkey ?? this.pubkey,
       tagsJson: tagsJson ?? this.tagsJson,
       sourceKind: sourceKind ?? this.sourceKind,
-      eventCreatedAt: eventCreatedAt ?? this.eventCreatedAt,
-      fetchedAt: fetchedAt ?? this.fetchedAt,
       rowid: rowid ?? this.rowid,
     );
   }
@@ -15721,12 +15620,6 @@ class IdentityEventsCompanion extends UpdateCompanion<IdentityEventRow> {
     if (sourceKind.present) {
       map['source_kind'] = Variable<int>(sourceKind.value);
     }
-    if (eventCreatedAt.present) {
-      map['event_created_at'] = Variable<int>(eventCreatedAt.value);
-    }
-    if (fetchedAt.present) {
-      map['fetched_at'] = Variable<DateTime>(fetchedAt.value);
-    }
     if (rowid.present) {
       map['rowid'] = Variable<int>(rowid.value);
     }
@@ -15739,8 +15632,6 @@ class IdentityEventsCompanion extends UpdateCompanion<IdentityEventRow> {
           ..write('pubkey: $pubkey, ')
           ..write('tagsJson: $tagsJson, ')
           ..write('sourceKind: $sourceKind, ')
-          ..write('eventCreatedAt: $eventCreatedAt, ')
-          ..write('fetchedAt: $fetchedAt, ')
           ..write('rowid: $rowid')
           ..write(')'))
         .toString();
@@ -23373,8 +23264,6 @@ typedef $$IdentityEventsTableCreateCompanionBuilder =
       required String pubkey,
       required String tagsJson,
       required int sourceKind,
-      required int eventCreatedAt,
-      required DateTime fetchedAt,
       Value<int> rowid,
     });
 typedef $$IdentityEventsTableUpdateCompanionBuilder =
@@ -23382,8 +23271,6 @@ typedef $$IdentityEventsTableUpdateCompanionBuilder =
       Value<String> pubkey,
       Value<String> tagsJson,
       Value<int> sourceKind,
-      Value<int> eventCreatedAt,
-      Value<DateTime> fetchedAt,
       Value<int> rowid,
     });
 
@@ -23408,16 +23295,6 @@ class $$IdentityEventsTableFilterComposer
 
   ColumnFilters<int> get sourceKind => $composableBuilder(
     column: $table.sourceKind,
-    builder: (column) => ColumnFilters(column),
-  );
-
-  ColumnFilters<int> get eventCreatedAt => $composableBuilder(
-    column: $table.eventCreatedAt,
-    builder: (column) => ColumnFilters(column),
-  );
-
-  ColumnFilters<DateTime> get fetchedAt => $composableBuilder(
-    column: $table.fetchedAt,
     builder: (column) => ColumnFilters(column),
   );
 }
@@ -23445,16 +23322,6 @@ class $$IdentityEventsTableOrderingComposer
     column: $table.sourceKind,
     builder: (column) => ColumnOrderings(column),
   );
-
-  ColumnOrderings<int> get eventCreatedAt => $composableBuilder(
-    column: $table.eventCreatedAt,
-    builder: (column) => ColumnOrderings(column),
-  );
-
-  ColumnOrderings<DateTime> get fetchedAt => $composableBuilder(
-    column: $table.fetchedAt,
-    builder: (column) => ColumnOrderings(column),
-  );
 }
 
 class $$IdentityEventsTableAnnotationComposer
@@ -23476,14 +23343,6 @@ class $$IdentityEventsTableAnnotationComposer
     column: $table.sourceKind,
     builder: (column) => column,
   );
-
-  GeneratedColumn<int> get eventCreatedAt => $composableBuilder(
-    column: $table.eventCreatedAt,
-    builder: (column) => column,
-  );
-
-  GeneratedColumn<DateTime> get fetchedAt =>
-      $composableBuilder(column: $table.fetchedAt, builder: (column) => column);
 }
 
 class $$IdentityEventsTableTableManager
@@ -23526,15 +23385,11 @@ class $$IdentityEventsTableTableManager
                 Value<String> pubkey = const Value.absent(),
                 Value<String> tagsJson = const Value.absent(),
                 Value<int> sourceKind = const Value.absent(),
-                Value<int> eventCreatedAt = const Value.absent(),
-                Value<DateTime> fetchedAt = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => IdentityEventsCompanion(
                 pubkey: pubkey,
                 tagsJson: tagsJson,
                 sourceKind: sourceKind,
-                eventCreatedAt: eventCreatedAt,
-                fetchedAt: fetchedAt,
                 rowid: rowid,
               ),
           createCompanionCallback:
@@ -23542,15 +23397,11 @@ class $$IdentityEventsTableTableManager
                 required String pubkey,
                 required String tagsJson,
                 required int sourceKind,
-                required int eventCreatedAt,
-                required DateTime fetchedAt,
                 Value<int> rowid = const Value.absent(),
               }) => IdentityEventsCompanion.insert(
                 pubkey: pubkey,
                 tagsJson: tagsJson,
                 sourceKind: sourceKind,
-                eventCreatedAt: eventCreatedAt,
-                fetchedAt: fetchedAt,
                 rowid: rowid,
               ),
           withReferenceMapper: (p0) => p0

--- a/mobile/packages/db_client/lib/src/database/app_database.g.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.g.dart
@@ -15362,6 +15362,693 @@ class PendingProfileSavesCompanion
   }
 }
 
+class $IdentityEventsTable extends IdentityEvents
+    with TableInfo<$IdentityEventsTable, IdentityEventRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $IdentityEventsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _pubkeyMeta = const VerificationMeta('pubkey');
+  @override
+  late final GeneratedColumn<String> pubkey = GeneratedColumn<String>(
+    'pubkey',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _tagsJsonMeta = const VerificationMeta(
+    'tagsJson',
+  );
+  @override
+  late final GeneratedColumn<String> tagsJson = GeneratedColumn<String>(
+    'tags_json',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _sourceKindMeta = const VerificationMeta(
+    'sourceKind',
+  );
+  @override
+  late final GeneratedColumn<int> sourceKind = GeneratedColumn<int>(
+    'source_kind',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _eventCreatedAtMeta = const VerificationMeta(
+    'eventCreatedAt',
+  );
+  @override
+  late final GeneratedColumn<int> eventCreatedAt = GeneratedColumn<int>(
+    'event_created_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _fetchedAtMeta = const VerificationMeta(
+    'fetchedAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> fetchedAt = GeneratedColumn<DateTime>(
+    'fetched_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: true,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    pubkey,
+    tagsJson,
+    sourceKind,
+    eventCreatedAt,
+    fetchedAt,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'identity_events';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<IdentityEventRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('pubkey')) {
+      context.handle(
+        _pubkeyMeta,
+        pubkey.isAcceptableOrUnknown(data['pubkey']!, _pubkeyMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_pubkeyMeta);
+    }
+    if (data.containsKey('tags_json')) {
+      context.handle(
+        _tagsJsonMeta,
+        tagsJson.isAcceptableOrUnknown(data['tags_json']!, _tagsJsonMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_tagsJsonMeta);
+    }
+    if (data.containsKey('source_kind')) {
+      context.handle(
+        _sourceKindMeta,
+        sourceKind.isAcceptableOrUnknown(data['source_kind']!, _sourceKindMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_sourceKindMeta);
+    }
+    if (data.containsKey('event_created_at')) {
+      context.handle(
+        _eventCreatedAtMeta,
+        eventCreatedAt.isAcceptableOrUnknown(
+          data['event_created_at']!,
+          _eventCreatedAtMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_eventCreatedAtMeta);
+    }
+    if (data.containsKey('fetched_at')) {
+      context.handle(
+        _fetchedAtMeta,
+        fetchedAt.isAcceptableOrUnknown(data['fetched_at']!, _fetchedAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_fetchedAtMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {pubkey};
+  @override
+  IdentityEventRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return IdentityEventRow(
+      pubkey: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}pubkey'],
+      )!,
+      tagsJson: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}tags_json'],
+      )!,
+      sourceKind: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}source_kind'],
+      )!,
+      eventCreatedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}event_created_at'],
+      )!,
+      fetchedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}fetched_at'],
+      )!,
+    );
+  }
+
+  @override
+  $IdentityEventsTable createAlias(String alias) {
+    return $IdentityEventsTable(attachedDatabase, alias);
+  }
+}
+
+class IdentityEventRow extends DataClass
+    implements Insertable<IdentityEventRow> {
+  /// Hex pubkey of the profile the identity event belongs to.
+  final String pubkey;
+
+  /// JSON-encoded `List<List<String>>` of the event's `i` tags only.
+  final String tagsJson;
+
+  /// Which event kind the tags came from: 10011 (current spec) or 0
+  /// (legacy fallback).
+  final int sourceKind;
+
+  /// `created_at` of the source event (unix seconds), used to keep the
+  /// newest event when relays disagree.
+  final int eventCreatedAt;
+
+  /// When this row was last written from a relay fetch.
+  final DateTime fetchedAt;
+  const IdentityEventRow({
+    required this.pubkey,
+    required this.tagsJson,
+    required this.sourceKind,
+    required this.eventCreatedAt,
+    required this.fetchedAt,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['pubkey'] = Variable<String>(pubkey);
+    map['tags_json'] = Variable<String>(tagsJson);
+    map['source_kind'] = Variable<int>(sourceKind);
+    map['event_created_at'] = Variable<int>(eventCreatedAt);
+    map['fetched_at'] = Variable<DateTime>(fetchedAt);
+    return map;
+  }
+
+  IdentityEventsCompanion toCompanion(bool nullToAbsent) {
+    return IdentityEventsCompanion(
+      pubkey: Value(pubkey),
+      tagsJson: Value(tagsJson),
+      sourceKind: Value(sourceKind),
+      eventCreatedAt: Value(eventCreatedAt),
+      fetchedAt: Value(fetchedAt),
+    );
+  }
+
+  factory IdentityEventRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return IdentityEventRow(
+      pubkey: serializer.fromJson<String>(json['pubkey']),
+      tagsJson: serializer.fromJson<String>(json['tagsJson']),
+      sourceKind: serializer.fromJson<int>(json['sourceKind']),
+      eventCreatedAt: serializer.fromJson<int>(json['eventCreatedAt']),
+      fetchedAt: serializer.fromJson<DateTime>(json['fetchedAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'pubkey': serializer.toJson<String>(pubkey),
+      'tagsJson': serializer.toJson<String>(tagsJson),
+      'sourceKind': serializer.toJson<int>(sourceKind),
+      'eventCreatedAt': serializer.toJson<int>(eventCreatedAt),
+      'fetchedAt': serializer.toJson<DateTime>(fetchedAt),
+    };
+  }
+
+  IdentityEventRow copyWith({
+    String? pubkey,
+    String? tagsJson,
+    int? sourceKind,
+    int? eventCreatedAt,
+    DateTime? fetchedAt,
+  }) => IdentityEventRow(
+    pubkey: pubkey ?? this.pubkey,
+    tagsJson: tagsJson ?? this.tagsJson,
+    sourceKind: sourceKind ?? this.sourceKind,
+    eventCreatedAt: eventCreatedAt ?? this.eventCreatedAt,
+    fetchedAt: fetchedAt ?? this.fetchedAt,
+  );
+  IdentityEventRow copyWithCompanion(IdentityEventsCompanion data) {
+    return IdentityEventRow(
+      pubkey: data.pubkey.present ? data.pubkey.value : this.pubkey,
+      tagsJson: data.tagsJson.present ? data.tagsJson.value : this.tagsJson,
+      sourceKind: data.sourceKind.present
+          ? data.sourceKind.value
+          : this.sourceKind,
+      eventCreatedAt: data.eventCreatedAt.present
+          ? data.eventCreatedAt.value
+          : this.eventCreatedAt,
+      fetchedAt: data.fetchedAt.present ? data.fetchedAt.value : this.fetchedAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('IdentityEventRow(')
+          ..write('pubkey: $pubkey, ')
+          ..write('tagsJson: $tagsJson, ')
+          ..write('sourceKind: $sourceKind, ')
+          ..write('eventCreatedAt: $eventCreatedAt, ')
+          ..write('fetchedAt: $fetchedAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(pubkey, tagsJson, sourceKind, eventCreatedAt, fetchedAt);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is IdentityEventRow &&
+          other.pubkey == this.pubkey &&
+          other.tagsJson == this.tagsJson &&
+          other.sourceKind == this.sourceKind &&
+          other.eventCreatedAt == this.eventCreatedAt &&
+          other.fetchedAt == this.fetchedAt);
+}
+
+class IdentityEventsCompanion extends UpdateCompanion<IdentityEventRow> {
+  final Value<String> pubkey;
+  final Value<String> tagsJson;
+  final Value<int> sourceKind;
+  final Value<int> eventCreatedAt;
+  final Value<DateTime> fetchedAt;
+  final Value<int> rowid;
+  const IdentityEventsCompanion({
+    this.pubkey = const Value.absent(),
+    this.tagsJson = const Value.absent(),
+    this.sourceKind = const Value.absent(),
+    this.eventCreatedAt = const Value.absent(),
+    this.fetchedAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  IdentityEventsCompanion.insert({
+    required String pubkey,
+    required String tagsJson,
+    required int sourceKind,
+    required int eventCreatedAt,
+    required DateTime fetchedAt,
+    this.rowid = const Value.absent(),
+  }) : pubkey = Value(pubkey),
+       tagsJson = Value(tagsJson),
+       sourceKind = Value(sourceKind),
+       eventCreatedAt = Value(eventCreatedAt),
+       fetchedAt = Value(fetchedAt);
+  static Insertable<IdentityEventRow> custom({
+    Expression<String>? pubkey,
+    Expression<String>? tagsJson,
+    Expression<int>? sourceKind,
+    Expression<int>? eventCreatedAt,
+    Expression<DateTime>? fetchedAt,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (pubkey != null) 'pubkey': pubkey,
+      if (tagsJson != null) 'tags_json': tagsJson,
+      if (sourceKind != null) 'source_kind': sourceKind,
+      if (eventCreatedAt != null) 'event_created_at': eventCreatedAt,
+      if (fetchedAt != null) 'fetched_at': fetchedAt,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  IdentityEventsCompanion copyWith({
+    Value<String>? pubkey,
+    Value<String>? tagsJson,
+    Value<int>? sourceKind,
+    Value<int>? eventCreatedAt,
+    Value<DateTime>? fetchedAt,
+    Value<int>? rowid,
+  }) {
+    return IdentityEventsCompanion(
+      pubkey: pubkey ?? this.pubkey,
+      tagsJson: tagsJson ?? this.tagsJson,
+      sourceKind: sourceKind ?? this.sourceKind,
+      eventCreatedAt: eventCreatedAt ?? this.eventCreatedAt,
+      fetchedAt: fetchedAt ?? this.fetchedAt,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (pubkey.present) {
+      map['pubkey'] = Variable<String>(pubkey.value);
+    }
+    if (tagsJson.present) {
+      map['tags_json'] = Variable<String>(tagsJson.value);
+    }
+    if (sourceKind.present) {
+      map['source_kind'] = Variable<int>(sourceKind.value);
+    }
+    if (eventCreatedAt.present) {
+      map['event_created_at'] = Variable<int>(eventCreatedAt.value);
+    }
+    if (fetchedAt.present) {
+      map['fetched_at'] = Variable<DateTime>(fetchedAt.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('IdentityEventsCompanion(')
+          ..write('pubkey: $pubkey, ')
+          ..write('tagsJson: $tagsJson, ')
+          ..write('sourceKind: $sourceKind, ')
+          ..write('eventCreatedAt: $eventCreatedAt, ')
+          ..write('fetchedAt: $fetchedAt, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $IdentityVerificationsTable extends IdentityVerifications
+    with TableInfo<$IdentityVerificationsTable, IdentityVerificationRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $IdentityVerificationsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _pubkeyMeta = const VerificationMeta('pubkey');
+  @override
+  late final GeneratedColumn<String> pubkey = GeneratedColumn<String>(
+    'pubkey',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _verifiedClaimsJsonMeta =
+      const VerificationMeta('verifiedClaimsJson');
+  @override
+  late final GeneratedColumn<String> verifiedClaimsJson =
+      GeneratedColumn<String>(
+        'verified_claims_json',
+        aliasedName,
+        false,
+        type: DriftSqlType.string,
+        requiredDuringInsert: true,
+      );
+  static const VerificationMeta _checkedAtFloorMeta = const VerificationMeta(
+    'checkedAtFloor',
+  );
+  @override
+  late final GeneratedColumn<int> checkedAtFloor = GeneratedColumn<int>(
+    'checked_at_floor',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    pubkey,
+    verifiedClaimsJson,
+    checkedAtFloor,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'identity_verifications';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<IdentityVerificationRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('pubkey')) {
+      context.handle(
+        _pubkeyMeta,
+        pubkey.isAcceptableOrUnknown(data['pubkey']!, _pubkeyMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_pubkeyMeta);
+    }
+    if (data.containsKey('verified_claims_json')) {
+      context.handle(
+        _verifiedClaimsJsonMeta,
+        verifiedClaimsJson.isAcceptableOrUnknown(
+          data['verified_claims_json']!,
+          _verifiedClaimsJsonMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_verifiedClaimsJsonMeta);
+    }
+    if (data.containsKey('checked_at_floor')) {
+      context.handle(
+        _checkedAtFloorMeta,
+        checkedAtFloor.isAcceptableOrUnknown(
+          data['checked_at_floor']!,
+          _checkedAtFloorMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_checkedAtFloorMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {pubkey};
+  @override
+  IdentityVerificationRow map(
+    Map<String, dynamic> data, {
+    String? tablePrefix,
+  }) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return IdentityVerificationRow(
+      pubkey: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}pubkey'],
+      )!,
+      verifiedClaimsJson: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}verified_claims_json'],
+      )!,
+      checkedAtFloor: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}checked_at_floor'],
+      )!,
+    );
+  }
+
+  @override
+  $IdentityVerificationsTable createAlias(String alias) {
+    return $IdentityVerificationsTable(attachedDatabase, alias);
+  }
+}
+
+class IdentityVerificationRow extends DataClass
+    implements Insertable<IdentityVerificationRow> {
+  /// Hex pubkey of the profile the verified claims belong to.
+  final String pubkey;
+
+  /// JSON-encoded list of verified claim objects
+  /// `{"platform": ..., "identity": ..., "proof": ...}`.
+  ///
+  /// Proof participates in cache matching: a rotated proof no longer
+  /// matches its snapshot entry, so the claim re-verifies instead of
+  /// serving a stale verdict.
+  final String verifiedClaimsJson;
+
+  /// Minimum verifier `checked_at` (unix seconds) across the verified
+  /// batch. Freshness = `checkedAtFloor + 24h > now`.
+  final int checkedAtFloor;
+  const IdentityVerificationRow({
+    required this.pubkey,
+    required this.verifiedClaimsJson,
+    required this.checkedAtFloor,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['pubkey'] = Variable<String>(pubkey);
+    map['verified_claims_json'] = Variable<String>(verifiedClaimsJson);
+    map['checked_at_floor'] = Variable<int>(checkedAtFloor);
+    return map;
+  }
+
+  IdentityVerificationsCompanion toCompanion(bool nullToAbsent) {
+    return IdentityVerificationsCompanion(
+      pubkey: Value(pubkey),
+      verifiedClaimsJson: Value(verifiedClaimsJson),
+      checkedAtFloor: Value(checkedAtFloor),
+    );
+  }
+
+  factory IdentityVerificationRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return IdentityVerificationRow(
+      pubkey: serializer.fromJson<String>(json['pubkey']),
+      verifiedClaimsJson: serializer.fromJson<String>(
+        json['verifiedClaimsJson'],
+      ),
+      checkedAtFloor: serializer.fromJson<int>(json['checkedAtFloor']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'pubkey': serializer.toJson<String>(pubkey),
+      'verifiedClaimsJson': serializer.toJson<String>(verifiedClaimsJson),
+      'checkedAtFloor': serializer.toJson<int>(checkedAtFloor),
+    };
+  }
+
+  IdentityVerificationRow copyWith({
+    String? pubkey,
+    String? verifiedClaimsJson,
+    int? checkedAtFloor,
+  }) => IdentityVerificationRow(
+    pubkey: pubkey ?? this.pubkey,
+    verifiedClaimsJson: verifiedClaimsJson ?? this.verifiedClaimsJson,
+    checkedAtFloor: checkedAtFloor ?? this.checkedAtFloor,
+  );
+  IdentityVerificationRow copyWithCompanion(
+    IdentityVerificationsCompanion data,
+  ) {
+    return IdentityVerificationRow(
+      pubkey: data.pubkey.present ? data.pubkey.value : this.pubkey,
+      verifiedClaimsJson: data.verifiedClaimsJson.present
+          ? data.verifiedClaimsJson.value
+          : this.verifiedClaimsJson,
+      checkedAtFloor: data.checkedAtFloor.present
+          ? data.checkedAtFloor.value
+          : this.checkedAtFloor,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('IdentityVerificationRow(')
+          ..write('pubkey: $pubkey, ')
+          ..write('verifiedClaimsJson: $verifiedClaimsJson, ')
+          ..write('checkedAtFloor: $checkedAtFloor')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(pubkey, verifiedClaimsJson, checkedAtFloor);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is IdentityVerificationRow &&
+          other.pubkey == this.pubkey &&
+          other.verifiedClaimsJson == this.verifiedClaimsJson &&
+          other.checkedAtFloor == this.checkedAtFloor);
+}
+
+class IdentityVerificationsCompanion
+    extends UpdateCompanion<IdentityVerificationRow> {
+  final Value<String> pubkey;
+  final Value<String> verifiedClaimsJson;
+  final Value<int> checkedAtFloor;
+  final Value<int> rowid;
+  const IdentityVerificationsCompanion({
+    this.pubkey = const Value.absent(),
+    this.verifiedClaimsJson = const Value.absent(),
+    this.checkedAtFloor = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  IdentityVerificationsCompanion.insert({
+    required String pubkey,
+    required String verifiedClaimsJson,
+    required int checkedAtFloor,
+    this.rowid = const Value.absent(),
+  }) : pubkey = Value(pubkey),
+       verifiedClaimsJson = Value(verifiedClaimsJson),
+       checkedAtFloor = Value(checkedAtFloor);
+  static Insertable<IdentityVerificationRow> custom({
+    Expression<String>? pubkey,
+    Expression<String>? verifiedClaimsJson,
+    Expression<int>? checkedAtFloor,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (pubkey != null) 'pubkey': pubkey,
+      if (verifiedClaimsJson != null)
+        'verified_claims_json': verifiedClaimsJson,
+      if (checkedAtFloor != null) 'checked_at_floor': checkedAtFloor,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  IdentityVerificationsCompanion copyWith({
+    Value<String>? pubkey,
+    Value<String>? verifiedClaimsJson,
+    Value<int>? checkedAtFloor,
+    Value<int>? rowid,
+  }) {
+    return IdentityVerificationsCompanion(
+      pubkey: pubkey ?? this.pubkey,
+      verifiedClaimsJson: verifiedClaimsJson ?? this.verifiedClaimsJson,
+      checkedAtFloor: checkedAtFloor ?? this.checkedAtFloor,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (pubkey.present) {
+      map['pubkey'] = Variable<String>(pubkey.value);
+    }
+    if (verifiedClaimsJson.present) {
+      map['verified_claims_json'] = Variable<String>(verifiedClaimsJson.value);
+    }
+    if (checkedAtFloor.present) {
+      map['checked_at_floor'] = Variable<int>(checkedAtFloor.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('IdentityVerificationsCompanion(')
+          ..write('pubkey: $pubkey, ')
+          ..write('verifiedClaimsJson: $verifiedClaimsJson, ')
+          ..write('checkedAtFloor: $checkedAtFloor, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$AppDatabase extends GeneratedDatabase {
   _$AppDatabase(QueryExecutor e) : super(e);
   $AppDatabaseManager get managers => $AppDatabaseManager(this);
@@ -15398,6 +16085,9 @@ abstract class _$AppDatabase extends GeneratedDatabase {
       $ProcessedGiftWrapsTable(this);
   late final $PendingProfileSavesTable pendingProfileSaves =
       $PendingProfileSavesTable(this);
+  late final $IdentityEventsTable identityEvents = $IdentityEventsTable(this);
+  late final $IdentityVerificationsTable identityVerifications =
+      $IdentityVerificationsTable(this);
   late final UserProfilesDao userProfilesDao = UserProfilesDao(
     this as AppDatabase,
   );
@@ -15456,6 +16146,11 @@ abstract class _$AppDatabase extends GeneratedDatabase {
       ProcessedGiftWrapsDao(this as AppDatabase);
   late final PendingProfileSavesDao pendingProfileSavesDao =
       PendingProfileSavesDao(this as AppDatabase);
+  late final IdentityEventsDao identityEventsDao = IdentityEventsDao(
+    this as AppDatabase,
+  );
+  late final IdentityVerificationsDao identityVerificationsDao =
+      IdentityVerificationsDao(this as AppDatabase);
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
@@ -15483,6 +16178,8 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     pendingGiftWraps,
     processedGiftWraps,
     pendingProfileSaves,
+    identityEvents,
+    identityVerifications,
   ];
 }
 
@@ -22671,6 +23368,401 @@ typedef $$PendingProfileSavesTableProcessedTableManager =
       PendingProfileSaveRow,
       PrefetchHooks Function()
     >;
+typedef $$IdentityEventsTableCreateCompanionBuilder =
+    IdentityEventsCompanion Function({
+      required String pubkey,
+      required String tagsJson,
+      required int sourceKind,
+      required int eventCreatedAt,
+      required DateTime fetchedAt,
+      Value<int> rowid,
+    });
+typedef $$IdentityEventsTableUpdateCompanionBuilder =
+    IdentityEventsCompanion Function({
+      Value<String> pubkey,
+      Value<String> tagsJson,
+      Value<int> sourceKind,
+      Value<int> eventCreatedAt,
+      Value<DateTime> fetchedAt,
+      Value<int> rowid,
+    });
+
+class $$IdentityEventsTableFilterComposer
+    extends Composer<_$AppDatabase, $IdentityEventsTable> {
+  $$IdentityEventsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get pubkey => $composableBuilder(
+    column: $table.pubkey,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get tagsJson => $composableBuilder(
+    column: $table.tagsJson,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get sourceKind => $composableBuilder(
+    column: $table.sourceKind,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get eventCreatedAt => $composableBuilder(
+    column: $table.eventCreatedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get fetchedAt => $composableBuilder(
+    column: $table.fetchedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$IdentityEventsTableOrderingComposer
+    extends Composer<_$AppDatabase, $IdentityEventsTable> {
+  $$IdentityEventsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get pubkey => $composableBuilder(
+    column: $table.pubkey,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get tagsJson => $composableBuilder(
+    column: $table.tagsJson,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get sourceKind => $composableBuilder(
+    column: $table.sourceKind,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get eventCreatedAt => $composableBuilder(
+    column: $table.eventCreatedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get fetchedAt => $composableBuilder(
+    column: $table.fetchedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$IdentityEventsTableAnnotationComposer
+    extends Composer<_$AppDatabase, $IdentityEventsTable> {
+  $$IdentityEventsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get pubkey =>
+      $composableBuilder(column: $table.pubkey, builder: (column) => column);
+
+  GeneratedColumn<String> get tagsJson =>
+      $composableBuilder(column: $table.tagsJson, builder: (column) => column);
+
+  GeneratedColumn<int> get sourceKind => $composableBuilder(
+    column: $table.sourceKind,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get eventCreatedAt => $composableBuilder(
+    column: $table.eventCreatedAt,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<DateTime> get fetchedAt =>
+      $composableBuilder(column: $table.fetchedAt, builder: (column) => column);
+}
+
+class $$IdentityEventsTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $IdentityEventsTable,
+          IdentityEventRow,
+          $$IdentityEventsTableFilterComposer,
+          $$IdentityEventsTableOrderingComposer,
+          $$IdentityEventsTableAnnotationComposer,
+          $$IdentityEventsTableCreateCompanionBuilder,
+          $$IdentityEventsTableUpdateCompanionBuilder,
+          (
+            IdentityEventRow,
+            BaseReferences<
+              _$AppDatabase,
+              $IdentityEventsTable,
+              IdentityEventRow
+            >,
+          ),
+          IdentityEventRow,
+          PrefetchHooks Function()
+        > {
+  $$IdentityEventsTableTableManager(
+    _$AppDatabase db,
+    $IdentityEventsTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$IdentityEventsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$IdentityEventsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$IdentityEventsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<String> pubkey = const Value.absent(),
+                Value<String> tagsJson = const Value.absent(),
+                Value<int> sourceKind = const Value.absent(),
+                Value<int> eventCreatedAt = const Value.absent(),
+                Value<DateTime> fetchedAt = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => IdentityEventsCompanion(
+                pubkey: pubkey,
+                tagsJson: tagsJson,
+                sourceKind: sourceKind,
+                eventCreatedAt: eventCreatedAt,
+                fetchedAt: fetchedAt,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String pubkey,
+                required String tagsJson,
+                required int sourceKind,
+                required int eventCreatedAt,
+                required DateTime fetchedAt,
+                Value<int> rowid = const Value.absent(),
+              }) => IdentityEventsCompanion.insert(
+                pubkey: pubkey,
+                tagsJson: tagsJson,
+                sourceKind: sourceKind,
+                eventCreatedAt: eventCreatedAt,
+                fetchedAt: fetchedAt,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$IdentityEventsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $IdentityEventsTable,
+      IdentityEventRow,
+      $$IdentityEventsTableFilterComposer,
+      $$IdentityEventsTableOrderingComposer,
+      $$IdentityEventsTableAnnotationComposer,
+      $$IdentityEventsTableCreateCompanionBuilder,
+      $$IdentityEventsTableUpdateCompanionBuilder,
+      (
+        IdentityEventRow,
+        BaseReferences<_$AppDatabase, $IdentityEventsTable, IdentityEventRow>,
+      ),
+      IdentityEventRow,
+      PrefetchHooks Function()
+    >;
+typedef $$IdentityVerificationsTableCreateCompanionBuilder =
+    IdentityVerificationsCompanion Function({
+      required String pubkey,
+      required String verifiedClaimsJson,
+      required int checkedAtFloor,
+      Value<int> rowid,
+    });
+typedef $$IdentityVerificationsTableUpdateCompanionBuilder =
+    IdentityVerificationsCompanion Function({
+      Value<String> pubkey,
+      Value<String> verifiedClaimsJson,
+      Value<int> checkedAtFloor,
+      Value<int> rowid,
+    });
+
+class $$IdentityVerificationsTableFilterComposer
+    extends Composer<_$AppDatabase, $IdentityVerificationsTable> {
+  $$IdentityVerificationsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get pubkey => $composableBuilder(
+    column: $table.pubkey,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get verifiedClaimsJson => $composableBuilder(
+    column: $table.verifiedClaimsJson,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get checkedAtFloor => $composableBuilder(
+    column: $table.checkedAtFloor,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$IdentityVerificationsTableOrderingComposer
+    extends Composer<_$AppDatabase, $IdentityVerificationsTable> {
+  $$IdentityVerificationsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get pubkey => $composableBuilder(
+    column: $table.pubkey,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get verifiedClaimsJson => $composableBuilder(
+    column: $table.verifiedClaimsJson,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get checkedAtFloor => $composableBuilder(
+    column: $table.checkedAtFloor,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$IdentityVerificationsTableAnnotationComposer
+    extends Composer<_$AppDatabase, $IdentityVerificationsTable> {
+  $$IdentityVerificationsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get pubkey =>
+      $composableBuilder(column: $table.pubkey, builder: (column) => column);
+
+  GeneratedColumn<String> get verifiedClaimsJson => $composableBuilder(
+    column: $table.verifiedClaimsJson,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get checkedAtFloor => $composableBuilder(
+    column: $table.checkedAtFloor,
+    builder: (column) => column,
+  );
+}
+
+class $$IdentityVerificationsTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $IdentityVerificationsTable,
+          IdentityVerificationRow,
+          $$IdentityVerificationsTableFilterComposer,
+          $$IdentityVerificationsTableOrderingComposer,
+          $$IdentityVerificationsTableAnnotationComposer,
+          $$IdentityVerificationsTableCreateCompanionBuilder,
+          $$IdentityVerificationsTableUpdateCompanionBuilder,
+          (
+            IdentityVerificationRow,
+            BaseReferences<
+              _$AppDatabase,
+              $IdentityVerificationsTable,
+              IdentityVerificationRow
+            >,
+          ),
+          IdentityVerificationRow,
+          PrefetchHooks Function()
+        > {
+  $$IdentityVerificationsTableTableManager(
+    _$AppDatabase db,
+    $IdentityVerificationsTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$IdentityVerificationsTableFilterComposer(
+                $db: db,
+                $table: table,
+              ),
+          createOrderingComposer: () =>
+              $$IdentityVerificationsTableOrderingComposer(
+                $db: db,
+                $table: table,
+              ),
+          createComputedFieldComposer: () =>
+              $$IdentityVerificationsTableAnnotationComposer(
+                $db: db,
+                $table: table,
+              ),
+          updateCompanionCallback:
+              ({
+                Value<String> pubkey = const Value.absent(),
+                Value<String> verifiedClaimsJson = const Value.absent(),
+                Value<int> checkedAtFloor = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => IdentityVerificationsCompanion(
+                pubkey: pubkey,
+                verifiedClaimsJson: verifiedClaimsJson,
+                checkedAtFloor: checkedAtFloor,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String pubkey,
+                required String verifiedClaimsJson,
+                required int checkedAtFloor,
+                Value<int> rowid = const Value.absent(),
+              }) => IdentityVerificationsCompanion.insert(
+                pubkey: pubkey,
+                verifiedClaimsJson: verifiedClaimsJson,
+                checkedAtFloor: checkedAtFloor,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$IdentityVerificationsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $IdentityVerificationsTable,
+      IdentityVerificationRow,
+      $$IdentityVerificationsTableFilterComposer,
+      $$IdentityVerificationsTableOrderingComposer,
+      $$IdentityVerificationsTableAnnotationComposer,
+      $$IdentityVerificationsTableCreateCompanionBuilder,
+      $$IdentityVerificationsTableUpdateCompanionBuilder,
+      (
+        IdentityVerificationRow,
+        BaseReferences<
+          _$AppDatabase,
+          $IdentityVerificationsTable,
+          IdentityVerificationRow
+        >,
+      ),
+      IdentityVerificationRow,
+      PrefetchHooks Function()
+    >;
 
 class $AppDatabaseManager {
   final _$AppDatabase _db;
@@ -22719,4 +23811,8 @@ class $AppDatabaseManager {
       $$ProcessedGiftWrapsTableTableManager(_db, _db.processedGiftWraps);
   $$PendingProfileSavesTableTableManager get pendingProfileSaves =>
       $$PendingProfileSavesTableTableManager(_db, _db.pendingProfileSaves);
+  $$IdentityEventsTableTableManager get identityEvents =>
+      $$IdentityEventsTableTableManager(_db, _db.identityEvents);
+  $$IdentityVerificationsTableTableManager get identityVerifications =>
+      $$IdentityVerificationsTableTableManager(_db, _db.identityVerifications);
 }

--- a/mobile/packages/db_client/lib/src/database/daos/daos.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/daos.dart
@@ -4,6 +4,8 @@ export 'direct_messages_dao.dart';
 export 'dm_reactions_dao.dart';
 export 'drafts_dao.dart';
 export 'hashtag_stats_dao.dart';
+export 'identity_events_dao.dart';
+export 'identity_verifications_dao.dart';
 export 'nip05_verifications_dao.dart';
 export 'nostr_events_dao.dart';
 export 'notifications_dao.dart';

--- a/mobile/packages/db_client/lib/src/database/daos/identity_events_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/identity_events_dao.dart
@@ -1,0 +1,41 @@
+// ABOUTME: Data Access Object for the NIP-39 identity-claims source cache.
+// ABOUTME: One row per profile mirroring the latest kind 10011/0 i tags.
+
+import 'package:db_client/db_client.dart';
+import 'package:drift/drift.dart';
+
+part 'identity_events_dao.g.dart';
+
+@DriftAccessor(tables: [IdentityEvents])
+class IdentityEventsDao extends DatabaseAccessor<AppDatabase>
+    with _$IdentityEventsDaoMixin {
+  IdentityEventsDao(super.attachedDatabase);
+
+  /// Upserts the identity-claims source for [pubkey].
+  ///
+  /// [tagsJson] is the JSON-encoded `i` tag list, [sourceKind] the event
+  /// kind the tags came from (10011 or 0), and [eventCreatedAt] the source
+  /// event's `created_at` in unix seconds.
+  Future<void> upsertEvent({
+    required String pubkey,
+    required String tagsJson,
+    required int sourceKind,
+    required int eventCreatedAt,
+  }) {
+    return into(identityEvents).insertOnConflictUpdate(
+      IdentityEventsCompanion.insert(
+        pubkey: pubkey,
+        tagsJson: tagsJson,
+        sourceKind: sourceKind,
+        eventCreatedAt: eventCreatedAt,
+        fetchedAt: DateTime.now(),
+      ),
+    );
+  }
+
+  /// Returns the cached identity-claims source for [pubkey], or null.
+  Future<IdentityEventRow?> getEvent(String pubkey) {
+    final query = select(identityEvents)..where((t) => t.pubkey.equals(pubkey));
+    return query.getSingleOrNull();
+  }
+}

--- a/mobile/packages/db_client/lib/src/database/daos/identity_events_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/identity_events_dao.dart
@@ -34,4 +34,9 @@ class IdentityEventsDao extends DatabaseAccessor<AppDatabase>
     final query = select(identityEvents)..where((t) => t.pubkey.equals(pubkey));
     return query.getSingleOrNull();
   }
+
+  /// Clears every cached identity-claims source row.
+  Future<int> clearAll() {
+    return delete(identityEvents).go();
+  }
 }

--- a/mobile/packages/db_client/lib/src/database/daos/identity_events_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/identity_events_dao.dart
@@ -13,22 +13,18 @@ class IdentityEventsDao extends DatabaseAccessor<AppDatabase>
 
   /// Upserts the identity-claims source for [pubkey].
   ///
-  /// [tagsJson] is the JSON-encoded `i` tag list, [sourceKind] the event
-  /// kind the tags came from (10011 or 0), and [eventCreatedAt] the source
-  /// event's `created_at` in unix seconds.
+  /// [tagsJson] is the JSON-encoded `i` tag list and [sourceKind] the event
+  /// kind the tags came from (10011 or 0).
   Future<void> upsertEvent({
     required String pubkey,
     required String tagsJson,
     required int sourceKind,
-    required int eventCreatedAt,
   }) {
     return into(identityEvents).insertOnConflictUpdate(
       IdentityEventsCompanion.insert(
         pubkey: pubkey,
         tagsJson: tagsJson,
         sourceKind: sourceKind,
-        eventCreatedAt: eventCreatedAt,
-        fetchedAt: DateTime.now(),
       ),
     );
   }

--- a/mobile/packages/db_client/lib/src/database/daos/identity_events_dao.g.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/identity_events_dao.g.dart
@@ -1,0 +1,19 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'identity_events_dao.dart';
+
+// ignore_for_file: type=lint
+mixin _$IdentityEventsDaoMixin on DatabaseAccessor<AppDatabase> {
+  $IdentityEventsTable get identityEvents => attachedDatabase.identityEvents;
+  IdentityEventsDaoManager get managers => IdentityEventsDaoManager(this);
+}
+
+class IdentityEventsDaoManager {
+  final _$IdentityEventsDaoMixin _db;
+  IdentityEventsDaoManager(this._db);
+  $$IdentityEventsTableTableManager get identityEvents =>
+      $$IdentityEventsTableTableManager(
+        _db.attachedDatabase,
+        _db.identityEvents,
+      );
+}

--- a/mobile/packages/db_client/lib/src/database/daos/identity_verifications_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/identity_verifications_dao.dart
@@ -1,0 +1,46 @@
+// ABOUTME: Data Access Object for the NIP-39 verification verdict cache.
+// ABOUTME: One verified-claims snapshot row per profile; verified-only.
+
+import 'package:db_client/db_client.dart';
+import 'package:drift/drift.dart';
+
+part 'identity_verifications_dao.g.dart';
+
+@DriftAccessor(tables: [IdentityVerifications])
+class IdentityVerificationsDao extends DatabaseAccessor<AppDatabase>
+    with _$IdentityVerificationsDaoMixin {
+  IdentityVerificationsDao(super.attachedDatabase);
+
+  /// Upserts the verified-claims snapshot for [pubkey].
+  ///
+  /// [verifiedClaimsJson] is the JSON-encoded list of verified
+  /// `{platform, identity, proof}` tuples; [checkedAtFloor] is the minimum
+  /// verifier `checked_at` (unix seconds) across the batch.
+  Future<void> upsertVerification({
+    required String pubkey,
+    required String verifiedClaimsJson,
+    required int checkedAtFloor,
+  }) {
+    return into(identityVerifications).insertOnConflictUpdate(
+      IdentityVerificationsCompanion.insert(
+        pubkey: pubkey,
+        verifiedClaimsJson: verifiedClaimsJson,
+        checkedAtFloor: checkedAtFloor,
+      ),
+    );
+  }
+
+  /// Returns the verified-claims snapshot for [pubkey], or null.
+  Future<IdentityVerificationRow?> getVerification(String pubkey) {
+    final query = select(identityVerifications)
+      ..where((t) => t.pubkey.equals(pubkey));
+    return query.getSingleOrNull();
+  }
+
+  /// Deletes the snapshot for [pubkey]. Returns the number of rows deleted.
+  Future<int> deleteVerification(String pubkey) {
+    return (delete(
+      identityVerifications,
+    )..where((t) => t.pubkey.equals(pubkey))).go();
+  }
+}

--- a/mobile/packages/db_client/lib/src/database/daos/identity_verifications_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/identity_verifications_dao.dart
@@ -43,4 +43,9 @@ class IdentityVerificationsDao extends DatabaseAccessor<AppDatabase>
       identityVerifications,
     )..where((t) => t.pubkey.equals(pubkey))).go();
   }
+
+  /// Clears every verified-claims snapshot row.
+  Future<int> clearAll() {
+    return delete(identityVerifications).go();
+  }
 }

--- a/mobile/packages/db_client/lib/src/database/daos/identity_verifications_dao.g.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/identity_verifications_dao.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'identity_verifications_dao.dart';
+
+// ignore_for_file: type=lint
+mixin _$IdentityVerificationsDaoMixin on DatabaseAccessor<AppDatabase> {
+  $IdentityVerificationsTable get identityVerifications =>
+      attachedDatabase.identityVerifications;
+  IdentityVerificationsDaoManager get managers =>
+      IdentityVerificationsDaoManager(this);
+}
+
+class IdentityVerificationsDaoManager {
+  final _$IdentityVerificationsDaoMixin _db;
+  IdentityVerificationsDaoManager(this._db);
+  $$IdentityVerificationsTableTableManager get identityVerifications =>
+      $$IdentityVerificationsTableTableManager(
+        _db.attachedDatabase,
+        _db.identityVerifications,
+      );
+}

--- a/mobile/packages/db_client/lib/src/database/tables.dart
+++ b/mobile/packages/db_client/lib/src/database/tables.dart
@@ -1475,3 +1475,76 @@ class ProcessedGiftWraps extends Table {
   @override
   Set<Column> get primaryKey => {giftWrapId};
 }
+
+/// Cache of the NIP-39 identity-claims source event per profile.
+///
+/// One row per viewed profile, mirroring the latest identity event seen on
+/// relays. Claims live in kind 10011 since the 2026-02 NIP-39 revision; the
+/// verifier web UI publishes kind 10011 only, so kind 0 `i` tags are a
+/// legacy fallback for pre-migration profiles (#3936). Rows are refreshed on
+/// every profile open (cache+fresh, like `user_profiles`), never expire, and
+/// survive logout — same class of viewer-independent public data as
+/// [UserProfiles].
+@DataClassName('IdentityEventRow')
+class IdentityEvents extends Table {
+  @override
+  String get tableName => 'identity_events';
+
+  /// Hex pubkey of the profile the identity event belongs to.
+  TextColumn get pubkey => text()();
+
+  /// JSON-encoded `List<List<String>>` of the event's `i` tags only.
+  TextColumn get tagsJson => text().named('tags_json')();
+
+  /// Which event kind the tags came from: 10011 (current spec) or 0
+  /// (legacy fallback).
+  IntColumn get sourceKind => integer().named('source_kind')();
+
+  /// `created_at` of the source event (unix seconds), used to keep the
+  /// newest event when relays disagree.
+  IntColumn get eventCreatedAt => integer().named('event_created_at')();
+
+  /// When this row was last written from a relay fetch.
+  DateTimeColumn get fetchedAt => dateTime().named('fetched_at')();
+
+  @override
+  Set<Column> get primaryKey => {pubkey};
+}
+
+/// Persistent cache of NIP-39 identity-claim verification verdicts.
+///
+/// One row per profile holding the set of claims the verifier confirmed,
+/// as a JSON list of `{platform, identity, proof}` tuples. Only
+/// `verified: true` results are ever persisted — negative results are not
+/// cached because the verifier returns rate-limit rejections as HTTP-200
+/// `verified: false` bodies that must never be frozen locally (#3936).
+///
+/// Freshness is anchored on the verifier's own `checked_at`:
+/// [checkedAtFloor] is the minimum `checked_at` across the batch, and the
+/// entry counts as fresh until `checkedAtFloor + 24h` — the verifier's
+/// server-side TTL for verified results. Stale entries are re-verified on
+/// the next profile open (stale-while-revalidate), not deleted. Rows
+/// survive logout, like [Nip05Verifications].
+@DataClassName('IdentityVerificationRow')
+class IdentityVerifications extends Table {
+  @override
+  String get tableName => 'identity_verifications';
+
+  /// Hex pubkey of the profile the verified claims belong to.
+  TextColumn get pubkey => text()();
+
+  /// JSON-encoded list of verified claim objects
+  /// `{"platform": ..., "identity": ..., "proof": ...}`.
+  ///
+  /// Proof participates in cache matching: a rotated proof no longer
+  /// matches its snapshot entry, so the claim re-verifies instead of
+  /// serving a stale verdict.
+  TextColumn get verifiedClaimsJson => text().named('verified_claims_json')();
+
+  /// Minimum verifier `checked_at` (unix seconds) across the verified
+  /// batch. Freshness = `checkedAtFloor + 24h > now`.
+  IntColumn get checkedAtFloor => integer().named('checked_at_floor')();
+
+  @override
+  Set<Column> get primaryKey => {pubkey};
+}

--- a/mobile/packages/db_client/lib/src/database/tables.dart
+++ b/mobile/packages/db_client/lib/src/database/tables.dart
@@ -1500,13 +1500,6 @@ class IdentityEvents extends Table {
   /// (legacy fallback).
   IntColumn get sourceKind => integer().named('source_kind')();
 
-  /// `created_at` of the source event (unix seconds), used to keep the
-  /// newest event when relays disagree.
-  IntColumn get eventCreatedAt => integer().named('event_created_at')();
-
-  /// When this row was last written from a relay fetch.
-  DateTimeColumn get fetchedAt => dateTime().named('fetched_at')();
-
   @override
   Set<Column> get primaryKey => {pubkey};
 }

--- a/mobile/packages/db_client/test/drift/app_database/generated/schema_v1.dart
+++ b/mobile/packages/db_client/test/drift/app_database/generated/schema_v1.dart
@@ -2865,6 +2865,141 @@ class PendingProfileSaves extends Table with TableInfo {
   bool get dontWriteConstraints => true;
 }
 
+class IdentityEvents extends Table with TableInfo {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  IdentityEvents(this.attachedDatabase, [this._alias]);
+  late final GeneratedColumn<String> pubkey = GeneratedColumn<String>(
+    'pubkey',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    $customConstraints: 'NOT NULL',
+  );
+  late final GeneratedColumn<String> tagsJson = GeneratedColumn<String>(
+    'tags_json',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    $customConstraints: 'NOT NULL',
+  );
+  late final GeneratedColumn<int> sourceKind = GeneratedColumn<int>(
+    'source_kind',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+    $customConstraints: 'NOT NULL',
+  );
+  late final GeneratedColumn<int> eventCreatedAt = GeneratedColumn<int>(
+    'event_created_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+    $customConstraints: 'NOT NULL',
+  );
+  late final GeneratedColumn<int> fetchedAt = GeneratedColumn<int>(
+    'fetched_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+    $customConstraints: 'NOT NULL',
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    pubkey,
+    tagsJson,
+    sourceKind,
+    eventCreatedAt,
+    fetchedAt,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'identity_events';
+  @override
+  Set<GeneratedColumn> get $primaryKey => {pubkey};
+  @override
+  Never map(Map<String, dynamic> data, {String? tablePrefix}) {
+    throw UnsupportedError('TableInfo.map in schema verification code');
+  }
+
+  @override
+  IdentityEvents createAlias(String alias) {
+    return IdentityEvents(attachedDatabase, alias);
+  }
+
+  @override
+  List<String> get customConstraints => const ['PRIMARY KEY(pubkey)'];
+  @override
+  bool get dontWriteConstraints => true;
+}
+
+class IdentityVerifications extends Table with TableInfo {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  IdentityVerifications(this.attachedDatabase, [this._alias]);
+  late final GeneratedColumn<String> pubkey = GeneratedColumn<String>(
+    'pubkey',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    $customConstraints: 'NOT NULL',
+  );
+  late final GeneratedColumn<String> verifiedClaimsJson =
+      GeneratedColumn<String>(
+        'verified_claims_json',
+        aliasedName,
+        false,
+        type: DriftSqlType.string,
+        requiredDuringInsert: true,
+        $customConstraints: 'NOT NULL',
+      );
+  late final GeneratedColumn<int> checkedAtFloor = GeneratedColumn<int>(
+    'checked_at_floor',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+    $customConstraints: 'NOT NULL',
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    pubkey,
+    verifiedClaimsJson,
+    checkedAtFloor,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'identity_verifications';
+  @override
+  Set<GeneratedColumn> get $primaryKey => {pubkey};
+  @override
+  Never map(Map<String, dynamic> data, {String? tablePrefix}) {
+    throw UnsupportedError('TableInfo.map in schema verification code');
+  }
+
+  @override
+  IdentityVerifications createAlias(String alias) {
+    return IdentityVerifications(attachedDatabase, alias);
+  }
+
+  @override
+  List<String> get customConstraints => const ['PRIMARY KEY(pubkey)'];
+  @override
+  bool get dontWriteConstraints => true;
+}
+
 class DatabaseAtV1 extends GeneratedDatabase {
   DatabaseAtV1(QueryExecutor e) : super(e);
   late final Event event = Event(this);
@@ -2893,6 +3028,9 @@ class DatabaseAtV1 extends GeneratedDatabase {
   late final PendingProfileSaves pendingProfileSaves = PendingProfileSaves(
     this,
   );
+  late final IdentityEvents identityEvents = IdentityEvents(this);
+  late final IdentityVerifications identityVerifications =
+      IdentityVerifications(this);
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
@@ -2920,6 +3058,8 @@ class DatabaseAtV1 extends GeneratedDatabase {
     pendingGiftWraps,
     processedGiftWraps,
     pendingProfileSaves,
+    identityEvents,
+    identityVerifications,
   ];
   @override
   StreamQueryUpdateRules get streamUpdateRules => const StreamQueryUpdateRules([

--- a/mobile/packages/db_client/test/drift/app_database/generated/schema_v1.dart
+++ b/mobile/packages/db_client/test/drift/app_database/generated/schema_v1.dart
@@ -2894,30 +2894,8 @@ class IdentityEvents extends Table with TableInfo {
     requiredDuringInsert: true,
     $customConstraints: 'NOT NULL',
   );
-  late final GeneratedColumn<int> eventCreatedAt = GeneratedColumn<int>(
-    'event_created_at',
-    aliasedName,
-    false,
-    type: DriftSqlType.int,
-    requiredDuringInsert: true,
-    $customConstraints: 'NOT NULL',
-  );
-  late final GeneratedColumn<int> fetchedAt = GeneratedColumn<int>(
-    'fetched_at',
-    aliasedName,
-    false,
-    type: DriftSqlType.int,
-    requiredDuringInsert: true,
-    $customConstraints: 'NOT NULL',
-  );
   @override
-  List<GeneratedColumn> get $columns => [
-    pubkey,
-    tagsJson,
-    sourceKind,
-    eventCreatedAt,
-    fetchedAt,
-  ];
+  List<GeneratedColumn> get $columns => [pubkey, tagsJson, sourceKind];
   @override
   String get aliasedName => _alias ?? actualTableName;
   @override

--- a/mobile/packages/db_client/test/src/database/app_database_test.dart
+++ b/mobile/packages/db_client/test/src/database/app_database_test.dart
@@ -1141,7 +1141,6 @@ void main() {
             pubkey: testPubkey,
             tagsJson: '[["i","github:alice","proof-a"]]',
             sourceKind: 10011,
-            eventCreatedAt: 100,
           );
           final eventRow = await database.identityEventsDao.getEvent(
             testPubkey,

--- a/mobile/packages/db_client/test/src/database/app_database_test.dart
+++ b/mobile/packages/db_client/test/src/database/app_database_test.dart
@@ -1114,6 +1114,142 @@ void main() {
       });
     });
 
+    group('identity caches (#3936)', () {
+      test(
+        'upgrade path — pre-#3936 database gets both identity tables on '
+        'reopen',
+        () async {
+          await database.customStatement('DROP TABLE identity_events');
+          await database.customStatement('DROP TABLE identity_verifications');
+          await database.close();
+
+          database = AppDatabase.test(NativeDatabase(File(tempDbPath)));
+
+          final tables = await database
+              .customSelect(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name IN ('identity_events', 'identity_verifications')",
+              )
+              .get();
+          expect(
+            tables,
+            hasLength(2),
+            reason: 'both identity tables must be re-created on reopen',
+          );
+
+          await database.identityEventsDao.upsertEvent(
+            pubkey: testPubkey,
+            tagsJson: '[["i","github:alice","proof-a"]]',
+            sourceKind: 10011,
+            eventCreatedAt: 100,
+          );
+          final eventRow = await database.identityEventsDao.getEvent(
+            testPubkey,
+          );
+          expect(eventRow, isNotNull);
+
+          await database.identityVerificationsDao.upsertVerification(
+            pubkey: testPubkey,
+            verifiedClaimsJson: '[]',
+            checkedAtFloor: 100,
+          );
+          final verificationRow = await database.identityVerificationsDao
+              .getVerification(testPubkey);
+          expect(verificationRow, isNotNull);
+        },
+      );
+
+      test(
+        'schema parity — identity_events fresh-install matches runtime '
+        'CREATE-IF-NOT-EXISTS path',
+        () async {
+          final freshColumns = await _collectTableInfo(
+            database,
+            'identity_events',
+          );
+          final freshIndexes = await _collectIndexNames(
+            database,
+            'identity_events',
+          );
+
+          expect(
+            freshColumns,
+            isNotEmpty,
+            reason: 'precondition: fresh install should have identity_events',
+          );
+
+          await database.customStatement('DROP TABLE identity_events');
+          await database.close();
+
+          database = AppDatabase.test(NativeDatabase(File(tempDbPath)));
+          await database
+              .customSelect(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name='identity_events'",
+              )
+              .get();
+
+          final recreatedColumns = await _collectTableInfo(
+            database,
+            'identity_events',
+          );
+          final recreatedIndexes = await _collectIndexNames(
+            database,
+            'identity_events',
+          );
+
+          expect(recreatedColumns, equals(freshColumns));
+          expect(recreatedIndexes, equals(freshIndexes));
+        },
+      );
+
+      test(
+        'schema parity — identity_verifications fresh-install matches '
+        'runtime CREATE-IF-NOT-EXISTS path',
+        () async {
+          final freshColumns = await _collectTableInfo(
+            database,
+            'identity_verifications',
+          );
+          final freshIndexes = await _collectIndexNames(
+            database,
+            'identity_verifications',
+          );
+
+          expect(
+            freshColumns,
+            isNotEmpty,
+            reason:
+                'precondition: fresh install should have '
+                'identity_verifications',
+          );
+
+          await database.customStatement('DROP TABLE identity_verifications');
+          await database.close();
+
+          database = AppDatabase.test(NativeDatabase(File(tempDbPath)));
+          await database
+              .customSelect(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name='identity_verifications'",
+              )
+              .get();
+
+          final recreatedColumns = await _collectTableInfo(
+            database,
+            'identity_verifications',
+          );
+          final recreatedIndexes = await _collectIndexNames(
+            database,
+            'identity_verifications',
+          );
+
+          expect(recreatedColumns, equals(freshColumns));
+          expect(recreatedIndexes, equals(freshIndexes));
+        },
+      );
+    });
+
     group('event table d_tag column', () {
       test(
         'upgrade path — adds, indexes, and backfills d_tag on reopen',

--- a/mobile/packages/db_client/test/src/database/daos/identity_events_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/identity_events_dao_test.dart
@@ -72,5 +72,30 @@ void main() {
         expect(await dao.getEvent(testPubkey), isNull);
       });
     });
+
+    group('clearAll', () {
+      test('removes every identity event row', () async {
+        const secondPubkey =
+            '1111111111111111111111111111111111111111111111111111111111111111';
+        await dao.upsertEvent(
+          pubkey: testPubkey,
+          tagsJson: tagsJson,
+          sourceKind: 10011,
+        );
+        await dao.upsertEvent(
+          pubkey: secondPubkey,
+          tagsJson: '[["i","github:bob","proof-b"]]',
+          sourceKind: 10011,
+        );
+
+        expect(await dao.clearAll(), equals(2));
+        expect(await dao.getEvent(testPubkey), isNull);
+        expect(await dao.getEvent(secondPubkey), isNull);
+      });
+
+      test('returns 0 when no row exists', () async {
+        expect(await dao.clearAll(), equals(0));
+      });
+    });
   });
 }

--- a/mobile/packages/db_client/test/src/database/daos/identity_events_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/identity_events_dao_test.dart
@@ -35,13 +35,11 @@ void main() {
 
   group(IdentityEventsDao, () {
     group('upsertEvent', () {
-      test('inserts a new row with the fetch timestamp', () async {
-        final before = DateTime.now().subtract(const Duration(seconds: 1));
+      test('inserts a new row', () async {
         await dao.upsertEvent(
           pubkey: testPubkey,
           tagsJson: tagsJson,
           sourceKind: 10011,
-          eventCreatedAt: 1784396891,
         );
 
         final row = await dao.getEvent(testPubkey);
@@ -49,8 +47,6 @@ void main() {
         expect(row!.pubkey, equals(testPubkey));
         expect(row.tagsJson, equals(tagsJson));
         expect(row.sourceKind, equals(10011));
-        expect(row.eventCreatedAt, equals(1784396891));
-        expect(row.fetchedAt.isAfter(before), isTrue);
       });
 
       test('replaces the existing row for the same pubkey', () async {
@@ -58,19 +54,16 @@ void main() {
           pubkey: testPubkey,
           tagsJson: tagsJson,
           sourceKind: 0,
-          eventCreatedAt: 100,
         );
         await dao.upsertEvent(
           pubkey: testPubkey,
           tagsJson: '[["i","github:alice","proof-b"]]',
           sourceKind: 10011,
-          eventCreatedAt: 200,
         );
 
         final row = await dao.getEvent(testPubkey);
         expect(row!.tagsJson, equals('[["i","github:alice","proof-b"]]'));
         expect(row.sourceKind, equals(10011));
-        expect(row.eventCreatedAt, equals(200));
       });
     });
 

--- a/mobile/packages/db_client/test/src/database/daos/identity_events_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/identity_events_dao_test.dart
@@ -1,0 +1,83 @@
+// ABOUTME: Unit tests for IdentityEventsDao (NIP-39 claims source cache).
+// ABOUTME: Tests upsert (insert + replace) and primary-key lookup.
+
+import 'dart:io';
+
+import 'package:db_client/db_client.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late AppDatabase database;
+  late IdentityEventsDao dao;
+  late String tempDbPath;
+
+  /// Valid 64-char hex pubkey for testing
+  const testPubkey =
+      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+  const tagsJson = '[["i","github:alice","proof-a"]]';
+
+  setUp(() async {
+    final tempDir = Directory.systemTemp.createTempSync('identity_events_');
+    tempDbPath = '${tempDir.path}/test.db';
+
+    database = AppDatabase.test(NativeDatabase(File(tempDbPath)));
+    dao = database.identityEventsDao;
+  });
+
+  tearDown(() async {
+    await database.close();
+    final dir = File(tempDbPath).parent;
+    if (dir.existsSync()) {
+      dir.deleteSync(recursive: true);
+    }
+  });
+
+  group(IdentityEventsDao, () {
+    group('upsertEvent', () {
+      test('inserts a new row with the fetch timestamp', () async {
+        final before = DateTime.now().subtract(const Duration(seconds: 1));
+        await dao.upsertEvent(
+          pubkey: testPubkey,
+          tagsJson: tagsJson,
+          sourceKind: 10011,
+          eventCreatedAt: 1784396891,
+        );
+
+        final row = await dao.getEvent(testPubkey);
+        expect(row, isNotNull);
+        expect(row!.pubkey, equals(testPubkey));
+        expect(row.tagsJson, equals(tagsJson));
+        expect(row.sourceKind, equals(10011));
+        expect(row.eventCreatedAt, equals(1784396891));
+        expect(row.fetchedAt.isAfter(before), isTrue);
+      });
+
+      test('replaces the existing row for the same pubkey', () async {
+        await dao.upsertEvent(
+          pubkey: testPubkey,
+          tagsJson: tagsJson,
+          sourceKind: 0,
+          eventCreatedAt: 100,
+        );
+        await dao.upsertEvent(
+          pubkey: testPubkey,
+          tagsJson: '[["i","github:alice","proof-b"]]',
+          sourceKind: 10011,
+          eventCreatedAt: 200,
+        );
+
+        final row = await dao.getEvent(testPubkey);
+        expect(row!.tagsJson, equals('[["i","github:alice","proof-b"]]'));
+        expect(row.sourceKind, equals(10011));
+        expect(row.eventCreatedAt, equals(200));
+      });
+    });
+
+    group('getEvent', () {
+      test('returns null when no row exists', () async {
+        expect(await dao.getEvent(testPubkey), isNull);
+      });
+    });
+  });
+}

--- a/mobile/packages/db_client/test/src/database/daos/identity_verifications_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/identity_verifications_dao_test.dart
@@ -1,0 +1,94 @@
+// ABOUTME: Unit tests for IdentityVerificationsDao (verified-claims cache).
+// ABOUTME: Tests upsert (insert + replace) and primary-key lookup.
+
+import 'dart:io';
+
+import 'package:db_client/db_client.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late AppDatabase database;
+  late IdentityVerificationsDao dao;
+  late String tempDbPath;
+
+  /// Valid 64-char hex pubkey for testing
+  const testPubkey =
+      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+  const claimsJson =
+      '[{"platform":"github","identity":"alice","proof":"proof-a"}]';
+
+  setUp(() async {
+    final tempDir = Directory.systemTemp.createTempSync('identity_verif_');
+    tempDbPath = '${tempDir.path}/test.db';
+
+    database = AppDatabase.test(NativeDatabase(File(tempDbPath)));
+    dao = database.identityVerificationsDao;
+  });
+
+  tearDown(() async {
+    await database.close();
+    final dir = File(tempDbPath).parent;
+    if (dir.existsSync()) {
+      dir.deleteSync(recursive: true);
+    }
+  });
+
+  group(IdentityVerificationsDao, () {
+    group('upsertVerification', () {
+      test('inserts a new snapshot row', () async {
+        await dao.upsertVerification(
+          pubkey: testPubkey,
+          verifiedClaimsJson: claimsJson,
+          checkedAtFloor: 1784422014,
+        );
+
+        final row = await dao.getVerification(testPubkey);
+        expect(row, isNotNull);
+        expect(row!.pubkey, equals(testPubkey));
+        expect(row.verifiedClaimsJson, equals(claimsJson));
+        expect(row.checkedAtFloor, equals(1784422014));
+      });
+
+      test('replaces the existing snapshot for the same pubkey', () async {
+        await dao.upsertVerification(
+          pubkey: testPubkey,
+          verifiedClaimsJson: claimsJson,
+          checkedAtFloor: 100,
+        );
+        await dao.upsertVerification(
+          pubkey: testPubkey,
+          verifiedClaimsJson: '[]',
+          checkedAtFloor: 200,
+        );
+
+        final row = await dao.getVerification(testPubkey);
+        expect(row!.verifiedClaimsJson, equals('[]'));
+        expect(row.checkedAtFloor, equals(200));
+      });
+    });
+
+    group('getVerification', () {
+      test('returns null when no row exists', () async {
+        expect(await dao.getVerification(testPubkey), isNull);
+      });
+    });
+
+    group('deleteVerification', () {
+      test('removes the snapshot and reports the deleted count', () async {
+        await dao.upsertVerification(
+          pubkey: testPubkey,
+          verifiedClaimsJson: claimsJson,
+          checkedAtFloor: 100,
+        );
+
+        expect(await dao.deleteVerification(testPubkey), equals(1));
+        expect(await dao.getVerification(testPubkey), isNull);
+      });
+
+      test('returns 0 when no row exists', () async {
+        expect(await dao.deleteVerification(testPubkey), equals(0));
+      });
+    });
+  });
+}

--- a/mobile/packages/db_client/test/src/database/daos/identity_verifications_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/identity_verifications_dao_test.dart
@@ -90,5 +90,31 @@ void main() {
         expect(await dao.deleteVerification(testPubkey), equals(0));
       });
     });
+
+    group('clearAll', () {
+      test('removes every verification snapshot row', () async {
+        const secondPubkey =
+            '1111111111111111111111111111111111111111111111111111111111111111';
+        await dao.upsertVerification(
+          pubkey: testPubkey,
+          verifiedClaimsJson: claimsJson,
+          checkedAtFloor: 100,
+        );
+        await dao.upsertVerification(
+          pubkey: secondPubkey,
+          verifiedClaimsJson:
+              '[{"platform":"github","identity":"bob","proof":"proof-b"}]',
+          checkedAtFloor: 200,
+        );
+
+        expect(await dao.clearAll(), equals(2));
+        expect(await dao.getVerification(testPubkey), isNull);
+        expect(await dao.getVerification(secondPubkey), isNull);
+      });
+
+      test('returns 0 when no row exists', () async {
+        expect(await dao.clearAll(), equals(0));
+      });
+    });
   });
 }

--- a/mobile/packages/profile_repository/lib/src/identity_claims_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/identity_claims_repository.dart
@@ -28,8 +28,8 @@ class IdentityClaimsRepository {
   /// Creates an [IdentityClaimsRepository] backed by [verifierClient].
   ///
   /// [identityVerificationsDao] enables the persistent verdict cache;
-  /// when null, [cachedVerifiedClaims] returns null and [verifiedClaims]
-  /// skips persistence.
+  /// when null, [cachedVerifiedClaims] returns null and [resolveClaims]
+  /// skips persistence on its verify path.
   IdentityClaimsRepository({
     required VerifierClient verifierClient,
     IdentityVerificationsDao? identityVerificationsDao,
@@ -40,6 +40,18 @@ class IdentityClaimsRepository {
   /// verifier's `checked_at`. Mirrors the service's KV TTL for verified
   /// results (divine-identify-verification-service/src/utils/cache.ts:4).
   static const Duration verifiedTtl = Duration(hours: 24);
+
+  /// Prefix of the verifier's rate-limit rejection message
+  /// (divine-identify-verification-service/src/routes/verify.ts:59-81). The
+  /// verifier returns rate-limit rejections as HTTP-200 `verified: false`
+  /// bodies it never caches server-side, so any result carrying this prefix
+  /// must leave the local snapshot untouched — otherwise a rate-limit burst
+  /// could overwrite real verdicts.
+  ///
+  /// [VerificationResult.error] is documented as a free-form, non-stable
+  /// string, so this is a best-effort prefix match; a stable server-side
+  /// rate-limit flag would remove the fragility entirely.
+  static const String rateLimitErrorPrefix = 'Rate limit exceeded';
 
   final VerifierClient _verifierClient;
   final IdentityVerificationsDao? _verificationsDao;
@@ -111,25 +123,51 @@ class IdentityClaimsRepository {
     return CachedVerifiedClaims(claims: verified, isFresh: isFresh);
   }
 
-  /// Parses claims from [tags] and asks the verifier to re-check them.
-  /// Returns only the verified ones, preserving input order.
+  /// Resolves the claims to render for [pubkey] from the freshest claim
+  /// source [freshTags], reusing the instant-path snapshot [cached] already
+  /// read via [cachedVerifiedClaims].
+  ///
+  /// This owns the stale-while-revalidate decision (kept here, not in the
+  /// blocs, per architecture.md's repository-owns-source-selection rule):
+  /// when [cached] is fresh and already covers every current claim, the
+  /// verifier is skipped and the parsed fresh claims are returned as-is.
+  /// Otherwise the claims are re-verified against the service, which also
+  /// refreshes the persistent snapshot. The source tags are parsed exactly
+  /// once regardless of which branch is taken.
+  ///
+  /// Throws [VerifierClientException] subtypes on the verify path — callers
+  /// should catch and keep the last-known-good claims rather than clearing
+  /// them.
+  Future<List<IdentityClaim>> resolveClaims({
+    required String pubkey,
+    required List<List<String>> freshTags,
+    required CachedVerifiedClaims? cached,
+  }) async {
+    final freshClaims = parseClaims(pubkey, freshTags);
+    if (cached != null && cached.isFresh) {
+      final verifiedSet = cached.claims.toSet();
+      if (freshClaims.every(verifiedSet.contains)) {
+        return freshClaims;
+      }
+    }
+    return _verifyClaims(pubkey: pubkey, claims: freshClaims);
+  }
+
+  /// Asks the verifier to re-check [claims] and returns only the verified
+  /// ones, preserving input order.
   ///
   /// On success the persistent snapshot for [pubkey] is updated: verified
   /// tuples are stored with the batch's minimum `checked_at`; a
   /// zero-verified response deletes the snapshot. Only positive verdicts
   /// are ever persisted — and when any result carries the verifier's
-  /// rate-limit error (an HTTP-200 `verified: false` the server itself
-  /// never caches, divine-identify-verification-service/src/routes/
-  /// verify.ts:59-81), the snapshot is left untouched so a rate-limit
-  /// burst cannot overwrite real verdicts.
+  /// rate-limit error (see [rateLimitErrorPrefix]) the snapshot is left
+  /// untouched so a rate-limit burst cannot overwrite real verdicts.
   ///
-  /// Throws [VerifierClientException] subtypes — callers should catch and
-  /// keep the last-known-good claims rather than clearing them.
-  Future<List<IdentityClaim>> verifiedClaims({
+  /// Throws [VerifierClientException] subtypes.
+  Future<List<IdentityClaim>> _verifyClaims({
     required String pubkey,
-    required List<List<String>> tags,
+    required List<IdentityClaim> claims,
   }) async {
-    final claims = parseClaims(pubkey, tags);
     if (claims.isEmpty) return const [];
     final results = await _verifierClient.verifyBatch(claims);
     final verifiedKeys = <String>{
@@ -158,7 +196,7 @@ class IdentityClaimsRepository {
 
     final rateLimited = results.any(
       (r) =>
-          !r.verified && (r.error?.startsWith('Rate limit exceeded') ?? false),
+          !r.verified && (r.error?.startsWith(rateLimitErrorPrefix) ?? false),
     );
     if (rateLimited) return;
 
@@ -188,7 +226,13 @@ class IdentityClaimsRepository {
     claim.proof,
   );
 
-  /// Decodes a stored snapshot into comparison tuples; null when malformed.
+  /// Decodes a stored snapshot into comparison tuples; null when malformed
+  /// or wrong-shaped.
+  ///
+  /// Catches [Object] (not just [Exception]): a valid-JSON-but-wrong-shape
+  /// row throws a [TypeError] (an [Error]) on the casts, which must still
+  /// uphold the null-when-malformed contract rather than escaping to a
+  /// reportable crash.
   static Set<(String, String, String)>? _decodeSnapshot(String json) {
     try {
       final decoded = jsonDecode(json) as List<dynamic>;
@@ -200,7 +244,7 @@ class IdentityClaimsRepository {
             entry['proof'] as String,
           ),
       };
-    } on Exception {
+    } on Object {
       return null;
     }
   }

--- a/mobile/packages/profile_repository/lib/src/identity_claims_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/identity_claims_repository.dart
@@ -25,10 +25,16 @@ class _VerificationOutcome {
   const _VerificationOutcome({
     required this.verified,
     required this.rateLimited,
+    this.confirmedNegativeKeys = const {},
   });
 
   final List<IdentityClaim> verified;
   final bool rateLimited;
+
+  /// Lowercased `platform:identity` keys the verifier explicitly judged
+  /// negative with a non-rate-limited result. Honored even inside a
+  /// rate-limited batch, where they must still drop their claim.
+  final Set<String> confirmedNegativeKeys;
 }
 
 /// Composes [VerifierClient] with NIP-39 `i` tag parsing off identity
@@ -54,9 +60,10 @@ class IdentityClaimsRepository {
   /// Prefix of the verifier's rate-limit rejection message
   /// (divine-identify-verification-service/src/routes/verify.ts:59-81). The
   /// verifier returns rate-limit rejections as HTTP-200 `verified: false`
-  /// bodies it never caches server-side, so any result carrying this prefix
-  /// must leave the local snapshot untouched — otherwise a rate-limit burst
-  /// could overwrite real verdicts.
+  /// bodies it never caches server-side, so a batch containing this prefix
+  /// must not write new verdicts to the local snapshot — otherwise a
+  /// rate-limit burst could overwrite real verdicts. (Per-claim confirmed
+  /// negatives inside such a batch are conclusive and are still pruned.)
   ///
   /// [VerificationResult.error] is documented as a free-form, non-stable
   /// string, so this is a best-effort prefix match; a stable server-side
@@ -145,6 +152,16 @@ class IdentityClaimsRepository {
   /// refreshes the persistent snapshot. The source tags are parsed exactly
   /// once regardless of which branch is taken.
   ///
+  /// [renderedClaims] is the caller's currently-rendered last-known-good
+  /// claim set. A rate-limited verifier outcome is inconclusive (the
+  /// service never caches it server-side), so it must not clear chips the
+  /// user can already see: any rendered or snapshot-cached claim still
+  /// present in [freshTags] is preserved, matched per `platform:identity`
+  /// case-insensitively (proof-agnostic, so a proof rotation coinciding
+  /// with a rate-limit window keeps the chip). Only a per-claim confirmed
+  /// negative verdict from a non-rate-limited result, or the claim's
+  /// removal from the source tags, drops a claim from the result.
+  ///
   /// Throws [VerifierClientException] subtypes on the verify path — callers
   /// should catch and keep the last-known-good claims rather than clearing
   /// them.
@@ -152,6 +169,7 @@ class IdentityClaimsRepository {
     required String pubkey,
     required List<List<String>> freshTags,
     required CachedVerifiedClaims? cached,
+    List<IdentityClaim> renderedClaims = const [],
   }) async {
     final freshClaims = parseClaims(pubkey, freshTags);
     if (cached != null && cached.isFresh) {
@@ -161,11 +179,11 @@ class IdentityClaimsRepository {
       }
     }
     final outcome = await _verifyClaims(pubkey: pubkey, claims: freshClaims);
-    if (outcome.rateLimited && cached != null && cached.claims.isNotEmpty) {
-      return _preserveCachedCurrentClaims(
+    if (outcome.rateLimited) {
+      return _preserveKnownGoodClaims(
         freshClaims: freshClaims,
-        cachedClaims: cached.claims,
-        verifiedClaims: outcome.verified,
+        knownGoodClaims: [...?cached?.claims, ...renderedClaims],
+        outcome: outcome,
       );
     }
     return outcome.verified;
@@ -178,8 +196,11 @@ class IdentityClaimsRepository {
   /// tuples are stored with the batch's minimum `checked_at`; a
   /// zero-verified response deletes the snapshot. Only positive verdicts
   /// are ever persisted — and when any result carries the verifier's
-  /// rate-limit error (see [rateLimitErrorPrefix]) the snapshot is left
-  /// untouched so a rate-limit burst cannot overwrite real verdicts.
+  /// rate-limit error (see [rateLimitErrorPrefix]) no new verdicts are
+  /// written, so a rate-limit burst cannot overwrite real verdicts. The
+  /// one exception: entries whose own result is a confirmed negative are
+  /// pruned from the snapshot even in a rate-limited batch, so a negated
+  /// claim cannot keep resurrecting from cache.
   ///
   /// Throws [VerifierClientException] subtypes.
   Future<_VerificationOutcome> _verifyClaims({
@@ -195,36 +216,54 @@ class IdentityClaimsRepository {
         if (r.verified)
           '${r.platform.toLowerCase()}:${r.identity.toLowerCase()}',
     };
+    final confirmedNegativeKeys = <String>{
+      for (final r in results)
+        if (!r.verified && !_isRateLimitResult(r))
+          '${r.platform.toLowerCase()}:${r.identity.toLowerCase()}',
+    };
     final verified = claims
-        .where(
-          (c) => verifiedKeys.contains(
-            '${c.platform.toLowerCase()}:${c.identity.toLowerCase()}',
-          ),
-        )
+        .where((c) => verifiedKeys.contains(_identityKeyOf(c)))
         .toList();
-    final rateLimited = _isRateLimited(results);
+    final rateLimited = results.any(_isRateLimitResult);
     await _persistOutcome(
       pubkey: pubkey,
       results: results,
       verified: verified,
       rateLimited: rateLimited,
+      confirmedNegativeKeys: confirmedNegativeKeys,
     );
-    return _VerificationOutcome(verified: verified, rateLimited: rateLimited);
+    return _VerificationOutcome(
+      verified: verified,
+      rateLimited: rateLimited,
+      confirmedNegativeKeys: confirmedNegativeKeys,
+    );
   }
 
-  List<IdentityClaim> _preserveCachedCurrentClaims({
+  /// Preservation for a rate-limited (inconclusive) batch: a fresh claim
+  /// survives when its own result verified it, or when it was known-good
+  /// (snapshot or rendered) and its own result was not a confirmed
+  /// negative. Matching is per `platform:identity`, case-insensitive and
+  /// proof-agnostic — the verifier judges identities, not proof strings,
+  /// so a rotated proof must not silently drop a chip while the verdict
+  /// is inconclusive.
+  List<IdentityClaim> _preserveKnownGoodClaims({
     required List<IdentityClaim> freshClaims,
-    required List<IdentityClaim> cachedClaims,
-    required List<IdentityClaim> verifiedClaims,
+    required List<IdentityClaim> knownGoodClaims,
+    required _VerificationOutcome outcome,
   }) {
-    final cachedTuples = {for (final claim in cachedClaims) _tupleOf(claim)};
-    final verifiedTuples = {
-      for (final claim in verifiedClaims) _tupleOf(claim),
+    final knownGoodKeys = {
+      for (final claim in knownGoodClaims) _identityKeyOf(claim),
+    };
+    final verifiedKeys = {
+      for (final claim in outcome.verified) _identityKeyOf(claim),
     };
     return [
       for (final claim in freshClaims)
-        if (verifiedTuples.contains(_tupleOf(claim)) ||
-            cachedTuples.contains(_tupleOf(claim)))
+        if (verifiedKeys.contains(_identityKeyOf(claim)) ||
+            (knownGoodKeys.contains(_identityKeyOf(claim)) &&
+                !outcome.confirmedNegativeKeys.contains(
+                  _identityKeyOf(claim),
+                )))
           claim,
     ];
   }
@@ -234,11 +273,19 @@ class IdentityClaimsRepository {
     required List<VerificationResult> results,
     required List<IdentityClaim> verified,
     required bool rateLimited,
+    required Set<String> confirmedNegativeKeys,
   }) async {
     final dao = _verificationsDao;
     if (dao == null) return;
 
-    if (rateLimited) return;
+    if (rateLimited) {
+      // A rate-limited batch persists no new verdicts, but any per-claim
+      // confirmed negative inside it is conclusive — prune those tuples
+      // so a negated claim cannot resurrect from the snapshot through
+      // the instant path or the fresh-and-covering skip.
+      await _pruneConfirmedNegatives(dao, pubkey, confirmedNegativeKeys);
+      return;
+    }
 
     if (verified.isEmpty) {
       await dao.deleteVerification(pubkey);
@@ -259,16 +306,57 @@ class IdentityClaimsRepository {
     );
   }
 
-  bool _isRateLimited(List<VerificationResult> results) {
-    return results.any(
-      (r) =>
-          !r.verified && (r.error?.startsWith(rateLimitErrorPrefix) ?? false),
-    );
+  /// Removes snapshot entries whose `platform:identity` key received a
+  /// confirmed (non-rate-limited) negative verdict. Rows that are missing
+  /// or malformed are left alone — the read path already treats them as
+  /// no-snapshot.
+  Future<void> _pruneConfirmedNegatives(
+    IdentityVerificationsDao dao,
+    String pubkey,
+    Set<String> confirmedNegativeKeys,
+  ) async {
+    if (confirmedNegativeKeys.isEmpty) return;
+    final row = await dao.getVerification(pubkey);
+    if (row == null) return;
+    final List<Map<String, dynamic>> kept;
+    try {
+      final entries = (jsonDecode(row.verifiedClaimsJson) as List<dynamic>)
+          .cast<Map<String, dynamic>>();
+      kept = [
+        for (final entry in entries)
+          if (!confirmedNegativeKeys.contains(
+            '${(entry['platform'] as String).toLowerCase()}'
+            ':${(entry['identity'] as String).toLowerCase()}',
+          ))
+            entry,
+      ];
+      if (kept.length == entries.length) return;
+    } on Object {
+      return;
+    }
+    if (kept.isEmpty) {
+      await dao.deleteVerification(pubkey);
+    } else {
+      await dao.upsertVerification(
+        pubkey: pubkey,
+        verifiedClaimsJson: jsonEncode(kept),
+        checkedAtFloor: row.checkedAtFloor,
+      );
+    }
   }
+
+  static bool _isRateLimitResult(VerificationResult result) =>
+      !result.verified &&
+      (result.error?.startsWith(rateLimitErrorPrefix) ?? false);
 
   /// Normalized comparison tuple for snapshot matching.
   static (String, String, String) _tupleOf(IdentityClaim claim) =>
       (claim.platform.toLowerCase(), claim.identity.toLowerCase(), claim.proof);
+
+  /// Normalized `platform:identity` key — the granularity the verifier
+  /// judges at (proofs are evidence, not identity).
+  static String _identityKeyOf(IdentityClaim claim) =>
+      '${claim.platform.toLowerCase()}:${claim.identity.toLowerCase()}';
 
   /// Decodes a stored snapshot into comparison tuples; null when malformed
   /// or wrong-shaped.

--- a/mobile/packages/profile_repository/lib/src/identity_claims_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/identity_claims_repository.dart
@@ -21,6 +21,16 @@ class CachedVerifiedClaims {
   final bool isFresh;
 }
 
+class _VerificationOutcome {
+  const _VerificationOutcome({
+    required this.verified,
+    required this.rateLimited,
+  });
+
+  final List<IdentityClaim> verified;
+  final bool rateLimited;
+}
+
 /// Composes [VerifierClient] with NIP-39 `i` tag parsing off identity
 /// events (kind 10011, with kind-0 tags as the legacy fallback) and a
 /// persistent verified-claims cache.
@@ -150,7 +160,15 @@ class IdentityClaimsRepository {
         return freshClaims;
       }
     }
-    return _verifyClaims(pubkey: pubkey, claims: freshClaims);
+    final outcome = await _verifyClaims(pubkey: pubkey, claims: freshClaims);
+    if (outcome.rateLimited && cached != null && cached.claims.isNotEmpty) {
+      return _preserveCachedCurrentClaims(
+        freshClaims: freshClaims,
+        cachedClaims: cached.claims,
+        verifiedClaims: outcome.verified,
+      );
+    }
+    return outcome.verified;
   }
 
   /// Asks the verifier to re-check [claims] and returns only the verified
@@ -164,11 +182,13 @@ class IdentityClaimsRepository {
   /// untouched so a rate-limit burst cannot overwrite real verdicts.
   ///
   /// Throws [VerifierClientException] subtypes.
-  Future<List<IdentityClaim>> _verifyClaims({
+  Future<_VerificationOutcome> _verifyClaims({
     required String pubkey,
     required List<IdentityClaim> claims,
   }) async {
-    if (claims.isEmpty) return const [];
+    if (claims.isEmpty) {
+      return const _VerificationOutcome(verified: [], rateLimited: false);
+    }
     final results = await _verifierClient.verifyBatch(claims);
     final verifiedKeys = <String>{
       for (final r in results)
@@ -182,22 +202,42 @@ class IdentityClaimsRepository {
           ),
         )
         .toList();
-    await _persistOutcome(pubkey: pubkey, results: results, verified: verified);
-    return verified;
+    final rateLimited = _isRateLimited(results);
+    await _persistOutcome(
+      pubkey: pubkey,
+      results: results,
+      verified: verified,
+      rateLimited: rateLimited,
+    );
+    return _VerificationOutcome(verified: verified, rateLimited: rateLimited);
+  }
+
+  List<IdentityClaim> _preserveCachedCurrentClaims({
+    required List<IdentityClaim> freshClaims,
+    required List<IdentityClaim> cachedClaims,
+    required List<IdentityClaim> verifiedClaims,
+  }) {
+    final cachedTuples = {for (final claim in cachedClaims) _tupleOf(claim)};
+    final verifiedTuples = {
+      for (final claim in verifiedClaims) _tupleOf(claim),
+    };
+    return [
+      for (final claim in freshClaims)
+        if (verifiedTuples.contains(_tupleOf(claim)) ||
+            cachedTuples.contains(_tupleOf(claim)))
+          claim,
+    ];
   }
 
   Future<void> _persistOutcome({
     required String pubkey,
     required List<VerificationResult> results,
     required List<IdentityClaim> verified,
+    required bool rateLimited,
   }) async {
     final dao = _verificationsDao;
     if (dao == null) return;
 
-    final rateLimited = results.any(
-      (r) =>
-          !r.verified && (r.error?.startsWith(rateLimitErrorPrefix) ?? false),
-    );
     if (rateLimited) return;
 
     if (verified.isEmpty) {
@@ -219,12 +259,16 @@ class IdentityClaimsRepository {
     );
   }
 
+  bool _isRateLimited(List<VerificationResult> results) {
+    return results.any(
+      (r) =>
+          !r.verified && (r.error?.startsWith(rateLimitErrorPrefix) ?? false),
+    );
+  }
+
   /// Normalized comparison tuple for snapshot matching.
-  static (String, String, String) _tupleOf(IdentityClaim claim) => (
-    claim.platform.toLowerCase(),
-    claim.identity.toLowerCase(),
-    claim.proof,
-  );
+  static (String, String, String) _tupleOf(IdentityClaim claim) =>
+      (claim.platform.toLowerCase(), claim.identity.toLowerCase(), claim.proof);
 
   /// Decodes a stored snapshot into comparison tuples; null when malformed
   /// or wrong-shaped.

--- a/mobile/packages/profile_repository/lib/src/identity_claims_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/identity_claims_repository.dart
@@ -1,17 +1,51 @@
 // ABOUTME: IdentityClaimsRepository — composes VerifierClient with NIP-39
-// ABOUTME: i tag parsing off kind 0 events.
+// ABOUTME: i tag parsing and a persistent verified-claims cache (#3936).
 
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:db_client/db_client.dart' hide Filter;
 import 'package:verifier_client/verifier_client.dart';
 
-/// Composes [VerifierClient] with NIP-39 `i` tag parsing off kind 0 events.
+/// Verified claims read from the persistent snapshot cache.
+class CachedVerifiedClaims {
+  /// Creates a [CachedVerifiedClaims].
+  const CachedVerifiedClaims({required this.claims, required this.isFresh});
+
+  /// The subset of the profile's current claims that the snapshot has a
+  /// positive verdict for (full-tuple match including proof).
+  final List<IdentityClaim> claims;
+
+  /// Whether the snapshot is within the verifier's 24h verified TTL
+  /// (anchored on the verifier's own `checked_at`).
+  final bool isFresh;
+}
+
+/// Composes [VerifierClient] with NIP-39 `i` tag parsing off identity
+/// events (kind 10011, with kind-0 tags as the legacy fallback) and a
+/// persistent verified-claims cache.
 class IdentityClaimsRepository {
   /// Creates an [IdentityClaimsRepository] backed by [verifierClient].
-  IdentityClaimsRepository({required VerifierClient verifierClient})
-    : _verifierClient = verifierClient;
+  ///
+  /// [identityVerificationsDao] enables the persistent verdict cache;
+  /// when null, [cachedVerifiedClaims] returns null and [verifiedClaims]
+  /// skips persistence.
+  IdentityClaimsRepository({
+    required VerifierClient verifierClient,
+    IdentityVerificationsDao? identityVerificationsDao,
+  }) : _verifierClient = verifierClient,
+       _verificationsDao = identityVerificationsDao;
+
+  /// Client-side freshness window for verified verdicts, anchored on the
+  /// verifier's `checked_at`. Mirrors the service's KV TTL for verified
+  /// results (divine-identify-verification-service/src/utils/cache.ts:4).
+  static const Duration verifiedTtl = Duration(hours: 24);
 
   final VerifierClient _verifierClient;
+  final IdentityVerificationsDao? _verificationsDao;
 
-  /// Parses NIP-39 identity claims out of the given kind-0 event tag list.
+  /// Parses NIP-39 identity claims out of the given identity-event tag
+  /// list (kind 10011, or kind 0 for pre-migration profiles).
   ///
   /// Filters to `['i', '<platform>:<identity>', '<proof>']` shape, skips
   /// malformed entries, dedupes case-insensitively on `<platform>:<identity>`
@@ -47,11 +81,50 @@ class IdentityClaimsRepository {
     return claims;
   }
 
-  /// Parses claims from [tags] and asks the verifier to re-check them. Returns
-  /// only the verified ones, preserving input order.
+  /// Returns the persisted verified subset of the claims in [tags], with a
+  /// freshness flag — without hitting the network.
   ///
-  /// Throws [VerifierClientException] subtypes — callers should catch and emit
-  /// empty / failure state without surfacing the message.
+  /// Matching is a full-tuple intersection: platform and identity compare
+  /// case-insensitively, proof compares exactly. A rotated proof therefore
+  /// misses the snapshot and re-verifies instead of serving a stale
+  /// verdict; removed claims are filtered out by the intersection.
+  ///
+  /// Returns null when no snapshot exists for [pubkey], the stored row is
+  /// corrupt, or no DAO is wired.
+  Future<CachedVerifiedClaims?> cachedVerifiedClaims({
+    required String pubkey,
+    required List<List<String>> tags,
+  }) async {
+    final dao = _verificationsDao;
+    if (dao == null) return null;
+    final row = await dao.getVerification(pubkey);
+    if (row == null) return null;
+    final snapshot = _decodeSnapshot(row.verifiedClaimsJson);
+    if (snapshot == null) return null;
+
+    final claims = parseClaims(pubkey, tags);
+    final verified = claims
+        .where((c) => snapshot.contains(_tupleOf(c)))
+        .toList();
+    final nowSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    final isFresh = nowSeconds < row.checkedAtFloor + verifiedTtl.inSeconds;
+    return CachedVerifiedClaims(claims: verified, isFresh: isFresh);
+  }
+
+  /// Parses claims from [tags] and asks the verifier to re-check them.
+  /// Returns only the verified ones, preserving input order.
+  ///
+  /// On success the persistent snapshot for [pubkey] is updated: verified
+  /// tuples are stored with the batch's minimum `checked_at`; a
+  /// zero-verified response deletes the snapshot. Only positive verdicts
+  /// are ever persisted — and when any result carries the verifier's
+  /// rate-limit error (an HTTP-200 `verified: false` the server itself
+  /// never caches, divine-identify-verification-service/src/routes/
+  /// verify.ts:59-81), the snapshot is left untouched so a rate-limit
+  /// burst cannot overwrite real verdicts.
+  ///
+  /// Throws [VerifierClientException] subtypes — callers should catch and
+  /// keep the last-known-good claims rather than clearing them.
   Future<List<IdentityClaim>> verifiedClaims({
     required String pubkey,
     required List<List<String>> tags,
@@ -64,12 +137,71 @@ class IdentityClaimsRepository {
         if (r.verified)
           '${r.platform.toLowerCase()}:${r.identity.toLowerCase()}',
     };
-    return claims
+    final verified = claims
         .where(
           (c) => verifiedKeys.contains(
             '${c.platform.toLowerCase()}:${c.identity.toLowerCase()}',
           ),
         )
         .toList();
+    await _persistOutcome(pubkey: pubkey, results: results, verified: verified);
+    return verified;
+  }
+
+  Future<void> _persistOutcome({
+    required String pubkey,
+    required List<VerificationResult> results,
+    required List<IdentityClaim> verified,
+  }) async {
+    final dao = _verificationsDao;
+    if (dao == null) return;
+
+    final rateLimited = results.any(
+      (r) =>
+          !r.verified && (r.error?.startsWith('Rate limit exceeded') ?? false),
+    );
+    if (rateLimited) return;
+
+    if (verified.isEmpty) {
+      await dao.deleteVerification(pubkey);
+      return;
+    }
+
+    final checkedAtFloor = results
+        .where((r) => r.verified)
+        .map((r) => r.checkedAt)
+        .reduce(min);
+    await dao.upsertVerification(
+      pubkey: pubkey,
+      verifiedClaimsJson: jsonEncode([
+        for (final c in verified)
+          {'platform': c.platform, 'identity': c.identity, 'proof': c.proof},
+      ]),
+      checkedAtFloor: checkedAtFloor,
+    );
+  }
+
+  /// Normalized comparison tuple for snapshot matching.
+  static (String, String, String) _tupleOf(IdentityClaim claim) => (
+    claim.platform.toLowerCase(),
+    claim.identity.toLowerCase(),
+    claim.proof,
+  );
+
+  /// Decodes a stored snapshot into comparison tuples; null when malformed.
+  static Set<(String, String, String)>? _decodeSnapshot(String json) {
+    try {
+      final decoded = jsonDecode(json) as List<dynamic>;
+      return {
+        for (final entry in decoded.cast<Map<String, dynamic>>())
+          (
+            (entry['platform'] as String).toLowerCase(),
+            (entry['identity'] as String).toLowerCase(),
+            entry['proof'] as String,
+          ),
+      };
+    } on Exception {
+      return null;
+    }
   }
 }

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -73,6 +73,7 @@ class ProfileRepository {
     ProfileSearchFilter? profileSearchFilter,
     BlockedProfileFilter? blockFilter,
     PendingProfileSavesDao? pendingProfileSavesDao,
+    IdentityEventsDao? identityEventsDao,
     List<String> indexerRelays = defaultProfileIndexerRelays,
   }) : _nostrClient = nostrClient,
        _userProfilesDao = userProfilesDao,
@@ -82,7 +83,13 @@ class ProfileRepository {
        _profileSearchFilter = profileSearchFilter,
        _blockFilter = blockFilter,
        _pendingProfileSavesDao = pendingProfileSavesDao,
+       _identityEventsDao = identityEventsDao,
        _indexerRelays = indexerRelays;
+
+  /// Event kind carrying NIP-39 identity claims since the 2026-02 spec
+  /// revision (nostr-protocol/nips#2216). Kind-0 `i` tags are the legacy
+  /// fallback for pre-migration profiles.
+  static const int identityEventKind = 10011;
 
   final NostrClient _nostrClient;
   final UserProfilesDao _userProfilesDao;
@@ -97,6 +104,12 @@ class ProfileRepository {
   /// offline-tolerant save path (e.g. legacy tests) — the queue methods
   /// no-op in that case.
   final PendingProfileSavesDao? _pendingProfileSavesDao;
+
+  /// Cache of the NIP-39 identity-claims source (`i` tags) per profile
+  /// (#3936). Null when the caller does not wire the identity cache — the
+  /// identity-tag methods then skip persistence and fall through to the
+  /// kind-0 tags.
+  final IdentityEventsDao? _identityEventsDao;
   final List<String> _indexerRelays;
 
   /// In-flight relay fetches keyed by pubkey. Concurrent callers for the
@@ -229,6 +242,115 @@ class ProfileRepository {
   /// back to the cache and automatically flow through this stream.
   Stream<UserProfile?> watchProfile({required String pubkey}) {
     return _userProfilesDao.watchProfile(pubkey);
+  }
+
+  /// Returns the cached NIP-39 `i` tag list for [pubkey] from local storage.
+  ///
+  /// Does NOT hit the network. Returns `null` when no identity source has
+  /// been cached yet, when the cached row is corrupt, or when no
+  /// [IdentityEventsDao] is wired. Use for instant chip rendering while
+  /// [freshIdentityTags] runs (#3936).
+  Future<List<List<String>>?> cachedIdentityTags(String pubkey) async {
+    final dao = _identityEventsDao;
+    if (dao == null) return null;
+    final row = await dao.getEvent(pubkey);
+    if (row == null) return null;
+    return _decodeIdentityTags(row.tagsJson);
+  }
+
+  /// Fetches the freshest NIP-39 identity-claims source for [pubkey] and
+  /// returns its `i` tags, updating the local cache.
+  ///
+  /// Consult order mirrors the verifier web UI
+  /// (divine-identify-verification-service): a live kind-10011 relay query
+  /// wins; when none is found, a previously cached kind-10011 row wins over
+  /// the kind-0 fallback so a transient relay miss never downgrades the
+  /// source; otherwise the caller-provided kind-0 [kind0Tags] are used and
+  /// cached so cold starts can render claims for pre-migration profiles.
+  ///
+  /// Never throws — relay failures fall through the consult order.
+  Future<List<List<String>>> freshIdentityTags({
+    required String pubkey,
+    required List<List<String>> kind0Tags,
+    int kind0CreatedAt = 0,
+  }) async {
+    final dao = _identityEventsDao;
+    final live = await _fetchIdentityEvent(pubkey);
+    if (live != null) {
+      final iTags = _identityTagsOf(live.tags);
+      await dao?.upsertEvent(
+        pubkey: pubkey,
+        tagsJson: jsonEncode(iTags),
+        sourceKind: identityEventKind,
+        eventCreatedAt: live.createdAt,
+      );
+      return iTags;
+    }
+
+    if (dao != null) {
+      final cachedRow = await dao.getEvent(pubkey);
+      if (cachedRow != null && cachedRow.sourceKind == identityEventKind) {
+        final cachedTags = _decodeIdentityTags(cachedRow.tagsJson);
+        if (cachedTags != null) return cachedTags;
+      }
+    }
+
+    final kind0ITags = _identityTagsOf(kind0Tags);
+    await dao?.upsertEvent(
+      pubkey: pubkey,
+      tagsJson: jsonEncode(kind0ITags),
+      sourceKind: 0,
+      eventCreatedAt: kind0CreatedAt,
+    );
+    return kind0ITags;
+  }
+
+  /// Queries relays for the newest kind-10011 identity event of [pubkey].
+  ///
+  /// Returns `null` when no event is found or the query fails.
+  Future<Event?> _fetchIdentityEvent(String pubkey) async {
+    try {
+      final events = await _nostrClient.queryEvents(
+        [
+          Filter(kinds: const [identityEventKind], authors: [pubkey], limit: 5),
+        ],
+        useCache: false,
+      );
+      final identityEvents = events
+          .where((e) => e.kind == identityEventKind)
+          .toList();
+      if (identityEvents.isEmpty) return null;
+      // Relays do not guarantee newest-first ordering, so pick the event
+      // with the highest createdAt — same rule as the kind-0 fetch above.
+      return identityEvents.reduce((a, b) => b.createdAt > a.createdAt ? b : a);
+    } on Exception catch (e) {
+      Log.warning(
+        'Kind-$identityEventKind fetch failed for $pubkey: $e',
+        name: 'ProfileRepository',
+      );
+      return null;
+    }
+  }
+
+  /// Filters [tags] down to structurally valid NIP-39 `i` tags.
+  static List<List<String>> _identityTagsOf(List<List<String>> tags) {
+    return [
+      for (final tag in tags)
+        if (tag.length >= 3 && tag[0] == 'i') tag,
+    ];
+  }
+
+  /// Decodes a stored `i` tag list; `null` when the JSON is malformed.
+  static List<List<String>>? _decodeIdentityTags(String tagsJson) {
+    try {
+      final decoded = jsonDecode(tagsJson) as List<dynamic>;
+      return [
+        for (final tag in decoded)
+          (tag as List<dynamic>).map((v) => v as String).toList(),
+      ];
+    } on Exception {
+      return null;
+    }
   }
 
   /// Watches profile stats by pubkey, emitting updates from local storage.

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -272,7 +272,6 @@ class ProfileRepository {
   Future<List<List<String>>> freshIdentityTags({
     required String pubkey,
     required List<List<String>> kind0Tags,
-    int kind0CreatedAt = 0,
   }) async {
     final dao = _identityEventsDao;
     final live = await _fetchIdentityEvent(pubkey);
@@ -282,7 +281,6 @@ class ProfileRepository {
         pubkey: pubkey,
         tagsJson: jsonEncode(iTags),
         sourceKind: identityEventKind,
-        eventCreatedAt: live.createdAt,
       );
       return iTags;
     }
@@ -300,7 +298,6 @@ class ProfileRepository {
       pubkey: pubkey,
       tagsJson: jsonEncode(kind0ITags),
       sourceKind: 0,
-      eventCreatedAt: kind0CreatedAt,
     );
     return kind0ITags;
   }
@@ -320,9 +317,16 @@ class ProfileRepository {
           .where((e) => e.kind == identityEventKind)
           .toList();
       if (identityEvents.isEmpty) return null;
-      // Relays do not guarantee newest-first ordering, so pick the event
-      // with the highest createdAt — same rule as the kind-0 fetch above.
-      return identityEvents.reduce((a, b) => b.createdAt > a.createdAt ? b : a);
+      // Relays do not guarantee newest-first ordering, so pick the newest
+      // event by created_at. On a same-second tie, NIP-01 breaks by lowest
+      // event id, so same-second events resolve to one deterministic winner
+      // regardless of relay return order.
+      return identityEvents.reduce((a, b) {
+        if (a.createdAt != b.createdAt) {
+          return b.createdAt > a.createdAt ? b : a;
+        }
+        return b.id.compareTo(a.id) < 0 ? b : a;
+      });
     } on Exception catch (e) {
       Log.warning(
         'Kind-$identityEventKind fetch failed for $pubkey: $e',
@@ -340,7 +344,13 @@ class ProfileRepository {
     ];
   }
 
-  /// Decodes a stored `i` tag list; `null` when the JSON is malformed.
+  /// Decodes a stored `i` tag list; `null` when the JSON is malformed or
+  /// wrong-shaped.
+  ///
+  /// Catches [Object] (not just [Exception]): a valid-JSON-but-wrong-shape
+  /// row throws a [TypeError] (an [Error]) on the casts, which must still
+  /// uphold the null-when-malformed contract rather than escaping to a
+  /// reportable crash.
   static List<List<String>>? _decodeIdentityTags(String tagsJson) {
     try {
       final decoded = jsonDecode(tagsJson) as List<dynamic>;
@@ -348,7 +358,7 @@ class ProfileRepository {
         for (final tag in decoded)
           (tag as List<dynamic>).map((v) => v as String).toList(),
       ];
-    } on Exception {
+    } on Object {
       return null;
     }
   }

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -268,7 +268,9 @@ class ProfileRepository {
   /// source; otherwise the caller-provided kind-0 [kind0Tags] are used and
   /// cached so cold starts can render claims for pre-migration profiles.
   ///
-  /// Never throws — relay failures fall through the consult order.
+  /// Never throws — relay failures fall through the consult order, and
+  /// cache reads/writes are best-effort so a local persistence failure
+  /// never discards tags already in hand.
   Future<List<List<String>>> freshIdentityTags({
     required String pubkey,
     required List<List<String>> kind0Tags,
@@ -277,29 +279,57 @@ class ProfileRepository {
     final live = await _fetchIdentityEvent(pubkey);
     if (live != null) {
       final iTags = _identityTagsOf(live.tags);
-      await dao?.upsertEvent(
-        pubkey: pubkey,
-        tagsJson: jsonEncode(iTags),
-        sourceKind: identityEventKind,
-      );
+      await _cacheIdentityTags(pubkey, iTags, identityEventKind);
       return iTags;
     }
 
+    var cacheReadFailed = false;
     if (dao != null) {
-      final cachedRow = await dao.getEvent(pubkey);
-      if (cachedRow != null && cachedRow.sourceKind == identityEventKind) {
-        final cachedTags = _decodeIdentityTags(cachedRow.tagsJson);
-        if (cachedTags != null) return cachedTags;
+      try {
+        final cachedRow = await dao.getEvent(pubkey);
+        if (cachedRow != null && cachedRow.sourceKind == identityEventKind) {
+          final cachedTags = _decodeIdentityTags(cachedRow.tagsJson);
+          if (cachedTags != null) return cachedTags;
+        }
+      } on Exception catch (e) {
+        cacheReadFailed = true;
+        Log.warning(
+          'Identity-tags cache read failed for $pubkey: $e',
+          name: 'ProfileRepository',
+        );
       }
     }
 
     final kind0ITags = _identityTagsOf(kind0Tags);
-    await dao?.upsertEvent(
-      pubkey: pubkey,
-      tagsJson: jsonEncode(kind0ITags),
-      sourceKind: 0,
-    );
+    // When the cached row could not be read, skip the fallback write — a
+    // blind upsert here could downgrade a valid but unreadable-this-tick
+    // kind-10011 row to a kind-0 source.
+    if (!cacheReadFailed) {
+      await _cacheIdentityTags(pubkey, kind0ITags, 0);
+    }
     return kind0ITags;
+  }
+
+  /// Best-effort persistence of the identity-claims source cache — a
+  /// failed write is logged and swallowed so [freshIdentityTags] can
+  /// still return the tags it already fetched.
+  Future<void> _cacheIdentityTags(
+    String pubkey,
+    List<List<String>> iTags,
+    int sourceKind,
+  ) async {
+    try {
+      await _identityEventsDao?.upsertEvent(
+        pubkey: pubkey,
+        tagsJson: jsonEncode(iTags),
+        sourceKind: sourceKind,
+      );
+    } on Exception catch (e) {
+      Log.warning(
+        'Identity-tags cache write failed for $pubkey: $e',
+        name: 'ProfileRepository',
+      );
+    }
   }
 
   /// Queries relays for the newest kind-10011 identity event of [pubkey].

--- a/mobile/packages/profile_repository/test/src/identity_claims_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/identity_claims_repository_test.dart
@@ -460,6 +460,7 @@ void main() {
         ),
       ).thenAnswer((_) async {});
       when(() => dao.deleteVerification(any())).thenAnswer((_) async => 1);
+      when(() => dao.getVerification(any())).thenAnswer((_) async => null);
     });
 
     test(
@@ -693,6 +694,402 @@ void main() {
             checkedAtFloor: any(named: 'checkedAtFloor'),
           ),
         );
+      },
+    );
+
+    test(
+      'preserves rendered claims when rate-limited with no usable snapshot '
+      '(#6176 review)',
+      () async {
+        const renderedClaim = IdentityClaim(
+          pubkey: _pubkey,
+          platform: 'github',
+          identity: 'octocat',
+          proof: 'a',
+        );
+        when(() => client.verifyBatch(any())).thenAnswer(
+          (_) async => const [
+            VerificationResult(
+              platform: 'github',
+              identity: 'octocat',
+              verified: false,
+              checkedAt: 900,
+              cached: false,
+              error: 'Rate limit exceeded for this pubkey',
+            ),
+          ],
+        );
+
+        final result = await repo.resolveClaims(
+          pubkey: _pubkey,
+          freshTags: [
+            ['i', 'github:octocat', 'a'],
+          ],
+          cached: null,
+          renderedClaims: const [renderedClaim],
+        );
+
+        expect(result, equals([renderedClaim]));
+        verifyNever(() => dao.deleteVerification(any()));
+        verifyNever(
+          () => dao.upsertVerification(
+            pubkey: any(named: 'pubkey'),
+            verifiedClaimsJson: any(named: 'verifiedClaimsJson'),
+            checkedAtFloor: any(named: 'checkedAtFloor'),
+          ),
+        );
+      },
+    );
+
+    test(
+      'preserves rendered claims when rate-limited with an empty snapshot '
+      'intersection',
+      () async {
+        const renderedClaim = IdentityClaim(
+          pubkey: _pubkey,
+          platform: 'github',
+          identity: 'octocat',
+          proof: 'a',
+        );
+        when(() => client.verifyBatch(any())).thenAnswer(
+          (_) async => const [
+            VerificationResult(
+              platform: 'github',
+              identity: 'octocat',
+              verified: false,
+              checkedAt: 900,
+              cached: false,
+              error: 'Rate limit exceeded for this pubkey',
+            ),
+          ],
+        );
+
+        final result = await repo.resolveClaims(
+          pubkey: _pubkey,
+          freshTags: [
+            ['i', 'github:octocat', 'a'],
+          ],
+          cached: const CachedVerifiedClaims(claims: [], isFresh: false),
+          renderedClaims: const [renderedClaim],
+        );
+
+        expect(result, equals([renderedClaim]));
+      },
+    );
+
+    test(
+      'drops rendered claims no longer present in the fresh tags even when '
+      'rate-limited',
+      () async {
+        const removedRenderedClaim = IdentityClaim(
+          pubkey: _pubkey,
+          platform: 'twitter',
+          identity: 'old',
+          proof: 'removed-proof',
+        );
+        when(() => client.verifyBatch(any())).thenAnswer(
+          (_) async => const [
+            VerificationResult(
+              platform: 'github',
+              identity: 'octocat',
+              verified: false,
+              checkedAt: 900,
+              cached: false,
+              error: 'Rate limit exceeded for this pubkey',
+            ),
+          ],
+        );
+
+        final result = await repo.resolveClaims(
+          pubkey: _pubkey,
+          freshTags: [
+            ['i', 'github:octocat', 'a'],
+          ],
+          cached: null,
+          renderedClaims: const [removedRenderedClaim],
+        );
+
+        expect(result, isEmpty);
+      },
+    );
+
+    test(
+      'clears rendered claims when the verifier returns a confirmed '
+      'negative (non-rate-limited)',
+      () async {
+        const renderedClaim = IdentityClaim(
+          pubkey: _pubkey,
+          platform: 'github',
+          identity: 'octocat',
+          proof: 'a',
+        );
+        when(() => client.verifyBatch(any())).thenAnswer(
+          (_) async => const [
+            VerificationResult(
+              platform: 'github',
+              identity: 'octocat',
+              verified: false,
+              checkedAt: 900,
+              cached: false,
+              error: 'Gist not found',
+            ),
+          ],
+        );
+
+        final result = await repo.resolveClaims(
+          pubkey: _pubkey,
+          freshTags: [
+            ['i', 'github:octocat', 'a'],
+          ],
+          cached: null,
+          renderedClaims: const [renderedClaim],
+        );
+
+        expect(result, isEmpty);
+        verify(() => dao.deleteVerification(_pubkey)).called(1);
+      },
+    );
+
+    test(
+      'preserves a rendered claim across proof rotation and casing drift '
+      'when rate-limited (identity-granular matching)',
+      () async {
+        const renderedClaim = IdentityClaim(
+          pubkey: _pubkey,
+          platform: 'github',
+          identity: 'octocat',
+          proof: 'old-proof',
+        );
+        when(() => client.verifyBatch(any())).thenAnswer(
+          (_) async => const [
+            VerificationResult(
+              platform: 'GitHub',
+              identity: 'Octocat',
+              verified: false,
+              checkedAt: 900,
+              cached: false,
+              error: 'Rate limit exceeded for this pubkey',
+            ),
+          ],
+        );
+
+        final result = await repo.resolveClaims(
+          pubkey: _pubkey,
+          freshTags: [
+            ['i', 'GitHub:Octocat', 'new-proof'],
+          ],
+          cached: null,
+          renderedClaims: const [renderedClaim],
+        );
+
+        // The verifier judges platform:identity, not proof strings — an
+        // inconclusive (rate-limited) verdict on a rotated proof must not
+        // drop the previously verified identity's chip.
+        expect(result, hasLength(1));
+        expect(result.single.proof, equals('new-proof'));
+      },
+    );
+
+    test(
+      'drops a claim whose own result is a confirmed negative inside a '
+      'rate-limited batch',
+      () async {
+        const githubClaim = IdentityClaim(
+          pubkey: _pubkey,
+          platform: 'github',
+          identity: 'octocat',
+          proof: 'a',
+        );
+        const twitterClaim = IdentityClaim(
+          pubkey: _pubkey,
+          platform: 'twitter',
+          identity: 'octo',
+          proof: 'b',
+        );
+        when(() => client.verifyBatch(any())).thenAnswer(
+          (_) async => const [
+            VerificationResult(
+              platform: 'github',
+              identity: 'octocat',
+              verified: false,
+              checkedAt: 900,
+              cached: false,
+              error: 'Rate limit exceeded for this platform',
+            ),
+            VerificationResult(
+              platform: 'twitter',
+              identity: 'octo',
+              verified: false,
+              checkedAt: 900,
+              cached: false,
+              error: 'Tweet not found',
+            ),
+          ],
+        );
+
+        final result = await repo.resolveClaims(
+          pubkey: _pubkey,
+          freshTags: [
+            ['i', 'github:octocat', 'a'],
+            ['i', 'twitter:octo', 'b'],
+          ],
+          cached: null,
+          renderedClaims: const [githubClaim, twitterClaim],
+        );
+
+        // github's own result is rate-limited (inconclusive) → preserved;
+        // twitter's own result is a confirmed negative → dropped even
+        // though the batch as a whole is rate-limited.
+        expect(result, equals([githubClaim]));
+        verifyNever(() => dao.deleteVerification(any()));
+        verifyNever(
+          () => dao.upsertVerification(
+            pubkey: any(named: 'pubkey'),
+            verifiedClaimsJson: any(named: 'verifiedClaimsJson'),
+            checkedAtFloor: any(named: 'checkedAtFloor'),
+          ),
+        );
+      },
+    );
+
+    group(
+      'confirmed-negative snapshot pruning during a rate-limited batch',
+      () {
+        const mixedResults = [
+          VerificationResult(
+            platform: 'github',
+            identity: 'octocat',
+            verified: false,
+            checkedAt: 900,
+            cached: false,
+            error: 'Rate limit exceeded for this platform',
+          ),
+          VerificationResult(
+            platform: 'twitter',
+            identity: 'octo',
+            verified: false,
+            checkedAt: 900,
+            cached: false,
+            error: 'Tweet not found',
+          ),
+        ];
+        const mixedTags = [
+          ['i', 'github:octocat', 'a'],
+          ['i', 'twitter:octo', 'b'],
+        ];
+
+        test('prunes the negated entry and keeps the rest', () async {
+          when(() => client.verifyBatch(any())).thenAnswer(
+            (_) async => mixedResults,
+          );
+          when(() => dao.getVerification(_pubkey)).thenAnswer(
+            (_) async => _row(
+              claimsJson:
+                  '[{"platform":"github","identity":"octocat","proof":"a"},'
+                  '{"platform":"Twitter","identity":"Octo","proof":"b"}]',
+              checkedAtFloor: 500,
+            ),
+          );
+
+          await repo.resolveClaims(
+            pubkey: _pubkey,
+            freshTags: mixedTags,
+            cached: null,
+          );
+
+          // twitter:octo got a confirmed negative → pruned (matched
+          // case-insensitively); github stays because its own result is
+          // only rate-limited. checkedAtFloor is preserved as-is.
+          verify(
+            () => dao.upsertVerification(
+              pubkey: _pubkey,
+              verifiedClaimsJson:
+                  '[{"platform":"github","identity":"octocat","proof":"a"}]',
+              checkedAtFloor: 500,
+            ),
+          ).called(1);
+          verifyNever(() => dao.deleteVerification(any()));
+        });
+
+        test('deletes the snapshot when every entry is negated', () async {
+          when(() => client.verifyBatch(any())).thenAnswer(
+            (_) async => mixedResults,
+          );
+          when(() => dao.getVerification(_pubkey)).thenAnswer(
+            (_) async => _row(
+              claimsJson:
+                  '[{"platform":"twitter","identity":"octo","proof":"b"}]',
+              checkedAtFloor: 500,
+            ),
+          );
+
+          await repo.resolveClaims(
+            pubkey: _pubkey,
+            freshTags: mixedTags,
+            cached: null,
+          );
+
+          verify(() => dao.deleteVerification(_pubkey)).called(1);
+          verifyNever(
+            () => dao.upsertVerification(
+              pubkey: any(named: 'pubkey'),
+              verifiedClaimsJson: any(named: 'verifiedClaimsJson'),
+              checkedAtFloor: any(named: 'checkedAtFloor'),
+            ),
+          );
+        });
+
+        test('writes nothing when no snapshot entry is negated', () async {
+          when(() => client.verifyBatch(any())).thenAnswer(
+            (_) async => mixedResults,
+          );
+          when(() => dao.getVerification(_pubkey)).thenAnswer(
+            (_) async => _row(
+              claimsJson:
+                  '[{"platform":"github","identity":"octocat","proof":"a"}]',
+              checkedAtFloor: 500,
+            ),
+          );
+
+          await repo.resolveClaims(
+            pubkey: _pubkey,
+            freshTags: mixedTags,
+            cached: null,
+          );
+
+          verifyNever(() => dao.deleteVerification(any()));
+          verifyNever(
+            () => dao.upsertVerification(
+              pubkey: any(named: 'pubkey'),
+              verifiedClaimsJson: any(named: 'verifiedClaimsJson'),
+              checkedAtFloor: any(named: 'checkedAtFloor'),
+            ),
+          );
+        });
+
+        test('leaves a malformed snapshot row alone', () async {
+          when(() => client.verifyBatch(any())).thenAnswer(
+            (_) async => mixedResults,
+          );
+          when(() => dao.getVerification(_pubkey)).thenAnswer(
+            (_) async => _row(claimsJson: 'not json', checkedAtFloor: 500),
+          );
+
+          await repo.resolveClaims(
+            pubkey: _pubkey,
+            freshTags: mixedTags,
+            cached: null,
+          );
+
+          verifyNever(() => dao.deleteVerification(any()));
+          verifyNever(
+            () => dao.upsertVerification(
+              pubkey: any(named: 'pubkey'),
+              verifiedClaimsJson: any(named: 'verifiedClaimsJson'),
+              checkedAtFloor: any(named: 'checkedAtFloor'),
+            ),
+          );
+        });
       },
     );
   });

--- a/mobile/packages/profile_repository/test/src/identity_claims_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/identity_claims_repository_test.dart
@@ -1,4 +1,4 @@
-// ABOUTME: Tests for IdentityClaimsRepository — parseClaims, verifiedClaims,
+// ABOUTME: Tests for IdentityClaimsRepository — parseClaims, resolveClaims,
 // ABOUTME: and the persistent verified-claims cache (#3936).
 
 import 'package:db_client/db_client.dart' hide Filter;
@@ -114,7 +114,7 @@ void main() {
     });
   });
 
-  group('IdentityClaimsRepository.verifiedClaims', () {
+  group('IdentityClaimsRepository.resolveClaims (verify path)', () {
     late _MockVerifierClient client;
     late IdentityClaimsRepository repo;
 
@@ -123,6 +123,7 @@ void main() {
       repo = IdentityClaimsRepository(verifierClient: client);
     });
 
+    // A null cache forces the verify path (no snapshot to skip against).
     test('returns only claims the verifier confirmed', () async {
       when(() => client.verifyBatch(any())).thenAnswer(
         (_) async => const [
@@ -142,27 +143,32 @@ void main() {
           ),
         ],
       );
-      final result = await repo.verifiedClaims(
+      final result = await repo.resolveClaims(
         pubkey: _pubkey,
-        tags: [
+        freshTags: [
           ['i', 'github:octocat', 'a'],
           ['i', 'twitter:fake', 'b'],
         ],
+        cached: null,
       );
       expect(result, hasLength(1));
       expect(result.single.platform, equals('github'));
     });
 
-    test('returns empty when there are no i tags', () async {
-      final result = await repo.verifiedClaims(
-        pubkey: _pubkey,
-        tags: const [
-          ['p', 'someone'],
-        ],
-      );
-      expect(result, isEmpty);
-      verifyNever(() => client.verifyBatch(any()));
-    });
+    test(
+      'returns empty and skips the verifier when there are no i tags',
+      () async {
+        final result = await repo.resolveClaims(
+          pubkey: _pubkey,
+          freshTags: const [
+            ['p', 'someone'],
+          ],
+          cached: null,
+        );
+        expect(result, isEmpty);
+        verifyNever(() => client.verifyBatch(any()));
+      },
+    );
 
     test('case-insensitively matches verifier results to claims', () async {
       // Verifier returns lowercase platform/identity even if claim used
@@ -178,11 +184,12 @@ void main() {
           ),
         ],
       );
-      final result = await repo.verifiedClaims(
+      final result = await repo.resolveClaims(
         pubkey: _pubkey,
-        tags: [
+        freshTags: [
           ['i', 'GitHub:Octocat', 'a'],
         ],
+        cached: null,
       );
       expect(result, hasLength(1));
       expect(result.single.platform, equals('GitHub'));
@@ -194,15 +201,114 @@ void main() {
         const VerifierApiException(500, 'boom'),
       );
       await expectLater(
-        () => repo.verifiedClaims(
+        () => repo.resolveClaims(
           pubkey: _pubkey,
-          tags: [
+          freshTags: [
             ['i', 'github:octocat', 'abc'],
           ],
+          cached: null,
         ),
         throwsA(isA<VerifierApiException>()),
       );
     });
+  });
+
+  group('IdentityClaimsRepository.resolveClaims (SWR decision)', () {
+    late _MockVerifierClient client;
+    late IdentityClaimsRepository repo;
+
+    const octocatClaim = IdentityClaim(
+      pubkey: _pubkey,
+      platform: 'github',
+      identity: 'octocat',
+      proof: 'a',
+    );
+
+    setUp(() {
+      client = _MockVerifierClient();
+      repo = IdentityClaimsRepository(verifierClient: client);
+    });
+
+    test(
+      'skips the verifier when a fresh snapshot covers every current claim',
+      () async {
+        final result = await repo.resolveClaims(
+          pubkey: _pubkey,
+          freshTags: [
+            ['i', 'github:octocat', 'a'],
+          ],
+          cached: const CachedVerifiedClaims(
+            claims: [octocatClaim],
+            isFresh: true,
+          ),
+        );
+        expect(result, equals([octocatClaim]));
+        verifyNever(() => client.verifyBatch(any()));
+      },
+    );
+
+    test('re-verifies when the snapshot is stale', () async {
+      when(() => client.verifyBatch(any())).thenAnswer(
+        (_) async => const [
+          VerificationResult(
+            platform: 'github',
+            identity: 'octocat',
+            verified: true,
+            checkedAt: 1,
+            cached: false,
+          ),
+        ],
+      );
+      final result = await repo.resolveClaims(
+        pubkey: _pubkey,
+        freshTags: [
+          ['i', 'github:octocat', 'a'],
+        ],
+        cached: const CachedVerifiedClaims(
+          claims: [octocatClaim],
+          isFresh: false,
+        ),
+      );
+      expect(result, equals([octocatClaim]));
+      verify(() => client.verifyBatch(any())).called(1);
+    });
+
+    test(
+      're-verifies when a fresh snapshot does not cover a new claim',
+      () async {
+        when(() => client.verifyBatch(any())).thenAnswer(
+          (_) async => const [
+            VerificationResult(
+              platform: 'github',
+              identity: 'octocat',
+              verified: true,
+              checkedAt: 1,
+              cached: false,
+            ),
+            VerificationResult(
+              platform: 'telegram',
+              identity: 'octo',
+              verified: true,
+              checkedAt: 1,
+              cached: false,
+            ),
+          ],
+        );
+        final result = await repo.resolveClaims(
+          pubkey: _pubkey,
+          freshTags: [
+            ['i', 'github:octocat', 'a'],
+            ['i', 'telegram:octo', 'b'],
+          ],
+          cached: const CachedVerifiedClaims(
+            claims: [octocatClaim],
+            isFresh: true,
+          ),
+        );
+        expect(result, hasLength(2));
+        verify(() => client.verifyBatch(any())).called(1);
+      },
+    );
   });
 
   group('IdentityClaimsRepository.cachedVerifiedClaims', () {
@@ -247,6 +353,34 @@ void main() {
         isNull,
       );
     });
+
+    test(
+      'returns null when the snapshot is valid JSON of the wrong shape '
+      '(TypeError, not just Exception)',
+      () async {
+        // A JSON object instead of a list, and a list of the wrong element
+        // shape, both throw TypeError on the decode casts — the decoder must
+        // still degrade to null rather than let an Error escape.
+        for (final malformed in const [
+          '{"platform":"github"}',
+          '[{"platform":123,"identity":"octocat","proof":"a"}]',
+        ]) {
+          when(() => dao.getVerification(_pubkey)).thenAnswer(
+            (_) async => _row(claimsJson: malformed, checkedAtFloor: 1),
+          );
+          expect(
+            await repo.cachedVerifiedClaims(
+              pubkey: _pubkey,
+              tags: [
+                ['i', 'github:octocat', 'a'],
+              ],
+            ),
+            isNull,
+            reason: 'wrong-shape snapshot "$malformed" should decode to null',
+          );
+        }
+      },
+    );
 
     test(
       'intersects current claims with the snapshot — case-insensitive '
@@ -306,7 +440,7 @@ void main() {
     });
   });
 
-  group('IdentityClaimsRepository.verifiedClaims persistence', () {
+  group('IdentityClaimsRepository.resolveClaims persistence', () {
     late _MockVerifierClient client;
     late _MockIdentityVerificationsDao dao;
     late IdentityClaimsRepository repo;
@@ -358,13 +492,14 @@ void main() {
           ],
         );
 
-        await repo.verifiedClaims(
+        await repo.resolveClaims(
           pubkey: _pubkey,
-          tags: [
+          freshTags: [
             ['i', 'github:octocat', 'a'],
             ['i', 'telegram:octo', 'b'],
             ['i', 'twitter:fake', 'c'],
           ],
+          cached: null,
         );
 
         final captured =
@@ -399,11 +534,12 @@ void main() {
         ],
       );
 
-      await repo.verifiedClaims(
+      await repo.resolveClaims(
         pubkey: _pubkey,
-        tags: [
+        freshTags: [
           ['i', 'github:octocat', 'a'],
         ],
+        cached: null,
       );
 
       verify(() => dao.deleteVerification(_pubkey)).called(1);
@@ -439,12 +575,13 @@ void main() {
           ],
         );
 
-        final result = await repo.verifiedClaims(
+        final result = await repo.resolveClaims(
           pubkey: _pubkey,
-          tags: [
+          freshTags: [
             ['i', 'github:octocat', 'a'],
             ['i', 'twitter:octo', 'b'],
           ],
+          cached: null,
         );
 
         expect(result, hasLength(1));
@@ -456,6 +593,55 @@ void main() {
           ),
         );
         verifyNever(() => dao.deleteVerification(any()));
+      },
+    );
+
+    test(
+      'leaves the snapshot untouched when every result is rate-limited '
+      '(zero verified must not trigger the delete path)',
+      () async {
+        // The rate-limit guard must be checked BEFORE the zero-verified
+        // delete: an all-rate-limited burst has no verified claims, so
+        // reordering the guards would wipe a good snapshot here.
+        when(() => client.verifyBatch(any())).thenAnswer(
+          (_) async => const [
+            VerificationResult(
+              platform: 'github',
+              identity: 'octocat',
+              verified: false,
+              checkedAt: 900,
+              cached: false,
+              error: 'Rate limit exceeded for this pubkey',
+            ),
+            VerificationResult(
+              platform: 'twitter',
+              identity: 'octo',
+              verified: false,
+              checkedAt: 900,
+              cached: false,
+              error: 'Rate limit exceeded for this platform',
+            ),
+          ],
+        );
+
+        final result = await repo.resolveClaims(
+          pubkey: _pubkey,
+          freshTags: [
+            ['i', 'github:octocat', 'a'],
+            ['i', 'twitter:octo', 'b'],
+          ],
+          cached: null,
+        );
+
+        expect(result, isEmpty);
+        verifyNever(() => dao.deleteVerification(any()));
+        verifyNever(
+          () => dao.upsertVerification(
+            pubkey: any(named: 'pubkey'),
+            verifiedClaimsJson: any(named: 'verifiedClaimsJson'),
+            checkedAtFloor: any(named: 'checkedAtFloor'),
+          ),
+        );
       },
     );
   });

--- a/mobile/packages/profile_repository/test/src/identity_claims_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/identity_claims_repository_test.dart
@@ -1,13 +1,31 @@
-// ABOUTME: Tests for IdentityClaimsRepository — parseClaims + verifiedClaims.
+// ABOUTME: Tests for IdentityClaimsRepository — parseClaims, verifiedClaims,
+// ABOUTME: and the persistent verified-claims cache (#3936).
 
+import 'package:db_client/db_client.dart' hide Filter;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart' hide VerificationResult;
 import 'package:profile_repository/profile_repository.dart';
 
 class _MockVerifierClient extends Mock implements VerifierClient {}
 
+class _MockIdentityVerificationsDao extends Mock
+    implements IdentityVerificationsDao {}
+
 const _pubkey =
     '1111111111111111111111111111111111111111111111111111111111111111';
+
+int _nowSeconds() => DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+IdentityVerificationRow _row({
+  required String claimsJson,
+  required int checkedAtFloor,
+}) {
+  return IdentityVerificationRow(
+    pubkey: _pubkey,
+    verifiedClaimsJson: claimsJson,
+    checkedAtFloor: checkedAtFloor,
+  );
+}
 
 void main() {
   setUpAll(() {
@@ -185,5 +203,260 @@ void main() {
         throwsA(isA<VerifierApiException>()),
       );
     });
+  });
+
+  group('IdentityClaimsRepository.cachedVerifiedClaims', () {
+    late _MockVerifierClient client;
+    late _MockIdentityVerificationsDao dao;
+    late IdentityClaimsRepository repo;
+
+    const snapshotJson =
+        '[{"platform":"github","identity":"octocat","proof":"a"}]';
+
+    setUp(() {
+      client = _MockVerifierClient();
+      dao = _MockIdentityVerificationsDao();
+      repo = IdentityClaimsRepository(
+        verifierClient: client,
+        identityVerificationsDao: dao,
+      );
+    });
+
+    test('returns null when no DAO is wired', () async {
+      final bare = IdentityClaimsRepository(verifierClient: client);
+      expect(
+        await bare.cachedVerifiedClaims(pubkey: _pubkey, tags: const []),
+        isNull,
+      );
+    });
+
+    test('returns null when no snapshot row exists', () async {
+      when(() => dao.getVerification(_pubkey)).thenAnswer((_) async => null);
+      expect(
+        await repo.cachedVerifiedClaims(pubkey: _pubkey, tags: const []),
+        isNull,
+      );
+    });
+
+    test('returns null when the stored snapshot is corrupt', () async {
+      when(() => dao.getVerification(_pubkey)).thenAnswer(
+        (_) async => _row(claimsJson: 'not json', checkedAtFloor: 1),
+      );
+      expect(
+        await repo.cachedVerifiedClaims(pubkey: _pubkey, tags: const []),
+        isNull,
+      );
+    });
+
+    test(
+      'intersects current claims with the snapshot — case-insensitive '
+      'platform/identity, exact proof',
+      () async {
+        when(() => dao.getVerification(_pubkey)).thenAnswer(
+          (_) async => _row(
+            claimsJson: snapshotJson,
+            checkedAtFloor: _nowSeconds(),
+          ),
+        );
+        final cached = await repo.cachedVerifiedClaims(
+          pubkey: _pubkey,
+          tags: [
+            ['i', 'GitHub:Octocat', 'a'],
+            ['i', 'twitter:unverified', 'b'],
+          ],
+        );
+        expect(cached, isNotNull);
+        expect(cached!.claims, hasLength(1));
+        expect(cached.claims.single.platform, equals('GitHub'));
+        expect(cached.isFresh, isTrue);
+      },
+    );
+
+    test('a rotated proof misses the snapshot', () async {
+      when(() => dao.getVerification(_pubkey)).thenAnswer(
+        (_) async => _row(
+          claimsJson: snapshotJson,
+          checkedAtFloor: _nowSeconds(),
+        ),
+      );
+      final cached = await repo.cachedVerifiedClaims(
+        pubkey: _pubkey,
+        tags: [
+          ['i', 'github:octocat', 'rotated-proof'],
+        ],
+      );
+      expect(cached!.claims, isEmpty);
+    });
+
+    test('is stale once checkedAtFloor is older than the 24h TTL', () async {
+      when(() => dao.getVerification(_pubkey)).thenAnswer(
+        (_) async => _row(
+          claimsJson: snapshotJson,
+          checkedAtFloor: _nowSeconds() - 25 * 3600,
+        ),
+      );
+      final cached = await repo.cachedVerifiedClaims(
+        pubkey: _pubkey,
+        tags: [
+          ['i', 'github:octocat', 'a'],
+        ],
+      );
+      expect(cached!.claims, hasLength(1));
+      expect(cached.isFresh, isFalse);
+    });
+  });
+
+  group('IdentityClaimsRepository.verifiedClaims persistence', () {
+    late _MockVerifierClient client;
+    late _MockIdentityVerificationsDao dao;
+    late IdentityClaimsRepository repo;
+
+    setUp(() {
+      client = _MockVerifierClient();
+      dao = _MockIdentityVerificationsDao();
+      repo = IdentityClaimsRepository(
+        verifierClient: client,
+        identityVerificationsDao: dao,
+      );
+      when(
+        () => dao.upsertVerification(
+          pubkey: any(named: 'pubkey'),
+          verifiedClaimsJson: any(named: 'verifiedClaimsJson'),
+          checkedAtFloor: any(named: 'checkedAtFloor'),
+        ),
+      ).thenAnswer((_) async {});
+      when(() => dao.deleteVerification(any())).thenAnswer((_) async => 1);
+    });
+
+    test(
+      'persists verified tuples with the minimum checked_at as floor',
+      () async {
+        when(() => client.verifyBatch(any())).thenAnswer(
+          (_) async => const [
+            VerificationResult(
+              platform: 'github',
+              identity: 'octocat',
+              verified: true,
+              checkedAt: 500,
+              cached: true,
+            ),
+            VerificationResult(
+              platform: 'telegram',
+              identity: 'octo',
+              verified: true,
+              checkedAt: 300,
+              cached: false,
+            ),
+            VerificationResult(
+              platform: 'twitter',
+              identity: 'fake',
+              verified: false,
+              checkedAt: 900,
+              cached: false,
+              error: 'Post not found',
+            ),
+          ],
+        );
+
+        await repo.verifiedClaims(
+          pubkey: _pubkey,
+          tags: [
+            ['i', 'github:octocat', 'a'],
+            ['i', 'telegram:octo', 'b'],
+            ['i', 'twitter:fake', 'c'],
+          ],
+        );
+
+        final captured =
+            verify(
+                  () => dao.upsertVerification(
+                    pubkey: _pubkey,
+                    verifiedClaimsJson: captureAny(
+                      named: 'verifiedClaimsJson',
+                    ),
+                    checkedAtFloor: 300,
+                  ),
+                ).captured.single
+                as String;
+        expect(captured, contains('"github"'));
+        expect(captured, contains('"telegram"'));
+        expect(captured, isNot(contains('"twitter"')));
+        verifyNever(() => dao.deleteVerification(any()));
+      },
+    );
+
+    test('deletes the snapshot when the verifier confirms none', () async {
+      when(() => client.verifyBatch(any())).thenAnswer(
+        (_) async => const [
+          VerificationResult(
+            platform: 'github',
+            identity: 'octocat',
+            verified: false,
+            checkedAt: 500,
+            cached: false,
+            error: 'Gist not found',
+          ),
+        ],
+      );
+
+      await repo.verifiedClaims(
+        pubkey: _pubkey,
+        tags: [
+          ['i', 'github:octocat', 'a'],
+        ],
+      );
+
+      verify(() => dao.deleteVerification(_pubkey)).called(1);
+      verifyNever(
+        () => dao.upsertVerification(
+          pubkey: any(named: 'pubkey'),
+          verifiedClaimsJson: any(named: 'verifiedClaimsJson'),
+          checkedAtFloor: any(named: 'checkedAtFloor'),
+        ),
+      );
+    });
+
+    test(
+      'leaves the snapshot untouched when any result is rate-limited',
+      () async {
+        when(() => client.verifyBatch(any())).thenAnswer(
+          (_) async => const [
+            VerificationResult(
+              platform: 'github',
+              identity: 'octocat',
+              verified: true,
+              checkedAt: 500,
+              cached: true,
+            ),
+            VerificationResult(
+              platform: 'twitter',
+              identity: 'octo',
+              verified: false,
+              checkedAt: 900,
+              cached: false,
+              error: 'Rate limit exceeded for this pubkey',
+            ),
+          ],
+        );
+
+        final result = await repo.verifiedClaims(
+          pubkey: _pubkey,
+          tags: [
+            ['i', 'github:octocat', 'a'],
+            ['i', 'twitter:octo', 'b'],
+          ],
+        );
+
+        expect(result, hasLength(1));
+        verifyNever(
+          () => dao.upsertVerification(
+            pubkey: any(named: 'pubkey'),
+            verifiedClaimsJson: any(named: 'verifiedClaimsJson'),
+            checkedAtFloor: any(named: 'checkedAtFloor'),
+          ),
+        );
+        verifyNever(() => dao.deleteVerification(any()));
+      },
+    );
   });
 }

--- a/mobile/packages/profile_repository/test/src/identity_claims_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/identity_claims_repository_test.dart
@@ -644,5 +644,56 @@ void main() {
         );
       },
     );
+
+    test(
+      'returns cached current claims when stale revalidation is rate-limited',
+      () async {
+        const cachedOctocatClaim = IdentityClaim(
+          pubkey: _pubkey,
+          platform: 'github',
+          identity: 'octocat',
+          proof: 'a',
+        );
+        const removedCachedClaim = IdentityClaim(
+          pubkey: _pubkey,
+          platform: 'twitter',
+          identity: 'old',
+          proof: 'removed-proof',
+        );
+        when(() => client.verifyBatch(any())).thenAnswer(
+          (_) async => const [
+            VerificationResult(
+              platform: 'github',
+              identity: 'octocat',
+              verified: false,
+              checkedAt: 900,
+              cached: false,
+              error: 'Rate limit exceeded for this pubkey',
+            ),
+          ],
+        );
+
+        final result = await repo.resolveClaims(
+          pubkey: _pubkey,
+          freshTags: [
+            ['i', 'github:octocat', 'a'],
+          ],
+          cached: const CachedVerifiedClaims(
+            claims: [cachedOctocatClaim, removedCachedClaim],
+            isFresh: false,
+          ),
+        );
+
+        expect(result, equals([cachedOctocatClaim]));
+        verifyNever(() => dao.deleteVerification(any()));
+        verifyNever(
+          () => dao.upsertVerification(
+            pubkey: any(named: 'pubkey'),
+            verifiedClaimsJson: any(named: 'verifiedClaimsJson'),
+            checkedAtFloor: any(named: 'checkedAtFloor'),
+          ),
+        );
+      },
+    );
   });
 }

--- a/mobile/packages/profile_repository/test/src/profile_repository_identity_tags_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_identity_tags_test.dart
@@ -378,5 +378,65 @@ void main() {
         ]),
       );
     });
+
+    test(
+      'still returns the live kind-10011 tags when the cache write fails',
+      () async {
+        stubQuery([_identityEvent()]);
+        when(
+          () => identityEventsDao.upsertEvent(
+            pubkey: any(named: 'pubkey'),
+            tagsJson: any(named: 'tagsJson'),
+            sourceKind: any(named: 'sourceKind'),
+          ),
+        ).thenThrow(Exception('disk full'));
+
+        final tags = await repository.freshIdentityTags(
+          pubkey: _pubkey,
+          kind0Tags: _kind0Tags,
+        );
+
+        // Persistence is best-effort — a failed cache write must not
+        // discard tags already fetched from the relay.
+        expect(
+          tags,
+          equals([
+            ['i', 'github:modern', 'modern-proof'],
+          ]),
+        );
+      },
+    );
+
+    test(
+      'falls back to kind-0 i tags when the cache read throws, without '
+      'writing the fallback over the unreadable row',
+      () async {
+        stubQuery(const []);
+        when(
+          () => identityEventsDao.getEvent(_pubkey),
+        ).thenThrow(Exception('db closed'));
+
+        final tags = await repository.freshIdentityTags(
+          pubkey: _pubkey,
+          kind0Tags: _kind0Tags,
+        );
+
+        expect(
+          tags,
+          equals([
+            ['i', 'github:legacy', 'legacy-proof'],
+          ]),
+        );
+        // A blind upsert here could downgrade a valid but
+        // unreadable-this-tick kind-10011 row to a kind-0 source.
+        verifyNever(
+          () => identityEventsDao.upsertEvent(
+            pubkey: any(named: 'pubkey'),
+            tagsJson: any(named: 'tagsJson'),
+            sourceKind: any(named: 'sourceKind'),
+          ),
+        );
+      },
+    );
   });
 }

--- a/mobile/packages/profile_repository/test/src/profile_repository_identity_tags_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_identity_tags_test.dart
@@ -44,8 +44,6 @@ IdentityEventRow _row({
     pubkey: _pubkey,
     tagsJson: tagsJson,
     sourceKind: sourceKind,
-    eventCreatedAt: 1000,
-    fetchedAt: DateTime(2026),
   );
 }
 
@@ -77,7 +75,6 @@ void main() {
         pubkey: any(named: 'pubkey'),
         tagsJson: any(named: 'tagsJson'),
         sourceKind: any(named: 'sourceKind'),
-        eventCreatedAt: any(named: 'eventCreatedAt'),
       ),
     ).thenAnswer((_) async {});
   });
@@ -119,6 +116,26 @@ void main() {
       ).thenAnswer((_) async => _row(tagsJson: 'not json'));
       expect(await repository.cachedIdentityTags(_pubkey), isNull);
     });
+
+    test(
+      'returns null when the cached row is valid JSON of the wrong shape '
+      '(TypeError, not just Exception)',
+      () async {
+        // Valid JSON whose shape breaks the decode casts throws a TypeError
+        // (an Error, not an Exception); the decoder must still degrade to
+        // null rather than let it escape to a reportable crash.
+        for (final malformed in const ['{"not":"a list"}', '[1,2,3]']) {
+          when(
+            () => identityEventsDao.getEvent(_pubkey),
+          ).thenAnswer((_) async => _row(tagsJson: malformed));
+          expect(
+            await repository.cachedIdentityTags(_pubkey),
+            isNull,
+            reason: 'wrong-shape "$malformed" should decode to null',
+          );
+        }
+      },
+    );
   });
 
   group('ProfileRepository.freshIdentityTags', () {
@@ -152,9 +169,52 @@ void main() {
             pubkey: _pubkey,
             tagsJson: '[["i","github:newest","newest-proof"]]',
             sourceKind: ProfileRepository.identityEventKind,
-            eventCreatedAt: 200,
           ),
         ).called(1);
+      },
+    );
+
+    test(
+      'breaks a same-second tie by lowest event id (deterministic across '
+      'relay return order)',
+      () async {
+        final eventA = _identityEvent(
+          createdAt: 500,
+          tags: const [
+            ['i', 'github:aaa', 'proof-a'],
+          ],
+        );
+        final eventB = _identityEvent(
+          createdAt: 500,
+          tags: const [
+            ['i', 'github:bbb', 'proof-b'],
+          ],
+        );
+        // Both share created_at, so NIP-01 picks the lowest event id.
+        final winner = eventA.id.compareTo(eventB.id) < 0 ? eventA : eventB;
+        final expectedTags = [
+          for (final tag in winner.tags)
+            if (tag.length >= 3 && tag[0] == 'i') tag,
+        ];
+
+        stubQuery([eventA, eventB]);
+        expect(
+          await repository.freshIdentityTags(
+            pubkey: _pubkey,
+            kind0Tags: _kind0Tags,
+          ),
+          equals(expectedTags),
+        );
+
+        stubQuery([eventB, eventA]);
+        expect(
+          await repository.freshIdentityTags(
+            pubkey: _pubkey,
+            kind0Tags: _kind0Tags,
+          ),
+          equals(expectedTags),
+          reason: 'winner must not depend on relay return order',
+        );
       },
     );
 
@@ -189,7 +249,6 @@ void main() {
           pubkey: any(named: 'pubkey'),
           tagsJson: any(named: 'tagsJson'),
           sourceKind: any(named: 'sourceKind'),
-          eventCreatedAt: any(named: 'eventCreatedAt'),
         ),
       );
     });
@@ -219,7 +278,6 @@ void main() {
             pubkey: any(named: 'pubkey'),
             tagsJson: any(named: 'tagsJson'),
             sourceKind: any(named: 'sourceKind'),
-            eventCreatedAt: any(named: 'eventCreatedAt'),
           ),
         );
       },
@@ -237,7 +295,6 @@ void main() {
         final tags = await repository.freshIdentityTags(
           pubkey: _pubkey,
           kind0Tags: _kind0Tags,
-          kind0CreatedAt: 42,
         );
 
         expect(
@@ -251,7 +308,6 @@ void main() {
             pubkey: _pubkey,
             tagsJson: '[["i","github:legacy","legacy-proof"]]',
             sourceKind: 0,
-            eventCreatedAt: 42,
           ),
         ).called(1);
       },

--- a/mobile/packages/profile_repository/test/src/profile_repository_identity_tags_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_identity_tags_test.dart
@@ -1,0 +1,326 @@
+// ABOUTME: Tests for ProfileRepository's NIP-39 identity-tags source API —
+// ABOUTME: kind-10011 consult order, kind-0 fallback, and caching (#3936).
+
+import 'package:db_client/db_client.dart' hide Filter, ProfileStats;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:profile_repository/profile_repository.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockUserProfilesDao extends Mock implements UserProfilesDao {}
+
+class _MockIdentityEventsDao extends Mock implements IdentityEventsDao {}
+
+class _MockHttpClient extends Mock implements Client {}
+
+const _pubkey =
+    'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2';
+
+const _kind0Tags = [
+  ['i', 'github:legacy', 'legacy-proof'],
+  ['p', 'not-an-i-tag'],
+];
+
+Event _identityEvent({
+  int createdAt = 1000,
+  int kind = ProfileRepository.identityEventKind,
+  List<List<String>> tags = const [
+    ['i', 'github:modern', 'modern-proof'],
+    ['alt', 'External Identities'],
+  ],
+}) {
+  return Event(_pubkey, kind, tags, '', createdAt: createdAt);
+}
+
+IdentityEventRow _row({
+  required String tagsJson,
+  int sourceKind = ProfileRepository.identityEventKind,
+}) {
+  return IdentityEventRow(
+    pubkey: _pubkey,
+    tagsJson: tagsJson,
+    sourceKind: sourceKind,
+    eventCreatedAt: 1000,
+    fetchedAt: DateTime(2026),
+  );
+}
+
+void main() {
+  late _MockNostrClient nostrClient;
+  late _MockIdentityEventsDao identityEventsDao;
+  late ProfileRepository repository;
+
+  setUpAll(() {
+    registerFallbackValue(<Filter>[]);
+  });
+
+  ProfileRepository buildRepository({bool withDao = true}) {
+    return ProfileRepository(
+      nostrClient: nostrClient,
+      userProfilesDao: _MockUserProfilesDao(),
+      httpClient: _MockHttpClient(),
+      identityEventsDao: withDao ? identityEventsDao : null,
+    );
+  }
+
+  setUp(() {
+    nostrClient = _MockNostrClient();
+    identityEventsDao = _MockIdentityEventsDao();
+    repository = buildRepository();
+
+    when(
+      () => identityEventsDao.upsertEvent(
+        pubkey: any(named: 'pubkey'),
+        tagsJson: any(named: 'tagsJson'),
+        sourceKind: any(named: 'sourceKind'),
+        eventCreatedAt: any(named: 'eventCreatedAt'),
+      ),
+    ).thenAnswer((_) async {});
+  });
+
+  void stubQuery(List<Event> events) {
+    when(
+      () => nostrClient.queryEvents(any(), useCache: false),
+    ).thenAnswer((_) async => events);
+  }
+
+  group('ProfileRepository.cachedIdentityTags', () {
+    test('returns null when no DAO is wired', () async {
+      final bare = buildRepository(withDao: false);
+      expect(await bare.cachedIdentityTags(_pubkey), isNull);
+    });
+
+    test('returns null when no row is cached', () async {
+      when(
+        () => identityEventsDao.getEvent(_pubkey),
+      ).thenAnswer((_) async => null);
+      expect(await repository.cachedIdentityTags(_pubkey), isNull);
+    });
+
+    test('returns the decoded cached tags', () async {
+      when(() => identityEventsDao.getEvent(_pubkey)).thenAnswer(
+        (_) async => _row(tagsJson: '[["i","github:modern","modern-proof"]]'),
+      );
+      expect(
+        await repository.cachedIdentityTags(_pubkey),
+        equals([
+          ['i', 'github:modern', 'modern-proof'],
+        ]),
+      );
+    });
+
+    test('returns null when the cached row is corrupt', () async {
+      when(
+        () => identityEventsDao.getEvent(_pubkey),
+      ).thenAnswer((_) async => _row(tagsJson: 'not json'));
+      expect(await repository.cachedIdentityTags(_pubkey), isNull);
+    });
+  });
+
+  group('ProfileRepository.freshIdentityTags', () {
+    test(
+      'returns the live kind-10011 i tags and caches them, picking the '
+      'newest event',
+      () async {
+        stubQuery([
+          _identityEvent(createdAt: 100),
+          _identityEvent(
+            createdAt: 200,
+            tags: const [
+              ['i', 'github:newest', 'newest-proof'],
+            ],
+          ),
+        ]);
+
+        final tags = await repository.freshIdentityTags(
+          pubkey: _pubkey,
+          kind0Tags: _kind0Tags,
+        );
+
+        expect(
+          tags,
+          equals([
+            ['i', 'github:newest', 'newest-proof'],
+          ]),
+        );
+        verify(
+          () => identityEventsDao.upsertEvent(
+            pubkey: _pubkey,
+            tagsJson: '[["i","github:newest","newest-proof"]]',
+            sourceKind: ProfileRepository.identityEventKind,
+            eventCreatedAt: 200,
+          ),
+        ).called(1);
+      },
+    );
+
+    test('strips non-i tags from the live event', () async {
+      stubQuery([_identityEvent()]);
+
+      final tags = await repository.freshIdentityTags(
+        pubkey: _pubkey,
+        kind0Tags: _kind0Tags,
+      );
+
+      expect(
+        tags,
+        equals([
+          ['i', 'github:modern', 'modern-proof'],
+        ]),
+      );
+    });
+
+    test('works without a DAO (no persistence)', () async {
+      stubQuery([_identityEvent()]);
+      final bare = buildRepository(withDao: false);
+
+      final tags = await bare.freshIdentityTags(
+        pubkey: _pubkey,
+        kind0Tags: _kind0Tags,
+      );
+
+      expect(tags, hasLength(1));
+      verifyNever(
+        () => identityEventsDao.upsertEvent(
+          pubkey: any(named: 'pubkey'),
+          tagsJson: any(named: 'tagsJson'),
+          sourceKind: any(named: 'sourceKind'),
+          eventCreatedAt: any(named: 'eventCreatedAt'),
+        ),
+      );
+    });
+
+    test(
+      'keeps a cached kind-10011 row when the live query finds nothing '
+      '(transient relay miss must not downgrade the source)',
+      () async {
+        stubQuery(const []);
+        when(() => identityEventsDao.getEvent(_pubkey)).thenAnswer(
+          (_) async => _row(tagsJson: '[["i","github:modern","modern-proof"]]'),
+        );
+
+        final tags = await repository.freshIdentityTags(
+          pubkey: _pubkey,
+          kind0Tags: _kind0Tags,
+        );
+
+        expect(
+          tags,
+          equals([
+            ['i', 'github:modern', 'modern-proof'],
+          ]),
+        );
+        verifyNever(
+          () => identityEventsDao.upsertEvent(
+            pubkey: any(named: 'pubkey'),
+            tagsJson: any(named: 'tagsJson'),
+            sourceKind: any(named: 'sourceKind'),
+            eventCreatedAt: any(named: 'eventCreatedAt'),
+          ),
+        );
+      },
+    );
+
+    test(
+      'falls back to kind-0 i tags when a cached kind-10011 row is corrupt, '
+      'and caches the fallback',
+      () async {
+        stubQuery(const []);
+        when(
+          () => identityEventsDao.getEvent(_pubkey),
+        ).thenAnswer((_) async => _row(tagsJson: 'not json'));
+
+        final tags = await repository.freshIdentityTags(
+          pubkey: _pubkey,
+          kind0Tags: _kind0Tags,
+          kind0CreatedAt: 42,
+        );
+
+        expect(
+          tags,
+          equals([
+            ['i', 'github:legacy', 'legacy-proof'],
+          ]),
+        );
+        verify(
+          () => identityEventsDao.upsertEvent(
+            pubkey: _pubkey,
+            tagsJson: '[["i","github:legacy","legacy-proof"]]',
+            sourceKind: 0,
+            eventCreatedAt: 42,
+          ),
+        ).called(1);
+      },
+    );
+
+    test(
+      'falls back to kind-0 i tags when nothing is cached, and does not '
+      'treat a kind-0-sourced row as authoritative',
+      () async {
+        stubQuery(const []);
+        when(() => identityEventsDao.getEvent(_pubkey)).thenAnswer(
+          (_) async => _row(
+            tagsJson: '[["i","github:stale","stale-proof"]]',
+            sourceKind: 0,
+          ),
+        );
+
+        final tags = await repository.freshIdentityTags(
+          pubkey: _pubkey,
+          kind0Tags: _kind0Tags,
+        );
+
+        expect(
+          tags,
+          equals([
+            ['i', 'github:legacy', 'legacy-proof'],
+          ]),
+        );
+      },
+    );
+
+    test('falls back to kind-0 i tags when the relay query throws', () async {
+      when(
+        () => nostrClient.queryEvents(any(), useCache: false),
+      ).thenThrow(Exception('relay down'));
+      when(
+        () => identityEventsDao.getEvent(_pubkey),
+      ).thenAnswer((_) async => null);
+
+      final tags = await repository.freshIdentityTags(
+        pubkey: _pubkey,
+        kind0Tags: _kind0Tags,
+      );
+
+      expect(
+        tags,
+        equals([
+          ['i', 'github:legacy', 'legacy-proof'],
+        ]),
+      );
+    });
+
+    test('ignores non-kind-10011 events in the relay response', () async {
+      stubQuery([_identityEvent(kind: 0)]);
+      when(
+        () => identityEventsDao.getEvent(_pubkey),
+      ).thenAnswer((_) async => null);
+
+      final tags = await repository.freshIdentityTags(
+        pubkey: _pubkey,
+        kind0Tags: _kind0Tags,
+      );
+
+      expect(
+        tags,
+        equals([
+          ['i', 'github:legacy', 'legacy-proof'],
+        ]),
+      );
+    });
+  });
+}

--- a/mobile/packages/verifier_client/lib/src/verifier_client.dart
+++ b/mobile/packages/verifier_client/lib/src/verifier_client.dart
@@ -1,5 +1,5 @@
 // ABOUTME: VerifierClient — HTTP client over verifier.divine.video.
-// ABOUTME: Stateless: every call hits the network; server owns freshness.
+// ABOUTME: Stateless: every call hits the network; caching lives above.
 
 import 'dart:async';
 import 'dart:convert';
@@ -13,8 +13,10 @@ import 'package:verifier_client/src/models/verification_result.dart';
 
 /// HTTP client for `https://verifier.divine.video`.
 ///
-/// Stateless: every call hits the network. The verifier owns freshness via
-/// Cloudflare KV; intentionally no client-side cache, no retry, no rechecking.
+/// Stateless: every call hits the network — intentionally no cache, retry,
+/// or rechecking at this layer. The verifier owns server-side freshness via
+/// Cloudflare KV; the client-side verdict cache lives one layer up, in
+/// `IdentityClaimsRepository` (#3936).
 class VerifierClient {
   /// Creates a [VerifierClient] pointed at [baseUrl].
   ///

--- a/mobile/test/blocs/my_profile/my_profile_bloc_test.dart
+++ b/mobile/test/blocs/my_profile/my_profile_bloc_test.dart
@@ -1472,6 +1472,56 @@ void main() {
         ],
         errors: () => [isA<VerifierApiException>()],
       );
+
+      late Completer<List<IdentityClaim>> staleResolve;
+      blocTest<MyProfileBloc, MyProfileState>(
+        'uses the newest verification result when requests overlap',
+        seed: () => MyProfileUpdated(
+          profile: createTestProfile(),
+        ),
+        setUp: () {
+          staleResolve = Completer<List<IdentityClaim>>();
+          var resolveCall = 0;
+          addTearDown(() {
+            if (!staleResolve.isCompleted) {
+              staleResolve.complete(const [aliceClaim]);
+            }
+          });
+          when(
+            () => mockClaimsRepository.cachedVerifiedClaims(
+              pubkey: testPubkey,
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockClaimsRepository.resolveClaims(
+              pubkey: testPubkey,
+              freshTags: any(named: 'freshTags'),
+              cached: any(named: 'cached'),
+            ),
+          ).thenAnswer((_) {
+            resolveCall += 1;
+            if (resolveCall == 1) return staleResolve.future;
+            return Future.value(const [bobClaim]);
+          });
+        },
+        build: createClaimsBloc,
+        act: (bloc) async {
+          bloc.add(const VerifiedClaimsRequested());
+          await pumpEventQueue();
+          bloc.add(const VerifiedClaimsRequested());
+          await pumpEventQueue();
+          staleResolve.complete(const [aliceClaim]);
+          await pumpEventQueue();
+        },
+        expect: () => [
+          isA<MyProfileUpdated>().having(
+            (s) => s.verifiedClaims,
+            'verifiedClaims',
+            [bobClaim],
+          ),
+        ],
+      );
     });
   });
 }

--- a/mobile/test/blocs/my_profile/my_profile_bloc_test.dart
+++ b/mobile/test/blocs/my_profile/my_profile_bloc_test.dart
@@ -1360,10 +1360,19 @@ void main() {
         identity: 'alice',
         proof: 'proof-a',
       );
+      const bobClaim = IdentityClaim(
+        pubkey: testPubkey,
+        platform: 'telegram',
+        identity: 'bob',
+        proof: 'proof-b',
+      );
 
       setUp(() {
         mockClaimsRepository = _MockIdentityClaimsRepository();
         registerFallbackValue(<List<String>>[]);
+        registerFallbackValue(
+          const CachedVerifiedClaims(claims: [], isFresh: false),
+        );
         when(
           () => mockProfileRepository.cachedIdentityTags(testPubkey),
         ).thenAnswer((_) async => identityTags);
@@ -1371,7 +1380,6 @@ void main() {
           () => mockProfileRepository.freshIdentityTags(
             pubkey: testPubkey,
             kind0Tags: any(named: 'kind0Tags'),
-            kind0CreatedAt: any(named: 'kind0CreatedAt'),
           ),
         ).thenAnswer((_) async => identityTags);
       });
@@ -1383,8 +1391,7 @@ void main() {
       );
 
       blocTest<MyProfileBloc, MyProfileState>(
-        'renders cached claims without a verifier call when the snapshot '
-        'is fresh and covers every claim',
+        'renders the cached snapshot instantly, then the resolved claims',
         seed: () => MyProfileLoaded(
           profile: createTestProfile(),
           isFresh: true,
@@ -1401,24 +1408,32 @@ void main() {
               isFresh: true,
             ),
           );
+          when(
+            () => mockClaimsRepository.resolveClaims(
+              pubkey: testPubkey,
+              freshTags: any(named: 'freshTags'),
+              cached: any(named: 'cached'),
+            ),
+          ).thenAnswer((_) async => const [aliceClaim, bobClaim]);
         },
         build: createClaimsBloc,
         act: (bloc) => bloc.add(const VerifiedClaimsRequested()),
+        // Instant chips from the cached snapshot, then whatever the
+        // repository's stale-while-revalidate resolveClaims returns. The
+        // skip-or-verify decision itself lives in (and is tested at) the
+        // repository, not the bloc.
         expect: () => [
           isA<MyProfileLoaded>().having(
             (s) => s.verifiedClaims,
             'verifiedClaims',
             [aliceClaim],
           ),
+          isA<MyProfileLoaded>().having(
+            (s) => s.verifiedClaims,
+            'verifiedClaims',
+            [aliceClaim, bobClaim],
+          ),
         ],
-        verify: (_) {
-          verifyNever(
-            () => mockClaimsRepository.verifiedClaims(
-              pubkey: any(named: 'pubkey'),
-              tags: any(named: 'tags'),
-            ),
-          );
-        },
       );
 
       blocTest<MyProfileBloc, MyProfileState>(
@@ -1439,9 +1454,10 @@ void main() {
             ),
           );
           when(
-            () => mockClaimsRepository.verifiedClaims(
+            () => mockClaimsRepository.resolveClaims(
               pubkey: testPubkey,
-              tags: any(named: 'tags'),
+              freshTags: any(named: 'freshTags'),
+              cached: any(named: 'cached'),
             ),
           ).thenThrow(const VerifierApiException(503, 'down'));
         },
@@ -1455,42 +1471,6 @@ void main() {
           ),
         ],
         errors: () => [isA<VerifierApiException>()],
-      );
-
-      blocTest<MyProfileBloc, MyProfileState>(
-        'emits cached claims then re-verifies when the snapshot is stale',
-        seed: () => MyProfileLoaded(
-          profile: createTestProfile(),
-          isFresh: true,
-        ),
-        setUp: () {
-          when(
-            () => mockClaimsRepository.cachedVerifiedClaims(
-              pubkey: testPubkey,
-              tags: any(named: 'tags'),
-            ),
-          ).thenAnswer(
-            (_) async => const CachedVerifiedClaims(
-              claims: [],
-              isFresh: false,
-            ),
-          );
-          when(
-            () => mockClaimsRepository.verifiedClaims(
-              pubkey: testPubkey,
-              tags: identityTags,
-            ),
-          ).thenAnswer((_) async => const [aliceClaim]);
-        },
-        build: createClaimsBloc,
-        act: (bloc) => bloc.add(const VerifiedClaimsRequested()),
-        expect: () => [
-          isA<MyProfileLoaded>().having(
-            (s) => s.verifiedClaims,
-            'verifiedClaims',
-            [aliceClaim],
-          ),
-        ],
       );
     });
   });

--- a/mobile/test/blocs/my_profile/my_profile_bloc_test.dart
+++ b/mobile/test/blocs/my_profile/my_profile_bloc_test.dart
@@ -1370,6 +1370,7 @@ void main() {
       setUp(() {
         mockClaimsRepository = _MockIdentityClaimsRepository();
         registerFallbackValue(<List<String>>[]);
+        registerFallbackValue(const <IdentityClaim>[]);
         registerFallbackValue(
           const CachedVerifiedClaims(claims: [], isFresh: false),
         );
@@ -1413,6 +1414,7 @@ void main() {
               pubkey: testPubkey,
               freshTags: any(named: 'freshTags'),
               cached: any(named: 'cached'),
+              renderedClaims: any(named: 'renderedClaims'),
             ),
           ).thenAnswer((_) async => const [aliceClaim, bobClaim]);
         },
@@ -1458,6 +1460,7 @@ void main() {
               pubkey: testPubkey,
               freshTags: any(named: 'freshTags'),
               cached: any(named: 'cached'),
+              renderedClaims: any(named: 'renderedClaims'),
             ),
           ).thenThrow(const VerifierApiException(503, 'down'));
         },
@@ -1498,6 +1501,7 @@ void main() {
               pubkey: testPubkey,
               freshTags: any(named: 'freshTags'),
               cached: any(named: 'cached'),
+              renderedClaims: any(named: 'renderedClaims'),
             ),
           ).thenAnswer((_) {
             resolveCall += 1;
@@ -1519,6 +1523,346 @@ void main() {
             (s) => s.verifiedClaims,
             'verifiedClaims',
             [bobClaim],
+          ),
+        ],
+      );
+
+      blocTest<MyProfileBloc, MyProfileState>(
+        'keeps rendered chips when the instant-path intersection is empty '
+        'and the verifier is unreachable',
+        seed: () => MyProfileLoaded(
+          profile: createTestProfile(),
+          isFresh: true,
+          verifiedClaims: const [aliceClaim],
+        ),
+        setUp: () {
+          when(
+            () => mockClaimsRepository.cachedVerifiedClaims(
+              pubkey: testPubkey,
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer(
+            (_) async => const CachedVerifiedClaims(claims: [], isFresh: false),
+          );
+          when(
+            () => mockClaimsRepository.resolveClaims(
+              pubkey: testPubkey,
+              freshTags: any(named: 'freshTags'),
+              cached: any(named: 'cached'),
+              renderedClaims: any(named: 'renderedClaims'),
+            ),
+          ).thenThrow(const VerifierApiException(503, 'down'));
+        },
+        build: createClaimsBloc,
+        act: (bloc) => bloc.add(const VerifiedClaimsRequested()),
+        // An empty snapshot intersection is not a confirmed negative, so
+        // the non-authoritative instant path must not clear visible chips.
+        expect: () => const <MyProfileState>[],
+        errors: () => [isA<VerifierApiException>()],
+      );
+
+      blocTest<MyProfileBloc, MyProfileState>(
+        'passes the rendered claims to resolveClaims so a rate-limited '
+        'outcome can preserve them',
+        seed: () => MyProfileUpdated(
+          profile: createTestProfile(),
+          verifiedClaims: const [aliceClaim],
+        ),
+        setUp: () {
+          when(
+            () => mockClaimsRepository.cachedVerifiedClaims(
+              pubkey: testPubkey,
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockClaimsRepository.resolveClaims(
+              pubkey: testPubkey,
+              freshTags: any(named: 'freshTags'),
+              cached: any(named: 'cached'),
+              renderedClaims: any(named: 'renderedClaims'),
+            ),
+          ).thenAnswer((_) async => const [aliceClaim]);
+        },
+        build: createClaimsBloc,
+        act: (bloc) => bloc.add(const VerifiedClaimsRequested()),
+        expect: () => const <MyProfileState>[],
+        verify: (_) {
+          verify(
+            () => mockClaimsRepository.resolveClaims(
+              pubkey: testPubkey,
+              freshTags: any(named: 'freshTags'),
+              cached: null,
+              renderedClaims: const [aliceClaim],
+            ),
+          ).called(1);
+        },
+      );
+
+      blocTest<MyProfileBloc, MyProfileState>(
+        'carries rendered claims through profile stream ticks',
+        seed: () => MyProfileLoaded(
+          profile: createTestProfile(),
+          isFresh: true,
+          verifiedClaims: const [aliceClaim],
+        ),
+        setUp: () {
+          when(
+            () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
+          ).thenAnswer((_) async => createTestProfile());
+          when(
+            () => mockProfileRepository.watchProfile(pubkey: testPubkey),
+          ).thenAnswer((_) => Stream.value(createTestProfile()));
+          when(
+            () => mockClaimsRepository.cachedVerifiedClaims(
+              pubkey: testPubkey,
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockClaimsRepository.resolveClaims(
+              pubkey: testPubkey,
+              freshTags: any(named: 'freshTags'),
+              cached: any(named: 'cached'),
+              renderedClaims: any(named: 'renderedClaims'),
+            ),
+          ).thenAnswer((_) async => const [aliceClaim]);
+        },
+        build: createClaimsBloc,
+        act: (bloc) => bloc.add(const MyProfileSubscriptionRequested()),
+        expect: () => [
+          isA<MyProfileLoading>().having(
+            (s) => s.verifiedClaims,
+            'verifiedClaims',
+            [aliceClaim],
+          ),
+          isA<MyProfileUpdated>().having(
+            (s) => s.verifiedClaims,
+            'verifiedClaims',
+            [aliceClaim],
+          ),
+        ],
+      );
+
+      blocTest<MyProfileBloc, MyProfileState>(
+        'unions instant-path chips rendered-first instead of replacing',
+        seed: () => MyProfileLoaded(
+          profile: createTestProfile(),
+          isFresh: true,
+          verifiedClaims: const [aliceClaim],
+        ),
+        setUp: () {
+          when(
+            () => mockClaimsRepository.cachedVerifiedClaims(
+              pubkey: testPubkey,
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer(
+            (_) async => const CachedVerifiedClaims(
+              claims: [bobClaim],
+              isFresh: false,
+            ),
+          );
+          when(
+            () => mockClaimsRepository.resolveClaims(
+              pubkey: testPubkey,
+              freshTags: any(named: 'freshTags'),
+              cached: any(named: 'cached'),
+              renderedClaims: any(named: 'renderedClaims'),
+            ),
+          ).thenAnswer((_) async => const [aliceClaim, bobClaim]);
+        },
+        build: createClaimsBloc,
+        act: (bloc) => bloc.add(const VerifiedClaimsRequested()),
+        // Rendered-first union keeps chip order stable, so the
+        // authoritative resolve emit is Equatable-suppressed afterwards.
+        expect: () => [
+          isA<MyProfileLoaded>().having(
+            (s) => s.verifiedClaims,
+            'verifiedClaims',
+            [aliceClaim, bobClaim],
+          ),
+        ],
+      );
+
+      blocTest<MyProfileBloc, MyProfileState>(
+        'clears chips when the authoritative resolve confirms a negative',
+        seed: () => MyProfileLoaded(
+          profile: createTestProfile(),
+          isFresh: true,
+          verifiedClaims: const [aliceClaim],
+        ),
+        setUp: () {
+          when(
+            () => mockClaimsRepository.cachedVerifiedClaims(
+              pubkey: testPubkey,
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockClaimsRepository.resolveClaims(
+              pubkey: testPubkey,
+              freshTags: any(named: 'freshTags'),
+              cached: any(named: 'cached'),
+              renderedClaims: any(named: 'renderedClaims'),
+            ),
+          ).thenAnswer((_) async => const <IdentityClaim>[]);
+        },
+        build: createClaimsBloc,
+        act: (bloc) => bloc.add(const VerifiedClaimsRequested()),
+        expect: () => [
+          isA<MyProfileLoaded>().having(
+            (s) => s.verifiedClaims,
+            'verifiedClaims',
+            isEmpty,
+          ),
+        ],
+      );
+
+      blocTest<MyProfileBloc, MyProfileState>(
+        'keeps chips and skips the resolve when the claims source read fails',
+        seed: () => MyProfileLoaded(
+          profile: createTestProfile(),
+          isFresh: true,
+          verifiedClaims: const [aliceClaim],
+        ),
+        setUp: () {
+          when(
+            () => mockClaimsRepository.cachedVerifiedClaims(
+              pubkey: testPubkey,
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockProfileRepository.freshIdentityTags(
+              pubkey: testPubkey,
+              kind0Tags: any(named: 'kind0Tags'),
+            ),
+          ).thenThrow(Exception('db closed'));
+        },
+        build: createClaimsBloc,
+        act: (bloc) => bloc.add(const VerifiedClaimsRequested()),
+        // Resolving against the kind-0 fallback could authoritatively
+        // clear kind-10011 chips, so the degraded tick keeps
+        // last-known-good and does not consult the verifier at all.
+        expect: () => const <MyProfileState>[],
+        errors: () => [isA<Exception>()],
+        verify: (_) {
+          verifyNever(
+            () => mockClaimsRepository.resolveClaims(
+              pubkey: any(named: 'pubkey'),
+              freshTags: any(named: 'freshTags'),
+              cached: any(named: 'cached'),
+              renderedClaims: any(named: 'renderedClaims'),
+            ),
+          );
+        },
+      );
+
+      blocTest<MyProfileBloc, MyProfileState>(
+        'does not double-render one identity when the cached casing differs',
+        seed: () => MyProfileLoaded(
+          profile: createTestProfile(),
+          isFresh: true,
+          verifiedClaims: const [aliceClaim],
+        ),
+        setUp: () {
+          when(
+            () => mockClaimsRepository.cachedVerifiedClaims(
+              pubkey: testPubkey,
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer(
+            (_) async => const CachedVerifiedClaims(
+              claims: [
+                IdentityClaim(
+                  pubkey: testPubkey,
+                  platform: 'GitHub',
+                  identity: 'Alice',
+                  proof: 'rotated-proof',
+                ),
+              ],
+              isFresh: false,
+            ),
+          );
+          when(
+            () => mockClaimsRepository.resolveClaims(
+              pubkey: testPubkey,
+              freshTags: any(named: 'freshTags'),
+              cached: any(named: 'cached'),
+              renderedClaims: any(named: 'renderedClaims'),
+            ),
+          ).thenThrow(const VerifierApiException(503, 'down'));
+        },
+        build: createClaimsBloc,
+        act: (bloc) => bloc.add(const VerifiedClaimsRequested()),
+        // The cached claim is the same platform:identity under different
+        // casing/proof — the union must not produce a second chip.
+        expect: () => const <MyProfileState>[],
+        errors: () => [isA<VerifierApiException>()],
+      );
+
+      late Completer<UserProfile?> cachedProfileGate;
+      blocTest<MyProfileBloc, MyProfileState>(
+        'reads claims after the cache await so a resolve landing mid-load '
+        'is not clobbered',
+        seed: () => MyProfileLoaded(
+          profile: createTestProfile(),
+          isFresh: true,
+          verifiedClaims: const [aliceClaim],
+        ),
+        setUp: () {
+          cachedProfileGate = Completer<UserProfile?>();
+          addTearDown(() {
+            if (!cachedProfileGate.isCompleted) {
+              cachedProfileGate.complete(null);
+            }
+          });
+          when(
+            () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
+          ).thenAnswer((_) => cachedProfileGate.future);
+          when(
+            () => mockProfileRepository.fetchFreshProfile(pubkey: testPubkey),
+          ).thenAnswer((_) async => createTestProfile());
+          when(
+            () => mockClaimsRepository.cachedVerifiedClaims(
+              pubkey: testPubkey,
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockClaimsRepository.resolveClaims(
+              pubkey: testPubkey,
+              freshTags: any(named: 'freshTags'),
+              cached: any(named: 'cached'),
+              renderedClaims: any(named: 'renderedClaims'),
+            ),
+          ).thenAnswer((_) async => const [aliceClaim, bobClaim]);
+        },
+        build: createClaimsBloc,
+        act: (bloc) async {
+          bloc.add(const MyProfileLoadRequested());
+          await pumpEventQueue();
+          bloc.add(const VerifiedClaimsRequested());
+          await pumpEventQueue();
+          cachedProfileGate.complete(createTestProfile());
+          await pumpEventQueue();
+        },
+        expect: () => [
+          isA<MyProfileLoaded>().having(
+            (s) => s.verifiedClaims,
+            'verifiedClaims',
+            [aliceClaim, bobClaim],
+          ),
+          isA<MyProfileLoading>().having(
+            (s) => s.verifiedClaims,
+            'verifiedClaims',
+            [aliceClaim, bobClaim],
+          ),
+          isA<MyProfileLoaded>().having(
+            (s) => s.verifiedClaims,
+            'verifiedClaims',
+            [aliceClaim, bobClaim],
           ),
         ],
       );

--- a/mobile/test/blocs/my_profile/my_profile_bloc_test.dart
+++ b/mobile/test/blocs/my_profile/my_profile_bloc_test.dart
@@ -1347,5 +1347,154 @@ void main() {
         },
       );
     });
+
+    group('VerifiedClaimsRequested (SWR cache, #3936)', () {
+      late _MockIdentityClaimsRepository mockClaimsRepository;
+
+      const identityTags = [
+        ['i', 'github:alice', 'proof-a'],
+      ];
+      const aliceClaim = IdentityClaim(
+        pubkey: testPubkey,
+        platform: 'github',
+        identity: 'alice',
+        proof: 'proof-a',
+      );
+
+      setUp(() {
+        mockClaimsRepository = _MockIdentityClaimsRepository();
+        registerFallbackValue(<List<String>>[]);
+        when(
+          () => mockProfileRepository.cachedIdentityTags(testPubkey),
+        ).thenAnswer((_) async => identityTags);
+        when(
+          () => mockProfileRepository.freshIdentityTags(
+            pubkey: testPubkey,
+            kind0Tags: any(named: 'kind0Tags'),
+            kind0CreatedAt: any(named: 'kind0CreatedAt'),
+          ),
+        ).thenAnswer((_) async => identityTags);
+      });
+
+      MyProfileBloc createClaimsBloc() => MyProfileBloc(
+        profileRepository: mockProfileRepository,
+        pubkey: testPubkey,
+        identityClaimsRepository: mockClaimsRepository,
+      );
+
+      blocTest<MyProfileBloc, MyProfileState>(
+        'renders cached claims without a verifier call when the snapshot '
+        'is fresh and covers every claim',
+        seed: () => MyProfileLoaded(
+          profile: createTestProfile(),
+          isFresh: true,
+        ),
+        setUp: () {
+          when(
+            () => mockClaimsRepository.cachedVerifiedClaims(
+              pubkey: testPubkey,
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer(
+            (_) async => const CachedVerifiedClaims(
+              claims: [aliceClaim],
+              isFresh: true,
+            ),
+          );
+        },
+        build: createClaimsBloc,
+        act: (bloc) => bloc.add(const VerifiedClaimsRequested()),
+        expect: () => [
+          isA<MyProfileLoaded>().having(
+            (s) => s.verifiedClaims,
+            'verifiedClaims',
+            [aliceClaim],
+          ),
+        ],
+        verify: (_) {
+          verifyNever(
+            () => mockClaimsRepository.verifiedClaims(
+              pubkey: any(named: 'pubkey'),
+              tags: any(named: 'tags'),
+            ),
+          );
+        },
+      );
+
+      blocTest<MyProfileBloc, MyProfileState>(
+        'keeps last-known-good claims when the verifier fails',
+        seed: () => MyProfileUpdated(
+          profile: createTestProfile(),
+        ),
+        setUp: () {
+          when(
+            () => mockClaimsRepository.cachedVerifiedClaims(
+              pubkey: testPubkey,
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer(
+            (_) async => const CachedVerifiedClaims(
+              claims: [aliceClaim],
+              isFresh: false,
+            ),
+          );
+          when(
+            () => mockClaimsRepository.verifiedClaims(
+              pubkey: testPubkey,
+              tags: any(named: 'tags'),
+            ),
+          ).thenThrow(const VerifierApiException(503, 'down'));
+        },
+        build: createClaimsBloc,
+        act: (bloc) => bloc.add(const VerifiedClaimsRequested()),
+        expect: () => [
+          isA<MyProfileUpdated>().having(
+            (s) => s.verifiedClaims,
+            'verifiedClaims',
+            [aliceClaim],
+          ),
+        ],
+        errors: () => [isA<VerifierApiException>()],
+      );
+
+      blocTest<MyProfileBloc, MyProfileState>(
+        'emits cached claims then re-verifies when the snapshot is stale',
+        seed: () => MyProfileLoaded(
+          profile: createTestProfile(),
+          isFresh: true,
+        ),
+        setUp: () {
+          when(
+            () => mockClaimsRepository.cachedVerifiedClaims(
+              pubkey: testPubkey,
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer(
+            (_) async => const CachedVerifiedClaims(
+              claims: [],
+              isFresh: false,
+            ),
+          );
+          when(
+            () => mockClaimsRepository.verifiedClaims(
+              pubkey: testPubkey,
+              tags: identityTags,
+            ),
+          ).thenAnswer((_) async => const [aliceClaim]);
+        },
+        build: createClaimsBloc,
+        act: (bloc) => bloc.add(const VerifiedClaimsRequested()),
+        expect: () => [
+          isA<MyProfileLoaded>().having(
+            (s) => s.verifiedClaims,
+            'verifiedClaims',
+            [aliceClaim],
+          ),
+        ],
+      );
+    });
   });
 }
+
+class _MockIdentityClaimsRepository extends Mock
+    implements IdentityClaimsRepository {}

--- a/mobile/test/blocs/other_profile/other_profile_bloc_test.dart
+++ b/mobile/test/blocs/other_profile/other_profile_bloc_test.dart
@@ -833,5 +833,291 @@ void main() {
         expect(event1, equals(event2));
       });
     });
+
+    group('VerifiedClaimsRequested (SWR cache, #3936)', () {
+      late _MockIdentityClaimsRepository mockClaimsRepository;
+
+      const identityTags = [
+        ['i', 'github:alice', 'proof-a'],
+      ];
+      const aliceClaim = IdentityClaim(
+        pubkey: testPubkey,
+        platform: 'github',
+        identity: 'alice',
+        proof: 'proof-a',
+      );
+      const bobClaim = IdentityClaim(
+        pubkey: testPubkey,
+        platform: 'telegram',
+        identity: 'bob',
+        proof: 'proof-b',
+      );
+
+      setUp(() {
+        mockClaimsRepository = _MockIdentityClaimsRepository();
+        registerFallbackValue(<List<String>>[]);
+        when(
+          () => mockProfileRepository.cachedIdentityTags(testPubkey),
+        ).thenAnswer((_) async => identityTags);
+        when(
+          () => mockProfileRepository.freshIdentityTags(
+            pubkey: testPubkey,
+            kind0Tags: any(named: 'kind0Tags'),
+            kind0CreatedAt: any(named: 'kind0CreatedAt'),
+          ),
+        ).thenAnswer((_) async => identityTags);
+      });
+
+      OtherProfileBloc createClaimsBloc() => OtherProfileBloc(
+        profileRepository: mockProfileRepository,
+        pubkey: testPubkey,
+        contentBlocklistRepository: mockBlocklistRepository,
+        currentUserPubkey: testCurrentUserPubkey,
+        followRepository: mockFollowRepository,
+        identityClaimsRepository: mockClaimsRepository,
+      );
+
+      blocTest<OtherProfileBloc, OtherProfileState>(
+        'renders cached claims without a verifier call when the snapshot '
+        'is fresh and covers every claim',
+        seed: () => OtherProfileLoaded(
+          profile: createTestProfile(),
+          isFresh: true,
+        ),
+        setUp: () {
+          when(
+            () => mockClaimsRepository.cachedVerifiedClaims(
+              pubkey: testPubkey,
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer(
+            (_) async => const CachedVerifiedClaims(
+              claims: [aliceClaim],
+              isFresh: true,
+            ),
+          );
+        },
+        build: createClaimsBloc,
+        act: (bloc) => bloc.add(const VerifiedClaimsRequested()),
+        expect: () => [
+          isA<OtherProfileLoaded>().having(
+            (s) => s.verifiedClaims,
+            'verifiedClaims',
+            [aliceClaim],
+          ),
+        ],
+        verify: (_) {
+          verifyNever(
+            () => mockClaimsRepository.verifiedClaims(
+              pubkey: any(named: 'pubkey'),
+              tags: any(named: 'tags'),
+            ),
+          );
+        },
+      );
+
+      blocTest<OtherProfileBloc, OtherProfileState>(
+        'emits cached claims then re-verifies when the snapshot is stale',
+        seed: () => OtherProfileLoaded(
+          profile: createTestProfile(),
+          isFresh: true,
+        ),
+        setUp: () {
+          when(
+            () => mockClaimsRepository.cachedVerifiedClaims(
+              pubkey: testPubkey,
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer(
+            (_) async => const CachedVerifiedClaims(
+              claims: [aliceClaim],
+              isFresh: false,
+            ),
+          );
+          when(
+            () => mockClaimsRepository.verifiedClaims(
+              pubkey: testPubkey,
+              tags: identityTags,
+            ),
+          ).thenAnswer((_) async => const [aliceClaim, bobClaim]);
+        },
+        build: createClaimsBloc,
+        act: (bloc) => bloc.add(const VerifiedClaimsRequested()),
+        expect: () => [
+          isA<OtherProfileLoaded>().having(
+            (s) => s.verifiedClaims,
+            'verifiedClaims',
+            [aliceClaim],
+          ),
+          isA<OtherProfileLoaded>().having(
+            (s) => s.verifiedClaims,
+            'verifiedClaims',
+            [aliceClaim, bobClaim],
+          ),
+        ],
+      );
+
+      blocTest<OtherProfileBloc, OtherProfileState>(
+        're-verifies when a fresh snapshot does not cover a new claim',
+        seed: () => OtherProfileLoaded(
+          profile: createTestProfile(),
+          isFresh: true,
+        ),
+        setUp: () {
+          when(
+            () => mockProfileRepository.freshIdentityTags(
+              pubkey: testPubkey,
+              kind0Tags: any(named: 'kind0Tags'),
+              kind0CreatedAt: any(named: 'kind0CreatedAt'),
+            ),
+          ).thenAnswer(
+            (_) async => const [
+              ['i', 'github:alice', 'proof-a'],
+              ['i', 'telegram:bob', 'proof-b'],
+            ],
+          );
+          when(
+            () => mockClaimsRepository.cachedVerifiedClaims(
+              pubkey: testPubkey,
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer(
+            (_) async => const CachedVerifiedClaims(
+              claims: [aliceClaim],
+              isFresh: true,
+            ),
+          );
+          when(
+            () => mockClaimsRepository.verifiedClaims(
+              pubkey: testPubkey,
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer((_) async => const [aliceClaim, bobClaim]);
+        },
+        build: createClaimsBloc,
+        act: (bloc) => bloc.add(const VerifiedClaimsRequested()),
+        expect: () => [
+          isA<OtherProfileLoaded>().having(
+            (s) => s.verifiedClaims,
+            'verifiedClaims',
+            [aliceClaim],
+          ),
+          isA<OtherProfileLoaded>().having(
+            (s) => s.verifiedClaims,
+            'verifiedClaims',
+            [aliceClaim, bobClaim],
+          ),
+        ],
+      );
+
+      blocTest<OtherProfileBloc, OtherProfileState>(
+        'keeps last-known-good claims when the verifier fails',
+        seed: () => OtherProfileLoaded(
+          profile: createTestProfile(),
+          isFresh: true,
+        ),
+        setUp: () {
+          when(
+            () => mockClaimsRepository.cachedVerifiedClaims(
+              pubkey: testPubkey,
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer(
+            (_) async => const CachedVerifiedClaims(
+              claims: [aliceClaim],
+              isFresh: false,
+            ),
+          );
+          when(
+            () => mockClaimsRepository.verifiedClaims(
+              pubkey: testPubkey,
+              tags: any(named: 'tags'),
+            ),
+          ).thenThrow(const VerifierApiException(503, 'down'));
+        },
+        build: createClaimsBloc,
+        act: (bloc) => bloc.add(const VerifiedClaimsRequested()),
+        expect: () => [
+          isA<OtherProfileLoaded>().having(
+            (s) => s.verifiedClaims,
+            'verifiedClaims',
+            [aliceClaim],
+          ),
+        ],
+        errors: () => [isA<VerifierApiException>()],
+      );
+
+      blocTest<OtherProfileBloc, OtherProfileState>(
+        'degrades to the network path when the cache read throws',
+        seed: () => OtherProfileLoaded(
+          profile: createTestProfile(),
+          isFresh: true,
+        ),
+        setUp: () {
+          when(
+            () => mockProfileRepository.cachedIdentityTags(testPubkey),
+          ).thenThrow(Exception('db corrupt'));
+          when(
+            () => mockClaimsRepository.verifiedClaims(
+              pubkey: testPubkey,
+              tags: identityTags,
+            ),
+          ).thenAnswer((_) async => const [aliceClaim]);
+        },
+        build: createClaimsBloc,
+        act: (bloc) => bloc.add(const VerifiedClaimsRequested()),
+        expect: () => [
+          isA<OtherProfileLoaded>().having(
+            (s) => s.verifiedClaims,
+            'verifiedClaims',
+            [aliceClaim],
+          ),
+        ],
+        errors: () => [isA<Exception>()],
+      );
+
+      blocTest<OtherProfileBloc, OtherProfileState>(
+        'carries claims through refresh instead of dropping them',
+        seed: () => OtherProfileLoaded(
+          profile: createTestProfile(),
+          isFresh: true,
+          verifiedClaims: const [aliceClaim],
+        ),
+        setUp: () {
+          when(
+            () => mockProfileRepository.fetchFreshProfile(
+              pubkey: testPubkey,
+              requireRawKind0: any(named: 'requireRawKind0'),
+            ),
+          ).thenAnswer((_) async => createTestProfile());
+          when(
+            () => mockClaimsRepository.cachedVerifiedClaims(
+              pubkey: testPubkey,
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer(
+            (_) async => const CachedVerifiedClaims(
+              claims: [aliceClaim],
+              isFresh: true,
+            ),
+          );
+        },
+        build: createClaimsBloc,
+        act: (bloc) => bloc.add(const OtherProfileRefreshRequested()),
+        expect: () => [
+          isA<OtherProfileLoading>().having(
+            (s) => s.verifiedClaims,
+            'verifiedClaims',
+            [aliceClaim],
+          ),
+          isA<OtherProfileLoaded>()
+              .having((s) => s.isFresh, 'isFresh', true)
+              .having((s) => s.verifiedClaims, 'verifiedClaims', [aliceClaim]),
+        ],
+      );
+    });
   });
 }
+
+class _MockIdentityClaimsRepository extends Mock
+    implements IdentityClaimsRepository {}

--- a/mobile/test/blocs/other_profile/other_profile_bloc_test.dart
+++ b/mobile/test/blocs/other_profile/other_profile_bloc_test.dart
@@ -1002,6 +1002,57 @@ void main() {
         errors: () => [isA<Exception>()],
       );
 
+      late Completer<List<IdentityClaim>> staleResolve;
+      blocTest<OtherProfileBloc, OtherProfileState>(
+        'uses the newest verification result when requests overlap',
+        seed: () => OtherProfileLoaded(
+          profile: createTestProfile(),
+          isFresh: true,
+        ),
+        setUp: () {
+          staleResolve = Completer<List<IdentityClaim>>();
+          var resolveCall = 0;
+          addTearDown(() {
+            if (!staleResolve.isCompleted) {
+              staleResolve.complete(const [aliceClaim]);
+            }
+          });
+          when(
+            () => mockClaimsRepository.cachedVerifiedClaims(
+              pubkey: testPubkey,
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockClaimsRepository.resolveClaims(
+              pubkey: testPubkey,
+              freshTags: any(named: 'freshTags'),
+              cached: any(named: 'cached'),
+            ),
+          ).thenAnswer((_) {
+            resolveCall += 1;
+            if (resolveCall == 1) return staleResolve.future;
+            return Future.value(const [bobClaim]);
+          });
+        },
+        build: createClaimsBloc,
+        act: (bloc) async {
+          bloc.add(const VerifiedClaimsRequested());
+          await pumpEventQueue();
+          bloc.add(const VerifiedClaimsRequested());
+          await pumpEventQueue();
+          staleResolve.complete(const [aliceClaim]);
+          await pumpEventQueue();
+        },
+        expect: () => [
+          isA<OtherProfileLoaded>().having(
+            (s) => s.verifiedClaims,
+            'verifiedClaims',
+            [bobClaim],
+          ),
+        ],
+      );
+
       blocTest<OtherProfileBloc, OtherProfileState>(
         'carries claims through refresh instead of dropping them',
         seed: () => OtherProfileLoaded(

--- a/mobile/test/blocs/other_profile/other_profile_bloc_test.dart
+++ b/mobile/test/blocs/other_profile/other_profile_bloc_test.dart
@@ -856,6 +856,9 @@ void main() {
       setUp(() {
         mockClaimsRepository = _MockIdentityClaimsRepository();
         registerFallbackValue(<List<String>>[]);
+        registerFallbackValue(
+          const CachedVerifiedClaims(claims: [], isFresh: false),
+        );
         when(
           () => mockProfileRepository.cachedIdentityTags(testPubkey),
         ).thenAnswer((_) async => identityTags);
@@ -863,7 +866,6 @@ void main() {
           () => mockProfileRepository.freshIdentityTags(
             pubkey: testPubkey,
             kind0Tags: any(named: 'kind0Tags'),
-            kind0CreatedAt: any(named: 'kind0CreatedAt'),
           ),
         ).thenAnswer((_) async => identityTags);
       });
@@ -878,8 +880,7 @@ void main() {
       );
 
       blocTest<OtherProfileBloc, OtherProfileState>(
-        'renders cached claims without a verifier call when the snapshot '
-        'is fresh and covers every claim',
+        'renders the cached snapshot instantly, then the resolved claims',
         seed: () => OtherProfileLoaded(
           profile: createTestProfile(),
           isFresh: true,
@@ -896,118 +897,41 @@ void main() {
               isFresh: true,
             ),
           );
+          when(
+            () => mockClaimsRepository.resolveClaims(
+              pubkey: testPubkey,
+              freshTags: any(named: 'freshTags'),
+              cached: any(named: 'cached'),
+            ),
+          ).thenAnswer((_) async => const [aliceClaim, bobClaim]);
         },
         build: createClaimsBloc,
         act: (bloc) => bloc.add(const VerifiedClaimsRequested()),
+        // Instant chips from the cached snapshot, then whatever the
+        // repository's stale-while-revalidate resolveClaims returns. The
+        // skip-or-verify decision itself lives in (and is tested at) the
+        // repository, not the bloc.
         expect: () => [
           isA<OtherProfileLoaded>().having(
             (s) => s.verifiedClaims,
             'verifiedClaims',
             [aliceClaim],
+          ),
+          isA<OtherProfileLoaded>().having(
+            (s) => s.verifiedClaims,
+            'verifiedClaims',
+            [aliceClaim, bobClaim],
           ),
         ],
         verify: (_) {
-          verifyNever(
-            () => mockClaimsRepository.verifiedClaims(
-              pubkey: any(named: 'pubkey'),
-              tags: any(named: 'tags'),
+          verify(
+            () => mockClaimsRepository.resolveClaims(
+              pubkey: testPubkey,
+              freshTags: any(named: 'freshTags'),
+              cached: any(named: 'cached'),
             ),
-          );
+          ).called(1);
         },
-      );
-
-      blocTest<OtherProfileBloc, OtherProfileState>(
-        'emits cached claims then re-verifies when the snapshot is stale',
-        seed: () => OtherProfileLoaded(
-          profile: createTestProfile(),
-          isFresh: true,
-        ),
-        setUp: () {
-          when(
-            () => mockClaimsRepository.cachedVerifiedClaims(
-              pubkey: testPubkey,
-              tags: any(named: 'tags'),
-            ),
-          ).thenAnswer(
-            (_) async => const CachedVerifiedClaims(
-              claims: [aliceClaim],
-              isFresh: false,
-            ),
-          );
-          when(
-            () => mockClaimsRepository.verifiedClaims(
-              pubkey: testPubkey,
-              tags: identityTags,
-            ),
-          ).thenAnswer((_) async => const [aliceClaim, bobClaim]);
-        },
-        build: createClaimsBloc,
-        act: (bloc) => bloc.add(const VerifiedClaimsRequested()),
-        expect: () => [
-          isA<OtherProfileLoaded>().having(
-            (s) => s.verifiedClaims,
-            'verifiedClaims',
-            [aliceClaim],
-          ),
-          isA<OtherProfileLoaded>().having(
-            (s) => s.verifiedClaims,
-            'verifiedClaims',
-            [aliceClaim, bobClaim],
-          ),
-        ],
-      );
-
-      blocTest<OtherProfileBloc, OtherProfileState>(
-        're-verifies when a fresh snapshot does not cover a new claim',
-        seed: () => OtherProfileLoaded(
-          profile: createTestProfile(),
-          isFresh: true,
-        ),
-        setUp: () {
-          when(
-            () => mockProfileRepository.freshIdentityTags(
-              pubkey: testPubkey,
-              kind0Tags: any(named: 'kind0Tags'),
-              kind0CreatedAt: any(named: 'kind0CreatedAt'),
-            ),
-          ).thenAnswer(
-            (_) async => const [
-              ['i', 'github:alice', 'proof-a'],
-              ['i', 'telegram:bob', 'proof-b'],
-            ],
-          );
-          when(
-            () => mockClaimsRepository.cachedVerifiedClaims(
-              pubkey: testPubkey,
-              tags: any(named: 'tags'),
-            ),
-          ).thenAnswer(
-            (_) async => const CachedVerifiedClaims(
-              claims: [aliceClaim],
-              isFresh: true,
-            ),
-          );
-          when(
-            () => mockClaimsRepository.verifiedClaims(
-              pubkey: testPubkey,
-              tags: any(named: 'tags'),
-            ),
-          ).thenAnswer((_) async => const [aliceClaim, bobClaim]);
-        },
-        build: createClaimsBloc,
-        act: (bloc) => bloc.add(const VerifiedClaimsRequested()),
-        expect: () => [
-          isA<OtherProfileLoaded>().having(
-            (s) => s.verifiedClaims,
-            'verifiedClaims',
-            [aliceClaim],
-          ),
-          isA<OtherProfileLoaded>().having(
-            (s) => s.verifiedClaims,
-            'verifiedClaims',
-            [aliceClaim, bobClaim],
-          ),
-        ],
       );
 
       blocTest<OtherProfileBloc, OtherProfileState>(
@@ -1029,9 +953,10 @@ void main() {
             ),
           );
           when(
-            () => mockClaimsRepository.verifiedClaims(
+            () => mockClaimsRepository.resolveClaims(
               pubkey: testPubkey,
-              tags: any(named: 'tags'),
+              freshTags: any(named: 'freshTags'),
+              cached: any(named: 'cached'),
             ),
           ).thenThrow(const VerifierApiException(503, 'down'));
         },
@@ -1058,9 +983,10 @@ void main() {
             () => mockProfileRepository.cachedIdentityTags(testPubkey),
           ).thenThrow(Exception('db corrupt'));
           when(
-            () => mockClaimsRepository.verifiedClaims(
+            () => mockClaimsRepository.resolveClaims(
               pubkey: testPubkey,
-              tags: identityTags,
+              freshTags: any(named: 'freshTags'),
+              cached: any(named: 'cached'),
             ),
           ).thenAnswer((_) async => const [aliceClaim]);
         },
@@ -1101,6 +1027,13 @@ void main() {
               isFresh: true,
             ),
           );
+          when(
+            () => mockClaimsRepository.resolveClaims(
+              pubkey: testPubkey,
+              freshTags: any(named: 'freshTags'),
+              cached: any(named: 'cached'),
+            ),
+          ).thenAnswer((_) async => const [aliceClaim]);
         },
         build: createClaimsBloc,
         act: (bloc) => bloc.add(const OtherProfileRefreshRequested()),

--- a/mobile/test/blocs/other_profile/other_profile_bloc_test.dart
+++ b/mobile/test/blocs/other_profile/other_profile_bloc_test.dart
@@ -856,6 +856,7 @@ void main() {
       setUp(() {
         mockClaimsRepository = _MockIdentityClaimsRepository();
         registerFallbackValue(<List<String>>[]);
+        registerFallbackValue(const <IdentityClaim>[]);
         registerFallbackValue(
           const CachedVerifiedClaims(claims: [], isFresh: false),
         );
@@ -902,6 +903,7 @@ void main() {
               pubkey: testPubkey,
               freshTags: any(named: 'freshTags'),
               cached: any(named: 'cached'),
+              renderedClaims: any(named: 'renderedClaims'),
             ),
           ).thenAnswer((_) async => const [aliceClaim, bobClaim]);
         },
@@ -929,6 +931,7 @@ void main() {
               pubkey: testPubkey,
               freshTags: any(named: 'freshTags'),
               cached: any(named: 'cached'),
+              renderedClaims: any(named: 'renderedClaims'),
             ),
           ).called(1);
         },
@@ -957,6 +960,7 @@ void main() {
               pubkey: testPubkey,
               freshTags: any(named: 'freshTags'),
               cached: any(named: 'cached'),
+              renderedClaims: any(named: 'renderedClaims'),
             ),
           ).thenThrow(const VerifierApiException(503, 'down'));
         },
@@ -987,6 +991,7 @@ void main() {
               pubkey: testPubkey,
               freshTags: any(named: 'freshTags'),
               cached: any(named: 'cached'),
+              renderedClaims: any(named: 'renderedClaims'),
             ),
           ).thenAnswer((_) async => const [aliceClaim]);
         },
@@ -1028,6 +1033,7 @@ void main() {
               pubkey: testPubkey,
               freshTags: any(named: 'freshTags'),
               cached: any(named: 'cached'),
+              renderedClaims: any(named: 'renderedClaims'),
             ),
           ).thenAnswer((_) {
             resolveCall += 1;
@@ -1083,6 +1089,7 @@ void main() {
               pubkey: testPubkey,
               freshTags: any(named: 'freshTags'),
               cached: any(named: 'cached'),
+              renderedClaims: any(named: 'renderedClaims'),
             ),
           ).thenAnswer((_) async => const [aliceClaim]);
         },
@@ -1097,6 +1104,358 @@ void main() {
           isA<OtherProfileLoaded>()
               .having((s) => s.isFresh, 'isFresh', true)
               .having((s) => s.verifiedClaims, 'verifiedClaims', [aliceClaim]),
+        ],
+      );
+
+      blocTest<OtherProfileBloc, OtherProfileState>(
+        'keeps rendered chips when the instant-path intersection is empty '
+        'and the verifier is unreachable',
+        seed: () => OtherProfileLoaded(
+          profile: createTestProfile(),
+          isFresh: true,
+          verifiedClaims: const [aliceClaim],
+        ),
+        setUp: () {
+          when(
+            () => mockClaimsRepository.cachedVerifiedClaims(
+              pubkey: testPubkey,
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer(
+            (_) async => const CachedVerifiedClaims(claims: [], isFresh: false),
+          );
+          when(
+            () => mockClaimsRepository.resolveClaims(
+              pubkey: testPubkey,
+              freshTags: any(named: 'freshTags'),
+              cached: any(named: 'cached'),
+              renderedClaims: any(named: 'renderedClaims'),
+            ),
+          ).thenThrow(const VerifierApiException(503, 'down'));
+        },
+        build: createClaimsBloc,
+        act: (bloc) => bloc.add(const VerifiedClaimsRequested()),
+        // An empty snapshot intersection is not a confirmed negative, so
+        // the non-authoritative instant path must not clear visible chips.
+        expect: () => const <OtherProfileState>[],
+        errors: () => [isA<VerifierApiException>()],
+      );
+
+      blocTest<OtherProfileBloc, OtherProfileState>(
+        'unions instant-path chips rendered-first instead of replacing',
+        seed: () => OtherProfileLoaded(
+          profile: createTestProfile(),
+          isFresh: true,
+          verifiedClaims: const [aliceClaim],
+        ),
+        setUp: () {
+          when(
+            () => mockClaimsRepository.cachedVerifiedClaims(
+              pubkey: testPubkey,
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer(
+            (_) async => const CachedVerifiedClaims(
+              claims: [bobClaim],
+              isFresh: false,
+            ),
+          );
+          when(
+            () => mockClaimsRepository.resolveClaims(
+              pubkey: testPubkey,
+              freshTags: any(named: 'freshTags'),
+              cached: any(named: 'cached'),
+              renderedClaims: any(named: 'renderedClaims'),
+            ),
+          ).thenAnswer((_) async => const [aliceClaim, bobClaim]);
+        },
+        build: createClaimsBloc,
+        act: (bloc) => bloc.add(const VerifiedClaimsRequested()),
+        // Rendered-first union keeps chip order stable, so the
+        // authoritative resolve emit is Equatable-suppressed afterwards.
+        expect: () => [
+          isA<OtherProfileLoaded>().having(
+            (s) => s.verifiedClaims,
+            'verifiedClaims',
+            [aliceClaim, bobClaim],
+          ),
+        ],
+      );
+
+      blocTest<OtherProfileBloc, OtherProfileState>(
+        'does not double-render one identity when the cached casing differs',
+        seed: () => OtherProfileLoaded(
+          profile: createTestProfile(),
+          isFresh: true,
+          verifiedClaims: const [aliceClaim],
+        ),
+        setUp: () {
+          when(
+            () => mockClaimsRepository.cachedVerifiedClaims(
+              pubkey: testPubkey,
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer(
+            (_) async => const CachedVerifiedClaims(
+              claims: [
+                IdentityClaim(
+                  pubkey: testPubkey,
+                  platform: 'GitHub',
+                  identity: 'Alice',
+                  proof: 'rotated-proof',
+                ),
+              ],
+              isFresh: false,
+            ),
+          );
+          when(
+            () => mockClaimsRepository.resolveClaims(
+              pubkey: testPubkey,
+              freshTags: any(named: 'freshTags'),
+              cached: any(named: 'cached'),
+              renderedClaims: any(named: 'renderedClaims'),
+            ),
+          ).thenThrow(const VerifierApiException(503, 'down'));
+        },
+        build: createClaimsBloc,
+        act: (bloc) => bloc.add(const VerifiedClaimsRequested()),
+        // The cached claim is the same platform:identity under different
+        // casing/proof — the union must not produce a second chip.
+        expect: () => const <OtherProfileState>[],
+        errors: () => [isA<VerifierApiException>()],
+      );
+
+      blocTest<OtherProfileBloc, OtherProfileState>(
+        'clears chips when the authoritative resolve confirms a negative',
+        seed: () => OtherProfileLoaded(
+          profile: createTestProfile(),
+          isFresh: true,
+          verifiedClaims: const [aliceClaim],
+        ),
+        setUp: () {
+          when(
+            () => mockClaimsRepository.cachedVerifiedClaims(
+              pubkey: testPubkey,
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockClaimsRepository.resolveClaims(
+              pubkey: testPubkey,
+              freshTags: any(named: 'freshTags'),
+              cached: any(named: 'cached'),
+              renderedClaims: any(named: 'renderedClaims'),
+            ),
+          ).thenAnswer((_) async => const <IdentityClaim>[]);
+        },
+        build: createClaimsBloc,
+        act: (bloc) => bloc.add(const VerifiedClaimsRequested()),
+        expect: () => [
+          isA<OtherProfileLoaded>().having(
+            (s) => s.verifiedClaims,
+            'verifiedClaims',
+            isEmpty,
+          ),
+        ],
+      );
+
+      blocTest<OtherProfileBloc, OtherProfileState>(
+        'keeps chips and skips the resolve when the claims source read fails',
+        seed: () => OtherProfileLoaded(
+          profile: createTestProfile(),
+          isFresh: true,
+          verifiedClaims: const [aliceClaim],
+        ),
+        setUp: () {
+          when(
+            () => mockClaimsRepository.cachedVerifiedClaims(
+              pubkey: testPubkey,
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockProfileRepository.freshIdentityTags(
+              pubkey: testPubkey,
+              kind0Tags: any(named: 'kind0Tags'),
+            ),
+          ).thenThrow(Exception('db closed'));
+        },
+        build: createClaimsBloc,
+        act: (bloc) => bloc.add(const VerifiedClaimsRequested()),
+        // Resolving against the kind-0 fallback could authoritatively
+        // clear kind-10011 chips, so the degraded tick keeps
+        // last-known-good and does not consult the verifier at all.
+        expect: () => const <OtherProfileState>[],
+        errors: () => [isA<Exception>()],
+        verify: (_) {
+          verifyNever(
+            () => mockClaimsRepository.resolveClaims(
+              pubkey: any(named: 'pubkey'),
+              freshTags: any(named: 'freshTags'),
+              cached: any(named: 'cached'),
+              renderedClaims: any(named: 'renderedClaims'),
+            ),
+          );
+        },
+      );
+
+      blocTest<OtherProfileBloc, OtherProfileState>(
+        'carries claims through reload instead of dropping them',
+        seed: () => OtherProfileLoaded(
+          profile: createTestProfile(),
+          isFresh: true,
+          verifiedClaims: const [aliceClaim],
+        ),
+        setUp: () {
+          when(
+            () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
+          ).thenAnswer((_) async => createTestProfile());
+          when(
+            () => mockProfileRepository.fetchFreshProfile(
+              pubkey: testPubkey,
+              requireRawKind0: any(named: 'requireRawKind0'),
+            ),
+          ).thenAnswer((_) async => createTestProfile());
+          when(
+            () => mockClaimsRepository.cachedVerifiedClaims(
+              pubkey: testPubkey,
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer(
+            (_) async => const CachedVerifiedClaims(
+              claims: [aliceClaim],
+              isFresh: true,
+            ),
+          );
+          when(
+            () => mockClaimsRepository.resolveClaims(
+              pubkey: testPubkey,
+              freshTags: any(named: 'freshTags'),
+              cached: any(named: 'cached'),
+              renderedClaims: any(named: 'renderedClaims'),
+            ),
+          ).thenAnswer((_) async => const [aliceClaim]);
+        },
+        build: createClaimsBloc,
+        act: (bloc) => bloc.add(const OtherProfileLoadRequested()),
+        expect: () => [
+          isA<OtherProfileLoading>().having(
+            (s) => s.verifiedClaims,
+            'verifiedClaims',
+            [aliceClaim],
+          ),
+          isA<OtherProfileLoaded>().having(
+            (s) => s.verifiedClaims,
+            'verifiedClaims',
+            [aliceClaim],
+          ),
+        ],
+      );
+
+      blocTest<OtherProfileBloc, OtherProfileState>(
+        'passes the rendered claims to resolveClaims so a rate-limited '
+        'outcome can preserve them',
+        seed: () => OtherProfileLoaded(
+          profile: createTestProfile(),
+          isFresh: true,
+          verifiedClaims: const [aliceClaim],
+        ),
+        setUp: () {
+          when(
+            () => mockClaimsRepository.cachedVerifiedClaims(
+              pubkey: testPubkey,
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockClaimsRepository.resolveClaims(
+              pubkey: testPubkey,
+              freshTags: any(named: 'freshTags'),
+              cached: any(named: 'cached'),
+              renderedClaims: any(named: 'renderedClaims'),
+            ),
+          ).thenAnswer((_) async => const [aliceClaim]);
+        },
+        build: createClaimsBloc,
+        act: (bloc) => bloc.add(const VerifiedClaimsRequested()),
+        expect: () => const <OtherProfileState>[],
+        verify: (_) {
+          verify(
+            () => mockClaimsRepository.resolveClaims(
+              pubkey: testPubkey,
+              freshTags: any(named: 'freshTags'),
+              cached: null,
+              renderedClaims: const [aliceClaim],
+            ),
+          ).called(1);
+        },
+      );
+
+      late Completer<UserProfile?> cachedProfileGate;
+      blocTest<OtherProfileBloc, OtherProfileState>(
+        'reads claims after the cache await so a resolve landing mid-load '
+        'is not clobbered',
+        seed: () => OtherProfileLoaded(
+          profile: createTestProfile(),
+          isFresh: true,
+          verifiedClaims: const [aliceClaim],
+        ),
+        setUp: () {
+          cachedProfileGate = Completer<UserProfile?>();
+          addTearDown(() {
+            if (!cachedProfileGate.isCompleted) {
+              cachedProfileGate.complete(null);
+            }
+          });
+          when(
+            () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
+          ).thenAnswer((_) => cachedProfileGate.future);
+          when(
+            () => mockProfileRepository.fetchFreshProfile(
+              pubkey: testPubkey,
+              requireRawKind0: any(named: 'requireRawKind0'),
+            ),
+          ).thenAnswer((_) async => createTestProfile());
+          when(
+            () => mockClaimsRepository.cachedVerifiedClaims(
+              pubkey: testPubkey,
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockClaimsRepository.resolveClaims(
+              pubkey: testPubkey,
+              freshTags: any(named: 'freshTags'),
+              cached: any(named: 'cached'),
+              renderedClaims: any(named: 'renderedClaims'),
+            ),
+          ).thenAnswer((_) async => const [aliceClaim, bobClaim]);
+        },
+        build: createClaimsBloc,
+        act: (bloc) async {
+          bloc.add(const OtherProfileLoadRequested());
+          await pumpEventQueue();
+          bloc.add(const VerifiedClaimsRequested());
+          await pumpEventQueue();
+          cachedProfileGate.complete(createTestProfile());
+          await pumpEventQueue();
+        },
+        expect: () => [
+          isA<OtherProfileLoaded>().having(
+            (s) => s.verifiedClaims,
+            'verifiedClaims',
+            [aliceClaim, bobClaim],
+          ),
+          isA<OtherProfileLoading>().having(
+            (s) => s.verifiedClaims,
+            'verifiedClaims',
+            [aliceClaim, bobClaim],
+          ),
+          isA<OtherProfileLoaded>().having(
+            (s) => s.verifiedClaims,
+            'verifiedClaims',
+            [aliceClaim, bobClaim],
+          ),
         ],
       );
     });

--- a/mobile/test/providers/user_profile_providers_test.dart
+++ b/mobile/test/providers/user_profile_providers_test.dart
@@ -32,6 +32,8 @@ class _MockProfileStatsDao extends Mock implements ProfileStatsDao {}
 class _MockPendingProfileSavesDao extends Mock
     implements PendingProfileSavesDao {}
 
+class _MockIdentityEventsDao extends Mock implements IdentityEventsDao {}
+
 class _TestNostrSession extends NostrSession {
   _TestNostrSession(this._readiness);
 
@@ -213,6 +215,9 @@ void main() {
         when(
           () => database.pendingProfileSavesDao,
         ).thenReturn(pendingProfileSavesDao);
+        when(
+          () => database.identityEventsDao,
+        ).thenReturn(_MockIdentityEventsDao());
 
         final container = ProviderContainer(
           overrides: [


### PR DESCRIPTION
## Description

Two coupled features, delineated in two commits:

**1. Correct claims source — kind 10011 (commit 1 + repository layer of commit 2).**
The verifier web UI has published NIP-39 identity claims to **kind 10011** (not kind 0) since April, per the 2026-02 NIP-39 revision (nostr-protocol/nips#2216); relay.divine.video stores these events and Amethyst publishes them too. Mobile read only kind-0 `i` tags, so claims added or removed through the verifier flow never appeared — including after #3937's editor round-trip. There are live profiles today whose verified GitHub claim exists only in kind 10011 while their kind 0 carries no `i` tags at all. `ProfileRepository` now consults kind 10011 first (cached row → live relay query → kind-0 `i` tags), mirroring the verifier UI's own consult order, and caches the source event in a new `identity_events` table so cold starts can render chips offline.

**2. Persistent verification cache (#3936's original ask).**
`VerifierClient` was intentionally stateless, so every profile open paid a 0.3–1.5s verifier round-trip before chips rendered; refresh dropped chips visibly and any network failure erased them. `IdentityClaimsRepository` now keeps a verified-only snapshot per profile in a new `identity_verifications` table:

- Chips render instantly from cache (parsed claims ∩ snapshot, full-tuple match including proof — a rotated proof re-verifies instead of serving a stale verdict).
- The verifier is skipped entirely when the snapshot is fresh (`checked_at + 24h`, mirroring the service's verified KV TTL and anchored on the server's own timestamp) and covers every current claim; otherwise it re-verifies on open (stale-while-revalidate, chips update live).
- Only `verified: true` results are persisted. The verifier returns pubkey/platform rate-limit rejections as HTTP-200 `verified: false` bodies it never caches server-side (`src/routes/verify.ts`), so any response containing one leaves the snapshot untouched — a rate-limit burst cannot freeze false 'unverified' verdicts.
- Both profile blocs keep last-known-good claims on verifier failure and thread claims through refresh instead of dropping them.

Both tables use the db_client runtime CREATE-IF-NOT-EXISTS idiom (schemaVersion stays 1) with schema-parity and upgrade-path tests.

**Related Issue:** Closes #3936

### ⚠️ Deviations from the issue as written

1. **Drift, not a Hive box.** The issue predates the data-foundation direction (#4335); the sibling NIP-05 verification cache already lives in Drift, and new Hive boxes are the pattern #4335 curbs.
2. **Cache clears on logout/nsec switch.** Both `identity_events` and `identity_verifications` are wired into the existing database cleanup path to satisfy #3936's acceptance criteria.
3. **Kind-10011 read path folded in.** Caching the kind-0-derived claims alone would have fossilized a stale source, so the source fix ships in the same PR.

## Out of Scope

- Publishing kind 10011 from mobile (the verifier flow owns claim writes).
- Cross-device sync, timer-based background refresh, divine-web parity (per issue).
- Known pre-existing gaps left untouched: the shell-route `/profile/:npub` path for another user has no `OtherProfileBloc` so chips never render there.

## Verification

- `flutter analyze lib test integration_test` — clean.
- `db_client`: full database + DAO suites incl. new schema-parity/upgrade tests (43 tests).
- `profile_repository`: full suite with coverage — 285 tests, both touched lib files fully covered (package enforces the VGV default gate).
- Bloc suites: `other_profile` + `my_profile` incl. new SWR cases: fresh-snapshot renders with zero verifier calls, stale-snapshot cached→fresh emits, verifier failure keeps last-known-good, cache-read failure degrades to network, refresh carries chips.
- Profile header widget tests (66).
- `dart run build_runner build` — generated files committed (`auth_providers.g.dart`, Drift outputs, schema snapshot regenerated via `drift_dev make-migrations`).
- Backend contract verified against `divine-identify-verification-service` source at origin/main, live probes of `verifier.divine.video` (batch/single/cache-hit behavior, `checked_at` stability), and a full local `wrangler dev` run (response shapes for failed/platform-error/validation paths, KV cache order, rate-limit behavior).

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)


