### PR TITLE
fix(support): ignore unknown moderation labels

### DIFF
--- a/mobile/lib/services/nsfw_content_filter.dart
+++ b/mobile/lib/services/nsfw_content_filter.dart
@@ -39,15 +39,10 @@ VideoContentFilter createNsfwFilter(
     // are noisy and would otherwise block autoplay on ordinary videos.
     final modLabels = video.moderationLabels;
     if (modLabels.isNotEmpty) {
-      final recognizedLabels = modLabels
-          .where((label) => ContentLabel.fromValue(label) != null)
-          .toList();
-      if (recognizedLabels.isNotEmpty) {
-        final pref = contentFilterService.getPreferenceForLabels(
-          recognizedLabels,
-        );
-        if (pref == ContentFilterPreference.hide) return true;
-      }
+      // getPreferenceForLabels ignores unrecognized labels, so a video tagged
+      // only with labels this client does not understand never force-hides.
+      final pref = contentFilterService.getPreferenceForLabels(modLabels);
+      if (pref == ContentFilterPreference.hide) return true;
     }
 
     return false;

--- a/mobile/lib/services/nsfw_content_filter.dart
+++ b/mobile/lib/services/nsfw_content_filter.dart
@@ -39,27 +39,15 @@ VideoContentFilter createNsfwFilter(
     // are noisy and would otherwise block autoplay on ordinary videos.
     final modLabels = video.moderationLabels;
     if (modLabels.isNotEmpty) {
-      // TODO(moderation-labels): Coordinate with Funnelcake server on
-      // namespacing conventions for non-safety labels (e.g. topic:*, lang:*,
-      // quality:*) so they can bypass this hide gate. Today any new ML label
-      // the mobile client has not been updated to recognize will force-hide
-      // every video carrying it, regardless of user preference. The
-      // conservative default is correct for safety labels but is too broad
-      // if the server starts emitting discovery/taxonomy labels in the same
-      // field. Track at: #4364.
-      //
-      // Conservative default: if the server tagged a video with a label
-      // we don't recognize, treat it as a hide signal. The alternative —
-      // silently showing the video — defeats the safety system whenever
-      // the relay introduces a new label the client has not been updated
-      // to understand.
-      final hasUnknown = modLabels.any(
-        (l) => ContentLabel.fromValue(l) == null,
-      );
-      if (hasUnknown) return true;
-
-      final pref = contentFilterService.getPreferenceForLabels(modLabels);
-      if (pref == ContentFilterPreference.hide) return true;
+      final recognizedLabels = modLabels
+          .where((label) => ContentLabel.fromValue(label) != null)
+          .toList();
+      if (recognizedLabels.isNotEmpty) {
+        final pref = contentFilterService.getPreferenceForLabels(
+          recognizedLabels,
+        );
+        if (pref == ContentFilterPreference.hide) return true;
+      }
     }
 
     return false;

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -695,13 +695,13 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
 
           // Check moderation labels (hide-only — never warn)
           if (modLabels.isNotEmpty) {
-            final hasUnknown = modLabels.any(
-              (label) => ContentLabel.fromValue(label) == null,
-            );
-            if (hasUnknown) return false;
-
-            final pref = service.getPreferenceForLabels(modLabels);
-            if (pref == ContentFilterPreference.hide) return false;
+            final recognizedLabels = modLabels
+                .where((label) => ContentLabel.fromValue(label) != null)
+                .toList();
+            if (recognizedLabels.isNotEmpty) {
+              final pref = service.getPreferenceForLabels(recognizedLabels);
+              if (pref == ContentFilterPreference.hide) return false;
+            }
           }
 
           return true;

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -693,15 +693,12 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
             if (pref == ContentFilterPreference.hide) return false;
           }
 
-          // Check moderation labels (hide-only — never warn)
+          // Check moderation labels (hide-only — never warn).
+          // getPreferenceForLabels ignores unrecognized labels, so a video
+          // tagged only with unknown labels never force-hides.
           if (modLabels.isNotEmpty) {
-            final recognizedLabels = modLabels
-                .where((label) => ContentLabel.fromValue(label) != null)
-                .toList();
-            if (recognizedLabels.isNotEmpty) {
-              final pref = service.getPreferenceForLabels(recognizedLabels);
-              if (pref == ContentFilterPreference.hide) return false;
-            }
+            final pref = service.getPreferenceForLabels(modLabels);
+            if (pref == ContentFilterPreference.hide) return false;
           }
 
           return true;

--- a/mobile/test/services/nsfw_content_filter_test.dart
+++ b/mobile/test/services/nsfw_content_filter_test.dart
@@ -347,7 +347,7 @@ void main() {
     });
 
     group('ML moderation labels (video.moderationLabels)', () {
-      test('hides videos with unknown ML moderation labels', () {
+      test('keeps videos with only unknown ML moderation labels', () {
         final filter = createNsfwFilter(
           contentFilterService,
           moderationLabelService: moderationLabelService,
@@ -356,7 +356,7 @@ void main() {
           moderationLabels: const ['some-new-server-label'],
         );
 
-        expect(filter(video), isTrue);
+        expect(filter(video), isFalse);
       });
 
       test('still hides videos with known hide labels', () {
@@ -414,12 +414,11 @@ void main() {
         expect(filter(video), isTrue);
       });
 
-      test('unknown label hides the video even if the user preferenced the '
-          'known label as show', () async {
+      test('ignores unknown labels when the user preferenced recognized '
+          'labels as show', () async {
         // Simulate an age-verified user who has explicitly opted in to
-        // seeing alcohol content. Without the unknown-label short-circuit, a
-        // video labeled ['alcohol', 'unknown-x'] would pass through
-        // because the combined preference resolves to show.
+        // seeing alcohol content. Unknown ML labels should not override that
+        // recognized preference.
         await ageService.initialize();
         await ageService.setAdultContentVerified(true);
         await contentFilterService.setPreference(
@@ -435,8 +434,7 @@ void main() {
           moderationLabels: const ['alcohol', 'unknown-x'],
         );
 
-        // The unknown label must force-hide regardless of user preference.
-        expect(filter(video), isTrue);
+        expect(filter(video), isFalse);
       });
 
       test(

--- a/mobile/test/services/video_event_service_adult_filter_test.dart
+++ b/mobile/test/services/video_event_service_adult_filter_test.dart
@@ -268,7 +268,9 @@ void main() {
 
         expect(filtered, isEmpty);
         verify(
-          () => mockContentFilterService.getPreferenceForLabels(['nudity']),
+          () => mockContentFilterService.getPreferenceForLabels(
+            ['nudity', 'some-new-server-label'],
+          ),
         ).called(greaterThanOrEqualTo(1));
       },
     );

--- a/mobile/test/services/video_event_service_adult_filter_test.dart
+++ b/mobile/test/services/video_event_service_adult_filter_test.dart
@@ -214,21 +214,21 @@ void main() {
     );
 
     test(
-      'filterVideoList hides videos with any other unknown moderation label',
+      'filterVideoList keeps videos with only unknown moderation labels',
       () {
         when(
           () => mockContentFilterService.getPreferenceForLabels(any()),
         ).thenReturn(ContentFilterPreference.show);
         videoEventService.setContentFilterService(mockContentFilterService);
 
-        final filtered = videoEventService.filterVideoList([
-          _buildVideo(
-            id: '6' * 64,
-            moderationLabels: const ['some-new-server-label'],
-          ),
-        ]);
+        final video = _buildVideo(
+          id: '6' * 64,
+          moderationLabels: const ['some-new-server-label'],
+        );
 
-        expect(filtered, isEmpty);
+        final filtered = videoEventService.filterVideoList([video]);
+
+        expect(filtered, [video]);
       },
     );
 
@@ -248,6 +248,28 @@ void main() {
         final filtered = videoEventService.filterVideoList([video]);
 
         expect(filtered, [video]);
+      },
+    );
+
+    test(
+      'filterVideoList hides videos with known hide labels alongside unknown labels',
+      () {
+        when(
+          () => mockContentFilterService.getPreferenceForLabels(any()),
+        ).thenReturn(ContentFilterPreference.hide);
+        videoEventService.setContentFilterService(mockContentFilterService);
+
+        final filtered = videoEventService.filterVideoList([
+          _buildVideo(
+            id: '8' * 64,
+            moderationLabels: const ['nudity', 'some-new-server-label'],
+          ),
+        ]);
+
+        expect(filtered, isEmpty);
+        verify(
+          () => mockContentFilterService.getPreferenceForLabels(['nudity']),
+        ).called(greaterThanOrEqualTo(1));
       },
     );
   });


### PR DESCRIPTION
## Summary
- stop treating unrecognized ML moderation labels as automatic hide signals
- keep recognized moderation labels enforcing user content preferences
- update service and repository bridge tests for unknown-only and mixed-label cases

Closes #6097

## Tests
- flutter analyze lib/services/video_event_service.dart lib/services/nsfw_content_filter.dart test/services/video_event_service_adult_filter_test.dart test/services/nsfw_content_filter_test.dart
- flutter test test/services/video_event_service_adult_filter_test.dart test/services/nsfw_content_filter_test.dart