### PR TITLE
fix(video-feed): show blurhash behind dead-media error card

### DIFF
--- a/mobile/lib/extensions/video_event_content_type_extension.dart
+++ b/mobile/lib/extensions/video_event_content_type_extension.dart
@@ -1,0 +1,20 @@
+// ABOUTME: App-side VideoEvent helper for the blurhash content-type fallback.
+// ABOUTME: Shared by the feed thumbnail and the pooled error overlay so the two
+// ABOUTME: call sites can't drift apart.
+
+import 'package:blurhash_service/blurhash_service.dart';
+import 'package:models/models.dart';
+
+/// Derives the [VineContentType] used to pick a generic blurhash gradient when
+/// a video carries no event-level [VideoEvent.blurhash].
+extension VideoEventContentType on VideoEvent {
+  /// Content-type inferred from the event's hashtags, group, title, and
+  /// content. `null` when nothing maps to a known category, in which case
+  /// [BlurhashDisplay] falls back to the default Vine gradient.
+  VineContentType? get blurhashContentType => BlurhashService.deriveContentType(
+    hashtags: hashtags,
+    group: group,
+    title: title,
+    content: content,
+  );
+}

--- a/mobile/lib/widgets/blurhash_display.dart
+++ b/mobile/lib/widgets/blurhash_display.dart
@@ -99,6 +99,7 @@ class _BlurhashDisplayState extends State<BlurhashDisplay> {
               child: CustomPaint(
                 painter: _BlurhashImagePainter(
                   snapshot.data!,
+                  fit: widget.fit,
                   opacity: widget.opacity,
                 ),
                 size: Size(
@@ -194,9 +195,10 @@ class _BlurhashDisplayState extends State<BlurhashDisplay> {
 
 /// Custom painter for rendering decoded blurhash image
 class _BlurhashImagePainter extends CustomPainter {
-  _BlurhashImagePainter(this.image, {this.opacity = 1.0});
+  _BlurhashImagePainter(this.image, {required this.fit, this.opacity = 1.0});
 
   final ui.Image image;
+  final BoxFit fit;
   final double opacity;
 
   // Paint color alpha modulates the drawn image, so opacity costs nothing
@@ -207,14 +209,16 @@ class _BlurhashImagePainter extends CustomPainter {
 
   @override
   void paint(Canvas canvas, Size size) {
-    // Scale the image to fit the widget size
-    final src = Rect.fromLTWH(
-      0,
-      0,
-      image.width.toDouble(),
-      image.height.toDouble(),
+    final imageSize = Size(image.width.toDouble(), image.height.toDouble());
+    final fittedSizes = applyBoxFit(fit, imageSize, size);
+    final src = Alignment.center.inscribe(
+      fittedSizes.source,
+      Offset.zero & imageSize,
     );
-    final dst = Rect.fromLTWH(0, 0, size.width, size.height);
+    final dst = Alignment.center.inscribe(
+      fittedSizes.destination,
+      Offset.zero & size,
+    );
 
     canvas.drawImageRect(image, src, dst, _paint);
   }
@@ -223,6 +227,7 @@ class _BlurhashImagePainter extends CustomPainter {
   bool shouldRepaint(covariant CustomPainter oldDelegate) {
     return oldDelegate is! _BlurhashImagePainter ||
         oldDelegate.image != image ||
+        oldDelegate.fit != fit ||
         oldDelegate.opacity != opacity;
   }
 }

--- a/mobile/lib/widgets/video_feed_item/pooled_video_error_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/pooled_video_error_overlay.dart
@@ -70,12 +70,12 @@ class _PooledVideoErrorOverlayState
     return widget.isSquare ? BoxFit.contain : BoxFit.cover;
   }
 
-  VineContentType? get _blurhashContentType =>
+  static VineContentType? _deriveContentType(VideoEvent video) =>
       BlurhashService.deriveContentType(
-        hashtags: widget.video.hashtags,
-        group: widget.video.group,
-        title: widget.video.title,
-        content: widget.video.content,
+        hashtags: video.hashtags,
+        group: video.group,
+        title: video.title,
+        content: video.content,
       );
 
   void _maybeAutoRetryAgeRestricted({required bool showVerifyAge}) {
@@ -179,7 +179,7 @@ class _PooledVideoErrorOverlayState
               // matching the feed grid's fallback. #6242
               BlurhashDisplay(
                 blurhash: widget.video.blurhash,
-                contentType: _blurhashContentType,
+                contentType: _deriveContentType(widget.video),
                 fit: _resolveBoxFit(),
               ),
               if (widget.video.thumbnailUrl != null &&

--- a/mobile/lib/widgets/video_feed_item/pooled_video_error_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/pooled_video_error_overlay.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Differentiates moderation-restricted (403), age-gated (401),
 // ABOUTME: missing (404), and generic playback errors.
 
+import 'package:blurhash_service/blurhash_service.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -12,6 +13,7 @@ import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/services/video_moderation_status_service.dart';
+import 'package:openvine/widgets/blurhash_display.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
 
 /// Error overlay for videos playing through the pooled video player.
@@ -67,6 +69,14 @@ class _PooledVideoErrorOverlayState
     if (!widget.shouldPortraitExpand) return BoxFit.contain;
     return widget.isSquare ? BoxFit.contain : BoxFit.cover;
   }
+
+  VineContentType? get _blurhashContentType =>
+      BlurhashService.deriveContentType(
+        hashtags: widget.video.hashtags,
+        group: widget.video.group,
+        title: widget.video.title,
+        content: widget.video.content,
+      );
 
   void _maybeAutoRetryAgeRestricted({required bool showVerifyAge}) {
     if (!showVerifyAge || widget.isVerifying || widget.onVerifyAge == null) {
@@ -161,19 +171,30 @@ class _PooledVideoErrorOverlayState
       children: [
         ColoredBox(
           color: VineTheme.backgroundColor,
-          child:
-              widget.video.thumbnailUrl != null &&
-                  widget.video.thumbnailUrl!.isNotEmpty
-              ? SizedBox.expand(
-                  child: VineCachedImage(
-                    imageUrl: widget.video.thumbnailUrl!,
-                    fit: _resolveBoxFit(),
-                    fadeInDuration: Duration.zero,
-                    fadeOutDuration: Duration.zero,
-                    errorWidget: (_, _, _) => const SizedBox.shrink(),
-                  ),
-                )
-              : const SizedBox.expand(),
+          child: Stack(
+            fit: StackFit.expand,
+            children: [
+              // Blurhash preview beneath the thumbnail so expired or missing
+              // media degrades to a soft placeholder instead of a bare color,
+              // matching the feed grid's fallback. #6242
+              BlurhashDisplay(
+                blurhash: widget.video.blurhash,
+                contentType: _blurhashContentType,
+                fit: _resolveBoxFit(),
+              ),
+              if (widget.video.thumbnailUrl != null &&
+                  widget.video.thumbnailUrl!.isNotEmpty)
+                VineCachedImage(
+                  imageUrl: widget.video.thumbnailUrl!,
+                  fit: _resolveBoxFit(),
+                  fadeInDuration: Duration.zero,
+                  fadeOutDuration: Duration.zero,
+                  // On a failed/expired thumbnail, reveal the blurhash beneath
+                  // rather than collapsing to a bare color.
+                  errorWidget: (_, _, _) => const SizedBox.shrink(),
+                ),
+            ],
+          ),
         ),
         ColoredBox(
           color: VineTheme.scrim50,

--- a/mobile/lib/widgets/video_feed_item/pooled_video_error_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/pooled_video_error_overlay.dart
@@ -2,7 +2,6 @@
 // ABOUTME: Differentiates moderation-restricted (403), age-gated (401),
 // ABOUTME: missing (404), and generic playback errors.
 
-import 'package:blurhash_service/blurhash_service.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -11,6 +10,7 @@ import 'package:infinite_video_feed/infinite_video_feed.dart'
     show VideoErrorType;
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
+import 'package:openvine/extensions/video_event_content_type_extension.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/services/video_moderation_status_service.dart';
 import 'package:openvine/widgets/blurhash_display.dart';
@@ -69,14 +69,6 @@ class _PooledVideoErrorOverlayState
     if (!widget.shouldPortraitExpand) return BoxFit.contain;
     return widget.isSquare ? BoxFit.contain : BoxFit.cover;
   }
-
-  static VineContentType? _deriveContentType(VideoEvent video) =>
-      BlurhashService.deriveContentType(
-        hashtags: video.hashtags,
-        group: video.group,
-        title: video.title,
-        content: video.content,
-      );
 
   void _maybeAutoRetryAgeRestricted({required bool showVerifyAge}) {
     if (!showVerifyAge || widget.isVerifying || widget.onVerifyAge == null) {
@@ -166,6 +158,13 @@ class _PooledVideoErrorOverlayState
     final showRetry = !isModerationRestricted && !showVerifyAge;
     _maybeAutoRetryAgeRestricted(showVerifyAge: showVerifyAge);
 
+    // Hard-walled states (forbidden / moderation-blocked / age-restricted)
+    // withhold the frame entirely: suppress both the event blurhash and the
+    // thumbnail so no frame-derived preview leaks, degrading to the generic
+    // content-type gradient only. notFound / generic keep the event blurhash
+    // and thumbnail fallback. #6242
+    final suppressPreviewMedia = isModerationRestricted || isAgeRestricted;
+
     return Stack(
       fit: StackFit.expand,
       children: [
@@ -178,11 +177,11 @@ class _PooledVideoErrorOverlayState
               // media degrades to a soft placeholder instead of a bare color,
               // matching the feed grid's fallback. #6242
               BlurhashDisplay(
-                blurhash: widget.video.blurhash,
-                contentType: _deriveContentType(widget.video),
-                fit: _resolveBoxFit(),
+                blurhash: suppressPreviewMedia ? null : widget.video.blurhash,
+                contentType: widget.video.blurhashContentType,
               ),
-              if (widget.video.thumbnailUrl != null &&
+              if (!suppressPreviewMedia &&
+                  widget.video.thumbnailUrl != null &&
                   widget.video.thumbnailUrl!.isNotEmpty)
                 VineCachedImage(
                   imageUrl: widget.video.thumbnailUrl!,

--- a/mobile/lib/widgets/video_feed_item/pooled_video_error_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/pooled_video_error_overlay.dart
@@ -113,6 +113,7 @@ class _PooledVideoErrorOverlayState
     final moderationStatus = moderationAsync?.whenOrNull(
       data: (status) => status,
     );
+    final isModerationStatusLoading = moderationAsync?.isLoading ?? false;
     final isModerationAgeRestricted =
         shouldEnrichNotFoundWithModeration &&
         moderationStatus != null &&
@@ -159,11 +160,13 @@ class _PooledVideoErrorOverlayState
     _maybeAutoRetryAgeRestricted(showVerifyAge: showVerifyAge);
 
     // Hard-walled states (forbidden / moderation-blocked / age-restricted)
-    // withhold the frame entirely: suppress both the event blurhash and the
-    // thumbnail so no frame-derived preview leaks, degrading to the generic
-    // content-type gradient only. notFound / generic keep the event blurhash
-    // and thumbnail fallback. #6242
-    final suppressPreviewMedia = isModerationRestricted || isAgeRestricted;
+    // withhold the frame entirely. While a Divine notFound moderation lookup is
+    // pending, fail closed for the preview layers too: suppress both the event
+    // blurhash and thumbnail so no frame-derived preview leaks before the
+    // moderation result lands. Plain notFound / generic failures keep the event
+    // blurhash and thumbnail fallback. #6242
+    final suppressPreviewMedia =
+        isModerationStatusLoading || isModerationRestricted || isAgeRestricted;
 
     return Stack(
       fit: StackFit.expand,

--- a/mobile/lib/widgets/video_thumbnail_widget.dart
+++ b/mobile/lib/widgets/video_thumbnail_widget.dart
@@ -3,13 +3,13 @@
 
 import 'dart:async';
 
-import 'package:blurhash_service/blurhash_service.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart'
     show HttpExceptionWithStatus;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:models/models.dart' hide AspectRatio, LogCategory;
+import 'package:openvine/extensions/video_event_content_type_extension.dart';
 import 'package:openvine/models/viewer_auth_result.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/utils/blossom_blob_hash.dart';
@@ -48,14 +48,6 @@ class _VideoThumbnailWidgetState extends State<VideoThumbnailWidget> {
     super.initState();
     _loadThumbnail();
   }
-
-  static VineContentType? _deriveContentType(VideoEvent video) =>
-      BlurhashService.deriveContentType(
-        hashtags: video.hashtags,
-        group: video.group,
-        title: video.title,
-        content: video.content,
-      );
 
   @override
   void didUpdateWidget(VideoThumbnailWidget oldWidget) {
@@ -108,7 +100,7 @@ class _VideoThumbnailWidgetState extends State<VideoThumbnailWidget> {
         // Show blurhash or flat color as background while image loads
         BlurhashDisplay(
           blurhash: widget.video.blurhash,
-          contentType: _deriveContentType(widget.video),
+          contentType: widget.video.blurhashContentType,
           width: widget.width,
           height: widget.height,
           fit: fit,

--- a/mobile/test/builders/test_video_event_builder.dart
+++ b/mobile/test/builders/test_video_event_builder.dart
@@ -13,6 +13,7 @@ class TestVideoEventBuilder {
     String? title,
     String? videoUrl,
     String? thumbnailUrl,
+    String? blurhash,
     List<String>? hashtags,
     DateTime? timestamp,
     int? createdAt,
@@ -28,6 +29,7 @@ class TestVideoEventBuilder {
       title: title ?? 'Test Video',
       videoUrl: videoUrl ?? 'https://example.com/test_video.mp4',
       thumbnailUrl: thumbnailUrl ?? 'https://example.com/test_thumbnail.jpg',
+      blurhash: blurhash,
       hashtags: hashtags ?? ['test'],
       rawTags: rawTags ?? {},
     );

--- a/mobile/test/widgets/pooled_video_error_overlay_test.dart
+++ b/mobile/test/widgets/pooled_video_error_overlay_test.dart
@@ -24,6 +24,14 @@ import '../helpers/test_provider_overrides.dart'
 Finder _findDivineIcon(DivineIconName name) =>
     find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
 
+/// The single blurhash layer rendered beneath the error scrim.
+BlurhashDisplay _blurhashOf(WidgetTester tester) =>
+    tester.widget<BlurhashDisplay>(find.byType(BlurhashDisplay));
+
+/// A valid event-level blurhash used to distinguish the frame-derived preview
+/// from the generic content-type fallback.
+const _eventBlurhash = 'LEHV6nWB2yk8pyo0adR*.7kCMdnj';
+
 void main() {
   group(PooledVideoErrorOverlay, () {
     late VideoEvent divineVideo;
@@ -496,6 +504,98 @@ void main() {
         expect(find.byType(BlurhashDisplay), findsOneWidget);
         expect(find.byType(VineCachedImage), findsNothing);
       });
+
+      testWidgets('keeps the event blurhash for not-found dead media', (
+        tester,
+      ) async {
+        final withBlurhash = TestVideoEventBuilder.create(
+          id: 'blurhash-video',
+          videoUrl: 'https://blossom.divine.video/$testSha256.mp4',
+          thumbnailUrl: '',
+          blurhash: _eventBlurhash,
+        );
+
+        await tester.pumpWidget(
+          buildWidget(errorType: VideoErrorType.notFound, video: withBlurhash),
+        );
+        await tester.pumpAndSettle();
+
+        // The event's own blurhash is passed through, not the generic
+        // content-type fallback, so broken/expired media still degrades to
+        // the real frame impression.
+        expect(_blurhashOf(tester).blurhash, equals(_eventBlurhash));
+      });
+    });
+
+    group('restricted media suppression', () {
+      // Keep the stubbed thumbnail off the real on-disk cache, matching the
+      // dead-media group, so the pre-suppression frame never hits the network.
+      setUp(() => debugImageCacheOverride = createMockMediaCacheManager());
+      tearDown(() => debugImageCacheOverride = null);
+
+      // Carries both a thumbnail and its own event blurhash, so a failure to
+      // suppress would surface a frame-derived preview.
+      VideoEvent restrictedVideo() => TestVideoEventBuilder.create(
+        id: 'restricted-video',
+        videoUrl: 'https://blossom.divine.video/$testSha256.mp4',
+        thumbnailUrl: 'https://blossom.divine.video/$testSha256.jpg',
+        blurhash: _eventBlurhash,
+      );
+
+      testWidgets('suppresses event blurhash and thumbnail for forbidden', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildWidget(
+            errorType: VideoErrorType.forbidden,
+            video: restrictedVideo(),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(_blurhashOf(tester).blurhash, isNull);
+        expect(find.byType(VineCachedImage), findsNothing);
+      });
+
+      testWidgets(
+        'suppresses event blurhash and thumbnail for age-restricted',
+        (tester) async {
+          await tester.pumpWidget(
+            buildWidget(
+              errorType: VideoErrorType.ageRestricted,
+              video: restrictedVideo(),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          expect(_blurhashOf(tester).blurhash, isNull);
+          expect(find.byType(VineCachedImage), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'suppresses event blurhash and thumbnail for moderation-blocked media',
+        (tester) async {
+          await tester.pumpWidget(
+            buildWidgetWithModeration(
+              errorType: VideoErrorType.notFound,
+              video: restrictedVideo(),
+              moderationStatus: const VideoModerationStatus(
+                moderated: true,
+                blocked: true,
+                quarantined: false,
+                ageRestricted: false,
+                needsReview: false,
+                aiGenerated: false,
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          expect(_blurhashOf(tester).blurhash, isNull);
+          expect(find.byType(VineCachedImage), findsNothing);
+        },
+      );
     });
 
     group('retry', () {

--- a/mobile/test/widgets/pooled_video_error_overlay_test.dart
+++ b/mobile/test/widgets/pooled_video_error_overlay_test.dart
@@ -13,7 +13,9 @@ import 'package:models/models.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/services/video_moderation_status_service.dart';
+import 'package:openvine/widgets/blurhash_display.dart';
 import 'package:openvine/widgets/video_feed_item/pooled_video_error_overlay.dart';
+import 'package:openvine/widgets/vine_cached_image.dart';
 
 import '../builders/test_video_event_builder.dart';
 
@@ -450,6 +452,39 @@ void main() {
           expect(find.text(l10n.videoErrorRetry), findsNothing);
         },
       );
+    });
+
+    group('dead media fallback', () {
+      testWidgets(
+        'renders a blurhash beneath the error card so expired media is '
+        'not a bare color',
+        (tester) async {
+          await tester.pumpWidget(
+            buildWidget(errorType: VideoErrorType.notFound),
+          );
+          await tester.pumpAndSettle();
+
+          expect(find.byType(BlurhashDisplay), findsOneWidget);
+        },
+      );
+
+      testWidgets('renders a blurhash when the thumbnail URL is missing', (
+        tester,
+      ) async {
+        final noThumbnail = TestVideoEventBuilder.create(
+          id: 'no-thumbnail-video',
+          videoUrl: 'https://blossom.divine.video/$testSha256.mp4',
+          thumbnailUrl: '',
+        );
+
+        await tester.pumpWidget(
+          buildWidget(errorType: VideoErrorType.notFound, video: noThumbnail),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byType(BlurhashDisplay), findsOneWidget);
+        expect(find.byType(VineCachedImage), findsNothing);
+      });
     });
 
     group('retry', () {

--- a/mobile/test/widgets/pooled_video_error_overlay_test.dart
+++ b/mobile/test/widgets/pooled_video_error_overlay_test.dart
@@ -18,6 +18,8 @@ import 'package:openvine/widgets/video_feed_item/pooled_video_error_overlay.dart
 import 'package:openvine/widgets/vine_cached_image.dart';
 
 import '../builders/test_video_event_builder.dart';
+import '../helpers/test_provider_overrides.dart'
+    show createMockMediaCacheManager;
 
 Finder _findDivineIcon(DivineIconName name) =>
     find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
@@ -455,15 +457,24 @@ void main() {
     });
 
     group('dead media fallback', () {
+      // Route the thumbnail through a stubbed cache so its load fails
+      // deterministically (like an expired 401/404) and stays off the real
+      // on-disk cache in the merged test isolate.
+      setUp(() => debugImageCacheOverride = createMockMediaCacheManager());
+      tearDown(() => debugImageCacheOverride = null);
+
       testWidgets(
-        'renders a blurhash beneath the error card so expired media is '
-        'not a bare color',
+        'reveals the blurhash when a present thumbnail fails to load (#6242)',
         (tester) async {
           await tester.pumpWidget(
             buildWidget(errorType: VideoErrorType.notFound),
           );
           await tester.pumpAndSettle();
 
+          // The thumbnail collapsed into its (empty) errorWidget, so it no
+          // longer covers the blurhash beneath it...
+          expect(find.byKey(const ValueKey('error')), findsOneWidget);
+          // ...leaving the blurhash visible instead of a bare color.
           expect(find.byType(BlurhashDisplay), findsOneWidget);
         },
       );

--- a/mobile/test/widgets/pooled_video_error_overlay_test.dart
+++ b/mobile/test/widgets/pooled_video_error_overlay_test.dart
@@ -2,6 +2,8 @@
 // ABOUTME: Verifies UI rendering for each VideoErrorType and moderation
 // ABOUTME: enrichment for divine URL 404 errors.
 
+import 'dart:async';
+
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -128,6 +130,36 @@ void main() {
                     value: playbackStatusCubit,
                     child: overlay,
                   ),
+          ),
+        ),
+      );
+    }
+
+    Widget buildWidgetWithModerationFuture({
+      required VideoErrorType? errorType,
+      required Future<VideoModerationStatus?> moderationFuture,
+      VideoEvent? video,
+    }) {
+      final overlay = PooledVideoErrorOverlay(
+        video: video ?? divineVideo,
+        onRetry: () => retryPressed = true,
+        onVerifyAge: () => verifyAgePressed = true,
+        errorType: errorType,
+      );
+      return ProviderScope(
+        overrides: [
+          videoModerationStatusProvider.overrideWith(
+            (ref, sha256) => moderationFuture,
+          ),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: BlocProvider(
+              create: (_) => VideoPlaybackStatusCubit(),
+              child: overlay,
+            ),
           ),
         ),
       );
@@ -594,6 +626,28 @@ void main() {
 
           expect(_blurhashOf(tester).blurhash, isNull);
           expect(find.byType(VineCachedImage), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'suppresses event blurhash and thumbnail while moderation is loading',
+        (tester) async {
+          final moderationCompleter = Completer<VideoModerationStatus?>();
+
+          await tester.pumpWidget(
+            buildWidgetWithModerationFuture(
+              errorType: VideoErrorType.notFound,
+              video: restrictedVideo(),
+              moderationFuture: moderationCompleter.future,
+            ),
+          );
+          await tester.pump();
+
+          expect(_blurhashOf(tester).blurhash, isNull);
+          expect(find.byType(VineCachedImage), findsNothing);
+
+          moderationCompleter.complete(null);
+          await tester.pumpAndSettle();
         },
       );
     });


### PR DESCRIPTION
Closes #6255

## Description

The pooled video error overlay fell back to a bare background color (`VineTheme.backgroundColor` with a `SizedBox.shrink()` thumbnail error widget) whenever a video failed and its thumbnail was missing or itself returned 401/404 from `media.divine.video`. So a dead/expired item — the exact case #6242 is about — rendered as a flat colored card with no visual context.

This renders the video's blurhash as a base layer beneath the thumbnail (content-type-derived default when the event has no blurhash), matching the feed grid's existing fallback. Expired or missing media now degrades to a soft blurred preview plus the existing error message/retry, instead of a flat color.

Restricted states still withhold frame-derived preview media: forbidden, moderation-blocked/quarantined, age-restricted, and Divine not-found media while its moderation lookup is still pending all suppress both the event blurhash and thumbnail, falling back to the generic content-type gradient only.

This also wires `BlurhashDisplay.fit` into the decoded blurhash painter so callers that pass `BoxFit.contain`/`cover` no longer hit a no-op parameter.

Closes #6242 —  (partial fix; follow-ups tracked in #6250–#6253)

## Out of Scope

This is the app-side, trust/safety-neutral slice of #6242. The remaining root causes were deliberately deferred because doing them here would change age-gate/moderation semantics or ship an unverifiable native change:

- #6250 — send BUD-01 auth so age-restricted thumbnails load *(trust/safety)*
- #6251 — auto-skip/prune unrecoverable 401/403 media like 404 *(trust/safety)*
- #6252 — map iOS NSURLErrorDomain -1013 *(native + needs repro)*
- #6253 — distinguish expired-token 401 from age-gate *(trust/safety; the current 401/unauthorized classifier still intentionally maps both to age-restricted)*

Full root-cause analysis is in the #6242 comment.

## Verification

- `flutter analyze lib/widgets/video_feed_item/pooled_video_error_overlay.dart lib/widgets/blurhash_display.dart test/widgets/pooled_video_error_overlay_test.dart` — clean
- `flutter test test/widgets/pooled_video_error_overlay_test.dart` — 25/25 pass
- Pre-push hook — clean:
  - changed-file analyzer
  - `test/widgets/blurhash_display_test.dart`
  - `test/widgets/pooled_video_error_overlay_test.dart`
  - `test/widgets/video_thumbnail_widget_test.dart`
- `mise exec -- dart format lib test integration_test` — clean

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
