### PR TITLE
fix(moderation): parse repeated label event tags

### DIFF
--- a/mobile/lib/constants/nostr_event_kinds.dart
+++ b/mobile/lib/constants/nostr_event_kinds.dart
@@ -13,4 +13,7 @@ class NostrEventKinds {
 
   /// Kind 7: Reaction (NIP-25)
   static const int reaction = 7;
+
+  /// Kind 1985: Labeling (NIP-32)
+  static const int label = 1985;
 }

--- a/mobile/lib/services/account_label_service.dart
+++ b/mobile/lib/services/account_label_service.dart
@@ -4,6 +4,7 @@
 import 'dart:async';
 
 import 'package:nostr_client/nostr_client.dart';
+import 'package:openvine/constants/nostr_event_kinds.dart';
 import 'package:openvine/models/content_label.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -131,7 +132,7 @@ class AccountLabelService {
       ];
 
       final event = await _authService.createAndSignEvent(
-        kind: 1985,
+        kind: NostrEventKinds.label,
         content: '',
         tags: tags,
       );

--- a/mobile/lib/services/moderation_label_service.dart
+++ b/mobile/lib/services/moderation_label_service.dart
@@ -7,6 +7,7 @@ import 'dart:convert';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/filter.dart';
 import 'package:nostr_sdk/nip05/nip05_validor.dart';
+import 'package:openvine/constants/nostr_event_kinds.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -100,6 +101,8 @@ class ModerationLabelService {
 
   /// SharedPreferences key for when the moderation pubkey was last resolved.
   static const String _resolvedAtKey = 'divine_moderation_resolved_at';
+
+  static const String _contentWarningNamespace = 'content-warning';
 
   /// NIP-05 address for the Divine moderation identity.
   static const String divineModerationNip05 = 'moderation@divine.video';
@@ -264,7 +267,7 @@ class ModerationLabelService {
     try {
       final filter = Filter(
         authors: [pubkey],
-        kinds: [1985], // NIP-32 label events
+        kinds: [NostrEventKinds.label], // NIP-32 label events
       );
 
       final events = await _nostrClient.queryEvents([filter]);
@@ -403,79 +406,87 @@ class ModerationLabelService {
       final tags = event.tags as List<dynamic>;
       final labelerPubkey = event.pubkey as String;
 
-      // Check if this is a content-warning label
-      bool isContentWarning = false;
-      String? labelValue;
-      String? targetEventId;
-      String? targetAddressableId;
-      String? targetPubkey;
-      String? contentHash;
-      double? confidence;
-      String? source;
-      bool isVerified = false;
+      final namespaces = <String>{};
+      final labels = <_PendingModerationLabel>[];
+      final eventIds = <String>[];
+      final addressableIds = <String>[];
+      final pubkeys = <String>[];
+      final hashes = <String>[];
 
       for (final tag in tags) {
         if (tag is! List || tag.length < 2) continue;
-        final tagName = tag[0] as String;
-        final tagValue = tag[1] as String;
+        final tagName = tag[0];
+        final tagValue = tag[1];
+        if (tagName is! String || tagValue is! String) continue;
 
         switch (tagName) {
           case 'L':
-            if (tagValue == 'content-warning') {
-              isContentWarning = true;
+            final namespace = _normalizeLabelNamespace(tagValue);
+            if (namespace != null) {
+              namespaces.add(namespace);
             }
           case 'l':
-            if (tag.length > 2 && tag[2] == 'content-warning') {
-              labelValue = tagValue;
-              isContentWarning = true;
-
-              // Parse optional 4th element as JSON metadata
-              if (tag.length > 3 && tag[3] is String) {
-                final parsed = _parseMetadata(tag[3] as String);
-                if (parsed != null) {
-                  confidence = parsed.confidence;
-                  source = parsed.source;
-                  isVerified = parsed.isVerified;
-                }
-              }
-            }
+            final metadata = tag.length > 3 && tag[3] is String
+                ? _parseMetadata(tag[3] as String)
+                : null;
+            labels.add(
+              _PendingModerationLabel(
+                value: tagValue,
+                namespace: tag.length > 2 && tag[2] is String
+                    ? _normalizeLabelNamespace(tag[2] as String)
+                    : null,
+                metadata: metadata,
+              ),
+            );
           case 'e':
-            targetEventId = tagValue;
+            eventIds.add(tagValue);
           case 'a':
-            targetAddressableId = tagValue;
+            addressableIds.add(tagValue);
           case 'p':
-            targetPubkey = tagValue;
+            pubkeys.add(tagValue);
           case 'x':
-            contentHash = tagValue;
+            hashes.add(tagValue);
         }
       }
 
-      if (!isContentWarning || labelValue == null) return;
+      for (final pending in labels) {
+        if (!_isContentWarningLabel(pending, namespaces)) continue;
 
-      final label = ModerationLabel(
-        labelerPubkey: labelerPubkey,
-        labelValue: labelValue,
-        targetEventId: targetEventId,
-        targetAddressableId: targetAddressableId,
-        targetPubkey: targetPubkey,
-        confidence: confidence,
-        source: source,
-        isVerified: isVerified,
-      );
-
-      if (targetEventId != null) {
-        _labelsByEventId.putIfAbsent(targetEventId, () => []).add(label);
-      }
-      if (targetAddressableId != null) {
-        _labelsByAddressableId
-            .putIfAbsent(targetAddressableId, () => [])
-            .add(label);
-      }
-      if (targetPubkey != null) {
-        _labelsByPubkey.putIfAbsent(targetPubkey, () => []).add(label);
-      }
-      if (contentHash != null) {
-        _labelsByHash.putIfAbsent(contentHash, () => []).add(label);
+        for (final eventId in eventIds) {
+          _labelsByEventId
+              .putIfAbsent(eventId, () => [])
+              .add(
+                pending.toModerationLabel(
+                  labelerPubkey: labelerPubkey,
+                  targetEventId: eventId,
+                ),
+              );
+        }
+        for (final addressableId in addressableIds) {
+          _labelsByAddressableId
+              .putIfAbsent(addressableId, () => [])
+              .add(
+                pending.toModerationLabel(
+                  labelerPubkey: labelerPubkey,
+                  targetAddressableId: addressableId,
+                ),
+              );
+        }
+        for (final pubkey in pubkeys) {
+          _labelsByPubkey
+              .putIfAbsent(pubkey, () => [])
+              .add(
+                pending.toModerationLabel(
+                  labelerPubkey: labelerPubkey,
+                  targetPubkey: pubkey,
+                ),
+              );
+        }
+        for (final hash in hashes) {
+          _labelsByHash
+              .putIfAbsent(hash, () => [])
+              .add(pending.toModerationLabel(labelerPubkey: labelerPubkey));
+        }
       }
     } catch (e) {
       Log.error(
@@ -484,6 +495,27 @@ class ModerationLabelService {
         category: LogCategory.system,
       );
     }
+  }
+
+  bool _isContentWarningLabel(
+    _PendingModerationLabel label,
+    Set<String> namespaces,
+  ) {
+    if (label.namespace == _contentWarningNamespace) return true;
+
+    // Leniency for non-conforming publishers: NIP-32 requires an `l` mark
+    // matching an `L` tag when `L` is present, but some events omit it. Accept
+    // that only when the event declares exactly one namespace and it is
+    // content-warning. With no `L`, unmarked `l` implies `ugc` and is ignored.
+    return label.namespace == null &&
+        namespaces.length == 1 &&
+        namespaces.single == _contentWarningNamespace;
+  }
+
+  static String? _normalizeLabelNamespace(String value) {
+    final normalized = value.trim().toLowerCase();
+    if (normalized.isEmpty) return null;
+    return normalized;
   }
 
   /// Parse JSON metadata from the 4th element of an `l` tag.
@@ -740,4 +772,32 @@ class _LabelMetadata {
   final double? confidence;
   final String? source;
   final bool isVerified;
+}
+
+class _PendingModerationLabel {
+  const _PendingModerationLabel({
+    required this.value,
+    required this.namespace,
+    required this.metadata,
+  });
+
+  final String value;
+  final String? namespace;
+  final _LabelMetadata? metadata;
+
+  ModerationLabel toModerationLabel({
+    required String labelerPubkey,
+    String? targetEventId,
+    String? targetAddressableId,
+    String? targetPubkey,
+  }) => ModerationLabel(
+    labelerPubkey: labelerPubkey,
+    labelValue: value,
+    targetEventId: targetEventId,
+    targetAddressableId: targetAddressableId,
+    targetPubkey: targetPubkey,
+    confidence: metadata?.confidence,
+    source: metadata?.source,
+    isVerified: metadata?.isVerified ?? false,
+  );
 }

--- a/mobile/test/services/moderation_label_service_test.dart
+++ b/mobile/test/services/moderation_label_service_test.dart
@@ -434,6 +434,171 @@ void main() {
         expect(labels.first.labelValue, equals('spam'));
       });
 
+      test('keeps every content-warning label with its metadata', () async {
+        const aiMetadata =
+            '{"confidence": 0.91, "source": "hiveai", "verified": true}';
+        const violenceMetadata =
+            '{"confidence": 0.42, "source": "human-review"}';
+        when(() => mockNostrClient.queryEvents(any())).thenAnswer(
+          (_) async => [
+            _FakeLabelEvent(
+              pubkey: service.divineModerationPubkeyHex,
+              tags: [
+                ['L', 'content-warning'],
+                ['l', 'ai-generated', 'content-warning', aiMetadata],
+                ['l', 'violence', 'content-warning', violenceMetadata],
+                ['e', 'multi_label_event'],
+              ],
+            ),
+          ],
+        );
+
+        await service.subscribeToLabeler(service.divineModerationPubkeyHex);
+
+        final warnings = service.getContentWarnings('multi_label_event');
+        expect(warnings.map((label) => label.labelValue), [
+          'ai-generated',
+          'violence',
+        ]);
+        expect(warnings[0].confidence, equals(0.91));
+        expect(warnings[0].source, equals('hiveai'));
+        expect(warnings[0].isVerified, isTrue);
+        expect(warnings[1].confidence, equals(0.42));
+        expect(warnings[1].source, equals('human-review'));
+        expect(warnings[1].isVerified, isFalse);
+
+        final aiResult = service.getAIDetectionResult('multi_label_event');
+        expect(aiResult, isNotNull);
+        expect(aiResult!.score, equals(0.91));
+        expect(aiResult.source, equals('hiveai'));
+        expect(aiResult.isVerified, isTrue);
+      });
+
+      test(
+        'indexes each repeated event and pubkey target separately',
+        () async {
+          when(() => mockNostrClient.queryEvents(any())).thenAnswer(
+            (_) async => [
+              _FakeLabelEvent(
+                pubkey: service.divineModerationPubkeyHex,
+                tags: [
+                  ['L', 'content-warning'],
+                  ['l', 'nudity', 'content-warning'],
+                  ['e', 'target_event_1'],
+                  ['e', 'target_event_2'],
+                  ['p', 'target_pubkey_1'],
+                  ['p', 'target_pubkey_2'],
+                ],
+              ),
+            ],
+          );
+
+          await service.subscribeToLabeler(service.divineModerationPubkeyHex);
+
+          for (final eventId in ['target_event_1', 'target_event_2']) {
+            final labels = service.getContentWarnings(eventId);
+            expect(labels, hasLength(1));
+            expect(labels.single.labelValue, equals('nudity'));
+            expect(labels.single.targetEventId, equals(eventId));
+            expect(labels.single.targetPubkey, isNull);
+          }
+          for (final pubkey in ['target_pubkey_1', 'target_pubkey_2']) {
+            final labels = service.getLabelsForPubkey(pubkey);
+            expect(labels, hasLength(1));
+            expect(labels.single.labelValue, equals('nudity'));
+            expect(labels.single.targetPubkey, equals(pubkey));
+            expect(labels.single.targetEventId, isNull);
+          }
+        },
+      );
+
+      test(
+        'accepts unmarked labels only for a single content-warning L',
+        () async {
+          when(() => mockNostrClient.queryEvents(any())).thenAnswer(
+            (_) async => [
+              _FakeLabelEvent(
+                pubkey: service.divineModerationPubkeyHex,
+                tags: [
+                  ['L', 'content-warning'],
+                  ['l', 'nudity'],
+                  ['e', 'unmarked_single_namespace_event'],
+                ],
+              ),
+              _FakeLabelEvent(
+                pubkey: service.divineModerationPubkeyHex,
+                tags: [
+                  ['l', 'violence'],
+                  ['e', 'unmarked_no_namespace_event'],
+                ],
+              ),
+              _FakeLabelEvent(
+                pubkey: service.divineModerationPubkeyHex,
+                tags: [
+                  ['L', 'content-warning'],
+                  ['L', 'other-namespace'],
+                  ['l', 'graphic-media'],
+                  ['e', 'unmarked_ambiguous_namespace_event'],
+                ],
+              ),
+            ],
+          );
+
+          await service.subscribeToLabeler(service.divineModerationPubkeyHex);
+
+          expect(
+            service
+                .getContentWarnings('unmarked_single_namespace_event')
+                .map((label) => label.labelValue),
+            ['nudity'],
+          );
+          expect(
+            service.hasContentWarning('unmarked_no_namespace_event'),
+            isFalse,
+          );
+          expect(
+            service.hasContentWarning('unmarked_ambiguous_namespace_event'),
+            isFalse,
+          );
+        },
+      );
+
+      test('trims and case-folds content-warning namespace only', () async {
+        when(() => mockNostrClient.queryEvents(any())).thenAnswer(
+          (_) async => [
+            _FakeLabelEvent(
+              pubkey: service.divineModerationPubkeyHex,
+              tags: [
+                ['L', ' Content-Warning '],
+                ['l', 'nudity', ' CONTENT-WARNING '],
+                ['e', 'case_folded_namespace_event'],
+              ],
+            ),
+            _FakeLabelEvent(
+              pubkey: service.divineModerationPubkeyHex,
+              tags: [
+                ['L', 'content_warning'],
+                ['l', 'violence', 'content_warning'],
+                ['e', 'underscore_namespace_event'],
+              ],
+            ),
+          ],
+        );
+
+        await service.subscribeToLabeler(service.divineModerationPubkeyHex);
+
+        expect(
+          service
+              .getContentWarnings('case_folded_namespace_event')
+              .map((label) => label.labelValue),
+          ['nudity'],
+        );
+        expect(
+          service.hasContentWarning('underscore_namespace_event'),
+          isFalse,
+        );
+      });
+
       test('ignores events without content-warning namespace', () async {
         when(() => mockNostrClient.queryEvents(any())).thenAnswer(
           (_) async => [
@@ -543,61 +708,58 @@ void main() {
         expect(service.getContentWarnings('followed_event'), hasLength(1));
       });
 
-      test(
-        'retries followed labelers enabled before relay readiness',
-        () async {
-          const followedLabeler =
-              'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
-          var canQueryRelays = false;
-          final gatedService = ModerationLabelService(
-            nostrClient: mockNostrClient,
-            authService: mockAuthService,
-            sharedPreferences: mockPrefs,
-            canQueryRelays: () => canQueryRelays,
-          );
-          when(() => mockNostrClient.queryEvents(any())).thenAnswer(
-            (_) async => [
-              _FakeLabelEvent(
-                pubkey: followedLabeler,
-                tags: [
-                  ['L', 'content-warning'],
-                  ['l', 'nudity', 'content-warning'],
-                  ['e', 'deferred_followed_event'],
-                ],
-              ),
-            ],
-          );
+      test('retries followed labelers enabled before relay readiness', () async {
+        const followedLabeler =
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+        var canQueryRelays = false;
+        final gatedService = ModerationLabelService(
+          nostrClient: mockNostrClient,
+          authService: mockAuthService,
+          sharedPreferences: mockPrefs,
+          canQueryRelays: () => canQueryRelays,
+        );
+        when(() => mockNostrClient.queryEvents(any())).thenAnswer(
+          (_) async => [
+            _FakeLabelEvent(
+              pubkey: followedLabeler,
+              tags: [
+                ['L', 'content-warning'],
+                ['l', 'nudity', 'content-warning'],
+                ['e', 'deferred_followed_event'],
+              ],
+            ),
+          ],
+        );
 
-          await gatedService.setFollowingModerationEnabled(
-            true,
-            followedPubkeys: [followedLabeler],
-          );
+        await gatedService.setFollowingModerationEnabled(
+          true,
+          followedPubkeys: [followedLabeler],
+        );
 
-          expect(gatedService.isFollowingModerationEnabled, isTrue);
-          expect(
-            gatedService.getContentWarnings('deferred_followed_event'),
-            isEmpty,
-          );
-          verifyNever(() => mockNostrClient.queryEvents(any()));
+        expect(gatedService.isFollowingModerationEnabled, isTrue);
+        expect(
+          gatedService.getContentWarnings('deferred_followed_event'),
+          isEmpty,
+        );
+        verifyNever(() => mockNostrClient.queryEvents(any()));
 
-          canQueryRelays = true;
-          await gatedService.syncFollowedLabelers([followedLabeler]);
+        canQueryRelays = true;
+        await gatedService.syncFollowedLabelers([followedLabeler]);
 
-          expect(
-            gatedService.getContentWarnings('deferred_followed_event'),
-            hasLength(1),
-          );
-          verify(() => mockNostrClient.queryEvents(any())).called(1);
-        },
-      );
+        expect(
+          gatedService.getContentWarnings('deferred_followed_event'),
+          hasLength(1),
+        );
+        verify(() => mockNostrClient.queryEvents(any())).called(1);
+      });
 
       test('coalesces concurrent labeler subscriptions', () async {
         const labeler =
             'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd';
         final events = Completer<List<Event>>();
-        when(() => mockNostrClient.queryEvents(any())).thenAnswer(
-          (_) => events.future,
-        );
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) => events.future);
 
         final firstSubscribe = service.subscribeToLabeler(labeler);
         final secondSubscribe = service.subscribeToLabeler(labeler);


### PR DESCRIPTION
## Summary
- Parse all content-warning labels in kind-1985 events instead of overwriting repeated l tags
- Index all repeated e/a/p/x targets with one ModerationLabel per label-target pair
- Trim and case-fold the content-warning namespace while preserving spec boundaries for other namespace spellings
- Add a NostrEventKinds.label constant and use it for kind-1985 publishing/querying

Closes #6088

## Verification
- flutter test test/services/moderation_label_service_test.dart
- flutter test test/services/effective_content_labels_test.dart test/services/nsfw_content_filter_test.dart test/services/video_moderation_status_service_test.dart test/services/video_event_service_content_filter_test.dart
- flutter analyze lib test integration_test
- pre-push hook analyzer and changed-file tests