### PR TITLE
fix(authentication): allow offline access for existing sessions

### DIFF
--- a/mobile/lib/services/auth/nostr_identity.dart
+++ b/mobile/lib/services/auth/nostr_identity.dart
@@ -120,6 +120,51 @@ class LocalNostrIdentity extends NostrIdentity implements IsolateDecryptSigner {
   }
 }
 
+/// Identity with only a public key available.
+///
+/// Used for restored OAuth sessions while offline: the app can keep account
+/// context for read-only/recording flows, but Nostr writes must wait until a
+/// local key or remote signer is available.
+class PubkeyOnlyNostrIdentity extends NostrIdentity {
+  PubkeyOnlyNostrIdentity({required this.pubkey});
+
+  @override
+  final String pubkey;
+
+  @override
+  Future<String?> getPublicKey() async => pubkey;
+
+  @override
+  Future<Event?> signEvent(Event event) async => null;
+
+  @override
+  Future<String?> signCanonicalPayload(Uint8List payload) async => null;
+
+  @override
+  bool get signsRemotelyNonInteractive => false;
+
+  @override
+  bool get signsWithLocalKey => false;
+
+  @override
+  Future<Map?> getRelays() async => null;
+
+  @override
+  Future<String?> encrypt(String pubkey, String plaintext) async => null;
+
+  @override
+  Future<String?> decrypt(String pubkey, String ciphertext) async => null;
+
+  @override
+  Future<String?> nip44Encrypt(String pubkey, String plaintext) async => null;
+
+  @override
+  Future<String?> nip44Decrypt(String pubkey, String ciphertext) async => null;
+
+  @override
+  void close() {}
+}
+
 /// Identity backed by a Keycast OAuth session.
 ///
 /// When a matching local private key is available, signs locally for speed.

--- a/mobile/lib/services/auth/oauth_session_coordinator.dart
+++ b/mobile/lib/services/auth/oauth_session_coordinator.dart
@@ -119,11 +119,11 @@ class OAuthSessionCoordinator {
             Log.warning(
               '_refreshOAuthSession: timed out after '
               '${_oauthRefreshTimeout.inMilliseconds}ms — '
-              'treating as failed',
+              'treating as network failure',
               name: 'OAuthSessionCoordinator',
               category: LogCategory.auth,
             );
-            return null;
+            throw OAuthNetworkException('OAuth refresh timed out');
           },
         )
         .whenComplete(() {
@@ -155,6 +155,8 @@ class OAuthSessionCoordinator {
         category: LogCategory.auth,
       );
       return refreshed;
+    } on OAuthNetworkException {
+      rethrow;
     } catch (e) {
       Log.error(
         '_refreshOAuthSession: failed: $e',
@@ -172,7 +174,12 @@ class OAuthSessionCoordinator {
   /// multiple in-flight RPC 401s and app-resume refresh all share a single
   /// refresh token exchange.
   Future<String?> refreshAccessToken() async {
-    final refreshed = await refreshSession();
+    final KeycastSession? refreshed;
+    try {
+      refreshed = await refreshSession();
+    } on OAuthNetworkException {
+      return null;
+    }
     return refreshed?.accessToken;
   }
 

--- a/mobile/lib/services/auth/oauth_session_coordinator.dart
+++ b/mobile/lib/services/auth/oauth_session_coordinator.dart
@@ -106,7 +106,11 @@ class OAuthSessionCoordinator {
   /// mid-session callers (401 retry, app resume) may omit it — the method
   /// falls back to [currentPubkeyFallback].
   ///
-  /// Returns the refreshed session on success, or `null` on failure.
+  /// Returns the refreshed session on success, or `null` when refresh is not
+  /// possible or the server rejects the token.
+  ///
+  /// Throws [OAuthNetworkException] when the refresh cannot reach Keycast or
+  /// times out. The refresh token is preserved for a later retry in that case.
   Future<KeycastSession?> refreshSession({String? expectedOwnerPubkey}) {
     final pending = _pendingOAuthRefresh;
     if (pending != null) return pending;

--- a/mobile/lib/services/auth/signer_factory.dart
+++ b/mobile/lib/services/auth/signer_factory.dart
@@ -169,7 +169,15 @@ class SignerFactory {
       }
       return LocalNostrIdentity(keyContainer: keyContainer);
     }
-    // Pub-key-only container with no remote signer — cannot sign.
+    if (authSource == AuthenticationSource.divineOAuth) {
+      Log.warning(
+        '_buildIdentity: using pubkey-only Divine OAuth identity with no '
+        'signing capability. pubkey=$pubkey',
+        name: 'SignerFactory',
+        category: LogCategory.auth,
+      );
+      return PubkeyOnlyNostrIdentity(pubkey: pubkey);
+    }
     throw StateError(
       '_buildIdentity: pub-key-only container with no remote signer. '
       'source=${authSource.name}, pubkey=$pubkey',

--- a/mobile/lib/services/auth/signer_factory.dart
+++ b/mobile/lib/services/auth/signer_factory.dart
@@ -114,7 +114,9 @@ class SignerFactory {
   ///
   /// Throws [StateError] if no valid identity can be constructed — this
   /// indicates a programming error in the auth flow, not a user-facing
-  /// condition.
+  /// condition. Set [allowPubkeyOnlyIdentity] only for the deliberate degraded
+  /// Divine OAuth restore path, where the account pubkey is known but signing
+  /// RPC is temporarily unavailable.
   NostrIdentity buildIdentity({
     required SecureKeyContainer? keyContainer,
     required AuthenticationSource authSource,
@@ -122,6 +124,7 @@ class SignerFactory {
     Nip07Service? nip07Service,
     NostrRemoteSigner? bunkerSigner,
     KeycastRpc? keycastSigner,
+    bool allowPubkeyOnlyIdentity = false,
   }) {
     if (keyContainer == null) {
       throw StateError(
@@ -169,7 +172,8 @@ class SignerFactory {
       }
       return LocalNostrIdentity(keyContainer: keyContainer);
     }
-    if (authSource == AuthenticationSource.divineOAuth) {
+    if (allowPubkeyOnlyIdentity &&
+        authSource == AuthenticationSource.divineOAuth) {
       Log.warning(
         '_buildIdentity: using pubkey-only Divine OAuth identity with no '
         'signing capability. pubkey=$pubkey',

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -4,7 +4,6 @@
 // with secure storage
 
 import 'dart:async';
-import 'dart:io';
 
 import 'package:cache_sync/cache_sync.dart';
 import 'package:flutter/foundation.dart';
@@ -801,9 +800,10 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
           name: 'AuthService',
           category: LogCategory.auth,
         );
-        if (await _restoreDegradedDivineOAuthSession(session)) {
-          return;
-        }
+        await _restoreDegradedDivineOAuthSession(
+          session,
+          anchorNpub: anchorNpub,
+        );
         return;
       } on TimeoutException catch (e) {
         Log.warning(
@@ -812,19 +812,10 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
           name: 'AuthService',
           category: LogCategory.auth,
         );
-        if (await _restoreDegradedDivineOAuthSession(session)) {
-          return;
-        }
-        return;
-      } on SocketException catch (e) {
-        Log.warning(
-          'initialize: synchronous refresh failed due to socket error: $e',
-          name: 'AuthService',
-          category: LogCategory.auth,
+        await _restoreDegradedDivineOAuthSession(
+          session,
+          anchorNpub: anchorNpub,
         );
-        if (await _restoreDegradedDivineOAuthSession(session)) {
-          return;
-        }
         return;
       }
 
@@ -868,15 +859,24 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     _setAuthState(AuthState.unauthenticated);
   }
 
-  Future<bool> _restoreDegradedDivineOAuthSession(
-    KeycastSession? session,
-  ) async {
+  Future<void> _restoreDegradedDivineOAuthSession(
+    KeycastSession? session, {
+    required String? anchorNpub,
+  }) async {
     final hasOwnerPubkey = session?.userPubkey?.isNotEmpty ?? false;
     final hasRefreshToken = session?.refreshToken?.isNotEmpty ?? false;
     if (session == null || !hasOwnerPubkey || !hasRefreshToken) {
       _hasExpiredOAuthSession = true;
       _setAuthState(AuthState.unauthenticated);
-      return false;
+      return;
+    }
+
+    if (_isCrossAccountRestore(
+      candidatePubkey: session.userPubkey,
+      anchorNpub: anchorNpub,
+    )) {
+      _setAuthState(AuthState.unauthenticated);
+      return;
     }
 
     Log.info(
@@ -888,8 +888,15 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     await signInWithDivineOAuth(
       session,
       rpcCapability: AuthRpcCapability.upgrading,
+      allowPubkeyOnlyIdentity: true,
     );
-    return true;
+    _hasExpiredOAuthSession = true;
+    unawaited(
+      _upgradeDivineRpcInBackground(
+        session,
+        expectedOwnerPubkey: session.userPubkey,
+      ),
+    );
   }
 
   /// Returns true when [candidatePubkey] belongs to a different account than
@@ -2621,7 +2628,8 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   /// Sign in using OAuth 2.0 flow
   Future<void> signInWithDivineOAuth(
     KeycastSession session, {
-    AuthRpcCapability rpcCapability = AuthRpcCapability.rpcReady,
+    AuthRpcCapability? rpcCapability,
+    bool allowPubkeyOnlyIdentity = false,
   }) async {
     Log.debug(
       'Signing in with Divine OAuth session',
@@ -2744,8 +2752,17 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
           );
         }
       }
-      await _setupUserSession(keyContainer, AuthenticationSource.divineOAuth);
-      _setRpcCapability(rpcCapability);
+      await _setupUserSession(
+        keyContainer,
+        AuthenticationSource.divineOAuth,
+        allowPubkeyOnlyIdentity: allowPubkeyOnlyIdentity,
+      );
+      _setRpcCapability(
+        rpcCapability ??
+            (session.hasRpcAccess
+                ? AuthRpcCapability.rpcReady
+                : AuthRpcCapability.upgrading),
+      );
 
       Log.info(
         '✅ Divine oauth session successfully integrated for $publicKeyHex',
@@ -3778,7 +3795,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   /// Throws [StateError] if no valid identity can be constructed — this
   /// indicates a programming error in the auth flow, not a user-facing
   /// condition.
-  NostrIdentity _buildIdentity() {
+  NostrIdentity _buildIdentity({bool allowPubkeyOnlyIdentity = false}) {
     return _signerFactory.buildIdentity(
       keyContainer: _currentKeyContainer,
       authSource: _authSource,
@@ -3786,14 +3803,16 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       nip07Service: _nip07Service,
       bunkerSigner: _bunkerSigner,
       keycastSigner: _keycastSigner,
+      allowPubkeyOnlyIdentity: allowPubkeyOnlyIdentity,
     );
   }
 
   /// Set up user session after successful authentication
   Future<void> _setupUserSession(
     SecureKeyContainer keyContainer,
-    AuthenticationSource source,
-  ) async {
+    AuthenticationSource source, {
+    bool allowPubkeyOnlyIdentity = false,
+  }) async {
     Log.info(
       '_setupUserSession: starting — '
       'pubkey=${keyContainer.publicKeyHex}, source=${source.name}',
@@ -3850,7 +3869,9 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     }
 
     // Build atomic identity AFTER stale signers are cleared.
-    _currentIdentity = _buildIdentity();
+    _currentIdentity = _buildIdentity(
+      allowPubkeyOnlyIdentity: allowPubkeyOnlyIdentity,
+    );
 
     // Create user profile
     _currentProfile = UserProfile(

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -4,6 +4,7 @@
 // with secure storage
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:cache_sync/cache_sync.dart';
 import 'package:flutter/foundation.dart';
@@ -456,6 +457,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       null => false,
       LocalNostrIdentity() => true,
       KeycastNostrIdentity() => true,
+      PubkeyOnlyNostrIdentity() => false,
       AmberNostrIdentity() => true,
       BunkerNostrIdentity() => true,
       Nip07NostrIdentity() => true,
@@ -791,19 +793,38 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       final KeycastSession? refreshed;
       try {
         refreshed = await _oauthCoordinator
-            .refreshSession(
-              expectedOwnerPubkey: session?.userPubkey,
-            )
+            .refreshSession(expectedOwnerPubkey: session?.userPubkey)
             .timeout(_startupNetworkOperationTimeout);
-      } on TimeoutException {
+      } on OAuthNetworkException catch (e) {
         Log.warning(
-          'initialize: synchronous refresh timed out '
-          '(${_startupNetworkOperationTimeout.inSeconds}s)',
+          'initialize: synchronous refresh failed due to network: $e',
           name: 'AuthService',
           category: LogCategory.auth,
         );
-        _hasExpiredOAuthSession = true;
-        _setAuthState(AuthState.unauthenticated);
+        if (await _restoreDegradedDivineOAuthSession(session)) {
+          return;
+        }
+        return;
+      } on TimeoutException catch (e) {
+        Log.warning(
+          'initialize: synchronous refresh timed out '
+          '(${_startupNetworkOperationTimeout.inSeconds}s): $e',
+          name: 'AuthService',
+          category: LogCategory.auth,
+        );
+        if (await _restoreDegradedDivineOAuthSession(session)) {
+          return;
+        }
+        return;
+      } on SocketException catch (e) {
+        Log.warning(
+          'initialize: synchronous refresh failed due to socket error: $e',
+          name: 'AuthService',
+          category: LogCategory.auth,
+        );
+        if (await _restoreDegradedDivineOAuthSession(session)) {
+          return;
+        }
         return;
       }
 
@@ -845,6 +866,30 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       category: LogCategory.auth,
     );
     _setAuthState(AuthState.unauthenticated);
+  }
+
+  Future<bool> _restoreDegradedDivineOAuthSession(
+    KeycastSession? session,
+  ) async {
+    final hasOwnerPubkey = session?.userPubkey?.isNotEmpty ?? false;
+    final hasRefreshToken = session?.refreshToken?.isNotEmpty ?? false;
+    if (session == null || !hasOwnerPubkey || !hasRefreshToken) {
+      _hasExpiredOAuthSession = true;
+      _setAuthState(AuthState.unauthenticated);
+      return false;
+    }
+
+    Log.info(
+      'initialize: keeping Divine OAuth session authenticated while RPC '
+      'refresh waits for connectivity',
+      name: 'AuthService',
+      category: LogCategory.auth,
+    );
+    await signInWithDivineOAuth(
+      session,
+      rpcCapability: AuthRpcCapability.upgrading,
+    );
+    return true;
   }
 
   /// Returns true when [candidatePubkey] belongs to a different account than
@@ -914,9 +959,19 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     required String caller,
     String? expectedOwnerPubkey,
   }) async {
-    final refreshed = await _oauthCoordinator.refreshSession(
-      expectedOwnerPubkey: expectedOwnerPubkey,
-    );
+    final KeycastSession? refreshed;
+    try {
+      refreshed = await _oauthCoordinator.refreshSession(
+        expectedOwnerPubkey: expectedOwnerPubkey,
+      );
+    } on OAuthNetworkException catch (e) {
+      Log.warning(
+        '$caller: refresh failed due to network: $e',
+        name: 'AuthService',
+        category: LogCategory.auth,
+      );
+      return false;
+    }
     if (refreshed != null) {
       Log.info(
         '$caller: refresh succeeded',
@@ -2564,7 +2619,10 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       _nostrConnect.onSignerCallbackReceived(relayUrl: relayUrl);
 
   /// Sign in using OAuth 2.0 flow
-  Future<void> signInWithDivineOAuth(KeycastSession session) async {
+  Future<void> signInWithDivineOAuth(
+    KeycastSession session, {
+    AuthRpcCapability rpcCapability = AuthRpcCapability.rpcReady,
+  }) async {
     Log.debug(
       'Signing in with Divine OAuth session',
       name: 'AuthService',
@@ -2576,11 +2634,15 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     _hasExpiredOAuthSession = false;
 
     try {
-      _keycastSigner = KeycastRpc.fromSession(
-        _oauthConfig,
-        session,
-        onTokenRefresh: _refreshAccessToken,
-      );
+      if (session.hasRpcAccess) {
+        _keycastSigner = KeycastRpc.fromSession(
+          _oauthConfig,
+          session,
+          onTokenRefresh: _refreshAccessToken,
+        );
+      } else {
+        _keycastSigner = null;
+      }
 
       // Prefer the pubkey stored in the session over an RPC call.
       // session.userPubkey is ground truth once populated — it is
@@ -2666,15 +2728,24 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
         );
       } else {
         keyContainer = SecureKeyContainer.fromPublicKey(publicKeyHex);
-        Log.info(
-          'signInWithDivineOAuth: no matching local nsec — '
-          'signing via RPC (pubkey=$publicKeyHex)',
-          name: 'AuthService',
-          category: LogCategory.auth,
-        );
+        if (_keycastSigner != null) {
+          Log.info(
+            'signInWithDivineOAuth: no matching local nsec — '
+            'signing via RPC (pubkey=$publicKeyHex)',
+            name: 'AuthService',
+            category: LogCategory.auth,
+          );
+        } else {
+          Log.info(
+            'signInWithDivineOAuth: no matching local nsec and RPC is not '
+            'ready — restored pubkey-only identity (pubkey=$publicKeyHex)',
+            name: 'AuthService',
+            category: LogCategory.auth,
+          );
+        }
       }
       await _setupUserSession(keyContainer, AuthenticationSource.divineOAuth);
-      _setRpcCapability(AuthRpcCapability.rpcReady);
+      _setRpcCapability(rpcCapability);
 
       Log.info(
         '✅ Divine oauth session successfully integrated for $publicKeyHex',

--- a/mobile/packages/keycast_flutter/lib/src/models/exceptions.dart
+++ b/mobile/packages/keycast_flutter/lib/src/models/exceptions.dart
@@ -24,6 +24,8 @@ class OAuthException extends KeycastException {
       : 'OAuthException: $message';
 }
 
+/// OAuth request failed before Keycast could authoritatively accept or reject
+/// the token, such as a network transport error or timeout.
 class OAuthNetworkException extends OAuthException {
   OAuthNetworkException([String? message])
     : super(message ?? 'OAuth request failed due to a network error');

--- a/mobile/packages/keycast_flutter/lib/src/models/exceptions.dart
+++ b/mobile/packages/keycast_flutter/lib/src/models/exceptions.dart
@@ -24,6 +24,11 @@ class OAuthException extends KeycastException {
       : 'OAuthException: $message';
 }
 
+class OAuthNetworkException extends OAuthException {
+  OAuthNetworkException([String? message])
+    : super(message ?? 'OAuth request failed due to a network error');
+}
+
 class RpcException extends KeycastException {
   RpcException(super.message, {this.method});
   final String? method;

--- a/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
+++ b/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
@@ -144,21 +144,23 @@ class KeycastOAuth {
   /// Attempt to refresh the session using a stored refresh token.
   ///
   /// Returns the new [KeycastSession] on success, or `null` if refresh
-  /// is not possible (no refresh token) or fails.
+  /// is not possible (no refresh token) or the server rejects the token.
   ///
   /// [userPubkey] is attached to the session before it is persisted so
   /// the saved session is always owner-bound.
   ///
   /// On HTTP error the consumed refresh token is cleared (server may have
-  /// rotated it). On network error or timeout the token is preserved since
-  /// the server may not have consumed it.
+  /// rotated it). On network error or timeout an [OAuthNetworkException] is
+  /// thrown and the token is preserved since the server may not have consumed
+  /// it.
   Future<KeycastSession?> refreshSession({String? userPubkey}) async {
     final refreshEpoch = _storageEpoch;
     final refreshToken = await _storage.read(_storageKeyRefreshToken);
     if (refreshToken == null) return null;
 
+    late final http.Response response;
     try {
-      final response = await _client
+      response = await _client
           .post(
             Uri.parse(config.tokenUrl),
             headers: {'Content-Type': 'application/json'},
@@ -169,29 +171,29 @@ class KeycastOAuth {
             }),
           )
           .timeout(requestTimeout);
-
-      if (response.statusCode == 200) {
-        final json = jsonDecode(response.body) as Map<String, dynamic>;
-        final tokenResponse = TokenResponse.fromJson(json);
-        var session = KeycastSession.fromTokenResponse(tokenResponse);
-        if (userPubkey != null && userPubkey.isNotEmpty) {
-          session = session.copyWith(userPubkey: userPubkey);
-        }
-        if (refreshEpoch != _storageEpoch) {
-          return null;
-        }
-        await _saveSession(session);
-        return session;
-      }
-
-      // HTTP error — server consumed the token, clear it
-      await _storage.delete(_storageKeyRefreshToken);
-      return null;
-    } catch (_) {
+    } catch (error) {
       // Network error or timeout — server may not have consumed the
-      // token, keep it so the next attempt can retry the refresh
-      return null;
+      // token, keep it so the next attempt can retry the refresh.
+      throw OAuthNetworkException('Refresh request failed: $error');
     }
+
+    if (response.statusCode == 200) {
+      final json = jsonDecode(response.body) as Map<String, dynamic>;
+      final tokenResponse = TokenResponse.fromJson(json);
+      var session = KeycastSession.fromTokenResponse(tokenResponse);
+      if (userPubkey != null && userPubkey.isNotEmpty) {
+        session = session.copyWith(userPubkey: userPubkey);
+      }
+      if (refreshEpoch != _storageEpoch) {
+        return null;
+      }
+      await _saveSession(session);
+      return session;
+    }
+
+    // HTTP error — server consumed the token, clear it
+    await _storage.delete(_storageKeyRefreshToken);
+    return null;
   }
 
   /// Get an active session, refreshing if the current one is expired.

--- a/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
+++ b/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
@@ -200,7 +200,11 @@ class KeycastOAuth {
   ///
   /// Tries [getSession] first. If that returns `null` (no session stored or
   /// token expired), falls back to [refreshSession] to obtain a fresh token.
-  /// Returns `null` only when no session can be recovered at all.
+  /// Returns `null` only when no session can be recovered at all because no
+  /// refresh token is available or the server rejects the token.
+  ///
+  /// Throws [OAuthNetworkException] when the refresh cannot reach Keycast or
+  /// times out. The refresh token is preserved for a later retry in that case.
   ///
   /// [userPubkey] is forwarded to [refreshSession] so the saved session
   /// is owner-bound when a refresh is needed.

--- a/mobile/packages/keycast_flutter/test/oauth_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/oauth_client_test.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
+import 'package:keycast_flutter/src/models/exceptions.dart';
 import 'package:keycast_flutter/src/models/keycast_session.dart';
 import 'package:keycast_flutter/src/oauth/callback_result.dart';
 import 'package:keycast_flutter/src/oauth/headless_models.dart';
@@ -1200,7 +1201,7 @@ void main() {
       });
 
       test(
-        'returns null but preserves refresh token on network error',
+        'throws network exception and preserves refresh token on network error',
         () async {
           final storage = MemoryKeycastStorage();
           await storage.write('keycast_refresh_token', 'my_refresh_token');
@@ -1214,9 +1215,11 @@ void main() {
             httpClient: mockClient,
             storage: storage,
           );
-          final result = await oauth.refreshSession();
 
-          expect(result, isNull);
+          await expectLater(
+            oauth.refreshSession(),
+            throwsA(isA<OAuthNetworkException>()),
+          );
           // Refresh token should be preserved (server didn't consume it)
           expect(
             await storage.read('keycast_refresh_token'),
@@ -1420,9 +1423,10 @@ void main() {
           requestTimeout: shortTimeout,
         );
 
-        final result = await oauth.refreshSession();
-
-        expect(result, isNull);
+        await expectLater(
+          oauth.refreshSession(),
+          throwsA(isA<OAuthNetworkException>()),
+        );
         // CRITICAL: a timeout is a network failure, not an auth
         // rejection — the refresh token must survive so the next
         // attempt can retry.

--- a/mobile/test/services/auth/oauth_session_coordinator_test.dart
+++ b/mobile/test/services/auth/oauth_session_coordinator_test.dart
@@ -114,6 +114,19 @@ void main() {
         expect(refreshSucceededCalls, isZero);
       });
 
+      test('rethrows OAuthNetworkException from the client', () async {
+        when(
+          () =>
+              oauthClient.refreshSession(userPubkey: any(named: 'userPubkey')),
+        ).thenThrow(OAuthNetworkException('offline'));
+
+        await expectLater(
+          build().refreshSession(),
+          throwsA(isA<OAuthNetworkException>()),
+        );
+        expect(refreshSucceededCalls, isZero);
+      });
+
       test('returns null when no OAuth client is configured', () async {
         final result = await build(nullClient: true).refreshSession();
 
@@ -160,16 +173,21 @@ void main() {
 
           final coordinator = build();
 
-          KeycastSession? firstResult;
+          Object? firstError;
           var firstDone = false;
-          coordinator.refreshSession().then((r) {
-            firstResult = r;
-            firstDone = true;
-          });
+          coordinator.refreshSession().then(
+            (_) {
+              firstDone = true;
+            },
+            onError: (Object error) {
+              firstError = error;
+              firstDone = true;
+            },
+          );
 
           async.elapse(oauthTimeout + const Duration(milliseconds: 1));
           expect(firstDone, isTrue);
-          expect(firstResult, isNull);
+          expect(firstError, isA<OAuthNetworkException>());
           expect(calls, equals(1));
 
           // Slot released: a fresh call issues a new client request.
@@ -323,41 +341,37 @@ void main() {
         },
       );
 
-      test(
-        "a detached future's late completion does not clobber a newer "
-        'in-flight slot',
-        () async {
-          final gates = [
-            Completer<KeycastSession?>(),
-            Completer<KeycastSession?>(),
-          ];
-          var calls = 0;
-          when(
-            () => oauthClient.refreshSession(
-              userPubkey: any(named: 'userPubkey'),
-            ),
-          ).thenAnswer((_) => gates[calls++].future);
+      test("a detached future's late completion does not clobber a newer "
+          'in-flight slot', () async {
+        final gates = [
+          Completer<KeycastSession?>(),
+          Completer<KeycastSession?>(),
+        ];
+        var calls = 0;
+        when(
+          () =>
+              oauthClient.refreshSession(userPubkey: any(named: 'userPubkey')),
+        ).thenAnswer((_) => gates[calls++].future);
 
-          final coordinator = build();
-          final first = coordinator.refreshSession(); // slot = refresh1
-          coordinator.detach(); // slot = null
-          final second = coordinator.refreshSession(); // slot = refresh2 (hung)
-          expect(calls, equals(2));
+        final coordinator = build();
+        final first = coordinator.refreshSession(); // slot = refresh1
+        coordinator.detach(); // slot = null
+        final second = coordinator.refreshSession(); // slot = refresh2 (hung)
+        expect(calls, equals(2));
 
-          // The detached refresh1 completes AFTER refresh2 took the slot.
-          gates[0].complete(null);
-          await first;
+        // The detached refresh1 completes AFTER refresh2 took the slot.
+        gates[0].complete(null);
+        await first;
 
-          // refresh1's whenComplete must NOT null refresh2's slot (identical
-          // guard is false), so a third call JOINS refresh2 instead of
-          // issuing a new client request.
-          final third = coordinator.refreshSession();
-          expect(calls, equals(2));
+        // refresh1's whenComplete must NOT null refresh2's slot (identical
+        // guard is false), so a third call JOINS refresh2 instead of
+        // issuing a new client request.
+        final third = coordinator.refreshSession();
+        expect(calls, equals(2));
 
-          gates[1].complete(_session());
-          await Future.wait([second, third]);
-        },
-      );
+        gates[1].complete(_session());
+        await Future.wait([second, third]);
+      });
 
       test('clears the in-flight expired-session refresh', () async {
         final coordinator = build();

--- a/mobile/test/services/auth/signer_factory_test.dart
+++ b/mobile/test/services/auth/signer_factory_test.dart
@@ -162,6 +162,17 @@ void main() {
         expect(identity, isA<LocalNostrIdentity>());
       });
 
+      test('divineOAuth with pub-key-only container and no remote signer '
+          'builds PubkeyOnlyNostrIdentity', () {
+        final identity = factory.buildIdentity(
+          keyContainer: pubOnlyContainer(),
+          authSource: AuthenticationSource.divineOAuth,
+        );
+
+        expect(identity, isA<PubkeyOnlyNostrIdentity>());
+        expect(identity.signsWithLocalKey, isFalse);
+      });
+
       test('throws StateError for pub-key-only container with no remote '
           'signer', () {
         expect(

--- a/mobile/test/services/auth/signer_factory_test.dart
+++ b/mobile/test/services/auth/signer_factory_test.dart
@@ -162,15 +162,35 @@ void main() {
         expect(identity, isA<LocalNostrIdentity>());
       });
 
-      test('divineOAuth with pub-key-only container and no remote signer '
+      test('divineOAuth with pub-key-only container and explicit opt-in '
           'builds PubkeyOnlyNostrIdentity', () {
         final identity = factory.buildIdentity(
           keyContainer: pubOnlyContainer(),
           authSource: AuthenticationSource.divineOAuth,
+          allowPubkeyOnlyIdentity: true,
         );
 
         expect(identity, isA<PubkeyOnlyNostrIdentity>());
         expect(identity.signsWithLocalKey, isFalse);
+      });
+
+      test('divineOAuth with pub-key-only container and no opt-in throws', () {
+        expect(
+          () => factory.buildIdentity(
+            keyContainer: pubOnlyContainer(),
+            authSource: AuthenticationSource.divineOAuth,
+          ),
+          throwsA(
+            isA<StateError>().having(
+              (e) => e.message,
+              'message',
+              allOf(
+                contains('pub-key-only container'),
+                contains(AuthenticationSource.divineOAuth.name),
+              ),
+            ),
+          ),
+        );
       });
 
       test('throws StateError for pub-key-only container with no remote '
@@ -321,10 +341,7 @@ void main() {
 
         expect(event, isNotNull);
         expect(event!.tags.where((t) => t.first == 'client'), hasLength(1));
-        expect(
-          event.tags.single,
-          equals(['client', 'SomeOtherClient']),
-        );
+        expect(event.tags.single, equals(['client', 'SomeOtherClient']));
       });
 
       test('honors an explicit createdAt', () async {
@@ -410,9 +427,9 @@ void main() {
         final remoteSigner = _MockNostrSigner();
         // Correct pubkey but no signature — remote identities must fail the
         // schnorr verification (local identities skip it).
-        when(() => remoteSigner.signEvent(any())).thenAnswer(
-          (_) async => Event(testPublicKey, 1, [], 'unsigned'),
-        );
+        when(
+          () => remoteSigner.signEvent(any()),
+        ).thenAnswer((_) async => Event(testPublicKey, 1, [], 'unsigned'));
         final identity = BunkerNostrIdentity(
           pubkey: testPublicKey,
           remoteSigner: remoteSigner,
@@ -457,64 +474,56 @@ void main() {
         },
       );
 
-      test(
-        'falls back to inline verification when the verify isolate cannot '
-        'spawn — a validly signed remote event is not dropped',
-        () async {
-          final failingFactory = SignerFactory(
-            verifyOffMain: (_) async =>
-                throw StateError('isolate spawn refused'),
-          );
-          final remoteSigner = _MockNostrSigner();
-          // Produce a REAL signature so the inline fallback can verify it.
-          when(() => remoteSigner.signEvent(any())).thenAnswer((inv) async {
-            final event = inv.positionalArguments.first as Event;
-            return LocalNostrSigner(testPrivateKey).signEvent(event);
-          });
-          final identity = BunkerNostrIdentity(
-            pubkey: testPublicKey,
-            remoteSigner: remoteSigner,
-          );
+      test('falls back to inline verification when the verify isolate cannot '
+          'spawn — a validly signed remote event is not dropped', () async {
+        final failingFactory = SignerFactory(
+          verifyOffMain: (_) async => throw StateError('isolate spawn refused'),
+        );
+        final remoteSigner = _MockNostrSigner();
+        // Produce a REAL signature so the inline fallback can verify it.
+        when(() => remoteSigner.signEvent(any())).thenAnswer((inv) async {
+          final event = inv.positionalArguments.first as Event;
+          return LocalNostrSigner(testPrivateKey).signEvent(event);
+        });
+        final identity = BunkerNostrIdentity(
+          pubkey: testPublicKey,
+          remoteSigner: remoteSigner,
+        );
 
-          final event = await failingFactory.createAndSignEvent(
-            identity: identity,
-            authSource: AuthenticationSource.bunker,
-            kind: 1,
-            content: 'valid despite spawn failure',
-          );
+        final event = await failingFactory.createAndSignEvent(
+          identity: identity,
+          authSource: AuthenticationSource.bunker,
+          kind: 1,
+          content: 'valid despite spawn failure',
+        );
 
-          expect(event, isNotNull);
-          expect(event!.isSigned, isTrue);
-        },
-      );
+        expect(event, isNotNull);
+        expect(event!.isSigned, isTrue);
+      });
 
-      test(
-        'inline fallback still rejects an invalid remote signature when the '
-        'verify isolate cannot spawn',
-        () async {
-          final failingFactory = SignerFactory(
-            verifyOffMain: (_) async =>
-                throw StateError('isolate spawn refused'),
-          );
-          final remoteSigner = _MockNostrSigner();
-          when(() => remoteSigner.signEvent(any())).thenAnswer(
-            (_) async => Event(testPublicKey, 1, [], 'unsigned'),
-          );
-          final identity = BunkerNostrIdentity(
-            pubkey: testPublicKey,
-            remoteSigner: remoteSigner,
-          );
+      test('inline fallback still rejects an invalid remote signature when the '
+          'verify isolate cannot spawn', () async {
+        final failingFactory = SignerFactory(
+          verifyOffMain: (_) async => throw StateError('isolate spawn refused'),
+        );
+        final remoteSigner = _MockNostrSigner();
+        when(
+          () => remoteSigner.signEvent(any()),
+        ).thenAnswer((_) async => Event(testPublicKey, 1, [], 'unsigned'));
+        final identity = BunkerNostrIdentity(
+          pubkey: testPublicKey,
+          remoteSigner: remoteSigner,
+        );
 
-          final event = await failingFactory.createAndSignEvent(
-            identity: identity,
-            authSource: AuthenticationSource.bunker,
-            kind: 1,
-            content: 'unsigned',
-          );
+        final event = await failingFactory.createAndSignEvent(
+          identity: identity,
+          authSource: AuthenticationSource.bunker,
+          kind: 1,
+          content: 'unsigned',
+        );
 
-          expect(event, isNull);
-        },
-      );
+        expect(event, isNull);
+      });
     });
   });
 }

--- a/mobile/test/services/auth_service_expired_session_downgrade_test.dart
+++ b/mobile/test/services/auth_service_expired_session_downgrade_test.dart
@@ -10,6 +10,8 @@ import 'package:keycast_flutter/keycast_flutter.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nostr_key_manager/nostr_key_manager.dart';
 import 'package:nostr_sdk/nostr_sdk.dart' show generatePrivateKey;
+import 'package:openvine/models/auth_rpc_capability.dart';
+import 'package:openvine/services/auth/nostr_identity.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/user_data_cleanup_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -239,6 +241,112 @@ void main() {
       );
     });
 
+    test('network refresh failure + no local keys keeps owner-bound session '
+        'authenticated in upgrading state', () async {
+      SharedPreferences.setMockInitialValues({
+        'authentication_source': 'divineOAuth',
+        'tos_accepted': true,
+      });
+
+      final pubkey = 'ab' * 32;
+      final expiredSession = KeycastSession(
+        bunkerUrl: 'https://login.divine.video/api/nostr',
+        accessToken: 'expired_token',
+        expiresAt: DateTime.now().subtract(const Duration(hours: 1)),
+        refreshToken: 'refresh_token_still_valid',
+        userPubkey: pubkey,
+      );
+      secureStorage['keycast_session'] = jsonEncode(expiredSession.toJson());
+      secureStorage['keycast_refresh_token'] = 'refresh_token_still_valid';
+
+      when(
+        () => mockOAuthClient.refreshSession(
+          userPubkey: any(named: 'userPubkey'),
+        ),
+      ).thenAnswer(
+        (_) => Future<KeycastSession?>.error(OAuthNetworkException('offline')),
+      );
+
+      final authService = createAuthService();
+
+      await runZonedGuarded(
+        () async {
+          await authService.initialize();
+
+          expect(authService.authState, equals(AuthState.authenticated));
+          expect(authService.isAuthenticated, isTrue);
+          expect(
+            authService.authRpcCapability,
+            equals(AuthRpcCapability.upgrading),
+          );
+          expect(authService.currentPublicKeyHex, pubkey);
+          expect(
+            authService.currentIdentity,
+            isA<PubkeyOnlyNostrIdentity>(),
+          );
+          expect(authService.canPublishNostrWritesNow, isFalse);
+          expect(
+            secureStorage['keycast_refresh_token'],
+            'refresh_token_still_valid',
+            reason: 'Offline launch must not discard the retry token.',
+          );
+          verify(
+            () => mockOAuthClient.refreshSession(
+              userPubkey: any(named: 'userPubkey'),
+            ),
+          ).called(1);
+        },
+        (error, stack) {
+          // Ignore background errors
+        },
+      );
+    });
+
+    test(
+      'rejected refresh + no local keys still falls to unauthenticated',
+      () async {
+        SharedPreferences.setMockInitialValues({
+          'authentication_source': 'divineOAuth',
+          'tos_accepted': true,
+        });
+
+        final pubkey = 'ab' * 32;
+        final expiredSession = KeycastSession(
+          bunkerUrl: 'https://login.divine.video/api/nostr',
+          accessToken: 'expired_token',
+          expiresAt: DateTime.now().subtract(const Duration(hours: 1)),
+          refreshToken: 'rejected_refresh_token',
+          userPubkey: pubkey,
+        );
+        secureStorage['keycast_session'] = jsonEncode(expiredSession.toJson());
+
+        when(
+          () => mockOAuthClient.refreshSession(
+            userPubkey: any(named: 'userPubkey'),
+          ),
+        ).thenAnswer((_) async => null);
+
+        final authService = createAuthService();
+
+        await runZonedGuarded(
+          () async {
+            await authService.initialize();
+
+            expect(authService.authState, equals(AuthState.unauthenticated));
+            expect(authService.isAuthenticated, isFalse);
+            verify(
+              () => mockOAuthClient.refreshSession(
+                userPubkey: any(named: 'userPubkey'),
+              ),
+            ).called(1);
+          },
+          (error, stack) {
+            // Ignore background errors
+          },
+        );
+      },
+    );
+
     test(
       'refresh succeeds → saves new session and attempts signInWithDivineOAuth',
       () async {
@@ -308,126 +416,120 @@ void main() {
       },
     );
 
-    test(
-      'isRpcUpgradeInProgress is false after upgrade completes',
-      () async {
-        // Regression for #4626: isRpcUpgradeInProgress must be false after
-        // _upgradeDivineRpcInBackground finishes so the session-expired sheet
-        // is no longer suppressed once the silent refresh has definitively
-        // resolved.
-        SharedPreferences.setMockInitialValues({
-          'authentication_source': 'divineOAuth',
-          'tos_accepted': true,
-        });
+    test('isRpcUpgradeInProgress is false after upgrade completes', () async {
+      // Regression for #4626: isRpcUpgradeInProgress must be false after
+      // _upgradeDivineRpcInBackground finishes so the session-expired sheet
+      // is no longer suppressed once the silent refresh has definitively
+      // resolved.
+      SharedPreferences.setMockInitialValues({
+        'authentication_source': 'divineOAuth',
+        'tos_accepted': true,
+      });
 
-        arrangeExpiredSessionWithLocalKeys();
+      arrangeExpiredSessionWithLocalKeys();
 
-        // Refresh fails immediately.
-        when(
-          () => mockOAuthClient.refreshSession(
-            userPubkey: any(named: 'userPubkey'),
-          ),
-        ).thenAnswer((_) async => null);
+      // Refresh fails immediately.
+      when(
+        () => mockOAuthClient.refreshSession(
+          userPubkey: any(named: 'userPubkey'),
+        ),
+      ).thenAnswer((_) async => null);
 
-        final authService = createAuthService();
+      final authService = createAuthService();
 
-        await runZonedGuarded(
-          () async {
-            await authService.initialize();
+      await runZonedGuarded(
+        () async {
+          await authService.initialize();
 
-            // The background upgrade is unawaited but resolves quickly since
-            // refreshSession returns immediately. Pump the event queue until
-            // the upgrade finishes — it should complete well within 1 second.
-            final deadline = DateTime.now().add(const Duration(seconds: 3));
-            while (authService.isRpcUpgradeInProgress &&
-                DateTime.now().isBefore(deadline)) {
-              await Future<void>.delayed(const Duration(milliseconds: 10));
-            }
+          // The background upgrade is unawaited but resolves quickly since
+          // refreshSession returns immediately. Pump the event queue until
+          // the upgrade finishes — it should complete well within 1 second.
+          final deadline = DateTime.now().add(const Duration(seconds: 3));
+          while (authService.isRpcUpgradeInProgress &&
+              DateTime.now().isBefore(deadline)) {
+            await Future<void>.delayed(const Duration(milliseconds: 10));
+          }
 
-            expect(
-              authService.isRpcUpgradeInProgress,
-              isFalse,
-              reason:
-                  'isRpcUpgradeInProgress must be false after the upgrade '
-                  'completes (failure path)',
-            );
+          expect(
+            authService.isRpcUpgradeInProgress,
+            isFalse,
+            reason:
+                'isRpcUpgradeInProgress must be false after the upgrade '
+                'completes (failure path)',
+          );
 
-            // Session is still flagged as expired (refresh failed).
-            expect(authService.hasExpiredOAuthSession, isTrue);
-          },
-          (error, stack) {
-            // Ignore background relay/RPC errors
-          },
-        );
-      },
-    );
+          // Session is still flagged as expired (refresh failed).
+          expect(authService.hasExpiredOAuthSession, isTrue);
+        },
+        (error, stack) {
+          // Ignore background relay/RPC errors
+        },
+      );
+    });
 
-    test(
-      'concurrent tryRefreshExpiredSession calls share one in-flight future '
-      '(single-flight guard)',
-      () async {
-        // Regression for #4626: if multiple UI surfaces call
-        // tryRefreshExpiredSession concurrently (e.g. profile header + settings
-        // tile both visible), only one token refresh should be attempted.
-        SharedPreferences.setMockInitialValues({
-          'authentication_source': 'divineOAuth',
-          'tos_accepted': true,
-        });
+    test('concurrent tryRefreshExpiredSession calls share one in-flight future '
+        '(single-flight guard)', () async {
+      // Regression for #4626: if multiple UI surfaces call
+      // tryRefreshExpiredSession concurrently (e.g. profile header + settings
+      // tile both visible), only one token refresh should be attempted.
+      SharedPreferences.setMockInitialValues({
+        'authentication_source': 'divineOAuth',
+        'tos_accepted': true,
+      });
 
-        arrangeExpiredSessionWithLocalKeys();
+      arrangeExpiredSessionWithLocalKeys();
 
-        // Refresh always returns null (failure).
-        when(
-          () => mockOAuthClient.refreshSession(
-            userPubkey: any(named: 'userPubkey'),
-          ),
-        ).thenAnswer((_) async => null);
+      // Refresh always returns null (failure).
+      when(
+        () => mockOAuthClient.refreshSession(
+          userPubkey: any(named: 'userPubkey'),
+        ),
+      ).thenAnswer((_) async => null);
 
-        final authService = createAuthService();
+      final authService = createAuthService();
 
-        await runZonedGuarded(
-          () async {
-            await authService.initialize();
+      await runZonedGuarded(
+        () async {
+          await authService.initialize();
 
-            // Wait for the background upgrade to finish before testing
-            // tryRefreshExpiredSession in isolation. This avoids the
-            // _pendingOAuthRefresh single-flight slot being held by the
-            // background upgrade, which would conflate call counts.
-            final deadline = DateTime.now().add(const Duration(seconds: 5));
-            while (authService.isRpcUpgradeInProgress &&
-                DateTime.now().isBefore(deadline)) {
-              await Future<void>.delayed(const Duration(milliseconds: 10));
-            }
+          // Wait for the background upgrade to finish before testing
+          // tryRefreshExpiredSession in isolation. This avoids the
+          // _pendingOAuthRefresh single-flight slot being held by the
+          // background upgrade, which would conflate call counts.
+          final deadline = DateTime.now().add(const Duration(seconds: 5));
+          while (authService.isRpcUpgradeInProgress &&
+              DateTime.now().isBefore(deadline)) {
+            await Future<void>.delayed(const Duration(milliseconds: 10));
+          }
 
-            // Session should be expired after init with failed refresh.
-            expect(authService.hasExpiredOAuthSession, isTrue);
+          // Session should be expired after init with failed refresh.
+          expect(authService.hasExpiredOAuthSession, isTrue);
 
-            // Reset interaction tracking after init's refresh calls.
-            clearInteractions(mockOAuthClient);
+          // Reset interaction tracking after init's refresh calls.
+          clearInteractions(mockOAuthClient);
 
-            // Two concurrent callers.
-            final results = await Future.wait([
-              authService.tryRefreshExpiredSession(),
-              authService.tryRefreshExpiredSession(),
-            ]);
+          // Two concurrent callers.
+          final results = await Future.wait([
+            authService.tryRefreshExpiredSession(),
+            authService.tryRefreshExpiredSession(),
+          ]);
 
-            // Both callers receive the same result (false — refresh failed).
-            expect(results, equals([false, false]));
+          // Both callers receive the same result (false — refresh failed).
+          expect(results, equals([false, false]));
 
-            // refreshSession was only called ONCE despite two concurrent
-            // tryRefreshExpiredSession calls (single-flight _pendingRefresh).
-            verify(
-              () => mockOAuthClient.refreshSession(
-                userPubkey: any(named: 'userPubkey'),
-              ),
-            ).called(1);
-          },
-          (error, stack) {
-            // Ignore background errors
-          },
-        );
-      },
-    );
+          // refreshSession was only called ONCE despite two concurrent
+          // tryRefreshExpiredSession calls (single-flight _pendingRefresh).
+          verify(
+            () => mockOAuthClient.refreshSession(
+              userPubkey: any(named: 'userPubkey'),
+            ),
+          ).called(1);
+        },
+        (error, stack) {
+          // Ignore background errors
+        },
+      );
+    });
 
     test(
       'hung refresh fails within the bounded time and clears the pending '

--- a/mobile/test/services/auth_service_expired_session_downgrade_test.dart
+++ b/mobile/test/services/auth_service_expired_session_downgrade_test.dart
@@ -259,13 +259,26 @@ void main() {
       secureStorage['keycast_session'] = jsonEncode(expiredSession.toJson());
       secureStorage['keycast_refresh_token'] = 'refresh_token_still_valid';
 
+      final refreshedSession = KeycastSession(
+        bunkerUrl: 'https://login.divine.video/api/nostr',
+        accessToken: 'fresh_token',
+        expiresAt: DateTime.now().add(const Duration(hours: 1)),
+        refreshToken: 'next_refresh_token',
+        userPubkey: pubkey,
+      );
+      final backgroundRefresh = Completer<KeycastSession?>();
+      var refreshCalls = 0;
       when(
         () => mockOAuthClient.refreshSession(
           userPubkey: any(named: 'userPubkey'),
         ),
-      ).thenAnswer(
-        (_) => Future<KeycastSession?>.error(OAuthNetworkException('offline')),
-      );
+      ).thenAnswer((_) {
+        refreshCalls++;
+        if (refreshCalls == 1) {
+          throw OAuthNetworkException('offline');
+        }
+        return backgroundRefresh.future;
+      });
 
       final authService = createAuthService();
 
@@ -280,21 +293,40 @@ void main() {
             equals(AuthRpcCapability.upgrading),
           );
           expect(authService.currentPublicKeyHex, pubkey);
-          expect(
-            authService.currentIdentity,
-            isA<PubkeyOnlyNostrIdentity>(),
-          );
+          expect(authService.currentIdentity, isA<PubkeyOnlyNostrIdentity>());
           expect(authService.canPublishNostrWritesNow, isFalse);
+          expect(
+            authService.hasExpiredOAuthSession,
+            isTrue,
+            reason:
+                'The degraded session stays retryable while RPC upgrade is '
+                'pending so manual re-login affordances remain available.',
+          );
           expect(
             secureStorage['keycast_refresh_token'],
             'refresh_token_still_valid',
             reason: 'Offline launch must not discard the retry token.',
           );
-          verify(
-            () => mockOAuthClient.refreshSession(
-              userPubkey: any(named: 'userPubkey'),
-            ),
-          ).called(1);
+          expect(refreshCalls, equals(2));
+
+          backgroundRefresh.complete(refreshedSession);
+          final deadline = DateTime.now().add(const Duration(seconds: 3));
+          while (authService.isRpcUpgradeInProgress &&
+              DateTime.now().isBefore(deadline)) {
+            await Future<void>.delayed(const Duration(milliseconds: 10));
+          }
+
+          expect(
+            authService.authRpcCapability,
+            equals(AuthRpcCapability.rpcReady),
+          );
+          expect(authService.currentIdentity, isA<KeycastNostrIdentity>());
+          expect(authService.canPublishNostrWritesNow, isTrue);
+          expect(
+            authService.hasExpiredOAuthSession,
+            isFalse,
+            reason: 'A successful background upgrade clears the retry flag.',
+          );
         },
         (error, stack) {
           // Ignore background errors

--- a/mobile/test/services/auth_service_multi_account_test.dart
+++ b/mobile/test/services/auth_service_multi_account_test.dart
@@ -1126,46 +1126,43 @@ void main() {
       },
     );
 
-    test(
-      'throws AccountRestoreFailedException when identity keys not found '
-      'and no primary keys can authenticate',
-      () async {
-        final pubkeyHex = testKeyContainer.publicKeyHex;
+    test('throws AccountRestoreFailedException when identity keys not found '
+        'and no primary keys can authenticate', () async {
+      final pubkeyHex = testKeyContainer.publicKeyHex;
 
-        // Return null for identity key lookup, and ensure no same-account
-        // PRIMARY fallback exists so the service resolves to unauthenticated
-        // rather than silently succeeding.
-        when(
-          () => mockKeyStorage.getIdentityKeyContainer(
-            any(),
-            biometricPrompt: any(named: 'biometricPrompt'),
-          ),
-        ).thenAnswer((_) async => null);
-        when(() => mockKeyStorage.hasKeys()).thenAnswer((_) async => false);
+      // Return null for identity key lookup, and ensure no same-account
+      // PRIMARY fallback exists so the service resolves to unauthenticated
+      // rather than silently succeeding.
+      when(
+        () => mockKeyStorage.getIdentityKeyContainer(
+          any(),
+          biometricPrompt: any(named: 'biometricPrompt'),
+        ),
+      ).thenAnswer((_) async => null);
+      when(() => mockKeyStorage.hasKeys()).thenAnswer((_) async => false);
 
-        await expectLater(
-          _ignoringDiscoveryErrors(
-            () => authService.signInForAccount(
-              pubkeyHex,
-              AuthenticationSource.automatic,
-            ),
+      await expectLater(
+        _ignoringDiscoveryErrors(
+          () => authService.signInForAccount(
+            pubkeyHex,
+            AuthenticationSource.automatic,
           ),
-          throwsA(
-            isA<AccountRestoreFailedException>()
-                .having((e) => e.pubkeyHex, 'pubkeyHex', pubkeyHex)
-                .having(
-                  (e) => e.resolvedState,
-                  'resolvedState',
-                  AuthState.unauthenticated,
-                ),
-          ),
-        );
+        ),
+        throwsA(
+          isA<AccountRestoreFailedException>()
+              .having((e) => e.pubkeyHex, 'pubkeyHex', pubkeyHex)
+              .having(
+                (e) => e.resolvedState,
+                'resolvedState',
+                AuthState.unauthenticated,
+              ),
+        ),
+      );
 
-        // The same-account fallback path was exercised before the guard threw.
-        verify(() => mockKeyStorage.hasKeys()).called(1);
-        expect(authService.authState, equals(AuthState.unauthenticated));
-      },
-    );
+      // The same-account fallback path was exercised before the guard threw.
+      verify(() => mockKeyStorage.hasKeys()).called(1);
+      expect(authService.authState, equals(AuthState.unauthenticated));
+    });
 
     test(
       'throws AccountRestoreFailedException when missing identity keys would '
@@ -1976,19 +1973,19 @@ void main() {
         await _ignoringDiscoveryErrors(authService.createNewIdentity);
 
         final deletedKeys = <String>[];
-        when(
-          () => mockSecureStorage.delete(key: any(named: 'key')),
-        ).thenAnswer((invocation) async {
-          final key = invocation.namedArguments[#key] as String;
-          deletedKeys.add(key);
+        when(() => mockSecureStorage.delete(key: any(named: 'key'))).thenAnswer(
+          (invocation) async {
+            final key = invocation.namedArguments[#key] as String;
+            deletedKeys.add(key);
 
-          final keycastSessionAttempts = deletedKeys
-              .where((deletedKey) => deletedKey == 'keycast_session')
-              .length;
-          if (key == 'keycast_session' && keycastSessionAttempts == 1) {
-            throw StateError('transient secure storage delete failure');
-          }
-        });
+            final keycastSessionAttempts = deletedKeys
+                .where((deletedKey) => deletedKey == 'keycast_session')
+                .length;
+            if (key == 'keycast_session' && keycastSessionAttempts == 1) {
+              throw StateError('transient secure storage delete failure');
+            }
+          },
+        );
 
         await authService.signOut(deleteKeys: true);
 
@@ -2016,16 +2013,16 @@ void main() {
         await _ignoringDiscoveryErrors(authService.createNewIdentity);
 
         final deletedKeys = <String>[];
-        when(
-          () => mockSecureStorage.delete(key: any(named: 'key')),
-        ).thenAnswer((invocation) async {
-          final key = invocation.namedArguments[#key] as String;
-          deletedKeys.add(key);
+        when(() => mockSecureStorage.delete(key: any(named: 'key'))).thenAnswer(
+          (invocation) async {
+            final key = invocation.namedArguments[#key] as String;
+            deletedKeys.add(key);
 
-          if (key == 'keycast_session') {
-            throw StateError('persistent secure storage delete failure');
-          }
-        });
+            if (key == 'keycast_session') {
+              throw StateError('persistent secure storage delete failure');
+            }
+          },
+        );
 
         await authService.signOut(deleteKeys: true);
 
@@ -2063,11 +2060,11 @@ void main() {
         await _ignoringDiscoveryErrors(authService.createNewIdentity);
 
         final deletedKeys = <String>[];
-        when(
-          () => mockSecureStorage.delete(key: any(named: 'key')),
-        ).thenAnswer((invocation) async {
-          deletedKeys.add(invocation.namedArguments[#key] as String);
-        });
+        when(() => mockSecureStorage.delete(key: any(named: 'key'))).thenAnswer(
+          (invocation) async {
+            deletedKeys.add(invocation.namedArguments[#key] as String);
+          },
+        );
 
         await authService.signOut(deleteKeys: true);
 
@@ -2825,6 +2822,99 @@ void main() {
                 'user must confirm explicitly via the welcome screen',
           );
           expect(localAuthService.currentPublicKeyHex, isNull);
+        } finally {
+          await localAuthService.dispose();
+        }
+      },
+    );
+
+    test(
+      'blocks cross-account restore when expired session refresh fails due to '
+      'network and would otherwise degrade into authenticated state',
+      () async {
+        final mockOAuthClient = _MockKeycastOAuth();
+        final expiredSessionData = {
+          'bunker_url': 'wss://keycast.example.com',
+          'access_token': 'expired_b_token',
+          'scope': 'policy:full',
+          'expires_at': DateTime.now()
+              .subtract(const Duration(seconds: 1))
+              .toIso8601String(),
+          'user_pubkey': accountB.publicKeyHex,
+          'refresh_token': 'b_refresh_token',
+        };
+        final storage = <String, String>{
+          'keycast_session': jsonEncode(expiredSessionData),
+          'keycast_refresh_token': 'b_refresh_token',
+        };
+
+        when(() => mockSecureStorage.read(key: any(named: 'key'))).thenAnswer((
+          invocation,
+        ) async {
+          final key = invocation.namedArguments[#key] as String;
+          return storage[key];
+        });
+        when(
+          () => mockSecureStorage.write(
+            key: any(named: 'key'),
+            value: any(named: 'value'),
+          ),
+        ).thenAnswer((invocation) async {
+          final key = invocation.namedArguments[#key] as String;
+          final value = invocation.namedArguments[#value] as String;
+          storage[key] = value;
+        });
+        when(() => mockSecureStorage.delete(key: any(named: 'key'))).thenAnswer(
+          (invocation) async {
+            final key = invocation.namedArguments[#key] as String;
+            storage.remove(key);
+          },
+        );
+
+        when(
+          () => mockOAuthClient.refreshSession(
+            userPubkey: any(named: 'userPubkey'),
+          ),
+        ).thenThrow(OAuthNetworkException('offline'));
+        when(mockOAuthClient.close).thenReturn(null);
+        when(mockOAuthClient.logout).thenAnswer((_) async {});
+
+        when(() => mockKeyStorage.hasKeys()).thenAnswer((_) async => false);
+
+        SharedPreferences.setMockInitialValues({
+          'authentication_source': 'divineOAuth',
+          'last_used_npub': accountB.npub,
+          'session_recovery_anchor_npub': accountA.npub,
+          kKnownAccountsKey: '[]',
+        });
+
+        final localAuthService = AuthService(
+          userDataCleanupService: mockCleanupService,
+          keyStorage: mockKeyStorage,
+          flutterSecureStorage: mockSecureStorage,
+          oauthClient: mockOAuthClient,
+        );
+
+        try {
+          await localAuthService.initialize();
+
+          expect(
+            localAuthService.authState,
+            equals(AuthState.unauthenticated),
+            reason:
+                'The degraded offline restore path must honor the same '
+                'cross-account anchor as the direct and refresh-success paths.',
+          );
+          expect(localAuthService.currentPublicKeyHex, isNull);
+          expect(
+            (await SharedPreferences.getInstance()).getString(
+              'session_recovery_anchor_npub',
+            ),
+            equals(accountA.npub),
+            reason:
+                'Blocked degraded restore must not clear the anchor before '
+                'the welcome screen can ask for confirmation.',
+          );
         } finally {
           await localAuthService.dispose();
         }


### PR DESCRIPTION
## Summary
- distinguish Keycast refresh transport failures from server-side refresh rejection
- keep owner-bound Divine OAuth sessions authenticated in a pubkey-only, RPC-upgrading state when startup refresh fails offline
- preserve automatic recovery by scheduling background RPC upgrade and keeping expired-session retry affordances armed until refresh succeeds
- apply the cross-account recovery-anchor guard to degraded offline restore as well as direct and refresh-success restore
- preserve refresh tokens on network failures and keep rejection/null refreshes unauthenticated

## Tests
- flutter test packages/keycast_flutter/test/oauth_client_test.dart test/services/auth/oauth_session_coordinator_test.dart test/services/auth_service_expired_session_downgrade_test.dart test/services/auth/signer_factory_test.dart test/services/auth_service_multi_account_test.dart
- flutter analyze
- pre-push hook affected analyze/tests
- GitHub checks green on f985982b

Closes #6133