### PR TITLE
fix(video-recorder): crash-proof clip-delete Undo and finalize it on recorder exit

### DIFF
--- a/mobile/lib/providers/clip_manager_provider.dart
+++ b/mobile/lib/providers/clip_manager_provider.dart
@@ -187,7 +187,7 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
     // A new recording supersedes any pending undo from a previous tap.
     if (state.pendingDeletion != null) {
       _cancelPendingDeletionTimer();
-      unawaited(_commitPendingDeletion());
+      unawaited(commitPendingDeletion());
     }
 
     final clipDuration =
@@ -403,7 +403,7 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
   Future<bool> removeClipById(String clipId) async {
     if (state.pendingDeletion != null) {
       _cancelPendingDeletionTimer();
-      await _commitPendingDeletion();
+      await commitPendingDeletion();
     }
 
     final index = _clips.indexWhere((c) => c.id == clipId);
@@ -470,7 +470,7 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
   void reorderClip(int oldIndex, int newIndex) {
     if (state.pendingDeletion != null) {
       _cancelPendingDeletionTimer();
-      unawaited(_commitPendingDeletion());
+      unawaited(commitPendingDeletion());
     }
 
     if (oldIndex < 0 ||
@@ -714,7 +714,7 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
     // its draft-decoupling effect by overwriting state.pendingDeletion.
     if (state.pendingDeletion != null) {
       _cancelPendingDeletionTimer();
-      await _commitPendingDeletion();
+      await commitPendingDeletion();
     }
 
     final lastIndex = _clips.length - 1;
@@ -743,7 +743,7 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
 
     _pendingDeletionTimer = Timer(pendingDeletionWindow, () {
       _pendingDeletionTimer = null;
-      unawaited(_commitPendingDeletion());
+      unawaited(commitPendingDeletion());
     });
   }
 
@@ -782,7 +782,12 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
 
   /// Drop the pending-deletion marker. The clip stays in library trash
   /// and the 30-day retention window owns hard-deletion from here.
-  Future<void> _commitPendingDeletion() async {
+  ///
+  /// Called internally when the user moves on from the undo opportunity
+  /// (new recording, reorder, another delete), and by the recorder-exit
+  /// navigation before the next step snapshots the clip list. No-ops
+  /// when no deletion is pending.
+  Future<void> commitPendingDeletion() async {
     final pending = state.pendingDeletion;
     if (pending == null) return;
     _cancelPendingDeletionTimer();
@@ -816,7 +821,7 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
   Future<void> clearAll({bool keepAutosavedDraft = false}) async {
     _cancelPendingDeletionTimer();
     if (state.pendingDeletion != null) {
-      await _commitPendingDeletion();
+      await commitPendingDeletion();
     }
     final clipCount = _clips.length;
     _clips.clear();

--- a/mobile/lib/widgets/video_recorder/clip_delete_snackbar.dart
+++ b/mobile/lib/widgets/video_recorder/clip_delete_snackbar.dart
@@ -17,6 +17,12 @@ import 'package:openvine/providers/clip_manager_provider.dart';
 /// before showing so rapid taps see only the latest snackbar.
 void showClipDeleteSnackbar(BuildContext context, WidgetRef ref) {
   final messenger = ScaffoldMessenger.of(context)..removeCurrentSnackBar();
+  // The snackbar is hosted by ScaffoldMessenger (above the Navigator), so it
+  // outlives the recorder route: the user can tap Undo after navigating on to
+  // the metadata screen, by which point this widget's `ref` is deactivated.
+  // Capture the (keep-alive) notifier now, while `ref` is still valid, instead
+  // of reading it in the deferred callback.
+  final clipManager = ref.read(clipManagerProvider.notifier);
   messenger.showSnackBar(
     DivineSnackbarContainer.snackBar(
       context.l10n.videoRecorderClipDeletedMessage,
@@ -25,7 +31,7 @@ void showClipDeleteSnackbar(BuildContext context, WidgetRef ref) {
       actionLabel: context.l10n.videoRecorderClipUndoLabel,
       onActionPressed: () {
         messenger.hideCurrentSnackBar();
-        ref.read(clipManagerProvider.notifier).undoPendingDeletion();
+        clipManager.undoPendingDeletion();
       },
     ),
   );

--- a/mobile/lib/widgets/video_recorder/clip_delete_snackbar.dart
+++ b/mobile/lib/widgets/video_recorder/clip_delete_snackbar.dart
@@ -17,11 +17,11 @@ import 'package:openvine/providers/clip_manager_provider.dart';
 /// before showing so rapid taps see only the latest snackbar.
 void showClipDeleteSnackbar(BuildContext context, WidgetRef ref) {
   final messenger = ScaffoldMessenger.of(context)..removeCurrentSnackBar();
-  // The snackbar is hosted by ScaffoldMessenger (above the Navigator), so it
-  // outlives the recorder route: the user can tap Undo after navigating on to
-  // the metadata screen, by which point this widget's `ref` is deactivated.
-  // Capture the (keep-alive) notifier now, while `ref` is still valid, instead
-  // of reading it in the deferred callback.
+  // The app-level ScaffoldMessenger outlives this widget's `ref`: the delete
+  // button can unmount on recorder rebuilds, and the snackbar survives route
+  // changes (recorder close, library push). Capture the keep-alive notifier
+  // now, while `ref` is still valid, instead of reading it in the deferred
+  // callback.
   final clipManager = ref.read(clipManagerProvider.notifier);
   messenger.showSnackBar(
     DivineSnackbarContainer.snackBar(

--- a/mobile/lib/widgets/video_recorder/video_recorder_navigation.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_navigation.dart
@@ -51,6 +51,16 @@ Future<void> openVideoEditorFromRecorder(
   final bloc = context.read<VideoRecorderBloc>();
   final recorderMode = bloc.state.recorderMode;
 
+  // Both next steps snapshot the clip list right here (classic renders it
+  // below, the editor seeds its session from it on init), so a clip-delete
+  // Undo honored after this point would silently diverge from that snapshot.
+  // Finalize the pending deletion and drop its snackbar instead.
+  if (ref.read(clipManagerProvider).pendingDeletion != null) {
+    ScaffoldMessenger.of(context).hideCurrentSnackBar();
+    await ref.read(clipManagerProvider.notifier).commitPendingDeletion();
+    if (!context.mounted) return;
+  }
+
   // Lip-sync records against a selected sound, so silence the clips before the
   // editor: only the chosen audio should be heard, with the clips muted and
   // the sound carried in as its own track (seeded on editor init).

--- a/mobile/test/providers/clip_manager_provider_test.dart
+++ b/mobile/test/providers/clip_manager_provider_test.dart
@@ -257,6 +257,39 @@ void main() {
       expect(state.clips.length, equals(1));
     });
 
+    test(
+      'commitPendingDeletion finalizes the delete so a later undo no-ops',
+      () async {
+        final notifier = container.read(clipManagerProvider.notifier);
+
+        notifier.addClip(
+          limitClipDuration: false,
+          video: EditorVideo.file('/path/to/video1.mp4'),
+          duration: const Duration(seconds: 1),
+          targetAspectRatio: .vertical,
+          originalAspectRatio: 9 / 16,
+        );
+        notifier.addClip(
+          limitClipDuration: false,
+          video: EditorVideo.file('/path/to/video2.mp4'),
+          duration: const Duration(seconds: 2),
+          targetAspectRatio: .vertical,
+          originalAspectRatio: 9 / 16,
+        );
+        await notifier.scheduleDeleteLastClip();
+        expect(container.read(clipManagerProvider).pendingDeletion, isNotNull);
+
+        await notifier.commitPendingDeletion();
+
+        expect(container.read(clipManagerProvider).pendingDeletion, isNull);
+
+        await notifier.undoPendingDeletion();
+
+        expect(container.read(clipManagerProvider).clips.length, equals(1));
+        verifyNever(() => mockClipLibraryService.restore(any()));
+      },
+    );
+
     test('clearAll removes all clips and resets state', () async {
       final notifier = container.read(clipManagerProvider.notifier);
 

--- a/mobile/test/widgets/video_recorder/clip_delete_snackbar_test.dart
+++ b/mobile/test/widgets/video_recorder/clip_delete_snackbar_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/clip_manager_provider.dart';
+import 'package:openvine/widgets/video_recorder/clip_delete_snackbar.dart';
+
+/// Records [undoPendingDeletion] calls without touching the real
+/// clip-manager dependencies. The base [ClipManagerNotifier.build] only
+/// registers an `onDispose` hook and returns an empty state, so it is safe
+/// to instantiate in isolation.
+class _SpyClipManagerNotifier extends ClipManagerNotifier {
+  int undoCalls = 0;
+
+  @override
+  Future<void> undoPendingDeletion() async {
+    undoCalls++;
+  }
+}
+
+/// Host that shows the snackbar and can navigate itself away, deactivating
+/// its own [WidgetRef] while the app-level snackbar stays on screen.
+class _HostPage extends ConsumerWidget {
+  const _HostPage();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      body: Column(
+        children: [
+          ElevatedButton(
+            key: const Key('show'),
+            onPressed: () => showClipDeleteSnackbar(context, ref),
+            child: const Text('show'),
+          ),
+          ElevatedButton(
+            key: const Key('navigate'),
+            onPressed: () => Navigator.of(context).pushReplacement(
+              MaterialPageRoute<void>(builder: (_) => const _OtherPage()),
+            ),
+            child: const Text('navigate'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _OtherPage extends StatelessWidget {
+  const _OtherPage();
+
+  @override
+  Widget build(BuildContext context) => const Scaffold(body: SizedBox.shrink());
+}
+
+void main() {
+  group(showClipDeleteSnackbar, () {
+    late _SpyClipManagerNotifier spy;
+    late String undoLabel;
+
+    setUp(() {
+      spy = _SpyClipManagerNotifier();
+      undoLabel = lookupAppLocalizations(
+        const Locale('en'),
+      ).videoRecorderClipUndoLabel;
+    });
+
+    Future<void> pumpHost(WidgetTester tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [clipManagerProvider.overrideWith(() => spy)],
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: _HostPage(),
+          ),
+        ),
+      );
+    }
+
+    testWidgets(
+      'Undo still reaches the notifier after the host widget unmounts',
+      (tester) async {
+        await pumpHost(tester);
+
+        await tester.tap(find.byKey(const Key('show')));
+        await tester.pumpAndSettle();
+        expect(find.text(undoLabel), findsOneWidget);
+
+        // Navigate away: the recorder route (and its ref) is disposed while
+        // the ScaffoldMessenger keeps the snackbar visible on the new route.
+        await tester.tap(find.byKey(const Key('navigate')));
+        await tester.pumpAndSettle();
+        expect(find.byType(_HostPage), findsNothing);
+        expect(find.text(undoLabel), findsOneWidget);
+
+        await tester.tap(find.text(undoLabel));
+        await tester.pump();
+
+        // Before the fix this threw "Using ref when a widget is ... unmounted"
+        // and never reached the notifier.
+        expect(tester.takeException(), isNull);
+        expect(spy.undoCalls, 1);
+      },
+    );
+
+    testWidgets('Undo triggers the notifier on the recorder screen', (
+      tester,
+    ) async {
+      await pumpHost(tester);
+
+      await tester.tap(find.byKey(const Key('show')));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text(undoLabel));
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+      expect(spy.undoCalls, 1);
+    });
+  });
+}

--- a/mobile/test/widgets/video_recorder/video_recorder_navigation_test.dart
+++ b/mobile/test/widgets/video_recorder/video_recorder_navigation_test.dart
@@ -14,6 +14,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/clip_manager_state.dart';
+import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
 import 'package:openvine/models/video_recorder/video_recorder_mode.dart';
 import 'package:openvine/providers/app_providers.dart';
@@ -24,7 +25,9 @@ import 'package:openvine/screens/library_screen.dart';
 import 'package:openvine/screens/video_editor/video_editor_screen.dart';
 import 'package:openvine/screens/video_metadata/video_metadata_screen.dart';
 import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/widgets/video_recorder/clip_delete_snackbar.dart';
 import 'package:openvine/widgets/video_recorder/video_recorder_navigation.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:sound_service/sound_service.dart';
 
 class _MockAuthService extends Mock implements AuthService {}
@@ -225,6 +228,38 @@ void main() {
         verify(() => audioSessionService.configureForMixedPlayback()).called(1);
       });
 
+      testWidgets('openVideoEditorFromRecorder finalizes a pending clip '
+          'deletion and dismisses the Undo snackbar', (tester) async {
+        fakeClipManager.initialPendingDeletion = ClipPendingDeletion(
+          clip: DivineVideoClip(
+            id: 'pending-clip',
+            video: EditorVideo.file('/path/to/video.mp4'),
+            duration: const Duration(seconds: 1),
+            recordedAt: DateTime(2026),
+            targetAspectRatio: .vertical,
+            originalAspectRatio: 9 / 16,
+          ),
+          originalIndex: 0,
+        );
+
+        await tester.pumpWidget(buildHarness());
+        await tester.pumpAndSettle();
+        final l10n = lookupAppLocalizations(const Locale('en'));
+
+        await tester.tap(find.byKey(const Key('show-delete-snackbar')));
+        await tester.pump();
+        expect(find.text(l10n.videoRecorderClipUndoLabel), findsOneWidget);
+
+        await tester.tap(find.byKey(const Key('open-editor')));
+        await tester.pumpAndSettle();
+
+        // The editor seeds its session from the clip list at navigation time
+        // (classic renders it), so a pending Undo must not survive the push.
+        expect(find.text('editor'), findsOneWidget);
+        expect(fakeClipManager.commitPendingDeletionCalls, equals(1));
+        expect(find.text(l10n.videoRecorderClipUndoLabel), findsNothing);
+      });
+
       testWidgets('openVideoEditorFromRecorder resets the session for a mode '
           'without a video editor (routes to metadata)', (tester) async {
         when(() => recorderBloc.state).thenReturn(
@@ -318,13 +353,22 @@ void main() {
 
 class _FakeClipManagerNotifier extends ClipManagerNotifier {
   bool muteAllClipsCalled = false;
+  int commitPendingDeletionCalls = 0;
+  ClipPendingDeletion? initialPendingDeletion;
 
   @override
-  ClipManagerState build() => ClipManagerState();
+  ClipManagerState build() =>
+      ClipManagerState(pendingDeletion: initialPendingDeletion);
 
   @override
   void muteAllClips() {
     muteAllClipsCalled = true;
+  }
+
+  @override
+  Future<void> commitPendingDeletion() async {
+    commitPendingDeletionCalls++;
+    state = state.copyWith(clearPendingDeletion: true);
   }
 }
 
@@ -346,6 +390,11 @@ class _RecorderHarness extends ConsumerWidget {
             key: const Key('open-library'),
             onPressed: () => unawaited(openRecorderLibrary(context, ref)),
             child: const Text('open library'),
+          ),
+          ElevatedButton(
+            key: const Key('show-delete-snackbar'),
+            onPressed: () => showClipDeleteSnackbar(context, ref),
+            child: const Text('show delete snackbar'),
           ),
         ],
       ),


### PR DESCRIPTION
Closes #6233

## What

Fix an iOS **FATAL** crash when tapping **Undo** on the recorder's "Clip moved to trash" snackbar after the hosting widget unmounts, and finalize a pending clip deletion when the user proceeds from the recorder to the next step.

Crashlytics `19a28701ebed005db8ea4d95a432c812` — `Bad state: Using "ref" when a widget is about to or has been unmounted is unsafe` at `clip_delete_snackbar.dart:28`, first seen 1.0.14, last seen 1.0.16.

## Why

**Crash fix.** The snackbar is shown through `ScaffoldMessenger`, which sits above the `Navigator`, so it outlives the widget that showed it — the delete button can unmount on recorder rebuilds (deleting the only clip hides it) and the snackbar survives route changes. The Undo callback held that widget's `WidgetRef` and called `ref.read(...)` at tap time, which throws once the widget is gone. `clipManagerProvider` is a global keep-alive `NotifierProvider` (never invalidated anywhere), so capturing its notifier synchronously, while `ref` is still valid, removes the deferred `ref` access entirely.

**Finalize on recorder exit.** Fixing the crash made Undo reachable after leaving the recorder, but both next steps snapshot the clip list at navigation time: classic mode starts the final render in `openVideoEditorFromRecorder`, and capture/lip-sync seed the editor session from a one-shot read. Honoring an Undo after that point silently diverges state — in classic the published video would omit the restored clip (`undoPendingDeletion` never invalidates `finalRenderedClip`, and the metadata preview player initializes once), and in capture/lip-sync the open editor timeline would never show it. Rather than propagating the undo into an in-flight render and a live editor session, the navigation boundary now commits the pending deletion and dismisses the snackbar — consistent with `addClip`/`reorderClip`/`removeClipById`, which already commit a pending deletion when the user moves on. The clip stays in library trash for 30 days, so it remains recoverable. Undo keeps working on the recorder itself and on paths with no snapshot (recorder close, clips-library push), which is where the crash actually fired.

## Test

- `clip_delete_snackbar_test.dart` (new): regression test that shows the snackbar, unmounts the host so its `ref` deactivates, taps Undo, and asserts the notifier is still reached. It fails against the old code with the exact `Bad state` error; a second test covers the still-mounted path.
- `video_recorder_navigation_test.dart`: `openVideoEditorFromRecorder` finalizes a pending deletion and dismisses the Undo snackbar before navigating.
- `clip_manager_provider_test.dart`: `commitPendingDeletion()` clears the pending marker so a later undo no-ops (`restore` is never called).
- `flutter analyze lib test integration_test` clean; all three affected suites pass.

Manual: record two clips → delete last → **Next** within 5s → snackbar dismissed, publish contains only the first clip, deleted clip sits in library trash. Undo on the recorder before Next restores the clip and the published video includes it. Deleting the only clip (the delete button unmounts) then tapping Undo no longer crashes.
