### PR TITLE
fix(video-recorder): meet 48dp min touch target on mode selector

### DIFF
--- a/mobile/lib/widgets/video_recorder/video_recorder_bottom_bar.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_bottom_bar.dart
@@ -29,13 +29,12 @@ class VideoRecorderBottomBar extends StatelessWidget {
         child: Padding(
           padding: const EdgeInsets.only(bottom: 4),
           child: Stack(
+            alignment: .center,
             children: [
-              Align(
-                child: VideoRecorderModeSelectorWheel(
-                  selectedMode: state.recorderMode,
-                  onModeChanged: (mode) => context
-                      .read<VideoRecorderBloc>()
-                      .add(VideoRecorderRecorderModeSet(mode)),
+              VideoRecorderModeSelectorWheel(
+                selectedMode: state.recorderMode,
+                onModeChanged: (mode) => context.read<VideoRecorderBloc>().add(
+                  VideoRecorderRecorderModeSet(mode),
                 ),
               ),
               const Align(

--- a/mobile/lib/widgets/video_recorder/video_recorder_library_button.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_library_button.dart
@@ -75,7 +75,8 @@ class _VideoRecorderLibraryButtonState
             ? context.l10n.videoRecorderLibraryOpenLabel(clips.length)
             : context.l10n.videoRecorderLibraryEmptyLabel,
         enabled: hasClips,
-        child: InkWell(
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
           onTap: hasClips
               ? () async {
                   await openRecorderLibrary(context, ref);

--- a/mobile/lib/widgets/video_recorder/video_recorder_mode_selector.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_mode_selector.dart
@@ -122,7 +122,7 @@ class _VideoRecorderModeSelectorWheelState
       builder: (context, constraints) {
         final sidePadding = (constraints.maxWidth - _itemExtent) / 2;
         return SizedBox(
-          height: _pillHeight,
+          height: kMinInteractiveDimension,
           child: Stack(
             alignment: .center,
             children: [

--- a/mobile/test/widgets/video_recorder/video_recorder_library_button_test.dart
+++ b/mobile/test/widgets/video_recorder/video_recorder_library_button_test.dart
@@ -225,7 +225,7 @@ void main() {
     });
 
     group('enabled/onTap consistency', () {
-      testWidgets('InkWell onTap is non-null when clips exist '
+      testWidgets('GestureDetector onTap is non-null when clips exist '
           'but thumbnailPath is null', (tester) async {
         // Session clips without thumbnails — button should still be enabled
         final clips = [
@@ -243,11 +243,18 @@ void main() {
         await tester.pumpWidget(buildWidget(clips: clips));
         await tester.pumpAndSettle();
 
-        final inkWell = tester.widget<InkWell>(find.byType(InkWell));
-        expect(inkWell.onTap, isNotNull);
+        final detector = tester
+            .widgetList<GestureDetector>(
+              find.descendant(
+                of: find.byType(VideoRecorderLibraryButton),
+                matching: find.byType(GestureDetector),
+              ),
+            )
+            .first;
+        expect(detector.onTap, isNotNull);
       });
 
-      testWidgets('InkWell onTap is non-null when no session clips '
+      testWidgets('GestureDetector onTap is non-null when no session clips '
           'but library has clips', (tester) async {
         // No session clips, but library service returns clips
         final libraryClip = DivineVideoClip(
@@ -267,11 +274,18 @@ void main() {
         await tester.pumpWidget(buildWidget());
         await tester.pumpAndSettle();
 
-        final inkWell = tester.widget<InkWell>(find.byType(InkWell));
-        expect(inkWell.onTap, isNotNull);
+        final detector = tester
+            .widgetList<GestureDetector>(
+              find.descendant(
+                of: find.byType(VideoRecorderLibraryButton),
+                matching: find.byType(GestureDetector),
+              ),
+            )
+            .first;
+        expect(detector.onTap, isNotNull);
       });
 
-      testWidgets('Semantics.enabled matches InkWell.onTap presence', (
+      testWidgets('Semantics.enabled matches GestureDetector.onTap presence', (
         tester,
       ) async {
         final clips = [
@@ -288,7 +302,14 @@ void main() {
         await tester.pumpWidget(buildWidget(clips: clips));
         await tester.pumpAndSettle();
 
-        final inkWell = tester.widget<InkWell>(find.byType(InkWell));
+        final detector = tester
+            .widgetList<GestureDetector>(
+              find.descendant(
+                of: find.byType(VideoRecorderLibraryButton),
+                matching: find.byType(GestureDetector),
+              ),
+            )
+            .first;
         final semantics = tester.widget<Semantics>(
           find
               .descendant(
@@ -299,7 +320,7 @@ void main() {
         );
 
         // Both should agree: button is enabled
-        expect(inkWell.onTap, isNotNull);
+        expect(detector.onTap, isNotNull);
         expect(semantics.properties.enabled, isTrue);
       });
     });

--- a/mobile/test/widgets/video_recorder/video_recorder_mode_selector_test.dart
+++ b/mobile/test/widgets/video_recorder/video_recorder_mode_selector_test.dart
@@ -105,13 +105,37 @@ void main() {
     });
 
     group('accessibility', () {
-      testWidgets('has Semantics for each mode', (tester) async {
+      testWidgets('each mode is exposed as a selectable Semantics button', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildWidget(mode: VideoRecorderMode.capture));
+        await tester.pumpAndSettle();
+
+        final selected = tester
+            .widgetList<Semantics>(find.byType(Semantics))
+            .firstWhere(
+              (s) => s.properties.label == VideoRecorderMode.capture.label,
+            );
+        expect(selected.properties.button, isTrue);
+        expect(selected.properties.selected, isTrue);
+      });
+
+      testWidgets('each mode tap target meets the 48dp minimum', (
+        tester,
+      ) async {
         await tester.pumpWidget(buildWidget());
         await tester.pumpAndSettle();
 
-        // Each mode should have a Text widget with the mode label
-        for (final mode in VideoRecorderMode.values) {
-          expect(find.text(mode.label), findsOneWidget);
+        final targets = find.descendant(
+          of: find.byType(ListView),
+          matching: find.byType(GestureDetector),
+        );
+        expect(targets, findsWidgets);
+        for (final target in targets.evaluate()) {
+          expect(
+            tester.getSize(find.byWidget(target.widget)).height,
+            greaterThanOrEqualTo(kMinInteractiveDimension),
+          );
         }
       });
     });

--- a/mobile/test/widgets/video_recorder/video_recorder_mode_selector_test.dart
+++ b/mobile/test/widgets/video_recorder/video_recorder_mode_selector_test.dart
@@ -111,13 +111,16 @@ void main() {
         await tester.pumpWidget(buildWidget(mode: VideoRecorderMode.capture));
         await tester.pumpAndSettle();
 
-        final selected = tester
-            .widgetList<Semantics>(find.byType(Semantics))
-            .firstWhere(
-              (s) => s.properties.label == VideoRecorderMode.capture.label,
-            );
-        expect(selected.properties.button, isTrue);
-        expect(selected.properties.selected, isTrue);
+        for (final mode in VideoRecorderMode.values) {
+          final semantics = tester
+              .widgetList<Semantics>(find.byType(Semantics))
+              .firstWhere((s) => s.properties.label == mode.label);
+          expect(semantics.properties.button, isTrue);
+          expect(
+            semantics.properties.selected,
+            mode == VideoRecorderMode.capture,
+          );
+        }
       });
 
       testWidgets('each mode tap target meets the 48dp minimum', (


### PR DESCRIPTION
Closes #6259

## Description

The horizontal recorder **mode selector** capped each item's tap target at the 34dp pill height, below the 48dp minimum touch target ([`accessibility.md`](.claude/rules/accessibility.md)). The wheel now takes a `kMinInteractiveDimension` (48dp) height, so each item's hit area meets the minimum. The **pill stays visually 34dp** — it's a fixed, centered `AnimatedContainer`, so only the invisible hit strip around each label grows; nothing moves on screen. Width was already fine (96dp item extent).

While in there, two related bottom-bar fixes:

- **Vertical centering.** The shorter library button (40dp) was pinned to the top of the bar because the `Stack` used its default `topStart` alignment while the button's `Align(centerLeft)` shrink-wrapped to 40dp. The `Stack` now uses `alignment: .center`, and the redundant `Align` wrapper around the wheel is removed — both the wheel and the library button are centered on the same line.
- **Library button tap.** Swapped `InkWell` → `GestureDetector(behavior: HitTestBehavior.opaque)`. The ink ripple was invisible anyway (the opaque thumbnail paints over it), and `opaque` keeps the full 40×40 tappable even during the brief window before a thumbnail loads.

**Related Issue:** 

## Out of Scope

- The library button itself is 40×40 dp (below the 48dp minimum). Pre-existing; left untouched to keep this PR focused on the mode selector. Can be a follow-up.

## Verification

- `flutter analyze lib/widgets/video_recorder test/widgets/video_recorder` — clean
- `flutter test test/widgets/video_recorder/` — 222 passing, including a new regression test asserting each mode item's tap target is ≥ `kMinInteractiveDimension`
- `dart format` — clean

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)