### PR TITLE
fix(proofmode): store C2PA manifest id under the key fromMetadata reads

### DIFF
--- a/mobile/lib/services/native_proofmode_service.dart
+++ b/mobile/lib/services/native_proofmode_service.dart
@@ -130,7 +130,10 @@ class NativeProofModeService {
               category: .video,
             );
 
-            metadata.putIfAbsent('c2pa_manifest_id', () => activeManifestId);
+            metadata.putIfAbsent(
+              NativeProofData.metadataC2paManifestIdKey,
+              () => activeManifestId,
+            );
 
             // Create NativeProofData from metadata
             final proofData = NativeProofData.fromMetadata(metadata);
@@ -264,7 +267,10 @@ class NativeProofModeService {
 
       if (manifestInfo?.activeManifest != null) {
         final String activeManifestId = manifestInfo!.activeManifest!;
-        metadata.putIfAbsent('c2pa_manifest_id', () => activeManifestId);
+        metadata.putIfAbsent(
+          NativeProofData.metadataC2paManifestIdKey,
+          () => activeManifestId,
+        );
       }
 
       // Create NativeProofData from metadata
@@ -399,10 +405,11 @@ class NativeProofModeService {
   /// Read proof metadata from the native proof directory
   ///
   /// Returns a map containing:
-  /// - 'csv': Sensor data CSV content
-  /// - 'signature': OpenPGP signature
-  /// - 'hash': SHA256 hash of media file
-  /// - 'timestamp': Timestamp data
+  /// - [NativeProofData.metadataSensorDataCsvKey]: Sensor data CSV content
+  /// - [NativeProofData.metadataPgpSignatureKey]: OpenPGP signature
+  /// - [NativeProofData.metadataPublicKeyKey]: Proof public key
+  /// - [NativeProofData.metadataDeviceAttestationKey]: Device attestation
+  /// - [NativeProofData.metadataHashKey]: SHA256 hash of media file
   static Future<Map<String, String>?> readProofMetadata(
     String proofHash, {
     bool warnIfMissing = true,
@@ -431,9 +438,10 @@ class NativeProofModeService {
       // Read CSV sensor data
       final csvFile = File('$proofDir/$proofHash.csv');
       if (csvFile.existsSync()) {
-        metadata['csv'] = await csvFile.readAsString();
+        metadata[NativeProofData.metadataSensorDataCsvKey] = await csvFile
+            .readAsString();
         Log.debug(
-          '🔐 Read CSV metadata (${metadata['csv']!.length} bytes)',
+          '🔐 Read CSV metadata (${metadata[NativeProofData.metadataSensorDataCsvKey]!.length} bytes)',
           name: 'NativeProofMode',
           category: LogCategory.system,
         );
@@ -442,9 +450,10 @@ class NativeProofModeService {
       // Read OpenPGP signature
       final sigFile = File('$proofDir/$proofHash.asc');
       if (sigFile.existsSync()) {
-        metadata['signature'] = await sigFile.readAsString();
+        metadata[NativeProofData.metadataPgpSignatureKey] = await sigFile
+            .readAsString();
         Log.debug(
-          '🔐 Read signature (${metadata['signature']!.length} bytes)',
+          '🔐 Read signature (${metadata[NativeProofData.metadataPgpSignatureKey]!.length} bytes)',
           name: 'NativeProofMode',
           category: LogCategory.system,
         );
@@ -453,9 +462,10 @@ class NativeProofModeService {
       // Read proof public key
       final pubkeyFile = File('$proofDir/$proofHash-pubkey.asc');
       if (pubkeyFile.existsSync()) {
-        metadata['publicKey'] = await pubkeyFile.readAsString();
+        metadata[NativeProofData.metadataPublicKeyKey] = await pubkeyFile
+            .readAsString();
         Log.debug(
-          '🔐 Read public key (${metadata['publicKey']!.length} bytes)',
+          '🔐 Read public key (${metadata[NativeProofData.metadataPublicKeyKey]!.length} bytes)',
           name: 'NativeProofMode',
           category: LogCategory.system,
         );
@@ -464,15 +474,16 @@ class NativeProofModeService {
       // Read local device attestation info
       final deviceAttestation = File('$proofDir/$proofHash.attest');
       if (deviceAttestation.existsSync()) {
-        metadata['deviceAttestation'] = await deviceAttestation.readAsString();
+        metadata[NativeProofData.metadataDeviceAttestationKey] =
+            await deviceAttestation.readAsString();
         Log.debug(
-          '🔐 Read device attestation (${metadata['deviceAttestation']!.length} bytes)',
+          '🔐 Read device attestation (${metadata[NativeProofData.metadataDeviceAttestationKey]!.length} bytes)',
           name: 'NativeProofMode',
           category: LogCategory.system,
         );
       }
 
-      metadata['hash'] = proofHash;
+      metadata[NativeProofData.metadataHashKey] = proofHash;
 
       Log.info(
         '🔐 Read native ProofMode metadata (${metadata.length} fields)',

--- a/mobile/lib/services/native_proofmode_service.dart
+++ b/mobile/lib/services/native_proofmode_service.dart
@@ -130,7 +130,7 @@ class NativeProofModeService {
               category: .video,
             );
 
-            metadata.putIfAbsent('c2paManifestId', () => activeManifestId);
+            metadata.putIfAbsent('c2pa_manifest_id', () => activeManifestId);
 
             // Create NativeProofData from metadata
             final proofData = NativeProofData.fromMetadata(metadata);
@@ -264,7 +264,7 @@ class NativeProofModeService {
 
       if (manifestInfo?.activeManifest != null) {
         final String activeManifestId = manifestInfo!.activeManifest!;
-        metadata.putIfAbsent('c2paManifestId', () => activeManifestId);
+        metadata.putIfAbsent('c2pa_manifest_id', () => activeManifestId);
       }
 
       // Create NativeProofData from metadata

--- a/mobile/packages/models/lib/src/native_proof_data.dart
+++ b/mobile/packages/models/lib/src/native_proof_data.dart
@@ -42,18 +42,20 @@ class NativeProofData {
   /// Create from raw proof metadata map (from NativeProofModeService)
   factory NativeProofData.fromMetadata(Map<String, String> metadata) =>
       NativeProofData(
-        videoHash: metadata['hash']!,
-        sensorDataCsv: metadata['csv'],
-        pgpSignature: metadata['signature'],
-        publicKey: metadata['publicKey'],
-        c2paManifestId: metadata['c2pa_manifest_id'],
-        deviceAttestation: metadata['deviceAttestation'],
-        creatorBindingAssertionLabel:
-            metadata['creator_binding_assertion_label'],
-        cawgIdentityAssertionLabel: metadata['cawg_identity_assertion_label'],
-        creatorBindingPayloadJson: metadata['creator_binding_payload_json'],
-        verifiedIdentityBundleJson: metadata['verified_identity_bundle_json'],
+        videoHash: metadata[metadataHashKey]!,
+        sensorDataCsv: metadata[metadataSensorDataCsvKey],
+        pgpSignature: metadata[metadataPgpSignatureKey],
+        publicKey: metadata[metadataPublicKeyKey],
+        c2paManifestId: metadata[metadataC2paManifestIdKey],
+        deviceAttestation: metadata[metadataDeviceAttestationKey],
       );
+
+  static const metadataHashKey = 'hash';
+  static const metadataSensorDataCsvKey = 'csv';
+  static const metadataPgpSignatureKey = 'signature';
+  static const metadataPublicKeyKey = 'publicKey';
+  static const metadataDeviceAttestationKey = 'deviceAttestation';
+  static const metadataC2paManifestIdKey = 'c2pa_manifest_id';
 
   /// SHA256 hash of the video file (used as proof identifier)
   final String videoHash;

--- a/mobile/test/services/native_proofmode_service_test.dart
+++ b/mobile/test/services/native_proofmode_service_test.dart
@@ -262,6 +262,7 @@ void main() {
       expect(proofData, isNotNull);
       expect(proofData!.videoHash, videoHash);
       expect(proofData.c2paManifestId, _SigningC2paSigningService.manifestId);
+      expect(c2paService.signVideoCallCount, 0);
     });
   });
 }
@@ -313,6 +314,7 @@ class _SigningC2paSigningService extends C2paSigningService {
 
   final String videoPath;
   final bool allowSign;
+  int signVideoCallCount = 0;
 
   @override
   Future<C2paSigningResult> signVideo({
@@ -321,6 +323,7 @@ class _SigningC2paSigningService extends C2paSigningService {
     Map<String, dynamic>? cawgIdentityAssertion,
     bool enableAdvancedCawgEmbedding = false,
   }) async {
+    signVideoCallCount += 1;
     if (!allowSign) {
       fail('signVideo should not be called when proof metadata exists');
     }

--- a/mobile/test/services/native_proofmode_service_test.dart
+++ b/mobile/test/services/native_proofmode_service_test.dart
@@ -166,6 +166,104 @@ void main() {
       );
     });
   });
+
+  group('proofFile C2PA manifest id propagation', () {
+    test('fresh proof generation carries the C2PA manifest id', () async {
+      final directory = await Directory.systemTemp.createTemp(
+        'native-proofmode-test-',
+      );
+      addTearDown(() async {
+        if (directory.existsSync()) {
+          await directory.delete(recursive: true);
+        }
+      });
+
+      final video = File('${directory.path}/video.mp4');
+      await video.writeAsBytes(const [1, 2, 3, 4]);
+
+      const generatedProofHash =
+          'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+      final proofDir = Directory('${directory.path}/$generatedProofHash');
+      await proofDir.create();
+      await File(
+        '${proofDir.path}/$generatedProofHash.asc',
+      ).writeAsString('signature');
+
+      final c2paService = _SigningC2paSigningService(video.path);
+      NativeProofModeService.c2paSigningServiceFactoryOverride = () =>
+          c2paService;
+
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(proofModeChannel, (call) async {
+            switch (call.method) {
+              case 'isAvailable':
+                return true;
+              case 'getProofDir':
+                final args = call.arguments as Map<Object?, Object?>;
+                return args['proofHash'] == generatedProofHash
+                    ? proofDir.path
+                    : null;
+              case 'generateProof':
+                return generatedProofHash;
+              default:
+                fail('Unexpected proof mode method call: ${call.method}');
+            }
+          });
+
+      final proofData = await NativeProofModeService.proofFile(video);
+
+      expect(proofData, isNotNull);
+      expect(proofData!.videoHash, generatedProofHash);
+      expect(proofData.c2paManifestId, _SigningC2paSigningService.manifestId);
+    });
+
+    test('existing proof metadata carries the C2PA manifest id', () async {
+      final directory = await Directory.systemTemp.createTemp(
+        'native-proofmode-test-',
+      );
+      addTearDown(() async {
+        if (directory.existsSync()) {
+          await directory.delete(recursive: true);
+        }
+      });
+
+      final video = File('${directory.path}/video.mp4');
+      await video.writeAsBytes(const [1, 2, 3, 4]);
+      final videoHash = await NativeProofModeService.generateSha256FileHash(
+        video.path,
+      );
+
+      final proofDir = Directory('${directory.path}/$videoHash');
+      await proofDir.create();
+      await File('${proofDir.path}/$videoHash.asc').writeAsString('signature');
+
+      final c2paService = _SigningC2paSigningService(
+        video.path,
+        allowSign: false,
+      );
+      NativeProofModeService.c2paSigningServiceFactoryOverride = () =>
+          c2paService;
+
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(proofModeChannel, (call) async {
+            switch (call.method) {
+              case 'isAvailable':
+                return true;
+              case 'getProofDir':
+                final args = call.arguments as Map<Object?, Object?>;
+                return args['proofHash'] == videoHash ? proofDir.path : null;
+              default:
+                fail('Unexpected proof mode method call: ${call.method}');
+            }
+          });
+
+      final proofData = await NativeProofModeService.proofFile(video);
+
+      expect(proofData, isNotNull);
+      expect(proofData!.videoHash, videoHash);
+      expect(proofData.c2paManifestId, _SigningC2paSigningService.manifestId);
+    });
+  });
 }
 
 Iterable<LogEntry> _logsContaining(String message) {
@@ -205,5 +303,32 @@ class _FailingC2paSigningService extends C2paSigningService {
   Future<ManifestStoreInfo?> readManifest(String filePath) async {
     readManifestCallCount += 1;
     return null;
+  }
+}
+
+class _SigningC2paSigningService extends C2paSigningService {
+  _SigningC2paSigningService(this.videoPath, {this.allowSign = true});
+
+  static const manifestId = 'urn:c2pa:test-manifest';
+
+  final String videoPath;
+  final bool allowSign;
+
+  @override
+  Future<C2paSigningResult> signVideo({
+    required String videoPath,
+    NostrCreatorBindingAssertion? creatorBindingAssertion,
+    Map<String, dynamic>? cawgIdentityAssertion,
+    bool enableAdvancedCawgEmbedding = false,
+  }) async {
+    if (!allowSign) {
+      fail('signVideo should not be called when proof metadata exists');
+    }
+    return C2paSigningResult(signedFilePath: this.videoPath, success: true);
+  }
+
+  @override
+  Future<ManifestStoreInfo?> readManifest(String filePath) async {
+    return const ManifestStoreInfo(activeManifest: manifestId);
   }
 }


### PR DESCRIPTION
## Summary

Relates to #838.

Every camera publish since 1.0.17 falsely showed the **"Post without the human-made check?"** dialog even though C2PA signing succeeded and the published video verified with all four checks green.

Root cause: a metadata key mismatch. `NativeProofModeService` inserted the manifest id with `metadata.putIfAbsent('c2paManifestId', ...)` (both the existing-metadata path and the fresh-generation path), but `NativeProofData.fromMetadata` reads `metadata['c2pa_manifest_id']` -- matching the snake_case convention of every other native metadata key. The manifest id was silently dropped from every proof manifest.

The mismatch has existed since the ProofMode C2PA integration (#1517, Feb 2026) but was harmless until #6068 (Jul 18) added the C2PA prompt gate, which reads `c2paManifestId` off the proof manifest and shows the dialog when it's missing -- turning silent data loss into a false-positive dialog on every recording. Publish still worked because the C2PA manifest is embedded in the video file itself and the publish path re-reads it, which is why "Post anyway" produced a fully verified video.

Evidence from device log (build 1.0.17):

```
10:08:20.247 C2PA Active Manifest ID: urn:c2pa:db0a5480-51fc-45bf-8401-d64eadb5fe74
10:08:22.508 🔐 C2PA prompt gate -- configured: true, hasProof: true, failed: true
```

## Changes

- `native_proofmode_service.dart`: write the manifest id under `c2pa_manifest_id` at both call sites, matching `NativeProofData.fromMetadata`. The camelCase `toJson`/`fromJson` draft round-trip is unchanged and consistent.
- `native_proof_data.dart`: centralize the raw native metadata keys on `NativeProofData` and remove stale raw identity metadata reads that had no writer.
- `native_proofmode_service_test.dart`: two regression tests asserting `proofFile` returns a `NativeProofData` whose `c2paManifestId` carries the active manifest -- one for the fresh-generation path, one for the existing-metadata path. The existing-metadata test also asserts signing is not invoked.

## Downstream effects

This restores more than the dialog gate:

- `proof-verification-level` can return `verified_mobile` for successful camera recordings instead of falling back to `verified_web`/`basic_proof`.
- Blossom uploads now include `X-ProofMode-C2PA` when the generated proof manifest has the C2PA manifest id.

Both are intended restorations of the existing provenance contract.

## Testing

- `flutter test test/services/native_proofmode_service_test.dart`
- `flutter test` from `mobile/packages/models`
- `flutter analyze lib test integration_test`
