### PR TITLE
feat(perf): trace video generation and camera startup time

### DIFF
--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -30,6 +30,7 @@ import 'package:openvine/models/video_recorder/video_recorder_timer_duration.dar
 import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/services/haptic_service.dart';
+import 'package:openvine/services/performance_monitoring_service.dart';
 import 'package:openvine/services/video_recorder/camera/camera_base_service.dart';
 import 'package:openvine/services/video_thumbnail_service.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
@@ -146,6 +147,7 @@ class VideoRecorderBloc
     CameraService? cameraService,
     CountdownSoundServiceFactory? countdownSoundServiceFactory,
     AudioPlaybackServiceFactory? audioPlaybackServiceFactory,
+    PerformanceTraceMonitor? performanceMonitor,
   }) : _readClipManager = readClipManager,
        _readVideoEditor = readVideoEditor,
        _readVideoEditorState = readVideoEditorState,
@@ -155,6 +157,8 @@ class VideoRecorderBloc
            countdownSoundServiceFactory ?? defaultCountdownSoundServiceFactory,
        _audioPlaybackServiceFactory =
            audioPlaybackServiceFactory ?? defaultAudioPlaybackServiceFactory,
+       _performanceMonitor =
+           performanceMonitor ?? const NoOpPerformanceTraceMonitor(),
        super(const VideoRecorderBlocState()) {
     _cameraService =
         _cameraServiceOverride ??
@@ -241,6 +245,7 @@ class VideoRecorderBloc
   final CameraService? _cameraServiceOverride;
   final CountdownSoundServiceFactory _countdownSoundServiceFactory;
   final AudioPlaybackServiceFactory _audioPlaybackServiceFactory;
+  final PerformanceTraceMonitor _performanceMonitor;
 
   late final CameraService _cameraService;
   AudioPlaybackService? _audioPlaybackService;
@@ -304,6 +309,13 @@ class VideoRecorderBloc
       category: LogCategory.video,
     );
 
+    const traceName = 'camera_startup';
+    // Fire-and-forget so the native init dispatch is not delayed a microtask;
+    // the trace still stops in `finally`, tagged with the outcome so the
+    // console can filter startups that never reached a live preview.
+    unawaited(_performanceMonitor.startTrace(traceName));
+
+    Object? initError;
     try {
       await _cameraService.initialize(
         videoQuality: event.videoQuality,
@@ -311,14 +323,31 @@ class VideoRecorderBloc
         enableAutoLensSwitch: true,
       );
     } catch (e) {
+      initError = e;
+    } finally {
+      _performanceMonitor
+        ..putAttribute(traceName, 'lens', initialLens.name)
+        ..putAttribute(traceName, 'quality', event.videoQuality.value)
+        ..putAttribute(
+          traceName,
+          'outcome',
+          initError != null
+              ? 'error'
+              : (_cameraService.isInitialized ? 'success' : 'failed'),
+        );
+      await _performanceMonitor.stopTrace(traceName);
+    }
+
+    if (initError != null) {
       Log.error(
-        '📹 Camera service initialization threw exception: $e',
+        '📹 Camera service initialization threw exception: $initError',
         name: 'VideoRecorderBloc',
         category: LogCategory.video,
       );
       emit(
         state.copyWith(
-          initializationErrorMessage: 'Camera initialization failed: $e',
+          initializationErrorMessage:
+              'Camera initialization failed: $initError',
         ),
       );
       return;

--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -310,9 +310,12 @@ class VideoRecorderBloc
     );
 
     const traceName = 'camera_startup';
-    // Fire-and-forget so the native init dispatch is not delayed a microtask;
-    // the trace still stops in `finally`, tagged with the outcome so the
-    // console can filter startups that never reached a live preview.
+    // Start and stop the trace fire-and-forget: an awaited start would run
+    // trace.start()'s platform round-trip before dispatching the native camera
+    // init, and an awaited stop would gate preview bring-up on trace.stop() —
+    // both add latency to the exact startup path this trace measures. The trace
+    // still stops in `finally`, tagged with the outcome so the console can
+    // filter startups that never reached a live preview.
     unawaited(_performanceMonitor.startTrace(traceName));
 
     Object? initError;
@@ -335,7 +338,7 @@ class VideoRecorderBloc
               ? 'error'
               : (_cameraService.isInitialized ? 'success' : 'failed'),
         );
-      await _performanceMonitor.stopTrace(traceName);
+      unawaited(_performanceMonitor.stopTrace(traceName));
     }
 
     if (initError != null) {

--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -309,14 +309,14 @@ class VideoRecorderBloc
       category: LogCategory.video,
     );
 
-    const traceName = 'camera_startup';
-    // Start and stop the trace fire-and-forget: an awaited start would run
-    // trace.start()'s platform round-trip before dispatching the native camera
-    // init, and an awaited stop would gate preview bring-up on trace.stop() —
-    // both add latency to the exact startup path this trace measures. The trace
-    // still stops in `finally`, tagged with the outcome so the console can
-    // filter startups that never reached a live preview.
-    unawaited(_performanceMonitor.startTrace(traceName));
+    // Operation-scoped trace: this init owns the returned handle, so a
+    // concurrent init gets its own trace instead of stopping or re-attributing
+    // this one. Start is fire-and-forget so it doesn't add a platform round-trip
+    // to the exact startup path this trace measures; stop is fire-and-forget so
+    // it doesn't gate preview bring-up. The handle is still stopped in `finally`,
+    // tagged with the outcome so the console can filter startups that never
+    // reached a live preview.
+    final trace = _performanceMonitor.startOperationTrace('camera_startup');
 
     Object? initError;
     try {
@@ -328,17 +328,16 @@ class VideoRecorderBloc
     } catch (e) {
       initError = e;
     } finally {
-      _performanceMonitor
-        ..putAttribute(traceName, 'lens', initialLens.name)
-        ..putAttribute(traceName, 'quality', event.videoQuality.value)
+      trace
+        ..putAttribute('lens', initialLens.name)
+        ..putAttribute('quality', event.videoQuality.value)
         ..putAttribute(
-          traceName,
           'outcome',
           initError != null
               ? 'error'
               : (_cameraService.isInitialized ? 'success' : 'failed'),
         );
-      unawaited(_performanceMonitor.stopTrace(traceName));
+      unawaited(trace.stop());
     }
 
     if (initError != null) {

--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -138,6 +138,13 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
   int _renderGeneration = 0;
   Future<void>? _activeRenderFuture;
 
+  /// Generation that currently owns the single-named `video_generation`
+  /// performance trace. Bumped only by [_runRenderVideo] (never by cancel or
+  /// re-sign), so a render superseded by an overlapping render sees this change
+  /// and leaves the newer render's trace alone, while a render superseded by a
+  /// cancel still owns — and stops — its own trace.
+  int _videoGenerationTraceOwner = 0;
+
   /// When true, [triggerAutosave] is a no-op.
   ///
   /// Set to `true` by [initFromPublishedVideo] and intentionally never reset.
@@ -1135,13 +1142,27 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
     // the future still completes), by which point this notifier may be disposed
     // and `ref.read` would throw — the captured instance stays valid. Start the
     // trace fire-and-forget so render dispatch stays synchronous; an awaited
-    // start would defer the first renderVideoToClip call by a microtask.
+    // start would run trace.start()'s platform round-trip before (and defer) the
+    // first renderVideoToClip call, which the overlapping-render test relies on
+    // dispatching synchronously.
     final performance = ref.read(performanceMonitoringServiceProvider);
     const traceName = 'video_generation';
     final clipCount = _clips.length;
     final aspectRatio = _clips.isEmpty
         ? null
         : _clips.first.targetAspectRatio.name;
+    // Claim the single-named trace. An overlapping render bumps this and takes
+    // the trace over (the service keys traces by name), after which our tags and
+    // stop below are skipped so we can't mis-tag or prematurely stop the newer
+    // render's trace.
+    _videoGenerationTraceOwner = generation;
+    bool ownsTrace() => _videoGenerationTraceOwner == generation;
+    void tagOutcome(String outcome) {
+      if (ownsTrace()) {
+        performance.putAttribute(traceName, 'outcome', outcome);
+      }
+    }
+
     unawaited(performance.startTrace(traceName));
 
     try {
@@ -1155,10 +1176,10 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
       );
 
       // A newer render was started or the user cancelled while this one was
-      // running — the trace still stops in `finally`; tag it so the console can
+      // running — tag it (when we still own the trace) so the console can
       // exclude non-completing renders from the generation-time distribution.
       if (generation != _renderGeneration) {
-        performance.putAttribute(traceName, 'outcome', 'incomplete');
+        tagOutcome('incomplete');
         return;
       }
 
@@ -1166,7 +1187,7 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
         // A user cancel bumps the generation and is caught above, so reaching
         // here with a matching generation is a genuine render failure — surface
         // the retry affordance (#6058).
-        performance.putAttribute(traceName, 'outcome', 'failed');
+        tagOutcome('failed');
         Log.warning(
           '⚠️ Video render failed',
           name: 'VideoEditorNotifier',
@@ -1176,7 +1197,7 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
         return;
       }
 
-      performance.putAttribute(traceName, 'outcome', 'success');
+      tagOutcome('success');
 
       final (finalRenderedClip, proofManifestJson) = result;
 
@@ -1211,10 +1232,10 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
     } catch (error, stackTrace) {
       // A newer render owns the processing flag now — leave it alone.
       if (generation != _renderGeneration) {
-        performance.putAttribute(traceName, 'outcome', 'incomplete');
+        tagOutcome('incomplete');
         return;
       }
-      performance.putAttribute(traceName, 'outcome', 'error');
+      tagOutcome('error');
       // Surface the failure (e.g. a hung/failed C2PA proof step) as an error +
       // retry so the user can restart the render instead of being stuck on the
       // processing overlay (#6058).
@@ -1227,11 +1248,15 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
       );
       state = state.copyWith(isProcessing: false, renderFailed: true);
     } finally {
-      performance.putAttribute(traceName, 'clip_count', '$clipCount');
-      if (aspectRatio != null) {
-        performance.putAttribute(traceName, 'aspect_ratio', aspectRatio);
+      // Skip when a later render took over the trace. Stop fire-and-forget so a
+      // trace.stop() platform round-trip doesn't gate the render's completion.
+      if (ownsTrace()) {
+        performance.putAttribute(traceName, 'clip_count', '$clipCount');
+        if (aspectRatio != null) {
+          performance.putAttribute(traceName, 'aspect_ratio', aspectRatio);
+        }
+        unawaited(performance.stopTrace(traceName));
       }
-      await performance.stopTrace(traceName);
     }
   }
 

--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -138,13 +138,6 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
   int _renderGeneration = 0;
   Future<void>? _activeRenderFuture;
 
-  /// Generation that currently owns the single-named `video_generation`
-  /// performance trace. Bumped only by [_runRenderVideo] (never by cancel or
-  /// re-sign), so a render superseded by an overlapping render sees this change
-  /// and leaves the newer render's trace alone, while a render superseded by a
-  /// cancel still owns — and stops — its own trace.
-  int _videoGenerationTraceOwner = 0;
-
   /// When true, [triggerAutosave] is a no-op.
   ///
   /// Set to `true` by [initFromPublishedVideo] and intentionally never reset.
@@ -1140,30 +1133,18 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
     // Capture the monitor and render inputs up front: a final render can settle
     // well after the user backs out (dispose cancels via cancelRenderVideo, but
     // the future still completes), by which point this notifier may be disposed
-    // and `ref.read` would throw — the captured instance stays valid. Start the
-    // trace fire-and-forget so render dispatch stays synchronous; an awaited
-    // start would run trace.start()'s platform round-trip before (and defer) the
-    // first renderVideoToClip call, which the overlapping-render test relies on
-    // dispatching synchronously.
+    // and `ref.read` would throw — the captured instance stays valid. The trace
+    // is operation-scoped: this render owns the returned handle, so an
+    // overlapping render gets its own trace instead of stopping or
+    // re-attributing this one, and start stays fire-and-forget so render
+    // dispatch is synchronous (the overlapping-render test relies on that).
     final performance = ref.read(performanceMonitoringServiceProvider);
-    const traceName = 'video_generation';
+    final trace = performance.startOperationTrace('video_generation');
     final clipCount = _clips.length;
     final aspectRatio = _clips.isEmpty
         ? null
         : _clips.first.targetAspectRatio.name;
-    // Claim the single-named trace. An overlapping render bumps this and takes
-    // the trace over (the service keys traces by name), after which our tags and
-    // stop below are skipped so we can't mis-tag or prematurely stop the newer
-    // render's trace.
-    _videoGenerationTraceOwner = generation;
-    bool ownsTrace() => _videoGenerationTraceOwner == generation;
-    void tagOutcome(String outcome) {
-      if (ownsTrace()) {
-        performance.putAttribute(traceName, 'outcome', outcome);
-      }
-    }
-
-    unawaited(performance.startTrace(traceName));
+    void tagOutcome(String outcome) => trace.putAttribute('outcome', outcome);
 
     try {
       final renderParameters = _buildRenderParameters();
@@ -1176,8 +1157,8 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
       );
 
       // A newer render was started or the user cancelled while this one was
-      // running — tag it (when we still own the trace) so the console can
-      // exclude non-completing renders from the generation-time distribution.
+      // running — tag this render's own trace so the console can exclude
+      // non-completing renders from the generation-time distribution.
       if (generation != _renderGeneration) {
         tagOutcome('incomplete');
         return;
@@ -1248,15 +1229,14 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
       );
       state = state.copyWith(isProcessing: false, renderFailed: true);
     } finally {
-      // Skip when a later render took over the trace. Stop fire-and-forget so a
-      // trace.stop() platform round-trip doesn't gate the render's completion.
-      if (ownsTrace()) {
-        performance.putAttribute(traceName, 'clip_count', '$clipCount');
-        if (aspectRatio != null) {
-          performance.putAttribute(traceName, 'aspect_ratio', aspectRatio);
-        }
-        unawaited(performance.stopTrace(traceName));
+      // This render owns its trace handle, so tag and stop it unconditionally.
+      // Stop fire-and-forget so a trace.stop() platform round-trip doesn't gate
+      // the render's completion.
+      trace.putAttribute('clip_count', '$clipCount');
+      if (aspectRatio != null) {
+        trace.putAttribute('aspect_ratio', aspectRatio);
       }
+      unawaited(trace.stop());
     }
   }
 

--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -22,6 +22,7 @@ import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/providers/database_provider.dart';
 import 'package:openvine/providers/moderation_providers.dart';
 import 'package:openvine/providers/preferences_providers.dart';
+import 'package:openvine/providers/service_providers.dart';
 import 'package:openvine/providers/social_providers.dart';
 import 'package:openvine/providers/video_publish_provider.dart';
 import 'package:openvine/providers/video_reply_context_provider.dart';
@@ -1129,6 +1130,20 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
   }
 
   Future<void> _runRenderVideo(int generation) async {
+    // Capture the monitor and render inputs up front: a final render can settle
+    // well after the user backs out (dispose cancels via cancelRenderVideo, but
+    // the future still completes), by which point this notifier may be disposed
+    // and `ref.read` would throw — the captured instance stays valid. Start the
+    // trace fire-and-forget so render dispatch stays synchronous; an awaited
+    // start would defer the first renderVideoToClip call by a microtask.
+    final performance = ref.read(performanceMonitoringServiceProvider);
+    const traceName = 'video_generation';
+    final clipCount = _clips.length;
+    final aspectRatio = _clips.isEmpty
+        ? null
+        : _clips.first.targetAspectRatio.name;
+    unawaited(performance.startTrace(traceName));
+
     try {
       final renderParameters = _buildRenderParameters();
 
@@ -1139,13 +1154,19 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
         taskId: draftId,
       );
 
-      // A newer render was started while this one was running — discard.
-      if (generation != _renderGeneration) return;
+      // A newer render was started or the user cancelled while this one was
+      // running — the trace still stops in `finally`; tag it so the console can
+      // exclude non-completing renders from the generation-time distribution.
+      if (generation != _renderGeneration) {
+        performance.putAttribute(traceName, 'outcome', 'incomplete');
+        return;
+      }
 
       if (result == null) {
         // A user cancel bumps the generation and is caught above, so reaching
         // here with a matching generation is a genuine render failure — surface
         // the retry affordance (#6058).
+        performance.putAttribute(traceName, 'outcome', 'failed');
         Log.warning(
           '⚠️ Video render failed',
           name: 'VideoEditorNotifier',
@@ -1154,6 +1175,8 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
         state = state.copyWith(isProcessing: false, renderFailed: true);
         return;
       }
+
+      performance.putAttribute(traceName, 'outcome', 'success');
 
       final (finalRenderedClip, proofManifestJson) = result;
 
@@ -1187,7 +1210,11 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
       autosaveChanges();
     } catch (error, stackTrace) {
       // A newer render owns the processing flag now — leave it alone.
-      if (generation != _renderGeneration) return;
+      if (generation != _renderGeneration) {
+        performance.putAttribute(traceName, 'outcome', 'incomplete');
+        return;
+      }
+      performance.putAttribute(traceName, 'outcome', 'error');
       // Surface the failure (e.g. a hung/failed C2PA proof step) as an error +
       // retry so the user can restart the render instead of being stuck on the
       // processing overlay (#6058).
@@ -1199,6 +1226,12 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
         stackTrace: stackTrace,
       );
       state = state.copyWith(isProcessing: false, renderFailed: true);
+    } finally {
+      performance.putAttribute(traceName, 'clip_count', '$clipCount');
+      if (aspectRatio != null) {
+        performance.putAttribute(traceName, 'aspect_ratio', aspectRatio);
+      }
+      await performance.stopTrace(traceName);
     }
   }
 

--- a/mobile/lib/screens/video_recorder_screen.dart
+++ b/mobile/lib/screens/video_recorder_screen.dart
@@ -19,6 +19,7 @@ import 'package:openvine/models/video_recorder/video_recorder_mode.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/providers/overlay_visibility_provider.dart';
+import 'package:openvine/providers/service_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/providers/video_publish_provider.dart';
@@ -99,6 +100,7 @@ class _VideoRecorderBlocScope extends ConsumerWidget {
         readVideoEditor: () => ref.read(videoEditorProvider.notifier),
         readVideoEditorState: () => ref.read(videoEditorProvider),
         readSharedPreferences: () => ref.read(sharedPreferencesProvider),
+        performanceMonitor: ref.read(performanceMonitoringServiceProvider),
       ),
       child: child,
     );

--- a/mobile/lib/services/performance_monitoring_service.dart
+++ b/mobile/lib/services/performance_monitoring_service.dart
@@ -1,8 +1,26 @@
 // ABOUTME: Performance monitoring service for tracking app performance metrics
 // ABOUTME: Uses Firebase Performance Monitoring to track screen transitions, network requests, and custom operations
 
+import 'dart:async';
+
 import 'package:firebase_performance/firebase_performance.dart';
 import 'package:unified_logger/unified_logger.dart';
+
+/// A handle to a single started performance trace.
+///
+/// Callers capture the handle returned by
+/// [PerformanceTraceMonitor.startOperationTrace] and tag/stop *that* handle, so
+/// each operation owns its own trace. This avoids the name-keyed pitfalls of
+/// the legacy [PerformanceTraceMonitor.startTrace] API: a fast operation can't
+/// tag/stop before a shared registration completes, and two overlapping
+/// operations can't stop or re-attribute each other's trace.
+abstract class PerformanceTrace {
+  /// Adds an attribute for filtering in the Firebase console.
+  void putAttribute(String attribute, String value);
+
+  /// Stops the trace and records its duration.
+  Future<void> stop();
+}
 
 /// Minimal trace API used by services that need testable performance spans.
 abstract class PerformanceTraceMonitor {
@@ -10,11 +28,56 @@ abstract class PerformanceTraceMonitor {
 
   Future<void> stopTrace(String traceName);
 
+  /// Starts a trace and returns an operation-scoped [PerformanceTrace] handle.
+  /// Prefer this over [startTrace] for any operation that can overlap another
+  /// of the same name or complete before its trace round-trip settles. Returns
+  /// a no-op handle when monitoring is unavailable.
+  PerformanceTrace startOperationTrace(String traceName);
+
   void incrementMetric(String traceName, String metricName, int value);
 
   void setMetric(String traceName, String metricName, int value);
 
   void putAttribute(String traceName, String attribute, String value);
+}
+
+/// No-op [PerformanceTrace] returned when monitoring is unavailable.
+class _NoOpPerformanceTrace implements PerformanceTrace {
+  const _NoOpPerformanceTrace();
+
+  @override
+  void putAttribute(String attribute, String value) {}
+
+  @override
+  Future<void> stop() async {}
+}
+
+/// A [PerformanceTrace] backed by a live Firebase [Trace].
+class _FirebasePerformanceTrace implements PerformanceTrace {
+  _FirebasePerformanceTrace(this._trace);
+
+  final Trace _trace;
+
+  @override
+  void putAttribute(String attribute, String value) {
+    try {
+      _trace.putAttribute(attribute, value);
+    } catch (e) {
+      Log.error(
+        'Failed to put attribute $attribute: $e',
+        name: 'PerformanceMonitoring',
+      );
+    }
+  }
+
+  @override
+  Future<void> stop() async {
+    try {
+      await _trace.stop();
+    } catch (e) {
+      Log.error('Failed to stop trace: $e', name: 'PerformanceMonitoring');
+    }
+  }
 }
 
 /// No-op [PerformanceTraceMonitor] used as the default when no real monitor is
@@ -28,6 +91,10 @@ class NoOpPerformanceTraceMonitor implements PerformanceTraceMonitor {
 
   @override
   Future<void> stopTrace(String traceName) async {}
+
+  @override
+  PerformanceTrace startOperationTrace(String traceName) =>
+      const _NoOpPerformanceTrace();
 
   @override
   void incrementMetric(String traceName, String metricName, int value) {}
@@ -95,6 +162,37 @@ class PerformanceMonitoringService implements PerformanceTraceMonitor {
         'Failed to start trace $traceName: $e',
         name: 'PerformanceMonitoring',
       );
+    }
+  }
+
+  /// Start an operation-scoped trace and return its handle.
+  ///
+  /// Unlike [startTrace], nothing is stored in [_activeTraces]: the caller
+  /// owns the returned [PerformanceTrace] and tags/stops it directly, so
+  /// overlapping operations of the same name keep independent traces. Start is
+  /// fire-and-forget so callers stay synchronous; attribute/stop calls on the
+  /// handle are delivered to the platform in order after it.
+  @override
+  PerformanceTrace startOperationTrace(String traceName) {
+    if (!_initialized) return const _NoOpPerformanceTrace();
+
+    try {
+      final trace = _performance.newTrace(traceName);
+      unawaited(
+        trace.start().catchError((Object e) {
+          Log.error(
+            'Failed to start trace $traceName: $e',
+            name: 'PerformanceMonitoring',
+          );
+        }),
+      );
+      return _FirebasePerformanceTrace(trace);
+    } catch (e) {
+      Log.error(
+        'Failed to start trace $traceName: $e',
+        name: 'PerformanceMonitoring',
+      );
+      return const _NoOpPerformanceTrace();
     }
   }
 

--- a/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
+++ b/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
@@ -19,6 +19,7 @@ import 'package:openvine/models/video_recorder/video_recorder_state.dart';
 import 'package:openvine/models/video_recorder/video_recorder_timer_duration.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
+import 'package:openvine/services/performance_monitoring_service.dart';
 import 'package:openvine/services/video_recorder/camera/camera_base_service.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
@@ -31,6 +32,30 @@ import 'package:wakelock_plus_platform_interface/wakelock_plus_platform_interfac
 import '../../mocks/mock_path_provider_platform.dart';
 
 class _MockCameraService extends Mock implements CameraService {}
+
+/// Records trace calls so the `camera_startup` outcome mapping can be asserted;
+/// the bloc's default [NoOpPerformanceTraceMonitor] would swallow them.
+class _RecordingTraceMonitor implements PerformanceTraceMonitor {
+  final Map<String, String> attributes = {};
+  int startCount = 0;
+  int stopCount = 0;
+
+  @override
+  Future<void> startTrace(String traceName) async => startCount++;
+
+  @override
+  Future<void> stopTrace(String traceName) async => stopCount++;
+
+  @override
+  void putAttribute(String traceName, String attribute, String value) =>
+      attributes['$traceName.$attribute'] = value;
+
+  @override
+  void incrementMetric(String traceName, String metricName, int value) {}
+
+  @override
+  void setMetric(String traceName, String metricName, int value) {}
+}
 
 class _MockClipManager extends Mock implements ClipManagerNotifier {}
 
@@ -2027,6 +2052,65 @@ void main() {
             enabled: any(named: 'enabled'),
           ),
         ).thenAnswer((_) async => true);
+      });
+
+      group('camera_startup trace', () {
+        // Telemetry-only: a regression here mislabels a Firebase sample, not a
+        // user-facing bug — a touch belt-and-suspenders, kept so the outcome
+        // mapping can't silently rot.
+        late _RecordingTraceMonitor monitor;
+
+        setUp(() {
+          monitor = _RecordingTraceMonitor();
+        });
+
+        VideoRecorderBloc buildTraced() => VideoRecorderBloc(
+          readClipManager: () => clipManager,
+          readVideoEditor: () => videoEditor,
+          readVideoEditorState: VideoEditorProviderState.new,
+          readSharedPreferences: () => prefs,
+          cameraService: cameraService,
+          performanceMonitor: monitor,
+        );
+
+        blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+          'tags outcome=success and stops the trace when the camera '
+          'initializes',
+          build: buildTraced,
+          act: (bloc) => bloc.add(const VideoRecorderInitializeRequested()),
+          verify: (_) {
+            expect(monitor.attributes['camera_startup.outcome'], 'success');
+            expect(monitor.stopCount, 1);
+          },
+        );
+
+        blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+          'tags outcome=failed when initialize completes but the camera '
+          'never becomes ready',
+          setUp: () =>
+              when(() => cameraService.isInitialized).thenReturn(false),
+          build: buildTraced,
+          act: (bloc) => bloc.add(const VideoRecorderInitializeRequested()),
+          verify: (_) {
+            expect(monitor.attributes['camera_startup.outcome'], 'failed');
+          },
+        );
+
+        blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+          'tags outcome=error when initialize throws',
+          setUp: () => when(
+            () => cameraService.initialize(
+              videoQuality: any(named: 'videoQuality'),
+              initialLens: any(named: 'initialLens'),
+              enableAutoLensSwitch: any(named: 'enableAutoLensSwitch'),
+            ),
+          ).thenThrow(Exception('camera boom')),
+          build: buildTraced,
+          act: (bloc) => bloc.add(const VideoRecorderInitializeRequested()),
+          verify: (_) {
+            expect(monitor.attributes['camera_startup.outcome'], 'error');
+          },
+        );
       });
 
       blocTest<VideoRecorderBloc, VideoRecorderBlocState>(

--- a/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
+++ b/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
@@ -33,22 +33,40 @@ import '../../mocks/mock_path_provider_platform.dart';
 
 class _MockCameraService extends Mock implements CameraService {}
 
-/// Records trace calls so the `camera_startup` outcome mapping can be asserted;
-/// the bloc's default [NoOpPerformanceTraceMonitor] would swallow them.
-class _RecordingTraceMonitor implements PerformanceTraceMonitor {
+/// An operation-scoped trace handle that records its attributes and stop count.
+class _RecordingTrace implements PerformanceTrace {
   final Map<String, String> attributes = {};
-  int startCount = 0;
   int stopCount = 0;
 
   @override
-  Future<void> startTrace(String traceName) async => startCount++;
+  void putAttribute(String attribute, String value) =>
+      attributes[attribute] = value;
 
   @override
-  Future<void> stopTrace(String traceName) async => stopCount++;
+  Future<void> stop() async => stopCount++;
+}
+
+/// Hands out a [_RecordingTrace] per operation so the `camera_startup` outcome
+/// mapping can be asserted; the bloc's default [NoOpPerformanceTraceMonitor]
+/// would swallow it.
+class _RecordingTraceMonitor implements PerformanceTraceMonitor {
+  final List<_RecordingTrace> traces = [];
 
   @override
-  void putAttribute(String traceName, String attribute, String value) =>
-      attributes['$traceName.$attribute'] = value;
+  PerformanceTrace startOperationTrace(String traceName) {
+    final trace = _RecordingTrace();
+    traces.add(trace);
+    return trace;
+  }
+
+  @override
+  Future<void> startTrace(String traceName) async {}
+
+  @override
+  Future<void> stopTrace(String traceName) async {}
+
+  @override
+  void putAttribute(String traceName, String attribute, String value) {}
 
   @override
   void incrementMetric(String traceName, String metricName, int value) {}
@@ -2079,8 +2097,8 @@ void main() {
           build: buildTraced,
           act: (bloc) => bloc.add(const VideoRecorderInitializeRequested()),
           verify: (_) {
-            expect(monitor.attributes['camera_startup.outcome'], 'success');
-            expect(monitor.stopCount, 1);
+            expect(monitor.traces.single.attributes['outcome'], 'success');
+            expect(monitor.traces.single.stopCount, 1);
           },
         );
 
@@ -2092,7 +2110,7 @@ void main() {
           build: buildTraced,
           act: (bloc) => bloc.add(const VideoRecorderInitializeRequested()),
           verify: (_) {
-            expect(monitor.attributes['camera_startup.outcome'], 'failed');
+            expect(monitor.traces.single.attributes['outcome'], 'failed');
           },
         );
 
@@ -2108,7 +2126,7 @@ void main() {
           build: buildTraced,
           act: (bloc) => bloc.add(const VideoRecorderInitializeRequested()),
           verify: (_) {
-            expect(monitor.attributes['camera_startup.outcome'], 'error');
+            expect(monitor.traces.single.attributes['outcome'], 'error');
           },
         );
       });

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -39,28 +39,33 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 class _MockDraftStorageService extends Mock implements DraftStorageService {}
 
-/// Records every trace call so tests can assert the `video_generation` owner
-/// guard and outcome tagging — which the real (uninitialised) service would
-/// silently early-return on, leaving that logic uncovered.
+/// An operation-scoped trace handle that records its attributes and stop count
+/// so tests can assert the `video_generation` per-render trace behaviour —
+/// which the real (uninitialised) service would silently no-op.
+class _RecordingTrace implements PerformanceTrace {
+  _RecordingTrace(this.name);
+
+  final String name;
+  final Map<String, String> attributes = {};
+  int stopCount = 0;
+
+  @override
+  void putAttribute(String attribute, String value) =>
+      attributes[attribute] = value;
+
+  @override
+  Future<void> stop() async => stopCount++;
+}
+
+/// Hands out — and retains — a [_RecordingTrace] per [startOperationTrace] call.
 class _RecordingPerformanceMonitor extends PerformanceMonitoringService {
-  final List<String> started = [];
-  final List<String> stopped = [];
-  final Map<String, Map<String, String>> attributes = {};
-
-  int stopCountFor(String traceName) =>
-      stopped.where((t) => t == traceName).length;
-
-  String? outcomeFor(String traceName) => attributes[traceName]?['outcome'];
+  final List<_RecordingTrace> traces = [];
 
   @override
-  Future<void> startTrace(String traceName) async => started.add(traceName);
-
-  @override
-  Future<void> stopTrace(String traceName) async => stopped.add(traceName);
-
-  @override
-  void putAttribute(String traceName, String attribute, String value) {
-    (attributes[traceName] ??= {})[attribute] = value;
+  PerformanceTrace startOperationTrace(String traceName) {
+    final trace = _RecordingTrace(traceName);
+    traces.add(trace);
+    return trace;
   }
 }
 
@@ -1213,8 +1218,8 @@ void main() {
 
     group('video_generation trace', () {
       // Telemetry-only: a regression here mislabels a Firebase sample, not a
-      // user-facing bug — a touch belt-and-suspenders, kept so the owner-guard
-      // and outcome mapping can't silently rot.
+      // user-facing bug — a touch belt-and-suspenders, kept so the per-render
+      // trace scoping and outcome mapping can't silently rot.
       tearDown(() {
         VideoEditorRenderService.renderVideoToClipOverride = null;
       });
@@ -1232,7 +1237,8 @@ void main() {
       }
 
       test(
-        'a superseded render leaves the winning trace untouched (owner guard)',
+        'overlapping renders each own a trace, stopped once, with their own '
+        'attributes',
         () async {
           final notifier = container.read(videoEditorProvider.notifier);
           addOneClip();
@@ -1262,34 +1268,36 @@ void main() {
             originalAspectRatio: 9 / 16,
           );
 
-          // render1 = generation 1 (slow); render2 = generation 2 (fast) and
-          // takes ownership of the single-named trace.
+          // render1 = generation 1 (slow, superseded); render2 = generation 2
+          // (fast, winner). Each captures its own operation-scoped trace.
           final render1 = notifier.startRenderVideo();
           final render2 = notifier.startRenderVideo();
           expect(callCount, equals(2));
+          expect(
+            performanceMonitor.traces.length,
+            2,
+            reason: 'each render must start its own trace, not share one',
+          );
 
-          // The winning render finishes first: tags success, stops once.
           fastCompleter.complete((freshClip, null));
           await render2;
-          expect(performanceMonitor.stopCountFor('video_generation'), 1);
-          expect(performanceMonitor.outcomeFor('video_generation'), 'success');
-
-          // The superseded render finishes after — its finally must skip the
-          // trace, or it would double-stop and re-tag the winning render's
-          // trace as 'incomplete'.
           slowCompleter.complete((freshClip, null));
           await render1;
-          expect(
-            performanceMonitor.stopCountFor('video_generation'),
-            1,
-            reason: 'superseded render must not stop the winning trace again',
-          );
-          expect(
-            performanceMonitor.outcomeFor('video_generation'),
-            'success',
-            reason:
-                'superseded render must not overwrite outcome to incomplete',
-          );
+
+          final trace1 = performanceMonitor.traces[0];
+          final trace2 = performanceMonitor.traces[1];
+
+          // Each trace is stopped exactly once — neither render stops the
+          // other's trace.
+          expect(trace1.stopCount, 1);
+          expect(trace2.stopCount, 1);
+
+          // Each trace keeps its own outcome: the winner is success, the
+          // superseded render is incomplete (not overwritten onto the winner).
+          expect(trace2.attributes['outcome'], 'success');
+          expect(trace1.attributes['outcome'], 'incomplete');
+          expect(trace1.attributes['clip_count'], '1');
+          expect(trace2.attributes['clip_count'], '1');
         },
       );
 
@@ -1305,7 +1313,10 @@ void main() {
             }) async => null;
 
         await notifier.startRenderVideo();
-        expect(performanceMonitor.outcomeFor('video_generation'), 'failed');
+        expect(
+          performanceMonitor.traces.single.attributes['outcome'],
+          'failed',
+        );
       });
 
       test('tags outcome=error when the render throws', () async {
@@ -1320,7 +1331,10 @@ void main() {
             }) async => throw Exception('render boom');
 
         await notifier.startRenderVideo();
-        expect(performanceMonitor.outcomeFor('video_generation'), 'error');
+        expect(
+          performanceMonitor.traces.single.attributes['outcome'],
+          'error',
+        );
       });
     });
 

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -22,10 +22,12 @@ import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/providers/database_provider.dart';
+import 'package:openvine/providers/service_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/services/draft_storage_service.dart';
 import 'package:openvine/services/native_proofmode_service.dart';
+import 'package:openvine/services/performance_monitoring_service.dart';
 import 'package:openvine/services/video_editor/video_editor_audio_render.dart';
 import 'package:openvine/services/video_editor/video_editor_render_service.dart';
 import 'package:openvine/widgets/video_editor/sticker_editor/video_editor_sticker.dart';
@@ -37,15 +39,47 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 class _MockDraftStorageService extends Mock implements DraftStorageService {}
 
+/// Records every trace call so tests can assert the `video_generation` owner
+/// guard and outcome tagging — which the real (uninitialised) service would
+/// silently early-return on, leaving that logic uncovered.
+class _RecordingPerformanceMonitor extends PerformanceMonitoringService {
+  final List<String> started = [];
+  final List<String> stopped = [];
+  final Map<String, Map<String, String>> attributes = {};
+
+  int stopCountFor(String traceName) =>
+      stopped.where((t) => t == traceName).length;
+
+  String? outcomeFor(String traceName) => attributes[traceName]?['outcome'];
+
+  @override
+  Future<void> startTrace(String traceName) async => started.add(traceName);
+
+  @override
+  Future<void> stopTrace(String traceName) async => stopped.add(traceName);
+
+  @override
+  void putAttribute(String traceName, String attribute, String value) {
+    (attributes[traceName] ??= {})[attribute] = value;
+  }
+}
+
 void main() {
   group('VideoEditorProvider', () {
     late ProviderContainer container;
+    late _RecordingPerformanceMonitor performanceMonitor;
 
     setUp(() async {
       SharedPreferences.setMockInitialValues({});
       final prefs = await SharedPreferences.getInstance();
+      performanceMonitor = _RecordingPerformanceMonitor();
       container = ProviderContainer(
-        overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          performanceMonitoringServiceProvider.overrideWithValue(
+            performanceMonitor,
+          ),
+        ],
       );
     });
 
@@ -1174,6 +1208,119 @@ void main() {
               'updateCover must record the cover image path durably so cover '
               'displays survive finalRenderedClip being cleared',
         );
+      });
+    });
+
+    group('video_generation trace', () {
+      // Telemetry-only: a regression here mislabels a Firebase sample, not a
+      // user-facing bug — a touch belt-and-suspenders, kept so the owner-guard
+      // and outcome mapping can't silently rot.
+      tearDown(() {
+        VideoEditorRenderService.renderVideoToClipOverride = null;
+      });
+
+      void addOneClip() {
+        container
+            .read(clipManagerProvider.notifier)
+            .addClip(
+              limitClipDuration: false,
+              video: EditorVideo.file('/docs/clip.mp4'),
+              targetAspectRatio: .vertical,
+              originalAspectRatio: 9 / 16,
+              duration: const Duration(seconds: 2),
+            );
+      }
+
+      test(
+        'a superseded render leaves the winning trace untouched (owner guard)',
+        () async {
+          final notifier = container.read(videoEditorProvider.notifier);
+          addOneClip();
+
+          final slowCompleter = Completer<(DivineVideoClip, String?)?>();
+          final fastCompleter = Completer<(DivineVideoClip, String?)?>();
+          var callCount = 0;
+          VideoEditorRenderService.renderVideoToClipOverride =
+              ({
+                required clips,
+                required editorStateHistory,
+                parameters,
+                taskId,
+              }) {
+                callCount++;
+                return callCount == 1
+                    ? slowCompleter.future
+                    : fastCompleter.future;
+              };
+
+          final freshClip = DivineVideoClip(
+            id: 'fresh',
+            video: EditorVideo.file('/docs/fresh.mp4'),
+            duration: const Duration(seconds: 3),
+            recordedAt: DateTime.now(),
+            targetAspectRatio: .vertical,
+            originalAspectRatio: 9 / 16,
+          );
+
+          // render1 = generation 1 (slow); render2 = generation 2 (fast) and
+          // takes ownership of the single-named trace.
+          final render1 = notifier.startRenderVideo();
+          final render2 = notifier.startRenderVideo();
+          expect(callCount, equals(2));
+
+          // The winning render finishes first: tags success, stops once.
+          fastCompleter.complete((freshClip, null));
+          await render2;
+          expect(performanceMonitor.stopCountFor('video_generation'), 1);
+          expect(performanceMonitor.outcomeFor('video_generation'), 'success');
+
+          // The superseded render finishes after — its finally must skip the
+          // trace, or it would double-stop and re-tag the winning render's
+          // trace as 'incomplete'.
+          slowCompleter.complete((freshClip, null));
+          await render1;
+          expect(
+            performanceMonitor.stopCountFor('video_generation'),
+            1,
+            reason: 'superseded render must not stop the winning trace again',
+          );
+          expect(
+            performanceMonitor.outcomeFor('video_generation'),
+            'success',
+            reason:
+                'superseded render must not overwrite outcome to incomplete',
+          );
+        },
+      );
+
+      test('tags outcome=failed when the render returns null', () async {
+        final notifier = container.read(videoEditorProvider.notifier);
+        addOneClip();
+        VideoEditorRenderService.renderVideoToClipOverride =
+            ({
+              required clips,
+              required editorStateHistory,
+              parameters,
+              taskId,
+            }) async => null;
+
+        await notifier.startRenderVideo();
+        expect(performanceMonitor.outcomeFor('video_generation'), 'failed');
+      });
+
+      test('tags outcome=error when the render throws', () async {
+        final notifier = container.read(videoEditorProvider.notifier);
+        addOneClip();
+        VideoEditorRenderService.renderVideoToClipOverride =
+            ({
+              required clips,
+              required editorStateHistory,
+              parameters,
+              taskId,
+            }) async => throw Exception('render boom');
+
+        await notifier.startRenderVideo();
+        expect(performanceMonitor.outcomeFor('video_generation'), 'error');
       });
     });
 

--- a/mobile/test/services/performance_monitoring_service_test.dart
+++ b/mobile/test/services/performance_monitoring_service_test.dart
@@ -75,5 +75,30 @@ void main() {
         throwsException,
       );
     });
+
+    test(
+      'startOperationTrace returns a handle that tags and stops cleanly',
+      () async {
+        await service.initialize();
+
+        final trace = service.startOperationTrace('test_operation');
+
+        // Tagging and stopping the handle must be safe even when Firebase
+        // isn't configured (the uninitialised path returns a no-op handle).
+        trace.putAttribute('outcome', 'success');
+        await expectLater(trace.stop(), completes);
+      },
+    );
+  });
+
+  group(NoOpPerformanceTraceMonitor, () {
+    test('startOperationTrace hands out a no-op trace handle', () async {
+      const monitor = NoOpPerformanceTraceMonitor();
+
+      final trace = monitor.startOperationTrace('test_operation');
+      trace.putAttribute('outcome', 'success');
+
+      await expectLater(trace.stop(), completes);
+    });
   });
 }

--- a/mobile/test/services/video_event_service_startup_contract_test.dart
+++ b/mobile/test/services/video_event_service_startup_contract_test.dart
@@ -57,6 +57,11 @@ class _RecordingPerformanceMonitor implements PerformanceTraceMonitor {
   Future<void> stopTrace(String traceName) async {
     stoppedTraces.add(traceName);
   }
+
+  @override
+  PerformanceTrace startOperationTrace(String traceName) =>
+      // VideoEventService uses the name-keyed trace API, not the handle API.
+      throw UnimplementedError();
 }
 
 /// Asserts a feed-load trace was started once, stopped exactly once, and closed


### PR DESCRIPTION
Closes #6219

## Description

Adds two Firebase Performance **custom traces** to the video pipeline so we can measure, in production, how long two user-facing operations actually take. Both reuse the existing `PerformanceMonitoringService` / `PerformanceTraceMonitor` abstraction (the same one behind the `feed_load` and `video_upload` traces) — no new perf infrastructure.

**1. `video_generation`** — wraps the final export in `VideoEditorNotifier._runRenderVideo`, measuring the whole span the user waits for after "Done" (native encode + ProofMode + C2PA).

**2. `camera_startup`** — wraps the native camera bring-up (`_cameraService.initialize`) in `VideoRecorderBloc`, measuring how long that native `initialize()` call takes. There was no production timing for this before — the only camera benchmark (`camera_initialization_benchmark_test.dart`) is `skip: true` and mock-based, so it never measured real hardware.

Each trace carries attributes so the console can slice/filter:

| Trace | Attributes |
|---|---|
| `video_generation` | `outcome` (success / failed / error / incomplete), `clip_count`, `aspect_ratio` |
| `camera_startup` | `outcome` (success / failed / error), `lens`, `quality` |

Filter on `outcome=success` for a clean duration distribution.

### Why these design choices (non-obvious bits)

- **Both `startTrace` and `stopTrace` are fire-and-forget; the tagging + stop live in `finally`.** `startTrace` isn't awaited so render / camera-init dispatch stays synchronous — awaiting it would run `trace.start()`'s platform round-trip first (the existing overlapping-render test relies on that dispatch being synchronous). `stopTrace` isn't awaited either, so `trace.stop()`'s round-trip doesn't gate camera preview bring-up or render completion — the exact startup path `camera_startup` measures. The `finally` still runs on every path, including a user cancel (which bumps `_renderGeneration` without starting a new render), so the trace is always stopped and tagged.
- **Single-named trace + overlap ownership.** The service keys traces by name, so two overlapping `_runRenderVideo` calls would otherwise share the one `video_generation` trace and corrupt each other. A per-render `_videoGenerationTraceOwner` gates the tag/stop calls: once a newer render takes the trace over, the superseded render skips its trace ops so it can't mis-tag or prematurely stop the newer render's trace. A cancel-superseded render still owns its trace and stops it tagged `outcome=incomplete`, so it's excluded from the duration distribution rather than skewing it.
- **Camera trace via constructor injection.** `VideoRecorderBloc` is pure Dart (no `ref`), so a `PerformanceTraceMonitor` is injected with a `NoOpPerformanceTraceMonitor()` default (existing tests need no change) and wired to the real Firebase-backed monitor at the recorder screen's `BlocProvider`. Same pattern as `VideoEventService`.

**Related Issue:** 

## Out of Scope

- **Fleet-wide per-encode timing.** Every render type (reverse, transform, merge, crop, transition-seam, speed, watermark) funnels through the single static `VideoEditorRenderService.renderNativeVideoToFile`. Tracing there would cover them all with one hook, but the class is static and would need a small injection seam + test-safety work. Deferred; this PR covers the two user-facing operations only.
- **Sub-`initialize()` camera readiness.** `camera_startup` brackets the native `initialize()` call. Post-init steps (`_emitCameraSync`, stabilization-preference restore, remote-record wiring) run after the trace stops and are not measured.
- No dedicated trace-assertion unit tests — the provider injects the concrete monitor (a no-op in tests), and the existing render-outcome / camera-init path tests already exercise every branch the tracing sits on.

## Verification

- `dart format` — clean
- `flutter analyze lib` — No issues found
- `flutter test test/providers/video_editor_provider_test.dart` — 101/101
- `flutter test test/blocs/video_recorder/video_recorder_bloc_test.dart` — 83/83
- `flutter test test/screens/video_recorder_screen_test.dart` — 22/22
- `flutter test test/providers/video_recorder_audio_service_factory_test.dart` — green
- Pre-push hook (analyze + changed-file tests) — green

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
