### PR TITLE
fix(router): skip router refresh on routing-identical review-status refetch

### DIFF
--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -63,6 +63,13 @@ final goRouterProvider = Provider<GoRouter>((ref) {
     authService.authStateStream,
   );
   ref.listen(currentMinorAccountReviewStatusProvider, (previous, next) {
+    // A resume/background refetch that resolves to a routing-identical status
+    // (active → active) must not refresh: refreshing churns the route pipeline
+    // and tears down a reel pushed on top mid-init. Only refresh when the
+    // redirect outcome can actually change.
+    if (!minorAccountReviewStatusAffectsRouting(previous, next)) {
+      return;
+    }
     refreshListenable.refresh();
   });
   ref.onDispose(refreshListenable.dispose);

--- a/mobile/lib/router/app_router_redirect.dart
+++ b/mobile/lib/router/app_router_redirect.dart
@@ -113,6 +113,11 @@ bool _isPublicRecorderLocation(String location) =>
 /// The slice of [MinorAccountReviewStatus] (plus its async loading shape)
 /// that [appRouterRedirect] actually branches on. Two emissions with an
 /// equal signature always produce the same redirect decision.
+///
+/// Keep this in sync with the review-status reads in [appRouterRedirect]: if
+/// the redirect starts branching on another field, add it here or the refresh
+/// gate will swallow genuine changes to it. The coupling is guarded by
+/// `test/router/router_refresh_gate_coupling_test.dart`.
 typedef _MinorReviewRoutingSignature = ({
   bool loadingWithoutValue,
   bool isRestricted,

--- a/mobile/lib/router/app_router_redirect.dart
+++ b/mobile/lib/router/app_router_redirect.dart
@@ -155,6 +155,10 @@ _MinorReviewRoutingSignature _minorReviewRoutingSignature(
 /// and tears down the reel's just-created player mid-initialization. Gating the
 /// refresh on this predicate keeps genuine restriction flips reactive while
 /// leaving an already-open reel untouched.
+///
+/// [previous] is nullable only for defensiveness and the first-emission tests;
+/// the production `ref.listen` at [goRouterProvider] omits `fireImmediately`,
+/// so Riverpod only ever invokes it with a real prior [AsyncValue].
 @visibleForTesting
 bool minorAccountReviewStatusAffectsRouting(
   AsyncValue<MinorAccountReviewStatus>? previous,

--- a/mobile/lib/router/app_router_redirect.dart
+++ b/mobile/lib/router/app_router_redirect.dart
@@ -110,6 +110,55 @@ bool _isAuthEntryLocation(String location) {
 bool _isPublicRecorderLocation(String location) =>
     location == VideoRecorderScreen.path;
 
+/// The slice of [MinorAccountReviewStatus] (plus its async loading shape)
+/// that [appRouterRedirect] actually branches on. Two emissions with an
+/// equal signature always produce the same redirect decision.
+typedef _MinorReviewRoutingSignature = ({
+  bool loadingWithoutValue,
+  bool isRestricted,
+  bool hasCase,
+  String? moderationConversationPubkey,
+  String? moderationConversationId,
+  bool allowsParentVideoOrEmail,
+});
+
+_MinorReviewRoutingSignature _minorReviewRoutingSignature(
+  AsyncValue<MinorAccountReviewStatus>? status,
+) {
+  // `value` (not `asData?.value`) mirrors `appRouterRedirect`, which reads the
+  // previous value that Riverpod carries through a background refetch.
+  final review = status?.value;
+  final reviewCase = review?.currentCase;
+  return (
+    loadingWithoutValue:
+        (status?.isLoading ?? false) && !(status?.hasValue ?? false),
+    isRestricted: review?.isRestricted ?? false,
+    hasCase: reviewCase != null,
+    moderationConversationPubkey: reviewCase?.moderationConversationPubkey,
+    moderationConversationId: reviewCase?.moderationConversationId,
+    allowsParentVideoOrEmail: reviewCase?.allowsParentVideoOrEmail ?? false,
+  );
+}
+
+/// Whether a review-status emission can change the router's redirect outcome.
+///
+/// The router refreshes on every [currentMinorAccountReviewStatusProvider]
+/// emission, but a background/resume refetch usually resolves to a routing-
+/// identical value (active → active). Refreshing for those churns the whole
+/// route pipeline while a video reel is pushed on top — reverting the reported
+/// location to the shell branch and firing a spurious `didPushNext` that pauses
+/// and tears down the reel's just-created player mid-initialization. Gating the
+/// refresh on this predicate keeps genuine restriction flips reactive while
+/// leaving an already-open reel untouched.
+@visibleForTesting
+bool minorAccountReviewStatusAffectsRouting(
+  AsyncValue<MinorAccountReviewStatus>? previous,
+  AsyncValue<MinorAccountReviewStatus> next,
+) {
+  return _minorReviewRoutingSignature(previous) !=
+      _minorReviewRoutingSignature(next);
+}
+
 /// Top-level GoRouter redirect: signer-callback → universal-link rewrite →
 /// minor-account-review gating → auth-route gating → unauthenticated gating.
 ///

--- a/mobile/test/router/app_router_redirect_test.dart
+++ b/mobile/test/router/app_router_redirect_test.dart
@@ -1,0 +1,96 @@
+// ABOUTME: Unit tests for the router-refresh gate that keeps a resume/background
+// ABOUTME: review-status refetch from tearing down a reel pushed on top mid-init.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/models/minor_account_review_status.dart';
+import 'package:openvine/router/app_router.dart';
+
+void main() {
+  group('minorAccountReviewStatusAffectsRouting', () {
+    final active = MinorAccountReviewStatus.active();
+    const restricted = MinorAccountReviewStatus(
+      restrictionStatus: AccountRestrictionStatus.restrictedMinorReview,
+    );
+    const restrictedWithConversation = MinorAccountReviewStatus(
+      restrictionStatus: AccountRestrictionStatus.restrictedMinorReview,
+      currentCase: MinorReviewCase(
+        id: 'case-1',
+        state: MinorReviewCaseState.underModeratorReview,
+        suspectedAgeBand: SuspectedAgeBand.unknown,
+        allowedResolution: MinorReviewResolutionType.unknown,
+        instructions: MinorReviewInstructions(title: '', body: ''),
+        supportEmail: 'support@divine.video',
+        moderationConversationId: 'conversation-1',
+      ),
+    );
+
+    test('does not refresh when a refetch resolves to the same status', () {
+      // The resume scenario: the provider re-emits a fresh-but-equal active
+      // value. The instances differ by identity, so the pre-fix code refreshed;
+      // the routing signature is unchanged, so the gate must skip it.
+      expect(
+        minorAccountReviewStatusAffectsRouting(
+          AsyncData(active),
+          AsyncData(MinorAccountReviewStatus.active()),
+        ),
+        isFalse,
+      );
+    });
+
+    test('refreshes when the restriction decision flips', () {
+      expect(
+        minorAccountReviewStatusAffectsRouting(
+          AsyncData(active),
+          const AsyncData(restricted),
+        ),
+        isTrue,
+      );
+    });
+
+    test('refreshes when a cold load resolves to a value', () {
+      expect(
+        minorAccountReviewStatusAffectsRouting(
+          const AsyncLoading<MinorAccountReviewStatus>(),
+          AsyncData(active),
+        ),
+        isTrue,
+      );
+    });
+
+    test('refreshes when a moderation conversation appears on the case', () {
+      expect(
+        minorAccountReviewStatusAffectsRouting(
+          const AsyncData(restricted),
+          const AsyncData(restrictedWithConversation),
+        ),
+        isTrue,
+      );
+    });
+
+    test('first emission refreshes only when it can gate routing', () {
+      // A first unrestricted value needs no refresh — GoRouter evaluates the
+      // redirect on the next navigation anyway, and there is nothing to gate.
+      expect(
+        minorAccountReviewStatusAffectsRouting(null, AsyncData(active)),
+        isFalse,
+      );
+      // A first restricted value, or a first cold-load without a value, must
+      // refresh so the gate fires.
+      expect(
+        minorAccountReviewStatusAffectsRouting(
+          null,
+          const AsyncData(restricted),
+        ),
+        isTrue,
+      );
+      expect(
+        minorAccountReviewStatusAffectsRouting(
+          null,
+          const AsyncLoading<MinorAccountReviewStatus>(),
+        ),
+        isTrue,
+      );
+    });
+  });
+}

--- a/mobile/test/router/app_router_redirect_test.dart
+++ b/mobile/test/router/app_router_redirect_test.dart
@@ -2,9 +2,36 @@
 // ABOUTME: review-status refetch from tearing down a reel pushed on top mid-init.
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/models/minor_account_review_status.dart';
 import 'package:openvine/router/app_router.dart';
+
+/// The retained-value loading emission a `ref.watch`-driven reload produces for
+/// a provider currently holding [value]: an `AsyncLoading` that still carries
+/// the prior value (`isLoading` && `hasValue`). This is the shape the router
+/// listener sees mid-refetch when the review-status provider reloads — distinct
+/// from a cold `AsyncLoading` (no value), which the other tests cover.
+Future<AsyncValue<MinorAccountReviewStatus>> _retainedLoadingEmission(
+  MinorAccountReviewStatus value,
+) async {
+  final bump = StateProvider((ref) => 0);
+  final provider = FutureProvider<MinorAccountReviewStatus>((ref) async {
+    ref.watch(bump);
+    return value;
+  });
+  final container = ProviderContainer();
+  addTearDown(container.dispose);
+
+  await container.read(provider.future);
+  final loadingEmissions = <AsyncValue<MinorAccountReviewStatus>>[];
+  container.listen(provider, (previous, next) {
+    if (next.isLoading) loadingEmissions.add(next);
+  });
+  container.read(bump.notifier).state++;
+  await container.read(provider.future);
+  return loadingEmissions.single;
+}
 
 void main() {
   group('minorAccountReviewStatusAffectsRouting', () {
@@ -37,6 +64,64 @@ void main() {
         isFalse,
       );
     });
+
+    test('does not refresh across a refetch that keeps the active value', () async {
+      // A real resume refetch emits a loading state that still carries the
+      // prior value, then resolves back to active. Neither edge changes the
+      // routing signature, so the gate must stay false. Guards the `!hasValue`
+      // half of `loadingWithoutValue`: a plain `isLoading` check would flip the
+      // signature mid-refetch and wrongly refresh, tearing down a reel on top.
+      final retainedLoading = await _retainedLoadingEmission(active);
+      expect(retainedLoading.isLoading && retainedLoading.hasValue, isTrue);
+
+      // active data -> retained loading
+      expect(
+        minorAccountReviewStatusAffectsRouting(
+          AsyncData(active),
+          retainedLoading,
+        ),
+        isFalse,
+      );
+      // retained loading -> fresh active data
+      expect(
+        minorAccountReviewStatusAffectsRouting(
+          retainedLoading,
+          AsyncData(MinorAccountReviewStatus.active()),
+        ),
+        isFalse,
+      );
+    });
+
+    test(
+      'does not refresh across a refetch that keeps the restricted value',
+      () async {
+        // Same edges for a restricted account. The loading emission is an
+        // `AsyncLoading` whose `.value` still holds the restricted status while
+        // `asData` is null. Reading `asData?.value` instead of `.value` in the
+        // signature would drop the restriction mid-refetch, flip the signature,
+        // and refresh — so this pins the `.value` read the gate relies on.
+        final retainedLoading = await _retainedLoadingEmission(restricted);
+        expect(retainedLoading, isA<AsyncLoading<MinorAccountReviewStatus>>());
+        expect(retainedLoading.value, restricted);
+
+        // restricted data -> retained loading
+        expect(
+          minorAccountReviewStatusAffectsRouting(
+            const AsyncData(restricted),
+            retainedLoading,
+          ),
+          isFalse,
+        );
+        // retained loading -> fresh restricted data
+        expect(
+          minorAccountReviewStatusAffectsRouting(
+            retainedLoading,
+            const AsyncData(restricted),
+          ),
+          isFalse,
+        );
+      },
+    );
 
     test('refreshes when the restriction decision flips', () {
       expect(

--- a/mobile/test/router/router_refresh_gate_coupling_test.dart
+++ b/mobile/test/router/router_refresh_gate_coupling_test.dart
@@ -1,0 +1,177 @@
+// ABOUTME: Coupling guard — proves appRouterRedirect only branches on the
+// ABOUTME: review-status fields that minorAccountReviewStatusAffectsRouting tracks.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/minor_account_review_status.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/router/app_router.dart';
+import 'package:openvine/router/providers/route_normalization_provider.dart';
+import 'package:openvine/screens/feed/video_feed_page.dart';
+import 'package:openvine/screens/minor_account_review_parent_contact_screen.dart';
+import 'package:openvine/screens/minor_account_review_under13_support_screen.dart';
+import 'package:openvine/services/auth_service.dart';
+
+import '../helpers/test_provider_overrides.dart';
+
+/// Authenticated identity is known but the signer-backed Nostr client has not
+/// finished initializing — mirrors the router-gating suite's harness.
+class _NotReadyNostrSession extends NostrSession {
+  @override
+  NostrSessionReadiness build() =>
+      const NostrSessionReadiness.identityKnown(pubkey: 'user-pubkey');
+}
+
+void main() {
+  // The router refreshes only when [minorAccountReviewStatusAffectsRouting]
+  // reports a routing-relevant change. That gate projects the review status
+  // onto the exact fields [appRouterRedirect] branches on. This suite pins the
+  // coupling from the *other* side: if the redirect ever starts depending on a
+  // review-status field the gate does not track, two statuses that share a
+  // routing signature will route differently and this test fails — signalling
+  // that `_minorReviewRoutingSignature` must be extended.
+  group('router-refresh gate stays coupled to appRouterRedirect', () {
+    late MockAuthService mockAuthService;
+
+    setUp(() {
+      resetNavigationState();
+      mockAuthService = createMockAuthService();
+      when(() => mockAuthService.isAuthenticated).thenReturn(true);
+      when(() => mockAuthService.authState).thenReturn(AuthState.authenticated);
+      when(() => mockAuthService.currentPublicKeyHex).thenReturn('user-pubkey');
+      when(
+        () => mockAuthService.authStateStream,
+      ).thenAnswer((_) => const Stream<AuthState>.empty());
+    });
+
+    // Protected locations that exercise the restricted-account branches of
+    // appRouterRedirect (feed → review screen, parent-contact gating,
+    // under-13 support gating).
+    final probeLocations = <String>[
+      VideoFeedPage.pathForIndex(0),
+      MinorAccountReviewParentContactScreen.path,
+      MinorAccountReviewUnder13SupportScreen.path,
+    ];
+
+    MinorAccountReviewStatus restrictedStatus({
+      required String id,
+      MinorReviewCaseState state =
+          MinorReviewCaseState.restrictedPendingUserResponse,
+      SuspectedAgeBand ageBand = SuspectedAgeBand.age13To15,
+      MinorReviewResolutionType resolution =
+          MinorReviewResolutionType.parentVideoOrEmail,
+      String instructionsTitle = 'Account review required',
+      String supportEmail = 'support@divine.video',
+    }) {
+      return MinorAccountReviewStatus(
+        restrictionStatus: AccountRestrictionStatus.restrictedMinorReview,
+        currentCase: MinorReviewCase(
+          id: id,
+          state: state,
+          suspectedAgeBand: ageBand,
+          allowedResolution: resolution,
+          instructions: MinorReviewInstructions(
+            title: instructionsTitle,
+            body: 'We need parental consent information.',
+          ),
+          supportEmail: supportEmail,
+          moderationConversationPubkey: 'moderation-pubkey',
+        ),
+      );
+    }
+
+    /// Lands the router at each probe location under [status] and returns the
+    /// resulting locations — the status's "routing fingerprint". Fully tears
+    /// its container down before returning so each call is self-contained.
+    Future<List<String>> routingFingerprint(
+      WidgetTester tester,
+      MinorAccountReviewStatus status,
+    ) async {
+      resetNavigationState();
+      final container = ProviderContainer(
+        overrides: [
+          ...getStandardTestOverrides(mockAuthService: mockAuthService),
+          nostrSessionProvider.overrideWith(_NotReadyNostrSession.new),
+          currentMinorAccountReviewStatusProvider.overrideWith(
+            (ref) async => status,
+          ),
+        ],
+      );
+      // Route normalization is required for the parent-contact fallbacks.
+      container.read(routeNormalizationProvider);
+      await container.read(currentMinorAccountReviewStatusProvider.future);
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp.router(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            routerConfig: container.read(goRouterProvider),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final router = container.read(goRouterProvider);
+      final landings = <String>[];
+      for (final location in probeLocations) {
+        router.go(location);
+        await tester.pumpAndSettle();
+        landings.add(router.routeInformationProvider.value.uri.toString());
+      }
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      container.dispose();
+      return landings;
+    }
+
+    testWidgets(
+      'a routing-identical status refetch produces identical redirect outcomes',
+      (tester) async {
+        // Two restricted statuses that differ ONLY in fields the redirect must
+        // not branch on (case state, id, instructions, support email). The
+        // signatured fields — isRestricted, hasCase, moderation ids, and
+        // allowsParentVideoOrEmail — are held equal.
+        final baseline = restrictedStatus(id: 'case-baseline');
+        final routingIdentical = restrictedStatus(
+          id: 'case-refetched',
+          state: MinorReviewCaseState.submittedForReview,
+          instructionsTitle: 'Updated review instructions',
+          supportEmail: 'help@divine.video',
+        );
+
+        // Precondition: the gate agrees these are routing-identical, so it
+        // suppresses the refresh (the whole point of the fix).
+        expect(
+          minorAccountReviewStatusAffectsRouting(
+            AsyncData(baseline),
+            AsyncData(routingIdentical),
+          ),
+          isFalse,
+          reason: 'fixtures must share a routing signature for this guard',
+        );
+
+        final baselineFingerprint = await routingFingerprint(tester, baseline);
+        final refetchedFingerprint = await routingFingerprint(
+          tester,
+          routingIdentical,
+        );
+
+        expect(
+          refetchedFingerprint,
+          baselineFingerprint,
+          reason:
+              'appRouterRedirect routed two statuses with an equal routing '
+              'signature differently. It now branches on a review-status field '
+              'that minorAccountReviewStatusAffectsRouting does not track, so a '
+              'genuine change to that field would be swallowed by the refresh '
+              'gate. Add the field to _minorReviewRoutingSignature.',
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes #6302

## Description

After backgrounding and resuming the app, tapping a video could open a black/frozen fullscreen player — the tapped video never plays.

**Root cause.** The router refreshes on **every** `currentMinorAccountReviewStatusProvider` emission (`goRouterProvider`). On resume, `accountStateResumeRefresherProvider.refreshOnResume()` re-fetches the minor-account review status (first resume per launch; TTL-gated to 15 min afterwards). `MinorAccountReviewStatus` has no value equality, so even an `active → active` resolve is a *new* emission that fires `refreshListenable.refresh()`.

That refresh churns the whole route pipeline while the pooled video reel is pushed on top via `context.push`: the reported location reverts to the shell branch (`/explore`), and a spurious `RouteAware.didPushNext` flips `FeedVideos._routeAllowsPlayback` to `false` → `isFeedActive` false → `InfiniteVideoFeed` releases the just-created player mid-initialization (`Abort stale init … during error handling`), so the video never plays.

Confirmed against a device log: moderation-status response `09:17:59.004` → location flip `.004` → player disposed `.017` → init aborted `.096`.

**Fix.** Gate the refresh on a routing-relevant projection of the review status — exactly the fields `appRouterRedirect` branches on (`loadingWithoutValue`, `isRestricted`, `hasCase`, moderation-conversation ids, `allowsParentVideoOrEmail`). A routing-identical refetch no longer refreshes; a genuine restriction flip still does. Conservative by design: any change that *could* alter the redirect outcome still triggers a refresh.

## Out of Scope

The underlying GoRouter behavior — an imperatively-pushed route's reported location reverting on `refreshListenable` refresh — is left as-is; this PR removes the needless refresh that exposes it rather than reworking the location provider.

## Verification

- `dart format` ✓ · `flutter analyze lib test` (changed files) ✓
- New unit tests `test/router/app_router_redirect_test.dart` (5/5) ✓
- Regression suites green: `minor_account_review_error_redirect`, `minor_account_review_router` (incl. "keeps restricted routing during a background refetch"), `fullscreen_feed_redirect`, `app_router` — 39/39.
- Manual repro is a narrow race (15-min resume-refetch TTL + fetch must resolve during player init); draft pending on-device confirmation.

**Related Issue:** 

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)