### PR TITLE
docs(content-warnings): document and guard the age-gate

### DIFF
--- a/mobile/lib/services/content_filter_service.dart
+++ b/mobile/lib/services/content_filter_service.dart
@@ -61,7 +61,14 @@ class ContentFilterService extends ChangeNotifier {
     ContentLabel.sexual,
   };
 
-  /// Visible categories locked to hide unless the user is age-verified.
+  /// Categories age-gated to [ContentFilterPreference.hide] until the viewer is
+  /// age-verified. This is a compliance control, not content-warning UX: these
+  /// categories (adult content plus alcohol, tobacco, gambling, and profanity)
+  /// must stay hidden from non-age-verified viewers regardless of how the label
+  /// was applied. A creator's own self-label does NOT exempt a video from the
+  /// gate — do not add a "self-labeled content warns instead of hides" bypass
+  /// here (see #5062). The `warn` defaults for the four non-adult categories
+  /// only take effect once the viewer is age-verified.
   static const Set<ContentLabel> ageRestrictedCategories = {
     ...adultCategories,
     ContentLabel.alcohol,
@@ -181,7 +188,9 @@ class ContentFilterService extends ChangeNotifier {
     if (alwaysFilteredCategories.contains(label)) {
       return ContentFilterPreference.hide;
     }
-    // Age-restricted categories are locked to hide if not age-verified.
+    // Compliance age-gate: age-restricted categories are locked to hide for
+    // non-age-verified viewers, whether the label is a creator self-label or a
+    // moderation label. Do not exempt self-labels here. See #5062.
     if (ageRestrictedCategories.contains(label) &&
         !ageVerificationService.isAdultContentVerified) {
       return ContentFilterPreference.hide;

--- a/mobile/lib/services/content_filter_service.dart
+++ b/mobile/lib/services/content_filter_service.dart
@@ -62,13 +62,11 @@ class ContentFilterService extends ChangeNotifier {
   };
 
   /// Categories age-gated to [ContentFilterPreference.hide] until the viewer is
-  /// age-verified. This is a compliance control, not content-warning UX: these
-  /// categories (adult content plus alcohol, tobacco, gambling, and profanity)
-  /// must stay hidden from non-age-verified viewers regardless of how the label
-  /// was applied. A creator's own self-label does NOT exempt a video from the
-  /// gate — do not add a "self-labeled content warns instead of hides" bypass
-  /// here (see #5062). The `warn` defaults for the four non-adult categories
-  /// only take effect once the viewer is age-verified.
+  /// age-verified. PR #5303 locked these labels behind age verification; do not
+  /// add a "self-labeled content warns instead of hides" bypass without
+  /// confirming the category policy first. The `warn` defaults for alcohol,
+  /// tobacco, profanity, and gambling only take effect once the viewer is
+  /// age-verified. See #5062 for the reported visibility symptom.
   static const Set<ContentLabel> ageRestrictedCategories = {
     ...adultCategories,
     ContentLabel.alcohol,
@@ -188,9 +186,8 @@ class ContentFilterService extends ChangeNotifier {
     if (alwaysFilteredCategories.contains(label)) {
       return ContentFilterPreference.hide;
     }
-    // Compliance age-gate: age-restricted categories are locked to hide for
-    // non-age-verified viewers, whether the label is a creator self-label or a
-    // moderation label. Do not exempt self-labels here. See #5062.
+    // Enforce the #5303 age gate for both creator self-labels and moderation
+    // labels.
     if (ageRestrictedCategories.contains(label) &&
         !ageVerificationService.isAdultContentVerified) {
       return ContentFilterPreference.hide;

--- a/mobile/test/services/video_event_service_content_filter_test.dart
+++ b/mobile/test/services/video_event_service_content_filter_test.dart
@@ -162,35 +162,38 @@ void main() {
   });
 
   group('creator self-labels (#5062)', () {
-    test(
-      'a self-labeled warn-category video stays visible behind the overlay '
-      'for a non-age-verified viewer',
-      () async {
-        expect(ageVerificationService.isAdultContentVerified, isFalse);
+    final nonAdultAgeRestrictedLabels = ContentFilterService
+        .ageRestrictedCategories
+        .where((label) => !ContentFilterService.adultCategories.contains(label))
+        .toList();
 
-        // flashing-lights is a warn category, not age-gated: the creator's
-        // self-label must keep the video visible (behind the overlay), not
-        // make it disappear. This is the reported behaviour in #5062.
+    test('a self-labeled warn-category video stays visible behind the overlay '
+        'for a non-age-verified viewer', () async {
+      expect(ageVerificationService.isAdultContentVerified, isFalse);
+
+      // flashing-lights is a warn category, not age-gated: the creator's
+      // self-label must keep the video visible (behind the overlay), not
+      // make it disappear. This is the reported behaviour in #5062.
+      final result = videoEventService.filterVideoList([
+        _createVideo(
+          id: 'video-flashing',
+          contentWarningLabels: const ['flashing-lights'],
+        ),
+      ]);
+
+      expect(result, hasLength(1));
+      expect(result.single.warnLabels, equals(['flashing-lights']));
+    });
+
+    test('self-labeled non-adult age-restricted videos are hidden for '
+        'non-age-verified viewers', () async {
+      expect(ageVerificationService.isAdultContentVerified, isFalse);
+
+      for (final label in nonAdultAgeRestrictedLabels) {
         final result = videoEventService.filterVideoList([
           _createVideo(
-            id: 'video-flashing',
-            contentWarningLabels: const ['flashing-lights'],
-          ),
-        ]);
-
-        expect(result, hasLength(1));
-        expect(result.single.warnLabels, equals(['flashing-lights']));
-      },
-    );
-
-    test(
-      'a self-labeled alcohol video is hidden for a non-age-verified viewer '
-      '(compliance age-gate)',
-      () async {
-        final result = videoEventService.filterVideoList([
-          _createVideo(
-            id: 'video-alcohol',
-            contentWarningLabels: const ['alcohol'],
+            id: 'video-${label.value}',
+            contentWarningLabels: [label.value],
           ),
         ]);
 
@@ -198,44 +201,31 @@ void main() {
           result,
           isEmpty,
           reason:
-              'alcohol is a compliance age-gated category; a creator '
-              'self-label must not exempt it for non-age-verified viewers. '
-              'See #5062.',
+              '${label.value} should stay hidden for non-age-verified '
+              'viewers even when applied as a creator self-label.',
         );
-      },
-    );
+      }
+    });
 
-    test(
-      'a self-labeled gambling video is hidden for a non-age-verified viewer '
-      '(compliance age-gate)',
-      () async {
+    test('self-labeled non-adult age-restricted videos become visible behind '
+        'the overlay once the viewer is age-verified', () async {
+      await ageVerificationService.setAdultContentVerified(true);
+
+      for (final label in nonAdultAgeRestrictedLabels) {
         final result = videoEventService.filterVideoList([
           _createVideo(
-            id: 'video-gambling',
-            contentWarningLabels: const ['gambling'],
+            id: 'video-${label.value}-verified',
+            contentWarningLabels: [label.value],
           ),
         ]);
 
-        expect(result, isEmpty);
-      },
-    );
-
-    test(
-      'a self-labeled alcohol video becomes visible behind the overlay once '
-      'the viewer is age-verified',
-      () async {
-        await ageVerificationService.setAdultContentVerified(true);
-
-        final result = videoEventService.filterVideoList([
-          _createVideo(
-            id: 'video-alcohol-verified',
-            contentWarningLabels: const ['alcohol'],
-          ),
-        ]);
-
-        expect(result, hasLength(1));
-        expect(result.single.warnLabels, equals(['alcohol']));
-      },
-    );
+        expect(
+          result,
+          hasLength(1),
+          reason: '${label.value} should be visible after age verification.',
+        );
+        expect(result.single.warnLabels, equals([label.value]));
+      }
+    });
   });
 }

--- a/mobile/test/services/video_event_service_content_filter_test.dart
+++ b/mobile/test/services/video_event_service_content_filter_test.dart
@@ -36,6 +36,7 @@ VideoEvent _createVideo({
       '1111111111111111111111111111111111111111111111111111111111111111',
   String? sha256,
   String? vineId,
+  List<String> contentWarningLabels = const [],
 }) {
   return VideoEvent(
     id: id,
@@ -45,6 +46,7 @@ VideoEvent _createVideo({
     timestamp: DateTime(2025),
     sha256: sha256,
     vineId: vineId,
+    contentWarningLabels: contentWarningLabels,
   );
 }
 
@@ -157,5 +159,83 @@ void main() {
       expect(result.single.contentWarningLabels, isEmpty);
       expect(result.single.warnLabels, equals(['flashing-lights']));
     });
+  });
+
+  group('creator self-labels (#5062)', () {
+    test(
+      'a self-labeled warn-category video stays visible behind the overlay '
+      'for a non-age-verified viewer',
+      () async {
+        expect(ageVerificationService.isAdultContentVerified, isFalse);
+
+        // flashing-lights is a warn category, not age-gated: the creator's
+        // self-label must keep the video visible (behind the overlay), not
+        // make it disappear. This is the reported behaviour in #5062.
+        final result = videoEventService.filterVideoList([
+          _createVideo(
+            id: 'video-flashing',
+            contentWarningLabels: const ['flashing-lights'],
+          ),
+        ]);
+
+        expect(result, hasLength(1));
+        expect(result.single.warnLabels, equals(['flashing-lights']));
+      },
+    );
+
+    test(
+      'a self-labeled alcohol video is hidden for a non-age-verified viewer '
+      '(compliance age-gate)',
+      () async {
+        final result = videoEventService.filterVideoList([
+          _createVideo(
+            id: 'video-alcohol',
+            contentWarningLabels: const ['alcohol'],
+          ),
+        ]);
+
+        expect(
+          result,
+          isEmpty,
+          reason:
+              'alcohol is a compliance age-gated category; a creator '
+              'self-label must not exempt it for non-age-verified viewers. '
+              'See #5062.',
+        );
+      },
+    );
+
+    test(
+      'a self-labeled gambling video is hidden for a non-age-verified viewer '
+      '(compliance age-gate)',
+      () async {
+        final result = videoEventService.filterVideoList([
+          _createVideo(
+            id: 'video-gambling',
+            contentWarningLabels: const ['gambling'],
+          ),
+        ]);
+
+        expect(result, isEmpty);
+      },
+    );
+
+    test(
+      'a self-labeled alcohol video becomes visible behind the overlay once '
+      'the viewer is age-verified',
+      () async {
+        await ageVerificationService.setAdultContentVerified(true);
+
+        final result = videoEventService.filterVideoList([
+          _createVideo(
+            id: 'video-alcohol-verified',
+            contentWarningLabels: const ['alcohol'],
+          ),
+        ]);
+
+        expect(result, hasLength(1));
+        expect(result.single.warnLabels, equals(['alcohol']));
+      },
+    );
   });
 }


### PR DESCRIPTION
## Description

The visibility half of #5062 was investigated end-to-end. On current builds,
warn-category self-labels (flashing-lights, spoiler, etc.) render behind the
blur overlay and stay visible, while age-gated categories (adult content plus
alcohol/tobacco/gambling/profanity) stay hidden for non-age-verified viewers.

This PR keeps behavior unchanged and documents the age gate by provenance:
PR #5303 locked these categories behind age verification. The comments now
point future maintainers to that origin and to #5062 as the reported visibility
symptom, without asserting an uncited policy rationale.

- **Document the age gate.** `ageRestrictedCategories` / `getPreference` now
  explain that self-labels and moderation labels both go through the #5303 age
  gate.
- **Guard test.** Pins that warn-category self-labels stay visible, while every
  non-adult age-gated category stays hidden for a non-age-verified viewer and
  becomes visible behind the overlay after age verification.

No behavior change (production diff is comment-only).

**Related Issue:** Relates to #5062

## Out of Scope

- Closing #5062 itself.
- Any change to the age gate's category membership or the Content Filters
  settings display.

## Verification

- `mise exec flutter@3.44.0 -- flutter test test/services/video_event_service_content_filter_test.dart`
- `mise exec flutter@3.44.0 -- flutter analyze`
- pre-push hook: changed-file analyzer and tests for `content_filter_service_test.dart` and `video_event_service_content_filter_test.dart`

## Type of Change

- [x] Documentation
- [x] Tests
