### PR TITLE
test(upload): de-flake in-flight marker assertion when file is missing

### DIFF
--- a/mobile/test/services/upload_manager_recovery_test.dart
+++ b/mobile/test/services/upload_manager_recovery_test.dart
@@ -350,20 +350,20 @@ void main() {
 
         uploadManager.resumeInterruptedUpload(upload.id);
 
-        // The failed status lands (synchronous in-memory Hive put) one future
-        // completion before the in-flight marker is cleared in whenComplete, so
-        // wait for both transitions rather than assuming they are atomic.
+        // Hive's synchronous put lands `failed` one future-completion before
+        // whenComplete clears the marker; wait for each transition separately
+        // so a stall names the exact one that failed, not a combined timeout.
         await TestHelpers.waitForCondition(
           () =>
-              uploadManager.getUpload(upload.id)?.status ==
-                  UploadStatus.failed &&
-              !uploadManager.isUploadInFlight(upload.id),
+              uploadManager.getUpload(upload.id)?.status == UploadStatus.failed,
           timeout: const Duration(seconds: 2),
           checkInterval: const Duration(milliseconds: 20),
         );
-        // The wait above already gates on both transitions; assert the
-        // named contract (marker cleared) explicitly for a clear failure.
-        expect(uploadManager.isUploadInFlight(upload.id), isFalse);
+        await TestHelpers.waitForCondition(
+          () => !uploadManager.isUploadInFlight(upload.id),
+          timeout: const Duration(seconds: 2),
+          checkInterval: const Duration(milliseconds: 20),
+        );
       },
     );
   });

--- a/mobile/test/services/upload_manager_recovery_test.dart
+++ b/mobile/test/services/upload_manager_recovery_test.dart
@@ -350,12 +350,19 @@ void main() {
 
         uploadManager.resumeInterruptedUpload(upload.id);
 
+        // The failed status lands (synchronous in-memory Hive put) one future
+        // completion before the in-flight marker is cleared in whenComplete, so
+        // wait for both transitions rather than assuming they are atomic.
         await TestHelpers.waitForCondition(
           () =>
-              uploadManager.getUpload(upload.id)?.status == UploadStatus.failed,
+              uploadManager.getUpload(upload.id)?.status ==
+                  UploadStatus.failed &&
+              !uploadManager.isUploadInFlight(upload.id),
           timeout: const Duration(seconds: 2),
           checkInterval: const Duration(milliseconds: 20),
         );
+        // The wait above already gates on both transitions; assert the
+        // named contract (marker cleared) explicitly for a clear failure.
         expect(uploadManager.isUploadInFlight(upload.id), isFalse);
       },
     );


### PR DESCRIPTION
Closes #6194

## Description

De-flakes the recovery-sweep test **"resumeInterruptedUpload clears in-flight marker when file is missing"** (added in #6084).

The test races: `_handleUploadFailure`'s `await _store.update(...)` flips the in-memory status to `failed` synchronously via Hive's `box.put`, one future-completion **before** the in-flight marker is cleared in `_performUpload`'s `whenComplete`. The test waited only for `status == failed` and then synchronously asserted `isUploadInFlight == false`, so a 20 ms poll tick landing in that window observed `failed` while the marker was still set. It reproduces on CI (seed-independent — the file runs in its own isolate via `skip_very_good_optimization`) and on `origin/main`'s own runs.

The fix folds the marker-clear into the `waitForCondition` so the test waits for **both** terminal transitions instead of assuming they are atomic; the 2 s timeout still fails loudly if the marker never clears. Production behavior is unchanged and correct — the marker faithfully tracks the upload future's lifetime.

## Context

Split out of #6175 (cache_sync migration) per review feedback — the flake is pre-existing and unrelated to that change, so it belongs in its own test-only PR rather than bundled under `chore(cache-sync)`.

## Verification

- `flutter test test/services/upload_manager_recovery_test.dart` — passes.

## Type of Change

- [x] 🧪 Test-only change
