### PR TITLE
fix(comment-video): preserve video metadata from REST comments

### DIFF
--- a/mobile/lib/blocs/comments/comments_list/comments_list_bloc.dart
+++ b/mobile/lib/blocs/comments/comments_list/comments_list_bloc.dart
@@ -281,10 +281,29 @@ class CommentsListBloc extends Bloc<CommentsListEvent, CommentsListState> {
   ) {
     final comment = event.comment;
 
-    // Skip if already in the map by id (relay echo of a confirmed comment).
+    // Skip if already in the map by id (relay echo of a confirmed comment),
+    // unless the echo carries video metadata missing from the REST bootstrap
+    // copy. In that case, upgrade in place so a REST-loaded video reply can
+    // render as soon as the relay echo arrives.
     // Blocked/muted authors are already filtered by the repository's
     // watchComments stream, so no additional check is needed here.
-    if (state.commentsById.containsKey(comment.id)) return;
+    final existingComment = state.commentsById[comment.id];
+    if (existingComment != null) {
+      if (!existingComment.hasVideo && comment.hasVideo) {
+        _emitStore(
+          emit,
+          Map<String, Comment>.from(state.commentsById)
+            ..[comment.id] = existingComment.copyWith(
+              videoUrl: comment.videoUrl,
+              thumbnailUrl: comment.thumbnailUrl,
+              videoDimensions: comment.videoDimensions,
+              videoDuration: comment.videoDuration,
+              videoBlurhash: comment.videoBlurhash,
+            ),
+        );
+      }
+      return;
+    }
 
     // Optimistic-post reconciliation: if a pending placeholder matches this
     // relay echo by author + content, swap it for the canonical comment so

--- a/mobile/packages/comments_repository/lib/src/comments_repository.dart
+++ b/mobile/packages/comments_repository/lib/src/comments_repository.dart
@@ -1113,7 +1113,7 @@ class CommentsRepository {
   }
 
   _CommentVideoMetadata _parseVideoMetadataFromImetaTags(
-    Iterable<dynamic> tags,
+    List<List<String>> tags,
   ) {
     String? videoUrl;
     String? thumbnailUrl;
@@ -1121,16 +1121,14 @@ class CommentsRepository {
     int? videoDuration;
     String? videoBlurhash;
 
-    for (final rawTag in tags) {
-      if (rawTag is! List) continue;
-      final tag = rawTag;
+    for (final tag in tags) {
       if (tag.isEmpty || tag.first != 'imeta') continue;
 
       String? imetaUrlCandidate;
       String? imetaMimeType;
 
       for (var i = 1; i < tag.length; i++) {
-        final field = tag[i].toString().trim();
+        final field = tag[i].trim();
         if (field.startsWith('url ')) {
           imetaUrlCandidate = field.substring(4).trim();
         } else if (field.startsWith('m ')) {

--- a/mobile/packages/comments_repository/lib/src/comments_repository.dart
+++ b/mobile/packages/comments_repository/lib/src/comments_repository.dart
@@ -1087,6 +1087,7 @@ class CommentsRepository {
       final parsedReplyToEventId = restComment.replyToEventId;
       final isTopLevel =
           parsedReplyToEventId == null || parsedReplyToEventId == rootEventId;
+      final videoMetadata = _parseVideoMetadataFromImetaTags(restComment.tags);
 
       return Comment(
         id: restComment.id,
@@ -1100,6 +1101,11 @@ class CommentsRepository {
         rootAddressableId: parsedRootAddressableId ?? rootAddressableId,
         replyToEventId: isTopLevel ? null : parsedReplyToEventId,
         replyToAuthorPubkey: isTopLevel ? null : restComment.replyToPubkey,
+        videoUrl: videoMetadata.videoUrl,
+        thumbnailUrl: videoMetadata.thumbnailUrl,
+        videoDimensions: videoMetadata.videoDimensions,
+        videoDuration: videoMetadata.videoDuration,
+        videoBlurhash: videoMetadata.videoBlurhash,
       );
     } on Exception {
       return null;
@@ -1107,7 +1113,7 @@ class CommentsRepository {
   }
 
   _CommentVideoMetadata _parseVideoMetadataFromImetaTags(
-    List<List<dynamic>> tags,
+    Iterable<dynamic> tags,
   ) {
     String? videoUrl;
     String? thumbnailUrl;
@@ -1115,7 +1121,9 @@ class CommentsRepository {
     int? videoDuration;
     String? videoBlurhash;
 
-    for (final tag in tags) {
+    for (final rawTag in tags) {
+      if (rawTag is! List) continue;
+      final tag = rawTag;
       if (tag.isEmpty || tag.first != 'imeta') continue;
 
       String? imetaUrlCandidate;

--- a/mobile/packages/comments_repository/test/src/comments_repository_test.dart
+++ b/mobile/packages/comments_repository/test/src/comments_repository_test.dart
@@ -237,6 +237,82 @@ void main() {
         },
       );
 
+      test('maps video metadata from REST imeta tags', () async {
+        when(() => mockFunnelcakeApiClient.isAvailable).thenReturn(true);
+        when(
+          () => mockFunnelcakeApiClient.getVideoComments(
+            videoId: any(named: 'videoId'),
+            sort: any(named: 'sort'),
+            limit: any(named: 'limit'),
+            offset: any(named: 'offset'),
+            cacheBustToken: any(named: 'cacheBustToken'),
+          ),
+        ).thenAnswer(
+          (_) async => VideoCommentsResponse(
+            comments: [
+              VideoComment(
+                id: 'rest_video_reply',
+                pubkey: testUserPubkey,
+                createdAt: 1000,
+                kind: EventKind.videoVertical,
+                content: 'REST video reply',
+                sig: 'sig',
+                tags: [
+                  ['E', testRootEventId],
+                  ['K', _testRootEventKind.toString()],
+                  ['P', testRootAuthorPubkey],
+                  ['e', testRootEventId],
+                  ['k', _testRootEventKind.toString()],
+                  ['p', testRootAuthorPubkey],
+                  [
+                    'imeta',
+                    'url https://media.divine.video/reply/12345',
+                    'm video/mp4',
+                    'image https://media.divine.video/reply/12345.jpg',
+                    'dim 720x1280',
+                    'duration 6',
+                    'blurhash LKO2?U%2Tw=w]~RBVZRi};RPxuwH',
+                  ],
+                ],
+              ),
+            ],
+            total: 1,
+          ),
+        );
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => []);
+
+        repository = CommentsRepository(
+          nostrClient: mockNostrClient,
+          funnelcakeApiClient: mockFunnelcakeApiClient,
+        );
+
+        final result = await repository.loadComments(
+          rootEventId: testRootEventId,
+          rootEventKind: _testRootEventKind,
+          includeVideoReplies: true,
+        );
+
+        expect(result.comments, hasLength(1));
+        expect(result.comments.first.hasVideo, isTrue);
+        expect(
+          result.comments.first.videoUrl,
+          equals('https://media.divine.video/reply/12345'),
+        );
+        expect(
+          result.comments.first.thumbnailUrl,
+          equals('https://media.divine.video/reply/12345.jpg'),
+        );
+        expect(result.comments.first.videoDimensions, equals('720x1280'));
+        expect(result.comments.first.videoDuration, equals(6));
+        expect(
+          result.comments.first.videoBlurhash,
+          equals('LKO2?U%2Tw=w]~RBVZRi};RPxuwH'),
+        );
+        verifyNever(() => mockNostrClient.queryEvents(any()));
+      });
+
       test('falls back to relay query when REST bootstrap throws', () async {
         when(() => mockFunnelcakeApiClient.isAvailable).thenReturn(true);
         when(

--- a/mobile/test/blocs/comments/comments_list/comments_list_bloc_test.dart
+++ b/mobile/test/blocs/comments/comments_list/comments_list_bloc_test.dart
@@ -49,6 +49,11 @@ void main() {
       DateTime? createdAt,
       String? replyToEventId,
       String? replyToAuthorPubkey,
+      String? videoUrl,
+      String? thumbnailUrl,
+      String? videoDimensions,
+      int? videoDuration,
+      String? videoBlurhash,
     }) => Comment(
       id: id,
       content: content ?? 'hello',
@@ -58,6 +63,11 @@ void main() {
       rootAuthorPubkey: validId('author'),
       replyToEventId: replyToEventId,
       replyToAuthorPubkey: replyToAuthorPubkey,
+      videoUrl: videoUrl,
+      thumbnailUrl: thumbnailUrl,
+      videoDimensions: videoDimensions,
+      videoDuration: videoDuration,
+      videoBlurhash: videoBlurhash,
     );
 
     CommentsListBloc createBloc({
@@ -606,6 +616,52 @@ void main() {
         ),
         act: (b) => b.add(NewCommentReceived(makeComment(validId('c1')))),
         expect: () => isEmpty,
+      );
+
+      blocTest<CommentsListBloc, CommentsListState>(
+        'upgrades duplicate relay echo when it adds missing video metadata',
+        build: createBloc,
+        seed: () => CommentsListState(
+          status: CommentsStatus.success,
+          commentsById: {
+            validId('c1'): makeComment(
+              validId('c1'),
+              content: 'REST video reply',
+            ),
+          },
+        ),
+        act: (b) => b.add(
+          NewCommentReceived(
+            makeComment(
+              validId('c1'),
+              content: 'REST video reply',
+              videoUrl: 'https://media.divine.video/reply/12345',
+              thumbnailUrl: 'https://media.divine.video/reply/12345.jpg',
+              videoDimensions: '720x1280',
+              videoDuration: 6,
+              videoBlurhash: 'LKO2?U%2Tw=w]~RBVZRi};RPxuwH',
+            ),
+          ),
+        ),
+        verify: (b) {
+          final comment = b.state.commentsById[validId('c1')]!;
+          expect(comment.hasVideo, isTrue);
+          expect(
+            comment.videoUrl,
+            equals('https://media.divine.video/reply/12345'),
+          );
+          expect(
+            comment.thumbnailUrl,
+            equals('https://media.divine.video/reply/12345.jpg'),
+          );
+          expect(comment.videoDimensions, equals('720x1280'));
+          expect(comment.videoDuration, equals(6));
+          expect(
+            comment.videoBlurhash,
+            equals('LKO2?U%2Tw=w]~RBVZRi};RPxuwH'),
+          );
+          expect(b.state.newCommentCount, 0);
+        },
       );
 
       blocTest<CommentsListBloc, CommentsListState>(

--- a/mobile/test/blocs/comments/comments_list/comments_list_bloc_test.dart
+++ b/mobile/test/blocs/comments/comments_list/comments_list_bloc_test.dart
@@ -627,6 +627,7 @@ void main() {
             validId('c1'): makeComment(
               validId('c1'),
               content: 'REST video reply',
+              replyToEventId: validId('parent'),
             ),
           },
         ),
@@ -646,6 +647,9 @@ void main() {
         verify: (b) {
           final comment = b.state.commentsById[validId('c1')]!;
           expect(comment.hasVideo, isTrue);
+          // Upgrade must merge in place, not replace with the echo: the
+          // existing REST copy's threading (a field the echo lacks) survives.
+          expect(comment.replyToEventId, equals(validId('parent')));
           expect(
             comment.videoUrl,
             equals('https://media.divine.video/reply/12345'),


### PR DESCRIPTION
## Summary

Fixes #6129 by preserving video metadata for video comments loaded through the Funnelcake REST bootstrap path, and by allowing a relay echo to upgrade an already-loaded comment row when it carries missing video metadata.

## Root Cause

The relay mapper parsed NIP-92 imeta video fields, but the REST mapper did not, so REST-loaded video comments could enter the comments store without videoUrl. The real-time relay echo for the same event was then ignored by the duplicate-id guard, leaving the no-video copy in place.

## Changes

- Parse imeta fields in _restCommentToComment and populate videoUrl, thumbnail, dimensions, duration, and blurhash.
- Make the shared imeta parser tolerate both relay and REST tag list shapes.
- Upgrade duplicate NewCommentReceived events when the existing store copy has no video metadata and the incoming copy does.
- Add regression coverage for REST imeta mapping and duplicate relay echo metadata upgrades.

## Validation

- flutter analyze
- flutter test test/src/comments_repository_test.dart from mobile/packages/comments_repository
- flutter test test/blocs/comments/comments_list/comments_list_bloc_test.dart from mobile
- Pre-push hook: merge-conflict check, analyzer, changed-file tests

## Notes

This addresses the REST parsing and relay self-heal portion of #6129. The broader video-reply optimistic insertion work overlaps #5862 and appears to already have related recently-posted-comment handling on current origin/main.