### PR TITLE
fix(router): keep New video taps in pooled feed

### DIFF
--- a/mobile/lib/router/providers/route_normalization_provider.dart
+++ b/mobile/lib/router/providers/route_normalization_provider.dart
@@ -9,6 +9,7 @@ import 'package:openvine/screens/auth/email_verification_screen.dart';
 import 'package:openvine/screens/auth/nostr_connect_screen.dart';
 import 'package:openvine/screens/auth/reset_password.dart';
 import 'package:openvine/screens/auth/welcome_screen.dart';
+import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/screens/minor_account_review_screen.dart';
 import 'package:openvine/screens/search_results/view/search_results_page.dart';
 import 'package:openvine/services/deep_link_service.dart';
@@ -27,6 +28,7 @@ bool shouldSkipRouteNormalization(String loc) {
       RegExp(r'^/apps/[^/]+/sandbox$').hasMatch(loc) ||
       loc.contains('${ResetPasswordScreen.path}?token=') ||
       loc.contains('${EmailVerificationScreen.path}?') ||
+      loc.startsWith('${PooledFullscreenVideoFeedScreen.path}?') ||
       loc.startsWith(SearchResultsPage.pathPrefix) ||
       RegExp(r'^/video/[^/]+/(likers|reposters)(\?.*)?$').hasMatch(loc)) {
     return true;

--- a/mobile/test/router/route_normalization_test.dart
+++ b/mobile/test/router/route_normalization_test.dart
@@ -3,6 +3,7 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/router/providers/route_normalization_provider.dart';
+import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/screens/minor_account_review_parent_consent_screen.dart';
 import 'package:openvine/screens/minor_account_review_parent_contact_screen.dart';
 import 'package:openvine/screens/minor_account_review_screen.dart';
@@ -55,6 +56,18 @@ void main() {
     test('does not skip canonical internal routes', () {
       expect(shouldSkipRouteNormalization('/video/abc123'), isFalse);
       expect(shouldSkipRouteNormalization('/home/0'), isFalse);
+    });
+
+    test('skips pooled feed routes carrying a selected video identity', () {
+      const videoId =
+          '672c4eb9fc29adb6b505713bc6da94af2244c1de55dc6f034e2bcdaba133ebbe';
+
+      expect(
+        shouldSkipRouteNormalization(
+          PooledFullscreenVideoFeedScreen.pathForVideoId(videoId),
+        ),
+        isTrue,
+      );
     });
 
     test('skips minor account review route family', () {


### PR DESCRIPTION
## Summary

- exempt selected-video pooled feed URLs from route normalization
- preserve the pushed feed and its in-memory arguments when opening Explore → New videos
- add a regression test using the production route builder and a full event ID

## Root cause

`RouteNormalizationProvider` passed `/pooled-video-feed?video=<id>` to `parseRoute`, whose raw slash split treated `pooled-video-feed?video=...` as an unknown first segment. The fallback rebuilt it as `/home/0`, popping the selected New video and revealing the existing For You feed.

## Verification

- TDD red: regression expected normalization skip but got `false`
- focused router/explore/New-video suite: 120 passed, 2 existing skips
- `flutter analyze`: no issues
- pre-push changed-file analyze: no issues
- pre-push affected test: 9 passed
- independent code review: ready to merge, no findings

Fixes #6203
