### PR TITLE
feat(drafts): add duplicate project option

### DIFF
--- a/mobile/lib/blocs/drafts_library/drafts_library_bloc.dart
+++ b/mobile/lib/blocs/drafts_library/drafts_library_bloc.dart
@@ -21,17 +21,23 @@ class DraftsLibraryBloc extends Bloc<DraftsLibraryEvent, DraftsLibraryState> {
     : _draftStorageService = draftStorageService,
       super(const DraftsLibraryInitial()) {
     on<DraftsLibraryLoadRequested>(_onLoadRequested, transformer: droppable());
-    on<DraftsLibraryDuplicateRequested>(
-      _onDuplicateRequested,
-      transformer: sequential(),
-    );
-    on<DraftsLibraryDeleteRequested>(
-      _onDeleteRequested,
-      transformer: sequential(),
-    );
+    // Duplicate and delete share ONE sequential queue so their handlers never
+    // interleave; separate buckets would let one finish mid-flight and emit a
+    // stale draft list (see [DraftsLibraryMutationEvent]).
+    on<DraftsLibraryMutationEvent>(_onMutation, transformer: sequential());
   }
 
   final DraftStorageService _draftStorageService;
+
+  Future<void> _onMutation(
+    DraftsLibraryMutationEvent event,
+    Emitter<DraftsLibraryState> emit,
+  ) {
+    return switch (event) {
+      DraftsLibraryDuplicateRequested() => _onDuplicateRequested(event, emit),
+      DraftsLibraryDeleteRequested() => _onDeleteRequested(event, emit),
+    };
+  }
 
   Future<void> _onLoadRequested(
     DraftsLibraryLoadRequested event,

--- a/mobile/lib/blocs/drafts_library/drafts_library_bloc.dart
+++ b/mobile/lib/blocs/drafts_library/drafts_library_bloc.dart
@@ -21,6 +21,10 @@ class DraftsLibraryBloc extends Bloc<DraftsLibraryEvent, DraftsLibraryState> {
     : _draftStorageService = draftStorageService,
       super(const DraftsLibraryInitial()) {
     on<DraftsLibraryLoadRequested>(_onLoadRequested, transformer: droppable());
+    on<DraftsLibraryDuplicateRequested>(
+      _onDuplicateRequested,
+      transformer: sequential(),
+    );
     on<DraftsLibraryDeleteRequested>(
       _onDeleteRequested,
       transformer: sequential(),
@@ -69,12 +73,64 @@ class DraftsLibraryBloc extends Bloc<DraftsLibraryEvent, DraftsLibraryState> {
     }
   }
 
+  Future<void> _onDuplicateRequested(
+    DraftsLibraryDuplicateRequested event,
+    Emitter<DraftsLibraryState> emit,
+  ) async {
+    final currentDrafts = switch (state) {
+      DraftsLibraryLoaded(:final drafts) ||
+      DraftsLibraryDraftDuplicated(:final drafts) ||
+      DraftsLibraryDuplicateFailed(:final drafts) ||
+      DraftsLibraryDraftDeleted(:final drafts) ||
+      DraftsLibraryDeleteFailed(:final drafts) => drafts,
+      _ => null,
+    };
+    if (currentDrafts == null) return;
+
+    DivineVideoDraft? source;
+    for (final draft in currentDrafts) {
+      if (draft.id == event.draftId) {
+        source = draft;
+        break;
+      }
+    }
+    if (source == null) return;
+
+    try {
+      Log.info(
+        '📚 Duplicating draft: ${event.draftId}',
+        name: 'DraftsLibraryBloc',
+        category: LogCategory.video,
+      );
+
+      final copy = source.duplicate(title: event.newTitle);
+      await _draftStorageService.saveDraft(copy);
+
+      final updatedDrafts = [...currentDrafts, copy]
+        ..sort((a, b) => b.lastModified.compareTo(a.lastModified));
+
+      emit(DraftsLibraryDraftDuplicated(drafts: updatedDrafts));
+      emit(DraftsLibraryLoaded(drafts: updatedDrafts));
+    } catch (e, stackTrace) {
+      Log.error(
+        '📚 Failed to duplicate draft: $e',
+        name: 'DraftsLibraryBloc',
+        category: LogCategory.video,
+      );
+      addError(e, stackTrace);
+      emit(DraftsLibraryDuplicateFailed(drafts: currentDrafts));
+      emit(DraftsLibraryLoaded(drafts: currentDrafts));
+    }
+  }
+
   Future<void> _onDeleteRequested(
     DraftsLibraryDeleteRequested event,
     Emitter<DraftsLibraryState> emit,
   ) async {
     final currentDrafts = switch (state) {
       DraftsLibraryLoaded(:final drafts) ||
+      DraftsLibraryDraftDuplicated(:final drafts) ||
+      DraftsLibraryDuplicateFailed(:final drafts) ||
       DraftsLibraryDraftDeleted(:final drafts) ||
       DraftsLibraryDeleteFailed(:final drafts) => drafts,
       _ => null,

--- a/mobile/lib/blocs/drafts_library/drafts_library_event.dart
+++ b/mobile/lib/blocs/drafts_library/drafts_library_event.dart
@@ -16,8 +16,20 @@ final class DraftsLibraryLoadRequested extends DraftsLibraryEvent {
   const DraftsLibraryLoadRequested();
 }
 
+/// Base class for events that mutate the persisted draft list (duplicate,
+/// delete).
+///
+/// These share a single `sequential()` queue in [DraftsLibraryBloc] so their
+/// handlers never interleave: each reads the current list, awaits a storage
+/// write, then emits the updated list. Registering them in separate buckets
+/// would let a delete complete mid-duplicate (or vice versa) and emit a stale
+/// snapshot that resurrects a deleted draft or drops a fresh copy.
+sealed class DraftsLibraryMutationEvent extends DraftsLibraryEvent {
+  const DraftsLibraryMutationEvent();
+}
+
 /// Event to duplicate a specific draft into a new independent project.
-final class DraftsLibraryDuplicateRequested extends DraftsLibraryEvent {
+final class DraftsLibraryDuplicateRequested extends DraftsLibraryMutationEvent {
   const DraftsLibraryDuplicateRequested(this.draftId, {this.newTitle});
 
   /// The ID of the draft to duplicate.
@@ -31,7 +43,7 @@ final class DraftsLibraryDuplicateRequested extends DraftsLibraryEvent {
 }
 
 /// Event to delete a specific draft.
-final class DraftsLibraryDeleteRequested extends DraftsLibraryEvent {
+final class DraftsLibraryDeleteRequested extends DraftsLibraryMutationEvent {
   const DraftsLibraryDeleteRequested(this.draftId);
 
   /// The ID of the draft to delete.

--- a/mobile/lib/blocs/drafts_library/drafts_library_event.dart
+++ b/mobile/lib/blocs/drafts_library/drafts_library_event.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Events for DraftsLibraryBloc - managing draft video projects
-// ABOUTME: Supports loading, and deleting drafts from the library
+// ABOUTME: Supports loading, duplicating, and deleting drafts from the library
 
 part of 'drafts_library_bloc.dart';
 
@@ -14,6 +14,20 @@ sealed class DraftsLibraryEvent extends Equatable {
 /// Event to load all drafts from storage.
 final class DraftsLibraryLoadRequested extends DraftsLibraryEvent {
   const DraftsLibraryLoadRequested();
+}
+
+/// Event to duplicate a specific draft into a new independent project.
+final class DraftsLibraryDuplicateRequested extends DraftsLibraryEvent {
+  const DraftsLibraryDuplicateRequested(this.draftId, {this.newTitle});
+
+  /// The ID of the draft to duplicate.
+  final String draftId;
+
+  /// Title for the copy. When null, the original title is kept.
+  final String? newTitle;
+
+  @override
+  List<Object?> get props => [draftId, newTitle];
 }
 
 /// Event to delete a specific draft.

--- a/mobile/lib/blocs/drafts_library/drafts_library_state.dart
+++ b/mobile/lib/blocs/drafts_library/drafts_library_state.dart
@@ -32,6 +32,28 @@ final class DraftsLibraryLoaded extends DraftsLibraryState {
   List<Object?> get props => [drafts];
 }
 
+/// A draft was successfully duplicated.
+final class DraftsLibraryDraftDuplicated extends DraftsLibraryState {
+  const DraftsLibraryDraftDuplicated({required this.drafts});
+
+  /// Updated list of drafts including the new copy.
+  final List<DivineVideoDraft> drafts;
+
+  @override
+  List<Object?> get props => [drafts];
+}
+
+/// Draft duplication failed.
+final class DraftsLibraryDuplicateFailed extends DraftsLibraryState {
+  const DraftsLibraryDuplicateFailed({required this.drafts});
+
+  /// Original list of drafts (unchanged due to failure).
+  final List<DivineVideoDraft> drafts;
+
+  @override
+  List<Object?> get props => [drafts];
+}
+
 /// A draft was successfully deleted.
 final class DraftsLibraryDraftDeleted extends DraftsLibraryState {
   const DraftsLibraryDraftDeleted({required this.drafts});

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -2809,6 +2809,20 @@
     "libraryNoClipsYetTitle": "እስካሁን ምንም ክሊፖች የሉም",
     "libraryNoClipsYetSubtitle": "የተቀዱ የቪዲዮ ቅንጥቦችህ እዚህ ይታያሉ",
     "libraryDraftDeletedSnackbar": "ረቂቅ ተሰርዟል።",
+    "libraryDraftDuplicatedSnackbar": "ረቂቅ ተባዝቷል።",
+    "libraryDraftDuplicateFailedSnackbar": "ረቂቅን ማባዛት አልተሳካም።",
+    "libraryDraftActionDuplicate": "አባዛ",
+    "libraryDraftCopyTitle": "{title} (ቅጂ {number})",
+    "@libraryDraftCopyTitle": {
+        "placeholders": {
+            "title": {
+                "type": "String"
+            },
+            "number": {
+                "type": "int"
+            }
+        }
+    },
     "libraryDraftDeleteFailedSnackbar": "ረቂቅን መሰረዝ አልተሳካም።",
     "libraryDraftActionPost": "ለጥፍ",
     "libraryDraftActionEdit": "አርትዕ",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2429,6 +2429,20 @@
     "libraryDraftActionPost": "نشر",
     "libraryDraftDeleteFailedSnackbar": "تعذّر حذف المسودة",
     "libraryDraftDeletedSnackbar": "تم حذف المسودة",
+    "libraryDraftDuplicatedSnackbar": "تم تكرار المسودة",
+    "libraryDraftDuplicateFailedSnackbar": "تعذّر تكرار المسودة",
+    "libraryDraftActionDuplicate": "تكرار",
+    "libraryDraftCopyTitle": "{title} (نسخة {number})",
+    "@libraryDraftCopyTitle": {
+        "placeholders": {
+            "title": {
+                "type": "String"
+            },
+            "number": {
+                "type": "int"
+            }
+        }
+    },
     "libraryGalleryPermissionDenied": "تم رفض إذن {destination}",
     "@libraryGalleryPermissionDenied": {
         "placeholders": {

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -2639,6 +2639,20 @@
     "libraryNoClipsYetTitle": "Още няма клипове",
     "libraryNoClipsYetSubtitle": "Записаните ти видео клипове ще се появят тук",
     "libraryDraftDeletedSnackbar": "Черновата е изтрита",
+    "libraryDraftDuplicatedSnackbar": "Черновата е дублирана",
+    "libraryDraftDuplicateFailedSnackbar": "Не успяхме да дублираме черновата",
+    "libraryDraftActionDuplicate": "Дублирай",
+    "libraryDraftCopyTitle": "{title} (копие {number})",
+    "@libraryDraftCopyTitle": {
+        "placeholders": {
+            "title": {
+                "type": "String"
+            },
+            "number": {
+                "type": "int"
+            }
+        }
+    },
     "libraryDraftDeleteFailedSnackbar": "Не успяхме да изтрием черновата",
     "libraryDraftActionPost": "Публикувай",
     "libraryDraftActionEdit": "Редактиране",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2437,6 +2437,20 @@
     "libraryDraftActionPost": "Posten",
     "libraryDraftDeleteFailedSnackbar": "Entwurf konnte nicht gelöscht werden",
     "libraryDraftDeletedSnackbar": "Entwurf gelöscht",
+    "libraryDraftDuplicatedSnackbar": "Entwurf dupliziert",
+    "libraryDraftDuplicateFailedSnackbar": "Entwurf konnte nicht dupliziert werden",
+    "libraryDraftActionDuplicate": "Duplizieren",
+    "libraryDraftCopyTitle": "{title} (Kopie {number})",
+    "@libraryDraftCopyTitle": {
+        "placeholders": {
+            "title": {
+                "type": "String"
+            },
+            "number": {
+                "type": "int"
+            }
+        }
+    },
     "libraryGalleryPermissionDenied": "{destination}: Berechtigung verweigert",
     "@libraryGalleryPermissionDenied": {
         "placeholders": {

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -3570,9 +3570,24 @@
   "libraryNoClipsYetSubtitle": "Your recorded video clips will appear here",
   "libraryDraftDeletedSnackbar": "Draft deleted",
   "libraryDraftDeleteFailedSnackbar": "Failed to delete draft",
+  "libraryDraftDuplicatedSnackbar": "Draft duplicated",
+  "libraryDraftDuplicateFailedSnackbar": "Failed to duplicate draft",
   "libraryDraftActionPost": "Post",
   "libraryDraftActionEdit": "Edit",
+  "libraryDraftActionDuplicate": "Duplicate",
   "libraryDraftActionDelete": "Delete draft",
+  "libraryDraftCopyTitle": "{title} (copy {number})",
+  "@libraryDraftCopyTitle": {
+    "description": "Title given to a duplicated draft. {number} disambiguates repeated copies, e.g. \"Trip (copy 2)\".",
+    "placeholders": {
+      "title": {
+        "type": "String"
+      },
+      "number": {
+        "type": "int"
+      }
+    }
+  },
   "libraryDeleteDraftTitle": "Delete Draft",
   "libraryDeleteDraftMessage": "Are you sure you want to delete \"{title}\"?",
   "@libraryDeleteDraftMessage": {

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2445,6 +2445,20 @@
     "libraryDraftActionPost": "Publicar",
     "libraryDraftDeleteFailedSnackbar": "No se pudo eliminar el borrador",
     "libraryDraftDeletedSnackbar": "Borrador eliminado",
+    "libraryDraftDuplicatedSnackbar": "Borrador duplicado",
+    "libraryDraftDuplicateFailedSnackbar": "No se pudo duplicar el borrador",
+    "libraryDraftActionDuplicate": "Duplicar",
+    "libraryDraftCopyTitle": "{title} (copia {number})",
+    "@libraryDraftCopyTitle": {
+        "placeholders": {
+            "title": {
+                "type": "String"
+            },
+            "number": {
+                "type": "int"
+            }
+        }
+    },
     "libraryGalleryPermissionDenied": "Permiso denegado para {destination}",
     "@libraryGalleryPermissionDenied": {
         "placeholders": {

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1546,6 +1546,20 @@
     "libraryNoClipsYetTitle": "Wala Pang Clip",
     "libraryNoClipsYetSubtitle": "Lalabas dito ang mga na-record mong video clip",
     "libraryDraftDeletedSnackbar": "Nabura ang draft",
+    "libraryDraftDuplicatedSnackbar": "Na-duplicate ang draft",
+    "libraryDraftDuplicateFailedSnackbar": "Hindi na-duplicate ang draft",
+    "libraryDraftActionDuplicate": "I-duplicate",
+    "libraryDraftCopyTitle": "{title} (kopya {number})",
+    "@libraryDraftCopyTitle": {
+        "placeholders": {
+            "title": {
+                "type": "String"
+            },
+            "number": {
+                "type": "int"
+            }
+        }
+    },
     "libraryDraftDeleteFailedSnackbar": "Hindi nabura ang draft",
     "libraryDraftActionPost": "I-post",
     "libraryDraftActionEdit": "I-edit",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2437,6 +2437,20 @@
     "libraryDraftActionPost": "Publier",
     "libraryDraftDeleteFailedSnackbar": "Échec de la suppression du brouillon",
     "libraryDraftDeletedSnackbar": "Brouillon supprimé",
+    "libraryDraftDuplicatedSnackbar": "Brouillon dupliqué",
+    "libraryDraftDuplicateFailedSnackbar": "Échec de la duplication du brouillon",
+    "libraryDraftActionDuplicate": "Dupliquer",
+    "libraryDraftCopyTitle": "{title} (copie {number})",
+    "@libraryDraftCopyTitle": {
+        "placeholders": {
+            "title": {
+                "type": "String"
+            },
+            "number": {
+                "type": "int"
+            }
+        }
+    },
     "libraryGalleryPermissionDenied": "Permission refusée pour {destination}",
     "@libraryGalleryPermissionDenied": {
         "placeholders": {

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2436,6 +2436,20 @@
     "libraryDraftActionPost": "Posting",
     "libraryDraftDeleteFailedSnackbar": "Gagal menghapus draf",
     "libraryDraftDeletedSnackbar": "Draf dihapus",
+    "libraryDraftDuplicatedSnackbar": "Draf diduplikat",
+    "libraryDraftDuplicateFailedSnackbar": "Gagal menduplikat draf",
+    "libraryDraftActionDuplicate": "Duplikat",
+    "libraryDraftCopyTitle": "{title} (salinan {number})",
+    "@libraryDraftCopyTitle": {
+        "placeholders": {
+            "title": {
+                "type": "String"
+            },
+            "number": {
+                "type": "int"
+            }
+        }
+    },
     "libraryGalleryPermissionDenied": "Izin ditolak untuk {destination}",
     "@libraryGalleryPermissionDenied": {
         "placeholders": {

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2437,6 +2437,20 @@
     "libraryDraftActionPost": "Pubblica",
     "libraryDraftDeleteFailedSnackbar": "Eliminazione bozza non riuscita",
     "libraryDraftDeletedSnackbar": "Bozza eliminata",
+    "libraryDraftDuplicatedSnackbar": "Bozza duplicata",
+    "libraryDraftDuplicateFailedSnackbar": "Duplicazione bozza non riuscita",
+    "libraryDraftActionDuplicate": "Duplica",
+    "libraryDraftCopyTitle": "{title} (copia {number})",
+    "@libraryDraftCopyTitle": {
+        "placeholders": {
+            "title": {
+                "type": "String"
+            },
+            "number": {
+                "type": "int"
+            }
+        }
+    },
     "libraryGalleryPermissionDenied": "Permesso negato per {destination}",
     "@libraryGalleryPermissionDenied": {
         "placeholders": {

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2429,6 +2429,20 @@
     "libraryDraftActionPost": "投稿",
     "libraryDraftDeleteFailedSnackbar": "下書きを削除できませんでした",
     "libraryDraftDeletedSnackbar": "下書きを削除しました",
+    "libraryDraftDuplicatedSnackbar": "下書きを複製しました",
+    "libraryDraftDuplicateFailedSnackbar": "下書きを複製できませんでした",
+    "libraryDraftActionDuplicate": "複製",
+    "libraryDraftCopyTitle": "{title}（コピー {number}）",
+    "@libraryDraftCopyTitle": {
+        "placeholders": {
+            "title": {
+                "type": "String"
+            },
+            "number": {
+                "type": "int"
+            }
+        }
+    },
     "libraryGalleryPermissionDenied": "{destination}の権限が拒否されました",
     "@libraryGalleryPermissionDenied": {
         "placeholders": {

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1760,6 +1760,20 @@
     "libraryDraftActionPost": "게시",
     "libraryDraftDeleteFailedSnackbar": "임시 저장을 삭제하지 못했어요",
     "libraryDraftDeletedSnackbar": "임시 저장을 삭제했어요",
+    "libraryDraftDuplicatedSnackbar": "임시 저장을 복제했어요",
+    "libraryDraftDuplicateFailedSnackbar": "임시 저장을 복제하지 못했어요",
+    "libraryDraftActionDuplicate": "복제",
+    "libraryDraftCopyTitle": "{title} (사본 {number})",
+    "@libraryDraftCopyTitle": {
+        "placeholders": {
+            "title": {
+                "type": "String"
+            },
+            "number": {
+                "type": "int"
+            }
+        }
+    },
     "libraryGalleryPermissionDenied": "{destination} 권한이 거부되었어요",
     "@libraryGalleryPermissionDenied": {
         "placeholders": {

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2437,6 +2437,20 @@
     "libraryDraftActionPost": "Plaatsen",
     "libraryDraftDeleteFailedSnackbar": "Concept verwijderen mislukt",
     "libraryDraftDeletedSnackbar": "Concept verwijderd",
+    "libraryDraftDuplicatedSnackbar": "Concept gedupliceerd",
+    "libraryDraftDuplicateFailedSnackbar": "Concept dupliceren mislukt",
+    "libraryDraftActionDuplicate": "Dupliceren",
+    "libraryDraftCopyTitle": "{title} (kopie {number})",
+    "@libraryDraftCopyTitle": {
+        "placeholders": {
+            "title": {
+                "type": "String"
+            },
+            "number": {
+                "type": "int"
+            }
+        }
+    },
     "libraryGalleryPermissionDenied": "Toestemming geweigerd voor {destination}",
     "@libraryGalleryPermissionDenied": {
         "placeholders": {

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2437,6 +2437,20 @@
     "libraryDraftActionPost": "Opublikuj",
     "libraryDraftDeleteFailedSnackbar": "Nie udało się usunąć wersji roboczej",
     "libraryDraftDeletedSnackbar": "Usunięto wersję roboczą",
+    "libraryDraftDuplicatedSnackbar": "Zduplikowano wersję roboczą",
+    "libraryDraftDuplicateFailedSnackbar": "Nie udało się zduplikować wersji roboczej",
+    "libraryDraftActionDuplicate": "Duplikuj",
+    "libraryDraftCopyTitle": "{title} (kopia {number})",
+    "@libraryDraftCopyTitle": {
+        "placeholders": {
+            "title": {
+                "type": "String"
+            },
+            "number": {
+                "type": "int"
+            }
+        }
+    },
     "libraryGalleryPermissionDenied": "Odmowa uprawnień: {destination}",
     "@libraryGalleryPermissionDenied": {
         "placeholders": {

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2437,6 +2437,20 @@
     "libraryDraftActionPost": "Publicar",
     "libraryDraftDeleteFailedSnackbar": "Falha ao excluir rascunho",
     "libraryDraftDeletedSnackbar": "Rascunho excluído",
+    "libraryDraftDuplicatedSnackbar": "Rascunho duplicado",
+    "libraryDraftDuplicateFailedSnackbar": "Falha ao duplicar rascunho",
+    "libraryDraftActionDuplicate": "Duplicar",
+    "libraryDraftCopyTitle": "{title} (cópia {number})",
+    "@libraryDraftCopyTitle": {
+        "placeholders": {
+            "title": {
+                "type": "String"
+            },
+            "number": {
+                "type": "int"
+            }
+        }
+    },
     "libraryGalleryPermissionDenied": "Permissão negada para {destination}",
     "@libraryGalleryPermissionDenied": {
         "placeholders": {

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2437,6 +2437,20 @@
     "libraryDraftActionPost": "Publică",
     "libraryDraftDeleteFailedSnackbar": "Nu s-a putut șterge ciorna",
     "libraryDraftDeletedSnackbar": "Ciornă ștearsă",
+    "libraryDraftDuplicatedSnackbar": "Ciornă duplicată",
+    "libraryDraftDuplicateFailedSnackbar": "Nu s-a putut duplica ciorna",
+    "libraryDraftActionDuplicate": "Duplică",
+    "libraryDraftCopyTitle": "{title} (copie {number})",
+    "@libraryDraftCopyTitle": {
+        "placeholders": {
+            "title": {
+                "type": "String"
+            },
+            "number": {
+                "type": "int"
+            }
+        }
+    },
     "libraryGalleryPermissionDenied": "Permisiune refuzată pentru {destination}",
     "@libraryGalleryPermissionDenied": {
         "placeholders": {

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2437,6 +2437,20 @@
     "libraryDraftActionPost": "Publicera",
     "libraryDraftDeleteFailedSnackbar": "Det gick inte att ta bort utkastet",
     "libraryDraftDeletedSnackbar": "Utkast borttaget",
+    "libraryDraftDuplicatedSnackbar": "Utkast duplicerat",
+    "libraryDraftDuplicateFailedSnackbar": "Det gick inte att duplicera utkastet",
+    "libraryDraftActionDuplicate": "Duplicera",
+    "libraryDraftCopyTitle": "{title} (kopia {number})",
+    "@libraryDraftCopyTitle": {
+        "placeholders": {
+            "title": {
+                "type": "String"
+            },
+            "number": {
+                "type": "int"
+            }
+        }
+    },
     "libraryGalleryPermissionDenied": "Behörighet nekad för {destination}",
     "@libraryGalleryPermissionDenied": {
         "placeholders": {

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2436,6 +2436,20 @@
     "libraryDraftActionPost": "Paylaş",
     "libraryDraftDeleteFailedSnackbar": "Taslak silinemedi",
     "libraryDraftDeletedSnackbar": "Taslak silindi",
+    "libraryDraftDuplicatedSnackbar": "Taslak çoğaltıldı",
+    "libraryDraftDuplicateFailedSnackbar": "Taslak çoğaltılamadı",
+    "libraryDraftActionDuplicate": "Çoğalt",
+    "libraryDraftCopyTitle": "{title} (kopya {number})",
+    "@libraryDraftCopyTitle": {
+        "placeholders": {
+            "title": {
+                "type": "String"
+            },
+            "number": {
+                "type": "int"
+            }
+        }
+    },
     "libraryGalleryPermissionDenied": "{destination} izni reddedildi",
     "@libraryGalleryPermissionDenied": {
         "placeholders": {

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -10542,6 +10542,18 @@ abstract class AppLocalizations {
   /// **'Failed to delete draft'**
   String get libraryDraftDeleteFailedSnackbar;
 
+  /// No description provided for @libraryDraftDuplicatedSnackbar.
+  ///
+  /// In en, this message translates to:
+  /// **'Draft duplicated'**
+  String get libraryDraftDuplicatedSnackbar;
+
+  /// No description provided for @libraryDraftDuplicateFailedSnackbar.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to duplicate draft'**
+  String get libraryDraftDuplicateFailedSnackbar;
+
   /// No description provided for @libraryDraftActionPost.
   ///
   /// In en, this message translates to:
@@ -10554,11 +10566,23 @@ abstract class AppLocalizations {
   /// **'Edit'**
   String get libraryDraftActionEdit;
 
+  /// No description provided for @libraryDraftActionDuplicate.
+  ///
+  /// In en, this message translates to:
+  /// **'Duplicate'**
+  String get libraryDraftActionDuplicate;
+
   /// No description provided for @libraryDraftActionDelete.
   ///
   /// In en, this message translates to:
   /// **'Delete draft'**
   String get libraryDraftActionDelete;
+
+  /// Title given to a duplicated draft. {number} disambiguates repeated copies, e.g. "Trip (copy 2)".
+  ///
+  /// In en, this message translates to:
+  /// **'{title} (copy {number})'**
+  String libraryDraftCopyTitle(String title, int number);
 
   /// No description provided for @libraryDeleteDraftTitle.
   ///

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -5915,13 +5915,27 @@ class AppLocalizationsAm extends AppLocalizations {
   String get libraryDraftDeleteFailedSnackbar => 'ረቂቅን መሰረዝ አልተሳካም።';
 
   @override
+  String get libraryDraftDuplicatedSnackbar => 'ረቂቅ ተባዝቷል።';
+
+  @override
+  String get libraryDraftDuplicateFailedSnackbar => 'ረቂቅን ማባዛት አልተሳካም።';
+
+  @override
   String get libraryDraftActionPost => 'ለጥፍ';
 
   @override
   String get libraryDraftActionEdit => 'አርትዕ';
 
   @override
+  String get libraryDraftActionDuplicate => 'አባዛ';
+
+  @override
   String get libraryDraftActionDelete => 'ረቂቅ ሰርዝ';
+
+  @override
+  String libraryDraftCopyTitle(String title, int number) {
+    return '$title (ቅጂ $number)';
+  }
 
   @override
   String get libraryDeleteDraftTitle => 'ረቂቅ ሰርዝ';

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -5999,13 +5999,27 @@ class AppLocalizationsAr extends AppLocalizations {
   String get libraryDraftDeleteFailedSnackbar => 'تعذّر حذف المسودة';
 
   @override
+  String get libraryDraftDuplicatedSnackbar => 'تم تكرار المسودة';
+
+  @override
+  String get libraryDraftDuplicateFailedSnackbar => 'تعذّر تكرار المسودة';
+
+  @override
   String get libraryDraftActionPost => 'نشر';
 
   @override
   String get libraryDraftActionEdit => 'تعديل';
 
   @override
+  String get libraryDraftActionDuplicate => 'تكرار';
+
+  @override
   String get libraryDraftActionDelete => 'حذف المسودة';
+
+  @override
+  String libraryDraftCopyTitle(String title, int number) {
+    return '$title (نسخة $number)';
+  }
 
   @override
   String get libraryDeleteDraftTitle => 'حذف المسودة';

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -6094,13 +6094,28 @@ class AppLocalizationsBg extends AppLocalizations {
       'Не успяхме да изтрием черновата';
 
   @override
+  String get libraryDraftDuplicatedSnackbar => 'Черновата е дублирана';
+
+  @override
+  String get libraryDraftDuplicateFailedSnackbar =>
+      'Не успяхме да дублираме черновата';
+
+  @override
   String get libraryDraftActionPost => 'Публикувай';
 
   @override
   String get libraryDraftActionEdit => 'Редактиране';
 
   @override
+  String get libraryDraftActionDuplicate => 'Дублирай';
+
+  @override
   String get libraryDraftActionDelete => 'Изтрий черновата';
+
+  @override
+  String libraryDraftCopyTitle(String title, int number) {
+    return '$title (копие $number)';
+  }
 
   @override
   String get libraryDeleteDraftTitle => 'Изтрий чернова';

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -6105,13 +6105,28 @@ class AppLocalizationsDe extends AppLocalizations {
       'Entwurf konnte nicht gelöscht werden';
 
   @override
+  String get libraryDraftDuplicatedSnackbar => 'Entwurf dupliziert';
+
+  @override
+  String get libraryDraftDuplicateFailedSnackbar =>
+      'Entwurf konnte nicht dupliziert werden';
+
+  @override
   String get libraryDraftActionPost => 'Posten';
 
   @override
   String get libraryDraftActionEdit => 'Bearbeiten';
 
   @override
+  String get libraryDraftActionDuplicate => 'Duplizieren';
+
+  @override
   String get libraryDraftActionDelete => 'Entwurf löschen';
+
+  @override
+  String libraryDraftCopyTitle(String title, int number) {
+    return '$title (Kopie $number)';
+  }
 
   @override
   String get libraryDeleteDraftTitle => 'Entwurf löschen';

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -6029,13 +6029,27 @@ class AppLocalizationsEn extends AppLocalizations {
   String get libraryDraftDeleteFailedSnackbar => 'Failed to delete draft';
 
   @override
+  String get libraryDraftDuplicatedSnackbar => 'Draft duplicated';
+
+  @override
+  String get libraryDraftDuplicateFailedSnackbar => 'Failed to duplicate draft';
+
+  @override
   String get libraryDraftActionPost => 'Post';
 
   @override
   String get libraryDraftActionEdit => 'Edit';
 
   @override
+  String get libraryDraftActionDuplicate => 'Duplicate';
+
+  @override
   String get libraryDraftActionDelete => 'Delete draft';
+
+  @override
+  String libraryDraftCopyTitle(String title, int number) {
+    return '$title (copy $number)';
+  }
 
   @override
   String get libraryDeleteDraftTitle => 'Delete Draft';

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -6081,13 +6081,28 @@ class AppLocalizationsEs extends AppLocalizations {
       'No se pudo eliminar el borrador';
 
   @override
+  String get libraryDraftDuplicatedSnackbar => 'Borrador duplicado';
+
+  @override
+  String get libraryDraftDuplicateFailedSnackbar =>
+      'No se pudo duplicar el borrador';
+
+  @override
   String get libraryDraftActionPost => 'Publicar';
 
   @override
   String get libraryDraftActionEdit => 'Editar';
 
   @override
+  String get libraryDraftActionDuplicate => 'Duplicar';
+
+  @override
   String get libraryDraftActionDelete => 'Eliminar borrador';
+
+  @override
+  String libraryDraftCopyTitle(String title, int number) {
+    return '$title (copia $number)';
+  }
 
   @override
   String get libraryDeleteDraftTitle => 'Eliminar borrador';

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -6104,13 +6104,28 @@ class AppLocalizationsFil extends AppLocalizations {
   String get libraryDraftDeleteFailedSnackbar => 'Hindi nabura ang draft';
 
   @override
+  String get libraryDraftDuplicatedSnackbar => 'Na-duplicate ang draft';
+
+  @override
+  String get libraryDraftDuplicateFailedSnackbar =>
+      'Hindi na-duplicate ang draft';
+
+  @override
   String get libraryDraftActionPost => 'I-post';
 
   @override
   String get libraryDraftActionEdit => 'I-edit';
 
   @override
+  String get libraryDraftActionDuplicate => 'I-duplicate';
+
+  @override
   String get libraryDraftActionDelete => 'Burahin ang draft';
+
+  @override
+  String libraryDraftCopyTitle(String title, int number) {
+    return '$title (kopya $number)';
+  }
 
   @override
   String get libraryDeleteDraftTitle => 'Burahin ang Draft';

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -6111,13 +6111,28 @@ class AppLocalizationsFr extends AppLocalizations {
       'Échec de la suppression du brouillon';
 
   @override
+  String get libraryDraftDuplicatedSnackbar => 'Brouillon dupliqué';
+
+  @override
+  String get libraryDraftDuplicateFailedSnackbar =>
+      'Échec de la duplication du brouillon';
+
+  @override
   String get libraryDraftActionPost => 'Publier';
 
   @override
   String get libraryDraftActionEdit => 'Modifier';
 
   @override
+  String get libraryDraftActionDuplicate => 'Dupliquer';
+
+  @override
   String get libraryDraftActionDelete => 'Supprimer le brouillon';
+
+  @override
+  String libraryDraftCopyTitle(String title, int number) {
+    return '$title (copie $number)';
+  }
 
   @override
   String get libraryDeleteDraftTitle => 'Supprimer le brouillon';

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -6009,13 +6009,27 @@ class AppLocalizationsId extends AppLocalizations {
   String get libraryDraftDeleteFailedSnackbar => 'Gagal menghapus draf';
 
   @override
+  String get libraryDraftDuplicatedSnackbar => 'Draf diduplikat';
+
+  @override
+  String get libraryDraftDuplicateFailedSnackbar => 'Gagal menduplikat draf';
+
+  @override
   String get libraryDraftActionPost => 'Posting';
 
   @override
   String get libraryDraftActionEdit => 'Edit';
 
   @override
+  String get libraryDraftActionDuplicate => 'Duplikat';
+
+  @override
   String get libraryDraftActionDelete => 'Hapus draf';
+
+  @override
+  String libraryDraftCopyTitle(String title, int number) {
+    return '$title (salinan $number)';
+  }
 
   @override
   String get libraryDeleteDraftTitle => 'Hapus draf';

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -6085,13 +6085,28 @@ class AppLocalizationsIt extends AppLocalizations {
       'Eliminazione bozza non riuscita';
 
   @override
+  String get libraryDraftDuplicatedSnackbar => 'Bozza duplicata';
+
+  @override
+  String get libraryDraftDuplicateFailedSnackbar =>
+      'Duplicazione bozza non riuscita';
+
+  @override
   String get libraryDraftActionPost => 'Pubblica';
 
   @override
   String get libraryDraftActionEdit => 'Modifica';
 
   @override
+  String get libraryDraftActionDuplicate => 'Duplica';
+
+  @override
   String get libraryDraftActionDelete => 'Elimina bozza';
+
+  @override
+  String libraryDraftCopyTitle(String title, int number) {
+    return '$title (copia $number)';
+  }
 
   @override
   String get libraryDeleteDraftTitle => 'Elimina bozza';

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -5787,13 +5787,27 @@ class AppLocalizationsJa extends AppLocalizations {
   String get libraryDraftDeleteFailedSnackbar => '下書きを削除できませんでした';
 
   @override
+  String get libraryDraftDuplicatedSnackbar => '下書きを複製しました';
+
+  @override
+  String get libraryDraftDuplicateFailedSnackbar => '下書きを複製できませんでした';
+
+  @override
   String get libraryDraftActionPost => '投稿';
 
   @override
   String get libraryDraftActionEdit => '編集';
 
   @override
+  String get libraryDraftActionDuplicate => '複製';
+
+  @override
   String get libraryDraftActionDelete => '下書きを削除';
+
+  @override
+  String libraryDraftCopyTitle(String title, int number) {
+    return '$title（コピー $number）';
+  }
 
   @override
   String get libraryDeleteDraftTitle => '下書きを削除';

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -5815,13 +5815,27 @@ class AppLocalizationsKo extends AppLocalizations {
   String get libraryDraftDeleteFailedSnackbar => '임시 저장을 삭제하지 못했어요';
 
   @override
+  String get libraryDraftDuplicatedSnackbar => '임시 저장을 복제했어요';
+
+  @override
+  String get libraryDraftDuplicateFailedSnackbar => '임시 저장을 복제하지 못했어요';
+
+  @override
   String get libraryDraftActionPost => '게시';
 
   @override
   String get libraryDraftActionEdit => '편집';
 
   @override
+  String get libraryDraftActionDuplicate => '복제';
+
+  @override
   String get libraryDraftActionDelete => '임시 저장 삭제';
+
+  @override
+  String libraryDraftCopyTitle(String title, int number) {
+    return '$title (사본 $number)';
+  }
 
   @override
   String get libraryDeleteDraftTitle => '임시 저장 삭제';

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -6062,13 +6062,28 @@ class AppLocalizationsNl extends AppLocalizations {
   String get libraryDraftDeleteFailedSnackbar => 'Concept verwijderen mislukt';
 
   @override
+  String get libraryDraftDuplicatedSnackbar => 'Concept gedupliceerd';
+
+  @override
+  String get libraryDraftDuplicateFailedSnackbar =>
+      'Concept dupliceren mislukt';
+
+  @override
   String get libraryDraftActionPost => 'Plaatsen';
 
   @override
   String get libraryDraftActionEdit => 'Bewerken';
 
   @override
+  String get libraryDraftActionDuplicate => 'Dupliceren';
+
+  @override
   String get libraryDraftActionDelete => 'Concept verwijderen';
+
+  @override
+  String libraryDraftCopyTitle(String title, int number) {
+    return '$title (kopie $number)';
+  }
 
   @override
   String get libraryDeleteDraftTitle => 'Concept verwijderen';

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -6188,13 +6188,28 @@ class AppLocalizationsPl extends AppLocalizations {
       'Nie udało się usunąć wersji roboczej';
 
   @override
+  String get libraryDraftDuplicatedSnackbar => 'Zduplikowano wersję roboczą';
+
+  @override
+  String get libraryDraftDuplicateFailedSnackbar =>
+      'Nie udało się zduplikować wersji roboczej';
+
+  @override
   String get libraryDraftActionPost => 'Opublikuj';
 
   @override
   String get libraryDraftActionEdit => 'Edytuj';
 
   @override
+  String get libraryDraftActionDuplicate => 'Duplikuj';
+
+  @override
   String get libraryDraftActionDelete => 'Usuń wersję roboczą';
+
+  @override
+  String libraryDraftCopyTitle(String title, int number) {
+    return '$title (kopia $number)';
+  }
 
   @override
   String get libraryDeleteDraftTitle => 'Usuń wersję roboczą';

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -6070,13 +6070,28 @@ class AppLocalizationsPt extends AppLocalizations {
   String get libraryDraftDeleteFailedSnackbar => 'Falha ao excluir rascunho';
 
   @override
+  String get libraryDraftDuplicatedSnackbar => 'Rascunho duplicado';
+
+  @override
+  String get libraryDraftDuplicateFailedSnackbar =>
+      'Falha ao duplicar rascunho';
+
+  @override
   String get libraryDraftActionPost => 'Publicar';
 
   @override
   String get libraryDraftActionEdit => 'Editar';
 
   @override
+  String get libraryDraftActionDuplicate => 'Duplicar';
+
+  @override
   String get libraryDraftActionDelete => 'Excluir rascunho';
+
+  @override
+  String libraryDraftCopyTitle(String title, int number) {
+    return '$title (cópia $number)';
+  }
 
   @override
   String get libraryDeleteDraftTitle => 'Excluir rascunho';

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -6186,13 +6186,28 @@ class AppLocalizationsRo extends AppLocalizations {
   String get libraryDraftDeleteFailedSnackbar => 'Nu s-a putut șterge ciorna';
 
   @override
+  String get libraryDraftDuplicatedSnackbar => 'Ciornă duplicată';
+
+  @override
+  String get libraryDraftDuplicateFailedSnackbar =>
+      'Nu s-a putut duplica ciorna';
+
+  @override
   String get libraryDraftActionPost => 'Publică';
 
   @override
   String get libraryDraftActionEdit => 'Editează';
 
   @override
+  String get libraryDraftActionDuplicate => 'Duplică';
+
+  @override
   String get libraryDraftActionDelete => 'Șterge ciorna';
+
+  @override
+  String libraryDraftCopyTitle(String title, int number) {
+    return '$title (copie $number)';
+  }
 
   @override
   String get libraryDeleteDraftTitle => 'Șterge ciorna';

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -6030,13 +6030,28 @@ class AppLocalizationsSv extends AppLocalizations {
       'Det gick inte att ta bort utkastet';
 
   @override
+  String get libraryDraftDuplicatedSnackbar => 'Utkast duplicerat';
+
+  @override
+  String get libraryDraftDuplicateFailedSnackbar =>
+      'Det gick inte att duplicera utkastet';
+
+  @override
   String get libraryDraftActionPost => 'Publicera';
 
   @override
   String get libraryDraftActionEdit => 'Redigera';
 
   @override
+  String get libraryDraftActionDuplicate => 'Duplicera';
+
+  @override
   String get libraryDraftActionDelete => 'Ta bort utkast';
+
+  @override
+  String libraryDraftCopyTitle(String title, int number) {
+    return '$title (kopia $number)';
+  }
 
   @override
   String get libraryDeleteDraftTitle => 'Ta bort utkast';

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -6013,13 +6013,27 @@ class AppLocalizationsTr extends AppLocalizations {
   String get libraryDraftDeleteFailedSnackbar => 'Taslak silinemedi';
 
   @override
+  String get libraryDraftDuplicatedSnackbar => 'Taslak çoğaltıldı';
+
+  @override
+  String get libraryDraftDuplicateFailedSnackbar => 'Taslak çoğaltılamadı';
+
+  @override
   String get libraryDraftActionPost => 'Paylaş';
 
   @override
   String get libraryDraftActionEdit => 'Düzenle';
 
   @override
+  String get libraryDraftActionDuplicate => 'Çoğalt';
+
+  @override
   String get libraryDraftActionDelete => 'Taslağı sil';
+
+  @override
+  String libraryDraftCopyTitle(String title, int number) {
+    return '$title (kopya $number)';
+  }
 
   @override
   String get libraryDeleteDraftTitle => 'Taslağı sil';

--- a/mobile/lib/models/divine_video_draft.dart
+++ b/mobile/lib/models/divine_video_draft.dart
@@ -392,6 +392,50 @@ class DivineVideoDraft {
 
   static const _sentinel = Object();
 
+  /// Returns an independent copy of this draft as a brand-new project.
+  ///
+  /// The copy gets a fresh [id] and `createdAt`/`lastModified` timestamps, and
+  /// its publish state is reset (`draft` status, no attempts, no error, no
+  /// [sourceDraftId]) so it starts clean. Pass [title] to rename the copy,
+  /// otherwise the original title is kept.
+  ///
+  /// Clip and rendered-file references are shared with the source rather than
+  /// copied on disk: clips are immutable inputs — edits produce new files or
+  /// live in metadata — so the two projects can be edited independently. This
+  /// mirrors how a publish copy shares files with its source, and file
+  /// reference-counting keeps shared files alive until the last referencing
+  /// draft is deleted.
+  DivineVideoDraft duplicate({String? title}) {
+    final now = DateTime.now();
+    return DivineVideoDraft(
+      id: 'draft_${now.microsecondsSinceEpoch}',
+      clips: clips,
+      title: title ?? this.title,
+      description: description,
+      hashtags: hashtags,
+      selectedApproach: selectedApproach,
+      createdAt: now,
+      lastModified: now,
+      expireTime: expireTime,
+      allowAudioReuse: allowAudioReuse,
+      publishStatus: PublishStatus.draft,
+      publishAttempts: 0,
+      proofManifestJson: proofManifestJson,
+      editorStateHistory: editorStateHistory,
+      editorEditingParameters: editorEditingParameters,
+      finalRenderedClip: finalRenderedClip,
+      collaboratorPubkeys: collaboratorPubkeys,
+      inspiredByVideo: inspiredByVideo,
+      inspiredByNpub: inspiredByNpub,
+      selectedSound: selectedSound,
+      contentWarning: contentWarning,
+      videoReplyContext: videoReplyContext,
+      shareReplyToFeed: shareReplyToFeed,
+      thumbnailTimestamp: thumbnailTimestamp,
+      customThumbnailPath: customThumbnailPath,
+    );
+  }
+
   Map<String, dynamic> toJson() => {
     'id': id,
     'clips': clips.map((clip) => clip.toJson()).toList(),

--- a/mobile/lib/services/draft_storage_service.dart
+++ b/mobile/lib/services/draft_storage_service.dart
@@ -542,11 +542,22 @@ class DraftStorageService {
     // Delete from DB first (clips cascade via FK), then delete files
     await _draftsDao.deleteDraft(id);
 
+    // Ghost frames live only in the clip `data` blob, so — like draft-local
+    // audio — the indexed-column check can't tell that a surviving draft (e.g.
+    // a duplicate sharing this draft's clips) still references them. Scan the
+    // other drafts' clips for shared ghost frames and keep those alive.
+    // Exclude this draft's own clips so its ghost frames aren't kept alive by
+    // rows that haven't cascade-deleted yet.
+    final referencedGhostFrames = await _referencedGhostFrameFilenames(
+      excludeDraftId: id,
+    );
+
     // Delete clip files only if not referenced by clip library
     await FileCleanupService.deleteRecordingClipsFiles(
       draft.clips,
       draftsDao: _draftsDao,
       clipsDao: _clipsDao,
+      referencedGhostFrameFilenames: referencedGhostFrames,
     );
 
     // Delete final rendered clip if present
@@ -555,6 +566,7 @@ class DraftStorageService {
         draft.finalRenderedClip!,
         draftsDao: _draftsDao,
         clipsDao: _clipsDao,
+        referencedGhostFrameFilenames: referencedGhostFrames,
       );
     }
 
@@ -615,6 +627,42 @@ class DraftStorageService {
       }
       for (final path in draft.localAudioFilePaths) {
         filenames.add(p.basename(path));
+      }
+    }
+
+    return filenames;
+  }
+
+  /// Basenames of clip ghost-frame files referenced by any clip other than
+  /// those belonging to [excludeDraftId], across all accounts.
+  ///
+  /// A clip's ghost frame is persisted only inside the clip `data` blob (no
+  /// indexed column), so a draft that shares clips with another draft — a
+  /// duplicate, or a publish copy — cannot be protected by the indexed-column
+  /// check when the sibling is deleted. This scans every remaining clip's blob
+  /// and collects the shared ghost basenames so deletion keeps them alive until
+  /// the last referencing clip is gone. Never throws: a corrupt blob is logged
+  /// and skipped.
+  Future<Set<String>> _referencedGhostFrameFilenames({
+    String? excludeDraftId,
+  }) async {
+    final clipRows = await _clipsDao.getAllClips();
+    final filenames = <String>{};
+
+    for (final row in clipRows) {
+      if (row.draftId == excludeDraftId) continue;
+      try {
+        final data = json.decode(row.data) as Map<String, dynamic>;
+        final ghostFramePath = data['ghostFramePath'] as String?;
+        if (ghostFramePath != null && ghostFramePath.isNotEmpty) {
+          filenames.add(p.basename(ghostFramePath));
+        }
+      } catch (e) {
+        Log.error(
+          '🧹 Skipping clip ${row.id} during ghost-frame reference scan: $e',
+          name: 'DraftStorageService',
+          category: LogCategory.video,
+        );
       }
     }
 

--- a/mobile/lib/services/draft_storage_service.dart
+++ b/mobile/lib/services/draft_storage_service.dart
@@ -643,10 +643,15 @@ class DraftStorageService {
   /// and collects the shared ghost basenames so deletion keeps them alive until
   /// the last referencing clip is gone. Never throws: a corrupt blob is logged
   /// and skipped.
+  ///
+  /// Trashed clips are included (`includeTrashed: true`): a soft-deleted clip
+  /// can still be restored, so a ghost frame it shares with the draft being
+  /// deleted must survive. This mirrors [ClipsDao.isFileReferenced], which
+  /// already protects the indexed video/thumbnail files of trashed clips.
   Future<Set<String>> _referencedGhostFrameFilenames({
     String? excludeDraftId,
   }) async {
-    final clipRows = await _clipsDao.getAllClips();
+    final clipRows = await _clipsDao.getAllClips(includeTrashed: true);
     final filenames = <String>{};
 
     for (final row in clipRows) {
@@ -692,16 +697,24 @@ class DraftStorageService {
     // Clear DB first (clips cascade via FK), then delete files
     await _draftsDao.clearAll();
 
+    // Every draft and its clips are gone; the clips that survive are library
+    // clips (active or trashed). Ghost frames live only in the clip `data`
+    // blob, so protect any a surviving library clip still references. No
+    // excludeDraftId — all remaining clips are legitimate survivors.
+    final referencedGhostFrames = await _referencedGhostFrameFilenames();
+
     // Delete clip files only if not referenced by clip library
     await FileCleanupService.deleteRecordingClipsFiles(
       allClips,
       draftsDao: _draftsDao,
       clipsDao: _clipsDao,
+      referencedGhostFrameFilenames: referencedGhostFrames,
     );
     await FileCleanupService.deleteRecordingClipsFiles(
       allFinalRenderedClips,
       draftsDao: _draftsDao,
       clipsDao: _clipsDao,
+      referencedGhostFrameFilenames: referencedGhostFrames,
     );
     await FileCleanupService.deleteFilesIfUnreferenced(
       allCustomThumbnailPaths,

--- a/mobile/lib/services/file_cleanup_service.dart
+++ b/mobile/lib/services/file_cleanup_service.dart
@@ -121,39 +121,95 @@ class FileCleanupService {
     }
   }
 
-  /// Deletes files for a RecordingClip if not referenced
+  /// Deletes clip ghost-frame files in [ghostFramePaths], skipping any still
+  /// referenced by another clip.
+  ///
+  /// A clip's ghost frame (the last-frame overlay used for continue-recording
+  /// alignment and transitions) is persisted only inside the clip `data` blob,
+  /// not an indexed file column, so a surviving clip that shares the same ghost
+  /// file (e.g. a draft and its duplicate) cannot be detected by the
+  /// indexed-column check. The caller supplies [referencedGhostFrameFilenames]
+  /// — the basenames of ghost frames still referenced by other clips — and a
+  /// file is kept when its basename is in that set. The indexed clip/draft
+  /// reference check still runs as a defensive backstop.
+  ///
+  /// Throws:
+  ///
+  /// * No exceptions – errors are logged and silently handled.
+  static Future<void> deleteGhostFrameFiles(
+    Iterable<String?> ghostFramePaths, {
+    required DraftsDao draftsDao,
+    required ClipsDao clipsDao,
+    Set<String> referencedGhostFrameFilenames = const {},
+  }) async {
+    for (final path in ghostFramePaths) {
+      if (path == null || path.isEmpty) continue;
+      if (referencedGhostFrameFilenames.contains(p.basename(path))) {
+        Log.info(
+          '🔗 Ghost frame still referenced by another clip, skipping delete: '
+          '$path',
+          name: 'FileCleanupService',
+          category: LogCategory.video,
+        );
+        continue;
+      }
+      await deleteFileIfUnreferenced(
+        path,
+        draftsDao: draftsDao,
+        clipsDao: clipsDao,
+      );
+    }
+  }
+
+  /// Deletes files for a RecordingClip if not referenced.
+  ///
+  /// Video and thumbnail files are protected by their indexed columns; ghost
+  /// frames live only in the clip `data` blob and are guarded instead by
+  /// [referencedGhostFrameFilenames] (see [deleteGhostFrameFiles]).
   static Future<void> deleteRecordingClipFiles(
     DivineVideoClip clip, {
     required DraftsDao draftsDao,
     required ClipsDao clipsDao,
+    Set<String> referencedGhostFrameFilenames = const {},
   }) async {
     await deleteFilesIfUnreferenced(
-      [clip.video.file?.path, clip.thumbnailPath, clip.ghostFramePath],
+      [clip.video.file?.path, clip.thumbnailPath],
       draftsDao: draftsDao,
       clipsDao: clipsDao,
     );
+    await deleteGhostFrameFiles(
+      [clip.ghostFramePath],
+      draftsDao: draftsDao,
+      clipsDao: clipsDao,
+      referencedGhostFrameFilenames: referencedGhostFrameFilenames,
+    );
   }
 
-  /// Deletes files for multiple RecordingClips if not referenced
+  /// Deletes files for multiple RecordingClips if not referenced.
+  ///
+  /// Video and thumbnail files are protected by their indexed columns; ghost
+  /// frames live only in the clip `data` blob and are guarded instead by
+  /// [referencedGhostFrameFilenames] (see [deleteGhostFrameFiles]).
   static Future<void> deleteRecordingClipsFiles(
     List<DivineVideoClip> clips, {
     required DraftsDao draftsDao,
     required ClipsDao clipsDao,
+    Set<String> referencedGhostFrameFilenames = const {},
   }) async {
-    final paths = clips
-        .expand(
-          (clip) => [
-            clip.video.file?.path,
-            clip.thumbnailPath,
-            clip.ghostFramePath,
-          ],
-        )
+    final indexedPaths = clips
+        .expand((clip) => [clip.video.file?.path, clip.thumbnailPath])
         .toList();
 
     await deleteFilesIfUnreferenced(
-      paths,
+      indexedPaths,
       draftsDao: draftsDao,
       clipsDao: clipsDao,
+    );
+    await deleteGhostFrameFiles(
+      clips.map((clip) => clip.ghostFramePath),
+      draftsDao: draftsDao,
+      clipsDao: clipsDao,
+      referencedGhostFrameFilenames: referencedGhostFrameFilenames,
     );
   }
 

--- a/mobile/lib/utils/draft_copy_naming.dart
+++ b/mobile/lib/utils/draft_copy_naming.dart
@@ -1,0 +1,47 @@
+// ABOUTME: Builds unique, numbered titles for duplicated drafts
+// ABOUTME: Strips an existing copy suffix so repeated copies don't stack
+
+/// Private-use sentinel char that is extremely unlikely to appear in a real
+/// draft title, used to locate the title slot inside a localized copy title.
+const String _titleSentinel = '\u{E000}';
+
+/// Sentinel copy number. Kept below 1000 so no locale renders it with a
+/// grouping separator, which would break the derived strip pattern.
+const int _numberSentinel = 999;
+
+/// Returns a unique numbered copy title for a duplicated draft.
+///
+/// [format] localizes a base title plus a numbered copy suffix, e.g.
+/// `'Trip (copy 2)'`. Any existing copy suffix on [sourceTitle] is stripped
+/// first — the strip pattern is derived from [format] itself, so it stays
+/// correct in every locale — so duplicating a copy yields `'Trip (copy 3)'`,
+/// never `'Trip (copy) (copy)'`. The number starts at 1 and increments until
+/// the formatted result is absent from [existingTitles].
+String nextDuplicateDraftTitle({
+  required String sourceTitle,
+  required Iterable<String> existingTitles,
+  required String Function(String base, int number) format,
+}) {
+  final base = _stripCopySuffix(sourceTitle, format);
+  final taken = existingTitles.toSet();
+  var number = 1;
+  while (taken.contains(format(base, number))) {
+    number++;
+  }
+  return format(base, number);
+}
+
+/// Removes a trailing copy suffix produced by [format] from [title], returning
+/// the bare base. Returns [title] unchanged when it does not end with a copy
+/// suffix (e.g. a custom name, or a `(copy 2)` that isn't at the very end).
+String _stripCopySuffix(
+  String title,
+  String Function(String base, int number) format,
+) {
+  final sample = format(_titleSentinel, _numberSentinel);
+  final source = RegExp.escape(sample)
+      .replaceFirst(_titleSentinel, '(.*)')
+      .replaceFirst('$_numberSentinel', r'(\d+)');
+  final match = RegExp('^$source\$').firstMatch(title);
+  return match != null ? match.group(1)! : title;
+}

--- a/mobile/lib/utils/draft_copy_naming.dart
+++ b/mobile/lib/utils/draft_copy_naming.dart
@@ -23,6 +23,10 @@ String nextDuplicateDraftTitle({
   required String Function(String base, int number) format,
 }) {
   final base = _stripCopySuffix(sourceTitle, format);
+  // Guard against a translation that drops the {number} placeholder: if the
+  // formatted title doesn't vary with the number, the loop below could never
+  // terminate. Fail soft to the number-1 form rather than hang the UI thread.
+  if (format(base, 1) == format(base, 2)) return format(base, 1);
   final taken = existingTitles.toSet();
   var number = 1;
   while (taken.contains(format(base, number))) {
@@ -42,6 +46,9 @@ String _stripCopySuffix(
   final source = RegExp.escape(sample)
       .replaceFirst(_titleSentinel, '(.*)')
       .replaceFirst('$_numberSentinel', r'(\d+)');
-  final match = RegExp('^$source\$').firstMatch(title);
+  // dotAll so the title slot `(.*)` spans newlines — a pasted multi-line title
+  // would otherwise never match, leaving its old suffix to stack on the next
+  // duplicate.
+  final match = RegExp('^$source\$', dotAll: true).firstMatch(title);
   return match != null ? match.group(1)! : title;
 }

--- a/mobile/lib/widgets/library/drafts_tab.dart
+++ b/mobile/lib/widgets/library/drafts_tab.dart
@@ -182,10 +182,11 @@ class DraftsTab extends ConsumerWidget {
     // Untitled drafts stay untitled; a titled draft gets a numbered copy
     // suffix that skips titles already taken, so repeated copies read
     // "Trip (copy 1)", "Trip (copy 2)" rather than stacking "(copy) (copy)".
-    final newTitle = draft.title.trim().isEmpty
+    final trimmedTitle = draft.title.trim();
+    final newTitle = trimmedTitle.isEmpty
         ? null
         : nextDuplicateDraftTitle(
-            sourceTitle: draft.title,
+            sourceTitle: trimmedTitle,
             existingTitles: _draftTitles(context),
             format: (base, number) =>
                 context.l10n.libraryDraftCopyTitle(base, number),

--- a/mobile/lib/widgets/library/drafts_tab.dart
+++ b/mobile/lib/widgets/library/drafts_tab.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Drafts tab widget for the clip library screen
-// ABOUTME: Displays a list of saved video drafts with options to edit or delete
+// ABOUTME: Lists saved video drafts with options to post, edit, duplicate, delete
 
 import 'dart:async';
 import 'dart:io';
@@ -16,6 +16,7 @@ import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/divine_video_draft.dart';
 import 'package:openvine/providers/video_publish_provider.dart';
 import 'package:openvine/screens/video_editor/video_editor_screen.dart';
+import 'package:openvine/utils/draft_copy_naming.dart';
 import 'package:openvine/widgets/library/empty_library_state.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -41,19 +42,28 @@ class DraftsTab extends ConsumerWidget {
     return BlocConsumer<DraftsLibraryBloc, DraftsLibraryState>(
       listenWhen: (previous, current) =>
           current is DraftsLibraryDraftDeleted ||
-          current is DraftsLibraryDeleteFailed,
+          current is DraftsLibraryDeleteFailed ||
+          current is DraftsLibraryDraftDuplicated ||
+          current is DraftsLibraryDuplicateFailed,
       listener: (context, state) {
-        final isSuccess = state is DraftsLibraryDraftDeleted;
+        final label = switch (state) {
+          DraftsLibraryDraftDeleted() =>
+            context.l10n.libraryDraftDeletedSnackbar,
+          DraftsLibraryDeleteFailed() =>
+            context.l10n.libraryDraftDeleteFailedSnackbar,
+          DraftsLibraryDraftDuplicated() =>
+            context.l10n.libraryDraftDuplicatedSnackbar,
+          DraftsLibraryDuplicateFailed() =>
+            context.l10n.libraryDraftDuplicateFailedSnackbar,
+          _ => null,
+        };
+        if (label == null) return;
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             backgroundColor: VineTheme.transparent,
             elevation: 0,
             behavior: SnackBarBehavior.floating,
-            content: DivineSnackbarContainer(
-              label: isSuccess
-                  ? context.l10n.libraryDraftDeletedSnackbar
-                  : context.l10n.libraryDraftDeleteFailedSnackbar,
-            ),
+            content: DivineSnackbarContainer(label: label),
           ),
         );
       },
@@ -94,6 +104,8 @@ class DraftsTab extends ConsumerWidget {
             ),
           ),
           DraftsLibraryLoaded(:final drafts) ||
+          DraftsLibraryDraftDuplicated(:final drafts) ||
+          DraftsLibraryDuplicateFailed(:final drafts) ||
           DraftsLibraryDraftDeleted(:final drafts) ||
           DraftsLibraryDeleteFailed(:final drafts) => () {
             final filtered = showAutosavedDraft
@@ -147,6 +159,11 @@ class DraftsTab extends ConsumerWidget {
           onTap: () => _openDraft(context, ref, draft),
         ),
         VineBottomSheetActionData(
+          iconPath: DivineIconName.copySimple.assetPath,
+          label: context.l10n.libraryDraftActionDuplicate,
+          onTap: () => _duplicateDraft(context, draft),
+        ),
+        VineBottomSheetActionData(
           iconPath: DivineIconName.trash.assetPath,
           label: context.l10n.libraryDraftActionDelete,
           isDestructive: true,
@@ -154,6 +171,40 @@ class DraftsTab extends ConsumerWidget {
         ),
       ],
     );
+  }
+
+  void _duplicateDraft(BuildContext context, DivineVideoDraft draft) {
+    Log.info(
+      '📚 Duplicate draft: ${draft.id}',
+      name: 'DraftsTab',
+      category: LogCategory.video,
+    );
+    // Untitled drafts stay untitled; a titled draft gets a numbered copy
+    // suffix that skips titles already taken, so repeated copies read
+    // "Trip (copy 1)", "Trip (copy 2)" rather than stacking "(copy) (copy)".
+    final newTitle = draft.title.trim().isEmpty
+        ? null
+        : nextDuplicateDraftTitle(
+            sourceTitle: draft.title,
+            existingTitles: _draftTitles(context),
+            format: (base, number) =>
+                context.l10n.libraryDraftCopyTitle(base, number),
+          );
+    context.read<DraftsLibraryBloc>().add(
+      DraftsLibraryDuplicateRequested(draft.id, newTitle: newTitle),
+    );
+  }
+
+  Iterable<String> _draftTitles(BuildContext context) {
+    final state = context.read<DraftsLibraryBloc>().state;
+    return switch (state) {
+      DraftsLibraryLoaded(:final drafts) ||
+      DraftsLibraryDraftDuplicated(:final drafts) ||
+      DraftsLibraryDuplicateFailed(:final drafts) ||
+      DraftsLibraryDraftDeleted(:final drafts) ||
+      DraftsLibraryDeleteFailed(:final drafts) => drafts.map((d) => d.title),
+      _ => const <String>[],
+    };
   }
 
   Future<void> _postDraft(

--- a/mobile/packages/db_client/lib/src/database/daos/clips_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/clips_dao.dart
@@ -63,13 +63,23 @@ class ClipsDao extends DatabaseAccessor<AppDatabase> with _$ClipsDaoMixin {
   }
 
   /// Get all clips sorted by recorded date (newest first). Excludes
-  /// trashed clips. When [ownerPubkey] is provided, returns only clips
-  /// owned by that account **plus** legacy clips with no owner.
-  Future<List<ClipRow>> getAllClips({int? limit, String? ownerPubkey}) {
+  /// trashed clips unless [includeTrashed] is true. When [ownerPubkey] is
+  /// provided, returns only clips owned by that account **plus** legacy
+  /// clips with no owner.
+  ///
+  /// [includeTrashed] is for file-reference scans that must keep a
+  /// trashed (restorable) clip's files alive — active-clip listings should
+  /// leave it at its default.
+  Future<List<ClipRow>> getAllClips({
+    int? limit,
+    String? ownerPubkey,
+    bool includeTrashed = false,
+  }) {
     final query = select(clips)
       ..where(
-        (t) =>
-            _ownedOrLegacy(t.ownerPubkey, ownerPubkey) & t.deletedAt.isNull(),
+        (t) => includeTrashed
+            ? _ownedOrLegacy(t.ownerPubkey, ownerPubkey)
+            : _ownedOrLegacy(t.ownerPubkey, ownerPubkey) & t.deletedAt.isNull(),
       )
       ..orderBy([
         (t) => OrderingTerm(expression: t.recordedAt, mode: OrderingMode.desc),

--- a/mobile/packages/db_client/test/src/database/daos/clips_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/clips_dao_test.dart
@@ -324,6 +324,70 @@ void main() {
         final results = await dao.getAllClips();
         expect(results, isEmpty);
       });
+
+      test('excludes trashed clips by default', () async {
+        await dao.upsertClip(
+          id: 'clip_active',
+          draftId: testDraftId,
+          orderIndex: 0,
+          durationMs: 3000,
+          recordedAt: DateTime(2023, 11, 14, 10),
+          filePath: 'active.mp4',
+          thumbnailPath: 'active.jpeg',
+          data: '{}',
+        );
+        await dao.upsertClip(
+          id: 'clip_trashed',
+          draftId: testDraftId,
+          orderIndex: 1,
+          durationMs: 4000,
+          recordedAt: DateTime(2023, 11, 14, 11),
+          filePath: 'trashed.mp4',
+          thumbnailPath: 'trashed.jpeg',
+          data: '{}',
+        );
+        await dao.softDeleteClip(
+          id: 'clip_trashed',
+          deletedAt: DateTime(2023, 11, 15),
+        );
+
+        final results = await dao.getAllClips();
+        expect(results, hasLength(1));
+        expect(results.single.id, equals('clip_active'));
+      });
+
+      test('includes trashed clips when includeTrashed is true', () async {
+        await dao.upsertClip(
+          id: 'clip_active',
+          draftId: testDraftId,
+          orderIndex: 0,
+          durationMs: 3000,
+          recordedAt: DateTime(2023, 11, 14, 10),
+          filePath: 'active.mp4',
+          thumbnailPath: 'active.jpeg',
+          data: '{}',
+        );
+        await dao.upsertClip(
+          id: 'clip_trashed',
+          draftId: testDraftId,
+          orderIndex: 1,
+          durationMs: 4000,
+          recordedAt: DateTime(2023, 11, 14, 11),
+          filePath: 'trashed.mp4',
+          thumbnailPath: 'trashed.jpeg',
+          data: '{}',
+        );
+        await dao.softDeleteClip(
+          id: 'clip_trashed',
+          deletedAt: DateTime(2023, 11, 15),
+        );
+
+        final results = await dao.getAllClips(includeTrashed: true);
+        expect(
+          results.map((c) => c.id),
+          containsAll(<String>['clip_active', 'clip_trashed']),
+        );
+      });
     });
 
     group('updateOrderIndex', () {

--- a/mobile/test/blocs/drafts_library/drafts_library_bloc_test.dart
+++ b/mobile/test/blocs/drafts_library/drafts_library_bloc_test.dart
@@ -221,6 +221,91 @@ void main() {
       );
     });
 
+    group('DraftsLibraryDuplicateRequested', () {
+      setUpAll(() {
+        registerFallbackValue(createDraft());
+      });
+
+      blocTest<DraftsLibraryBloc, DraftsLibraryState>(
+        'does nothing when not in loaded state',
+        build: createBloc,
+        act: (bloc) =>
+            bloc.add(const DraftsLibraryDuplicateRequested('draft1')),
+        expect: () => [],
+      );
+
+      blocTest<DraftsLibraryBloc, DraftsLibraryState>(
+        'does nothing when the draft id is not in the list',
+        seed: () => DraftsLibraryLoaded(drafts: [createDraft(id: 'draft1')]),
+        build: createBloc,
+        act: (bloc) =>
+            bloc.add(const DraftsLibraryDuplicateRequested('missing')),
+        expect: () => [],
+      );
+
+      blocTest<DraftsLibraryBloc, DraftsLibraryState>(
+        'duplicates the draft, saves it, and updates the list',
+        setUp: () {
+          when(
+            () => mockDraftStorageService.saveDraft(any()),
+          ).thenAnswer((_) async {});
+        },
+        seed: () => DraftsLibraryLoaded(drafts: [createDraft(id: 'draft1')]),
+        build: createBloc,
+        act: (bloc) => bloc.add(
+          const DraftsLibraryDuplicateRequested('draft1', newTitle: 'Copy'),
+        ),
+        expect: () => [
+          isA<DraftsLibraryDraftDuplicated>().having(
+            (s) => s.drafts.length,
+            'drafts.length',
+            2,
+          ),
+          isA<DraftsLibraryLoaded>().having(
+            (s) => s.drafts.length,
+            'drafts.length',
+            2,
+          ),
+        ],
+        verify: (_) {
+          final saved =
+              verify(
+                    () => mockDraftStorageService.saveDraft(captureAny()),
+                  ).captured.single
+                  as DivineVideoDraft;
+          expect(saved.id, isNot('draft1'));
+          expect(saved.title, 'Copy');
+          expect(saved.publishStatus, PublishStatus.draft);
+        },
+      );
+
+      blocTest<DraftsLibraryBloc, DraftsLibraryState>(
+        'emits failure result when save fails',
+        setUp: () {
+          when(
+            () => mockDraftStorageService.saveDraft(any()),
+          ).thenThrow(Exception('Save failed'));
+        },
+        seed: () => DraftsLibraryLoaded(drafts: [createDraft(id: 'draft1')]),
+        build: createBloc,
+        act: (bloc) =>
+            bloc.add(const DraftsLibraryDuplicateRequested('draft1')),
+        errors: () => [isA<Exception>()],
+        expect: () => [
+          isA<DraftsLibraryDuplicateFailed>().having(
+            (s) => s.drafts.length,
+            'drafts.length',
+            1,
+          ),
+          isA<DraftsLibraryLoaded>().having(
+            (s) => s.drafts.length,
+            'drafts.length',
+            1,
+          ),
+        ],
+      );
+    });
+
     group('DraftsLibraryDeleteRequested', () {
       blocTest<DraftsLibraryBloc, DraftsLibraryState>(
         'does nothing when not in loaded state',

--- a/mobile/test/blocs/drafts_library/drafts_library_event_test.dart
+++ b/mobile/test/blocs/drafts_library/drafts_library_event_test.dart
@@ -19,6 +19,45 @@ void main() {
       });
     });
 
+    group(DraftsLibraryDuplicateRequested, () {
+      test('supports value equality', () {
+        expect(
+          const DraftsLibraryDuplicateRequested('draft1', newTitle: 'Copy'),
+          equals(
+            const DraftsLibraryDuplicateRequested('draft1', newTitle: 'Copy'),
+          ),
+        );
+      });
+
+      test('different draftIds are not equal', () {
+        expect(
+          const DraftsLibraryDuplicateRequested('draft1'),
+          isNot(equals(const DraftsLibraryDuplicateRequested('draft2'))),
+        );
+      });
+
+      test('different titles are not equal', () {
+        expect(
+          const DraftsLibraryDuplicateRequested('draft1', newTitle: 'A'),
+          isNot(
+            equals(
+              const DraftsLibraryDuplicateRequested('draft1', newTitle: 'B'),
+            ),
+          ),
+        );
+      });
+
+      test('props contains draftId and newTitle', () {
+        expect(
+          const DraftsLibraryDuplicateRequested(
+            'draft1',
+            newTitle: 'Copy',
+          ).props,
+          ['draft1', 'Copy'],
+        );
+      });
+    });
+
     group(DraftsLibraryDeleteRequested, () {
       test('supports value equality', () {
         expect(

--- a/mobile/test/blocs/drafts_library/drafts_library_state_test.dart
+++ b/mobile/test/blocs/drafts_library/drafts_library_state_test.dart
@@ -79,6 +79,36 @@ void main() {
       });
     });
 
+    group(DraftsLibraryDraftDuplicated, () {
+      test('supports value equality', () {
+        final draft = createDraft(id: 'draft1');
+        expect(
+          DraftsLibraryDraftDuplicated(drafts: [draft]),
+          equals(DraftsLibraryDraftDuplicated(drafts: [draft])),
+        );
+      });
+
+      test('props contains drafts', () {
+        final drafts = [createDraft(id: 'draft1')];
+        expect(DraftsLibraryDraftDuplicated(drafts: drafts).props, [drafts]);
+      });
+    });
+
+    group(DraftsLibraryDuplicateFailed, () {
+      test('supports value equality', () {
+        final draft = createDraft(id: 'draft1');
+        expect(
+          DraftsLibraryDuplicateFailed(drafts: [draft]),
+          equals(DraftsLibraryDuplicateFailed(drafts: [draft])),
+        );
+      });
+
+      test('props contains drafts', () {
+        final drafts = [createDraft(id: 'draft1')];
+        expect(DraftsLibraryDuplicateFailed(drafts: drafts).props, [drafts]);
+      });
+    });
+
     group(DraftsLibraryDraftDeleted, () {
       test('supports value equality', () {
         final draft = createDraft(id: 'draft1');

--- a/mobile/test/models/divine_video_draft_duplicate_test.dart
+++ b/mobile/test/models/divine_video_draft_duplicate_test.dart
@@ -2,8 +2,10 @@
 // ABOUTME: Validates fresh id/timestamps, reset publish state, shared content
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart' show AudioEvent, InspiredByInfo;
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/divine_video_draft.dart';
+import 'package:openvine/models/video_reply_context.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 
 DivineVideoClip _createTestClip([String id = 'clip_1']) => DivineVideoClip(
@@ -28,11 +30,31 @@ DivineVideoDraft _createDraft() => DivineVideoDraft(
   publishAttempts: 3,
   publishError: 'some error',
   sourceDraftId: 'draft_source',
+  expireTime: const Duration(days: 7),
+  allowAudioReuse: true,
   proofManifestJson: '{"videoHash":"abc"}',
   editorStateHistory: const {'foo': 'bar'},
+  editorEditingParameters: const {'brightness': 0.5},
   collaboratorPubkeys: const {'pubkey1'},
+  inspiredByVideo: const InspiredByInfo(addressableId: '34236:pubkey:dtag'),
+  inspiredByNpub: 'npub_inspired',
+  selectedSound: AudioEvent.fromLocalImport(
+    id: 'audio_1',
+    filePath: '/tmp/sound.m4a',
+    createdAt: 1700000000,
+    title: 'A sound',
+    mimeType: 'audio/mp4',
+  ),
   finalRenderedClip: _createTestClip('rendered'),
   contentWarning: 'sensitive',
+  videoReplyContext: const VideoReplyContext(
+    rootEventId: 'root_event',
+    rootEventKind: 34236,
+    rootAuthorPubkey: 'author_pubkey',
+  ),
+  shareReplyToFeed: true,
+  thumbnailTimestamp: const Duration(milliseconds: 500),
+  customThumbnailPath: '/tmp/cover.jpg',
 );
 
 void main() {
@@ -87,6 +109,29 @@ void main() {
       expect(copy.proofManifestJson, equals(draft.proofManifestJson));
       expect(copy.contentWarning, equals(draft.contentWarning));
       expect(copy.finalRenderedClip, equals(draft.finalRenderedClip));
+    });
+
+    // Guards against a field silently dropped from duplicate(): unlike
+    // copyWith, duplicate() has no `?? this.x` fallback, so an omitted argument
+    // resets to a default. Every non-publish field the copy must carry is
+    // asserted here so a future drop fails loudly.
+    test('carries every non-publish field to the copy', () {
+      final draft = _createDraft();
+      final copy = draft.duplicate();
+
+      expect(copy.expireTime, equals(draft.expireTime));
+      expect(copy.allowAudioReuse, equals(draft.allowAudioReuse));
+      expect(
+        copy.editorEditingParameters,
+        equals(draft.editorEditingParameters),
+      );
+      expect(copy.inspiredByVideo, equals(draft.inspiredByVideo));
+      expect(copy.inspiredByNpub, equals(draft.inspiredByNpub));
+      expect(copy.selectedSound, equals(draft.selectedSound));
+      expect(copy.videoReplyContext, equals(draft.videoReplyContext));
+      expect(copy.shareReplyToFeed, equals(draft.shareReplyToFeed));
+      expect(copy.thumbnailTimestamp, equals(draft.thumbnailTimestamp));
+      expect(copy.customThumbnailPath, equals(draft.customThumbnailPath));
     });
 
     test('leaves the source draft unchanged', () {

--- a/mobile/test/models/divine_video_draft_duplicate_test.dart
+++ b/mobile/test/models/divine_video_draft_duplicate_test.dart
@@ -1,0 +1,102 @@
+// ABOUTME: Tests for DivineVideoDraft.duplicate
+// ABOUTME: Validates fresh id/timestamps, reset publish state, shared content
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/divine_video_draft.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
+
+DivineVideoClip _createTestClip([String id = 'clip_1']) => DivineVideoClip(
+  id: id,
+  video: EditorVideo.file('/tmp/test.mp4'),
+  duration: const Duration(seconds: 6),
+  recordedAt: DateTime(2025),
+  originalAspectRatio: 9 / 16,
+  targetAspectRatio: .vertical,
+);
+
+DivineVideoDraft _createDraft() => DivineVideoDraft(
+  id: 'draft_1',
+  clips: [_createTestClip(), _createTestClip('clip_2')],
+  title: 'My Project',
+  description: 'A test draft',
+  hashtags: const {'test', 'vine'},
+  selectedApproach: 'camera',
+  createdAt: DateTime(2025),
+  lastModified: DateTime(2025),
+  publishStatus: PublishStatus.failed,
+  publishAttempts: 3,
+  publishError: 'some error',
+  sourceDraftId: 'draft_source',
+  proofManifestJson: '{"videoHash":"abc"}',
+  editorStateHistory: const {'foo': 'bar'},
+  collaboratorPubkeys: const {'pubkey1'},
+  finalRenderedClip: _createTestClip('rendered'),
+  contentWarning: 'sensitive',
+);
+
+void main() {
+  group('DivineVideoDraft.duplicate', () {
+    test('assigns a fresh id distinct from the source', () {
+      final draft = _createDraft();
+      final copy = draft.duplicate();
+
+      expect(copy.id, isNot(equals(draft.id)));
+      expect(copy.id, startsWith('draft_'));
+    });
+
+    test('resets publish state', () {
+      final copy = _createDraft().duplicate();
+
+      expect(copy.publishStatus, equals(PublishStatus.draft));
+      expect(copy.publishAttempts, equals(0));
+      expect(copy.publishError, isNull);
+      expect(copy.sourceDraftId, isNull);
+    });
+
+    test('refreshes createdAt and lastModified', () {
+      final draft = _createDraft();
+      final copy = draft.duplicate();
+
+      expect(copy.createdAt.isAfter(draft.createdAt), isTrue);
+      expect(copy.lastModified.isAfter(draft.lastModified), isTrue);
+    });
+
+    test('keeps the original title when none is provided', () {
+      final copy = _createDraft().duplicate();
+
+      expect(copy.title, equals('My Project'));
+    });
+
+    test('overrides the title when one is provided', () {
+      final copy = _createDraft().duplicate(title: 'My Project (copy)');
+
+      expect(copy.title, equals('My Project (copy)'));
+    });
+
+    test('shares clips and content with the source', () {
+      final draft = _createDraft();
+      final copy = draft.duplicate();
+
+      expect(copy.clips, same(draft.clips));
+      expect(copy.description, equals(draft.description));
+      expect(copy.hashtags, equals(draft.hashtags));
+      expect(copy.selectedApproach, equals(draft.selectedApproach));
+      expect(copy.editorStateHistory, equals(draft.editorStateHistory));
+      expect(copy.collaboratorPubkeys, equals(draft.collaboratorPubkeys));
+      expect(copy.proofManifestJson, equals(draft.proofManifestJson));
+      expect(copy.contentWarning, equals(draft.contentWarning));
+      expect(copy.finalRenderedClip, equals(draft.finalRenderedClip));
+    });
+
+    test('leaves the source draft unchanged', () {
+      final draft = _createDraft();
+      draft.duplicate(title: 'Something else');
+
+      expect(draft.id, equals('draft_1'));
+      expect(draft.title, equals('My Project'));
+      expect(draft.publishStatus, equals(PublishStatus.failed));
+      expect(draft.sourceDraftId, equals('draft_source'));
+    });
+  });
+}

--- a/mobile/test/services/draft_storage_service_test.dart
+++ b/mobile/test/services/draft_storage_service_test.dart
@@ -1669,6 +1669,75 @@ void main() {
         );
       });
 
+      test('keeps a ghost frame still referenced by a trashed clip when the '
+          'draft is deleted', () async {
+        final ghost = writeGhost('ghost_trashed_shared.jpg');
+        final draft = draftWithGhost(
+          id: 'draft_trashed_sibling',
+          ghostPath: ghost.path,
+        );
+        await service.saveDraft(draft);
+
+        // A soft-deleted clip that still references the same ghost frame.
+        // It can be restored from trash, so its ghost file must survive the
+        // draft deletion. Clip data blobs store the ghost basename.
+        await database.clipsDao.upsertClip(
+          id: 'trashed_sharing_clip',
+          orderIndex: 0,
+          durationMs: 6000,
+          recordedAt: DateTime(2025),
+          data: json.encode({'ghostFramePath': 'ghost_trashed_shared.jpg'}),
+          filePath: null,
+          thumbnailPath: null,
+        );
+        await database.clipsDao.softDeleteClip(
+          id: 'trashed_sharing_clip',
+          deletedAt: DateTime(2025, 6),
+        );
+
+        await service.deleteDraft(draft.id);
+
+        expect(
+          ghost.existsSync(),
+          isTrue,
+          reason:
+              'a ghost frame still referenced by a trashed (restorable) clip '
+              'must not be deleted when a sharing draft is removed',
+        );
+      });
+
+      test('keeps a ghost frame referenced by a surviving library clip when '
+          'all drafts are cleared', () async {
+        final ghost = writeGhost('ghost_cleared_shared.jpg');
+        final draft = draftWithGhost(
+          id: 'draft_cleared',
+          ghostPath: ghost.path,
+        );
+        await service.saveDraft(draft);
+
+        // A library clip (no draftId) survives clearAllDrafts and still
+        // references the same ghost frame. Clip data blobs store the basename.
+        await database.clipsDao.upsertClip(
+          id: 'surviving_library_clip',
+          orderIndex: 0,
+          durationMs: 6000,
+          recordedAt: DateTime(2025),
+          data: json.encode({'ghostFramePath': 'ghost_cleared_shared.jpg'}),
+          filePath: null,
+          thumbnailPath: null,
+        );
+
+        await service.clearAllDrafts();
+
+        expect(
+          ghost.existsSync(),
+          isTrue,
+          reason:
+              'clearing all drafts must not delete a ghost frame a surviving '
+              'library clip still references',
+        );
+      });
+
       test('still deletes the target ghost frame when a sibling clip row has a '
           'corrupt data blob', () async {
         final ghost = writeGhost('ghost_target.jpg');

--- a/mobile/test/services/draft_storage_service_test.dart
+++ b/mobile/test/services/draft_storage_service_test.dart
@@ -1586,5 +1586,119 @@ void main() {
         );
       });
     });
+
+    group('clip ghost-frame file hygiene', () {
+      late Directory docsDir;
+
+      setUp(() {
+        docsDir = Directory(documentsPath)..createSync(recursive: true);
+      });
+
+      tearDown(() {
+        if (docsDir.existsSync()) docsDir.deleteSync(recursive: true);
+      });
+
+      File writeGhost(String basename) {
+        final file = File(p.join(documentsPath, basename));
+        file.parent.createSync(recursive: true);
+        file.writeAsBytesSync(const [0, 1, 2, 3]);
+        return file;
+      }
+
+      DivineVideoDraft draftWithGhost({
+        required String id,
+        required String ghostPath,
+      }) => DivineVideoDraft.create(
+        id: id,
+        clips: [
+          DivineVideoClip(
+            id: 'clip_$id',
+            video: EditorVideo.file('/path/to/video.mp4'),
+            duration: const Duration(seconds: 6),
+            recordedAt: DateTime(2025),
+            targetAspectRatio: AspectRatio.square,
+            originalAspectRatio: 9 / 16,
+            ghostFramePath: ghostPath,
+          ),
+        ],
+        title: 'Ghost draft',
+        description: '',
+        hashtags: const {},
+        selectedApproach: 'video',
+      );
+
+      test('deletes a clip ghost frame when the draft is deleted', () async {
+        final ghost = writeGhost('ghost_only.jpg');
+        final draft = draftWithGhost(id: 'draft_ghost', ghostPath: ghost.path);
+        await service.saveDraft(draft);
+
+        await service.deleteDraft(draft.id);
+
+        expect(
+          ghost.existsSync(),
+          isFalse,
+          reason:
+              'deleting the only draft that references a ghost frame must '
+              'remove its file',
+        );
+      });
+
+      test('keeps a ghost frame shared with a duplicate when the source draft '
+          'is deleted', () async {
+        final ghost = writeGhost('ghost_shared.jpg');
+        final source = draftWithGhost(
+          id: 'draft_source',
+          ghostPath: ghost.path,
+        );
+        // duplicate() shares the source's clip objects (including
+        // ghostFramePath) with a fresh draft id — the flagship "copy then edit
+        // independently" flow.
+        final copy = source.duplicate(title: 'Copy');
+
+        await service.saveDraft(source);
+        await service.saveDraft(copy);
+
+        await service.deleteDraft(source.id);
+
+        expect(
+          ghost.existsSync(),
+          isTrue,
+          reason:
+              'a ghost frame shared with a surviving duplicate must not be '
+              'deleted until the last referencing draft is gone',
+        );
+      });
+
+      test('still deletes the target ghost frame when a sibling clip row has a '
+          'corrupt data blob', () async {
+        final ghost = writeGhost('ghost_target.jpg');
+        final draft = draftWithGhost(
+          id: 'draft_target',
+          ghostPath: ghost.path,
+        );
+        await service.saveDraft(draft);
+
+        // A sibling clip row whose data blob can't be parsed. The ghost-frame
+        // reference scan runs after the target draft's rows are deleted, so an
+        // unguarded throw here would leak the deleted draft's ghost file.
+        await database.clipsDao.upsertClip(
+          id: 'corrupt_sibling_clip',
+          orderIndex: 0,
+          durationMs: 6000,
+          recordedAt: DateTime(2025),
+          data: 'not-json',
+          filePath: null,
+          thumbnailPath: null,
+        );
+
+        await service.deleteDraft(draft.id);
+
+        expect(
+          ghost.existsSync(),
+          isFalse,
+          reason: 'a corrupt sibling clip must not block ghost-frame cleanup',
+        );
+      });
+    });
   });
 }

--- a/mobile/test/utils/draft_copy_naming_test.dart
+++ b/mobile/test/utils/draft_copy_naming_test.dart
@@ -1,0 +1,81 @@
+// ABOUTME: Tests for nextDuplicateDraftTitle
+// ABOUTME: Validates numbering, suffix stripping, and locale independence
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/utils/draft_copy_naming.dart';
+
+// Mimics the English "{title} (copy {number})" ARB template.
+String _en(String base, int number) => '$base (copy $number)';
+
+// Mimics the Japanese "{title}（コピー {number}）" ARB template.
+String _ja(String base, int number) => '$base（コピー $number）';
+
+void main() {
+  group('nextDuplicateDraftTitle', () {
+    test('numbers the first copy from 1', () {
+      expect(
+        nextDuplicateDraftTitle(
+          sourceTitle: 'Trip',
+          existingTitles: const ['Trip'],
+          format: _en,
+        ),
+        equals('Trip (copy 1)'),
+      );
+    });
+
+    test('strips an existing copy suffix instead of stacking', () {
+      expect(
+        nextDuplicateDraftTitle(
+          sourceTitle: 'Trip (copy 1)',
+          existingTitles: const ['Trip', 'Trip (copy 1)'],
+          format: _en,
+        ),
+        equals('Trip (copy 2)'),
+      );
+    });
+
+    test('skips numbers already taken', () {
+      expect(
+        nextDuplicateDraftTitle(
+          sourceTitle: 'Trip',
+          existingTitles: const ['Trip', 'Trip (copy 1)', 'Trip (copy 2)'],
+          format: _en,
+        ),
+        equals('Trip (copy 3)'),
+      );
+    });
+
+    test('does not strip a copy suffix that is not at the end', () {
+      expect(
+        nextDuplicateDraftTitle(
+          sourceTitle: 'A (copy 1) B',
+          existingTitles: const [],
+          format: _en,
+        ),
+        equals('A (copy 1) B (copy 1)'),
+      );
+    });
+
+    test('treats a custom title as its own base', () {
+      expect(
+        nextDuplicateDraftTitle(
+          sourceTitle: 'My Best Video',
+          existingTitles: const [],
+          format: _en,
+        ),
+        equals('My Best Video (copy 1)'),
+      );
+    });
+
+    test('derives the strip pattern from the format for any locale', () {
+      expect(
+        nextDuplicateDraftTitle(
+          sourceTitle: 'テスト（コピー 1）',
+          existingTitles: const ['テスト（コピー 1）'],
+          format: _ja,
+        ),
+        equals('テスト（コピー 2）'),
+      );
+    });
+  });
+}

--- a/mobile/test/utils/draft_copy_naming_test.dart
+++ b/mobile/test/utils/draft_copy_naming_test.dart
@@ -77,5 +77,33 @@ void main() {
         equals('テスト（コピー 2）'),
       );
     });
+
+    test(
+      'strips a copy suffix from a multi-line title instead of stacking',
+      () {
+        expect(
+          nextDuplicateDraftTitle(
+            sourceTitle: 'Line 1\nLine 2 (copy 1)',
+            existingTitles: const ['Line 1\nLine 2 (copy 1)'],
+            format: _en,
+          ),
+          equals('Line 1\nLine 2 (copy 2)'),
+        );
+      },
+    );
+
+    test('fails soft when the format drops the number placeholder', () {
+      // A broken translation that ignores {number} would otherwise loop
+      // forever; the guard returns the number-1 form instead of hanging.
+      String noNumber(String base, int number) => '$base (copy)';
+      expect(
+        nextDuplicateDraftTitle(
+          sourceTitle: 'Trip',
+          existingTitles: const ['Trip (copy)'],
+          format: noNumber,
+        ),
+        equals('Trip (copy)'),
+      );
+    });
   });
 }

--- a/mobile/test/widgets/library/drafts_tab_test.dart
+++ b/mobile/test/widgets/library/drafts_tab_test.dart
@@ -346,6 +346,68 @@ void main() {
         ).called(1);
       });
     });
+
+    group('snackbar feedback', () {
+      Future<void> pumpWithEmittedState(
+        WidgetTester tester,
+        DraftsLibraryState emitted,
+      ) async {
+        final drafts = [createDraft(id: 'draft1')];
+        whenListen(
+          mockBloc,
+          Stream<DraftsLibraryState>.value(emitted),
+          initialState: DraftsLibraryLoaded(drafts: drafts),
+        );
+
+        await tester.pumpWidget(buildWidget());
+        await tester.pump(); // deliver the emitted state
+        await tester.pump(); // start the snackbar entrance animation
+      }
+
+      testWidgets('shows the duplicated snackbar on '
+          '$DraftsLibraryDraftDuplicated', (tester) async {
+        await pumpWithEmittedState(
+          tester,
+          DraftsLibraryDraftDuplicated(drafts: [createDraft(id: 'draft1')]),
+        );
+
+        expect(find.text(en.libraryDraftDuplicatedSnackbar), findsOneWidget);
+      });
+
+      testWidgets('shows the duplicate-failed snackbar on '
+          '$DraftsLibraryDuplicateFailed', (tester) async {
+        await pumpWithEmittedState(
+          tester,
+          DraftsLibraryDuplicateFailed(drafts: [createDraft(id: 'draft1')]),
+        );
+
+        expect(
+          find.text(en.libraryDraftDuplicateFailedSnackbar),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('shows the deleted snackbar on $DraftsLibraryDraftDeleted', (
+        tester,
+      ) async {
+        await pumpWithEmittedState(
+          tester,
+          const DraftsLibraryDraftDeleted(drafts: []),
+        );
+
+        expect(find.text(en.libraryDraftDeletedSnackbar), findsOneWidget);
+      });
+
+      testWidgets('shows the delete-failed snackbar on '
+          '$DraftsLibraryDeleteFailed', (tester) async {
+        await pumpWithEmittedState(
+          tester,
+          DraftsLibraryDeleteFailed(drafts: [createDraft(id: 'draft1')]),
+        );
+
+        expect(find.text(en.libraryDraftDeleteFailedSnackbar), findsOneWidget);
+      });
+    });
   });
 
   group(DraftListTile, () {

--- a/mobile/test/widgets/library/drafts_tab_test.dart
+++ b/mobile/test/widgets/library/drafts_tab_test.dart
@@ -257,6 +257,95 @@ void main() {
         },
       );
     });
+
+    group('duplicate action', () {
+      testWidgets('shows duplicate action in the options menu', (tester) async {
+        when(
+          () => mockBloc.state,
+        ).thenReturn(DraftsLibraryLoaded(drafts: [createDraft(id: 'draft1')]));
+
+        await tester.pumpWidget(buildWidget());
+        await tester.tap(find.byType(IconButton));
+        await tester.pumpAndSettle();
+
+        expect(find.text(en.libraryDraftActionDuplicate), findsOneWidget);
+      });
+
+      testWidgets(
+        'dispatches duplicate event with a numbered copy title when tapped',
+        (tester) async {
+          when(() => mockBloc.state).thenReturn(
+            DraftsLibraryLoaded(
+              drafts: [createDraft(id: 'draft1', title: 'My Project')],
+            ),
+          );
+
+          await tester.pumpWidget(buildWidget());
+          await tester.tap(find.byType(IconButton));
+          await tester.pumpAndSettle();
+          await tester.tap(find.text(en.libraryDraftActionDuplicate));
+          await tester.pumpAndSettle();
+
+          verify(
+            () => mockBloc.add(
+              DraftsLibraryDuplicateRequested(
+                'draft1',
+                newTitle: en.libraryDraftCopyTitle('My Project', 1),
+              ),
+            ),
+          ).called(1);
+        },
+      );
+
+      testWidgets('numbers the next copy instead of stacking suffixes', (
+        tester,
+      ) async {
+        when(() => mockBloc.state).thenReturn(
+          DraftsLibraryLoaded(
+            drafts: [
+              createDraft(id: 'copy', title: 'My Project (copy 1)'),
+              createDraft(id: 'orig', title: 'My Project'),
+            ],
+          ),
+        );
+
+        await tester.pumpWidget(buildWidget());
+        // First tile is the existing copy; open its options menu.
+        await tester.tap(find.byType(IconButton).first);
+        await tester.pumpAndSettle();
+        await tester.tap(find.text(en.libraryDraftActionDuplicate));
+        await tester.pumpAndSettle();
+
+        verify(
+          () => mockBloc.add(
+            DraftsLibraryDuplicateRequested(
+              'copy',
+              newTitle: en.libraryDraftCopyTitle('My Project', 2),
+            ),
+          ),
+        ).called(1);
+      });
+
+      testWidgets('duplicate of an untitled draft keeps a null title', (
+        tester,
+      ) async {
+        when(() => mockBloc.state).thenReturn(
+          DraftsLibraryLoaded(
+            drafts: [createDraft(id: 'draft1', title: '')],
+          ),
+        );
+
+        await tester.pumpWidget(buildWidget());
+        await tester.tap(find.byType(IconButton));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text(en.libraryDraftActionDuplicate));
+        await tester.pumpAndSettle();
+
+        verify(
+          () => mockBloc.add(const DraftsLibraryDuplicateRequested('draft1')),
+        ).called(1);
+      });
+    });
   });
 
   group(DraftListTile, () {


### PR DESCRIPTION
## Description

Adds a **Duplicate** action to the drafts options sheet (between Edit and Delete), so creators can copy an existing project and edit each copy independently — e.g. turning one long recording into separate parts of a series.

Flow: tap Duplicate → `DraftsLibraryDuplicateRequested(draftId, newTitle)` → `DraftsLibraryBloc` builds the copy via `DivineVideoDraft.duplicate(...)`, saves it, and refreshes the list with the copy on top → success/failure snackbar (mirrors delete). The UI stays logic-free.

**Why share files instead of copying them:** the copy reuses the source's clip/render files on disk rather than duplicating gigabytes, mirroring how the existing publish copy already shares files. This is safe because clips are immutable inputs (trim/split are metadata-only, renders create new files) and file deletion is reference-counted via indexed DB columns, so deleting one project never strips files another still references. Result: duplication is instant, and copies edit independently. Clip rows are namespaced per draft (`<draftId>:<clipId>`), so reusing clip IDs cannot collide.

**Why numbered copy titles:** re-duplicating naively produced "Trip (copy) (copy)". Titles are now numbered and de-duplicated ("Trip (copy 1)", "Trip (copy 2)"), stripping any existing suffix first so a copy-of-a-copy continues the count. The strip pattern is derived from the localized format string itself, so it stays correct in every locale (e.g. de "(Kopie N)", ja "（コピー N）"). Untitled drafts stay untitled. New l10n keys are translated into all 17 non-English locales.

**Related Issue:** Closes #6188

## Out of Scope

None.

## Verification

- `flutter analyze` on changed lib/test — clean
- `flutter test` for the affected suites (model, bloc, event, state, widget, new `draft_copy_naming`, ARB consistency) — all green
- `dart format` — clean
- pre-commit + pre-push hooks passed

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
