### PR TITLE
fix(video-player): stop EventChannel sends while app is backgrounded

### DIFF
--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
@@ -978,7 +978,7 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
     }
 
     private func sendStateUpdateOnMain() {
-        guard let player, let sink = eventSink else { return }
+        guard !isBackgrounded, let player, let sink = eventSink else { return }
 
         let currentTime = CMTimeGetSeconds(player.currentTime())
         let actualPositionMs = currentTime.millisecondsClamped
@@ -1160,6 +1160,15 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
     /// Whether the player was playing before the app went to background.
     private var wasPlayingBeforePause = false
 
+    /// Suspends `EventChannel` sends while the app is backgrounded. A periodic
+    /// time-observer tick (or a KVO / end-of-item callback) firing during the
+    /// resign-active → suspend window would otherwise reach `sink(...)` after
+    /// the Flutter shell is torn down, throwing
+    /// `NSInternalInconsistencyException: Sending a message before the
+    /// FlutterEngine has been run.` This is the EventChannel analog of
+    /// `VideoTextureOutput.suspendFrameDelivery()`.
+    private var isBackgrounded = false
+
     func onAppBackgrounded() {
         // Stop the texture frame driver first. A display-link or
         // AVFoundation-notification frame delivered during the
@@ -1172,11 +1181,16 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         if wasPlayingBeforePause {
             player?.pause()
             audioOverlayManager.pauseAndDeactivateAll()
+            // Runs synchronously on the resign-active callback while the shell
+            // is still alive, so the final paused state reaches Dart before the
+            // gate below closes.
             sendStateUpdate()
         }
+        isBackgrounded = true
     }
 
     func onAppForegrounded() {
+        isBackgrounded = false
         textureOutput?.resumeFrameDelivery()
         if wasPlayingBeforePause {
             player?.play()

--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
@@ -1197,8 +1197,12 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             player?.rate = Float(speed)
             audioOverlayManager.resumeActive(speed: speed)
             wasPlayingBeforePause = false
-            sendStateUpdate()
         }
+        // Resync unconditionally: a status change suppressed by the gate
+        // while backgrounded (e.g. a paused item that failed on a dropped
+        // connection) would otherwise leave Dart on stale state until the
+        // next interaction.
+        sendStateUpdate()
     }
 
     // MARK: - Dispose


### PR DESCRIPTION
## Description

Fixes an iOS crash in the native `divine_video_player` package:
`DivineVideoPlayerInstance.sendStateUpdateOnMain()` →
`NSInternalInconsistencyException: Sending a message before the FlutterEngine has been run.`

**Root cause:** the `AVPlayer` periodic time observer (0.2s, main queue) — and other async player callbacks (KVO status/buffering, end-of-item, watchdogs) — call `sendStateUpdate()`, which sends on the `EventChannel` sink. During the iOS **resign-active → suspend** window the Flutter shell can already be torn down, but the sink closure is still non-nil (`onCancel`/`dispose()` only run on explicit Dart-side teardown, not on backgrounding). One such tick firing after teardown throws.

The **texture** path already guarded this exact window via `VideoTextureOutput.suspendFrameDelivery()` (see the comment in `onAppBackgrounded()`); the **EventChannel** path had no equivalent.

**Fix:** a new `isBackgrounded` flag gates `sendStateUpdateOnMain()`, driven by the existing `onAppBackgrounded()` / `onAppForegrounded()` lifecycle hooks (already fanned out from the plugin's `willResignActive` / `didBecomeActive` observers). It is set *after* the final synchronous paused-state send — which still runs while the shell is alive at resign-active — so the foreground path is unchanged and no legitimate updates are lost. The app declares no `audio` background mode, so playback is suspended in the background regardless.

Crashlytics: iOS, `owner: DEVELOPER`, recurring across `1.0.12` → `1.0.16`, `processState: BACKGROUND`.

**Related Issue:** Closes #6221

## Out of Scope

Hard-teardown paths (engine detach, OOM reclaim of the `FlutterViewController`, zombie-player replacement) are already covered by `detachFromEngine` / `dispose()` nulling the sink — untouched here. This PR only closes the background suspend-window gap.

## Verification

- Native Swift change only (no Dart / generated-code / ARB inputs touched; no ratchets affected).
- Manual test on device: play a video, background the app **during playback** (home / app switcher), return — no crash, playback + state resume correctly. Confirmed working.
- No native XCTest target exists in the `darwin/` package and iOS app-lifecycle isn't reproducible via the Dart test harness, so this is verified by iOS build + the manual background test above.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
