### PR TITLE
fix(crash): downgrade all NetworkImage HTTP failures to non-fatal

### DIFF
--- a/mobile/lib/utils/recoverable_flutter_error.dart
+++ b/mobile/lib/utils/recoverable_flutter_error.dart
@@ -24,13 +24,14 @@ String? classifyRecoverableFlutterError(FlutterErrorDetails details) {
   final context = details.context?.toDescription() ?? '';
   final hasRecoverableMediaHost = _containsRecoverableMediaHost(error);
 
-  // A raw NetworkImage load that fails with ANY non-2xx HTTP status is
+  // A raw NetworkImage load that fails with any non-200 HTTP status is
   // recoverable — the widget falls back to a placeholder. Flutter throws the
   // same NetworkImageLoadException ("HTTP request failed, statusCode: <code>")
-  // for 404 (missing), 401/403 (unauthorized), and 5xx (server error) alike,
-  // so match the status-agnostic prefix rather than a single code. Classified
-  // by Flutter's image-loading library/context rather than host, because a
-  // failed image from any source is recoverable.
+  // for every response where statusCode != 200 — 404 (missing), 401/403
+  // (unauthorized), and 5xx (server error) alike — so match the
+  // status-agnostic prefix rather than a single code. Classified by Flutter's
+  // image-loading library/context rather than host, because a failed image
+  // from any source is recoverable.
   final isImageHttpFailure =
       error.contains('HTTP request failed, statusCode: ') &&
       (library.contains('_network_image_io') ||

--- a/mobile/lib/utils/recoverable_flutter_error.dart
+++ b/mobile/lib/utils/recoverable_flutter_error.dart
@@ -24,11 +24,15 @@ String? classifyRecoverableFlutterError(FlutterErrorDetails details) {
   final context = details.context?.toDescription() ?? '';
   final hasRecoverableMediaHost = _containsRecoverableMediaHost(error);
 
-  // Image 404s are classified by Flutter's image-loading context rather than
-  // host, because a missing image from any source is recoverable — the app
-  // falls back to a placeholder.
-  final isImage404 =
-      error.contains('HTTP request failed, statusCode: 404') &&
+  // A raw NetworkImage load that fails with ANY non-2xx HTTP status is
+  // recoverable — the widget falls back to a placeholder. Flutter throws the
+  // same NetworkImageLoadException ("HTTP request failed, statusCode: <code>")
+  // for 404 (missing), 401/403 (unauthorized), and 5xx (server error) alike,
+  // so match the status-agnostic prefix rather than a single code. Classified
+  // by Flutter's image-loading library/context rather than host, because a
+  // failed image from any source is recoverable.
+  final isImageHttpFailure =
+      error.contains('HTTP request failed, statusCode: ') &&
       (library.contains('_network_image_io') ||
           context.contains('image codec') ||
           context.contains('image resource'));
@@ -57,7 +61,7 @@ String? classifyRecoverableFlutterError(FlutterErrorDetails details) {
   final isMediaCacheLoadFailure =
       details.exception is MediaCacheImageLoadException;
 
-  if (isImage404 ||
+  if (isImageHttpFailure ||
       isMediaHostLookup ||
       isInterruptedMediaDownload ||
       isMissingHttpHost ||

--- a/mobile/test/utils/recoverable_flutter_error_test.dart
+++ b/mobile/test/utils/recoverable_flutter_error_test.dart
@@ -23,6 +23,30 @@ void main() {
       );
     });
 
+    // A raw NetworkImage that fails with a non-404 HTTP status (401, 403, 500,
+    // …) is just as recoverable as a 404 — the widget falls back to a
+    // placeholder. Before this was broadened, only 404 was downgraded, so
+    // these slipped through as FATAL Crashlytics reports
+    // (issue 72eb9f44799fa6513097c0049f68bc3b was dominated by 401/500).
+    for (final statusCode in const [401, 403, 500, 502]) {
+      test('classifies image $statusCode codec failures as recoverable', () {
+        final details = FlutterErrorDetails(
+          exception: Exception(
+            'HTTP request failed, statusCode: $statusCode, '
+            'https://media.divine.video/hash.jpg. '
+            'Error thrown resolving an image codec.',
+          ),
+          context: ErrorDescription('resolving an image codec'),
+          library: 'image resource service',
+        );
+
+        expect(
+          classifyRecoverableFlutterError(details),
+          'Recoverable media load failure',
+        );
+      });
+    }
+
     test('classifies Divine media host lookup failures as recoverable', () {
       const details = FlutterErrorDetails(
         exception: SocketException("Failed host lookup: 'media.divine.video'"),


### PR DESCRIPTION
Closes #6229

## What

Broaden `classifyRecoverableFlutterError` so that a raw Flutter `NetworkImage` load failing with **any** non-2xx HTTP status is treated as a non-fatal, recoverable media error — not just `statusCode: 404`.

## Why

Crashlytics issue `72eb9f44799fa6513097c0049f68bc3b` ("`NetworkImage._loadAsync` — HTTP request failed") is reported as **FATAL** on iOS production (last seen 1.0.16).

The app already downgrades recoverable image-load errors to non-fatal in `recoverable_flutter_error.dart`, but the check only matched `HTTP request failed, statusCode: 404`. Flutter throws the **same** `NetworkImageLoadException` for every non-200 response (`response.statusCode != HttpStatus.ok`), so 401/403/5xx failures fell through to `recordFlutterFatalError` and were logged as fatal crashes.

The 15 most recent events for this issue confirm the pattern — no 404s remain (those are already downgraded), and it is now dominated by:

- **statusCode 401** — 12 events (`media.divine.video`, `blossom.primal.net`)
- **statusCode 500** — 3 events (`media.divine.video`)

A missing/forbidden/erroring thumbnail is recoverable in every case: the widget falls back to a placeholder. Matching the status-agnostic prefix (kept behind the same image library/context guard) closes the leak for all statuses and stays host-agnostic, which also covers the `blossom.primal.net` avatar events.

## Changes

- `isImage404` → `isImageHttpFailure`: match `HTTP request failed, statusCode: ` instead of the `404` literal.
- Regression tests for 401/403/500/502 using the real Flutter error shape (`library: 'image resource service'`, `context: 'resolving an image codec'`).

## Testing

- `flutter analyze lib/utils/recoverable_flutter_error.dart test/utils/recoverable_flutter_error_test.dart` — clean
- `flutter test test/utils/recoverable_flutter_error_test.dart` — 12/12 pass

## Note

The underlying source is still the raw `NetworkImage` bypass in `video_thumbnail_widget.dart` (`_shouldBypassCacheManager`), which sidesteps `VineCachedImage`. This PR reliably stops the fatal reports via error classification; migrating that bypass off raw `NetworkImage` is a larger, separate change with desktop-reliability tradeoffs and is intentionally out of scope here.