### PR TITLE
fix(bluesky): refresh status after NIP-05 claim

### DIFF
--- a/mobile/lib/blocs/crosspost_settings/crosspost_settings_cubit.dart
+++ b/mobile/lib/blocs/crosspost_settings/crosspost_settings_cubit.dart
@@ -30,13 +30,13 @@ class CrosspostSettingsCubit extends Cubit<CrosspostSettingsState> {
     try {
       final result = await _apiClient.getStatus();
       emit(
-        state.copyWith(
+        CrosspostSettingsState(
           status: CrosspostSettingsStatus.loaded,
           enabled: result.crosspostEnabled,
           username: result.username,
           handle: result.handle,
           provisioningState: result.provisioningState,
-          clearError: true,
+          attempt: state.attempt,
         ),
       );
     } catch (e, stackTrace) {

--- a/mobile/lib/screens/settings/bluesky_settings_screen.dart
+++ b/mobile/lib/screens/settings/bluesky_settings_screen.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Bluesky crosspost settings screen with toggle switch
 // ABOUTME: Allows users to enable/disable publishing videos to Bluesky
 
+import 'dart:async';
+
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -105,7 +107,7 @@ class _BlueskySettingsView extends StatelessWidget {
               textColor: VineTheme.whiteText,
               onPressed: () {
                 context.read<CrosspostSettingsCubit>().acknowledgeError();
-                context.push(Nip05SettingsScreen.path);
+                unawaited(_openClaimFlowAndRefresh(context));
               },
             ),
           ),
@@ -152,7 +154,7 @@ class _UsernameRequiredNotice extends StatelessWidget {
         style: const TextStyle(color: VineTheme.lightText, fontSize: 14),
       ),
       trailing: TextButton(
-        onPressed: () => context.push(Nip05SettingsScreen.path),
+        onPressed: () => unawaited(_openClaimFlowAndRefresh(context)),
         child: Text(
           context.l10n.blueskySetUpHandle,
           style: const TextStyle(color: VineTheme.vineGreen),
@@ -160,6 +162,13 @@ class _UsernameRequiredNotice extends StatelessWidget {
       ),
     );
   }
+}
+
+Future<void> _openClaimFlowAndRefresh(BuildContext context) async {
+  final cubit = context.read<CrosspostSettingsCubit>();
+  await context.push(Nip05SettingsScreen.path);
+  if (!context.mounted) return;
+  await cubit.loadStatus();
 }
 
 class _CrosspostToggle extends StatelessWidget {

--- a/mobile/test/blocs/crosspost_settings/crosspost_settings_cubit_test.dart
+++ b/mobile/test/blocs/crosspost_settings/crosspost_settings_cubit_test.dart
@@ -27,9 +27,7 @@ void main() {
 
     group('initial state', () {
       test('is CrosspostSettingsState with initial status', () {
-        when(
-          () => apiClient.getStatus(),
-        ).thenAnswer((_) async => loadedStatus);
+        when(() => apiClient.getStatus()).thenAnswer((_) async => loadedStatus);
         final cubit = CrosspostSettingsCubit(
           apiClient: apiClient,
           pubkey: testPubkey,
@@ -41,9 +39,7 @@ void main() {
 
     group('loadStatus', () {
       test('emits loaded state on successful status fetch', () async {
-        when(
-          () => apiClient.getStatus(),
-        ).thenAnswer((_) async => loadedStatus);
+        when(() => apiClient.getStatus()).thenAnswer((_) async => loadedStatus);
 
         final cubit = CrosspostSettingsCubit(
           apiClient: apiClient,
@@ -91,6 +87,37 @@ void main() {
         expect(cubit.state.status, CrosspostSettingsStatus.loaded);
         expect(cubit.state.enabled, isFalse);
       });
+
+      test(
+        'clears nullable status fields when latest status omits them',
+        () async {
+          var getStatusCallCount = 0;
+          when(() => apiClient.getStatus()).thenAnswer((_) async {
+            getStatusCallCount += 1;
+            if (getStatusCallCount == 1) return loadedStatus;
+            return const CrosspostStatus(crosspostEnabled: false);
+          });
+
+          final cubit = CrosspostSettingsCubit(
+            apiClient: apiClient,
+            pubkey: testPubkey,
+          );
+          addTearDown(cubit.close);
+          await Future<void>.delayed(Duration.zero);
+
+          expect(cubit.state.username, 'testuser');
+          expect(cubit.state.handle, 'testuser.divine.video');
+          expect(cubit.state.provisioningState, 'ready');
+
+          await cubit.loadStatus();
+
+          expect(cubit.state.status, CrosspostSettingsStatus.loaded);
+          expect(cubit.state.enabled, isFalse);
+          expect(cubit.state.username, isNull);
+          expect(cubit.state.handle, isNull);
+          expect(cubit.state.provisioningState, isNull);
+        },
+      );
     });
 
     group('toggleCrosspost', () {
@@ -320,9 +347,7 @@ void main() {
 
       test('emits toggling state optimistically before API call', () async {
         final completer = Completer<CrosspostStatus>();
-        when(
-          () => apiClient.getStatus(),
-        ).thenAnswer((_) async => loadedStatus);
+        when(() => apiClient.getStatus()).thenAnswer((_) async => loadedStatus);
         when(
           () => apiClient.setCrosspost(pubkey: testPubkey, enabled: false),
         ).thenAnswer((_) => completer.future);

--- a/mobile/test/screens/settings/bluesky_settings_screen_test.dart
+++ b/mobile/test/screens/settings/bluesky_settings_screen_test.dart
@@ -1,11 +1,8 @@
-import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:openvine/blocs/crosspost_settings/crosspost_settings_cubit.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/settings/bluesky_settings_screen.dart';
@@ -13,186 +10,23 @@ import 'package:openvine/screens/settings/nip05_settings_screen.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/crosspost_api_client.dart';
 
-class _MockCrosspostSettingsCubit extends MockCubit<CrosspostSettingsState>
-    implements CrosspostSettingsCubit {}
-
 class _MockAuthService extends Mock implements AuthService {}
 
 class _MockCrosspostApiClient extends Mock implements CrosspostApiClient {}
 
 void main() {
-  group('BlueskySettingsScreen view', () {
-    late _MockCrosspostSettingsCubit cubit;
-
-    setUp(() {
-      cubit = _MockCrosspostSettingsCubit();
-    });
-
-    Widget buildSubject() {
-      return MaterialApp(
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-        theme: ThemeData.dark(),
-        home: BlocProvider<CrosspostSettingsCubit>.value(
-          value: cubit,
-          child: Scaffold(
-            body: BlocConsumer<CrosspostSettingsCubit, CrosspostSettingsState>(
-              listener: (context, state) {
-                if (state.status == CrosspostSettingsStatus.failure) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(
-                      content: Text('Failed to update crosspost setting'),
-                    ),
-                  );
-                }
-              },
-              builder: (context, state) {
-                if (state.status == CrosspostSettingsStatus.loading) {
-                  return const Center(child: CircularProgressIndicator());
-                }
-                return ListView(
-                  children: [
-                    SwitchListTile(
-                      secondary: const Icon(Icons.cloud_upload),
-                      title: const Text('Publish videos to Bluesky'),
-                      subtitle: Text(
-                        state.enabled
-                            ? 'Your videos will be published to Bluesky'
-                            : 'Your videos will not be published to Bluesky',
-                      ),
-                      value: state.enabled,
-                      onChanged:
-                          state.status == CrosspostSettingsStatus.toggling
-                          ? null
-                          : (value) => context
-                                .read<CrosspostSettingsCubit>()
-                                .toggleCrosspost(enabled: value),
-                    ),
-                    if (state.handle != null)
-                      ListTile(
-                        title: const Text('Bluesky Handle'),
-                        subtitle: Text(state.handle!),
-                      ),
-                  ],
-                );
-              },
-            ),
-          ),
-        ),
-      );
-    }
-
-    testWidgets('renders loading indicator when status is loading', (
-      tester,
-    ) async {
-      when(() => cubit.state).thenReturn(
-        const CrosspostSettingsState(status: CrosspostSettingsStatus.loading),
-      );
-
-      await tester.pumpWidget(buildSubject());
-
-      expect(find.byType(CircularProgressIndicator), findsOneWidget);
-    });
-
-    testWidgets('renders toggle when loaded', (tester) async {
-      when(() => cubit.state).thenReturn(
-        const CrosspostSettingsState(
-          status: CrosspostSettingsStatus.loaded,
-          enabled: true,
-          handle: 'testuser.divine.video',
-          provisioningState: 'ready',
-        ),
-      );
-
-      await tester.pumpWidget(buildSubject());
-
-      expect(find.byType(SwitchListTile), findsOneWidget);
-      expect(find.text('Publish videos to Bluesky'), findsOneWidget);
-      expect(
-        find.text('Your videos will be published to Bluesky'),
-        findsOneWidget,
-      );
-    });
-
-    testWidgets('renders handle when present', (tester) async {
-      when(() => cubit.state).thenReturn(
-        const CrosspostSettingsState(
-          status: CrosspostSettingsStatus.loaded,
-          enabled: true,
-          handle: 'testuser.divine.video',
-        ),
-      );
-
-      await tester.pumpWidget(buildSubject());
-
-      expect(find.text('testuser.divine.video'), findsOneWidget);
-    });
-
-    testWidgets('calls toggleCrosspost when switch is tapped', (tester) async {
-      when(() => cubit.state).thenReturn(
-        const CrosspostSettingsState(
-          status: CrosspostSettingsStatus.loaded,
-          enabled: true,
-          handle: 'testuser.divine.video',
-        ),
-      );
-      when(
-        () => cubit.toggleCrosspost(enabled: false),
-      ).thenAnswer((_) async {});
-
-      await tester.pumpWidget(buildSubject());
-      await tester.tap(find.byType(Switch));
-      await tester.pump();
-
-      verify(() => cubit.toggleCrosspost(enabled: false)).called(1);
-    });
-
-    testWidgets('shows disabled subtitle when crosspost is off', (
-      tester,
-    ) async {
-      when(() => cubit.state).thenReturn(
-        const CrosspostSettingsState(status: CrosspostSettingsStatus.loaded),
-      );
-
-      await tester.pumpWidget(buildSubject());
-
-      expect(
-        find.text('Your videos will not be published to Bluesky'),
-        findsOneWidget,
-      );
-    });
-
-    testWidgets('shows snackbar on failure', (tester) async {
-      whenListen(
-        cubit,
-        Stream.fromIterable(const [
-          CrosspostSettingsState(
-            status: CrosspostSettingsStatus.failure,
-            enabled: true,
-          ),
-        ]),
-        initialState: const CrosspostSettingsState(
-          status: CrosspostSettingsStatus.loaded,
-          enabled: true,
-        ),
-      );
-
-      await tester.pumpWidget(buildSubject());
-      await tester.pump();
-
-      expect(find.text('Failed to update crosspost setting'), findsOneWidget);
-    });
-  });
-
-  group('BlueskySettingsScreen (real widget)', () {
+  group('BlueskySettingsScreen', () {
     late _MockAuthService authService;
     late _MockCrosspostApiClient apiClient;
+    late AppLocalizations l10n;
 
     const claimRouteMarker = 'NIP05 CLAIM ROUTE';
+    const returnFromClaimFlow = 'Return from claim flow';
 
     setUp(() {
       authService = _MockAuthService();
       apiClient = _MockCrosspostApiClient();
+      l10n = lookupAppLocalizations(const Locale('en'));
       when(() => authService.currentPublicKeyHex).thenReturn('pubkeyhex');
     });
 
@@ -206,7 +40,17 @@ void main() {
           ),
           GoRoute(
             path: Nip05SettingsScreen.path,
-            builder: (_, _) => const Scaffold(body: Text(claimRouteMarker)),
+            builder: (context, _) => Scaffold(
+              body: Column(
+                children: [
+                  const Text(claimRouteMarker),
+                  TextButton(
+                    onPressed: context.pop,
+                    child: const Text(returnFromClaimFlow),
+                  ),
+                ],
+              ),
+            ),
           ),
         ],
       );
@@ -228,17 +72,17 @@ void main() {
     testWidgets('shows the claim notice when no username is claimed', (
       tester,
     ) async {
-      when(() => apiClient.getStatus()).thenAnswer(
-        (_) async => const CrosspostStatus(crosspostEnabled: false),
-      );
+      when(
+        () => apiClient.getStatus(),
+      ).thenAnswer((_) async => const CrosspostStatus(crosspostEnabled: false));
 
       await tester.pumpWidget(buildApp());
       await tester.pumpAndSettle();
 
-      expect(
-        find.text('Set up a divine.video handle before publishing to Bluesky'),
-        findsOneWidget,
-      );
+      expect(find.text(l10n.blueskyUsernameRequired), findsOneWidget);
+      expect(find.byType(SwitchListTile), findsOneWidget);
+      expect(find.text(l10n.blueskyPublishVideos), findsOneWidget);
+      expect(find.text(l10n.blueskyDisabledSubtitle), findsOneWidget);
     });
 
     testWidgets('hides the claim notice once a username is claimed', (
@@ -256,23 +100,23 @@ void main() {
       await tester.pumpWidget(buildApp());
       await tester.pumpAndSettle();
 
-      expect(
-        find.text('Set up a divine.video handle before publishing to Bluesky'),
-        findsNothing,
-      );
+      expect(find.text(l10n.blueskyUsernameRequired), findsNothing);
+      expect(find.text('testuser.divine.video'), findsOneWidget);
     });
 
     testWidgets('claim notice Set up button routes to the nip05 screen', (
       tester,
     ) async {
-      when(() => apiClient.getStatus()).thenAnswer(
-        (_) async => const CrosspostStatus(crosspostEnabled: false),
-      );
+      when(
+        () => apiClient.getStatus(),
+      ).thenAnswer((_) async => const CrosspostStatus(crosspostEnabled: false));
 
       await tester.pumpWidget(buildApp());
       await tester.pumpAndSettle();
 
-      await tester.tap(find.widgetWithText(TextButton, 'Set up'));
+      await tester.tap(
+        find.widgetWithText(TextButton, l10n.blueskySetUpHandle),
+      );
       await tester.pumpAndSettle();
 
       expect(find.text(claimRouteMarker), findsOneWidget);
@@ -291,7 +135,6 @@ void main() {
         await tester.tap(find.byType(Switch));
         await tester.pumpAndSettle();
 
-        // The toggle short-circuits (no API call) and offers a claim action.
         verifyNever(
           () => apiClient.setCrosspost(
             pubkey: any(named: 'pubkey'),
@@ -300,10 +143,83 @@ void main() {
         );
         expect(find.byType(SnackBarAction), findsOneWidget);
 
-        await tester.tap(find.text('Set up').last);
+        await tester.tap(find.text(l10n.blueskySetUpHandle).last);
         await tester.pumpAndSettle();
 
         expect(find.text(claimRouteMarker), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'refreshes status and hides the claim notice after returning from claim',
+      (tester) async {
+        var getStatusCallCount = 0;
+        when(() => apiClient.getStatus()).thenAnswer((_) async {
+          getStatusCallCount += 1;
+          if (getStatusCallCount == 1) {
+            return const CrosspostStatus(crosspostEnabled: false);
+          }
+          return const CrosspostStatus(
+            crosspostEnabled: false,
+            username: 'testuser',
+            handle: 'testuser.divine.video',
+            provisioningState: 'pending',
+          );
+        });
+
+        await tester.pumpWidget(buildApp());
+        await tester.pumpAndSettle();
+
+        expect(find.text(l10n.blueskyUsernameRequired), findsOneWidget);
+
+        await tester.tap(
+          find.widgetWithText(TextButton, l10n.blueskySetUpHandle),
+        );
+        await tester.pumpAndSettle();
+        expect(find.text(claimRouteMarker), findsOneWidget);
+
+        await tester.tap(find.text(returnFromClaimFlow));
+        await tester.pumpAndSettle();
+
+        verify(() => apiClient.getStatus()).called(2);
+        expect(find.text(l10n.blueskyUsernameRequired), findsNothing);
+        expect(find.text('testuser.divine.video'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'snackbar claim action refreshes status after returning from claim',
+      (tester) async {
+        var getStatusCallCount = 0;
+        when(() => apiClient.getStatus()).thenAnswer((_) async {
+          getStatusCallCount += 1;
+          if (getStatusCallCount == 1) {
+            return const CrosspostStatus(crosspostEnabled: false);
+          }
+          return const CrosspostStatus(
+            crosspostEnabled: false,
+            username: 'testuser',
+            handle: 'testuser.divine.video',
+            provisioningState: 'pending',
+          );
+        });
+
+        await tester.pumpWidget(buildApp());
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byType(Switch));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text(l10n.blueskySetUpHandle).last);
+        await tester.pumpAndSettle();
+        expect(find.text(claimRouteMarker), findsOneWidget);
+
+        await tester.tap(find.text(returnFromClaimFlow));
+        await tester.pumpAndSettle();
+
+        verify(() => apiClient.getStatus()).called(2);
+        expect(find.text(l10n.blueskyUsernameRequired), findsNothing);
+        expect(find.text('testuser.divine.video'), findsOneWidget);
       },
     );
   });


### PR DESCRIPTION
## Summary
- Refresh Bluesky crosspost status when returning from the NIP-05 claim flow from both entry points.
- Rebuild loaded crosspost state from status responses so nullable username/handle/provisioning fields can clear on refresh.
- Replace copied Bluesky settings view tests with real widget coverage for the claim notice, snackbar action, and return refresh paths.

## Verification
- flutter test test/screens/settings/bluesky_settings_screen_test.dart test/blocs/crosspost_settings/crosspost_settings_cubit_test.dart
- flutter analyze lib test integration_test
- flutter test test/blocs/crosspost_settings/
- pre-push checks: analyzer and changed-file tests

Closes #6201