### PR TITLE
fix(notifications): reclassify comment-likes via payload root_event_pubkey

### DIFF
--- a/mobile/packages/funnelcake_api_client/lib/src/models/relay_notification.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/models/relay_notification.dart
@@ -19,6 +19,7 @@ class RelayNotification {
     this.referencedVideoThumbnail,
     this.referencedDTag,
     this.rootEventId,
+    this.rootEventPubkey,
     this.targetCommentId,
   });
 
@@ -68,6 +69,7 @@ class RelayNotification {
           : null,
       referencedDTag: (rawDTag != null && rawDTag.isNotEmpty) ? rawDTag : null,
       rootEventId: _nonEmpty(json['root_event_id'] as String?),
+      rootEventPubkey: _nonEmpty(json['root_event_pubkey'] as String?),
       targetCommentId: _nonEmpty(json['target_comment_id'] as String?),
     );
   }
@@ -130,6 +132,15 @@ class RelayNotification {
   /// the notification directly to the video instead of resolving the comment
   /// event through a relay round-trip.
   final String? rootEventId;
+
+  /// Pubkey of the root video's author, when Funnelcake can resolve it.
+  ///
+  /// Authoritative ownership signal: for a reaction anchored to the user's
+  /// comment on someone else's video this is the *other* creator's pubkey,
+  /// while for a like on the user's own video it is the user's own pubkey.
+  /// Lets app layers detect a "liked your comment" that would otherwise be
+  /// mislabelled "liked your video" without a metadata round-trip.
+  final String? rootEventPubkey;
 
   /// Comment event ID included by Funnelcake for NIP-22 comment notifications.
   final String? targetCommentId;

--- a/mobile/packages/funnelcake_api_client/lib/src/models/relay_notification.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/models/relay_notification.dart
@@ -20,6 +20,7 @@ class RelayNotification {
     this.referencedDTag,
     this.rootEventId,
     this.rootEventPubkey,
+    this.rootAddressableId,
     this.targetCommentId,
   });
 
@@ -69,7 +70,10 @@ class RelayNotification {
           : null,
       referencedDTag: (rawDTag != null && rawDTag.isNotEmpty) ? rawDTag : null,
       rootEventId: _nonEmpty(json['root_event_id'] as String?),
-      rootEventPubkey: _nonEmpty(json['root_event_pubkey'] as String?),
+      rootEventPubkey: _nonEmpty(
+        (json['root_event_pubkey'] as String?)?.toLowerCase(),
+      ),
+      rootAddressableId: _nonEmpty(json['root_addressable_id'] as String?),
       targetCommentId: _nonEmpty(json['target_comment_id'] as String?),
     );
   }
@@ -148,6 +152,13 @@ class RelayNotification {
   /// owner — to detect a "liked your comment" that would otherwise be
   /// mislabelled "liked your video" without a metadata round-trip.
   final String? rootEventPubkey;
+
+  /// Full NIP-33 coordinate for the root video, when Funnelcake can resolve it.
+  ///
+  /// For actor-anchored comment/reply rows this lets taps route directly to the
+  /// stable root video (`34236:<root_event_pubkey>:<root_d_tag>`) instead of
+  /// resolving the comment event first.
+  final String? rootAddressableId;
 
   /// Comment event ID included by Funnelcake for NIP-22 comment notifications.
   final String? targetCommentId;

--- a/mobile/packages/funnelcake_api_client/lib/src/models/relay_notification.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/models/relay_notification.dart
@@ -133,12 +133,19 @@ class RelayNotification {
   /// event through a relay round-trip.
   final String? rootEventId;
 
-  /// Pubkey of the root video's author, when Funnelcake can resolve it.
+  /// Pubkey of the root video's author, when Funnelcake can resolve it
+  /// (from the reaction's NIP-22 root `P` tag / root coordinate).
   ///
-  /// Authoritative ownership signal: for a reaction anchored to the user's
-  /// comment on someone else's video this is the *other* creator's pubkey,
-  /// while for a like on the user's own video it is the user's own pubkey.
-  /// Lets app layers detect a "liked your comment" that would otherwise be
+  /// This is the *root* author, not necessarily the owner of the event the
+  /// notification anchors on: for a reaction on the user's comment on someone
+  /// else's video it is the *other* creator, and for a reaction on the user's
+  /// own video-reply it is again the other creator (the thread's root video
+  /// author), even though the user owns the replied-with video. It equals the
+  /// user's own pubkey only for a reaction on the user's own top-level video.
+  ///
+  /// Because of that, app layers use it as a *fallback* ownership signal —
+  /// consulted only when the anchor event's own metadata can't resolve the
+  /// owner — to detect a "liked your comment" that would otherwise be
   /// mislabelled "liked your video" without a metadata round-trip.
   final String? rootEventPubkey;
 

--- a/mobile/packages/funnelcake_api_client/test/src/models/relay_notification_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/models/relay_notification_test.dart
@@ -443,6 +443,45 @@ void main() {
         expect(notification.rootEventPubkey, equals('deadbeef' * 8));
       });
 
+      test('lowercases root_event_pubkey', () {
+        final json = {
+          'id': 'notif_123',
+          'source_pubkey': 'aabbccdd' * 8,
+          'source_event_id': '11223344' * 8,
+          'source_kind': 7,
+          'referenced_event_id': '55667788' * 8,
+          'notification_type': 'reaction',
+          'created_at': 1712345678,
+          'read': false,
+          'root_event_pubkey': 'DEADBEEF' * 8,
+        };
+
+        final notification = RelayNotification.fromJson(json);
+
+        expect(notification.rootEventPubkey, equals('deadbeef' * 8));
+      });
+
+      test('parses root_addressable_id', () {
+        final json = {
+          'id': 'notif_123',
+          'source_pubkey': 'aabbccdd' * 8,
+          'source_event_id': '11223344' * 8,
+          'source_kind': 7,
+          'referenced_event_id': '55667788' * 8,
+          'notification_type': 'reaction',
+          'created_at': 1712345678,
+          'read': false,
+          'root_addressable_id': '34236:${'deadbeef' * 8}:root-d-tag',
+        };
+
+        final notification = RelayNotification.fromJson(json);
+
+        expect(
+          notification.rootAddressableId,
+          equals('34236:${'deadbeef' * 8}:root-d-tag'),
+        );
+      });
+
       test('treats empty or absent root_event_pubkey as null', () {
         final absent = RelayNotification.fromJson({
           'id': 'notif_123',
@@ -466,6 +505,31 @@ void main() {
 
         expect(absent.rootEventPubkey, isNull);
         expect(empty.rootEventPubkey, isNull);
+      });
+
+      test('treats empty or absent root_addressable_id as null', () {
+        final absent = RelayNotification.fromJson({
+          'id': 'notif_123',
+          'source_pubkey': 'aabbccdd' * 8,
+          'source_event_id': '11223344' * 8,
+          'source_kind': 7,
+          'notification_type': 'reaction',
+          'created_at': 1712345678,
+          'read': false,
+        });
+        final empty = RelayNotification.fromJson({
+          'id': 'notif_123',
+          'source_pubkey': 'aabbccdd' * 8,
+          'source_event_id': '11223344' * 8,
+          'source_kind': 7,
+          'notification_type': 'reaction',
+          'created_at': 1712345678,
+          'read': false,
+          'root_addressable_id': '',
+        });
+
+        expect(absent.rootAddressableId, isNull);
+        expect(empty.rootAddressableId, isNull);
       });
     });
 

--- a/mobile/packages/funnelcake_api_client/test/src/models/relay_notification_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/models/relay_notification_test.dart
@@ -424,6 +424,49 @@ void main() {
         expect(notification.rootEventId, isNull);
         expect(notification.targetCommentId, isNull);
       });
+
+      test('parses root_event_pubkey (root video author)', () {
+        final json = {
+          'id': 'notif_123',
+          'source_pubkey': 'aabbccdd' * 8,
+          'source_event_id': '11223344' * 8,
+          'source_kind': 7,
+          'referenced_event_id': '55667788' * 8,
+          'notification_type': 'reaction',
+          'created_at': 1712345678,
+          'read': false,
+          'root_event_pubkey': 'deadbeef' * 8,
+        };
+
+        final notification = RelayNotification.fromJson(json);
+
+        expect(notification.rootEventPubkey, equals('deadbeef' * 8));
+      });
+
+      test('treats empty or absent root_event_pubkey as null', () {
+        final absent = RelayNotification.fromJson({
+          'id': 'notif_123',
+          'source_pubkey': 'aabbccdd' * 8,
+          'source_event_id': '11223344' * 8,
+          'source_kind': 7,
+          'notification_type': 'reaction',
+          'created_at': 1712345678,
+          'read': false,
+        });
+        final empty = RelayNotification.fromJson({
+          'id': 'notif_123',
+          'source_pubkey': 'aabbccdd' * 8,
+          'source_event_id': '11223344' * 8,
+          'source_kind': 7,
+          'notification_type': 'reaction',
+          'created_at': 1712345678,
+          'read': false,
+          'root_event_pubkey': '',
+        });
+
+        expect(absent.rootEventPubkey, isNull);
+        expect(empty.rootEventPubkey, isNull);
+      });
     });
 
     group('dedupeKey', () {

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -1146,8 +1146,8 @@ class NotificationRepository {
           notificationId: n.id,
           sourcePubkey: n.sourcePubkey,
           referencedVideoEventId: eventId,
-          referencedVideoOwnerPubkey:
-              videosById[eventId]?.pubkey ?? n.rootEventPubkey,
+          referencedVideoOwnerPubkey: videosById[eventId]?.pubkey,
+          rootEventPubkey: n.rootEventPubkey,
         );
         misattributed?.add(n);
         continue;
@@ -1433,10 +1433,13 @@ class NotificationRepository {
     NotificationKind mapped,
     RelayNotification notification,
   ) {
-    // The current payload does not include the owning pubkey for the parent
-    // video, so synthesizing a stable route here can point at the wrong
-    // creator's addressable video. Fall back to resolver-based navigation
-    // until the API includes an authoritative owner component.
+    // The payload now carries the root video's author (`root_event_pubkey`),
+    // but a stable owner-scoped route for these reclassified foreign-video
+    // rows also needs the root video's d-tag, and the recipient-scoped
+    // [_recipientScopedVideoAddressableId] pins the pubkey to [_userPubkey] —
+    // wrong for another creator's video. Synthesizing an owner-scoped route
+    // for these rows is a focused follow-up; until then, fall back to
+    // resolver-based navigation.
     return null;
   }
 
@@ -1445,21 +1448,29 @@ class NotificationRepository {
     required Map<String, VideoStats> videosById,
     String? rootEventPubkey,
   }) {
-    // Authoritative owner straight from the payload: the root video's author.
-    // For a reaction anchored to the user's comment on someone else's video
-    // this is the *other* creator, so a "liked your video" here is a mislabel
-    // and must be reclassified — even when the video metadata was never
-    // fetched (the anchor id is the comment, not a video, so [videosById]
-    // can't resolve it). A genuine like on the user's own video carries the
-    // user's own pubkey here, so the guard never fires for it.
+    // Authoritative owner of the event the notification actually anchors on.
+    // When metadata resolves it, it decides ownership outright: a like/repost
+    // on the user's own video — including a video-reply whose thread root
+    // belongs to another creator — is a genuine "…your video" and must NOT be
+    // reclassified. Trusting the payload's root author here instead would
+    // mislabel that like as "liked your comment" and silently drop the repost.
+    final ownerPubkey = videosById[referencedVideoEventId]?.pubkey;
+    if (ownerPubkey != null && ownerPubkey.isNotEmpty) {
+      return ownerPubkey != _userPubkey;
+    }
+    // Anchor metadata is unresolvable — the anchor id is the user's comment,
+    // not a video, so [videosById] can't own it. Fall back to the payload's
+    // root video author: for a reaction on the user's comment on someone
+    // else's video this is the *other* creator, so a "liked your video" here
+    // is a mislabel and must be reclassified without a metadata round-trip.
+    // A genuine like on the user's own top-level video carries the user's own
+    // pubkey here, so the fallback stays inert for it.
     if (rootEventPubkey != null &&
         rootEventPubkey.isNotEmpty &&
         rootEventPubkey != _userPubkey) {
       return true;
     }
-    final ownerPubkey = videosById[referencedVideoEventId]?.pubkey;
-    if (ownerPubkey == null || ownerPubkey.isEmpty) return false;
-    return ownerPubkey != _userPubkey;
+    return false;
   }
 
   void _logReclassifiedOwnerMismatch({
@@ -1467,6 +1478,7 @@ class NotificationRepository {
     required String sourcePubkey,
     required String referencedVideoEventId,
     required String? referencedVideoOwnerPubkey,
+    required String? rootEventPubkey,
   }) {
     Log.info(
       'Reclassifying misattributed video notification as actor-anchored: '
@@ -1474,6 +1486,7 @@ class NotificationRepository {
       'sourcePubkey=$sourcePubkey '
       'referencedVideoEventId=$referencedVideoEventId '
       'referencedVideoOwnerPubkey=${referencedVideoOwnerPubkey ?? 'unknown'} '
+      'rootEventPubkey=${rootEventPubkey ?? 'unknown'} '
       'currentUserPubkey=$_userPubkey',
       name: 'NotificationRepository',
       category: LogCategory.api,

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -63,6 +63,32 @@ abstract class _NotificationRetryConfig {
   static const maxBackoff = Duration(milliseconds: 1500);
 }
 
+class _VideoMetadataLookup {
+  const _VideoMetadataLookup({
+    required this.videosById,
+    required this.notFoundIds,
+  });
+
+  const _VideoMetadataLookup.empty()
+    : videosById = const <String, VideoStats>{},
+      notFoundIds = const <String>{};
+
+  final Map<String, VideoStats> videosById;
+  final Set<String> notFoundIds;
+}
+
+class _VideoMetadataResult {
+  const _VideoMetadataResult({
+    required this.id,
+    this.stats,
+    this.notFound = false,
+  });
+
+  final String id;
+  final VideoStats? stats;
+  final bool notFound;
+}
+
 /// Number of notifications loaded per page.
 ///
 /// Bounds both the cold-start cache hydration and the first-page REST
@@ -469,7 +495,10 @@ class NotificationRepository {
           ? Future.value(<String, UserProfile>{})
           : _profileRepository.fetchBatchProfiles(pubkeys: pubkeys);
       final videosFuture = _fetchVideoMetadata(eventIds);
-      final (profiles, videosById) = await (profilesFuture, videosFuture).wait;
+      final (profiles, videoMetadata) = await (
+        profilesFuture,
+        videosFuture,
+      ).wait;
 
       if (generation != _fetchGeneration) return;
 
@@ -480,7 +509,7 @@ class NotificationRepository {
         return switch (item) {
           VideoNotification(:final actors, :final videoEventId) => () {
             final actor = actors.first;
-            final video = videosById[videoEventId];
+            final video = videoMetadata.videosById[videoEventId];
             return item.copyWith(
               actors: _isCachedVideoPlaceholder(item)
                   ? [_buildActor(actor.pubkey, profiles)]
@@ -1039,14 +1068,15 @@ class NotificationRepository {
       pubkeys: pubkeys,
     );
     final videosFuture = _fetchVideoMetadata(eventIds);
-    final (profiles, videosById) = await (profilesFuture, videosFuture).wait;
+    final (profiles, videoMetadata) = await (profilesFuture, videosFuture).wait;
 
     final consolidated = _consolidateFollows(raw);
     final misattributed = <RelayNotification>[];
     final videos = _groupVideoAnchored(
       consolidated,
       profiles,
-      videosById,
+      videoMetadata.videosById,
+      videoNotFoundIds: videoMetadata.notFoundIds,
       misattributed: misattributed,
     );
     final actors = _mapActorAnchored(consolidated, profiles);
@@ -1086,26 +1116,38 @@ class NotificationRepository {
 
   /// Fetches [VideoStats] for each id in parallel.
   ///
-  /// Per-id failures are tolerated — a single failed lookup yields no
-  /// entry in the result map.
-  Future<Map<String, VideoStats>> _fetchVideoMetadata(
+  /// Per-id failures are tolerated for display metadata, but only a `null`
+  /// return from [FunnelcakeApiClient.getVideoStats] is treated as a confirmed
+  /// not-found. Thrown errors are transient/unknown misses and must not drive
+  /// ownership reclassification.
+  Future<_VideoMetadataLookup> _fetchVideoMetadata(
     List<String> eventIds,
   ) async {
-    if (eventIds.isEmpty) return const <String, VideoStats>{};
+    if (eventIds.isEmpty) return const _VideoMetadataLookup.empty();
     final futures = eventIds.map((id) async {
       try {
-        return await _funnelcakeApiClient.getVideoStats(id);
+        final stats = await _funnelcakeApiClient.getVideoStats(id);
+        return _VideoMetadataResult(
+          id: id,
+          stats: stats,
+          notFound: stats == null,
+        );
       } on Object {
-        return null;
+        return _VideoMetadataResult(id: id);
       }
     });
     final results = await Future.wait(futures);
     final map = <String, VideoStats>{};
-    for (var i = 0; i < eventIds.length; i++) {
-      final stats = results[i];
-      if (stats != null) map[eventIds[i]] = stats;
+    final notFoundIds = <String>{};
+    for (final result in results) {
+      final stats = result.stats;
+      if (stats != null) {
+        map[result.id] = stats;
+      } else if (result.notFound) {
+        notFoundIds.add(result.id);
+      }
     }
-    return map;
+    return _VideoMetadataLookup(videosById: map, notFoundIds: notFoundIds);
   }
 
   /// Builds [VideoNotification]s by grouping like/comment/repost
@@ -1124,6 +1166,7 @@ class NotificationRepository {
     List<RelayNotification> raw,
     Map<String, UserProfile> profiles,
     Map<String, VideoStats> videosById, {
+    required Set<String> videoNotFoundIds,
     List<RelayNotification>? misattributed,
   }) {
     bool isVideoAnchored(NotificationKind k) =>
@@ -1138,8 +1181,10 @@ class NotificationRepository {
       final eventId = _videoAnchorEventId(kind, n);
       if (eventId == null || eventId.isEmpty) continue;
       if (_hasKnownReferencedVideoOwnerMismatch(
+        kind: kind,
         referencedVideoEventId: eventId,
         videosById: videosById,
+        videoNotFoundIds: videoNotFoundIds,
         rootEventPubkey: n.rootEventPubkey,
       )) {
         _logReclassifiedOwnerMismatch(
@@ -1423,7 +1468,7 @@ class NotificationRepository {
   }
 
   /// Returns the stable NIP-33 addressable ID for an actor-anchored
-  /// notification, when the server provided the video's `d_tag`.
+  /// notification, when the server provided the root video's full coordinate.
   ///
   /// Only populated for `likeComment` and `reply` — the tap handler uses
   /// it to navigate directly to the video without a relay round-trip.
@@ -1433,19 +1478,18 @@ class NotificationRepository {
     NotificationKind mapped,
     RelayNotification notification,
   ) {
-    // The payload now carries the root video's author (`root_event_pubkey`),
-    // but a stable owner-scoped route for these reclassified foreign-video
-    // rows also needs the root video's d-tag, and the recipient-scoped
-    // [_recipientScopedVideoAddressableId] pins the pubkey to [_userPubkey] —
-    // wrong for another creator's video. Synthesizing an owner-scoped route
-    // for these rows is a focused follow-up; until then, fall back to
-    // resolver-based navigation.
-    return null;
+    if (mapped != NotificationKind.likeComment &&
+        mapped != NotificationKind.reply) {
+      return null;
+    }
+    return _nonEmpty(notification.rootAddressableId);
   }
 
   bool _hasKnownReferencedVideoOwnerMismatch({
+    required NotificationKind kind,
     required String referencedVideoEventId,
     required Map<String, VideoStats> videosById,
+    required Set<String> videoNotFoundIds,
     String? rootEventPubkey,
   }) {
     // Authoritative owner of the event the notification actually anchors on.
@@ -1458,13 +1502,19 @@ class NotificationRepository {
     if (ownerPubkey != null && ownerPubkey.isNotEmpty) {
       return ownerPubkey != _userPubkey;
     }
-    // Anchor metadata is unresolvable — the anchor id is the user's comment,
-    // not a video, so [videosById] can't own it. Fall back to the payload's
-    // root video author: for a reaction on the user's comment on someone
-    // else's video this is the *other* creator, so a "liked your video" here
-    // is a mislabel and must be reclassified without a metadata round-trip.
-    // A genuine like on the user's own top-level video carries the user's own
-    // pubkey here, so the fallback stays inert for it.
+    // Only a confirmed not-found is precise enough for the weaker root-author
+    // fallback. A thrown metadata fetch may be a timeout or API failure for a
+    // real user-owned video, so it must leave the row video-anchored.
+    if (!videoNotFoundIds.contains(referencedVideoEventId)) return false;
+
+    // Repost reclassification is destructive: foreign-video reposts are
+    // intentionally dropped later. Do not let root author alone delete a row.
+    if (kind == NotificationKind.repost) return false;
+
+    // The anchor may be a comment id rather than a video id. In that confirmed
+    // not-found case, fall back to the payload's root video author: for a
+    // reaction on the user's comment on someone else's video this is the other
+    // creator, so a "liked your video" row should be actor-anchored instead.
     if (rootEventPubkey != null &&
         rootEventPubkey.isNotEmpty &&
         rootEventPubkey != _userPubkey) {

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -1140,12 +1140,14 @@ class NotificationRepository {
       if (_hasKnownReferencedVideoOwnerMismatch(
         referencedVideoEventId: eventId,
         videosById: videosById,
+        rootEventPubkey: n.rootEventPubkey,
       )) {
         _logReclassifiedOwnerMismatch(
           notificationId: n.id,
           sourcePubkey: n.sourcePubkey,
           referencedVideoEventId: eventId,
-          referencedVideoOwnerPubkey: videosById[eventId]?.pubkey,
+          referencedVideoOwnerPubkey:
+              videosById[eventId]?.pubkey ?? n.rootEventPubkey,
         );
         misattributed?.add(n);
         continue;
@@ -1441,7 +1443,20 @@ class NotificationRepository {
   bool _hasKnownReferencedVideoOwnerMismatch({
     required String referencedVideoEventId,
     required Map<String, VideoStats> videosById,
+    String? rootEventPubkey,
   }) {
+    // Authoritative owner straight from the payload: the root video's author.
+    // For a reaction anchored to the user's comment on someone else's video
+    // this is the *other* creator, so a "liked your video" here is a mislabel
+    // and must be reclassified — even when the video metadata was never
+    // fetched (the anchor id is the comment, not a video, so [videosById]
+    // can't resolve it). A genuine like on the user's own video carries the
+    // user's own pubkey here, so the guard never fires for it.
+    if (rootEventPubkey != null &&
+        rootEventPubkey.isNotEmpty &&
+        rootEventPubkey != _userPubkey) {
+      return true;
+    }
     final ownerPubkey = videosById[referencedVideoEventId]?.pubkey;
     if (ownerPubkey == null || ownerPubkey.isEmpty) return false;
     return ownerPubkey != _userPubkey;

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -117,6 +117,7 @@ void main() {
     String? referencedEventId = 'video_default',
     String? referencedDTag,
     String? rootEventId,
+    String? rootEventPubkey,
     String? targetCommentId,
     String? content,
     bool isReferencedVideo = true,
@@ -134,6 +135,7 @@ void main() {
       referencedEventId: referencedEventId,
       referencedDTag: referencedDTag,
       rootEventId: rootEventId,
+      rootEventPubkey: rootEventPubkey,
       targetCommentId: targetCommentId,
       content: content,
       isReferencedVideo: isReferencedVideo,
@@ -1333,6 +1335,59 @@ void main() {
         final item = page.items.single as ActorNotification;
         expect(item.type, equals(NotificationKind.likeComment));
         expect(item.targetEventId, equals('foreign_video'));
+      });
+
+      test(
+        "reaction on the user's comment (non-owned root_event_pubkey) is "
+        'reclassified as likeComment without video metadata (#5634)',
+        () async {
+          // Residual edge of #5634/#5949: Funnelcake left target_comment_id
+          // empty but populated the root video (referenced_video +
+          // root_event_pubkey). The anchor id is the comment, so videosById
+          // cannot resolve ownership; the authoritative owner is the payload's
+          // root_event_pubkey. No video stats are stubbed on purpose.
+          stubNotifications([
+            makeNotification(
+              referencedEventId: 'my_comment',
+              rootEventPubkey: 'other_owner_pubkey',
+            ),
+          ]);
+          stubProfiles({});
+
+          final page = await repository.getNotifications();
+
+          final item = page.items.single as ActorNotification;
+          expect(item.type, equals(NotificationKind.likeComment));
+        },
+      );
+
+      test("reaction on the user's own video (root_event_pubkey == user) "
+          'stays like', () async {
+        stubNotifications([
+          makeNotification(
+            referencedEventId: 'own_video',
+            rootEventPubkey: userPubkey,
+          ),
+        ]);
+        stubProfiles({});
+
+        final page = await repository.getNotifications();
+
+        final item = page.items.single as VideoNotification;
+        expect(item.type, equals(NotificationKind.like));
+      });
+
+      test('reaction with no root_event_pubkey and no video metadata stays '
+          'like (guard inert)', () async {
+        stubNotifications([
+          makeNotification(referencedEventId: 'unknown_video'),
+        ]);
+        stubProfiles({});
+
+        final page = await repository.getNotifications();
+
+        final item = page.items.single as VideoNotification;
+        expect(item.type, equals(NotificationKind.like));
       });
 
       test('comment on a non-owned video is reclassified as reply '

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -118,6 +118,7 @@ void main() {
     String? referencedDTag,
     String? rootEventId,
     String? rootEventPubkey,
+    String? rootAddressableId,
     String? targetCommentId,
     String? content,
     bool isReferencedVideo = true,
@@ -136,6 +137,7 @@ void main() {
       referencedDTag: referencedDTag,
       rootEventId: rootEventId,
       rootEventPubkey: rootEventPubkey,
+      rootAddressableId: rootAddressableId,
       targetCommentId: targetCommentId,
       content: content,
       isReferencedVideo: isReferencedVideo,
@@ -183,6 +185,13 @@ void main() {
     when(
       () => funnelcakeApiClient.getVideoStats(eventId),
     ).thenAnswer((_) async => stats);
+  }
+
+  /// Stubs `getVideoStats(eventId)` to return a confirmed 404/not-found.
+  void stubVideoStatsNotFound(String eventId) {
+    when(
+      () => funnelcakeApiClient.getVideoStats(eventId),
+    ).thenAnswer((_) async => null);
   }
 
   UserProfile makeProfile(
@@ -1339,13 +1348,13 @@ void main() {
 
       test(
         "reaction on the user's comment (non-owned root_event_pubkey) is "
-        'reclassified as likeComment without video metadata (#5634)',
+        'reclassified as likeComment after a confirmed metadata 404 (#5634)',
         () async {
           // Residual edge of #5634/#5949: Funnelcake left target_comment_id
           // empty but populated the root video (referenced_video +
           // root_event_pubkey). The anchor id is the comment, so videosById
-          // cannot resolve ownership; the authoritative owner is the payload's
-          // root_event_pubkey. No video stats are stubbed on purpose.
+          // gets a confirmed not-found and cannot resolve ownership; the
+          // fallback owner is the payload's root_event_pubkey.
           stubNotifications([
             makeNotification(
               referencedEventId: 'my_comment',
@@ -1353,6 +1362,7 @@ void main() {
             ),
           ]);
           stubProfiles({});
+          stubVideoStatsNotFound('my_comment');
 
           final page = await repository.getNotifications();
 
@@ -1376,6 +1386,47 @@ void main() {
         final item = page.items.single as VideoNotification;
         expect(item.type, equals(NotificationKind.like));
       });
+
+      test('repost on the user-owned referenced video survives when metadata '
+          'throws and root_event_pubkey is another creator', () async {
+        stubNotifications([
+          makeNotification(
+            notificationType: 'repost',
+            sourceKind: 6,
+            referencedEventId: 'my_video_reply',
+            rootEventPubkey: 'other_owner_pubkey',
+          ),
+        ]);
+        stubProfiles({});
+
+        final page = await repository.getNotifications();
+
+        final item = page.items.single as VideoNotification;
+        expect(item.type, equals(NotificationKind.repost));
+        expect(item.videoEventId, equals('my_video_reply'));
+      });
+
+      test(
+        'repost does not get dropped from the root_event_pubkey fallback alone',
+        () async {
+          stubNotifications([
+            makeNotification(
+              notificationType: 'repost',
+              sourceKind: 6,
+              referencedEventId: 'unknown_anchor',
+              rootEventPubkey: 'other_owner_pubkey',
+            ),
+          ]);
+          stubProfiles({});
+          stubVideoStatsNotFound('unknown_anchor');
+
+          final page = await repository.getNotifications();
+
+          final item = page.items.single as VideoNotification;
+          expect(item.type, equals(NotificationKind.repost));
+          expect(item.videoEventId, equals('unknown_anchor'));
+        },
+      );
 
       test(
         'like on the user-owned referenced video stays like even when '
@@ -1502,6 +1553,27 @@ void main() {
         expect(item.type, equals(NotificationKind.likeComment));
         expect(item.targetEventId, equals('comment_event_xyz'));
       });
+
+      test(
+        'likeComment carries root addressable id for direct video routing',
+        () async {
+          const rootAddressableId =
+              '${NIP71VideoKinds.addressableShortVideo}:other_owner:root-d-tag';
+          stubNotifications([
+            makeNotification(
+              isReferencedVideo: false,
+              referencedEventId: 'comment_event_xyz',
+              rootAddressableId: rootAddressableId,
+            ),
+          ]);
+          stubProfiles({});
+
+          final page = await repository.getNotifications();
+          final item = page.items.single as ActorNotification;
+          expect(item.type, equals(NotificationKind.likeComment));
+          expect(item.videoAddressableId, equals(rootAddressableId));
+        },
+      );
 
       test(
         'likeComment leaves videoAddressableId null even when referencedDTag '

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -1377,18 +1377,62 @@ void main() {
         expect(item.type, equals(NotificationKind.like));
       });
 
-      test('reaction with no root_event_pubkey and no video metadata stays '
-          'like (guard inert)', () async {
-        stubNotifications([
-          makeNotification(referencedEventId: 'unknown_video'),
-        ]);
-        stubProfiles({});
+      test(
+        'like on the user-owned referenced video stays like even when '
+        'root_event_pubkey is another creator (video-reply; metadata wins)',
+        () async {
+          // Reliability order: the anchor event's own metadata is authoritative
+          // over the payload's root author. A like on the user's own
+          // video-reply resolves to the user in videosById, while the thread's
+          // root video belongs to someone else. It must stay "liked your video"
+          // — trusting root_event_pubkey here would mislabel it as likeComment.
+          stubNotifications([
+            makeNotification(
+              referencedEventId: 'my_video_reply',
+              rootEventPubkey: 'other_owner_pubkey',
+            ),
+          ]);
+          stubProfiles({});
+          stubVideoStats(
+            'my_video_reply',
+            makeVideoStats(id: 'my_video_reply'),
+          );
 
-        final page = await repository.getNotifications();
+          final page = await repository.getNotifications();
 
-        final item = page.items.single as VideoNotification;
-        expect(item.type, equals(NotificationKind.like));
-      });
+          final item = page.items.single as VideoNotification;
+          expect(item.type, equals(NotificationKind.like));
+        },
+      );
+
+      test(
+        'repost on the user-owned referenced video stays repost even when '
+        'root_event_pubkey is another creator (not silently dropped)',
+        () async {
+          // The repost case is the sharper failure: a misattributed repost is
+          // dropped by _reclassifiedMisattributedKind. If the payload root
+          // author overrode the user-owned anchor metadata, a genuine
+          // "reposted your video" on the user's own video-reply would vanish.
+          stubNotifications([
+            makeNotification(
+              notificationType: 'repost',
+              sourceKind: 6,
+              referencedEventId: 'my_video_reply',
+              rootEventPubkey: 'other_owner_pubkey',
+            ),
+          ]);
+          stubProfiles({});
+          stubVideoStats(
+            'my_video_reply',
+            makeVideoStats(id: 'my_video_reply'),
+          );
+
+          final page = await repository.getNotifications();
+
+          final item = page.items.single as VideoNotification;
+          expect(item.type, equals(NotificationKind.repost));
+        },
+      );
 
       test('comment on a non-owned video is reclassified as reply '
           'instead of commented on your video (#4813)', () async {


### PR DESCRIPTION
## Description

Closes #5949.

Fixes the residual notification edge behind #5634 / #5949: a reaction on the user's comment on another creator's video could still render as "liked your video" when Funnelcake left `target_comment_id` empty but supplied the thread root video context.

The client now consumes the existing root fields from the notification payload:

- `funnelcake_api_client`: parses `root_event_pubkey` into `RelayNotification`, normalizing it to lowercase, and parses `root_addressable_id`.
- `notification_repository`: keeps `videosById` anchor ownership authoritative when metadata resolves, then uses `root_event_pubkey` only as a weaker fallback after `getVideoStats` returns a confirmed 404/not-found.
- The root fallback is limited to actor-style repairs (`like -> likeComment`, `comment -> reply`) and cannot silently drop repost rows.
- Actor-anchored comment/reply rows use `root_addressable_id` for stable direct video routing when Funnelcake provides it.

This preserves the intended comment-like reclassification without treating timeouts, 5xx responses, or other transient metadata fetch failures as proof that the anchor was a comment.

**Related Issue:** #5634

## Out of Scope

- The robust backend fix, where Funnelcake sets `target_comment_id` or an explicit type from the reaction's own `k:1111` tag so the client never depends on resolving the comment event, is tracked in `divine-funnelcake` #410 (with #409/#458).

## Verification

- `flutter test packages/funnelcake_api_client`
- `flutter test packages/notification_repository`
- `flutter analyze packages/funnelcake_api_client packages/notification_repository`
- Pre-push hook: merge-conflict check, analyzer, and changed-file tests all passed.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
