### PR TITLE
fix(comments): make flag-content report sheet scrollable so Submit is reachable

### DIFF
--- a/mobile/lib/screens/comments/widgets/comment_options_modal.dart
+++ b/mobile/lib/screens/comments/widgets/comment_options_modal.dart
@@ -326,6 +326,9 @@ class _ReasonRadioTile extends StatelessWidget {
       label:
           '${context.l10n.reportReasonTitle(reason)}. '
           '${context.l10n.reportReasonSubtitle(reason)}',
+      // excludeSemantics drops the child subtree — including the
+      // GestureDetector's tap action — so the action is re-declared here.
+      onTap: onTap,
       excludeSemantics: true,
       child: GestureDetector(
         onTap: onTap,

--- a/mobile/lib/screens/comments/widgets/comment_options_modal.dart
+++ b/mobile/lib/screens/comments/widgets/comment_options_modal.dart
@@ -171,6 +171,9 @@ class _OptionTile extends StatelessWidget {
       identifier: identifier,
       button: true,
       label: semanticLabel,
+      // excludeSemantics drops the child subtree — including the
+      // GestureDetector's tap action — so the action is re-declared here.
+      onTap: onTap,
       excludeSemantics: true,
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,

--- a/mobile/lib/screens/comments/widgets/comment_options_modal.dart
+++ b/mobile/lib/screens/comments/widgets/comment_options_modal.dart
@@ -225,27 +225,42 @@ class _FlagContentSheetState extends State<_FlagContentSheet> {
 
   @override
   Widget build(BuildContext context) {
+    // The reasons scroll while Submit stays pinned below them, so Submit is
+    // always visible — even with all 11 reasons under large accessibility
+    // text scales, which otherwise pushed it off-screen in a plain Column.
     return Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Padding(
-          padding: const EdgeInsets.fromLTRB(20, 8, 20, 16),
-          child: Text(
-            context.l10n.commentOptionsFlagReasonPrompt,
-            style: VineTheme.bodyMediumFont(color: VineTheme.onSurfaceMuted),
+        Flexible(
+          child: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(20, 8, 20, 16),
+                  child: Text(
+                    context.l10n.commentOptionsFlagReasonPrompt,
+                    style: VineTheme.bodyMediumFont(
+                      color: VineTheme.onSurfaceMuted,
+                    ),
+                  ),
+                ),
+                for (final reason in ContentFilterReason.values)
+                  _ReasonRadioTile(
+                    reason: reason,
+                    isSelected: _selectedReason == reason,
+                    onTap: () {
+                      setState(() {
+                        _selectedReason = reason;
+                      });
+                    },
+                  ),
+              ],
+            ),
           ),
         ),
-        for (final reason in ContentFilterReason.values)
-          _ReasonRadioTile(
-            reason: reason,
-            isSelected: _selectedReason == reason,
-            onTap: () {
-              setState(() {
-                _selectedReason = reason;
-              });
-            },
-          ),
         Padding(
           padding: const EdgeInsets.fromLTRB(20, 12, 20, 16),
           child: SizedBox(
@@ -305,62 +320,70 @@ class _ReasonRadioTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: onTap,
-      child: Container(
-        color: VineTheme.transparent,
-        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
-        child: Row(
-          children: [
-            Container(
-              width: 20,
-              height: 20,
-              decoration: BoxDecoration(
-                shape: BoxShape.circle,
-                border: Border.all(
-                  color: isSelected
-                      ? VineTheme.vineGreen
-                      : VineTheme.onSurfaceMuted,
-                  width: 2,
+    return Semantics(
+      button: true,
+      selected: isSelected,
+      label:
+          '${context.l10n.reportReasonTitle(reason)}. '
+          '${context.l10n.reportReasonSubtitle(reason)}',
+      excludeSemantics: true,
+      child: GestureDetector(
+        onTap: onTap,
+        child: Container(
+          color: VineTheme.transparent,
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+          child: Row(
+            children: [
+              Container(
+                width: 20,
+                height: 20,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  border: Border.all(
+                    color: isSelected
+                        ? VineTheme.vineGreen
+                        : VineTheme.onSurfaceMuted,
+                    width: 2,
+                  ),
+                ),
+                child: isSelected
+                    ? Center(
+                        child: Container(
+                          width: 10,
+                          height: 10,
+                          decoration: const BoxDecoration(
+                            shape: BoxShape.circle,
+                            color: VineTheme.vineGreen,
+                          ),
+                        ),
+                      )
+                    : null,
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      context.l10n.reportReasonTitle(reason),
+                      style: VineTheme.bodyLargeFont(
+                        color: isSelected
+                            ? VineTheme.onSurface
+                            : VineTheme.onSurfaceVariant,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      context.l10n.reportReasonSubtitle(reason),
+                      style: VineTheme.bodySmallFont(
+                        color: VineTheme.onSurfaceMuted,
+                      ),
+                    ),
+                  ],
                 ),
               ),
-              child: isSelected
-                  ? Center(
-                      child: Container(
-                        width: 10,
-                        height: 10,
-                        decoration: const BoxDecoration(
-                          shape: BoxShape.circle,
-                          color: VineTheme.vineGreen,
-                        ),
-                      ),
-                    )
-                  : null,
-            ),
-            const SizedBox(width: 12),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    context.l10n.reportReasonTitle(reason),
-                    style: VineTheme.bodyLargeFont(
-                      color: isSelected
-                          ? VineTheme.onSurface
-                          : VineTheme.onSurfaceVariant,
-                    ),
-                  ),
-                  const SizedBox(height: 2),
-                  Text(
-                    context.l10n.reportReasonSubtitle(reason),
-                    style: VineTheme.bodySmallFont(
-                      color: VineTheme.onSurfaceMuted,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/mobile/test/screens/comments/comment_options_modal_test.dart
+++ b/mobile/test/screens/comments/comment_options_modal_test.dart
@@ -258,11 +258,13 @@ void main() {
       await tester.pumpAndSettle();
 
       // Each reason is a labelled, selectable button for screen readers (it
-      // was a bare GestureDetector exposing no button role).
+      // was a bare GestureDetector exposing no button role). The tap action
+      // is asserted too: excludeSemantics drops the child subtree, so without
+      // an explicit onTap the node reads as a button that cannot be activated.
       final harassment = find.text(l10n.reportReasonHarassment);
       expect(
         tester.getSemantics(harassment),
-        isSemantics(isButton: true, isSelected: false),
+        isSemantics(isButton: true, isSelected: false, hasTapAction: true),
       );
       expect(
         tester.getSemantics(harassment).label,

--- a/mobile/test/screens/comments/comment_options_modal_test.dart
+++ b/mobile/test/screens/comments/comment_options_modal_test.dart
@@ -143,8 +143,25 @@ void main() {
         // real error and hangs pumpAndSettle.
         final caughtErrors = <FlutterErrorDetails>[];
         final previousOnError = FlutterError.onError;
-        FlutterError.onError = caughtErrors.add;
         addTearDown(() => FlutterError.onError = previousOnError);
+
+        // Runs [flow] with framework errors collected instead of failing the
+        // test, and restores the real handler before returning.
+        //
+        // Nothing inside may call expect(): flutter_test reports a
+        // TestFailure through FlutterError.onError, so the collector would
+        // swallow it, `_pendingExceptionDetails` would stay null, and the
+        // binding's own assert would fire before it can complete the test —
+        // hanging the shard instead of reporting the regression. Measure
+        // inside, assert outside.
+        Future<void> collectingErrors(Future<void> Function() flow) async {
+          FlutterError.onError = caughtErrors.add;
+          try {
+            await flow();
+          } finally {
+            FlutterError.onError = previousOnError;
+          }
+        }
 
         // Flutter's TextPainter asserts `debugSize == size` when a
         // RenderParagraph is scrolled under a non-1.0 textScale in tests — a
@@ -206,45 +223,61 @@ void main() {
           await tester.pump(const Duration(milliseconds: 400));
         }
 
-        await tester.tap(find.text('Open options'));
-        await settle();
-
-        // Options sheet -> choose Flag Content.
-        await tester.tap(find.text(l10n.commentOptionsFlagContentLabel));
-        await settle();
-
-        // Opening the sheet must not overflow — the unfixed sheet clipped
-        // Submit off-screen here.
-        expect(unexpectedErrors(), isEmpty, reason: 'overflow on sheet open');
-
-        // Submit is pinned: on-screen and hittable before any scroll (the
-        // unfixed sheet clipped it off-screen).
         final submit = find.widgetWithText(
           ElevatedButton,
           l10n.commentOptionsFlagSubmit,
         );
-        expect(submit, findsOneWidget);
+        final lastReason = find.text(l10n.reportReasonOther);
         final viewportHeight =
             tester.view.physicalSize.height / tester.view.devicePixelRatio;
-        final submitRect = tester.getRect(submit);
+
+        late List<String> errorsOnOpen;
+        late int submitMatchesOnOpen;
+        late Rect submitRect;
+        late Rect submitRectAfterScroll;
+        late double lastReasonCenterDy;
+
+        await collectingErrors(() async {
+          await tester.tap(find.text('Open options'));
+          await settle();
+
+          // Options sheet -> choose Flag Content.
+          await tester.tap(find.text(l10n.commentOptionsFlagContentLabel));
+          await settle();
+          errorsOnOpen = unexpectedErrors();
+
+          submitMatchesOnOpen = submit.evaluate().length;
+          submitRect = tester.getRect(submit);
+
+          // The last reason must be reachable by scrolling and must sit above
+          // the pinned Submit — never hidden behind it.
+          await tester.ensureVisible(lastReason);
+          await settle();
+          submitRectAfterScroll = tester.getRect(submit);
+          lastReasonCenterDy = tester.getCenter(lastReason).dy;
+
+          await tester.tap(lastReason);
+          await settle();
+          await tester.tap(submit);
+          await settle();
+        });
+
+        // Opening the sheet must not overflow — the unfixed sheet clipped
+        // Submit off-screen here.
+        expect(errorsOnOpen, isEmpty, reason: 'overflow on sheet open');
+
+        // Submit is pinned: on-screen and hittable before any scroll (the
+        // unfixed sheet clipped it off-screen).
+        expect(submitMatchesOnOpen, 1);
         expect(submitRect.top, greaterThanOrEqualTo(0));
         expect(submitRect.bottom, lessThanOrEqualTo(viewportHeight));
 
-        // The last reason must be reachable by scrolling and must sit above
-        // the pinned Submit — never hidden behind it.
-        final lastReason = find.text(l10n.reportReasonOther);
-        await tester.ensureVisible(lastReason);
-        await settle();
         // Submit did not move when the reasons scrolled: it is pinned, not
         // part of the scroll view.
-        expect(tester.getRect(submit), submitRect);
-        expect(tester.getCenter(lastReason).dy, lessThan(submitRect.top));
-        await tester.tap(lastReason);
-        await settle();
+        expect(submitRectAfterScroll, submitRect);
+        expect(lastReasonCenterDy, lessThan(submitRect.top));
 
-        // Submit is still pinned; submitting reports the last reason.
-        await tester.tap(submit);
-        await settle();
+        // Submit stayed hittable; submitting reports the last reason.
         expect(result, isA<CommentReportResult>());
         expect(
           (result! as CommentReportResult).reason,

--- a/mobile/test/screens/comments/comment_options_modal_test.dart
+++ b/mobile/test/screens/comments/comment_options_modal_test.dart
@@ -1,5 +1,5 @@
-// ABOUTME: Widget tests for comment options modal tap targets.
-// ABOUTME: Verifies option rows respond across transparent icon/text gaps.
+// ABOUTME: Widget tests for the comment options modal (delete, flag).
+// ABOUTME: Option-row taps and the flag sheet's pinned Submit at large text.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -7,6 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/screens/comments/widgets/comment_options_modal.dart';
+import 'package:openvine/services/content_moderation_types.dart';
 
 void main() {
   group(CommentOptionsModal, () {
@@ -68,6 +69,261 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(result, isA<CommentDeleteResult>());
+    });
+
+    testWidgets(
+      'flag content Submit stays pinned and reachable with every reason at '
+      'large text scale',
+      (tester) async {
+        // Reproduces the reported bug: on a phone-height viewport at the 1.35
+        // accessibility text scale, the 11 reason tiles + Submit exceed the
+        // sheet height. The unfixed sheet did not scroll, clipping Submit
+        // off-screen; the fix pins Submit below the scrolling reasons so it
+        // stays visible.
+        tester.view.physicalSize = const Size(1179, 2556); // iPhone 16 Pro
+        tester.view.devicePixelRatio = 3;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        // Capture raw framework errors (e.g. RenderFlex overflow) directly,
+        // bypassing the inspector describe-transform that otherwise masks the
+        // real error and hangs pumpAndSettle.
+        final caughtErrors = <FlutterErrorDetails>[];
+        final previousOnError = FlutterError.onError;
+        FlutterError.onError = caughtErrors.add;
+        addTearDown(() => FlutterError.onError = previousOnError);
+
+        // Flutter's TextPainter asserts `debugSize == size` when a
+        // RenderParagraph is scrolled under a non-1.0 textScale in tests — a
+        // framework issue, not this widget. Everything else (an overflow in
+        // particular) is a real error the fix must prevent.
+        List<String> unexpectedErrors() => caughtErrors
+            .map((e) => e.exceptionAsString())
+            .where((e) => !e.contains('debugSize == size'))
+            .toList();
+
+        CommentOptionResult? result;
+
+        final router = GoRouter(
+          routes: [
+            GoRoute(
+              path: '/',
+              builder: (context, state) => Scaffold(
+                body: Builder(
+                  builder: (context) {
+                    return TextButton(
+                      onPressed: () async {
+                        result =
+                            await CommentOptionsModal.showForOtherUserIntegrated(
+                              context,
+                              authorPubkey:
+                                  'author0123456789abcdef0123456789abcdef012'
+                                  '3456789ab',
+                            );
+                      },
+                      child: const Text('Open options'),
+                    );
+                  },
+                ),
+              ),
+            ),
+          ],
+        );
+
+        await tester.pumpWidget(
+          MaterialApp.router(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            builder: (context, child) => MediaQuery.withClampedTextScaling(
+              minScaleFactor: 1.35,
+              maxScaleFactor: 1.35,
+              child: child!,
+            ),
+            routerConfig: router,
+          ),
+        );
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+
+        // Bounded pumps rather than pumpAndSettle: an overflow in the sheet
+        // would otherwise trigger a Flutter inspector error-describe cascade
+        // that never settles, masking the real failure.
+        Future<void> settle() async {
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 400));
+        }
+
+        await tester.tap(find.text('Open options'));
+        await settle();
+
+        // Options sheet -> choose Flag Content.
+        await tester.tap(find.text(l10n.commentOptionsFlagContentLabel));
+        await settle();
+
+        // Opening the sheet must not overflow — the unfixed sheet clipped
+        // Submit off-screen here.
+        expect(unexpectedErrors(), isEmpty, reason: 'overflow on sheet open');
+
+        // Submit is pinned: on-screen and hittable before any scroll (the
+        // unfixed sheet clipped it off-screen).
+        final submit = find.widgetWithText(
+          ElevatedButton,
+          l10n.commentOptionsFlagSubmit,
+        );
+        expect(submit, findsOneWidget);
+        final viewportHeight =
+            tester.view.physicalSize.height / tester.view.devicePixelRatio;
+        final submitRect = tester.getRect(submit);
+        expect(submitRect.top, greaterThanOrEqualTo(0));
+        expect(submitRect.bottom, lessThanOrEqualTo(viewportHeight));
+
+        // The last reason must be reachable by scrolling and must sit above
+        // the pinned Submit — never hidden behind it.
+        final lastReason = find.text(l10n.reportReasonOther);
+        await tester.ensureVisible(lastReason);
+        await settle();
+        // Submit did not move when the reasons scrolled: it is pinned, not
+        // part of the scroll view.
+        expect(tester.getRect(submit), submitRect);
+        expect(tester.getCenter(lastReason).dy, lessThan(submitRect.top));
+        await tester.tap(lastReason);
+        await settle();
+
+        // Submit is still pinned; submitting reports the last reason.
+        await tester.tap(submit);
+        await settle();
+        expect(result, isA<CommentReportResult>());
+        expect(
+          (result! as CommentReportResult).reason,
+          ContentFilterReason.other,
+        );
+
+        // No real framework error anywhere in the open -> select -> submit
+        // -> dismiss flow. The debugSize allowlist is coupled to an
+        // SDK-internal string, so also assert the real hazard — an overflow —
+        // directly and message-stably.
+        expect(
+          caughtErrors.where((e) => e.exceptionAsString().contains('overflow')),
+          isEmpty,
+          reason: 'flag sheet overflowed',
+        );
+        expect(
+          unexpectedErrors(),
+          isEmpty,
+          reason: 'unexpected framework error',
+        );
+      },
+    );
+
+    testWidgets('flag reason tiles expose selectable button semantics', (
+      tester,
+    ) async {
+      final semanticsHandle = tester.ensureSemantics();
+
+      final router = GoRouter(
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (context, state) => Scaffold(
+              body: Builder(
+                builder: (context) => TextButton(
+                  onPressed: () =>
+                      CommentOptionsModal.showForOtherUserIntegrated(
+                        context,
+                        authorPubkey:
+                            'author0123456789abcdef0123456789abcdef012'
+                            '3456789ab',
+                      ),
+                  child: const Text('Open options'),
+                ),
+              ),
+            ),
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        MaterialApp.router(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          routerConfig: router,
+        ),
+      );
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+
+      await tester.tap(find.text('Open options'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(l10n.commentOptionsFlagContentLabel));
+      await tester.pumpAndSettle();
+
+      // Each reason is a labelled, selectable button for screen readers (it
+      // was a bare GestureDetector exposing no button role).
+      final harassment = find.text(l10n.reportReasonHarassment);
+      expect(
+        tester.getSemantics(harassment),
+        isSemantics(isButton: true, isSelected: false),
+      );
+      expect(
+        tester.getSemantics(harassment).label,
+        contains(l10n.reportReasonHarassment),
+      );
+
+      semanticsHandle.dispose();
+    });
+
+    testWidgets('flag Submit is disabled until a reason is selected', (
+      tester,
+    ) async {
+      final router = GoRouter(
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (context, state) => Scaffold(
+              body: Builder(
+                builder: (context) => TextButton(
+                  onPressed: () =>
+                      CommentOptionsModal.showForOtherUserIntegrated(
+                        context,
+                        authorPubkey:
+                            'author0123456789abcdef0123456789abcdef012'
+                            '3456789ab',
+                      ),
+                  child: const Text('Open options'),
+                ),
+              ),
+            ),
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        MaterialApp.router(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          routerConfig: router,
+        ),
+      );
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+
+      await tester.tap(find.text('Open options'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(l10n.commentOptionsFlagContentLabel));
+      await tester.pumpAndSettle();
+
+      final submit = find.widgetWithText(
+        ElevatedButton,
+        l10n.commentOptionsFlagSubmit,
+      );
+
+      // Submit is disabled (onPressed null) until a reason is chosen.
+      expect(tester.widget<ElevatedButton>(submit).onPressed, isNull);
+
+      // Choosing a reason enables it.
+      await tester.tap(find.text(l10n.reportReasonHarassment));
+      await tester.pumpAndSettle();
+      expect(tester.widget<ElevatedButton>(submit).onPressed, isNotNull);
     });
   });
 }

--- a/mobile/test/screens/comments/comment_options_modal_test.dart
+++ b/mobile/test/screens/comments/comment_options_modal_test.dart
@@ -71,6 +71,59 @@ void main() {
       expect(result, isA<CommentDeleteResult>());
     });
 
+    testWidgets('option rows expose activatable button semantics', (
+      tester,
+    ) async {
+      final semanticsHandle = tester.ensureSemantics();
+
+      final router = GoRouter(
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (context, state) => Scaffold(
+              body: Builder(
+                builder: (context) => TextButton(
+                  onPressed: () =>
+                      CommentOptionsModal.showForOtherUserIntegrated(
+                        context,
+                        authorPubkey:
+                            'author0123456789abcdef0123456789abcdef012'
+                            '3456789ab',
+                      ),
+                  child: const Text('Open options'),
+                ),
+              ),
+            ),
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        MaterialApp.router(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          routerConfig: router,
+        ),
+      );
+
+      await tester.tap(find.text('Open options'));
+      await tester.pumpAndSettle();
+
+      // The Flag Content row gates the whole report flow, so it has to be
+      // activatable by a screen reader — excludeSemantics drops the child
+      // subtree, which otherwise leaves a button with no tap action.
+      expect(
+        tester.getSemantics(find.bySemanticsIdentifier('flag_content_option')),
+        isSemantics(isButton: true, hasTapAction: true),
+      );
+      expect(
+        tester.getSemantics(find.bySemanticsIdentifier('block_user_option')),
+        isSemantics(isButton: true, hasTapAction: true),
+      );
+
+      semanticsHandle.dispose();
+    });
+
     testWidgets(
       'flag content Submit stays pinned and reachable with every reason at '
       'large text scale',


### PR DESCRIPTION
## Description

Reporting a comment was impossible for some users: the **Flag Content** sheet lays out all 11 report reasons plus the Submit button in a single non-scrolling column, so once the reasons fill the sheet, Submit is pushed off the bottom with no way to reach it. Large accessibility text scales make it worse (the original report came from a user at 1.35 text scale), but 11 reasons overflow most phones on their own. Blocking is unaffected because it's a separate, shorter sheet.

Submit is now **pinned** below a scrollable reason list, so it stays visible without scrolling regardless of reason count or text scale. While in the same file, each reason tile now also exposes **button / selected / label semantics** (it was a bare `GestureDetector` with no button role), so screen-reader users can report a comment too. This is a Trust & Safety and accessibility fix on a harassment-response path.

**Related Issue:** Closes #6311

## Out of Scope

Other `VineBottomSheet(scrollable: false)` sheets may share the same overflow trap; auditing them is a separate follow-up, not this PR.

## Verification

Four widget tests, each mutation-checked (fails on the pre-fix code, passes on the fix):

- **Submit reachable at 1.35 text scale** — reproduces the overflow, taps Submit *without scrolling* to prove it stays pinned, re-reads Submit's rect after scrolling to prove it doesn't move, and scrolls to the last reason asserting it sits *above* Submit (never hidden behind it). A message-stable "no `overflow`" assertion backs the SDK-coupled `debugSize` allowlist.
- **Reason-tile a11y** — asserts each tile exposes `isButton` / `isSelected` / label semantics.
- **Submit disabled until a reason is selected** — asserts `onPressed` is null on open and non-null after a reason is chosen.
- Plus the pre-existing delete-option test, unchanged.

`flutter analyze` clean; `dart format` clean; all four design-system ceiling ratchets pass (no new violations). Reviewed by two independent adversarial passes (layout correctness + test quality), both "ready"; their hardening notes were resolved.

Visual before-state is the reporter's screen recording on #6311; I can attach an after-recording from the simulator if wanted.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
