### PR TITLE
fix(feed): sanitize malformed UTF-16 display text

### DIFF
--- a/mobile/lib/widgets/classic_vines_tab.dart
+++ b/mobile/lib/widgets/classic_vines_tab.dart
@@ -388,7 +388,7 @@ class _ClassicVideoItem extends StatelessWidget {
                 ),
                 child: UserName.fromPubKey(
                   video.pubkey,
-                  embeddedName: video.authorName,
+                  embeddedName: video.displayAuthorName,
                   maxLines: 1,
                   style: const TextStyle(
                     color: VineTheme.whiteText,

--- a/mobile/lib/widgets/composable_video_grid.dart
+++ b/mobile/lib/widgets/composable_video_grid.dart
@@ -598,11 +598,11 @@ class _VideoInfoSection extends StatelessWidget {
             container: true,
             explicitChildNodes: true,
             label: context.l10n.videoGridAuthorSemanticLabel(
-              video.authorName ?? '',
+              video.displayAuthorName ?? '',
             ),
             child: UserName.fromPubKey(
               video.pubkey,
-              embeddedName: video.authorName,
+              embeddedName: video.displayAuthorName,
               maxLines: 1,
               style: VineTheme.titleTinyFont().copyWith(
                 decoration: TextDecoration.none,

--- a/mobile/lib/widgets/user_name.dart
+++ b/mobile/lib/widgets/user_name.dart
@@ -91,8 +91,9 @@ class UserName extends ConsumerWidget {
       effectivePubkey = pubkey!;
 
       // Use embedded name from REST API as fallback, then generated name.
-      final fallbackName =
-          embeddedName ?? UserProfile.defaultDisplayNameFor(pubkey!);
+      final fallbackName = embeddedName != null
+          ? UserProfile.sanitizeDisplayName(embeddedName!)
+          : UserProfile.defaultDisplayNameFor(pubkey!);
 
       displayName = switch (profileAsync) {
         AsyncData(:final value) when value != null => value.betterDisplayName(

--- a/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
@@ -471,7 +471,7 @@ class _UnifiedShareSheetState extends ConsumerState<_UnifiedShareSheet> {
     );
     final watermarkText = resolveWatermarkText(
       profile: profile,
-      fallbackAuthorName: widget.video.authorName,
+      fallbackAuthorName: widget.video.displayAuthorName,
     );
 
     await _presentAfterDismiss<void>((hostContext) {

--- a/mobile/lib/widgets/video_feed_item/actions/share_sheet_header.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_sheet_header.dart
@@ -32,9 +32,9 @@ class _ShareSheetHeader extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final profileAsync = ref.watch(userProfileReactiveProvider(video.pubkey));
 
-    final videoTitle = video.title?.isNotEmpty == true
-        ? video.title!
-        : video.content;
+    final videoTitle = video.displayTitle?.isNotEmpty == true
+        ? video.displayTitle!
+        : video.displayContent;
 
     return Padding(
       padding: const EdgeInsets.all(16),

--- a/mobile/lib/widgets/video_feed_item/actions/video_description_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/video_description_overlay.dart
@@ -40,8 +40,8 @@ class VideoDescriptionOverlay extends StatelessWidget {
               label: context.l10n.videoFeedDescriptionSemanticLabel,
               child: LinkifiedText(
                 text: video.content.isNotEmpty
-                    ? video.content
-                    : video.title ?? '',
+                    ? video.displayContent
+                    : video.displayTitle ?? '',
                 style: const TextStyle(
                   color: VineTheme.whiteText,
                   fontSize: 16,

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
@@ -114,7 +114,8 @@ class _OriginalSoundSection extends ConsumerWidget {
         creatorProfile?.bestDisplayName ??
         (reusedCreatorPubkey != null
             ? UserProfile.defaultDisplayNameFor(creatorPubkey)
-            : video.authorName ?? UserProfile.generatedNameFor(video.pubkey));
+            : video.displayAuthorName ??
+                  UserProfile.generatedNameFor(video.pubkey));
 
     return MetadataSection(
       label: context.l10n.metadataSoundsLabel,

--- a/mobile/lib/widgets/video_feed_item/video_author_info_section.dart
+++ b/mobile/lib/widgets/video_feed_item/video_author_info_section.dart
@@ -48,7 +48,7 @@ class VideoAuthorInfoSection extends ConsumerWidget {
     final avatarUrl = profile?.picture ?? video.authorAvatar;
     final displayName =
         profile?.bestDisplayName ??
-        video.authorName ??
+        video.displayAuthorName ??
         UserProfile.generatedNameFor(video.pubkey);
 
     return Column(
@@ -99,7 +99,7 @@ class VideoAuthorInfoSection extends ConsumerWidget {
                       label: context.l10n.videoAuthorSemanticLabel(displayName),
                       child: UserName.fromPubKey(
                         video.pubkey,
-                        embeddedName: video.authorName,
+                        embeddedName: video.displayAuthorName,
                         style: VineTheme.titleSmallFont(),
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,

--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -143,7 +143,8 @@ class VideoOverlayActions extends ConsumerWidget {
     final video = this.video;
     final previewData = this.previewData;
     final authorPubkey = previewData?.pubkey ?? video!.pubkey;
-    final trimmedTitle = previewData?.title.trim() ?? video?.title?.trim();
+    final trimmedTitle =
+        previewData?.title.trim() ?? video?.displayTitle?.trim();
     final titleText = trimmedTitle == null || trimmedTitle.isEmpty
         ? null
         : trimmedTitle;

--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -143,13 +143,15 @@ class VideoOverlayActions extends ConsumerWidget {
     final video = this.video;
     final previewData = this.previewData;
     final authorPubkey = previewData?.pubkey ?? video!.pubkey;
-    final trimmedTitle =
-        previewData?.title.trim() ?? video?.displayTitle?.trim();
+    final trimmedTitle = previewData != null
+        ? UserProfile.sanitizeDisplayName(previewData.title).trim()
+        : video?.displayTitle?.trim();
     final titleText = trimmedTitle == null || trimmedTitle.isEmpty
         ? null
         : trimmedTitle;
-    final descriptionText =
-        previewData?.description.trim() ?? video!.displayContent.trim();
+    final descriptionText = previewData != null
+        ? UserProfile.sanitizeDisplayName(previewData.description).trim()
+        : video!.displayContent.trim();
 
     // Check if there's meaningful text content to display
     final hasTextContent =
@@ -301,7 +303,7 @@ class VideoOverlayActions extends ConsumerWidget {
                       final avatarUrl = profile?.picture ?? video?.authorAvatar;
                       final displayName =
                           profile?.bestDisplayName ??
-                          video?.authorName ??
+                          video?.displayAuthorName ??
                           UserProfile.generatedNameFor(authorPubkey);
                       final isOgViner = ref.watch(
                         ogVinerCacheServiceProvider.select(
@@ -760,7 +762,7 @@ class VideoAuthorRow extends ConsumerWidget {
                 const SizedBox(width: 6),
                 UserName.fromPubKey(
                   video.pubkey,
-                  embeddedName: video.authorName,
+                  embeddedName: video.displayAuthorName,
                   style: const TextStyle(
                     color: VineTheme.whiteText,
                     fontSize: 12,

--- a/mobile/packages/models/lib/src/user_profile.dart
+++ b/mobile/packages/models/lib/src/user_profile.dart
@@ -231,6 +231,9 @@ class UserProfile {
     return defaultDisplayName;
   }
 
+  /// Normalizes user-controlled display names before passing them to UI text.
+  static String sanitizeDisplayName(String value) => stripZalgo(value);
+
   /// A display handle for the user, prefixed with `@`.
   ///
   /// Prefers NIP-05 identifier, falls back to [name]. Returns an empty

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -972,6 +972,13 @@ class VideoEvent {
   /// Zalgo-safe video title for display. Returns `null` when no title is set.
   String? get displayTitle => title != null ? stripZalgo(title!) : null;
 
+  /// Zalgo-safe embedded author name for display.
+  ///
+  /// Returns `null` when no embedded author name is set. Profile display-name
+  /// getters have their own sanitizer path.
+  String? get displayAuthorName =>
+      authorName != null ? stripZalgo(authorName!) : null;
+
   /// Root event id from an uppercase NIP-22 reply tag.
   ///
   /// Lowercase reply tags describe nearest-parent threading and mentions.

--- a/mobile/packages/models/test/src/video_event_display_test.dart
+++ b/mobile/packages/models/test/src/video_event_display_test.dart
@@ -5,13 +5,18 @@ import 'package:models/models.dart';
 import 'package:test/test.dart';
 
 void main() {
-  VideoEvent build({String? title, String content = ''}) => VideoEvent(
+  VideoEvent build({
+    String? title,
+    String content = '',
+    String? authorName,
+  }) => VideoEvent(
     id: 'a' * 64,
     pubkey: 'b' * 64,
     createdAt: 1735689600,
     content: content,
     timestamp: DateTime.utc(2026),
     title: title,
+    authorName: authorName,
   );
 
   group('VideoEvent.displayTitle', () {
@@ -58,6 +63,25 @@ void main() {
       final malformed = String.fromCharCodes([0xD800, 0x61, 0xDC00]);
 
       expect(build(content: malformed).displayContent, equals('\uFFFDa\uFFFD'));
+    });
+  });
+
+  group('VideoEvent.displayAuthorName', () {
+    test('returns null when authorName is null', () {
+      expect(build().displayAuthorName, isNull);
+    });
+
+    test('returns author name unchanged when no sanitizer is needed', () {
+      expect(build(authorName: 'Creator').displayAuthorName, equals('Creator'));
+    });
+
+    test('replaces malformed UTF-16 in author name', () {
+      final malformed = String.fromCharCodes([0xD800, 0x61, 0xDC00]);
+
+      expect(
+        build(authorName: malformed).displayAuthorName,
+        equals('\uFFFDa\uFFFD'),
+      );
     });
   });
 }

--- a/mobile/packages/models/test/src/video_event_display_test.dart
+++ b/mobile/packages/models/test/src/video_event_display_test.dart
@@ -30,6 +30,12 @@ void main() {
         equals('o\u0300\u0301'),
       );
     });
+
+    test('replaces malformed UTF-16 in title', () {
+      final malformed = String.fromCharCodes([0xD800, 0x61, 0xDC00]);
+
+      expect(build(title: malformed).displayTitle, equals('\uFFFDa\uFFFD'));
+    });
   });
 
   group('VideoEvent.displayContent', () {
@@ -46,6 +52,12 @@ void main() {
         build(content: 'a\u0300\u0301\u0302\u0303').displayContent,
         equals('a\u0300\u0301'),
       );
+    });
+
+    test('replaces malformed UTF-16 in content', () {
+      final malformed = String.fromCharCodes([0xD800, 0x61, 0xDC00]);
+
+      expect(build(content: malformed).displayContent, equals('\uFFFDa\uFFFD'));
     });
   });
 }

--- a/mobile/packages/text_sanitizer/lib/src/text_sanitizer.dart
+++ b/mobile/packages/text_sanitizer/lib/src/text_sanitizer.dart
@@ -1,5 +1,46 @@
 // ABOUTME: Sanitizes user-generated text for safe display in UI widgets.
 
+/// Replaces unpaired UTF-16 surrogates with U+FFFD, while preserving valid
+/// surrogate pairs such as emoji.
+///
+/// Dart strings can contain unpaired surrogate code units when they originate
+/// from escaped JSON or external event data. Flutter text layout assumes valid
+/// UTF-16 and may crash while shaping those strings, so display boundaries
+/// should normalize them before handing text to widgets.
+String sanitizeUtf16(String text) {
+  final units = text.codeUnits;
+  StringBuffer? result;
+
+  for (var i = 0; i < units.length; i++) {
+    final unit = units[i];
+    final isHighSurrogate = unit >= 0xD800 && unit <= 0xDBFF;
+    final isLowSurrogate = unit >= 0xDC00 && unit <= 0xDFFF;
+
+    if (isHighSurrogate &&
+        i + 1 < units.length &&
+        units[i + 1] >= 0xDC00 &&
+        units[i + 1] <= 0xDFFF) {
+      if (result != null) {
+        result
+          ..writeCharCode(unit)
+          ..writeCharCode(units[i + 1]);
+      }
+      i++;
+      continue;
+    }
+
+    if (isHighSurrogate || isLowSurrogate) {
+      result ??= StringBuffer()..write(text.substring(0, i));
+      result.writeCharCode(0xFFFD);
+      continue;
+    }
+
+    result?.writeCharCode(unit);
+  }
+
+  return result?.toString() ?? text;
+}
+
 /// Caps combining diacritical characters per grapheme cluster to prevent Zalgo
 /// text from overflowing layout bounds.
 ///
@@ -11,8 +52,9 @@
 /// Safe for both NFC and NFD-encoded text: NFC precomposed characters (e.g.
 /// U+00E9 é) contain no combining chars and pass through unchanged.
 String stripZalgo(String text, {int maxCombining = 2}) {
+  final sanitizedText = sanitizeUtf16(text);
   final result = StringBuffer();
-  final runes = text.runes.toList();
+  final runes = sanitizedText.runes.toList();
   var i = 0;
   while (i < runes.length) {
     result.writeCharCode(runes[i]);

--- a/mobile/packages/text_sanitizer/lib/src/text_sanitizer.dart
+++ b/mobile/packages/text_sanitizer/lib/src/text_sanitizer.dart
@@ -41,8 +41,8 @@ String sanitizeUtf16(String text) {
   return result?.toString() ?? text;
 }
 
-/// Caps combining diacritical characters per grapheme cluster to prevent Zalgo
-/// text from overflowing layout bounds.
+/// Normalizes malformed UTF-16 and caps combining diacritical characters per
+/// grapheme cluster to prevent Zalgo text from overflowing layout bounds.
 ///
 /// Allows up to [maxCombining] combining chars per base character (default 2),
 /// which covers all legitimate accented scripts including Vietnamese
@@ -51,6 +51,9 @@ String sanitizeUtf16(String text) {
 ///
 /// Safe for both NFC and NFD-encoded text: NFC precomposed characters (e.g.
 /// U+00E9 é) contain no combining chars and pass through unchanged.
+///
+/// Unpaired UTF-16 surrogates are replaced with U+FFFD before grapheme
+/// processing so Flutter text layout receives well-formed display text.
 String stripZalgo(String text, {int maxCombining = 2}) {
   final sanitizedText = sanitizeUtf16(text);
   final result = StringBuffer();

--- a/mobile/packages/text_sanitizer/test/src/text_sanitizer_test.dart
+++ b/mobile/packages/text_sanitizer/test/src/text_sanitizer_test.dart
@@ -14,6 +14,12 @@ void main() {
 
       expect(sanitizeUtf16(emoji), equals('😀'));
     });
+
+    test('preserves valid surrogate pairs after malformed code units', () {
+      final mixed = String.fromCharCodes([0xD800, 0xD83D, 0xDE00, 0x61]);
+
+      expect(sanitizeUtf16(mixed), equals('\uFFFD😀a'));
+    });
   });
 
   group(stripZalgo, () {

--- a/mobile/packages/text_sanitizer/test/src/text_sanitizer_test.dart
+++ b/mobile/packages/text_sanitizer/test/src/text_sanitizer_test.dart
@@ -2,6 +2,20 @@ import 'package:test/test.dart';
 import 'package:text_sanitizer/text_sanitizer.dart';
 
 void main() {
+  group(sanitizeUtf16, () {
+    test('replaces unpaired UTF-16 surrogates', () {
+      final malformed = String.fromCharCodes([0xD800, 0x61, 0xDC00]);
+
+      expect(sanitizeUtf16(malformed), equals('\uFFFDa\uFFFD'));
+    });
+
+    test('preserves valid surrogate pairs', () {
+      final emoji = String.fromCharCodes([0xD83D, 0xDE00]);
+
+      expect(sanitizeUtf16(emoji), equals('😀'));
+    });
+  });
+
   group(stripZalgo, () {
     test('returns empty string unchanged', () {
       expect(stripZalgo(''), equals(''));

--- a/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
+++ b/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
@@ -26,6 +26,7 @@ import 'package:openvine/blocs/video_volume/video_volume_cubit.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/viewer_auth_result.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/feed/feed_auto_advance_cubit.dart';
 import 'package:openvine/screens/feed/feed_settings_menu.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
@@ -344,6 +345,52 @@ void main() {
         expect(find.byType(FeedVideos), findsNothing);
         expect(find.byType(InfiniteVideoFeed), findsNothing);
       });
+
+      testWidgets(
+        'renders malformed UTF-16 feed display text without a Flutter exception',
+        (tester) async {
+          final nativePlayer = _NativePlayerHarness(tester)..install();
+          addTearDown(nativePlayer.dispose);
+
+          final malformedTitle = String.fromCharCodes([0xD800, 0x61]);
+          final malformedContent = String.fromCharCodes([0x62, 0xDC00]);
+          final malformedAuthorName = String.fromCharCodes([
+            0xD800,
+            0xD83D,
+            0xDE00,
+          ]);
+          final video = VideoEvent(
+            id: testVideoId1,
+            pubkey: testPubkey,
+            createdAt: 1757385263,
+            content: malformedContent,
+            timestamp: DateTime.fromMillisecondsSinceEpoch(1757385263 * 1000),
+            title: malformedTitle,
+            videoUrl: 'https://example.com/video.mp4',
+            authorName: malformedAuthorName,
+          );
+
+          await tester.pumpWidget(
+            buildSubject(
+              state: FullscreenFeedState(
+                status: FullscreenFeedStatus.ready,
+                videos: [video],
+              ),
+              additionalOverrides: [
+                userProfileReactiveProvider(testPubkey).overrideWith(
+                  (ref) => Stream<UserProfile?>.value(null),
+                ),
+              ],
+            ),
+          );
+          await tester.pump();
+
+          expect(tester.takeException(), isNull);
+          expect(find.text('\uFFFDa'), findsOneWidget);
+          expect(find.text('b\uFFFD'), findsOneWidget);
+          expect(find.text('\uFFFD😀'), findsOneWidget);
+        },
+      );
 
       testWidgets(
         'renders empty-state when status is emptyAfterRemoval and pop is a '

--- a/mobile/test/widgets/user_name_nip05_test.dart
+++ b/mobile/test/widgets/user_name_nip05_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart';
 import 'package:openvine/providers/nip05_verification_provider.dart';
+import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/services/nip05_verification_service.dart';
 import 'package:openvine/widgets/user_name.dart';
 
@@ -96,5 +97,36 @@ void main() {
 
     expect(find.text('Alice'), findsOneWidget);
     expect(_specialCheckmark(), findsOneWidget);
+  });
+
+  testWidgets('sanitizes embedded display name fallback while profile loads', (
+    tester,
+  ) async {
+    final malformedName = String.fromCharCodes([0xD800, 0xD83D, 0xDE00]);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          userProfileReactiveProvider(defaultPubkey).overrideWith(
+            (ref) => const Stream<UserProfile?>.empty(),
+          ),
+          nip05VerificationProvider.overrideWith(
+            (ref, pubkey) async => Nip05VerificationStatus.none,
+          ),
+        ],
+        child: MaterialApp(
+          home: Scaffold(
+            body: UserName.fromPubKey(
+              defaultPubkey,
+              embeddedName: malformedName,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('\uFFFD😀'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- replace unpaired UTF-16 surrogates at the shared text display boundary
- route feed title/description/share display paths through sanitized VideoEvent getters
- add regression coverage for malformed and valid surrogate pairs

Fixes #6111.

## Verification
- text sanitizer and VideoEvent display tests pass
- affected feed widget tests pass
- pre-push analyzer and changed-file tests pass