### PR TITLE
fix(apps): enable Android image upload in Nostr app sandbox WebView

### DIFF
--- a/mobile/lib/screens/apps/nostr_app_sandbox_screen.dart
+++ b/mobile/lib/screens/apps/nostr_app_sandbox_screen.dart
@@ -12,6 +12,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:http/http.dart' as http;
+import 'package:image_picker/image_picker.dart';
 import 'package:nostr_app_bridge_repository/nostr_app_bridge_repository.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
@@ -39,6 +40,11 @@ class NostrAppSandboxScreen extends ConsumerStatefulWidget {
   static const routeName = 'nostr-app-sandbox';
   static const path = '/apps/:appId/sandbox';
   static const bridgeChannelName = 'divineSandboxBridge';
+
+  /// Default [ImagePicker] backing the Android `<input type="file">` picker.
+  /// Exposed so tests can swap in a mock; production reads it as-is.
+  @visibleForTesting
+  static ImagePicker imagePicker = ImagePicker();
 
   const NostrAppSandboxScreen({
     required this.app,
@@ -273,6 +279,25 @@ class _NostrAppSandboxScreenState extends ConsumerState<NostrAppSandboxScreen> {
         }
       },
     );
+
+    // Without this, `webview_flutter` silently ignores HTML file inputs on
+    // Android, so image uploads inside sandboxed apps (e.g. badges) do nothing.
+    final platformController = controller.platform;
+    if (platformController is AndroidWebViewController) {
+      await platformController.setOnShowFileSelector(
+        (params) => sandboxAndroidFileSelector(
+          params,
+          NostrAppSandboxScreen.imagePicker,
+        ),
+      );
+      // The picker hands back a file:// URI; the WebView can only read it with
+      // file access enabled, which defaults to false on Android 11+. Without
+      // this the file is chosen but never populates the <input> (0-byte read).
+      // Cross-origin reads from file:// stay disabled (their own settings
+      // default to false), so an allowed https app can't script-read local
+      // files — only the user-chosen upload is readable.
+      await platformController.setAllowFileAccess(true);
+    }
 
     // Replace the pigeon message channel with the native frame-attesting one
     // (iOS: WKScriptMessageHandler reading frameInfo; Android: WebMessageListener
@@ -740,4 +765,56 @@ class _BootstrappedSandboxPage {
 
   final Uri baseUri;
   final String html;
+}
+
+/// Resolves an Android WebView file-chooser request into `file://` URIs the
+/// WebView can read back into the HTML `<input type="file">`.
+///
+/// Sandboxed apps only ever need images (e.g. badge artwork), so this offers
+/// the native image picker — camera when the input requests capture, gallery
+/// otherwise. Returns an empty list when the input wants a non-image type or
+/// the user cancels, which the WebView treats as "no file selected".
+@visibleForTesting
+Future<List<String>> sandboxAndroidFileSelector(
+  FileSelectorParams params,
+  ImagePicker picker,
+) async {
+  final acceptsImage =
+      params.acceptTypes.isEmpty || params.acceptTypes.any(_acceptsImageType);
+  if (!acceptsImage) {
+    return const <String>[];
+  }
+
+  try {
+    if (params.mode == FileSelectorMode.openMultiple) {
+      final files = await picker.pickMultiImage();
+      return files.map((file) => Uri.file(file.path).toString()).toList();
+    }
+
+    final source = params.isCaptureEnabled
+        ? ImageSource.camera
+        : ImageSource.gallery;
+    final file = await picker.pickImage(source: source);
+    if (file == null) {
+      return const <String>[];
+    }
+    return <String>[Uri.file(file.path).toString()];
+  } catch (error, stackTrace) {
+    Log.error(
+      'Sandbox WebView file selection failed: $error',
+      name: 'NostrAppSandboxScreen',
+      category: LogCategory.ui,
+      error: error,
+      stackTrace: stackTrace,
+    );
+    return const <String>[];
+  }
+}
+
+bool _acceptsImageType(String type) {
+  final normalized = type.trim().toLowerCase();
+  return normalized.startsWith('image/') ||
+      const {'.jpg', '.jpeg', '.png', '.gif', '.webp', '.heic'}.contains(
+        normalized,
+      );
 }

--- a/mobile/lib/screens/apps/nostr_app_sandbox_screen.dart
+++ b/mobile/lib/screens/apps/nostr_app_sandbox_screen.dart
@@ -3,6 +3,7 @@
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 import 'dart:math';
 
 import 'package:divine_ui/divine_ui.dart';
@@ -12,6 +13,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:http/http.dart' as http;
+import 'package:image_metadata_stripper/image_metadata_stripper.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:nostr_app_bridge_repository/nostr_app_bridge_repository.dart';
 import 'package:openvine/l10n/l10n.dart';
@@ -26,6 +28,7 @@ import 'package:webview_flutter_wkwebview/webview_flutter_wkwebview.dart';
 typedef SandboxViewBuilder =
     Widget Function(void Function(Uri uri) onNavigationAttempt);
 typedef SandboxJavaScriptRunner = Future<void> Function(String script);
+typedef SandboxImageMetadataStripper = Future<File> Function(File imageFile);
 
 const _bridgePayloadObjectMessage = 'Bridge payload must be a JSON object';
 const _bridgeMethodRequiredMessage = 'Bridge method is required';
@@ -765,23 +768,40 @@ class _BootstrappedSandboxPage {
 /// Resolves an Android WebView file-chooser request into `file://` URIs the
 /// WebView can read back into the HTML `<input type="file">`.
 ///
-/// Sandboxed apps only ever need images (e.g. badge artwork), so this offers
-/// the native image picker — camera when the input requests capture, gallery
-/// otherwise. Returns an empty list when the input wants a non-image type or
-/// the user cancels, which the WebView treats as "no file selected".
+/// This intentionally narrows Android sandbox uploads to images for now:
+/// camera when the input requests capture, gallery otherwise. Picked files are
+/// stripped of metadata before being exposed to the sandbox so third-party apps
+/// do not receive GPS or device EXIF. Returns an empty list when the input wants
+/// a non-image type, save mode, or the user cancels, which the WebView treats as
+/// "no file selected".
 @visibleForTesting
 Future<List<String>> sandboxAndroidFileSelector(
   FileSelectorParams params,
-  ImagePicker picker,
-) async {
+  ImagePicker picker, {
+  SandboxImageMetadataStripper? metadataStripper,
+}) async {
   if (!_acceptsImages(params.acceptTypes)) {
     return const <String>[];
   }
 
+  if (params.mode == FileSelectorMode.save) {
+    return const <String>[];
+  }
+
+  final stripMetadata =
+      metadataStripper ?? ImageMetadataStripper.stripMetadataInPlace;
+
   try {
     if (params.mode == FileSelectorMode.openMultiple) {
+      if (params.isCaptureEnabled) {
+        final file = await picker.pickImage(source: ImageSource.camera);
+        if (file == null) {
+          return const <String>[];
+        }
+        return _strippedFileUris([file], stripMetadata);
+      }
       final files = await picker.pickMultiImage();
-      return files.map((file) => Uri.file(file.path).toString()).toList();
+      return _strippedFileUris(files, stripMetadata);
     }
 
     final source = params.isCaptureEnabled
@@ -791,7 +811,7 @@ Future<List<String>> sandboxAndroidFileSelector(
     if (file == null) {
       return const <String>[];
     }
-    return <String>[Uri.file(file.path).toString()];
+    return _strippedFileUris([file], stripMetadata);
   } catch (error, stackTrace) {
     // Expected, user-driven paths land here too (e.g. denying the camera
     // permission throws PlatformException), so log at warning, not error.
@@ -805,6 +825,18 @@ Future<List<String>> sandboxAndroidFileSelector(
     );
     return const <String>[];
   }
+}
+
+Future<List<String>> _strippedFileUris(
+  List<XFile> files,
+  SandboxImageMetadataStripper stripMetadata,
+) async {
+  final strippedFiles = <String>[];
+  for (final file in files) {
+    final strippedFile = await stripMetadata(File(file.path));
+    strippedFiles.add(Uri.file(strippedFile.path).toString());
+  }
+  return strippedFiles;
 }
 
 /// Whether the `<input accept="…">` tokens permit an image.
@@ -831,7 +863,17 @@ bool _isAnyFileToken(String type) {
 bool _acceptsImageType(String type) {
   final normalized = type.trim().toLowerCase();
   return normalized.startsWith('image/') ||
-      const {'.jpg', '.jpeg', '.png', '.gif', '.webp', '.heic'}.contains(
-        normalized,
-      );
+      const {
+        '.avif',
+        '.bmp',
+        '.gif',
+        '.heic',
+        '.heif',
+        '.jpg',
+        '.jpeg',
+        '.png',
+        '.tif',
+        '.tiff',
+        '.webp',
+      }.contains(normalized);
 }

--- a/mobile/lib/screens/apps/nostr_app_sandbox_screen.dart
+++ b/mobile/lib/screens/apps/nostr_app_sandbox_screen.dart
@@ -41,11 +41,6 @@ class NostrAppSandboxScreen extends ConsumerStatefulWidget {
   static const path = '/apps/:appId/sandbox';
   static const bridgeChannelName = 'divineSandboxBridge';
 
-  /// Default [ImagePicker] backing the Android `<input type="file">` picker.
-  /// Exposed so tests can swap in a mock; production reads it as-is.
-  @visibleForTesting
-  static ImagePicker imagePicker = ImagePicker();
-
   const NostrAppSandboxScreen({
     required this.app,
     this.sandboxBuilder,
@@ -284,18 +279,18 @@ class _NostrAppSandboxScreenState extends ConsumerState<NostrAppSandboxScreen> {
     // Android, so image uploads inside sandboxed apps (e.g. badges) do nothing.
     final platformController = controller.platform;
     if (platformController is AndroidWebViewController) {
+      final imagePicker = ImagePicker();
       await platformController.setOnShowFileSelector(
-        (params) => sandboxAndroidFileSelector(
-          params,
-          NostrAppSandboxScreen.imagePicker,
-        ),
+        (params) => sandboxAndroidFileSelector(params, imagePicker),
       );
       // The picker hands back a file:// URI; the WebView can only read it with
       // file access enabled, which defaults to false on Android 11+. Without
       // this the file is chosen but never populates the <input> (0-byte read).
-      // Cross-origin reads from file:// stay disabled (their own settings
-      // default to false), so an allowed https app can't script-read local
-      // files — only the user-chosen upload is readable.
+      // The https sandbox document still can't script-read local file
+      // contents: same-origin policy blocks fetch/XHR to file://, and canvas
+      // tainting blocks reading back <img src="file://…"> pixels. (The
+      // setAllow*FileURLs knobs govern file://-origin documents, which we
+      // never load, so they stay at their safe defaults.)
       await platformController.setAllowFileAccess(true);
     }
 
@@ -800,10 +795,13 @@ Future<List<String>> sandboxAndroidFileSelector(
     }
     return <String>[Uri.file(file.path).toString()];
   } catch (error, stackTrace) {
-    Log.error(
+    // Expected, user-driven paths land here too (e.g. denying the camera
+    // permission throws PlatformException), so log at warning, not error.
+    Log.log(
       'Sandbox WebView file selection failed: $error',
       name: 'NostrAppSandboxScreen',
       category: LogCategory.ui,
+      level: LogLevel.warning,
       error: error,
       stackTrace: stackTrace,
     );

--- a/mobile/lib/screens/apps/nostr_app_sandbox_screen.dart
+++ b/mobile/lib/screens/apps/nostr_app_sandbox_screen.dart
@@ -774,9 +774,7 @@ Future<List<String>> sandboxAndroidFileSelector(
   FileSelectorParams params,
   ImagePicker picker,
 ) async {
-  final acceptsImage =
-      params.acceptTypes.isEmpty || params.acceptTypes.any(_acceptsImageType);
-  if (!acceptsImage) {
+  if (!_acceptsImages(params.acceptTypes)) {
     return const <String>[];
   }
 
@@ -807,6 +805,27 @@ Future<List<String>> sandboxAndroidFileSelector(
     );
     return const <String>[];
   }
+}
+
+/// Whether the `<input accept="…">` tokens permit an image.
+///
+/// An empty list and every "any file" spelling fall through to the image
+/// picker. Android delivers a plain `<input type="file">` (no accept attr) as
+/// `['']`, not `[]`, so `''` counts as accept-anything alongside `*` and
+/// `*/*`. Otherwise the input must explicitly allow an image MIME type
+/// (`image/*`, `image/png`, …) or a listed bare extension.
+bool _acceptsImages(List<String> acceptTypes) {
+  if (acceptTypes.isEmpty) {
+    return true;
+  }
+  return acceptTypes.any(
+    (type) => _isAnyFileToken(type) || _acceptsImageType(type),
+  );
+}
+
+bool _isAnyFileToken(String type) {
+  final normalized = type.trim().toLowerCase();
+  return normalized.isEmpty || normalized == '*' || normalized == '*/*';
 }
 
 bool _acceptsImageType(String type) {

--- a/mobile/test/screens/apps/nostr_app_sandbox_screen_test.dart
+++ b/mobile/test/screens/apps/nostr_app_sandbox_screen_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/foundation.dart';
@@ -895,14 +896,39 @@ void main() {
       );
     }
 
+    Future<File> passthroughStripper(File imageFile) async => imageFile;
+
     test('returns a file:// URI picked from the gallery', () async {
       when(
         () => picker.pickImage(source: ImageSource.gallery),
       ).thenAnswer((_) async => XFile('/tmp/badge.png'));
 
-      final result = await sandboxAndroidFileSelector(params(), picker);
+      final result = await sandboxAndroidFileSelector(
+        params(),
+        picker,
+        metadataStripper: passthroughStripper,
+      );
 
       expect(result, equals(['file:///tmp/badge.png']));
+    });
+
+    test('strips image metadata before returning the file URI', () async {
+      final strippedPaths = <String>[];
+      when(
+        () => picker.pickImage(source: ImageSource.gallery),
+      ).thenAnswer((_) async => XFile('/tmp/badge.png'));
+
+      final result = await sandboxAndroidFileSelector(
+        params(),
+        picker,
+        metadataStripper: (imageFile) async {
+          strippedPaths.add(imageFile.path);
+          return File('/tmp/badge-stripped.jpg');
+        },
+      );
+
+      expect(strippedPaths, equals(['/tmp/badge.png']));
+      expect(result, equals(['file:///tmp/badge-stripped.jpg']));
     });
 
     test('uses the camera when the input requests capture', () async {
@@ -913,6 +939,7 @@ void main() {
       final result = await sandboxAndroidFileSelector(
         params(isCaptureEnabled: true),
         picker,
+        metadataStripper: passthroughStripper,
       );
 
       expect(result, equals(['file:///tmp/shot.jpg']));
@@ -924,7 +951,11 @@ void main() {
         () => picker.pickImage(source: ImageSource.gallery),
       ).thenAnswer((_) async => null);
 
-      final result = await sandboxAndroidFileSelector(params(), picker);
+      final result = await sandboxAndroidFileSelector(
+        params(),
+        picker,
+        metadataStripper: passthroughStripper,
+      );
 
       expect(result, isEmpty);
     });
@@ -937,9 +968,42 @@ void main() {
       final result = await sandboxAndroidFileSelector(
         params(mode: FileSelectorMode.openMultiple),
         picker,
+        metadataStripper: passthroughStripper,
       );
 
       expect(result, equals(['file:///tmp/a.png', 'file:///tmp/b.png']));
+    });
+
+    test(
+      'uses the camera for openMultiple when capture is requested',
+      () async {
+        when(
+          () => picker.pickImage(source: ImageSource.camera),
+        ).thenAnswer((_) async => XFile('/tmp/capture.jpg'));
+
+        final result = await sandboxAndroidFileSelector(
+          params(mode: FileSelectorMode.openMultiple, isCaptureEnabled: true),
+          picker,
+          metadataStripper: passthroughStripper,
+        );
+
+        expect(result, equals(['file:///tmp/capture.jpg']));
+        verifyNever(() => picker.pickMultiImage());
+        verifyNever(() => picker.pickImage(source: ImageSource.gallery));
+      },
+    );
+
+    test('does not open the picker for save mode', () async {
+      final result = await sandboxAndroidFileSelector(
+        params(mode: FileSelectorMode.save),
+        picker,
+        metadataStripper: passthroughStripper,
+      );
+
+      expect(result, isEmpty);
+      verifyNever(() => picker.pickImage(source: ImageSource.gallery));
+      verifyNever(() => picker.pickImage(source: ImageSource.camera));
+      verifyNever(() => picker.pickMultiImage());
     });
 
     test('does not open the picker for a non-image accept type', () async {
@@ -962,6 +1026,7 @@ void main() {
       final result = await sandboxAndroidFileSelector(
         params(acceptTypes: const []),
         picker,
+        metadataStripper: passthroughStripper,
       );
 
       expect(result, equals(['file:///tmp/any.webp']));
@@ -980,10 +1045,30 @@ void main() {
         final result = await sandboxAndroidFileSelector(
           params(acceptTypes: [anyToken]),
           picker,
+          metadataStripper: passthroughStripper,
         );
 
         expect(result, equals(['file:///tmp/any.png']));
       });
+    }
+
+    for (final extension in const ['.avif', '.bmp', '.heif', '.tif']) {
+      test(
+        'opens the gallery for image extension token "$extension"',
+        () async {
+          when(
+            () => picker.pickImage(source: ImageSource.gallery),
+          ).thenAnswer((_) async => XFile('/tmp/extension-image'));
+
+          final result = await sandboxAndroidFileSelector(
+            params(acceptTypes: [extension]),
+            picker,
+            metadataStripper: passthroughStripper,
+          );
+
+          expect(result, equals(['file:///tmp/extension-image']));
+        },
+      );
     }
 
     test('returns empty when picking throws', () async {
@@ -991,7 +1076,11 @@ void main() {
         () => picker.pickImage(source: ImageSource.gallery),
       ).thenThrow(Exception('picker exploded'));
 
-      final result = await sandboxAndroidFileSelector(params(), picker);
+      final result = await sandboxAndroidFileSelector(
+        params(),
+        picker,
+        metadataStripper: passthroughStripper,
+      );
 
       expect(result, isEmpty);
     });

--- a/mobile/test/screens/apps/nostr_app_sandbox_screen_test.dart
+++ b/mobile/test/screens/apps/nostr_app_sandbox_screen_test.dart
@@ -6,6 +6,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:nostr_app_bridge_repository/nostr_app_bridge_repository.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/signer/nostr_signer.dart';
@@ -13,7 +15,10 @@ import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/screens/apps/nostr_app_sandbox_bridge.dart';
 import 'package:openvine/screens/apps/nostr_app_sandbox_screen.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:webview_flutter_android/webview_flutter_android.dart';
 import 'package:webview_flutter_platform_interface/webview_flutter_platform_interface.dart';
+
+class _MockImagePicker extends Mock implements ImagePicker {}
 
 void main() {
   group('NostrAppSandboxScreen', () {
@@ -868,6 +873,108 @@ void main() {
           isEmpty,
         );
       });
+    });
+  });
+
+  group('sandboxAndroidFileSelector', () {
+    late _MockImagePicker picker;
+
+    setUp(() {
+      picker = _MockImagePicker();
+    });
+
+    FileSelectorParams params({
+      List<String> acceptTypes = const ['image/*'],
+      bool isCaptureEnabled = false,
+      FileSelectorMode mode = FileSelectorMode.open,
+    }) {
+      return FileSelectorParams(
+        isCaptureEnabled: isCaptureEnabled,
+        acceptTypes: acceptTypes,
+        mode: mode,
+      );
+    }
+
+    test('returns a file:// URI picked from the gallery', () async {
+      when(
+        () => picker.pickImage(source: ImageSource.gallery),
+      ).thenAnswer((_) async => XFile('/tmp/badge.png'));
+
+      final result = await sandboxAndroidFileSelector(params(), picker);
+
+      expect(result, equals(['file:///tmp/badge.png']));
+    });
+
+    test('uses the camera when the input requests capture', () async {
+      when(
+        () => picker.pickImage(source: ImageSource.camera),
+      ).thenAnswer((_) async => XFile('/tmp/shot.jpg'));
+
+      final result = await sandboxAndroidFileSelector(
+        params(isCaptureEnabled: true),
+        picker,
+      );
+
+      expect(result, equals(['file:///tmp/shot.jpg']));
+      verifyNever(() => picker.pickImage(source: ImageSource.gallery));
+    });
+
+    test('returns empty when the user cancels the picker', () async {
+      when(
+        () => picker.pickImage(source: ImageSource.gallery),
+      ).thenAnswer((_) async => null);
+
+      final result = await sandboxAndroidFileSelector(params(), picker);
+
+      expect(result, isEmpty);
+    });
+
+    test('picks multiple images in openMultiple mode', () async {
+      when(() => picker.pickMultiImage()).thenAnswer(
+        (_) async => [XFile('/tmp/a.png'), XFile('/tmp/b.png')],
+      );
+
+      final result = await sandboxAndroidFileSelector(
+        params(mode: FileSelectorMode.openMultiple),
+        picker,
+      );
+
+      expect(result, equals(['file:///tmp/a.png', 'file:///tmp/b.png']));
+    });
+
+    test('does not open the picker for a non-image accept type', () async {
+      final result = await sandboxAndroidFileSelector(
+        params(acceptTypes: const ['application/pdf']),
+        picker,
+      );
+
+      expect(result, isEmpty);
+      verifyNever(() => picker.pickImage(source: ImageSource.gallery));
+      verifyNever(() => picker.pickImage(source: ImageSource.camera));
+      verifyNever(() => picker.pickMultiImage());
+    });
+
+    test('falls back to gallery images when no accept type is set', () async {
+      when(
+        () => picker.pickImage(source: ImageSource.gallery),
+      ).thenAnswer((_) async => XFile('/tmp/any.webp'));
+
+      final result = await sandboxAndroidFileSelector(
+        params(acceptTypes: const []),
+        picker,
+      );
+
+      expect(result, equals(['file:///tmp/any.webp']));
+    });
+
+    test('returns empty when picking throws', () async {
+      when(
+        () => picker.pickImage(source: ImageSource.gallery),
+      ).thenThrow(Exception('picker exploded'));
+
+      final result = await sandboxAndroidFileSelector(params(), picker);
+
+      expect(result, isEmpty);
     });
   });
 }

--- a/mobile/test/screens/apps/nostr_app_sandbox_screen_test.dart
+++ b/mobile/test/screens/apps/nostr_app_sandbox_screen_test.dart
@@ -967,6 +967,25 @@ void main() {
       expect(result, equals(['file:///tmp/any.webp']));
     });
 
+    // Android hands a plain `<input type="file">` (no accept attr) to the
+    // selector as `['']`, `['*']`, or `['*/*']` — not `[]`. All mean
+    // "accept anything" and must open the picker, not silently no-op.
+    for (final anyToken in const ['', '*', '*/*']) {
+      test('opens the gallery for the accept-anything token '
+          '"$anyToken"', () async {
+        when(
+          () => picker.pickImage(source: ImageSource.gallery),
+        ).thenAnswer((_) async => XFile('/tmp/any.png'));
+
+        final result = await sandboxAndroidFileSelector(
+          params(acceptTypes: [anyToken]),
+          picker,
+        );
+
+        expect(result, equals(['file:///tmp/any.png']));
+      });
+    }
+
     test('returns empty when picking throws', () async {
       when(
         () => picker.pickImage(source: ImageSource.gallery),


### PR DESCRIPTION
Closes #6263

## Problem: users can't create badges (Android side)

In the Divine Badges app (`badges.divine.video`, embedded via `NostrAppSandboxScreen`), creating a badge requires uploading a badge image. On Android that step was impossible: `webview_flutter` never surfaces an HTML `<input type="file">` to a picker unless a file-chooser handler is registered, so tapping "upload image" did nothing — the whole badge-creation flow was blocked on Android.

> Note: the badge upload also fails on every platform due to a separate **server-side** CORS bug on `upload.divine.video` (it rejects the `x-sha256` header in its preflight) — fixed in **divinevideo/divine-upload-server#11**. This PR is the Android-side prerequisite so that, once the server allows the header, Android users can actually pick and upload the image.

## What

Wires up Android file input in `NostrAppSandboxScreen`:

- Register an `image_picker`-backed `AndroidWebViewController.setOnShowFileSelector`. It offers the camera when the input requests capture, the gallery otherwise, supports multi-select, and returns `file://` URIs. An empty accept list and the "any file" spellings Android sends — `''` (a plain `<input type="file">` arrives as `['']`, not `[]`), `'*'`, `'*/*'` — fall through to the gallery; non-image accept types, save mode, and cancellation return an empty list ("no file selected").
- Strip selected image metadata before returning the `file://` URI to the sandbox WebView so third-party apps do not receive GPS/device EXIF.
- Enable `setAllowFileAccess(true)` on the Android controller. The picker hands back a `file://` URI, and the WebView can only read it with file access enabled — which defaults to `false` on Android 11+ (API 30). Without it the file is chosen but never populates the input (0-byte read). The https sandbox document still can't script-read local file contents: same-origin policy blocks fetch/XHR to `file://`, and canvas tainting blocks reading back `<img src="file://…">` pixels.

iOS already handles `<input type="file">` natively via WKWebView, so this is Android-only.

## Merge order / dependency

End-to-end badge upload stays blocked until the server-side CORS fix (divine-upload-server#11) ships. This PR makes Android file *selection* work and can merge independently; the full flow only lights up once the server side lands.

## Test plan

- `flutter test test/screens/apps/nostr_app_sandbox_screen_test.dart` — 59 passing, incl. `sandboxAndroidFileSelector` cases for gallery, camera-capture, cancel, multi-select, metadata stripping, non-image type ignored, save mode ignored, empty-list + `''`/`'*'`/`'*/*'` accept-anything, additional image extension tokens, and picker throws.
- `flutter analyze` clean.

The Android controller wiring (`setOnShowFileSelector` / `setAllowFileAccess`) can't be exercised in a widget test — the test harness's mocked `WebViewPlatform` isn't a concrete `AndroidWebViewController` — so it was verified manually on a device:

- **Gallery upload** — open the badges app → tap image upload → gallery picker opens → selected image populates the `<input>` (non-zero read).
- **Camera capture** — an input with `capture` opens the camera; captured photo populates the input. Denying the camera permission degrades gracefully (empty selection, warning log).
- **Security (file-access scope)** — from an allowed https sandbox app, confirm a scripted `fetch('file:///…')` / same-page `file://` read still fails; only the user-chosen upload is readable.
- End-to-end upload still blocked by the server CORS issue above until divine-upload-server#11 ships.
