### PR TITLE
fix(auth): read keycast login error code and nudge toward sign-in options

### DIFF
--- a/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
+++ b/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
@@ -79,6 +79,7 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
         email: email,
         clearEmailError: true,
         clearGeneralError: true,
+        clearSignInFailureReason: true,
         clearInviteGateRecovery: true,
       ),
     );
@@ -95,6 +96,7 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
         clearPasswordError: true,
         clearConfirmPasswordError: true,
         clearGeneralError: true,
+        clearSignInFailureReason: true,
         clearInviteGateRecovery: true,
       ),
     );
@@ -110,6 +112,7 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
         confirmPassword: confirmPassword,
         clearConfirmPasswordError: true,
         clearGeneralError: true,
+        clearSignInFailureReason: true,
         clearInviteGateRecovery: true,
       ),
     );
@@ -168,6 +171,7 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
       current.copyWith(
         isSubmitting: true,
         clearGeneralError: true,
+        clearSignInFailureReason: true,
         clearInviteGateRecovery: true,
       ),
     );
@@ -215,23 +219,44 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
     );
 
     if (!result.success || result.code == null) {
-      final errorMsg =
-          result.errorDescription ?? result.error ?? 'Sign in failed';
+      final reason = _signInFailureReasonFrom(result.failure);
       Log.warning(
-        'Sign in failed: $errorMsg',
+        'Sign in failed: code=${result.errorCode}, reason=$reason',
         name: 'DivineAuthCubit',
         category: LogCategory.auth,
       );
 
       final current = state;
       if (current is DivineAuthFormState) {
-        emit(current.copyWith(isSubmitting: false, generalError: errorMsg));
+        emit(
+          current.copyWith(
+            isSubmitting: false,
+            signInFailureReason: reason,
+          ),
+        );
       }
       return;
     }
 
     // Exchange code for tokens
     await _exchangeCodeAndLogin(result.code!, verifier);
+  }
+
+  /// Translates the client-layer [KeycastLoginFailure] into the UI-facing
+  /// [SignInFailureReason]. Keeps the client taxonomy out of the state layer.
+  SignInFailureReason _signInFailureReasonFrom(KeycastLoginFailure failure) {
+    switch (failure) {
+      case KeycastLoginFailure.invalidCredentials:
+        return SignInFailureReason.invalidCredentials;
+      case KeycastLoginFailure.emailNotVerified:
+        return SignInFailureReason.emailNotVerified;
+      case KeycastLoginFailure.invalidEmail:
+        return SignInFailureReason.invalidEmail;
+      case KeycastLoginFailure.network:
+        return SignInFailureReason.network;
+      case KeycastLoginFailure.unknown:
+        return SignInFailureReason.unknown;
+    }
   }
 
   Future<void> _handleSignUp(String email, String password) async {

--- a/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
+++ b/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
@@ -221,7 +221,8 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
     if (!result.success || result.code == null) {
       final reason = _signInFailureReasonFrom(result.failure);
       Log.warning(
-        'Sign in failed: code=${result.errorCode}, reason=$reason',
+        'Sign in failed: code=${result.errorCode}, reason=$reason, '
+        'description=${result.errorDescription}',
         name: 'DivineAuthCubit',
         category: LogCategory.auth,
       );
@@ -229,10 +230,7 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
       final current = state;
       if (current is DivineAuthFormState) {
         emit(
-          current.copyWith(
-            isSubmitting: false,
-            signInFailureReason: reason,
-          ),
+          current.copyWith(isSubmitting: false, signInFailureReason: reason),
         );
       }
       return;

--- a/mobile/lib/blocs/divine_auth/divine_auth_state.dart
+++ b/mobile/lib/blocs/divine_auth/divine_auth_state.dart
@@ -3,6 +3,29 @@
 
 part of 'divine_auth_cubit.dart';
 
+/// Why an email/password sign-in failed, mapped to localized copy by the UI.
+///
+/// Kept out of [KeycastLoginFailure] so the presentation layer never imports
+/// the client package's taxonomy. Never carries a message string — the rule in
+/// `state_management.md` (no error strings in state) is why this is an enum.
+enum SignInFailureReason {
+  /// Wrong credentials or no such account. Copy must not imply the account
+  /// exists (keycast returns an identical 401 for both).
+  invalidCredentials,
+
+  /// The account's email is not yet verified.
+  emailNotVerified,
+
+  /// The submitted email was malformed.
+  invalidEmail,
+
+  /// A network/transport problem prevented a verdict.
+  network,
+
+  /// Any other unexpected failure.
+  unknown,
+}
+
 /// State for Divine authentication cubit
 sealed class DivineAuthState extends Equatable {
   const DivineAuthState();
@@ -28,6 +51,7 @@ class DivineAuthFormState extends DivineAuthState {
     this.passwordError,
     this.confirmPasswordError,
     this.generalError,
+    this.signInFailureReason,
     this.showInviteGateRecovery = false,
     this.inviteRecoveryCode,
     this.inviteRecoverySourceSlug,
@@ -63,6 +87,12 @@ class DivineAuthFormState extends DivineAuthState {
 
   /// General error message (e.g., network error, auth failure)
   final String? generalError;
+
+  /// Typed reason the last email/password sign-in failed, or null.
+  ///
+  /// Sign-in failures use this instead of [generalError] so the UI can map to
+  /// localized copy; other auth flows still use [generalError] pending #4336.
+  final SignInFailureReason? signInFailureReason;
 
   /// Whether the user should be sent back through the invite gate.
   final bool showInviteGateRecovery;
@@ -106,6 +136,7 @@ class DivineAuthFormState extends DivineAuthState {
     String? passwordError,
     String? confirmPasswordError,
     String? generalError,
+    SignInFailureReason? signInFailureReason,
     bool? showInviteGateRecovery,
     String? inviteRecoveryCode,
     String? inviteRecoverySourceSlug,
@@ -117,6 +148,7 @@ class DivineAuthFormState extends DivineAuthState {
     bool clearPasswordError = false,
     bool clearConfirmPasswordError = false,
     bool clearGeneralError = false,
+    bool clearSignInFailureReason = false,
     bool clearInviteGateRecovery = false,
   }) {
     return DivineAuthFormState(
@@ -136,6 +168,9 @@ class DivineAuthFormState extends DivineAuthState {
       generalError: clearGeneralError
           ? null
           : (generalError ?? this.generalError),
+      signInFailureReason: clearSignInFailureReason
+          ? null
+          : (signInFailureReason ?? this.signInFailureReason),
       showInviteGateRecovery:
           !clearInviteGateRecovery &&
           (showInviteGateRecovery ?? this.showInviteGateRecovery),
@@ -164,6 +199,7 @@ class DivineAuthFormState extends DivineAuthState {
     passwordError,
     confirmPasswordError,
     generalError,
+    signInFailureReason,
     showInviteGateRecovery,
     inviteRecoveryCode,
     inviteRecoverySourceSlug,

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -4679,5 +4679,12 @@
   "settingsStorageError": "የሆነ ችግር ተፈጥሯል",
   "settingsStorageMaxSizeLabel": "ከፍተኛ የመሸጎጫ መጠን",
   "settingsStorageApproxVideos": "≈ {count} ቪዲዮዎች",
-  "settingsStorageRemoveBrokenConfirmTitle": "የተበላሹ ክሊፖችን ማስወገድ?"
+  "settingsStorageRemoveBrokenConfirmTitle": "የተበላሹ ክሊፖችን ማስወገድ?",
+  "authSignInErrorInvalidCredentials": "የተሳሳተ ኢሜይል ወይም የይለፍ ቃል። እንደገና ይሞክሩ።",
+  "authSignInErrorEmailNotVerified": "ከመግባትዎ በፊት ኢሜይልዎን ያረጋግጡ — ለአገናኙ የገቢ መልእክት ሳጥንዎን ይመልከቱ።",
+  "authSignInErrorInvalidEmail": "ይህ ትክክለኛ የኢሜይል አድራሻ አይመስልም።",
+  "authSignInErrorNetwork": "አገልጋዩ ጋር መድረስ አልተቻለም። ግንኙነትዎን አረጋግጠው እንደገና ይሞክሩ።",
+  "authSignInErrorGeneric": "የሆነ ችግር ተፈጥሯል። እባክዎ እንደገና ይሞክሩ።",
+  "authSignInOptionsHintPrefix": "ባለፈው ጊዜ እንዴት እንደገቡ እርግጠኛ አይደሉም? ",
+  "authSignInOptionsHintCta": "ሁሉንም የመግቢያ አማራጮች ይመልከቱ"
 }

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -4554,5 +4554,12 @@
   "settingsStorageError": "حدث خطأ ما",
   "settingsStorageMaxSizeLabel": "الحد الأقصى لحجم ذاكرة التخزين المؤقت",
   "settingsStorageApproxVideos": "≈ {count} مقطع فيديو",
-  "settingsStorageRemoveBrokenConfirmTitle": "إزالة المقاطع التالفة؟"
+  "settingsStorageRemoveBrokenConfirmTitle": "إزالة المقاطع التالفة؟",
+  "authSignInErrorInvalidCredentials": "البريد الإلكتروني أو كلمة المرور غير صحيحة. حاول مرة أخرى.",
+  "authSignInErrorEmailNotVerified": "تحقق من بريدك الإلكتروني قبل تسجيل الدخول — راجع صندوق الوارد للحصول على الرابط.",
+  "authSignInErrorInvalidEmail": "لا يبدو هذا عنوان بريد إلكتروني صالحًا.",
+  "authSignInErrorNetwork": "تعذّر الوصول إلى الخادم. تحقق من اتصالك وحاول مرة أخرى.",
+  "authSignInErrorGeneric": "حدث خطأ ما. حاول مرة أخرى.",
+  "authSignInOptionsHintPrefix": "لست متأكدًا كيف سجّلت الدخول آخر مرة؟ ",
+  "authSignInOptionsHintCta": "عرض جميع خيارات تسجيل الدخول"
 }

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -4685,5 +4685,12 @@
   "settingsStorageError": "Нещо се обърка",
   "settingsStorageMaxSizeLabel": "Максимален размер на кеша",
   "settingsStorageApproxVideos": "≈ {count} видеа",
-  "settingsStorageRemoveBrokenConfirmTitle": "Премахване на повредените клипове?"
+  "settingsStorageRemoveBrokenConfirmTitle": "Премахване на повредените клипове?",
+  "authSignInErrorInvalidCredentials": "Грешен имейл или парола. Опитай отново.",
+  "authSignInErrorEmailNotVerified": "Потвърди имейла си, преди да влезеш — провери входящата си поща за връзката.",
+  "authSignInErrorInvalidEmail": "Това не изглежда като валиден имейл адрес.",
+  "authSignInErrorNetwork": "Сървърът е недостъпен. Провери връзката си и опитай отново.",
+  "authSignInErrorGeneric": "Нещо се обърка. Опитай отново.",
+  "authSignInOptionsHintPrefix": "Не си сигурен как влезе последния път? ",
+  "authSignInOptionsHintCta": "Виж всички опции за вход"
 }

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -4554,5 +4554,12 @@
   "settingsStorageError": "Etwas ist schiefgelaufen",
   "settingsStorageMaxSizeLabel": "Maximale Cache-Größe",
   "settingsStorageApproxVideos": "≈ {count} Videos",
-  "settingsStorageRemoveBrokenConfirmTitle": "Defekte Clips entfernen?"
+  "settingsStorageRemoveBrokenConfirmTitle": "Defekte Clips entfernen?",
+  "authSignInErrorInvalidCredentials": "Falsche E-Mail oder falsches Passwort. Versuch es noch mal.",
+  "authSignInErrorEmailNotVerified": "Bestätige deine E-Mail, bevor du dich anmeldest – schau in deinem Posteingang nach dem Link.",
+  "authSignInErrorInvalidEmail": "Das sieht nicht nach einer gültigen E-Mail-Adresse aus.",
+  "authSignInErrorNetwork": "Server nicht erreichbar. Prüf deine Verbindung und versuch es noch mal.",
+  "authSignInErrorGeneric": "Etwas ist schiefgelaufen. Bitte versuch es noch mal.",
+  "authSignInOptionsHintPrefix": "Nicht sicher, wie du letztes Mal reingekommen bist? ",
+  "authSignInOptionsHintCta": "Alle Anmeldeoptionen ansehen"
 }

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -1656,6 +1656,34 @@
   "authInfoAmberDescription": "Use the Amber signer app on Android to manage your Nostr keys securely.",
   "authInfoBrowserExtensionTitle": "Browser Extension",
   "authInfoBrowserExtensionDescription": "Sign in with a NIP-07 browser extension like Alby or nos2x. Your keys stay in the extension — Divine never sees them.",
+  "authSignInErrorInvalidCredentials": "Wrong email or password. Give it another try.",
+  "@authSignInErrorInvalidCredentials": {
+    "description": "Shown when email/password sign-in fails. Must stay neutral about whether the account exists — the server returns the same error for a wrong password and an unknown account."
+  },
+  "authSignInErrorEmailNotVerified": "Verify your email before signing in — check your inbox for the link.",
+  "@authSignInErrorEmailNotVerified": {
+    "description": "Shown when the account exists but its email is not yet verified (HTTP 403 on sign-in)."
+  },
+  "authSignInErrorInvalidEmail": "That doesn't look like a valid email address.",
+  "@authSignInErrorInvalidEmail": {
+    "description": "Shown when the submitted email is malformed on sign-in."
+  },
+  "authSignInErrorNetwork": "Can't reach the server. Check your connection and try again.",
+  "@authSignInErrorNetwork": {
+    "description": "Shown when a network/transport problem prevents a sign-in verdict."
+  },
+  "authSignInErrorGeneric": "Something went wrong. Please try again.",
+  "@authSignInErrorGeneric": {
+    "description": "Fallback shown for any other sign-in failure."
+  },
+  "authSignInOptionsHintPrefix": "Not sure how you got in last time? ",
+  "@authSignInOptionsHintPrefix": {
+    "description": "Leading prose of the tappable hint under a failed sign-in, before the call-to-action span. Trailing space is intentional."
+  },
+  "authSignInOptionsHintCta": "See every sign-in option",
+  "@authSignInOptionsHintCta": {
+    "description": "Tappable call-to-action span of the failed-sign-in hint. Opens the sheet listing all sign-in methods."
+  },
   "authCreateAccountTitle": "Create account",
   "authBackToInviteCode": "Back to invite code",
   "authUseDivineNoBackup": "Use Divine with no backup",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -4554,5 +4554,12 @@
   "settingsStorageError": "Algo salió mal",
   "settingsStorageMaxSizeLabel": "Tamaño máximo de caché",
   "settingsStorageApproxVideos": "≈ {count} videos",
-  "settingsStorageRemoveBrokenConfirmTitle": "¿Eliminar clips dañados?"
+  "settingsStorageRemoveBrokenConfirmTitle": "¿Eliminar clips dañados?",
+  "authSignInErrorInvalidCredentials": "Correo o contraseña incorrectos. Inténtalo de nuevo.",
+  "authSignInErrorEmailNotVerified": "Verifica tu correo antes de iniciar sesión: revisa tu bandeja de entrada para ver el enlace.",
+  "authSignInErrorInvalidEmail": "Eso no parece una dirección de correo válida.",
+  "authSignInErrorNetwork": "No se puede conectar con el servidor. Comprueba tu conexión e inténtalo de nuevo.",
+  "authSignInErrorGeneric": "Algo salió mal. Inténtalo de nuevo.",
+  "authSignInOptionsHintPrefix": "¿No sabes cómo entraste la última vez? ",
+  "authSignInOptionsHintCta": "Ver todas las opciones de inicio de sesión"
 }

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -3137,5 +3137,12 @@
   "settingsStorageError": "May nangyaring mali",
   "settingsStorageMaxSizeLabel": "Pinakamataas na laki ng cache",
   "settingsStorageApproxVideos": "≈ {count} video",
-  "settingsStorageRemoveBrokenConfirmTitle": "Alisin ang mga sirang clip?"
+  "settingsStorageRemoveBrokenConfirmTitle": "Alisin ang mga sirang clip?",
+  "authSignInErrorInvalidCredentials": "Mali ang email o password. Subukan ulit.",
+  "authSignInErrorEmailNotVerified": "I-verify ang iyong email bago mag-sign in — tingnan ang inbox mo para sa link.",
+  "authSignInErrorInvalidEmail": "Mukhang hindi iyon wastong email address.",
+  "authSignInErrorNetwork": "Hindi maabot ang server. Tingnan ang iyong koneksyon at subukan ulit.",
+  "authSignInErrorGeneric": "May nangyaring mali. Subukan ulit.",
+  "authSignInOptionsHintPrefix": "Hindi sigurado kung paano ka nakapasok noong huli? ",
+  "authSignInOptionsHintCta": "Tingnan ang lahat ng opsyon sa pag-sign in"
 }

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -4554,5 +4554,12 @@
   "settingsStorageError": "Une erreur s'est produite",
   "settingsStorageMaxSizeLabel": "Taille maximale du cache",
   "settingsStorageApproxVideos": "≈ {count} vidéos",
-  "settingsStorageRemoveBrokenConfirmTitle": "Supprimer les clips défectueux ?"
+  "settingsStorageRemoveBrokenConfirmTitle": "Supprimer les clips défectueux ?",
+  "authSignInErrorInvalidCredentials": "E-mail ou mot de passe incorrect. Réessaie.",
+  "authSignInErrorEmailNotVerified": "Vérifie ton e-mail avant de te connecter — consulte ta boîte de réception pour le lien.",
+  "authSignInErrorInvalidEmail": "Cette adresse e-mail ne semble pas valide.",
+  "authSignInErrorNetwork": "Impossible de joindre le serveur. Vérifie ta connexion et réessaie.",
+  "authSignInErrorGeneric": "Une erreur s'est produite. Réessaie.",
+  "authSignInOptionsHintPrefix": "Tu ne sais plus comment tu t'es connecté la dernière fois ? ",
+  "authSignInOptionsHintCta": "Voir toutes les options de connexion"
 }

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -4554,5 +4554,12 @@
   "settingsStorageError": "Terjadi kesalahan",
   "settingsStorageMaxSizeLabel": "Ukuran cache maksimum",
   "settingsStorageApproxVideos": "≈ {count} video",
-  "settingsStorageRemoveBrokenConfirmTitle": "Hapus klip rusak?"
+  "settingsStorageRemoveBrokenConfirmTitle": "Hapus klip rusak?",
+  "authSignInErrorInvalidCredentials": "Email atau kata sandi salah. Coba lagi.",
+  "authSignInErrorEmailNotVerified": "Verifikasi emailmu sebelum masuk — cek kotak masuk untuk tautannya.",
+  "authSignInErrorInvalidEmail": "Itu sepertinya bukan alamat email yang valid.",
+  "authSignInErrorNetwork": "Tidak dapat menjangkau server. Periksa koneksimu dan coba lagi.",
+  "authSignInErrorGeneric": "Ada yang salah. Coba lagi.",
+  "authSignInOptionsHintPrefix": "Tidak yakin bagaimana kamu masuk terakhir kali? ",
+  "authSignInOptionsHintCta": "Lihat semua opsi masuk"
 }

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -4554,5 +4554,12 @@
   "settingsStorageError": "Qualcosa è andato storto",
   "settingsStorageMaxSizeLabel": "Dimensione massima cache",
   "settingsStorageApproxVideos": "≈ {count} video",
-  "settingsStorageRemoveBrokenConfirmTitle": "Rimuovere le clip danneggiate?"
+  "settingsStorageRemoveBrokenConfirmTitle": "Rimuovere le clip danneggiate?",
+  "authSignInErrorInvalidCredentials": "Email o password errati. Riprova.",
+  "authSignInErrorEmailNotVerified": "Verifica la tua email prima di accedere: controlla la posta in arrivo per il link.",
+  "authSignInErrorInvalidEmail": "Non sembra un indirizzo email valido.",
+  "authSignInErrorNetwork": "Impossibile raggiungere il server. Controlla la connessione e riprova.",
+  "authSignInErrorGeneric": "Qualcosa è andato storto. Riprova.",
+  "authSignInOptionsHintPrefix": "Non sai come hai effettuato l'accesso l'ultima volta? ",
+  "authSignInOptionsHintCta": "Vedi tutte le opzioni di accesso"
 }

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -4554,5 +4554,12 @@
   "settingsStorageError": "問題が発生しました",
   "settingsStorageMaxSizeLabel": "最大キャッシュサイズ",
   "settingsStorageApproxVideos": "≈ {count} 本の動画",
-  "settingsStorageRemoveBrokenConfirmTitle": "壊れたクリップを削除しますか？"
+  "settingsStorageRemoveBrokenConfirmTitle": "壊れたクリップを削除しますか？",
+  "authSignInErrorInvalidCredentials": "メールアドレスまたはパスワードが違います。もう一度お試しください。",
+  "authSignInErrorEmailNotVerified": "サインインする前にメールを認証してください。受信トレイのリンクを確認してください。",
+  "authSignInErrorInvalidEmail": "有効なメールアドレスではないようです。",
+  "authSignInErrorNetwork": "サーバーに接続できません。接続を確認してもう一度お試しください。",
+  "authSignInErrorGeneric": "問題が発生しました。もう一度お試しください。",
+  "authSignInOptionsHintPrefix": "前回どうやってログインしたか分かりませんか? ",
+  "authSignInOptionsHintCta": "すべてのサインイン方法を見る"
 }

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -3878,5 +3878,12 @@
   "settingsStorageError": "문제가 발생했습니다",
   "settingsStorageMaxSizeLabel": "최대 캐시 크기",
   "settingsStorageApproxVideos": "≈ 동영상 {count}개",
-  "settingsStorageRemoveBrokenConfirmTitle": "손상된 클립을 제거할까요?"
+  "settingsStorageRemoveBrokenConfirmTitle": "손상된 클립을 제거할까요?",
+  "authSignInErrorInvalidCredentials": "이메일 또는 비밀번호가 잘못되었습니다. 다시 시도해 주세요.",
+  "authSignInErrorEmailNotVerified": "로그인하기 전에 이메일을 인증하세요 — 받은 편지함에서 링크를 확인하세요.",
+  "authSignInErrorInvalidEmail": "유효한 이메일 주소가 아닌 것 같습니다.",
+  "authSignInErrorNetwork": "서버에 연결할 수 없습니다. 연결을 확인하고 다시 시도해 주세요.",
+  "authSignInErrorGeneric": "문제가 발생했습니다. 다시 시도해 주세요.",
+  "authSignInOptionsHintPrefix": "지난번에 어떻게 로그인했는지 기억나지 않나요? ",
+  "authSignInOptionsHintCta": "모든 로그인 옵션 보기"
 }

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -4554,5 +4554,12 @@
   "settingsStorageError": "Er ging iets mis",
   "settingsStorageMaxSizeLabel": "Maximale cachegrootte",
   "settingsStorageApproxVideos": "≈ {count} video's",
-  "settingsStorageRemoveBrokenConfirmTitle": "Kapotte clips verwijderen?"
+  "settingsStorageRemoveBrokenConfirmTitle": "Kapotte clips verwijderen?",
+  "authSignInErrorInvalidCredentials": "Verkeerd e-mailadres of wachtwoord. Probeer het opnieuw.",
+  "authSignInErrorEmailNotVerified": "Verifieer je e-mail voordat je inlogt — check je inbox voor de link.",
+  "authSignInErrorInvalidEmail": "Dat lijkt geen geldig e-mailadres.",
+  "authSignInErrorNetwork": "Kan de server niet bereiken. Controleer je verbinding en probeer het opnieuw.",
+  "authSignInErrorGeneric": "Er ging iets mis. Probeer het opnieuw.",
+  "authSignInOptionsHintPrefix": "Weet je niet meer hoe je de vorige keer inlogde? ",
+  "authSignInOptionsHintCta": "Bekijk alle inlogopties"
 }

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -4554,5 +4554,12 @@
   "settingsStorageError": "Coś poszło nie tak",
   "settingsStorageMaxSizeLabel": "Maksymalny rozmiar pamięci podręcznej",
   "settingsStorageApproxVideos": "≈ {count} filmów",
-  "settingsStorageRemoveBrokenConfirmTitle": "Usunąć uszkodzone klipy?"
+  "settingsStorageRemoveBrokenConfirmTitle": "Usunąć uszkodzone klipy?",
+  "authSignInErrorInvalidCredentials": "Nieprawidłowy e-mail lub hasło. Spróbuj ponownie.",
+  "authSignInErrorEmailNotVerified": "Zweryfikuj swój e-mail przed zalogowaniem — sprawdź link w skrzynce odbiorczej.",
+  "authSignInErrorInvalidEmail": "To nie wygląda na prawidłowy adres e-mail.",
+  "authSignInErrorNetwork": "Nie można połączyć się z serwerem. Sprawdź połączenie i spróbuj ponownie.",
+  "authSignInErrorGeneric": "Coś poszło nie tak. Spróbuj ponownie.",
+  "authSignInOptionsHintPrefix": "Nie wiesz, jak zalogowałeś się ostatnim razem? ",
+  "authSignInOptionsHintCta": "Zobacz wszystkie opcje logowania"
 }

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -4554,5 +4554,12 @@
   "settingsStorageError": "Algo deu errado",
   "settingsStorageMaxSizeLabel": "Tamanho máximo do cache",
   "settingsStorageApproxVideos": "≈ {count} vídeos",
-  "settingsStorageRemoveBrokenConfirmTitle": "Remover clipes quebrados?"
+  "settingsStorageRemoveBrokenConfirmTitle": "Remover clipes quebrados?",
+  "authSignInErrorInvalidCredentials": "E-mail ou senha incorretos. Tente de novo.",
+  "authSignInErrorEmailNotVerified": "Verifique seu e-mail antes de entrar — confira o link na sua caixa de entrada.",
+  "authSignInErrorInvalidEmail": "Isso não parece um endereço de e-mail válido.",
+  "authSignInErrorNetwork": "Não foi possível conectar ao servidor. Verifique sua conexão e tente de novo.",
+  "authSignInErrorGeneric": "Algo deu errado. Tente de novo.",
+  "authSignInOptionsHintPrefix": "Não sabe como entrou da última vez? ",
+  "authSignInOptionsHintCta": "Ver todas as opções de login"
 }

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -4554,5 +4554,12 @@
   "settingsStorageError": "Ceva n-a mers bine",
   "settingsStorageMaxSizeLabel": "Dimensiune maximă cache",
   "settingsStorageApproxVideos": "≈ {count} videoclipuri",
-  "settingsStorageRemoveBrokenConfirmTitle": "Elimini clipurile deteriorate?"
+  "settingsStorageRemoveBrokenConfirmTitle": "Elimini clipurile deteriorate?",
+  "authSignInErrorInvalidCredentials": "E-mail sau parolă greșite. Mai încearcă o dată.",
+  "authSignInErrorEmailNotVerified": "Verifică-ți e-mailul înainte de a te conecta — caută linkul în inbox.",
+  "authSignInErrorInvalidEmail": "Nu pare o adresă de e-mail validă.",
+  "authSignInErrorNetwork": "Serverul nu poate fi contactat. Verifică-ți conexiunea și încearcă din nou.",
+  "authSignInErrorGeneric": "Ceva n-a mers bine. Încearcă din nou.",
+  "authSignInOptionsHintPrefix": "Nu știi sigur cum te-ai conectat data trecută? ",
+  "authSignInOptionsHintCta": "Vezi toate opțiunile de conectare"
 }

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -4554,5 +4554,12 @@
   "settingsStorageError": "Något gick fel",
   "settingsStorageMaxSizeLabel": "Maximal cachestorlek",
   "settingsStorageApproxVideos": "≈ {count} videor",
-  "settingsStorageRemoveBrokenConfirmTitle": "Ta bort trasiga klipp?"
+  "settingsStorageRemoveBrokenConfirmTitle": "Ta bort trasiga klipp?",
+  "authSignInErrorInvalidCredentials": "Fel e-post eller lösenord. Försök igen.",
+  "authSignInErrorEmailNotVerified": "Verifiera din e-post innan du loggar in – kolla din inkorg efter länken.",
+  "authSignInErrorInvalidEmail": "Det där ser inte ut som en giltig e-postadress.",
+  "authSignInErrorNetwork": "Kan inte nå servern. Kontrollera din anslutning och försök igen.",
+  "authSignInErrorGeneric": "Något gick fel. Försök igen.",
+  "authSignInOptionsHintPrefix": "Osäker på hur du loggade in förra gången? ",
+  "authSignInOptionsHintCta": "Se alla inloggningsalternativ"
 }

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -4554,5 +4554,12 @@
   "settingsStorageError": "Bir şeyler ters gitti",
   "settingsStorageMaxSizeLabel": "Maksimum önbellek boyutu",
   "settingsStorageApproxVideos": "≈ {count} video",
-  "settingsStorageRemoveBrokenConfirmTitle": "Bozuk klipler kaldırılsın mı?"
+  "settingsStorageRemoveBrokenConfirmTitle": "Bozuk klipler kaldırılsın mı?",
+  "authSignInErrorInvalidCredentials": "E-posta veya şifre yanlış. Tekrar dene.",
+  "authSignInErrorEmailNotVerified": "Giriş yapmadan önce e-postanı doğrula — bağlantı için gelen kutunu kontrol et.",
+  "authSignInErrorInvalidEmail": "Bu geçerli bir e-posta adresi gibi görünmüyor.",
+  "authSignInErrorNetwork": "Sunucuya ulaşılamıyor. Bağlantını kontrol edip tekrar dene.",
+  "authSignInErrorGeneric": "Bir şeyler ters gitti. Lütfen tekrar dene.",
+  "authSignInOptionsHintPrefix": "Geçen sefer nasıl giriş yaptığını hatırlamıyor musun? ",
+  "authSignInOptionsHintCta": "Tüm giriş seçeneklerini gör"
 }

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -5022,6 +5022,48 @@ abstract class AppLocalizations {
   /// **'Sign in with a NIP-07 browser extension like Alby or nos2x. Your keys stay in the extension — Divine never sees them.'**
   String get authInfoBrowserExtensionDescription;
 
+  /// Shown when email/password sign-in fails. Must stay neutral about whether the account exists — the server returns the same error for a wrong password and an unknown account.
+  ///
+  /// In en, this message translates to:
+  /// **'Wrong email or password. Give it another try.'**
+  String get authSignInErrorInvalidCredentials;
+
+  /// Shown when the account exists but its email is not yet verified (HTTP 403 on sign-in).
+  ///
+  /// In en, this message translates to:
+  /// **'Verify your email before signing in — check your inbox for the link.'**
+  String get authSignInErrorEmailNotVerified;
+
+  /// Shown when the submitted email is malformed on sign-in.
+  ///
+  /// In en, this message translates to:
+  /// **'That doesn\'t look like a valid email address.'**
+  String get authSignInErrorInvalidEmail;
+
+  /// Shown when a network/transport problem prevents a sign-in verdict.
+  ///
+  /// In en, this message translates to:
+  /// **'Can\'t reach the server. Check your connection and try again.'**
+  String get authSignInErrorNetwork;
+
+  /// Fallback shown for any other sign-in failure.
+  ///
+  /// In en, this message translates to:
+  /// **'Something went wrong. Please try again.'**
+  String get authSignInErrorGeneric;
+
+  /// Leading prose of the tappable hint under a failed sign-in, before the call-to-action span. Trailing space is intentional.
+  ///
+  /// In en, this message translates to:
+  /// **'Not sure how you got in last time? '**
+  String get authSignInOptionsHintPrefix;
+
+  /// Tappable call-to-action span of the failed-sign-in hint. Opens the sheet listing all sign-in methods.
+  ///
+  /// In en, this message translates to:
+  /// **'See every sign-in option'**
+  String get authSignInOptionsHintCta;
+
   /// No description provided for @authCreateAccountTitle.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -2827,6 +2827,30 @@ class AppLocalizationsAm extends AppLocalizations {
       'እንደ Alby ወይም nos2x ያሉ የ NIP-07 አሳሽ ቅጥያ በመጠቀም ይግቡ። ቁልፎችዎ በቅጥያው ውስጥ ይቀራሉ — Divine በፍፁም አያያቸውም።';
 
   @override
+  String get authSignInErrorInvalidCredentials =>
+      'የተሳሳተ ኢሜይል ወይም የይለፍ ቃል። እንደገና ይሞክሩ።';
+
+  @override
+  String get authSignInErrorEmailNotVerified =>
+      'ከመግባትዎ በፊት ኢሜይልዎን ያረጋግጡ — ለአገናኙ የገቢ መልእክት ሳጥንዎን ይመልከቱ።';
+
+  @override
+  String get authSignInErrorInvalidEmail => 'ይህ ትክክለኛ የኢሜይል አድራሻ አይመስልም።';
+
+  @override
+  String get authSignInErrorNetwork =>
+      'አገልጋዩ ጋር መድረስ አልተቻለም። ግንኙነትዎን አረጋግጠው እንደገና ይሞክሩ።';
+
+  @override
+  String get authSignInErrorGeneric => 'የሆነ ችግር ተፈጥሯል። እባክዎ እንደገና ይሞክሩ።';
+
+  @override
+  String get authSignInOptionsHintPrefix => 'ባለፈው ጊዜ እንዴት እንደገቡ እርግጠኛ አይደሉም? ';
+
+  @override
+  String get authSignInOptionsHintCta => 'ሁሉንም የመግቢያ አማራጮች ይመልከቱ';
+
+  @override
   String get authCreateAccountTitle => 'መለያ ይፍጠሩ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -2860,6 +2860,32 @@ class AppLocalizationsAr extends AppLocalizations {
       'سجّل الدخول باستخدام إضافة متصفح NIP-07 مثل Alby أو nos2x. تبقى مفاتيحك داخل الإضافة — Divine لا يراها أبدًا.';
 
   @override
+  String get authSignInErrorInvalidCredentials =>
+      'البريد الإلكتروني أو كلمة المرور غير صحيحة. حاول مرة أخرى.';
+
+  @override
+  String get authSignInErrorEmailNotVerified =>
+      'تحقق من بريدك الإلكتروني قبل تسجيل الدخول — راجع صندوق الوارد للحصول على الرابط.';
+
+  @override
+  String get authSignInErrorInvalidEmail =>
+      'لا يبدو هذا عنوان بريد إلكتروني صالحًا.';
+
+  @override
+  String get authSignInErrorNetwork =>
+      'تعذّر الوصول إلى الخادم. تحقق من اتصالك وحاول مرة أخرى.';
+
+  @override
+  String get authSignInErrorGeneric => 'حدث خطأ ما. حاول مرة أخرى.';
+
+  @override
+  String get authSignInOptionsHintPrefix =>
+      'لست متأكدًا كيف سجّلت الدخول آخر مرة؟ ';
+
+  @override
+  String get authSignInOptionsHintCta => 'عرض جميع خيارات تسجيل الدخول';
+
+  @override
   String get authCreateAccountTitle => 'إنشاء حساب';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -2925,6 +2925,32 @@ class AppLocalizationsBg extends AppLocalizations {
       'Влезте чрез NIP-07 разширение за браузър като Alby или nos2x. Ключовете ви остават в разширението — Divine никога не ги вижда.';
 
   @override
+  String get authSignInErrorInvalidCredentials =>
+      'Грешен имейл или парола. Опитай отново.';
+
+  @override
+  String get authSignInErrorEmailNotVerified =>
+      'Потвърди имейла си, преди да влезеш — провери входящата си поща за връзката.';
+
+  @override
+  String get authSignInErrorInvalidEmail =>
+      'Това не изглежда като валиден имейл адрес.';
+
+  @override
+  String get authSignInErrorNetwork =>
+      'Сървърът е недостъпен. Провери връзката си и опитай отново.';
+
+  @override
+  String get authSignInErrorGeneric => 'Нещо се обърка. Опитай отново.';
+
+  @override
+  String get authSignInOptionsHintPrefix =>
+      'Не си сигурен как влезе последния път? ';
+
+  @override
+  String get authSignInOptionsHintCta => 'Виж всички опции за вход';
+
+  @override
   String get authCreateAccountTitle => 'Създаване на акаунт';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -2911,6 +2911,33 @@ class AppLocalizationsDe extends AppLocalizations {
       'Melde dich mit einer NIP-07-Browser-Erweiterung wie Alby oder nos2x an. Deine Schlüssel bleiben in der Erweiterung — Divine sieht sie nie.';
 
   @override
+  String get authSignInErrorInvalidCredentials =>
+      'Falsche E-Mail oder falsches Passwort. Versuch es noch mal.';
+
+  @override
+  String get authSignInErrorEmailNotVerified =>
+      'Bestätige deine E-Mail, bevor du dich anmeldest – schau in deinem Posteingang nach dem Link.';
+
+  @override
+  String get authSignInErrorInvalidEmail =>
+      'Das sieht nicht nach einer gültigen E-Mail-Adresse aus.';
+
+  @override
+  String get authSignInErrorNetwork =>
+      'Server nicht erreichbar. Prüf deine Verbindung und versuch es noch mal.';
+
+  @override
+  String get authSignInErrorGeneric =>
+      'Etwas ist schiefgelaufen. Bitte versuch es noch mal.';
+
+  @override
+  String get authSignInOptionsHintPrefix =>
+      'Nicht sicher, wie du letztes Mal reingekommen bist? ';
+
+  @override
+  String get authSignInOptionsHintCta => 'Alle Anmeldeoptionen ansehen';
+
+  @override
   String get authCreateAccountTitle => 'Konto erstellen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -2878,6 +2878,33 @@ class AppLocalizationsEn extends AppLocalizations {
       'Sign in with a NIP-07 browser extension like Alby or nos2x. Your keys stay in the extension — Divine never sees them.';
 
   @override
+  String get authSignInErrorInvalidCredentials =>
+      'Wrong email or password. Give it another try.';
+
+  @override
+  String get authSignInErrorEmailNotVerified =>
+      'Verify your email before signing in — check your inbox for the link.';
+
+  @override
+  String get authSignInErrorInvalidEmail =>
+      'That doesn\'t look like a valid email address.';
+
+  @override
+  String get authSignInErrorNetwork =>
+      'Can\'t reach the server. Check your connection and try again.';
+
+  @override
+  String get authSignInErrorGeneric =>
+      'Something went wrong. Please try again.';
+
+  @override
+  String get authSignInOptionsHintPrefix =>
+      'Not sure how you got in last time? ';
+
+  @override
+  String get authSignInOptionsHintCta => 'See every sign-in option';
+
+  @override
   String get authCreateAccountTitle => 'Create account';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -2912,6 +2912,33 @@ class AppLocalizationsEs extends AppLocalizations {
       'Iniciá sesión con una extensión del navegador NIP-07 como Alby o nos2x. Tus claves se quedan en la extensión — Divine nunca las ve.';
 
   @override
+  String get authSignInErrorInvalidCredentials =>
+      'Correo o contraseña incorrectos. Inténtalo de nuevo.';
+
+  @override
+  String get authSignInErrorEmailNotVerified =>
+      'Verifica tu correo antes de iniciar sesión: revisa tu bandeja de entrada para ver el enlace.';
+
+  @override
+  String get authSignInErrorInvalidEmail =>
+      'Eso no parece una dirección de correo válida.';
+
+  @override
+  String get authSignInErrorNetwork =>
+      'No se puede conectar con el servidor. Comprueba tu conexión e inténtalo de nuevo.';
+
+  @override
+  String get authSignInErrorGeneric => 'Algo salió mal. Inténtalo de nuevo.';
+
+  @override
+  String get authSignInOptionsHintPrefix =>
+      '¿No sabes cómo entraste la última vez? ';
+
+  @override
+  String get authSignInOptionsHintCta =>
+      'Ver todas las opciones de inicio de sesión';
+
+  @override
   String get authCreateAccountTitle => 'Crear cuenta';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -2923,6 +2923,33 @@ class AppLocalizationsFil extends AppLocalizations {
       'Mag-sign in gamit ang NIP-07 browser extension tulad ng Alby o nos2x. Nananatili sa extension ang iyong mga key — hindi ito nakikita ng Divine.';
 
   @override
+  String get authSignInErrorInvalidCredentials =>
+      'Mali ang email o password. Subukan ulit.';
+
+  @override
+  String get authSignInErrorEmailNotVerified =>
+      'I-verify ang iyong email bago mag-sign in — tingnan ang inbox mo para sa link.';
+
+  @override
+  String get authSignInErrorInvalidEmail =>
+      'Mukhang hindi iyon wastong email address.';
+
+  @override
+  String get authSignInErrorNetwork =>
+      'Hindi maabot ang server. Tingnan ang iyong koneksyon at subukan ulit.';
+
+  @override
+  String get authSignInErrorGeneric => 'May nangyaring mali. Subukan ulit.';
+
+  @override
+  String get authSignInOptionsHintPrefix =>
+      'Hindi sigurado kung paano ka nakapasok noong huli? ';
+
+  @override
+  String get authSignInOptionsHintCta =>
+      'Tingnan ang lahat ng opsyon sa pag-sign in';
+
+  @override
   String get authCreateAccountTitle => 'Gumawa ng account';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -2920,6 +2920,32 @@ class AppLocalizationsFr extends AppLocalizations {
       'Connectez-vous avec une extension de navigateur NIP-07 comme Alby ou nos2x. Vos clés restent dans l\'extension — Divine ne les voit jamais.';
 
   @override
+  String get authSignInErrorInvalidCredentials =>
+      'E-mail ou mot de passe incorrect. Réessaie.';
+
+  @override
+  String get authSignInErrorEmailNotVerified =>
+      'Vérifie ton e-mail avant de te connecter — consulte ta boîte de réception pour le lien.';
+
+  @override
+  String get authSignInErrorInvalidEmail =>
+      'Cette adresse e-mail ne semble pas valide.';
+
+  @override
+  String get authSignInErrorNetwork =>
+      'Impossible de joindre le serveur. Vérifie ta connexion et réessaie.';
+
+  @override
+  String get authSignInErrorGeneric => 'Une erreur s\'est produite. Réessaie.';
+
+  @override
+  String get authSignInOptionsHintPrefix =>
+      'Tu ne sais plus comment tu t\'es connecté la dernière fois ? ';
+
+  @override
+  String get authSignInOptionsHintCta => 'Voir toutes les options de connexion';
+
+  @override
   String get authCreateAccountTitle => 'Créer un compte';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -2854,6 +2854,32 @@ class AppLocalizationsId extends AppLocalizations {
       'Masuk dengan ekstensi peramban NIP-07 seperti Alby atau nos2x. Kunci Anda tetap di ekstensi — Divine tidak pernah melihatnya.';
 
   @override
+  String get authSignInErrorInvalidCredentials =>
+      'Email atau kata sandi salah. Coba lagi.';
+
+  @override
+  String get authSignInErrorEmailNotVerified =>
+      'Verifikasi emailmu sebelum masuk — cek kotak masuk untuk tautannya.';
+
+  @override
+  String get authSignInErrorInvalidEmail =>
+      'Itu sepertinya bukan alamat email yang valid.';
+
+  @override
+  String get authSignInErrorNetwork =>
+      'Tidak dapat menjangkau server. Periksa koneksimu dan coba lagi.';
+
+  @override
+  String get authSignInErrorGeneric => 'Ada yang salah. Coba lagi.';
+
+  @override
+  String get authSignInOptionsHintPrefix =>
+      'Tidak yakin bagaimana kamu masuk terakhir kali? ';
+
+  @override
+  String get authSignInOptionsHintCta => 'Lihat semua opsi masuk';
+
+  @override
   String get authCreateAccountTitle => 'Buat akun';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -2912,6 +2912,32 @@ class AppLocalizationsIt extends AppLocalizations {
       'Accedi con un\'estensione del browser NIP-07 come Alby o nos2x. Le tue chiavi restano nell\'estensione — Divine non le vede mai.';
 
   @override
+  String get authSignInErrorInvalidCredentials =>
+      'Email o password errati. Riprova.';
+
+  @override
+  String get authSignInErrorEmailNotVerified =>
+      'Verifica la tua email prima di accedere: controlla la posta in arrivo per il link.';
+
+  @override
+  String get authSignInErrorInvalidEmail =>
+      'Non sembra un indirizzo email valido.';
+
+  @override
+  String get authSignInErrorNetwork =>
+      'Impossibile raggiungere il server. Controlla la connessione e riprova.';
+
+  @override
+  String get authSignInErrorGeneric => 'Qualcosa è andato storto. Riprova.';
+
+  @override
+  String get authSignInOptionsHintPrefix =>
+      'Non sai come hai effettuato l\'accesso l\'ultima volta? ';
+
+  @override
+  String get authSignInOptionsHintCta => 'Vedi tutte le opzioni di accesso';
+
+  @override
   String get authCreateAccountTitle => 'Crea account';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -2744,6 +2744,29 @@ class AppLocalizationsJa extends AppLocalizations {
       'Alby や nos2x のような NIP-07 ブラウザ拡張機能でサインインします。鍵は拡張機能内に保持され、Divine からは見えません。';
 
   @override
+  String get authSignInErrorInvalidCredentials =>
+      'メールアドレスまたはパスワードが違います。もう一度お試しください。';
+
+  @override
+  String get authSignInErrorEmailNotVerified =>
+      'サインインする前にメールを認証してください。受信トレイのリンクを確認してください。';
+
+  @override
+  String get authSignInErrorInvalidEmail => '有効なメールアドレスではないようです。';
+
+  @override
+  String get authSignInErrorNetwork => 'サーバーに接続できません。接続を確認してもう一度お試しください。';
+
+  @override
+  String get authSignInErrorGeneric => '問題が発生しました。もう一度お試しください。';
+
+  @override
+  String get authSignInOptionsHintPrefix => '前回どうやってログインしたか分かりませんか? ';
+
+  @override
+  String get authSignInOptionsHintCta => 'すべてのサインイン方法を見る';
+
+  @override
   String get authCreateAccountTitle => 'アカウントを作ろう';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -2755,6 +2755,29 @@ class AppLocalizationsKo extends AppLocalizations {
       'Alby 또는 nos2x와 같은 NIP-07 브라우저 확장 프로그램으로 로그인하세요. 키는 확장 프로그램에 그대로 유지되며 Divine은 절대 볼 수 없습니다.';
 
   @override
+  String get authSignInErrorInvalidCredentials =>
+      '이메일 또는 비밀번호가 잘못되었습니다. 다시 시도해 주세요.';
+
+  @override
+  String get authSignInErrorEmailNotVerified =>
+      '로그인하기 전에 이메일을 인증하세요 — 받은 편지함에서 링크를 확인하세요.';
+
+  @override
+  String get authSignInErrorInvalidEmail => '유효한 이메일 주소가 아닌 것 같습니다.';
+
+  @override
+  String get authSignInErrorNetwork => '서버에 연결할 수 없습니다. 연결을 확인하고 다시 시도해 주세요.';
+
+  @override
+  String get authSignInErrorGeneric => '문제가 발생했습니다. 다시 시도해 주세요.';
+
+  @override
+  String get authSignInOptionsHintPrefix => '지난번에 어떻게 로그인했는지 기억나지 않나요? ';
+
+  @override
+  String get authSignInOptionsHintCta => '모든 로그인 옵션 보기';
+
+  @override
   String get authCreateAccountTitle => '계정 만들기';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -2893,6 +2893,32 @@ class AppLocalizationsNl extends AppLocalizations {
       'Meld je aan met een NIP-07-browserextensie zoals Alby of nos2x. Je sleutels blijven in de extensie — Divine ziet ze nooit.';
 
   @override
+  String get authSignInErrorInvalidCredentials =>
+      'Verkeerd e-mailadres of wachtwoord. Probeer het opnieuw.';
+
+  @override
+  String get authSignInErrorEmailNotVerified =>
+      'Verifieer je e-mail voordat je inlogt — check je inbox voor de link.';
+
+  @override
+  String get authSignInErrorInvalidEmail =>
+      'Dat lijkt geen geldig e-mailadres.';
+
+  @override
+  String get authSignInErrorNetwork =>
+      'Kan de server niet bereiken. Controleer je verbinding en probeer het opnieuw.';
+
+  @override
+  String get authSignInErrorGeneric => 'Er ging iets mis. Probeer het opnieuw.';
+
+  @override
+  String get authSignInOptionsHintPrefix =>
+      'Weet je niet meer hoe je de vorige keer inlogde? ';
+
+  @override
+  String get authSignInOptionsHintCta => 'Bekijk alle inlogopties';
+
+  @override
   String get authCreateAccountTitle => 'Account aanmaken';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -2960,6 +2960,32 @@ class AppLocalizationsPl extends AppLocalizations {
       'Zaloguj się przez rozszerzenie przeglądarki NIP-07, takie jak Alby lub nos2x. Twoje klucze pozostają w rozszerzeniu — Divine nigdy ich nie widzi.';
 
   @override
+  String get authSignInErrorInvalidCredentials =>
+      'Nieprawidłowy e-mail lub hasło. Spróbuj ponownie.';
+
+  @override
+  String get authSignInErrorEmailNotVerified =>
+      'Zweryfikuj swój e-mail przed zalogowaniem — sprawdź link w skrzynce odbiorczej.';
+
+  @override
+  String get authSignInErrorInvalidEmail =>
+      'To nie wygląda na prawidłowy adres e-mail.';
+
+  @override
+  String get authSignInErrorNetwork =>
+      'Nie można połączyć się z serwerem. Sprawdź połączenie i spróbuj ponownie.';
+
+  @override
+  String get authSignInErrorGeneric => 'Coś poszło nie tak. Spróbuj ponownie.';
+
+  @override
+  String get authSignInOptionsHintPrefix =>
+      'Nie wiesz, jak zalogowałeś się ostatnim razem? ';
+
+  @override
+  String get authSignInOptionsHintCta => 'Zobacz wszystkie opcje logowania';
+
+  @override
   String get authCreateAccountTitle => 'Utwórz konto';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -2904,6 +2904,32 @@ class AppLocalizationsPt extends AppLocalizations {
       'Entre com uma extensão do navegador NIP-07 como Alby ou nos2x. Suas chaves ficam na extensão — Divine nunca as vê.';
 
   @override
+  String get authSignInErrorInvalidCredentials =>
+      'E-mail ou senha incorretos. Tente de novo.';
+
+  @override
+  String get authSignInErrorEmailNotVerified =>
+      'Verifique seu e-mail antes de entrar — confira o link na sua caixa de entrada.';
+
+  @override
+  String get authSignInErrorInvalidEmail =>
+      'Isso não parece um endereço de e-mail válido.';
+
+  @override
+  String get authSignInErrorNetwork =>
+      'Não foi possível conectar ao servidor. Verifique sua conexão e tente de novo.';
+
+  @override
+  String get authSignInErrorGeneric => 'Algo deu errado. Tente de novo.';
+
+  @override
+  String get authSignInOptionsHintPrefix =>
+      'Não sabe como entrou da última vez? ';
+
+  @override
+  String get authSignInOptionsHintCta => 'Ver todas as opções de login';
+
+  @override
   String get authCreateAccountTitle => 'Criar conta';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -2974,6 +2974,32 @@ class AppLocalizationsRo extends AppLocalizations {
       'Conectează-te cu o extensie de browser NIP-07 precum Alby sau nos2x. Cheile tale rămân în extensie — Divine nu le vede niciodată.';
 
   @override
+  String get authSignInErrorInvalidCredentials =>
+      'E-mail sau parolă greșite. Mai încearcă o dată.';
+
+  @override
+  String get authSignInErrorEmailNotVerified =>
+      'Verifică-ți e-mailul înainte de a te conecta — caută linkul în inbox.';
+
+  @override
+  String get authSignInErrorInvalidEmail =>
+      'Nu pare o adresă de e-mail validă.';
+
+  @override
+  String get authSignInErrorNetwork =>
+      'Serverul nu poate fi contactat. Verifică-ți conexiunea și încearcă din nou.';
+
+  @override
+  String get authSignInErrorGeneric => 'Ceva n-a mers bine. Încearcă din nou.';
+
+  @override
+  String get authSignInOptionsHintPrefix =>
+      'Nu știi sigur cum te-ai conectat data trecută? ';
+
+  @override
+  String get authSignInOptionsHintCta => 'Vezi toate opțiunile de conectare';
+
+  @override
   String get authCreateAccountTitle => 'Creează cont';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -2876,6 +2876,32 @@ class AppLocalizationsSv extends AppLocalizations {
       'Logga in med ett NIP-07-webbläsartillägg som Alby eller nos2x. Dina nycklar stannar i tillägget — Divine ser dem aldrig.';
 
   @override
+  String get authSignInErrorInvalidCredentials =>
+      'Fel e-post eller lösenord. Försök igen.';
+
+  @override
+  String get authSignInErrorEmailNotVerified =>
+      'Verifiera din e-post innan du loggar in – kolla din inkorg efter länken.';
+
+  @override
+  String get authSignInErrorInvalidEmail =>
+      'Det där ser inte ut som en giltig e-postadress.';
+
+  @override
+  String get authSignInErrorNetwork =>
+      'Kan inte nå servern. Kontrollera din anslutning och försök igen.';
+
+  @override
+  String get authSignInErrorGeneric => 'Något gick fel. Försök igen.';
+
+  @override
+  String get authSignInOptionsHintPrefix =>
+      'Osäker på hur du loggade in förra gången? ';
+
+  @override
+  String get authSignInOptionsHintCta => 'Se alla inloggningsalternativ';
+
+  @override
   String get authCreateAccountTitle => 'Skapa konto';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -2862,6 +2862,33 @@ class AppLocalizationsTr extends AppLocalizations {
       'Alby veya nos2x gibi bir NIP-07 tarayıcı uzantısıyla giriş yapın. Anahtarlarınız uzantıda kalır — Divine bunları asla görmez.';
 
   @override
+  String get authSignInErrorInvalidCredentials =>
+      'E-posta veya şifre yanlış. Tekrar dene.';
+
+  @override
+  String get authSignInErrorEmailNotVerified =>
+      'Giriş yapmadan önce e-postanı doğrula — bağlantı için gelen kutunu kontrol et.';
+
+  @override
+  String get authSignInErrorInvalidEmail =>
+      'Bu geçerli bir e-posta adresi gibi görünmüyor.';
+
+  @override
+  String get authSignInErrorNetwork =>
+      'Sunucuya ulaşılamıyor. Bağlantını kontrol edip tekrar dene.';
+
+  @override
+  String get authSignInErrorGeneric =>
+      'Bir şeyler ters gitti. Lütfen tekrar dene.';
+
+  @override
+  String get authSignInOptionsHintPrefix =>
+      'Geçen sefer nasıl giriş yaptığını hatırlamıyor musun? ';
+
+  @override
+  String get authSignInOptionsHintCta => 'Tüm giriş seçeneklerini gör';
+
+  @override
   String get authCreateAccountTitle => 'Hesap oluştur';
 
   @override

--- a/mobile/lib/screens/auth/login_options_screen.dart
+++ b/mobile/lib/screens/auth/login_options_screen.dart
@@ -374,8 +374,6 @@ class _SignInContentState extends ConsumerState<_SignInContent> {
                 ] else if (widget.state.generalError != null) ...[
                   const SizedBox(height: 16),
                   AuthErrorBox(message: widget.state.generalError!),
-                  const SizedBox(height: 8),
-                  const _SignInOptionsHint(),
                 ],
 
                 const SizedBox(height: 24),
@@ -496,7 +494,6 @@ class _SignInOptionsHint extends ConsumerWidget {
     final l10n = context.l10n;
     return Semantics(
       button: true,
-      label: l10n.authSignInOptionsHintPrefix + l10n.authSignInOptionsHintCta,
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
         onTap: () => _showInfoSheet(
@@ -518,7 +515,6 @@ class _SignInOptionsHint extends ConsumerWidget {
                   ),
                 ],
               ),
-              textScaler: MediaQuery.textScalerOf(context),
             ),
           ),
         ),

--- a/mobile/lib/screens/auth/login_options_screen.dart
+++ b/mobile/lib/screens/auth/login_options_screen.dart
@@ -5,6 +5,7 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -72,8 +73,22 @@ class _LoginOptionsView extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocListener<DivineAuthCubit, DivineAuthState>(
       listenWhen: (prev, next) =>
-          next is DivineAuthEmailVerification || next is DivineAuthSuccess,
+          next is DivineAuthEmailVerification ||
+          next is DivineAuthSuccess ||
+          (prev is DivineAuthFormState &&
+              next is DivineAuthFormState &&
+              next.signInFailureReason != null &&
+              prev.signInFailureReason != next.signInFailureReason),
       listener: (context, state) {
+        if (state is DivineAuthFormState && state.signInFailureReason != null) {
+          // Announce the failure to screen readers as it appears.
+          SemanticsService.sendAnnouncement(
+            View.of(context),
+            _signInErrorMessage(context, state.signInFailureReason!),
+            Directionality.of(context),
+          );
+          return;
+        }
         if (state is DivineAuthSuccess) {
           // Signal password managers to save credentials.
           TextInput.finishAutofillContext();
@@ -345,10 +360,22 @@ class _SignInContentState extends ConsumerState<_SignInContent> {
                   ),
                 ),
 
-                // General error
-                if (widget.state.generalError != null) ...[
+                // Sign-in error, with a nudge toward every sign-in option.
+                if (widget.state.signInFailureReason != null) ...[
+                  const SizedBox(height: 16),
+                  AuthErrorBox(
+                    message: _signInErrorMessage(
+                      context,
+                      widget.state.signInFailureReason!,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  const _SignInOptionsHint(),
+                ] else if (widget.state.generalError != null) ...[
                   const SizedBox(height: 16),
                   AuthErrorBox(message: widget.state.generalError!),
+                  const SizedBox(height: 8),
+                  const _SignInOptionsHint(),
                 ],
 
                 const SizedBox(height: 24),
@@ -435,6 +462,67 @@ class _SignInContentState extends ConsumerState<_SignInContent> {
           ),
         ),
       ],
+    );
+  }
+}
+
+/// Localized copy for a failed sign-in. Kept neutral about account existence
+/// for [SignInFailureReason.invalidCredentials] — see the enum doc.
+String _signInErrorMessage(BuildContext context, SignInFailureReason reason) {
+  final l10n = context.l10n;
+  switch (reason) {
+    case SignInFailureReason.invalidCredentials:
+      return l10n.authSignInErrorInvalidCredentials;
+    case SignInFailureReason.emailNotVerified:
+      return l10n.authSignInErrorEmailNotVerified;
+    case SignInFailureReason.invalidEmail:
+      return l10n.authSignInErrorInvalidEmail;
+    case SignInFailureReason.network:
+      return l10n.authSignInErrorNetwork;
+    case SignInFailureReason.unknown:
+      return l10n.authSignInErrorGeneric;
+  }
+}
+
+/// Tappable hint under a failed sign-in that opens the full sign-in options
+/// sheet. Safe for every user: it never claims an account exists, so it works
+/// whether the failure was a typo, an unverified email, or a Nostr-native user
+/// on the wrong screen. The whole line is one 48dp tap target.
+class _SignInOptionsHint extends ConsumerWidget {
+  const _SignInOptionsHint();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = context.l10n;
+    return Semantics(
+      button: true,
+      label: l10n.authSignInOptionsHintPrefix + l10n.authSignInOptionsHintCta,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: () => _showInfoSheet(
+          context,
+          showNip07: ref.read(authServiceProvider).isNip07Available,
+        ),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(minHeight: 48),
+          child: Align(
+            alignment: Alignment.centerLeft,
+            child: Text.rich(
+              TextSpan(
+                style: VineTheme.bodyMediumFont(color: VineTheme.secondaryText),
+                children: [
+                  TextSpan(text: l10n.authSignInOptionsHintPrefix),
+                  TextSpan(
+                    text: l10n.authSignInOptionsHintCta,
+                    style: VineTheme.bodyMediumFont(color: VineTheme.vineGreen),
+                  ),
+                ],
+              ),
+              textScaler: MediaQuery.textScalerOf(context),
+            ),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/mobile/packages/keycast_flutter/lib/src/oauth/headless_models.dart
+++ b/mobile/packages/keycast_flutter/lib/src/oauth/headless_models.dart
@@ -48,6 +48,29 @@ class HeadlessRegisterResult {
   final String? errorDescription;
 }
 
+/// Typed classification of a failed `POST /api/headless/login`.
+///
+/// Maps the server's machine-readable `code` (and the client-synthesized
+/// transport codes) to a small set the UI can localize. Deliberately login-
+/// specific; [KeycastAuthFailure] models the register/poll taxonomy instead.
+enum KeycastLoginFailure {
+  /// Wrong email/password OR no such account — the server returns an identical
+  /// 401 for both, so this value must never imply the account exists.
+  invalidCredentials,
+
+  /// Account exists but its email has not been verified (HTTP 403).
+  emailNotVerified,
+
+  /// The submitted email was malformed (HTTP 400).
+  invalidEmail,
+
+  /// Transport failure (timeout / no connection) before a server verdict.
+  network,
+
+  /// Any other server or client error.
+  unknown,
+}
+
 /// Result from POST /api/headless/login
 class HeadlessLoginResult {
   HeadlessLoginResult({
@@ -55,34 +78,66 @@ class HeadlessLoginResult {
     this.code,
     this.pubkey,
     this.state,
-    this.error,
+    this.errorCode,
     this.errorDescription,
   });
 
   factory HeadlessLoginResult.fromJson(Map<String, dynamic> json) {
+    final success = json['success'] as bool? ?? false;
+    // `json['code']` is the OAuth authorization code on success and the
+    // machine failure code on error — disambiguate on `success`.
+    final rawCode = json['code'] as String?;
     return HeadlessLoginResult(
-      success: json['success'] as bool? ?? false,
-      code: json['code'] as String?,
+      success: success,
+      code: success ? rawCode : null,
       pubkey: json['pubkey'] as String?,
       state: json['state'] as String?,
-      error: json['error'] as String?,
-      errorDescription: json['error_description'] as String?,
+      errorCode: success ? null : rawCode,
+      errorDescription:
+          json['error'] as String? ?? json['error_description'] as String?,
     );
   }
 
   factory HeadlessLoginResult.error(String message, {String? code}) {
     return HeadlessLoginResult(
       success: false,
-      error: code ?? 'client_error',
+      errorCode: code ?? 'client_error',
       errorDescription: message,
     );
   }
   final bool success;
+
+  /// OAuth authorization code — present only on success (`json['code']`).
   final String? code;
   final String? pubkey;
   final String? state;
-  final String? error;
+
+  /// Machine-readable failure code (e.g. `INVALID_CREDENTIALS`), failure only.
+  ///
+  /// Keycast sends this in `json['code']` on the error path and the human
+  /// message in `json['error']` — the two must not be conflated.
+  final String? errorCode;
+
+  /// Human-readable error message from the server (`json['error']`).
   final String? errorDescription;
+
+  /// Typed classification of the failure, for localization in the UI layer.
+  KeycastLoginFailure get failure {
+    switch (errorCode) {
+      case 'INVALID_CREDENTIALS':
+        return KeycastLoginFailure.invalidCredentials;
+      case 'EMAIL_NOT_VERIFIED':
+        return KeycastLoginFailure.emailNotVerified;
+      case 'INVALID_EMAIL':
+        return KeycastLoginFailure.invalidEmail;
+      case 'timeout':
+      case 'connection_error':
+      case 'network_error':
+        return KeycastLoginFailure.network;
+      default:
+        return KeycastLoginFailure.unknown;
+    }
+  }
 }
 
 /// Result from GET /api/oauth/poll

--- a/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
+++ b/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
@@ -532,14 +532,19 @@ class KeycastOAuth {
         return (HeadlessLoginResult.fromJson(json), verifier);
       }
 
-      // Handle specific error codes
-      final error = json['error'] as String? ?? 'login_failed';
+      // Keycast sends the machine code in `code` and the human message in
+      // `error`; earlier code read them swapped, dropping the code entirely.
+      final errorCode = json['code'] as String? ?? 'login_failed';
       final description =
+          json['error'] as String? ??
           json['error_description'] as String? ??
           json['message'] as String? ??
           'Login failed';
 
-      return (HeadlessLoginResult.error(description, code: error), verifier);
+      return (
+        HeadlessLoginResult.error(description, code: errorCode),
+        verifier,
+      );
     } on TimeoutException {
       return (
         HeadlessLoginResult.error(

--- a/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
+++ b/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
@@ -564,7 +564,10 @@ class KeycastOAuth {
           verifier,
         );
       }
-      return (HeadlessLoginResult.error('Network error: $e'), verifier);
+      return (
+        HeadlessLoginResult.error('Network error: $e', code: 'network_error'),
+        verifier,
+      );
     }
   }
 

--- a/mobile/packages/keycast_flutter/test/headless_models_test.dart
+++ b/mobile/packages/keycast_flutter/test/headless_models_test.dart
@@ -106,7 +106,7 @@ void main() {
         expect(result.code, isNull);
         expect(result.pubkey, isNull);
         expect(result.state, isNull);
-        expect(result.error, isNull);
+        expect(result.errorCode, isNull);
         expect(result.errorDescription, isNull);
       });
 
@@ -125,14 +125,12 @@ void main() {
     });
 
     group('fromJson', () {
-      test('parses complete JSON response', () {
+      test('parses a success response (code is the OAuth code)', () {
         final json = {
           'success': true,
           'code': 'auth_code_xyz',
           'pubkey': 'user_pk',
           'state': 'my_state',
-          'error': null,
-          'error_description': null,
         };
 
         final result = HeadlessLoginResult.fromJson(json);
@@ -141,7 +139,7 @@ void main() {
         expect(result.code, 'auth_code_xyz');
         expect(result.pubkey, 'user_pk');
         expect(result.state, 'my_state');
-        expect(result.error, isNull);
+        expect(result.errorCode, isNull);
         expect(result.errorDescription, isNull);
       });
 
@@ -154,23 +152,29 @@ void main() {
         expect(result.code, isNull);
         expect(result.pubkey, isNull);
         expect(result.state, isNull);
-        expect(result.error, isNull);
+        expect(result.errorCode, isNull);
         expect(result.errorDescription, isNull);
       });
 
-      test('parses error fields', () {
-        final json = {
-          'success': false,
-          'error': 'invalid_credentials',
-          'error_description': 'Wrong password',
-        };
+      test(
+        'on a failure body, code is the machine code, not the OAuth code',
+        () {
+          // Real keycast 401: {"code":"INVALID_CREDENTIALS","error":"..."}.
+          final json = {
+            'success': false,
+            'code': 'INVALID_CREDENTIALS',
+            'error': 'Invalid email or password',
+          };
 
-        final result = HeadlessLoginResult.fromJson(json);
+          final result = HeadlessLoginResult.fromJson(json);
 
-        expect(result.success, isFalse);
-        expect(result.error, 'invalid_credentials');
-        expect(result.errorDescription, 'Wrong password');
-      });
+          expect(result.success, isFalse);
+          expect(result.code, isNull, reason: 'no OAuth code on failure');
+          expect(result.errorCode, 'INVALID_CREDENTIALS');
+          expect(result.errorDescription, 'Invalid email or password');
+          expect(result.failure, KeycastLoginFailure.invalidCredentials);
+        },
+      );
     });
 
     group('error factory', () {
@@ -178,7 +182,7 @@ void main() {
         final result = HeadlessLoginResult.error('Login failed');
 
         expect(result.success, isFalse);
-        expect(result.error, 'client_error');
+        expect(result.errorCode, 'client_error');
         expect(result.errorDescription, 'Login failed');
       });
 
@@ -189,8 +193,30 @@ void main() {
         );
 
         expect(result.success, isFalse);
-        expect(result.error, 'connection_error');
+        expect(result.errorCode, 'connection_error');
         expect(result.errorDescription, 'Network error');
+        expect(result.failure, KeycastLoginFailure.network);
+      });
+    });
+
+    group('failure classification', () {
+      test('maps each server code and defaults unknown', () {
+        HeadlessLoginResult err(String code) =>
+            HeadlessLoginResult.error('msg', code: code);
+
+        expect(
+          err('INVALID_CREDENTIALS').failure,
+          KeycastLoginFailure.invalidCredentials,
+        );
+        expect(
+          err('EMAIL_NOT_VERIFIED').failure,
+          KeycastLoginFailure.emailNotVerified,
+        );
+        expect(err('INVALID_EMAIL').failure, KeycastLoginFailure.invalidEmail);
+        expect(err('timeout').failure, KeycastLoginFailure.network);
+        expect(err('connection_error').failure, KeycastLoginFailure.network);
+        expect(err('INTERNAL_ERROR').failure, KeycastLoginFailure.unknown);
+        expect(err('anything_else').failure, KeycastLoginFailure.unknown);
       });
     });
   });

--- a/mobile/packages/keycast_flutter/test/oauth_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/oauth_client_test.dart
@@ -570,7 +570,7 @@ void main() {
         );
 
         expect(result.success, isFalse);
-        expect(result.error, 'endpoint_not_found');
+        expect(result.errorCode, 'endpoint_not_found');
       });
 
       test('returns error on 500+ server error', () async {
@@ -585,7 +585,7 @@ void main() {
         );
 
         expect(result.success, isFalse);
-        expect(result.error, 'server_error');
+        expect(result.errorCode, 'server_error');
         expect(result.errorDescription, contains('503'));
       });
 
@@ -601,15 +601,19 @@ void main() {
         );
 
         expect(result.success, isFalse);
-        expect(result.error, 'invalid_response');
+        expect(result.errorCode, 'invalid_response');
       });
 
-      test('returns error with error fields from response', () async {
+      test('reads keycast INVALID_CREDENTIALS 401 (machine code + '
+          'human message, no error_description)', () async {
+        // Byte-for-byte the body keycast returns on a failed login (observed
+        // via a cargo test + live e2e against keycast @5cda156):
+        // {"error":"Invalid email or password","code":"INVALID_CREDENTIALS"}
         final mockClient = MockClient((request) async {
           return http.Response(
             jsonEncode({
-              'error': 'invalid_credentials',
-              'error_description': 'Wrong password',
+              'code': 'INVALID_CREDENTIALS',
+              'error': 'Invalid email or password',
             }),
             401,
           );
@@ -622,8 +626,52 @@ void main() {
         );
 
         expect(result.success, isFalse);
-        expect(result.error, 'invalid_credentials');
-        expect(result.errorDescription, 'Wrong password');
+        expect(result.errorCode, 'INVALID_CREDENTIALS');
+        expect(result.failure, KeycastLoginFailure.invalidCredentials);
+        // The human message keycast actually sends, not a client fallback.
+        expect(result.errorDescription, 'Invalid email or password');
+      });
+
+      test('classifies EMAIL_NOT_VERIFIED 403', () async {
+        final mockClient = MockClient((request) async {
+          return http.Response(
+            jsonEncode({
+              'code': 'EMAIL_NOT_VERIFIED',
+              'error': 'Please verify your email address before signing in',
+            }),
+            403,
+          );
+        });
+
+        final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+        final (result, _) = await oauth.headlessLogin(
+          email: 'test@example.com',
+          password: 'password123',
+        );
+
+        expect(result.errorCode, 'EMAIL_NOT_VERIFIED');
+        expect(result.failure, KeycastLoginFailure.emailNotVerified);
+      });
+
+      test('classifies INVALID_EMAIL 400', () async {
+        final mockClient = MockClient((request) async {
+          return http.Response(
+            jsonEncode({
+              'code': 'INVALID_EMAIL',
+              'error': 'Please enter a valid email address.',
+            }),
+            400,
+          );
+        });
+
+        final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+        final (result, _) = await oauth.headlessLogin(
+          email: 'bad',
+          password: 'password123',
+        );
+
+        expect(result.errorCode, 'INVALID_EMAIL');
+        expect(result.failure, KeycastLoginFailure.invalidEmail);
       });
 
       test('returns error on SocketException', () async {
@@ -638,7 +686,8 @@ void main() {
         );
 
         expect(result.success, isFalse);
-        expect(result.error, 'connection_error');
+        expect(result.errorCode, 'connection_error');
+        expect(result.failure, KeycastLoginFailure.network);
       });
 
       test('returns error on other network errors', () async {
@@ -1457,7 +1506,8 @@ void main() {
           );
 
           expect(result.success, isFalse);
-          expect(result.error, 'timeout');
+          expect(result.errorCode, 'timeout');
+          expect(result.failure, KeycastLoginFailure.network);
           expect(verifier, isNotEmpty);
         },
       );

--- a/mobile/packages/keycast_flutter/test/oauth_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/oauth_client_test.dart
@@ -702,6 +702,8 @@ void main() {
         );
 
         expect(result.success, isFalse);
+        expect(result.errorCode, 'network_error');
+        expect(result.failure, KeycastLoginFailure.network);
         expect(result.errorDescription, contains('Network error'));
       });
     });

--- a/mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart
+++ b/mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart
@@ -551,7 +551,8 @@ void main() {
         );
 
         blocTest<DivineAuthCubit, DivineAuthState>(
-          'emits general error when login returns unsuccessful result',
+          'emits invalidCredentials reason on a keycast 401 '
+          '(INVALID_CREDENTIALS), no error string in state',
           setUp: () {
             when(
               () => mockOAuth.headlessLogin(
@@ -563,7 +564,8 @@ void main() {
               (_) async => (
                 HeadlessLoginResult(
                   success: false,
-                  errorDescription: 'Invalid credentials',
+                  errorCode: 'INVALID_CREDENTIALS',
+                  errorDescription: 'Invalid email or password',
                 ),
                 testVerifier,
               ),
@@ -587,13 +589,57 @@ void main() {
               email: testEmail,
               password: testPassword,
               isSignIn: true,
-              generalError: 'Invalid credentials',
+              signInFailureReason: SignInFailureReason.invalidCredentials,
             ),
           ],
         );
 
         blocTest<DivineAuthCubit, DivineAuthState>(
-          'emits general error when login returns success but no code',
+          'emits emailNotVerified reason on a keycast 403',
+          setUp: () {
+            when(
+              () => mockOAuth.headlessLogin(
+                email: any(named: 'email'),
+                password: any(named: 'password'),
+                scope: any(named: 'scope'),
+              ),
+            ).thenAnswer(
+              (_) async => (
+                HeadlessLoginResult(
+                  success: false,
+                  errorCode: 'EMAIL_NOT_VERIFIED',
+                  errorDescription:
+                      'Please verify your email address before signing in',
+                ),
+                testVerifier,
+              ),
+            );
+          },
+          build: buildCubit,
+          seed: () => const DivineAuthFormState(
+            email: testEmail,
+            password: testPassword,
+            isSignIn: true,
+          ),
+          act: (cubit) => cubit.submit(),
+          expect: () => [
+            const DivineAuthFormState(
+              email: testEmail,
+              password: testPassword,
+              isSignIn: true,
+              isSubmitting: true,
+            ),
+            const DivineAuthFormState(
+              email: testEmail,
+              password: testPassword,
+              isSignIn: true,
+              signInFailureReason: SignInFailureReason.emailNotVerified,
+            ),
+          ],
+        );
+
+        blocTest<DivineAuthCubit, DivineAuthState>(
+          'emits unknown reason when login returns success but no code',
           setUp: () {
             when(
               () => mockOAuth.headlessLogin(
@@ -623,49 +669,7 @@ void main() {
               email: testEmail,
               password: testPassword,
               isSignIn: true,
-              generalError: 'Sign in failed',
-            ),
-          ],
-        );
-
-        blocTest<DivineAuthCubit, DivineAuthState>(
-          'uses error field as fallback when errorDescription is null',
-          setUp: () {
-            when(
-              () => mockOAuth.headlessLogin(
-                email: any(named: 'email'),
-                password: any(named: 'password'),
-                scope: any(named: 'scope'),
-              ),
-            ).thenAnswer(
-              (_) async => (
-                HeadlessLoginResult(
-                  success: false,
-                  error: 'invalid_credentials',
-                ),
-                testVerifier,
-              ),
-            );
-          },
-          build: buildCubit,
-          seed: () => const DivineAuthFormState(
-            email: testEmail,
-            password: testPassword,
-            isSignIn: true,
-          ),
-          act: (cubit) => cubit.submit(),
-          expect: () => [
-            const DivineAuthFormState(
-              email: testEmail,
-              password: testPassword,
-              isSignIn: true,
-              isSubmitting: true,
-            ),
-            const DivineAuthFormState(
-              email: testEmail,
-              password: testPassword,
-              isSignIn: true,
-              generalError: 'invalid_credentials',
+              signInFailureReason: SignInFailureReason.unknown,
             ),
           ],
         );
@@ -1667,13 +1671,14 @@ void main() {
           emailError: 'e',
           passwordError: 'p',
           generalError: 'g',
+          signInFailureReason: SignInFailureReason.invalidCredentials,
           showInviteGateRecovery: true,
           inviteRecoveryCode: 'AB12-EF34',
           inviteRecoverySourceSlug: 'lele-pons',
           obscurePassword: false,
           isSubmitting: true,
         );
-        expect(state.props, hasLength(16));
+        expect(state.props, hasLength(17));
       });
     });
 

--- a/mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart
+++ b/mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart
@@ -639,6 +639,61 @@ void main() {
         );
 
         blocTest<DivineAuthCubit, DivineAuthState>(
+          'emits network reason and logs description on transport failure',
+          setUp: () {
+            when(
+              () => mockOAuth.headlessLogin(
+                email: any(named: 'email'),
+                password: any(named: 'password'),
+                scope: any(named: 'scope'),
+              ),
+            ).thenAnswer(
+              (_) async => (
+                HeadlessLoginResult.error(
+                  'Network error: ClientException: XMLHttpRequest error.',
+                  code: 'network_error',
+                ),
+                testVerifier,
+              ),
+            );
+          },
+          build: buildCubit,
+          seed: () => const DivineAuthFormState(
+            email: testEmail,
+            password: testPassword,
+            isSignIn: true,
+          ),
+          act: (cubit) => cubit.submit(),
+          expect: () => [
+            const DivineAuthFormState(
+              email: testEmail,
+              password: testPassword,
+              isSignIn: true,
+              isSubmitting: true,
+            ),
+            const DivineAuthFormState(
+              email: testEmail,
+              password: testPassword,
+              isSignIn: true,
+              signInFailureReason: SignInFailureReason.network,
+            ),
+          ],
+          verify: (_) {
+            final logMessage = LogCaptureService()
+                .getRecentLogs()
+                .map((entry) => entry.message)
+                .lastWhere((message) => message.startsWith('Sign in failed:'));
+
+            expect(logMessage, contains('code=network_error'));
+            expect(logMessage, contains('reason=SignInFailureReason.network'));
+            expect(
+              logMessage,
+              contains('ClientException: XMLHttpRequest error.'),
+            );
+          },
+        );
+
+        blocTest<DivineAuthCubit, DivineAuthState>(
           'emits unknown reason when login returns success but no code',
           setUp: () {
             when(

--- a/mobile/test/screens/auth/login_options_screen_test.dart
+++ b/mobile/test/screens/auth/login_options_screen_test.dart
@@ -130,6 +130,12 @@ void main() {
           ),
           findsOneWidget,
         );
+        expect(
+          _optionsHint(
+            lookupAppLocalizations(const Locale('en')).authSignInOptionsHintCta,
+          ),
+          findsNothing,
+        );
       });
 
       testWidgets('displays email field', (tester) async {

--- a/mobile/test/screens/auth/login_options_screen_test.dart
+++ b/mobile/test/screens/auth/login_options_screen_test.dart
@@ -28,6 +28,12 @@ class _MockPendingVerificationService extends Mock
 Finder _divineIcon(DivineIconName name) =>
     find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
 
+/// The options hint renders its two-color copy in a [RichText] (via
+/// `Text.rich`), which `find.text` cannot match — match on the plain text.
+Finder _optionsHint(String cta) => find.byWidgetPredicate(
+  (w) => w is RichText && w.text.toPlainText().contains(cta),
+);
+
 void main() {
   late _MockKeycastOAuth mockOAuth;
   late _MockAuthService mockAuthService;
@@ -349,7 +355,7 @@ void main() {
           (_) async => (
             HeadlessLoginResult(
               success: false,
-              error: 'test',
+              errorCode: 'test',
               errorDescription: 'test error',
             ),
             'test-verifier',
@@ -389,50 +395,117 @@ void main() {
         ).called(1);
       });
 
-      testWidgets('displays general error on failed sign in', (tester) async {
-        when(
-          () => mockOAuth.headlessLogin(
-            email: any(named: 'email'),
-            password: any(named: 'password'),
-            scope: any(named: 'scope'),
-          ),
-        ).thenAnswer(
-          (_) async => (
-            HeadlessLoginResult(
-              success: false,
-              error: 'invalid_credentials',
-              errorDescription: 'Invalid email or password',
+      testWidgets(
+        'shows localized error + options hint on a failed sign in',
+        (tester) async {
+          when(
+            () => mockOAuth.headlessLogin(
+              email: any(named: 'email'),
+              password: any(named: 'password'),
+              scope: any(named: 'scope'),
             ),
-            'test-verifier',
-          ),
-        );
+          ).thenAnswer(
+            (_) async => (
+              HeadlessLoginResult(
+                success: false,
+                errorCode: 'INVALID_CREDENTIALS',
+                errorDescription: 'Invalid email or password',
+              ),
+              'test-verifier',
+            ),
+          );
 
-        await tester.pumpWidget(createTestWidget());
-        await tester.pumpAndSettle();
+          final l10n = lookupAppLocalizations(const Locale('en'));
 
-        // Enter email and password
-        await tester.enterText(
-          find.descendant(
-            of: find.widgetWithText(DivineAuthTextField, 'Email'),
-            matching: find.byType(TextField),
-          ),
-          'user@example.com',
-        );
-        await tester.enterText(
-          find.descendant(
-            of: find.widgetWithText(DivineAuthTextField, 'Password'),
-            matching: find.byType(TextField),
-          ),
-          'Password123!',
-        );
+          await tester.pumpWidget(createTestWidget());
+          await tester.pumpAndSettle();
 
-        // Tap sign in
-        await tester.tap(find.widgetWithText(DivineButton, 'Sign in'));
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 100));
+          // Hint is absent before any failure.
+          expect(_optionsHint(l10n.authSignInOptionsHintCta), findsNothing);
 
-        expect(find.text('Invalid email or password'), findsOneWidget);
-      });
+          await tester.enterText(
+            find.descendant(
+              of: find.widgetWithText(DivineAuthTextField, 'Email'),
+              matching: find.byType(TextField),
+            ),
+            'user@example.com',
+          );
+          await tester.enterText(
+            find.descendant(
+              of: find.widgetWithText(DivineAuthTextField, 'Password'),
+              matching: find.byType(TextField),
+            ),
+            'Password123!',
+          );
+
+          await tester.tap(find.widgetWithText(DivineButton, 'Sign in'));
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 100));
+
+          // Localized copy, not the raw server message, and not the old
+          // hardcoded "Login failed" literal.
+          expect(
+            find.text(l10n.authSignInErrorInvalidCredentials),
+            findsOneWidget,
+          );
+          expect(find.text('Invalid email or password'), findsNothing);
+          expect(find.text('Login failed'), findsNothing);
+          // The nudge toward every sign-in option appears.
+          expect(_optionsHint(l10n.authSignInOptionsHintCta), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'tapping the options hint opens the sign-in options sheet',
+        (tester) async {
+          when(
+            () => mockOAuth.headlessLogin(
+              email: any(named: 'email'),
+              password: any(named: 'password'),
+              scope: any(named: 'scope'),
+            ),
+          ).thenAnswer(
+            (_) async => (
+              HeadlessLoginResult(
+                success: false,
+                errorCode: 'INVALID_CREDENTIALS',
+                errorDescription: 'Invalid email or password',
+              ),
+              'test-verifier',
+            ),
+          );
+
+          final l10n = lookupAppLocalizations(const Locale('en'));
+
+          await tester.pumpWidget(createTestWidget());
+          await tester.pumpAndSettle();
+
+          await tester.enterText(
+            find.descendant(
+              of: find.widgetWithText(DivineAuthTextField, 'Email'),
+              matching: find.byType(TextField),
+            ),
+            'user@example.com',
+          );
+          await tester.enterText(
+            find.descendant(
+              of: find.widgetWithText(DivineAuthTextField, 'Password'),
+              matching: find.byType(TextField),
+            ),
+            'Password123!',
+          );
+
+          await tester.tap(find.widgetWithText(DivineButton, 'Sign in'));
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 100));
+
+          await tester.tap(_optionsHint(l10n.authSignInOptionsHintCta));
+          await tester.pumpAndSettle();
+
+          expect(find.text(l10n.authSignInOptionsTitle), findsOneWidget);
+          expect(find.text(l10n.authInfoEmailPasswordTitle), findsOneWidget);
+        },
+      );
 
       testWidgets('shows email validation error for empty form', (
         tester,


### PR DESCRIPTION
Closes #3158

## TL;DR

Two things ship together on this one screen:

1. **A real, verified bug (the fix):** a failed email/password sign-in showed the hardcoded English literal **"Login failed"** in an 18-locale app. keycast returns `{"code":"INVALID_CREDENTIALS","error":"Invalid email or password"}`, but the client read the fields swapped and **never read `code`**, so the machine code was discarded and the user saw a client-side fallback string.
2. **The nudge #3158 asked for**, redirected to where it's actually useful (see *Premise* below).

## Context — the issue's premise was retracted

#3158 was auto-created from the closed draft PR #3157, whose justification ("~97k pubkey-only users hit this") **was retracted by its own author**: those rows are legacy **Vine import** records, not Nostr-signer signups. This was corroborated in keycast's source — `create_preloaded_user` is documented *"for importing users from external systems (e.g., Vine)"*, all pubkey-only rows are admin-created, and a user who signs in with a Nostr key (nsec / NIP-46 / Amber / NIP-07) has **no keycast account at all**. So the Nostr-import buttons the original hint pointed at can't help the real pubkey-only population, and are wrong for the one overlap cohort (users who ran *Secure Account* — they should type their email).

The nudge therefore points at the **existing sign-in-options sheet** (the ⓘ explainer already on the screen), which is true and safe for *every* user and never asserts an account exists — matching keycast's non-enumerating 401.

## What changed

**Client (`keycast_flutter`)**
- `HeadlessLoginResult` now exposes `errorCode` (reads `json['code']`) and a typed `KeycastLoginFailure`; the field-role swap is fixed. `code` stays the OAuth code on success, `errorCode` the machine code on failure.

**State / BLoC**
- Sign-in failures emit a `SignInFailureReason` **enum** on `DivineAuthState` — no error strings in state (per `state_management.md`).

**UI**
- The error renders localized copy via `context.l10n`, distinct for `INVALID_CREDENTIALS` / `EMAIL_NOT_VERIFIED` / `INVALID_EMAIL` / network / generic.
- A tappable `_SignInOptionsHint` (whole-line 48 dp target, `VineTheme.*Font()`) under the error opens the existing options sheet; the error is announced to screen readers via `SemanticsService.sendAnnouncement`.

**l10n**
- 7 new keys, translated across **all 18 locales**.

## Verified

- **H1 confirmed at three levels:** source read → keycast `cargo test` render → **live Docker e2e** (`{"error":"Invalid email or password","code":"INVALID_CREDENTIALS"}` off the wire).
- Corrected the two login-401 tests that asserted a *fictional* server body (which is why this bug shipped).
- `flutter analyze` clean; raw-`TextStyle` ratchet unchanged; `arb_consistency_test` passes; keycast_flutter 211 tests, cubit 66, screen 21 (2 new hint tests), 215 auth-adjacent total. Pre-commit + pre-push hooks green.

## Deliberately out of scope (follow-ups)

- `EMAIL_NOT_VERIFIED` gets correct *copy* but no resend/route action — keycast's 403 returns no `device_code`, so an actionable flow needs a new backend endpoint.
- Full migration of the other `String?` error fields on `DivineAuthFormState` (tracked by epic #4336).
- Layout/scroll-into-view for the alternatives — measured low value (keyboard is down when the error shows; alternatives are visible on 5/6 devices at default text size).

## Test plan

- [x] `flutter test packages/keycast_flutter` (211)
- [x] `flutter test test/blocs/divine_auth test/screens/auth test/l10n/arb_consistency_test.dart` (all green)
- [x] `flutter analyze lib test packages/keycast_flutter` — clean
- [ ] Manual QA on device: fail a sign-in, confirm the localized error + hint appear and the hint opens the options sheet
- [ ] Final copy sign-off from design

🤖 Generated with [Claude Code](https://claude.com/claude-code)
