### PR TITLE
fix(analytics): align creator video count with profile

### DIFF
--- a/mobile/lib/features/creator_analytics/creator_analytics_repository.dart
+++ b/mobile/lib/features/creator_analytics/creator_analytics_repository.dart
@@ -97,12 +97,12 @@ class FunnelcakeCreatorAnalyticsRepository
     final sourcesUsed = <AnalyticsDataSource>{};
 
     final socialFuture = _getSocialCounts(pubkey);
-    final videos = await _fetchAuthorVideos(pubkey);
-    if (videos.isNotEmpty) {
+    final authored = await _fetchAuthorVideos(pubkey);
+    if (authored.isNotEmpty) {
       sourcesUsed.add(AnalyticsDataSource.authorVideos);
     }
 
-    final bulkResult = await _enrichVideosWithBulkStats(videos);
+    final bulkResult = await _enrichVideosWithBulkStats(authored);
     var hydratedVideos = bulkResult.videos;
     if (bulkResult.hydratedCount > 0) {
       sourcesUsed.add(AnalyticsDataSource.bulkVideoStats);
@@ -114,18 +114,24 @@ class FunnelcakeCreatorAnalyticsRepository
       sourcesUsed.add(AnalyticsDataSource.videoViewsEndpoint);
     }
 
+    // Collapse edited addressable videos AFTER hydration so the cross-source
+    // max-merge sees each edit sibling's hydrated counts — matching the profile
+    // feed's getAuthorFeed (hydrate-then-merge). Collapsing first would fetch
+    // stats only for the surviving event id and drop older edits' counts.
+    final videos = mergeProfileFeedVideoLists(const [], hydratedVideos);
+
     final social = await socialFuture;
-    final withViewData = hydratedVideos
+    final withViewData = videos
         .where((video) => extractViewLikeCount(video) != null)
         .length;
 
     return CreatorAnalyticsSnapshot(
-      videos: hydratedVideos,
+      videos: videos,
       socialCounts: social,
       diagnostics: CreatorAnalyticsDiagnostics(
-        totalVideos: hydratedVideos.length,
+        totalVideos: videos.length,
         videosWithAnyViews: withViewData,
-        videosMissingViews: hydratedVideos.length - withViewData,
+        videosMissingViews: videos.length - withViewData,
         videosHydratedByBulkStats: bulkResult.hydratedCount,
         videosHydratedByViewsEndpoint: endpointResult.hydratedCount,
         sourcesUsed: sourcesUsed,
@@ -167,10 +173,13 @@ class FunnelcakeCreatorAnalyticsRepository
       if (before <= 0) break;
     }
 
-    final authored = collected
+    // Guard: the author endpoint can leak videos where the pubkey is a
+    // p-tagged collaborator rather than the event author. Mirrors the profile
+    // feed's getAuthorFeed filter. Edit siblings are collapsed later, after
+    // hydration, by the caller.
+    return collected
         .where((video) => !video.isRepost && video.pubkey == pubkey)
         .toList();
-    return mergeProfileFeedVideoLists(const [], authored);
   }
 
   Future<_HydrationResult> _enrichVideosWithBulkStats(

--- a/mobile/lib/features/creator_analytics/creator_analytics_repository.dart
+++ b/mobile/lib/features/creator_analytics/creator_analytics_repository.dart
@@ -5,6 +5,7 @@ import 'dart:math' as math;
 
 import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:models/models.dart';
+import 'package:videos_repository/videos_repository.dart';
 
 /// Provenance source for analytics values.
 enum AnalyticsDataSource { authorVideos, bulkVideoStats, videoViewsEndpoint }
@@ -166,8 +167,10 @@ class FunnelcakeCreatorAnalyticsRepository
       if (before <= 0) break;
     }
 
-    final seen = <String>{};
-    return collected.where((video) => seen.add(video.id)).toList();
+    final authored = collected
+        .where((video) => !video.isRepost && video.pubkey == pubkey)
+        .toList();
+    return mergeProfileFeedVideoLists(const [], authored);
   }
 
   Future<_HydrationResult> _enrichVideosWithBulkStats(

--- a/mobile/test/features/creator_analytics/creator_analytics_repository_test.dart
+++ b/mobile/test/features/creator_analytics/creator_analytics_repository_test.dart
@@ -209,55 +209,72 @@ void main() {
       },
     );
 
-    test('dedupes edited addressable videos by profile feed key', () async {
-      const pubkey = 'pubkey';
-      final api = MockFunnelcakeApiClient();
+    test(
+      'collapses edit siblings after hydration so higher counts survive',
+      () async {
+        const pubkey = 'pubkey';
+        final api = MockFunnelcakeApiClient();
 
-      when(() => api.isAvailable).thenReturn(true);
-      when(() => api.getSocialCounts(pubkey)).thenAnswer((_) async => null);
-      when(
-        () => api.getBulkVideoStats(any()),
-      ).thenAnswer((_) async => const BulkVideoStatsResponse(stats: {}));
-      when(() => api.getVideoViews(any())).thenAnswer((_) async => 0);
+        when(() => api.isAvailable).thenReturn(true);
+        when(() => api.getSocialCounts(pubkey)).thenAnswer((_) async => null);
+        when(() => api.getVideoViews(any())).thenAnswer((_) async => 0);
+        // Per-event-id stats: the older edit accumulated more views while it
+        // was live than the newer edit has since.
+        when(() => api.getBulkVideoStats(any())).thenAnswer((invocation) async {
+          final ids = invocation.positionalArguments[0] as List<String>;
+          return BulkVideoStatsResponse(
+            stats: {
+              for (final id in ids)
+                id: BulkVideoStatsEntry(
+                  eventId: id,
+                  reactions: 0,
+                  comments: 0,
+                  reposts: 0,
+                  loops: 0,
+                  views: id == 'older-event' ? 1000 : 5,
+                ),
+            },
+          );
+        });
 
-      when(
-        () => api.getVideosByAuthor(
-          pubkey: pubkey,
-          limit: 100,
-          before: any(named: 'before'),
-        ),
-      ).thenAnswer(
-        (_) async => VideosByAuthorResponse(
-          videos: [
-            _videoStats(
-              id: 'older-event',
-              pubkey: pubkey,
-              dTag: 'same-video',
-              loops: 12,
-              rawTags: const {'views': '12'},
-            ),
-            _videoStats(
-              id: 'newer-event',
-              pubkey: pubkey,
-              dTag: 'same-video',
-              createdAtSeconds: 1739350100,
-              loops: 18,
-              rawTags: const {'views': '18'},
-            ),
-          ],
-        ),
-      );
+        when(
+          () => api.getVideosByAuthor(
+            pubkey: pubkey,
+            limit: 100,
+            before: any(named: 'before'),
+          ),
+        ).thenAnswer(
+          (_) async => VideosByAuthorResponse(
+            videos: [
+              _videoStats(
+                id: 'older-event',
+                pubkey: pubkey,
+                dTag: 'same-video',
+              ),
+              _videoStats(
+                id: 'newer-event',
+                pubkey: pubkey,
+                dTag: 'same-video',
+                createdAtSeconds: 1739350100,
+              ),
+            ],
+          ),
+        );
 
-      final repo = FunnelcakeCreatorAnalyticsRepository(api);
-      final snapshot = await repo.fetchCreatorAnalytics(pubkey);
+        final repo = FunnelcakeCreatorAnalyticsRepository(api);
+        final snapshot = await repo.fetchCreatorAnalytics(pubkey);
 
-      expect(snapshot.diagnostics.totalVideos, 1);
-      expect(snapshot.videos.single.id, 'newer-event');
-      expect(snapshot.videos.single.rawTags['views'], '18');
-      expect(snapshot.videos.single.originalLoops, 18);
-      verify(() => api.getBulkVideoStats(['newer-event'])).called(1);
-      verifyNever(() => api.getVideoViews('older-event'));
-    });
+        // Both edit siblings collapse to one video keyed on the newest event
+        // id, but stats are hydrated for every sibling BEFORE the collapse, so
+        // the max-merge keeps the older edit's higher view count.
+        expect(snapshot.diagnostics.totalVideos, 1);
+        expect(snapshot.videos.single.id, 'newer-event');
+        expect(snapshot.videos.single.rawTags['views'], '1000');
+        verify(
+          () => api.getBulkVideoStats(['older-event', 'newer-event']),
+        ).called(1);
+      },
+    );
 
     test('excludes collaborator rows leaked by author endpoint', () async {
       const pubkey = 'pubkey';
@@ -290,7 +307,10 @@ void main() {
 
       expect(snapshot.diagnostics.totalVideos, 1);
       expect(snapshot.videos.single.id, 'authored');
-      verifyNever(() => api.getBulkVideoStats(['collaborator-leak']));
+      // Bulk stats are batched into one call, so a filter regression would
+      // surface as ['authored', 'collaborator-leak'] here — assert the exact
+      // surviving-id list rather than the (unreachable) single-leak list.
+      verify(() => api.getBulkVideoStats(['authored'])).called(1);
       verifyNever(() => api.getVideoViews('collaborator-leak'));
     });
   });

--- a/mobile/test/features/creator_analytics/creator_analytics_repository_test.dart
+++ b/mobile/test/features/creator_analytics/creator_analytics_repository_test.dart
@@ -29,15 +29,18 @@ VideoEvent _video({
 VideoStats _videoStats({
   required String id,
   required String pubkey,
+  String? dTag,
+  int createdAtSeconds = 1739350000,
   int? loops,
   int? views,
+  Map<String, String> rawTags = const {},
 }) {
   return VideoStats(
     id: id,
     pubkey: pubkey,
-    createdAt: DateTime.fromMillisecondsSinceEpoch(1739350000 * 1000),
+    createdAt: DateTime.fromMillisecondsSinceEpoch(createdAtSeconds * 1000),
     kind: 34236,
-    dTag: id,
+    dTag: dTag ?? id,
     title: id,
     thumbnail: 'thumb',
     videoUrl: 'videoUrl',
@@ -47,6 +50,7 @@ VideoStats _videoStats({
     engagementScore: 0,
     loops: loops,
     views: views,
+    rawTags: rawTags,
   );
 }
 
@@ -204,5 +208,90 @@ void main() {
         expect(snapshot.videos.first.rawTags['views'], '0');
       },
     );
+
+    test('dedupes edited addressable videos by profile feed key', () async {
+      const pubkey = 'pubkey';
+      final api = MockFunnelcakeApiClient();
+
+      when(() => api.isAvailable).thenReturn(true);
+      when(() => api.getSocialCounts(pubkey)).thenAnswer((_) async => null);
+      when(
+        () => api.getBulkVideoStats(any()),
+      ).thenAnswer((_) async => const BulkVideoStatsResponse(stats: {}));
+      when(() => api.getVideoViews(any())).thenAnswer((_) async => 0);
+
+      when(
+        () => api.getVideosByAuthor(
+          pubkey: pubkey,
+          limit: 100,
+          before: any(named: 'before'),
+        ),
+      ).thenAnswer(
+        (_) async => VideosByAuthorResponse(
+          videos: [
+            _videoStats(
+              id: 'older-event',
+              pubkey: pubkey,
+              dTag: 'same-video',
+              loops: 12,
+              rawTags: const {'views': '12'},
+            ),
+            _videoStats(
+              id: 'newer-event',
+              pubkey: pubkey,
+              dTag: 'same-video',
+              createdAtSeconds: 1739350100,
+              loops: 18,
+              rawTags: const {'views': '18'},
+            ),
+          ],
+        ),
+      );
+
+      final repo = FunnelcakeCreatorAnalyticsRepository(api);
+      final snapshot = await repo.fetchCreatorAnalytics(pubkey);
+
+      expect(snapshot.diagnostics.totalVideos, 1);
+      expect(snapshot.videos.single.id, 'newer-event');
+      expect(snapshot.videos.single.rawTags['views'], '18');
+      expect(snapshot.videos.single.originalLoops, 18);
+      verify(() => api.getBulkVideoStats(['newer-event'])).called(1);
+      verifyNever(() => api.getVideoViews('older-event'));
+    });
+
+    test('excludes collaborator rows leaked by author endpoint', () async {
+      const pubkey = 'pubkey';
+      final api = MockFunnelcakeApiClient();
+
+      when(() => api.isAvailable).thenReturn(true);
+      when(() => api.getSocialCounts(pubkey)).thenAnswer((_) async => null);
+      when(
+        () => api.getBulkVideoStats(any()),
+      ).thenAnswer((_) async => const BulkVideoStatsResponse(stats: {}));
+      when(() => api.getVideoViews(any())).thenAnswer((_) async => 0);
+
+      when(
+        () => api.getVideosByAuthor(
+          pubkey: pubkey,
+          limit: 100,
+          before: any(named: 'before'),
+        ),
+      ).thenAnswer(
+        (_) async => VideosByAuthorResponse(
+          videos: [
+            _videoStats(id: 'authored', pubkey: pubkey),
+            _videoStats(id: 'collaborator-leak', pubkey: 'collaborator-pubkey'),
+          ],
+        ),
+      );
+
+      final repo = FunnelcakeCreatorAnalyticsRepository(api);
+      final snapshot = await repo.fetchCreatorAnalytics(pubkey);
+
+      expect(snapshot.diagnostics.totalVideos, 1);
+      expect(snapshot.videos.single.id, 'authored');
+      verifyNever(() => api.getBulkVideoStats(['collaborator-leak']));
+      verifyNever(() => api.getVideoViews('collaborator-leak'));
+    });
   });
 }


### PR DESCRIPTION
## Summary

Fixes #5836.

Creator analytics now applies the same author/profile video identity rules as the profile feed before hydrating stats:

- filters Funnelcake author results to self-authored, non-repost videos
- dedupes edited addressable videos via mergeProfileFeedVideoLists
- keeps downstream video counts and aggregate analytics totals based on the canonical video list

## Root Cause

The analytics repository deduped Funnelcake getVideosByAuthor results by raw event id. Edited addressable videos keep the same stable d tag but get new event ids, so analytics counted each edit as a separate video while the profile feed collapsed them by pubkey:stableId.

## Validation

- flutter test test/features/creator_analytics/creator_analytics_repository_test.dart
- flutter analyze
- pre-push hook: analyzer and changed-file tests passed