### PR TITLE
fix(router): make every route-error screen escapable (safePop + home button)

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -2202,6 +2202,7 @@
     "routeInvalidSoundId": "ልክ ያልሆነ የድምጽ መታወቂያ",
     "routeInvalidCategory": "ልክ ያልሆነ ምድብ",
     "routeNoVideosToDisplay": "ምንም የሚታዩ ቪዲዮዎች የሉም",
+    "routeGoHome": "ወደ ቤት ሂድ",
     "routeInvalidProfileId": "ልክ ያልሆነ የመገለጫ መታወቂያ",
     "routeUnknownPath": "ያ ገጽ በመተግበሪያው ውስጥ የለም።",
     "routeDefaultListName": "ዝርዝር",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -1874,6 +1874,7 @@
     "routeInvalidSoundId": "مُعرِّف صوت غير صالح",
     "routeInvalidCategory": "فئة غير صالحة",
     "routeNoVideosToDisplay": "لا توجد مقاطع فيديو لعرضها",
+    "routeGoHome": "الذهاب إلى الرئيسية",
     "routeInvalidProfileId": "مُعرِّف ملف شخصي غير صالح",
     "routeUnknownPath": "هذه الصفحة غير متوفرة في التطبيق.",
     "routeDefaultListName": "قائمة",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -2081,6 +2081,7 @@
     "routeInvalidSoundId": "Невалиден идентификатор на звука",
     "routeInvalidCategory": "Невалидна категория",
     "routeNoVideosToDisplay": "Няма видеа за показване",
+    "routeGoHome": "Към началото",
     "routeInvalidProfileId": "Невалиден ID на потребителския профил",
     "routeUnknownPath": "Тази страница не е налична в приложението.",
     "routeDefaultListName": "Списък",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -1882,6 +1882,7 @@
     "routeInvalidSoundId": "Ungültige Sound-ID",
     "routeInvalidCategory": "Ungültige Kategorie",
     "routeNoVideosToDisplay": "Keine Videos zum Anzeigen",
+    "routeGoHome": "Zur Startseite",
     "routeInvalidProfileId": "Ungültige Profil-ID",
     "routeUnknownPath": "Diese Seite gibt es in der App nicht.",
     "routeDefaultListName": "Liste",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2583,6 +2583,10 @@
   "routeInvalidSoundId": "Invalid sound ID",
   "routeInvalidCategory": "Invalid category",
   "routeNoVideosToDisplay": "No videos to display",
+  "routeGoHome": "Go home",
+  "@routeGoHome": {
+    "description": "Button on a full-screen route error page that navigates back to the home feed. Always shown so the user is never stranded on a dead-end error screen."
+  },
   "routeInvalidProfileId": "Invalid profile ID",
   "routeUnknownPath": "That page isn’t in the app.",
   "@routeUnknownPath": {

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -1886,6 +1886,7 @@
     "routeInvalidSoundId": "ID de sonido inválido",
     "routeInvalidCategory": "Categoría inválida",
     "routeNoVideosToDisplay": "No hay videos para mostrar",
+    "routeGoHome": "Ir al inicio",
     "routeInvalidProfileId": "ID de perfil inválido",
     "routeUnknownPath": "Esa página no está en la app.",
     "routeDefaultListName": "Lista",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1204,6 +1204,7 @@
     "routeInvalidSoundId": "Invalid na sound ID",
     "routeInvalidCategory": "Invalid na category",
     "routeNoVideosToDisplay": "Walang video na maipapakita",
+    "routeGoHome": "Pumunta sa home",
     "routeInvalidProfileId": "Invalid na profile ID",
     "routeUnknownPath": "Wala ang page na iyon sa app.",
     "routeDefaultListName": "Listahan",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -1882,6 +1882,7 @@
     "routeInvalidSoundId": "ID de son invalide",
     "routeInvalidCategory": "Catégorie invalide",
     "routeNoVideosToDisplay": "Aucune vidéo à afficher",
+    "routeGoHome": "Aller à l'accueil",
     "routeInvalidProfileId": "ID de profil invalide",
     "routeUnknownPath": "Cette page n’est pas dans l’app.",
     "routeDefaultListName": "Liste",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -1881,6 +1881,7 @@
     "routeInvalidSoundId": "ID suara tidak valid",
     "routeInvalidCategory": "Kategori tidak valid",
     "routeNoVideosToDisplay": "Tidak ada video untuk ditampilkan",
+    "routeGoHome": "Ke beranda",
     "routeInvalidProfileId": "ID profil tidak valid",
     "routeUnknownPath": "Halaman itu tidak ada di aplikasi.",
     "routeDefaultListName": "Daftar",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -1882,6 +1882,7 @@
     "routeInvalidSoundId": "ID audio non valido",
     "routeInvalidCategory": "Categoria non valida",
     "routeNoVideosToDisplay": "Nessun video da mostrare",
+    "routeGoHome": "Vai alla home",
     "routeInvalidProfileId": "ID profilo non valido",
     "routeUnknownPath": "Quella pagina non è nell’app.",
     "routeDefaultListName": "Lista",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -1874,6 +1874,7 @@
     "routeInvalidSoundId": "無効なサウンド ID",
     "routeInvalidCategory": "無効なカテゴリ",
     "routeNoVideosToDisplay": "表示する動画がないよ",
+    "routeGoHome": "ホームに戻る",
     "routeInvalidProfileId": "無効なプロフィール ID",
     "routeUnknownPath": "このページはアプリ内にありません。",
     "routeDefaultListName": "リスト",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1205,6 +1205,7 @@
     "routeInvalidSoundId": "잘못된 사운드 ID예요",
     "routeInvalidCategory": "잘못된 카테고리예요",
     "routeNoVideosToDisplay": "표시할 영상이 없어요",
+    "routeGoHome": "홈으로 가기",
     "routeInvalidProfileId": "잘못된 프로필 ID예요",
     "routeUnknownPath": "앱에 없는 화면이에요.",
     "routeDefaultListName": "목록",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -1882,6 +1882,7 @@
     "routeInvalidSoundId": "Ongeldige geluid-ID",
     "routeInvalidCategory": "Ongeldige categorie",
     "routeNoVideosToDisplay": "Geen video's om weer te geven",
+    "routeGoHome": "Naar home",
     "routeInvalidProfileId": "Ongeldige profiel-ID",
     "routeUnknownPath": "Die pagina zit niet in de app.",
     "routeDefaultListName": "Lijst",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -1882,6 +1882,7 @@
     "routeInvalidSoundId": "Nieprawidłowy ID dźwięku",
     "routeInvalidCategory": "Nieprawidłowa kategoria",
     "routeNoVideosToDisplay": "Brak filmów do wyświetlenia",
+    "routeGoHome": "Przejdź do strony głównej",
     "routeInvalidProfileId": "Nieprawidłowy ID profilu",
     "routeUnknownPath": "Tej strony nie ma w aplikacji.",
     "routeDefaultListName": "Lista",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -1882,6 +1882,7 @@
     "routeInvalidSoundId": "ID de som inválido",
     "routeInvalidCategory": "Categoria inválida",
     "routeNoVideosToDisplay": "Nenhum vídeo para exibir",
+    "routeGoHome": "Ir para o início",
     "routeInvalidProfileId": "ID de perfil inválido",
     "routeUnknownPath": "Essa página não existe no app.",
     "routeDefaultListName": "Lista",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -1882,6 +1882,7 @@
     "routeInvalidSoundId": "ID de sunet invalid",
     "routeInvalidCategory": "Categorie invalidă",
     "routeNoVideosToDisplay": "Niciun videoclip de afișat",
+    "routeGoHome": "Mergi acasă",
     "routeInvalidProfileId": "ID de profil invalid",
     "routeUnknownPath": "Această pagină nu e în aplicație.",
     "routeDefaultListName": "Listă",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -1882,6 +1882,7 @@
     "routeInvalidSoundId": "Ogiltigt ljud-ID",
     "routeInvalidCategory": "Ogiltig kategori",
     "routeNoVideosToDisplay": "Inga videor att visa",
+    "routeGoHome": "Till startsidan",
     "routeInvalidProfileId": "Ogiltigt profil-ID",
     "routeUnknownPath": "Den sidan finns inte i appen.",
     "routeDefaultListName": "Lista",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -1881,6 +1881,7 @@
     "routeInvalidSoundId": "Geçersiz ses kimliği",
     "routeInvalidCategory": "Geçersiz kategori",
     "routeNoVideosToDisplay": "Gösterilecek video yok",
+    "routeGoHome": "Ana sayfaya git",
     "routeInvalidProfileId": "Geçersiz profil kimliği",
     "routeUnknownPath": "Bu sayfa uygulamada yok.",
     "routeDefaultListName": "Liste",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -7932,6 +7932,12 @@ abstract class AppLocalizations {
   /// **'No videos to display'**
   String get routeNoVideosToDisplay;
 
+  /// Button on a full-screen route error page that navigates back to the home feed. Always shown so the user is never stranded on a dead-end error screen.
+  ///
+  /// In en, this message translates to:
+  /// **'Go home'**
+  String get routeGoHome;
+
   /// No description provided for @routeInvalidProfileId.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -4460,6 +4460,9 @@ class AppLocalizationsAm extends AppLocalizations {
   String get routeNoVideosToDisplay => 'ምንም የሚታዩ ቪዲዮዎች የሉም';
 
   @override
+  String get routeGoHome => 'ወደ ቤት ሂድ';
+
+  @override
   String get routeInvalidProfileId => 'ልክ ያልሆነ የመገለጫ መታወቂያ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -4523,6 +4523,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get routeNoVideosToDisplay => 'لا توجد مقاطع فيديو لعرضها';
 
   @override
+  String get routeGoHome => 'الذهاب إلى الرئيسية';
+
+  @override
   String get routeInvalidProfileId => 'مُعرِّف ملف شخصي غير صالح';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -4600,6 +4600,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get routeNoVideosToDisplay => 'Няма видеа за показване';
 
   @override
+  String get routeGoHome => 'Към началото';
+
+  @override
   String get routeInvalidProfileId => 'Невалиден ID на потребителския профил';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -4607,6 +4607,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get routeNoVideosToDisplay => 'Keine Videos zum Anzeigen';
 
   @override
+  String get routeGoHome => 'Zur Startseite';
+
+  @override
   String get routeInvalidProfileId => 'Ungültige Profil-ID';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -4553,6 +4553,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get routeNoVideosToDisplay => 'No videos to display';
 
   @override
+  String get routeGoHome => 'Go home';
+
+  @override
   String get routeInvalidProfileId => 'Invalid profile ID';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -4596,6 +4596,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get routeNoVideosToDisplay => 'No hay videos para mostrar';
 
   @override
+  String get routeGoHome => 'Ir al inicio';
+
+  @override
   String get routeInvalidProfileId => 'ID de perfil inválido';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -4612,6 +4612,9 @@ class AppLocalizationsFil extends AppLocalizations {
   String get routeNoVideosToDisplay => 'Walang video na maipapakita';
 
   @override
+  String get routeGoHome => 'Pumunta sa home';
+
+  @override
   String get routeInvalidProfileId => 'Invalid na profile ID';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -4616,6 +4616,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get routeNoVideosToDisplay => 'Aucune vidéo à afficher';
 
   @override
+  String get routeGoHome => 'Aller à l\'accueil';
+
+  @override
   String get routeInvalidProfileId => 'ID de profil invalide';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -4525,6 +4525,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get routeNoVideosToDisplay => 'Tidak ada video untuk ditampilkan';
 
   @override
+  String get routeGoHome => 'Ke beranda';
+
+  @override
   String get routeInvalidProfileId => 'ID profil tidak valid';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -4599,6 +4599,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get routeNoVideosToDisplay => 'Nessun video da mostrare';
 
   @override
+  String get routeGoHome => 'Vai alla home';
+
+  @override
   String get routeInvalidProfileId => 'ID profilo non valido';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -4345,6 +4345,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get routeNoVideosToDisplay => '表示する動画がないよ';
 
   @override
+  String get routeGoHome => 'ホームに戻る';
+
+  @override
   String get routeInvalidProfileId => '無効なプロフィール ID';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -4363,6 +4363,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get routeNoVideosToDisplay => '표시할 영상이 없어요';
 
   @override
+  String get routeGoHome => '홈으로 가기';
+
+  @override
   String get routeInvalidProfileId => '잘못된 프로필 ID예요';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -4572,6 +4572,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get routeNoVideosToDisplay => 'Geen video\'s om weer te geven';
 
   @override
+  String get routeGoHome => 'Naar home';
+
+  @override
   String get routeInvalidProfileId => 'Ongeldige profiel-ID';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -4670,6 +4670,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get routeNoVideosToDisplay => 'Brak filmów do wyświetlenia';
 
   @override
+  String get routeGoHome => 'Przejdź do strony głównej';
+
+  @override
   String get routeInvalidProfileId => 'Nieprawidłowy ID profilu';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -4580,6 +4580,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get routeNoVideosToDisplay => 'Nenhum vídeo para exibir';
 
   @override
+  String get routeGoHome => 'Ir para o início';
+
+  @override
   String get routeInvalidProfileId => 'ID de perfil inválido';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -4683,6 +4683,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get routeNoVideosToDisplay => 'Niciun videoclip de afișat';
 
   @override
+  String get routeGoHome => 'Mergi acasă';
+
+  @override
   String get routeInvalidProfileId => 'ID de profil invalid';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -4550,6 +4550,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get routeNoVideosToDisplay => 'Inga videor att visa';
 
   @override
+  String get routeGoHome => 'Till startsidan';
+
+  @override
   String get routeInvalidProfileId => 'Ogiltigt profil-ID';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -4537,6 +4537,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get routeNoVideosToDisplay => 'Gösterilecek video yok';
 
   @override
+  String get routeGoHome => 'Ana sayfaya git';
+
+  @override
   String get routeInvalidProfileId => 'Geçersiz profil kimliği';
 
   @override

--- a/mobile/lib/router/route_error_screen.dart
+++ b/mobile/lib/router/route_error_screen.dart
@@ -4,18 +4,29 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:openvine/extensions/safe_pop_extension.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/screens/feed/video_feed_page.dart';
 
-/// Full-screen error state for bad route parameters and (later) unmatched paths.
+/// Full-screen error state for bad route parameters and unmatched paths.
 ///
-/// Matches the previous inline pattern in [GoRoute] builders: [DiVineAppBar] with
-/// [AppLocalizations.routeErrorTitle] and a short [message] in the body.
+/// Matches the previous inline pattern in [GoRoute] builders: [DiVineAppBar]
+/// with [AppLocalizations.routeErrorTitle] and a short [message] in the body.
+///
+/// Every instance is escapable, even when reached via `go` / a deep link that
+/// leaves nothing to pop back to:
+/// - the app-bar back control degrades to [BuildContext.safePop] (home when the
+///   back stack is empty) instead of throwing `GoError: There is nothing to
+///   pop`, and
+/// - a [showHomeButton] action under [message] always routes to the home feed,
+///   so a screen with [showBackButton] `false` still has a way out.
 class RouteErrorScreen extends StatelessWidget {
   const RouteErrorScreen({
     required this.message,
     this.title,
     this.showBackButton = false,
     this.onBackPressed,
+    this.showHomeButton = true,
     super.key,
   });
 
@@ -25,17 +36,22 @@ class RouteErrorScreen extends StatelessWidget {
   /// App bar title; defaults to [AppLocalizations.routeErrorTitle].
   final String? title;
 
-  /// When true, shows the leading back control (defaults to [GoRouter.pop] if
-  /// [onBackPressed] is omitted).
+  /// When true, shows the leading back control. When [onBackPressed] is
+  /// omitted it degrades to [BuildContext.safePop], so the control never
+  /// throws on a `go`-navigated route with an empty back stack.
   final bool showBackButton;
 
   final VoidCallback? onBackPressed;
+
+  /// When true (the default), renders a home action under [message] so the
+  /// screen is always escapable regardless of [showBackButton].
+  final bool showHomeButton;
 
   @override
   Widget build(BuildContext context) {
     final VoidCallback? backHandler = !showBackButton
         ? null
-        : (onBackPressed ?? () => context.pop<void>());
+        : (onBackPressed ?? () => context.safePop());
 
     return Scaffold(
       backgroundColor: VineTheme.backgroundColor,
@@ -44,7 +60,21 @@ class RouteErrorScreen extends StatelessWidget {
         showBackButton: showBackButton,
         onBackPressed: backHandler,
       ),
-      body: Center(child: Text(message)),
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(message),
+            if (showHomeButton) ...[
+              const SizedBox(height: 24),
+              DivineButton(
+                label: context.l10n.routeGoHome,
+                onPressed: () => context.go(VideoFeedPage.pathForIndex(0)),
+              ),
+            ],
+          ],
+        ),
+      ),
     );
   }
 }

--- a/mobile/lib/router/route_error_screen.dart
+++ b/mobile/lib/router/route_error_screen.dart
@@ -63,15 +63,14 @@ class RouteErrorScreen extends StatelessWidget {
       body: Center(
         child: Column(
           mainAxisSize: MainAxisSize.min,
+          spacing: 24,
           children: [
             Text(message),
-            if (showHomeButton) ...[
-              const SizedBox(height: 24),
+            if (showHomeButton)
               DivineButton(
                 label: context.l10n.routeGoHome,
                 onPressed: () => context.go(VideoFeedPage.pathForIndex(0)),
               ),
-            ],
           ],
         ),
       ),

--- a/mobile/test/router/route_error_screen_test.dart
+++ b/mobile/test/router/route_error_screen_test.dart
@@ -1,0 +1,158 @@
+// ABOUTME: Widget tests for RouteErrorScreen — message, always-escapable home
+// ABOUTME: button, and safePop back handling so no route can strand the user.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/l10n/generated/app_localizations_en.dart';
+import 'package:openvine/router/route_error_screen.dart';
+
+void main() {
+  final strings = AppLocalizationsEn();
+
+  Future<void> pumpErrorScreen(
+    WidgetTester tester, {
+    required Widget errorScreen,
+    String initialLocation = '/err',
+  }) async {
+    final router = GoRouter(
+      initialLocation: initialLocation,
+      routes: [
+        GoRoute(
+          path: '/home/:index',
+          builder: (_, _) => const _HomeMarker(),
+        ),
+        GoRoute(path: '/err', builder: (_, _) => errorScreen),
+        GoRoute(
+          path: '/first',
+          builder: (context, _) => Scaffold(
+            body: Center(
+              child: TextButton(
+                onPressed: () => context.push('/err'),
+                child: const Text('open error'),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      MaterialApp.router(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        locale: const Locale('en'),
+        routerConfig: router,
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  group(RouteErrorScreen, () {
+    testWidgets('renders the message and a home button by default', (
+      tester,
+    ) async {
+      await pumpErrorScreen(
+        tester,
+        errorScreen: const RouteErrorScreen(message: 'boom'),
+      );
+
+      expect(find.text('boom'), findsOneWidget);
+      expect(
+        find.widgetWithText(DivineButton, strings.routeGoHome),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('home button navigates to the home feed', (tester) async {
+      await pumpErrorScreen(
+        tester,
+        errorScreen: const RouteErrorScreen(message: 'boom'),
+      );
+
+      await tester.tap(find.widgetWithText(DivineButton, strings.routeGoHome));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(_HomeMarker), findsOneWidget);
+    });
+
+    testWidgets('showHomeButton: false hides the home button', (tester) async {
+      await pumpErrorScreen(
+        tester,
+        errorScreen: const RouteErrorScreen(
+          message: 'boom',
+          showHomeButton: false,
+        ),
+      );
+
+      expect(find.text('boom'), findsOneWidget);
+      expect(
+        find.widgetWithText(DivineButton, strings.routeGoHome),
+        findsNothing,
+      );
+    });
+
+    testWidgets('shows no back button by default', (tester) async {
+      await pumpErrorScreen(
+        tester,
+        errorScreen: const RouteErrorScreen(message: 'boom'),
+      );
+
+      expect(find.byTooltip('Back'), findsNothing);
+    });
+
+    testWidgets(
+      'back control falls back to the home feed when the stack is empty',
+      (tester) async {
+        await pumpErrorScreen(
+          tester,
+          errorScreen: const RouteErrorScreen(
+            message: 'boom',
+            showBackButton: true,
+          ),
+        );
+
+        // Reached via `go` (single-entry stack) → nothing to pop → safePop
+        // lands on the home feed instead of throwing GoError.
+        await tester.tap(find.byTooltip('Back'));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(_HomeMarker), findsOneWidget);
+      },
+    );
+
+    testWidgets('back control pops when there is a route to pop to', (
+      tester,
+    ) async {
+      await pumpErrorScreen(
+        tester,
+        errorScreen: const RouteErrorScreen(
+          message: 'boom',
+          showBackButton: true,
+        ),
+        initialLocation: '/first',
+      );
+
+      await tester.tap(find.text('open error'));
+      await tester.pumpAndSettle();
+      expect(find.text('boom'), findsOneWidget);
+
+      await tester.tap(find.byTooltip('Back'));
+      await tester.pumpAndSettle();
+
+      // Popped back to the pushing screen rather than being forced home.
+      expect(find.text('open error'), findsOneWidget);
+      expect(find.byType(_HomeMarker), findsNothing);
+    });
+  });
+}
+
+class _HomeMarker extends StatelessWidget {
+  const _HomeMarker();
+
+  @override
+  Widget build(BuildContext context) =>
+      const Scaffold(body: Center(child: Text('home-marker')));
+}


### PR DESCRIPTION
## Description

`RouteErrorScreen` — the shared full-screen route-error / not-found state used by ~24 route builders — could strand the user with no way out:

- Callers using the default `showBackButton: false` had no back affordance at all.
- Callers using `showBackButton: true` without an `onBackPressed` triggered a plain pop, which throws `GoError: There is nothing to pop` on a `go`-navigated route with an empty back stack (two list routes hit this today).

This surfaced as the reported "Error / No videos to display" screen with no back button after resuming the app from the background.

Changes:

- Default the app-bar back control to `context.safePop()`, which pops when possible and otherwise falls back to the home feed instead of throwing.
- Add an always-visible go-home action (`DivineButton`) under the error message, gated by a new `showHomeButton` flag (defaults `true`), so every error screen has a guaranteed way out — including the `showBackButton: false` ones.
- Add the `routeGoHome` string across all 18 locales.

Complements #6199, which recovered the pooled fullscreen feed's data and added a back button to that one screen; this generalizes escapability to every `RouteErrorScreen` and removes the crash in the back-button path.

**Related Issue:** Closes #6262

## Out of Scope

The gift-wrap subscription-replay log volume on resume (a separate, cosmetic logging concern) is not addressed here.

## Verification

- `flutter analyze lib/router lib/l10n test/router` — no issues
- `flutter test test/router/route_error_screen_test.dart` — 6 new tests (message renders; home button navigates to the feed; `showHomeButton: false` hides it; no back button by default; back → home on an empty stack; back → pop when there is a route to pop to)
- `flutter test test/l10n/arb_consistency_test.dart` — passes (all locales define `routeGoHome`)
- `flutter test test/screens/curated_list_by_author_screen_test.dart test/screens/subtitle_editor/subtitle_editor_screen_test.dart test/router/route_error_routing_test.dart` — existing caller tests pass
- Pre-commit hook: format + analyzer

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
