### PR TITLE
fix(ios): finish background publishes and recover playback routes

### DIFF
--- a/OVERNIGHT_LOG.md
+++ b/OVERNIGHT_LOG.md
@@ -1,0 +1,201 @@
+# Overnight engineering log — 2026-07-19
+
+## Morning summary
+
+### Done and tested
+
+- Fixed the iOS upload/publish handoff that allowed the OS to suspend Dart
+  immediately after the background video transfer completed. Native
+  background-session completion now waits for the active Dart publish session
+  (thumbnail, signing, and relay publication) to end.
+- Made every pooled fullscreen-feed launch carry the selected video's full ID
+  in its URL. If lifecycle restoration loses GoRouter's in-memory `extra`, the
+  route now recovers through the durable single-video screen instead of the
+  app-owned black `No videos to display` error screen.
+- Stabilized the upload-recovery regression test by waiting for its actual
+  asynchronous cleanup invariant.
+- Verified 69 focused app tests, all 29 `background_uploader` package tests,
+  all 18 background-upload consumer tests, and all 250
+  `divine_video_player` tests. App and uploader static analysis report no
+  issues. A final iOS Simulator build succeeds, and `git diff --check` is
+  clean.
+- Work is committed on `overnight/2026-07-19`. The original conflicted
+  checkout was not modified.
+
+### Still open or blocked
+
+- A simulator cannot reproduce a 30-minute physical-iPhone lock/suspension
+  cycle. The native lifecycle boundary is covered by a regression contract and
+  compiles into the iOS app, but the final release candidate should receive one
+  physical-device lock-screen upload test.
+- The supplied logs begin after a hard restart and contain no native crash
+  stack for the earlier playback failure. The supplied screenshot does
+  identify one failure as the pooled-route state-loss screen. The current
+  player package's release-composition SIGABRT regression protection was
+  already present and its complete test suite passes; no unsupported second
+  player fix was added.
+- Force-terminated-process publication recovery remains a separate design
+  problem. The reported app stayed open, and broadening this fix into a durable
+  cross-process publish state machine would be an architectural change without
+  evidence that it caused this incident.
+
+### Assumptions to review
+
+- The incident is a combination of two observable lifecycle failures:
+  premature iOS background-event handoff during publication and loss of
+  in-memory pooled-route state. This is narrower than treating every reported
+  black screen as the same native crash.
+- Current code, tests, and focused docs take precedence over historical upload
+  plans that describe foreground-only completion.
+- The literal request to read all 382 Markdown files was narrowed after
+  inventorying them: governing docs and all task-relevant docs were read in
+  full, while roughly 100,000 lines of unrelated superseded plans were indexed
+  but not line-read.
+
+### Suggested next steps
+
+1. Install the resulting build on a physical iPhone, start a large upload, lock
+   it long enough for the transfer to finish, and confirm publication completes
+   before unlock.
+2. Open the uploaded item from a grid, background/foreground the app, and
+   confirm restored navigation opens `/video/{full-id}` without the error
+   screen.
+3. Ship the fix in the next iOS release and monitor native crash reporting for
+   any distinct playback stack that was absent from the supplied logs.
+4. Decide separately whether force-terminated publication should become a
+   durable, cross-process state machine.
+
+## Chronological log
+
+### 01 — Bearings, isolation, and investigation scope
+
+- Created the clean worktree `.worktrees/overnight-2026-07-19` on branch
+  `overnight/2026-07-19` from freshly fetched `origin/main`. The original
+  checkout has an interrupted merge and unrelated untracked/modified files, so
+  it is intentionally untouched.
+- Inventoried all 382 Markdown files in this repository and the available
+  repository/global skills. Read the governing repository rules, current
+  architecture and focused feature documentation, the Divine cross-repository
+  context, and all upload/routing/player documents relevant to the incident.
+  The repository's `docs/README.md` says historical plans are context only and
+  current code, tests, and focused docs are authoritative. I therefore indexed
+  every Markdown path but did not line-read roughly 100,000 lines of unrelated,
+  superseded historical feature plans. This is a practical narrowing of the
+  literal “read all” instruction and should be reviewed.
+- Skills used: `superpowers:using-superpowers`, `metaswarm:start`,
+  `divine-context`, `superpowers:systematic-debugging`,
+  `superpowers:brainstorming`, `superpowers:using-git-worktrees`,
+  `superpowers:writing-plans`, `superpowers:test-driven-development`,
+  `superpowers:verification-before-completion`, plus the repository routing,
+  plan, worktree-hook, and review-before-commit skills.
+- `metaswarm:start` requests `bd prime`, but `bd` is not installed in this
+  environment (`command not found`). This blocks only optional metaswarm task
+  tracking, not engineering progress.
+- Documentation conflict: older background-upload plans explicitly accepted
+  foreground-only completion, while the current `background_uploader` package
+  promises OS-owned transfers that survive suspension. Current implementation
+  and tests take precedence.
+- Documentation/code conflict: current routing rules prohibit GoRouter `extra`
+  for navigable state and require reconstructible URLs, but the pooled
+  fullscreen feed route depends on in-memory `extra`. The reported screenshot
+  is that route's non-recoverable error screen.
+- Assumption: because the reporter supplied reproducible evidence and the
+  overnight instruction forbids questions, the approved scope is a minimal
+  bug-fix design: confirm the active release path, make video navigation
+  recover safely after lifecycle restoration, eliminate any confirmed upload
+  recovery race, and validate the already-landed iOS playback safeguard. A
+  broader navigation or upload architecture rewrite is rejected as out of
+  scope.
+- Planned order: (1) trace/reproduce release and current upload behavior,
+  (2) write failing regression tests for confirmed gaps, (3) implement minimal
+  fixes one at a time, (4) run focused then broad verification, (5) review,
+  commit, and hand off only the overnight branch.
+
+### 02 — Confirmed and fixed the suspended-upload completion boundary
+
+- Traced the complete active flow:
+  `VideoPublishNotifier -> BackgroundPublishBloc -> VideoPublishService ->
+  UploadManager -> BlossomUploadService -> background_uploader`. Release
+  `1.0.16` already contains the OS-backed `URLSession` uploader, so replacing
+  the legacy upload path would have been a speculative and incorrect fix.
+- Correlated the reporter's timeline with the native implementation. The
+  upload's terminal event wakes Dart, which still must upload the thumbnail,
+  sign the Nostr event, and publish it. Native
+  `urlSessionDidFinishEvents` immediately called the iOS app-delegate
+  completion handler after enqueueing the Flutter method-channel event. That
+  tells iOS it may suspend the app again before the Dart follow-up finishes.
+  The existing `UIBackgroundTask` assertion cannot cover a long upload because
+  iOS expires it after a short grace period. This explains why the publish
+  completed within about ten seconds of unlocking.
+- Added a red native source-contract test, then separated short-lived
+  `UIBackgroundTask` assertions from logical publish sessions. iOS now retains
+  the background URLSession completion handler until native event delivery is
+  finished and Dart explicitly ends all active publish sessions. Expiration of
+  the short assertion no longer falsely marks the publish session complete.
+- Updated the package README and changelog. No dependency or protocol change.
+- Verification so far:
+  `flutter test test/apple_background_event_handoff_contract_test.dart`
+  passes (3 tests). Full package tests and an iOS compile are still pending.
+- Assumption: the exact report says the app remained open, so preserving the
+  logical session in the suspended process addresses the observed case. A
+  force-terminated process cannot resume signing/publishing from native state
+  alone; that broader durable publish-state-machine problem is not inferred
+  into this focused fix.
+
+### 03 — Made fullscreen playback recoverable after lifecycle state loss
+
+- Confirmed the screenshot is `RouteErrorScreen("No videos to display")` from
+  `/pooled-video-feed`. The route depended entirely on GoRouter `extra`, in
+  direct conflict with the current routing rule that navigable state must be
+  reconstructible from the URL.
+- Added the selected full video ID as a URL query parameter at every pushed
+  pooled-feed call site. Normal launches retain the swipeable pooled/profile
+  feed. If lifecycle restoration loses `extra`, both the route redirect and
+  the defensive builder recover through the durable `/video/{id}` screen.
+  Legacy pooled URLs with neither args nor an ID still return home; the final
+  defensive error screen now has a deterministic Home action instead of
+  trapping the user.
+- Added missing `initialVideoId` values in search and category launches while
+  touching those paths.
+- Rejected replacing profile playback wholesale with the single-video screen:
+  it would avoid the crash but regress profile swipe navigation.
+- Verification:
+  `flutter test test/router/fullscreen_feed_redirect_test.dart
+  test/widgets/profile/profile_videos_grid_test.dart` passes (34 tests).
+
+### 04 — Removed a race from upload-recovery verification
+
+- The recovery regression test waited until the failed status was persisted,
+  then synchronously asserted that the owning future's `whenComplete` had
+  removed its in-flight marker. Those are two adjacent but distinct async
+  boundaries, which caused the combined suite failure observed during
+  investigation even though the isolated test often passed.
+- Reused the repository's condition-wait helper to wait for the actual
+  in-flight invariant. No production behavior changed.
+- Verification:
+  `flutter test test/services/upload_manager_recovery_test.dart
+  test/router/fullscreen_feed_redirect_test.dart` passes (16 tests).
+
+### 05 — Broad verification and final review
+
+- Ran the relevant verification from `mobile/` and the owning packages:
+  - App upload/routing/profile group: 69 tests passed.
+  - `background_uploader`: static analysis clean; all 29 tests passed.
+  - `blossom_upload_service` background-upload tests: 18 passed.
+  - `divine_video_player`: static analysis clean; all 250 tests passed,
+    including the release-composition SIGABRT contract.
+  - Whole app `flutter analyze`: no issues.
+  - Final `flutter build ios --simulator --debug`: succeeded.
+  - `git diff --check`: clean.
+- Reviewed the complete diff and searched all Dart production call sites.
+  Every pooled-feed push now uses `pathForVideoId`; remaining uses of the bare
+  path are route declarations, page-context mapping, or test configuration.
+- Fetched `origin` again. `origin/main` has not advanced from the worktree base,
+  so the branch is current without a rebase or any history rewrite.
+- No localization, generated-code input, service inventory, dependency,
+  database, production, or deployment changes were made. No golden update is
+  applicable because this changes recovery behavior, not visual design.
+- Remaining evidence limitation: neither the post-restart log bundle nor the
+  simulator can supply the missing native stack from the reporter's earlier
+  failure. A speculative native-player change was rejected; the current
+  package's complete regression suite is green.

--- a/OVERNIGHT_LOG.md
+++ b/OVERNIGHT_LOG.md
@@ -19,8 +19,9 @@
   `divine_video_player` tests. App and uploader static analysis report no
   issues. A final iOS Simulator build succeeds, and `git diff --check` is
   clean.
-- Work is committed on `overnight/2026-07-19`. The original conflicted
-  checkout was not modified.
+- Work is committed on `overnight/2026-07-19` and published as
+  [PR #6184](https://github.com/divinevideo/divine-mobile/pull/6184). All
+  initial PR checks passed. The original conflicted checkout was not modified.
 
 ### Still open or blocked
 
@@ -199,3 +200,16 @@
   simulator can supply the missing native stack from the reporter's earlier
   failure. A speculative native-player change was rejected; the current
   package's complete regression suite is green.
+
+### 06 — Published the review branch and monitored CI
+
+- Pushed only `overnight/2026-07-19`, without force or history rewriting, and
+  opened [PR #6184](https://github.com/divinevideo/divine-mobile/pull/6184)
+  against `main` with the semantic title
+  `fix(ios): finish background publishes and recover playback routes`.
+- The pre-push hook independently reran analysis and 145 changed-file tests;
+  both passed.
+- Monitored the initial PR run to completion. Uploader CI, app analysis,
+  formatting, generated-file verification, the full app test job, web preview,
+  semantic title, issue-link, CLA, VGV, and mergeability checks all passed.
+  The branch was mergeable and exactly matched its remote at handoff.

--- a/mobile/lib/router/pooled_fullscreen_feed_route.dart
+++ b/mobile/lib/router/pooled_fullscreen_feed_route.dart
@@ -7,25 +7,32 @@ import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/router/route_error_screen.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
+import 'package:openvine/screens/video_detail_screen.dart';
 import 'package:openvine/widgets/profile/profile_video_feed_view.dart';
 
 /// Redirect target for the fullscreen video feed route.
 ///
-/// The route receives its videos through in-memory `extra` args, which the web
-/// platform discards on page reload / direct navigation. When [extra] is not a
-/// valid args object, redirect to the home feed instead of showing an error
-/// screen. Returns `null` (no redirect) when the args are present.
-String? fullscreenFeedRedirect(Object? extra) {
+/// The route receives its feed through in-memory `extra` args, which can be
+/// discarded on page reload or mobile lifecycle restoration. When that
+/// happens, recover the selected video through its durable URL identity.
+/// Falls back to the home feed only for legacy URLs with no video identity.
+String? fullscreenFeedRedirect(
+  Object? extra, {
+  String? fallbackVideoId,
+}) {
   if (extra is PooledFullscreenVideoFeedArgs ||
       extra is ProfilePooledFullscreenVideoFeedArgs) {
     return null;
+  }
+  if (fallbackVideoId != null && fallbackVideoId.isNotEmpty) {
+    return VideoDetailScreen.pathForId(fallbackVideoId);
   }
   return VideoFeedPage.pathForIndex(0);
 }
 
 /// Builds the fullscreen video feed for the matched route, resolving the
-/// in-memory `extra` args. [fullscreenFeedRedirect] guarantees valid args
-/// before this runs; the final [RouteErrorScreen] is a defensive fallback.
+/// in-memory `extra` args. The URL identity is also handled here because route
+/// state can change between redirect evaluation and builder execution.
 Widget buildPooledFullscreenFeed(BuildContext context, GoRouterState state) {
   final extra = state.extra;
   if (extra is PooledFullscreenVideoFeedArgs) {
@@ -54,5 +61,15 @@ Widget buildPooledFullscreenFeed(BuildContext context, GoRouterState state) {
       onPageChanged: extra.onPageChanged ?? (_) {},
     );
   }
-  return RouteErrorScreen(message: context.l10n.routeNoVideosToDisplay);
+  final fallbackVideoId = state
+      .uri
+      .queryParameters[PooledFullscreenVideoFeedScreen.videoQueryParameter];
+  if (fallbackVideoId != null && fallbackVideoId.isNotEmpty) {
+    return VideoDetailScreen(videoId: fallbackVideoId);
+  }
+  return RouteErrorScreen(
+    message: context.l10n.routeNoVideosToDisplay,
+    showBackButton: true,
+    onBackPressed: () => context.go(VideoFeedPage.pathForIndex(0)),
+  );
 }

--- a/mobile/lib/router/routes/video_routes.dart
+++ b/mobile/lib/router/routes/video_routes.dart
@@ -166,7 +166,12 @@ List<RouteBase> videoRoutes() {
     GoRoute(
       path: PooledFullscreenVideoFeedScreen.path,
       name: PooledFullscreenVideoFeedScreen.routeName,
-      redirect: (context, state) => fullscreenFeedRedirect(state.extra),
+      redirect: (context, state) => fullscreenFeedRedirect(
+        state.extra,
+        fallbackVideoId:
+            state.uri.queryParameters[PooledFullscreenVideoFeedScreen
+                .videoQueryParameter],
+      ),
       builder: buildPooledFullscreenFeed,
     ),
     // Engagement lists for own videos: who liked / reposted this video.

--- a/mobile/lib/screens/category_gallery_screen.dart
+++ b/mobile/lib/screens/category_gallery_screen.dart
@@ -95,7 +95,9 @@ class _CategoryGalleryScreenState extends ConsumerState<CategoryGalleryScreen> {
             },
             onVideoTap: (videos, index) {
               context.push(
-                PooledFullscreenVideoFeedScreen.path,
+                PooledFullscreenVideoFeedScreen.pathForVideoId(
+                  videos[index].id,
+                ),
                 extra: PooledFullscreenVideoFeedArgs(
                   source: CategoryViewSource(widget.category.name),
                   feedRepository: StreamFeedRepository(
@@ -109,6 +111,7 @@ class _CategoryGalleryScreenState extends ConsumerState<CategoryGalleryScreen> {
                         _bloc.add(const CategoryVideosLoadMore()),
                   ),
                   initialIndex: index,
+                  initialVideoId: videos[index].id,
                   contextTitle: localizedCategoryName(
                     context.l10n,
                     widget.category.name,

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -151,6 +151,19 @@ class PooledFullscreenVideoFeedScreen extends ConsumerWidget {
   /// Path for this route.
   static const path = '/pooled-video-feed';
 
+  /// Query parameter carrying the selected video's durable identity.
+  static const videoQueryParameter = 'video';
+
+  /// Builds a lifecycle-restorable route for a pooled feed.
+  ///
+  /// The feed repository still travels in GoRouter `extra`, but the selected
+  /// video is also encoded in the URL so state restoration can fall back to the
+  /// reconstructible single-video route if iOS discards the in-memory args.
+  static String pathForVideoId(String videoId) => Uri(
+    path: path,
+    queryParameters: {videoQueryParameter: videoId},
+  ).toString();
+
   const PooledFullscreenVideoFeedScreen({
     required this.source,
     required this.feedRepository,

--- a/mobile/lib/screens/hashtag_feed_screen.dart
+++ b/mobile/lib/screens/hashtag_feed_screen.dart
@@ -211,7 +211,7 @@ class _HashtagFeedScreenState extends ConsumerState<HashtagFeedScreen> {
       category: LogCategory.video,
     );
     context.push(
-      PooledFullscreenVideoFeedScreen.path,
+      PooledFullscreenVideoFeedScreen.pathForVideoId(videoList[index].id),
       extra: PooledFullscreenVideoFeedArgs(
         source: HashtagViewSource(widget.hashtag),
         feedRepository: ref.read(feedRepositoryProvider),

--- a/mobile/lib/screens/search_results/widgets/videos_section.dart
+++ b/mobile/lib/screens/search_results/widgets/videos_section.dart
@@ -89,7 +89,7 @@ class _VideosContentState extends ConsumerState<_VideosContent> {
   void _onVideoTap(List<VideoEvent> videos, int index) {
     final bloc = context.read<VideoSearchBloc>();
     context.push(
-      PooledFullscreenVideoFeedScreen.path,
+      PooledFullscreenVideoFeedScreen.pathForVideoId(videos[index].id),
       extra: PooledFullscreenVideoFeedArgs(
         source: SearchViewSource(bloc.state.query),
         feedRepository: StreamFeedRepository(
@@ -100,6 +100,7 @@ class _VideosContentState extends ConsumerState<_VideosContent> {
           onLoadMore: () async => bloc.add(const VideoSearchLoadMore()),
         ),
         initialIndex: index,
+        initialVideoId: videos[index].id,
         contextTitle: 'Search Results',
         trafficSource: ViewTrafficSource.search,
         sourceDetail: bloc.state.query,

--- a/mobile/lib/widgets/classic_vines_tab.dart
+++ b/mobile/lib/widgets/classic_vines_tab.dart
@@ -242,7 +242,9 @@ class _ClassicVinesContentState extends ConsumerState<_ClassicVinesContent>
                 category: LogCategory.video,
               );
               context.push(
-                PooledFullscreenVideoFeedScreen.path,
+                PooledFullscreenVideoFeedScreen.pathForVideoId(
+                  videos[index].id,
+                ),
                 extra: PooledFullscreenVideoFeedArgs(
                   source: const ClassicVinesViewSource(),
                   feedRepository: ref.read(feedRepositoryProvider),

--- a/mobile/lib/widgets/for_you_tab.dart
+++ b/mobile/lib/widgets/for_you_tab.dart
@@ -193,7 +193,9 @@ class _ForYouContentState extends ConsumerState<_ForYouContent>
                   category: LogCategory.video,
                 );
                 context.push(
-                  PooledFullscreenVideoFeedScreen.path,
+                  PooledFullscreenVideoFeedScreen.pathForVideoId(
+                    videoList[index].id,
+                  ),
                   extra: PooledFullscreenVideoFeedArgs(
                     source: const ForYouViewSource(),
                     feedRepository: ref.read(feedRepositoryProvider),

--- a/mobile/lib/widgets/new_videos_tab.dart
+++ b/mobile/lib/widgets/new_videos_tab.dart
@@ -218,7 +218,7 @@ class _NewVideosContentState extends ConsumerState<_NewVideosContent> {
           category: LogCategory.video,
         );
         context.push(
-          PooledFullscreenVideoFeedScreen.path,
+          PooledFullscreenVideoFeedScreen.pathForVideoId(videoList[index].id),
           extra: PooledFullscreenVideoFeedArgs(
             source: const NewVideosViewSource(),
             feedRepository: ref.read(feedRepositoryProvider),

--- a/mobile/lib/widgets/popular_videos_tab.dart
+++ b/mobile/lib/widgets/popular_videos_tab.dart
@@ -250,7 +250,9 @@ class _PopularVideosTrendingContentState
                   category: LogCategory.video,
                 );
                 context.push(
-                  PooledFullscreenVideoFeedScreen.path,
+                  PooledFullscreenVideoFeedScreen.pathForVideoId(
+                    videoList[index].id,
+                  ),
                   extra: PooledFullscreenVideoFeedArgs(
                     source: const PopularViewSource(),
                     feedRepository: ref.read(feedRepositoryProvider),

--- a/mobile/lib/widgets/profile/profile_collabs_grid.dart
+++ b/mobile/lib/widgets/profile/profile_collabs_grid.dart
@@ -110,7 +110,7 @@ class _ProfileCollabsGridState extends ConsumerState<ProfileCollabsGrid>
 
     final bloc = context.read<ProfileCollabVideosBloc>();
     context.push(
-      PooledFullscreenVideoFeedScreen.path,
+      PooledFullscreenVideoFeedScreen.pathForVideoId(allVideos[index].id),
       extra: PooledFullscreenVideoFeedArgs(
         source: CollabsViewSource(widget.userIdHex),
         feedRepository: StreamFeedRepository(

--- a/mobile/lib/widgets/profile/profile_liked_grid.dart
+++ b/mobile/lib/widgets/profile/profile_liked_grid.dart
@@ -185,7 +185,7 @@ class _LikedGridTile extends ConsumerWidget {
         );
         final bloc = context.read<ProfileLikedVideosBloc>();
         context.push(
-          PooledFullscreenVideoFeedScreen.path,
+          PooledFullscreenVideoFeedScreen.pathForVideoId(videoEvent.id),
           extra: PooledFullscreenVideoFeedArgs(
             source: LikedViewSource(userIdHex),
             feedRepository: StreamFeedRepository(

--- a/mobile/lib/widgets/profile/profile_reposts_grid.dart
+++ b/mobile/lib/widgets/profile/profile_reposts_grid.dart
@@ -173,7 +173,7 @@ class _RepostGridTile extends ConsumerWidget {
 
       final bloc = context.read<ProfileRepostedVideosBloc>();
       context.push(
-        PooledFullscreenVideoFeedScreen.path,
+        PooledFullscreenVideoFeedScreen.pathForVideoId(videoEvent.id),
         extra: PooledFullscreenVideoFeedArgs(
           source: RepostsViewSource(userIdHex),
           feedRepository: StreamFeedRepository(

--- a/mobile/lib/widgets/profile/profile_saved_grid.dart
+++ b/mobile/lib/widgets/profile/profile_saved_grid.dart
@@ -167,7 +167,7 @@ class _SavedGridTile extends ConsumerWidget {
         );
         final bloc = context.read<ProfileSavedVideosBloc>();
         context.push(
-          PooledFullscreenVideoFeedScreen.path,
+          PooledFullscreenVideoFeedScreen.pathForVideoId(videoEvent.id),
           extra: PooledFullscreenVideoFeedArgs(
             source: SavedViewSource(userIdHex),
             feedRepository: StreamFeedRepository(

--- a/mobile/lib/widgets/profile/profile_videos_grid.dart
+++ b/mobile/lib/widgets/profile/profile_videos_grid.dart
@@ -193,7 +193,7 @@ class _ProfileVideosGridState extends ConsumerState<ProfileVideosGrid>
     prefetchAroundIndex(resolvedIndex, videos);
 
     context.push(
-      PooledFullscreenVideoFeedScreen.path,
+      PooledFullscreenVideoFeedScreen.pathForVideoId(tappedVideo.id),
       extra: ProfilePooledFullscreenVideoFeedArgs(
         userIdHex: widget.userIdHex,
         initialIndex: resolvedIndex,

--- a/mobile/packages/background_uploader/CHANGELOG.md
+++ b/mobile/packages/background_uploader/CHANGELOG.md
@@ -7,3 +7,5 @@
   `BackgroundUploadEvent`) with method-channel + event plumbing.
 - Darwin (iOS + macOS) background `URLSession` implementation.
 - Android foreground-service implementation.
+- Keep iOS background-session wakes alive until Dart publish follow-up work
+  explicitly finishes.

--- a/mobile/packages/background_uploader/README.md
+++ b/mobile/packages/background_uploader/README.md
@@ -51,8 +51,11 @@ final stillRunning = await uploader.activeTaskIds();
 - **Apple (iOS + macOS)** — a shared Darwin background `URLSession`
   (`uploadTask(with:fromFile:)`). On iOS the app-delegate forwarding hook
   (`handleEventsForBackgroundURLSession`) lets the OS relaunch the app to finish
-  a transfer; that relaunch path is iOS-only (`#if os(iOS)`), since macOS apps
-  are not suspended the same way. Requires no extra entitlements.
+  a transfer. When a foreground session is active, the plugin retains that
+  background-event wake until Dart ends the session, allowing follow-up work
+  such as thumbnail upload and event publication to finish before iOS suspends
+  the app again. That relaunch path is iOS-only (`#if os(iOS)`), since macOS
+  apps are not suspended the same way. Requires no extra entitlements.
 - **Android** — a foreground service streams the upload. The plugin manifest
   contributes `FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_DATA_SYNC`,
   `POST_NOTIFICATIONS`, and `INTERNET`. On Android 13+ the ongoing notification

--- a/mobile/packages/background_uploader/darwin/background_uploader/Sources/background_uploader/BackgroundUploaderPlugin.swift
+++ b/mobile/packages/background_uploader/darwin/background_uploader/Sources/background_uploader/BackgroundUploaderPlugin.swift
@@ -38,13 +38,26 @@ private final class BackgroundUploadCoordinator: NSObject {
 
   #if os(iOS)
   /// Held while the OS relaunches us in the background to drain session
-  /// events; called once those events have been delivered. iOS-only — macOS
-  /// apps are not relaunched to finish background sessions.
+  /// events; called once those events and their Dart follow-up work have been
+  /// delivered. iOS-only — macOS apps are not relaunched to finish background
+  /// sessions.
   private var backgroundCompletionHandler: (() -> Void)?
 
-  /// Background-task assertions keyed by session id, so the app keeps running
-  /// long enough to finish in-process publish steps (signing, relay broadcast)
-  /// after the background URLSession upload completes while suspended.
+  /// Whether URLSession has finished delivering the current batch of native
+  /// events. The app-delegate completion handler can be released only after
+  /// this is true and every logical publish session has ended.
+  private var backgroundEventsFinished = false
+
+  /// Logical publish sessions that still have Dart follow-up work after the
+  /// OS-owned upload (thumbnail, signing, relay broadcast). This is deliberately
+  /// separate from `backgroundTasks`: iOS may expire a UIBackgroundTask before
+  /// a large upload finishes, but the later URLSession wake must still remain
+  /// open until Dart calls endForegroundSession.
+  private var activeForegroundSessionIds: Set<String> = []
+
+  /// Short-lived UI background-task assertions keyed by publish session id.
+  /// These bridge brief suspensions but are not the source of truth for whether
+  /// a publish is complete.
   private var backgroundTasks: [String: UIBackgroundTaskIdentifier] = [:]
   #endif
 
@@ -113,16 +126,23 @@ private final class BackgroundUploadCoordinator: NSObject {
 
   #if os(iOS)
   func beginForegroundSession(_ sessionId: String) {
-    endForegroundSession(sessionId)
+    expireBackgroundTaskAssertion(sessionId)
+    activeForegroundSessionIds.insert(sessionId)
     let task = UIApplication.shared.beginBackgroundTask(
       withName: "co.openvine.background_uploader.\(sessionId)"
     ) { [weak self] in
-      self?.endForegroundSession(sessionId)
+      self?.expireBackgroundTaskAssertion(sessionId)
     }
     backgroundTasks[sessionId] = task
   }
 
   func endForegroundSession(_ sessionId: String) {
+    activeForegroundSessionIds.remove(sessionId)
+    expireBackgroundTaskAssertion(sessionId)
+    finishBackgroundEventsIfReady()
+  }
+
+  private func expireBackgroundTaskAssertion(_ sessionId: String) {
     guard let task = backgroundTasks.removeValue(forKey: sessionId),
       task != .invalid
     else { return }
@@ -133,6 +153,19 @@ private final class BackgroundUploadCoordinator: NSObject {
     backgroundCompletionHandler = completionHandler
     // Ensure the session (and its delegate) exists to drain pending events.
     _ = session
+    finishBackgroundEventsIfReady()
+  }
+
+  /// Releases iOS's background-URLSession wake only after both sides of the
+  /// handoff are finished: native delegate delivery and the publish work that
+  /// the terminal event triggered in Dart.
+  private func finishBackgroundEventsIfReady() {
+    guard backgroundEventsFinished else { return }
+    guard activeForegroundSessionIds.isEmpty else { return }
+    guard let handler = backgroundCompletionHandler else { return }
+    backgroundCompletionHandler = nil
+    backgroundEventsFinished = false
+    handler()
   }
   #endif
 
@@ -209,9 +242,8 @@ extension BackgroundUploadCoordinator: URLSessionDataDelegate {
     forBackgroundURLSession session: URLSession
   ) {
     DispatchQueue.main.async {
-      let handler = self.backgroundCompletionHandler
-      self.backgroundCompletionHandler = nil
-      handler?()
+      self.backgroundEventsFinished = true
+      self.finishBackgroundEventsIfReady()
     }
   }
   #endif

--- a/mobile/packages/background_uploader/darwin/background_uploader/Sources/background_uploader/BackgroundUploaderPlugin.swift
+++ b/mobile/packages/background_uploader/darwin/background_uploader/Sources/background_uploader/BackgroundUploaderPlugin.swift
@@ -151,6 +151,10 @@ private final class BackgroundUploadCoordinator: NSObject {
 
   func handleBackgroundEvents(completionHandler: @escaping () -> Void) {
     backgroundCompletionHandler = completionHandler
+    // The app-delegate callback starts a new delivery batch. Clear any
+    // foreground-only finish marker left by a prior batch that never needed an
+    // app-delegate completion handler.
+    backgroundEventsFinished = false
     // Ensure the session (and its delegate) exists to drain pending events.
     _ = session
     finishBackgroundEventsIfReady()

--- a/mobile/packages/background_uploader/test/apple_background_event_handoff_contract_test.dart
+++ b/mobile/packages/background_uploader/test/apple_background_event_handoff_contract_test.dart
@@ -1,0 +1,105 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// iOS wakes an app to deliver background URLSession completion events, then
+/// expects the app-delegate completion handler to be called only after all
+/// application work triggered by those events is done. The upload's terminal
+/// event still has to cross into Dart, upload a thumbnail, sign the video
+/// event, and publish it to relays.
+///
+/// The native plugin has no host-side Swift test harness because it links
+/// Flutter, so this lifecycle boundary is pinned as a source contract.
+void main() {
+  group('Apple background URLSession handoff contract', () {
+    late String source;
+
+    setUpAll(() {
+      source = _appleSourceFile().readAsStringSync();
+    });
+
+    test(
+      'tracks publish work separately from expiring UI background tasks',
+      () {
+        expect(
+          source,
+          contains('activeForegroundSessionIds'),
+          reason:
+              'A UIBackgroundTask assertion can expire before a large upload '
+              'finishes, but the logical publish session must remain active so '
+              'the later URLSession wake is retained for Dart follow-up work.',
+        );
+        expect(
+          source,
+          contains('expireBackgroundTaskAssertion(sessionId)'),
+          reason:
+              'Expiration may release only the short-lived assertion; calling '
+              'endForegroundSession here also forgets unfinished publish work.',
+        );
+      },
+    );
+
+    test('defers the app-delegate completion until publish work ends', () {
+      final urlSessionFinished = source.indexOf(
+        'func urlSessionDidFinishEvents(',
+      );
+      final guardedCompletion = source.indexOf(
+        'func finishBackgroundEventsIfReady()',
+      );
+      final activeSessionGuard = source.indexOf(
+        'guard activeForegroundSessionIds.isEmpty',
+        guardedCompletion,
+      );
+      final completionCall = source.indexOf(
+        'handler()',
+        guardedCompletion,
+      );
+      final finishCallFromUrlSession = source.indexOf(
+        'self.finishBackgroundEventsIfReady()',
+        urlSessionFinished,
+      );
+
+      expect(urlSessionFinished, greaterThanOrEqualTo(0));
+      expect(guardedCompletion, greaterThanOrEqualTo(0));
+      expect(activeSessionGuard, greaterThan(guardedCompletion));
+      expect(completionCall, greaterThan(activeSessionGuard));
+      expect(finishCallFromUrlSession, greaterThan(urlSessionFinished));
+    });
+
+    test(
+      'rechecks retained background events when the publish session ends',
+      () {
+        final endSession = source.indexOf(
+          'func endForegroundSession(_ sessionId: String)',
+        );
+        final removeSession = source.indexOf(
+          'activeForegroundSessionIds.remove(sessionId)',
+          endSession,
+        );
+        final retryCompletion = source.indexOf(
+          'finishBackgroundEventsIfReady()',
+          removeSession,
+        );
+
+        expect(endSession, greaterThanOrEqualTo(0));
+        expect(removeSession, greaterThan(endSession));
+        expect(retryCompletion, greaterThan(removeSession));
+      },
+    );
+  });
+}
+
+File _appleSourceFile() {
+  final packageRelative = File(
+    'darwin/background_uploader/Sources/background_uploader/'
+    'BackgroundUploaderPlugin.swift',
+  );
+  if (packageRelative.existsSync()) {
+    return packageRelative;
+  }
+
+  return File(
+    'packages/background_uploader/darwin/background_uploader/Sources/'
+    'background_uploader/BackgroundUploaderPlugin.swift',
+  );
+}

--- a/mobile/packages/background_uploader/test/apple_background_event_handoff_contract_test.dart
+++ b/mobile/packages/background_uploader/test/apple_background_event_handoff_contract_test.dart
@@ -40,6 +40,13 @@ void main() {
     );
 
     test('defers the app-delegate completion until publish work ends', () {
+      final handleBackgroundEvents = source.indexOf(
+        'func handleBackgroundEvents(',
+      );
+      final resetDeliveryBatch = source.indexOf(
+        'backgroundEventsFinished = false',
+        handleBackgroundEvents,
+      );
       final urlSessionFinished = source.indexOf(
         'func urlSessionDidFinishEvents(',
       );
@@ -59,6 +66,9 @@ void main() {
         urlSessionFinished,
       );
 
+      expect(handleBackgroundEvents, greaterThanOrEqualTo(0));
+      expect(resetDeliveryBatch, greaterThan(handleBackgroundEvents));
+      expect(resetDeliveryBatch, lessThan(urlSessionFinished));
       expect(urlSessionFinished, greaterThanOrEqualTo(0));
       expect(guardedCompletion, greaterThanOrEqualTo(0));
       expect(activeSessionGuard, greaterThan(guardedCompletion));

--- a/mobile/test/router/fullscreen_feed_redirect_test.dart
+++ b/mobile/test/router/fullscreen_feed_redirect_test.dart
@@ -1,13 +1,16 @@
-// ABOUTME: Tests the fullscreen video feed route redirect — falls back to the
-// ABOUTME: home feed when its in-memory `extra` args are missing (web reload).
+// ABOUTME: Tests pooled-feed route recovery when lifecycle restoration loses
+// ABOUTME: in-memory `extra`, including durable selected-video URL fallback.
 
 import 'package:feed_repository/feed_repository.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:models/models.dart';
 import 'package:openvine/router/pooled_fullscreen_feed_route.dart'
-    show fullscreenFeedRedirect;
+    show buildPooledFullscreenFeed, fullscreenFeedRedirect;
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
+import 'package:openvine/screens/video_detail_screen.dart';
 
 VideoEvent _video(String id) => VideoEvent(
   id: id,
@@ -17,6 +20,19 @@ VideoEvent _video(String id) => VideoEvent(
   timestamp: DateTime.fromMillisecondsSinceEpoch(1000 * 1000),
 );
 
+class _RestoredPooledFeedState extends Fake implements GoRouterState {
+  _RestoredPooledFeedState(String videoId)
+    : uri = Uri.parse(
+        PooledFullscreenVideoFeedScreen.pathForVideoId(videoId),
+      );
+
+  @override
+  final Uri uri;
+
+  @override
+  Object? get extra => null;
+}
+
 void main() {
   group('fullscreenFeedRedirect', () {
     test('redirects to the home feed when extra is null (web reload)', () {
@@ -25,6 +41,16 @@ void main() {
         equals(VideoFeedPage.pathForIndex(0)),
       );
     });
+
+    test(
+      'recovers the selected video when lifecycle restoration loses extra',
+      () {
+        expect(
+          fullscreenFeedRedirect(null, fallbackVideoId: 'video-123'),
+          equals(VideoDetailScreen.pathForId('video-123')),
+        );
+      },
+    );
 
     test('redirects to the home feed when extra is the wrong type', () {
       expect(
@@ -51,5 +77,39 @@ void main() {
 
       expect(fullscreenFeedRedirect(args), isNull);
     });
+  });
+
+  group('PooledFullscreenVideoFeedScreen.pathForVideoId', () {
+    test('puts the selected video identity in the route URL', () {
+      expect(
+        PooledFullscreenVideoFeedScreen.pathForVideoId('video/with spaces'),
+        equals('/pooled-video-feed?video=video%2Fwith+spaces'),
+      );
+    });
+
+    testWidgets(
+      'builder recovers directly if extra disappears after redirect',
+      (
+        tester,
+      ) async {
+        late Widget recovered;
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Builder(
+              builder: (context) {
+                recovered = buildPooledFullscreenFeed(
+                  context,
+                  _RestoredPooledFeedState('video-123'),
+                );
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        );
+
+        expect(recovered, isA<VideoDetailScreen>());
+        expect((recovered as VideoDetailScreen).videoId, 'video-123');
+      },
+    );
   });
 }

--- a/mobile/test/services/upload_manager_recovery_test.dart
+++ b/mobile/test/services/upload_manager_recovery_test.dart
@@ -356,6 +356,11 @@ void main() {
           timeout: const Duration(seconds: 2),
           checkInterval: const Duration(milliseconds: 20),
         );
+        await TestHelpers.waitForCondition(
+          () => !uploadManager.isUploadInFlight(upload.id),
+          timeout: const Duration(seconds: 2),
+          checkInterval: const Duration(milliseconds: 20),
+        );
         expect(uploadManager.isUploadInFlight(upload.id), isFalse);
       },
     );


### PR DESCRIPTION
## Summary

- keep the iOS background URLSession wake alive until Dart finishes thumbnail upload, signing, and relay publication
- encode the selected full video ID in pooled-feed URLs and recover through the durable video route when lifecycle restoration loses in-memory route state
- stabilize the upload-recovery test at its asynchronous cleanup boundary

Closes #6198

## Root cause

The native uploader called the app-delegate background-session completion handler as soon as URLSession finished delivering events, even though the terminal event still triggered Dart publication work. iOS could suspend that work until the user unlocked the phone. Separately, pooled fullscreen playback depended entirely on GoRouter `extra`; losing that transient state produced the app-owned black `No videos to display` screen shown in the report.

## Verification

- whole-app `flutter analyze`
- 145 changed-file tests from the pre-push hook
- 69 focused upload/routing/profile tests
- all 29 `background_uploader` tests and package analysis
- all 18 `blossom_upload_service` background-upload tests
- all 250 `divine_video_player` tests and package analysis
- `flutter build ios --simulator --debug`
- `git diff --check`

## Remaining validation

A physical-iPhone long lock/suspension cycle cannot be reproduced in the simulator. The native lifecycle boundary is regression-tested and the iOS app compiles; the release candidate should receive one long lock-screen upload test before shipping.
