### PR TITLE
fix(clips): render a placeholder when a clip thumbnail file is missing

### DIFF
--- a/mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart
@@ -14,6 +14,7 @@ import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/services/video_thumbnail_service.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
+import 'package:openvine/widgets/video_clip/clip_thumbnail_image.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:time_formatter/time_formatter.dart';
@@ -368,9 +369,7 @@ class _VideoMetadataCoverScreenState
                   _BottomArea(
                     clip: widget.clip,
                     thumbnail: (
-                      file: widget.clip.thumbnailPath != null
-                          ? File(widget.clip.thumbnailPath!)
-                          : null,
+                      path: widget.clip.thumbnailPath,
                       networkUrl: widget.thumbnailUrl,
                     ),
                     stripThumbnails: _stripThumbnails,
@@ -450,7 +449,7 @@ class _VideoAreaState extends State<_VideoArea> {
     }
     final localPath = widget.clip.thumbnailPath;
     if (localPath != null) {
-      return Image.file(File(localPath), fit: BoxFit.cover);
+      return ClipThumbnailImage(path: localPath, fit: BoxFit.cover);
     }
     return const ColoredBox(color: VineTheme.onSurfaceMuted);
   }
@@ -570,7 +569,7 @@ class _BottomArea extends StatelessWidget {
   });
 
   final DivineVideoClip clip;
-  final ({File? file, String? networkUrl})? thumbnail;
+  final ({String? path, String? networkUrl})? thumbnail;
   final List<StripThumbnail> stripThumbnails;
   final Duration clipDuration;
   final Duration selectedPosition;
@@ -606,7 +605,7 @@ class _ThumbnailStrip extends StatefulWidget {
   });
 
   final DivineVideoClip clip;
-  final ({File? file, String? networkUrl})? thumbnail;
+  final ({String? path, String? networkUrl})? thumbnail;
   final List<StripThumbnail> stripThumbnails;
   final Duration clipDuration;
   final Duration selectedPosition;
@@ -783,7 +782,7 @@ class _ThumbnailStripState extends State<_ThumbnailStrip> {
 class _SlotImage extends StatelessWidget {
   const _SlotImage({required this.thumbnail, this.stripThumbnailPath});
 
-  final ({File? file, String? networkUrl})? thumbnail;
+  final ({String? path, String? networkUrl})? thumbnail;
   final String? stripThumbnailPath;
 
   @override
@@ -798,18 +797,25 @@ class _SlotImage extends StatelessWidget {
                   const ColoredBox(color: VineTheme.surfaceContainerHigh),
             ),
           )
-        : thumbnail?.file != null
-        ? Image.file(thumbnail!.file!, fit: .cover, excludeFromSemantics: true)
+        : thumbnail?.path != null
+        ? ClipThumbnailImage(
+            path: thumbnail!.path!,
+            fit: .cover,
+            excludeFromSemantics: true,
+            placeholder: const ColoredBox(
+              color: VineTheme.surfaceContainerHigh,
+            ),
+          )
         : const ColoredBox(color: VineTheme.surfaceContainerHigh);
 
     if (stripThumbnailPath == null) return fallback;
 
-    return Image.file(
-      File(stripThumbnailPath!),
+    return ClipThumbnailImage(
+      path: stripThumbnailPath!,
       fit: BoxFit.cover,
       gaplessPlayback: true,
       excludeFromSemantics: true,
-      errorBuilder: (_, _, _) => fallback,
+      placeholder: fallback,
     );
   }
 }

--- a/mobile/lib/widgets/library/drafts_tab.dart
+++ b/mobile/lib/widgets/library/drafts_tab.dart
@@ -18,6 +18,7 @@ import 'package:openvine/providers/video_publish_provider.dart';
 import 'package:openvine/screens/video_editor/video_editor_screen.dart';
 import 'package:openvine/utils/draft_copy_naming.dart';
 import 'package:openvine/widgets/library/empty_library_state.dart';
+import 'package:openvine/widgets/video_clip/clip_thumbnail_image.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Tab widget displaying a list of saved drafts.
@@ -369,20 +370,20 @@ class DraftListTile extends StatelessWidget {
         width: 40,
         height: 40,
         decoration: ShapeDecoration(
-          image: thumbnailExists
-              ? DecorationImage(
-                  image: FileImage(File(thumbnailPath)),
-                  fit: BoxFit.cover,
-                )
-              : null,
-          color: thumbnailExists ? null : VineTheme.cardBackground,
+          color: VineTheme.cardBackground,
           shape: RoundedRectangleBorder(
             side: const BorderSide(color: VineTheme.onSurfaceDisabled),
             borderRadius: BorderRadius.circular(16),
           ),
         ),
         child: thumbnailExists
-            ? null
+            ? ClipRRect(
+                borderRadius: BorderRadius.circular(16),
+                child: ClipThumbnailImage(
+                  path: thumbnailPath,
+                  fit: BoxFit.cover,
+                ),
+              )
             : const DivineIcon(
                 icon: DivineIconName.filmSlate,
                 color: VineTheme.secondaryText,

--- a/mobile/lib/widgets/library/drafts_tab.dart
+++ b/mobile/lib/widgets/library/drafts_tab.dart
@@ -2,8 +2,6 @@
 // ABOUTME: Lists saved video drafts with options to post, edit, duplicate, delete
 
 import 'dart:async';
-import 'dart:io';
-
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -354,8 +352,6 @@ class DraftListTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final thumbnailPath = draft.coverThumbnailPath;
-    final thumbnailExists =
-        thumbnailPath != null && File(thumbnailPath).existsSync();
 
     return ListTile(
       onTap: onTap,
@@ -372,16 +368,26 @@ class DraftListTile extends StatelessWidget {
         decoration: ShapeDecoration(
           color: VineTheme.cardBackground,
           shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(16),
+          ),
+        ),
+        foregroundDecoration: ShapeDecoration(
+          shape: RoundedRectangleBorder(
             side: const BorderSide(color: VineTheme.onSurfaceDisabled),
             borderRadius: BorderRadius.circular(16),
           ),
         ),
-        child: thumbnailExists
+        child: thumbnailPath != null
             ? ClipRRect(
                 borderRadius: BorderRadius.circular(16),
                 child: ClipThumbnailImage(
                   path: thumbnailPath,
                   fit: BoxFit.cover,
+                  placeholder: const DivineIcon(
+                    icon: DivineIconName.filmSlate,
+                    color: VineTheme.secondaryText,
+                    size: 20,
+                  ),
                 ),
               )
             : const DivineIcon(

--- a/mobile/lib/widgets/upload_failure_sheet.dart
+++ b/mobile/lib/widgets/upload_failure_sheet.dart
@@ -1,8 +1,6 @@
 // ABOUTME: Bottom sheet shown when a background video upload fails.
 // ABOUTME: Displays error reason with retry and save-to-drafts actions.
 
-import 'dart:io';
-
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -151,33 +149,19 @@ class _UploadFailureSheetContent extends StatelessWidget {
   }
 }
 
-class _DraftPreview extends StatefulWidget {
+class _DraftPreview extends StatelessWidget {
   const _DraftPreview({this.clip});
 
   final DivineVideoClip? clip;
 
-  @override
-  State<_DraftPreview> createState() => _DraftPreviewState();
-}
-
-class _DraftPreviewState extends State<_DraftPreview> {
-  late final bool _hasThumb;
-
-  @override
-  void initState() {
-    super.initState();
-    final path = widget.clip?.thumbnailPath;
-    _hasThumb = path != null && File(path).existsSync();
-  }
-
-  void _openPreview() {
-    final clip = widget.clip;
-    if (clip == null) return;
+  void _openPreview(BuildContext context) {
+    final currentClip = clip;
+    if (currentClip == null) return;
 
     Navigator.of(context).push(
       PageRouteBuilder<void>(
         pageBuilder: (_, _, _) =>
-            VideoMetadataPreviewScreen(clip: clip, previewOnly: true),
+            VideoMetadataPreviewScreen(clip: currentClip, previewOnly: true),
         transitionsBuilder: (_, animation, _, child) {
           return FadeTransition(opacity: animation, child: child);
         },
@@ -188,26 +172,29 @@ class _DraftPreviewState extends State<_DraftPreview> {
   @override
   Widget build(BuildContext context) {
     const previewHeight = 160.0;
-    final aspectRatio = widget.clip?.targetAspectRatio.value ?? 9 / 16;
+    final path = clip?.thumbnailPath;
+    final aspectRatio = clip?.targetAspectRatio.value ?? 9 / 16;
     final previewWidth = previewHeight * aspectRatio;
+    final placeholder = SvgPicture.asset(
+      'assets/stickers/alert.svg',
+      height: 132,
+      width: 132,
+    );
 
     return GestureDetector(
-      onTap: _hasThumb ? _openPreview : null,
+      onTap: path != null ? () => _openPreview(context) : null,
       child: ClipRRect(
         borderRadius: .circular(12),
         child: SizedBox(
           height: previewHeight,
           width: previewWidth,
-          child: _hasThumb
+          child: path != null
               ? ClipThumbnailImage(
-                  path: widget.clip!.thumbnailPath!,
+                  path: path,
                   fit: BoxFit.cover,
+                  placeholder: placeholder,
                 )
-              : SvgPicture.asset(
-                  'assets/stickers/alert.svg',
-                  height: 132,
-                  width: 132,
-                ),
+              : placeholder,
         ),
       ),
     );

--- a/mobile/lib/widgets/upload_failure_sheet.dart
+++ b/mobile/lib/widgets/upload_failure_sheet.dart
@@ -15,6 +15,7 @@ import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/screens/library_screen.dart';
 import 'package:openvine/screens/video_metadata/video_metadata_preview_screen.dart';
 import 'package:openvine/services/video_publish/video_publish_service.dart';
+import 'package:openvine/widgets/video_clip/clip_thumbnail_image.dart';
 
 /// Shows a bottom sheet when a background upload fails.
 ///
@@ -198,7 +199,10 @@ class _DraftPreviewState extends State<_DraftPreview> {
           height: previewHeight,
           width: previewWidth,
           child: _hasThumb
-              ? Image.file(File(widget.clip!.thumbnailPath!), fit: BoxFit.cover)
+              ? ClipThumbnailImage(
+                  path: widget.clip!.thumbnailPath!,
+                  fit: BoxFit.cover,
+                )
               : SvgPicture.asset(
                   'assets/stickers/alert.svg',
                   height: 132,

--- a/mobile/lib/widgets/video_clip/clip_thumbnail_image.dart
+++ b/mobile/lib/widgets/video_clip/clip_thumbnail_image.dart
@@ -1,0 +1,73 @@
+// ABOUTME: Error-tolerant Image.file wrapper for clip thumbnail and ghost
+// ABOUTME: frame paths whose backing file can be missing (#5796).
+
+import 'dart:io';
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+
+/// Renders a clip thumbnail / ghost frame from a local file path without
+/// crashing when the file is gone.
+///
+/// Clip thumbnail and ghost paths are persisted as absolute paths; on iOS
+/// the app container UUID changes on reinstall/update and cached files can
+/// be evicted, so the file may not exist by the time it is decoded. A bare
+/// `Image.file` has no image-stream error listener in that case, and the
+/// resulting `PathNotFoundException` is recorded as a fatal crash
+/// (Crashlytics 71e200c8, #5796). This widget renders [placeholder]
+/// instead.
+class ClipThumbnailImage extends StatelessWidget {
+  const ClipThumbnailImage({
+    required this.path,
+    super.key,
+    this.fit,
+    this.width,
+    this.height,
+    this.cacheHeight,
+    this.placeholder,
+  });
+
+  /// Absolute path of the thumbnail/ghost file.
+  final String path;
+
+  final BoxFit? fit;
+  final double? width;
+  final double? height;
+  final int? cacheHeight;
+
+  /// Rendered when the file is missing or undecodable. Defaults to a
+  /// neutral card-background tile with a film-slate icon (same fallback
+  /// the drafts list uses for a clip with no thumbnail).
+  final Widget? placeholder;
+
+  @override
+  Widget build(BuildContext context) {
+    return Image.file(
+      File(path),
+      fit: fit,
+      width: width,
+      height: height,
+      cacheHeight: cacheHeight,
+      errorBuilder: (context, error, stackTrace) =>
+          placeholder ?? const _MissingThumbnailPlaceholder(),
+    );
+  }
+}
+
+class _MissingThumbnailPlaceholder extends StatelessWidget {
+  const _MissingThumbnailPlaceholder();
+
+  @override
+  Widget build(BuildContext context) {
+    return const ColoredBox(
+      color: VineTheme.cardBackground,
+      child: Center(
+        child: DivineIcon(
+          icon: DivineIconName.filmSlate,
+          color: VineTheme.secondaryText,
+          size: 20,
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/widgets/video_clip/clip_thumbnail_image.dart
+++ b/mobile/lib/widgets/video_clip/clip_thumbnail_image.dart
@@ -24,6 +24,8 @@ class ClipThumbnailImage extends StatelessWidget {
     this.width,
     this.height,
     this.cacheHeight,
+    this.gaplessPlayback = false,
+    this.excludeFromSemantics = false,
     this.placeholder,
   });
 
@@ -34,6 +36,8 @@ class ClipThumbnailImage extends StatelessWidget {
   final double? width;
   final double? height;
   final int? cacheHeight;
+  final bool gaplessPlayback;
+  final bool excludeFromSemantics;
 
   /// Rendered when the file is missing or undecodable. Defaults to a
   /// neutral card-background tile with a film-slate icon (same fallback
@@ -48,6 +52,8 @@ class ClipThumbnailImage extends StatelessWidget {
       width: width,
       height: height,
       cacheHeight: cacheHeight,
+      gaplessPlayback: gaplessPlayback,
+      excludeFromSemantics: excludeFromSemantics,
       errorBuilder: (context, error, stackTrace) =>
           placeholder ?? const _MissingThumbnailPlaceholder(),
     );

--- a/mobile/lib/widgets/video_clip/video_clip_preview.dart
+++ b/mobile/lib/widgets/video_clip/video_clip_preview.dart
@@ -16,6 +16,7 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/services/gallery_save_service.dart';
 import 'package:openvine/services/video_editor/stop_motion_render_service.dart';
 import 'package:openvine/widgets/stop_motion/stop_motion_player.dart';
+import 'package:openvine/widgets/video_clip/clip_thumbnail_image.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 class VideoClipPreview extends ConsumerStatefulWidget {
@@ -224,8 +225,8 @@ class _VideoClipPreviewSheetState extends ConsumerState<VideoClipPreview> {
                                     Hero(
                                       tag:
                                           'Video-Clip-Preview-${widget.clip.id}',
-                                      child: Image.file(
-                                        File(widget.clip.thumbnailPath!),
+                                      child: ClipThumbnailImage(
+                                        path: widget.clip.thumbnailPath!,
                                         fit: BoxFit.cover,
                                       ),
                                     ),

--- a/mobile/lib/widgets/video_clip/video_clip_thumbnail_card.dart
+++ b/mobile/lib/widgets/video_clip/video_clip_thumbnail_card.dart
@@ -1,13 +1,12 @@
 // ABOUTME: Thumbnail card widget for displaying video clips in grid layout
 // ABOUTME: Shows thumbnail with duration badge, selection state, and tap handlers
 
-import 'dart:io';
-
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/utils/video_editor_utils.dart';
+import 'package:openvine/widgets/video_clip/clip_thumbnail_image.dart';
 
 /// Thumbnail card for a single clip in the grid.
 ///
@@ -69,6 +68,8 @@ class _VideoClipThumbnailCardState extends State<VideoClipThumbnailCard> {
   Widget build(BuildContext context) {
     // Calculate aspect ratio for container
     final aspectRatio = widget.clip.targetAspectRatio.value;
+    final showDurationBadge =
+        widget.showDurationBadge && !widget.clip.isStopMotion;
 
     final l10n = context.l10n;
     return Semantics(
@@ -116,13 +117,13 @@ class _VideoClipThumbnailCardState extends State<VideoClipThumbnailCard> {
                     /// recordings: their playback length (frame count / 12fps)
                     /// is a tiny, misleading value, so they read as a still
                     /// image marked only by the stop-motion badge.
-                    if (widget.showDurationBadge && !widget.clip.isStopMotion)
+                    if (showDurationBadge)
                       _DurationBadge(clip: widget.clip),
 
                     if (widget.clip.libraryTitle case final title?)
                       _TitleBadge(
                         title: title,
-                        bottomOffset: widget.showDurationBadge ? 32 : 8,
+                        bottomOffset: showDurationBadge ? 32 : 8,
                       ),
 
                     /// Selection check circle - top right
@@ -140,58 +141,32 @@ class _VideoClipThumbnailCardState extends State<VideoClipThumbnailCard> {
 }
 
 /// Builds the thumbnail image or placeholder.
-///
-/// Checks thumbnail file existence synchronously on init and refreshes
-/// via [didUpdateWidget] when the clip's thumbnail path changes.
-class _Thumbnail extends StatefulWidget {
+class _Thumbnail extends StatelessWidget {
   const _Thumbnail({required this.clip});
 
   final DivineVideoClip clip;
 
   @override
-  State<_Thumbnail> createState() => _ThumbnailState();
-}
-
-class _ThumbnailState extends State<_Thumbnail> {
-  late bool _thumbnailExists;
-
-  @override
-  void initState() {
-    super.initState();
-    _thumbnailExists = _checkThumbnailExists();
-  }
-
-  @override
-  void didUpdateWidget(_Thumbnail oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (oldWidget.clip.thumbnailPath != widget.clip.thumbnailPath) {
-      _thumbnailExists = _checkThumbnailExists();
-    }
-  }
-
-  /// Checks if the thumbnail file exists on disk.
-  bool _checkThumbnailExists() {
-    if (widget.clip.thumbnailPath == null) {
-      return false;
-    }
-    return File(widget.clip.thumbnailPath!).existsSync();
-  }
-
-  @override
   Widget build(BuildContext context) {
-    if (_thumbnailExists && widget.clip.thumbnailPath != null) {
+    final thumbnailPath = clip.thumbnailPath;
+    if (thumbnailPath != null) {
       return Hero(
-        tag: 'Video-Clip-Preview-${widget.clip.id}',
+        tag: 'Video-Clip-Preview-${clip.id}',
         // Stop-motion clips use a full-resolution still as their thumbnail;
         // bound the decode to the grid cell so it doesn't cost tens of MB.
-        child: Image.file(
-          File(widget.clip.thumbnailPath!),
-          fit: .cover,
+        child: ClipThumbnailImage(
+          path: thumbnailPath,
+          fit: BoxFit.cover,
           cacheHeight:
               (MediaQuery.sizeOf(context).width *
                       MediaQuery.devicePixelRatioOf(context) /
                       2)
                   .round(),
+          placeholder: const DivineIcon(
+            icon: DivineIconName.videoCamera,
+            color: VineTheme.lightText,
+            size: 32,
+          ),
         ),
       );
     }

--- a/mobile/lib/widgets/video_clip/video_clip_thumbnail_card.dart
+++ b/mobile/lib/widgets/video_clip/video_clip_thumbnail_card.dart
@@ -117,8 +117,7 @@ class _VideoClipThumbnailCardState extends State<VideoClipThumbnailCard> {
                     /// recordings: their playback length (frame count / 12fps)
                     /// is a tiny, misleading value, so they read as a still
                     /// image marked only by the stop-motion badge.
-                    if (showDurationBadge)
-                      _DurationBadge(clip: widget.clip),
+                    if (showDurationBadge) _DurationBadge(clip: widget.clip),
 
                     if (widget.clip.libraryTitle case final title?)
                       _TitleBadge(

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_thumbnail.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_thumbnail.dart
@@ -1,9 +1,8 @@
-import 'dart:io';
-
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
+import 'package:openvine/widgets/video_clip/clip_thumbnail_image.dart';
 
 class VideoEditorThumbnail extends ConsumerWidget {
   const VideoEditorThumbnail({
@@ -23,7 +22,10 @@ class VideoEditorThumbnail extends ConsumerWidget {
     return FittedBox(
       fit: .cover,
       child: clip.thumbnailPath != null
-          ? Image.file(File(clip.thumbnailPath!))
+          ? ClipThumbnailImage(
+              path: clip.thumbnailPath!,
+              placeholder: SizedBox.fromSize(size: contentSize),
+            )
           : SizedBox.fromSize(
               size: contentSize,
               child: const Center(

--- a/mobile/lib/widgets/video_metadata/modes/capture/video_metadata_capture_preview_thumbnail.dart
+++ b/mobile/lib/widgets/video_metadata/modes/capture/video_metadata_capture_preview_thumbnail.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:divine_ui/divine_ui.dart';
@@ -6,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
+import 'package:openvine/widgets/video_clip/clip_thumbnail_image.dart';
 import 'package:pro_image_editor/features/filter_editor/widgets/filter_generator.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 
@@ -26,7 +26,10 @@ class VideoMetadataCapturePreviewThumbnail extends ConsumerWidget {
       );
     }
 
-    final thumbnail = Image.file(File(clip.thumbnailPath!), fit: .cover);
+    final thumbnail = ClipThumbnailImage(
+      path: clip.thumbnailPath!,
+      fit: .cover,
+    );
 
     return Stack(
       fit: .expand,

--- a/mobile/lib/widgets/video_metadata/modes/classic/video_metadata_classic_preview_thumbnail.dart
+++ b/mobile/lib/widgets/video_metadata/modes/classic/video_metadata_classic_preview_thumbnail.dart
@@ -1,6 +1,4 @@
 import 'dart:async';
-import 'dart:io';
-
 import 'package:divine_ui/divine_ui.dart';
 import 'package:divine_video_player/divine_video_player.dart';
 import 'package:flutter/material.dart';
@@ -8,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
+import 'package:openvine/widgets/video_clip/clip_thumbnail_image.dart';
 import 'package:openvine/widgets/video_editor/video_editor_processing_overlay.dart';
 
 class VideoMetadataClassicPreviewThumbnail extends ConsumerStatefulWidget {
@@ -129,7 +128,10 @@ class _VideoMetadataClassicPreviewThumbnailState
                           key: const ValueKey('thumbnail'),
                           fit: StackFit.expand,
                           children: [
-                            Image.file(File(clip.thumbnailPath!), fit: .cover),
+                            ClipThumbnailImage(
+                              path: clip.thumbnailPath!,
+                              fit: .cover,
+                            ),
                             VideoEditorProcessingOverlay(
                               clip: clip,
                               isProcessing:

--- a/mobile/lib/widgets/video_metadata/modes/edit/video_metadata_edit_stack.dart
+++ b/mobile/lib/widgets/video_metadata/modes/edit/video_metadata_edit_stack.dart
@@ -1,8 +1,6 @@
 // ABOUTME: Full-screen scaffold for editing already-published video metadata.
 // ABOUTME: Reuses VideoMetadataFormFields from the capture stack.
 
-import 'dart:io';
-
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart' hide AspectRatio;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -13,6 +11,7 @@ import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/screens/video_metadata/video_metadata_cover_screen.dart';
+import 'package:openvine/widgets/video_clip/clip_thumbnail_image.dart';
 import 'package:openvine/widgets/video_metadata/modes/edit/video_metadata_edit_bottom_bar.dart';
 import 'package:openvine/widgets/video_metadata/video_metadata_form_fields.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
@@ -221,9 +220,12 @@ class _EditClipPreview extends StatelessWidget {
               fit: StackFit.expand,
               children: [
                 if (pendingThumbnailPath != null)
-                  Image.file(
-                    File(pendingThumbnailPath!),
+                  ClipThumbnailImage(
+                    path: pendingThumbnailPath!,
                     fit: BoxFit.cover,
+                    placeholder: const ColoredBox(
+                      color: VineTheme.onSurfaceMuted,
+                    ),
                   )
                 else if (thumbnailUrl != null)
                   VineCachedImage(imageUrl: thumbnailUrl)

--- a/mobile/lib/widgets/video_metadata/modes/edit/video_metadata_edit_stack.dart
+++ b/mobile/lib/widgets/video_metadata/modes/edit/video_metadata_edit_stack.dart
@@ -43,9 +43,7 @@ class _VideoMetadataEditStackState extends State<VideoMetadataEditStack> {
   @override
   Widget build(BuildContext context) {
     return ProviderScope(
-      overrides: [
-        videoEditorProvider.overrideWith(VideoEditorNotifier.new),
-      ],
+      overrides: [videoEditorProvider.overrideWith(VideoEditorNotifier.new)],
       child: _VideoMetadataEditStackContent(
         video: widget.video,
         initialCollaboratorPubkeys: _initialCollaboratorPubkeys,
@@ -223,9 +221,9 @@ class _EditClipPreview extends StatelessWidget {
                   ClipThumbnailImage(
                     path: pendingThumbnailPath!,
                     fit: BoxFit.cover,
-                    placeholder: const ColoredBox(
-                      color: VineTheme.onSurfaceMuted,
-                    ),
+                    placeholder: thumbnailUrl != null
+                        ? VineCachedImage(imageUrl: thumbnailUrl)
+                        : const ColoredBox(color: VineTheme.onSurfaceMuted),
                   )
                 else if (thumbnailUrl != null)
                   VineCachedImage(imageUrl: thumbnailUrl)

--- a/mobile/lib/widgets/video_recorder/video_recorder_ghost_frame.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_ghost_frame.dart
@@ -1,10 +1,9 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
+import 'package:openvine/widgets/video_clip/clip_thumbnail_image.dart';
 
 /// Semi-transparent overlay of the last recorded clip's final frame.
 ///
@@ -70,8 +69,8 @@ class VideoRecorderGhostFrame extends ConsumerWidget {
                 opacity: 0.48,
                 child: Transform.flip(
                   flipX: ghostData.isFrontCamera,
-                  child: Image.file(
-                    File(ghostData.path),
+                  child: ClipThumbnailImage(
+                    path: ghostData.path,
                     fit: .cover,
                     width: .infinity,
                     height: .infinity,
@@ -82,6 +81,7 @@ class VideoRecorderGhostFrame extends ConsumerWidget {
                         (MediaQuery.sizeOf(context).height *
                                 MediaQuery.devicePixelRatioOf(context))
                             .round(),
+                    placeholder: const SizedBox.shrink(),
                   ),
                 ),
               ),

--- a/mobile/lib/widgets/video_recorder/video_recorder_library_button.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_library_button.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -8,6 +6,7 @@ import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
+import 'package:openvine/widgets/video_clip/clip_thumbnail_image.dart';
 import 'package:openvine/widgets/video_recorder/video_recorder_navigation.dart';
 
 class VideoRecorderLibraryButton extends ConsumerStatefulWidget {
@@ -162,15 +161,16 @@ class _VideoRecorderLibraryButtonState
                       children: [...previousChildren, ?currentChild],
                     ),
                     child: thumbnailPath != null
-                        ? Image.file(
-                            File(thumbnailPath),
+                        ? ClipThumbnailImage(
                             key: ValueKey(thumbnailPath),
+                            path: thumbnailPath,
                             fit: BoxFit.cover,
                             // Stop-motion stills are full-resolution photos;
                             // bound the decode to the 40px button.
                             cacheHeight:
                                 (40 * MediaQuery.devicePixelRatioOf(context))
                                     .round(),
+                            placeholder: const SizedBox.shrink(),
                           )
                         : const SizedBox.shrink(),
                   ),

--- a/mobile/test/widgets/video_clip/clip_thumbnail_image_test.dart
+++ b/mobile/test/widgets/video_clip/clip_thumbnail_image_test.dart
@@ -1,0 +1,79 @@
+// ABOUTME: Regression tests for #5796 — a missing clip thumbnail/ghost file
+// ABOUTME: must render a placeholder instead of crashing with
+// ABOUTME: PathNotFoundException from FileImage._loadAsync.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/widgets/video_clip/clip_thumbnail_image.dart';
+
+void main() {
+  group(ClipThumbnailImage, () {
+    Future<Image> pumpAndGetImage(
+      WidgetTester tester, {
+      Widget? placeholder,
+    }) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ClipThumbnailImage(
+              path: '/nonexistent/container/thumbnail_123.jpg',
+              placeholder: placeholder,
+            ),
+          ),
+        ),
+      );
+      return tester.widget<Image>(find.byType(Image));
+    }
+
+    testWidgets('wires an errorBuilder so a missing file cannot crash', (
+      tester,
+    ) async {
+      final image = await pumpAndGetImage(tester);
+
+      expect(
+        image.errorBuilder,
+        isNotNull,
+        reason:
+            'without an errorBuilder a missing thumbnail file surfaces '
+            'PathNotFoundException as a fatal crash (#5796)',
+      );
+    });
+
+    testWidgets('errorBuilder renders the neutral placeholder', (
+      tester,
+    ) async {
+      final image = await pumpAndGetImage(tester);
+
+      final fallback = image.errorBuilder!(
+        tester.element(find.byType(Image)),
+        Exception('PathNotFoundException'),
+        StackTrace.current,
+      );
+      await tester.pumpWidget(MaterialApp(home: Scaffold(body: fallback)));
+
+      expect(find.byType(DivineIcon), findsOneWidget);
+      expect(find.byType(ColoredBox), findsWidgets);
+    });
+
+    testWidgets('errorBuilder renders a custom placeholder when given', (
+      tester,
+    ) async {
+      const marker = Key('custom-placeholder');
+      final image = await pumpAndGetImage(
+        tester,
+        placeholder: const SizedBox.shrink(key: marker),
+      );
+
+      final fallback = image.errorBuilder!(
+        tester.element(find.byType(Image)),
+        Exception('PathNotFoundException'),
+        StackTrace.current,
+      );
+      await tester.pumpWidget(MaterialApp(home: Scaffold(body: fallback)));
+
+      expect(find.byKey(marker), findsOneWidget);
+      expect(find.byType(DivineIcon), findsNothing);
+    });
+  });
+}

--- a/mobile/test/widgets/video_clip/clip_thumbnail_image_test.dart
+++ b/mobile/test/widgets/video_clip/clip_thumbnail_image_test.dart
@@ -1,6 +1,5 @@
 // ABOUTME: Regression tests for #5796 — a missing clip thumbnail/ghost file
-// ABOUTME: must render a placeholder instead of crashing with
-// ABOUTME: PathNotFoundException from FileImage._loadAsync.
+// ABOUTME: must render a placeholder instead of surfacing PathNotFoundException.
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
@@ -9,69 +8,51 @@ import 'package:openvine/widgets/video_clip/clip_thumbnail_image.dart';
 
 void main() {
   group(ClipThumbnailImage, () {
-    Future<Image> pumpAndGetImage(
+    Future<void> pumpMissingThumbnail(
       WidgetTester tester, {
       Widget? placeholder,
     }) async {
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
-            body: ClipThumbnailImage(
-              path: '/nonexistent/container/thumbnail_123.jpg',
-              placeholder: placeholder,
+            body: SizedBox(
+              width: 120,
+              height: 120,
+              child: ClipThumbnailImage(
+                path: '/nonexistent/container/thumbnail_123.jpg',
+                placeholder: placeholder,
+              ),
             ),
           ),
         ),
       );
-      return tester.widget<Image>(find.byType(Image));
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 100)),
+      );
+      await tester.pump();
     }
 
-    testWidgets('wires an errorBuilder so a missing file cannot crash', (
+    testWidgets('renders the neutral placeholder for a missing file', (
       tester,
     ) async {
-      final image = await pumpAndGetImage(tester);
+      await pumpMissingThumbnail(tester);
 
-      expect(
-        image.errorBuilder,
-        isNotNull,
-        reason:
-            'without an errorBuilder a missing thumbnail file surfaces '
-            'PathNotFoundException as a fatal crash (#5796)',
-      );
-    });
-
-    testWidgets('errorBuilder renders the neutral placeholder', (
-      tester,
-    ) async {
-      final image = await pumpAndGetImage(tester);
-
-      final fallback = image.errorBuilder!(
-        tester.element(find.byType(Image)),
-        Exception('PathNotFoundException'),
-        StackTrace.current,
-      );
-      await tester.pumpWidget(MaterialApp(home: Scaffold(body: fallback)));
-
+      expect(tester.takeException(), isNull);
       expect(find.byType(DivineIcon), findsOneWidget);
       expect(find.byType(ColoredBox), findsWidgets);
     });
 
-    testWidgets('errorBuilder renders a custom placeholder when given', (
+    testWidgets('renders a custom placeholder for a missing file', (
       tester,
     ) async {
       const marker = Key('custom-placeholder');
-      final image = await pumpAndGetImage(
+
+      await pumpMissingThumbnail(
         tester,
         placeholder: const SizedBox.shrink(key: marker),
       );
 
-      final fallback = image.errorBuilder!(
-        tester.element(find.byType(Image)),
-        Exception('PathNotFoundException'),
-        StackTrace.current,
-      );
-      await tester.pumpWidget(MaterialApp(home: Scaffold(body: fallback)));
-
+      expect(tester.takeException(), isNull);
       expect(find.byKey(marker), findsOneWidget);
       expect(find.byType(DivineIcon), findsNothing);
     });


### PR DESCRIPTION
## Summary

Fixes #5796 — Crashlytics `71e200c8` (FATAL, regressed, last seen 1.0.16): `PathNotFoundException` from `FileImage._loadAsync` recorded as a fatal crash when a clip thumbnail or ghost-frame file is missing.

Clip thumbnail/ghost paths are persisted as absolute paths. On iOS the app container UUID changes on every reinstall/update, and cached files (`Library/Caches/thumbnail_*.jpg`) can be evicted — so the file can be gone by decode time. The rendering call sites had no `errorBuilder`, so the async image-load failure reached `FlutterError.onError` as a fatal. Several sites guarded with `existsSync()`, but that is race-prone because the file can vanish between the check and the decode and it does not attach an error listener.

## What changed

- New shared `ClipThumbnailImage` widget (`mobile/lib/widgets/video_clip/clip_thumbnail_image.dart`): wraps `Image.file` with an `errorBuilder` rendering a neutral placeholder, with optional placeholder overrides and pass-throughs for `gaplessPlayback` and `excludeFromSemantics`.
- Routed clip-thumbnail and ghost-frame `Image.file` / `FileImage` call sites through `ClipThumbnailImage`, including the recorder library button and cover-picker placeholder/fallback paths.
- Removed nearby `existsSync()` thumbnail gates where the wrapper can render the same placeholder on decode failure, which avoids inconsistent missing-thumbnail UI and closes the race the wrapper is meant to handle.
- Kept the drafts list border visible by drawing the stroke as a foreground decoration over thumbnail children.
- Improved the edit metadata preview fallback so a missing pending local thumbnail falls back to the existing thumbnail URL when available.
- The deeper fix (persist relative paths so container-UUID churn self-heals) is explicitly left to the issue's follow-up discussion.

## Testing

- `flutter test test/widgets/video_clip/clip_thumbnail_image_test.dart`
- `flutter test test/widgets/video_clip test/widgets/library test/widgets/video_recorder test/widgets/video_metadata`
- `flutter analyze lib test integration_test`
- Push hook also ran changed-file analyzer/tests successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code), then completed by Codex.
