### PR TITLE
fix(crash): guard GoRouter extra casts against restored maps

### DIFF
--- a/mobile/lib/router/routes/lists_routes.dart
+++ b/mobile/lib/router/routes/lists_routes.dart
@@ -30,7 +30,7 @@ List<RouteBase> listsRoutes(Ref ref) {
           return RouteErrorScreen(message: ctx.l10n.routeInvalidListId);
         }
         // Extra data contains listName, videoIds, authorPubkey
-        final extra = st.extra as CuratedListRouteExtra?;
+        final extra = extraAs<CuratedListRouteExtra>(st.extra);
         return CuratedListFeedScreen(
           listId: listId,
           listName: extra?.listName ?? ctx.l10n.routeDefaultListName,
@@ -55,10 +55,7 @@ List<RouteBase> listsRoutes(Ref ref) {
             listId.isEmpty) {
           return RouteErrorScreen(message: ctx.l10n.routeInvalidListId);
         }
-        return CuratedListByAuthorScreen(
-          authorPubkey: pubkey,
-          listId: listId,
-        );
+        return CuratedListByAuthorScreen(authorPubkey: pubkey, listId: listId);
       },
     ),
 

--- a/mobile/lib/router/routes/profile_routes.dart
+++ b/mobile/lib/router/routes/profile_routes.dart
@@ -4,6 +4,7 @@
 import 'package:go_router/go_router.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/router/route_error_screen.dart';
+import 'package:openvine/router/routes/route_extras.dart';
 import 'package:openvine/router/widgets/followers_screen_router.dart';
 import 'package:openvine/router/widgets/following_screen_router.dart';
 import 'package:openvine/router/widgets/other_profile_screen_router.dart';
@@ -73,14 +74,11 @@ List<RouteBase> profileRoutes() {
       name: FollowersScreenRouter.routeName,
       builder: (ctx, st) {
         final pubkey = st.pathParameters['pubkey'];
-        final displayName = st.extra as String?;
+        final displayName = extraAs<String>(st.extra);
         if (pubkey == null || pubkey.isEmpty) {
           return RouteErrorScreen(message: ctx.l10n.routeInvalidUserId);
         }
-        return FollowersScreenRouter(
-          pubkey: pubkey,
-          displayName: displayName,
-        );
+        return FollowersScreenRouter(pubkey: pubkey, displayName: displayName);
       },
     ),
     // Following screen - routes to My or Others based on pubkey
@@ -89,14 +87,11 @@ List<RouteBase> profileRoutes() {
       name: FollowingScreenRouter.routeName,
       builder: (ctx, st) {
         final pubkey = st.pathParameters['pubkey'];
-        final displayName = st.extra as String?;
+        final displayName = extraAs<String>(st.extra);
         if (pubkey == null || pubkey.isEmpty) {
           return RouteErrorScreen(message: ctx.l10n.routeInvalidUserId);
         }
-        return FollowingScreenRouter(
-          pubkey: pubkey,
-          displayName: displayName,
-        );
+        return FollowingScreenRouter(pubkey: pubkey, displayName: displayName);
       },
     ),
     // Other user's profile screen (no bottom nav, pushed from feeds/search)
@@ -110,9 +105,9 @@ List<RouteBase> profileRoutes() {
           return RouteErrorScreen(message: ctx.l10n.routeInvalidProfileId);
         }
         // Extract profile hints from extra (for users without Kind 0 profiles)
-        final extra = st.extra as Map<String, String?>?;
-        final displayNameHint = extra?['displayName'];
-        final avatarUrlHint = extra?['avatarUrl'];
+        final extra = extraAs<Map<String, dynamic>>(st.extra);
+        final displayNameHint = extra?['displayName'] as String?;
+        final avatarUrlHint = extra?['avatarUrl'] as String?;
         return OtherProfileScreenRouter(
           npub: npub,
           displayNameHint: displayNameHint,

--- a/mobile/lib/router/routes/route_extras.dart
+++ b/mobile/lib/router/routes/route_extras.dart
@@ -1,6 +1,22 @@
 // ABOUTME: Extra data classes for GoRouter navigation
 // ABOUTME: Used to pass structured data between routes via GoRouter extra
 
+/// Safely reads a GoRouter `state.extra` payload as [T].
+///
+/// Returns `null` when [extra] is not a [T]. This matters after route
+/// restoration or a deep link: Flutter serializes `extra` and hands it back
+/// as a plain `Map<String, dynamic>` rather than the originally-passed typed
+/// object, so a raw `extra as T` cast throws
+/// `type '_Map<String, dynamic>' is not a subtype of type 'T'` and crashes the
+/// route builder (Crashlytics iOS 5b96bfc6…, efec8882…). Each affected route
+/// already tolerates a missing payload (optional hints, id-based loaders, or a
+/// `??` fallback), so returning `null` degrades gracefully instead of crashing.
+///
+/// The deeper fix is to stop passing typed objects through `extra` entirely
+/// (see `.claude/rules/routing.md` — `extra` breaks deep linking and
+/// restoration); that migration is tracked separately.
+T? extraAs<T>(Object? extra) => extra is T ? extra : null;
+
 /// Extra data for curated list route (passed via GoRouter extra)
 class CuratedListRouteExtra {
   const CuratedListRouteExtra({

--- a/mobile/lib/router/routes/search_routes.dart
+++ b/mobile/lib/router/routes/search_routes.dart
@@ -6,6 +6,7 @@ import 'package:models/models.dart' show VideoCategory;
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/router/navigator_keys.dart';
 import 'package:openvine/router/route_error_screen.dart';
+import 'package:openvine/router/routes/route_extras.dart';
 import 'package:openvine/screens/category_gallery_screen.dart';
 import 'package:openvine/screens/hashtag_feed_screen.dart';
 import 'package:openvine/screens/hashtag_screen_router.dart';
@@ -61,7 +62,7 @@ List<RouteBase> searchRoutes() {
       builder: (ctx, st) {
         final categoryName = st.pathParameters['categoryName'];
         final category =
-            st.extra as VideoCategory? ??
+            extraAs<VideoCategory>(st.extra) ??
             VideoCategory(name: categoryName ?? '', videoCount: 0);
 
         if (category.name.isEmpty) {

--- a/mobile/lib/router/routes/video_routes.dart
+++ b/mobile/lib/router/routes/video_routes.dart
@@ -9,6 +9,7 @@ import 'package:openvine/router/fade_upwards_page.dart';
 import 'package:openvine/router/navigator_keys.dart';
 import 'package:openvine/router/pooled_fullscreen_feed_route.dart';
 import 'package:openvine/router/route_error_screen.dart';
+import 'package:openvine/router/routes/route_extras.dart';
 import 'package:openvine/router/widgets/sound_detail_loader.dart';
 import 'package:openvine/screens/creator_analytics_screen.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
@@ -29,10 +30,8 @@ List<RouteBase> videoRoutes() {
       name: VideoRecorderScreen.routeName,
       // The recorder is a modal creation mode, not the next screen in a
       // flow — open it with the fade-upwards transition.
-      pageBuilder: (_, state) => fadeUpwardsPage(
-        state: state,
-        child: const VideoRecorderRoute(),
-      ),
+      pageBuilder: (_, state) =>
+          fadeUpwardsPage(state: state, child: const VideoRecorderRoute()),
     ),
     GoRoute(
       path: CreatorAnalyticsScreen.path,
@@ -77,8 +76,8 @@ List<RouteBase> videoRoutes() {
         if (extra is AudioEvent) {
           sound = extra;
         } else if (extra is Map<String, dynamic>) {
-          sound = extra['sound'] as AudioEvent?;
-          sourceVideo = extra['sourceVideo'] as VideoEvent?;
+          sound = extraAs<AudioEvent>(extra['sound']);
+          sourceVideo = extraAs<VideoEvent>(extra['sourceVideo']);
         }
         if (sound != null) {
           return SoundDetailScreen(sound: sound, sourceVideo: sourceVideo);
@@ -93,7 +92,7 @@ List<RouteBase> videoRoutes() {
       name: OriginalSoundDetailScreen.routeName,
       builder: (ctx, st) {
         final pubkey = st.pathParameters['pubkey'];
-        final video = st.extra as VideoEvent?;
+        final video = extraAs<VideoEvent>(st.extra);
         if (pubkey == null || pubkey.isEmpty) {
           return RouteErrorScreen(message: ctx.l10n.routerInvalidCreator);
         }
@@ -143,7 +142,7 @@ List<RouteBase> videoRoutes() {
         if (videoId == null || videoId.isEmpty) {
           return RouteErrorScreen(message: ctx.l10n.routeInvalidVideoId);
         }
-        final prefetched = st.extra as VideoEvent?;
+        final prefetched = extraAs<VideoEvent>(st.extra);
         return VideoMetadataEditScreen(
           videoId: videoId,
           prefetched: prefetched,
@@ -158,7 +157,7 @@ List<RouteBase> videoRoutes() {
         if (videoId == null || videoId.isEmpty) {
           return RouteErrorScreen(message: ctx.l10n.routeInvalidVideoId);
         }
-        final prefetched = st.extra as VideoEvent?;
+        final prefetched = extraAs<VideoEvent>(st.extra);
         return SubtitleEditorScreen(videoId: videoId, prefetched: prefetched);
       },
     ),

--- a/mobile/test/router/routes/route_extras_test.dart
+++ b/mobile/test/router/routes/route_extras_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/router/routes/route_extras.dart';
+
+void main() {
+  group('extraAs', () {
+    test('returns the value when it already is the requested type', () {
+      const extra = CuratedListRouteExtra(listName: 'Favourites');
+
+      expect(extraAs<CuratedListRouteExtra>(extra), same(extra));
+    });
+
+    test('returns null for a restored Map instead of throwing (the route '
+        'restoration / deep-link crash)', () {
+      // After restoration or a deep link GoRouter hands `extra` back as a
+      // plain Map<String, dynamic>, not the typed object. A raw `as` cast
+      // throws here (Crashlytics 5b96bfc6… / efec8882…); the guard must
+      // return null so the route falls back gracefully.
+      final restored = <String, dynamic>{
+        'listName': 'Favourites',
+        'videoIds': <String>['a', 'b'],
+      };
+
+      expect(extraAs<CuratedListRouteExtra>(restored), isNull);
+    });
+
+    test('reads a restored Map when the caller asks for a Map', () {
+      final restored = <String, dynamic>{
+        'displayName': 'Ada',
+        'avatarUrl': null,
+      };
+
+      final map = extraAs<Map<String, dynamic>>(restored);
+
+      expect(map, same(restored));
+      expect(map?['displayName'] as String?, 'Ada');
+      expect(map?['avatarUrl'] as String?, isNull);
+    });
+
+    test('returns null for a scalar-type mismatch', () {
+      expect(extraAs<String>(<String, dynamic>{'a': 1}), isNull);
+      expect(extraAs<String>('hint'), 'hint');
+    });
+
+    test('returns null for a null payload', () {
+      expect(extraAs<CuratedListRouteExtra>(null), isNull);
+    });
+  });
+}


### PR DESCRIPTION
Closes #6183

## Root cause

Two FRESH-on-1.0.16 iOS fatals, same defect:
- `profile_routes.dart` — `type '_Map<String, dynamic>' is not a subtype of type 'Map<String, String?>?' in type cast` (Crashlytics `5b96bfc6…`, 8 users)
- `video_routes.dart` — `… is not a subtype of type 'AudioEvent?'` (Crashlytics `efec8882…`, 4 users)

On route restoration or a deep link, GoRouter hands `state.extra` back as a plain `_Map<String, dynamic>` rather than the originally-passed typed object (this is the documented `extra`-breaks-restoration pitfall in `.claude/rules/routing.md`). Route builders that cast it directly then throw and crash while building the route. Repro breadcrumbs match: the video crash follows an 18-minute background→resume into `route_name: sound`; the profile crash lands on `route_name: profile_view` after restoration.

## Fix

Add `extraAs<T>(extra)` — a guarded `extra is T ? extra : null` — in `route_extras.dart`, and route every unsafe typed-`extra` read through it across `profile`/`video`/`search`/`lists` routes. Each affected route already tolerates a missing payload (optional display hints, id-based loaders like `SoundDetailLoader`, or a `?? fallback`), so the guard degrades gracefully instead of crashing. **No behaviour change for valid live extras.**

This also fixes the same latent cast in three sibling video routes (`OriginalSoundDetail`, `VideoMetadataEdit`, `SubtitleEditor` — all `st.extra as VideoEvent?`) before they surface as new fatals.

Not in scope: migrating off `extra` for typed objects entirely (the deeper fix routing.md recommends) — tracked separately; this PR stops the crash.

## Test plan

- [x] TDD regression test (`route_extras_test.dart`): a restored `Map` → `extraAs<CuratedListRouteExtra>` returns `null` (a raw `as` throws here); typed value passes through; `Map` read path preserved. 5 tests green.
- [x] All `test/router/` pass (263), `flutter analyze` clean, `dart format` clean.
- [ ] Confirm both Crashlytics issues stop on a build > 1.0.16.

Crashlytics notes added to both issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)