### PR TITLE
fix(profile): stop stale kind-0 events blanking the cached profile

### DIFF
--- a/mobile/lib/screens/profile_screen_router.dart
+++ b/mobile/lib/screens/profile_screen_router.dart
@@ -129,6 +129,7 @@ class _ProfileScreenRouterState extends ConsumerState<ProfileScreenRouter>
       }
 
       return BlocProvider<MyProfileBloc>(
+        key: ValueKey((profileRepository, identityClaimsRepository)),
         create: (context) =>
             MyProfileBloc(
                 profileRepository: profileRepository,

--- a/mobile/packages/db_client/lib/src/database/daos/user_profiles_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/user_profiles_dao.dart
@@ -165,6 +165,10 @@ class UserProfilesDao extends DatabaseAccessor<AppDatabase>
   ///
   /// Inserts or updates all given profiles in a single batch operation.
   /// Uses a Drift batch for efficiency when writing many profiles at once.
+  ///
+  /// This is intentionally a blind batch write for uncached bulk imports.
+  /// Use [upsertProfile] when writing an already-cached pubkey where
+  /// newest-wins clobber protection matters.
   Future<void> upsertProfiles(List<UserProfile> profiles) async {
     if (profiles.isEmpty) return;
     await batch((b) {

--- a/mobile/packages/db_client/lib/src/database/daos/user_profiles_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/user_profiles_dao.dart
@@ -15,35 +15,75 @@ class UserProfilesDao extends DatabaseAccessor<AppDatabase>
     with _$UserProfilesDaoMixin {
   UserProfilesDao(super.attachedDatabase);
 
-  /// Upsert profile from domain model (insert or update)
+  /// Upsert profile from domain model, keeping the newest version.
   ///
-  /// Converts UserProfile domain model to database companion and
-  /// inserts/updates.
-  /// If profile with same pubkey exists, updates it. Otherwise inserts
-  /// new profile.
+  /// Converts a [UserProfile] domain model to a database companion and writes
+  /// it only when it should win over the currently-cached row for the same
+  /// pubkey. Newest-wins is applied here — at the single write chokepoint —
+  /// so every caller (relay event routing, REST caching, direct cache writes)
+  /// is protected from a stale or blank kind-0 clobbering a good cached
+  /// profile, without each caller having to guard on its own.
+  ///
+  /// Replacement rule for an incoming profile vs the existing row:
+  /// - no existing row: insert;
+  /// - incoming is newer (`createdAt` later): replace;
+  /// - incoming is older: keep the existing row untouched;
+  /// - same `createdAt`: replace only when the incoming profile is *richer*
+  ///   (more non-empty identity fields), which breaks ties toward the more
+  ///   complete profile. A genuine field clear rides in on a strictly newer
+  ///   event, so it still applies.
+  ///
+  /// The read and the conditional write run in a transaction so concurrent
+  /// writers cannot race between the compare and the write.
   ///
   /// For simple CRUD operations (get, watch, delete), use AppDbClient instead.
   Future<void> upsertProfile(UserProfile profile) {
-    return into(userProfiles).insertOnConflictUpdate(
-      UserProfilesCompanion.insert(
-        pubkey: profile.pubkey,
-        displayName: Value(profile.displayName),
-        name: Value(profile.name),
-        about: Value(profile.about),
-        picture: Value(profile.picture),
-        banner: Value(profile.banner),
-        website: Value(profile.website),
-        nip05: Value(profile.nip05),
-        lud16: Value(profile.lud16),
-        lud06: Value(profile.lud06),
-        rawData: Value(
-          profile.rawData.isNotEmpty ? jsonEncode(profile.rawData) : null,
+    return transaction(() async {
+      final existing = await getProfile(profile.pubkey);
+      if (existing != null && !_incomingWins(profile, existing)) {
+        return;
+      }
+      await into(userProfiles).insertOnConflictUpdate(
+        UserProfilesCompanion.insert(
+          pubkey: profile.pubkey,
+          displayName: Value(profile.displayName),
+          name: Value(profile.name),
+          about: Value(profile.about),
+          picture: Value(profile.picture),
+          banner: Value(profile.banner),
+          website: Value(profile.website),
+          nip05: Value(profile.nip05),
+          lud16: Value(profile.lud16),
+          lud06: Value(profile.lud06),
+          rawData: Value(
+            profile.rawData.isNotEmpty ? jsonEncode(profile.rawData) : null,
+          ),
+          createdAt: profile.createdAt,
+          eventId: profile.eventId,
+          lastFetched: DateTime.now(),
         ),
-        createdAt: profile.createdAt,
-        eventId: profile.eventId,
-        lastFetched: DateTime.now(),
-      ),
-    );
+      );
+    });
+  }
+
+  /// Whether [incoming] should replace [existing] under the newest-wins rule
+  /// documented on [upsertProfile].
+  static bool _incomingWins(UserProfile incoming, UserProfile existing) {
+    if (incoming.createdAt.isAfter(existing.createdAt)) return true;
+    if (incoming.createdAt.isBefore(existing.createdAt)) return false;
+    return _identityRichness(incoming) > _identityRichness(existing);
+  }
+
+  /// Counts the non-empty identity fields on [profile], used only as the
+  /// equal-`createdAt` tiebreak in [_incomingWins].
+  static int _identityRichness(UserProfile profile) {
+    var count = 0;
+    if (profile.name?.isNotEmpty ?? false) count++;
+    if (profile.displayName?.isNotEmpty ?? false) count++;
+    if (profile.picture?.isNotEmpty ?? false) count++;
+    if (profile.about?.isNotEmpty ?? false) count++;
+    if (profile.banner?.isNotEmpty ?? false) count++;
+    return count;
   }
 
   /// Get a single profile by pubkey with domain model conversion.

--- a/mobile/packages/db_client/test/src/database/daos/user_profiles_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/user_profiles_dao_test.dart
@@ -1,12 +1,14 @@
 // ABOUTME: Unit tests for UserProfilesDao with UserProfile domain model.
 // ABOUTME: Tests upsertProfile for inserting and updating user profiles.
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:db_client/db_client.dart';
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart';
+import 'package:nostr_sdk/event.dart';
 
 void main() {
   late AppDatabase database;
@@ -213,6 +215,179 @@ void main() {
       });
     });
 
+    group('upsertProfile newest-wins', () {
+      test(
+        'older kind-0 does not overwrite a newer richer cached row',
+        () async {
+          await dao.upsertProfile(
+            createProfile(
+              eventId: 'new',
+              name: 'Alice',
+              displayName: 'Alice in Wonderland',
+              picture: 'https://example.com/alice.jpg',
+              createdAt: DateTime.utc(2024, 1, 2),
+            ),
+          );
+
+          // A stale kind-0 arriving late on a background subscription.
+          await dao.upsertProfile(
+            createProfile(
+              eventId: 'old',
+              name: 'Old Alice',
+              displayName: 'Old',
+              createdAt: DateTime.utc(2024),
+            ),
+          );
+
+          final result = await dao.getProfile(testPubkey);
+          expect(result, isNotNull);
+          expect(result!.name, equals('Alice'));
+          expect(result.displayName, equals('Alice in Wonderland'));
+          expect(result.picture, equals('https://example.com/alice.jpg'));
+          expect(result.eventId, equals('new'));
+        },
+      );
+
+      test('older blank kind-0 leaves name and picture intact', () async {
+        await dao.upsertProfile(
+          createProfile(
+            eventId: 'good',
+            name: 'Alice',
+            picture: 'https://example.com/alice.jpg',
+            createdAt: DateTime.utc(2024, 1, 2),
+          ),
+        );
+
+        // Blank placeholder profile (identicon + name-from-pubkey) that is
+        // older than the good cached row must not blank it.
+        await dao.upsertProfile(
+          createProfile(eventId: 'blank', createdAt: DateTime.utc(2024)),
+        );
+
+        final result = await dao.getProfile(testPubkey);
+        expect(result, isNotNull);
+        expect(result!.name, equals('Alice'));
+        expect(result.picture, equals('https://example.com/alice.jpg'));
+        expect(result.eventId, equals('good'));
+      });
+
+      test(
+        'newer kind-0 applies, including a legitimate field clear',
+        () async {
+          await dao.upsertProfile(
+            createProfile(
+              eventId: 'old',
+              name: 'Alice',
+              picture: 'https://example.com/alice.jpg',
+              about: 'the original bio',
+              createdAt: DateTime.utc(2024),
+            ),
+          );
+
+          // The user deliberately removed their picture in a newer event.
+          // A field clear in a NEWER event is a real edit and must apply.
+          await dao.upsertProfile(
+            createProfile(
+              eventId: 'new',
+              name: 'Alice',
+              about: 'the original bio',
+              createdAt: DateTime.utc(2024, 1, 2),
+            ),
+          );
+
+          final result = await dao.getProfile(testPubkey);
+          expect(result, isNotNull);
+          expect(result!.eventId, equals('new'));
+          expect(result.picture, isNull);
+          expect(result.name, equals('Alice'));
+        },
+      );
+
+      test('equal-createdAt richer profile wins', () async {
+        final sameTime = DateTime.utc(2024, 6);
+        await dao.upsertProfile(
+          createProfile(eventId: 'sparse', name: 'Alice', createdAt: sameTime),
+        );
+
+        await dao.upsertProfile(
+          createProfile(
+            eventId: 'rich',
+            name: 'Alice',
+            displayName: 'Alice in Wonderland',
+            picture: 'https://example.com/alice.jpg',
+            createdAt: sameTime,
+          ),
+        );
+
+        final result = await dao.getProfile(testPubkey);
+        expect(result, isNotNull);
+        expect(result!.eventId, equals('rich'));
+        expect(result.displayName, equals('Alice in Wonderland'));
+        expect(result.picture, equals('https://example.com/alice.jpg'));
+      });
+
+      test('equal-createdAt blank profile does not win', () async {
+        final sameTime = DateTime.utc(2024, 6);
+        await dao.upsertProfile(
+          createProfile(
+            eventId: 'rich',
+            name: 'Alice',
+            displayName: 'Alice in Wonderland',
+            picture: 'https://example.com/alice.jpg',
+            createdAt: sameTime,
+          ),
+        );
+
+        await dao.upsertProfile(
+          createProfile(eventId: 'blank', createdAt: sameTime),
+        );
+
+        final result = await dao.getProfile(testPubkey);
+        expect(result, isNotNull);
+        expect(result!.eventId, equals('rich'));
+        expect(result.name, equals('Alice'));
+        expect(result.picture, equals('https://example.com/alice.jpg'));
+      });
+
+      test(
+        'stale blank kind-0 through EventRouter conversion keeps good row',
+        () async {
+          // Mirrors EventRouter._handleProfileEvent: build a kind-0 event,
+          // convert with UserProfile.fromNostrEvent, then upsert. A good
+          // profile arrives first, then a stale blank kind-0 fans in on a
+          // background feed subscription — the good row must survive.
+          UserProfile fromKind0(
+            Map<String, dynamic> content,
+            DateTime createdAt,
+          ) => UserProfile.fromNostrEvent(
+            Event(
+              testPubkey,
+              0,
+              const <List<String>>[],
+              jsonEncode(content),
+              createdAt: createdAt.millisecondsSinceEpoch ~/ 1000,
+            ),
+          );
+
+          await dao.upsertProfile(
+            fromKind0(
+              {'name': 'Alice', 'picture': 'https://example.com/alice.jpg'},
+              DateTime.utc(2024, 1, 2),
+            ),
+          );
+
+          await dao.upsertProfile(
+            fromKind0(<String, dynamic>{}, DateTime.utc(2024)),
+          );
+
+          final result = await dao.getProfile(testPubkey);
+          expect(result, isNotNull);
+          expect(result!.name, equals('Alice'));
+          expect(result.picture, equals('https://example.com/alice.jpg'));
+        },
+      );
+    });
+
     group('getProfilesByPubkeys', () {
       test('returns empty list for empty input', () async {
         final results = await dao.getProfilesByPubkeys([]);
@@ -225,9 +400,10 @@ void main() {
           createProfile(pubkey: testPubkey2, name: 'Bob'),
         );
 
-        final results = await dao.getProfilesByPubkeys(
-          [testPubkey, testPubkey2],
-        );
+        final results = await dao.getProfilesByPubkeys([
+          testPubkey,
+          testPubkey2,
+        ]);
         expect(results, hasLength(2));
 
         final names = results.map((p) => p.name).toSet();
@@ -237,9 +413,10 @@ void main() {
       test('omits pubkeys not in database', () async {
         await dao.upsertProfile(createProfile(name: 'Alice'));
 
-        final results = await dao.getProfilesByPubkeys(
-          [testPubkey, testPubkey2],
-        );
+        final results = await dao.getProfilesByPubkeys([
+          testPubkey,
+          testPubkey2,
+        ]);
         expect(results, hasLength(1));
         expect(results.first.name, equals('Alice'));
       });

--- a/mobile/packages/profile_repository/test/src/profile_repository_cache_newest_wins_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_cache_newest_wins_test.dart
@@ -1,0 +1,104 @@
+// ABOUTME: Verifies ProfileRepository.cacheProfile is protected by the DAO's
+// ABOUTME: newest-wins guard so a stale or blank kind-0 cannot blank a good
+// ABOUTME: cached profile for the same pubkey.
+
+import 'package:db_client/db_client.dart' hide Filter, ProfileStats;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:profile_repository/profile_repository.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockHttpClient extends Mock implements Client {}
+
+void main() {
+  group('ProfileRepository.cacheProfile newest-wins', () {
+    const testPubkey =
+        'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2';
+
+    late AppDatabase db;
+    late ProfileRepository repository;
+
+    UserProfile profile({
+      required String eventId,
+      required DateTime createdAt,
+      String? name,
+      String? picture,
+    }) => UserProfile(
+      pubkey: testPubkey,
+      eventId: eventId,
+      name: name,
+      picture: picture,
+      rawData: const {},
+      createdAt: createdAt,
+    );
+
+    setUp(() {
+      db = AppDatabase.test(NativeDatabase.memory());
+      repository = ProfileRepository(
+        nostrClient: _MockNostrClient(),
+        userProfilesDao: db.userProfilesDao,
+        httpClient: _MockHttpClient(),
+      );
+    });
+
+    tearDown(() async {
+      await db.close();
+    });
+
+    test(
+      'keeps the newer cached row when an older profile is cached',
+      () async {
+        await repository.cacheProfile(
+          profile(
+            eventId: 'new',
+            name: 'Alice',
+            picture: 'https://example.com/alice.jpg',
+            createdAt: DateTime.utc(2024, 1, 2),
+          ),
+        );
+
+        await repository.cacheProfile(
+          profile(
+            eventId: 'old',
+            name: 'Old Alice',
+            createdAt: DateTime.utc(2024),
+          ),
+        );
+
+        final cached = await repository.getCachedProfile(pubkey: testPubkey);
+        expect(cached, isNotNull);
+        expect(cached!.name, equals('Alice'));
+        expect(cached.picture, equals('https://example.com/alice.jpg'));
+        expect(cached.eventId, equals('new'));
+      },
+    );
+
+    test(
+      'keeps name and picture when an older blank profile is cached',
+      () async {
+        await repository.cacheProfile(
+          profile(
+            eventId: 'good',
+            name: 'Alice',
+            picture: 'https://example.com/alice.jpg',
+            createdAt: DateTime.utc(2024, 1, 2),
+          ),
+        );
+
+        await repository.cacheProfile(
+          profile(eventId: 'blank', createdAt: DateTime.utc(2024)),
+        );
+
+        final cached = await repository.getCachedProfile(pubkey: testPubkey);
+        expect(cached, isNotNull);
+        expect(cached!.name, equals('Alice'));
+        expect(cached.picture, equals('https://example.com/alice.jpg'));
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes #6196

## Problem

Users' **own** profile spontaneously "resets" to the generic blank profile — identicon avatar plus a name-from-pubkey — even though a good kind-0 was cached and displayed a moment earlier.

## Root causes

**1. Data clobber at the DAO write chokepoint.** The Drift `UserProfilesDao.upsertProfile` was a blind full-row `insertOnConflictUpdate` with no newest-wins guard. A stale or blank kind-0 for the user's own pubkey — arriving late on any background feed/video subscription — overwrote the good cached row, and `MyProfileBloc.watchProfile` streamed the blank straight to the header. Three writers hit this unguarded chokepoint:

- `EventRouter._handleProfileEvent` (only de-dupes kind-0 *within a batch*, never against the DB row)
- `ProfileRepository.cacheProfile`
- `ProfileRepository._cacheProfileIfNewer` (has its own createdAt guard, but the other two bypass it)

**2. Stale Riverpod dep capture.** `BlocProvider<MyProfileBloc>` in `profile_screen_router.dart` had no `ValueKey` over its Riverpod-provided dependencies, so it could keep a stale `profileRepository` across an identity flip (account switch / sign-out / cold-start signer swap), violating the documented "Bridging Riverpod-provided dependencies into BlocProvider" rule in `.claude/rules/state_management.md`.

## Fix

**Part A — newest-wins at the DAO chokepoint (fixes all three writers at once).** `upsertProfile` is now a transactional read-compare instead of a blind upsert. For an incoming profile vs the existing row (same pubkey):

- no existing row → insert;
- incoming `createdAt` is newer → replace;
- incoming `createdAt` is older → keep existing (no-op);
- equal `createdAt` → replace only when the incoming profile is *richer* (more non-empty fields among name, displayName, picture, about, banner); otherwise keep.

The read + conditional write run inside a Drift `transaction(...)` so concurrent writers can't race between the compare and the write. There is intentionally **no** "not-emptier" guard beyond the equal-timestamp tiebreak — a genuine field clear is a *newer* event and must still apply, so it does. `lastFetched` is only bumped on the write path; a keep leaves the row untouched (nothing reads `lastFetched` for staleness, so this is harmless).

**Part B — ValueKey on the bloc provider.** Added `key: ValueKey((profileRepository, identityClaimsRepository))` to `BlocProvider<MyProfileBloc>`. These repos don't override `==`, so the record key compares by identity — exactly the pattern used by `feed_videos.dart`'s `videoInteractionsBlocKey`. When a repository's identity flips, the key changes, the old bloc closes, and `create:` re-runs with fresh deps instead of keeping a stale capture.

## Callers affected

All `upsertProfile(UserProfile)` callers now go through the newest-wins guard: `EventRouter`, `ProfileRepository.cacheProfile`, `ProfileRepository._cacheProfileIfNewer`, and the Funnelcake REST cache paths. `_cacheProfileIfNewer` keeps its own createdAt guard and stays consistent (same createdAt rule). `upsertProfiles` (batch) and the unused `AppDbClient.upsertProfile(Companion)` are left as-is (out of scope; the batch path is not a source of the own-profile reset). Nothing reads `lastFetched` for SWR/staleness, so leaving it stale on a keep changes no behavior.

## Tests

- **db_client** (`user_profiles_dao_test.dart`): older-does-not-overwrite-newer-richer, older-blank-leaves-name/picture, newer-applies-including-a-legitimate-field-clear, equal-createdAt-richer-wins, equal-createdAt-blank-loses, plus an EventRouter-path test that feeds a stale blank kind-0 (via `UserProfile.fromNostrEvent`) after a good one and asserts the good row survives. Watched them fail red against the blind upsert, then go green.
- **profile_repository** (`profile_repository_cache_newest_wins_test.dart`, new): `cacheProfile` with a real in-memory DAO keeps the newer row when an older/blank profile is cached.

## Verification

- `flutter analyze` on the changed lib file and both packages: **No issues found!**
- db_client full suite: 841 passed. profile_repository full suite: 266 passed.
- mobile `test/blocs/my_profile` + `test/screens/profile_screen_router_test.dart`: 50 passed (3 pre-existing skips unrelated to this change).

## Test plan

- Own profile: sign in, confirm the header shows the real avatar/name, then let background feeds run — the header must not flip to the generic identicon.
- Account switch: switch accounts and back; the header must show the correct identity's profile, not a stale one.
