### PR TITLE
fix(video-metadata): relabel C2PA "Post anyway" to "Skip"

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -3895,7 +3895,7 @@
     "videoMetadataC2paMissingBody": "የይዘት መታወቂያዎችን መጨመር አልቻልንም፣ ስለዚህ ይህ ቪዲዮ በሰው እንደተሰራ አይረጋገጥም። እንደገና ለመሞከር እንደገና ይፍጠሩ ወይም እንዳለ ይለጥፉ።",
     "videoMetadataC2paMissingNote": "የይዘት መታወቂያዎች የበይነመረብ ግንኙነት ያስፈልጋቸዋል።",
     "videoMetadataC2paMissingRegenerate": "እንደገና ፍጠር",
-    "videoMetadataC2paMissingPostAnyway": "ለማንኛውም ለጥፍ",
+    "videoMetadataC2paMissingSkip": "ዝለል",
     "videoMetadataGenerationFailed": "ማመንጨት አልተሳካም",
     "@videoMetadataEditCoverSuccessAnnouncement": {
         "description": "Screen-reader announcement spoken after the user confirms a new cover thumbnail and the screen is about to close. Visual users get the screen pop as feedback; this is the audio equivalent."

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -3770,7 +3770,7 @@
     "videoMetadataC2paMissingBody": "تعذّر علينا إضافة بيانات اعتماد المحتوى، لذا لن يتم تأكيد هذا الفيديو على أنه من صنع إنسان. أعد الإنشاء للمحاولة مرة أخرى، أو انشره كما هو.",
     "videoMetadataC2paMissingNote": "تتطلب بيانات اعتماد المحتوى اتصالاً بالإنترنت.",
     "videoMetadataC2paMissingRegenerate": "إعادة الإنشاء",
-    "videoMetadataC2paMissingPostAnyway": "النشر على أي حال",
+    "videoMetadataC2paMissingSkip": "تخطّي",
     "videoMetadataGenerationFailed": "فشل الإنشاء",
     "videoMetadataTagsPickerSearchHint": "ابحث أو أضف وسوماً",
     "videoMetadataTagsPickerEmptyHint": "أضف وسوماً ليكتشف الآخرون فيديوك",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -3901,7 +3901,7 @@
     "videoMetadataC2paMissingBody": "Не успяхме да добавим удостоверения за съдържанието, затова това видео няма да бъде потвърдено като създадено от човек. Генерирайте отново, за да опитате пак, или го публикувайте както е.",
     "videoMetadataC2paMissingNote": "Удостоверенията за съдържание изискват интернет връзка.",
     "videoMetadataC2paMissingRegenerate": "Генерирай отново",
-    "videoMetadataC2paMissingPostAnyway": "Публикувай въпреки това",
+    "videoMetadataC2paMissingSkip": "Пропусни",
     "videoMetadataGenerationFailed": "Генерирането е неуспешно",
     "@videoMetadataEditCoverSuccessAnnouncement": {
         "description": "Screen-reader announcement spoken after the user confirms a new cover thumbnail and the screen is about to close. Visual users get the screen pop as feedback; this is the audio equivalent."

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -3770,7 +3770,7 @@
     "videoMetadataC2paMissingBody": "Wir konnten keine Content Credentials hinzufügen – dieses Video wird daher nicht als von Menschen gemacht bestätigt. Neu generieren, um es erneut zu versuchen, oder so posten.",
     "videoMetadataC2paMissingNote": "Content Credentials brauchen eine Internetverbindung.",
     "videoMetadataC2paMissingRegenerate": "Neu generieren",
-    "videoMetadataC2paMissingPostAnyway": "Trotzdem posten",
+    "videoMetadataC2paMissingSkip": "Überspringen",
     "videoMetadataGenerationFailed": "Generierung fehlgeschlagen",
     "videoMetadataTagsPickerSearchHint": "Tags suchen oder hinzufügen",
     "videoMetadataTagsPickerEmptyHint": "Tags hinzufügen, damit andere dein Video entdecken",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -3518,9 +3518,9 @@
   "@videoMetadataC2paMissingRegenerate": {
     "description": "Primary button on the missing-content-credential bottom sheet. Re-renders the video to attempt the C2PA signature again."
   },
-  "videoMetadataC2paMissingPostAnyway": "Post anyway",
-  "@videoMetadataC2paMissingPostAnyway": {
-    "description": "Secondary button on the missing-content-credential bottom sheet. Publishes the video without a C2PA content credential."
+  "videoMetadataC2paMissingSkip": "Skip",
+  "@videoMetadataC2paMissingSkip": {
+    "description": "Secondary button on the missing-content-credential bottom sheet. Dismisses the prompt and continues without a C2PA content credential, so the user can post the video without provenance."
   },
   "videoMetadataGenerationFailed": "Generation failed",
   "@videoMetadataGenerationFailed": {

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -3770,7 +3770,7 @@
     "videoMetadataC2paMissingBody": "No pudimos añadir las credenciales de contenido, así que este vídeo no se confirmará como hecho por humanos. Vuelve a generarlo para intentarlo de nuevo o publícalo tal cual.",
     "videoMetadataC2paMissingNote": "Las credenciales de contenido necesitan conexión a internet.",
     "videoMetadataC2paMissingRegenerate": "Volver a generar",
-    "videoMetadataC2paMissingPostAnyway": "Publicar igualmente",
+    "videoMetadataC2paMissingSkip": "Omitir",
     "videoMetadataGenerationFailed": "Generación fallida",
     "videoMetadataTagsPickerSearchHint": "Buscar o añadir etiquetas",
     "videoMetadataTagsPickerEmptyHint": "Añade etiquetas para que otros descubran tu vídeo",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -2017,7 +2017,7 @@
     "videoMetadataC2paMissingBody": "Hindi kami nakapaglagay ng content credentials, kaya hindi makukumpirma na gawa ng tao ang video na ito. I-regenerate para subukan ulit, o i-post na lang ito.",
     "videoMetadataC2paMissingNote": "Kailangan ng internet connection ang content credentials.",
     "videoMetadataC2paMissingRegenerate": "I-regenerate",
-    "videoMetadataC2paMissingPostAnyway": "I-post pa rin",
+    "videoMetadataC2paMissingSkip": "Laktawan",
     "videoMetadataGenerationFailed": "Nabigo ang paggawa",
     "videoMetadataEditCoverTitle": "Edit cover",
     "videoMetadataEditCoverCloseSemanticLabel": "Close cover editor",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -3770,7 +3770,7 @@
     "videoMetadataC2paMissingBody": "Nous n’avons pas pu ajouter les informations d’authenticité, cette vidéo ne sera donc pas confirmée comme faite par un humain. Régénérez pour réessayer, ou publiez-la telle quelle.",
     "videoMetadataC2paMissingNote": "Les informations d’authenticité nécessitent une connexion internet.",
     "videoMetadataC2paMissingRegenerate": "Régénérer",
-    "videoMetadataC2paMissingPostAnyway": "Publier quand même",
+    "videoMetadataC2paMissingSkip": "Ignorer",
     "videoMetadataGenerationFailed": "Échec de la génération",
     "videoMetadataTagsPickerSearchHint": "Rechercher ou ajouter des tags",
     "videoMetadataTagsPickerEmptyHint": "Ajoute des tags pour que d'autres découvrent ta vidéo",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -3770,7 +3770,7 @@
     "videoMetadataC2paMissingBody": "Kami tidak dapat menambahkan kredensial konten, jadi video ini tidak akan dikonfirmasi sebagai buatan manusia. Buat ulang untuk mencoba lagi, atau posting apa adanya.",
     "videoMetadataC2paMissingNote": "Kredensial konten memerlukan koneksi internet.",
     "videoMetadataC2paMissingRegenerate": "Buat ulang",
-    "videoMetadataC2paMissingPostAnyway": "Tetap posting",
+    "videoMetadataC2paMissingSkip": "Lewati",
     "videoMetadataGenerationFailed": "Pembuatan gagal",
     "videoMetadataTagsPickerSearchHint": "Cari atau tambahkan tag",
     "videoMetadataTagsPickerEmptyHint": "Tambahkan tag agar orang menemukan videomu",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -3770,7 +3770,7 @@
     "videoMetadataC2paMissingBody": "Non è stato possibile aggiungere le credenziali di contenuto, quindi questo video non sarà confermato come fatto da un umano. Rigenera per riprovare oppure pubblicalo così com’è.",
     "videoMetadataC2paMissingNote": "Le credenziali di contenuto richiedono una connessione a internet.",
     "videoMetadataC2paMissingRegenerate": "Rigenera",
-    "videoMetadataC2paMissingPostAnyway": "Pubblica comunque",
+    "videoMetadataC2paMissingSkip": "Salta",
     "videoMetadataGenerationFailed": "Generazione non riuscita",
     "videoMetadataTagsPickerSearchHint": "Cerca o aggiungi tag",
     "videoMetadataTagsPickerEmptyHint": "Aggiungi tag per far scoprire il tuo video",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -3770,7 +3770,7 @@
     "videoMetadataC2paMissingBody": "コンテンツ認証情報を追加できなかったため、この動画は人間が作成したものとして確認されません。もう一度試すには再生成するか、このまま投稿してください。",
     "videoMetadataC2paMissingNote": "コンテンツ認証情報にはインターネット接続が必要です。",
     "videoMetadataC2paMissingRegenerate": "再生成",
-    "videoMetadataC2paMissingPostAnyway": "そのまま投稿",
+    "videoMetadataC2paMissingSkip": "スキップ",
     "videoMetadataGenerationFailed": "生成に失敗しました",
     "videoMetadataTagsPickerSearchHint": "タグを検索または追加",
     "videoMetadataTagsPickerEmptyHint": "タグを追加して動画を見つけてもらおう",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -3101,7 +3101,7 @@
     "videoMetadataC2paMissingBody": "콘텐츠 자격 증명을 추가할 수 없어 이 동영상은 사람이 제작한 것으로 확인되지 않습니다. 다시 시도하려면 재생성하거나 그대로 게시하세요.",
     "videoMetadataC2paMissingNote": "콘텐츠 자격 증명에는 인터넷 연결이 필요합니다.",
     "videoMetadataC2paMissingRegenerate": "재생성",
-    "videoMetadataC2paMissingPostAnyway": "그래도 게시",
+    "videoMetadataC2paMissingSkip": "건너뛰기",
     "videoMetadataGenerationFailed": "생성 실패",
     "videoMetadataTagsPickerSearchHint": "태그 검색 또는 추가",
     "videoMetadataTagsPickerEmptyHint": "사람들이 동영상을 발견할 수 있도록 태그를 추가하세요",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -3770,7 +3770,7 @@
     "videoMetadataC2paMissingBody": "We konden geen content credentials toevoegen, dus deze video wordt niet bevestigd als door mensen gemaakt. Genereer opnieuw om het nog eens te proberen, of plaats hem zo.",
     "videoMetadataC2paMissingNote": "Content credentials hebben een internetverbinding nodig.",
     "videoMetadataC2paMissingRegenerate": "Opnieuw genereren",
-    "videoMetadataC2paMissingPostAnyway": "Toch plaatsen",
+    "videoMetadataC2paMissingSkip": "Overslaan",
     "videoMetadataGenerationFailed": "Genereren mislukt",
     "videoMetadataTagsPickerSearchHint": "Tags zoeken of toevoegen",
     "videoMetadataTagsPickerEmptyHint": "Voeg tags toe zodat anderen je video ontdekken",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -3770,7 +3770,7 @@
     "videoMetadataC2paMissingBody": "Nie udało się dodać poświadczeń treści, więc ten film nie zostanie potwierdzony jako stworzony przez człowieka. Wygeneruj ponownie, aby spróbować jeszcze raz, lub opublikuj bez zmian.",
     "videoMetadataC2paMissingNote": "Poświadczenia treści wymagają połączenia z internetem.",
     "videoMetadataC2paMissingRegenerate": "Wygeneruj ponownie",
-    "videoMetadataC2paMissingPostAnyway": "Opublikuj mimo to",
+    "videoMetadataC2paMissingSkip": "Pomiń",
     "videoMetadataGenerationFailed": "Generowanie nie powiodło się",
     "videoMetadataTagsPickerSearchHint": "Szukaj lub dodaj tagi",
     "videoMetadataTagsPickerEmptyHint": "Dodaj tagi, aby inni odkryli Twój film",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -3770,7 +3770,7 @@
     "videoMetadataC2paMissingBody": "Não foi possível adicionar as credenciais de conteúdo, por isso este vídeo não será confirmado como feito por humano. Gere novamente para tentar outra vez ou publique como está.",
     "videoMetadataC2paMissingNote": "As credenciais de conteúdo precisam de conexão com a internet.",
     "videoMetadataC2paMissingRegenerate": "Gerar novamente",
-    "videoMetadataC2paMissingPostAnyway": "Publicar mesmo assim",
+    "videoMetadataC2paMissingSkip": "Ignorar",
     "videoMetadataGenerationFailed": "Falha na geração",
     "videoMetadataTagsPickerSearchHint": "Pesquisar ou adicionar tags",
     "videoMetadataTagsPickerEmptyHint": "Adiciona tags para que outros descubram o teu vídeo",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -3770,7 +3770,7 @@
     "videoMetadataC2paMissingBody": "Nu am putut adăuga acreditările de conținut, așa că acest videoclip nu va fi confirmat ca fiind făcut de om. Regenerează pentru a încerca din nou sau publică-l așa cum este.",
     "videoMetadataC2paMissingNote": "Acreditările de conținut necesită o conexiune la internet.",
     "videoMetadataC2paMissingRegenerate": "Regenerează",
-    "videoMetadataC2paMissingPostAnyway": "Publică oricum",
+    "videoMetadataC2paMissingSkip": "Omite",
     "videoMetadataGenerationFailed": "Generarea a eșuat",
     "videoMetadataTagsPickerSearchHint": "Caută sau adaugă etichete",
     "videoMetadataTagsPickerEmptyHint": "Adaugă etichete pentru ca alții să-ți descopere videoclipul",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -3770,7 +3770,7 @@
     "videoMetadataC2paMissingBody": "Vi kunde inte lägga till innehållsuppgifter, så den här videon bekräftas inte som gjord av människa. Generera om för att försöka igen, eller publicera som den är.",
     "videoMetadataC2paMissingNote": "Innehållsuppgifter kräver en internetanslutning.",
     "videoMetadataC2paMissingRegenerate": "Generera om",
-    "videoMetadataC2paMissingPostAnyway": "Publicera ändå",
+    "videoMetadataC2paMissingSkip": "Hoppa över",
     "videoMetadataGenerationFailed": "Genereringen misslyckades",
     "videoMetadataTagsPickerSearchHint": "Sök eller lägg till taggar",
     "videoMetadataTagsPickerEmptyHint": "Lägg till taggar så att andra hittar din video",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -3770,7 +3770,7 @@
     "videoMetadataC2paMissingBody": "İçerik kimlik bilgilerini ekleyemedik, bu nedenle bu video insan yapımı olarak doğrulanmayacak. Yeniden denemek için yeniden oluştur ya da olduğu gibi paylaş.",
     "videoMetadataC2paMissingNote": "İçerik kimlik bilgileri internet bağlantısı gerektirir.",
     "videoMetadataC2paMissingRegenerate": "Yeniden oluştur",
-    "videoMetadataC2paMissingPostAnyway": "Yine de paylaş",
+    "videoMetadataC2paMissingSkip": "Atla",
     "videoMetadataGenerationFailed": "Oluşturma başarısız",
     "videoMetadataTagsPickerSearchHint": "Etiket ara veya ekle",
     "videoMetadataTagsPickerEmptyHint": "İnsanların videonu keşfetmesi için etiket ekle",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -10380,11 +10380,11 @@ abstract class AppLocalizations {
   /// **'Regenerate'**
   String get videoMetadataC2paMissingRegenerate;
 
-  /// Secondary button on the missing-content-credential bottom sheet. Publishes the video without a C2PA content credential.
+  /// Secondary button on the missing-content-credential bottom sheet. Dismisses the prompt and continues without a C2PA content credential, so the user can post the video without provenance.
   ///
   /// In en, this message translates to:
-  /// **'Post anyway'**
-  String get videoMetadataC2paMissingPostAnyway;
+  /// **'Skip'**
+  String get videoMetadataC2paMissingSkip;
 
   /// Warning shown over the metadata screen preview when rendering (generating) the final video failed and no clip was produced. Sits above a retry icon button.
   ///

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -5800,7 +5800,7 @@ class AppLocalizationsAm extends AppLocalizations {
   String get videoMetadataC2paMissingRegenerate => 'እንደገና ፍጠር';
 
   @override
-  String get videoMetadataC2paMissingPostAnyway => 'ለማንኛውም ለጥፍ';
+  String get videoMetadataC2paMissingSkip => 'ዝለል';
 
   @override
   String get videoMetadataGenerationFailed => 'ማመንጨት አልተሳካም';

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -5884,7 +5884,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get videoMetadataC2paMissingRegenerate => 'إعادة الإنشاء';
 
   @override
-  String get videoMetadataC2paMissingPostAnyway => 'النشر على أي حال';
+  String get videoMetadataC2paMissingSkip => 'تخطّي';
 
   @override
   String get videoMetadataGenerationFailed => 'فشل الإنشاء';

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -5970,7 +5970,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get videoMetadataC2paMissingRegenerate => 'Генерирай отново';
 
   @override
-  String get videoMetadataC2paMissingPostAnyway => 'Публикувай въпреки това';
+  String get videoMetadataC2paMissingSkip => 'Пропусни';
 
   @override
   String get videoMetadataGenerationFailed => 'Генерирането е неуспешно';

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -5988,7 +5988,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get videoMetadataC2paMissingRegenerate => 'Neu generieren';
 
   @override
-  String get videoMetadataC2paMissingPostAnyway => 'Trotzdem posten';
+  String get videoMetadataC2paMissingSkip => 'Überspringen';
 
   @override
   String get videoMetadataGenerationFailed => 'Generierung fehlgeschlagen';

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -5914,7 +5914,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get videoMetadataC2paMissingRegenerate => 'Regenerate';
 
   @override
-  String get videoMetadataC2paMissingPostAnyway => 'Post anyway';
+  String get videoMetadataC2paMissingSkip => 'Skip';
 
   @override
   String get videoMetadataGenerationFailed => 'Generation failed';

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -5963,7 +5963,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get videoMetadataC2paMissingRegenerate => 'Volver a generar';
 
   @override
-  String get videoMetadataC2paMissingPostAnyway => 'Publicar igualmente';
+  String get videoMetadataC2paMissingSkip => 'Omitir';
 
   @override
   String get videoMetadataGenerationFailed => 'Generación fallida';

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -5988,7 +5988,7 @@ class AppLocalizationsFil extends AppLocalizations {
   String get videoMetadataC2paMissingRegenerate => 'I-regenerate';
 
   @override
-  String get videoMetadataC2paMissingPostAnyway => 'I-post pa rin';
+  String get videoMetadataC2paMissingSkip => 'Laktawan';
 
   @override
   String get videoMetadataGenerationFailed => 'Nabigo ang paggawa';

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -5992,7 +5992,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get videoMetadataC2paMissingRegenerate => 'Régénérer';
 
   @override
-  String get videoMetadataC2paMissingPostAnyway => 'Publier quand même';
+  String get videoMetadataC2paMissingSkip => 'Ignorer';
 
   @override
   String get videoMetadataGenerationFailed => 'Échec de la génération';

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -5893,7 +5893,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get videoMetadataC2paMissingRegenerate => 'Buat ulang';
 
   @override
-  String get videoMetadataC2paMissingPostAnyway => 'Tetap posting';
+  String get videoMetadataC2paMissingSkip => 'Lewati';
 
   @override
   String get videoMetadataGenerationFailed => 'Pembuatan gagal';

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -5970,7 +5970,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get videoMetadataC2paMissingRegenerate => 'Rigenera';
 
   @override
-  String get videoMetadataC2paMissingPostAnyway => 'Pubblica comunque';
+  String get videoMetadataC2paMissingSkip => 'Salta';
 
   @override
   String get videoMetadataGenerationFailed => 'Generazione non riuscita';

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -5680,7 +5680,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get videoMetadataC2paMissingRegenerate => '再生成';
 
   @override
-  String get videoMetadataC2paMissingPostAnyway => 'そのまま投稿';
+  String get videoMetadataC2paMissingSkip => 'スキップ';
 
   @override
   String get videoMetadataGenerationFailed => '生成に失敗しました';

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -5701,7 +5701,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get videoMetadataC2paMissingRegenerate => '재생성';
 
   @override
-  String get videoMetadataC2paMissingPostAnyway => '그래도 게시';
+  String get videoMetadataC2paMissingSkip => '건너뛰기';
 
   @override
   String get videoMetadataGenerationFailed => '생성 실패';

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -5944,7 +5944,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get videoMetadataC2paMissingRegenerate => 'Opnieuw genereren';
 
   @override
-  String get videoMetadataC2paMissingPostAnyway => 'Toch plaatsen';
+  String get videoMetadataC2paMissingSkip => 'Overslaan';
 
   @override
   String get videoMetadataGenerationFailed => 'Genereren mislukt';

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -6064,7 +6064,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get videoMetadataC2paMissingRegenerate => 'Wygeneruj ponownie';
 
   @override
-  String get videoMetadataC2paMissingPostAnyway => 'Opublikuj mimo to';
+  String get videoMetadataC2paMissingSkip => 'Pomiń';
 
   @override
   String get videoMetadataGenerationFailed => 'Generowanie nie powiodło się';

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -5954,7 +5954,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get videoMetadataC2paMissingRegenerate => 'Gerar novamente';
 
   @override
-  String get videoMetadataC2paMissingPostAnyway => 'Publicar mesmo assim';
+  String get videoMetadataC2paMissingSkip => 'Ignorar';
 
   @override
   String get videoMetadataGenerationFailed => 'Falha na geração';

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -6071,7 +6071,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get videoMetadataC2paMissingRegenerate => 'Regenerează';
 
   @override
-  String get videoMetadataC2paMissingPostAnyway => 'Publică oricum';
+  String get videoMetadataC2paMissingSkip => 'Omite';
 
   @override
   String get videoMetadataGenerationFailed => 'Generarea a eșuat';

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -5915,7 +5915,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get videoMetadataC2paMissingRegenerate => 'Generera om';
 
   @override
-  String get videoMetadataC2paMissingPostAnyway => 'Publicera ändå';
+  String get videoMetadataC2paMissingSkip => 'Hoppa över';
 
   @override
   String get videoMetadataGenerationFailed => 'Genereringen misslyckades';

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -5900,7 +5900,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get videoMetadataC2paMissingRegenerate => 'Yeniden oluştur';
 
   @override
-  String get videoMetadataC2paMissingPostAnyway => 'Yine de paylaş';
+  String get videoMetadataC2paMissingSkip => 'Atla';
 
   @override
   String get videoMetadataGenerationFailed => 'Oluşturma başarısız';

--- a/mobile/lib/screens/video_metadata/video_metadata_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_screen.dart
@@ -15,7 +15,7 @@ import 'package:openvine/widgets/video_metadata/modes/capture/video_metadata_cap
 import 'package:openvine/widgets/video_metadata/modes/classic/video_metadata_classic_stack.dart';
 
 /// The user's choice on the "C2PA signing failed" prompt.
-enum _C2paMissingChoice { regenerate, postAnyway }
+enum _C2paMissingChoice { regenerate, skip }
 
 /// Screen for editing video metadata including title, description, tags, and
 /// expiration settings.
@@ -81,9 +81,9 @@ class _VideoMetadataScreenState extends ConsumerState<VideoMetadataScreen> {
       primaryButtonText: l10n.videoMetadataC2paMissingRegenerate,
       onPrimaryPressed: () =>
           Navigator.of(context).pop(_C2paMissingChoice.regenerate),
-      secondaryButtonText: l10n.videoMetadataC2paMissingPostAnyway,
+      secondaryButtonText: l10n.videoMetadataC2paMissingSkip,
       onSecondaryPressed: () =>
-          Navigator.of(context).pop(_C2paMissingChoice.postAnyway),
+          Navigator.of(context).pop(_C2paMissingChoice.skip),
       isDismissible: false,
       enableDrag: false,
     );
@@ -95,10 +95,10 @@ class _VideoMetadataScreenState extends ConsumerState<VideoMetadataScreen> {
       case null:
         // Regenerate, or a system-back with no choice: re-sign the existing
         // render (no re-encode) rather than silently forfeiting provenance.
-        // Only an explicit "Post anyway" publishes without the credential
+        // Only an explicit "Skip" publishes without the credential
         // (#6058).
         unawaited(notifier.retryC2paSigning());
-      case _C2paMissingChoice.postAnyway:
+      case _C2paMissingChoice.skip:
         // Explicit consent to publish without a content credential.
         notifier.acknowledgeC2paSigningFailure();
     }

--- a/mobile/test/screens/video_metadata_screen_test.dart
+++ b/mobile/test/screens/video_metadata_screen_test.dart
@@ -180,8 +180,8 @@ void main() {
 
     group('C2PA signing prompt (#6058)', () {
       testWidgets(
-        'prompts to regenerate or post anyway when signing fails, and '
-        '"Post anyway" clears the flag',
+        'prompts to regenerate or skip when signing fails, and '
+        '"Skip" clears the flag',
         (tester) async {
           final container = ProviderContainer(
             overrides: [
@@ -226,14 +226,14 @@ void main() {
           );
 
           await tester.tap(
-            find.text(l10n.videoMetadataC2paMissingPostAnyway),
+            find.text(l10n.videoMetadataC2paMissingSkip),
           );
           await tester.pumpAndSettle();
 
           expect(
             container.read(videoEditorProvider).c2paSigningFailed,
             isFalse,
-            reason: 'posting anyway clears the pending prompt',
+            reason: 'skipping clears the pending prompt',
           );
           expect(find.text(l10n.videoMetadataC2paMissingTitle), findsNothing);
         },


### PR DESCRIPTION
Closes #6305

## What

Renames the secondary button on the C2PA missing-content-credential
bottom sheet (shown after a render when signing failed, #6058) from
**"Post anyway"** to **"Skip"** across all 18 locales.

## Why

The button's handler is `acknowledgeC2paSigningFailure()`, which only
sets `c2paSigningFailed = false` and dismisses the sheet — it does **not**
publish anything. The user lands back on the metadata form and still has
to post separately.

Labeling it "Post anyway" made users expect an immediate post; when
nothing happened, the button read as broken/confusing. "Skip" describes
what actually happens — skip the content-credential step and continue —
and pairs cleanly against the primary "Regenerate" action.

## Scope

- Value updated in all `app_*.arb` locales + regenerated
  `lib/l10n/generated/`.
- To avoid a misleading internal name, the l10n key is renamed
  (`videoMetadataC2paMissingPostAnyway` → `videoMetadataC2paMissingSkip`)
  and the private `_C2paMissingChoice.postAnyway` enum case → `.skip`,
  with the ARB description and adjacent code comment updated to match.
- Stale test copy in `video_metadata_screen_test.dart` aligned.
- The sheet **title/body** wording ("post it as-is") is intentionally
  left untouched — changing those translated body strings as a review
  side effect would drift the English source from 16+ locales, which the
  copy-alignment policy discourages. Happy to do that as a separate,
  deliberate copy pass if product wants it.

## Verification

- `flutter test test/l10n/arb_consistency_test.dart` ✅
- `flutter test test/screens/video_metadata_screen_test.dart` ✅ (9/9)
- `flutter analyze lib/l10n lib/screens/video_metadata test/screens/video_metadata_screen_test.dart` ✅