### PR TITLE
fix(video): dispose VideoEventService when its provider rebuilds

### DIFF
--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -156,6 +156,10 @@ VideoEventService videoEventService(Ref ref) {
     videoFilterBuilder: videoFilterBuilder,
     performanceMonitor: ref.watch(performanceMonitoringServiceProvider),
   );
+  // Without this, every NostrService client swap (auth cold start, account
+  // switch) orphans a service whose periodic timers and auth subscription
+  // keep running against the disposed EventRouter above (#6174).
+  ref.onDispose(service.dispose);
   var persistedDeletions = const <ContentDeletion>[];
   try {
     persistedDeletions = ContentDeletionService.parseDeletionHistory(

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -269,7 +269,7 @@ final class VideoEventServiceProvider
   }
 }
 
-String _$videoEventServiceHash() => r'fc7641c67bd08d04d656a7e69ef9668ff5beaee2';
+String _$videoEventServiceHash() => r'4f32c751466a87eaef78b39472c339d306a57be8';
 
 /// Video event publisher for publishing video events to Nostr relays
 

--- a/mobile/test/providers/video_event_service_dispose_test.dart
+++ b/mobile/test/providers/video_event_service_dispose_test.dart
@@ -1,0 +1,57 @@
+// ABOUTME: Regression test for #6174 — videoEventServiceProvider must dispose
+// ABOUTME: the VideoEventService it created when the provider state is torn down.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/providers/video_providers.dart';
+
+import '../helpers/test_provider_overrides.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('videoEventServiceProvider disposal (#6174)', () {
+    late ProviderContainer container;
+
+    setUp(() {
+      container = ProviderContainer(
+        overrides: getStandardTestOverrides().cast(),
+      );
+    });
+
+    tearDown(() {
+      container.dispose();
+    });
+
+    test('disposes the previous service when the provider rebuilds', () {
+      final first = container.read(videoEventServiceProvider);
+
+      // A NostrService client swap (auth cold start, account switch)
+      // invalidates the provider; the orphaned service must be disposed so
+      // its periodic timers and auth subscription stop running against the
+      // already-disposed EventRouter.
+      container.invalidate(videoEventServiceProvider);
+      final second = container.read(videoEventServiceProvider);
+
+      expect(identical(first, second), isFalse);
+      expect(
+        () => first.addListener(() {}),
+        throwsFlutterError,
+        reason:
+            'the replaced VideoEventService must be disposed; a live '
+            'ChangeNotifier here means orphaned timers keep firing',
+      );
+    });
+
+    test('disposes the service when the container is torn down', () {
+      final service = container.read(videoEventServiceProvider);
+
+      container.dispose();
+      container = ProviderContainer(
+        overrides: getStandardTestOverrides().cast(),
+      );
+
+      expect(() => service.addListener(() {}), throwsFlutterError);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Fixes #6174 — `videoEventServiceProvider` registers `ref.onDispose` for the `EventRouter` it creates and for the video observer, but never for the `VideoEventService` itself. Every `NostrService` client swap (authenticated cold start's placeholder-to-real-identity swap, account switch) rebuilds the provider and orphans a service whose:

- periodic `_retryTimer` (`Timer.periodic`) keeps firing against the already-disposed `EventRouter`,
- `_likeCountBatchTimer` and `_authStateSubscription` stay live,
- `_isDisposed` guards never engage.

Orphans accumulate across account switches — live timers operating on disposed infrastructure. Contributes to the ongoing memory-pressure work (#5905 family).

## What changed

- One line in `mobile/lib/providers/video_providers.dart`: `ref.onDispose(service.dispose)` after service construction (plus the regenerated `video_providers.g.dart` — provider body hash changed).
- Regression test `mobile/test/providers/video_event_service_dispose_test.dart`: asserts the replaced service is disposed on provider invalidation and on container teardown (a disposed `ChangeNotifier` throws on `addListener`). Both tests fail without the fix (verified red first).

## Testing

- New regression tests red before / green after.
- Full `test/providers/` suite (543 tests), sample screens reading the provider (hashtag feed, explore), `flutter analyze lib test integration_test` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)