### PR TITLE
fix(support): anchor log-export share sheet so iPad idiom can present it

### DIFF
--- a/mobile/lib/screens/settings/support_center_screen.dart
+++ b/mobile/lib/screens/settings/support_center_screen.dart
@@ -9,6 +9,7 @@ import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/services/bug_report_service.dart';
 import 'package:openvine/services/zendesk_support_service.dart';
+import 'package:openvine/utils/share_position_origin.dart';
 import 'package:openvine/widgets/bug_report_dialog.dart';
 import 'package:openvine/widgets/feature_request_dialog.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -128,6 +129,9 @@ class SupportCenterScreen extends ConsumerWidget {
     BugReportService bugReportService,
     String? userPubkey,
   ) async {
+    // Resolve the popover anchor before any await — iPad idiom (including
+    // iOS builds on Apple Silicon Macs) rejects the share sheet without it.
+    final sharePositionOrigin = sharePositionOriginForContext(context);
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: Text(context.l10n.supportExportingLogs),
@@ -138,6 +142,7 @@ class SupportCenterScreen extends ConsumerWidget {
     final result = await bugReportService.exportLogsToFile(
       currentScreen: 'SupportCenterScreen',
       userPubkey: userPubkey,
+      sharePositionOrigin: sharePositionOrigin,
     );
     if (!context.mounted) return;
 

--- a/mobile/lib/services/bug_report_service.dart
+++ b/mobile/lib/services/bug_report_service.dart
@@ -759,9 +759,16 @@ class BugReportService {
   ///
   /// On success, [LogExportResult.filePath] is populated when the caller
   /// can show the user where the file landed (currently desktop only).
+  ///
+  /// [sharePositionOrigin] anchors the iOS share sheet popover. It is
+  /// required on iPad idiom (real iPads and iOS builds running on
+  /// Apple Silicon Macs) — share_plus rejects the share with
+  /// "sharePositionOrigin: argument must be set" when it is missing
+  /// there.
   Future<LogExportResult> exportLogsToFile({
     String? currentScreen,
     String? userPubkey,
+    ui.Rect? sharePositionOrigin,
   }) async {
     try {
       Log.info(
@@ -831,7 +838,12 @@ class BugReportService {
       if (_isDesktop) {
         return _exportLogsDesktop(content, fileName, allLogLines.length);
       }
-      return _exportLogsNative(content, fileName, allLogLines.length);
+      return _exportLogsNative(
+        content,
+        fileName,
+        allLogLines.length,
+        sharePositionOrigin: sharePositionOrigin,
+      );
     } catch (e, stackTrace) {
       Log.error(
         'Failed to export logs: $e',
@@ -1119,8 +1131,9 @@ class BugReportService {
   Future<LogExportResult> _exportLogsNative(
     String content,
     String fileName,
-    int lineCount,
-  ) async {
+    int lineCount, {
+    ui.Rect? sharePositionOrigin,
+  }) async {
     try {
       // Get temporary directory
       final tempDir = await getTemporaryDirectory();
@@ -1146,6 +1159,7 @@ class BugReportService {
           files: [XFile(filePath)],
           subject: 'OpenVine Full Logs',
           text: 'OpenVine Full Logs',
+          sharePositionOrigin: sharePositionOrigin,
         ),
       );
 

--- a/mobile/macos/Runner/Release.entitlements
+++ b/mobile/macos/Runner/Release.entitlements
@@ -20,7 +20,7 @@
 	<array>
 		<string>$(AppIdentifierPrefix)$(CFBundleIdentifier)</string>
 	</array>
-	<key>com.apple.security.files.user-selected.read-only</key>
+	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
 	<key>com.apple.security.files.downloads.read-write</key>
 	<true/>

--- a/mobile/test/utils/share_position_origin_test.dart
+++ b/mobile/test/utils/share_position_origin_test.dart
@@ -1,0 +1,45 @@
+// ABOUTME: Tests for sharePositionOriginForContext, the popover anchor
+// ABOUTME: helper required by share_plus on iPad idiom (incl. iOS-on-Mac).
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/utils/share_position_origin.dart';
+
+void main() {
+  group('sharePositionOriginForContext', () {
+    testWidgets('returns the global bounds of a laid-out widget', (
+      tester,
+    ) async {
+      final key = GlobalKey();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Center(child: SizedBox(key: key, width: 120, height: 48)),
+        ),
+      );
+
+      final origin = sharePositionOriginForContext(key.currentContext!);
+
+      final box = key.currentContext!.findRenderObject()! as RenderBox;
+      final expected = box.localToGlobal(Offset.zero) & box.size;
+      expect(origin, equals(expected));
+      expect(origin!.isEmpty, isFalse);
+      expect(origin.size, equals(const Size(120, 48)));
+    });
+
+    testWidgets('returns null for a zero-sized widget', (tester) async {
+      final key = GlobalKey();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Align(
+            alignment: Alignment.topLeft,
+            child: SizedBox.shrink(key: key),
+          ),
+        ),
+      );
+
+      final origin = sharePositionOriginForContext(key.currentContext!);
+
+      expect(origin, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

**Save Logs in Support Center failed instantly with "Failed to export logs" — no share sheet, no dialog — on iOS builds running on Apple Silicon Macs ("Designed for iPad") and on real iPads.**

Root cause: on iPad idiom, `share_plus` requires a `sharePositionOrigin` popover anchor and rejects the share with a `FlutterError` ("sharePositionOrigin: argument must be set") when it is missing (verified in `FPPSharePlusPlugin.m` of share_plus 12.0.1). `BugReportService._exportLogsNative` called `SharePlus.instance.share` without one, the error hit the catch block, and the user saw the failure toast with nothing else happening.

## Changes

- `exportLogsToFile` accepts an optional `sharePositionOrigin` and threads it into the native share sheet params.
- Support Center screen resolves the anchor via the existing `sharePositionOriginForContext` helper before awaiting, and passes it through.
- **Separate, related fix (native macOS build):** `Release.entitlements` granted only `com.apple.security.files.user-selected.read-only`, so the sandboxed desktop Save As export could not write the picked file outside `~/Downloads`. Swapped to `user-selected.read-write`.
- New test coverage for `sharePositionOriginForContext` (global bounds for laid-out widget, null for zero-size).

## Testing

- `flutter analyze` on changed files: clean
- `flutter test test/utils/share_position_origin_test.dart`: pass
- `flutter test test/unit/services/bug_report_log_export_test.dart`: pass
- Manual repro path: Divine 1.0.16 (804) iOS-on-Mac, Support Center → Save Logs previously showed only the red "Failed to export logs" snackbar; share flow requires manual verification on device/TestFlight build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)