### PR TITLE
fix(video-editor): let adjacent clip transitions fully consume a shared clip

### DIFF
--- a/mobile/lib/models/video_editor/transition_geometry.dart
+++ b/mobile/lib/models/video_editor/transition_geometry.dart
@@ -23,10 +23,12 @@ bool _shortensTimeline(ClipTransitionType type) => !_isDip(type);
 /// Per-side playback duration a [transition] consumes at the boundary between
 /// clips of playback durations [a] and [b].
 ///
-/// An overlap (dissolve/slide/push/wipe) blends both clips at once and consumes
-/// 2× its duration per side; a dip (fadeToBlack/White) fades out then in,
-/// consuming half its duration per side. Clamped to the shorter clip so a
-/// transition can never overrun a clip.
+/// An overlap (dissolve/slide/push/wipe) blends both clips for its duration and
+/// consumes exactly that duration per side — the blend fills the consumed span,
+/// with no solo lead reserved (the native compositor renders the fully-consumed
+/// overlap). A dip (fadeToBlack/White) fades out then in, consuming half its
+/// duration per side. Clamped to the shorter clip so a transition can never
+/// overrun a clip.
 Duration transitionConsumedPerSide(
   Duration a,
   Duration b,
@@ -35,7 +37,7 @@ Duration transitionConsumedPerSide(
   final shorter = a < b ? a : b;
   final requested = _isDip(transition.type)
       ? Duration(microseconds: transition.duration.inMicroseconds ~/ 2)
-      : transition.duration * 2;
+      : transition.duration;
   return requested < shorter ? requested : shorter;
 }
 
@@ -47,9 +49,7 @@ Duration transitionDurationForConsumed(
   ClipTransitionType type,
 ) {
   if (consumed <= Duration.zero) return Duration.zero;
-  return _isDip(type)
-      ? consumed * 2
-      : Duration(microseconds: consumed.inMicroseconds ~/ 2);
+  return _isDip(type) ? consumed * 2 : consumed;
 }
 
 /// Maps each clip id to its outgoing transition, clamped so that **no clip is
@@ -225,9 +225,9 @@ Duration loopTransitionRoomPerSide(List<DivineVideoClip> clips) {
 /// timeline, preview and export line up 1:1.
 ///
 /// Mirrors `TransitionSeamRenderService.computeSeamSpans`: per side an overlap
-/// consumes 2× its duration (solo lead-in/out around the blend) and its seam
-/// plays 1.5× the consumed span; a dip consumes half its duration per side and
-/// its seam plays the full 2× consumed span (dips don't shorten).
+/// consumes its duration and its seam plays that same span (the blend fills
+/// it); a dip consumes half its duration per side and its seam plays the full
+/// 2× consumed span (dips don't shorten).
 class LoopWrapDisplay {
   const LoopWrapDisplay._({
     required this.consumedPerSide,
@@ -262,9 +262,7 @@ class LoopWrapDisplay {
       wrap,
     );
     if (consumed <= Duration.zero) return none;
-    final blend = _isDip(wrap.type)
-        ? Duration.zero
-        : Duration(microseconds: consumed.inMicroseconds ~/ 2);
+    final blend = _isDip(wrap.type) ? Duration.zero : consumed;
     return LoopWrapDisplay._(
       consumedPerSide: consumed,
       seamDuration: consumed * 2 - blend,

--- a/mobile/lib/services/video_editor/transition_seam_render_service.dart
+++ b/mobile/lib/services/video_editor/transition_seam_render_service.dart
@@ -279,9 +279,9 @@ class TransitionSeamRenderService {
   /// `_render` converts [consumed] back into each clip's own source time for
   /// trimming.
   ///
-  /// For overlaps the blend is always half the consumed span, guaranteeing a
-  /// solo lead-in/out on each side (a segment equal to the blend degenerates
-  /// into a hard cut).
+  /// For overlaps the blend fills the consumed span (blend == consumed): the
+  /// two clips overlap for the whole consumed span, with no solo lead — the
+  /// native compositor renders the fully-consumed overlap.
   @visibleForTesting
   ({Duration consumed, Duration blend, ClipTransition seamTransition})
   computeSeamSpans(
@@ -295,11 +295,12 @@ class TransitionSeamRenderService {
       transition,
     );
     if (_isOverlap(transition.type)) {
-      final blend = _half(consumed);
       return (
         consumed: consumed,
-        blend: blend,
-        seamTransition: transition.copyWith(duration: blend),
+        blend: consumed,
+        seamTransition: transition.duration == consumed
+            ? transition
+            : transition.copyWith(duration: consumed),
       );
     }
     final dip = _min(transition.duration, consumed * 2);
@@ -370,8 +371,6 @@ class TransitionSeamRenderService {
   bool _isOverlap(ClipTransitionType type) =>
       type != ClipTransitionType.fadeToBlack &&
       type != ClipTransitionType.fadeToWhite;
-
-  Duration _half(Duration d) => Duration(microseconds: d.inMicroseconds ~/ 2);
 
   Duration _min(Duration a, Duration b) => a < b ? a : b;
 

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_transition_sheet.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_transition_sheet.dart
@@ -158,10 +158,10 @@ Future<void> _showTransitionSheet(
         toPlaceholder: toClip.thumbnailPath,
       ),
       child: TransitionPickerView(
-        // Overlaps blend both clips at once (so cap at half the room); dips fade
-        // out then in (so up to twice it). The room already excludes what the
-        // adjacent clips' own transitions consume, so two transitions never
-        // over-consume a shared clip — which the native compositor can't render.
+        // Overlaps blend both clips for their duration (so cap at the room);
+        // dips fade out then in (so up to twice the room). The room already
+        // excludes what the adjacent clips' own transitions consume, so two
+        // transitions never over-consume a shared clip.
         overlapMaxMs: _snapDurationMs(
           transitionDurationForConsumed(
             roomPerSide,
@@ -260,12 +260,12 @@ class TransitionPickerView extends StatefulWidget {
   });
 
   /// Duration-slider ceilings for the two transition families. An overlap
-  /// (dissolve/slide/push/wipe) blends both clips at once, so it's capped at
-  /// half the available per-side room; a dip (fadeToBlack/White) fades out then
-  /// in, so it can run up to twice it. The room already excludes what the
-  /// adjacent clips' own transitions consume, so two transitions never overlap
-  /// on a shared clip. The render path clamps to the same budget. Default to
-  /// [_maxDurationMs] in tests.
+  /// (dissolve/slide/push/wipe) blends both clips for its duration, so it's
+  /// capped at the available per-side room; a dip (fadeToBlack/White) fades out
+  /// then in, so it can run up to twice the room. The room already excludes what
+  /// the adjacent clips' own transitions consume, so two transitions never
+  /// overlap on a shared clip. The render path clamps to the same budget.
+  /// Default to [_maxDurationMs] in tests.
   final int overlapMaxMs;
   final int dipMaxMs;
 
@@ -299,7 +299,8 @@ class _TransitionPickerViewState extends State<TransitionPickerView>
   ];
 
   /// Dip transitions fade out then in (no simultaneous blend), so they may run
-  /// up to twice the shorter clip; overlaps blend both at once and cap at half.
+  /// up to twice the shorter clip; overlaps blend both at once and cap at the
+  /// room.
   bool _isDip(ClipTransitionType? type) =>
       type == ClipTransitionType.fadeToBlack ||
       type == ClipTransitionType.fadeToWhite;

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1791,10 +1791,10 @@ packages:
     dependency: "direct main"
     description:
       name: pro_video_editor
-      sha256: aa05eb426dc98607dd6f776b4da9a5bb09c80c44e72138d299409d52a38b920d
+      sha256: addbda628f0e97b474c219c458f0e3f69ba7a39f70bee30bb45d0e8a85899187
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.0"
+    version: "2.7.1"
   process:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -314,7 +314,7 @@ dependencies:
   firebase_performance: ^0.11.1+4
   firebase_messaging: ^16.1.1
   audio_session: ^0.2.2
-  pro_video_editor: ^2.6.0
+  pro_video_editor: ^2.7.1
   pro_image_editor: ^13.2.0
   flutter_colorpicker: ^1.1.0
   file_picker: ^10.3.7

--- a/mobile/test/models/video_editor/transition_geometry_test.dart
+++ b/mobile/test/models/video_editor/transition_geometry_test.dart
@@ -12,15 +12,16 @@ void main() {
   const fadeToBlack = ClipTransition(type: ClipTransitionType.fadeToBlack);
 
   group('transitionConsumedPerSide', () {
-    test('an overlap consumes twice its duration per side', () {
+    test('an overlap consumes its duration per side', () {
       final t = dissolve.copyWith(duration: const Duration(milliseconds: 400));
+      // The blend fills the consumed span → 400ms consumed per side.
       expect(
         transitionConsumedPerSide(
           const Duration(seconds: 3),
           const Duration(seconds: 3),
           t,
         ),
-        equals(const Duration(milliseconds: 800)),
+        equals(const Duration(milliseconds: 400)),
       );
     });
 
@@ -51,13 +52,13 @@ void main() {
   });
 
   group('transitionDurationForConsumed', () {
-    test('inverts the overlap geometry (consumed × 0.5)', () {
+    test('inverts the overlap geometry (identity — blend fills consumed)', () {
       expect(
         transitionDurationForConsumed(
           const Duration(milliseconds: 800),
           ClipTransitionType.dissolve,
         ),
-        equals(const Duration(milliseconds: 400)),
+        equals(const Duration(milliseconds: 800)),
       );
     });
 
@@ -141,7 +142,7 @@ void main() {
     });
 
     test('passes an in-bounds overlap through unchanged', () {
-      // Two 2s clips → overlap ceiling is half the shorter clip = 1s. 800ms is
+      // Two 2s clips → overlap ceiling is the shorter clip (2s). 800ms is
       // within bounds.
       final eightHundred = dissolve.copyWith(
         duration: const Duration(milliseconds: 800),
@@ -154,16 +155,17 @@ void main() {
       expect(clampTransitions(clips)['a'], equals(eightHundred));
     });
 
-    test('clamps an overlap longer than half the shorter clip', () {
+    test('clamps an overlap that would over-consume the shorter clip', () {
       final tooLong = dissolve.copyWith(
         duration: const Duration(milliseconds: 1500),
       );
       final clips = [
-        clip('a', const Duration(seconds: 2), transition: tooLong),
-        clip('b', const Duration(seconds: 2)),
+        clip('a', const Duration(seconds: 1), transition: tooLong),
+        clip('b', const Duration(seconds: 1)),
       ];
 
-      // Half the shorter (2s) clip = 1s.
+      // A 1500ms overlap wants to consume 1500ms/side, over the 1s clip →
+      // clamped so its consumption fits: 1000ms consumed = 1000ms blend.
       expect(
         clampTransitions(clips)['a']?.duration,
         equals(const Duration(seconds: 1)),
@@ -188,18 +190,20 @@ void main() {
     });
 
     test('clamps on playbackDuration for speed-changed clips', () {
-      // A 2× clip of 4s source occupies 2s of playback → overlap ceiling 1s.
+      // A 2× clip of 2s source occupies 1s of playback → a 1500ms overlap
+      // clamps to that 1s playback, not the 2s source span the trimmed-duration
+      // basis would have used.
       final tooLong = dissolve.copyWith(
         duration: const Duration(milliseconds: 1500),
       );
       final clips = [
         clip(
           'a',
-          const Duration(seconds: 4),
+          const Duration(seconds: 2),
           transition: tooLong,
           playbackSpeed: 2,
         ),
-        clip('b', const Duration(seconds: 4), playbackSpeed: 2),
+        clip('b', const Duration(seconds: 2), playbackSpeed: 2),
       ];
 
       expect(
@@ -227,23 +231,23 @@ void main() {
     });
 
     test('splits a shared middle clip between two over-consuming overlaps', () {
-      // 3×1s clips with a dissolve at the overlap ceiling (500ms) on both
-      // boundaries. Each alone would consume the whole 1s middle clip, leaving
-      // no solo body — and the native overlap (planOverlap) then falls back to
-      // a hard cut, dropping the transition. Clamped, they split the clip: each
-      // becomes 250ms so the middle keeps 500ms of solo body for both blends.
-      final overlap500 = dissolve.copyWith(
-        duration: const Duration(milliseconds: 500),
+      // 3×1s clips with a 600ms dissolve on both boundaries. Each consumes
+      // 600ms per side; together (1200ms) they over-consume the 1s middle clip,
+      // so both scale down to 500ms — exactly filling it (500 + 500). Two 500ms
+      // overlaps would already fit without clamping now that the blend fills the
+      // consumed span with no solo lead.
+      final overlap600 = dissolve.copyWith(
+        duration: const Duration(milliseconds: 600),
       );
       final clips = [
-        clip('a', const Duration(seconds: 1), transition: overlap500),
-        clip('b', const Duration(seconds: 1), transition: overlap500),
+        clip('a', const Duration(seconds: 1), transition: overlap600),
+        clip('b', const Duration(seconds: 1), transition: overlap600),
         clip('c', const Duration(seconds: 1)),
       ];
 
       final clamped = clampTransitions(clips);
-      expect(clamped['a']?.duration, equals(const Duration(milliseconds: 250)));
-      expect(clamped['b']?.duration, equals(const Duration(milliseconds: 250)));
+      expect(clamped['a']?.duration, equals(const Duration(milliseconds: 500)));
+      expect(clamped['b']?.duration, equals(const Duration(milliseconds: 500)));
     });
 
     test('does not reduce a single dip even when the middle clip is short', () {
@@ -263,10 +267,12 @@ void main() {
     test(
       'scales the two boundaries by their demand on an over-consumed clip',
       () {
-        // The middle clip (1s) is over-consumed: its incoming dip wants 1s/side
-        // (2s dip) and its outgoing overlap wants 1s/side (500ms dissolve). They
-        // share the 1s budget proportionally to their equal demand → 0.5s each,
-        // so neither side over-runs and the clip is split between them.
+        // The middle clip (1s) is over-consumed: its incoming dip wants
+        // 1000ms/side (2s dip) and its outgoing overlap wants 500ms/side (500ms
+        // dissolve, blend fills the consumed span). Both boundaries scale by the
+        // same factor (1000/1500 ≈ 0.667): the dip's 667ms consumed → 1333ms,
+        // the overlap's 333ms consumed → 333ms blend. Asserted in whole ms since
+        // the proportional scale lands off a round microsecond.
         final dip2s = fadeToBlack.copyWith(
           duration: const Duration(seconds: 2),
         );
@@ -280,13 +286,8 @@ void main() {
         ];
 
         final clamped = clampTransitions(clips);
-        // Dip: 0.5s consumed → duration 1s. Overlap: 0.5s consumed → duration
-        // 250ms.
-        expect(clamped['a']?.duration, equals(const Duration(seconds: 1)));
-        expect(
-          clamped['b']?.duration,
-          equals(const Duration(milliseconds: 250)),
-        );
+        expect(clamped['a']?.duration.inMilliseconds, equals(1333));
+        expect(clamped['b']?.duration.inMilliseconds, equals(333));
       },
     );
   });
@@ -549,8 +550,8 @@ void main() {
 
     group('clampTransitions', () {
       test('passes an in-bounds single-clip wrap through unchanged', () {
-        // One 4s clip: an 800ms dissolve carves 1.6s head + 1.6s tail, leaving
-        // an 0.8s middle body, so it fits and is not reduced.
+        // One 4s clip: an 800ms dissolve carves 800ms head + 800ms tail,
+        // leaving a 2.4s middle body, so it fits and is not reduced.
         final wrap = dissolve.copyWith(
           duration: const Duration(milliseconds: 800),
         );
@@ -563,8 +564,9 @@ void main() {
       });
 
       test('clamps a single-clip wrap that would consume the whole clip', () {
-        // A 1500ms dissolve on a 2s clip wants 2×(1500×2)=6s of a 2s clip; the
-        // head+tail budget caps it to half the clip per side → 500ms.
+        // A 1500ms dissolve on a 2s single clip wants 1500ms/side; head + tail
+        // (3000ms) over-consume the 2s clip, so it's scaled to fit — 1000ms
+        // consumed/side → 1000ms blend.
         final tooLong = dissolve.copyWith(
           duration: const Duration(milliseconds: 1500),
         );
@@ -572,13 +574,14 @@ void main() {
           clampTransitions([
             clip('a', const Duration(seconds: 2), transition: tooLong),
           ])['a']?.duration,
-          equals(const Duration(milliseconds: 500)),
+          equals(const Duration(seconds: 1)),
         );
       });
 
       test('passes an in-bounds multi-clip wrap through unchanged', () {
-        // Two 4s clips, no interior transition: a 500ms dissolve carves 1s from
-        // the last clip's tail and 1s from the first clip's head, both fit.
+        // Two 4s clips, no interior transition: a 500ms dissolve carves 500ms
+        // from the last clip's tail and 500ms from the first clip's head, both
+        // fit.
         final wrap = dissolve.copyWith(
           duration: const Duration(milliseconds: 500),
         );
@@ -668,7 +671,8 @@ void main() {
       });
 
       test('shortens first head + last tail and appends the overlap seam', () {
-        // 500ms dissolve → 1s consumed per side, seam 2s−1s/2... = 1.5s.
+        // 500ms dissolve → 500ms consumed per side (the blend fills it), seam =
+        // 2×500 − 500 = 500ms.
         final wrap = dissolve.copyWith(
           duration: const Duration(milliseconds: 500),
         );
@@ -678,20 +682,23 @@ void main() {
         ];
         final display = LoopWrapDisplay.fromClips(clips);
 
-        expect(display.consumedPerSide, equals(const Duration(seconds: 1)));
+        expect(
+          display.consumedPerSide,
+          equals(const Duration(milliseconds: 500)),
+        );
         expect(
           display.seamDuration,
-          equals(const Duration(milliseconds: 1500)),
+          equals(const Duration(milliseconds: 500)),
         );
         expect(
           display.displayDuration(clips.first, isFirst: true, isLast: false),
-          equals(const Duration(seconds: 2)),
+          equals(const Duration(milliseconds: 2500)),
         );
         expect(
           display.displayDuration(clips.last, isFirst: false, isLast: true),
-          equals(const Duration(seconds: 2)),
+          equals(const Duration(milliseconds: 2500)),
         );
-        // Total = 6s − 2×1s + 1.5s = 5.5s — exactly the export length
+        // Total = 6s − 2×500ms + 500ms = 5.5s — exactly the export length
         // (6s − 500ms blend).
         expect(
           display.displayTotal(clips),
@@ -730,10 +737,11 @@ void main() {
         ];
         final display = LoopWrapDisplay.fromClips(clips);
 
-        // 250ms dissolve → 500ms per side, both from the same clip.
+        // 250ms dissolve → 250ms per side (the blend fills it), both from the
+        // same clip → 3s − 2×250ms.
         expect(
           display.displayDuration(clips.first, isFirst: true, isLast: true),
-          equals(const Duration(seconds: 2)),
+          equals(const Duration(milliseconds: 2500)),
         );
       });
     });
@@ -757,9 +765,9 @@ void main() {
       });
 
       test('excludes the neighbours own internal transitions', () {
-        // a→b dissolve (500ms) consumes 1s of b's head, leaving 1s tail for the
-        // wrap; a's own outgoing consumes 1s of its tail, leaving 2s head. The
-        // tighter side (1s) wins.
+        // a→b dissolve (500ms) consumes 500ms of b's head, leaving 1500ms tail
+        // for the wrap; a's own outgoing consumes 500ms of its tail, leaving 2s
+        // head. The tighter side (1500ms) wins.
         final internal = dissolve.copyWith(
           duration: const Duration(milliseconds: 500),
         );
@@ -768,7 +776,7 @@ void main() {
             clip('a', const Duration(seconds: 3), transition: internal),
             clip('b', const Duration(seconds: 2)),
           ]),
-          equals(const Duration(seconds: 1)),
+          equals(const Duration(milliseconds: 1500)),
         );
       });
     });

--- a/mobile/test/services/video_editor/transition_seam_render_service_test.dart
+++ b/mobile/test/services/video_editor/transition_seam_render_service_test.dart
@@ -55,7 +55,8 @@ void main() {
       // The last clip's transition is the loop-restart wrap. Its consumption is
       // applied even before the seam file lands, so the display axis (timeline
       // strips) never shifts under the playhead; only the blend itself is
-      // missing until rendered. A 500ms dissolve consumes 2×500ms per side.
+      // missing until rendered. A 500ms dissolve consumes 500ms per side (the
+      // blend fills the consumed span).
       final clips = [clip('a'), clip('b', transition: dissolve)];
       final result = buildSeamAwarePlayerClips(
         clips,
@@ -64,11 +65,11 @@ void main() {
 
       expect(result, hasLength(2));
       expect(result[0].uri, equals('/tmp/a.mp4'));
-      expect(result[0].start, equals(const Duration(seconds: 1)));
+      expect(result[0].start, equals(const Duration(milliseconds: 500)));
       expect(result[0].end, equals(const Duration(seconds: 3)));
       expect(result[1].uri, equals('/tmp/b.mp4'));
       expect(result[1].start, equals(Duration.zero));
-      expect(result[1].end, equals(const Duration(seconds: 2)));
+      expect(result[1].end, equals(const Duration(milliseconds: 2500)));
     });
 
     test('consumes the first head + last tail and appends the wrap seam', () {
@@ -283,17 +284,17 @@ void main() {
 
     final service = TransitionSeamRenderService();
 
-    test('overlap uses 2× blend with a solo lead-in/out on long clips', () {
+    test('overlap blend fills the consumed span on long clips', () {
       final spans = service.computeSeamSpans(
         sized('a', const Duration(seconds: 3)),
         sized('b', const Duration(seconds: 3)),
         dissolve,
       );
 
-      expect(spans.consumed, equals(const Duration(seconds: 1)));
+      // The blend fills the consumed span (no solo lead): 500ms each.
+      expect(spans.consumed, equals(const Duration(milliseconds: 500)));
       expect(spans.blend, equals(const Duration(milliseconds: 500)));
-      // Solo lead = consumed - blend > 0 → never a degenerate hard cut.
-      expect(spans.blend, lessThan(spans.consumed));
+      expect(spans.blend, equals(spans.consumed));
       expect(spans.seamTransition.duration, equals(spans.blend));
     });
 
@@ -305,10 +306,10 @@ void main() {
         dissolve, // 500ms, longer than the 200ms clip
       );
 
-      // Clamped to the whole 200ms clip; still blends (blend < consumed).
+      // Clamped to the whole 200ms clip; the blend fills it (blend == consumed).
       expect(spans.consumed, equals(const Duration(milliseconds: 200)));
-      expect(spans.blend, equals(const Duration(milliseconds: 100)));
-      expect(spans.blend, lessThan(spans.consumed));
+      expect(spans.blend, equals(const Duration(milliseconds: 200)));
+      expect(spans.blend, equals(spans.consumed));
     });
 
     test('dip takes half the duration per side and cannot outrun the span', () {
@@ -336,19 +337,19 @@ void main() {
     });
 
     test('clamps on playbackDuration, not source, for speed-changed clips', () {
-      // 4× clips of 2s source each occupy only 500ms of wall-clock time, so the
-      // overlap must clamp to that playback span (consumed 500ms, blend 250ms)
-      // — not the 2s source span the trimmed-duration basis would have used
-      // (which would have allowed the full 1000ms consumed / 500ms blend).
+      // 4× clips of 2s source each occupy only 500ms of wall-clock time, so a
+      // 1s overlap must clamp to that 500ms playback span (consumed 500ms,
+      // blend 500ms) — not the 2s source span the trimmed-duration basis would
+      // have used (which would have allowed the full 1000ms consumed / blend).
       final spans = service.computeSeamSpans(
         sized('a', const Duration(seconds: 2), playbackSpeed: 4),
         sized('b', const Duration(seconds: 2), playbackSpeed: 4),
-        dissolve, // 500ms
+        dissolve.copyWith(duration: const Duration(seconds: 1)),
       );
 
       expect(spans.consumed, equals(const Duration(milliseconds: 500)));
-      expect(spans.blend, equals(const Duration(milliseconds: 250)));
-      expect(spans.blend, lessThan(spans.consumed));
+      expect(spans.blend, equals(const Duration(milliseconds: 500)));
+      expect(spans.blend, equals(spans.consumed));
       expect(spans.seamTransition.duration, equals(spans.blend));
     });
   });

--- a/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
@@ -728,9 +728,9 @@ void main() {
   // from the drawn strip by a gap width near each boundary.
   //
   //   clips: c0 = 4 s, c1 = 4 s with a 500 ms dissolve loop wrap
-  //   → consumed = 1 s per side, display c0 = 3 s, c1 = 3 s, seam = 1.5 s
-  //   display layout @ pps 52, clipGap 1:
-  //     [0…156 px] gap [157…313 px]  seam [313…391 px]  (total 7.5 s → 390 px)
+  //   → consumed = 500 ms per side (the blend fills it), display c0 = 3500 ms,
+  //     c1 = 3500 ms, seam = 500 ms. Total is still 7.5 s → 390 px since only
+  //     the 500 ms blend shortens the export.
   group('loop-wrap-aware geometry', () {
     const dissolve = ClipTransition(type: ClipTransitionType.dissolve);
     final wrapClips = [
@@ -748,42 +748,45 @@ void main() {
     const clipGap = 1.0;
 
     test('LoopWrapDisplay carries the expected consumed span', () {
-      expect(wrap.consumedPerSide, equals(const Duration(seconds: 1)));
+      expect(
+        wrap.consumedPerSide,
+        equals(const Duration(milliseconds: 500)),
+      );
       expect(wrap.displayTotal(wrapClips), equals(displayTotal));
     });
 
     test('positionToOffset counts the gap on the display boundary', () {
-      // 3.5 s is 0.5 s into c1 on the display axis (c1 starts at display 3 s),
-      // so the gap after c0 is already crossed → +1 gap.
-      const pos = Duration(milliseconds: 3500);
+      // 3.6 s is past c1's display start (3500 ms), so the gap after c0 is
+      // already crossed → +1 gap.
+      const pos = Duration(milliseconds: 3600);
       expect(
         timelinePositionToScrollOffset(wrapClips, pos, pps, wrap: wrap),
-        equals(3.5 * pps + clipGap),
+        equals(3.6 * pps + clipGap),
       );
     });
 
     test('positionToOffset without the wrap misses the display gap', () {
-      // Without the wrap the raw c0 duration (4 s) still contains 3.5 s, so the
+      // Without the wrap the raw c0 duration (4 s) still contains 3.6 s, so the
       // gap is not counted — the drift the wrap parameter fixes.
-      const pos = Duration(milliseconds: 3500);
+      const pos = Duration(milliseconds: 3600);
       expect(
         timelinePositionToScrollOffset(wrapClips, pos, pps),
-        equals(3.5 * pps),
+        equals(3.6 * pps),
       );
     });
 
     test('positionToOffset maps the seam region past every clip gap', () {
-      // 6.5 s is 0.5 s into the seam (bodies end at display 6 s); one gap sits
-      // before it (between c0 and c1).
-      const pos = Duration(milliseconds: 6500);
+      // Bodies end at display 7000 ms (2×3500 ms), so 7.25 s is inside the seam
+      // region; one gap sits before it (between c0 and c1).
+      const pos = Duration(milliseconds: 7250);
       expect(
         timelinePositionToScrollOffset(wrapClips, pos, pps, wrap: wrap),
-        equals(6.5 * pps + clipGap),
+        equals(7.25 * pps + clipGap),
       );
     });
 
     test('offsetToPosition round-trips a display-axis position', () {
-      const pos = Duration(milliseconds: 3500);
+      const pos = Duration(milliseconds: 3600);
       final offset = timelinePositionToScrollOffset(
         wrapClips,
         pos,


### PR DESCRIPTION
# Please hold off on reviewing this for now.

# It is close to done, but there is still a problematic iOS bug: on some devices, videos rendered this way hang in the video player — on loop restart the audio keeps playing while the picture freezes. I want that fixed before anyone spends time on a review.


## Summary

Reworks the overlap-transition consumption model so two consecutive transitions can each be full-length on a shared clip. An overlap (slide/dissolve/push/wipe) now consumes exactly its blend duration per side (`consumed = blend`) instead of reserving an extra solo lead — so two 0.5s blends fill a 1s middle clip exactly (0.5 + 0.5 = 1.0), adjacent transitions chain directly, and the picker's duration ceiling roughly doubles.

## Why

The old model reserved a full blend-length solo lead on each side of an overlap (`consumed = 2× duration`). That had two visible costs on short clips:

- **Restrictive cap:** a 1s single clip capped a loop-slide at 0.25s (half the room, halved again by the 2× budget), and two transitions could never both reach their full length on a shared clip.
- **Forced gap:** two consecutive transitions on a 1s middle clip always left a ~0.5s solo stretch between the two animations.

Removing the solo lead makes the shared clip the only constraint: `blend_A + blend_B ≤ shared clip`. Two 0.5s blends fit a 1s clip exactly, with no artificial reservation and no gap. The no-overlap clamp still prevents blends from overrunning a shared clip (e.g. two 0.6s on a 1s clip clamp to 0.5s each).

## Native dependency (blocking)

The blend now fully consumes the adjacent clip's contributed region, so the **native renderer must composite a fully-consumed overlap** (no non-blended frames) — otherwise it falls back to a hard cut (`not enough content for boundary`). That fix is **hm21/pro_video_editor#179**. This PR must not merge until that lands, is published, and `pro_video_editor` is bumped to `^2.7.1` here. (A temporary local path override was used during development and is intentionally not part of this PR.)

## Testing

- `flutter test` (transition geometry, seam render, transition sheet, timeline geometry): **192 passing**. `flutter analyze` + `dart format` clean.
- Verified on Android against the local native fix: consecutive and fully-consumed transitions render; both 0.5s on a 1s clip work.
- iOS/macOS device check pending (native Swift mirror is in the same pro_video_editor PR).

## Notes

- The seam-cache-miss-on-reclamp preview drop (the original mechanism diagnosed under this issue) is greatly reduced here — blends now fit, so re-clamping rarely happens — but not separately eliminated. A `cachedForPair` seam fallback is a clean follow-up if it still surfaces.
- Draft: blocked on hm21/pro_video_editor#179 publish + the `pro_video_editor` version bump.

Closes #6187
