### PR TITLE
fix(feed): deprioritize recently seen For You videos

### DIFF
--- a/mobile/lib/providers/for_you_provider.dart
+++ b/mobile/lib/providers/for_you_provider.dart
@@ -150,13 +150,19 @@ class ForYouFeed extends _$ForYouFeed {
               .toList(),
         ),
       );
+      final freshOrderedVideos = prioritizeNotRecentlySeenVideos(
+        filteredVideos,
+        seenVideoLookup: SeenVideoLookup(
+          wasSeenRecently: ref.read(seenVideosServiceProvider).wasSeenRecently,
+        ),
+      );
 
       _sessionSeed = requestSeed;
       _nextCursor = response.nextCursor;
       final hasMore = response.hasMore && _nextCursor != null;
 
       return VideoFeedState(
-        videos: filteredVideos,
+        videos: freshOrderedVideos,
         hasMoreContent: hasMore,
         lastUpdated: DateTime.now(),
       );
@@ -234,7 +240,14 @@ class ForYouFeed extends _$ForYouFeed {
             .toList(),
       );
       final newVideos = dedupeByFeedKey(
-        filteredVideos,
+        prioritizeNotRecentlySeenVideos(
+          filteredVideos,
+          seenVideoLookup: SeenVideoLookup(
+            wasSeenRecently: ref
+                .read(seenVideosServiceProvider)
+                .wasSeenRecently,
+          ),
+        ),
         alreadySeen: currentState.videos.map((video) => video.feedDedupKey),
       );
       final mergedVideos = [...currentState.videos, ...newVideos];

--- a/mobile/lib/providers/for_you_provider.dart
+++ b/mobile/lib/providers/for_you_provider.dart
@@ -150,10 +150,17 @@ class ForYouFeed extends _$ForYouFeed {
               .toList(),
         ),
       );
+      final seenVideosService = ref.read(seenVideosServiceProvider);
+      await seenVideosService.initialize();
+      if (!ref.mounted) {
+        return const VideoFeedState(videos: [], hasMoreContent: false);
+      }
+
       final freshOrderedVideos = prioritizeNotRecentlySeenVideos(
         filteredVideos,
         seenVideoLookup: SeenVideoLookup(
-          wasSeenRecently: ref.read(seenVideosServiceProvider).wasSeenRecently,
+          wasSeenRecently: seenVideosService.wasSeenRecently,
+          initialize: seenVideosService.initialize,
         ),
       );
 
@@ -239,13 +246,16 @@ class ForYouFeed extends _$ForYouFeed {
             .where((v) => !blocklistRepository.shouldFilterFromFeeds(v.pubkey))
             .toList(),
       );
+      final seenVideosService = ref.read(seenVideosServiceProvider);
+      await seenVideosService.initialize();
+      if (!ref.mounted) return;
+
       final newVideos = dedupeByFeedKey(
         prioritizeNotRecentlySeenVideos(
           filteredVideos,
           seenVideoLookup: SeenVideoLookup(
-            wasSeenRecently: ref
-                .read(seenVideosServiceProvider)
-                .wasSeenRecently,
+            wasSeenRecently: seenVideosService.wasSeenRecently,
+            initialize: seenVideosService.initialize,
           ),
         ),
         alreadySeen: currentState.videos.map((video) => video.feedDedupKey),

--- a/mobile/lib/providers/for_you_provider.g.dart
+++ b/mobile/lib/providers/for_you_provider.g.dart
@@ -48,7 +48,7 @@ final class ForYouFeedProvider
   ForYouFeed create() => ForYouFeed();
 }
 
-String _$forYouFeedHash() => r'0a1d1bbd0ef8509befd8dcd3f4f30e20a6b172ae';
+String _$forYouFeedHash() => r'640655c60aa6d5de3ec6d1caf13229ccfeb3fdf6';
 
 /// For You recommendations feed provider - ML-powered personalized videos
 ///

--- a/mobile/lib/providers/for_you_provider.g.dart
+++ b/mobile/lib/providers/for_you_provider.g.dart
@@ -48,7 +48,7 @@ final class ForYouFeedProvider
   ForYouFeed create() => ForYouFeed();
 }
 
-String _$forYouFeedHash() => r'640655c60aa6d5de3ec6d1caf13229ccfeb3fdf6';
+String _$forYouFeedHash() => r'a63593c4c8e0b12d250df9515c1d2e92c13710e4';
 
 /// For You recommendations feed provider - ML-powered personalized videos
 ///

--- a/mobile/lib/providers/seen_videos_notifier.dart
+++ b/mobile/lib/providers/seen_videos_notifier.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Riverpod notifier for tracking seen videos with reactive state
 // ABOUTME: Provides observable state that videoEventsProvider can watch for reordering
 
+import 'package:openvine/providers/video_providers.dart';
 import 'package:openvine/services/seen_videos_service.dart';
 import 'package:openvine/state/seen_videos_state.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -15,12 +16,12 @@ class SeenVideosNotifier extends _$SeenVideosNotifier {
 
   @override
   SeenVideosState build() {
+    _service = ref.watch(seenVideosServiceProvider);
     _initializeService();
     return SeenVideosState.initial;
   }
 
   void _initializeService() {
-    _service = SeenVideosService();
     _service!
         .initialize()
         .then((_) {

--- a/mobile/lib/providers/seen_videos_notifier.g.dart
+++ b/mobile/lib/providers/seen_videos_notifier.g.dart
@@ -45,7 +45,7 @@ final class SeenVideosNotifierProvider
 }
 
 String _$seenVideosNotifierHash() =>
-    r'11e527c825dd2b21de09445aeaf4a14299cb7700';
+    r'8d3d69b2c8cbc1fb2d71857a1421f38ecdaf1dc8';
 
 /// Notifier for managing seen videos state reactively
 

--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -485,6 +485,7 @@ VideosRepository videosRepository(Ref ref) {
     inMemoryFeedCache: InMemoryFeedCache(),
     seenVideoLookup: SeenVideoLookup(
       wasSeenRecently: seenVideosService.wasSeenRecently,
+      initialize: seenVideosService.initialize,
     ),
   );
 

--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -109,10 +109,13 @@ PersonalEventCacheService personalEventCacheService(Ref ref) {
   return service;
 }
 
-/// Seen videos service for tracking viewed content
-@riverpod
+/// Seen videos service for tracking viewed content.
+@Riverpod(keepAlive: true)
 SeenVideosService seenVideosService(Ref ref) {
-  return SeenVideosService();
+  final service = SeenVideosService();
+  unawaited(service.initialize());
+  ref.onDispose(service.dispose);
+  return service;
 }
 
 /// Subscription manager for centralized subscription management
@@ -454,6 +457,7 @@ VideosRepository videosRepository(Ref ref) {
   final contentFilterService = ref.watch(contentFilterServiceProvider);
   final moderationLabelService = ref.watch(moderationLabelServiceProvider);
   final funnelcakeClient = ref.watch(funnelcakeApiClientProvider);
+  final seenVideosService = ref.watch(seenVideosServiceProvider);
   final divineHostFilterService = ref.read(divineHostFilterServiceProvider);
   final feedAspectRatioPreference = ref.watch(
     feedAspectRatioPreferenceServiceProvider,
@@ -479,6 +483,9 @@ VideosRepository videosRepository(Ref ref) {
     ),
     funnelcakeApiClient: funnelcakeClient,
     inMemoryFeedCache: InMemoryFeedCache(),
+    seenVideoLookup: SeenVideoLookup(
+      wasSeenRecently: seenVideosService.wasSeenRecently,
+    ),
   );
 
   // Clear the in-memory feed cache (home + per-author) on logout/account

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -114,12 +114,12 @@ final class PersonalEventCacheServiceProvider
 String _$personalEventCacheServiceHash() =>
     r'f8fbeaaa8db79abff62ce85e3ca683320c5f0e50';
 
-/// Seen videos service for tracking viewed content
+/// Seen videos service for tracking viewed content.
 
 @ProviderFor(seenVideosService)
 final seenVideosServiceProvider = SeenVideosServiceProvider._();
 
-/// Seen videos service for tracking viewed content
+/// Seen videos service for tracking viewed content.
 
 final class SeenVideosServiceProvider
     extends
@@ -129,14 +129,14 @@ final class SeenVideosServiceProvider
           SeenVideosService
         >
     with $Provider<SeenVideosService> {
-  /// Seen videos service for tracking viewed content
+  /// Seen videos service for tracking viewed content.
   SeenVideosServiceProvider._()
     : super(
         from: null,
         argument: null,
         retry: null,
         name: r'seenVideosServiceProvider',
-        isAutoDispose: true,
+        isAutoDispose: false,
         dependencies: null,
         $allTransitiveDependencies: null,
       );
@@ -164,7 +164,7 @@ final class SeenVideosServiceProvider
   }
 }
 
-String _$seenVideosServiceHash() => r'74099bd4d859b446a3fc0cf1a7f416756a104e43';
+String _$seenVideosServiceHash() => r'933e55ea8a18eee2890da07089a3164a8ec424de';
 
 /// Subscription manager for centralized subscription management
 
@@ -905,7 +905,7 @@ final class VideosRepositoryProvider
   }
 }
 
-String _$videosRepositoryHash() => r'e4ef1b585f6dc5a957af569cd01f750e60ba5838';
+String _$videosRepositoryHash() => r'093a23f6a9643229b97858b28f79359e531ecb37';
 
 /// Provider for LikesRepository instance
 ///

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -905,7 +905,7 @@ final class VideosRepositoryProvider
   }
 }
 
-String _$videosRepositoryHash() => r'093a23f6a9643229b97858b28f79359e531ecb37';
+String _$videosRepositoryHash() => r'f98257a666f2fede19dd41cbc4e5dca57ae65328';
 
 /// Provider for LikesRepository instance
 ///

--- a/mobile/lib/services/seen_videos_service.dart
+++ b/mobile/lib/services/seen_videos_service.dart
@@ -78,6 +78,7 @@ class SeenVideosService {
   final Map<String, SeenVideoMetrics> _seenVideos = {};
   SharedPreferences? _prefs;
   bool _isInitialized = false;
+  Future<void>? _initializeFuture;
 
   /// Whether the service has been initialized
   bool get isInitialized => _isInitialized;
@@ -86,9 +87,17 @@ class SeenVideosService {
   int get seenVideoCount => _seenVideos.length;
 
   /// Initialize the service and load seen videos from storage
-  Future<void> initialize() async {
-    if (_isInitialized) return;
+  Future<void> initialize() {
+    if (_isInitialized) return Future.value();
+    final pending = _initializeFuture;
+    if (pending != null) return pending;
 
+    final future = _initialize();
+    _initializeFuture = future;
+    return future;
+  }
+
+  Future<void> _initialize() async {
     try {
       _prefs = await SharedPreferences.getInstance();
       await _loadSeenVideos();
@@ -105,6 +114,10 @@ class SeenVideosService {
         name: 'SeenVideosService',
         category: LogCategory.system,
       );
+    } finally {
+      if (!_isInitialized) {
+        _initializeFuture = null;
+      }
     }
   }
 

--- a/mobile/packages/videos_repository/lib/src/seen_video_lookup.dart
+++ b/mobile/packages/videos_repository/lib/src/seen_video_lookup.dart
@@ -1,0 +1,50 @@
+// ABOUTME: Flutter-free seen-video lookup port used by feed freshness policy.
+// ABOUTME: Lets app-layer persistence influence repository ordering.
+
+import 'package:models/models.dart';
+
+/// Default window used to move recently watched For You candidates later.
+const Duration defaultRecentlySeenVideoWindow = Duration(hours: 24);
+
+/// Function signature for checking whether a video was seen recently.
+typedef WasVideoSeenRecently = bool Function(String videoId, {Duration within});
+
+/// Port for app-layer seen-video persistence.
+///
+/// The repository package stays Flutter-free; the app injects this with its
+/// persisted seen-video service implementation.
+class SeenVideoLookup {
+  /// Creates a lookup from a recently-seen predicate.
+  const SeenVideoLookup({required this.wasSeenRecently});
+
+  /// Returns whether a video ID was seen within the supplied recency window.
+  final WasVideoSeenRecently wasSeenRecently;
+}
+
+/// Returns candidates with not-recently-seen videos first.
+///
+/// Recently seen videos are appended instead of dropped so small candidate
+/// pools still produce a feed.
+List<VideoEvent> prioritizeNotRecentlySeenVideos(
+  Iterable<VideoEvent> videos, {
+  SeenVideoLookup? seenVideoLookup,
+  Duration recencyWindow = defaultRecentlySeenVideoWindow,
+}) {
+  final candidates = videos.toList();
+  if (seenVideoLookup == null || candidates.length < 2) return candidates;
+
+  final notRecentlySeen = <VideoEvent>[];
+  final recentlySeen = <VideoEvent>[];
+
+  for (final video in candidates) {
+    if (video.id.isNotEmpty &&
+        seenVideoLookup.wasSeenRecently(video.id, within: recencyWindow)) {
+      recentlySeen.add(video);
+    } else {
+      notRecentlySeen.add(video);
+    }
+  }
+
+  if (notRecentlySeen.isEmpty || recentlySeen.isEmpty) return candidates;
+  return [...notRecentlySeen, ...recentlySeen];
+}

--- a/mobile/packages/videos_repository/lib/src/seen_video_lookup.dart
+++ b/mobile/packages/videos_repository/lib/src/seen_video_lookup.dart
@@ -9,16 +9,25 @@ const Duration defaultRecentlySeenVideoWindow = Duration(hours: 24);
 /// Function signature for checking whether a video was seen recently.
 typedef WasVideoSeenRecently = bool Function(String videoId, {Duration within});
 
+/// Function signature for waiting until the lookup has loaded persisted state.
+typedef InitializeSeenVideoLookup = Future<void> Function();
+
 /// Port for app-layer seen-video persistence.
 ///
 /// The repository package stays Flutter-free; the app injects this with its
 /// persisted seen-video service implementation.
 class SeenVideoLookup {
   /// Creates a lookup from a recently-seen predicate.
-  const SeenVideoLookup({required this.wasSeenRecently});
+  const SeenVideoLookup({required this.wasSeenRecently, this.initialize});
 
   /// Returns whether a video ID was seen within the supplied recency window.
   final WasVideoSeenRecently wasSeenRecently;
+
+  /// Loads any persisted seen-video state needed by [wasSeenRecently].
+  final InitializeSeenVideoLookup? initialize;
+
+  /// Waits for [initialize] when the app layer provides one.
+  Future<void> ensureInitialized() => initialize?.call() ?? Future.value();
 }
 
 /// Returns candidates with not-recently-seen videos first.
@@ -30,7 +39,7 @@ List<VideoEvent> prioritizeNotRecentlySeenVideos(
   SeenVideoLookup? seenVideoLookup,
   Duration recencyWindow = defaultRecentlySeenVideoWindow,
 }) {
-  final candidates = videos.toList();
+  final candidates = videos is List<VideoEvent> ? videos : videos.toList();
   if (seenVideoLookup == null || candidates.length < 2) return candidates;
 
   final notRecentlySeen = <VideoEvent>[];

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -2513,7 +2513,7 @@ class VideosRepository {
         _funnelcakeApiClient == null ||
         !_funnelcakeApiClient.isAvailable) {
       return HomeFeedResult(
-        videos: prioritizeNotRecentlySeenVideos(
+        videos: await _orderForYouFreshness(
           await getPopularVideos(
             limit: limit,
             until: until,
@@ -2521,7 +2521,6 @@ class VideosRepository {
             preferredLanguages: preferredLanguages,
             viewerCountry: viewerCountry,
           ),
-          seenVideoLookup: _seenVideoLookup,
         ),
       );
     }
@@ -2529,26 +2528,18 @@ class VideosRepository {
     final recommendationCursor = cursor ?? until?.toString();
     late final RecommendationsResponse response;
     try {
-      response = recommendationCursor == null
-          ? await _funnelcakeApiClient.getRecommendations(
-              pubkey: effectiveUserPubkey,
-              limit: limit,
-              seed: requestSeed,
-              preferredLanguages: preferredLanguages,
-              viewerCountry: viewerCountry,
-            )
-          : await _funnelcakeApiClient.getRecommendations(
-              pubkey: effectiveUserPubkey,
-              limit: limit,
-              cursor: recommendationCursor,
-              seed: requestSeed,
-              preferredLanguages: preferredLanguages,
-              viewerCountry: viewerCountry,
-            );
+      response = await _fetchRecommendationsPage(
+        pubkey: effectiveUserPubkey,
+        limit: limit,
+        cursor: recommendationCursor,
+        seed: requestSeed,
+        preferredLanguages: preferredLanguages,
+        viewerCountry: viewerCountry,
+      );
     } on FunnelcakeException {
       if (recommendationCursor != null) rethrow;
       return HomeFeedResult(
-        videos: prioritizeNotRecentlySeenVideos(
+        videos: await _orderForYouFreshness(
           await getPopularVideos(
             limit: limit,
             until: until,
@@ -2556,42 +2547,34 @@ class VideosRepository {
             preferredLanguages: preferredLanguages,
             viewerCountry: viewerCountry,
           ),
-          seenVideoLookup: _seenVideoLookup,
         ),
       );
     }
-    // Recommendation responses can carry the same addressable video more than
-    // once in a single page: the server's emitted-id cursor dedupes by event
-    // id, so a republished coordinate (same kind:pubkey:d-tag, fresh event id)
-    // slips through. Dedupe by feedDedupKey here — as getNewVideos already does
-    // — so the forYou feed never shows the same video twice.
-    final videos = <VideoEvent>[];
-    _appendUniqueVideos(
-      videos,
-      _transformVideoStats(response.videos),
-      seenVideoKeys: <String>{},
+
+    final result = await _buildRecommendedVideosResult(
+      response: response,
+      pubkey: effectiveUserPubkey,
+      limit: limit,
+      requestSeed: requestSeed,
+      recommendationCursor: recommendationCursor,
+      preferredLanguages: preferredLanguages,
+      viewerCountry: viewerCountry,
     );
 
-    if (videos.isEmpty) {
+    if (result.videos.isEmpty) {
       return HomeFeedResult(
-        videos: await getPopularVideos(
-          limit: limit,
-          until: until,
-          skipCache: skipCache,
-          preferredLanguages: preferredLanguages,
-          viewerCountry: viewerCountry,
+        videos: await _orderForYouFreshness(
+          await getPopularVideos(
+            limit: limit,
+            until: until,
+            skipCache: skipCache,
+            preferredLanguages: preferredLanguages,
+            viewerCountry: viewerCountry,
+          ),
         ),
       );
     }
 
-    final result = HomeFeedResult(
-      videos: prioritizeNotRecentlySeenVideos(
-        videos,
-        seenVideoLookup: _seenVideoLookup,
-      ),
-      paginationCursor: response.nextCursor,
-      hasMore: response.hasMore,
-    );
     if (isFirstPage) {
       _recommendationSessionSeed = requestSeed;
     }
@@ -2601,11 +2584,123 @@ class VideosRepository {
     return result;
   }
 
-  HomeFeedResult _withForYouFreshnessOrdering(HomeFeedResult result) {
-    final orderedVideos = prioritizeNotRecentlySeenVideos(
-      result.videos,
+  Future<RecommendationsResponse> _fetchRecommendationsPage({
+    required String pubkey,
+    required int limit,
+    required String? cursor,
+    required String seed,
+    required List<String> preferredLanguages,
+    required String? viewerCountry,
+  }) {
+    if (cursor == null) {
+      return _funnelcakeApiClient!.getRecommendations(
+        pubkey: pubkey,
+        limit: limit,
+        seed: seed,
+        preferredLanguages: preferredLanguages,
+        viewerCountry: viewerCountry,
+      );
+    }
+
+    return _funnelcakeApiClient!.getRecommendations(
+      pubkey: pubkey,
+      limit: limit,
+      cursor: cursor,
+      seed: seed,
+      preferredLanguages: preferredLanguages,
+      viewerCountry: viewerCountry,
+    );
+  }
+
+  Future<HomeFeedResult> _buildRecommendedVideosResult({
+    required RecommendationsResponse response,
+    required String pubkey,
+    required int limit,
+    required String requestSeed,
+    required String? recommendationCursor,
+    required List<String> preferredLanguages,
+    required String? viewerCountry,
+  }) async {
+    await _seenVideoLookup?.ensureInitialized();
+
+    // Recommendation responses can carry the same addressable video more than
+    // once in a page: the server's emitted-id cursor dedupes by event id, so a
+    // republished coordinate (same kind:pubkey:d-tag, fresh event id) slips
+    // through. Dedupe by feedDedupKey here — as getNewVideos already does — so
+    // the forYou feed never shows the same video twice.
+    final videos = <VideoEvent>[];
+    final seenVideoKeys = <String>{};
+    var currentResponse = response;
+    var nextCursor = currentResponse.nextCursor;
+    var hasMore = currentResponse.hasMore;
+    var fetchedCursor = recommendationCursor;
+
+    while (true) {
+      _appendUniqueVideos(
+        videos,
+        _transformVideoStats(currentResponse.videos),
+        seenVideoKeys: seenVideoKeys,
+      );
+
+      if (videos.isEmpty ||
+          _seenVideoLookup == null ||
+          _hasNotRecentlySeenForYouCandidate(videos) ||
+          !hasMore ||
+          nextCursor == null ||
+          nextCursor == fetchedCursor) {
+        break;
+      }
+
+      fetchedCursor = nextCursor;
+      currentResponse = await _fetchRecommendationsPage(
+        pubkey: pubkey,
+        limit: limit,
+        cursor: fetchedCursor,
+        seed: requestSeed,
+        preferredLanguages: preferredLanguages,
+        viewerCountry: viewerCountry,
+      );
+      nextCursor = currentResponse.nextCursor;
+      hasMore = currentResponse.hasMore;
+    }
+
+    return HomeFeedResult(
+      videos: prioritizeNotRecentlySeenVideos(
+        videos,
+        seenVideoLookup: _seenVideoLookup,
+      ),
+      paginationCursor: nextCursor,
+      hasMore: hasMore,
+    );
+  }
+
+  bool _hasNotRecentlySeenForYouCandidate(List<VideoEvent> videos) {
+    final lookup = _seenVideoLookup;
+    if (lookup == null) return true;
+    return videos.any(
+      (video) =>
+          video.id.isEmpty ||
+          !lookup.wasSeenRecently(
+            video.id,
+            within: defaultRecentlySeenVideoWindow,
+          ),
+    );
+  }
+
+  Future<List<VideoEvent>> _orderForYouFreshness(
+    List<VideoEvent> videos,
+  ) async {
+    await _seenVideoLookup?.ensureInitialized();
+    return prioritizeNotRecentlySeenVideos(
+      videos,
       seenVideoLookup: _seenVideoLookup,
     );
+  }
+
+  Future<HomeFeedResult> _withForYouFreshnessOrdering(
+    HomeFeedResult result,
+  ) async {
+    final orderedVideos = await _orderForYouFreshness(result.videos);
     if (identical(orderedVideos, result.videos)) return result;
     return HomeFeedResult(
       videos: orderedVideos,

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -16,6 +16,7 @@ import 'package:videos_repository/src/in_memory_feed_cache.dart';
 import 'package:videos_repository/src/popular_videos_page.dart';
 import 'package:videos_repository/src/profile_video_merge.dart';
 import 'package:videos_repository/src/recommendation_session_seed.dart';
+import 'package:videos_repository/src/seen_video_lookup.dart';
 import 'package:videos_repository/src/video_content_filter.dart';
 import 'package:videos_repository/src/video_event_filter.dart';
 import 'package:videos_repository/src/video_local_storage.dart';
@@ -151,13 +152,15 @@ class VideosRepository {
     VideoWarningLabelsResolver? warningLabelsResolver,
     FunnelcakeApiClient? funnelcakeApiClient,
     InMemoryFeedCache? inMemoryFeedCache,
+    SeenVideoLookup? seenVideoLookup,
   }) : _nostrClient = nostrClient,
        _localStorage = localStorage,
        _blockFilter = blockFilter,
        _contentFilter = contentFilter,
        _warningLabelsResolver = warningLabelsResolver,
        _funnelcakeApiClient = funnelcakeApiClient,
-       _inMemoryFeedCache = inMemoryFeedCache;
+       _inMemoryFeedCache = inMemoryFeedCache,
+       _seenVideoLookup = seenVideoLookup;
 
   final NostrClient _nostrClient;
   final VideoLocalStorage? _localStorage;
@@ -166,6 +169,7 @@ class VideosRepository {
   final VideoWarningLabelsResolver? _warningLabelsResolver;
   final FunnelcakeApiClient? _funnelcakeApiClient;
   final InMemoryFeedCache? _inMemoryFeedCache;
+  final SeenVideoLookup? _seenVideoLookup;
   String _recommendationSessionSeed = generateRecommendationSessionSeed();
 
   /// Clears the in-memory feed cache.
@@ -671,10 +675,7 @@ class VideosRepository {
           until: until,
         );
         final mergedVideos = skipCache && until == null
-            ? await _mergeRecentApiVideosWithRelayRefresh(
-                videos,
-                limit: limit,
-              )
+            ? await _mergeRecentApiVideosWithRelayRefresh(videos, limit: limit)
             : videos;
         // Hydrate views/loops — list endpoint omits them for some rows.
         final hydrated = await _hydrateVideosWithBulkStats(mergedVideos);
@@ -739,11 +740,7 @@ class VideosRepository {
       final candidates = [...relayVideos, ...apiVideos]
         ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
       final merged = <VideoEvent>[];
-      _appendUniqueVideos(
-        merged,
-        candidates,
-        seenVideoKeys: <String>{},
-      );
+      _appendUniqueVideos(merged, candidates, seenVideoKeys: <String>{});
       return merged.take(limit).toList();
     } on Object catch (e) {
       Log.warning(
@@ -2504,7 +2501,7 @@ class VideosRepository {
         '$preferenceCacheSuffix';
     if (!skipCache && until == null && cursor == null) {
       final cached = _inMemoryFeedCache?.get(cacheKey);
-      if (cached != null) return cached;
+      if (cached != null) return _withForYouFreshnessOrdering(cached);
     }
 
     final isFirstPage = until == null && cursor == null;
@@ -2516,12 +2513,15 @@ class VideosRepository {
         _funnelcakeApiClient == null ||
         !_funnelcakeApiClient.isAvailable) {
       return HomeFeedResult(
-        videos: await getPopularVideos(
-          limit: limit,
-          until: until,
-          skipCache: skipCache,
-          preferredLanguages: preferredLanguages,
-          viewerCountry: viewerCountry,
+        videos: prioritizeNotRecentlySeenVideos(
+          await getPopularVideos(
+            limit: limit,
+            until: until,
+            skipCache: skipCache,
+            preferredLanguages: preferredLanguages,
+            viewerCountry: viewerCountry,
+          ),
+          seenVideoLookup: _seenVideoLookup,
         ),
       );
     }
@@ -2548,12 +2548,15 @@ class VideosRepository {
     } on FunnelcakeException {
       if (recommendationCursor != null) rethrow;
       return HomeFeedResult(
-        videos: await getPopularVideos(
-          limit: limit,
-          until: until,
-          skipCache: skipCache,
-          preferredLanguages: preferredLanguages,
-          viewerCountry: viewerCountry,
+        videos: prioritizeNotRecentlySeenVideos(
+          await getPopularVideos(
+            limit: limit,
+            until: until,
+            skipCache: skipCache,
+            preferredLanguages: preferredLanguages,
+            viewerCountry: viewerCountry,
+          ),
+          seenVideoLookup: _seenVideoLookup,
         ),
       );
     }
@@ -2582,7 +2585,10 @@ class VideosRepository {
     }
 
     final result = HomeFeedResult(
-      videos: videos,
+      videos: prioritizeNotRecentlySeenVideos(
+        videos,
+        seenVideoLookup: _seenVideoLookup,
+      ),
       paginationCursor: response.nextCursor,
       hasMore: response.hasMore,
     );
@@ -2593,6 +2599,23 @@ class VideosRepository {
       _inMemoryFeedCache?.set(cacheKey, result);
     }
     return result;
+  }
+
+  HomeFeedResult _withForYouFreshnessOrdering(HomeFeedResult result) {
+    final orderedVideos = prioritizeNotRecentlySeenVideos(
+      result.videos,
+      seenVideoLookup: _seenVideoLookup,
+    );
+    if (identical(orderedVideos, result.videos)) return result;
+    return HomeFeedResult(
+      videos: orderedVideos,
+      videoListSources: result.videoListSources,
+      listOnlyVideoIds: result.listOnlyVideoIds,
+      consumedItemCount: result.consumedItemCount,
+      nextCursor: result.nextCursor,
+      paginationCursor: result.paginationCursor,
+      hasMore: result.hasMore,
+    );
   }
 
   /// Fetches personalized video recommendations.

--- a/mobile/packages/videos_repository/lib/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/videos_repository.dart
@@ -13,6 +13,7 @@ export 'src/in_memory_feed_cache.dart';
 export 'src/popular_videos_page.dart';
 export 'src/profile_video_merge.dart';
 export 'src/recommendation_session_seed.dart';
+export 'src/seen_video_lookup.dart';
 export 'src/video_content_filter.dart';
 export 'src/video_event_filter.dart';
 export 'src/video_local_storage.dart';

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -11041,6 +11041,82 @@ void main() {
         ).called(2);
       });
 
+      test(
+        'reorders cached recommendations when seen state changes',
+        () async {
+          final first = _createVideoStats(
+            id: 'first-video',
+            pubkey: 'first-pubkey',
+            dTag: 'first-dtag',
+            videoUrl: 'https://example.com/first.mp4',
+          );
+          final second = _createVideoStats(
+            id: 'second-video',
+            pubkey: 'second-pubkey',
+            dTag: 'second-dtag',
+            videoUrl: 'https://example.com/second.mp4',
+          );
+          when(
+            () => mockFunnelcakeClient.getRecommendations(
+              seed: any(named: 'seed'),
+              pubkey: any(named: 'pubkey'),
+              limit: any(named: 'limit'),
+              fallback: any(named: 'fallback'),
+              category: any(named: 'category'),
+              preferredLanguages: any(named: 'preferredLanguages'),
+              viewerCountry: any(named: 'viewerCountry'),
+            ),
+          ).thenAnswer(
+            (_) async => RecommendationsResponse(
+              videos: [first, second],
+              source: 'personalized',
+              nextCursor: 'page-2',
+              hasMore: true,
+            ),
+          );
+
+          final recentlySeenIds = <String>{};
+          final repo = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+            inMemoryFeedCache: InMemoryFeedCache(),
+            seenVideoLookup: SeenVideoLookup(
+              wasSeenRecently:
+                  (videoId, {within = const Duration(hours: 24)}) =>
+                      recentlySeenIds.contains(videoId),
+            ),
+          );
+
+          final fresh = await repo.getRecommendedVideos(
+            userPubkey: 'user-pubkey',
+            limit: 10,
+          );
+          recentlySeenIds.add('first-video');
+          final cached = await repo.getRecommendedVideos(
+            userPubkey: 'user-pubkey',
+            limit: 10,
+          );
+
+          expect(fresh.videos.map((video) => video.id), [
+            'first-video',
+            'second-video',
+          ]);
+          expect(cached.videos.map((video) => video.id), [
+            'second-video',
+            'first-video',
+          ]);
+          expect(cached.paginationCursor, equals('page-2'));
+          expect(cached.hasMore, isTrue);
+          verify(
+            () => mockFunnelcakeClient.getRecommendations(
+              seed: any(named: 'seed'),
+              pubkey: 'user-pubkey',
+              limit: 10,
+            ),
+          ).called(1);
+        },
+      );
+
       test('keeps the same session seed across cursor pagination', () async {
         final requestedSeeds = <String?>[];
         var callCount = 0;

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -162,9 +162,7 @@ void main() {
                 ),
               ],
             );
-            when(
-              () => mockNostrClient.queryEvents(any()),
-            ).thenAnswer(
+            when(() => mockNostrClient.queryEvents(any())).thenAnswer(
               (_) async => [
                 _createVideoEvent(
                   id: 'relay-video',
@@ -10575,6 +10573,178 @@ void main() {
           ),
         ).called(1);
       });
+
+      test(
+        'moves recently seen recommendations after unseen candidates',
+        () async {
+          final recentlySeen = _createVideoStats(
+            id: 'recently-seen-video',
+            pubkey: 'recently-seen-pubkey',
+            dTag: 'recently-seen-dtag',
+            videoUrl: 'https://example.com/recently-seen.mp4',
+          );
+          final unseen = _createVideoStats(
+            id: 'unseen-video',
+            pubkey: 'unseen-pubkey',
+            dTag: 'unseen-dtag',
+            videoUrl: 'https://example.com/unseen.mp4',
+          );
+          when(
+            () => mockFunnelcakeClient.getRecommendations(
+              seed: any(named: 'seed'),
+              pubkey: any(named: 'pubkey'),
+              limit: any(named: 'limit'),
+              fallback: any(named: 'fallback'),
+              category: any(named: 'category'),
+              preferredLanguages: any(named: 'preferredLanguages'),
+              viewerCountry: any(named: 'viewerCountry'),
+            ),
+          ).thenAnswer(
+            (_) async => RecommendationsResponse(
+              videos: [recentlySeen, unseen],
+              source: 'personalized',
+            ),
+          );
+
+          final repo = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+            seenVideoLookup: SeenVideoLookup(
+              wasSeenRecently:
+                  (videoId, {within = const Duration(hours: 24)}) =>
+                      videoId == 'recently-seen-video',
+            ),
+          );
+
+          final result = await repo.getRecommendedVideos(
+            userPubkey: 'user-pubkey',
+            limit: 10,
+          );
+
+          expect(result.videos.map((video) => video.id), [
+            'unseen-video',
+            'recently-seen-video',
+          ]);
+        },
+      );
+
+      test(
+        'keeps recently seen recommendations as fallback when all are seen',
+        () async {
+          final firstSeen = _createVideoStats(
+            id: 'first-seen-video',
+            pubkey: 'first-seen-pubkey',
+            dTag: 'first-seen-dtag',
+            videoUrl: 'https://example.com/first-seen.mp4',
+          );
+          final secondSeen = _createVideoStats(
+            id: 'second-seen-video',
+            pubkey: 'second-seen-pubkey',
+            dTag: 'second-seen-dtag',
+            videoUrl: 'https://example.com/second-seen.mp4',
+          );
+          when(
+            () => mockFunnelcakeClient.getRecommendations(
+              seed: any(named: 'seed'),
+              pubkey: any(named: 'pubkey'),
+              limit: any(named: 'limit'),
+              fallback: any(named: 'fallback'),
+              category: any(named: 'category'),
+              preferredLanguages: any(named: 'preferredLanguages'),
+              viewerCountry: any(named: 'viewerCountry'),
+            ),
+          ).thenAnswer(
+            (_) async => RecommendationsResponse(
+              videos: [firstSeen, secondSeen],
+              source: 'personalized',
+            ),
+          );
+
+          final repo = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+            seenVideoLookup: SeenVideoLookup(
+              wasSeenRecently: (_, {within = const Duration(hours: 24)}) =>
+                  true,
+            ),
+          );
+
+          final result = await repo.getRecommendedVideos(
+            userPubkey: 'user-pubkey',
+            limit: 10,
+          );
+
+          expect(result.videos.map((video) => video.id), [
+            'first-seen-video',
+            'second-seen-video',
+          ]);
+        },
+      );
+
+      test(
+        'orders cursor pages while preserving pagination metadata',
+        () async {
+          final requestedCursors = <String?>[];
+          when(
+            () => mockFunnelcakeClient.getRecommendations(
+              seed: any(named: 'seed'),
+              pubkey: any(named: 'pubkey'),
+              limit: any(named: 'limit'),
+              cursor: any(named: 'cursor'),
+              fallback: any(named: 'fallback'),
+              category: any(named: 'category'),
+              preferredLanguages: any(named: 'preferredLanguages'),
+              viewerCountry: any(named: 'viewerCountry'),
+            ),
+          ).thenAnswer((invocation) async {
+            final cursor = invocation.namedArguments[#cursor] as String?;
+            requestedCursors.add(cursor);
+            return RecommendationsResponse(
+              videos: [
+                _createVideoStats(
+                  id: 'recently-seen-$cursor',
+                  pubkey: 'recently-seen-pubkey-$cursor',
+                  dTag: 'recently-seen-dtag-$cursor',
+                  videoUrl: 'https://example.com/recently-seen-$cursor.mp4',
+                ),
+                _createVideoStats(
+                  id: 'unseen-$cursor',
+                  pubkey: 'unseen-pubkey-$cursor',
+                  dTag: 'unseen-dtag-$cursor',
+                  videoUrl: 'https://example.com/unseen-$cursor.mp4',
+                ),
+              ],
+              source: 'personalized',
+              nextCursor: 'next-$cursor',
+              hasMore: true,
+            );
+          });
+
+          final repo = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+            seenVideoLookup: SeenVideoLookup(
+              wasSeenRecently:
+                  (videoId, {within = const Duration(hours: 24)}) =>
+                      videoId.startsWith('recently-seen-'),
+            ),
+          );
+
+          final result = await repo.getRecommendedVideos(
+            userPubkey: 'user-pubkey',
+            cursor: 'cursor-1',
+            limit: 10,
+          );
+
+          expect(requestedCursors, ['cursor-1']);
+          expect(result.paginationCursor, 'next-cursor-1');
+          expect(result.hasMore, isTrue);
+          expect(result.videos.map((video) => video.id), [
+            'unseen-cursor-1',
+            'recently-seen-cursor-1',
+          ]);
+        },
+      );
 
       test(
         'deduplicates videos sharing an addressable identity in one page',

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -10682,6 +10682,152 @@ void main() {
       );
 
       test(
+        'waits for seen lookup initialization before freshness ordering',
+        () async {
+          final recentlySeen = _createVideoStats(
+            id: 'recently-seen-video',
+            pubkey: 'recently-seen-pubkey',
+            dTag: 'recently-seen-dtag',
+            videoUrl: 'https://example.com/recently-seen.mp4',
+          );
+          final unseen = _createVideoStats(
+            id: 'unseen-video',
+            pubkey: 'unseen-pubkey',
+            dTag: 'unseen-dtag',
+            videoUrl: 'https://example.com/unseen.mp4',
+          );
+          when(
+            () => mockFunnelcakeClient.getRecommendations(
+              seed: any(named: 'seed'),
+              pubkey: any(named: 'pubkey'),
+              limit: any(named: 'limit'),
+              fallback: any(named: 'fallback'),
+              category: any(named: 'category'),
+              preferredLanguages: any(named: 'preferredLanguages'),
+              viewerCountry: any(named: 'viewerCountry'),
+            ),
+          ).thenAnswer(
+            (_) async => RecommendationsResponse(
+              videos: [recentlySeen, unseen],
+              source: 'personalized',
+            ),
+          );
+
+          final initializeCompleter = Completer<void>();
+          var initialized = false;
+          final repo = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+            seenVideoLookup: SeenVideoLookup(
+              initialize: () => initializeCompleter.future,
+              wasSeenRecently:
+                  (videoId, {within = const Duration(hours: 24)}) =>
+                      initialized && videoId == 'recently-seen-video',
+            ),
+          );
+
+          var completed = false;
+          final resultFuture = repo
+              .getRecommendedVideos(userPubkey: 'user-pubkey', limit: 10)
+              .then((result) {
+                completed = true;
+                return result;
+              });
+
+          await pumpEventQueue();
+          expect(completed, isFalse);
+
+          initialized = true;
+          initializeCompleter.complete();
+          final result = await resultFuture;
+
+          expect(result.videos.map((video) => video.id), [
+            'unseen-video',
+            'recently-seen-video',
+          ]);
+        },
+      );
+
+      test(
+        'fetches deeper recommendation pages when the first page is all seen',
+        () async {
+          final firstSeen = _createVideoStats(
+            id: 'first-seen-video',
+            pubkey: 'first-seen-pubkey',
+            dTag: 'first-seen-dtag',
+            videoUrl: 'https://example.com/first-seen.mp4',
+          );
+          final secondSeen = _createVideoStats(
+            id: 'second-seen-video',
+            pubkey: 'second-seen-pubkey',
+            dTag: 'second-seen-dtag',
+            videoUrl: 'https://example.com/second-seen.mp4',
+          );
+          final deeperUnseen = _createVideoStats(
+            id: 'deeper-unseen-video',
+            pubkey: 'deeper-unseen-pubkey',
+            dTag: 'deeper-unseen-dtag',
+            videoUrl: 'https://example.com/deeper-unseen.mp4',
+          );
+          final requestedCursors = <String?>[];
+          when(
+            () => mockFunnelcakeClient.getRecommendations(
+              seed: any(named: 'seed'),
+              pubkey: any(named: 'pubkey'),
+              limit: any(named: 'limit'),
+              cursor: any(named: 'cursor'),
+              fallback: any(named: 'fallback'),
+              category: any(named: 'category'),
+              preferredLanguages: any(named: 'preferredLanguages'),
+              viewerCountry: any(named: 'viewerCountry'),
+            ),
+          ).thenAnswer((invocation) async {
+            final cursor = invocation.namedArguments[#cursor] as String?;
+            requestedCursors.add(cursor);
+            if (cursor == null) {
+              return RecommendationsResponse(
+                videos: [firstSeen, secondSeen],
+                source: 'personalized',
+                nextCursor: 'page-2',
+                hasMore: true,
+              );
+            }
+            expect(cursor, equals('page-2'));
+            return RecommendationsResponse(
+              videos: [deeperUnseen],
+              source: 'personalized',
+              nextCursor: 'page-3',
+              hasMore: true,
+            );
+          });
+
+          final repo = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+            seenVideoLookup: SeenVideoLookup(
+              wasSeenRecently:
+                  (videoId, {within = const Duration(hours: 24)}) =>
+                      videoId != 'deeper-unseen-video',
+            ),
+          );
+
+          final result = await repo.getRecommendedVideos(
+            userPubkey: 'user-pubkey',
+            limit: 2,
+          );
+
+          expect(result.videos.map((video) => video.id), [
+            'deeper-unseen-video',
+            'first-seen-video',
+            'second-seen-video',
+          ]);
+          expect(result.paginationCursor, equals('page-3'));
+          expect(result.hasMore, isTrue);
+          expect(requestedCursors, [null, 'page-2']);
+        },
+      );
+
+      test(
         'orders cursor pages while preserving pagination metadata',
         () async {
           final requestedCursors = <String?>[];
@@ -11116,11 +11262,17 @@ void main() {
       test(
         'falls back to popular videos when recommendations are empty',
         () async {
-          final popular = _createVideoStats(
-            id: 'popular-video',
-            pubkey: 'popular-pubkey',
-            dTag: 'popular-dtag',
-            videoUrl: 'https://example.com/popular.mp4',
+          final seenPopular = _createVideoStats(
+            id: 'seen-popular-video',
+            pubkey: 'seen-popular-pubkey',
+            dTag: 'seen-popular-dtag',
+            videoUrl: 'https://example.com/seen-popular.mp4',
+          );
+          final unseenPopular = _createVideoStats(
+            id: 'unseen-popular-video',
+            pubkey: 'unseen-popular-pubkey',
+            dTag: 'unseen-popular-dtag',
+            videoUrl: 'https://example.com/unseen-popular.mp4',
           );
           when(
             () => mockFunnelcakeClient.getRecommendations(
@@ -11139,11 +11291,16 @@ void main() {
               limit: any(named: 'limit'),
               before: any(named: 'before'),
             ),
-          ).thenAnswer((_) async => [popular]);
+          ).thenAnswer((_) async => [seenPopular, unseenPopular]);
 
           final repo = VideosRepository(
             nostrClient: mockNostrClient,
             funnelcakeApiClient: mockFunnelcakeClient,
+            seenVideoLookup: SeenVideoLookup(
+              wasSeenRecently:
+                  (videoId, {within = const Duration(hours: 24)}) =>
+                      videoId == 'seen-popular-video',
+            ),
           );
 
           final result = await repo.getRecommendedVideos(
@@ -11151,8 +11308,10 @@ void main() {
             limit: 10,
           );
 
-          expect(result.videos, hasLength(1));
-          expect(result.videos.single.id, equals('popular-video'));
+          expect(result.videos.map((video) => video.id), [
+            'unseen-popular-video',
+            'seen-popular-video',
+          ]);
           verify(
             () => mockFunnelcakeClient.getWatchingVideos(limit: 10),
           ).called(1);


### PR DESCRIPTION
## Summary
- add a Flutter-free seen-video lookup port and For You freshness ordering helper in videos_repository
- wire the app's persisted SeenVideosService into the home For You repository path and the legacy Explore For You provider
- consolidate SeenVideosNotifier onto the shared keep-alive service instance
- await seen-video store readiness before ordering and page deeper when the current For You page is entirely recently seen
- apply freshness ordering consistently to popular fallbacks and keep cache reads from rebuilding unnecessarily

Closes #6209

## Tests
- flutter test test/src/videos_repository_test.dart --name getRecommendedVideos (from mobile/packages/videos_repository)
- flutter test test/src/videos_repository_test.dart (from mobile/packages/videos_repository)
- very_good test --coverage --min-coverage 100 (from mobile/packages/videos_repository)
- flutter test test/providers/explore_feed_refresh_retention_test.dart (from mobile)
- flutter test test/services/seen_videos_service_test.dart (from mobile)
- flutter analyze (from mobile)
- pre-push hook: changed-file analysis, generated-file verification, videos_repository_test.dart, seen_videos_notifier_test.dart, seen_videos_service_test.dart
