### PR TITLE
fix(feed): sanitize unpaired UTF-16 surrogates in display text

### DIFF
--- a/mobile/lib/utils/string_utils.dart
+++ b/mobile/lib/utils/string_utils.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Provides safe substring operations and string truncation for logging
 
 import 'package:count_formatter/count_formatter.dart';
+import 'package:text_sanitizer/text_sanitizer.dart' as text_sanitizer;
 
 /// Utility functions for safe string operations
 class StringUtils {
@@ -52,25 +53,6 @@ class StringUtils {
   /// this at render boundaries that display untrusted text.
   ///
   /// Returns [input] unchanged when it is already well-formed.
-  static String sanitizeUtf16(String input) {
-    final units = input.codeUnits;
-    final out = <int>[];
-    for (var i = 0; i < units.length; i++) {
-      final unit = units[i];
-      if (unit >= 0xD800 && unit <= 0xDBFF) {
-        final next = i + 1 < units.length ? units[i + 1] : 0;
-        if (next >= 0xDC00 && next <= 0xDFFF) {
-          out
-            ..add(unit)
-            ..add(next);
-          i++;
-        }
-      } else if (unit >= 0xDC00 && unit <= 0xDFFF) {
-        continue;
-      } else {
-        out.add(unit);
-      }
-    }
-    return out.length == units.length ? input : String.fromCharCodes(out);
-  }
+  static String sanitizeUtf16(String input) =>
+      text_sanitizer.sanitizeUtf16(input);
 }

--- a/mobile/lib/widgets/linkified_text/linkified_text.dart
+++ b/mobile/lib/widgets/linkified_text/linkified_text.dart
@@ -8,6 +8,7 @@ import 'package:openvine/providers/repository_providers.dart';
 import 'package:openvine/widgets/linkified_text/linkified_text_navigation.dart';
 import 'package:openvine/widgets/linkified_text/linkified_text_span_builder.dart';
 import 'package:openvine/widgets/linkified_text/linkified_text_support.dart';
+import 'package:text_sanitizer/text_sanitizer.dart';
 
 class LinkifiedText extends ConsumerStatefulWidget {
   const LinkifiedText({
@@ -44,7 +45,9 @@ class _LinkifiedTextState extends ConsumerState<LinkifiedText> {
 
   @override
   Widget build(BuildContext context) {
-    final text = widget.text;
+    // Unpaired surrogates in sender-controlled content crash the
+    // paragraph builder during layout (#6111).
+    final text = sanitizeUtf16(widget.text);
     if (text.isEmpty) {
       _replaceCurrentSpans(const []);
       return const SizedBox.shrink();

--- a/mobile/lib/widgets/linkified_text/selectable_linkified_text.dart
+++ b/mobile/lib/widgets/linkified_text/selectable_linkified_text.dart
@@ -9,7 +9,6 @@ import 'package:openvine/widgets/linkified_text/linkified_text_navigation.dart';
 import 'package:openvine/widgets/linkified_text/linkified_text_span_builder.dart';
 import 'package:openvine/widgets/linkified_text/linkified_text_support.dart';
 import 'package:text_sanitizer/text_sanitizer.dart';
-import 'package:text_sanitizer/text_sanitizer.dart';
 
 class SelectableLinkifiedText extends ConsumerStatefulWidget {
   const SelectableLinkifiedText({

--- a/mobile/lib/widgets/linkified_text/selectable_linkified_text.dart
+++ b/mobile/lib/widgets/linkified_text/selectable_linkified_text.dart
@@ -8,6 +8,8 @@ import 'package:openvine/providers/repository_providers.dart';
 import 'package:openvine/widgets/linkified_text/linkified_text_navigation.dart';
 import 'package:openvine/widgets/linkified_text/linkified_text_span_builder.dart';
 import 'package:openvine/widgets/linkified_text/linkified_text_support.dart';
+import 'package:text_sanitizer/text_sanitizer.dart';
+import 'package:text_sanitizer/text_sanitizer.dart';
 
 class SelectableLinkifiedText extends ConsumerStatefulWidget {
   const SelectableLinkifiedText({
@@ -38,7 +40,9 @@ class _SelectableLinkifiedTextState
 
   @override
   Widget build(BuildContext context) {
-    final text = widget.text;
+    // Unpaired surrogates in sender-controlled content crash the
+    // paragraph builder during layout (#6111).
+    final text = sanitizeUtf16(widget.text);
     if (text.isEmpty) {
       _replaceCurrentSpans(const []);
       return const SizedBox.shrink();

--- a/mobile/packages/models/lib/src/profile_search_result.dart
+++ b/mobile/packages/models/lib/src/profile_search_result.dart
@@ -146,11 +146,12 @@ class ProfileSearchResult {
 
   /// Get the best display name available.
   ///
-  /// Sanitizes [displayName] and [name] against zalgo overflow; the [pubkey]
+  /// Sanitizes [displayName] and [name] for display (zalgo caps,
+  /// well-formed UTF-16); the [pubkey]
   /// hex fallback is returned as-is (hex contains no combining characters).
   String get bestDisplayName {
     final source = displayName ?? name;
-    return source != null ? stripZalgo(source) : pubkey;
+    return source != null ? sanitizeForDisplay(source) : pubkey;
   }
 
   /// Converts this [ProfileSearchResult] to a [UserProfile] for app use.

--- a/mobile/packages/models/lib/src/user_profile.dart
+++ b/mobile/packages/models/lib/src/user_profile.dart
@@ -225,16 +225,16 @@ class UserProfile {
   /// If [anonymousPlaceholder] is provided, it takes priority over the
   /// generated name when no display name or name is set.
   String betterDisplayName(String? anonymousPlaceholder) {
-    if (displayName?.isNotEmpty ?? false)
+    if (displayName?.isNotEmpty ?? false) {
       return sanitizeForDisplay(displayName!);
+    }
     if (name?.isNotEmpty ?? false) return sanitizeForDisplay(name!);
     if (anonymousPlaceholder != null) return anonymousPlaceholder;
     return defaultDisplayName;
   }
 
   /// Normalizes user-controlled display names before passing them to UI text.
-  static String sanitizeDisplayName(String value) =>
-      sanitizeForDisplay(value);
+  static String sanitizeDisplayName(String value) => sanitizeForDisplay(value);
 
   /// A display handle for the user, prefixed with `@`.
   ///
@@ -300,8 +300,9 @@ class UserProfile {
   ///
   /// Falls back to [defaultDisplayName] when no display name or name is set.
   String get bestDisplayName {
-    if (displayName?.isNotEmpty ?? false)
+    if (displayName?.isNotEmpty ?? false) {
       return sanitizeForDisplay(displayName!);
+    }
     if (name?.isNotEmpty ?? false) return sanitizeForDisplay(name!);
     return defaultDisplayName;
   }

--- a/mobile/packages/models/lib/src/user_profile.dart
+++ b/mobile/packages/models/lib/src/user_profile.dart
@@ -225,14 +225,16 @@ class UserProfile {
   /// If [anonymousPlaceholder] is provided, it takes priority over the
   /// generated name when no display name or name is set.
   String betterDisplayName(String? anonymousPlaceholder) {
-    if (displayName?.isNotEmpty ?? false) return stripZalgo(displayName!);
-    if (name?.isNotEmpty ?? false) return stripZalgo(name!);
+    if (displayName?.isNotEmpty ?? false)
+      return sanitizeForDisplay(displayName!);
+    if (name?.isNotEmpty ?? false) return sanitizeForDisplay(name!);
     if (anonymousPlaceholder != null) return anonymousPlaceholder;
     return defaultDisplayName;
   }
 
   /// Normalizes user-controlled display names before passing them to UI text.
-  static String sanitizeDisplayName(String value) => stripZalgo(value);
+  static String sanitizeDisplayName(String value) =>
+      sanitizeForDisplay(value);
 
   /// A display handle for the user, prefixed with `@`.
   ///
@@ -298,8 +300,9 @@ class UserProfile {
   ///
   /// Falls back to [defaultDisplayName] when no display name or name is set.
   String get bestDisplayName {
-    if (displayName?.isNotEmpty ?? false) return stripZalgo(displayName!);
-    if (name?.isNotEmpty ?? false) return stripZalgo(name!);
+    if (displayName?.isNotEmpty ?? false)
+      return sanitizeForDisplay(displayName!);
+    if (name?.isNotEmpty ?? false) return sanitizeForDisplay(name!);
     return defaultDisplayName;
   }
 

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -966,18 +966,18 @@ class VideoEvent {
       shareKind == NIP71VideoKinds.addressableShortVideo ||
       shareKind == NIP71VideoKinds.addressableNormalVideo;
 
-  /// Zalgo-safe video content for display.
-  String get displayContent => stripZalgo(content);
+  /// Display-sanitized video content (zalgo caps, well-formed UTF-16).
+  String get displayContent => sanitizeForDisplay(content);
 
-  /// Zalgo-safe video title for display. Returns `null` when no title is set.
-  String? get displayTitle => title != null ? stripZalgo(title!) : null;
+  /// Display-sanitized video title. Returns `null` when no title is set.
+  String? get displayTitle => title != null ? sanitizeForDisplay(title!) : null;
 
   /// Zalgo-safe embedded author name for display.
   ///
   /// Returns `null` when no embedded author name is set. Profile display-name
   /// getters have their own sanitizer path.
   String? get displayAuthorName =>
-      authorName != null ? stripZalgo(authorName!) : null;
+      authorName != null ? sanitizeForDisplay(authorName!) : null;
 
   /// Root event id from an uppercase NIP-22 reply tag.
   ///

--- a/mobile/packages/models/test/src/profile_search_result_test.dart
+++ b/mobile/packages/models/test/src/profile_search_result_test.dart
@@ -328,6 +328,15 @@ void main() {
 
         expect(result.bestDisplayName, equals('B\u0300\u0301'));
       });
+
+      test('replaces unpaired surrogates in displayName', () {
+        final result = ProfileSearchResult(
+          pubkey: testPubkey,
+          displayName: String.fromCharCodes([0x68, 0x69, 0xD83D]),
+        );
+
+        expect(result.bestDisplayName, equals('hi\uFFFD'));
+      });
     });
 
     group('toUserProfile', () {

--- a/mobile/packages/models/test/src/user_profile_test.dart
+++ b/mobile/packages/models/test/src/user_profile_test.dart
@@ -537,6 +537,20 @@ void main() {
 
         expect(profile.bestDisplayName, equals('B\u0300\u0301'));
       });
+
+      test('replaces unpaired surrogates in displayName', () {
+        // A lone surrogate in a display name crashes Flutter's
+        // paragraph builder if it reaches a Text widget (#6111).
+        final profile = UserProfile(
+          pubkey: testPubkey,
+          rawData: const {},
+          createdAt: testCreatedAt,
+          eventId: testEventId,
+          displayName: String.fromCharCodes([0x68, 0x69, 0xD83D]),
+        );
+
+        expect(profile.bestDisplayName, equals('hi\uFFFD'));
+      });
     });
 
     group('betterDisplayName', () {

--- a/mobile/packages/models/test/src/video_event_display_test.dart
+++ b/mobile/packages/models/test/src/video_event_display_test.dart
@@ -64,6 +64,20 @@ void main() {
 
       expect(build(content: malformed).displayContent, equals('\uFFFDa\uFFFD'));
     });
+
+    test('replaces unpaired surrogates from truncated emoji in content', () {
+      // Lone high surrogate (truncated emoji) crashes Flutter's
+      // paragraph builder if it reaches a Text widget (#6111).
+      final content = String.fromCharCodes([0x68, 0x69, 0xD83D]);
+      expect(build(content: content).displayContent, equals('hi\uFFFD'));
+    });
+
+    test('preserves valid emoji pairs in content', () {
+      expect(
+        build(content: 'fun \u{1F600}').displayContent,
+        equals('fun \u{1F600}'),
+      );
+    });
   });
 
   group('VideoEvent.displayAuthorName', () {

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -1625,11 +1625,13 @@ class NotificationRepository {
 
     final displayName = profile.displayName;
     if (_isUsableActorName(displayName, pubkey)) {
-      return stripZalgo(displayName!).trim();
+      return sanitizeForDisplay(displayName!).trim();
     }
 
     final name = profile.name;
-    if (_isUsableActorName(name, pubkey)) return stripZalgo(name!).trim();
+    if (_isUsableActorName(name, pubkey)) {
+      return sanitizeForDisplay(name!).trim();
+    }
 
     return null;
   }

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -435,6 +435,21 @@ void main() {
         expect(item.actors.first.displayName, equals('A\u0300\u0301'));
       });
 
+      test('replaces unpaired surrogates in explicit display names', () async {
+        stubNotifications([makeNotification(sourcePubkey: 'surrogate_pub')]);
+        stubProfiles({
+          'surrogate_pub': makeProfile(
+            'surrogate_pub',
+            displayName: String.fromCharCodes([0x68, 0x69, 0xD83D]),
+          ),
+        });
+
+        final page = await repository.getNotifications();
+
+        final item = page.items.single as VideoNotification;
+        expect(item.actors.first.displayName, equals('hi\uFFFD'));
+      });
+
       test('rethrows on API error after logging', () async {
         when(
           () => funnelcakeApiClient.getNotifications(

--- a/mobile/packages/text_sanitizer/lib/src/text_sanitizer.dart
+++ b/mobile/packages/text_sanitizer/lib/src/text_sanitizer.dart
@@ -74,6 +74,15 @@ String stripZalgo(String text, {int maxCombining = 2}) {
   return result.toString();
 }
 
+/// Sanitizes user-generated text for display: replaces unpaired UTF-16
+/// surrogates with U+FFFD ([sanitizeUtf16]) and caps combining chars
+/// ([stripZalgo]).
+///
+/// Use this at the boundary where untrusted event content becomes
+/// display text (titles, captions, display names, comments).
+String sanitizeForDisplay(String text, {int maxCombining = 2}) =>
+    stripZalgo(text, maxCombining: maxCombining);
+
 bool _isCombining(int cp) =>
     (cp >= 0x0300 && cp <= 0x036F) ||
     cp == 0x0489 ||

--- a/mobile/packages/text_sanitizer/test/src/text_sanitizer_test.dart
+++ b/mobile/packages/text_sanitizer/test/src/text_sanitizer_test.dart
@@ -80,4 +80,71 @@ void main() {
       expect(stripZalgo(input), equals('\u00E9S\u0300\u0301i'));
     });
   });
+
+  group('$sanitizeUtf16 edge cases', () {
+    test('returns empty string unchanged', () {
+      expect(sanitizeUtf16(''), equals(''));
+    });
+
+    test('returns plain ASCII unchanged', () {
+      expect(sanitizeUtf16('hello'), equals('hello'));
+    });
+
+    test('preserves a valid surrogate pair (emoji)', () {
+      // U+1F600 grinning face = D83D DE00
+      const emoji = '\u{1F600}';
+      expect(sanitizeUtf16(emoji), equals(emoji));
+    });
+
+    test('replaces a lone high surrogate', () {
+      final input = String.fromCharCodes([0x61, 0xD83D, 0x62]);
+      expect(sanitizeUtf16(input), equals('a\uFFFDb'));
+    });
+
+    test('replaces a lone low surrogate', () {
+      final input = String.fromCharCodes([0x61, 0xDE00, 0x62]);
+      expect(sanitizeUtf16(input), equals('a\uFFFDb'));
+    });
+
+    test('replaces a trailing high surrogate from a truncated emoji', () {
+      final input = String.fromCharCodes([0x68, 0x69, 0xD83D]);
+      expect(sanitizeUtf16(input), equals('hi\uFFFD'));
+    });
+
+    test('keeps valid pairs while replacing adjacent lone surrogates', () {
+      // lone low surrogate + valid pair + lone high surrogate
+      final input = String.fromCharCodes([0xDE00, 0xD83D, 0xDE00, 0xD83D]);
+      expect(sanitizeUtf16(input), equals('\uFFFD\u{1F600}\uFFFD'));
+    });
+
+    test('returns the identical instance when already well-formed', () {
+      const input = 'well formed \u{1F600} text';
+      expect(sanitizeUtf16(input), same(input));
+    });
+  });
+
+  group(sanitizeForDisplay, () {
+    test('replaces lone surrogates and caps combining chars', () {
+      // lone high surrogate, then o + 4 combining chars
+      final input = String.fromCharCodes([
+        0xD83D,
+        0x6F,
+        0x0300,
+        0x0301,
+        0x0302,
+        0x0303,
+      ]);
+      expect(sanitizeForDisplay(input), equals('\uFFFDo\u0300\u0301'));
+    });
+
+    test('returns well-formed clean text unchanged', () {
+      const input = 'clean \u{1F600} text';
+      expect(sanitizeForDisplay(input), equals(input));
+    });
+
+    test('forwards maxCombining to stripZalgo', () {
+      const input = 'a\u0300\u0301\u0302';
+      expect(sanitizeForDisplay(input, maxCombining: 1), equals('a\u0300'));
+    });
+  });
 }

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -252,6 +252,9 @@ dependencies:
   # Models - Shared Nostr/data model definitions
   models:
 
+  # Text Sanitizer - display-safe user text (zalgo caps, UTF-16 well-formed)
+  text_sanitizer:
+
   # Videos Repository - Video feed data layer
   videos_repository:
 

--- a/mobile/test/screens/inbox/conversation/widgets/message_bubble_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/message_bubble_test.dart
@@ -237,7 +237,7 @@ void main() {
           );
 
           expect(tester.takeException(), isNull);
-          expect(find.text('beforeafter'), findsOneWidget);
+          expect(find.text('before\uFFFDafter'), findsOneWidget);
         },
       );
     });

--- a/mobile/test/utils/string_utils_test.dart
+++ b/mobile/test/utils/string_utils_test.dart
@@ -22,30 +22,30 @@ void main() {
         expect(result.runes.last, equals(0x1F600));
       });
 
-      test('drops an unpaired high surrogate', () {
+      test('replaces an unpaired high surrogate', () {
         final input = 'a${String.fromCharCode(0xD83D)}b';
-        expect(StringUtils.sanitizeUtf16(input), equals('ab'));
+        expect(StringUtils.sanitizeUtf16(input), equals('a\uFFFDb'));
       });
 
-      test('drops an unpaired low surrogate', () {
+      test('replaces an unpaired low surrogate', () {
         final input = 'a${String.fromCharCode(0xDE00)}b';
-        expect(StringUtils.sanitizeUtf16(input), equals('ab'));
+        expect(StringUtils.sanitizeUtf16(input), equals('a\uFFFDb'));
       });
 
-      test('drops a trailing unpaired high surrogate', () {
+      test('replaces a trailing unpaired high surrogate', () {
         final input = 'trail${String.fromCharCode(0xD83D)}';
-        expect(StringUtils.sanitizeUtf16(input), equals('trail'));
+        expect(StringUtils.sanitizeUtf16(input), equals('trail\uFFFD'));
       });
 
-      test('drops a high surrogate followed by a non-surrogate', () {
+      test('replaces a high surrogate followed by a non-surrogate', () {
         final input = '${String.fromCharCode(0xD83D)}x';
-        expect(StringUtils.sanitizeUtf16(input), equals('x'));
+        expect(StringUtils.sanitizeUtf16(input), equals('\uFFFDx'));
       });
 
       test('preserves adjacent valid pairs separated by an unpaired one', () {
         final input = '😀${String.fromCharCode(0xD83D)}😀';
         final result = StringUtils.sanitizeUtf16(input);
-        expect(result, equals('😀😀'));
+        expect(result, equals('😀\uFFFD😀'));
       });
     });
   });

--- a/mobile/test/widgets/linkified_text/linkified_text_utf16_test.dart
+++ b/mobile/test/widgets/linkified_text/linkified_text_utf16_test.dart
@@ -1,0 +1,64 @@
+// ABOUTME: Regression test for Crashlytics #6111 — malformed UTF-16 in
+// ABOUTME: user content must not crash LinkifiedText's paragraph layout.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/widgets/linkified_text/linkified_text_widgets.dart';
+
+void main() {
+  group('LinkifiedText UTF-16 safety', () {
+    testWidgets('renders text containing a lone high surrogate', (
+      tester,
+    ) async {
+      // A truncated emoji leaves an unpaired high surrogate; the raw
+      // string crashes _NativeParagraphBuilder.addText (#6111).
+      final malformed = 'broken ${String.fromCharCode(0xD83D)} #vine';
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: LinkifiedText(text: malformed)),
+        ),
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(LinkifiedText), findsOneWidget);
+    });
+
+    testWidgets('renders plain text containing a lone low surrogate', (
+      tester,
+    ) async {
+      final malformed = 'oops${String.fromCharCode(0xDE00)}';
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: LinkifiedText(text: malformed)),
+        ),
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('oops\uFFFD'), findsOneWidget);
+    });
+
+    testWidgets('renders $SelectableLinkifiedText with a lone surrogate', (
+      tester,
+    ) async {
+      final malformed = 'sel ${String.fromCharCode(0xD83D)} #vine';
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: SelectableLinkifiedText(text: malformed)),
+        ),
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(SelectableLinkifiedText), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Companion to the merged #6273 (which closed #6111 by making `stripZalgo` normalize unpaired UTF-16 surrogates to U+FFFD). This PR was written in parallel against the same Crashlytics issue and has been rebased onto #6273; it now carries the **residual pieces #6273 did not cover**:

- **`LinkifiedText` / `SelectableLinkifiedText` sanitize their input.** Comments and bios reach these widgets as raw event content — they bypass the model display getters #6273 hardened, so a lone surrogate in a comment still crashed paragraph layout on `main`.
- **`sanitizeForDisplay()`** convenience in `text_sanitizer` (`sanitizeUtf16` + `stripZalgo`) with tests.
- **`StringUtils.sanitizeUtf16` (DM path) delegates to the shared package implementation** instead of keeping a second divergent copy; the DM `MessageBubble` test is aligned to the U+FFFD replacement semantics #6273 standardized.
- **Surrogate regression pins** on `UserProfile.bestDisplayName`, `ProfileSearchResult.bestDisplayName`, and notification actor names, plus new widget regression tests in `mobile/test/widgets/linkified_text/linkified_text_utf16_test.dart` (verified red on pre-fix code).

## Testing

- `text_sanitizer` (23), `models` display suites (153), `notification_repository` (126), linkified/DM/string-utils widget suites — all green after the rebase.
- `flutter analyze lib test integration_test` clean.
- `text_sanitizer` keeps 100% line coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)