### PR TITLE
fix(authentication): retry degraded OAuth restore on resume

### DIFF
--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -693,7 +693,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       final storedSession = await KeycastSession.load(_flutterSecureStorage);
       final storedOwnerPubkey = storedSession?.userPubkey;
       if (upgradeOwnerPubkey != null &&
-          storedOwnerPubkey != null &&
+          storedSession != null &&
           storedOwnerPubkey != upgradeOwnerPubkey) {
         Log.warning(
           'OAuth RPC upgrade: refusing refresh for owner $upgradeOwnerPubkey '
@@ -729,6 +729,15 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
           category: LogCategory.auth,
         );
         await _clearDismissedDivineLoginBannerForCurrentUser();
+        if (!upgradeContextStillCurrent()) {
+          Log.warning(
+            'OAuth RPC upgrade: discarding refreshed signer after banner clear '
+            'because the signed-in account changed',
+            name: 'AuthService',
+            category: LogCategory.auth,
+          );
+          return;
+        }
         _keycastSigner = KeycastRpc.fromSession(
           _oauthConfig,
           refreshed,
@@ -4259,25 +4268,27 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       final session = await _oauthClient.getSession();
       if (!resumeContextStillCurrent()) return;
 
-      if (_keycastSigner == null &&
-          session != null &&
+      if (session != null &&
           session.hasRpcAccess &&
           session.userPubkey == resumeOwnerPubkey) {
-        Log.info(
-          '📱 App resumed - rebuilding OAuth RPC signer from stored session',
-          name: 'AuthService',
-          category: LogCategory.auth,
-        );
-        await _clearDismissedDivineLoginBannerForCurrentUser();
-        _keycastSigner = KeycastRpc.fromSession(
-          _oauthConfig,
-          session,
-          onTokenRefresh: _refreshAccessToken,
-        );
-        _currentIdentity = _buildIdentity();
-        _hasExpiredOAuthSession = false;
-        _setRpcCapability(AuthRpcCapability.rpcReady);
-        _authStateController.add(_authState);
+        if (_keycastSigner == null) {
+          Log.info(
+            '📱 App resumed - rebuilding OAuth RPC signer from stored session',
+            name: 'AuthService',
+            category: LogCategory.auth,
+          );
+          await _clearDismissedDivineLoginBannerForCurrentUser();
+          if (!resumeContextStillCurrent()) return;
+          _keycastSigner = KeycastRpc.fromSession(
+            _oauthConfig,
+            session,
+            onTokenRefresh: _refreshAccessToken,
+          );
+          _currentIdentity = _buildIdentity();
+          _hasExpiredOAuthSession = false;
+          _setRpcCapability(AuthRpcCapability.rpcReady);
+          _authStateController.add(_authState);
+        }
         return;
       }
 

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -721,6 +721,12 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
         _setRpcCapability(AuthRpcCapability.rpcReady);
         return;
       }
+    } on OAuthNetworkException catch (e) {
+      Log.warning(
+        'initialize: background RPC refresh failed due to network: $e',
+        name: 'AuthService',
+        category: LogCategory.auth,
+      );
     } catch (e) {
       Log.error(
         'initialize: background RPC refresh failed: $e',
@@ -4217,7 +4223,11 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
 
   Future<void> _refreshOAuthTokenOnResume() async {
     try {
-      if (_oauthClient == null || _keycastSigner == null) return;
+      if (_oauthClient == null) return;
+      final isDegradedOAuth =
+          _authSource == AuthenticationSource.divineOAuth &&
+          _hasExpiredOAuthSession;
+      if (_keycastSigner == null && !isDegradedOAuth) return;
 
       final resumeOwnerPubkey = currentPublicKeyHex;
       if (resumeOwnerPubkey == null) return;
@@ -4234,26 +4244,16 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
         name: 'AuthService',
         category: LogCategory.auth,
       );
-      final refreshed = await _oauthCoordinator.refreshSession(
+      await _upgradeDivineRpcInBackground(
+        session,
         expectedOwnerPubkey: resumeOwnerPubkey,
       );
-      if (!resumeContextStillCurrent()) {
-        Log.warning(
-          '📱 App resumed - discarding stale OAuth refresh result',
-          name: 'AuthService',
-          category: LogCategory.auth,
-        );
-        return;
-      }
-      if (refreshed != null) {
-        _keycastSigner = KeycastRpc.fromSession(
-          _oauthConfig,
-          refreshed,
-          onTokenRefresh: _refreshAccessToken,
-        );
-        _currentIdentity = _buildIdentity();
-        _setRpcCapability(AuthRpcCapability.rpcReady);
-      }
+    } on OAuthNetworkException catch (e) {
+      Log.warning(
+        '📱 App resumed - OAuth refresh failed due to network: $e',
+        name: 'AuthService',
+        category: LogCategory.auth,
+      );
     } catch (e) {
       Log.error(
         '📱 App resumed - OAuth refresh failed: $e',

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -656,7 +656,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     return localKey.publicKeyHex == targetPubkey;
   }
 
-  /// Background RPC refresh with bounded timeout.
+  /// Background RPC upgrade with bounded timeout.
   ///
   /// On success: rebuilds identity to [KeycastNostrIdentity] and sets
   /// [AuthRpcCapability.rpcReady]. On failure: preserves the local identity
@@ -664,9 +664,10 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   Future<void> _upgradeDivineRpcInBackground(
     KeycastSession? session, {
     String? expectedOwnerPubkey,
+    bool notifyAuthStateOnFailure = true,
   }) async {
     Log.info(
-      'initialize: starting background RPC refresh...',
+      'OAuth RPC upgrade: starting background refresh...',
       name: 'AuthService',
       category: LogCategory.auth,
     );
@@ -682,6 +683,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
         currentPublicKeyHex == upgradeOwnerPubkey;
 
     _isRpcUpgradeInProgress = true;
+    var didUpgrade = false;
     try {
       if (_oauthClient == null) {
         _setRpcCapability(AuthRpcCapability.unavailable);
@@ -697,7 +699,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
 
       if (!upgradeContextStillCurrent()) {
         Log.warning(
-          'initialize: discarding stale background RPC refresh — '
+          'OAuth RPC upgrade: discarding stale background refresh — '
           'signed out or switched accounts while it was in flight',
           name: 'AuthService',
           category: LogCategory.auth,
@@ -707,7 +709,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
 
       if (refreshed != null) {
         Log.info(
-          'initialize: background RPC refresh succeeded',
+          'OAuth RPC upgrade: background refresh succeeded',
           name: 'AuthService',
           category: LogCategory.auth,
         );
@@ -719,25 +721,29 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
         );
         _currentIdentity = _buildIdentity();
         _setRpcCapability(AuthRpcCapability.rpcReady);
+        didUpgrade = true;
         return;
       }
     } on OAuthNetworkException catch (e) {
       Log.warning(
-        'initialize: background RPC refresh failed due to network: $e',
+        'OAuth RPC upgrade: background refresh failed due to network: $e',
         name: 'AuthService',
         category: LogCategory.auth,
       );
     } catch (e) {
       Log.error(
-        'initialize: background RPC refresh failed: $e',
+        'OAuth RPC upgrade: background refresh failed: $e',
         name: 'AuthService',
         category: LogCategory.auth,
       );
     } finally {
       _isRpcUpgradeInProgress = false;
-      // Nudge the auth stream so widgets re-evaluate whether the
-      // session-expired sheet should be shown now that the upgrade has resolved.
-      _authStateController.add(_authState);
+      // Nudge the auth stream so widgets re-evaluate after successful upgrades
+      // and after startup failures. Resume failures leave degraded state
+      // unchanged and should not re-present the session-expired sheet.
+      if (didUpgrade || notifyAuthStateOnFailure) {
+        _authStateController.add(_authState);
+      }
     }
 
     // A late failure must not downgrade whichever account is active now.
@@ -4237,22 +4243,36 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
 
       final session = await _oauthClient.getSession();
       if (!resumeContextStillCurrent()) return;
-      if (session != null) return;
+
+      if (session != null &&
+          session.hasRpcAccess &&
+          session.userPubkey == resumeOwnerPubkey) {
+        Log.info(
+          '📱 App resumed - rebuilding OAuth RPC signer from stored session',
+          name: 'AuthService',
+          category: LogCategory.auth,
+        );
+        _keycastSigner = KeycastRpc.fromSession(
+          _oauthConfig,
+          session,
+          onTokenRefresh: _refreshAccessToken,
+        );
+        _currentIdentity = _buildIdentity();
+        _hasExpiredOAuthSession = false;
+        _setRpcCapability(AuthRpcCapability.rpcReady);
+        _authStateController.add(_authState);
+        return;
+      }
 
       Log.info(
-        '📱 App resumed - OAuth token expired, refreshing',
+        '📱 App resumed - OAuth RPC session unavailable, refreshing',
         name: 'AuthService',
         category: LogCategory.auth,
       );
       await _upgradeDivineRpcInBackground(
         session,
         expectedOwnerPubkey: resumeOwnerPubkey,
-      );
-    } on OAuthNetworkException catch (e) {
-      Log.warning(
-        '📱 App resumed - OAuth refresh failed due to network: $e',
-        name: 'AuthService',
-        category: LogCategory.auth,
+        notifyAuthStateOnFailure: false,
       );
     } catch (e) {
       Log.error(

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -690,6 +690,21 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
         return;
       }
 
+      final storedSession = await KeycastSession.load(_flutterSecureStorage);
+      final storedOwnerPubkey = storedSession?.userPubkey;
+      if (upgradeOwnerPubkey != null &&
+          storedOwnerPubkey != null &&
+          storedOwnerPubkey != upgradeOwnerPubkey) {
+        Log.warning(
+          'OAuth RPC upgrade: refusing refresh for owner $upgradeOwnerPubkey '
+          'because stored session belongs to $storedOwnerPubkey',
+          name: 'AuthService',
+          category: LogCategory.auth,
+        );
+        _setRpcCapability(AuthRpcCapability.unavailable);
+        return;
+      }
+
       // The shared refresh future is internally bounded by
       // [_oauthRefreshTimeout] (see [OAuthSessionCoordinator]), so this await
       // cannot block startup indefinitely.
@@ -4244,7 +4259,8 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       final session = await _oauthClient.getSession();
       if (!resumeContextStillCurrent()) return;
 
-      if (session != null &&
+      if (_keycastSigner == null &&
+          session != null &&
           session.hasRpcAccess &&
           session.userPubkey == resumeOwnerPubkey) {
         Log.info(
@@ -4252,6 +4268,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
           name: 'AuthService',
           category: LogCategory.auth,
         );
+        await _clearDismissedDivineLoginBannerForCurrentUser();
         _keycastSigner = KeycastRpc.fromSession(
           _oauthConfig,
           session,

--- a/mobile/test/services/auth_service_expired_session_downgrade_test.dart
+++ b/mobile/test/services/auth_service_expired_session_downgrade_test.dart
@@ -14,7 +14,9 @@ import 'package:openvine/models/auth_rpc_capability.dart';
 import 'package:openvine/services/auth/nostr_identity.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/user_data_cleanup_service.dart';
+import 'package:openvine/utils/divine_login_banner_dismissal.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
 
 import '../helpers/shared_channel_override.dart';
 
@@ -22,6 +24,26 @@ class _MockUserDataCleanupService extends Mock
     implements UserDataCleanupService {}
 
 class _MockKeycastOAuth extends Mock implements KeycastOAuth {}
+
+class _DelayingSharedPreferencesStore extends InMemorySharedPreferencesStore {
+  _DelayingSharedPreferencesStore.withData(
+    super.data, {
+    required this.delayedRemoveKey,
+  }) : super.withData();
+
+  final String delayedRemoveKey;
+  final removeStarted = Completer<void>();
+  final allowRemove = Completer<void>();
+
+  @override
+  Future<bool> remove(String key) async {
+    if (key == delayedRemoveKey && !removeStarted.isCompleted) {
+      removeStarted.complete();
+      await allowRemove.future;
+    }
+    return super.remove(key);
+  }
+}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -153,20 +175,24 @@ void main() {
       Object? unexpectedError;
       StackTrace? unexpectedStack;
 
-      await runZonedGuarded(
-        body,
-        (error, stack) {
-          if (error is UnsupportedError && error.message == 'Mocked response') {
-            return;
-          }
-          unexpectedError ??= error;
-          unexpectedStack ??= stack;
-        },
-      );
+      await runZonedGuarded(body, (error, stack) {
+        if (error is UnsupportedError && error.message == 'Mocked response') {
+          return;
+        }
+        unexpectedError ??= error;
+        unexpectedStack ??= stack;
+      });
 
       if (unexpectedError != null) {
         Error.throwWithStackTrace(unexpectedError!, unexpectedStack!);
       }
+    }
+
+    Map<String, Object> prefixedSharedPreferencesData(SharedPreferences prefs) {
+      return {
+        for (final key in prefs.getKeys())
+          if (prefs.get(key) case final Object value) 'flutter.$key': value,
+      };
     }
 
     test(
@@ -646,9 +672,7 @@ void main() {
           refreshToken: 'refresh_token_still_valid',
           userPubkey: pubkey,
         );
-        secureStorage['keycast_session'] = jsonEncode(
-          expiredSession.toJson(),
-        );
+        secureStorage['keycast_session'] = jsonEncode(expiredSession.toJson());
         secureStorage['keycast_refresh_token'] = 'refresh_token_still_valid';
 
         var refreshCalls = 0;
@@ -693,6 +717,137 @@ void main() {
         });
       },
     );
+
+    test(
+      'healthy OAuth resume keeps the stored RPC session without refreshing',
+      () async {
+        SharedPreferences.setMockInitialValues({
+          'authentication_source': 'divineOAuth',
+          'tos_accepted': true,
+        });
+
+        final privateKeyHex = generatePrivateKey();
+        final container = SecureKeyContainer.fromPrivateKeyHex(privateKeyHex);
+        final session = KeycastSession(
+          bunkerUrl: 'https://login.divine.video/api/nostr',
+          accessToken: 'fresh_token',
+          expiresAt: DateTime.now().add(const Duration(hours: 1)),
+          refreshToken: 'refresh_token_still_valid',
+          userPubkey: container.publicKeyHex,
+        );
+        secureStorage['keycast_session'] = jsonEncode(session.toJson());
+        secureStorage['keycast_refresh_token'] = 'refresh_token_still_valid';
+        secureStorage['nostr_primary_key'] =
+            'privateKeyHex:$privateKeyHex'
+            '|publicKeyHex:${container.publicKeyHex}'
+            '|npub:${container.npub}';
+
+        var refreshCalls = 0;
+        when(
+          () => mockOAuthClient.getSession(),
+        ).thenAnswer((_) async => session);
+        when(
+          () => mockOAuthClient.refreshSession(
+            userPubkey: any(named: 'userPubkey'),
+          ),
+        ).thenAnswer((_) async {
+          refreshCalls++;
+          return null;
+        });
+
+        final authService = createAuthService();
+
+        await runIgnoringMockedHttpErrors(() async {
+          await authService.initialize();
+
+          expect(authService.authState, equals(AuthState.authenticated));
+          expect(authService.authRpcCapability, AuthRpcCapability.rpcReady);
+          expect(authService.currentIdentity, isA<KeycastNostrIdentity>());
+          expect(authService.hasExpiredOAuthSession, isFalse);
+
+          authService.onAppResumed();
+          await pumpEventQueue();
+
+          expect(refreshCalls, isZero);
+          expect(authService.authRpcCapability, AuthRpcCapability.rpcReady);
+          expect(authService.currentIdentity, isA<KeycastNostrIdentity>());
+          expect(authService.hasExpiredOAuthSession, isFalse);
+          expect(
+            secureStorage['keycast_refresh_token'],
+            'refresh_token_still_valid',
+            reason: 'Healthy resume must not risk rotating the refresh token.',
+          );
+        });
+      },
+    );
+
+    test('stale resume rebuild does not attach a signer after sign-out during '
+        'banner clear', () async {
+      SharedPreferences.setMockInitialValues({
+        'authentication_source': 'divineOAuth',
+        'tos_accepted': true,
+      });
+
+      final pubkey = 'ab' * 32;
+      final expiredSession = KeycastSession(
+        bunkerUrl: 'https://login.divine.video/api/nostr',
+        accessToken: 'expired_token',
+        expiresAt: DateTime.now().subtract(const Duration(hours: 1)),
+        refreshToken: 'refresh_token_still_valid',
+        userPubkey: pubkey,
+      );
+      secureStorage['keycast_session'] = jsonEncode(expiredSession.toJson());
+      secureStorage['keycast_refresh_token'] = 'refresh_token_still_valid';
+
+      when(
+        () => mockOAuthClient.refreshSession(
+          userPubkey: any(named: 'userPubkey'),
+        ),
+      ).thenAnswer((_) {
+        throw OAuthNetworkException('offline');
+      });
+      when(() => mockOAuthClient.logout()).thenAnswer((_) async {});
+
+      final authService = createAuthService();
+
+      await runIgnoringMockedHttpErrors(() async {
+        await authService.initialize();
+        await waitForRpcUpgradeToSettle(authService);
+
+        expect(authService.currentPublicKeyHex, pubkey);
+        expect(authService.currentIdentity, isA<PubkeyOnlyNostrIdentity>());
+
+        final storedRpcSession = expiredSession.copyWith(
+          accessToken: 'fresh_token',
+          expiresAt: DateTime.now().add(const Duration(hours: 1)),
+        );
+        when(
+          () => mockOAuthClient.getSession(),
+        ).thenAnswer((_) async => storedRpcSession);
+
+        final prefs = await SharedPreferences.getInstance();
+        final delayedPrefs = _DelayingSharedPreferencesStore.withData(
+          prefixedSharedPreferencesData(prefs),
+          delayedRemoveKey: 'flutter.${divineLoginBannerDismissalKey(pubkey)}',
+        );
+        SharedPreferencesStorePlatform.instance = delayedPrefs;
+        SharedPreferences.resetStatic();
+
+        authService.onAppResumed();
+        await delayedPrefs.removeStarted.future;
+
+        await authService.signOut();
+        delayedPrefs.allowRemove.complete();
+        await pumpEventQueue();
+
+        expect(authService.authState, equals(AuthState.unauthenticated));
+        expect(authService.currentIdentity, isNull);
+        expect(
+          authService.authRpcCapability,
+          isNot(equals(AuthRpcCapability.rpcReady)),
+        );
+      });
+    });
 
     test('stale degraded resume refresh does not attach a signer after '
         'sign-out', () async {
@@ -766,9 +921,7 @@ void main() {
       final authService = createAuthService();
 
       await runIgnoringMockedHttpErrors(() async {
-        final imported = await authService.importFromHex(
-          generatePrivateKey(),
-        );
+        final imported = await authService.importFromHex(generatePrivateKey());
         expect(imported.success, isTrue);
         expect(
           authService.authenticationSource,

--- a/mobile/test/services/auth_service_expired_session_downgrade_test.dart
+++ b/mobile/test/services/auth_service_expired_session_downgrade_test.dart
@@ -137,6 +137,38 @@ void main() {
       );
     }
 
+    Future<void> waitForRpcUpgradeToSettle(AuthService authService) async {
+      await pumpEventQueue();
+      final deadline = DateTime.now().add(const Duration(seconds: 3));
+      while (authService.isRpcUpgradeInProgress &&
+          DateTime.now().isBefore(deadline)) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
+      expect(authService.isRpcUpgradeInProgress, isFalse);
+    }
+
+    Future<void> runIgnoringMockedHttpErrors(
+      Future<void> Function() body,
+    ) async {
+      Object? unexpectedError;
+      StackTrace? unexpectedStack;
+
+      await runZonedGuarded(
+        body,
+        (error, stack) {
+          if (error is UnsupportedError && error.message == 'Mocked response') {
+            return;
+          }
+          unexpectedError ??= error;
+          unexpectedStack ??= stack;
+        },
+      );
+
+      if (unexpectedError != null) {
+        Error.throwWithStackTrace(unexpectedError!, unexpectedStack!);
+      }
+    }
+
     test(
       'refresh fails + local keys exist → auth source stays divineOAuth',
       () async {
@@ -332,6 +364,221 @@ void main() {
           // Ignore background errors
         },
       );
+    });
+
+    test('degraded OAuth restore retries on resume but stays authenticated '
+        'when the device is still offline', () async {
+      SharedPreferences.setMockInitialValues({
+        'authentication_source': 'divineOAuth',
+        'tos_accepted': true,
+      });
+
+      final pubkey = 'ab' * 32;
+      final expiredSession = KeycastSession(
+        bunkerUrl: 'https://login.divine.video/api/nostr',
+        accessToken: 'expired_token',
+        expiresAt: DateTime.now().subtract(const Duration(hours: 1)),
+        refreshToken: 'refresh_token_still_valid',
+        userPubkey: pubkey,
+      );
+      secureStorage['keycast_session'] = jsonEncode(expiredSession.toJson());
+      secureStorage['keycast_refresh_token'] = 'refresh_token_still_valid';
+
+      var refreshCalls = 0;
+      when(() => mockOAuthClient.getSession()).thenAnswer((_) async => null);
+      when(
+        () => mockOAuthClient.refreshSession(
+          userPubkey: any(named: 'userPubkey'),
+        ),
+      ).thenAnswer((_) {
+        refreshCalls++;
+        throw OAuthNetworkException('offline');
+      });
+
+      final authService = createAuthService();
+
+      await runIgnoringMockedHttpErrors(() async {
+        await authService.initialize();
+        await waitForRpcUpgradeToSettle(authService);
+        expect(refreshCalls, equals(2));
+
+        refreshCalls = 0;
+        authService.onAppResumed();
+        await waitForRpcUpgradeToSettle(authService);
+
+        expect(refreshCalls, equals(1));
+        expect(authService.authState, equals(AuthState.authenticated));
+        expect(authService.isAuthenticated, isTrue);
+        expect(authService.currentPublicKeyHex, pubkey);
+        expect(authService.currentIdentity, isA<PubkeyOnlyNostrIdentity>());
+        expect(authService.canPublishNostrWritesNow, isFalse);
+        expect(authService.hasExpiredOAuthSession, isTrue);
+        expect(
+          secureStorage['keycast_refresh_token'],
+          'refresh_token_still_valid',
+          reason: 'Offline resume must not discard the retry token.',
+        );
+      });
+    });
+
+    test(
+      'degraded OAuth restore retries on resume when connectivity returns',
+      () async {
+        SharedPreferences.setMockInitialValues({
+          'authentication_source': 'divineOAuth',
+          'tos_accepted': true,
+        });
+
+        final pubkey = 'ab' * 32;
+        final expiredSession = KeycastSession(
+          bunkerUrl: 'https://login.divine.video/api/nostr',
+          accessToken: 'expired_token',
+          expiresAt: DateTime.now().subtract(const Duration(hours: 1)),
+          refreshToken: 'refresh_token_still_valid',
+          userPubkey: pubkey,
+        );
+        secureStorage['keycast_session'] = jsonEncode(expiredSession.toJson());
+        secureStorage['keycast_refresh_token'] = 'refresh_token_still_valid';
+
+        final refreshedSession = KeycastSession(
+          bunkerUrl: 'https://login.divine.video/api/nostr',
+          accessToken: 'fresh_token',
+          expiresAt: DateTime.now().add(const Duration(hours: 1)),
+          refreshToken: 'next_refresh_token',
+          userPubkey: pubkey,
+        );
+        var resumeRefreshEnabled = false;
+        var refreshCalls = 0;
+        when(() => mockOAuthClient.getSession()).thenAnswer((_) async => null);
+        when(
+          () => mockOAuthClient.refreshSession(
+            userPubkey: any(named: 'userPubkey'),
+          ),
+        ).thenAnswer((_) {
+          refreshCalls++;
+          if (!resumeRefreshEnabled) {
+            throw OAuthNetworkException('offline');
+          }
+          return Future<KeycastSession?>.value(refreshedSession);
+        });
+
+        final authService = createAuthService();
+
+        await runIgnoringMockedHttpErrors(() async {
+          await authService.initialize();
+          await waitForRpcUpgradeToSettle(authService);
+          expect(refreshCalls, equals(2));
+
+          refreshCalls = 0;
+          resumeRefreshEnabled = true;
+          authService.onAppResumed();
+          await waitForRpcUpgradeToSettle(authService);
+
+          expect(refreshCalls, equals(1));
+          expect(authService.authState, equals(AuthState.authenticated));
+          expect(
+            authService.authRpcCapability,
+            equals(AuthRpcCapability.rpcReady),
+          );
+          expect(authService.currentIdentity, isA<KeycastNostrIdentity>());
+          expect(authService.canPublishNostrWritesNow, isTrue);
+          expect(authService.hasExpiredOAuthSession, isFalse);
+        });
+      },
+    );
+
+    test('stale degraded resume refresh does not attach a signer after '
+        'sign-out', () async {
+      SharedPreferences.setMockInitialValues({
+        'authentication_source': 'divineOAuth',
+        'tos_accepted': true,
+      });
+
+      final pubkey = 'ab' * 32;
+      final expiredSession = KeycastSession(
+        bunkerUrl: 'https://login.divine.video/api/nostr',
+        accessToken: 'expired_token',
+        expiresAt: DateTime.now().subtract(const Duration(hours: 1)),
+        refreshToken: 'refresh_token_still_valid',
+        userPubkey: pubkey,
+      );
+      secureStorage['keycast_session'] = jsonEncode(expiredSession.toJson());
+      secureStorage['keycast_refresh_token'] = 'refresh_token_still_valid';
+
+      final resumeRefresh = Completer<KeycastSession?>();
+      var refreshCalls = 0;
+      when(() => mockOAuthClient.getSession()).thenAnswer((_) async => null);
+      when(() => mockOAuthClient.logout()).thenAnswer((_) async {});
+      when(
+        () => mockOAuthClient.refreshSession(
+          userPubkey: any(named: 'userPubkey'),
+        ),
+      ).thenAnswer((_) {
+        refreshCalls++;
+        if (refreshCalls <= 2) {
+          throw OAuthNetworkException('offline');
+        }
+        return resumeRefresh.future;
+      });
+
+      final authService = createAuthService();
+
+      await runIgnoringMockedHttpErrors(() async {
+        await authService.initialize();
+        await waitForRpcUpgradeToSettle(authService);
+        expect(refreshCalls, equals(2));
+        expect(authService.currentIdentity, isA<PubkeyOnlyNostrIdentity>());
+
+        authService.onAppResumed();
+        await pumpEventQueue();
+        expect(authService.isRpcUpgradeInProgress, isTrue);
+
+        await authService.signOut();
+        resumeRefresh.complete(
+          KeycastSession(
+            bunkerUrl: 'https://login.divine.video/api/nostr',
+            accessToken: 'fresh_token',
+            expiresAt: DateTime.now().add(const Duration(hours: 1)),
+            refreshToken: 'next_refresh_token',
+            userPubkey: pubkey,
+          ),
+        );
+        await waitForRpcUpgradeToSettle(authService);
+
+        expect(authService.authState, equals(AuthState.unauthenticated));
+        expect(authService.currentIdentity, isNull);
+        expect(
+          authService.authRpcCapability,
+          isNot(equals(AuthRpcCapability.rpcReady)),
+        );
+      });
+    });
+
+    test('non-OAuth local identities do not refresh OAuth on resume', () async {
+      SharedPreferences.setMockInitialValues({'tos_accepted': true});
+
+      final authService = createAuthService();
+
+      await runIgnoringMockedHttpErrors(() async {
+        final imported = await authService.importFromHex(
+          generatePrivateKey(),
+        );
+        expect(imported.success, isTrue);
+        expect(
+          authService.authenticationSource,
+          AuthenticationSource.importedKeys,
+        );
+
+        authService.onAppResumed();
+        await pumpEventQueue();
+
+        verifyNever(() => mockOAuthClient.getSession());
+        verifyNever(
+          () => mockOAuthClient.refreshSession(
+            userPubkey: any(named: 'userPubkey'),
+          ),
+        );
+      });
     });
 
     test(

--- a/mobile/test/services/auth_service_expired_session_downgrade_test.dart
+++ b/mobile/test/services/auth_service_expired_session_downgrade_test.dart
@@ -108,15 +108,18 @@ void main() {
 
     /// Helper: stores an expired Keycast session and a valid local nsec
     void arrangeExpiredSessionWithLocalKeys() {
+      final privateKeyHex = generatePrivateKey();
+      final container = SecureKeyContainer.fromPrivateKeyHex(privateKeyHex);
       final expiredSession = KeycastSession(
         bunkerUrl: 'https://login.divine.video/api/nostr',
         accessToken: 'expired_token_abc123',
         expiresAt: DateTime.now().subtract(const Duration(hours: 1)),
+        refreshToken: 'refresh_token_still_valid',
+        userPubkey: container.publicKeyHex,
       );
       secureStorage['keycast_session'] = jsonEncode(expiredSession.toJson());
+      secureStorage['keycast_refresh_token'] = 'refresh_token_still_valid';
 
-      final privateKeyHex = generatePrivateKey();
-      final container = SecureKeyContainer.fromPrivateKeyHex(privateKeyHex);
       secureStorage['nostr_primary_key'] =
           'privateKeyHex:$privateKeyHex'
           '|publicKeyHex:${container.publicKeyHex}'
@@ -128,13 +131,15 @@ void main() {
       final keyStorage = SecureKeyStorage(
         securityConfig: const SecurityConfig(requireHardwareBacked: false),
       );
-      return AuthService(
+      final authService = AuthService(
         userDataCleanupService: mockCleanupService,
         keyStorage: keyStorage,
         oauthClient: mockOAuthClient,
         oauthRefreshTimeout:
             oauthRefreshTimeout ?? AuthService.rpcRefreshTimeout,
       );
+      addTearDown(authService.dispose);
+      return authService;
     }
 
     Future<void> waitForRpcUpgradeToSettle(AuthService authService) async {
@@ -183,45 +188,41 @@ void main() {
 
         final authService = createAuthService();
 
-        await runZonedGuarded(
-          () async {
-            await authService.initialize();
+        await runIgnoringMockedHttpErrors(() async {
+          await authService.initialize();
 
-            // Auth source preserved as divineOAuth, not downgraded
-            expect(
-              authService.authenticationSource,
-              equals(AuthenticationSource.divineOAuth),
-              reason:
-                  'Auth source should stay divineOAuth when refresh fails '
-                  'but local keys exist',
-            );
-            expect(
-              authService.isAnonymous,
-              isFalse,
-              reason:
-                  'isAnonymous should be false — user registered via OAuth, '
-                  'session just expired',
-            );
-            expect(authService.isAuthenticated, isTrue);
-            expect(
-              authService.hasExpiredOAuthSession,
-              isTrue,
-              reason:
-                  'hasExpiredOAuthSession should be true so UI can show '
-                  '"session expired" instead of "Secure Your Account"',
-            );
+          // Auth source preserved as divineOAuth, not downgraded
+          expect(
+            authService.authenticationSource,
+            equals(AuthenticationSource.divineOAuth),
+            reason:
+                'Auth source should stay divineOAuth when refresh fails '
+                'but local keys exist',
+          );
+          expect(
+            authService.isAnonymous,
+            isFalse,
+            reason:
+                'isAnonymous should be false — user registered via OAuth, '
+                'session just expired',
+          );
+          expect(authService.isAuthenticated, isTrue);
+          expect(
+            authService.hasExpiredOAuthSession,
+            isTrue,
+            reason:
+                'hasExpiredOAuthSession should be true so UI can show '
+                '"session expired" instead of "Secure Your Account"',
+          );
 
-            // Verify refresh was attempted
-            verify(
-              () => mockOAuthClient.refreshSession(
-                userPubkey: any(named: 'userPubkey'),
-              ),
-            ).called(1);
-          },
-          (error, stack) {
-            // Ignore background relay discovery errors
-          },
-        );
+          // Verify refresh was attempted
+          await waitForRpcUpgradeToSettle(authService);
+          verify(
+            () => mockOAuthClient.refreshSession(
+              userPubkey: any(named: 'userPubkey'),
+            ),
+          ).called(1);
+        });
       },
     );
 
@@ -334,6 +335,12 @@ void main() {
             'refresh_token_still_valid',
             reason: 'Offline launch must not discard the retry token.',
           );
+          final retryDeadline = DateTime.now().add(const Duration(seconds: 3));
+          while (refreshCalls < 2 && DateTime.now().isBefore(retryDeadline)) {
+            await Future<void>.delayed(const Duration(milliseconds: 10));
+          }
+          expect(refreshCalls, equals(2));
+
           backgroundRefresh.complete(refreshedSession);
           await waitForRpcUpgradeToSettle(authService);
 
@@ -419,6 +426,143 @@ void main() {
           'refresh_token_still_valid',
           reason: 'Offline resume must not discard the retry token.',
         );
+      });
+    });
+
+    test('degraded OAuth resume does not refresh another account token when '
+        'getSession returns null', () async {
+      SharedPreferences.setMockInitialValues({
+        'authentication_source': 'divineOAuth',
+        'tos_accepted': true,
+      });
+
+      final activePubkey = 'ab' * 32;
+      final otherPubkey = 'cd' * 32;
+      final expiredActiveSession = KeycastSession(
+        bunkerUrl: 'https://login.divine.video/api/nostr',
+        accessToken: 'expired_active_token',
+        expiresAt: DateTime.now().subtract(const Duration(hours: 1)),
+        refreshToken: 'refresh_token_account_a',
+        userPubkey: activePubkey,
+      );
+      secureStorage['keycast_session'] = jsonEncode(
+        expiredActiveSession.toJson(),
+      );
+      secureStorage['keycast_refresh_token'] = 'refresh_token_account_a';
+
+      var refreshCalls = 0;
+      when(() => mockOAuthClient.getSession()).thenAnswer((_) async => null);
+      when(
+        () => mockOAuthClient.refreshSession(
+          userPubkey: any(named: 'userPubkey'),
+        ),
+      ).thenAnswer((_) {
+        refreshCalls++;
+        throw OAuthNetworkException('offline');
+      });
+
+      final authService = createAuthService();
+
+      await runIgnoringMockedHttpErrors(() async {
+        await authService.initialize();
+        await waitForRpcUpgradeToSettle(authService);
+
+        final expiredOtherSession = KeycastSession(
+          bunkerUrl: 'https://login.divine.video/api/nostr',
+          accessToken: 'expired_other_token',
+          expiresAt: DateTime.now().subtract(const Duration(hours: 1)),
+          refreshToken: 'refresh_token_account_b',
+          userPubkey: otherPubkey,
+        );
+        secureStorage['keycast_session'] = jsonEncode(
+          expiredOtherSession.toJson(),
+        );
+        secureStorage['keycast_refresh_token'] = 'refresh_token_account_b';
+
+        refreshCalls = 0;
+        authService.onAppResumed();
+        await waitForRpcUpgradeToSettle(authService);
+
+        expect(refreshCalls, isZero);
+        expect(authService.authState, equals(AuthState.authenticated));
+        expect(authService.currentPublicKeyHex, activePubkey);
+        expect(authService.currentIdentity, isA<PubkeyOnlyNostrIdentity>());
+        expect(authService.canPublishNostrWritesNow, isFalse);
+        expect(authService.hasExpiredOAuthSession, isTrue);
+        expect(
+          secureStorage['keycast_refresh_token'],
+          'refresh_token_account_b',
+          reason: 'Resume must not consume another account refresh token.',
+        );
+      });
+    });
+
+    test('degraded OAuth resume does not rebuild or refresh a mismatched '
+        'stored RPC session', () async {
+      SharedPreferences.setMockInitialValues({
+        'authentication_source': 'divineOAuth',
+        'tos_accepted': true,
+      });
+
+      final activePubkey = 'ab' * 32;
+      final otherPubkey = 'cd' * 32;
+      final expiredActiveSession = KeycastSession(
+        bunkerUrl: 'https://login.divine.video/api/nostr',
+        accessToken: 'expired_active_token',
+        expiresAt: DateTime.now().subtract(const Duration(hours: 1)),
+        refreshToken: 'refresh_token_account_a',
+        userPubkey: activePubkey,
+      );
+      secureStorage['keycast_session'] = jsonEncode(
+        expiredActiveSession.toJson(),
+      );
+      secureStorage['keycast_refresh_token'] = 'refresh_token_account_a';
+
+      var returnMismatchedSession = false;
+      var refreshCalls = 0;
+      late final KeycastSession validOtherSession;
+      when(() => mockOAuthClient.getSession()).thenAnswer(
+        (_) async => returnMismatchedSession ? validOtherSession : null,
+      );
+      when(
+        () => mockOAuthClient.refreshSession(
+          userPubkey: any(named: 'userPubkey'),
+        ),
+      ).thenAnswer((_) {
+        refreshCalls++;
+        throw OAuthNetworkException('offline');
+      });
+
+      final authService = createAuthService();
+
+      await runIgnoringMockedHttpErrors(() async {
+        await authService.initialize();
+        await waitForRpcUpgradeToSettle(authService);
+
+        validOtherSession = KeycastSession(
+          bunkerUrl: 'https://login.divine.video/api/nostr',
+          accessToken: 'fresh_other_token',
+          expiresAt: DateTime.now().add(const Duration(hours: 1)),
+          refreshToken: 'refresh_token_account_b',
+          userPubkey: otherPubkey,
+        );
+        secureStorage['keycast_session'] = jsonEncode(
+          validOtherSession.toJson(),
+        );
+        secureStorage['keycast_refresh_token'] = 'refresh_token_account_b';
+
+        refreshCalls = 0;
+        returnMismatchedSession = true;
+        authService.onAppResumed();
+        await waitForRpcUpgradeToSettle(authService);
+
+        expect(refreshCalls, isZero);
+        expect(authService.authState, equals(AuthState.authenticated));
+        expect(authService.currentPublicKeyHex, activePubkey);
+        expect(authService.currentIdentity, isA<PubkeyOnlyNostrIdentity>());
+        expect(authService.authRpcCapability, AuthRpcCapability.unavailable);
+        expect(authService.canPublishNostrWritesNow, isFalse);
+        expect(authService.hasExpiredOAuthSession, isTrue);
       });
     });
 

--- a/mobile/test/services/auth_service_expired_session_downgrade_test.dart
+++ b/mobile/test/services/auth_service_expired_session_downgrade_test.dart
@@ -139,11 +139,6 @@ void main() {
 
     Future<void> waitForRpcUpgradeToSettle(AuthService authService) async {
       await pumpEventQueue();
-      final deadline = DateTime.now().add(const Duration(seconds: 3));
-      while (authService.isRpcUpgradeInProgress &&
-          DateTime.now().isBefore(deadline)) {
-        await Future<void>.delayed(const Duration(milliseconds: 10));
-      }
       expect(authService.isRpcUpgradeInProgress, isFalse);
     }
 
@@ -339,14 +334,8 @@ void main() {
             'refresh_token_still_valid',
             reason: 'Offline launch must not discard the retry token.',
           );
-          expect(refreshCalls, equals(2));
-
           backgroundRefresh.complete(refreshedSession);
-          final deadline = DateTime.now().add(const Duration(seconds: 3));
-          while (authService.isRpcUpgradeInProgress &&
-              DateTime.now().isBefore(deadline)) {
-            await Future<void>.delayed(const Duration(milliseconds: 10));
-          }
+          await waitForRpcUpgradeToSettle(authService);
 
           expect(
             authService.authRpcCapability,
@@ -400,7 +389,12 @@ void main() {
       await runIgnoringMockedHttpErrors(() async {
         await authService.initialize();
         await waitForRpcUpgradeToSettle(authService);
-        expect(refreshCalls, equals(2));
+
+        final authEvents = <AuthState>[];
+        final authSubscription = authService.authStateStream.listen(
+          authEvents.add,
+        );
+        addTearDown(authSubscription.cancel);
 
         refreshCalls = 0;
         authService.onAppResumed();
@@ -413,6 +407,13 @@ void main() {
         expect(authService.currentIdentity, isA<PubkeyOnlyNostrIdentity>());
         expect(authService.canPublishNostrWritesNow, isFalse);
         expect(authService.hasExpiredOAuthSession, isTrue);
+        expect(
+          authEvents,
+          isEmpty,
+          reason:
+              'Failed offline resume retries leave degraded state unchanged '
+              'and should not nudge profile UI to re-show the expired sheet.',
+        );
         expect(
           secureStorage['keycast_refresh_token'],
           'refresh_token_still_valid',
@@ -467,8 +468,6 @@ void main() {
         await runIgnoringMockedHttpErrors(() async {
           await authService.initialize();
           await waitForRpcUpgradeToSettle(authService);
-          expect(refreshCalls, equals(2));
-
           refreshCalls = 0;
           resumeRefreshEnabled = true;
           authService.onAppResumed();
@@ -480,6 +479,70 @@ void main() {
             authService.authRpcCapability,
             equals(AuthRpcCapability.rpcReady),
           );
+          expect(authService.currentIdentity, isA<KeycastNostrIdentity>());
+          expect(authService.canPublishNostrWritesNow, isTrue);
+          expect(authService.hasExpiredOAuthSession, isFalse);
+        });
+      },
+    );
+
+    test(
+      'resume rebuilds a missing signer from a matching stored RPC session',
+      () async {
+        SharedPreferences.setMockInitialValues({
+          'authentication_source': 'divineOAuth',
+          'tos_accepted': true,
+        });
+
+        final pubkey = 'ab' * 32;
+        final expiredSession = KeycastSession(
+          bunkerUrl: 'https://login.divine.video/api/nostr',
+          accessToken: 'expired_token',
+          expiresAt: DateTime.now().subtract(const Duration(hours: 1)),
+          refreshToken: 'refresh_token_still_valid',
+          userPubkey: pubkey,
+        );
+        secureStorage['keycast_session'] = jsonEncode(
+          expiredSession.toJson(),
+        );
+        secureStorage['keycast_refresh_token'] = 'refresh_token_still_valid';
+
+        var refreshCalls = 0;
+        when(
+          () => mockOAuthClient.refreshSession(
+            userPubkey: any(named: 'userPubkey'),
+          ),
+        ).thenAnswer((_) {
+          refreshCalls++;
+          throw OAuthNetworkException('offline');
+        });
+
+        final authService = createAuthService();
+
+        await runIgnoringMockedHttpErrors(() async {
+          await authService.initialize();
+          await waitForRpcUpgradeToSettle(authService);
+
+          expect(authService.authState, equals(AuthState.authenticated));
+          expect(authService.currentPublicKeyHex, pubkey);
+          expect(authService.currentIdentity, isA<PubkeyOnlyNostrIdentity>());
+          expect(authService.hasExpiredOAuthSession, isTrue);
+          expect(authService.canPublishNostrWritesNow, isFalse);
+
+          final storedRpcSession = expiredSession.copyWith(
+            accessToken: 'fresh_token',
+            expiresAt: DateTime.now().add(const Duration(hours: 1)),
+          );
+          when(
+            () => mockOAuthClient.getSession(),
+          ).thenAnswer((_) async => storedRpcSession);
+
+          final refreshCallsBeforeResume = refreshCalls;
+          authService.onAppResumed();
+          await pumpEventQueue();
+
+          expect(refreshCalls, equals(refreshCallsBeforeResume));
+          expect(authService.authRpcCapability, AuthRpcCapability.rpcReady);
           expect(authService.currentIdentity, isA<KeycastNostrIdentity>());
           expect(authService.canPublishNostrWritesNow, isTrue);
           expect(authService.hasExpiredOAuthSession, isFalse);
@@ -506,7 +569,7 @@ void main() {
       secureStorage['keycast_refresh_token'] = 'refresh_token_still_valid';
 
       final resumeRefresh = Completer<KeycastSession?>();
-      var refreshCalls = 0;
+      var resumeRefreshStarted = false;
       when(() => mockOAuthClient.getSession()).thenAnswer((_) async => null);
       when(() => mockOAuthClient.logout()).thenAnswer((_) async {});
       when(
@@ -514,8 +577,7 @@ void main() {
           userPubkey: any(named: 'userPubkey'),
         ),
       ).thenAnswer((_) {
-        refreshCalls++;
-        if (refreshCalls <= 2) {
+        if (!resumeRefreshStarted) {
           throw OAuthNetworkException('offline');
         }
         return resumeRefresh.future;
@@ -526,9 +588,9 @@ void main() {
       await runIgnoringMockedHttpErrors(() async {
         await authService.initialize();
         await waitForRpcUpgradeToSettle(authService);
-        expect(refreshCalls, equals(2));
         expect(authService.currentIdentity, isA<PubkeyOnlyNostrIdentity>());
 
+        resumeRefreshStarted = true;
         authService.onAppResumed();
         await pumpEventQueue();
         expect(authService.isRpcUpgradeInProgress, isTrue);


### PR DESCRIPTION
## Summary
- Allow app-resume OAuth refresh for degraded Divine OAuth sessions that are authenticated but have no Keycast signer yet.
- Preserve healthy signer-present OAuth sessions on resume without rotating refresh tokens.
- Rebuild a missing resume signer only from an owner-matching stored RPC session, with ownership rechecked after async banner-dismissal cleanup.
- Route remaining resume refresh through the existing owner-bound background RPC upgrade path so stale results after sign-out/account changes are discarded.
- Treat offline/network resume refresh failures as expected warning-level failures while preserving the refresh token and degraded authenticated state.

## Root Cause
#6245 introduced a degraded Divine OAuth state where _authSource == divineOAuth and _hasExpiredOAuthSession == true, but _keycastSigner == null. The resume hook still used signer presence as its OAuth-session gate, so it skipped the exact state that needed a retry after connectivity returned.

The first retry implementation also sent healthy signer-present resumes through refresh, which could rotate or lose the durable refresh token unnecessarily. Resume signer restoration now returns immediately for owner-matching valid RPC sessions, and only rebuilds the signer when it is actually missing.

## Validation
- dart format lib/services/auth_service.dart test/services/auth_service_expired_session_downgrade_test.dart
- mise exec -- dart format lib test integration_test
- flutter test test/services/auth_service_expired_session_downgrade_test.dart
- flutter test test/services/auth_service_expired_session_downgrade_test.dart test/services/auth_service_multi_account_test.dart test/services/auth_service_local_first_startup_test.dart test/services/auth/oauth_session_coordinator_test.dart
- flutter analyze lib/services/auth_service.dart test/services/auth_service_expired_session_downgrade_test.dart
- flutter analyze lib test integration_test
- Pre-push hook: merge-conflict check, analyzer, changed auth test file

Closes #6248
