### PR TITLE
fix(ios): finish background publishes and recover routes

### DIFF
--- a/mobile/lib/router/pooled_fullscreen_feed_route.dart
+++ b/mobile/lib/router/pooled_fullscreen_feed_route.dart
@@ -7,25 +7,32 @@ import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/router/route_error_screen.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
+import 'package:openvine/screens/video_detail_screen.dart';
 import 'package:openvine/widgets/profile/profile_video_feed_view.dart';
 
 /// Redirect target for the fullscreen video feed route.
 ///
-/// The route receives its videos through in-memory `extra` args, which the web
-/// platform discards on page reload / direct navigation. When [extra] is not a
-/// valid args object, redirect to the home feed instead of showing an error
-/// screen. Returns `null` (no redirect) when the args are present.
-String? fullscreenFeedRedirect(Object? extra) {
+/// The route receives its feed through in-memory `extra` args, which can be
+/// discarded on page reload or mobile lifecycle restoration. When that
+/// happens, recover the selected video through its durable URL identity.
+/// Falls back to the home feed only for legacy URLs with no video identity.
+String? fullscreenFeedRedirect(
+  Object? extra, {
+  String? fallbackVideoId,
+}) {
   if (extra is PooledFullscreenVideoFeedArgs ||
       extra is ProfilePooledFullscreenVideoFeedArgs) {
     return null;
+  }
+  if (fallbackVideoId != null && fallbackVideoId.isNotEmpty) {
+    return VideoDetailScreen.pathForId(fallbackVideoId);
   }
   return VideoFeedPage.pathForIndex(0);
 }
 
 /// Builds the fullscreen video feed for the matched route, resolving the
-/// in-memory `extra` args. [fullscreenFeedRedirect] guarantees valid args
-/// before this runs; the final [RouteErrorScreen] is a defensive fallback.
+/// in-memory `extra` args. The URL identity is also handled here because route
+/// state can change between redirect evaluation and builder execution.
 Widget buildPooledFullscreenFeed(BuildContext context, GoRouterState state) {
   final extra = state.extra;
   if (extra is PooledFullscreenVideoFeedArgs) {
@@ -54,5 +61,15 @@ Widget buildPooledFullscreenFeed(BuildContext context, GoRouterState state) {
       onPageChanged: extra.onPageChanged ?? (_) {},
     );
   }
-  return RouteErrorScreen(message: context.l10n.routeNoVideosToDisplay);
+  final fallbackVideoId = state
+      .uri
+      .queryParameters[PooledFullscreenVideoFeedScreen.videoQueryParameter];
+  if (fallbackVideoId != null && fallbackVideoId.isNotEmpty) {
+    return VideoDetailScreen(videoId: fallbackVideoId);
+  }
+  return RouteErrorScreen(
+    message: context.l10n.routeNoVideosToDisplay,
+    showBackButton: true,
+    onBackPressed: () => context.go(VideoFeedPage.pathForIndex(0)),
+  );
 }

--- a/mobile/lib/router/routes/video_routes.dart
+++ b/mobile/lib/router/routes/video_routes.dart
@@ -165,7 +165,12 @@ List<RouteBase> videoRoutes() {
     GoRoute(
       path: PooledFullscreenVideoFeedScreen.path,
       name: PooledFullscreenVideoFeedScreen.routeName,
-      redirect: (context, state) => fullscreenFeedRedirect(state.extra),
+      redirect: (context, state) => fullscreenFeedRedirect(
+        state.extra,
+        fallbackVideoId:
+            state.uri.queryParameters[PooledFullscreenVideoFeedScreen
+                .videoQueryParameter],
+      ),
       builder: buildPooledFullscreenFeed,
     ),
     // Engagement lists for own videos: who liked / reposted this video.

--- a/mobile/lib/screens/category_gallery_screen.dart
+++ b/mobile/lib/screens/category_gallery_screen.dart
@@ -95,7 +95,9 @@ class _CategoryGalleryScreenState extends ConsumerState<CategoryGalleryScreen> {
             },
             onVideoTap: (videos, index) {
               context.push(
-                PooledFullscreenVideoFeedScreen.path,
+                PooledFullscreenVideoFeedScreen.pathForVideoId(
+                  videos[index].id,
+                ),
                 extra: PooledFullscreenVideoFeedArgs(
                   source: CategoryViewSource(widget.category.name),
                   feedRepository: StreamFeedRepository(
@@ -109,6 +111,7 @@ class _CategoryGalleryScreenState extends ConsumerState<CategoryGalleryScreen> {
                         _bloc.add(const CategoryVideosLoadMore()),
                   ),
                   initialIndex: index,
+                  initialVideoId: videos[index].id,
                   contextTitle: localizedCategoryName(
                     context.l10n,
                     widget.category.name,

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -151,6 +151,19 @@ class PooledFullscreenVideoFeedScreen extends ConsumerWidget {
   /// Path for this route.
   static const path = '/pooled-video-feed';
 
+  /// Query parameter carrying the selected video's durable identity.
+  static const videoQueryParameter = 'video';
+
+  /// Builds a lifecycle-restorable route for a pooled feed.
+  ///
+  /// The feed repository still travels in GoRouter `extra`, but the selected
+  /// video is also encoded in the URL so state restoration can fall back to the
+  /// reconstructible single-video route if iOS discards the in-memory args.
+  static String pathForVideoId(String videoId) => Uri(
+    path: path,
+    queryParameters: {videoQueryParameter: videoId},
+  ).toString();
+
   const PooledFullscreenVideoFeedScreen({
     required this.source,
     required this.feedRepository,

--- a/mobile/lib/screens/hashtag_feed_screen.dart
+++ b/mobile/lib/screens/hashtag_feed_screen.dart
@@ -211,7 +211,7 @@ class _HashtagFeedScreenState extends ConsumerState<HashtagFeedScreen> {
       category: LogCategory.video,
     );
     context.push(
-      PooledFullscreenVideoFeedScreen.path,
+      PooledFullscreenVideoFeedScreen.pathForVideoId(videoList[index].id),
       extra: PooledFullscreenVideoFeedArgs(
         source: HashtagViewSource(widget.hashtag),
         feedRepository: ref.read(feedRepositoryProvider),

--- a/mobile/lib/screens/search_results/widgets/videos_section.dart
+++ b/mobile/lib/screens/search_results/widgets/videos_section.dart
@@ -89,7 +89,7 @@ class _VideosContentState extends ConsumerState<_VideosContent> {
   void _onVideoTap(List<VideoEvent> videos, int index) {
     final bloc = context.read<VideoSearchBloc>();
     context.push(
-      PooledFullscreenVideoFeedScreen.path,
+      PooledFullscreenVideoFeedScreen.pathForVideoId(videos[index].id),
       extra: PooledFullscreenVideoFeedArgs(
         source: SearchViewSource(bloc.state.query),
         feedRepository: StreamFeedRepository(
@@ -100,6 +100,7 @@ class _VideosContentState extends ConsumerState<_VideosContent> {
           onLoadMore: () async => bloc.add(const VideoSearchLoadMore()),
         ),
         initialIndex: index,
+        initialVideoId: videos[index].id,
         contextTitle: 'Search Results',
         trafficSource: ViewTrafficSource.search,
         sourceDetail: bloc.state.query,

--- a/mobile/lib/widgets/classic_vines_tab.dart
+++ b/mobile/lib/widgets/classic_vines_tab.dart
@@ -242,7 +242,9 @@ class _ClassicVinesContentState extends ConsumerState<_ClassicVinesContent>
                 category: LogCategory.video,
               );
               context.push(
-                PooledFullscreenVideoFeedScreen.path,
+                PooledFullscreenVideoFeedScreen.pathForVideoId(
+                  videos[index].id,
+                ),
                 extra: PooledFullscreenVideoFeedArgs(
                   source: const ClassicVinesViewSource(),
                   feedRepository: ref.read(feedRepositoryProvider),

--- a/mobile/lib/widgets/for_you_tab.dart
+++ b/mobile/lib/widgets/for_you_tab.dart
@@ -193,7 +193,9 @@ class _ForYouContentState extends ConsumerState<_ForYouContent>
                   category: LogCategory.video,
                 );
                 context.push(
-                  PooledFullscreenVideoFeedScreen.path,
+                  PooledFullscreenVideoFeedScreen.pathForVideoId(
+                    videoList[index].id,
+                  ),
                   extra: PooledFullscreenVideoFeedArgs(
                     source: const ForYouViewSource(),
                     feedRepository: ref.read(feedRepositoryProvider),

--- a/mobile/lib/widgets/new_videos_tab.dart
+++ b/mobile/lib/widgets/new_videos_tab.dart
@@ -218,7 +218,7 @@ class _NewVideosContentState extends ConsumerState<_NewVideosContent> {
           category: LogCategory.video,
         );
         context.push(
-          PooledFullscreenVideoFeedScreen.path,
+          PooledFullscreenVideoFeedScreen.pathForVideoId(videoList[index].id),
           extra: PooledFullscreenVideoFeedArgs(
             source: const NewVideosViewSource(),
             feedRepository: ref.read(feedRepositoryProvider),

--- a/mobile/lib/widgets/popular_videos_tab.dart
+++ b/mobile/lib/widgets/popular_videos_tab.dart
@@ -250,7 +250,9 @@ class _PopularVideosTrendingContentState
                   category: LogCategory.video,
                 );
                 context.push(
-                  PooledFullscreenVideoFeedScreen.path,
+                  PooledFullscreenVideoFeedScreen.pathForVideoId(
+                    videoList[index].id,
+                  ),
                   extra: PooledFullscreenVideoFeedArgs(
                     source: const PopularViewSource(),
                     feedRepository: ref.read(feedRepositoryProvider),

--- a/mobile/lib/widgets/profile/profile_collabs_grid.dart
+++ b/mobile/lib/widgets/profile/profile_collabs_grid.dart
@@ -110,7 +110,7 @@ class _ProfileCollabsGridState extends ConsumerState<ProfileCollabsGrid>
 
     final bloc = context.read<ProfileCollabVideosBloc>();
     context.push(
-      PooledFullscreenVideoFeedScreen.path,
+      PooledFullscreenVideoFeedScreen.pathForVideoId(allVideos[index].id),
       extra: PooledFullscreenVideoFeedArgs(
         source: CollabsViewSource(widget.userIdHex),
         feedRepository: StreamFeedRepository(

--- a/mobile/lib/widgets/profile/profile_liked_grid.dart
+++ b/mobile/lib/widgets/profile/profile_liked_grid.dart
@@ -185,7 +185,7 @@ class _LikedGridTile extends ConsumerWidget {
         );
         final bloc = context.read<ProfileLikedVideosBloc>();
         context.push(
-          PooledFullscreenVideoFeedScreen.path,
+          PooledFullscreenVideoFeedScreen.pathForVideoId(videoEvent.id),
           extra: PooledFullscreenVideoFeedArgs(
             source: LikedViewSource(userIdHex),
             feedRepository: StreamFeedRepository(

--- a/mobile/lib/widgets/profile/profile_reposts_grid.dart
+++ b/mobile/lib/widgets/profile/profile_reposts_grid.dart
@@ -173,7 +173,7 @@ class _RepostGridTile extends ConsumerWidget {
 
       final bloc = context.read<ProfileRepostedVideosBloc>();
       context.push(
-        PooledFullscreenVideoFeedScreen.path,
+        PooledFullscreenVideoFeedScreen.pathForVideoId(videoEvent.id),
         extra: PooledFullscreenVideoFeedArgs(
           source: RepostsViewSource(userIdHex),
           feedRepository: StreamFeedRepository(

--- a/mobile/lib/widgets/profile/profile_saved_grid.dart
+++ b/mobile/lib/widgets/profile/profile_saved_grid.dart
@@ -167,7 +167,7 @@ class _SavedGridTile extends ConsumerWidget {
         );
         final bloc = context.read<ProfileSavedVideosBloc>();
         context.push(
-          PooledFullscreenVideoFeedScreen.path,
+          PooledFullscreenVideoFeedScreen.pathForVideoId(videoEvent.id),
           extra: PooledFullscreenVideoFeedArgs(
             source: SavedViewSource(userIdHex),
             feedRepository: StreamFeedRepository(

--- a/mobile/lib/widgets/profile/profile_videos_grid.dart
+++ b/mobile/lib/widgets/profile/profile_videos_grid.dart
@@ -193,7 +193,7 @@ class _ProfileVideosGridState extends ConsumerState<ProfileVideosGrid>
     prefetchAroundIndex(resolvedIndex, videos);
 
     context.push(
-      PooledFullscreenVideoFeedScreen.path,
+      PooledFullscreenVideoFeedScreen.pathForVideoId(tappedVideo.id),
       extra: ProfilePooledFullscreenVideoFeedArgs(
         userIdHex: widget.userIdHex,
         initialIndex: resolvedIndex,

--- a/mobile/packages/background_uploader/CHANGELOG.md
+++ b/mobile/packages/background_uploader/CHANGELOG.md
@@ -7,3 +7,5 @@
   `BackgroundUploadEvent`) with method-channel + event plumbing.
 - Darwin (iOS + macOS) background `URLSession` implementation.
 - Android foreground-service implementation.
+- Keep iOS background-session wakes alive until Dart publish follow-up work
+  explicitly finishes.

--- a/mobile/packages/background_uploader/CHANGELOG.md
+++ b/mobile/packages/background_uploader/CHANGELOG.md
@@ -8,4 +8,4 @@
 - Darwin (iOS + macOS) background `URLSession` implementation.
 - Android foreground-service implementation.
 - Keep iOS background-session wakes alive until Dart publish follow-up work
-  explicitly finishes.
+  explicitly finishes, with a native watchdog to balance the completion handler.

--- a/mobile/packages/background_uploader/README.md
+++ b/mobile/packages/background_uploader/README.md
@@ -52,10 +52,12 @@ final stillRunning = await uploader.activeTaskIds();
   (`uploadTask(with:fromFile:)`). On iOS the app-delegate forwarding hook
   (`handleEventsForBackgroundURLSession`) lets the OS relaunch the app to finish
   a transfer. When a foreground session is active, the plugin retains that
-  background-event wake until Dart ends the session, allowing follow-up work
-  such as thumbnail upload and event publication to finish before iOS suspends
-  the app again. That relaunch path is iOS-only (`#if os(iOS)`), since macOS
-  apps are not suspended the same way. Requires no extra entitlements.
+  background-event wake until Dart ends the session, with a native watchdog to
+  balance iOS's completion handler if Dart follow-up work wedges. This allows
+  thumbnail upload and event publication to finish before iOS suspends the app
+  again while still protecting future background scheduling. That relaunch path
+  is iOS-only (`#if os(iOS)`), since macOS apps are not suspended the same way.
+  Requires no extra entitlements.
 - **Android** — a foreground service streams the upload. The plugin manifest
   contributes `FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_DATA_SYNC`,
   `POST_NOTIFICATIONS`, and `INTERNET`. On Android 13+ the ongoing notification

--- a/mobile/packages/background_uploader/README.md
+++ b/mobile/packages/background_uploader/README.md
@@ -51,8 +51,11 @@ final stillRunning = await uploader.activeTaskIds();
 - **Apple (iOS + macOS)** — a shared Darwin background `URLSession`
   (`uploadTask(with:fromFile:)`). On iOS the app-delegate forwarding hook
   (`handleEventsForBackgroundURLSession`) lets the OS relaunch the app to finish
-  a transfer; that relaunch path is iOS-only (`#if os(iOS)`), since macOS apps
-  are not suspended the same way. Requires no extra entitlements.
+  a transfer. When a foreground session is active, the plugin retains that
+  background-event wake until Dart ends the session, allowing follow-up work
+  such as thumbnail upload and event publication to finish before iOS suspends
+  the app again. That relaunch path is iOS-only (`#if os(iOS)`), since macOS
+  apps are not suspended the same way. Requires no extra entitlements.
 - **Android** — a foreground service streams the upload. The plugin manifest
   contributes `FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_DATA_SYNC`,
   `POST_NOTIFICATIONS`, and `INTERNET`. On Android 13+ the ongoing notification

--- a/mobile/packages/background_uploader/darwin/background_uploader/Sources/background_uploader/BackgroundUploaderPlugin.swift
+++ b/mobile/packages/background_uploader/darwin/background_uploader/Sources/background_uploader/BackgroundUploaderPlugin.swift
@@ -43,6 +43,13 @@ private final class BackgroundUploadCoordinator: NSObject {
   /// sessions.
   private var backgroundCompletionHandler: (() -> Void)?
 
+  /// Maximum time to retain iOS's background-session wake for Dart follow-up
+  /// work. The OS completion handler must always be balanced, even if Dart's
+  /// publish future wedges.
+  private static let backgroundCompletionWatchdogInterval: TimeInterval = 25
+
+  private var backgroundCompletionWatchdog: Timer?
+
   /// Whether URLSession has finished delivering the current batch of native
   /// events. The app-delegate completion handler can be released only after
   /// this is true and every logical publish session has ended.
@@ -151,6 +158,15 @@ private final class BackgroundUploadCoordinator: NSObject {
 
   func handleBackgroundEvents(completionHandler: @escaping () -> Void) {
     backgroundCompletionHandler = completionHandler
+    backgroundCompletionWatchdog?.invalidate()
+    backgroundCompletionWatchdog = Timer.scheduledTimer(
+      withTimeInterval: Self.backgroundCompletionWatchdogInterval,
+      repeats: false
+    ) { [weak self] _ in
+      DispatchQueue.main.async {
+        self?.forceFinishBackgroundEvents()
+      }
+    }
     // The app-delegate callback starts a new delivery batch. Clear any
     // foreground-only finish marker left by a prior batch that never needed an
     // app-delegate completion handler.
@@ -166,9 +182,23 @@ private final class BackgroundUploadCoordinator: NSObject {
   private func finishBackgroundEventsIfReady() {
     guard backgroundEventsFinished else { return }
     guard activeForegroundSessionIds.isEmpty else { return }
+    completeBackgroundEvents()
+  }
+
+  /// Safety net for a Dart publish future that never resolves. This releases
+  /// iOS's app-delegate completion handler but does not cancel Dart work; if
+  /// the publish later ends, `endForegroundSession` becomes a no-op for the
+  /// already-released handler.
+  private func forceFinishBackgroundEvents() {
+    completeBackgroundEvents()
+  }
+
+  private func completeBackgroundEvents() {
     guard let handler = backgroundCompletionHandler else { return }
     backgroundCompletionHandler = nil
     backgroundEventsFinished = false
+    backgroundCompletionWatchdog?.invalidate()
+    backgroundCompletionWatchdog = nil
     handler()
   }
   #endif

--- a/mobile/packages/background_uploader/darwin/background_uploader/Sources/background_uploader/BackgroundUploaderPlugin.swift
+++ b/mobile/packages/background_uploader/darwin/background_uploader/Sources/background_uploader/BackgroundUploaderPlugin.swift
@@ -38,13 +38,26 @@ private final class BackgroundUploadCoordinator: NSObject {
 
   #if os(iOS)
   /// Held while the OS relaunches us in the background to drain session
-  /// events; called once those events have been delivered. iOS-only — macOS
-  /// apps are not relaunched to finish background sessions.
+  /// events; called once those events and their Dart follow-up work have been
+  /// delivered. iOS-only — macOS apps are not relaunched to finish background
+  /// sessions.
   private var backgroundCompletionHandler: (() -> Void)?
 
-  /// Background-task assertions keyed by session id, so the app keeps running
-  /// long enough to finish in-process publish steps (signing, relay broadcast)
-  /// after the background URLSession upload completes while suspended.
+  /// Whether URLSession has finished delivering the current batch of native
+  /// events. The app-delegate completion handler can be released only after
+  /// this is true and every logical publish session has ended.
+  private var backgroundEventsFinished = false
+
+  /// Logical publish sessions that still have Dart follow-up work after the
+  /// OS-owned upload (thumbnail, signing, relay broadcast). This is deliberately
+  /// separate from `backgroundTasks`: iOS may expire a UIBackgroundTask before
+  /// a large upload finishes, but the later URLSession wake must still remain
+  /// open until Dart calls endForegroundSession.
+  private var activeForegroundSessionIds: Set<String> = []
+
+  /// Short-lived UI background-task assertions keyed by publish session id.
+  /// These bridge brief suspensions but are not the source of truth for whether
+  /// a publish is complete.
   private var backgroundTasks: [String: UIBackgroundTaskIdentifier] = [:]
   #endif
 
@@ -113,16 +126,23 @@ private final class BackgroundUploadCoordinator: NSObject {
 
   #if os(iOS)
   func beginForegroundSession(_ sessionId: String) {
-    endForegroundSession(sessionId)
+    expireBackgroundTaskAssertion(sessionId)
+    activeForegroundSessionIds.insert(sessionId)
     let task = UIApplication.shared.beginBackgroundTask(
       withName: "co.openvine.background_uploader.\(sessionId)"
     ) { [weak self] in
-      self?.endForegroundSession(sessionId)
+      self?.expireBackgroundTaskAssertion(sessionId)
     }
     backgroundTasks[sessionId] = task
   }
 
   func endForegroundSession(_ sessionId: String) {
+    activeForegroundSessionIds.remove(sessionId)
+    expireBackgroundTaskAssertion(sessionId)
+    finishBackgroundEventsIfReady()
+  }
+
+  private func expireBackgroundTaskAssertion(_ sessionId: String) {
     guard let task = backgroundTasks.removeValue(forKey: sessionId),
       task != .invalid
     else { return }
@@ -131,8 +151,25 @@ private final class BackgroundUploadCoordinator: NSObject {
 
   func handleBackgroundEvents(completionHandler: @escaping () -> Void) {
     backgroundCompletionHandler = completionHandler
+    // The app-delegate callback starts a new delivery batch. Clear any
+    // foreground-only finish marker left by a prior batch that never needed an
+    // app-delegate completion handler.
+    backgroundEventsFinished = false
     // Ensure the session (and its delegate) exists to drain pending events.
     _ = session
+    finishBackgroundEventsIfReady()
+  }
+
+  /// Releases iOS's background-URLSession wake only after both sides of the
+  /// handoff are finished: native delegate delivery and the publish work that
+  /// the terminal event triggered in Dart.
+  private func finishBackgroundEventsIfReady() {
+    guard backgroundEventsFinished else { return }
+    guard activeForegroundSessionIds.isEmpty else { return }
+    guard let handler = backgroundCompletionHandler else { return }
+    backgroundCompletionHandler = nil
+    backgroundEventsFinished = false
+    handler()
   }
   #endif
 
@@ -209,9 +246,8 @@ extension BackgroundUploadCoordinator: URLSessionDataDelegate {
     forBackgroundURLSession session: URLSession
   ) {
     DispatchQueue.main.async {
-      let handler = self.backgroundCompletionHandler
-      self.backgroundCompletionHandler = nil
-      handler?()
+      self.backgroundEventsFinished = true
+      self.finishBackgroundEventsIfReady()
     }
   }
   #endif

--- a/mobile/packages/background_uploader/test/apple_background_event_handoff_contract_test.dart
+++ b/mobile/packages/background_uploader/test/apple_background_event_handoff_contract_test.dart
@@ -57,10 +57,7 @@ void main() {
         'guard activeForegroundSessionIds.isEmpty',
         guardedCompletion,
       );
-      final completionCall = source.indexOf(
-        'handler()',
-        guardedCompletion,
-      );
+      final completionCall = source.indexOf('handler()', guardedCompletion);
       final finishCallFromUrlSession = source.indexOf(
         'self.finishBackgroundEventsIfReady()',
         urlSessionFinished,
@@ -96,6 +93,43 @@ void main() {
         expect(retryCompletion, greaterThan(removeSession));
       },
     );
+
+    test('arms a watchdog that balances the app-delegate completion', () {
+      final handleBackgroundEvents = source.indexOf(
+        'func handleBackgroundEvents(',
+      );
+      final watchdogInterval = source.indexOf(
+        'backgroundCompletionWatchdogInterval',
+      );
+      final scheduledTimer = source.indexOf(
+        'Timer.scheduledTimer',
+        handleBackgroundEvents,
+      );
+      final forceFinish = source.indexOf('func forceFinishBackgroundEvents()');
+      final completeBackgroundEvents = source.indexOf(
+        'func completeBackgroundEvents()',
+      );
+      final clearsHandler = source.indexOf(
+        'backgroundCompletionHandler = nil',
+        completeBackgroundEvents,
+      );
+      final invalidatesWatchdog = source.indexOf(
+        'backgroundCompletionWatchdog?.invalidate()',
+        completeBackgroundEvents,
+      );
+      final completionCall = source.indexOf(
+        'handler()',
+        completeBackgroundEvents,
+      );
+
+      expect(watchdogInterval, greaterThanOrEqualTo(0));
+      expect(scheduledTimer, greaterThan(handleBackgroundEvents));
+      expect(forceFinish, greaterThan(scheduledTimer));
+      expect(completeBackgroundEvents, greaterThan(forceFinish));
+      expect(clearsHandler, greaterThan(completeBackgroundEvents));
+      expect(invalidatesWatchdog, greaterThan(clearsHandler));
+      expect(completionCall, greaterThan(invalidatesWatchdog));
+    });
   });
 }
 

--- a/mobile/packages/background_uploader/test/apple_background_event_handoff_contract_test.dart
+++ b/mobile/packages/background_uploader/test/apple_background_event_handoff_contract_test.dart
@@ -1,0 +1,115 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// iOS wakes an app to deliver background URLSession completion events, then
+/// expects the app-delegate completion handler to be called only after all
+/// application work triggered by those events is done. The upload's terminal
+/// event still has to cross into Dart, upload a thumbnail, sign the video
+/// event, and publish it to relays.
+///
+/// The native plugin has no host-side Swift test harness because it links
+/// Flutter, so this lifecycle boundary is pinned as a source contract.
+void main() {
+  group('Apple background URLSession handoff contract', () {
+    late String source;
+
+    setUpAll(() {
+      source = _appleSourceFile().readAsStringSync();
+    });
+
+    test(
+      'tracks publish work separately from expiring UI background tasks',
+      () {
+        expect(
+          source,
+          contains('activeForegroundSessionIds'),
+          reason:
+              'A UIBackgroundTask assertion can expire before a large upload '
+              'finishes, but the logical publish session must remain active so '
+              'the later URLSession wake is retained for Dart follow-up work.',
+        );
+        expect(
+          source,
+          contains('expireBackgroundTaskAssertion(sessionId)'),
+          reason:
+              'Expiration may release only the short-lived assertion; calling '
+              'endForegroundSession here also forgets unfinished publish work.',
+        );
+      },
+    );
+
+    test('defers the app-delegate completion until publish work ends', () {
+      final handleBackgroundEvents = source.indexOf(
+        'func handleBackgroundEvents(',
+      );
+      final resetDeliveryBatch = source.indexOf(
+        'backgroundEventsFinished = false',
+        handleBackgroundEvents,
+      );
+      final urlSessionFinished = source.indexOf(
+        'func urlSessionDidFinishEvents(',
+      );
+      final guardedCompletion = source.indexOf(
+        'func finishBackgroundEventsIfReady()',
+      );
+      final activeSessionGuard = source.indexOf(
+        'guard activeForegroundSessionIds.isEmpty',
+        guardedCompletion,
+      );
+      final completionCall = source.indexOf(
+        'handler()',
+        guardedCompletion,
+      );
+      final finishCallFromUrlSession = source.indexOf(
+        'self.finishBackgroundEventsIfReady()',
+        urlSessionFinished,
+      );
+
+      expect(handleBackgroundEvents, greaterThanOrEqualTo(0));
+      expect(resetDeliveryBatch, greaterThan(handleBackgroundEvents));
+      expect(resetDeliveryBatch, lessThan(urlSessionFinished));
+      expect(urlSessionFinished, greaterThanOrEqualTo(0));
+      expect(guardedCompletion, greaterThanOrEqualTo(0));
+      expect(activeSessionGuard, greaterThan(guardedCompletion));
+      expect(completionCall, greaterThan(activeSessionGuard));
+      expect(finishCallFromUrlSession, greaterThan(urlSessionFinished));
+    });
+
+    test(
+      'rechecks retained background events when the publish session ends',
+      () {
+        final endSession = source.indexOf(
+          'func endForegroundSession(_ sessionId: String)',
+        );
+        final removeSession = source.indexOf(
+          'activeForegroundSessionIds.remove(sessionId)',
+          endSession,
+        );
+        final retryCompletion = source.indexOf(
+          'finishBackgroundEventsIfReady()',
+          removeSession,
+        );
+
+        expect(endSession, greaterThanOrEqualTo(0));
+        expect(removeSession, greaterThan(endSession));
+        expect(retryCompletion, greaterThan(removeSession));
+      },
+    );
+  });
+}
+
+File _appleSourceFile() {
+  final packageRelative = File(
+    'darwin/background_uploader/Sources/background_uploader/'
+    'BackgroundUploaderPlugin.swift',
+  );
+  if (packageRelative.existsSync()) {
+    return packageRelative;
+  }
+
+  return File(
+    'packages/background_uploader/darwin/background_uploader/Sources/'
+    'background_uploader/BackgroundUploaderPlugin.swift',
+  );
+}

--- a/mobile/test/router/fullscreen_feed_redirect_test.dart
+++ b/mobile/test/router/fullscreen_feed_redirect_test.dart
@@ -1,13 +1,16 @@
-// ABOUTME: Tests the fullscreen video feed route redirect — falls back to the
-// ABOUTME: home feed when its in-memory `extra` args are missing (web reload).
+// ABOUTME: Tests pooled-feed route recovery when lifecycle restoration loses
+// ABOUTME: in-memory `extra`, including durable selected-video URL fallback.
 
 import 'package:feed_repository/feed_repository.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:models/models.dart';
 import 'package:openvine/router/pooled_fullscreen_feed_route.dart'
-    show fullscreenFeedRedirect;
+    show buildPooledFullscreenFeed, fullscreenFeedRedirect;
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
+import 'package:openvine/screens/video_detail_screen.dart';
 
 VideoEvent _video(String id) => VideoEvent(
   id: id,
@@ -17,6 +20,19 @@ VideoEvent _video(String id) => VideoEvent(
   timestamp: DateTime.fromMillisecondsSinceEpoch(1000 * 1000),
 );
 
+class _RestoredPooledFeedState extends Fake implements GoRouterState {
+  _RestoredPooledFeedState(String videoId)
+    : uri = Uri.parse(
+        PooledFullscreenVideoFeedScreen.pathForVideoId(videoId),
+      );
+
+  @override
+  final Uri uri;
+
+  @override
+  Object? get extra => null;
+}
+
 void main() {
   group('fullscreenFeedRedirect', () {
     test('redirects to the home feed when extra is null (web reload)', () {
@@ -25,6 +41,16 @@ void main() {
         equals(VideoFeedPage.pathForIndex(0)),
       );
     });
+
+    test(
+      'recovers the selected video when lifecycle restoration loses extra',
+      () {
+        expect(
+          fullscreenFeedRedirect(null, fallbackVideoId: 'video-123'),
+          equals(VideoDetailScreen.pathForId('video-123')),
+        );
+      },
+    );
 
     test('redirects to the home feed when extra is the wrong type', () {
       expect(
@@ -51,5 +77,39 @@ void main() {
 
       expect(fullscreenFeedRedirect(args), isNull);
     });
+  });
+
+  group('PooledFullscreenVideoFeedScreen.pathForVideoId', () {
+    test('puts the selected video identity in the route URL', () {
+      expect(
+        PooledFullscreenVideoFeedScreen.pathForVideoId('video/with spaces'),
+        equals('/pooled-video-feed?video=video%2Fwith+spaces'),
+      );
+    });
+
+    testWidgets(
+      'builder recovers directly if extra disappears after redirect',
+      (
+        tester,
+      ) async {
+        late Widget recovered;
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Builder(
+              builder: (context) {
+                recovered = buildPooledFullscreenFeed(
+                  context,
+                  _RestoredPooledFeedState('video-123'),
+                );
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        );
+
+        expect(recovered, isA<VideoDetailScreen>());
+        expect((recovered as VideoDetailScreen).videoId, 'video-123');
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

- keep the iOS background URLSession wake alive until Dart finishes thumbnail upload, signing, and relay publication, with a native watchdog that balances the completion handler if Dart follow-up work wedges
- encode the selected full video ID in pooled-feed URLs and recover through the durable video route when lifecycle restoration loses in-memory route state
- exclude the root `OVERNIGHT_LOG.md` process artifact from the mergeable diff

Closes #6198
Supersedes #6184

## Root cause

The native uploader called the app-delegate background-session completion handler as soon as URLSession finished delivering events, even though the terminal event still triggered Dart publication work. iOS could suspend that work until the user unlocked the phone.

Separately, pooled fullscreen playback depended entirely on GoRouter `extra`; losing that transient state produced the app-owned black `No videos to display` screen shown in the report.

## Verification

- `git diff --check origin/main...HEAD`
- `flutter test test/router/fullscreen_feed_redirect_test.dart test/widgets/profile/profile_videos_grid_test.dart test/services/upload_manager_recovery_test.dart`
- `flutter test` from `mobile/packages/background_uploader`
- `flutter analyze` from `mobile/packages/background_uploader`
- `flutter analyze` from `mobile`
- pre-push hook: analyzer plus changed-file tests

## Remaining validation

A physical-iPhone long lock/suspension cycle cannot be reproduced in the simulator. The native lifecycle boundary is regression-tested and the iOS app compiles; the release candidate should receive one long lock-screen upload test before shipping.
