### PR TITLE
feat(dm): save shared videos from messages

### DIFF
--- a/docs/superpowers/plans/2026-07-20-dm-video-save.md
+++ b/docs/superpowers/plans/2026-07-20-dm-video-save.md
@@ -1,0 +1,290 @@
+# DM Shared-Video Save Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an ownership-aware Save video action to full shared-video DM cards.
+
+**Architecture:** Normalize URL and NIP-18 `q` references into one `DmVideoTarget`, then use that target for preview resolution, copy-link behavior, and save resolution. The conversation presents the existing original or watermarked gallery-save sheet after resolving the canonical `VideoEvent`.
+
+**Tech Stack:** Flutter, Dart, BLoC/Cubit, Riverpod compatibility providers, `VideosRepository`, NIP-17/NIP-18 DM models, mocktail widget tests.
+
+---
+
+### Task 1: Normalize DM video identity
+
+**Files:**
+- Create: `mobile/lib/screens/inbox/conversation/dm_video_target.dart`
+- Modify: `mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart`
+- Modify: `mobile/lib/screens/inbox/conversation/widgets/video_link_preview_cubit.dart`
+- Create: `mobile/test/screens/inbox/conversation/dm_video_target_test.dart`
+- Test: `mobile/test/screens/inbox/conversation/widgets/video_link_preview_cubit_test.dart`
+
+- [ ] **Step 1: Write target normalization tests**
+
+Cover canonical URLs, regular event refs, addressable refs, URL-plus-structured
+metadata, and malformed addressable refs:
+
+```dart
+final target = resolveDmVideoTarget(
+  content: 'watch https://divine.video/video/skate-loop',
+  sharedVideoRef: const DmSharedVideoRef(
+    coordinateOrId: '34236:$author:skate-loop',
+    videoKind: DmSharedVideoKind.addressableShortVideo,
+  ),
+);
+
+expect(target?.stableId, 'skate-loop');
+expect(target?.fallbackRouteIds, ['34236:$author:skate-loop']);
+expect(target?.canonicalUrl, 'https://divine.video/video/skate-loop');
+```
+
+- [ ] **Step 2: Run the target tests and confirm they fail**
+
+Run:
+
+```bash
+cd mobile
+flutter test test/screens/inbox/conversation/dm_video_target_test.dart
+```
+
+Expected: compilation failure because `DmVideoTarget` and
+`resolveDmVideoTarget` do not exist.
+
+- [ ] **Step 3: Implement the normalized target**
+
+Create an immutable value object and resolver:
+
+```dart
+class DmVideoTarget {
+  const DmVideoTarget({
+    required this.stableId,
+    this.authorPubkey,
+    this.videoKind,
+  });
+
+  final String stableId;
+  final String? authorPubkey;
+  final int? videoKind;
+
+  String get canonicalUrl => 'https://divine.video/video/$stableId';
+
+  List<String> get fallbackRouteIds {
+    final author = authorPubkey;
+    final kind = videoKind;
+    if (author == null || kind == null) return const [];
+    return ['$kind:$author:$stableId'];
+  }
+}
+```
+
+`resolveDmVideoTarget` must prefer the URL's stable ID while retaining valid
+author/kind metadata from the structured ref. For an addressable ref, use
+`DmSharedVideoRef.dTag` and parse the author from `coordinateOrId`.
+
+- [ ] **Step 4: Make the card and cubit use the shared target**
+
+Replace `_SharedVideoTarget` and `_videoTargetFromRef` in
+`message_bubble.dart`. Make `VideoLinkPreviewCubit` resolve with
+`target.fallbackRouteIds` so the preview and save action cannot drift.
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+
+```bash
+cd mobile
+flutter test \
+  test/screens/inbox/conversation/dm_video_target_test.dart \
+  test/screens/inbox/conversation/widgets/video_link_preview_cubit_test.dart \
+  test/screens/inbox/conversation/widgets/message_bubble_test.dart
+```
+
+Expected: all pass.
+
+### Task 2: Add Save video to DM actions
+
+**Files:**
+- Modify: `mobile/lib/screens/inbox/conversation/widgets/message_actions_sheet.dart`
+- Modify: `mobile/lib/screens/inbox/conversation/widgets/reaction_picker_overlay.dart`
+- Modify: `mobile/test/screens/inbox/conversation/widgets/reaction_picker_overlay_test.dart`
+
+- [ ] **Step 1: Write failing action tests**
+
+Open the overlay with `isVideoShare: true`, assert that **Save video** appears,
+tap it, and assert:
+
+```dart
+expect(result?.action, MessageAction.saveVideo);
+```
+
+Also assert the action is absent for text-only messages.
+
+- [ ] **Step 2: Run the overlay tests and confirm failure**
+
+Run:
+
+```bash
+cd mobile
+flutter test test/screens/inbox/conversation/widgets/reaction_picker_overlay_test.dart
+```
+
+Expected: **Save video** is not found and `MessageAction.saveVideo` is absent.
+
+- [ ] **Step 3: Add the action**
+
+Add `saveVideo` to `MessageAction`. In both action-sheet renderers, insert:
+
+```dart
+if (isVideoShare)
+  _ActionTile(
+    icon: DivineIconName.downloadSimple,
+    label: l10n.shareSheetSaveVideo,
+    onTap: () => onSelected(MessageAction.saveVideo),
+  ),
+```
+
+The dormant `MessageActionsSheet` must stay aligned with the active
+`ReactionPickerOverlay`.
+
+- [ ] **Step 4: Run overlay tests**
+
+Run the command from Step 2. Expected: all pass.
+
+### Task 3: Resolve and present the correct save flow
+
+**Files:**
+- Modify: `mobile/lib/screens/inbox/conversation/conversation_view.dart`
+- Modify: `mobile/test/screens/inbox/conversation/conversation_view_test.dart`
+
+- [ ] **Step 1: Write failing conversation tests**
+
+Add tests proving:
+
+- a structured full-card share without a plaintext URL shows **Copy video URL**
+  and **Save video**;
+- selecting Save video fetches with the normalized stable ID and fallbacks;
+- current-user content calls `downloadOriginal`;
+- other-creator content calls `downloadWithWatermark`;
+- a repository miss shows `notificationsVideoUnavailable`.
+
+Override `videosRepositoryProvider` and `watermarkDownloadServiceProvider` with
+mocks, and return a `WatermarkDownloadSuccess` so the established progress
+sheet completes deterministically.
+
+- [ ] **Step 2: Run the conversation tests and confirm failure**
+
+Run:
+
+```bash
+cd mobile
+flutter test test/screens/inbox/conversation/conversation_view_test.dart \
+  --plain-name 'shared video save'
+```
+
+Expected: the structured share lacks the actions and no save method is called.
+
+- [ ] **Step 3: Implement conversation save presentation**
+
+Normalize the full-card target before opening the action overlay:
+
+```dart
+final videoTarget = resolveDmVideoTarget(
+  content: message.content,
+  sharedVideoRef: resolveOwnShareVideoRef(message),
+);
+```
+
+For `MessageAction.copyVideoUrl`, copy `videoTarget.canonicalUrl`. For
+`MessageAction.saveVideo`, resolve through `VideosRepository`, check the
+authenticated pubkey against `video.pubkey`, and present
+`showSaveOriginalSheet` or `showWatermarkDownloadSheet`. Use
+`resolveWatermarkText` for other creators and show
+`notificationsVideoUnavailable` on null/error.
+
+- [ ] **Step 4: Run focused conversation and save tests**
+
+Run:
+
+```bash
+cd mobile
+flutter test \
+  test/screens/inbox/conversation/conversation_view_test.dart \
+  test/screens/inbox/conversation/widgets/reaction_picker_overlay_test.dart \
+  test/widgets/save_original_progress_sheet_test.dart \
+  test/widgets/watermark_download_progress_sheet_test.dart \
+  test/services/watermark_download_service_test.dart
+```
+
+Expected: all pass.
+
+### Task 4: Verify and publish
+
+**Files:**
+- Verify all files changed by Tasks 1-3.
+
+- [ ] **Step 1: Format**
+
+```bash
+cd mobile
+mise exec -- dart format \
+  lib/screens/inbox/conversation/dm_video_target.dart \
+  lib/screens/inbox/conversation/conversation_view.dart \
+  lib/screens/inbox/conversation/widgets/message_actions_sheet.dart \
+  lib/screens/inbox/conversation/widgets/message_bubble.dart \
+  lib/screens/inbox/conversation/widgets/reaction_picker_overlay.dart \
+  lib/screens/inbox/conversation/widgets/video_link_preview_cubit.dart \
+  test/screens/inbox/conversation/dm_video_target_test.dart \
+  test/screens/inbox/conversation/conversation_view_test.dart \
+  test/screens/inbox/conversation/widgets/reaction_picker_overlay_test.dart \
+  test/screens/inbox/conversation/widgets/video_link_preview_cubit_test.dart
+```
+
+- [ ] **Step 2: Run localization consistency**
+
+No ARB change is expected because the design reuses existing localized copy:
+
+```bash
+cd mobile
+flutter test test/l10n/arb_consistency_test.dart
+```
+
+- [ ] **Step 3: Run static analysis**
+
+```bash
+cd mobile
+flutter analyze lib test
+```
+
+Expected: no issues.
+
+- [ ] **Step 4: Inspect and commit**
+
+```bash
+git diff --check
+git status --short
+git diff --stat
+git add \
+  docs/superpowers/specs/2026-07-20-dm-video-save-design.md \
+  docs/superpowers/plans/2026-07-20-dm-video-save.md \
+  mobile/lib/screens/inbox/conversation/dm_video_target.dart \
+  mobile/lib/screens/inbox/conversation/conversation_view.dart \
+  mobile/lib/screens/inbox/conversation/widgets/message_actions_sheet.dart \
+  mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart \
+  mobile/lib/screens/inbox/conversation/widgets/reaction_picker_overlay.dart \
+  mobile/lib/screens/inbox/conversation/widgets/video_link_preview_cubit.dart \
+  mobile/test/screens/inbox/conversation/dm_video_target_test.dart \
+  mobile/test/screens/inbox/conversation/conversation_view_test.dart \
+  mobile/test/screens/inbox/conversation/widgets/reaction_picker_overlay_test.dart \
+  mobile/test/screens/inbox/conversation/widgets/video_link_preview_cubit_test.dart
+git commit -m "feat(dm): save shared videos from messages"
+```
+
+- [ ] **Step 5: Rebase and push**
+
+```bash
+git fetch origin
+git rebase origin/main
+git push -u origin feat/dm-video-save
+```
+
+Create a Conventional Commit PR targeting `main`, then inspect GitHub checks.

--- a/docs/superpowers/specs/2026-07-20-dm-video-save-design.md
+++ b/docs/superpowers/specs/2026-07-20-dm-video-save-design.md
@@ -1,0 +1,100 @@
+# DM Shared-Video Save Design
+
+## Goal
+
+Let someone save a video directly from an existing shared-video direct
+message. The action must work for both legacy `divine.video/video/...` links
+and structured NIP-18 `q` references carried by NIP-17 messages.
+
+## Scope
+
+- Add **Save video** to the long-press actions for a full shared-video DM card.
+- Keep **Copy video URL** working and make it available for structured shares,
+  even when the plaintext message contains no Divine URL.
+- Resolve the canonical `VideoEvent` through the same
+  `VideosRepository.fetchVideoWithStatsForRouteId` path used by the preview.
+- Save another creator's video with their watermark.
+- Save the current user's own video without a watermark.
+- Reuse the existing download, permission, settings-retry, progress, success,
+  and failure sheets.
+- Show existing localized "Video unavailable" feedback when resolution fails.
+
+## Non-goals
+
+- Sending arbitrary encrypted video-file attachments in DMs.
+- Changing NIP-17, NIP-18, Blossom, or message persistence.
+- Adding a permanent download button to the video card.
+- Redesigning the conversation or reaction picker.
+- Saving compact quoted-video reply previews; this action applies to the
+  message's own full shared-video card.
+
+## Architecture
+
+### Shared DM video target
+
+Introduce a small conversation-layer value object that normalizes a message's
+video identity:
+
+- stable ID from a canonical Divine URL when present;
+- otherwise event ID or `d` tag from `DmSharedVideoRef`;
+- author pubkey and video kind from the structured reference when available;
+- author-scoped fallback route IDs for addressable videos;
+- canonical Divine URL for copy-link behavior.
+
+Both `MessageBubble` and `ConversationView` use this resolver. This removes the
+current mismatch where the bubble renders a structured video card but the
+long-press menu recognizes only plaintext URLs.
+
+### Long-press action flow
+
+`ReactionPickerOverlay` continues to own the combined reactions/actions sheet.
+For a normalized full-card video target it shows:
+
+1. Copy text
+2. Copy video URL
+3. Save video
+4. Delete for everyone or Report, depending on message direction
+
+Selecting **Save video** closes the action sheet, resolves the `VideoEvent`
+through `VideosRepository`, and then:
+
+- opens `showSaveOriginalSheet` when `video.pubkey` matches the authenticated
+  user's full pubkey;
+- otherwise resolves the cached creator profile, derives the normal Divine
+  watermark text, and opens `showWatermarkDownloadSheet`.
+
+The existing save sheets own network download, cache reuse, gallery
+permissions, app-settings retry, progress, success, sharing, and errors.
+
+### Failure behavior
+
+- Malformed structured references degrade to a plain message unless a valid
+  Divine URL is also present.
+- A repository miss or exception produces the existing localized
+  `notificationsVideoUnavailable` snackbar.
+- Permission and download failures remain inside the established save sheets.
+- Every async boundary checks that the initiating context is still mounted.
+
+## UX Notes
+
+- The feature stays in the established long-press interaction, avoiding a new
+  icon over the dominant tap-to-open card surface.
+- The action label reuses the existing localized `shareSheetSaveVideo` copy.
+- Structured and URL-based shares now have identical actions.
+- Resolution reuses the same repository and route fallbacks as the preview, so
+  a displayed card normally resolves from local memory/cache before the save
+  sheet starts its explicit download progress.
+
+## Testing
+
+- Unit-test URL, regular-event, addressable, malformed, and combined
+  target normalization.
+- Verify the preview cubit uses the normalized author-scoped fallbacks.
+- Widget-test that video long-press actions show and return **Save video**.
+- Widget-test that structured-reference cards receive video actions without a
+  plaintext URL.
+- Widget-test ownership routing: own video opens original save; another
+  creator's video opens watermarked save.
+- Widget-test repository misses show unavailable feedback.
+- Run focused DM/save tests, localization consistency, and `flutter analyze`.
+

--- a/mobile/lib/blocs/dm/shared_video_save/shared_video_save_cubit.dart
+++ b/mobile/lib/blocs/dm/shared_video_save/shared_video_save_cubit.dart
@@ -1,0 +1,119 @@
+// ABOUTME: Cubit for resolving a shared DM video before opening the save sheet.
+// ABOUTME: Keeps repository/profile lookups and in-flight guarding out of widgets.
+
+import 'package:equatable/equatable.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:models/models.dart' hide LogCategory;
+import 'package:openvine/screens/inbox/conversation/dm_video_target.dart';
+import 'package:openvine/utils/watermark_text_resolver.dart';
+import 'package:profile_repository/profile_repository.dart';
+import 'package:unified_logger/unified_logger.dart';
+import 'package:videos_repository/videos_repository.dart';
+
+enum SharedVideoSaveStatus {
+  idle,
+  resolving,
+  originalReady,
+  watermarkReady,
+  unavailable,
+}
+
+class SharedVideoSaveState extends Equatable {
+  const SharedVideoSaveState({
+    this.status = SharedVideoSaveStatus.idle,
+    this.video,
+    this.watermarkText,
+  });
+
+  final SharedVideoSaveStatus status;
+  final VideoEvent? video;
+  final String? watermarkText;
+
+  @override
+  List<Object?> get props => [status, video?.id, watermarkText];
+}
+
+class SharedVideoSaveCubit extends Cubit<SharedVideoSaveState> {
+  SharedVideoSaveCubit({
+    required VideosRepository videosRepository,
+    required ProfileRepository? profileRepository,
+    required String? currentPubkey,
+  }) : _videosRepository = videosRepository,
+       _profileRepository = profileRepository,
+       _currentPubkey = currentPubkey,
+       super(const SharedVideoSaveState());
+
+  final VideosRepository _videosRepository;
+  final ProfileRepository? _profileRepository;
+  final String? _currentPubkey;
+
+  Future<void> save(DmVideoTarget target) async {
+    if (state.status == SharedVideoSaveStatus.resolving) return;
+
+    emit(const SharedVideoSaveState(status: SharedVideoSaveStatus.resolving));
+    try {
+      final video = await _videosRepository.fetchVideoWithStatsForRouteId(
+        target.stableId,
+        fallbackRouteIds: target.fallbackRouteIds,
+      );
+      if (isClosed) return;
+      if (video == null) {
+        emit(
+          const SharedVideoSaveState(status: SharedVideoSaveStatus.unavailable),
+        );
+        return;
+      }
+
+      if (video.pubkey == _currentPubkey) {
+        emit(
+          SharedVideoSaveState(
+            status: SharedVideoSaveStatus.originalReady,
+            video: video,
+          ),
+        );
+        return;
+      }
+
+      final profile = await _cachedProfile(video.pubkey);
+      if (isClosed) return;
+      emit(
+        SharedVideoSaveState(
+          status: SharedVideoSaveStatus.watermarkReady,
+          video: video,
+          watermarkText: resolveWatermarkText(
+            profile: profile,
+            fallbackAuthorName: video.authorName,
+          ),
+        ),
+      );
+    } catch (error) {
+      Log.warning(
+        'Shared DM video save resolve failed for ${target.stableId}: $error',
+        name: 'SharedVideoSaveCubit',
+        category: LogCategory.ui,
+      );
+      if (!isClosed) {
+        emit(
+          const SharedVideoSaveState(status: SharedVideoSaveStatus.unavailable),
+        );
+      }
+    }
+  }
+
+  void reset() {
+    if (!isClosed) emit(const SharedVideoSaveState());
+  }
+
+  Future<UserProfile?> _cachedProfile(String pubkey) async {
+    try {
+      return await _profileRepository?.getCachedProfile(pubkey: pubkey);
+    } catch (error) {
+      Log.warning(
+        'Shared DM video save profile lookup failed for $pubkey: $error',
+        name: 'SharedVideoSaveCubit',
+        category: LogCategory.ui,
+      );
+      return null;
+    }
+  }
+}

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -11,6 +11,7 @@ import 'package:go_router/go_router.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/dm/conversation/conversation_bloc.dart';
 import 'package:openvine/blocs/dm/reactions/conversation_reactions_cubit.dart';
+import 'package:openvine/blocs/dm/shared_video_save/shared_video_save_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/l10n/localized_time_formatter.dart';
 import 'package:openvine/providers/app_providers.dart';
@@ -23,7 +24,7 @@ import 'package:openvine/services/collaborator_invite_parser.dart';
 import 'package:openvine/services/collaborator_invite_service.dart';
 import 'package:openvine/utils/clipboard_utils.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
-import 'package:openvine/utils/watermark_text_resolver.dart';
+import 'package:openvine/utils/string_utils.dart';
 import 'package:openvine/widgets/profile/more_sheet/more_sheet_content.dart';
 import 'package:openvine/widgets/profile/more_sheet/more_sheet_result.dart';
 import 'package:openvine/widgets/profile/profile_header_widget.dart'
@@ -54,54 +55,15 @@ class ConversationView extends ConsumerStatefulWidget {
 enum _FailedMessageAction { resend, delete }
 
 class _ConversationViewState extends ConsumerState<ConversationView> {
-  Future<void> _saveSharedVideo(DmVideoTarget target) async {
-    try {
-      final video = await ref
-          .read(videosRepositoryProvider)
-          .fetchVideoWithStatsForRouteId(
-            target.stableId,
-            fallbackRouteIds: target.fallbackRouteIds,
-          );
-      if (!mounted) return;
-      if (video == null) {
-        _showVideoUnavailable();
-        return;
-      }
-
-      final currentPubkey = ref.read(authServiceProvider).currentPublicKeyHex;
-      if (video.pubkey == currentPubkey) {
-        await showSaveOriginalSheet(context: context, ref: ref, video: video);
-        return;
-      }
-
-      final profile = await ref
-          .read(profileRepositoryProvider)
-          ?.getCachedProfile(pubkey: video.pubkey);
-      if (!mounted) return;
-      final watermarkText = resolveWatermarkText(
-        profile: profile,
-        fallbackAuthorName: video.authorName,
-      );
-      await showWatermarkDownloadSheet(
-        context: context,
-        ref: ref,
-        video: video,
-        watermarkText: watermarkText,
-      );
-    } on Exception {
-      if (mounted) _showVideoUnavailable();
-    }
-  }
-
-  void _showVideoUnavailable() {
+  void _showSnackbar(String message, {required bool error}) {
     ScaffoldMessenger.of(context)
       ..hideCurrentSnackBar()
-      ..showSnackBar(
-        DivineSnackbarContainer.snackBar(
-          context.l10n.notificationsVideoUnavailable,
-          error: true,
-        ),
-      );
+      ..showSnackBar(DivineSnackbarContainer.snackBar(message, error: error));
+    SemanticsService.sendAnnouncement(
+      View.of(context),
+      message,
+      Directionality.of(context),
+    );
   }
 
   Future<void> _onOptions(String otherPubkey, String displayName) async {
@@ -190,106 +152,152 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
               ? truncateNpubForDisplay(NostrKeyUtils.encodePubKey(otherPubkey))
               : '');
 
-    return Scaffold(
-      backgroundColor: VineTheme.surfaceBackground,
-      body: BlocListener<ConversationBloc, ConversationState>(
-        // A hard failure is shown on the bubble itself (tap → resend/delete),
-        // so this listener only handles the toasts that have no bubble —
-        // a policy block and a partial (self-wrap) delivery — plus a
-        // screen-reader announcement (no toast) for hard failures, since
-        // the red in-bubble row is silent to assistive tech until focused.
-        // Also fire on a sentPartial → sentPartial transition whose rumor-id
-        // set changed: with concurrent() sends, a second overlapping partial
-        // keeps the same sendStatus and would otherwise never surface its
-        // recovery snackbar.
-        listenWhen: (previous, current) =>
-            (previous.sendStatus != current.sendStatus ||
-                (current.sendStatus == SendStatus.sentPartial &&
-                    previous.lastPartialSend != current.lastPartialSend)) &&
-            (current.sendStatus == SendStatus.sentPartial ||
-                current.sendStatus == SendStatus.blocked ||
-                current.sendStatus == SendStatus.failed),
-        listener: _onSendOutcome,
-        child: Column(
-          children: [
-            // Wrap the AppBar + messages region in a Listener so any
-            // tap above the input bar — back button, title, options,
-            // dead space in the messages area, a MessageBubble —
-            // dismisses the keyboard before any navigation or sheet
-            // animation begins. The `_SendBar` is intentionally
-            // OUTSIDE this Listener: wrapping the input would
-            // `unfocus` on pointer-down and race with the TextField's
-            // own focus request, producing a re-focus flicker on
-            // every input tap.
-            //
-            // `Listener` catches pointer-downs without entering the
-            // gesture arena, so descendant tap/long-press recognizers
-            // (MessageBubble.onLongPress, ConversationAppBar's three
-            // buttons) still resolve normally afterwards. Matches the
-            // pattern shipped in `comments_list.dart`.
-            Expanded(
-              child: Listener(
-                behavior: HitTestBehavior.translucent,
-                onPointerDown: (_) =>
-                    FocusManager.instance.primaryFocus?.unfocus(),
-                child: Column(
-                  children: [
-                    ConversationAppBar(
-                      displayName: displayName,
-                      handle: handle,
-                      onBack: () => context.pop(),
-                      onTitleTap: otherPubkey.isNotEmpty
-                          ? () => context.push(
-                              '${OtherProfileScreen.path}/${NostrKeyUtils.encodePubKey(otherPubkey)}',
-                            )
-                          : null,
-                      onOptions: () => _onOptions(otherPubkey, displayName),
-                    ),
-                    Expanded(
-                      // Force the messages card to fill the available width
-                      // regardless of its content. Without this, the empty /
-                      // loading state's SingleChildScrollView shrink-wraps the
-                      // ClipRRect down to the EmptyConversation column's
-                      // intrinsic width and the surface card renders as a
-                      // narrow strip; the ListView (with messages) is fine on
-                      // its own.
-                      child: SizedBox(
-                        width: double.infinity,
-                        child: ClipRRect(
-                          borderRadius: BorderRadius.circular(32),
-                          child: ColoredBox(
-                            color: VineTheme.surfaceContainerHigh,
-                            child: _ConversationContent(
-                              currentPubkey: currentPubkey,
-                              otherPubkey: otherPubkey,
-                              participantPubkeys: widget.participantPubkeys,
-                              blockedPubkeys: blockedReactors,
-                              displayName: displayName,
-                              imageUrl: profile?.picture,
-                              nip05: profile?.shortDisplayNip05,
-                              onSaveVideo: _saveSharedVideo,
-                              onViewProfile: () {
-                                final npub = NostrKeyUtils.encodePubKey(
-                                  otherPubkey,
-                                );
-                                context.push(
-                                  '${OtherProfileScreen.path}/$npub',
-                                );
-                              },
+    return BlocProvider(
+      create: (_) => SharedVideoSaveCubit(
+        videosRepository: ref.read(videosRepositoryProvider),
+        profileRepository: ref.read(profileRepositoryProvider),
+        currentPubkey: currentPubkey,
+      ),
+      child: BlocListener<SharedVideoSaveCubit, SharedVideoSaveState>(
+        listener: _onSharedVideoSaveState,
+        child: Scaffold(
+          backgroundColor: VineTheme.surfaceBackground,
+          body: BlocListener<ConversationBloc, ConversationState>(
+            // A hard failure is shown on the bubble itself (tap → resend/delete),
+            // so this listener only handles the toasts that have no bubble —
+            // a policy block and a partial (self-wrap) delivery — plus a
+            // screen-reader announcement (no toast) for hard failures, since
+            // the red in-bubble row is silent to assistive tech until focused.
+            // Also fire on a sentPartial → sentPartial transition whose rumor-id
+            // set changed: with concurrent() sends, a second overlapping partial
+            // keeps the same sendStatus and would otherwise never surface its
+            // recovery snackbar.
+            listenWhen: (previous, current) =>
+                (previous.sendStatus != current.sendStatus ||
+                    (current.sendStatus == SendStatus.sentPartial &&
+                        previous.lastPartialSend != current.lastPartialSend)) &&
+                (current.sendStatus == SendStatus.sentPartial ||
+                    current.sendStatus == SendStatus.blocked ||
+                    current.sendStatus == SendStatus.failed),
+            listener: _onSendOutcome,
+            child: Column(
+              children: [
+                // Wrap the AppBar + messages region in a Listener so any
+                // tap above the input bar — back button, title, options,
+                // dead space in the messages area, a MessageBubble —
+                // dismisses the keyboard before any navigation or sheet
+                // animation begins. The `_SendBar` is intentionally
+                // OUTSIDE this Listener: wrapping the input would
+                // `unfocus` on pointer-down and race with the TextField's
+                // own focus request, producing a re-focus flicker on
+                // every input tap.
+                //
+                // `Listener` catches pointer-downs without entering the
+                // gesture arena, so descendant tap/long-press recognizers
+                // (MessageBubble.onLongPress, ConversationAppBar's three
+                // buttons) still resolve normally afterwards. Matches the
+                // pattern shipped in `comments_list.dart`.
+                Expanded(
+                  child: Listener(
+                    behavior: HitTestBehavior.translucent,
+                    onPointerDown: (_) =>
+                        FocusManager.instance.primaryFocus?.unfocus(),
+                    child: Column(
+                      children: [
+                        ConversationAppBar(
+                          displayName: displayName,
+                          handle: handle,
+                          onBack: () => context.pop(),
+                          onTitleTap: otherPubkey.isNotEmpty
+                              ? () => context.push(
+                                  '${OtherProfileScreen.path}/${NostrKeyUtils.encodePubKey(otherPubkey)}',
+                                )
+                              : null,
+                          onOptions: () => _onOptions(otherPubkey, displayName),
+                        ),
+                        Expanded(
+                          // Force the messages card to fill the available width
+                          // regardless of its content. Without this, the empty /
+                          // loading state's SingleChildScrollView shrink-wraps the
+                          // ClipRRect down to the EmptyConversation column's
+                          // intrinsic width and the surface card renders as a
+                          // narrow strip; the ListView (with messages) is fine on
+                          // its own.
+                          child: SizedBox(
+                            width: double.infinity,
+                            child: ClipRRect(
+                              borderRadius: BorderRadius.circular(32),
+                              child: ColoredBox(
+                                color: VineTheme.surfaceContainerHigh,
+                                child: _ConversationContent(
+                                  currentPubkey: currentPubkey,
+                                  otherPubkey: otherPubkey,
+                                  participantPubkeys: widget.participantPubkeys,
+                                  blockedPubkeys: blockedReactors,
+                                  displayName: displayName,
+                                  imageUrl: profile?.picture,
+                                  nip05: profile?.shortDisplayNip05,
+                                  onViewProfile: () {
+                                    final npub = NostrKeyUtils.encodePubKey(
+                                      otherPubkey,
+                                    );
+                                    context.push(
+                                      '${OtherProfileScreen.path}/$npub',
+                                    );
+                                  },
+                                ),
+                              ),
                             ),
                           ),
                         ),
-                      ),
+                      ],
                     ),
-                  ],
+                  ),
                 ),
-              ),
+                _SendBar(participantPubkeys: widget.participantPubkeys),
+              ],
             ),
-            _SendBar(participantPubkeys: widget.participantPubkeys),
-          ],
+          ),
         ),
       ),
     );
+  }
+
+  Future<void> _onSharedVideoSaveState(
+    BuildContext context,
+    SharedVideoSaveState state,
+  ) async {
+    switch (state.status) {
+      case SharedVideoSaveStatus.idle:
+        return;
+      case SharedVideoSaveStatus.resolving:
+        _showSnackbar(context.l10n.libraryPreparingVideo, error: false);
+        return;
+      case SharedVideoSaveStatus.unavailable:
+        _showSnackbar(context.l10n.notificationsVideoUnavailable, error: true);
+        context.read<SharedVideoSaveCubit>().reset();
+        return;
+      case SharedVideoSaveStatus.originalReady:
+        final video = state.video;
+        if (video == null) return;
+        ScaffoldMessenger.of(context).hideCurrentSnackBar();
+        await showSaveOriginalSheet(context: context, ref: ref, video: video);
+        if (context.mounted) context.read<SharedVideoSaveCubit>().reset();
+        return;
+      case SharedVideoSaveStatus.watermarkReady:
+        final video = state.video;
+        final watermarkText = state.watermarkText;
+        if (video == null || watermarkText == null) return;
+        ScaffoldMessenger.of(context).hideCurrentSnackBar();
+        await showWatermarkDownloadSheet(
+          context: context,
+          ref: ref,
+          video: video,
+          watermarkText: watermarkText,
+        );
+        if (context.mounted) context.read<SharedVideoSaveCubit>().reset();
+        return;
+    }
   }
 
   void _onSendOutcome(BuildContext context, ConversationState state) {
@@ -401,7 +409,6 @@ class _ConversationContent extends StatelessWidget {
     required this.participantPubkeys,
     required this.blockedPubkeys,
     required this.displayName,
-    required this.onSaveVideo,
     this.imageUrl,
     this.nip05,
     this.onViewProfile,
@@ -414,7 +421,6 @@ class _ConversationContent extends StatelessWidget {
   /// Effective block/mute set; reactions from these pubkeys are hidden.
   final Set<String> blockedPubkeys;
   final String displayName;
-  final Future<void> Function(DmVideoTarget target) onSaveVideo;
   final String? imageUrl;
   final String? nip05;
   final VoidCallback? onViewProfile;
@@ -455,7 +461,6 @@ class _ConversationContent extends StatelessWidget {
                     participantPubkeys: participantPubkeys,
                     blockedPubkeys: blockedPubkeys,
                     senderDisplayName: displayName,
-                    onSaveVideo: onSaveVideo,
                   ),
         };
       },
@@ -500,7 +505,6 @@ class _MessageList extends StatelessWidget {
     required this.participantPubkeys,
     required this.blockedPubkeys,
     required this.senderDisplayName,
-    required this.onSaveVideo,
   });
 
   final List<DmMessage> messages;
@@ -510,7 +514,6 @@ class _MessageList extends StatelessWidget {
   /// Effective block/mute set; reactions from these pubkeys are hidden.
   final Set<String> blockedPubkeys;
   final String senderDisplayName;
-  final Future<void> Function(DmVideoTarget target) onSaveVideo;
 
   Future<void> _onMessageLongPress(
     BuildContext context,
@@ -519,7 +522,7 @@ class _MessageList extends StatelessWidget {
     DmDeliveryStatus deliveryStatus,
   ) async {
     final videoTarget = resolveDmVideoTarget(
-      content: message.content,
+      content: StringUtils.sanitizeUtf16(message.content),
       sharedVideoRef: resolveOwnShareVideoRef(message),
     );
     // Reaction picker hidden on failed-send own DMs — reacting to a
@@ -556,7 +559,7 @@ class _MessageList extends StatelessWidget {
         await ClipboardUtils.copy(context, videoTarget.canonicalUrl);
       case MessageAction.saveVideo:
         if (videoTarget == null) return;
-        await onSaveVideo(videoTarget);
+        context.read<SharedVideoSaveCubit>().save(videoTarget);
       case MessageAction.delete:
         context.read<ConversationBloc>().add(
           ConversationMessageDeleted(rumorId: message.id),
@@ -591,9 +594,7 @@ class _MessageList extends StatelessWidget {
     final bloc = context.read<ConversationBloc>();
     final failedIds = bloc.state.failedSiblingRumorIdsFor(message.id);
     final resendIds = failedIds.isEmpty ? [message.id] : failedIds;
-    final undeliveredIds = bloc.state.undeliveredSiblingRumorIdsFor(
-      message.id,
-    );
+    final undeliveredIds = bloc.state.undeliveredSiblingRumorIdsFor(message.id);
     final cancelIds = undeliveredIds.isEmpty ? [message.id] : undeliveredIds;
 
     // Per `accessibility.md`, async visible state changes must announce

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -16,18 +16,21 @@ import 'package:openvine/l10n/localized_time_formatter.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/feed/dm_reply_context.dart';
+import 'package:openvine/screens/inbox/conversation/dm_video_target.dart';
 import 'package:openvine/screens/inbox/conversation/widgets/widgets.dart';
 import 'package:openvine/screens/other_profile_screen.dart';
 import 'package:openvine/services/collaborator_invite_parser.dart';
 import 'package:openvine/services/collaborator_invite_service.dart';
 import 'package:openvine/utils/clipboard_utils.dart';
-import 'package:openvine/utils/divine_video_url.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
+import 'package:openvine/utils/watermark_text_resolver.dart';
 import 'package:openvine/widgets/profile/more_sheet/more_sheet_content.dart';
 import 'package:openvine/widgets/profile/more_sheet/more_sheet_result.dart';
 import 'package:openvine/widgets/profile/profile_header_widget.dart'
     show truncateNpubForDisplay;
 import 'package:openvine/widgets/report_content_dialog.dart';
+import 'package:openvine/widgets/save_original_progress_sheet.dart';
+import 'package:openvine/widgets/watermark_download_progress_sheet.dart';
 
 /// View for a single DM conversation.
 ///
@@ -51,6 +54,56 @@ class ConversationView extends ConsumerStatefulWidget {
 enum _FailedMessageAction { resend, delete }
 
 class _ConversationViewState extends ConsumerState<ConversationView> {
+  Future<void> _saveSharedVideo(DmVideoTarget target) async {
+    try {
+      final video = await ref
+          .read(videosRepositoryProvider)
+          .fetchVideoWithStatsForRouteId(
+            target.stableId,
+            fallbackRouteIds: target.fallbackRouteIds,
+          );
+      if (!mounted) return;
+      if (video == null) {
+        _showVideoUnavailable();
+        return;
+      }
+
+      final currentPubkey = ref.read(authServiceProvider).currentPublicKeyHex;
+      if (video.pubkey == currentPubkey) {
+        await showSaveOriginalSheet(context: context, ref: ref, video: video);
+        return;
+      }
+
+      final profile = await ref
+          .read(profileRepositoryProvider)
+          ?.getCachedProfile(pubkey: video.pubkey);
+      if (!mounted) return;
+      final watermarkText = resolveWatermarkText(
+        profile: profile,
+        fallbackAuthorName: video.authorName,
+      );
+      await showWatermarkDownloadSheet(
+        context: context,
+        ref: ref,
+        video: video,
+        watermarkText: watermarkText,
+      );
+    } on Exception {
+      if (mounted) _showVideoUnavailable();
+    }
+  }
+
+  void _showVideoUnavailable() {
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(
+        DivineSnackbarContainer.snackBar(
+          context.l10n.notificationsVideoUnavailable,
+          error: true,
+        ),
+      );
+  }
+
   Future<void> _onOptions(String otherPubkey, String displayName) async {
     if (otherPubkey.isEmpty) return;
 
@@ -214,6 +267,7 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
                               displayName: displayName,
                               imageUrl: profile?.picture,
                               nip05: profile?.shortDisplayNip05,
+                              onSaveVideo: _saveSharedVideo,
                               onViewProfile: () {
                                 final npub = NostrKeyUtils.encodePubKey(
                                   otherPubkey,
@@ -347,6 +401,7 @@ class _ConversationContent extends StatelessWidget {
     required this.participantPubkeys,
     required this.blockedPubkeys,
     required this.displayName,
+    required this.onSaveVideo,
     this.imageUrl,
     this.nip05,
     this.onViewProfile,
@@ -359,6 +414,7 @@ class _ConversationContent extends StatelessWidget {
   /// Effective block/mute set; reactions from these pubkeys are hidden.
   final Set<String> blockedPubkeys;
   final String displayName;
+  final Future<void> Function(DmVideoTarget target) onSaveVideo;
   final String? imageUrl;
   final String? nip05;
   final VoidCallback? onViewProfile;
@@ -399,6 +455,7 @@ class _ConversationContent extends StatelessWidget {
                     participantPubkeys: participantPubkeys,
                     blockedPubkeys: blockedPubkeys,
                     senderDisplayName: displayName,
+                    onSaveVideo: onSaveVideo,
                   ),
         };
       },
@@ -443,6 +500,7 @@ class _MessageList extends StatelessWidget {
     required this.participantPubkeys,
     required this.blockedPubkeys,
     required this.senderDisplayName,
+    required this.onSaveVideo,
   });
 
   final List<DmMessage> messages;
@@ -452,6 +510,7 @@ class _MessageList extends StatelessWidget {
   /// Effective block/mute set; reactions from these pubkeys are hidden.
   final Set<String> blockedPubkeys;
   final String senderDisplayName;
+  final Future<void> Function(DmVideoTarget target) onSaveVideo;
 
   Future<void> _onMessageLongPress(
     BuildContext context,
@@ -459,7 +518,10 @@ class _MessageList extends StatelessWidget {
     bool isSent,
     DmDeliveryStatus deliveryStatus,
   ) async {
-    final videoUrl = tryExtractDivineVideoUrl(message.content);
+    final videoTarget = resolveDmVideoTarget(
+      content: message.content,
+      sharedVideoRef: resolveOwnShareVideoRef(message),
+    );
     // Reaction picker hidden on failed-send own DMs — reacting to a
     // message the recipient never received is meaningless (#4633 round 25).
     // A failed bubble's resend/delete affordance lives on a single TAP
@@ -468,7 +530,7 @@ class _MessageList extends StatelessWidget {
     final result = await ReactionPickerOverlay.show(
       context: context,
       isSent: isSent,
-      isVideoShare: videoUrl != null,
+      isVideoShare: videoTarget != null,
       showPicker: showPicker,
     );
     if (result == null) return;
@@ -490,8 +552,11 @@ class _MessageList extends StatelessWidget {
       case MessageAction.copy:
         await ClipboardUtils.copy(context, message.content);
       case MessageAction.copyVideoUrl:
-        if (videoUrl == null) return;
-        await ClipboardUtils.copy(context, videoUrl);
+        if (videoTarget == null) return;
+        await ClipboardUtils.copy(context, videoTarget.canonicalUrl);
+      case MessageAction.saveVideo:
+        if (videoTarget == null) return;
+        await onSaveVideo(videoTarget);
       case MessageAction.delete:
         context.read<ConversationBloc>().add(
           ConversationMessageDeleted(rumorId: message.id),

--- a/mobile/lib/screens/inbox/conversation/dm_video_target.dart
+++ b/mobile/lib/screens/inbox/conversation/dm_video_target.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/foundation.dart';
+import 'package:models/models.dart';
+import 'package:openvine/utils/divine_video_url.dart';
+
+/// Normalized identity and routing metadata for a video shared in a DM.
+@immutable
+class DmVideoTarget {
+  const DmVideoTarget({
+    required this.stableId,
+    this.authorPubkey,
+    this.videoKind,
+  });
+
+  /// Stable route ID used by Divine video URLs and repository lookups.
+  final String stableId;
+
+  /// Full author pubkey when supplied by a structured NIP-18 reference.
+  final String? authorPubkey;
+
+  /// NIP-71 video event kind when supplied by a structured reference.
+  final int? videoKind;
+
+  /// Canonical web URL for copying or sharing this video.
+  String get canonicalUrl => 'https://divine.video/video/$stableId';
+
+  /// Author-scoped repository route used to disambiguate addressable videos.
+  List<String> get fallbackRouteIds {
+    final author = authorPubkey;
+    final kind = videoKind;
+    if (author == null || kind == null) return const [];
+    return ['$kind:$author:$stableId'];
+  }
+}
+
+/// Resolves the video represented by a DM's plaintext and structured citation.
+///
+/// Canonical Divine URLs remain the primary stable identity for compatibility
+/// with older messages. A valid NIP-18 `q` reference contributes author/kind
+/// routing metadata, or supplies the identity when no URL is present.
+DmVideoTarget? resolveDmVideoTarget({
+  required String content,
+  DmSharedVideoRef? sharedVideoRef,
+}) {
+  final urlStableId = divineVideoUrlRegex.firstMatch(content)?.group(1);
+  final structuredTarget = _targetFromRef(sharedVideoRef);
+
+  if (urlStableId != null) {
+    return DmVideoTarget(
+      stableId: urlStableId,
+      authorPubkey: structuredTarget?.authorPubkey,
+      videoKind: structuredTarget?.videoKind,
+    );
+  }
+
+  return structuredTarget;
+}
+
+DmVideoTarget? _targetFromRef(DmSharedVideoRef? ref) {
+  if (ref == null) return null;
+  if (!ref.isAddressable) {
+    return DmVideoTarget(
+      stableId: ref.coordinateOrId,
+      authorPubkey: ref.authorPubkey,
+      videoKind: ref.videoKind.kind,
+    );
+  }
+
+  final parts = ref.coordinateOrId.split(':');
+  if (parts.length < 3) return null;
+  final kind = int.tryParse(parts.first);
+  final author = parts[1].isNotEmpty ? parts[1] : ref.authorPubkey;
+  final stableId = ref.dTag;
+  if (kind == null || stableId == null) return null;
+
+  return DmVideoTarget(
+    stableId: stableId,
+    authorPubkey: author,
+    videoKind: kind,
+  );
+}

--- a/mobile/lib/screens/inbox/conversation/dm_video_target.dart
+++ b/mobile/lib/screens/inbox/conversation/dm_video_target.dart
@@ -1,3 +1,6 @@
+// ABOUTME: Normalized identity for videos shared inside DM messages.
+// ABOUTME: Resolves legacy Divine URLs and structured q references consistently.
+
 import 'package:flutter/foundation.dart';
 import 'package:models/models.dart';
 import 'package:openvine/utils/divine_video_url.dart';
@@ -30,6 +33,17 @@ class DmVideoTarget {
     if (author == null || kind == null) return const [];
     return ['$kind:$author:$stableId'];
   }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is DmVideoTarget &&
+          stableId == other.stableId &&
+          authorPubkey == other.authorPubkey &&
+          videoKind == other.videoKind;
+
+  @override
+  int get hashCode => Object.hash(stableId, authorPubkey, videoKind);
 }
 
 /// Resolves the video represented by a DM's plaintext and structured citation.

--- a/mobile/lib/screens/inbox/conversation/widgets/message_actions_sheet.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/message_actions_sheet.dart
@@ -13,6 +13,9 @@ enum MessageAction {
   /// Copy the divine.video video URL embedded in the message.
   copyVideoUrl,
 
+  /// Save the shared video to the device gallery.
+  saveVideo,
+
   /// Delete the message for everyone (NIP-09 kind 5).
   delete,
 
@@ -26,9 +29,8 @@ enum MessageAction {
 /// - Sent messages: Copy, Delete for everyone
 /// - Received messages: Copy, Report
 ///
-/// When [isVideoShare] is true, an extra "Copy video URL" entry is
-/// surfaced after "Copy text" so the user can grab the shared video's
-/// link without the surrounding message body.
+/// When [isVideoShare] is true, "Copy video URL" and "Save Video" entries
+/// are surfaced after "Copy text".
 ///
 /// Returns the selected [MessageAction], or null if dismissed.
 class MessageActionsSheet {
@@ -51,6 +53,12 @@ class MessageActionsSheet {
           iconPath: DivineIconName.linkSimple.assetPath,
           label: l10n.dmMessageActionCopyVideoUrl,
           onTap: () => result = MessageAction.copyVideoUrl,
+        ),
+      if (isVideoShare)
+        VineBottomSheetActionData(
+          iconPath: DivineIconName.downloadSimple.assetPath,
+          label: l10n.shareSheetSaveVideo,
+          onTap: () => result = MessageAction.saveVideo,
         ),
       if (isSent)
         VineBottomSheetActionData(

--- a/mobile/lib/screens/inbox/conversation/widgets/message_actions_sheet.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/message_actions_sheet.dart
@@ -1,9 +1,5 @@
-// ABOUTME: Bottom sheet with actions for a DM message bubble.
-// ABOUTME: Shows Copy for all messages, Delete for sent, Report for received.
-
-import 'package:divine_ui/divine_ui.dart';
-import 'package:flutter/material.dart';
-import 'package:openvine/l10n/l10n.dart';
+// ABOUTME: Message action enum shared by DM long-press menu implementations.
+// ABOUTME: Keeps action handling independent from the concrete overlay UI.
 
 /// Actions available from the message long-press sheet.
 enum MessageAction {
@@ -21,61 +17,4 @@ enum MessageAction {
 
   /// Report the message.
   report,
-}
-
-/// Shows a bottom sheet with actions for a single DM message.
-///
-/// [isSent] controls which options appear:
-/// - Sent messages: Copy, Delete for everyone
-/// - Received messages: Copy, Report
-///
-/// When [isVideoShare] is true, "Copy video URL" and "Save Video" entries
-/// are surfaced after "Copy text".
-///
-/// Returns the selected [MessageAction], or null if dismissed.
-class MessageActionsSheet {
-  static Future<MessageAction?> show({
-    required BuildContext context,
-    required bool isSent,
-    bool isVideoShare = false,
-  }) async {
-    MessageAction? result;
-
-    final l10n = context.l10n;
-    final options = <VineBottomSheetActionData>[
-      VineBottomSheetActionData(
-        iconPath: DivineIconName.copy.assetPath,
-        label: l10n.dmMessageActionCopyText,
-        onTap: () => result = MessageAction.copy,
-      ),
-      if (isVideoShare)
-        VineBottomSheetActionData(
-          iconPath: DivineIconName.linkSimple.assetPath,
-          label: l10n.dmMessageActionCopyVideoUrl,
-          onTap: () => result = MessageAction.copyVideoUrl,
-        ),
-      if (isVideoShare)
-        VineBottomSheetActionData(
-          iconPath: DivineIconName.downloadSimple.assetPath,
-          label: l10n.shareSheetSaveVideo,
-          onTap: () => result = MessageAction.saveVideo,
-        ),
-      if (isSent)
-        VineBottomSheetActionData(
-          iconPath: DivineIconName.trash.assetPath,
-          label: l10n.dmMessageActionDeleteForEveryone,
-          onTap: () => result = MessageAction.delete,
-        ),
-      if (!isSent)
-        VineBottomSheetActionData(
-          iconPath: DivineIconName.flag.assetPath,
-          label: l10n.dmMessageActionReport,
-          onTap: () => result = MessageAction.report,
-        ),
-    ];
-
-    await VineBottomSheetActionMenu.show(context: context, options: options);
-
-    return result;
-  }
 }

--- a/mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart
@@ -18,6 +18,7 @@ import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/router/nav_extensions.dart';
 import 'package:openvine/screens/feed/dm_reply_context.dart';
 import 'package:openvine/screens/hashtag_screen_router.dart';
+import 'package:openvine/screens/inbox/conversation/dm_video_target.dart';
 import 'package:openvine/screens/inbox/conversation/widgets/video_link_preview_cubit.dart';
 import 'package:openvine/screens/search_results/view/search_results_page.dart';
 import 'package:openvine/screens/video_detail_screen.dart';
@@ -151,10 +152,13 @@ class MessageBubble extends StatelessWidget {
     // well-formed input.
     final safeMessage = StringUtils.sanitizeUtf16(message);
     final videoMatch = divineVideoUrlRegex.firstMatch(safeMessage);
-    final structuredVideo = _videoTargetFromRef(sharedVideoRef);
-    final videoStableId = videoMatch?.group(1) ?? structuredVideo?.stableId;
-    final videoAuthorPubkey = structuredVideo?.authorPubkey;
-    final videoKind = structuredVideo?.videoKind;
+    final videoTarget = resolveDmVideoTarget(
+      content: safeMessage,
+      sharedVideoRef: sharedVideoRef,
+    );
+    final videoStableId = videoTarget?.stableId;
+    final videoAuthorPubkey = videoTarget?.authorPubkey;
+    final videoKind = videoTarget?.videoKind;
 
     // Slice the message body around the video URL.
     //
@@ -194,7 +198,7 @@ class MessageBubble extends StatelessWidget {
           .where((line) => !_nostrRefLineRegex.hasMatch(line))
           .toList();
       personalMessage = beforeLines.isEmpty ? null : beforeLines.join('\n');
-    } else if (structuredVideo != null) {
+    } else if (videoTarget != null) {
       final lines = safeMessage
           .split('\n')
           .map((line) => line.trim())
@@ -400,42 +404,6 @@ class MessageBubble extends StatelessWidget {
       bottomRight: Radius.circular(isSent ? 4 : 16),
     );
   }
-}
-
-class _SharedVideoTarget {
-  const _SharedVideoTarget({
-    required this.stableId,
-    required this.videoKind,
-    this.authorPubkey,
-  });
-
-  final String stableId;
-  final int videoKind;
-  final String? authorPubkey;
-}
-
-_SharedVideoTarget? _videoTargetFromRef(DmSharedVideoRef? ref) {
-  if (ref == null) return null;
-  if (!ref.isAddressable) {
-    return _SharedVideoTarget(
-      stableId: ref.coordinateOrId,
-      videoKind: ref.videoKind.kind,
-      authorPubkey: ref.authorPubkey,
-    );
-  }
-
-  final coordParts = ref.coordinateOrId.split(':');
-  if (coordParts.length < 3) return null;
-  final kind = int.tryParse(coordParts[0]);
-  final author = coordParts[1];
-  final dTag = coordParts.sublist(2).join(':');
-  if (kind == null || dTag.isEmpty) return null;
-
-  return _SharedVideoTarget(
-    stableId: dTag,
-    videoKind: kind,
-    authorPubkey: author.isNotEmpty ? author : ref.authorPubkey,
-  );
 }
 
 /// Renders message text with inline markdown (bold / italic / strike /
@@ -710,7 +678,10 @@ class _QuotedVideoPreview extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final target = _videoTargetFromRef(quotedVideoRef);
+    final target = resolveDmVideoTarget(
+      content: '',
+      sharedVideoRef: quotedVideoRef,
+    );
     if (target == null) return const SizedBox.shrink();
     final videosRepository = ref.watch(videosRepositoryProvider);
     return BlocProvider(

--- a/mobile/lib/screens/inbox/conversation/widgets/reaction_picker_overlay.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/reaction_picker_overlay.dart
@@ -238,6 +238,12 @@ class _ActionList extends StatelessWidget {
           label: l10n.dmMessageActionCopyVideoUrl,
           onTap: () => onSelected(MessageAction.copyVideoUrl),
         ),
+      if (isVideoShare)
+        _ActionTile(
+          icon: DivineIconName.downloadSimple,
+          label: l10n.shareSheetSaveVideo,
+          onTap: () => onSelected(MessageAction.saveVideo),
+        ),
       if (isSent)
         _ActionTile(
           icon: DivineIconName.trash,

--- a/mobile/lib/screens/inbox/conversation/widgets/video_link_preview_cubit.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/video_link_preview_cubit.dart
@@ -5,6 +5,7 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:models/models.dart' hide LogCategory;
+import 'package:openvine/screens/inbox/conversation/dm_video_target.dart';
 import 'package:unified_logger/unified_logger.dart';
 import 'package:videos_repository/videos_repository.dart';
 
@@ -65,9 +66,14 @@ class VideoLinkPreviewCubit extends Cubit<VideoLinkPreviewState> {
 
   Future<void> _resolve() async {
     try {
+      final target = DmVideoTarget(
+        stableId: _videoStableId,
+        authorPubkey: _authorPubkey,
+        videoKind: _videoKind,
+      );
       final video = await _videosRepository.fetchVideoWithStatsForRouteId(
-        _videoStableId,
-        fallbackRouteIds: _authorScopedFallbackRouteIds(),
+        target.stableId,
+        fallbackRouteIds: target.fallbackRouteIds,
       );
       if (isClosed) return;
       if (video != null) {
@@ -83,18 +89,5 @@ class VideoLinkPreviewCubit extends Cubit<VideoLinkPreviewState> {
     }
 
     if (!isClosed) emit(const VideoLinkPreviewNotFound());
-  }
-
-  /// Author/kind-scoped addressable coordinate used as a resolution fallback.
-  ///
-  /// The primary bare-id lookup already covers every acceptable video kind, but
-  /// an invite preview knows the exact creator and kind, so an addressable
-  /// `kind:pubkey:d-tag` route lets the repository disambiguate should the bare
-  /// d-tag ever be shared across authors.
-  List<String> _authorScopedFallbackRouteIds() {
-    final author = _authorPubkey;
-    final kind = _videoKind;
-    if (author == null || kind == null) return const [];
-    return ['$kind:$author:$_videoStableId'];
   }
 }

--- a/mobile/lib/utils/divine_video_url.dart
+++ b/mobile/lib/utils/divine_video_url.dart
@@ -18,8 +18,3 @@ final divineVideoUrlLineRegex = RegExp(
   r'^https?://(?:www\.)?divine\.video/video/[\w-]+$',
   caseSensitive: false,
 );
-
-/// Returns the full divine.video URL contained in [content], or null if
-/// the message body doesn't include one.
-String? tryExtractDivineVideoUrl(String content) =>
-    divineVideoUrlRegex.firstMatch(content)?.group(0);

--- a/mobile/packages/dm_repository/lib/src/dm_shared_video_citation.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_shared_video_citation.dart
@@ -53,12 +53,7 @@ class DmSharedVideoCitation {
       if (dTag == null || dTag.isEmpty) return null;
       final coordinate = '$videoKind:$authorPubkey:$dTag';
       final naddr = NIP19Tlv.encodeNaddr(
-        Naddr(
-          id: dTag,
-          author: authorPubkey,
-          kind: videoKind,
-          relays: [relay],
-        ),
+        Naddr(id: dTag, author: authorPubkey, kind: videoKind, relays: [relay]),
       );
       return DmSharedVideoCitation(
         qTag: ['q', coordinate, relay],
@@ -106,8 +101,12 @@ class DmSharedVideoCitation {
         );
       }
 
-      // Regular event id (64-hex).
-      if (_isHex64(value)) {
+      // Regular video event id (64-hex). Require the author slot used by our
+      // NIP-19 `nevent` share shape so ordinary note `q` tags do not masquerade
+      // as saveable Divine videos.
+      if (_isHex64(value) &&
+          explicitAuthor != null &&
+          _isHex64(explicitAuthor)) {
         return DmSharedVideoRef(
           coordinateOrId: value,
           videoKind: DmSharedVideoKind.shortVideo,

--- a/mobile/packages/dm_repository/test/src/dm_shared_video_citation_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_shared_video_citation_test.dart
@@ -137,6 +137,15 @@ void main() {
       expect(ref.isAddressable, isFalse);
     });
 
+    test('does not parse a bare note q tag as a shared video', () {
+      expect(
+        DmSharedVideoCitation.parse([
+          ['q', eventId, relay],
+        ]),
+        isNull,
+      );
+    });
+
     test('returns null when there is no q tag', () {
       expect(
         DmSharedVideoCitation.parse([

--- a/mobile/test/blocs/dm/shared_video_save/shared_video_save_cubit_test.dart
+++ b/mobile/test/blocs/dm/shared_video_save/shared_video_save_cubit_test.dart
@@ -1,0 +1,170 @@
+// ABOUTME: Tests for SharedVideoSaveCubit.
+// ABOUTME: Verifies resolve states, in-flight guarding, and watermark text.
+
+import 'dart:async';
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:openvine/blocs/dm/shared_video_save/shared_video_save_cubit.dart';
+import 'package:openvine/screens/inbox/conversation/dm_video_target.dart';
+import 'package:profile_repository/profile_repository.dart';
+import 'package:videos_repository/videos_repository.dart';
+
+import '../../../builders/video_event_builder.dart';
+
+class _MockVideosRepository extends Mock implements VideosRepository {}
+
+class _MockProfileRepository extends Mock implements ProfileRepository {}
+
+void main() {
+  const currentPubkey =
+      'aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd';
+  const otherPubkey =
+      '1122334411223344112233441122334411223344112233441122334411223344';
+  const target = DmVideoTarget(
+    stableId: 'skate-loop',
+    authorPubkey: otherPubkey,
+    videoKind: 34236,
+  );
+
+  late _MockVideosRepository videosRepository;
+  late _MockProfileRepository profileRepository;
+
+  setUpAll(() {
+    registerFallbackValue(<String>[]);
+  });
+
+  setUp(() {
+    videosRepository = _MockVideosRepository();
+    profileRepository = _MockProfileRepository();
+  });
+
+  SharedVideoSaveCubit createCubit({String? currentUser = currentPubkey}) {
+    return SharedVideoSaveCubit(
+      videosRepository: videosRepository,
+      profileRepository: profileRepository,
+      currentPubkey: currentUser,
+    );
+  }
+
+  group(SharedVideoSaveCubit, () {
+    blocTest<SharedVideoSaveCubit, SharedVideoSaveState>(
+      'emits originalReady for the current user video',
+      build: () {
+        final video = VideoEventBuilder(
+          id: target.stableId,
+          pubkey: currentPubkey,
+        ).build();
+        when(
+          () => videosRepository.fetchVideoWithStatsForRouteId(
+            target.stableId,
+            fallbackRouteIds: target.fallbackRouteIds,
+          ),
+        ).thenAnswer((_) async => video);
+        return createCubit();
+      },
+      act: (cubit) => cubit.save(target),
+      expect: () => [
+        const SharedVideoSaveState(status: SharedVideoSaveStatus.resolving),
+        isA<SharedVideoSaveState>()
+            .having(
+              (state) => state.status,
+              'status',
+              SharedVideoSaveStatus.originalReady,
+            )
+            .having((state) => state.video?.id, 'video id', target.stableId),
+      ],
+    );
+
+    blocTest<SharedVideoSaveCubit, SharedVideoSaveState>(
+      'emits watermarkReady with resolved profile text for another creator',
+      build: () {
+        final video = VideoEventBuilder(
+          id: target.stableId,
+          pubkey: otherPubkey,
+        ).build();
+        when(
+          () => videosRepository.fetchVideoWithStatsForRouteId(
+            target.stableId,
+            fallbackRouteIds: target.fallbackRouteIds,
+          ),
+        ).thenAnswer((_) async => video);
+        when(
+          () => profileRepository.getCachedProfile(pubkey: otherPubkey),
+        ).thenAnswer(
+          (_) async => UserProfile(
+            pubkey: otherPubkey,
+            rawData: const {},
+            createdAt: DateTime.fromMillisecondsSinceEpoch(0),
+            eventId: 'profile',
+            nip05: 'alice@example.com',
+          ),
+        );
+        return createCubit();
+      },
+      act: (cubit) => cubit.save(target),
+      expect: () => [
+        const SharedVideoSaveState(status: SharedVideoSaveStatus.resolving),
+        isA<SharedVideoSaveState>()
+            .having(
+              (state) => state.status,
+              'status',
+              SharedVideoSaveStatus.watermarkReady,
+            )
+            .having((state) => state.video?.id, 'video id', target.stableId)
+            .having(
+              (state) => state.watermarkText,
+              'watermark text',
+              'alice@example.com',
+            ),
+      ],
+    );
+
+    blocTest<SharedVideoSaveCubit, SharedVideoSaveState>(
+      'emits unavailable when resolve throws',
+      build: () {
+        when(
+          () => videosRepository.fetchVideoWithStatsForRouteId(
+            target.stableId,
+            fallbackRouteIds: target.fallbackRouteIds,
+          ),
+        ).thenThrow(StateError('closed'));
+        return createCubit();
+      },
+      act: (cubit) => cubit.save(target),
+      expect: () => [
+        const SharedVideoSaveState(status: SharedVideoSaveStatus.resolving),
+        const SharedVideoSaveState(status: SharedVideoSaveStatus.unavailable),
+      ],
+    );
+
+    test('drops a second save request while resolve is in flight', () async {
+      final completer = Completer<VideoEvent?>();
+      when(
+        () => videosRepository.fetchVideoWithStatsForRouteId(
+          target.stableId,
+          fallbackRouteIds: target.fallbackRouteIds,
+        ),
+      ).thenAnswer((_) => completer.future);
+
+      final cubit = createCubit();
+      addTearDown(cubit.close);
+
+      final first = cubit.save(target);
+      final second = cubit.save(target);
+
+      verify(
+        () => videosRepository.fetchVideoWithStatsForRouteId(
+          target.stableId,
+          fallbackRouteIds: target.fallbackRouteIds,
+        ),
+      ).called(1);
+
+      completer.complete(null);
+      await Future.wait([first, second]);
+      expect(cubit.state.status, SharedVideoSaveStatus.unavailable);
+    });
+  });
+}

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -2,6 +2,8 @@
 // ABOUTME: Verifies loading, error, empty, and loaded message states,
 // ABOUTME: plus the app bar and input bar rendering.
 
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:db_client/db_client.dart';
@@ -1513,10 +1515,10 @@ void main() {
       // not. The earlier "renders MessageBubble" test only proves the
       // bubble renders — this test proves the full chain
       // Listener (conversation_view) → MessageBubble → onLongPress
-      // → MessageActionsSheet.show is intact after the swap.
+      // → ReactionPickerOverlay.show is intact after the swap.
       testWidgets(
         'long-pressing a $MessageBubble still surfaces '
-        '$MessageActionsSheet',
+        'message actions',
         (tester) async {
           await pumpWithMessage(tester);
 
@@ -1542,6 +1544,8 @@ void main() {
             find.text(l10n.dmMessageActionDeleteForEveryone),
             findsNothing,
           );
+          expect(find.text(l10n.dmMessageActionCopyVideoUrl), findsNothing);
+          expect(find.text(l10n.shareSheetSaveVideo), findsNothing);
         },
       );
 
@@ -1571,19 +1575,27 @@ void main() {
 
       DmMessage sharedVideoMessage({
         required String senderPubkey,
+        String content = 'watch this',
+        String? replyToId,
+        DmSharedVideoRef? sharedVideoRef,
+        bool includeSharedVideoRef = true,
       }) => DmMessage(
         id: 'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
         conversationId:
             'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
         senderPubkey: senderPubkey,
-        content: 'watch this',
+        content: content,
         createdAt: now.millisecondsSinceEpoch ~/ 1000,
         giftWrapId:
             'aaaaaaaabbbbbbbbccccccccddddddddaaaaaaaabbbbbbbbccccccccdddddddd',
-        sharedVideoRef: DmSharedVideoRef(
-          coordinateOrId: '34236:$senderPubkey:$stableId',
-          videoKind: DmSharedVideoKind.addressableShortVideo,
-        ),
+        replyToId: replyToId,
+        sharedVideoRef: includeSharedVideoRef
+            ? sharedVideoRef ??
+                  DmSharedVideoRef(
+                    coordinateOrId: '34236:$senderPubkey:$stableId',
+                    videoKind: DmSharedVideoKind.addressableShortVideo,
+                  )
+            : null,
       );
 
       Future<void> openSaveAction(
@@ -1606,6 +1618,82 @@ void main() {
         expect(find.text(l10n.dmMessageActionCopyVideoUrl), findsOneWidget);
         expect(find.text(l10n.shareSheetSaveVideo), findsOneWidget);
       }
+
+      testWidgets('saves a legacy Divine URL share', (tester) async {
+        final message = sharedVideoMessage(
+          senderPubkey: currentPubkey,
+          content: 'watch this\nhttps://divine.video/video/$stableId',
+          includeSharedVideoRef: false,
+        );
+        final video = VideoEventBuilder(
+          id: stableId,
+          pubkey: currentPubkey,
+        ).build();
+        when(
+          () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+            stableId,
+            fallbackRouteIds: any(named: 'fallbackRouteIds'),
+          ),
+        ).thenAnswer((_) async => video);
+        when(
+          () => mockWatermarkDownloadService.downloadOriginal(
+            video: video,
+            onProgress: any(named: 'onProgress'),
+          ),
+        ).thenAnswer((invocation) async {
+          final onProgress =
+              invocation.namedArguments[#onProgress]
+                  as void Function(OriginalSaveStage);
+          onProgress(OriginalSaveStage.downloading);
+          onProgress(OriginalSaveStage.saving);
+          return const WatermarkDownloadSuccess('/tmp/original.mp4');
+        });
+
+        await openSaveAction(tester, message: message);
+        clearInteractions(mockVideosRepository);
+        await tester.tap(find.text(l10n.shareSheetSaveVideo));
+        await tester.pumpAndSettle();
+
+        verify(
+          () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+            stableId,
+            fallbackRouteIds: any(named: 'fallbackRouteIds'),
+          ),
+        ).called(1);
+        verify(
+          () => mockWatermarkDownloadService.downloadOriginal(
+            video: video,
+            onProgress: any(named: 'onProgress'),
+          ),
+        ).called(1);
+      });
+
+      testWidgets('does not offer video actions for a reply citation', (
+        tester,
+      ) async {
+        final message = sharedVideoMessage(
+          senderPubkey: otherPubkey,
+          replyToId:
+              '1111111111111111111111111111111111111111111111111111111111111111',
+        );
+
+        await tester.pumpWidget(
+          buildSubject(
+            state: ConversationState(
+              status: ConversationStatus.loaded,
+              messages: [message],
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.longPress(find.text('watch this'));
+        await tester.pumpAndSettle();
+
+        expect(find.text(l10n.dmMessageActionCopyText), findsOneWidget);
+        expect(find.text(l10n.dmMessageActionCopyVideoUrl), findsNothing);
+        expect(find.text(l10n.shareSheetSaveVideo), findsNothing);
+      });
 
       testWidgets(
         'saves the original for the current user structured share',
@@ -1708,6 +1796,22 @@ void main() {
       testWidgets('shows unavailable feedback when the video cannot resolve', (
         tester,
       ) async {
+        final announcements = <Map<Object?, Object?>>[];
+        tester.binding.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(
+              SystemChannels.accessibility,
+              (Object? message) async {
+                if (message is Map) announcements.add(message);
+                return null;
+              },
+            );
+        addTearDown(
+          () => tester.binding.defaultBinaryMessenger
+              .setMockDecodedMessageHandler<Object?>(
+                SystemChannels.accessibility,
+                null,
+              ),
+        );
         final message = sharedVideoMessage(senderPubkey: otherPubkey);
 
         await openSaveAction(tester, message: message);
@@ -1721,6 +1825,10 @@ void main() {
           ),
           findsOneWidget,
         );
+        final announcedMessages = announcements
+            .where((m) => m['type'] == 'announce')
+            .map((m) => (m['data'] as Map?)?['message']);
+        expect(announcedMessages, contains(l10n.notificationsVideoUnavailable));
         verifyNever(
           () => mockWatermarkDownloadService.downloadOriginal(
             video: any(named: 'video'),
@@ -1734,6 +1842,75 @@ void main() {
             onProgress: any(named: 'onProgress'),
           ),
         );
+      });
+
+      testWidgets('drops a second save request while the first is resolving', (
+        tester,
+      ) async {
+        final message = sharedVideoMessage(senderPubkey: currentPubkey);
+        final video = VideoEventBuilder(
+          id: stableId,
+          pubkey: currentPubkey,
+        ).build();
+        final resolveCompleter = Completer<VideoEvent?>();
+        var resolveCalls = 0;
+        when(
+          () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+            stableId,
+            fallbackRouteIds: ['34236:$currentPubkey:$stableId'],
+          ),
+        ).thenAnswer((_) {
+          resolveCalls += 1;
+          if (resolveCalls == 1) return Future<VideoEvent?>.value();
+          return resolveCompleter.future;
+        });
+        when(
+          () => mockWatermarkDownloadService.downloadOriginal(
+            video: video,
+            onProgress: any(named: 'onProgress'),
+          ),
+        ).thenAnswer((invocation) async {
+          final onProgress =
+              invocation.namedArguments[#onProgress]
+                  as void Function(OriginalSaveStage);
+          onProgress(OriginalSaveStage.downloading);
+          onProgress(OriginalSaveStage.saving);
+          return const WatermarkDownloadSuccess('/tmp/original.mp4');
+        });
+
+        await openSaveAction(tester, message: message);
+        clearInteractions(mockVideosRepository);
+        await tester.tap(find.text(l10n.shareSheetSaveVideo));
+        await tester.pump();
+        expect(
+          find.descendant(
+            of: find.byType(SnackBar),
+            matching: find.text(l10n.libraryPreparingVideo),
+          ),
+          findsOneWidget,
+        );
+
+        await tester.longPress(find.text('watch this'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text(l10n.shareSheetSaveVideo));
+        await tester.pump();
+
+        verify(
+          () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+            stableId,
+            fallbackRouteIds: ['34236:$currentPubkey:$stableId'],
+          ),
+        ).called(1);
+
+        resolveCompleter.complete(video);
+        await tester.pumpAndSettle();
+
+        verify(
+          () => mockWatermarkDownloadService.downloadOriginal(
+            video: video,
+            onProgress: any(named: 'onProgress'),
+          ),
+        ).called(1);
       });
     });
 

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -20,8 +20,10 @@ import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/collaborator_invite.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
+import 'package:openvine/providers/watermark_download_provider.dart';
 import 'package:openvine/screens/inbox/conversation/conversation_view.dart';
 import 'package:openvine/screens/inbox/conversation/widgets/widgets.dart';
+import 'package:openvine/services/watermark_download_service.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 import 'package:videos_repository/videos_repository.dart';
 import 'package:visibility_detector/visibility_detector.dart';
@@ -43,6 +45,9 @@ class _MockConversationReactionsCubit
     implements ConversationReactionsCubit {}
 
 class _MockVideosRepository extends Mock implements VideosRepository {}
+
+class _MockWatermarkDownloadService extends Mock
+    implements WatermarkDownloadService {}
 
 class _MockContentBlocklistRepository extends Mock
     implements ContentBlocklistRepository {}
@@ -79,6 +84,7 @@ void main() {
     late _MockCollaboratorInviteActionsCubit mockInviteActionsCubit;
     late _MockConversationReactionsCubit mockReactionsCubit;
     late _MockVideosRepository mockVideosRepository;
+    late _MockWatermarkDownloadService mockWatermarkDownloadService;
     late MockNostrClient mockNostrClient;
     late _MockAuthService mockAuthService;
     late _MockContentBlocklistRepository mockBlocklist;
@@ -104,6 +110,7 @@ void main() {
           emoji: '',
         ),
       );
+      registerFallbackValue(VideoEventBuilder().build());
     });
 
     setUp(() {
@@ -115,6 +122,7 @@ void main() {
       mockInviteActionsCubit = _MockCollaboratorInviteActionsCubit();
       mockReactionsCubit = _MockConversationReactionsCubit();
       mockVideosRepository = _MockVideosRepository();
+      mockWatermarkDownloadService = _MockWatermarkDownloadService();
       mockNostrClient = createMockNostrService();
       mockAuthService = _MockAuthService(currentPubkey);
       mockBlocklist = _MockContentBlocklistRepository();
@@ -165,6 +173,10 @@ void main() {
         mockNostrService: mockNostrClient,
         additionalOverrides: [
           videosRepositoryProvider.overrideWithValue(mockVideosRepository),
+          watermarkDownloadServiceProvider.overrideWithValue(
+            mockWatermarkDownloadService,
+          ),
+          profileRepositoryProvider.overrideWithValue(null),
           fetchUserProfileProvider(
             otherPubkey,
           ).overrideWith((ref) async => otherProfile),
@@ -1552,6 +1564,177 @@ void main() {
           expect(find.byType(EmojiEditor), findsOneWidget);
         },
       );
+    });
+
+    group('shared video saving', () {
+      const stableId = 'skate-loop';
+
+      DmMessage sharedVideoMessage({
+        required String senderPubkey,
+      }) => DmMessage(
+        id: 'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+        conversationId:
+            'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+        senderPubkey: senderPubkey,
+        content: 'watch this',
+        createdAt: now.millisecondsSinceEpoch ~/ 1000,
+        giftWrapId:
+            'aaaaaaaabbbbbbbbccccccccddddddddaaaaaaaabbbbbbbbccccccccdddddddd',
+        sharedVideoRef: DmSharedVideoRef(
+          coordinateOrId: '34236:$senderPubkey:$stableId',
+          videoKind: DmSharedVideoKind.addressableShortVideo,
+        ),
+      );
+
+      Future<void> openSaveAction(
+        WidgetTester tester, {
+        required DmMessage message,
+      }) async {
+        await tester.pumpWidget(
+          buildSubject(
+            state: ConversationState(
+              status: ConversationStatus.loaded,
+              messages: [message],
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.longPress(find.text('watch this'));
+        await tester.pumpAndSettle();
+
+        expect(find.text(l10n.dmMessageActionCopyVideoUrl), findsOneWidget);
+        expect(find.text(l10n.shareSheetSaveVideo), findsOneWidget);
+      }
+
+      testWidgets(
+        'saves the original for the current user structured share',
+        (tester) async {
+          final message = sharedVideoMessage(senderPubkey: currentPubkey);
+          final video = VideoEventBuilder(
+            id: stableId,
+            pubkey: currentPubkey,
+          ).build();
+          when(
+            () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+              stableId,
+              fallbackRouteIds: ['34236:$currentPubkey:$stableId'],
+            ),
+          ).thenAnswer((_) async => video);
+          when(
+            () => mockWatermarkDownloadService.downloadOriginal(
+              video: video,
+              onProgress: any(named: 'onProgress'),
+            ),
+          ).thenAnswer((invocation) async {
+            final onProgress =
+                invocation.namedArguments[#onProgress]
+                    as void Function(OriginalSaveStage);
+            onProgress(OriginalSaveStage.downloading);
+            onProgress(OriginalSaveStage.saving);
+            return const WatermarkDownloadSuccess('/tmp/original.mp4');
+          });
+
+          await openSaveAction(tester, message: message);
+          await tester.tap(find.text(l10n.shareSheetSaveVideo));
+          await tester.pumpAndSettle();
+
+          verify(
+            () => mockWatermarkDownloadService.downloadOriginal(
+              video: video,
+              onProgress: any(named: 'onProgress'),
+            ),
+          ).called(1);
+          verifyNever(
+            () => mockWatermarkDownloadService.downloadWithWatermark(
+              video: any(named: 'video'),
+              watermarkText: any(named: 'watermarkText'),
+              onProgress: any(named: 'onProgress'),
+            ),
+          );
+        },
+      );
+
+      testWidgets(
+        'saves a watermarked copy for another creator structured share',
+        (tester) async {
+          final message = sharedVideoMessage(senderPubkey: otherPubkey);
+          final video = VideoEventBuilder(
+            id: stableId,
+            pubkey: otherPubkey,
+          ).build();
+          when(
+            () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+              stableId,
+              fallbackRouteIds: ['34236:$otherPubkey:$stableId'],
+            ),
+          ).thenAnswer((_) async => video);
+          when(
+            () => mockWatermarkDownloadService.downloadWithWatermark(
+              video: video,
+              watermarkText: any(named: 'watermarkText'),
+              onProgress: any(named: 'onProgress'),
+            ),
+          ).thenAnswer((invocation) async {
+            final onProgress =
+                invocation.namedArguments[#onProgress]
+                    as void Function(WatermarkDownloadStage);
+            onProgress(WatermarkDownloadStage.downloading);
+            onProgress(WatermarkDownloadStage.watermarking);
+            onProgress(WatermarkDownloadStage.saving);
+            return const WatermarkDownloadSuccess('/tmp/watermarked.mp4');
+          });
+
+          await openSaveAction(tester, message: message);
+          await tester.tap(find.text(l10n.shareSheetSaveVideo));
+          await tester.pumpAndSettle();
+
+          verify(
+            () => mockWatermarkDownloadService.downloadWithWatermark(
+              video: video,
+              watermarkText: any(named: 'watermarkText'),
+              onProgress: any(named: 'onProgress'),
+            ),
+          ).called(1);
+          verifyNever(
+            () => mockWatermarkDownloadService.downloadOriginal(
+              video: any(named: 'video'),
+              onProgress: any(named: 'onProgress'),
+            ),
+          );
+        },
+      );
+
+      testWidgets('shows unavailable feedback when the video cannot resolve', (
+        tester,
+      ) async {
+        final message = sharedVideoMessage(senderPubkey: otherPubkey);
+
+        await openSaveAction(tester, message: message);
+        await tester.tap(find.text(l10n.shareSheetSaveVideo));
+        await tester.pumpAndSettle();
+
+        expect(
+          find.descendant(
+            of: find.byType(SnackBar),
+            matching: find.text(l10n.notificationsVideoUnavailable),
+          ),
+          findsOneWidget,
+        );
+        verifyNever(
+          () => mockWatermarkDownloadService.downloadOriginal(
+            video: any(named: 'video'),
+            onProgress: any(named: 'onProgress'),
+          ),
+        );
+        verifyNever(
+          () => mockWatermarkDownloadService.downloadWithWatermark(
+            video: any(named: 'video'),
+            watermarkText: any(named: 'watermarkText'),
+            onProgress: any(named: 'onProgress'),
+          ),
+        );
+      });
     });
 
     // #5418 — the reaction pill + who-reacted sheet must hide reactions from

--- a/mobile/test/screens/inbox/conversation/dm_video_target_test.dart
+++ b/mobile/test/screens/inbox/conversation/dm_video_target_test.dart
@@ -1,3 +1,6 @@
+// ABOUTME: Unit tests for resolveDmVideoTarget and DmVideoTarget.
+// ABOUTME: Covers legacy Divine URL and structured NIP-18 q-reference resolution.
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart';
 import 'package:openvine/screens/inbox/conversation/dm_video_target.dart';

--- a/mobile/test/screens/inbox/conversation/dm_video_target_test.dart
+++ b/mobile/test/screens/inbox/conversation/dm_video_target_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart';
+import 'package:openvine/screens/inbox/conversation/dm_video_target.dart';
+
+void main() {
+  const author =
+      '1122334411223344112233441122334411223344112233441122334411223344';
+  const eventId =
+      'aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd';
+
+  group('resolveDmVideoTarget', () {
+    test('resolves a canonical Divine URL', () {
+      final target = resolveDmVideoTarget(
+        content: 'watch https://divine.video/video/skate-loop',
+      );
+
+      expect(target, isNotNull);
+      expect(target!.stableId, 'skate-loop');
+      expect(target.authorPubkey, isNull);
+      expect(target.videoKind, isNull);
+      expect(target.fallbackRouteIds, isEmpty);
+      expect(
+        target.canonicalUrl,
+        'https://divine.video/video/skate-loop',
+      );
+    });
+
+    test('resolves a regular-event structured reference', () {
+      final target = resolveDmVideoTarget(
+        content: 'watch this',
+        sharedVideoRef: const DmSharedVideoRef(
+          coordinateOrId: eventId,
+          videoKind: DmSharedVideoKind.shortVideo,
+          authorPubkey: author,
+        ),
+      );
+
+      expect(target, isNotNull);
+      expect(target!.stableId, eventId);
+      expect(target.authorPubkey, author);
+      expect(target.videoKind, 22);
+      expect(target.fallbackRouteIds, ['22:$author:$eventId']);
+      expect(
+        target.canonicalUrl,
+        'https://divine.video/video/$eventId',
+      );
+    });
+
+    test('resolves an addressable structured reference', () {
+      final target = resolveDmVideoTarget(
+        content: 'watch this',
+        sharedVideoRef: const DmSharedVideoRef(
+          coordinateOrId: '34236:$author:skate-loop',
+          videoKind: DmSharedVideoKind.addressableShortVideo,
+        ),
+      );
+
+      expect(target, isNotNull);
+      expect(target!.stableId, 'skate-loop');
+      expect(target.authorPubkey, author);
+      expect(target.videoKind, 34236);
+      expect(target.fallbackRouteIds, ['34236:$author:skate-loop']);
+      expect(
+        target.canonicalUrl,
+        'https://divine.video/video/skate-loop',
+      );
+    });
+
+    test(
+      'prefers the URL identity and retains structured routing metadata',
+      () {
+        final target = resolveDmVideoTarget(
+          content: 'https://divine.video/video/url-stable-id',
+          sharedVideoRef: const DmSharedVideoRef(
+            coordinateOrId: '34236:$author:structured-stable-id',
+            videoKind: DmSharedVideoKind.addressableShortVideo,
+          ),
+        );
+
+        expect(target, isNotNull);
+        expect(target!.stableId, 'url-stable-id');
+        expect(target.authorPubkey, author);
+        expect(target.videoKind, 34236);
+        expect(target.fallbackRouteIds, ['34236:$author:url-stable-id']);
+      },
+    );
+
+    test('rejects a malformed addressable reference without a URL', () {
+      final target = resolveDmVideoTarget(
+        content: 'watch this',
+        sharedVideoRef: const DmSharedVideoRef(
+          coordinateOrId: '34236:$author',
+          videoKind: DmSharedVideoKind.addressableShortVideo,
+        ),
+      );
+
+      expect(target, isNull);
+    });
+
+    test('falls back to a URL when the structured reference is malformed', () {
+      final target = resolveDmVideoTarget(
+        content: 'https://divine.video/video/url-stable-id',
+        sharedVideoRef: const DmSharedVideoRef(
+          coordinateOrId: '34236:$author',
+          videoKind: DmSharedVideoKind.addressableShortVideo,
+        ),
+      );
+
+      expect(target, isNotNull);
+      expect(target!.stableId, 'url-stable-id');
+      expect(target.authorPubkey, isNull);
+      expect(target.videoKind, isNull);
+      expect(target.fallbackRouteIds, isEmpty);
+    });
+  });
+}

--- a/mobile/test/screens/inbox/conversation/widgets/reaction_picker_overlay_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/reaction_picker_overlay_test.dart
@@ -7,12 +7,15 @@ import 'dart:async';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/screens/inbox/conversation/widgets/message_actions_sheet.dart';
 import 'package:openvine/screens/inbox/conversation/widgets/reaction_picker_overlay.dart';
 
 import '../../../../helpers/test_provider_overrides.dart';
 
 void main() {
+  final l10n = lookupAppLocalizations(const Locale('en'));
+
   Future<void> openOverlay(
     WidgetTester tester, {
     bool isSent = false,
@@ -58,8 +61,8 @@ void main() {
         findsOneWidget,
       );
       expect(find.text('Copy text'), findsOneWidget);
-      expect(find.text('Copy video URL'), findsNothing);
-      expect(find.text('Save Video'), findsNothing);
+      expect(find.text(l10n.dmMessageActionCopyVideoUrl), findsNothing);
+      expect(find.text(l10n.shareSheetSaveVideo), findsNothing);
       expect(find.text('Delete for everyone'), findsOneWidget);
     });
 
@@ -68,8 +71,8 @@ void main() {
     ) async {
       await openOverlay(tester, isVideoShare: true);
 
-      expect(find.text('Copy video URL'), findsOneWidget);
-      expect(find.text('Save Video'), findsOneWidget);
+      expect(find.text(l10n.dmMessageActionCopyVideoUrl), findsOneWidget);
+      expect(find.text(l10n.shareSheetSaveVideo), findsOneWidget);
     });
 
     testWidgets('returns saveVideo after selecting Save video', (tester) async {
@@ -97,7 +100,7 @@ void main() {
       await tester.tap(find.text('open'));
       await tester.pumpAndSettle();
 
-      await tester.tap(find.text('Save Video'));
+      await tester.tap(find.text(l10n.shareSheetSaveVideo));
       await tester.pumpAndSettle();
 
       expect(result?.action, MessageAction.saveVideo);

--- a/mobile/test/screens/inbox/conversation/widgets/reaction_picker_overlay_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/reaction_picker_overlay_test.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/screens/inbox/conversation/widgets/message_actions_sheet.dart';
 import 'package:openvine/screens/inbox/conversation/widgets/reaction_picker_overlay.dart';
 
 import '../../../../helpers/test_provider_overrides.dart';
@@ -57,7 +58,49 @@ void main() {
         findsOneWidget,
       );
       expect(find.text('Copy text'), findsOneWidget);
+      expect(find.text('Copy video URL'), findsNothing);
+      expect(find.text('Save Video'), findsNothing);
       expect(find.text('Delete for everyone'), findsOneWidget);
+    });
+
+    testWidgets('shows copy and save actions for a shared video', (
+      tester,
+    ) async {
+      await openOverlay(tester, isVideoShare: true);
+
+      expect(find.text('Copy video URL'), findsOneWidget);
+      expect(find.text('Save Video'), findsOneWidget);
+    });
+
+    testWidgets('returns saveVideo after selecting Save video', (tester) async {
+      ReactionPickerResult? result;
+      await tester.pumpWidget(
+        testMaterialApp(
+          home: Builder(
+            builder: (context) {
+              return Scaffold(
+                body: TextButton(
+                  onPressed: () async {
+                    result = await ReactionPickerOverlay.show(
+                      context: context,
+                      isSent: false,
+                      isVideoShare: true,
+                    );
+                  },
+                  child: const Text('open'),
+                ),
+              );
+            },
+          ),
+        ),
+      );
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Save Video'));
+      await tester.pumpAndSettle();
+
+      expect(result?.action, MessageAction.saveVideo);
     });
 
     testWidgets('dismisses after selecting a quick reaction', (tester) async {

--- a/mobile/test/utils/divine_video_url_test.dart
+++ b/mobile/test/utils/divine_video_url_test.dart
@@ -20,30 +20,33 @@ void main() {
     });
   });
 
-  group('tryExtractDivineVideoUrl', () {
+  group('divineVideoUrlRegex', () {
     const validId = 'abc123def456';
 
+    String? firstDivineVideoUrl(String content) =>
+        divineVideoUrlRegex.firstMatch(content)?.group(0);
+
     test('returns null when content has no URL', () {
-      expect(tryExtractDivineVideoUrl('just plain text'), isNull);
+      expect(firstDivineVideoUrl('just plain text'), isNull);
     });
 
     test('extracts canonical https URL', () {
       expect(
-        tryExtractDivineVideoUrl('see https://divine.video/video/$validId'),
+        firstDivineVideoUrl('see https://divine.video/video/$validId'),
         equals('https://divine.video/video/$validId'),
       );
     });
 
     test('extracts http URL (no scheme upgrade)', () {
       expect(
-        tryExtractDivineVideoUrl('http://divine.video/video/$validId here'),
+        firstDivineVideoUrl('http://divine.video/video/$validId here'),
         equals('http://divine.video/video/$validId'),
       );
     });
 
     test('extracts URL with www subdomain', () {
       expect(
-        tryExtractDivineVideoUrl(
+        firstDivineVideoUrl(
           'check https://www.divine.video/video/$validId',
         ),
         equals('https://www.divine.video/video/$validId'),
@@ -53,14 +56,14 @@ void main() {
     group('casing', () {
       test('matches HTTPS in uppercase', () {
         expect(
-          tryExtractDivineVideoUrl('HTTPS://DIVINE.VIDEO/VIDEO/$validId'),
+          firstDivineVideoUrl('HTTPS://DIVINE.VIDEO/VIDEO/$validId'),
           equals('HTTPS://DIVINE.VIDEO/VIDEO/$validId'),
         );
       });
 
       test('matches mixed-case host and path', () {
         expect(
-          tryExtractDivineVideoUrl('https://Divine.Video/Video/$validId'),
+          firstDivineVideoUrl('https://Divine.Video/Video/$validId'),
           equals('https://Divine.Video/Video/$validId'),
         );
       });
@@ -69,7 +72,7 @@ void main() {
     group('trailing punctuation', () {
       test('strips trailing period', () {
         expect(
-          tryExtractDivineVideoUrl(
+          firstDivineVideoUrl(
             'watch this: https://divine.video/video/$validId.',
           ),
           equals('https://divine.video/video/$validId'),
@@ -78,7 +81,7 @@ void main() {
 
       test('strips trailing comma', () {
         expect(
-          tryExtractDivineVideoUrl(
+          firstDivineVideoUrl(
             'see https://divine.video/video/$validId, nice right?',
           ),
           equals('https://divine.video/video/$validId'),
@@ -87,7 +90,7 @@ void main() {
 
       test('strips trailing closing paren', () {
         expect(
-          tryExtractDivineVideoUrl(
+          firstDivineVideoUrl(
             'parenthetical (https://divine.video/video/$validId)',
           ),
           equals('https://divine.video/video/$validId'),
@@ -96,7 +99,7 @@ void main() {
 
       test('strips trailing exclamation mark', () {
         expect(
-          tryExtractDivineVideoUrl('https://divine.video/video/$validId!'),
+          firstDivineVideoUrl('https://divine.video/video/$validId!'),
           equals('https://divine.video/video/$validId'),
         );
       });
@@ -105,7 +108,7 @@ void main() {
     group('query strings and fragments', () {
       test('excludes ?query=string from match', () {
         expect(
-          tryExtractDivineVideoUrl(
+          firstDivineVideoUrl(
             'https://divine.video/video/$validId?utm=share',
           ),
           equals('https://divine.video/video/$validId'),
@@ -114,7 +117,7 @@ void main() {
 
       test('excludes #fragment from match', () {
         expect(
-          tryExtractDivineVideoUrl(
+          firstDivineVideoUrl(
             'https://divine.video/video/$validId#t=10',
           ),
           equals('https://divine.video/video/$validId'),
@@ -127,7 +130,7 @@ void main() {
         const hexId =
             'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2';
         expect(
-          tryExtractDivineVideoUrl('https://divine.video/video/$hexId'),
+          firstDivineVideoUrl('https://divine.video/video/$hexId'),
           equals('https://divine.video/video/$hexId'),
         );
       });
@@ -135,7 +138,7 @@ void main() {
       test('matches hyphenated d-tag', () {
         const dTag = 'my-video-d-tag-2026';
         expect(
-          tryExtractDivineVideoUrl('https://divine.video/video/$dTag'),
+          firstDivineVideoUrl('https://divine.video/video/$dTag'),
           equals('https://divine.video/video/$dTag'),
         );
       });
@@ -143,7 +146,7 @@ void main() {
       test('matches alphanumeric d-tag with underscore', () {
         const dTag = 'abc_123_xyz';
         expect(
-          tryExtractDivineVideoUrl('https://divine.video/video/$dTag'),
+          firstDivineVideoUrl('https://divine.video/video/$dTag'),
           equals('https://divine.video/video/$dTag'),
         );
       });
@@ -152,21 +155,21 @@ void main() {
     group('rejects non-canonical shapes', () {
       test('rejects non-divine domain', () {
         expect(
-          tryExtractDivineVideoUrl('https://example.com/video/$validId'),
+          firstDivineVideoUrl('https://example.com/video/$validId'),
           isNull,
         );
       });
 
       test('rejects /video/ path missing the id', () {
         expect(
-          tryExtractDivineVideoUrl('https://divine.video/video/'),
+          firstDivineVideoUrl('https://divine.video/video/'),
           isNull,
         );
       });
 
       test('rejects non-/video/ path on divine.video', () {
         expect(
-          tryExtractDivineVideoUrl('https://divine.video/profile/$validId'),
+          firstDivineVideoUrl('https://divine.video/profile/$validId'),
           isNull,
         );
       });
@@ -174,7 +177,7 @@ void main() {
 
     test('extracts first URL when content has multiple', () {
       expect(
-        tryExtractDivineVideoUrl(
+        firstDivineVideoUrl(
           'a https://divine.video/video/aaa111 b https://divine.video/video/bbb222',
         ),
         equals('https://divine.video/video/aaa111'),


### PR DESCRIPTION
Closes #6214

## Summary

- add **Save Video** to shared-video DM card long-press actions
- resolve shared-video saves through a guarded cubit with pending/unavailable feedback and a11y announcements
- normalize legacy Divine URLs and structured NIP-18 video references so cards, copy-link, and saving resolve the same video
- save the current user's own videos as originals and other creators' videos with the existing Divine watermark flow
- reject bare non-video `q` references so ordinary quoted notes do not expose video actions

## Test plan

- `flutter test test/blocs/dm/shared_video_save/shared_video_save_cubit_test.dart test/screens/inbox/conversation/dm_video_target_test.dart test/screens/inbox/conversation/conversation_view_test.dart test/screens/inbox/conversation/widgets/reaction_picker_overlay_test.dart test/utils/divine_video_url_test.dart packages/dm_repository/test/src/dm_shared_video_citation_test.dart`
- `flutter analyze lib test`