### PR TITLE
fix(video-feed): correct empty profile feed diagnostics

### DIFF
--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -5874,6 +5874,17 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     SubscriptionType subscriptionType,
   ) => _applyLikeCountToVideo(videoId, likeCount, subscriptionType);
 
+  List<Filter> _buildDiagnosticProbeFilters(List<Filter> filters) {
+    return filters.map((filter) {
+      final diagnosticFilter = Filter.fromJson(filter.toJson());
+      final existingLimit = diagnosticFilter.limit;
+      diagnosticFilter.limit = existingLimit == null || existingLimit > 100
+          ? 100
+          : existingLimit;
+      return diagnosticFilter;
+    }).toList();
+  }
+
   /// Run automatic diagnostics when feed fails to load events
   /// This logs relay status, connection info, and tests direct queries to help debug
   Future<void> _runAutoDiagnostics(
@@ -5972,40 +5983,39 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
         }
       }
 
-      // 3. Test direct query to see if events exist in database
+      // 3. Test direct query with the same filters to see if matching events
+      // exist in the database.
+      final diagnosticFilters = _buildDiagnosticProbeFilters(filters);
       Log.warning(
-        '🔍 Testing direct database query (bypassing subscription)...',
+        '🔍 Testing direct database query with subscription filters (bypassing subscription)...',
         name: 'VideoEventService',
         category: LogCategory.video,
       );
 
-      final directQueryEvents = await _nostrService.queryEvents([
-        Filter(
-          kinds: const [NIP71VideoKinds.addressableShortVideo],
-          limit: 100,
-        ),
-      ]);
+      final directQueryEvents = await _nostrService.queryEvents(
+        diagnosticFilters,
+      );
 
       Log.warning(
-        '✅ Direct query returned ${directQueryEvents.length} video events',
+        '✅ Filtered direct query returned ${directQueryEvents.length} matching events',
         name: 'VideoEventService',
         category: LogCategory.video,
       );
 
       if (directQueryEvents.isEmpty) {
-        Log.error(
-          '❌ DIAGNOSTIC: Relay cache has NO video events!',
+        Log.info(
+          '✅ DIAGNOSTIC: No cached events match the empty $subscriptionType subscription filters.',
           name: 'VideoEventService',
           category: LogCategory.video,
         );
-        Log.error(
-          '   This means relay connection is not returning video events.',
+        Log.info(
+          '   This is an expected empty state for sparse/profile feeds when the author or filter has no videos.',
           name: 'VideoEventService',
           category: LogCategory.video,
         );
       } else {
         Log.warning(
-          '✅ DIAGNOSTIC: Database HAS ${directQueryEvents.length} events, but subscription returned 0.',
+          '✅ DIAGNOSTIC: Database HAS ${directQueryEvents.length} events matching the subscription filters, but subscription returned 0.',
           name: 'VideoEventService',
           category: LogCategory.video,
         );
@@ -6017,7 +6027,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
 
         // Log sample events to help compare with subscription filters
         Log.warning(
-          '📄 Sample events in database:',
+          '📄 Sample matching events in database:',
           name: 'VideoEventService',
           category: LogCategory.video,
         );

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -5984,7 +5984,10 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       }
 
       // 3. Test direct query with the same filters to see if matching events
-      // exist in the database.
+      // exist in the database. queryEvents only consults the local cache for
+      // single-filter queries, so probe each filter separately — otherwise
+      // repost-enabled (multi-filter) feeds skip the cache entirely and the
+      // "subscription broken" branch below can never fire.
       final diagnosticFilters = _buildDiagnosticProbeFilters(filters);
       Log.warning(
         '🔍 Testing direct database query with subscription filters (bypassing subscription)...',
@@ -5992,9 +5995,12 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
         category: LogCategory.video,
       );
 
-      final directQueryEvents = await _nostrService.queryEvents(
-        diagnosticFilters,
-      );
+      final directQueryEvents = <Event>[];
+      for (final diagnosticFilter in diagnosticFilters) {
+        directQueryEvents.addAll(
+          await _nostrService.queryEvents([diagnosticFilter]),
+        );
+      }
 
       Log.warning(
         '✅ Filtered direct query returned ${directQueryEvents.length} matching events',
@@ -6009,7 +6015,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
           category: LogCategory.video,
         );
         Log.info(
-          '   This is an expected empty state for sparse/profile feeds when the author or filter has no videos.',
+          '   Expected when the requested authors or filters have no matching cached videos.',
           name: 'VideoEventService',
           category: LogCategory.video,
         );

--- a/mobile/test/services/video_event_service_eose_empty_test.dart
+++ b/mobile/test/services/video_event_service_eose_empty_test.dart
@@ -212,31 +212,46 @@ void main() {
         capturedOnEose!();
         await pumpEventQueue();
 
-        final capturedFilters =
-            verify(
-                  () => mockNostrService.queryEvents(captureAny()),
-                ).captured.single
-                as List<Filter>;
+        final capturedCalls = verify(
+          () => mockNostrService.queryEvents(captureAny()),
+        ).captured.cast<List<Filter>>();
 
-        expect(capturedFilters, hasLength(2));
         expect(
-          capturedFilters.every(
+          capturedCalls,
+          hasLength(2),
+          reason:
+              'Each subscription filter is probed separately so the local '
+              'cache is consulted (queryEvents only reads cache for '
+              'single-filter queries).',
+        );
+        expect(
+          capturedCalls.every((filters) => filters.length == 1),
+          isTrue,
+          reason: 'Probe must query one filter at a time to hit the cache',
+        );
+
+        final probeFilters = capturedCalls
+            .map((filters) => filters.single)
+            .toList();
+
+        expect(
+          probeFilters.every(
             (filter) => filter.authors != null && filter.authors!.isNotEmpty,
           ),
           isTrue,
           reason: 'Diagnostic probe must not fall back to a global video query',
         );
         expect(
-          capturedFilters.map((filter) => filter.authors).toList(),
+          probeFilters.map((filter) => filter.authors).toList(),
           everyElement(equals([_profileAuthor])),
         );
         expect(
-          capturedFilters.first.kinds,
+          probeFilters.first.kinds,
           equals(NIP71VideoKinds.getAllVideoKinds()),
         );
-        expect(capturedFilters.first.limit, 100);
-        expect(capturedFilters.last.kinds, equals([16]));
-        expect(capturedFilters.last.limit, 50);
+        expect(probeFilters.first.limit, 100);
+        expect(probeFilters.last.kinds, equals([16]));
+        expect(probeFilters.last.limit, 50);
       },
     );
 

--- a/mobile/test/services/video_event_service_eose_empty_test.dart
+++ b/mobile/test/services/video_event_service_eose_empty_test.dart
@@ -9,12 +9,17 @@ import 'package:mocktail/mocktail.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/filter.dart';
+import 'package:openvine/constants/nip71_migration.dart';
 import 'package:openvine/services/subscription_manager.dart';
 import 'package:openvine/services/video_event_service.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 class _MockNostrClient extends Mock implements NostrClient {}
 
 class _MockSubscriptionManager extends Mock implements SubscriptionManager {}
+
+const _profileAuthor =
+    '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
 
 void main() {
   setUpAll(() {
@@ -26,17 +31,33 @@ void main() {
     late _MockNostrClient mockNostrService;
     late _MockSubscriptionManager mockSubscriptionManager;
 
-    setUp(() {
+    setUp(() async {
       mockNostrService = _MockNostrClient();
       mockSubscriptionManager = _MockSubscriptionManager();
 
       when(() => mockNostrService.isInitialized).thenReturn(true);
       when(() => mockNostrService.connectedRelayCount).thenReturn(1);
+      when(
+        () => mockNostrService.configuredRelays,
+      ).thenReturn(['wss://relay.example.com']);
+      when(
+        () => mockNostrService.connectedRelays,
+      ).thenReturn(['wss://relay.example.com']);
+      when(
+        () => mockNostrService.queryEvents(any()),
+      ).thenAnswer((_) async => <Event>[]);
+      when(mockNostrService.getRelayStats).thenAnswer((_) async => null);
 
       videoEventService = VideoEventService(
         mockNostrService,
         subscriptionManager: mockSubscriptionManager,
       );
+
+      await LogCaptureService().clearAllLogs();
+    });
+
+    tearDown(() {
+      videoEventService.dispose();
     });
 
     test('should clear per-subscription loading state when EOSE arrives '
@@ -165,5 +186,152 @@ void main() {
         );
       });
     });
+
+    test(
+      'runs empty-feed diagnostic query with profile author filters',
+      () async {
+        void Function()? capturedOnEose;
+        final controller = StreamController<Event>();
+        addTearDown(controller.close);
+
+        when(
+          () => mockNostrService.subscribe(any(), onEose: any(named: 'onEose')),
+        ).thenAnswer((invocation) {
+          capturedOnEose =
+              invocation.namedArguments[#onEose] as void Function()?;
+          return controller.stream;
+        });
+
+        await videoEventService.subscribeToVideoFeed(
+          subscriptionType: SubscriptionType.profile,
+          authors: const [_profileAuthor],
+          includeReposts: true,
+          limit: 250,
+        );
+
+        capturedOnEose!();
+        await pumpEventQueue();
+
+        final capturedFilters =
+            verify(
+                  () => mockNostrService.queryEvents(captureAny()),
+                ).captured.single
+                as List<Filter>;
+
+        expect(capturedFilters, hasLength(2));
+        expect(
+          capturedFilters.every(
+            (filter) => filter.authors != null && filter.authors!.isNotEmpty,
+          ),
+          isTrue,
+          reason: 'Diagnostic probe must not fall back to a global video query',
+        );
+        expect(
+          capturedFilters.map((filter) => filter.authors).toList(),
+          everyElement(equals([_profileAuthor])),
+        );
+        expect(
+          capturedFilters.first.kinds,
+          equals(NIP71VideoKinds.getAllVideoKinds()),
+        );
+        expect(capturedFilters.first.limit, 100);
+        expect(capturedFilters.last.kinds, equals([16]));
+        expect(capturedFilters.last.limit, 50);
+      },
+    );
+
+    test('logs expected empty profile state without subscription error', () async {
+      void Function()? capturedOnEose;
+      final controller = StreamController<Event>();
+      addTearDown(controller.close);
+
+      when(
+        () => mockNostrService.subscribe(any(), onEose: any(named: 'onEose')),
+      ).thenAnswer((invocation) {
+        capturedOnEose = invocation.namedArguments[#onEose] as void Function()?;
+        return controller.stream;
+      });
+
+      await videoEventService.subscribeToVideoFeed(
+        subscriptionType: SubscriptionType.profile,
+        authors: const [_profileAuthor],
+      );
+
+      capturedOnEose!();
+      await pumpEventQueue();
+
+      final logs = LogCaptureService().getRecentLogs();
+      expect(
+        logs.where(
+          (entry) =>
+              entry.level == LogLevel.error &&
+              entry.message.contains(
+                'subscription filtering is too restrictive OR subscription stream is broken',
+              ),
+        ),
+        isEmpty,
+      );
+      expect(
+        logs.where(
+          (entry) =>
+              entry.level == LogLevel.info &&
+              entry.message.contains(
+                'No cached events match the empty SubscriptionType.profile subscription filters',
+              ),
+        ),
+        isNotEmpty,
+      );
+    });
+
+    test(
+      'keeps subscription error when filtered diagnostic query has events',
+      () async {
+        void Function()? capturedOnEose;
+        final controller = StreamController<Event>();
+        addTearDown(controller.close);
+
+        when(
+          () => mockNostrService.subscribe(any(), onEose: any(named: 'onEose')),
+        ).thenAnswer((invocation) {
+          capturedOnEose =
+              invocation.namedArguments[#onEose] as void Function()?;
+          return controller.stream;
+        });
+        when(() => mockNostrService.queryEvents(any())).thenAnswer(
+          (_) async => [
+            Event(
+              _profileAuthor,
+              NIP71VideoKinds.addressableShortVideo,
+              const [
+                ['d', 'diagnostic-video'],
+                ['url', 'https://example.com/video.mp4'],
+              ],
+              '',
+              createdAt: 1000,
+            )..id = 'diagnostic-video-event',
+          ],
+        );
+
+        await videoEventService.subscribeToVideoFeed(
+          subscriptionType: SubscriptionType.profile,
+          authors: const [_profileAuthor],
+        );
+
+        capturedOnEose!();
+        await pumpEventQueue();
+
+        final logs = LogCaptureService().getRecentLogs();
+        expect(
+          logs.where(
+            (entry) =>
+                entry.level == LogLevel.error &&
+                entry.message.contains(
+                  'subscription filtering is too restrictive OR subscription stream is broken',
+                ),
+          ),
+          isNotEmpty,
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

- Run empty-feed auto diagnostics against the subscription's own filters instead of a global video-only probe.
- Cap diagnostic probe limits without dropping authors, kinds, repost filters, tags, or time bounds.
- Reclassify zero matching diagnostic results as an expected empty state, while preserving the error path when matching cached events exist but the subscription returned zero.
- Add regression coverage for author-scoped profile diagnostics, expected-empty logging, and the genuine subscription-broken branch.

## Root Cause

_runAutoDiagnostics compared an author-scoped subscription against an unscoped kinds:[34236] database query. For a profile with no videos, the global probe could still find unrelated events and log a false ERROR that the subscription was too restrictive or broken.

## Validation

- flutter analyze
- flutter test test/services/video_event_service_eose_empty_test.dart
- Pre-push hook: changed-file analyze and test/services/video_event_service_eose_empty_test.dart

Fixes #6243