### PR TITLE
fix(media-cache): cancel in-flight downloads when app is backgrounded

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1761,12 +1761,17 @@ class _DivineAppState extends ConsumerState<DivineApp>
     // Tear down in-flight media downloads before the OS suspends the app.
     // On Apple platforms cupertino_http delivers NSURLSession callbacks
     // through a Dart FFI trampoline that aborts if the isolate is suspended
-    // mid-request. The caches stay usable and resume downloading on return.
+    // mid-request. Cancellation also latches a suspension so prefetch loops
+    // cannot re-arm fresh native requests in the same window; the latch is
+    // lifted on resume, when downloads work again.
     if (state == AppLifecycleState.paused ||
         state == AppLifecycleState.hidden ||
         state == AppLifecycleState.detached) {
       openVineMediaCache.cancelInFlightDownloads();
       openVineImageCache.cancelInFlightDownloads();
+    } else if (state == AppLifecycleState.resumed) {
+      openVineMediaCache.resumeDownloads();
+      openVineImageCache.resumeDownloads();
     }
   }
 

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1755,6 +1755,21 @@ class _DivineAppState extends ConsumerState<DivineApp>
     _memoryPressureHandler.onMemoryPressure();
   }
 
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    super.didChangeAppLifecycleState(state);
+    // Tear down in-flight media downloads before the OS suspends the app.
+    // On Apple platforms cupertino_http delivers NSURLSession callbacks
+    // through a Dart FFI trampoline that aborts if the isolate is suspended
+    // mid-request. The caches stay usable and resume downloading on return.
+    if (state == AppLifecycleState.paused ||
+        state == AppLifecycleState.hidden ||
+        state == AppLifecycleState.detached) {
+      openVineMediaCache.cancelInFlightDownloads();
+      openVineImageCache.cancelInFlightDownloads();
+    }
+  }
+
   /// Logs a memory snapshot at info and annotates Crashlytics custom keys so
   /// OOM crash reports carry the last-seen memory footprint and gauges.
   void _emitMemorySnapshot(MemorySnapshot snapshot) {

--- a/mobile/packages/media_cache/lib/src/cancellable_downloader.dart
+++ b/mobile/packages/media_cache/lib/src/cancellable_downloader.dart
@@ -54,6 +54,16 @@ abstract class CancellableDownloader {
     Map<String, String>? headers,
   });
 
+  /// Cancels every in-flight download without releasing the downloader.
+  ///
+  /// Unlike [close], the downloader stays usable afterwards — new [download]
+  /// calls still work. Used to tear down in-flight requests when the app is
+  /// backgrounded: on Apple platforms the native NSURLSession stack
+  /// (`cupertino_http`) delivers delegate callbacks through a Dart FFI
+  /// trampoline that aborts the process if the isolate is suspended while a
+  /// request is still in flight.
+  void cancelActiveDownloads();
+
   /// Releases any resources owned by this downloader.
   Future<void> close();
 }
@@ -109,6 +119,17 @@ class HttpCancellableDownloader implements CancellableDownloader {
     }
     await Future.wait<File?>(activeDownloads.map((download) => download.file));
     _client.close();
+  }
+
+  @override
+  void cancelActiveDownloads() {
+    if (_isClosed) return;
+    // Copy first: cancel() settles each download and removes it from the set
+    // via its onComplete callback, which would mutate _activeDownloads mid
+    // iteration. The client is left open so the downloader keeps working.
+    for (final download in _activeDownloads.toList(growable: false)) {
+      download.cancel();
+    }
   }
 }
 

--- a/mobile/packages/media_cache/lib/src/media_cache_manager.dart
+++ b/mobile/packages/media_cache/lib/src/media_cache_manager.dart
@@ -1335,6 +1335,16 @@ class MediaCacheManager extends CacheManager {
   /// isolate aborts the process in the FFI trampoline.
   void cancelInFlightDownloads() {
     if (_isClosed) return;
+    // Cancel manager-level operations first, mirroring [close]. An operation
+    // still awaiting _resolveBaseCacheDir() has not started its download yet,
+    // so it is absent from the downloader's active set; cancelling it here
+    // sets cancelledBeforeStart so startDownload() bails instead of issuing a
+    // fresh NSURLSession request after the isolate is already suspended.
+    for (final operation in _activeCancellableOperations.toList(
+      growable: false,
+    )) {
+      operation.cancel();
+    }
     _downloader.cancelActiveDownloads();
   }
 

--- a/mobile/packages/media_cache/lib/src/media_cache_manager.dart
+++ b/mobile/packages/media_cache/lib/src/media_cache_manager.dart
@@ -412,6 +412,13 @@ class MediaCacheManager extends CacheManager {
 
   bool _isClosed = false;
 
+  /// Latched by [cancelInFlightDownloads], cleared by [resumeDownloads].
+  /// While set, cancellable downloads complete with `null` instead of
+  /// reaching the network, so autonomous prefetch loops (disk prefetcher
+  /// cycles, [preCacheFiles] batches) cannot re-arm fresh native requests
+  /// after a background cancellation.
+  bool _downloadsSuspended = false;
+
   bool _isProcessingResponse(FileInfo fileInfo) =>
       fileInfo.statusCode == HttpStatus.accepted;
 
@@ -744,6 +751,14 @@ class MediaCacheManager extends CacheManager {
           getCachedFileSync(key) ??
           (aliasKey != null ? getCachedFileSync(aliasKey) : null);
       if (cached != null) return CancellableCacheOperation.completed(cached);
+    }
+
+    // Suspended (app backgrounded): refuse to start anything new. Prefetch
+    // loops keep requesting the next item after their current download is
+    // cancelled; without this gate they would re-arm fresh native requests
+    // right in the suspension window [cancelInFlightDownloads] just cleared.
+    if (_downloadsSuspended) {
+      return CancellableCacheOperation.fromDownload(_CompletedNullDownload());
     }
 
     // Join an in-flight download for the same key (started by either
@@ -1221,6 +1236,11 @@ class MediaCacheManager extends CacheManager {
 
     // Process in batches
     for (var i = 0; i < items.length; i += batchSize) {
+      // Backgrounded mid-run: stop opening new batches. The downloads would
+      // be refused by the suspension gate anyway; bailing here also skips
+      // the per-item cache probes. Callers re-trigger prefetch on the next
+      // interaction after resume.
+      if (_downloadsSuspended) return;
       final batch = <Future<File?>>[];
       final end = (i + batchSize > items.length) ? items.length : i + batchSize;
 
@@ -1326,15 +1346,24 @@ class MediaCacheManager extends CacheManager {
   @visibleForTesting
   Future<void> waitForPendingAliasWrites() => _aliasWriteQueue;
 
-  /// Cancels in-flight cancellable downloads without closing the manager.
+  /// Cancels in-flight cancellable downloads and suspends new ones without
+  /// closing the manager.
   ///
-  /// Unlike [close], the manager stays usable — new downloads work again once
-  /// the app resumes. Wire this to app-background transitions so in-flight
-  /// NSURLSession (`cupertino_http`) requests are torn down before the OS
-  /// suspends the Dart isolate; a late delegate callback into a suspended
-  /// isolate aborts the process in the FFI trampoline.
+  /// Unlike [close], the manager stays usable — cached files still resolve,
+  /// and downloads work again after [resumeDownloads]. Wire this to
+  /// app-background transitions so in-flight NSURLSession (`cupertino_http`)
+  /// requests are torn down before the OS suspends the Dart isolate; a late
+  /// delegate callback into a suspended isolate aborts the process in the
+  /// FFI trampoline.
+  ///
+  /// The suspension latch is required on top of the one-shot cancellation:
+  /// prefetch loops (disk prefetcher cycles, [preCacheFiles] batches) react
+  /// to a cancelled download by advancing to their next item, which would
+  /// otherwise start a fresh native request inside the same suspension
+  /// window.
   void cancelInFlightDownloads() {
     if (_isClosed) return;
+    _downloadsSuspended = true;
     // Cancel manager-level operations first, mirroring [close]. An operation
     // still awaiting _resolveBaseCacheDir() has not started its download yet,
     // so it is absent from the downloader's active set; cancelling it here
@@ -1346,6 +1375,15 @@ class MediaCacheManager extends CacheManager {
       operation.cancel();
     }
     _downloader.cancelActiveDownloads();
+  }
+
+  /// Lifts the download suspension latched by [cancelInFlightDownloads].
+  ///
+  /// Wire this to the app returning to the foreground
+  /// (`AppLifecycleState.resumed`) so prefetch and on-demand downloads work
+  /// again.
+  void resumeDownloads() {
+    _downloadsSuspended = false;
   }
 
   /// Closes this manager and releases owned downloader resources.

--- a/mobile/packages/media_cache/lib/src/media_cache_manager.dart
+++ b/mobile/packages/media_cache/lib/src/media_cache_manager.dart
@@ -1326,6 +1326,18 @@ class MediaCacheManager extends CacheManager {
   @visibleForTesting
   Future<void> waitForPendingAliasWrites() => _aliasWriteQueue;
 
+  /// Cancels in-flight cancellable downloads without closing the manager.
+  ///
+  /// Unlike [close], the manager stays usable — new downloads work again once
+  /// the app resumes. Wire this to app-background transitions so in-flight
+  /// NSURLSession (`cupertino_http`) requests are torn down before the OS
+  /// suspends the Dart isolate; a late delegate callback into a suspended
+  /// isolate aborts the process in the FFI trampoline.
+  void cancelInFlightDownloads() {
+    if (_isClosed) return;
+    _downloader.cancelActiveDownloads();
+  }
+
   /// Closes this manager and releases owned downloader resources.
   ///
   /// Cancels active cancellable downloads and completes pending cache

--- a/mobile/packages/media_cache/test/src/cancellable_downloader_test.dart
+++ b/mobile/packages/media_cache/test/src/cancellable_downloader_test.dart
@@ -115,6 +115,79 @@ void main() {
     });
 
     test(
+      'cancelActiveDownloads aborts in-flight downloads without closing '
+      'the client',
+      () async {
+        final client = _CallbackClient((request) async {
+          await (request as http.AbortableRequest).abortTrigger;
+          throw http.RequestAbortedException(request.url);
+        });
+        final downloader = HttpCancellableDownloader(client);
+        final target = File('${tempDir.path}/cancel_active.mp4');
+
+        final download = downloader.download(
+          url: 'https://example.com/cancel_active.mp4',
+          targetFile: target,
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        downloader.cancelActiveDownloads();
+
+        expect(await download.file, isNull);
+        expect(download.isCancelled, isTrue);
+        expect(client.closed, isFalse);
+        expect(target.existsSync(), isFalse);
+      },
+    );
+
+    test('download still works after cancelActiveDownloads', () async {
+      var firstRequest = true;
+      final client = _CallbackClient((request) async {
+        if (firstRequest) {
+          firstRequest = false;
+          await (request as http.AbortableRequest).abortTrigger;
+          throw http.RequestAbortedException(request.url);
+        }
+        return http.StreamedResponse(
+          Stream<List<int>>.fromIterable([utf8.encode('ok')]),
+          200,
+        );
+      });
+      final downloader = HttpCancellableDownloader(client);
+
+      final first = downloader.download(
+        url: 'https://example.com/first.mp4',
+        targetFile: File('${tempDir.path}/first.mp4'),
+      );
+      await Future<void>.delayed(Duration.zero);
+      downloader.cancelActiveDownloads();
+      await first.file;
+
+      final second = await downloader
+          .download(
+            url: 'https://example.com/second.mp4',
+            targetFile: File('${tempDir.path}/second.mp4'),
+          )
+          .file;
+
+      expect(second, isNotNull);
+      expect(second!.readAsStringSync(), equals('ok'));
+      expect(client.closed, isFalse);
+    });
+
+    test('cancelActiveDownloads is a no-op after close', () async {
+      final client = _CallbackClient(
+        (_) async => http.StreamedResponse(const Stream.empty(), 200),
+      );
+      final downloader = HttpCancellableDownloader(client);
+
+      await downloader.close();
+      downloader.cancelActiveDownloads();
+
+      expect(client.closed, isTrue);
+    });
+
+    test(
       'download after close completes with null without using client',
       () async {
         var sendCalled = false;

--- a/mobile/packages/media_cache/test/src/cancellable_downloader_test.dart
+++ b/mobile/packages/media_cache/test/src/cancellable_downloader_test.dart
@@ -140,6 +140,32 @@ void main() {
       },
     );
 
+    test('cancelActiveDownloads cancels every concurrent download', () async {
+      final client = _CallbackClient((request) async {
+        await (request as http.AbortableRequest).abortTrigger;
+        throw http.RequestAbortedException(request.url);
+      });
+      final downloader = HttpCancellableDownloader(client);
+
+      final first = downloader.download(
+        url: 'https://example.com/multi_first.mp4',
+        targetFile: File('${tempDir.path}/multi_first.mp4'),
+      );
+      final second = downloader.download(
+        url: 'https://example.com/multi_second.mp4',
+        targetFile: File('${tempDir.path}/multi_second.mp4'),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      downloader.cancelActiveDownloads();
+
+      expect(await first.file, isNull);
+      expect(await second.file, isNull);
+      expect(first.isCancelled, isTrue);
+      expect(second.isCancelled, isTrue);
+      expect(client.closed, isFalse);
+    });
+
     test('download still works after cancelActiveDownloads', () async {
       var firstRequest = true;
       final client = _CallbackClient((request) async {

--- a/mobile/packages/media_cache/test/src/helpers/mocks.dart
+++ b/mobile/packages/media_cache/test/src/helpers/mocks.dart
@@ -210,6 +210,17 @@ class FakeCancellableDownloader implements CancellableDownloader {
     return dl;
   }
 
+  /// Number of times [cancelActiveDownloads] was called.
+  int cancelActiveCallCount = 0;
+
+  @override
+  void cancelActiveDownloads() {
+    cancelActiveCallCount += 1;
+    for (final dl in downloads) {
+      dl.cancel();
+    }
+  }
+
   @override
   Future<void> close() async {
     closed = true;

--- a/mobile/packages/media_cache/test/src/media_cache_manager_mocked_test.dart
+++ b/mobile/packages/media_cache/test/src/media_cache_manager_mocked_test.dart
@@ -130,6 +130,99 @@ void main() {
           expect(await op.file, isNull);
         },
       );
+
+      test(
+        'suspends later preCacheFiles batches until resumeDownloads',
+        () async {
+          final downloader = FakeCancellableDownloader();
+          final timestamp = DateTime.now().millisecondsSinceEpoch;
+          cacheManager = TestableMediaCacheManager(
+            config: MediaCacheConfig(
+              cacheKey: 'cancel_inflight_batches_$timestamp',
+              enableSyncManifest: true,
+            ),
+            mockGetFileFromCache: (key) async => null,
+            downloaderOverride: downloader,
+          );
+
+          final preCacheFuture = cacheManager.preCacheFiles(
+            [
+              (url: 'https://example.com/v1.mp4', key: 'v1'),
+              (url: 'https://example.com/v2.mp4', key: 'v2'),
+              (url: 'https://example.com/v3.mp4', key: 'v3'),
+              (url: 'https://example.com/v4.mp4', key: 'v4'),
+            ],
+            batchSize: 2,
+          );
+          for (var i = 0; i < 50 && downloader.downloads.length < 2; i++) {
+            await Future<void>.delayed(const Duration(milliseconds: 1));
+          }
+          expect(downloader.downloads, hasLength(2));
+
+          // Backgrounding cancels batch 1. Cancellation resolves the batch's
+          // Future.wait, so without the suspension latch the loop would
+          // advance to batch 2 and issue two fresh native requests inside
+          // the same suspension window.
+          cacheManager.cancelInFlightDownloads();
+          for (var i = 0; i < 50 && downloader.downloads.length < 4; i++) {
+            await Future<void>.delayed(const Duration(milliseconds: 1));
+          }
+          expect(downloader.downloads, hasLength(2));
+          await preCacheFuture;
+
+          // Foregrounding lifts the latch; a fresh prefetch downloads again.
+          cacheManager.resumeDownloads();
+          final resumedFuture = cacheManager.preCacheFiles(
+            [
+              (url: 'https://example.com/v5.mp4', key: 'v5'),
+              (url: 'https://example.com/v6.mp4', key: 'v6'),
+            ],
+            batchSize: 2,
+          );
+          for (var i = 0; i < 50 && downloader.downloads.length < 4; i++) {
+            await Future<void>.delayed(const Duration(milliseconds: 1));
+          }
+          expect(downloader.downloads, hasLength(4));
+          downloader.downloads[2].completeNull();
+          downloader.downloads[3].completeNull();
+          await resumedFuture;
+        },
+      );
+
+      test(
+        'refuses new downloads while suspended and works after '
+        'resumeDownloads',
+        () async {
+          final downloader = FakeCancellableDownloader();
+          final timestamp = DateTime.now().millisecondsSinceEpoch;
+          cacheManager = TestableMediaCacheManager(
+            config: MediaCacheConfig(
+              cacheKey: 'cancel_inflight_suspend_$timestamp',
+              enableSyncManifest: true,
+            ),
+            downloaderOverride: downloader,
+          )..cancelInFlightDownloads();
+
+          final suspendedOp = cacheManager.cacheFileCancellable(
+            'https://example.com/video.mp4',
+            key: 'cancel_inflight_suspend_key',
+          );
+          expect(await suspendedOp.file, isNull);
+          expect(downloader.downloads, isEmpty);
+
+          cacheManager.resumeDownloads();
+          final resumedOp = cacheManager.cacheFileCancellable(
+            'https://example.com/video.mp4',
+            key: 'cancel_inflight_suspend_key',
+          );
+          for (var i = 0; i < 50 && downloader.downloads.isEmpty; i++) {
+            await Future<void>.delayed(const Duration(milliseconds: 1));
+          }
+          expect(downloader.downloads, hasLength(1));
+          downloader.downloads.single.completeNull();
+          expect(await resumedOp.file, isNull);
+        },
+      );
     });
 
     group('cacheFile', () {

--- a/mobile/packages/media_cache/test/src/media_cache_manager_mocked_test.dart
+++ b/mobile/packages/media_cache/test/src/media_cache_manager_mocked_test.dart
@@ -94,6 +94,42 @@ void main() {
         cacheManager.cancelInFlightDownloads();
         expect(downloader.cancelActiveCallCount, 0);
       });
+
+      test(
+        'cancels a deferred op before it issues a download',
+        () async {
+          final downloader = FakeCancellableDownloader();
+          final timestamp = DateTime.now().millisecondsSinceEpoch;
+          cacheManager = TestableMediaCacheManager(
+            config: MediaCacheConfig(
+              cacheKey: 'cancel_inflight_deferred_$timestamp',
+              enableSyncManifest: true,
+            ),
+            downloaderOverride: downloader,
+          );
+
+          // Register an operation but do not pump: it is suspended in the
+          // deferred _resolveBaseCacheDir window, before _downloader.download()
+          // has run, so it is not yet in the downloader's active set.
+          final op = cacheManager.cacheFileCancellable(
+            'https://example.com/video.mp4',
+            key: 'cancel_inflight_deferred_key',
+          );
+
+          cacheManager.cancelInFlightDownloads();
+
+          // Let the deferred startDownload resume. It must bail at the
+          // cancelledBeforeStart guard and never issue a download — otherwise
+          // a fresh NSURLSession request fires after the app is suspended.
+          for (var i = 0; i < 50 && downloader.downloads.isEmpty; i++) {
+            await Future<void>.delayed(const Duration(milliseconds: 1));
+          }
+
+          expect(downloader.downloads, isEmpty);
+          expect(op.isCancelled, isTrue);
+          expect(await op.file, isNull);
+        },
+      );
     });
 
     group('cacheFile', () {

--- a/mobile/packages/media_cache/test/src/media_cache_manager_mocked_test.dart
+++ b/mobile/packages/media_cache/test/src/media_cache_manager_mocked_test.dart
@@ -21,6 +21,9 @@ class _ThrowingCancellableDownloader implements CancellableDownloader {
   }
 
   @override
+  void cancelActiveDownloads() {}
+
+  @override
   Future<void> close() async {}
 }
 
@@ -45,6 +48,52 @@ void main() {
 
     tearDown(() {
       cacheManager.resetForTesting();
+    });
+
+    group('cancelInFlightDownloads', () {
+      test('forwards to the downloader without closing the manager', () async {
+        final downloader = FakeCancellableDownloader();
+        final timestamp = DateTime.now().millisecondsSinceEpoch;
+        cacheManager = TestableMediaCacheManager(
+          config: MediaCacheConfig(
+            cacheKey: 'cancel_inflight_$timestamp',
+            enableSyncManifest: true,
+          ),
+          mockGetFileFromCache: (key) async => null,
+          downloaderOverride: downloader,
+        );
+        expect(downloader.cancelActiveCallCount, 0);
+
+        cacheManager.cancelInFlightDownloads();
+
+        expect(downloader.cancelActiveCallCount, 1);
+        expect(downloader.closed, isFalse);
+      });
+
+      test('is a no-op once the manager is closed', () async {
+        final downloader = FakeCancellableDownloader();
+        final repo = MockCacheInfoRepository();
+        when(repo.open).thenAnswer((_) async => true);
+        when(repo.getAllObjects).thenAnswer((_) async => []);
+        when(repo.close).thenAnswer((_) async => true);
+
+        final timestamp = DateTime.now().millisecondsSinceEpoch;
+        cacheManager = TestableMediaCacheManager(
+          config: MediaCacheConfig(
+            cacheKey: 'cancel_inflight_closed_$timestamp',
+            enableSyncManifest: true,
+          ),
+          repoOverride: repo,
+          mockGetFileFromCache: (key) async => null,
+          downloaderOverride: downloader,
+        );
+
+        await cacheManager.close();
+        expect(downloader.closed, isTrue);
+
+        cacheManager.cancelInFlightDownloads();
+        expect(downloader.cancelActiveCallCount, 0);
+      });
     });
 
     group('cacheFile', () {


### PR DESCRIPTION
Closes #6223

## Description

iOS-only mitigation for a `cupertino_http` FFI crash seen in Crashlytics: `SIGABRT` in `DLRT_GetFfiCallbackMetadata` / `dart::SimpleHashMap::Lookup`, blamed on `_NativeCupertinoHttp_protocolTrampoline`.

`media_cache`'s cancellable downloader uses `cupertino_http` (NSURLSession) on Apple platforms. NSURLSession delivers delegate callbacks (`dataTask:didReceiveData:`) through a Dart FFI trampoline on its own OS threads, independent of the app lifecycle. When iOS suspends the app with a request still in flight, a late callback into the now-paused Dart isolate can't resolve its FFI callback metadata and aborts the process. Every sampled crash event had `processState: BACKGROUND`; the issue has been present since 1.0.5 and is still hitting the current 1.0.16 build.

This adds a lifecycle-driven teardown: on `paused` / `hidden` / `detached`, both media caches (`openVineMediaCache`, `openVineImageCache`) cancel their in-flight downloads, so no NSURLSession callbacks are pending when the OS suspends the isolate. The caches stay open and resume downloading on return.

Layering: the `media_cache` package gets a pure cancel hook — `MediaCacheManager.cancelInFlightDownloads()` → `CancellableDownloader.cancelActiveDownloads()` — with no Flutter-lifecycle dependency; the app layer (`_DivineAppState`, already a `WidgetsBindingObserver`) wires it to the lifecycle.

**Follow-up (2nd commit): also cancel deferred downloads.** `cancelInFlightDownloads()` initially cancelled only the downloader's active set, so an operation still awaiting `_resolveBaseCacheDir()` (the async `getTemporaryDirectory()` round-trip before `_downloader.download()` runs) was missed — `cancelledBeforeStart` stayed false, and on resume `startDownload()` would fire a fresh NSURLSession request after the isolate was suspended, i.e. the same crash. This is reachable at cold start because the image cache (`enableSyncManifest: false`) skips setting `_baseCacheDir` in `initialize()`, forcing the first grid load's ~20 concurrent thumbnail requests through that window. It now mirrors `close()`: cancel `_activeCancellableOperations` first (so `startDownload()` bails), then the downloader. Adds a regression test (verified red without the fix) plus a multi-concurrent downloader cancel test.

**Follow-up (3rd commit, review): suspend-latch so prefetch loops cannot re-arm.** The one-shot cancellation left a re-entry gap (flagged by review): prefetch loops react to a cancelled download by advancing to their next item — `preCacheFiles` resolves its batch `Future.wait` and opens the next batch, and the disk prefetcher cycle moves to the next video (nothing flips the feed's `isActive` on app-background, so `cancelCycle` may never run while frames are stopped) — re-arming fresh NSURLSession requests inside the same suspension window. `cancelInFlightDownloads()` now latches a suspension checked in `_cacheFileCancellable` (single choke point; placed after the cached fast-path so cached files still resolve) and at the top of each `preCacheFiles` batch; the new `resumeDownloads()` lifts it, wired to `AppLifecycleState.resumed` for both caches. Adds a multi-batch regression test (verified red without the latch) and a direct suspend/resume test.

**Why a mitigation and not a version bump:** `cupertino_http` 3.0.2 is already the latest on pub.dev and the app is on it; the earlier v2→v3 bump (#5102) shipped in 1.0.16 and did not fix this. This shrinks the suspension race window but can't fully close it — iOS may still deliver a callback during the suspend transition. If the crash rate stays material on a post-fix build, the reliable fix is routing the iOS `media_cache` path back to `dart:io` (which loses HTTP/2+3 and the shared AVPlayer connection pool), deliberately out of scope here.

**Related Issue:**

## Out of Scope

- The guaranteed fix (iOS `media_cache` → `dart:io` behind a flag), pending whether this mitigation is sufficient.
- Platform-gating the cancellation to Apple only — kept cross-platform on purpose; Android's `cronet_http` stack is also native and cancel-on-background is harmless there.
- Strengthening the `'cancelActiveDownloads is a no-op after close'` test (currently re-asserts `client.closed`) and adding an app-layer test for the `main.dart` lifecycle wiring — heavyweight, since the global cache singletons have no injection seam and the app layer is behavior-first.
- Tightening the `cancelActiveDownloads` "mid-iteration" code comment (removal is actually async, not synchronous) — cosmetic.

## Verification

- `flutter analyze` (media_cache): clean
- `flutter analyze lib/main.dart`: clean
- `flutter test` (media_cache): 204 passed, coverage 98.14% (≥ 98% gate)
- Follow-up fix: affected `media_cache` suites green (69 tests, incl. 2 new); the new deferred-cancel regression test was confirmed red against the pre-fix code, and the pre-push hook ran the changed-file tests green.
- Manual (iOS Simulator): feed scroll — prefetch/download/playback unaffected in the foreground; prefetch completes with `cancelled=false`, players create/dispose normally.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

