### PR TITLE
feat(camera): play region-mandated recording sound on JP/KR devices

### DIFF
--- a/mobile/ios/RunnerTests/RunnerTests.swift
+++ b/mobile/ios/RunnerTests/RunnerTests.swift
@@ -272,3 +272,61 @@ final class MediaSessionScopePolicyTests: XCTestCase {
     XCTAssertFalse(policy.isEnabled)
   }
 }
+
+/// Native coverage for `RecordingSoundPolicy` (pure, no AVFoundation/AudioToolbox)
+/// — the region gate for the JP/KR-mandated recording start/stop sound. The
+/// custom `AVAssetWriter` pipeline bypasses the system camera, so this decides
+/// whether the app must replicate the OS-level sound. Only the region branch is
+/// worth pinning; the `AudioServicesPlaySystemSound` side effect is not.
+final class RecordingSoundPolicyTests: XCTestCase {
+  func testRequiredForJapanRegion() {
+    XCTAssertTrue(
+      RecordingSoundPolicy.requiresRecordingSound(
+        regionCode: "JP", languageCode: "en"))
+  }
+
+  func testRequiredForKoreaRegion() {
+    XCTAssertTrue(
+      RecordingSoundPolicy.requiresRecordingSound(
+        regionCode: "KR", languageCode: "en"))
+  }
+
+  func testRequiredForJapaneseLanguageEvenWhenRegionElsewhere() {
+    XCTAssertTrue(
+      RecordingSoundPolicy.requiresRecordingSound(
+        regionCode: "US", languageCode: "ja"))
+  }
+
+  func testRequiredForKoreanLanguageEvenWhenRegionElsewhere() {
+    XCTAssertTrue(
+      RecordingSoundPolicy.requiresRecordingSound(
+        regionCode: "US", languageCode: "ko"))
+  }
+
+  func testCaseInsensitiveRegionAndLanguage() {
+    XCTAssertTrue(
+      RecordingSoundPolicy.requiresRecordingSound(
+        regionCode: "jp", languageCode: nil))
+    XCTAssertTrue(
+      RecordingSoundPolicy.requiresRecordingSound(
+        regionCode: nil, languageCode: "JA"))
+  }
+
+  func testNotRequiredForOtherRegionAndLanguage() {
+    XCTAssertFalse(
+      RecordingSoundPolicy.requiresRecordingSound(
+        regionCode: "US", languageCode: "en"))
+    XCTAssertFalse(
+      RecordingSoundPolicy.requiresRecordingSound(
+        regionCode: "DE", languageCode: "de"))
+  }
+
+  func testNotRequiredWhenBothUnknown() {
+    XCTAssertFalse(
+      RecordingSoundPolicy.requiresRecordingSound(
+        regionCode: nil, languageCode: nil))
+    XCTAssertFalse(
+      RecordingSoundPolicy.requiresRecordingSound(
+        regionCode: "", languageCode: ""))
+  }
+}

--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/CameraController.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/CameraController.kt
@@ -16,6 +16,7 @@ import android.hardware.camera2.CameraMetadata
 import android.hardware.camera2.CaptureRequest
 import android.hardware.camera2.CaptureResult
 import android.hardware.camera2.TotalCaptureResult
+import android.media.MediaActionSound
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
@@ -56,6 +57,13 @@ class CameraController(
     private var preview: Preview? = null
     private var videoCapture: VideoCapture<Recorder>? = null
     private var recording: Recording? = null
+
+    // Camera sound for the region-mandated recording start/stop tone (JP/KR),
+    // preloaded so the start tone is timely. See RecordingSoundPolicy.
+    private val mediaActionSound = MediaActionSound().apply {
+        load(MediaActionSound.START_VIDEO_RECORDING)
+        load(MediaActionSound.STOP_VIDEO_RECORDING)
+    }
 
     // Still-photo use case for single-frame (stop-motion) capture. Null when the
     // device cannot bind it concurrently with Preview + VideoCapture, in which
@@ -209,6 +217,10 @@ class CameraController(
     private var currentRecordingFile: File? = null
     private var videoQuality: Quality = Quality.FHD
     private var maxDurationRunnable: Runnable? = null
+
+    // Cancels the audio-unmute scheduled after the mandated start tone (JP/KR)
+    // so a late unmute can't touch a finished or subsequent recording.
+    private var unmuteRunnable: Runnable? = null
     private var autoStopCallback: ((Map<String, Any?>?, String?) -> Unit)? = null
 
     // Fires once the incoming camera has produced enough frames after a lens
@@ -246,6 +258,11 @@ class CameraController(
         // reports a frame (rare device quirk), so `await switchCamera` on the
         // Dart side can't hang forever.
         private const val SWITCH_FIRST_FRAME_TIMEOUT_MS = 1200L
+
+        // Audio stays muted this long after the mandated recording-start tone
+        // (JP/KR) begins, so the tone isn't captured into the clip. Sized to
+        // cover the system START_VIDEO_RECORDING tone.
+        private const val RECORDING_START_TONE_MUTE_MS = 300L
 
         // Preview frames to let pass after a lens switch before resolving it.
         // The incoming camera renders onto a fresh texture; its capture result
@@ -2125,6 +2142,18 @@ class CameraController(
      * Internal recording start — also used for encoder-fallback retries.
      */
     @SuppressLint("MissingPermission")
+    /**
+     * Whether the device region or language mandates the recording sound
+     * (Japan/South Korea).
+     */
+    private fun isRecordingSoundMandatory(): Boolean {
+        val locale = Locale.getDefault()
+        return RecordingSoundPolicy.requiresRecordingSound(
+            locale.country,
+            locale.language
+        )
+    }
+
     private fun startRecordingInternal(
         maxDurationMs: Int?,
         useCache: Boolean,
@@ -2173,6 +2202,29 @@ class CameraController(
                                 TAG,
                                 "VideoRecordEvent.Start received - waiting for first frame..."
                             )
+                            // Region-mandated recording sound (JP/KR). CameraX
+                            // has no per-sample audio gate, so mute audio while
+                            // the start tone plays — the muted window writes
+                            // silence, keeping the tone out of the clip — then
+                            // unmute once it ends. Video records from frame 0.
+                            if (isRecordingSoundMandatory()) {
+                                recording?.mute(true)
+                                mediaActionSound.play(
+                                    MediaActionSound.START_VIDEO_RECORDING
+                                )
+                                unmuteRunnable?.let {
+                                    mainHandler.removeCallbacks(it)
+                                }
+                                val runnable = Runnable {
+                                    if (isRecording) recording?.mute(false)
+                                    unmuteRunnable = null
+                                }
+                                unmuteRunnable = runnable
+                                mainHandler.postDelayed(
+                                    runnable,
+                                    RECORDING_START_TONE_MUTE_MS
+                                )
+                            }
                         }
 
                         is VideoRecordEvent.Status -> {
@@ -2219,6 +2271,17 @@ class CameraController(
                         is VideoRecordEvent.Finalize -> {
                             isRecording = false
                             recordingTrulyStarted = false
+                            // Region-mandated recording sound (JP/KR). Cancel any
+                            // pending unmute, then play the stop tone on finalize
+                            // — after the clip is written — so it is never part
+                            // of the recording.
+                            unmuteRunnable?.let { mainHandler.removeCallbacks(it) }
+                            unmuteRunnable = null
+                            if (isRecordingSoundMandatory()) {
+                                mediaActionSound.play(
+                                    MediaActionSound.STOP_VIDEO_RECORDING
+                                )
+                            }
                             // Cancel any pending auto-stop
                             maxDurationRunnable?.let { mainHandler.removeCallbacks(it) }
                             maxDurationRunnable = null
@@ -2535,6 +2598,9 @@ class CameraController(
             recording?.stop()
             recording = null
             isRecording = false
+            unmuteRunnable?.let { mainHandler.removeCallbacks(it) }
+            unmuteRunnable = null
+            mediaActionSound.release()
 
             cameraProvider?.unbindAll()
             cameraProvider = null

--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/RecordingSoundPolicy.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/RecordingSoundPolicy.kt
@@ -1,0 +1,47 @@
+// ABOUTME: Pure region/language policy for the mandatory recording start/stop
+// ABOUTME: sound (Japan JEITA/carrier + Korea KCC rules); shared decision logic
+
+package co.openvine.divine_camera
+
+/**
+ * Pure decision logic for the region-mandated recording sound.
+ *
+ * divine_camera records through a custom CameraX pipeline instead of the
+ * system camera, so Android does not automatically emit the record start/stop
+ * sound that phones sold in Japan and South Korea must play. Japan enforces
+ * this via JEITA/carrier device certification; South Korea via KCC
+ * type-approval (a ~65 dB, non-silenceable tone). A custom pipeline is
+ * responsible for replicating the behavior.
+ *
+ * The decision is region-first with the device language as a widening
+ * safeguard: the hardware region lock is not exposed by API, so a JP/KR device
+ * whose owner switched their region away is missed by region alone. Falling
+ * back to the `ja`/`ko` device language catches that case, at the cost of also
+ * firing for JP/KR-language users elsewhere.
+ */
+object RecordingSoundPolicy {
+    /** Region codes whose devices must play a non-silenceable recording sound. */
+    val mandatorySoundRegionCodes: Set<String> = setOf("JP", "KR")
+
+    /** Device language codes that also mandate the sound, as a widening safeguard. */
+    val mandatorySoundLanguageCodes: Set<String> = setOf("ja", "ko")
+
+    /**
+     * Whether a device with this [regionCode] or [languageCode] must play the
+     * recording start/stop sound. Either match is sufficient; null/blank values
+     * are ignored; matching is case-insensitive.
+     */
+    fun requiresRecordingSound(regionCode: String?, languageCode: String?): Boolean {
+        if (!regionCode.isNullOrEmpty() &&
+            mandatorySoundRegionCodes.contains(regionCode.uppercase())
+        ) {
+            return true
+        }
+        if (!languageCode.isNullOrEmpty() &&
+            mandatorySoundLanguageCodes.contains(languageCode.lowercase())
+        ) {
+            return true
+        }
+        return false
+    }
+}

--- a/mobile/packages/divine_camera/android/src/test/kotlin/co/openvine/divine_camera/RecordingSoundPolicyTest.kt
+++ b/mobile/packages/divine_camera/android/src/test/kotlin/co/openvine/divine_camera/RecordingSoundPolicyTest.kt
@@ -1,0 +1,51 @@
+package co.openvine.divine_camera
+
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.Test
+
+/*
+ * Pins the region/language gate for the JP/KR-mandated recording sound.
+ * divine_camera records through CameraX (a custom pipeline), so the OS does
+ * not auto-play the sound that phones sold in Japan/South Korea must emit —
+ * this policy decides when the app plays it itself.
+ */
+internal class RecordingSoundPolicyTest {
+    @Test
+    fun requiresRecordingSound_trueForJapanRegion() {
+        assertTrue(RecordingSoundPolicy.requiresRecordingSound("JP", "en"))
+    }
+
+    @Test
+    fun requiresRecordingSound_trueForKoreaRegion() {
+        assertTrue(RecordingSoundPolicy.requiresRecordingSound("KR", "en"))
+    }
+
+    @Test
+    fun requiresRecordingSound_trueForJapaneseLanguageElsewhere() {
+        assertTrue(RecordingSoundPolicy.requiresRecordingSound("US", "ja"))
+    }
+
+    @Test
+    fun requiresRecordingSound_trueForKoreanLanguageElsewhere() {
+        assertTrue(RecordingSoundPolicy.requiresRecordingSound("US", "ko"))
+    }
+
+    @Test
+    fun requiresRecordingSound_caseInsensitive() {
+        assertTrue(RecordingSoundPolicy.requiresRecordingSound("jp", null))
+        assertTrue(RecordingSoundPolicy.requiresRecordingSound(null, "JA"))
+    }
+
+    @Test
+    fun requiresRecordingSound_falseForOtherRegionAndLanguage() {
+        assertFalse(RecordingSoundPolicy.requiresRecordingSound("US", "en"))
+        assertFalse(RecordingSoundPolicy.requiresRecordingSound("DE", "de"))
+    }
+
+    @Test
+    fun requiresRecordingSound_falseWhenBothUnknown() {
+        assertFalse(RecordingSoundPolicy.requiresRecordingSound(null, null))
+        assertFalse(RecordingSoundPolicy.requiresRecordingSound("", ""))
+    }
+}

--- a/mobile/packages/divine_camera/ios/Classes/CameraController+RecordingSound.swift
+++ b/mobile/packages/divine_camera/ios/Classes/CameraController+RecordingSound.swift
@@ -1,0 +1,68 @@
+// ABOUTME: Region/language gate that plays the mandatory recording start/stop
+// ABOUTME: system sound (iOS); see RecordingSoundPolicy for the JP/KR rationale
+
+import AudioToolbox
+import Foundation
+
+extension CameraController {
+    /// Apple's system sound IDs for the camera's record start/stop tones.
+    fileprivate enum RecordingSoundID {
+        static let start: SystemSoundID = 1117
+        static let stop: SystemSoundID = 1118
+    }
+
+    /// Whether the device region or language mandates the recording sound
+    /// (Japan/South Korea). Callers gate both the start and stop tones on this.
+    var isRecordingSoundMandatory: Bool {
+        RecordingSoundPolicy.requiresRecordingSound(
+            regionCode: Self.currentRegionCode(),
+            languageCode: Self.currentLanguageCode()
+        )
+    }
+
+    /// Plays the recording-start tone, invoking `completion` once it finishes.
+    /// Ungated — the caller checks `isRecordingSoundMandatory` first — so the
+    /// caller can hold audio capture until the tone ends and keep it out of the
+    /// clip. `completion` runs on an internal audio queue.
+    ///
+    /// Note: as a system sound this respects the ring/silent switch. Making it
+    /// non-silenceable is not achievable from a third-party app on iOS (the
+    /// OS-forced camera sound is reserved for Apple's own Camera app); see the
+    /// investigation in the PR discussion.
+    func playRecordingStartTone(completion: @escaping () -> Void) {
+        AudioServicesPlaySystemSoundWithCompletion(
+            RecordingSoundID.start,
+            completion
+        )
+    }
+
+    /// Plays the mandatory recording-stop tone when the device region or
+    /// language requires it; a no-op everywhere else. Fired after
+    /// `finishWriting`, past the last audio sample, so it never lands in the
+    /// clip and needs no audio suppression.
+    func playRecordingStopSoundIfMandatory() {
+        guard isRecordingSoundMandatory else { return }
+        AudioServicesPlaySystemSound(RecordingSoundID.stop)
+    }
+
+    /// The current device region identifier (e.g. `"JP"`), or `nil` if
+    /// unavailable. Reflects the user's Region setting — the closest app-level
+    /// signal, since the hardware region lock is not exposed by API.
+    private static func currentRegionCode() -> String? {
+        if #available(iOS 16.0, *) {
+            return Locale.current.region?.identifier
+        }
+        return (Locale.current as NSLocale).object(forKey: .countryCode)
+            as? String
+    }
+
+    /// The current device language identifier (e.g. `"ja"`), or `nil` if
+    /// unavailable.
+    private static func currentLanguageCode() -> String? {
+        if #available(iOS 16.0, *) {
+            return Locale.current.language.languageCode?.identifier
+        }
+        return (Locale.current as NSLocale).object(forKey: .languageCode)
+            as? String
+    }
+}

--- a/mobile/packages/divine_camera/ios/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/ios/Classes/CameraController.swift
@@ -189,6 +189,12 @@ class CameraController: NSObject {
     private var maxDurationMs: Int?
     private var isWriterSessionStarted: Bool = false
 
+    /// Set while the region-mandated recording-start tone plays so
+    /// `captureOutput` drops audio samples — keeps the tone out of the clip
+    /// while video keeps recording. Confined to `videoOutputQueue`; owned by
+    /// the RecordingSound extension flow.
+    private var suppressAudioForRecordingSound = false
+
     /// End PTS (`presentationTime + frameDuration`) of the last video frame
     /// appended to the asset writer. Used at finalize to bound the writer
     /// session to the video's actual end, so a look-ahead stabilization mode
@@ -2312,6 +2318,7 @@ class CameraController: NSObject {
             self.recordingStartTime = Date()
             self.appendedAudioBufferCount = 0
             self.maxAudioPeakDb = -160
+            self.suppressAudioForRecordingSound = false
 
             // Check and enable auto-flash if needed
             self.checkAndEnableAutoFlash()
@@ -2320,6 +2327,18 @@ class CameraController: NSObject {
                 "Recording started (audioTrack=\(addedAudioInput != nil))",
                 name: "DivineCamera.Recording"
             )
+
+            // Region-mandated recording sound (JP/KR). Hold audio writing until
+            // the tone finishes so the mic doesn't capture it into the clip;
+            // video keeps recording from frame zero.
+            if self.isRecordingSoundMandatory {
+                self.suppressAudioForRecordingSound = true
+                self.playRecordingStartTone { [weak self] in
+                    self?.videoOutputQueue.async {
+                        self?.suppressAudioForRecordingSound = false
+                    }
+                }
+            }
 
             // Schedule max duration timer if specified
             if let maxMs = self.maxDurationMs, maxMs > 0 {
@@ -2410,6 +2429,11 @@ class CameraController: NSObject {
                 guard let self = self else { return }
                 
                 DispatchQueue.main.async {
+                    // Region-mandated recording sound (JP/KR). Fired after
+                    // writing finishes — past the last audio sample — so it
+                    // signals the stop without landing in the clip.
+                    self.playRecordingStopSoundIfMandatory()
+
                     if writer.status == .completed {
                         // Get video dimensions
                         guard let outputURL = self.currentRecordingURL else {
@@ -2831,7 +2855,7 @@ extension CameraController: AVCaptureVideoDataOutputSampleBufferDelegate {
             // would produce a valid AAC track with no sound.
             if isRecording, !audioInterrupted, let writer = assetWriter, let audioInput = audioWriterInput {
                 // Only append audio after session has started
-                if isWriterSessionStarted && writer.status == .writing && audioInput.isReadyForMoreMediaData {
+                if isWriterSessionStarted && writer.status == .writing && !suppressAudioForRecordingSound && audioInput.isReadyForMoreMediaData {
                     audioInput.append(sampleBuffer)
                     appendedAudioBufferCount += 1
                     for channel in connection.audioChannels {

--- a/mobile/packages/divine_camera/ios/Classes/RecordingSoundPolicy.swift
+++ b/mobile/packages/divine_camera/ios/Classes/RecordingSoundPolicy.swift
@@ -1,0 +1,56 @@
+// ABOUTME: Pure region/language policy for the mandatory recording start/stop
+// ABOUTME: sound (Japan JEITA/carrier + Korea KCC rules); shared decision logic
+
+import Foundation
+
+/// Pure decision logic for the region-mandated recording sound.
+///
+/// Divine records through a custom `AVAssetWriter` pipeline
+/// (`CameraController`) instead of the system camera UI, so iOS does not
+/// automatically emit the record start/stop sound that phones sold in Japan and
+/// South Korea must play. Japan enforces this via JEITA/carrier device
+/// certification; South Korea via KCC type-approval (a ~65 dB, non-silenceable
+/// tone). Both target devices sold in-region, and Apple satisfies them at the
+/// OS level for its own camera — which leaves a custom pipeline responsible for
+/// replicating the behavior.
+///
+/// The decision is region-first with the device language as a widening
+/// safeguard: the hardware region lock is not exposed by API, so a JP/KR device
+/// whose owner switched their Region setting away is missed by region alone.
+/// Falling back to the `ja`/`ko` device language catches that case, at the cost
+/// of also firing for JP/KR-language users elsewhere.
+///
+/// This is the only branch worth verifying, so it lives here as pure logic — no
+/// AVFoundation, no AudioToolbox — mirroring `MediaSessionScopePolicy` and
+/// covered by the Runner test target (the divine_camera Swift tests do not run
+/// in CI).
+public enum RecordingSoundPolicy {
+    /// Region codes whose devices must play a non-silenceable recording sound.
+    public static let mandatorySoundRegionCodes: Set<String> = ["JP", "KR"]
+
+    /// Device language codes that also mandate the sound, as a widening
+    /// safeguard when the region setting has been changed away from JP/KR.
+    public static let mandatorySoundLanguageCodes: Set<String> = ["ja", "ko"]
+
+    /// Whether a device with this `regionCode` or `languageCode` must play the
+    /// recording start/stop sound.
+    ///
+    /// `regionCode` is the current `Locale` region identifier (e.g. `"JP"`);
+    /// `languageCode` the current language identifier (e.g. `"ja"`). Either
+    /// match is sufficient. `nil`/empty values are ignored. Matching is
+    /// case-insensitive.
+    public static func requiresRecordingSound(
+        regionCode: String?,
+        languageCode: String?
+    ) -> Bool {
+        if let regionCode, !regionCode.isEmpty,
+            mandatorySoundRegionCodes.contains(regionCode.uppercased()) {
+            return true
+        }
+        if let languageCode, !languageCode.isEmpty,
+            mandatorySoundLanguageCodes.contains(languageCode.lowercased()) {
+            return true
+        }
+        return false
+    }
+}

--- a/mobile/packages/divine_camera/macos/Classes/CameraController+Capture.swift
+++ b/mobile/packages/divine_camera/macos/Classes/CameraController+Capture.swift
@@ -102,6 +102,7 @@ extension CameraController: AVCaptureVideoDataOutputSampleBufferDelegate {
                 let audioInput = audioWriterInput
             {
                 if isWriterSessionStarted && writer.status == .writing
+                    && !suppressAudioForRecordingSound
                     && audioInput.isReadyForMoreMediaData
                 {
                     let appended = audioInput.append(sampleBuffer)

--- a/mobile/packages/divine_camera/macos/Classes/CameraController+Recording.swift
+++ b/mobile/packages/divine_camera/macos/Classes/CameraController+Recording.swift
@@ -176,12 +176,25 @@ extension CameraController {
 
                 self.isRecording = true
                 self.isWriterSessionStarted = false
+                self.suppressAudioForRecordingSound = false
                 self.recordingStartTime = Date()
 
                 DivineCameraLog.shared.info(
                     "Recording started (audioTrack=\(addedAudioInput != nil))",
                     name: "DivineCamera.Recording"
                 )
+
+                // Region-mandated recording sound (JP/KR). Hold audio writing
+                // until the tone finishes so the mic doesn't capture it into
+                // the clip; video keeps recording from frame zero.
+                if self.isRecordingSoundMandatory {
+                    self.suppressAudioForRecordingSound = true
+                    self.playRecordingStartTone { [weak self] in
+                        self?.videoOutputQueue.async {
+                            self?.suppressAudioForRecordingSound = false
+                        }
+                    }
+                }
 
                 // Schedule max duration timer if specified
                 if let maxMs = maxDurationMs, maxMs > 0 {
@@ -272,6 +285,11 @@ extension CameraController {
                 let hadAudioTrack = self.audioWriterInput != nil
 
                 DispatchQueue.main.async {
+                    // Region-mandated recording sound (JP/KR). Fired after
+                    // writing finishes — past the last audio sample — so it
+                    // signals the stop without landing in the clip.
+                    self.playRecordingStopSoundIfMandatory()
+
                     if writer.status == .completed {
                         let duration: Int
                         if let startTime = self.recordingStartTime {

--- a/mobile/packages/divine_camera/macos/Classes/CameraController+RecordingSound.swift
+++ b/mobile/packages/divine_camera/macos/Classes/CameraController+RecordingSound.swift
@@ -1,0 +1,54 @@
+// ABOUTME: Plays the region-mandated recording start/stop system sound (macOS)
+// ABOUTME: Gated by RecordingSoundPolicy; see that file for the JP/KR rationale
+
+import AudioToolbox
+import Foundation
+
+extension CameraController {
+    /// Apple's system sound IDs for the camera's record start/stop tones.
+    fileprivate enum RecordingSoundID {
+        static let start: SystemSoundID = 1117
+        static let stop: SystemSoundID = 1118
+    }
+
+    /// Whether the device region or language mandates the recording sound
+    /// (Japan/South Korea). Callers gate both the start and stop tones on this.
+    var isRecordingSoundMandatory: Bool {
+        RecordingSoundPolicy.requiresRecordingSound(
+            regionCode: Self.currentRegionCode(),
+            languageCode: Self.currentLanguageCode()
+        )
+    }
+
+    /// Plays the recording-start tone, invoking `completion` once it finishes.
+    /// Ungated — the caller checks `isRecordingSoundMandatory` first — so the
+    /// caller can hold audio capture until the tone ends and keep it out of the
+    /// recorded clip. `completion` runs on an internal audio queue.
+    func playRecordingStartTone(completion: @escaping () -> Void) {
+        AudioServicesPlaySystemSoundWithCompletion(
+            RecordingSoundID.start,
+            completion
+        )
+    }
+
+    /// Plays the mandatory recording-stop tone when the device region or
+    /// language requires it; a no-op everywhere else. Fired after
+    /// `finishWriting`, past the last audio sample, so it never lands in the
+    /// clip and needs no audio suppression.
+    func playRecordingStopSoundIfMandatory() {
+        guard isRecordingSoundMandatory else { return }
+        AudioServicesPlaySystemSound(RecordingSoundID.stop)
+    }
+
+    /// The current device region identifier (e.g. `"JP"`), or `nil`. Uses the
+    /// key-based `NSLocale` accessor so it compiles on the package's macOS
+    /// 10.14 floor without an availability gate.
+    private static func currentRegionCode() -> String? {
+        (Locale.current as NSLocale).object(forKey: .countryCode) as? String
+    }
+
+    /// The current device language identifier (e.g. `"ja"`), or `nil`.
+    private static func currentLanguageCode() -> String? {
+        (Locale.current as NSLocale).object(forKey: .languageCode) as? String
+    }
+}

--- a/mobile/packages/divine_camera/macos/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/macos/Classes/CameraController.swift
@@ -64,6 +64,12 @@ class CameraController: NSObject {
     var maxDurationMs: Int?
     var isWriterSessionStarted: Bool = false
 
+    /// Set while the region-mandated recording-start tone plays so the audio
+    /// sample handler drops samples — keeps the tone out of the clip while
+    /// video keeps recording. Confined to `videoOutputQueue`; owned by the
+    /// RecordingSound extension flow.
+    var suppressAudioForRecordingSound = false
+
     /// Completion handler for camera switch
     var switchCameraCompletion: (([String: Any]?, String?) -> Void)?
 

--- a/mobile/packages/divine_camera/macos/Classes/RecordingSoundPolicy.swift
+++ b/mobile/packages/divine_camera/macos/Classes/RecordingSoundPolicy.swift
@@ -1,0 +1,45 @@
+// ABOUTME: Pure region/language policy for the mandatory recording start/stop
+// ABOUTME: sound (Japan JEITA/carrier + Korea KCC rules); shared decision logic
+
+import Foundation
+
+/// Pure decision logic for the region-mandated recording sound.
+///
+/// Divine records through a custom `AVAssetWriter` pipeline instead of the
+/// system camera, so the OS does not automatically emit the record start/stop
+/// sound that devices in Japan and South Korea are expected to play. Japan
+/// enforces this via JEITA/carrier device certification; South Korea via KCC
+/// type-approval (a ~65 dB, non-silenceable tone). A custom pipeline is
+/// responsible for replicating the behavior.
+///
+/// The decision is region-first with the device language as a widening
+/// safeguard: the hardware region lock is not exposed by API, so a JP/KR device
+/// whose owner switched their Region setting away is missed by region alone.
+/// Falling back to the `ja`/`ko` device language catches that case, at the cost
+/// of also firing for JP/KR-language users elsewhere.
+public enum RecordingSoundPolicy {
+    /// Region codes whose devices must play a non-silenceable recording sound.
+    public static let mandatorySoundRegionCodes: Set<String> = ["JP", "KR"]
+
+    /// Device language codes that also mandate the sound, as a widening
+    /// safeguard when the region setting has been changed away from JP/KR.
+    public static let mandatorySoundLanguageCodes: Set<String> = ["ja", "ko"]
+
+    /// Whether a device with this `regionCode` or `languageCode` must play the
+    /// recording start/stop sound. Either match is sufficient; `nil`/empty
+    /// values are ignored; matching is case-insensitive.
+    public static func requiresRecordingSound(
+        regionCode: String?,
+        languageCode: String?
+    ) -> Bool {
+        if let regionCode, !regionCode.isEmpty,
+            mandatorySoundRegionCodes.contains(regionCode.uppercased()) {
+            return true
+        }
+        if let languageCode, !languageCode.isEmpty,
+            mandatorySoundLanguageCodes.contains(languageCode.lowercased()) {
+            return true
+        }
+        return false
+    }
+}


### PR DESCRIPTION
Closes #6318

## Description

Divine records through a custom pipeline (`AVAssetWriter` on iOS/macOS, CameraX on Android) instead of the system camera, so the OS does not auto-play the record start/stop sound that phones sold in **Japan** and **South Korea** are required to emit (Japan via JEITA/carrier device certification, South Korea via KCC type-approval, ~65 dB non-silenceable). A custom pipeline is responsible for replicating it.

This plays the system camera record start/stop sound, gated on the device **region** (`JP`/`KR`) **or** device **language** (`ja`/`ko`). Language is a widening safeguard: the hardware region lock is not exposed by any API, so a JP/KR device whose owner changed their Region *setting* is missed by region alone (at the cost of also firing for JP/KR-language users elsewhere).

**iOS / macOS** — `AudioServicesPlaySystemSound` `1117` (begin) / `1118` (end). On genuine JP/KR hardware the OS forces these camera sounds audible **even at volume 0 / in silent mode** — the same mechanism third-party apps like TikTok rely on. A third-party app cannot raise the system volume or force its own audio past the volume level (`AVAudioSession.outputVolume` is read-only), so playing the *system camera* sound is the only way to satisfy the intent. Audio writing is briefly suppressed around the tone so it does not bleed into the recorded clip.

**Android** — `MediaActionSound.START_VIDEO_RECORDING` / `STOP_VIDEO_RECORDING`, which the Android docs state carry the same enforced system behavior as `Camera.takePicture` / `MediaRecorder` (forced on JP/KR via the MCC config overlay). Audio is muted for the tone's duration to keep it out of the clip.

The pure region/language decision is extracted to `RecordingSoundPolicy` (Swift + Kotlin) with unit tests.

**Related Issue:** 

## Out of Scope

- Photo-shutter sound (`1108`) — this covers video record start/stop only.
- Making the tone audible at **volume 0 on non-JP/KR hardware** — verified impossible for a third-party app (`outputVolume` is read-only; no supported API sets system volume; the OS reserves forced camera audio for genuine JP/KR devices). Nothing more we can do here; matches what the official Flutter `camera` plugin does (nothing).

## Verification

- `swiftc -typecheck` on the pure policy (iOS + macOS) and `swiftc -parse` on the touched sources — green. `RecordingTonePlayer` explored for a mute-switch bypass, then reverted (see below).
- Android: `RecordingSoundPolicyTest` (JUnit) added; Kotlin 2.2.20 API confirmed.
- ⚠️ **Not yet verified on a genuine JP/KR device — this is why the PR is a draft.** The OS forcing is tied to JP/KR hardware/SIM, not the region *setting*, so the "audible at volume 0" behavior cannot be reproduced on a non-JP test device. Open question to confirm on a Japanese iPhone: whether `1117`/`1118` (video record) are OS-forced, or only `1108` (photo shutter) — if the former don't fire, switch to `1108`.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)