### PR TITLE
fix(dm): route fully-followed group chats to the inbox, not message requests

### DIFF
--- a/mobile/lib/blocs/dm/unread_count/dm_unread_count_cubit.dart
+++ b/mobile/lib/blocs/dm/unread_count/dm_unread_count_cubit.dart
@@ -17,8 +17,8 @@ import 'package:rxdart/rxdart.dart';
 ///
 /// The badge must equal the unread conversations the Messages list actually
 /// renders. That list is **follow-aware**: it shows accepted conversations
-/// (the user has replied) PLUS 1:1 conversations from followed peers the user
-/// has not replied to yet, and it hides blocklisted peers. Counting only
+/// (the user has replied) PLUS unreplied conversations where every non-self
+/// participant is followed, and it hides blocklisted peers. Counting only
 /// `currentUserHasSent == true` (the previous behaviour) undercounted unread
 /// chats from followed-but-unreplied peers. See #4976.
 ///

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -4892,10 +4892,9 @@ class DmRepository {
       // 1:1 or group alike. Derived from actual participants rather than
       // the stored `isGroup` flag, which can drift from the row's real
       // participants and mis-route followed 1:1 peers to requests (#5374).
-      final allFollowed =
-          otherPubkeys.isNotEmpty && otherPubkeys.every(isFollowing);
+      final allFollowed = otherPubkeys.every(isFollowing);
 
-      if (otherPubkeys.isEmpty || allFollowed) {
+      if (allFollowed) {
         followed.add(conversation);
       } else {
         if (_classifyDiagnostics) {

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -4862,16 +4862,17 @@ class DmRepository {
   /// Classifies potential request conversations by follow state.
   ///
   /// Conversations where `currentUserHasSent == false` are "potential
-  /// requests". A 1:1 conversation from a followed contact goes to the
-  /// followed list (Messages tab); everything else is a true request.
+  /// requests". A conversation goes to the followed list (Messages tab)
+  /// when EVERY deduplicated non-self participant is followed — a 1:1
+  /// from a followed contact, or a group made up entirely of followed
+  /// contacts. Any unfollowed participant makes it a true request, so a
+  /// stranger added to a group still lands under Message requests.
   ///
-  /// 1:1-ness is derived from the deduplicated non-self participant count,
-  /// NOT the denormalized `DmConversation.isGroup` flag. That column is
-  /// written from `participants.length > 2` and overwritten on every
-  /// upsert, so it can drift from a row's real participants — which was
-  /// stranding followed 1:1 peers under "Message requests" (#5374). Groups
-  /// (2+ non-self participants) are always requests here, independent of
-  /// follow state.
+  /// Participant counting uses the deduplicated non-self set, NOT the
+  /// denormalized `DmConversation.isGroup` flag. That column is written
+  /// from `participants.length > 2` and overwritten on every upsert, so
+  /// it can drift from a row's real participants — which was stranding
+  /// followed 1:1 peers under "Message requests" (#5374).
   static ({List<DmConversation> followed, List<DmConversation> requests})
   classifyPotentialRequests(
     List<DmConversation> potentialRequests, {
@@ -4886,15 +4887,15 @@ class DmRepository {
           .where((pk) => pk != userPubkey)
           .toSet();
 
-      // A 1:1 conversation from a followed contact is not a request even
-      // if the user hasn't replied yet. Derive 1:1-ness from the actual
-      // (deduplicated) non-self participant count rather than the stored
-      // `isGroup` flag, which can drift from the row's real participants and
-      // mis-route followed 1:1 peers to requests (#5374).
-      final isOneToOne = otherPubkeys.length == 1;
-      final isFollowedContact = isOneToOne && otherPubkeys.any(isFollowing);
+      // A conversation whose every (deduplicated) non-self participant is
+      // followed is not a request even if the user hasn't replied yet —
+      // 1:1 or group alike. Derived from actual participants rather than
+      // the stored `isGroup` flag, which can drift from the row's real
+      // participants and mis-route followed 1:1 peers to requests (#5374).
+      final allFollowed =
+          otherPubkeys.isNotEmpty && otherPubkeys.every(isFollowing);
 
-      if (otherPubkeys.isEmpty || isFollowedContact) {
+      if (otherPubkeys.isEmpty || allFollowed) {
         followed.add(conversation);
       } else {
         if (_classifyDiagnostics) {

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -9988,7 +9988,7 @@ void main() {
         expect(result.requests, hasLength(1));
       });
 
-      test('group conversation always goes to requests', () {
+      test('group with every member followed goes to followed list', () {
         final conv = makeConversation(
           id: 'conv1',
           participantPubkeys: [_validPubkeyA, _validPubkeyB, _validPubkeyC],
@@ -9998,7 +9998,41 @@ void main() {
         final result = DmRepository.classifyPotentialRequests(
           [conv],
           userPubkey: _validPubkeyA,
-          isFollowing: (_) => true, // Even if all are followed
+          isFollowing: (_) => true,
+        );
+
+        expect(result.followed, hasLength(1));
+        expect(result.requests, isEmpty);
+      });
+
+      test('group with any unfollowed member goes to requests', () {
+        final conv = makeConversation(
+          id: 'conv1',
+          participantPubkeys: [_validPubkeyA, _validPubkeyB, _validPubkeyC],
+          isGroup: true,
+        );
+
+        final result = DmRepository.classifyPotentialRequests(
+          [conv],
+          userPubkey: _validPubkeyA,
+          isFollowing: (pk) => pk == _validPubkeyB,
+        );
+
+        expect(result.followed, isEmpty);
+        expect(result.requests, hasLength(1));
+      });
+
+      test('group with no followed members goes to requests', () {
+        final conv = makeConversation(
+          id: 'conv1',
+          participantPubkeys: [_validPubkeyA, _validPubkeyB, _validPubkeyC],
+          isGroup: true,
+        );
+
+        final result = DmRepository.classifyPotentialRequests(
+          [conv],
+          userPubkey: _validPubkeyA,
+          isFollowing: (_) => false,
         );
 
         expect(result.followed, isEmpty);
@@ -10028,7 +10062,7 @@ void main() {
 
       test(
         'conversation with 2+ non-self participants is a request even when '
-        'isGroup is false and a member is followed',
+        'isGroup is false and only one member is followed',
         () {
           final conv = makeConversation(
             id: 'conv1',
@@ -10040,7 +10074,7 @@ void main() {
           final result = DmRepository.classifyPotentialRequests(
             [conv],
             userPubkey: _validPubkeyA,
-            isFollowing: (_) => true,
+            isFollowing: (pk) => pk == _validPubkeyB,
           );
 
           expect(result.followed, isEmpty);

--- a/mobile/test/blocs/dm/conversation_list/conversation_list_bloc_test.dart
+++ b/mobile/test/blocs/dm/conversation_list/conversation_list_bloc_test.dart
@@ -1260,7 +1260,7 @@ void main() {
       group('group conversation classification', () {
         blocTest<ConversationListBloc, ConversationListState>(
           'classifies group conversation as request '
-          'when user has not sent regardless of follow state',
+          'when user has not sent and any member is unfollowed',
           setUp: () {
             // _testPubkey2 is followed, _testPubkey3 is not.
             when(
@@ -1285,6 +1285,35 @@ void main() {
           verify: (bloc) {
             expect(bloc.state.conversations, isEmpty);
             expect(bloc.state.requestConversations, hasLength(1));
+          },
+        );
+
+        blocTest<ConversationListBloc, ConversationListState>(
+          'classifies group conversation as inbox '
+          'when every member is followed even if user has not sent',
+          setUp: () {
+            when(
+              () => mockFollowRepository.isFollowing(_testPubkey2),
+            ).thenReturn(true);
+            when(
+              () => mockFollowRepository.isFollowing(_testPubkey3),
+            ).thenReturn(true);
+            when(() => mockDmRepository.userPubkey).thenReturn(_testPubkey1);
+
+            final conversations = [
+              _createConversation(
+                id: _testConversationId1,
+                isGroup: true,
+                participantPubkeys: [_testPubkey1, _testPubkey2, _testPubkey3],
+              ),
+            ];
+            _stubStreams(mockDmRepository, potentialRequests: conversations);
+          },
+          build: createBloc,
+          act: (bloc) => bloc.add(const ConversationListStarted()),
+          verify: (bloc) {
+            expect(bloc.state.conversations, hasLength(1));
+            expect(bloc.state.requestConversations, isEmpty);
           },
         );
 

--- a/mobile/test/blocs/dm/unread_count/dm_unread_count_cubit_test.dart
+++ b/mobile/test/blocs/dm/unread_count/dm_unread_count_cubit_test.dart
@@ -76,6 +76,24 @@ DmConversation _convo(
   );
 }
 
+DmConversation _groupConvo(
+  String id, {
+  required List<String> peers,
+  required bool isRead,
+  required bool currentUserHasSent,
+  int timestamp = 1700000000,
+}) {
+  return DmConversation(
+    id: id,
+    participantPubkeys: [_me, ...peers],
+    isGroup: true,
+    createdAt: timestamp,
+    lastMessageTimestamp: timestamp,
+    isRead: isRead,
+    currentUserHasSent: currentUserHasSent,
+  );
+}
+
 /// Pad an index into a unique 64-char hex conversation id / pubkey.
 String _hex(int i) => i.toRadixString(16).padLeft(64, '0');
 
@@ -196,6 +214,29 @@ void main() {
         acceptedController.add(const []);
         potentialController.add([
           _convo('c1', peer: _alice, isRead: false, currentUserHasSent: false),
+        ]);
+        await _settle();
+
+        expect(cubit.state, equals(1));
+      },
+    );
+
+    test(
+      'counts an unread group when every peer is followed and the user has '
+      'never replied',
+      () async {
+        followed.addAll({_alice, _bob});
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
+
+        acceptedController.add(const []);
+        potentialController.add([
+          _groupConvo(
+            'group-1',
+            peers: [_alice, _bob],
+            isRead: false,
+            currentUserHasSent: false,
+          ),
         ]);
         await _settle();
 


### PR DESCRIPTION
Closes #6298

## Description

Part of the Messages UX revision (follows #6286, independent code; not stacked).

`DmRepository.classifyPotentialRequests` previously routed every potential-request conversation with 2+ deduplicated non-self participants to Message requests regardless of follow state. That was conservative scoping from the #5374 1:1 misrouting fix, not a product decision.

**New rule:** a potential-request conversation goes to the main Messages inbox when **every** deduplicated non-self participant is followed, whether the row is 1:1 or group-shaped. Any unfollowed member still routes the thread to Requests, so a stranger cannot bypass the request gate by adding the user to a group with people they follow.

This keeps the classifier, `ConversationListBloc`, and `DmUnreadCountCubit` aligned. The protected-minor inbox gate still filters after classification and is unaffected.

Current receive-path note: brand-new inbound messages with extra p-tags still default to canonical 1:1 unless a matching group row already exists, to avoid phantom groups from non-compliant clients. This PR updates the classification rule for already-materialized potential-request group rows and keeps the badge/list behavior ready for fuller inbound group support; it does not add group creation UI or change participant resolution.

**Related Issue:** Follows #5374

## Out of Scope

Group-chat creation UI, participant management, and the inbound group-materialization policy.

## Verification

- `dart format --set-exit-if-changed lib/blocs/dm/unread_count/dm_unread_count_cubit.dart test/blocs/dm/unread_count/dm_unread_count_cubit_test.dart packages/dm_repository/lib/src/dm_repository.dart`
- `flutter analyze`
- `flutter test test/blocs/dm/unread_count/dm_unread_count_cubit_test.dart`
- `flutter test test/blocs/dm/conversation_list/conversation_list_bloc_test.dart --plain-name 'group conversation classification'`
- `flutter test test/src/dm_repository_test.dart --plain-name 'classifyPotentialRequests'` from `mobile/packages/dm_repository`
- Pre-push hook: no merge conflicts with `main`, changed-file analyzer passed, and changed-file tests passed, including full `packages/dm_repository/test/src/dm_repository_test.dart`
- Existing PR run: dm_repository coverage 93.60% (gate: 93)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
