### PR TITLE
fix(blurhash): own spec-correct codec, drop unmaintained blurhash_dart

### DIFF
--- a/.github/workflows/divine_blurhash.yaml
+++ b/.github/workflows/divine_blurhash.yaml
@@ -1,0 +1,26 @@
+# ABOUTME: CI workflow for the divine_blurhash package.
+# ABOUTME: Runs tests, formatting, and analysis only when divine_blurhash files change.
+
+name: Divine Blurhash CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "mobile/packages/divine_blurhash/**"
+      - ".github/workflows/divine_blurhash.yaml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "mobile/packages/divine_blurhash/**"
+      - ".github/workflows/divine_blurhash.yaml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
+    with:
+      working_directory: "mobile/packages/divine_blurhash"

--- a/mobile/packages/blurhash_service/lib/src/blurhash_service.dart
+++ b/mobile/packages/blurhash_service/lib/src/blurhash_service.dart
@@ -58,11 +58,10 @@ class BlurhashService {
   /// Max width used when downscaling before encoding.
   static const int _encodeMaxWidth = 128;
 
-  /// Default punch (contrast) applied to every decoded hash. Kept below 1
-  /// on purpose: the softer look reads better in the feed and it also damps
-  /// the DCT overshoot high-component legacy hashes produce. This is an
-  /// intentional product choice for all placeholders, not only legacy ones.
-  static const double defaultPunch = 0.8;
+  /// Default punch (contrast) applied to every decoded hash. Kept at 1 to
+  /// match divine-web's decoder default, so the same hash renders with
+  /// identical contrast on both clients.
+  static const double defaultPunch = 1;
 
   /// Process-wide memo for [decodeBlurhash]. Decoding is a pure function
   /// of (hash, width, height, punch) and runs synchronously on the UI

--- a/mobile/packages/blurhash_service/lib/src/blurhash_service.dart
+++ b/mobile/packages/blurhash_service/lib/src/blurhash_service.dart
@@ -5,7 +5,7 @@
 
 import 'dart:ui' as ui;
 
-import 'package:blurhash_dart/blurhash_dart.dart' as blurhash_dart;
+import 'package:divine_blurhash/divine_blurhash.dart';
 import 'package:flutter/foundation.dart';
 import 'package:image/image.dart' as img;
 import 'package:unified_logger/unified_logger.dart';
@@ -22,33 +22,47 @@ String? _generateBlurhashSync(Uint8List imageBytes) {
     image.height,
   );
 
+  // Average (box) interpolation: the default (nearest) picks single source
+  // pixels when downscaling, which skews the encoded colors on high-detail
+  // frames.
   final resized = image.width > BlurhashService._encodeMaxWidth
-      ? img.copyResize(image, width: BlurhashService._encodeMaxWidth)
+      ? img.copyResize(
+          image,
+          width: BlurhashService._encodeMaxWidth,
+          interpolation: img.Interpolation.average,
+        )
       : image;
 
-  return blurhash_dart.BlurHash.encode(
-    resized,
+  return encodeBlurHash(
+    resized.getBytes(order: img.ChannelOrder.rgba),
+    resized.width,
+    resized.height,
     numCompX: componentX,
     numCompY: componentY,
-  ).hash;
+  );
 }
 
 /// Service for generating and decoding Blurhash
 /// placeholders.
 class BlurhashService {
-  /// Components for 9:16 portrait videos (4:7 ≈ 0.57, matches 9:16 ≈ 0.5625).
-  static const int _portraitComponentX = 4;
-  static const int _portraitComponentY = 7;
+  /// Components for 9:16 portrait videos. Kept low on purpose: high counts
+  /// (the previous 4×7) cause visible DCT ringing — dark/bright blobs that
+  /// aren't in the source frame.
+  static const int _portraitComponentX = 3;
+  static const int _portraitComponentY = 4;
 
-  /// Components for 1:1 square and landscape videos (balanced).
-  static const int _squareComponentX = 4;
-  static const int _squareComponentY = 4;
+  /// Components for 1:1 square videos.
+  static const int _squareComponentX = 3;
+  static const int _squareComponentY = 3;
 
   /// Max width used when downscaling before encoding.
   static const int _encodeMaxWidth = 128;
 
-  /// Default punch (contrast) value.
-  static const double defaultPunch = 1;
+  /// Default punch (contrast) applied to every decoded hash. Kept below 1
+  /// on purpose: the softer look reads better in the feed and it also damps
+  /// the DCT overshoot high-component legacy hashes produce. This is an
+  /// intentional product choice for all placeholders, not only legacy ones.
+  static const double defaultPunch = 0.8;
 
   /// Process-wide memo for [decodeBlurhash]. Decoding is a pure function
   /// of (hash, width, height, punch) and runs synchronously on the UI
@@ -63,7 +77,8 @@ class BlurhashService {
   );
 
   /// Returns component counts suited to the image's aspect ratio.
-  /// Supports 9:16 portrait, 1:1 square, and landscape; falls back to portrait.
+  /// Divine only produces 9:16 portrait and 1:1 square videos; anything
+  /// square-or-wider gets square components, tall formats get portrait.
   static (int compX, int compY) _componentsForAspectRatio(
     int width,
     int height,
@@ -72,7 +87,7 @@ class BlurhashService {
       return (_portraitComponentX, _portraitComponentY);
     }
     final ratio = width / height;
-    // Square or landscape: ratio ≥ 0.9 (covers 1:1 and any wider format)
+    // 1:1 square (and any wider format)
     if (ratio >= 0.9) return (_squareComponentX, _squareComponentY);
     // Portrait 9:16 (and any other tall format)
     return (_portraitComponentX, _portraitComponentY);
@@ -148,16 +163,17 @@ class BlurhashService {
         return cached;
       }
 
-      // Use real blurhash_dart library to decode
-      final blurHashObject = blurhash_dart.BlurHash.decode(
-        blurhash,
-        punch: punch,
-      );
-      final image = blurHashObject.toImage(width, height);
-
-      // RGBA pixel data of the decoded image (getBytes already returns a
-      // buffer we own — no defensive copy needed)
-      final pixels = image.getBytes(order: img.ChannelOrder.rgba);
+      final Uint8List pixels;
+      try {
+        pixels = decodeBlurHash(blurhash, width, height, punch: punch);
+      } on BlurHashDecodeException catch (e) {
+        Log.error(
+          'Malformed blurhash: ${e.message}',
+          name: 'BlurhashService',
+          category: LogCategory.system,
+        );
+        return null;
+      }
 
       // Extract colors from the decoded pixel data
       final colors = _extractColorsFromPixels(

--- a/mobile/packages/blurhash_service/pubspec.yaml
+++ b/mobile/packages/blurhash_service/pubspec.yaml
@@ -10,7 +10,8 @@ environment:
   flutter: ^3.41.1
 
 dependencies:
-  blurhash_dart: ^1.2.1
+  divine_blurhash:
+    path: ../divine_blurhash
   flutter:
     sdk: flutter
   image: ^4.1.7

--- a/mobile/packages/blurhash_service/test/src/blurhash_service_test.dart
+++ b/mobile/packages/blurhash_service/test/src/blurhash_service_test.dart
@@ -3,8 +3,10 @@ import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:blurhash_service/blurhash_service.dart';
+import 'package:divine_blurhash/divine_blurhash.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:image/image.dart' as img;
+import 'package:unified_logger/unified_logger.dart';
 
 /// Creates a solid-colour JPEG with the given [width] and [height].
 Uint8List _makeJpeg({required int width, required int height}) {
@@ -98,6 +100,32 @@ void main() {
       expect(BlurhashService.decodeBlurhash('short'), isNull);
     });
 
+    test(
+      'logs an error when a valid-charset hash has a mismatched length',
+      () async {
+        await LogCaptureService().clearAllLogs();
+
+        // A real hash truncated mid-string: passes the charset/length-floor
+        // check but its length no longer matches its declared component count,
+        // so decoding bails. Corrupt/truncated tags must stay observable.
+        const truncatedHash = 'L6Pj0^jE.AyE_3t7t7R*';
+
+        expect(BlurhashService.decodeBlurhash(truncatedHash), isNull);
+
+        final errors = LogCaptureService()
+            .getRecentLogs(minLevel: LogLevel.error)
+            .where((entry) => entry.name == 'BlurhashService')
+            .toList();
+        expect(
+          errors,
+          isNotEmpty,
+          reason:
+              'a malformed blurhash must emit an error log, not fail '
+              'silently',
+        );
+      },
+    );
+
     test('blurhash data provides gradient', () {
       final testBlurhash = BlurhashService.getDefaultVineBlurhash();
       final data = BlurhashService.decodeBlurhash(testBlurhash);
@@ -114,23 +142,203 @@ void main() {
       expect(data!.isValid, isTrue);
     });
 
+    test('decodes grayscale content without a color tint', () async {
+      // Regression: blurhash_dart's decodeAc misses the spec's integer
+      // division, which inflates red/green in every AC component — a
+      // white→black gradient decoded with navy blue shadows and a cream
+      // top. The spec-correct decode must keep gray pixels gray.
+      final gradient = img.Image(width: 128, height: 227);
+      for (var y = 0; y < gradient.height; y++) {
+        final v = (230 - (y / gradient.height) * 215).round();
+        for (var x = 0; x < gradient.width; x++) {
+          gradient.setPixelRgb(x, y, v, v, v);
+        }
+      }
+      final hash = await BlurhashService.generateBlurhash(
+        Uint8List.fromList(img.encodePng(gradient)),
+      );
+      expect(hash, isNotNull);
+
+      final data = BlurhashService.decodeBlurhash(hash!);
+      expect(data, isNotNull);
+      final pixels = data!.pixels!;
+      for (var i = 0; i + 3 < pixels.length; i += 4) {
+        final r = pixels[i];
+        final g = pixels[i + 1];
+        final b = pixels[i + 2];
+        expect(
+          (r - g).abs() <= 2 && (g - b).abs() <= 2 && (r - b).abs() <= 2,
+          isTrue,
+          reason: 'pixel ${i ~/ 4} is tinted: r=$r g=$g b=$b',
+        );
+      }
+    });
+
+    test('decodes a solid fill back to its source color', () async {
+      // DC reference vector: a solid fill carries no AC energy, so every
+      // decoded pixel must round-trip the DC (average) color on all three
+      // channels. The expected values are the source color itself — an
+      // independent reference, not this decoder's own output — so a channel
+      // swap or a broken DC/sRGB round-trip fails it. (The AC division
+      // regression is guarded separately by the grayscale-tint test above;
+      // it can't be pinned here because a solid fill has ~zero AC energy.)
+      const sourceR = 100;
+      const sourceG = 149;
+      const sourceB = 237;
+      final image = img.Image(width: 128, height: 128);
+      img.fill(image, color: img.ColorRgb8(sourceR, sourceG, sourceB));
+      final hash = await BlurhashService.generateBlurhash(
+        Uint8List.fromList(img.encodePng(image)),
+      );
+      expect(hash, isNotNull);
+
+      final data = BlurhashService.decodeBlurhash(hash!, punch: 1);
+      expect(data, isNotNull);
+      final pixels = data!.pixels!;
+      for (var i = 0; i + 3 < pixels.length; i += 4) {
+        expect(
+          (pixels[i] - sourceR).abs(),
+          lessThanOrEqualTo(5),
+          reason: 'red @ ${i ~/ 4}: ${pixels[i]}',
+        );
+        expect(
+          (pixels[i + 1] - sourceG).abs(),
+          lessThanOrEqualTo(5),
+          reason: 'green @ ${i ~/ 4}: ${pixels[i + 1]}',
+        );
+        expect(
+          (pixels[i + 2] - sourceB).abs(),
+          lessThanOrEqualTo(5),
+          reason: 'blue @ ${i ~/ 4}: ${pixels[i + 2]}',
+        );
+      }
+    });
+
+    test(
+      'punch scales AC contrast, including the first component row',
+      () async {
+        // A pure horizontal gradient puts nearly all of its AC energy in the
+        // first component row (j = 0, i > 0) — exactly the row blurhash_dart's
+        // punch skipped. Our decode bakes punch into maxAc for every AC term,
+        // so the left↔right contrast must scale ~linearly with punch. A plain
+        // `contrast(high) > contrast(low)` check is NOT enough: the upstream
+        // first-row-skip bug still satisfies it via the tiny residual energy
+        // in the punched j > 0 rows (measured 175 vs 173 at punch 1 vs 0.5).
+        // The ratio assertion below fails under that bug (it needs the
+        // dominant first-row AC to actually be scaled): correct decode gives
+        // ~175 vs ~81, the skip bug gives ~175 vs ~173.
+        final gradient = img.Image(width: 128, height: 128);
+        for (var x = 0; x < gradient.width; x++) {
+          final v = (x / (gradient.width - 1) * 255).round();
+          for (var y = 0; y < gradient.height; y++) {
+            gradient.setPixelRgb(x, y, v, v, v);
+          }
+        }
+        final hash = await BlurhashService.generateBlurhash(
+          Uint8List.fromList(img.encodePng(gradient)),
+        );
+        expect(hash, isNotNull);
+
+        int horizontalContrast(double punch) {
+          final data = BlurhashService.decodeBlurhash(
+            hash!,
+            width: 16,
+            punch: punch,
+          )!;
+          final pixels = data.pixels!;
+          final left = pixels[0];
+          final right = pixels[(16 - 1) * 4];
+          return (right - left).abs();
+        }
+
+        final softContrast = horizontalContrast(0.5);
+        final fullContrast = horizontalContrast(1);
+        expect(
+          fullContrast,
+          greaterThan((softContrast * 1.4).round()),
+          reason:
+              'punch must scale the dominant first-row AC contrast, '
+              'not skip it',
+        );
+      },
+    );
+
+    test(
+      'defaultPunch softens a legacy high-component (4x7) hash',
+      () async {
+        // The PR softens DCT ringing on already-published legacy hashes,
+        // which used 4x7 / 4x4 components. Those hashes are still live and
+        // decode with defaultPunch (0.8), never a punch override, so exercise
+        // that exact path: a 4x7 hash decoded at 0.8 must show a smaller
+        // value spread (less overshoot/ringing) than the same hash at 1.0.
+        final source = img.Image(width: 128, height: 227);
+        for (var y = 0; y < source.height; y++) {
+          for (var x = 0; x < source.width; x++) {
+            final v = ((x ~/ 16) + (y ~/ 16)).isEven ? 245 : 10;
+            source.setPixelRgb(x, y, v, v, v);
+          }
+        }
+        // Encode the legacy shape directly — the service only emits 3x4/3x3
+        // now, so this reproduces a pre-PR production hash. numCompX defaults
+        // to 4; numCompY: 7 makes it the 4x7 shape.
+        final legacyHash = encodeBlurHash(
+          source.getBytes(order: img.ChannelOrder.rgba),
+          source.width,
+          source.height,
+          numCompY: 7,
+        );
+
+        int valueSpread(double punch) {
+          final data = BlurhashService.decodeBlurhash(
+            legacyHash,
+            punch: punch,
+          )!;
+          final pixels = data.pixels!;
+          var lo = 255;
+          var hi = 0;
+          for (var i = 0; i + 3 < pixels.length; i += 4) {
+            for (var c = 0; c < 3; c++) {
+              lo = lo < pixels[i + c] ? lo : pixels[i + c];
+              hi = hi > pixels[i + c] ? hi : pixels[i + c];
+            }
+          }
+          return hi - lo;
+        }
+
+        expect(
+          valueSpread(BlurhashService.defaultPunch),
+          lessThan(valueSpread(1)),
+          reason: 'defaultPunch must damp legacy-hash contrast/ringing',
+        );
+      },
+    );
+
     group('generateBlurhash aspect-ratio component selection', () {
       // Blurhash length = 6 + 2 * (compX * compY - 1)
-      // Portrait 4×7 → 6 + 2*27 = 60 chars
-      // Square   4×4 → 6 + 2*15 = 36 chars
+      // Portrait 3×4 → 6 + 2*11 = 28 chars
+      // Square   3×3 → 6 + 2*8  = 22 chars
 
-      test('uses 4×7 components for 9:16 portrait image', () async {
+      test('uses 3×4 components for 9:16 portrait image', () async {
         final bytes = _makeJpeg(width: 90, height: 160);
         final hash = await BlurhashService.generateBlurhash(bytes);
         expect(hash, isNotNull);
-        expect(hash!.length, equals(60));
+        expect(hash!.length, equals(28));
       });
 
-      test('uses 4×4 components for 1:1 square image', () async {
+      test('uses 3×3 components for 1:1 square image', () async {
         final bytes = _makeJpeg(width: 100, height: 100);
         final hash = await BlurhashService.generateBlurhash(bytes);
         expect(hash, isNotNull);
-        expect(hash!.length, equals(36));
+        expect(hash!.length, equals(22));
+      });
+
+      test('falls back to square components for landscape input', () async {
+        // Divine only produces 9:16 and 1:1 videos; wider input (e.g.
+        // imported media) shares the square components.
+        final bytes = _makeJpeg(width: 160, height: 90);
+        final hash = await BlurhashService.generateBlurhash(bytes);
+        expect(hash, isNotNull);
+        expect(hash!.length, equals(22));
       });
 
       test('accepts valid square hashes that do not start with L', () async {
@@ -151,7 +359,7 @@ void main() {
           await thumbnailFile.readAsBytes(),
         );
         expect(hash, isNotNull);
-        expect(hash!.length, equals(60));
+        expect(hash!.length, equals(28));
       });
 
       test('runs encoding in a background isolate '

--- a/mobile/packages/blurhash_service/test/src/blurhash_service_test.dart
+++ b/mobile/packages/blurhash_service/test/src/blurhash_service_test.dart
@@ -192,7 +192,7 @@ void main() {
       );
       expect(hash, isNotNull);
 
-      final data = BlurhashService.decodeBlurhash(hash!, punch: 1);
+      final data = BlurhashService.decodeBlurhash(hash!);
       expect(data, isNotNull);
       final pixels = data!.pixels!;
       for (var i = 0; i + 3 < pixels.length; i += 4) {
@@ -264,13 +264,13 @@ void main() {
     );
 
     test(
-      'defaultPunch softens a legacy high-component (4x7) hash',
+      'decodes a legacy high-component (4x7) hash without a tint',
       () async {
-        // The PR softens DCT ringing on already-published legacy hashes,
-        // which used 4x7 / 4x4 components. Those hashes are still live and
-        // decode with defaultPunch (0.8), never a punch override, so exercise
-        // that exact path: a 4x7 hash decoded at 0.8 must show a smaller
-        // value spread (less overshoot/ringing) than the same hash at 1.0.
+        // Pre-PR production hashes used 4x7 / 4x4 components and are still
+        // live in published Nostr events — the decoder must keep handling
+        // them. The high-contrast grayscale checkerboard also pins channel
+        // symmetry under heavy ringing: the old blurhash_dart decode bug
+        // tinted exactly this kind of content.
         final source = img.Image(width: 128, height: 227);
         for (var y = 0; y < source.height; y++) {
           for (var x = 0; x < source.width; x++) {
@@ -288,28 +288,20 @@ void main() {
           numCompY: 7,
         );
 
-        int valueSpread(double punch) {
-          final data = BlurhashService.decodeBlurhash(
-            legacyHash,
-            punch: punch,
-          )!;
-          final pixels = data.pixels!;
-          var lo = 255;
-          var hi = 0;
-          for (var i = 0; i + 3 < pixels.length; i += 4) {
-            for (var c = 0; c < 3; c++) {
-              lo = lo < pixels[i + c] ? lo : pixels[i + c];
-              hi = hi > pixels[i + c] ? hi : pixels[i + c];
-            }
-          }
-          return hi - lo;
+        final data = BlurhashService.decodeBlurhash(legacyHash);
+        expect(data, isNotNull);
+        final pixels = data!.pixels!;
+        expect(pixels, hasLength(32 * 32 * 4));
+        for (var i = 0; i + 3 < pixels.length; i += 4) {
+          final r = pixels[i];
+          final g = pixels[i + 1];
+          final b = pixels[i + 2];
+          expect(
+            (r - g).abs() <= 2 && (g - b).abs() <= 2 && (r - b).abs() <= 2,
+            isTrue,
+            reason: 'pixel ${i ~/ 4} is tinted: r=$r g=$g b=$b',
+          );
         }
-
-        expect(
-          valueSpread(BlurhashService.defaultPunch),
-          lessThan(valueSpread(1)),
-          reason: 'defaultPunch must damp legacy-hash contrast/ringing',
-        );
       },
     );
 

--- a/mobile/packages/divine_blurhash/README.md
+++ b/mobile/packages/divine_blurhash/README.md
@@ -10,7 +10,7 @@ caller owns image decoding/resizing.
 import 'package:divine_blurhash/divine_blurhash.dart';
 
 final hash = encodeBlurHash(rgba, width, height, numCompX: 3, numCompY: 4);
-final pixels = decodeBlurHash(hash, 32, 32, punch: 0.8); // RGBA
+final pixels = decodeBlurHash(hash, 32, 32); // RGBA
 ```
 
 ## Why this exists
@@ -34,4 +34,4 @@ spec-compliant decoder (e.g. divine-web's JS decoder).
 
 - `String encodeBlurHash(Uint8List rgba, int width, int height, {int numCompX = 4, int numCompY = 3})`
 - `Uint8List decodeBlurHash(String blurHash, int width, int height, {double punch = 1.0})`
-  — throws [`BlurHashDecodeException`] on a malformed hash.
+  — throws `BlurHashDecodeException` on a malformed hash.

--- a/mobile/packages/divine_blurhash/README.md
+++ b/mobile/packages/divine_blurhash/README.md
@@ -1,0 +1,37 @@
+# divine_blurhash
+
+Spec-correct [BlurHash](https://blurha.sh) encoder and decoder for Divine.
+
+Pure Dart — no Flutter, no `image` dependency. Both functions operate on
+raw RGBA byte buffers (`width * height * 4`, `[r, g, b, a, …]`), so the
+caller owns image decoding/resizing.
+
+```dart
+import 'package:divine_blurhash/divine_blurhash.dart';
+
+final hash = encodeBlurHash(rgba, width, height, numCompX: 3, numCompY: 4);
+final pixels = decodeBlurHash(hash, 32, 32, punch: 0.8); // RGBA
+```
+
+## Why this exists
+
+We previously used [`blurhash_dart`](https://pub.dev/packages/blurhash_dart),
+which is unmaintained (last release `1.2.1`, ~3 years ago) and ships two
+decode bugs that produce visibly wrong placeholders:
+
+- **Colour tint.** `decodeAc` divides with `/` where the spec requires
+  integer division (`~/`), inflating red/green in every AC component.
+  Grayscale content decodes with a blue/cream tint.
+- **Broken punch.** Its `punch` (contrast) parameter skips the entire
+  first AC row and column instead of scaling every AC term.
+
+Since the package is abandoned there is no upstream fix to wait for, so
+Divine owns a clean, spec-correct implementation instead. Encoding follows
+the same reference algorithm and stays interoperable with any other
+spec-compliant decoder (e.g. divine-web's JS decoder).
+
+## API
+
+- `String encodeBlurHash(Uint8List rgba, int width, int height, {int numCompX = 4, int numCompY = 3})`
+- `Uint8List decodeBlurHash(String blurHash, int width, int height, {double punch = 1.0})`
+  — throws [`BlurHashDecodeException`] on a malformed hash.

--- a/mobile/packages/divine_blurhash/analysis_options.yaml
+++ b/mobile/packages/divine_blurhash/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:very_good_analysis/analysis_options.yaml

--- a/mobile/packages/divine_blurhash/lib/divine_blurhash.dart
+++ b/mobile/packages/divine_blurhash/lib/divine_blurhash.dart
@@ -1,0 +1,6 @@
+/// Spec-correct BlurHash encoder and decoder, operating on raw RGBA bytes.
+library;
+
+export 'src/blurhash_decoder.dart' show decodeBlurHash;
+export 'src/blurhash_encoder.dart' show encodeBlurHash;
+export 'src/blurhash_exception.dart' show BlurHashDecodeException;

--- a/mobile/packages/divine_blurhash/lib/src/base83.dart
+++ b/mobile/packages/divine_blurhash/lib/src/base83.dart
@@ -1,0 +1,50 @@
+import 'package:divine_blurhash/src/blurhash_exception.dart';
+
+/// Base83 alphabet from the BlurHash spec.
+const String base83Alphabet =
+    '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+    'abcdefghijklmnopqrstuvwxyz'
+    r'#$%*+,-.:;=?@[]^_{|}~';
+
+/// Reverse index of [base83Alphabet] for O(1) character lookup. Decoding
+/// runs synchronously per hash, so a linear `indexOf` scan per character
+/// would add up.
+final Map<String, int> _reverseIndex = {
+  for (var i = 0; i < base83Alphabet.length; i++) base83Alphabet[i]: i,
+};
+
+/// Decodes the base83 substring `value[from..to)` into an integer.
+///
+/// Throws [BlurHashDecodeException] on any character outside the base83
+/// alphabet.
+int decode83(String value, int from, int to) {
+  var result = 0;
+  for (var i = from; i < to; i++) {
+    final digit = _reverseIndex[value[i]];
+    if (digit == null) {
+      throw BlurHashDecodeException(
+        'invalid base83 character "${value[i]}" at index $i',
+      );
+    }
+    result = result * 83 + digit;
+  }
+  return result;
+}
+
+/// Encodes [value] as a base83 string of exactly [length] characters.
+String encode83(int value, int length) {
+  final buffer = StringBuffer();
+  for (var i = 1; i <= length; i++) {
+    final digit = (value ~/ _pow83(length - i)) % 83;
+    buffer.write(base83Alphabet[digit]);
+  }
+  return buffer.toString();
+}
+
+int _pow83(int exponent) {
+  var result = 1;
+  for (var i = 0; i < exponent; i++) {
+    result *= 83;
+  }
+  return result;
+}

--- a/mobile/packages/divine_blurhash/lib/src/blurhash_decoder.dart
+++ b/mobile/packages/divine_blurhash/lib/src/blurhash_decoder.dart
@@ -59,6 +59,23 @@ Uint8List decodeBlurHash(
     componentsB[i] = signPow((quantB - 9) / 9, 2) * maxAc;
   }
 
+  // Precomputed DCT basis tables: this decode runs synchronously on the
+  // caller's isolate, and cos() per (pixel, component) pair would cost
+  // width*height*numCompY*(numCompX+1) evaluations vs. these
+  // width*numCompX + height*numCompY.
+  final basisX = Float64List(width * numCompX);
+  for (var x = 0; x < width; x++) {
+    for (var i = 0; i < numCompX; i++) {
+      basisX[x * numCompX + i] = math.cos(math.pi * x * i / width);
+    }
+  }
+  final basisY = Float64List(height * numCompY);
+  for (var y = 0; y < height; y++) {
+    for (var j = 0; j < numCompY; j++) {
+      basisY[y * numCompY + j] = math.cos(math.pi * y * j / height);
+    }
+  }
+
   final pixels = Uint8List(width * height * 4);
   var offset = 0;
   for (var y = 0; y < height; y++) {
@@ -67,9 +84,9 @@ Uint8List decodeBlurHash(
       var g = 0.0;
       var b = 0.0;
       for (var j = 0; j < numCompY; j++) {
-        final basisY = math.cos(math.pi * y * j / height);
+        final cosY = basisY[y * numCompY + j];
         for (var i = 0; i < numCompX; i++) {
-          final basis = math.cos(math.pi * x * i / width) * basisY;
+          final basis = basisX[x * numCompX + i] * cosY;
           final index = i + j * numCompX;
           r += componentsR[index] * basis;
           g += componentsG[index] * basis;

--- a/mobile/packages/divine_blurhash/lib/src/blurhash_decoder.dart
+++ b/mobile/packages/divine_blurhash/lib/src/blurhash_decoder.dart
@@ -1,0 +1,86 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:divine_blurhash/src/base83.dart';
+import 'package:divine_blurhash/src/blurhash_exception.dart';
+import 'package:divine_blurhash/src/color_math.dart';
+
+/// Decodes [blurHash] into a `width * height` RGBA pixel buffer.
+///
+/// The returned buffer is `[r, g, b, a, …]` with alpha fixed at 255.
+///
+/// [punch] scales the contrast of every AC component uniformly (it is
+/// baked into `maxAc`, so it applies to the first component row and column
+/// too — unlike `blurhash_dart`, which skipped them).
+///
+/// Throws [BlurHashDecodeException] when [blurHash] is shorter than 6
+/// characters, contains a non-base83 character, or its length does not
+/// match the component count declared in its size flag.
+Uint8List decodeBlurHash(
+  String blurHash,
+  int width,
+  int height, {
+  double punch = 1.0,
+}) {
+  if (blurHash.length < 6) {
+    throw BlurHashDecodeException(
+      'too short: length ${blurHash.length} is below the 6-character minimum',
+    );
+  }
+
+  final sizeFlag = decode83(blurHash, 0, 1);
+  final numCompX = (sizeFlag % 9) + 1;
+  final numCompY = (sizeFlag ~/ 9) + 1;
+  final expectedLength = 4 + 2 * numCompX * numCompY;
+  if (blurHash.length != expectedLength) {
+    throw BlurHashDecodeException(
+      'length ${blurHash.length} does not match the declared '
+      '${numCompX}x$numCompY components (expected $expectedLength)',
+    );
+  }
+
+  final maxAc = (decode83(blurHash, 1, 2) + 1) / 166.0 * punch;
+  final dcValue = decode83(blurHash, 2, 6);
+
+  final count = numCompX * numCompY;
+  final componentsR = Float64List(count);
+  final componentsG = Float64List(count);
+  final componentsB = Float64List(count);
+  componentsR[0] = sRgbToLinear(dcValue >> 16);
+  componentsG[0] = sRgbToLinear((dcValue >> 8) & 255);
+  componentsB[0] = sRgbToLinear(dcValue & 255);
+  for (var i = 1; i < count; i++) {
+    final value = decode83(blurHash, 4 + i * 2, 6 + i * 2);
+    final quantR = value ~/ (19 * 19);
+    final quantG = (value ~/ 19) % 19;
+    final quantB = value % 19;
+    componentsR[i] = signPow((quantR - 9) / 9, 2) * maxAc;
+    componentsG[i] = signPow((quantG - 9) / 9, 2) * maxAc;
+    componentsB[i] = signPow((quantB - 9) / 9, 2) * maxAc;
+  }
+
+  final pixels = Uint8List(width * height * 4);
+  var offset = 0;
+  for (var y = 0; y < height; y++) {
+    for (var x = 0; x < width; x++) {
+      var r = 0.0;
+      var g = 0.0;
+      var b = 0.0;
+      for (var j = 0; j < numCompY; j++) {
+        final basisY = math.cos(math.pi * y * j / height);
+        for (var i = 0; i < numCompX; i++) {
+          final basis = math.cos(math.pi * x * i / width) * basisY;
+          final index = i + j * numCompX;
+          r += componentsR[index] * basis;
+          g += componentsG[index] * basis;
+          b += componentsB[index] * basis;
+        }
+      }
+      pixels[offset++] = linearToSRgb(r);
+      pixels[offset++] = linearToSRgb(g);
+      pixels[offset++] = linearToSRgb(b);
+      pixels[offset++] = 255;
+    }
+  }
+  return pixels;
+}

--- a/mobile/packages/divine_blurhash/lib/src/blurhash_encoder.dart
+++ b/mobile/packages/divine_blurhash/lib/src/blurhash_encoder.dart
@@ -1,0 +1,112 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:divine_blurhash/src/base83.dart';
+import 'package:divine_blurhash/src/color_math.dart';
+
+/// Encodes a `width * height` RGBA pixel buffer into a BlurHash string.
+///
+/// [rgba] must be `width * height * 4` bytes in `[r, g, b, a, …]` order;
+/// the alpha channel is ignored. [numCompX] and [numCompY] (1–9 each)
+/// control the horizontal/vertical DCT component counts — more components
+/// mean more detail but a longer hash and more visible DCT ringing.
+///
+/// Throws [ArgumentError] when the component counts are out of range or
+/// [rgba] does not match `width * height * 4`.
+String encodeBlurHash(
+  Uint8List rgba,
+  int width,
+  int height, {
+  int numCompX = 4,
+  int numCompY = 3,
+}) {
+  if (numCompX < 1 || numCompX > 9 || numCompY < 1 || numCompY > 9) {
+    throw ArgumentError(
+      'numCompX ($numCompX) and numCompY ($numCompY) must each be 1–9',
+    );
+  }
+  if (rgba.length != width * height * 4) {
+    throw ArgumentError(
+      'rgba length ${rgba.length} does not match width*height*4 '
+      '(${width * height * 4})',
+    );
+  }
+
+  final count = numCompX * numCompY;
+  final factorsR = Float64List(count);
+  final factorsG = Float64List(count);
+  final factorsB = Float64List(count);
+  final scale = 1.0 / (width * height);
+
+  for (var j = 0; j < numCompY; j++) {
+    for (var i = 0; i < numCompX; i++) {
+      final normalisation = (i == 0 && j == 0) ? 1.0 : 2.0;
+      var r = 0.0;
+      var g = 0.0;
+      var b = 0.0;
+      for (var y = 0; y < height; y++) {
+        final basisY = math.cos(math.pi * j * y / height);
+        for (var x = 0; x < width; x++) {
+          final basis =
+              normalisation * math.cos(math.pi * i * x / width) * basisY;
+          final offset = (y * width + x) * 4;
+          r += basis * sRgbToLinear(rgba[offset]);
+          g += basis * sRgbToLinear(rgba[offset + 1]);
+          b += basis * sRgbToLinear(rgba[offset + 2]);
+        }
+      }
+      final index = i + j * numCompX;
+      factorsR[index] = r * scale;
+      factorsG[index] = g * scale;
+      factorsB[index] = b * scale;
+    }
+  }
+
+  final buffer = StringBuffer()
+    ..write(encode83((numCompX - 1) + (numCompY - 1) * 9, 1));
+
+  final double maximumValue;
+  if (count > 1) {
+    var actualMax = 0.0;
+    for (var i = 1; i < count; i++) {
+      actualMax = math.max(actualMax, factorsR[i].abs());
+      actualMax = math.max(actualMax, factorsG[i].abs());
+      actualMax = math.max(actualMax, factorsB[i].abs());
+    }
+    final quantisedMax = math.max(
+      0,
+      math.min(82, (actualMax * 166 - 0.5).floor()),
+    );
+    maximumValue = (quantisedMax + 1) / 166.0;
+    buffer.write(encode83(quantisedMax, 1));
+  } else {
+    maximumValue = 1.0;
+    buffer.write(encode83(0, 1));
+  }
+
+  buffer.write(encode83(_encodeDc(factorsR[0], factorsG[0], factorsB[0]), 4));
+  for (var i = 1; i < count; i++) {
+    buffer.write(
+      encode83(
+        _encodeAc(factorsR[i], factorsG[i], factorsB[i], maximumValue),
+        2,
+      ),
+    );
+  }
+  return buffer.toString();
+}
+
+int _encodeDc(double r, double g, double b) {
+  final roundedR = linearToSRgb(r);
+  final roundedG = linearToSRgb(g);
+  final roundedB = linearToSRgb(b);
+  return (roundedR << 16) + (roundedG << 8) + roundedB;
+}
+
+int _encodeAc(double r, double g, double b, double maximumValue) {
+  int quant(double value) => math.max(
+    0,
+    math.min(18, (signPow(value / maximumValue, 0.5) * 9 + 9.5).floor()),
+  );
+  return quant(r) * 19 * 19 + quant(g) * 19 + quant(b);
+}

--- a/mobile/packages/divine_blurhash/lib/src/blurhash_encoder.dart
+++ b/mobile/packages/divine_blurhash/lib/src/blurhash_encoder.dart
@@ -38,6 +38,19 @@ String encodeBlurHash(
   final factorsB = Float64List(count);
   final scale = 1.0 / (width * height);
 
+  // Precomputed linear-light pixels: sRgbToLinear costs a pow() call, so
+  // converting once per pixel instead of once per (pixel, component) pair
+  // cuts that work by the component count.
+  final pixelCount = width * height;
+  final linearR = Float64List(pixelCount);
+  final linearG = Float64List(pixelCount);
+  final linearB = Float64List(pixelCount);
+  for (var p = 0; p < pixelCount; p++) {
+    linearR[p] = sRgbToLinear(rgba[p * 4]);
+    linearG[p] = sRgbToLinear(rgba[p * 4 + 1]);
+    linearB[p] = sRgbToLinear(rgba[p * 4 + 2]);
+  }
+
   for (var j = 0; j < numCompY; j++) {
     for (var i = 0; i < numCompX; i++) {
       final normalisation = (i == 0 && j == 0) ? 1.0 : 2.0;
@@ -49,10 +62,10 @@ String encodeBlurHash(
         for (var x = 0; x < width; x++) {
           final basis =
               normalisation * math.cos(math.pi * i * x / width) * basisY;
-          final offset = (y * width + x) * 4;
-          r += basis * sRgbToLinear(rgba[offset]);
-          g += basis * sRgbToLinear(rgba[offset + 1]);
-          b += basis * sRgbToLinear(rgba[offset + 2]);
+          final p = y * width + x;
+          r += basis * linearR[p];
+          g += basis * linearG[p];
+          b += basis * linearB[p];
         }
       }
       final index = i + j * numCompX;

--- a/mobile/packages/divine_blurhash/lib/src/blurhash_exception.dart
+++ b/mobile/packages/divine_blurhash/lib/src/blurhash_exception.dart
@@ -1,0 +1,13 @@
+/// Thrown by `decodeBlurHash` when a hash string is malformed — too short,
+/// contains a non-base83 character, or its length does not match the
+/// component count declared in its size flag.
+class BlurHashDecodeException implements Exception {
+  /// Creates a [BlurHashDecodeException] with a human-readable [message].
+  const BlurHashDecodeException(this.message);
+
+  /// Describes why the hash could not be decoded.
+  final String message;
+
+  @override
+  String toString() => 'BlurHashDecodeException: $message';
+}

--- a/mobile/packages/divine_blurhash/lib/src/color_math.dart
+++ b/mobile/packages/divine_blurhash/lib/src/color_math.dart
@@ -1,0 +1,24 @@
+import 'dart:math' as math;
+
+/// Converts an 8-bit sRGB channel value (0–255) to linear light (0–1).
+double sRgbToLinear(int value) {
+  final v = value / 255.0;
+  if (v <= 0.04045) return v / 12.92;
+  return math.pow((v + 0.055) / 1.055, 2.4).toDouble();
+}
+
+/// Converts a linear-light channel value to an 8-bit sRGB value (0–255).
+///
+/// Values outside 0–1 (AC overshoot) are clamped before conversion.
+int linearToSRgb(double value) {
+  final v = value.clamp(0.0, 1.0);
+  if (v <= 0.0031308) {
+    return (v * 12.92 * 255 + 0.5).toInt();
+  }
+  return ((1.055 * math.pow(v, 1 / 2.4) - 0.055) * 255 + 0.5).toInt();
+}
+
+/// Raises [value] to [exponent] while preserving its sign
+/// (`sign(value) * pow(|value|, exponent)`).
+double signPow(double value, double exponent) =>
+    math.pow(value.abs(), exponent).toDouble() * value.sign;

--- a/mobile/packages/divine_blurhash/pubspec.yaml
+++ b/mobile/packages/divine_blurhash/pubspec.yaml
@@ -1,0 +1,16 @@
+name: divine_blurhash
+description: >
+  Spec-correct BlurHash encoder and decoder for Divine. Pure Dart, no
+  Flutter dependency; operates on raw RGBA byte buffers. Replaces the
+  unmaintained blurhash_dart package, whose decode path had two spec
+  bugs (integer-division tint and a punch first-row/column skip).
+version: 0.1.0
+publish_to: none
+resolution: workspace
+
+environment:
+  sdk: ^3.11.0
+
+dev_dependencies:
+  test: ^1.26.3
+  very_good_analysis: ^10.2.0

--- a/mobile/packages/divine_blurhash/test/src/base83_test.dart
+++ b/mobile/packages/divine_blurhash/test/src/base83_test.dart
@@ -1,0 +1,33 @@
+import 'package:divine_blurhash/src/base83.dart';
+import 'package:divine_blurhash/src/blurhash_exception.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('base83', () {
+    test('decode83 round-trips values produced by encode83', () {
+      for (final value in [0, 1, 82, 83, 1000, 571786]) {
+        final encoded = encode83(value, 4);
+        expect(encoded.length, 4);
+        expect(decode83(encoded, 0, encoded.length), value);
+      }
+    });
+
+    test('encode83 pads to the requested length', () {
+      expect(encode83(0, 4), '0000');
+      expect(encode83(1, 1), '1');
+    });
+
+    test('decode83 reads only the requested slice', () {
+      // '10' -> 1*83 + 0 across [0,2); '0' alone across [1,2).
+      expect(decode83('10', 0, 2), 83);
+      expect(decode83('10', 1, 2), 0);
+    });
+
+    test('decode83 throws on a non-base83 character', () {
+      expect(
+        () => decode83('A/', 0, 2),
+        throwsA(isA<BlurHashDecodeException>()),
+      );
+    });
+  });
+}

--- a/mobile/packages/divine_blurhash/test/src/blurhash_decoder_test.dart
+++ b/mobile/packages/divine_blurhash/test/src/blurhash_decoder_test.dart
@@ -1,0 +1,47 @@
+import 'package:divine_blurhash/divine_blurhash.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('decodeBlurHash', () {
+    // A real 4x3 hash (size flag 'L' → 4 components wide, 3 tall, 28 chars).
+    const validHash = 'L6Pj0^jE.AyE_3t7t7R**0o#DgR4';
+
+    test('fills a width*height*4 RGBA buffer with opaque pixels', () {
+      final pixels = decodeBlurHash(validHash, 4, 5);
+      expect(pixels, hasLength(4 * 5 * 4));
+      for (var i = 3; i < pixels.length; i += 4) {
+        expect(pixels[i], 255, reason: 'alpha at pixel ${i ~/ 4}');
+      }
+    });
+
+    test('decodes a 1x1-component hash (no AC terms)', () {
+      // Size flag '0' → 1x1 components, so the hash is exactly 6 chars.
+      final oneByOne = decodeBlurHash('00Fdrz', 2, 2);
+      expect(oneByOne, hasLength(2 * 2 * 4));
+    });
+
+    test('throws when the hash is shorter than 6 characters', () {
+      expect(
+        () => decodeBlurHash('short', 4, 4),
+        throwsA(isA<BlurHashDecodeException>()),
+      );
+    });
+
+    test('throws when the length does not match the size flag', () {
+      // validHash truncated: charset is fine, declared components need 28.
+      expect(
+        () => decodeBlurHash('L6Pj0^jE.AyE_3t7t7R*', 4, 4),
+        throwsA(isA<BlurHashDecodeException>()),
+      );
+    });
+
+    test('throws on a non-base83 character after the size flag', () {
+      // '0' → 1x1 → expected length 6, so length passes; the '/' at index 1
+      // is rejected while reading maxAc.
+      expect(
+        () => decodeBlurHash('0/0000', 2, 2),
+        throwsA(isA<BlurHashDecodeException>()),
+      );
+    });
+  });
+}

--- a/mobile/packages/divine_blurhash/test/src/blurhash_encoder_test.dart
+++ b/mobile/packages/divine_blurhash/test/src/blurhash_encoder_test.dart
@@ -1,0 +1,71 @@
+import 'dart:typed_data';
+
+import 'package:divine_blurhash/divine_blurhash.dart';
+import 'package:test/test.dart';
+
+Uint8List _solid(int width, int height, int r, int g, int b) {
+  final rgba = Uint8List(width * height * 4);
+  for (var i = 0; i < width * height; i++) {
+    rgba[i * 4] = r;
+    rgba[i * 4 + 1] = g;
+    rgba[i * 4 + 2] = b;
+    rgba[i * 4 + 3] = 255;
+  }
+  return rgba;
+}
+
+void main() {
+  group('encodeBlurHash', () {
+    test('produces a hash of the spec length for the component count', () {
+      final hash = encodeBlurHash(
+        _solid(8, 8, 100, 149, 237),
+        8,
+        8,
+        numCompX: 3,
+        numCompY: 4,
+      );
+      // length = 6 + 2 * (compX * compY - 1)
+      expect(hash.length, 6 + 2 * (3 * 4 - 1));
+    });
+
+    test('encodes a 1x1-component hash with no AC terms', () {
+      final hash = encodeBlurHash(
+        _solid(4, 4, 10, 20, 30),
+        4,
+        4,
+        numCompX: 1,
+        numCompY: 1,
+      );
+      expect(hash.length, 6);
+      // A 1x1 hash is decodable and carries a solid colour.
+      expect(() => decodeBlurHash(hash, 2, 2), returnsNormally);
+    });
+
+    test('rejects component counts outside 1–9', () {
+      final rgba = _solid(2, 2, 0, 0, 0);
+      expect(
+        () => encodeBlurHash(rgba, 2, 2, numCompX: 0),
+        throwsArgumentError,
+      );
+      expect(
+        () => encodeBlurHash(rgba, 2, 2, numCompX: 10),
+        throwsArgumentError,
+      );
+      expect(
+        () => encodeBlurHash(rgba, 2, 2, numCompY: 0),
+        throwsArgumentError,
+      );
+      expect(
+        () => encodeBlurHash(rgba, 2, 2, numCompY: 10),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects an rgba buffer that is not width*height*4', () {
+      expect(
+        () => encodeBlurHash(Uint8List(10), 2, 2),
+        throwsArgumentError,
+      );
+    });
+  });
+}

--- a/mobile/packages/divine_blurhash/test/src/blurhash_exception_test.dart
+++ b/mobile/packages/divine_blurhash/test/src/blurhash_exception_test.dart
@@ -1,0 +1,18 @@
+import 'package:divine_blurhash/divine_blurhash.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('BlurHashDecodeException', () {
+    test('stores its message', () {
+      const exception = BlurHashDecodeException('bad hash');
+      expect(exception.message, 'bad hash');
+    });
+
+    test('toString prefixes the message', () {
+      expect(
+        const BlurHashDecodeException('bad hash').toString(),
+        'BlurHashDecodeException: bad hash',
+      );
+    });
+  });
+}

--- a/mobile/packages/divine_blurhash/test/src/blurhash_reference_vector_test.dart
+++ b/mobile/packages/divine_blurhash/test/src/blurhash_reference_vector_test.dart
@@ -1,0 +1,111 @@
+import 'dart:typed_data';
+
+import 'package:divine_blurhash/divine_blurhash.dart';
+import 'package:test/test.dart';
+
+/// 8x8 field with distinct per-channel structure: r ramps horizontally,
+/// g vertically, b diagonally. Any channel-order mistake changes its hash.
+Uint8List _colourField() {
+  final rgba = Uint8List(8 * 8 * 4);
+  for (var y = 0; y < 8; y++) {
+    for (var x = 0; x < 8; x++) {
+      final o = (y * 8 + x) * 4;
+      rgba[o] = x * 32;
+      rgba[o + 1] = y * 32;
+      rgba[o + 2] = (x + y) * 16;
+      rgba[o + 3] = 255;
+    }
+  }
+  return rgba;
+}
+
+/// 32x32 hard vertical black/white split. Its dominant AC factor is the
+/// square wave's fundamental, ~2/pi ~ 0.64 — overshooting maxAc (83/166),
+/// so encoding it drives the quantised-maxAc ceiling (82) and, depending
+/// on the overshooting term's sign, one of the AC quantisation clamps:
+/// black-left makes it negative (lower clamp, 0), white-left makes it
+/// positive (upper clamp, 18).
+Uint8List _halfSplit({required bool blackLeft}) {
+  final rgba = Uint8List(32 * 32 * 4);
+  for (var y = 0; y < 32; y++) {
+    for (var x = 0; x < 32; x++) {
+      final o = (y * 32 + x) * 4;
+      final v = (x < 16) == blackLeft ? 0 : 255;
+      rgba[o] = v;
+      rgba[o + 1] = v;
+      rgba[o + 2] = v;
+      rgba[o + 3] = 255;
+    }
+  }
+  return rgba;
+}
+
+void main() {
+  group('reference vectors', () {
+    // The expected values below were computed with an independent
+    // implementation of the woltapp/blurhash reference algorithm, not
+    // with this package. Round-trip tests cannot catch a symmetric
+    // encode/decode convention error (it round-trips cleanly here while
+    // every other client renders the hash wrong); pinning the exact
+    // wire format keeps the README's cross-client interop claim
+    // falsifiable.
+    test(
+      'encodes a channel-distinguishing colour field to the exact '
+      'reference hash',
+      () {
+        // Default components (4x3).
+        expect(
+          encodeBlurHash(_colourField(), 8, 8),
+          'LjF={q31a^xuumRofSnPf4fSfRfP',
+        );
+      },
+    );
+
+    test(
+      'clamps quantised maxAc (82) and AC terms (18) on a hard '
+      'black/white split',
+      () {
+        // Default components (4x3). Without the 82 ceiling the maxAc
+        // character changes; without the AC clamps the overshooting
+        // AC pairs change (lower clamp on the black-left split, upper
+        // clamp on the white-left one).
+        final blackLeft = encodeBlurHash(
+          _halfSplit(blackLeft: true),
+          32,
+          32,
+        );
+        expect(blackLeft, 'L~Lqe900Rj-;ofWBayj[fQfQfQfQ');
+        expect(
+          blackLeft[1],
+          '~',
+          reason: 'maxAc must clamp to base83 index 82',
+        );
+
+        final whiteLeft = encodeBlurHash(
+          _halfSplit(blackLeft: false),
+          32,
+          32,
+        );
+        expect(whiteLeft, 'L~Lqe9~qt7IUofofj[ayfQfQfQfQ');
+      },
+    );
+
+    test(
+      'decodes the canonical woltapp example hash to reference pixel '
+      'values',
+      () {
+        final pixels = decodeBlurHash('LEHV6nWB2yk8pyo0adR*.7kCMdnj', 8, 8);
+        (int, int, int) rgbAt(int x, int y) {
+          final o = (y * 8 + x) * 4;
+          return (pixels[o], pixels[o + 1], pixels[o + 2]);
+        }
+
+        expect(rgbAt(0, 0), (135, 164, 177));
+        expect(rgbAt(7, 0), (144, 167, 179));
+        expect(rgbAt(0, 7), (134, 144, 148));
+        expect(rgbAt(7, 7), (140, 144, 145));
+        expect(rgbAt(3, 4), (154, 126, 118));
+      },
+    );
+  });
+}

--- a/mobile/packages/divine_blurhash/test/src/blurhash_round_trip_test.dart
+++ b/mobile/packages/divine_blurhash/test/src/blurhash_round_trip_test.dart
@@ -1,0 +1,111 @@
+import 'dart:typed_data';
+
+import 'package:divine_blurhash/divine_blurhash.dart';
+import 'package:test/test.dart';
+
+Uint8List _solid(int width, int height, int r, int g, int b) {
+  final rgba = Uint8List(width * height * 4);
+  for (var i = 0; i < width * height; i++) {
+    rgba[i * 4] = r;
+    rgba[i * 4 + 1] = g;
+    rgba[i * 4 + 2] = b;
+    rgba[i * 4 + 3] = 255;
+  }
+  return rgba;
+}
+
+/// Builds a horizontal grayscale ramp (black at x=0 → white at x=width-1).
+Uint8List _horizontalGrayRamp(int width, int height) {
+  final rgba = Uint8List(width * height * 4);
+  for (var y = 0; y < height; y++) {
+    for (var x = 0; x < width; x++) {
+      final v = (x / (width - 1) * 255).round();
+      final o = (y * width + x) * 4;
+      rgba[o] = v;
+      rgba[o + 1] = v;
+      rgba[o + 2] = v;
+      rgba[o + 3] = 255;
+    }
+  }
+  return rgba;
+}
+
+void main() {
+  group('encode → decode round trip', () {
+    test('a solid fill decodes back to its source colour', () {
+      const sourceR = 100;
+      const sourceG = 149;
+      const sourceB = 237;
+      // Encode at a realistic width (the service downscales to ≤128 before
+      // encoding). A uniform fill still produces a tiny residual AC term
+      // ∝ 1/width in the discrete DCT — negligible at this size, so the
+      // decode stays within a few levels of the source on every channel.
+      final hash = encodeBlurHash(
+        _solid(128, 128, sourceR, sourceG, sourceB),
+        128,
+        128,
+        numCompX: 3,
+      );
+
+      final pixels = decodeBlurHash(hash, 32, 32);
+      for (var i = 0; i + 3 < pixels.length; i += 4) {
+        expect((pixels[i] - sourceR).abs(), lessThanOrEqualTo(5));
+        expect((pixels[i + 1] - sourceG).abs(), lessThanOrEqualTo(5));
+        expect((pixels[i + 2] - sourceB).abs(), lessThanOrEqualTo(5));
+      }
+    });
+
+    test('grayscale content decodes without a colour tint', () {
+      // The blurhash_dart decode bug this replaces inflated red/green in
+      // every AC component, tinting grayscale ramps. Spec-correct integer
+      // division keeps gray pixels gray.
+      final hash = encodeBlurHash(
+        _horizontalGrayRamp(64, 64),
+        64,
+        64,
+        numCompY: 4,
+      );
+
+      final pixels = decodeBlurHash(hash, 32, 32);
+      for (var i = 0; i + 3 < pixels.length; i += 4) {
+        final r = pixels[i];
+        final g = pixels[i + 1];
+        final b = pixels[i + 2];
+        expect(
+          (r - g).abs() <= 3 && (g - b).abs() <= 3 && (r - b).abs() <= 3,
+          isTrue,
+          reason: 'pixel ${i ~/ 4} is tinted: r=$r g=$g b=$b',
+        );
+      }
+    });
+
+    test('punch scales AC contrast on the first component row', () {
+      // A horizontal ramp puts almost all AC energy in the first component
+      // row (j = 0, i > 0) — the row blurhash_dart's punch skipped. Ours
+      // bakes punch into maxAc for every AC term, so the left↔right contrast
+      // must scale with punch, not stay flat.
+      final hash = encodeBlurHash(
+        // Default 4×3 components — the horizontal ramp's AC lands in the
+        // first component row.
+        _horizontalGrayRamp(64, 64),
+        64,
+        64,
+      );
+
+      int horizontalContrast(double punch) {
+        final pixels = decodeBlurHash(hash, 16, 16, punch: punch);
+        final left = pixels[0];
+        final right = pixels[(16 - 1) * 4];
+        return (right - left).abs();
+      }
+
+      final soft = horizontalContrast(0.5);
+      final full = horizontalContrast(1);
+      expect(
+        full,
+        greaterThan((soft * 1.4).round()),
+        reason: 'punch must scale the dominant first-row AC contrast',
+      );
+    });
+  });
+}

--- a/mobile/packages/divine_blurhash/test/src/color_math_test.dart
+++ b/mobile/packages/divine_blurhash/test/src/color_math_test.dart
@@ -1,0 +1,36 @@
+import 'package:divine_blurhash/src/color_math.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('color math', () {
+    test('sRgbToLinear maps the channel extremes to 0 and 1', () {
+      expect(sRgbToLinear(0), 0.0);
+      expect(sRgbToLinear(255), closeTo(1, 1e-9));
+    });
+
+    test('sRgbToLinear uses the linear segment for small values', () {
+      // v = 10/255 ≈ 0.039 ≤ 0.04045 → v / 12.92
+      expect(sRgbToLinear(10), closeTo(10 / 255 / 12.92, 1e-12));
+    });
+
+    test('linearToSRgb maps 0 and 1 back to the channel extremes', () {
+      expect(linearToSRgb(0), 0);
+      expect(linearToSRgb(1), 255);
+    });
+
+    test('linearToSRgb uses the linear segment near zero', () {
+      expect(linearToSRgb(0.002), (0.002 * 12.92 * 255 + 0.5).toInt());
+    });
+
+    test('linearToSRgb clamps out-of-range values', () {
+      expect(linearToSRgb(-0.5), 0);
+      expect(linearToSRgb(1.5), 255);
+    });
+
+    test('signPow preserves the sign of its input', () {
+      expect(signPow(2, 2), closeTo(4, 1e-9));
+      expect(signPow(-2, 2), closeTo(-4, 1e-9));
+      expect(signPow(0, 2), 0.0);
+    });
+  });
+}

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -192,14 +192,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "10.0.0"
-  blurhash_dart:
-    dependency: "direct main"
-    description:
-      name: blurhash_dart
-      sha256: "43955b6c2e30a7d440028d1af0fa185852f3534b795cc6eb81fbf397b464409f"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.2.1"
   boolean_selector:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -38,6 +38,7 @@ workspace:
   - packages/count_formatter
   - packages/curated_list_repository
   - packages/curation_repository
+  - packages/divine_blurhash
   - packages/divine_ui
   - packages/db_client
   - packages/divine_camera
@@ -179,7 +180,6 @@ dependencies:
   share_plus: ^12.0.0 # Cross-platform sharing
   google_fonts: ^6.3.2 # For using Google Fonts including Pacifico
   flutter_svg: ^2.0.10+1 # For custom SVG icons
-  blurhash_dart: ^1.2.1 # Generate blurhash for progressive image loading
   skeletonizer: ^2.1.2 # Skeleton loading animations with shimmer effect
 
   # Blurhash Service - Blurhash generation and decoding for image placeholders

--- a/mobile/scripts/baseline/package_coverage_floors.txt
+++ b/mobile/scripts/baseline/package_coverage_floors.txt
@@ -20,6 +20,7 @@ count_formatter 100
 curated_list_repository 100
 curation_repository 100
 db_client 40
+divine_blurhash 100
 divine_camera 100
 divine_quick_actions 76
 divine_ui 100


### PR DESCRIPTION
Closes #6071

## Description

Blurhash placeholders looked broken, most visibly on 9:16 videos: grayscale/low-chroma content rendered with **navy-blue shadows and a cream cast**, and high-contrast frames showed dark/bright blobs that don't exist in the source.

Both root causes are decode bugs in [`blurhash_dart`](https://pub.dev/packages/blurhash_dart):

1. **`decodeAc` misses the spec's integer division** (`value / (19*19)` instead of `value ~/ (19*19)`), inflating red/green in every AC component by up to ~23% of maxAc while blue stays exact — grayscale content picks up a blue/cream tint.
2. **Its `punch` parameter is broken** — it skips the first AC row and column instead of scaling every AC term.

### Why a new package instead of a workaround

This supersedes #6070, which fixed the decode by extracting the DCT components in `blurhash_service` and reusing only `blurhash_dart`'s iDCT. That left an in-repo workaround routing around a third-party dependency, and review asked (reasonably) for an upstream bug report + a tracking issue / removal plan.

**`blurhash_dart` is unmaintained** — `1.2.1` is the latest release (~3 years old), and we already pin exactly that. There is no upstream to file against and no realistic removal date to track. Tracking a fiction indefinitely is not worth it, so instead of carrying a workaround, **Divine owns the codec**:

- New pure-Dart **`divine_blurhash`** package: spec-correct `encodeBlurHash` / `decodeBlurHash` on raw RGBA buffers, no Flutter/`image` dependency, its own CI workflow and **100% test coverage**. Encoding follows the reference algorithm, so web clients (and any spec-compliant decoder) decode the same hashes.
- `blurhash_service` delegates to it and **drops `blurhash_dart` entirely** — removed from both package pubspecs and the lockfile. The malformed-hash error log is preserved (now via `BlurHashDecodeException`).

### Ringing / contrast (carried over from #6070)

- Portrait components lowered **4×7 → 3×4**, square **4×4 → 3×3** (blurhash-recommended range; Divine only produces 9:16 and 1:1 videos) to kill Gibbs ringing. Fewer components also make the synchronous UI-thread decode cheaper.
- Pre-encode downscale uses `average` interpolation instead of the default `nearest`, which sampled stray pixels on detailed frames.
- Decode `punch` stays at the spec default **`1.0`, matching divine-web's decoder** — the same hash renders with identical contrast on both clients. This resolves the owner call that was blocking #6070: no component-count-derived special-casing, no tracked mobile/web divergence. Legacy 4×7 hashes render at full contrast exactly like on web (a regression test pins that they still decode untinted); ringing on newly produced hashes is handled by the component reduction above.

### Interop + performance hardening (added in review)

- **Reference-vector tests** pin the wire format against values computed with an independent implementation of the reference algorithm: exact expected hash strings for deterministic inputs, plus exact RGB values for the canonical `LEHV6nWB2yk8pyo0adR*.7kCMdnj` hash. Round-trip tests alone cannot catch a symmetric encode/decode convention error — it round-trips cleanly here while every other client renders the hash wrong. The vectors also exercise the encoder's quantisation clamps (maxAc ceiling 82, AC 0/18), which mutation testing showed were previously uncovered by the suite.
- The decoder precomputes its DCT basis tables (~70× fewer `cos` calls at the default 32×32 decode, which runs synchronously on the UI isolate), and the encoder converts sRGB→linear once per pixel instead of once per pixel×component pair. The reference vectors prove both refactors are output-identical.

## Verification

- `flutter test --coverage` in `mobile/packages/divine_blurhash` — 27/27, **100% coverage** (base83, color math, encoder, decoder, round-trip incl. grayscale-tint and punch-scaling regressions, cross-implementation reference vectors).
- `flutter test` in `mobile/packages/blurhash_service` — 44/44, including the decode-fix regression tests (grayscale tint, solid-fill reference vector, punch scales the first AC row, legacy 4×7 hashes decode untinted).
- App widget tests consuming `BlurhashDisplay` / `VideoThumbnailWidget` — 20/20.
- `flutter analyze` + `dart format` — clean on both packages.

## Out of Scope

- The inherent blurhash brightness bias on high-dynamic-range frames (linear-space averaging) — canonical behavior, all clients share it.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
