### PR TITLE
fix(router): harden query route normalization

### DIFF
--- a/mobile/lib/router/providers/page_context_provider.dart
+++ b/mobile/lib/router/providers/page_context_provider.dart
@@ -192,7 +192,7 @@ bool _isKnownRouteShape(List<String> segments) {
                   segments[1] == 'message-requests')) ||
           (length == 2 && segments[1] == 'message-requests');
     case 'hashtag':
-      return length == 2 || length == 3;
+      return length == 2;
     case 'categories':
       return length == 2;
     case 'video-editor':
@@ -214,9 +214,7 @@ bool _isKnownRouteShape(List<String> segments) {
     case 'list':
       return length == 2 || length == 3;
     case 'people-lists':
-      return (length == 2 && segments[1] == 'new') ||
-          length == 2 ||
-          (length == 3 && segments[2] == 'add-people');
+      return length == 2 || (length == 3 && segments[2] == 'add-people');
     case 'nostr-settings':
       return length == 1 ||
           (length == 2 && segments[1] == Nip05SettingsScreen.subpath);
@@ -245,7 +243,6 @@ bool _isKnownRouteShape(List<String> segments) {
     case 'legal':
     case 'bluesky-settings':
     case 'edit-profile':
-    case 'setup-profile':
     case 'clips':
     case 'clips-no-sound':
     case 'clips-only':
@@ -265,7 +262,7 @@ bool _isKnownRouteShape(List<String> segments) {
 /// Parse a URL path into a structured RouteContext
 /// Normalizes negative indices to 0 and decodes URL-encoded parameters
 RouteContext parseRoute(String path) {
-  return parseKnownRoute(path) ??
+  return _parseRoute(path, knownOnly: false) ??
       const RouteContext(type: RouteType.home, videoIndex: 0);
 }
 
@@ -275,6 +272,10 @@ RouteContext parseRoute(String path) {
 /// incomplete paths return null so GoRouter can handle them instead of being
 /// rewritten to home.
 RouteContext? parseKnownRoute(String path) {
+  return _parseRoute(path, knownOnly: true);
+}
+
+RouteContext? _parseRoute(String path, {required bool knownOnly}) {
   final pathOnly = path.split('#').first.split('?').first;
   final segments = pathOnly.split('/').where((s) => s.isNotEmpty).toList();
 
@@ -282,7 +283,7 @@ RouteContext? parseKnownRoute(String path) {
     return const RouteContext(type: RouteType.home, videoIndex: 0);
   }
 
-  if (!_isKnownRouteShape(segments)) {
+  if (knownOnly && !_isKnownRouteShape(segments)) {
     return null;
   }
 
@@ -304,7 +305,7 @@ RouteContext? parseKnownRoute(String path) {
 
     case 'profile':
       if (segments.length < 2) {
-        return null;
+        return knownOnly ? null : const RouteContext(type: RouteType.home);
       }
       final npub = _safeDecode(segments[1]); // Decode URL encoding
       // Grid mode (no index) vs feed mode (with index)
@@ -361,7 +362,7 @@ RouteContext? parseKnownRoute(String path) {
 
     case 'hashtag':
       if (segments.length < 2) {
-        return null;
+        return knownOnly ? null : const RouteContext(type: RouteType.home);
       }
       final tag = _safeDecode(segments[1]); // Decode URL encoding
       final rawIndex = segments.length > 2 ? int.tryParse(segments[2]) : null;
@@ -374,7 +375,7 @@ RouteContext? parseKnownRoute(String path) {
 
     case 'categories':
       if (segments.length < 2) {
-        return null;
+        return knownOnly ? null : const RouteContext(type: RouteType.home);
       }
       final categoryName = _safeDecode(segments[1]);
       return RouteContext(
@@ -517,14 +518,14 @@ RouteContext? parseKnownRoute(String path) {
       return const RouteContext(type: RouteType.developerOptions);
     case 'following':
       if (segments.length < 2) {
-        return null;
+        return knownOnly ? null : const RouteContext(type: RouteType.home);
       }
       final followingPubkey = _safeDecode(segments[1]);
       return RouteContext(type: RouteType.following, npub: followingPubkey);
 
     case 'followers':
       if (segments.length < 2) {
-        return null;
+        return knownOnly ? null : const RouteContext(type: RouteType.home);
       }
       final followersPubkey = _safeDecode(segments[1]);
       return RouteContext(type: RouteType.followers, npub: followersPubkey);
@@ -533,7 +534,7 @@ RouteContext? parseKnownRoute(String path) {
       return const RouteContext(type: RouteType.videoFeed);
     case 'list':
       if (segments.length < 2) {
-        return null;
+        return knownOnly ? null : const RouteContext(type: RouteType.explore);
       }
       // Web-canonical deep-link shape /list/:pubkey/:listId — the author
       // key rides in [RouteContext.npub] so buildRoute can reconstruct the
@@ -556,7 +557,7 @@ RouteContext? parseKnownRoute(String path) {
         return const RouteContext(type: RouteType.peopleListCreate);
       }
       if (segments.length < 2) {
-        return null;
+        return knownOnly ? null : const RouteContext(type: RouteType.home);
       }
       final peopleListId = _safeDecode(segments[1]);
       if (segments.length > 2 && segments[2] == 'add-people') {
@@ -572,14 +573,14 @@ RouteContext? parseKnownRoute(String path) {
 
     case 'sound':
       if (segments.length < 2) {
-        return null;
+        return knownOnly ? null : const RouteContext(type: RouteType.home);
       }
       final soundId = _safeDecode(segments[1]);
       return RouteContext(type: RouteType.sound, soundId: soundId);
 
     case 'original-sound':
       if (segments.length < 2) {
-        return null;
+        return knownOnly ? null : const RouteContext(type: RouteType.home);
       }
       final originalSoundPubkey = _safeDecode(segments[1]);
       return RouteContext(
@@ -589,7 +590,7 @@ RouteContext? parseKnownRoute(String path) {
 
     case 'profile-view':
       if (segments.length < 2) {
-        return null;
+        return knownOnly ? null : const RouteContext(type: RouteType.home);
       }
       final profileViewNpub = _safeDecode(segments[1]);
       return RouteContext(type: RouteType.profileView, npub: profileViewNpub);
@@ -602,7 +603,7 @@ RouteContext? parseKnownRoute(String path) {
 
     case 'video':
       if (segments.length < 2) {
-        return null;
+        return knownOnly ? null : const RouteContext(type: RouteType.home);
       }
       final videoId = _safeDecode(segments[1]);
       return RouteContext(type: RouteType.videoDetail, videoId: videoId);

--- a/mobile/lib/router/providers/page_context_provider.dart
+++ b/mobile/lib/router/providers/page_context_provider.dart
@@ -168,6 +168,100 @@ String _safeDecode(String segment) {
   }
 }
 
+/// Returns whether [segments] matches one of the route shapes modeled below.
+///
+/// GoRouter rejects paths with extra or unknown segments. Keep the parser's
+/// normalizer contract aligned with that behavior so malformed paths are left
+/// to GoRouter instead of being shortened into a different valid route.
+bool _isKnownRouteShape(List<String> segments) {
+  final firstSegment = segments.first;
+  final length = segments.length;
+
+  switch (firstSegment) {
+    case 'home':
+    case 'explore':
+    case 'notifications':
+    case 'liked-videos':
+      return length <= 2;
+    case 'profile':
+      return length == 2 || length == 3;
+    case 'inbox':
+      return length == 1 ||
+          (length == 3 &&
+              (segments[1] == 'conversation' ||
+                  segments[1] == 'message-requests')) ||
+          (length == 2 && segments[1] == 'message-requests');
+    case 'hashtag':
+      return length == 2 || length == 3;
+    case 'categories':
+      return length == 2;
+    case 'video-editor':
+    case 'video-edit':
+    case 'subtitle-edit':
+      return length == 1 || length == 2;
+    case 'settings':
+      return length == 1 ||
+          (length == 2 &&
+              segments[1] == MonetizationLinksSettingsScreen.subpath);
+    case 'apps':
+      return length == 1 || length == 2;
+    case 'following':
+    case 'followers':
+    case 'sound':
+    case 'original-sound':
+    case 'profile-view':
+      return length == 2;
+    case 'list':
+      return length == 2 || length == 3;
+    case 'people-lists':
+      return (length == 2 && segments[1] == 'new') ||
+          length == 2 ||
+          (length == 3 && segments[2] == 'add-people');
+    case 'nostr-settings':
+      return length == 1 ||
+          (length == 2 && segments[1] == Nip05SettingsScreen.subpath);
+    case 'welcome':
+      return length == 1 || (length == 2 && segments[1] == 'login-options');
+    case 'video':
+      return length == 2;
+    case 'video-recorder':
+    case 'video-metadata':
+    case 'badges':
+    case 'creator-analytics':
+    case 'relay-settings':
+    case 'relay-diagnostic':
+    case 'blossom-settings':
+    case 'notification-settings':
+    case 'key-management':
+    case 'safety-settings':
+    case 'content-filters':
+    case 'content-preferences':
+    case 'general-settings':
+    case 'storage-management':
+    case 'invites':
+    case 'app-language':
+    case 'appearance-settings':
+    case 'support-center':
+    case 'legal':
+    case 'bluesky-settings':
+    case 'edit-profile':
+    case 'setup-profile':
+    case 'clips':
+    case 'clips-no-sound':
+    case 'clips-only':
+    case 'drafts':
+    case 'import-key':
+    case 'developer-options':
+    case 'video-feed':
+    case 'discover-lists':
+    case 'secure-account':
+    case 'pooled-video-feed':
+      return length == 1;
+    default:
+      return false;
+  }
+}
+
 /// Parse a URL path into a structured RouteContext
 /// Normalizes negative indices to 0 and decodes URL-encoded parameters
 RouteContext parseRoute(String path) {
@@ -186,6 +280,10 @@ RouteContext? parseKnownRoute(String path) {
 
   if (segments.isEmpty) {
     return const RouteContext(type: RouteType.home, videoIndex: 0);
+  }
+
+  if (!_isKnownRouteShape(segments)) {
+    return null;
   }
 
   final firstSegment = segments[0];

--- a/mobile/lib/router/providers/page_context_provider.dart
+++ b/mobile/lib/router/providers/page_context_provider.dart
@@ -171,7 +171,18 @@ String _safeDecode(String segment) {
 /// Parse a URL path into a structured RouteContext
 /// Normalizes negative indices to 0 and decodes URL-encoded parameters
 RouteContext parseRoute(String path) {
-  final segments = path.split('/').where((s) => s.isNotEmpty).toList();
+  return parseKnownRoute(path) ??
+      const RouteContext(type: RouteType.home, videoIndex: 0);
+}
+
+/// Parse a URL path only when its route family is explicitly modeled.
+///
+/// This is the route normalizer's fail-closed entry point: unknown or
+/// incomplete paths return null so GoRouter can handle them instead of being
+/// rewritten to home.
+RouteContext? parseKnownRoute(String path) {
+  final pathOnly = path.split('#').first.split('?').first;
+  final segments = pathOnly.split('/').where((s) => s.isNotEmpty).toList();
 
   if (segments.isEmpty) {
     return const RouteContext(type: RouteType.home, videoIndex: 0);
@@ -195,7 +206,7 @@ RouteContext parseRoute(String path) {
 
     case 'profile':
       if (segments.length < 2) {
-        return const RouteContext(type: RouteType.home);
+        return null;
       }
       final npub = _safeDecode(segments[1]); // Decode URL encoding
       // Grid mode (no index) vs feed mode (with index)
@@ -252,7 +263,7 @@ RouteContext parseRoute(String path) {
 
     case 'hashtag':
       if (segments.length < 2) {
-        return const RouteContext(type: RouteType.home);
+        return null;
       }
       final tag = _safeDecode(segments[1]); // Decode URL encoding
       final rawIndex = segments.length > 2 ? int.tryParse(segments[2]) : null;
@@ -265,7 +276,7 @@ RouteContext parseRoute(String path) {
 
     case 'categories':
       if (segments.length < 2) {
-        return const RouteContext(type: RouteType.home);
+        return null;
       }
       final categoryName = _safeDecode(segments[1]);
       return RouteContext(
@@ -407,10 +418,16 @@ RouteContext parseRoute(String path) {
     case 'developer-options':
       return const RouteContext(type: RouteType.developerOptions);
     case 'following':
+      if (segments.length < 2) {
+        return null;
+      }
       final followingPubkey = _safeDecode(segments[1]);
       return RouteContext(type: RouteType.following, npub: followingPubkey);
 
     case 'followers':
+      if (segments.length < 2) {
+        return null;
+      }
       final followersPubkey = _safeDecode(segments[1]);
       return RouteContext(type: RouteType.followers, npub: followersPubkey);
 
@@ -418,7 +435,7 @@ RouteContext parseRoute(String path) {
       return const RouteContext(type: RouteType.videoFeed);
     case 'list':
       if (segments.length < 2) {
-        return const RouteContext(type: RouteType.explore);
+        return null;
       }
       // Web-canonical deep-link shape /list/:pubkey/:listId — the author
       // key rides in [RouteContext.npub] so buildRoute can reconstruct the
@@ -441,9 +458,9 @@ RouteContext parseRoute(String path) {
         return const RouteContext(type: RouteType.peopleListCreate);
       }
       if (segments.length < 2) {
-        return const RouteContext(type: RouteType.home);
+        return null;
       }
-      final peopleListId = Uri.decodeComponent(segments[1]);
+      final peopleListId = _safeDecode(segments[1]);
       if (segments.length > 2 && segments[2] == 'add-people') {
         return RouteContext(
           type: RouteType.peopleListAddPeople,
@@ -457,14 +474,14 @@ RouteContext parseRoute(String path) {
 
     case 'sound':
       if (segments.length < 2) {
-        return const RouteContext(type: RouteType.home);
+        return null;
       }
       final soundId = _safeDecode(segments[1]);
       return RouteContext(type: RouteType.sound, soundId: soundId);
 
     case 'original-sound':
       if (segments.length < 2) {
-        return const RouteContext(type: RouteType.home);
+        return null;
       }
       final originalSoundPubkey = _safeDecode(segments[1]);
       return RouteContext(
@@ -474,7 +491,7 @@ RouteContext parseRoute(String path) {
 
     case 'profile-view':
       if (segments.length < 2) {
-        return const RouteContext(type: RouteType.home);
+        return null;
       }
       final profileViewNpub = _safeDecode(segments[1]);
       return RouteContext(type: RouteType.profileView, npub: profileViewNpub);
@@ -487,13 +504,13 @@ RouteContext parseRoute(String path) {
 
     case 'video':
       if (segments.length < 2) {
-        return const RouteContext(type: RouteType.home);
+        return null;
       }
       final videoId = _safeDecode(segments[1]);
       return RouteContext(type: RouteType.videoDetail, videoId: videoId);
 
     default:
-      return const RouteContext(type: RouteType.home, videoIndex: 0);
+      return null;
   }
 }
 

--- a/mobile/lib/router/providers/route_normalization_provider.dart
+++ b/mobile/lib/router/providers/route_normalization_provider.dart
@@ -1,36 +1,32 @@
 // ABOUTME: Route normalization provider - ensures canonical URL format
-// ABOUTME: Redirects to canonical URLs for negative indices, encoding, unknown paths
+// ABOUTME: Redirects to canonical URLs for negative indices and encoding
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/router/router.dart';
-import 'package:openvine/screens/auth/email_verification_screen.dart';
 import 'package:openvine/screens/auth/nostr_connect_screen.dart';
-import 'package:openvine/screens/auth/reset_password.dart';
 import 'package:openvine/screens/auth/welcome_screen.dart';
-import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/screens/minor_account_review_screen.dart';
-import 'package:openvine/screens/search_results/view/search_results_page.dart';
 import 'package:openvine/services/deep_link_service.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 @visibleForTesting
 bool shouldSkipRouteNormalization(String loc) {
-  // Skip normalization for auth-related routes.
-  // EmailVerificationScreen supports both token mode (?token=) and polling
-  // mode (?deviceCode=). Use contains() to handle both path-only and full URL
-  // formats (deep links include host).
+  // buildRoute cannot emit query strings or fragments for any RouteContext.
+  // Normalizing these locations would drop route-owned state by construction.
+  if (loc.contains('?') || loc.contains('#')) {
+    return true;
+  }
+
+  // These route families are valid GoRouter paths, but parseRoute/buildRoute
+  // model only their parent routes and would rebuild them shorter.
   if (loc.startsWith(WelcomeScreen.path) ||
       loc.startsWith(NostrConnectScreen.path) ||
       loc == MinorAccountReviewScreen.path ||
       loc.startsWith('${MinorAccountReviewScreen.path}/') ||
       RegExp(r'^/apps/[^/]+/sandbox$').hasMatch(loc) ||
-      loc.contains('${ResetPasswordScreen.path}?token=') ||
-      loc.contains('${EmailVerificationScreen.path}?') ||
-      loc.startsWith('${PooledFullscreenVideoFeedScreen.path}?') ||
-      loc.startsWith(SearchResultsPage.pathPrefix) ||
-      RegExp(r'^/video/[^/]+/(likers|reposters)(\?.*)?$').hasMatch(loc)) {
+      RegExp(r'^/video/[^/]+/(likers|reposters)$').hasMatch(loc)) {
     return true;
   }
 
@@ -78,8 +74,12 @@ final routeNormalizationProvider = Provider<void>((ref) {
       return;
     }
 
-    // Parse and rebuild to get canonical form
-    final parsed = parseRoute(loc);
+    // Parse and rebuild to get canonical form. Unknown or incomplete routes
+    // are left to GoRouter instead of being rewritten to home.
+    final parsed = parseKnownRoute(loc);
+    if (parsed == null) {
+      return;
+    }
     final canonical = buildRoute(parsed);
 
     // If not canonical, schedule post-frame redirect

--- a/mobile/lib/router/providers/route_normalization_provider.dart
+++ b/mobile/lib/router/providers/route_normalization_provider.dart
@@ -19,8 +19,9 @@ bool shouldSkipRouteNormalization(String loc) {
     return true;
   }
 
-  // These route families are valid GoRouter paths, but parseRoute/buildRoute
-  // model only their parent routes and would rebuild them shorter.
+  // Skip GoRouter-owned flows before canonicalization. Some entries also fail
+  // closed in parseKnownRoute; keeping them here documents route families that
+  // must stay unnormalized if the modeled parser grows later.
   if (loc.startsWith(WelcomeScreen.path) ||
       loc.startsWith(NostrConnectScreen.path) ||
       loc == MinorAccountReviewScreen.path ||

--- a/mobile/test/router/route_coverage_test.dart
+++ b/mobile/test/router/route_coverage_test.dart
@@ -279,6 +279,15 @@ void main() {
       });
 
       test(
+        '${ExploreScreen.pathForTab('popular')} parses to RouteType.explore',
+        () {
+          final context = parseRoute(ExploreScreen.pathForTab('popular'));
+          expect(context.type, RouteType.explore);
+          expect(context.videoIndex, isNull);
+        },
+      );
+
+      test(
         '${ExploreScreen.pathForIndex(3)} parses to RouteType.explore with index 3',
         () {
           final context = parseRoute(ExploreScreen.pathForIndex(3));

--- a/mobile/test/router/route_coverage_test.dart
+++ b/mobile/test/router/route_coverage_test.dart
@@ -14,6 +14,7 @@ import 'package:openvine/screens/category_gallery_screen.dart';
 import 'package:openvine/screens/curated_list_by_author_screen.dart';
 import 'package:openvine/screens/curated_list_feed_screen.dart';
 import 'package:openvine/screens/explore/explore_screen.dart';
+import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
 import 'package:openvine/screens/hashtag_screen_router.dart';
 import 'package:openvine/screens/key_import_screen.dart';
@@ -433,9 +434,7 @@ void main() {
         expect(context.type, RouteType.subtitleEdit);
       });
       test('/subtitle-edit/:videoId parses videoId', () {
-        final context = parseRoute(
-          SubtitleEditorScreen.pathFor('test-id-abc'),
-        );
+        final context = parseRoute(SubtitleEditorScreen.pathFor('test-id-abc'));
         expect(context.type, RouteType.subtitleEdit);
         expect(context.videoId, 'test-id-abc');
       });
@@ -460,10 +459,28 @@ void main() {
         expect(context.videoIndex, 0);
       });
 
+      test('Unknown route is not a known normalizable route', () {
+        expect(parseKnownRoute('/unknown-route'), isNull);
+      });
+
       test('Negative index is normalized to 0', () {
         final context = parseRoute(VideoFeedPage.pathForIndex(-5));
         expect(context.type, RouteType.home);
         expect(context.videoIndex, 0);
+      });
+
+      test('Incomplete following route defaults to home without throwing', () {
+        expect(() => parseRoute('/following'), returnsNormally);
+        final context = parseRoute('/following');
+        expect(context.type, RouteType.home);
+        expect(parseKnownRoute('/following'), isNull);
+      });
+
+      test('Incomplete followers route defaults to home without throwing', () {
+        expect(() => parseRoute('/followers'), returnsNormally);
+        final context = parseRoute('/followers');
+        expect(context.type, RouteType.home);
+        expect(parseKnownRoute('/followers'), isNull);
       });
     });
 
@@ -478,6 +495,39 @@ void main() {
         final encoded = Uri.encodeComponent('nostr+bitcoin');
         final context = parseRoute('${HashtagScreenRouter.basePath}/$encoded');
         expect(context.hashtag, 'nostr+bitcoin');
+      });
+    });
+
+    group('Query and fragment handling', () {
+      const videoId =
+          '672c4eb9fc29adb6b505713bc6da94af2244c1de55dc6f034e2bcdaba133ebbe';
+      const pubkey =
+          '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+      test('pooled feed query route parses as pooled feed', () {
+        final context = parseRoute(
+          PooledFullscreenVideoFeedScreen.pathForVideoId(videoId),
+        );
+        expect(context.type, RouteType.pooledVideoFeed);
+      });
+
+      test('people list create query route parses as create route', () {
+        final context = parseRoute(
+          CreatePeopleListPage.pathWithInitialPubkey(pubkey),
+        );
+        expect(context.type, RouteType.peopleListCreate);
+      });
+
+      test('people list create fragment route parses as create route', () {
+        final context = parseRoute('${CreatePeopleListPage.path}#$pubkey');
+        expect(context.type, RouteType.peopleListCreate);
+      });
+
+      test('people list IDs with malformed encoding do not throw', () {
+        expect(() => parseRoute('/people-lists/foo%'), returnsNormally);
+        final context = parseRoute('/people-lists/foo%');
+        expect(context.type, RouteType.peopleListMembers);
+        expect(context.listId, 'foo%');
       });
     });
   });
@@ -658,16 +708,13 @@ void main() {
         },
       );
 
-      test(
-        '/list/:pubkey/:listId with an encoded list id round-trips',
-        () {
-          final path = CuratedListByAuthorScreen.pathFor(
-            pubkey: authorPubkey,
-            listId: 'my favorite vines',
-          );
-          expect(buildRoute(parseRoute(path)), path);
-        },
-      );
+      test('/list/:pubkey/:listId with an encoded list id round-trips', () {
+        final path = CuratedListByAuthorScreen.pathFor(
+          pubkey: authorPubkey,
+          listId: 'my favorite vines',
+        );
+        expect(buildRoute(parseRoute(path)), path);
+      });
     });
   });
 }

--- a/mobile/test/router/route_normalization_test.dart
+++ b/mobile/test/router/route_normalization_test.dart
@@ -2,15 +2,25 @@
 // ABOUTME: Prevents universal links from being rewritten by internal canonicalization
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:openvine/router/providers/route_normalization_provider.dart';
+import 'package:openvine/features/people_lists/view/create_people_list_page.dart';
+import 'package:openvine/router/router.dart';
+import 'package:openvine/screens/auth/email_verification_screen.dart';
+import 'package:openvine/screens/auth/reset_password.dart';
+import 'package:openvine/screens/auth/welcome_screen.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/screens/minor_account_review_parent_consent_screen.dart';
 import 'package:openvine/screens/minor_account_review_parent_contact_screen.dart';
 import 'package:openvine/screens/minor_account_review_screen.dart';
 import 'package:openvine/screens/minor_account_review_under13_screen.dart';
 import 'package:openvine/screens/minor_account_review_under13_support_screen.dart';
+import 'package:openvine/screens/search_results/view/search_results_page.dart';
 
 void main() {
+  const videoId =
+      '672c4eb9fc29adb6b505713bc6da94af2244c1de55dc6f034e2bcdaba133ebbe';
+  const pubkey =
+      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
   group('shouldSkipRouteNormalization', () {
     test('skips divine video universal links', () {
       expect(
@@ -30,9 +40,7 @@ void main() {
 
     test('skips divine invite universal links', () {
       expect(
-        shouldSkipRouteNormalization(
-          'https://divine.video/invite/ABCD-EFGH',
-        ),
+        shouldSkipRouteNormalization('https://divine.video/invite/ABCD-EFGH'),
         isTrue,
       );
     });
@@ -53,166 +61,125 @@ void main() {
       );
     });
 
-    test('does not skip canonical internal routes', () {
-      expect(shouldSkipRouteNormalization('/video/abc123'), isFalse);
-      expect(shouldSkipRouteNormalization('/home/0'), isFalse);
-    });
+    test('does not skip modeled internal routes without query or fragment', () {
+      final routes = {
+        '/video/$videoId': 'video detail is fully modeled',
+        '/home/0': 'canonical home path is fully modeled',
+        '/home/-3': 'negative index can be normalized losslessly',
+      };
 
-    test('skips pooled feed routes carrying a selected video identity', () {
-      const videoId =
-          '672c4eb9fc29adb6b505713bc6da94af2244c1de55dc6f034e2bcdaba133ebbe';
-
-      expect(
-        shouldSkipRouteNormalization(
-          PooledFullscreenVideoFeedScreen.pathForVideoId(videoId),
-        ),
-        isTrue,
-      );
-    });
-
-    test('skips minor account review route family', () {
-      for (final route in [
-        MinorAccountReviewScreen.path,
-        MinorAccountReviewScreen.welcomePath,
-        MinorAccountReviewLoadingScreen.path,
-        MinorAccountReviewParentConsentScreen.path,
-        MinorAccountReviewParentContactScreen.path,
-        MinorAccountReviewUnder13Screen.path,
-        MinorAccountReviewUnder13SupportScreen.path,
-      ]) {
-        expect(shouldSkipRouteNormalization(route), isTrue, reason: route);
+      for (final entry in routes.entries) {
+        expect(
+          shouldSkipRouteNormalization(entry.key),
+          isFalse,
+          reason: entry.value,
+        );
       }
     });
 
-    test('skips video engagement list routes', () {
-      // parseRoute/buildRoute don't know about /likers and /reposters
-      // sub-routes, so without skipping the normalizer would rewrite them
-      // back to /video/<id> and the engagement screen would never render.
+    test(
+      'skips all query or fragment routes because canonicalization is lossy',
+      () {
+        final routes = {
+          PooledFullscreenVideoFeedScreen.pathForVideoId(videoId):
+              'pooled feed carries selected video identity in query',
+          CreatePeopleListPage.pathWithInitialPubkey(pubkey):
+              'create people list seeds a full pubkey in query',
+          SearchResultsPage.pathForQuery('nostr', requestFocusOnMount: true):
+              'search focus state lives in query',
+          '${EmailVerificationScreen.path}?deviceCode=abc123':
+              'email verification polling state lives in query',
+          '${ResetPasswordScreen.path}?token=abc123':
+              'password reset token lives in query',
+          '/home/0#top': 'fragments cannot be rebuilt from RouteContext',
+          '/video/$videoId/likers?a=34236%3A$pubkey%3Adtag':
+              'engagement list filter state lives in query',
+        };
+
+        for (final entry in routes.entries) {
+          expect(
+            shouldSkipRouteNormalization(entry.key),
+            isTrue,
+            reason: entry.value,
+          );
+        }
+      },
+    );
+
+    test('skips parse-but-build-shorter route families', () {
+      final routes = {
+        WelcomeScreen.path:
+            'welcome subtree is GoRouter-owned and normalization-sensitive',
+        WelcomeScreen.loginOptionsPath:
+            'welcome subtree is GoRouter-owned and normalization-sensitive',
+        '/apps/primal/sandbox':
+            'app sandbox is not represented in RouteContext',
+        '/video/$videoId/likers':
+            'video engagement list suffix is not represented in RouteContext',
+        '/video/$videoId/reposters':
+            'video engagement list suffix is not represented in RouteContext',
+        MinorAccountReviewScreen.path:
+            'minor account review flow is GoRouter-owned',
+        MinorAccountReviewScreen.welcomePath:
+            'minor account review flow is GoRouter-owned',
+        MinorAccountReviewLoadingScreen.path:
+            'minor account review flow is GoRouter-owned',
+        MinorAccountReviewParentConsentScreen.path:
+            'minor account review flow is GoRouter-owned',
+        MinorAccountReviewParentContactScreen.path:
+            'minor account review flow is GoRouter-owned',
+        MinorAccountReviewUnder13Screen.path:
+            'minor account review flow is GoRouter-owned',
+        MinorAccountReviewUnder13SupportScreen.path:
+            'minor account review flow is GoRouter-owned',
+      };
+
+      for (final entry in routes.entries) {
+        expect(
+          shouldSkipRouteNormalization(entry.key),
+          isTrue,
+          reason: entry.value,
+        );
+      }
+    });
+  });
+
+  group('normalization classification', () {
+    test('normalizes modeled routes only', () {
+      final routes = {
+        '/home/-3': '/home/0',
+        '/profile/$pubkey/-1': '/profile/$pubkey/0',
+        '/hashtag/nostr%20video': '/hashtag/nostr%20video',
+      };
+
+      for (final entry in routes.entries) {
+        final parsed = parseKnownRoute(entry.key);
+        expect(parsed, isNotNull, reason: entry.key);
+        expect(buildRoute(parsed!), entry.value, reason: entry.key);
+      }
+    });
+
+    test('leaves unknown and incomplete routes to GoRouter', () {
       expect(
-        shouldSkipRouteNormalization('/video/abc123/likers'),
-        isTrue,
+        parseKnownRoute('/search-results/nostr'),
+        isNull,
+        reason: 'search results are GoRouter-owned, not RouteContext modeled',
       );
       expect(
-        shouldSkipRouteNormalization('/video/abc123/reposters'),
-        isTrue,
+        parseKnownRoute('/verify-email'),
+        isNull,
+        reason: 'auth deep links are GoRouter-owned',
       );
       expect(
-        shouldSkipRouteNormalization(
-          '/video/abc123/likers?a=34236%3Apubkey%3Adtag',
-        ),
-        isTrue,
+        parseKnownRoute('/wat/xyz'),
+        isNull,
+        reason: 'unknown routes should not be rewritten to home',
       );
       expect(
-        shouldSkipRouteNormalization(
-          '/video/abc123/reposters?a=34236%3Apubkey%3Adtag',
-        ),
-        isTrue,
+        parseKnownRoute('/following'),
+        isNull,
+        reason: 'incomplete dynamic routes should not throw or normalize',
       );
     });
   });
 }
-
-//import 'package:flutter/material.dart';
-//import 'package:flutter_test/flutter_test.dart';
-//import 'package:flutter_riverpod/flutter_riverpod.dart';
-//import 'package:openvine/router/app_router.dart';
-//import 'package:openvine/router/route_normalization_provider.dart';
-//import 'package:openvine/providers/home_feed_provider.dart';
-//
-//void main() {
-//  // Disable HomeFeed timer in tests by setting poll interval to 1 year
-//  final testOverrides = [
-//    homeFeedPollIntervalProvider.overrideWithValue(const Duration(days: 365)),
-//  ];
-//
-//  Widget shell(ProviderContainer c) => UncontrolledProviderScope(
-//    container: c,
-//    child: MaterialApp.router(localizationsDelegates: AppLocalizations.localizationsDelegates, supportedLocales: AppLocalizations.supportedLocales, routerConfig: c.read(goRouterProvider)),
-//  );
-//
-//  String currentLocation(ProviderContainer c) {
-//    final router = c.read(goRouterProvider);
-//    return router.routeInformationProvider.value.uri.toString();
-//  }
-//
-//  testWidgets('normalizes negative indices: /home/-3 -> /home/0', (
-//    tester,
-//  ) async {
-//    final c = ProviderContainer(overrides: testOverrides);
-//    addTearDown(c.dispose);
-//
-//    await tester.pumpWidget(shell(c));
-//
-//    // Activate normalization provider
-//    c.read(routeNormalizationProvider);
-//
-//    c.read(goRouterProvider).go('/home/-3');
-//    await tester.pump(); // Process the navigation
-//    await tester.pump(); // Process the post-frame callback redirect
-//
-//    // After normalization, router location should be canonical
-//    expect(currentLocation(c), '/home/0');
-//  });
-//
-//  testWidgets('normalizes unknown path -> /home/0', (tester) async {
-//    final c = ProviderContainer(overrides: testOverrides);
-//    addTearDown(c.dispose);
-//
-//    await tester.pumpWidget(shell(c));
-//
-//    c.read(routeNormalizationProvider);
-//
-//    c.read(goRouterProvider).go('/wat/xyz');
-//    await tester.pump(); // Process the navigation
-//    await tester.pump(); // Process the post-frame callback redirect
-//
-//    expect(currentLocation(c), '/home/0');
-//  });
-//
-//  testWidgets('encodes hashtag param consistently', (tester) async {
-//    final c = ProviderContainer(overrides: testOverrides);
-//    addTearDown(c.dispose);
-//
-//    await tester.pumpWidget(shell(c));
-//
-//    c.read(routeNormalizationProvider);
-//
-//    c.read(goRouterProvider).go('/hashtag/rust lang/1'); // space in tag
-//    await tester.pump(); // Process the navigation
-//    await tester.pump(); // Process the post-frame callback redirect
-//
-//    // Should be URL-encoded
-//    expect(currentLocation(c), contains('rust%20lang'));
-//  });
-//
-//  testWidgets('normalizes profile with negative index', (tester) async {
-//    final c = ProviderContainer(overrides: testOverrides);
-//    addTearDown(c.dispose);
-//
-//    await tester.pumpWidget(shell(c));
-//
-//    c.read(routeNormalizationProvider);
-//
-//    c.read(goRouterProvider).go('/profile/npubXYZ/-5');
-//    await tester.pump(); // Process the navigation
-//    await tester.pump(); // Process the post-frame callback redirect
-//
-//    expect(currentLocation(c), '/profile/npubXYZ/0');
-//  });
-//
-//  testWidgets('preserves valid canonical URLs unchanged', (tester) async {
-//    final c = ProviderContainer(overrides: testOverrides);
-//    addTearDown(c.dispose);
-//
-//    await tester.pumpWidget(shell(c));
-//
-//    c.read(routeNormalizationProvider);
-//
-//    c.read(goRouterProvider).go('/home/5');
-//    await tester.pump(); // Process the navigation
-//    await tester.pump(); // Process the post-frame callback redirect
-//
-//    expect(currentLocation(c), '/home/5');
-//  });
-//}
-//

--- a/mobile/test/router/route_normalization_test.dart
+++ b/mobile/test/router/route_normalization_test.dart
@@ -7,12 +7,14 @@ import 'package:openvine/router/router.dart';
 import 'package:openvine/screens/auth/email_verification_screen.dart';
 import 'package:openvine/screens/auth/reset_password.dart';
 import 'package:openvine/screens/auth/welcome_screen.dart';
+import 'package:openvine/screens/explore/explore_screen.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/screens/minor_account_review_parent_consent_screen.dart';
 import 'package:openvine/screens/minor_account_review_parent_contact_screen.dart';
 import 'package:openvine/screens/minor_account_review_screen.dart';
 import 'package:openvine/screens/minor_account_review_under13_screen.dart';
 import 'package:openvine/screens/minor_account_review_under13_support_screen.dart';
+import 'package:openvine/screens/profile_setup/profile_setup.dart';
 import 'package:openvine/screens/search_results/view/search_results_page.dart';
 
 void main() {
@@ -180,11 +182,18 @@ void main() {
         isNull,
         reason: 'incomplete dynamic routes should not throw or normalize',
       );
+      expect(
+        parseKnownRoute(ProfileSetupScreen.setupPath),
+        isNull,
+        reason: 'setup profile must not normalize to edit profile',
+      );
     });
 
     test('leaves routes with unmodeled trailing segments to GoRouter', () {
       for (final route in [
+        ExploreScreen.pathForTab('popular'),
         '/people-lists/new/extra',
+        '/hashtag/dogs/3',
         '/video/$videoId/bogus',
         '/profile/$pubkey/0/extra',
       ]) {

--- a/mobile/test/router/route_normalization_test.dart
+++ b/mobile/test/router/route_normalization_test.dart
@@ -181,5 +181,19 @@ void main() {
         reason: 'incomplete dynamic routes should not throw or normalize',
       );
     });
+
+    test('leaves routes with unmodeled trailing segments to GoRouter', () {
+      for (final route in [
+        '/people-lists/new/extra',
+        '/video/$videoId/bogus',
+        '/profile/$pubkey/0/extra',
+      ]) {
+        expect(
+          parseKnownRoute(route),
+          isNull,
+          reason: 'unmodeled suffix must not be normalized away: $route',
+        );
+      }
+    });
   });
 }


### PR DESCRIPTION
## Summary

- strip query strings and fragments before route parsing so query-bearing paths do not contaminate path segments
- add a nullable `parseKnownRoute` path for normalization so unknown or incomplete routes fail closed instead of rewriting to `/home/0`
- skip query/fragment routes structurally and document the remaining parse-but-build-shorter exemptions
- cover pooled feed, people-list create query routes, malformed people-list IDs, and the normalizer skip/classification table

Closes #6205
Follow-up: #6271

## Verification

- `flutter test test/router/route_coverage_test.dart test/router/route_normalization_test.dart`
- `flutter analyze`
- pre-push hook: analyzer and changed router tests passed