### PR TITLE
fix(security): stop accepting arbitrary TLS certs on relay and Dio sockets

### DIFF
--- a/mobile/lib/utils/relay_url_utils.dart
+++ b/mobile/lib/utils/relay_url_utils.dart
@@ -1,24 +1,17 @@
 // ABOUTME: Helpers for resolving API base URLs from Nostr relay WebSocket URLs.
 // ABOUTME: Keeps REST endpoints aligned with active relay configuration.
 
+import 'package:nostr_sdk/nostr_sdk.dart' as nostr_sdk;
+
 const _divineRelayHost = 'relay.divine.video';
 const _divineApiBaseUrl = 'https://api.divine.video';
 
-/// Hosts allowed to use cleartext (`ws://` / `http://`) schemes.
-///
-/// Mirrors the loopback allowlist enforced by `network_security_config.xml`
-/// (Android), `NSAllowsLocalNetworking` (iOS/macOS), and the local Docker
-/// stack address `localHost` from `mobile/lib/models/environment_config.dart`.
-/// Any change here must be reflected in:
-///
-///  * `mobile/android/app/src/main/res/xml/network_security_config.xml`
-///  * `mobile/packages/nostr_sdk/lib/nip46/nostr_remote_signer_info.dart`
-///  * `mobile/packages/nostr_client/lib/src/relay_manager.dart`
-const _loopbackHosts = <String>{'localhost', '127.0.0.1', '10.0.2.2', '::1'};
-
 /// True if [host] is a recognized loopback address that may be reached over
 /// cleartext (`ws://` / `http://`).
-bool isLoopbackHost(String host) => _loopbackHosts.contains(host.toLowerCase());
+///
+/// Delegates to the package-level source of truth in `nostr_sdk`; native
+/// cleartext transport config must mirror that predicate.
+bool isLoopbackHost(String host) => nostr_sdk.isLoopbackHost(host);
 
 /// Relay hosts operated by Divine across all environments.
 ///
@@ -76,9 +69,9 @@ bool usesUserChosenRelay(
 /// as the upstream "is this URL a usable relay endpoint" check.
 ///
 /// This predicate is the single source of truth for the application-layer
-/// transport allowlist. The package layer (`nostr_sdk`, `nostr_client`)
-/// duplicates this rule in-package because those packages cannot import from
-/// `mobile/lib/`; any change here must be mirrored there.
+/// relay URL allowlist. The loopback host predicate itself lives in
+/// `nostr_sdk` so package-layer callers can share it without importing app
+/// code.
 bool isRelayUrlAllowed(String url) {
   final uri = Uri.tryParse(url.trim());
   if (uri == null || !uri.hasAuthority || uri.host.isEmpty) return false;

--- a/mobile/packages/nostr_client/lib/src/relay_manager.dart
+++ b/mobile/packages/nostr_client/lib/src/relay_manager.dart
@@ -10,20 +10,6 @@ import 'package:nostr_client/src/models/relay_manager_config.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:nostr_sdk/relay/client_connected.dart';
 
-/// Hosts allowed to use cleartext (`ws://`) relay schemes.
-///
-/// Mirrors `isLoopbackHost` in `mobile/lib/utils/relay_url_utils.dart`. Any
-/// change here must be reflected there and in `network_security_config.xml`.
-const _relayLoopbackHosts = <String>{
-  'localhost',
-  '127.0.0.1',
-  '10.0.2.2',
-  '::1',
-};
-
-bool _isLoopbackHost(String host) =>
-    _relayLoopbackHosts.contains(host.toLowerCase());
-
 /// {@template relay_manager}
 /// Manages relay configuration and connection status.
 ///
@@ -720,7 +706,7 @@ class RelayManager {
     // valid port).
     final uri = Uri.tryParse(normalized);
     if (uri == null || uri.host.isEmpty) return null;
-    if (uri.scheme == 'ws' && !_isLoopbackHost(uri.host)) return null;
+    if (uri.scheme == 'ws' && !isLoopbackHost(uri.host)) return null;
     return normalized;
   }
 

--- a/mobile/packages/nostr_sdk/lib/nip46/nostr_remote_signer_info.dart
+++ b/mobile/packages/nostr_sdk/lib/nip46/nostr_remote_signer_info.dart
@@ -1,21 +1,7 @@
 import '../client_utils/keys.dart';
 import '../nip19/nip19.dart';
+import '../utils/loopback_host.dart';
 import '../utils/string_util.dart';
-
-/// Hosts allowed to use cleartext (`ws://`) bunker / nostrconnect relays.
-///
-/// Mirrors [`isLoopbackHost` in
-/// `mobile/lib/utils/relay_url_utils.dart`](../../../../../lib/utils/relay_url_utils.dart).
-/// Any change here must be reflected there and in `network_security_config.xml`.
-const _bunkerLoopbackHosts = <String>{
-  'localhost',
-  '127.0.0.1',
-  '10.0.2.2',
-  '::1',
-};
-
-bool _isLoopbackHost(String host) =>
-    _bunkerLoopbackHosts.contains(host.toLowerCase());
 
 /// True if [url] is a relay URL acceptable for a NIP-46 bunker / nostrconnect
 /// connection. Allows `wss://` for any host, and `ws://` only for loopback
@@ -29,7 +15,7 @@ bool _isAllowedBunkerRelayUrl(String url) {
   if (uri.path.startsWith('//')) return false;
   final scheme = uri.scheme.toLowerCase();
   if (scheme == 'wss') return true;
-  if (scheme == 'ws') return _isLoopbackHost(uri.host);
+  if (scheme == 'ws') return isLoopbackHost(uri.host);
   return false;
 }
 

--- a/mobile/packages/nostr_sdk/lib/nostr_sdk.dart
+++ b/mobile/packages/nostr_sdk/lib/nostr_sdk.dart
@@ -68,6 +68,7 @@ export 'upload/nip96_uploader.dart';
 // File upload support
 export 'upload/upload_util.dart';
 export 'utils/date_format_util.dart';
+export 'utils/loopback_host.dart';
 export 'utils/redact_http_headers_for_logs.dart';
 export 'utils/string_util.dart';
 export 'zap/lnurl_response.dart';

--- a/mobile/packages/nostr_sdk/lib/relay/platform_websocket_factory.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/platform_websocket_factory.dart
@@ -10,8 +10,9 @@ import 'web_socket_connection_manager.dart';
 /// {@template platform_websocket_channel_factory}
 /// Platform-aware WebSocket channel factory.
 ///
-/// On non-web platforms (iOS, Android, desktop), uses custom SSL handling
-/// that accepts self-signed certificates for wss:// connections.
+/// On non-web platforms (iOS, Android, desktop), wss:// connections use
+/// platform certificate validation for remote hosts and tolerate
+/// self-signed certificates only for local-stack loopback hosts.
 /// On web platform, uses standard WebSocket.connect().
 /// {@endtemplate}
 class PlatformWebSocketChannelFactory implements WebSocketChannelFactory {

--- a/mobile/packages/nostr_sdk/lib/relay/relay_base_io.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_base_io.dart
@@ -9,13 +9,21 @@ import 'package:web_socket_channel/io.dart';
 /// Creates a WebSocket channel for non-web platforms.
 ///
 /// Remote hosts go through platform certificate validation; self-signed
-/// certificates are tolerated only for local-stack loopback hosts.
-WebSocketChannel createSecureWebSocketChannel(Uri wsUrl) {
+/// certificates are tolerated only for local-stack loopback hosts in debug
+/// builds.
+HttpClient createSecureWebSocketHttpClient() {
   final httpClient = HttpClient();
   httpClient.badCertificateCallback = (cert, host, port) =>
-      isLoopbackHost(host);
+      allowsLocalBadCertificateHost(host);
+  return httpClient;
+}
 
-  return IOWebSocketChannel.connect(wsUrl, customClient: httpClient);
+/// Creates a WebSocket channel for non-web platforms.
+WebSocketChannel createSecureWebSocketChannel(Uri wsUrl) {
+  return IOWebSocketChannel.connect(
+    wsUrl,
+    customClient: createSecureWebSocketHttpClient(),
+  );
 }
 
 /// Creates a standard WebSocket channel for non-web platforms

--- a/mobile/packages/nostr_sdk/lib/relay/relay_base_io.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_base_io.dart
@@ -2,13 +2,18 @@
 // ABOUTME: Provides access to IOWebSocketChannel and HttpClient for SSL certificate handling
 
 import 'dart:io';
+import 'package:nostr_sdk/utils/loopback_host.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 import 'package:web_socket_channel/io.dart';
 
-/// Creates a WebSocket channel with custom SSL handling for non-web platforms
+/// Creates a WebSocket channel for non-web platforms.
+///
+/// Remote hosts go through platform certificate validation; self-signed
+/// certificates are tolerated only for local-stack loopback hosts.
 WebSocketChannel createSecureWebSocketChannel(Uri wsUrl) {
   final httpClient = HttpClient();
-  httpClient.badCertificateCallback = (cert, host, port) => true;
+  httpClient.badCertificateCallback = (cert, host, port) =>
+      isLoopbackHost(host);
 
   return IOWebSocketChannel.connect(wsUrl, customClient: httpClient);
 }

--- a/mobile/packages/nostr_sdk/lib/utils/dio_util.dart
+++ b/mobile/packages/nostr_sdk/lib/utils/dio_util.dart
@@ -8,6 +8,7 @@ import 'package:dio/dio.dart';
 import 'package:dio/io.dart';
 import 'package:dio_cookie_manager/dio_cookie_manager.dart';
 import 'package:cookie_jar/cookie_jar.dart';
+import 'package:nostr_sdk/utils/loopback_host.dart';
 
 Dio? _dio;
 var cookieJar = CookieJar();
@@ -19,7 +20,8 @@ class DioUtil {
       if (_dio!.httpClientAdapter is IOHttpClientAdapter) {
         (_dio!.httpClientAdapter as IOHttpClientAdapter).createHttpClient = () {
           final client = HttpClient();
-          client.badCertificateCallback = (cert, host, port) => true;
+          client.badCertificateCallback = (cert, host, port) =>
+              isLoopbackHost(host);
           return client;
         };
       }

--- a/mobile/packages/nostr_sdk/lib/utils/dio_util.dart
+++ b/mobile/packages/nostr_sdk/lib/utils/dio_util.dart
@@ -14,16 +14,25 @@ Dio? _dio;
 var cookieJar = CookieJar();
 
 class DioUtil {
+  static HttpClient createHttpClient() {
+    final client = HttpClient();
+    client.badCertificateCallback = (cert, host, port) =>
+        allowsLocalBadCertificateHost(host);
+    return client;
+  }
+
+  static void resetForTesting() {
+    _dio?.close(force: true);
+    _dio = null;
+    cookieJar = CookieJar();
+  }
+
   static Dio getDio() {
     if (_dio == null) {
       _dio = Dio();
       if (_dio!.httpClientAdapter is IOHttpClientAdapter) {
-        (_dio!.httpClientAdapter as IOHttpClientAdapter).createHttpClient = () {
-          final client = HttpClient();
-          client.badCertificateCallback = (cert, host, port) =>
-              isLoopbackHost(host);
-          return client;
-        };
+        (_dio!.httpClientAdapter as IOHttpClientAdapter).createHttpClient =
+            createHttpClient;
       }
 
       // _dio!.options.connectTimeout = Duration(minutes: 1);

--- a/mobile/packages/nostr_sdk/lib/utils/loopback_host.dart
+++ b/mobile/packages/nostr_sdk/lib/utils/loopback_host.dart
@@ -2,6 +2,8 @@
 // ABOUTME: Bad TLS certificates are tolerated only for these hosts; remote
 // ABOUTME: hosts always go through platform certificate validation.
 
+import 'package:flutter/foundation.dart';
+
 /// The hosts the local Docker stack is reachable on (see AGENTS.md,
 /// "Local Stack Development"). `10.0.2.2` is the Android emulator's alias
 /// for the host machine; `::1` is the IPv6 loopback.
@@ -19,3 +21,10 @@ const Set<String> _loopbackHosts = {
 /// these hosts, but remote hosts (the divine relay, the funnelcake API)
 /// must always pass platform certificate validation.
 bool isLoopbackHost(String host) => _loopbackHosts.contains(host.toLowerCase());
+
+/// Whether a bad TLS certificate may be tolerated for [host].
+///
+/// This is intentionally debug-only. The local-stack production allowance is
+/// cleartext (`ws://` / `http://`) loopback, not self-signed TLS.
+bool allowsLocalBadCertificateHost(String host) =>
+    kDebugMode && isLoopbackHost(host);

--- a/mobile/packages/nostr_sdk/lib/utils/loopback_host.dart
+++ b/mobile/packages/nostr_sdk/lib/utils/loopback_host.dart
@@ -1,0 +1,21 @@
+// ABOUTME: Loopback-host predicate for the local-stack TLS allowance.
+// ABOUTME: Bad TLS certificates are tolerated only for these hosts; remote
+// ABOUTME: hosts always go through platform certificate validation.
+
+/// The hosts the local Docker stack is reachable on (see AGENTS.md,
+/// "Local Stack Development"). `10.0.2.2` is the Android emulator's alias
+/// for the host machine; `::1` is the IPv6 loopback.
+const Set<String> _loopbackHosts = {
+  'localhost',
+  '127.0.0.1',
+  '::1',
+  '10.0.2.2',
+};
+
+/// Whether [host] is a local-stack loopback host.
+///
+/// Used to scope `HttpClient.badCertificateCallback`: self-signed
+/// certificates are acceptable when developing against the local stack on
+/// these hosts, but remote hosts (the divine relay, the funnelcake API)
+/// must always pass platform certificate validation.
+bool isLoopbackHost(String host) => _loopbackHosts.contains(host.toLowerCase());

--- a/mobile/packages/nostr_sdk/test/unit/loopback_host_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/loopback_host_test.dart
@@ -1,8 +1,14 @@
 // ABOUTME: Tests for the loopback-host TLS allowance predicate.
 // ABOUTME: Pins that bad certificates are only tolerated for local-stack hosts.
 
+import 'dart:io';
+
+import 'package:dio/io.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:nostr_sdk/utils/loopback_host.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:nostr_sdk/relay/relay_base_io.dart';
+import 'package:nostr_sdk/utils/dio_util.dart';
 
 void main() {
   group('isLoopbackHost', () {
@@ -47,4 +53,85 @@ void main() {
       expect(isLoopbackHost('192.168.1.10'), isFalse);
     });
   });
+
+  group('allowsLocalBadCertificateHost', () {
+    test('allows loopback hosts only in debug builds', () {
+      expect(allowsLocalBadCertificateHost('localhost'), kDebugMode);
+      expect(allowsLocalBadCertificateHost('10.0.2.2'), kDebugMode);
+    });
+
+    test('always rejects remote hosts', () {
+      expect(allowsLocalBadCertificateHost('relay.divine.video'), isFalse);
+      expect(allowsLocalBadCertificateHost('api.divine.video'), isFalse);
+    });
+  });
+
+  group('call-site certificate callbacks', () {
+    late _FakeCertificate cert;
+
+    setUp(() {
+      cert = _FakeCertificate();
+    });
+
+    test('relay websocket HttpClient rejects bad remote certificates', () {
+      final client = _RecordingHttpClient();
+
+      HttpOverrides.runZoned(
+        createSecureWebSocketHttpClient,
+        createHttpClient: (_) => client,
+      );
+
+      final callback = client.recordedBadCertificateCallback;
+      expect(callback, isNotNull);
+      expect(callback!(cert, 'relay.divine.video', 443), isFalse);
+      expect(callback(cert, 'localhost', 443), kDebugMode);
+    });
+
+    test('DioUtil wires the same bad certificate policy into Dio', () {
+      DioUtil.resetForTesting();
+      addTearDown(DioUtil.resetForTesting);
+      final client = _RecordingHttpClient();
+
+      HttpOverrides.runZoned(() {
+        final dio = DioUtil.getDio();
+        final adapter = dio.httpClientAdapter;
+
+        expect(adapter, isA<IOHttpClientAdapter>());
+        final createHttpClient =
+            (adapter as IOHttpClientAdapter).createHttpClient;
+        expect(createHttpClient, isNotNull);
+        expect(createHttpClient!(), same(client));
+      }, createHttpClient: (_) => client);
+
+      final callback = client.recordedBadCertificateCallback;
+      expect(callback, isNotNull);
+      expect(callback!(cert, 'api.divine.video', 443), isFalse);
+      expect(callback(cert, '10.0.2.2', 443), kDebugMode);
+    });
+
+    test('loopback predicate is exported from the package barrel', () {
+      expect(isLoopbackHost('127.0.0.1'), isTrue);
+      expect(allowsLocalBadCertificateHost('relay.divine.video'), isFalse);
+    });
+  });
+}
+
+class _FakeCertificate implements X509Certificate {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _RecordingHttpClient implements HttpClient {
+  bool Function(X509Certificate cert, String host, int port)?
+  recordedBadCertificateCallback;
+
+  @override
+  set badCertificateCallback(
+    bool Function(X509Certificate cert, String host, int port)? callback,
+  ) {
+    recordedBadCertificateCallback = callback;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/mobile/packages/nostr_sdk/test/unit/loopback_host_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/loopback_host_test.dart
@@ -1,0 +1,50 @@
+// ABOUTME: Tests for the loopback-host TLS allowance predicate.
+// ABOUTME: Pins that bad certificates are only tolerated for local-stack hosts.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/utils/loopback_host.dart';
+
+void main() {
+  group('isLoopbackHost', () {
+    test('returns true for localhost', () {
+      expect(isLoopbackHost('localhost'), isTrue);
+    });
+
+    test('returns true for 127.0.0.1', () {
+      expect(isLoopbackHost('127.0.0.1'), isTrue);
+    });
+
+    test('returns true for IPv6 loopback ::1', () {
+      expect(isLoopbackHost('::1'), isTrue);
+    });
+
+    test('returns true for the Android emulator host alias 10.0.2.2', () {
+      expect(isLoopbackHost('10.0.2.2'), isTrue);
+    });
+
+    test('is case-insensitive for localhost', () {
+      expect(isLoopbackHost('LOCALHOST'), isTrue);
+    });
+
+    test('returns false for the divine relay host', () {
+      expect(isLoopbackHost('relay.divine.video'), isFalse);
+    });
+
+    test('returns false for the funnelcake API host', () {
+      expect(isLoopbackHost('api.divine.video'), isFalse);
+    });
+
+    test('returns false for a host that merely contains localhost', () {
+      expect(isLoopbackHost('localhost.attacker.example'), isFalse);
+      expect(isLoopbackHost('evil-localhost'), isFalse);
+    });
+
+    test('returns false for a spoofed loopback-prefixed IP', () {
+      expect(isLoopbackHost('127.0.0.1.attacker.example'), isFalse);
+    });
+
+    test('returns false for an arbitrary LAN address', () {
+      expect(isLoopbackHost('192.168.1.10'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- `relay_base_io.dart` (relay websocket) and `dio_util.dart` (Dio HTTP used by NIP-96 discovery and zap/LNURL flows) no longer accept arbitrary TLS certificates for remote hosts.
- Remote `wss://` / `https://` hosts now go through platform certificate validation. Self-signed TLS is tolerated only for local-stack loopback hosts in debug builds.
- Moved the loopback host predicate into exported `nostr_sdk` utility code and collapsed the app, `nostr_client`, and NIP-46 copies onto that predicate.
- Updated the `PlatformWebSocketChannelFactory` docstring that documented the old accept-any-cert behavior.

Certificate/public-key pinning for Divine-operated hosts remains possible future hardening beyond platform validation. This PR removes the accept-any-cert hole while preserving cleartext local-stack development.

## Tests
- `flutter test test/unit/loopback_host_test.dart` (nostr_sdk)
- `flutter test test/unit/nostr_remote_signer_info_test.dart test/unit/exports_test.dart` (nostr_sdk)
- `flutter test test/src/relay_manager_test.dart` (nostr_client)
- `flutter test test/utils/relay_url_utils_test.dart` (mobile)
- `flutter analyze` (nostr_sdk)
- `flutter test` (nostr_sdk)
- `flutter analyze` (mobile)
- pre-push analyzer and changed-file tests

Closes #5893