### PR TITLE
fix(video-player): classify auth-required media errors

### DIFF
--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
@@ -10,6 +10,7 @@ import androidx.media3.common.PlaybackException
 import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.HttpDataSource
 import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.SeekParameters
@@ -756,30 +757,35 @@ internal class DivineVideoPlayerInstance(
             map["errorMessage"] = error.localizedMessage
                 ?: error.cause?.localizedMessage
                 ?: error.errorCodeName
-            map["errorCode"] = when (error.errorCode) {
-                PlaybackException.ERROR_CODE_IO_BAD_HTTP_STATUS -> {
-                    val status = (error.cause as? androidx.media3.datasource.HttpDataSource.InvalidResponseCodeException)?.responseCode ?: 0
-                    when {
-                        status == 202 -> "media_processing"
-                        status == 401 -> "auth_required"
-                        status in 400..499 -> "http_client_error"
-                        else -> "http_server_error"
-                    }
-                }
-                PlaybackException.ERROR_CODE_IO_FILE_NOT_FOUND,
-                PlaybackException.ERROR_CODE_IO_INVALID_HTTP_CONTENT_TYPE,
-                PlaybackException.ERROR_CODE_IO_NO_PERMISSION -> "http_client_error"
-                PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED -> "network_error"
-                PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_TIMEOUT -> "timeout"
-                in 2000..2999 -> "decoder_error"
-                in 3000..3999 -> "parse_error"
-                in 4000..4999 -> "decoder_error"
-                in 6000..6999 -> "decoder_error"
-                else -> "unknown"
-            }
+            map["errorCode"] = errorCodeFor(error)
         }
         sink.success(map)
     }
+
+    private fun errorCodeFor(error: PlaybackException): String =
+        when (error.errorCode) {
+            PlaybackException.ERROR_CODE_IO_BAD_HTTP_STATUS -> {
+                val status =
+                    (error.cause as? HttpDataSource.InvalidResponseCodeException)
+                        ?.responseCode ?: 0
+                when {
+                    status == 202 -> "media_processing"
+                    status == 401 -> "auth_required"
+                    status in 400..499 -> "http_client_error"
+                    else -> "http_server_error"
+                }
+            }
+            PlaybackException.ERROR_CODE_IO_FILE_NOT_FOUND,
+            PlaybackException.ERROR_CODE_IO_INVALID_HTTP_CONTENT_TYPE,
+            PlaybackException.ERROR_CODE_IO_NO_PERMISSION -> "http_client_error"
+            PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED -> "network_error"
+            PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_TIMEOUT -> "timeout"
+            in 2000..2999 -> "decoder_error"
+            in 3000..3999 -> "parse_error"
+            in 4000..4999 -> "decoder_error"
+            in 6000..6999 -> "decoder_error"
+            else -> "unknown"
+        }
 
     private fun computeTotalDuration(exoPlayer: ExoPlayer): Long {
         var total = 0L
@@ -1013,7 +1019,7 @@ internal class DivineVideoPlayerInstance(
             pendingSetClipsResult?.error(
                 "PLAYER_ERROR",
                 error.message ?: "Unknown playback error",
-                null,
+                mapOf("errorCode" to errorCodeFor(error)),
             )
             pendingSetClipsResult = null
             sendStateUpdate()

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
@@ -761,6 +761,7 @@ internal class DivineVideoPlayerInstance(
                     val status = (error.cause as? androidx.media3.datasource.HttpDataSource.InvalidResponseCodeException)?.responseCode ?: 0
                     when {
                         status == 202 -> "media_processing"
+                        status == 401 -> "auth_required"
                         status in 400..499 -> "http_client_error"
                         else -> "http_server_error"
                     }

--- a/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
+++ b/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
@@ -2,12 +2,15 @@ package com.divinevideo.divine_video_player
 
 import android.content.Context
 import android.graphics.SurfaceTexture
+import android.net.Uri
 import android.os.Handler
 import android.os.SystemClock
 import android.view.Surface
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
+import androidx.media3.datasource.DataSpec
+import androidx.media3.datasource.HttpDataSource
 import androidx.media3.exoplayer.ExoPlayer
 import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.MethodCall
@@ -25,6 +28,7 @@ import io.mockk.unmockkConstructor
 import io.mockk.unmockkStatic
 import io.mockk.verify
 import io.mockk.verifyOrder
+import java.io.IOException
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -442,7 +446,27 @@ class DivineVideoPlayerInstanceTest {
         every { error.message } returns "boom"
         listener.onPlayerError(error)
 
-        verify(exactly = 1) { result.error("PLAYER_ERROR", "boom", null) }
+        verify(exactly = 1) {
+            result.error("PLAYER_ERROR", "boom", mapOf("errorCode" to "unknown"))
+        }
+        verify(exactly = 0) { result.success(any()) }
+    }
+
+    @Test
+    fun `onPlayerError maps pending HTTP 401 setClips failure to auth_required`() {
+        val listener = capturePlayerListener()
+        val result = mockk<MethodChannel.Result>(relaxed = true)
+        instance.onMethodCall(setClipsCall("https://example.com/protected.mp4"), result)
+
+        listener.onPlayerError(httpStatusError(401))
+
+        verify(exactly = 1) {
+            result.error(
+                "PLAYER_ERROR",
+                "HTTP 401",
+                mapOf("errorCode" to "auth_required"),
+            )
+        }
         verify(exactly = 0) { result.success(any()) }
     }
 
@@ -461,6 +485,31 @@ class DivineVideoPlayerInstanceTest {
             null,
             PlaybackException.ERROR_CODE_DECODER_INIT_FAILED,
         ).also { unmockkStatic(SystemClock::class) }
+    }
+
+    private fun httpStatusError(status: Int): PlaybackException {
+        mockkStatic(SystemClock::class)
+        mockkStatic(Uri::class)
+        every { SystemClock.elapsedRealtime() } returns 0L
+        every { Uri.parse("https://example.com/protected.mp4") } returns mockk(relaxed = true)
+        try {
+            val cause = HttpDataSource.InvalidResponseCodeException(
+                status,
+                "HTTP $status",
+                IOException("HTTP $status"),
+                emptyMap(),
+                DataSpec(Uri.parse("https://example.com/protected.mp4")),
+                ByteArray(0),
+            )
+            return PlaybackException(
+                "HTTP $status",
+                cause,
+                PlaybackException.ERROR_CODE_IO_BAD_HTTP_STATUS,
+            )
+        } finally {
+            unmockkStatic(Uri::class)
+            unmockkStatic(SystemClock::class)
+        }
     }
 
     @Test
@@ -499,7 +548,9 @@ class DivineVideoPlayerInstanceTest {
 
         // The third gives up and surfaces the error to Dart.
         listener.onPlayerError(decoderInitError("final boom"))
-        verify(exactly = 1) { result.error("PLAYER_ERROR", "final boom", null) }
+        verify(exactly = 1) {
+            result.error("PLAYER_ERROR", "final boom", mapOf("errorCode" to "decoder_error"))
+        }
     }
 
     @Test
@@ -512,7 +563,9 @@ class DivineVideoPlayerInstanceTest {
         listener.onPlayerError(decoderInitError())
         listener.onPlayerError(decoderInitError())
         listener.onPlayerError(decoderInitError("gave up"))
-        verify(exactly = 1) { result.error("PLAYER_ERROR", "gave up", null) }
+        verify(exactly = 1) {
+            result.error("PLAYER_ERROR", "gave up", mapOf("errorCode" to "decoder_error"))
+        }
 
         // A new clip load gets the full budget: the next decoder error is
         // retried instead of immediately failing the new pending result.

--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
@@ -1062,6 +1062,9 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             if httpResponse.statusCode == 202 {
                 return "media_processing"
             }
+            if httpResponse.statusCode == 401 {
+                return "auth_required"
+            }
             return httpResponse.statusCode >= 500 ? "http_server_error" : "http_client_error"
         }
 
@@ -1076,6 +1079,8 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             return "network_error"
         case (NSURLErrorDomain, NSURLErrorTimedOut):
             return "timeout"
+        case (NSURLErrorDomain, NSURLErrorUserAuthenticationRequired):
+            return "auth_required"
         default:
             // AVFoundation format / decoder errors.
             if err.domain == AVFoundationErrorDomain {

--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
@@ -64,6 +64,7 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
     private var speed: Double = 1.0
     private var currentStatus: String = "idle"
     private var errorMessage: String?
+    private var errorCode: String?
     private var firstFrameRendered: Bool = false
     private var videoWidth: Int = 0
     private var videoHeight: Int = 0
@@ -271,6 +272,8 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                 self.safePreroll(at: startTime)
 
                 self.currentStatus = "ready"
+                self.errorMessage = nil
+                self.errorCode = nil
                 self.clearSetClipsTimeout()
                 DivineVideoPlayerLog.shared.info(
                     "Player \(self.playerId) ready: \(self.clipCount) clip(s), "
@@ -282,6 +285,7 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             } catch {
                 self.currentStatus = "error"
                 self.errorMessage = error.localizedDescription
+                self.errorCode = self.errorCode(for: error as NSError)
                 self.clearSetClipsTimeout()
                 self.clearBufferingWatchdog(resetReported: true)
                 DivineVideoPlayerLog.shared.error(
@@ -294,7 +298,7 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                     FlutterError(
                         code: "COMPOSITION_ERROR",
                         message: error.localizedDescription,
-                        details: nil
+                        details: self.errorCode.map { ["errorCode": $0] }
                     )
                 )
             }
@@ -617,6 +621,7 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         currentStatus = "idle"
         errorMessage = nil  // clear stale error so sendStateUpdate never emits
                             // status="error" after media has been released.
+        errorCode = nil
         sendStateUpdate()
         result(nil)
     }
@@ -839,12 +844,19 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                 case .readyToPlay:
                     self.clearSetClipsTimeout()
                     self.currentStatus = "ready"
+                    self.errorMessage = nil
+                    self.errorCode = nil
                     self.updateVideoSize(from: item)
                 case .failed:
                     self.clearSetClipsTimeout()
                     self.clearBufferingWatchdog(resetReported: true)
                     self.currentStatus = "error"
                     self.errorMessage = item.error?.localizedDescription
+                    if let itemError = item.error as NSError? {
+                        self.errorCode = self.errorCode(for: itemError)
+                    } else {
+                        self.errorCode = nil
+                    }
                     DivineVideoPlayerLog.shared.error(
                         "Player \(self.playerId) item failed: "
                             + "\(item.error?.localizedDescription ?? "unknown")",
@@ -1055,8 +1067,14 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             return nil
         }
 
-        guard let err = nsError else { return currentStatus == "error" ? "unknown" : nil }
+        guard let err = nsError else {
+            return currentStatus == "error" ? (errorCode ?? "unknown") : nil
+        }
 
+        return errorCode(for: err)
+    }
+
+    private func errorCode(for err: NSError) -> String {
         // HTTP errors carried inside AVFoundation errors.
         if let httpResponse = err.userInfo["NSURLErrorFailingURLResponseErrorKey"] as? HTTPURLResponse {
             if httpResponse.statusCode == 202 {

--- a/mobile/packages/divine_video_player/lib/src/player_error_code.dart
+++ b/mobile/packages/divine_video_player/lib/src/player_error_code.dart
@@ -66,11 +66,13 @@ enum NativePlayerErrorCode {
   /// to the next source instead of retrying the current one.
   ///
   /// Network / timeout errors are transient and should stay on the same
-  /// source. HTTP 4xx/5xx and parse errors indicate the current source is not
-  /// usable right now, so the feed should skip to the next available source.
+  /// source. Auth errors apply to the whole media asset and should surface
+  /// immediately. Other HTTP 4xx/5xx and parse errors indicate the current
+  /// source is not usable right now, so the feed should skip to the next
+  /// available source.
   bool get shouldFailover => switch (this) {
     mediaProcessing => false,
-    authRequired => true,
+    authRequired => false,
     httpClientError => true,
     httpServerError => true,
     parseError => true,

--- a/mobile/packages/divine_video_player/lib/src/player_error_code.dart
+++ b/mobile/packages/divine_video_player/lib/src/player_error_code.dart
@@ -13,10 +13,16 @@ enum NativePlayerErrorCode {
   /// iOS: CoreMedia / AVFoundation errors whose message includes HTTP 202.
   mediaProcessing,
 
+  /// Authentication is required to load the media.
+  ///
+  /// Android: `ERROR_CODE_IO_BAD_HTTP_STATUS` with response code 401.
+  /// iOS: HTTP 401 in `userInfo` or `NSURLErrorUserAuthenticationRequired`.
+  authRequired,
+
   /// HTTP 4xx response from the media server.
   ///
-  /// Android: `ERROR_CODE_IO_BAD_HTTP_STATUS` when 400–499.
-  /// iOS: `NSError` with HTTP status in `userInfo`.
+  /// Android: `ERROR_CODE_IO_BAD_HTTP_STATUS` when 400–499, except 401.
+  /// iOS: `NSError` with HTTP status in `userInfo`, except 401.
   httpClientError,
 
   /// HTTP 5xx response from the media server.
@@ -64,6 +70,7 @@ enum NativePlayerErrorCode {
   /// usable right now, so the feed should skip to the next available source.
   bool get shouldFailover => switch (this) {
     mediaProcessing => false,
+    authRequired => true,
     httpClientError => true,
     httpServerError => true,
     parseError => true,
@@ -83,6 +90,7 @@ enum NativePlayerErrorCode {
     mediaProcessing => true,
     networkError => true,
     timeout => true,
+    authRequired => false,
     httpServerError => false,
     httpClientError => false,
     parseError => false,
@@ -93,6 +101,7 @@ enum NativePlayerErrorCode {
   /// Parses the string value sent over the platform channel.
   static NativePlayerErrorCode fromString(String value) => switch (value) {
     'media_processing' => mediaProcessing,
+    'auth_required' => authRequired,
     'http_client_error' => httpClientError,
     'http_server_error' => httpServerError,
     'network_error' => networkError,

--- a/mobile/packages/divine_video_player/test/src/android_auth_error_contract_test.dart
+++ b/mobile/packages/divine_video_player/test/src/android_auth_error_contract_test.dart
@@ -1,0 +1,48 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Android native auth error contract', () {
+    test('maps HTTP 401 responses to auth_required', () {
+      final source = _androidSourceFile().readAsStringSync();
+
+      final badStatusBranch = source.indexOf(
+        'PlaybackException.ERROR_CODE_IO_BAD_HTTP_STATUS',
+      );
+      final statusCheck = source.indexOf('status == 401');
+      final statusMapping = source.indexOf('"auth_required"', statusCheck);
+      final genericClientMapping = source.indexOf(
+        'status in 400..499 -> "http_client_error"',
+      );
+
+      expect(badStatusBranch, greaterThanOrEqualTo(0));
+      expect(statusCheck, greaterThan(badStatusBranch));
+      expect(statusMapping, greaterThan(statusCheck));
+      expect(
+        statusMapping,
+        lessThan(genericClientMapping),
+        reason:
+            'HTTP 401 must be classified before the generic 4xx mapping so '
+            'Dart can route it through the age-gate path without parsing the '
+            'raw error message.',
+      );
+    });
+  });
+}
+
+File _androidSourceFile() {
+  final packageRelative = File(
+    'android/src/main/kotlin/com/divinevideo/divine_video_player/'
+    'DivineVideoPlayerInstance.kt',
+  );
+  if (packageRelative.existsSync()) {
+    return packageRelative;
+  }
+
+  return File(
+    'packages/divine_video_player/'
+    'android/src/main/kotlin/com/divinevideo/divine_video_player/'
+    'DivineVideoPlayerInstance.kt',
+  );
+}

--- a/mobile/packages/divine_video_player/test/src/apple_auth_error_contract_test.dart
+++ b/mobile/packages/divine_video_player/test/src/apple_auth_error_contract_test.dart
@@ -1,0 +1,65 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Apple native auth error contract', () {
+    test('maps NSURLError auth-required failures to auth_required', () {
+      final source = _appleSourceFile().readAsStringSync();
+
+      final authCase = source.indexOf('NSURLErrorUserAuthenticationRequired');
+      final authMapping = source.indexOf('return "auth_required"', authCase);
+      final defaultCase = source.indexOf('default:', authCase);
+
+      expect(
+        authCase,
+        greaterThanOrEqualTo(0),
+        reason:
+            'Bare AVFoundation NSURLErrorDomain -1013 failures must not fall '
+            'through to unknown.',
+      );
+      expect(authMapping, greaterThan(authCase));
+      expect(
+        authMapping,
+        lessThan(defaultCase),
+        reason:
+            'The auth-required case must be handled inside the '
+            'NSURLErrorDomain '
+            'switch before default maps unrecognised errors to unknown.',
+      );
+    });
+
+    test('maps HTTP 401 responses to auth_required', () {
+      final source = _appleSourceFile().readAsStringSync();
+
+      final responseBranch = source.indexOf(
+        'NSURLErrorFailingURLResponseErrorKey',
+      );
+      final statusCheck = source.indexOf('httpResponse.statusCode == 401');
+      final statusMapping = source.indexOf('return "auth_required"');
+
+      expect(responseBranch, greaterThanOrEqualTo(0));
+      expect(statusCheck, greaterThan(responseBranch));
+      expect(statusMapping, greaterThan(statusCheck));
+    });
+  });
+}
+
+/// The iOS and macOS players share a single Darwin source tree
+/// (`darwin/divine_video_player/Sources/`), so the auth contract is asserted
+/// once.
+File _appleSourceFile() {
+  final packageRelative = File(
+    'darwin/divine_video_player/Sources/divine_video_player/'
+    'DivineVideoPlayerInstance.swift',
+  );
+  if (packageRelative.existsSync()) {
+    return packageRelative;
+  }
+
+  return File(
+    'packages/divine_video_player/'
+    'darwin/divine_video_player/Sources/divine_video_player/'
+    'DivineVideoPlayerInstance.swift',
+  );
+}

--- a/mobile/packages/divine_video_player/test/src/apple_auth_error_contract_test.dart
+++ b/mobile/packages/divine_video_player/test/src/apple_auth_error_contract_test.dart
@@ -36,11 +36,33 @@ void main() {
         'NSURLErrorFailingURLResponseErrorKey',
       );
       final statusCheck = source.indexOf('httpResponse.statusCode == 401');
-      final statusMapping = source.indexOf('return "auth_required"');
+      final statusMapping = source.indexOf(
+        'return "auth_required"',
+        statusCheck,
+      );
 
       expect(responseBranch, greaterThanOrEqualTo(0));
       expect(statusCheck, greaterThan(responseBranch));
       expect(statusMapping, greaterThan(statusCheck));
+    });
+
+    test('returns typed auth details from composition-load failures', () {
+      final source = _appleSourceFile().readAsStringSync();
+
+      final catchBlock = source.indexOf('} catch {');
+      final derivedCode = source.indexOf(
+        'self.errorCode = self.errorCode(for: error as NSError)',
+        catchBlock,
+      );
+      final flutterError = source.indexOf('FlutterError(', derivedCode);
+      final details = source.indexOf(
+        r'details: self.errorCode.map { ["errorCode": $0] }',
+        flutterError,
+      );
+
+      expect(catchBlock, greaterThanOrEqualTo(0));
+      expect(derivedCode, greaterThan(catchBlock));
+      expect(details, greaterThan(flutterError));
     });
   });
 }

--- a/mobile/packages/divine_video_player/test/src/video_player_state_test.dart
+++ b/mobile/packages/divine_video_player/test/src/video_player_state_test.dart
@@ -8,6 +8,10 @@ void main() {
         expect(NativePlayerErrorCode.mediaProcessing.shouldFailover, isFalse);
       });
 
+      test('returns true for authRequired', () {
+        expect(NativePlayerErrorCode.authRequired.shouldFailover, isTrue);
+      });
+
       test('returns true for httpClientError', () {
         expect(NativePlayerErrorCode.httpClientError.shouldFailover, isTrue);
       });
@@ -50,6 +54,10 @@ void main() {
         expect(NativePlayerErrorCode.timeout.isTransient, isTrue);
       });
 
+      test('returns false for authRequired', () {
+        expect(NativePlayerErrorCode.authRequired.isTransient, isFalse);
+      });
+
       test('returns false for httpServerError', () {
         expect(NativePlayerErrorCode.httpServerError.isTransient, isFalse);
       });
@@ -76,6 +84,13 @@ void main() {
         expect(
           NativePlayerErrorCode.fromString('media_processing'),
           equals(NativePlayerErrorCode.mediaProcessing),
+        );
+      });
+
+      test('parses auth_required', () {
+        expect(
+          NativePlayerErrorCode.fromString('auth_required'),
+          equals(NativePlayerErrorCode.authRequired),
         );
       });
 

--- a/mobile/packages/divine_video_player/test/src/video_player_state_test.dart
+++ b/mobile/packages/divine_video_player/test/src/video_player_state_test.dart
@@ -8,8 +8,8 @@ void main() {
         expect(NativePlayerErrorCode.mediaProcessing.shouldFailover, isFalse);
       });
 
-      test('returns true for authRequired', () {
-        expect(NativePlayerErrorCode.authRequired.shouldFailover, isTrue);
+      test('returns false for authRequired', () {
+        expect(NativePlayerErrorCode.authRequired.shouldFailover, isFalse);
       });
 
       test('returns true for httpClientError', () {

--- a/mobile/packages/infinite_video_feed/lib/src/utils/playback_sources.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/utils/playback_sources.dart
@@ -1,4 +1,5 @@
 import 'package:divine_video_player/divine_video_player.dart';
+import 'package:flutter/services.dart';
 import 'package:infinite_video_feed/src/models/video_error_type.dart';
 import 'package:infinite_video_feed/src/utils/canonical_divine_url.dart';
 import 'package:models/models.dart';
@@ -114,6 +115,23 @@ VideoErrorType classifyVideoError({
 bool isMediaProcessingError(Object? error, {String? errorMessage}) {
   final lower = '${errorMessage ?? ''} ${error ?? ''}'.toLowerCase();
   return _mentionsHttpStatus(lower, 202);
+}
+
+/// Extracts a canonical native player error code from method-channel failures.
+NativePlayerErrorCode? nativePlayerErrorCodeFromError(Object? error) {
+  if (error is! PlatformException) return null;
+
+  final details = error.details;
+  if (details is Map) {
+    final rawCode = details['errorCode'];
+    if (rawCode is String) {
+      final parsed = NativePlayerErrorCode.fromString(rawCode);
+      if (parsed != NativePlayerErrorCode.unknown) return parsed;
+    }
+  }
+
+  final parsed = NativePlayerErrorCode.fromString(error.code);
+  return parsed == NativePlayerErrorCode.unknown ? null : parsed;
 }
 
 bool _mentionsHttpStatus(String lower, int status) {

--- a/mobile/packages/infinite_video_feed/lib/src/utils/playback_sources.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/utils/playback_sources.dart
@@ -1,3 +1,4 @@
+import 'package:divine_video_player/divine_video_player.dart';
 import 'package:infinite_video_feed/src/models/video_error_type.dart';
 import 'package:infinite_video_feed/src/utils/canonical_divine_url.dart';
 import 'package:models/models.dart';
@@ -65,9 +66,19 @@ List<String> resolvePlaybackSources(
   return orderedUniqueSources([resolvedSource, originalUrl]);
 }
 
-/// Classifies a playback failure into a [VideoErrorType] using the error
-/// message and (optionally) the source that produced it.
-VideoErrorType classifyVideoError({String? errorMessage, String? source}) {
+/// Classifies a playback failure into a [VideoErrorType] using the typed native
+/// error code, error message, and optionally the source that produced it.
+VideoErrorType classifyVideoError({
+  NativePlayerErrorCode? errorCode,
+  String? errorMessage,
+  String? source,
+}) {
+  final typedErrorType = switch (errorCode) {
+    NativePlayerErrorCode.authRequired => VideoErrorType.ageRestricted,
+    _ => null,
+  };
+  if (typedErrorType != null) return typedErrorType;
+
   final lower = (errorMessage ?? '').toLowerCase();
   // Divine derivative URLs can legitimately return HTTP 202 while MP4/HLS
   // processing catches up after upload. Treat that as transient playback

--- a/mobile/packages/infinite_video_feed/lib/src/utils/source_loader.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/utils/source_loader.dart
@@ -70,6 +70,17 @@ Future<(String, int)> setSourceWithFallbacks({
       abortIfStale(source);
       lastError = error;
       lastStackTrace = stackTrace;
+      final nativeErrorCode = nativePlayerErrorCodeFromError(error);
+      if (nativeErrorCode == NativePlayerErrorCode.authRequired) {
+        log(
+          'Source failed without failover index $index: '
+          'failedSource=$source '
+          'attempt=$attemptIndex '
+          'code=$nativeErrorCode '
+          'error=$lastError',
+        );
+        Error.throwWithStackTrace(error, stackTrace);
+      }
       // Only wait-and-retry a processing (HTTP 202) source when it is the last
       // resort. While a fallback is still queued — for Divine that is always
       // the guaranteed raw blob — prefer it immediately instead of stalling up

--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -1229,6 +1229,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
         stackTrace: stackTrace,
       );
       final errorType = classifyVideoError(
+        errorCode: nativePlayerErrorCodeFromError(e),
         errorMessage: e.toString(),
       );
       unawaited(_controllers.remove(index)?.dispose());
@@ -1373,6 +1374,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
         index,
         isTerminal: _isTerminalPlaybackFailure(e),
         errorType: classifyVideoError(
+          errorCode: nativePlayerErrorCodeFromError(e),
           errorMessage: e.toString(),
           source: nextSource,
         ),
@@ -1476,7 +1478,11 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
       } else {
         _stopAndMarkError(
           index,
-          classifyVideoError(errorMessage: e.toString(), source: source),
+          classifyVideoError(
+            errorCode: nativePlayerErrorCodeFromError(e),
+            errorMessage: e.toString(),
+            source: source,
+          ),
         );
       }
     } finally {

--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -1679,6 +1679,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
           }
 
           final errorType = classifyVideoError(
+            errorCode: errorCode,
             errorMessage: errorMessage,
           );
           if (_isTerminalPlaybackFailure(errorMessage)) {

--- a/mobile/packages/infinite_video_feed/test/src/utils/playback_sources_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/utils/playback_sources_test.dart
@@ -1,4 +1,5 @@
 import 'package:divine_video_player/divine_video_player.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:infinite_video_feed/src/models/video_error_type.dart';
 import 'package:infinite_video_feed/src/utils/playback_sources.dart';
@@ -269,6 +270,30 @@ void main() {
       expect(
         isMediaProcessingError(Exception('Response completed in 2025 ms')),
         isFalse,
+      );
+    });
+  });
+
+  group('nativePlayerErrorCodeFromError', () {
+    test('parses errorCode from PlatformException details', () {
+      expect(
+        nativePlayerErrorCodeFromError(
+          PlatformException(
+            code: 'COMPOSITION_ERROR',
+            message: 'NSURLErrorDomain error -1013',
+            details: const <String, Object?>{'errorCode': 'auth_required'},
+          ),
+        ),
+        equals(NativePlayerErrorCode.authRequired),
+      );
+    });
+
+    test('ignores unknown PlatformException codes', () {
+      expect(
+        nativePlayerErrorCodeFromError(
+          PlatformException(code: 'COMPOSITION_ERROR'),
+        ),
+        isNull,
       );
     });
   });

--- a/mobile/packages/infinite_video_feed/test/src/utils/playback_sources_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/utils/playback_sources_test.dart
@@ -1,3 +1,4 @@
+import 'package:divine_video_player/divine_video_player.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:infinite_video_feed/src/models/video_error_type.dart';
 import 'package:infinite_video_feed/src/utils/playback_sources.dart';
@@ -120,6 +121,25 @@ void main() {
   });
 
   group('classifyVideoError', () {
+    test('returns ageRestricted for typed authRequired without 401 text', () {
+      expect(
+        classifyVideoError(
+          errorCode: NativePlayerErrorCode.authRequired,
+          errorMessage: 'NSURLErrorDomain error -1013',
+        ),
+        equals(VideoErrorType.ageRestricted),
+      );
+    });
+
+    test('keeps null typed code on the existing generic path', () {
+      expect(
+        classifyVideoError(
+          errorMessage: 'NSURLErrorDomain error -1013',
+        ),
+        equals(VideoErrorType.generic),
+      );
+    });
+
     test('returns ageRestricted for 401', () {
       expect(
         classifyVideoError(errorMessage: 'HTTP 401 Unauthorized'),

--- a/mobile/packages/infinite_video_feed/test/src/utils/source_loader_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/utils/source_loader_test.dart
@@ -1,5 +1,5 @@
 import 'package:divine_video_player/divine_video_player.dart';
-import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:infinite_video_feed/src/utils/source_loader.dart';
 
@@ -188,6 +188,35 @@ void main() {
         expect(clips[1].httpHeaders, equals(headers));
       },
     );
+
+    test('does not fail over typed auth-required errors', () async {
+      final clips = <VideoClip>[];
+      final authError = PlatformException(
+        code: 'COMPOSITION_ERROR',
+        message: 'NSURLErrorDomain error -1013',
+        details: const <String, Object?>{'errorCode': 'auth_required'},
+      );
+      final controller = _RecordingControllerWithFailures(
+        clips.add,
+        failures: [authError],
+      );
+      addTearDown(controller.dispose);
+
+      await expectLater(
+        () => setSourceWithFallbacks(
+          index: 0,
+          controller: controller,
+          sources: ['optimizedUrl', 'hlsUrl'],
+          log: logs.add,
+        ),
+        throwsA(same(authError)),
+      );
+
+      expect(clips.map((clip) => clip.uri), equals(['optimizedUrl']));
+      expect(logs, hasLength(1));
+      expect(logs.single, contains('Source failed without failover'));
+      expect(logs.single, contains('code=NativePlayerErrorCode.authRequired'));
+    });
 
     test('uses headers returned for the successful failover source', () async {
       final clips = <VideoClip>[];

--- a/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
@@ -2969,17 +2969,21 @@ void main() {
       }
 
       testWidgets(
-        'classifies typed auth-required runtime failures as age restricted',
+        'does not fail over typed auth-required runtime failures',
         (tester) async {
           DivineVideoPlayerController.resetIdCounterForTesting();
           final harness = _NativePlayerHarness(tester);
           await harness.install(playerIds: const <int>[0, 1, 2, 3]);
+          const divineUrl =
+              'https://media.divine.video/'
+              '10fe4777d60fa224878fd9be348a3410e6b70ba2d865e5ae82526a8f1d053326/'
+              '720p.mp4';
 
           try {
             await tester.pumpWidget(
               _wrapFeed(
                 InfiniteVideoFeed(
-                  videos: [_makeVideo('auth_required')],
+                  videos: [_makeVideo('auth_required', videoUrl: divineUrl)],
                   cache: cache,
                   prefetchCount: 0,
                   preloadGracePeriod: Duration.zero,
@@ -2997,6 +3001,55 @@ void main() {
               'errorCode': 'auth_required',
               'errorMessage': 'NSURLErrorDomain error -1013',
             });
+            await tester.pump();
+            await tester.pump();
+
+            expect(find.text('VIDEO_ERROR:ageRestricted'), findsOneWidget);
+            final setClipsAfterError = harness.countCalls('setClips');
+
+            await tester.pump(const Duration(milliseconds: 400));
+            await tester.pump();
+
+            expect(harness.countCalls('setClips'), equals(setClipsAfterError));
+          } finally {
+            await tester.pumpWidget(const SizedBox.shrink());
+            await tester.pump();
+            await harness.dispose();
+          }
+        },
+      );
+
+      testWidgets(
+        'classifies typed auth-required composition failures as age restricted',
+        (tester) async {
+          DivineVideoPlayerController.resetIdCounterForTesting();
+          final harness = _NativePlayerHarness(tester);
+          await harness.install(playerIds: const <int>[0, 1, 2, 3]);
+          harness.setClipsFailures[0] = <Exception>[
+            PlatformException(
+              code: 'COMPOSITION_ERROR',
+              message: 'NSURLErrorDomain error -1013',
+              details: const <String, Object?>{'errorCode': 'auth_required'},
+            ),
+          ];
+
+          try {
+            await tester.pumpWidget(
+              _wrapFeed(
+                InfiniteVideoFeed(
+                  videos: [
+                    _makeVideo('auth_required_init'),
+                    _makeVideo('next'),
+                  ],
+                  cache: cache,
+                  prefetchCount: 0,
+                  preloadGracePeriod: Duration.zero,
+                  autoRetryBaseDelay: const Duration(milliseconds: 200),
+                  errorBuilder: (_, _, _, errorType) =>
+                      Text('VIDEO_ERROR:${errorType.name}'),
+                ),
+              ),
+            );
             await tester.pump();
             await tester.pump();
 

--- a/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
@@ -2969,6 +2969,53 @@ void main() {
       }
 
       testWidgets(
+        'classifies typed auth-required runtime failures as age restricted',
+        (tester) async {
+          DivineVideoPlayerController.resetIdCounterForTesting();
+          final harness = _NativePlayerHarness(tester);
+          await harness.install(playerIds: const <int>[0, 1, 2, 3]);
+
+          try {
+            await tester.pumpWidget(
+              _wrapFeed(
+                InfiniteVideoFeed(
+                  videos: [_makeVideo('auth_required')],
+                  cache: cache,
+                  prefetchCount: 0,
+                  preloadGracePeriod: Duration.zero,
+                  autoRetryBaseDelay: const Duration(milliseconds: 200),
+                  errorBuilder: (_, _, _, errorType) =>
+                      Text('VIDEO_ERROR:${errorType.name}'),
+                ),
+              ),
+            );
+            await tester.pump();
+            await tester.pump();
+
+            await harness.sendEvent(0, const <Object?, Object?>{
+              'status': 'error',
+              'errorCode': 'auth_required',
+              'errorMessage': 'NSURLErrorDomain error -1013',
+            });
+            await tester.pump();
+            await tester.pump();
+
+            expect(find.text('VIDEO_ERROR:ageRestricted'), findsOneWidget);
+            final setClipsAfterError = harness.countCalls('setClips');
+
+            await tester.pump(const Duration(milliseconds: 400));
+            await tester.pump();
+
+            expect(harness.countCalls('setClips'), equals(setClipsAfterError));
+          } finally {
+            await tester.pumpWidget(const SizedBox.shrink());
+            await tester.pump();
+            await harness.dispose();
+          }
+        },
+      );
+
+      testWidgets(
         'does not auto-retry terminal no-video-track failover failures',
         (tester) async {
           DivineVideoPlayerController.resetIdCounterForTesting();


### PR DESCRIPTION
## Summary
- add a typed native auth-required player error code and parse it on Dart
- map iOS NSURLErrorUserAuthenticationRequired and native HTTP 401 responses to auth_required on iOS/Android
- classify typed auth_required runtime failures as age restricted without relying on 401 text

## Tests
- flutter analyze (mobile/packages/divine_video_player)
- flutter analyze (mobile/packages/infinite_video_feed)
- flutter test --coverage (mobile/packages/divine_video_player)
- flutter test --coverage (mobile/packages/infinite_video_feed)
- pre-push hook analyzer + changed-file tests

Native Android unit tests were not run locally because this checkout has no Gradle wrapper and the shell does not have a gradle executable.

Closes #6252