### PR TITLE
fix(crash): treat MediaCacheImageProvider load failures as non-fatal

### DIFF
--- a/mobile/lib/utils/recoverable_flutter_error.dart
+++ b/mobile/lib/utils/recoverable_flutter_error.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:media_cache/media_cache.dart';
 
 const _recoverableMediaLoadReason = 'Recoverable media load failure';
 const _recoverableMediaHosts = <String>{
@@ -48,11 +49,20 @@ String? classifyRecoverableFlutterError(FlutterErrorDetails details) {
           context.contains('image codec') ||
           context.contains('instantiateImageCodecWithSize'));
 
+  // A MediaCacheImageProvider download that finishes without a usable file
+  // (dead legacy media, non-2xx, DNS failure) is recoverable by contract —
+  // the widget falls back to a placeholder. It is host-agnostic because dead
+  // Vine avatars are commonly proxied through web.archive.org, which is not a
+  // recoverable-media host.
+  final isMediaCacheLoadFailure =
+      details.exception is MediaCacheImageLoadException;
+
   if (isImage404 ||
       isMediaHostLookup ||
       isInterruptedMediaDownload ||
       isMissingHttpHost ||
-      isInvalidImageData) {
+      isInvalidImageData ||
+      isMediaCacheLoadFailure) {
     return _recoverableMediaLoadReason;
   }
 

--- a/mobile/test/utils/recoverable_flutter_error_test.dart
+++ b/mobile/test/utils/recoverable_flutter_error_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:media_cache/media_cache.dart';
 import 'package:openvine/utils/recoverable_flutter_error.dart';
 
 void main() {
@@ -65,6 +66,27 @@ void main() {
       final details = FlutterErrorDetails(
         exception: ArgumentError('No host specified in URI https:///thumb.jpg'),
         library: 'dart:_http',
+      );
+
+      expect(
+        classifyRecoverableFlutterError(details),
+        'Recoverable media load failure',
+      );
+    });
+
+    test('classifies MediaCacheImageProvider download-without-file failures as '
+        'recoverable regardless of host', () {
+      // Dead legacy Vine avatars are commonly served through
+      // web.archive.org, which is not in the recoverable-media host set —
+      // the exception type alone must classify it, so the broken avatar
+      // falls back to a placeholder instead of a fatal crash (#5782 follow
+      // up: the download-without-file branch was still reported as fatal).
+      const details = FlutterErrorDetails(
+        exception: MediaCacheImageLoadException(
+          'https://web.archive.org/web/20150907190604/'
+          'http://v.cdn.vine.co/r/avatars/broken.jpg',
+        ),
+        library: 'package:media_cache/src/media_cache_image_provider.dart',
       );
 
       expect(


### PR DESCRIPTION
Closes #6181

## Root cause

Crashlytics iOS issue `975327951e70a1acb98303a1285ca34b` — **`MediaCacheImageProvider._loadAsync`** — is the #2 fatal by impacted users (**43 users / 58 events on 1.0.16**, first seen 1.0.15).

A `MediaCacheImageProvider` download that completes **without a usable file** (dead legacy media, non-2xx, DNS failure) throws `MediaCacheImageLoadException`. That propagates through `MultiFrameImageStreamCompleter` to `FlutterError.onError` and is recorded as a **FATAL** crash. The representative event is a dead Vine avatar proxied through `web.archive.org`:

> `MediaCacheImageProvider failed to load "https://web.archive.org/web/…/v.cdn.vine.co/r/avatars/…": download completed without a file`

`main.dart`'s `FlutterError.onError` already downgrades recoverable media/image errors to non-fatal via `classifyRecoverableFlutterError`, but its checks are **host-based**, and `web.archive.org` is not in the recoverable-media host set — so these slipped through as fatal.

PR #5782 fixed the **scroll-away cancellation** branch (returns a never-completing future). The genuine **download-without-file** branch was still fatal — this is that follow-up.

## Fix

`classifyRecoverableFlutterError` now recognises `MediaCacheImageLoadException` **by type** (host-agnostic). The class is documented as an always-recoverable load failure, so any instance is recorded non-fatal and the widget shows its placeholder instead of the app logging a fatal crash. One `||` clause + one import; no behaviour change for real crashes.

## Test plan

- [x] TDD: added a failing test (`MediaCacheImageLoadException` via a `web.archive.org` URL → classified recoverable), watched it fail (`Actual: <null>`), then implemented.
- [x] Full classifier suite green (8 tests); `flutter analyze` clean; `dart format` clean.
- [ ] Confirm the Crashlytics issue's event rate drops on a build > 1.0.16 (issue left OPEN per the crash-agent convention).

Crashlytics note added to the issue with this PR link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)