### PR TITLE
chore(feature-flags): remove unused feature flags

### DIFF
--- a/mobile/lib/features/feature_flags/README.md
+++ b/mobile/lib/features/feature_flags/README.md
@@ -16,10 +16,8 @@ The feature flag system follows clean architecture principles with clear separat
 
 ## Available Feature Flags
 
-- `newCameraUI` - Enhanced camera interface with new controls
 - `enhancedVideoPlayer` - Improved video playback engine with better performance
 - `enhancedAnalytics` - Detailed usage tracking and insights
-- `newProfileLayout` - Redesigned user profile screen
 - `debugTools` - Developer debugging utilities and diagnostics
 
 ## Quick Start
@@ -31,7 +29,7 @@ import 'package:openvine/features/feature_flags/widgets/feature_flag_widget.dart
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 
 FeatureFlagWidget(
-  flag: FeatureFlag.newCameraUI,
+  flag: FeatureFlag.enhancedAnalytics,
   disabled: const StandardCameraWidget(),
   child: const EnhancedCameraWidget(),
 )
@@ -47,7 +45,7 @@ class MyWidget extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final isNewCameraEnabled = ref.watch(
-      isFeatureEnabledProvider(FeatureFlag.newCameraUI)
+      isFeatureEnabledProvider(FeatureFlag.enhancedAnalytics)
     );
     
     if (isNewCameraEnabled) {
@@ -81,7 +79,7 @@ bool getDefault(FeatureFlag flag) {
   switch (flag) {
     case FeatureFlag.debugTools:
       return kDebugMode; // Only enabled in debug builds
-    case FeatureFlag.newCameraUI:
+    case FeatureFlag.enhancedAnalytics:
       return false; // Disabled by default
     // ... other flags
   }
@@ -122,7 +120,7 @@ Comprehensive test coverage with 47 tests across:
 ```dart
 testWidgets('should show enhanced feature when flag enabled', (tester) async {
   final mockPrefs = MockSharedPreferences();
-  when(mockPrefs.getBool('ff_newCameraUI')).thenReturn(true);
+  when(mockPrefs.getBool('ff_enhancedAnalytics')).thenReturn(true);
   
   await tester.pumpWidget(
     ProviderScope(

--- a/mobile/lib/features/feature_flags/models/feature_flag.dart
+++ b/mobile/lib/features/feature_flags/models/feature_flag.dart
@@ -2,25 +2,11 @@
 // ABOUTME: Provides type-safe flag definitions with display names and descriptions
 
 enum FeatureFlag {
-  newCameraUI('New Camera UI', 'Enhanced camera interface with new controls'),
   enhancedAnalytics(
     'Enhanced Analytics',
     'Detailed usage tracking and insights',
   ),
-  newProfileLayout('New Profile Layout', 'Redesigned user profile screen'),
   debugTools('Debug Tools', 'Developer debugging utilities and diagnostics'),
-  routerDrivenHome(
-    'Router-Driven Home Screen',
-    'New router-driven home screen architecture (eliminates lifecycle bugs)',
-  ),
-  enableVideoEditorV1(
-    'Video Editor V1',
-    'Enable video editing functionality (disabled on web, enabled on native platforms)',
-  ),
-  classicsHashtags(
-    'Classics Trending Hashtags',
-    'Show trending hashtags section on the Classics tab',
-  ),
   curatedLists('Curated Lists', 'Enable curated lists feature in share menu'),
   blueskyPublishing(
     'Bluesky Publishing',

--- a/mobile/lib/features/feature_flags/services/build_configuration.dart
+++ b/mobile/lib/features/feature_flags/services/build_configuration.dart
@@ -9,24 +9,10 @@ class BuildConfiguration {
   /// Get the default value for a feature flag from environment variables
   bool getDefault(FeatureFlag flag) {
     switch (flag) {
-      case FeatureFlag.newCameraUI:
-        return const bool.fromEnvironment('FF_NEW_CAMERA_UI');
       case FeatureFlag.enhancedAnalytics:
         return const bool.fromEnvironment('FF_ENHANCED_ANALYTICS');
-      case FeatureFlag.newProfileLayout:
-        return const bool.fromEnvironment('FF_NEW_PROFILE_LAYOUT');
       case FeatureFlag.debugTools:
         return const bool.fromEnvironment('FF_DEBUG_TOOLS', defaultValue: true);
-      case FeatureFlag.routerDrivenHome:
-        return const bool.fromEnvironment('FF_ROUTER_DRIVEN_HOME');
-      case FeatureFlag.enableVideoEditorV1:
-        // Video editor now works on all platforms (uses dialog-based editor)
-        return const bool.fromEnvironment(
-          'FF_ENABLE_VIDEO_EDITOR_V1',
-          defaultValue: true,
-        );
-      case FeatureFlag.classicsHashtags:
-        return const bool.fromEnvironment('FF_CLASSICS_HASHTAGS');
       case FeatureFlag.curatedLists:
         return const bool.fromEnvironment(
           'FF_CURATED_LISTS',
@@ -67,20 +53,10 @@ class BuildConfiguration {
   /// Get the environment variable key for a flag
   String getEnvironmentKey(FeatureFlag flag) {
     switch (flag) {
-      case FeatureFlag.newCameraUI:
-        return 'FF_NEW_CAMERA_UI';
       case FeatureFlag.enhancedAnalytics:
         return 'FF_ENHANCED_ANALYTICS';
-      case FeatureFlag.newProfileLayout:
-        return 'FF_NEW_PROFILE_LAYOUT';
       case FeatureFlag.debugTools:
         return 'FF_DEBUG_TOOLS';
-      case FeatureFlag.routerDrivenHome:
-        return 'FF_ROUTER_DRIVEN_HOME';
-      case FeatureFlag.enableVideoEditorV1:
-        return 'FF_ENABLE_VIDEO_EDITOR_V1';
-      case FeatureFlag.classicsHashtags:
-        return 'FF_CLASSICS_HASHTAGS';
       case FeatureFlag.curatedLists:
         return 'FF_CURATED_LISTS';
       case FeatureFlag.blueskyPublishing:

--- a/mobile/lib/screens/settings/nostr_settings_screen.dart
+++ b/mobile/lib/screens/settings/nostr_settings_screen.dart
@@ -13,7 +13,6 @@ import 'package:nostr_key_manager/nostr_key_manager.dart'
     show SecureKeyStorageException;
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
-import 'package:openvine/features/feature_flags/screens/feature_flag_screen.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
@@ -91,16 +90,6 @@ class NostrSettingsScreen extends ConsumerWidget {
                 onTap: () => context.push(BlossomSettingsScreen.path),
               ),
               const _SignatureVerificationTile(),
-              _SettingsTile(
-                icon: Icons.science,
-                title: context.l10n.settingsExperimentalFeatures,
-                subtitle:
-                    context.l10n.nostrSettingsExperimentalFeaturesSubtitle,
-                onTap: () => Navigator.push(
-                  context,
-                  MaterialPageRoute(builder: (_) => const FeatureFlagScreen()),
-                ),
-              ),
 
               // Account section
               if (isAuthenticated) ...[

--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -8,8 +8,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide LogCategory, NIP71VideoKinds;
-import 'package:openvine/features/feature_flags/models/feature_flag.dart';
-import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/l10n/l10n.dart';
 // For isVideoActiveProvider (router-driven)
 import 'package:openvine/providers/app_providers.dart';
@@ -670,15 +668,12 @@ class VideoOverlayActionColumn extends ConsumerWidget {
     // your own video, so the slot is reused for Edit instead. Both gates
     // resolve to false for non-owners and during preview / when the
     // editor feature flag is off, leaving the column unchanged.
-    final editorEnabled = ref
-        .watch(featureFlagServiceProvider)
-        .isEnabled(FeatureFlag.enableVideoEditorV1);
     final currentUserPubkey = ref
         .watch(authServiceProvider)
         .currentPublicKeyHex;
     final isOwnVideo =
         currentUserPubkey != null && currentUserPubkey == video.pubkey;
-    final showEditButton = !isPreviewMode && editorEnabled && isOwnVideo;
+    final showEditButton = !isPreviewMode && isOwnVideo;
 
     return Column(
       spacing: 20,

--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -665,9 +665,9 @@ class VideoOverlayActionColumn extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     // Owners get an [EditActionButton] at the top of the column (above
     // Like) and the [ReportActionButton] is suppressed — you can't report
-    // your own video, so the slot is reused for Edit instead. Both gates
-    // resolve to false for non-owners and during preview / when the
-    // editor feature flag is off, leaving the column unchanged.
+    // your own video, so the slot is reused for Edit instead. The gate
+    // resolves to false for non-owners and during preview, leaving the
+    // column unchanged.
     final currentUserPubkey = ref
         .watch(authServiceProvider)
         .currentPublicKeyHex;

--- a/mobile/test/core/feature_flag_test.dart
+++ b/mobile/test/core/feature_flag_test.dart
@@ -7,12 +7,10 @@ import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 void main() {
   group('FeatureFlag enum', () {
     test('should have display names', () {
-      expect(FeatureFlag.newCameraUI.displayName, equals('New Camera UI'));
       expect(FeatureFlag.debugTools.displayName, equals('Debug Tools'));
     });
 
     test('should have descriptions', () {
-      expect(FeatureFlag.newCameraUI.description, isNotEmpty);
       expect(FeatureFlag.debugTools.description, isNotEmpty);
     });
 
@@ -27,10 +25,8 @@ void main() {
     });
 
     test('should include expected flags for OpenVine', () {
-      expect(FeatureFlag.values, contains(FeatureFlag.newCameraUI));
       expect(FeatureFlag.values, contains(FeatureFlag.accountSwitching));
       expect(FeatureFlag.values, contains(FeatureFlag.enhancedAnalytics));
-      expect(FeatureFlag.values, contains(FeatureFlag.newProfileLayout));
       expect(FeatureFlag.values, contains(FeatureFlag.debugTools));
       expect(FeatureFlag.values, contains(FeatureFlag.integratedApps));
       expect(FeatureFlag.values, contains(FeatureFlag.videoReplies));

--- a/mobile/test/features/feature_flags/feature_flag_workflow_test.dart
+++ b/mobile/test/features/feature_flags/feature_flag_workflow_test.dart
@@ -89,25 +89,27 @@ void main() {
 
       // Verify settings screen loaded
       expect(find.text('Feature Flags'), findsOneWidget);
-      expect(find.text('New Camera UI'), findsOneWidget);
+      expect(find.text('Enhanced Analytics'), findsOneWidget);
 
-      // Enable the new camera UI feature
+      // Enable the feature flag
       // Update mock to return true when getBool is called after toggle
-      when(() => mockPrefs.getBool('ff_newCameraUI')).thenReturn(true);
-      when(() => mockPrefs.containsKey('ff_newCameraUI')).thenReturn(true);
+      when(() => mockPrefs.getBool('ff_enhancedAnalytics')).thenReturn(true);
+      when(
+        () => mockPrefs.containsKey('ff_enhancedAnalytics'),
+      ).thenReturn(true);
 
-      final newCameraSwitch = find.descendant(
+      final flagSwitch = find.descendant(
         of: find.ancestor(
-          of: find.text('New Camera UI'),
+          of: find.text('Enhanced Analytics'),
           matching: find.byType(Card),
         ),
         matching: find.byType(Switch),
       );
-      await tester.tap(newCameraSwitch);
+      await tester.tap(flagSwitch);
       await tester.pumpAndSettle();
 
       // Verify persistence call was made
-      verify(() => mockPrefs.setBool('ff_newCameraUI', true)).called(1);
+      verify(() => mockPrefs.setBool('ff_enhancedAnalytics', true)).called(1);
 
       // Navigate back to home
       await tester.tap(find.byType(DivineAppBarIconButton).first);
@@ -120,8 +122,10 @@ void main() {
 
     testWidgets('should handle multiple flags independently', (tester) async {
       // Set up mixed initial state
-      when(() => mockPrefs.getBool('ff_newCameraUI')).thenReturn(true);
-      when(() => mockPrefs.containsKey('ff_newCameraUI')).thenReturn(true);
+      when(() => mockPrefs.getBool('ff_enhancedAnalytics')).thenReturn(true);
+      when(
+        () => mockPrefs.containsKey('ff_enhancedAnalytics'),
+      ).thenReturn(true);
 
       await tester.pumpWidget(
         ProviderScope(
@@ -133,7 +137,7 @@ void main() {
               body: Column(
                 children: [
                   const FeatureFlagWidget(
-                    flag: FeatureFlag.newCameraUI,
+                    flag: FeatureFlag.enhancedAnalytics,
                     disabled: Text('Standard Camera'),
                     child: Text('Enhanced Camera'),
                   ),
@@ -181,7 +185,7 @@ void main() {
       );
 
       // Verify the feature flag list items are present
-      expect(find.text('New Camera UI'), findsOneWidget);
+      expect(find.text('Enhanced Analytics'), findsOneWidget);
     });
 
     testWidgets('should persist flag changes across app restarts', (
@@ -207,26 +211,30 @@ void main() {
       await service1.initialize();
       await tester.pumpAndSettle();
 
-      // Change a flag - find the newCameraUI switch specifically
-      when(() => mockPrefs.getBool('ff_newCameraUI')).thenReturn(true);
-      when(() => mockPrefs.containsKey('ff_newCameraUI')).thenReturn(true);
+      // Change a flag - find the enhancedAnalytics switch specifically
+      when(() => mockPrefs.getBool('ff_enhancedAnalytics')).thenReturn(true);
+      when(
+        () => mockPrefs.containsKey('ff_enhancedAnalytics'),
+      ).thenReturn(true);
 
-      final newCameraSwitch = find.descendant(
+      final flagSwitch = find.descendant(
         of: find.ancestor(
-          of: find.text('New Camera UI'),
+          of: find.text('Enhanced Analytics'),
           matching: find.byType(Card),
         ),
         matching: find.byType(Switch),
       );
-      await tester.tap(newCameraSwitch);
+      await tester.tap(flagSwitch);
       await tester.pumpAndSettle();
 
       // Verify persistence call
-      verify(() => mockPrefs.setBool('ff_newCameraUI', true)).called(1);
+      verify(() => mockPrefs.setBool('ff_enhancedAnalytics', true)).called(1);
 
       // Simulate app restart by setting up persistence response
-      when(() => mockPrefs.getBool('ff_newCameraUI')).thenReturn(true);
-      when(() => mockPrefs.containsKey('ff_newCameraUI')).thenReturn(true);
+      when(() => mockPrefs.getBool('ff_enhancedAnalytics')).thenReturn(true);
+      when(
+        () => mockPrefs.containsKey('ff_enhancedAnalytics'),
+      ).thenReturn(true);
 
       // Create new app instance (simulating restart)
       await tester.pumpWidget(
@@ -255,8 +263,10 @@ void main() {
 
     testWidgets('should handle flag reset functionality', (tester) async {
       // Set up flags with user overrides
-      when(() => mockPrefs.getBool('ff_newCameraUI')).thenReturn(true);
-      when(() => mockPrefs.containsKey('ff_newCameraUI')).thenReturn(true);
+      when(() => mockPrefs.getBool('ff_enhancedAnalytics')).thenReturn(true);
+      when(
+        () => mockPrefs.containsKey('ff_enhancedAnalytics'),
+      ).thenReturn(true);
 
       await tester.pumpWidget(
         ProviderScope(
@@ -268,7 +278,7 @@ void main() {
               body: Column(
                 children: [
                   FeatureFlagWidget(
-                    flag: FeatureFlag.newCameraUI,
+                    flag: FeatureFlag.enhancedAnalytics,
                     disabled: Text('Standard Camera'),
                     child: Text('Enhanced Camera'),
                   ),
@@ -319,8 +329,10 @@ void main() {
 
     testWidgets('should show override indicators correctly', (tester) async {
       // Set up one flag with user override, one with default
-      when(() => mockPrefs.getBool('ff_newCameraUI')).thenReturn(true);
-      when(() => mockPrefs.containsKey('ff_newCameraUI')).thenReturn(true);
+      when(() => mockPrefs.getBool('ff_enhancedAnalytics')).thenReturn(true);
+      when(
+        () => mockPrefs.containsKey('ff_enhancedAnalytics'),
+      ).thenReturn(true);
 
       await tester.pumpWidget(
         ProviderScope(
@@ -364,7 +376,7 @@ void main() {
               body: Column(
                 children: [
                   const FeatureFlagWidget(
-                    flag: FeatureFlag.newCameraUI,
+                    flag: FeatureFlag.enhancedAnalytics,
                     disabled: Text('Standard Camera'),
                     child: Text('Enhanced Camera'),
                   ),
@@ -414,14 +426,14 @@ void main() {
       await tester.pumpAndSettle();
 
       // Try to toggle a flag - should not crash the app but should update UI
-      final newCameraSwitch = find.descendant(
+      final flagSwitch = find.descendant(
         of: find.ancestor(
-          of: find.text('New Camera UI'),
+          of: find.text('Enhanced Analytics'),
           matching: find.byType(Card),
         ),
         matching: find.byType(Switch),
       );
-      await tester.tap(newCameraSwitch);
+      await tester.tap(flagSwitch);
       await tester.pumpAndSettle();
 
       // App should still be functional
@@ -450,7 +462,7 @@ class TestHomeScreen extends ConsumerWidget {
       body: Column(
         children: [
           const FeatureFlagWidget(
-            flag: FeatureFlag.newCameraUI,
+            flag: FeatureFlag.enhancedAnalytics,
             disabled: Text('Standard Camera UI'),
             child: Text('Enhanced Camera UI'),
           ),
@@ -472,7 +484,7 @@ class TestContentScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     return const Scaffold(
       body: FeatureFlagWidget(
-        flag: FeatureFlag.newCameraUI,
+        flag: FeatureFlag.enhancedAnalytics,
         disabled: Text('Standard Camera'),
         child: Text('New Camera Feature Enabled'),
       ),

--- a/mobile/test/models/feature_flag_state_test.dart
+++ b/mobile/test/models/feature_flag_state_test.dart
@@ -9,64 +9,64 @@ void main() {
   group('FeatureFlagState', () {
     test('should store flag values', () {
       const state = FeatureFlagState({
-        FeatureFlag.newCameraUI: true,
+        FeatureFlag.enhancedAnalytics: true,
       });
 
-      expect(state.isEnabled(FeatureFlag.newCameraUI), isTrue);
+      expect(state.isEnabled(FeatureFlag.enhancedAnalytics), isTrue);
     });
 
     test('should return false for undefined flags', () {
       const state = FeatureFlagState({});
-      expect(state.isEnabled(FeatureFlag.newCameraUI), isFalse);
+      expect(state.isEnabled(FeatureFlag.enhancedAnalytics), isFalse);
       expect(state.isEnabled(FeatureFlag.debugTools), isFalse);
     });
 
     test('should be immutable', () {
       const state1 = FeatureFlagState({});
-      final state2 = state1.copyWith(FeatureFlag.newCameraUI, true);
+      final state2 = state1.copyWith(FeatureFlag.enhancedAnalytics, true);
 
-      expect(state1.isEnabled(FeatureFlag.newCameraUI), isFalse);
-      expect(state2.isEnabled(FeatureFlag.newCameraUI), isTrue);
+      expect(state1.isEnabled(FeatureFlag.enhancedAnalytics), isFalse);
+      expect(state2.isEnabled(FeatureFlag.enhancedAnalytics), isTrue);
     });
 
     test('should provide all flag values', () {
       const state = FeatureFlagState({
-        FeatureFlag.newCameraUI: true,
+        FeatureFlag.enhancedAnalytics: true,
         FeatureFlag.debugTools: true,
       });
 
       final allFlags = state.allFlags;
-      expect(allFlags[FeatureFlag.newCameraUI], isTrue);
+      expect(allFlags[FeatureFlag.enhancedAnalytics], isTrue);
       expect(allFlags[FeatureFlag.debugTools], isTrue);
     });
 
     test('should handle copyWith for multiple flags', () {
-      const state1 = FeatureFlagState({FeatureFlag.newCameraUI: false});
+      const state1 = FeatureFlagState({FeatureFlag.enhancedAnalytics: false});
 
-      final state2 = state1.copyWith(FeatureFlag.newCameraUI, true);
+      final state2 = state1.copyWith(FeatureFlag.enhancedAnalytics, true);
       final state3 = state2.copyWith(FeatureFlag.accountSwitching, true);
 
-      expect(state3.isEnabled(FeatureFlag.newCameraUI), isTrue);
+      expect(state3.isEnabled(FeatureFlag.enhancedAnalytics), isTrue);
       expect(state3.isEnabled(FeatureFlag.accountSwitching), isTrue);
 
       // Original states should remain unchanged
-      expect(state1.isEnabled(FeatureFlag.newCameraUI), isFalse);
+      expect(state1.isEnabled(FeatureFlag.enhancedAnalytics), isFalse);
       expect(state2.isEnabled(FeatureFlag.accountSwitching), isFalse);
     });
 
     test('should support equality comparison', () {
       const state1 = FeatureFlagState({
-        FeatureFlag.newCameraUI: true,
+        FeatureFlag.enhancedAnalytics: true,
         FeatureFlag.debugTools: false,
       });
 
       const state2 = FeatureFlagState({
-        FeatureFlag.newCameraUI: true,
+        FeatureFlag.enhancedAnalytics: true,
         FeatureFlag.debugTools: false,
       });
 
       const state3 = FeatureFlagState({
-        FeatureFlag.newCameraUI: false,
+        FeatureFlag.enhancedAnalytics: false,
         FeatureFlag.debugTools: false,
       });
 

--- a/mobile/test/providers/feature_flag_provider_test.dart
+++ b/mobile/test/providers/feature_flag_provider_test.dart
@@ -83,8 +83,10 @@ void main() {
       }
 
       // Set up specific flag value
-      when(() => mockPrefs.getBool('ff_newCameraUI')).thenReturn(true);
-      when(() => mockPrefs.containsKey('ff_newCameraUI')).thenReturn(true);
+      when(() => mockPrefs.getBool('ff_enhancedAnalytics')).thenReturn(true);
+      when(
+        () => mockPrefs.containsKey('ff_enhancedAnalytics'),
+      ).thenReturn(true);
 
       final container = ProviderContainer(
         overrides: [sharedPreferencesProvider.overrideWithValue(mockPrefs)],
@@ -94,7 +96,7 @@ void main() {
       await service.initialize();
 
       final isEnabled = container.read(
-        isFeatureEnabledProvider(FeatureFlag.newCameraUI),
+        isFeatureEnabledProvider(FeatureFlag.enhancedAnalytics),
       );
       expect(isEnabled, isTrue);
 
@@ -124,16 +126,16 @@ void main() {
 
       // Initial state
       final initialEnabled = container.read(
-        isFeatureEnabledProvider(FeatureFlag.newCameraUI),
+        isFeatureEnabledProvider(FeatureFlag.enhancedAnalytics),
       );
       expect(initialEnabled, isFalse);
 
       // Change flag
-      await service.setFlag(FeatureFlag.newCameraUI, true);
+      await service.setFlag(FeatureFlag.enhancedAnalytics, true);
 
       // State should update
       final newEnabled = container.read(
-        isFeatureEnabledProvider(FeatureFlag.newCameraUI),
+        isFeatureEnabledProvider(FeatureFlag.enhancedAnalytics),
       );
       expect(newEnabled, isTrue);
 

--- a/mobile/test/screens/feature_flag_screen_test.dart
+++ b/mobile/test/screens/feature_flag_screen_test.dart
@@ -147,8 +147,10 @@ void main() {
 
     testWidgets('should show override indicators', (tester) async {
       // Set up one flag as having user override
-      when(() => mockPrefs.getBool('ff_newCameraUI')).thenReturn(true);
-      when(() => mockPrefs.containsKey('ff_newCameraUI')).thenReturn(true);
+      when(() => mockPrefs.getBool('ff_enhancedAnalytics')).thenReturn(true);
+      when(
+        () => mockPrefs.containsKey('ff_enhancedAnalytics'),
+      ).thenReturn(true);
 
       await tester.pumpWidget(
         ProviderScope(
@@ -169,18 +171,18 @@ void main() {
       await service.initialize();
       await tester.pumpAndSettle();
 
-      // Find the switch for newCameraUI specifically
-      final newCameraSwitch = find.descendant(
+      // Find the switch for enhancedAnalytics specifically
+      final flagSwitch = find.descendant(
         of: find.ancestor(
-          of: find.text('New Camera UI'),
+          of: find.text('Enhanced Analytics'),
           matching: find.byType(Card),
         ),
         matching: find.byType(Switch),
       );
-      expect(newCameraSwitch, findsOneWidget);
+      expect(flagSwitch, findsOneWidget);
 
       // Check if the override switch shows true
-      final switchWidget = tester.widget<Switch>(newCameraSwitch);
+      final switchWidget = tester.widget<Switch>(flagSwitch);
       expect(switchWidget.value, isTrue);
     });
 
@@ -222,8 +224,10 @@ void main() {
 
     testWidgets('should show flag states correctly', (tester) async {
       // Set up mixed flag states
-      when(() => mockPrefs.getBool('ff_newCameraUI')).thenReturn(true);
-      when(() => mockPrefs.containsKey('ff_newCameraUI')).thenReturn(true);
+      when(() => mockPrefs.getBool('ff_enhancedAnalytics')).thenReturn(true);
+      when(
+        () => mockPrefs.containsKey('ff_enhancedAnalytics'),
+      ).thenReturn(true);
 
       await tester.pumpWidget(
         ProviderScope(
@@ -249,14 +253,16 @@ void main() {
       expect(switches, hasLength(FeatureFlag.values.length));
 
       // Find switches by looking for the flag display names
-      expect(find.text('New Camera UI'), findsOneWidget);
+      expect(find.text('Enhanced Analytics'), findsOneWidget);
       // TOOD(any): Fix and re-enable these tests
     }, skip: true);
 
     testWidgets('should handle individual flag reset', (tester) async {
       // Set up a flag with user override
-      when(() => mockPrefs.getBool('ff_newCameraUI')).thenReturn(true);
-      when(() => mockPrefs.containsKey('ff_newCameraUI')).thenReturn(true);
+      when(() => mockPrefs.getBool('ff_enhancedAnalytics')).thenReturn(true);
+      when(
+        () => mockPrefs.containsKey('ff_enhancedAnalytics'),
+      ).thenReturn(true);
 
       await tester.pumpWidget(
         ProviderScope(

--- a/mobile/test/screens/video_editor_route_test.dart
+++ b/mobile/test/screens/video_editor_route_test.dart
@@ -227,9 +227,6 @@ class _MockFeatureFlagService extends FeatureFlagService {
 
   @override
   bool isEnabled(FeatureFlag flag) {
-    if (flag == FeatureFlag.enableVideoEditorV1) {
-      return enableVideoEditor;
-    }
     return false;
   }
 }

--- a/mobile/test/services/build_config_test.dart
+++ b/mobile/test/services/build_config_test.dart
@@ -22,11 +22,9 @@ void main() {
     test('should provide defaults when env vars not set', () {
       const config = BuildConfiguration();
 
-      // When FF_NEW_CAMERA_UI is not set, should default to false
-      expect(config.getDefault(FeatureFlag.newCameraUI), isFalse);
+      // When the env vars are not set, these flags default to false
       expect(config.getDefault(FeatureFlag.accountSwitching), isFalse);
       expect(config.getDefault(FeatureFlag.enhancedAnalytics), isFalse);
-      expect(config.getDefault(FeatureFlag.newProfileLayout), isFalse);
     });
 
     test('should have debug tools enabled by default in debug builds', () {
@@ -73,10 +71,6 @@ void main() {
     test('should provide environment variable key mapping', () {
       const config = BuildConfiguration();
 
-      expect(
-        config.getEnvironmentKey(FeatureFlag.newCameraUI),
-        equals('FF_NEW_CAMERA_UI'),
-      );
       expect(
         config.getEnvironmentKey(FeatureFlag.debugTools),
         equals('FF_DEBUG_TOOLS'),

--- a/mobile/test/services/feature_flag_service_test.dart
+++ b/mobile/test/services/feature_flag_service_test.dart
@@ -35,11 +35,11 @@ void main() {
 
     group('initialization', () {
       test('should load saved flags from preferences', () async {
-        when(() => mockPrefs.getBool('ff_newCameraUI')).thenReturn(true);
+        when(() => mockPrefs.getBool('ff_enhancedAnalytics')).thenReturn(true);
 
         await service.initialize();
 
-        expect(service.isEnabled(FeatureFlag.newCameraUI), isTrue);
+        expect(service.isEnabled(FeatureFlag.enhancedAnalytics), isTrue);
         expect(service.isEnabled(FeatureFlag.accountSwitching), isFalse);
       });
 
@@ -56,19 +56,19 @@ void main() {
 
       test('should prefer user settings over build defaults', () async {
         // Build default is false, user set to true
-        when(() => mockPrefs.getBool('ff_newCameraUI')).thenReturn(true);
+        when(() => mockPrefs.getBool('ff_enhancedAnalytics')).thenReturn(true);
 
         await service.initialize();
 
-        expect(service.isEnabled(FeatureFlag.newCameraUI), isTrue);
+        expect(service.isEnabled(FeatureFlag.enhancedAnalytics), isTrue);
       });
     });
 
     group('flag management', () {
       test('should save flag changes to preferences', () async {
-        await service.setFlag(FeatureFlag.newCameraUI, true);
+        await service.setFlag(FeatureFlag.enhancedAnalytics, true);
 
-        verify(() => mockPrefs.setBool('ff_newCameraUI', true)).called(1);
+        verify(() => mockPrefs.setBool('ff_enhancedAnalytics', true)).called(1);
       });
 
       test('should notify listeners on flag change', () async {
@@ -78,17 +78,19 @@ void main() {
 
       test('should reset flag to build default', () async {
         when(
-          () => mockPrefs.remove('ff_newCameraUI'),
+          () => mockPrefs.remove('ff_enhancedAnalytics'),
         ).thenAnswer((_) async => true);
 
-        await service.setFlag(FeatureFlag.newCameraUI, true);
-        await service.resetFlag(FeatureFlag.newCameraUI);
+        await service.setFlag(FeatureFlag.enhancedAnalytics, true);
+        await service.resetFlag(FeatureFlag.enhancedAnalytics);
 
-        verify(() => mockPrefs.remove('ff_newCameraUI')).called(1);
+        verify(() => mockPrefs.remove('ff_enhancedAnalytics')).called(1);
         expect(
-          service.isEnabled(FeatureFlag.newCameraUI),
+          service.isEnabled(FeatureFlag.enhancedAnalytics),
           equals(
-            const BuildConfiguration().getDefault(FeatureFlag.newCameraUI),
+            const BuildConfiguration().getDefault(
+              FeatureFlag.enhancedAnalytics,
+            ),
           ),
         );
       });
@@ -96,7 +98,7 @@ void main() {
       test('should reset all flags', () async {
         when(() => mockPrefs.remove(any())).thenAnswer((_) async => true);
 
-        await service.setFlag(FeatureFlag.newCameraUI, true);
+        await service.setFlag(FeatureFlag.enhancedAnalytics, true);
         await service.setFlag(FeatureFlag.accountSwitching, true);
 
         await service.resetAllFlags();
@@ -109,9 +111,11 @@ void main() {
 
     group('state queries', () {
       test('should identify user overrides', () async {
-        when(() => mockPrefs.containsKey('ff_newCameraUI')).thenReturn(true);
+        when(
+          () => mockPrefs.containsKey('ff_enhancedAnalytics'),
+        ).thenReturn(true);
 
-        expect(service.hasUserOverride(FeatureFlag.newCameraUI), isTrue);
+        expect(service.hasUserOverride(FeatureFlag.enhancedAnalytics), isTrue);
         expect(
           service.hasUserOverride(FeatureFlag.accountSwitching),
           isFalse,
@@ -119,9 +123,9 @@ void main() {
       });
 
       test('should provide flag metadata', () {
-        final metadata = service.getFlagMetadata(FeatureFlag.newCameraUI);
+        final metadata = service.getFlagMetadata(FeatureFlag.enhancedAnalytics);
 
-        expect(metadata.flag, equals(FeatureFlag.newCameraUI));
+        expect(metadata.flag, equals(FeatureFlag.enhancedAnalytics));
         expect(metadata.isEnabled, isNotNull);
         expect(metadata.hasUserOverride, isNotNull);
         expect(metadata.buildDefault, isNotNull);
@@ -142,11 +146,11 @@ void main() {
       test('should update state when flags change', () async {
         final initialState = service.currentState;
 
-        await service.setFlag(FeatureFlag.newCameraUI, true);
+        await service.setFlag(FeatureFlag.enhancedAnalytics, true);
 
         final newState = service.currentState;
         expect(newState, isNot(equals(initialState)));
-        expect(newState.isEnabled(FeatureFlag.newCameraUI), isTrue);
+        expect(newState.isEnabled(FeatureFlag.enhancedAnalytics), isTrue);
       });
     });
   });

--- a/mobile/test/widgets/feature_flag_widget_test.dart
+++ b/mobile/test/widgets/feature_flag_widget_test.dart
@@ -36,8 +36,10 @@ void main() {
 
     testWidgets('should show child when flag enabled', (tester) async {
       // Set flag as enabled
-      when(() => mockPrefs.getBool('ff_newCameraUI')).thenReturn(true);
-      when(() => mockPrefs.containsKey('ff_newCameraUI')).thenReturn(true);
+      when(() => mockPrefs.getBool('ff_enhancedAnalytics')).thenReturn(true);
+      when(
+        () => mockPrefs.containsKey('ff_enhancedAnalytics'),
+      ).thenReturn(true);
 
       await tester.pumpWidget(
         ProviderScope(
@@ -46,7 +48,7 @@ void main() {
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
             home: FeatureFlagWidget(
-              flag: FeatureFlag.newCameraUI,
+              flag: FeatureFlag.enhancedAnalytics,
               child: Text('Enabled Content'),
             ),
           ),
@@ -73,7 +75,7 @@ void main() {
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
             home: FeatureFlagWidget(
-              flag: FeatureFlag.newCameraUI,
+              flag: FeatureFlag.enhancedAnalytics,
               disabled: Text('Disabled Content'),
               child: Text('Enabled Content'),
             ),
@@ -100,7 +102,7 @@ void main() {
                 children: [
                   const Text('Before'),
                   FeatureFlagWidget(
-                    flag: FeatureFlag.newCameraUI,
+                    flag: FeatureFlag.enhancedAnalytics,
                     child: Container(
                       height: 100,
                       width: 100,
@@ -131,7 +133,7 @@ void main() {
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
             home: FeatureFlagWidget(
-              flag: FeatureFlag.newCameraUI,
+              flag: FeatureFlag.enhancedAnalytics,
               disabled: Text('Disabled Content'),
               child: Text('Enabled Content'),
             ),
@@ -146,15 +148,17 @@ void main() {
       expect(find.text('Enabled Content'), findsNothing);
 
       // Enable the flag
-      when(() => mockPrefs.getBool('ff_newCameraUI')).thenReturn(true);
-      when(() => mockPrefs.containsKey('ff_newCameraUI')).thenReturn(true);
+      when(() => mockPrefs.getBool('ff_enhancedAnalytics')).thenReturn(true);
+      when(
+        () => mockPrefs.containsKey('ff_enhancedAnalytics'),
+      ).thenReturn(true);
 
       // Trigger a rebuild by getting the service and changing the flag
       final container = ProviderScope.containerOf(
         tester.element(find.byType(FeatureFlagWidget)),
       );
       final service = container.read(featureFlagServiceProvider);
-      await service.setFlag(FeatureFlag.newCameraUI, true);
+      await service.setFlag(FeatureFlag.enhancedAnalytics, true);
 
       await tester.pumpAndSettle();
 
@@ -165,8 +169,10 @@ void main() {
 
     testWidgets('should handle multiple flags independently', (tester) async {
       // Set up different states for different flags
-      when(() => mockPrefs.getBool('ff_newCameraUI')).thenReturn(true);
-      when(() => mockPrefs.containsKey('ff_newCameraUI')).thenReturn(true);
+      when(() => mockPrefs.getBool('ff_enhancedAnalytics')).thenReturn(true);
+      when(
+        () => mockPrefs.containsKey('ff_enhancedAnalytics'),
+      ).thenReturn(true);
 
       await tester.pumpWidget(
         ProviderScope(
@@ -177,7 +183,7 @@ void main() {
             home: Column(
               children: [
                 FeatureFlagWidget(
-                  flag: FeatureFlag.newCameraUI,
+                  flag: FeatureFlag.enhancedAnalytics,
                   disabled: Text('Camera UI Disabled'),
                   child: Text('Camera UI Enabled'),
                 ),
@@ -216,7 +222,7 @@ void main() {
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
             home: FeatureFlagWidget(
-              flag: FeatureFlag.newCameraUI,
+              flag: FeatureFlag.enhancedAnalytics,
               disabled: Text('Disabled Content'),
               loading: CircularProgressIndicator(),
               child: Text('Enabled Content'),

--- a/mobile/test/widgets/nostr_settings_screen_test.dart
+++ b/mobile/test/widgets/nostr_settings_screen_test.dart
@@ -10,7 +10,6 @@ import 'package:nostr_key_manager/nostr_key_manager.dart'
     show SecureKeyStorageException;
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
-import 'package:openvine/features/feature_flags/screens/feature_flag_screen.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
@@ -93,19 +92,6 @@ void main() {
       );
       await tester.pumpAndSettle();
     }
-
-    testWidgets('shows Experimental Features tile and opens feature flags', (
-      tester,
-    ) async {
-      await pumpSubject(tester);
-
-      expect(find.text(l10n.settingsExperimentalFeatures), findsOneWidget);
-
-      await tester.tap(find.text(l10n.settingsExperimentalFeatures));
-      await tester.pumpAndSettle();
-
-      expect(find.byType(FeatureFlagScreen), findsOneWidget);
-    });
 
     testWidgets('hides Relays and Relay Diagnostics tiles when '
         'advancedRelaySettings flag is off', (tester) async {


### PR DESCRIPTION
Closes #6257

## What

Removes five feature flags that had no remaining call sites in `lib/`:
`newCameraUI`, `newProfileLayout`, `routerDrivenHome`,
`enableVideoEditorV1`, `classicsHashtags`.

## Why

These flags were dead — nothing in `lib/` read them anymore. Removing the
enum values surfaced dangling references that broke `flutter analyze` and
the test suite:

- The flag test files used `newCameraUI` as their generic example flag
  (79 references across six files). Renamed consistently to
  `enhancedAnalytics`, which shares the same `false` build default, so the
  defaults-based assertions stay valid.
- The feed edit button no longer needs a flag gate — it shows for owned,
  non-preview videos — so its `featureFlagServiceProvider` lookup and the
  two now-orphaned imports in `video_feed_item.dart` are dropped. Its
  gating comment is refreshed to match (no more flag reference).
- The experimental-features settings tile was **duplicated** in both the
  Nostr settings screen and the general settings screen. The redundant
  Nostr copy is removed (dropping its now-unused `FeatureFlagScreen`
  import); the general-settings entry point stays. The
  `nostr_settings_screen` widget test that asserted the removed tile is
  dropped to match.

## Testing

- `flutter analyze` — clean
- Feature-flag suite + touched tests (incl. `nostr_settings_screen_test`):
  all pass

## Optional follow-ups (not in this PR)

- l10n key `nostrSettingsExperimentalFeaturesSubtitle` is now unused (only
  in the ARB + generated files). Left in place — removing it touches 17
  `app_*.arb` files.
- The skipped `video_editor_route_test.dart` "Edit Button Tests" group is
  now semantically stale (the edit button is no longer flag-gated). Left
  as the pre-existing skip.
