### PR TITLE
fix(support): unblock self-custody DMs

### DIFF
--- a/mobile/lib/providers/protected_minor_providers.dart
+++ b/mobile/lib/providers/protected_minor_providers.dart
@@ -144,21 +144,27 @@ final isProtectedMinorProvider = Provider<bool>((ref) {
 /// absent answer (airplane mode, cleared storage, blocked keycast domain,
 /// expired token), so "no answer" must restrict rather than lift.
 ///
-/// Restricted unless a positive not-protected verdict exists:
+/// Keycast-backed accounts are restricted unless a positive not-protected
+/// verdict exists:
 /// - trusted live `notProtected` -> unrestricted (persisted for cold start);
 /// - persisted last-known `notProtected` -> unrestricted, so adults don't eat
 ///   a lockout on every network blip;
 /// - everything else (protected, unknown, loading, missing token, never
 ///   resolved, unauthenticated) -> restricted.
 ///
-/// Accepted cost per the design doc's fail-safe posture: a brand-new install
-/// during a keycast outage can DM only official accounts until the first
-/// check clears (rare, self-heals).
+/// Pure self-custody accounts are outside Keycast's verified-minor signal and
+/// must not be permanently restricted by an answer Keycast can never provide.
 final isDmRestrictedProvider = Provider<bool>((ref) {
   final authState = ref.watch(currentAuthStateProvider);
-  final pubkey = ref.watch(authServiceProvider).currentPublicKeyHex;
+  final authService = ref.watch(authServiceProvider);
+  final pubkey = authService.currentPublicKeyHex;
+  final authSource = authService.authenticationSource;
   final store = ref.watch(protectedMinorStickyStoreProvider);
   final live = ref.watch(protectedMinorStatusProvider);
+
+  if (authSource == AuthenticationSource.divineOAuth) {
+    store.markKeycastAccount(pubkey);
+  }
 
   final trusted = trustedProtectedMinorStatus(
     authenticated: authState == AuthState.authenticated,
@@ -171,9 +177,22 @@ final isDmRestrictedProvider = Provider<bool>((ref) {
     if (trusted.kind == ProtectedMinorStatusKind.protected) return true;
     if (trusted.kind == ProtectedMinorStatusKind.notProtected) return false;
   }
-  // No trusted answer: only a persisted positive not-protected lifts the
-  // restriction; a never-seen account fails closed.
-  return store.lastKnownFor(pubkey) ?? true;
+  // No trusted answer: an explicit persisted verdict wins. Otherwise, fail
+  // closed only when Keycast could apply to this account now or historically.
+  final lastKnown = store.lastKnownFor(pubkey);
+  if (lastKnown != null) return lastKnown;
+  if (authState != AuthState.authenticated || pubkey == null) return true;
+  if (authSource == AuthenticationSource.divineOAuth) return true;
+  if (store.wasKeycastAccountFor(pubkey)) return true;
+  return switch (authSource) {
+    AuthenticationSource.automatic ||
+    AuthenticationSource.importedKeys ||
+    AuthenticationSource.bunker ||
+    AuthenticationSource.amber ||
+    AuthenticationSource.nip07 => false,
+    AuthenticationSource.none => true,
+    AuthenticationSource.divineOAuth => true,
+  };
 });
 
 /// Whether the current DM restriction comes from a confirmed protected-minor
@@ -203,11 +222,11 @@ final hasConfirmedDmRestrictionProvider = Provider<bool>((ref) {
 /// a direct reuse) so the call site documents intent, and the two conditions
 /// can diverge later without touching the screen.
 ///
-/// Fails closed for the same reason DMs do: the restricted party can trivially
-/// suppress the input that produces "unknown" (airplane mode, cleared storage,
-/// blocked keycast domain, expired token), so a missing answer must hide the
-/// affordance rather than hand over the key. This is why it does NOT reuse the
-/// fail-OPEN [isProtectedMinorProvider] that #175's content lock consumes.
+/// Uses the same signal-applicability boundary as the DM seam: Keycast-backed
+/// accounts fail closed on an absent answer, while pure self-custody accounts
+/// are not restricted by a Keycast verdict that cannot exist for them. This is
+/// why it does NOT reuse the fail-OPEN [isProtectedMinorProvider] that #175's
+/// content lock consumes.
 final isKeyManagementRestrictedProvider = Provider<bool>(
   (ref) => ref.watch(isDmRestrictedProvider),
 );

--- a/mobile/lib/providers/protected_minor_providers.dart
+++ b/mobile/lib/providers/protected_minor_providers.dart
@@ -163,6 +163,8 @@ final isDmRestrictedProvider = Provider<bool>((ref) {
   final live = ref.watch(protectedMinorStatusProvider);
 
   if (authSource == AuthenticationSource.divineOAuth) {
+    // Intentional fire-and-forget monotonic marker; SharedPreferences updates
+    // its in-memory cache before the Future completes.
     store.markKeycastAccount(pubkey);
   }
 

--- a/mobile/lib/screens/other_profile_screen.dart
+++ b/mobile/lib/screens/other_profile_screen.dart
@@ -167,8 +167,8 @@ class _OtherProfileViewState extends ConsumerState<OtherProfileView> {
   /// (protected minor, or an unresolved status that fails closed) and this
   /// pubkey is not an approved official recipient. Drives hiding the Message
   /// affordance and guards the tap itself.
-  bool _messagingBlockedForProtectedMinor() {
-    if (!ref.read(isDmRestrictedProvider)) return false;
+  bool _messagingBlockedForProtectedMinor({bool? isDmRestricted}) {
+    if (!(isDmRestricted ?? ref.read(isDmRestrictedProvider))) return false;
     return !ref
         .read(officialAccountsServiceProvider)
         .isApprovedMinorDmRecipientSync(widget.pubkey);
@@ -426,7 +426,10 @@ class _OtherProfileViewState extends ConsumerState<OtherProfileView> {
                   headerProfile?.bestDisplayName ??
                   widget.displayNameHint ??
                   context.l10n.profileTitle;
-              final isMessageRestricted = _messagingBlockedForProtectedMinor();
+              final isDmRestricted = ref.watch(isDmRestrictedProvider);
+              final isMessageRestricted = _messagingBlockedForProtectedMinor(
+                isDmRestricted: isDmRestricted,
+              );
 
               return Scaffold(
                 backgroundColor: VineTheme.surfaceBackground,

--- a/mobile/lib/screens/other_profile_screen.dart
+++ b/mobile/lib/screens/other_profile_screen.dart
@@ -426,6 +426,7 @@ class _OtherProfileViewState extends ConsumerState<OtherProfileView> {
                   headerProfile?.bestDisplayName ??
                   widget.displayNameHint ??
                   context.l10n.profileTitle;
+              final isMessageRestricted = _messagingBlockedForProtectedMinor();
 
               return Scaffold(
                 backgroundColor: VineTheme.surfaceBackground,
@@ -455,9 +456,8 @@ class _OtherProfileViewState extends ConsumerState<OtherProfileView> {
                     scrollController: _scrollController,
                     onBack: context.pop,
                     onMore: _more,
-                    onMessageUser: _messagingBlockedForProtectedMinor()
-                        ? null
-                        : _messageUser,
+                    onMessageUser: _messageUser,
+                    isMessageRestricted: isMessageRestricted,
                     onShareProfile: _shareProfile,
                     onBlockedTap: _showUnblockConfirmation,
                     displayNameHint: widget.displayNameHint,

--- a/mobile/lib/services/protected_minor_sticky_store.dart
+++ b/mobile/lib/services/protected_minor_sticky_store.dart
@@ -16,6 +16,8 @@ class ProtectedMinorStickyStore {
   final SharedPreferences _prefs;
 
   static String _key(String pubkey) => 'protected_minor_sticky_$pubkey';
+  static String _keycastAccountKey(String pubkey) =>
+      'protected_minor_keycast_account_$pubkey';
 
   /// Last-known protected status for [pubkey]. Null/unconfirmed -> false.
   bool isProtectedMinorFor(String? pubkey) =>
@@ -27,6 +29,23 @@ class ProtectedMinorStickyStore {
   /// closed, while a persisted positive not-protected relaxes it.
   bool? lastKnownFor(String? pubkey) =>
       pubkey == null ? null : _prefs.getBool(_key(pubkey));
+
+  /// Whether [pubkey] has ever authenticated through Keycast/Divine OAuth on
+  /// this device. The #176 DM seam uses this to keep fail-closed behavior for
+  /// accounts Keycast could have a protected-minor verdict for, even if the
+  /// same pubkey later appears through a self-custody auth source.
+  bool wasKeycastAccountFor(String? pubkey) =>
+      pubkey != null && (_prefs.getBool(_keycastAccountKey(pubkey)) ?? false);
+
+  /// Persist that [pubkey] is Keycast-backed. This marker is monotonic: once
+  /// a pubkey has been associated with Keycast, absent verdicts must keep
+  /// failing closed for DM safety.
+  Future<void> markKeycastAccount(String? pubkey) async {
+    if (pubkey == null) return;
+    final key = _keycastAccountKey(pubkey);
+    if (_prefs.getBool(key) == true) return;
+    await _prefs.setBool(key, true);
+  }
 
   /// Apply a live keycast status: confirmed protected -> persist true;
   /// confirmed not-protected -> persist false; unknown -> retain. A write is

--- a/mobile/lib/widgets/profile/profile_action_buttons_widget.dart
+++ b/mobile/lib/widgets/profile/profile_action_buttons_widget.dart
@@ -28,6 +28,7 @@ class ProfileActionButtons extends ConsumerWidget {
     this.onEditProfile,
     this.onOpenClips,
     this.onMessageUser,
+    this.isMessageRestricted = false,
     this.onShareProfile,
     this.onBlockedTap,
     super.key,
@@ -41,6 +42,7 @@ class ProfileActionButtons extends ConsumerWidget {
   final VoidCallback? onEditProfile;
   final VoidCallback? onOpenClips;
   final VoidCallback? onMessageUser;
+  final bool isMessageRestricted;
   final void Function(BuildContext context)? onShareProfile;
 
   /// Callback when the Blocked button is tapped.
@@ -49,9 +51,7 @@ class ProfileActionButtons extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     if (isOwnProfile) {
-      return _ActionButtonsRow(
-        children: _buildOwnProfileButtons(context),
-      );
+      return _ActionButtonsRow(children: _buildOwnProfileButtons(context));
     }
 
     final followRepository = ref.watch(followRepositoryProvider);
@@ -79,6 +79,7 @@ class ProfileActionButtons extends ConsumerWidget {
         currentUserPubkey: nostrClient.publicKey,
         isBlocked: isBlocked,
         canTargetUser: canTargetUser,
+        isMessageRestricted: isMessageRestricted,
         onMessageUser: onMessageUser,
         onShareProfile: onShareProfile,
         onBlockedTap: onBlockedTap,
@@ -143,6 +144,7 @@ class _OtherProfileButtons extends StatelessWidget {
     required this.currentUserPubkey,
     required this.isBlocked,
     required this.canTargetUser,
+    required this.isMessageRestricted,
     required this.onMessageUser,
     required this.onShareProfile,
     required this.onBlockedTap,
@@ -158,6 +160,9 @@ class _OtherProfileButtons extends StatelessWidget {
   /// an explanation (disclosure invariant).
   final bool canTargetUser;
 
+  /// Whether the protected-minor DM policy hides only the message affordance.
+  final bool isMessageRestricted;
+
   final VoidCallback? onMessageUser;
   final void Function(BuildContext context)? onShareProfile;
   final VoidCallback? onBlockedTap;
@@ -168,6 +173,7 @@ class _OtherProfileButtons extends StatelessWidget {
     return BlocSelector<MyFollowingBloc, MyFollowingState, bool>(
       selector: (state) => state.isFollowing(userIdHex),
       builder: (context, isFollowing) {
+        final canShowMessage = canTargetUser && !isMessageRestricted;
         final followButton = FollowFromProfileButtonView(
           pubkey: userIdHex,
           displayName: displayName ?? l10n.profileUserFallback,
@@ -191,16 +197,18 @@ class _OtherProfileButtons extends StatelessWidget {
           // Following: [Message (expanded)] [Following] [Share]
           children = [
             if (canTargetUser) ...[
-              Expanded(
-                child: DivineButton(
-                  expanded: true,
-                  leadingIcon: .envelopeSimple,
-                  type: .secondary,
-                  size: .small,
-                  label: l10n.profileMessageLabel,
-                  onPressed: onMessageUser,
+              if (canShowMessage)
+                Expanded(
+                  child: DivineButton(
+                    expanded: true,
+                    leadingIcon: .envelopeSimple,
+                    type: .secondary,
+                    size: .small,
+                    label: l10n.profileMessageLabel,
+                    onPressed: onMessageUser,
+                  ),
                 ),
-              ),
+              if (!canShowMessage) const Spacer(),
               followButton,
             ] else
               const Spacer(),
@@ -211,13 +219,14 @@ class _OtherProfileButtons extends StatelessWidget {
           children = [
             if (canTargetUser) ...[
               Expanded(child: followButton),
-              DivineButton(
-                leadingIcon: .envelopeSimple,
-                type: .secondary,
-                size: .small,
-                label: '',
-                onPressed: onMessageUser,
-              ),
+              if (canShowMessage)
+                DivineButton(
+                  leadingIcon: .envelopeSimple,
+                  type: .secondary,
+                  size: .small,
+                  label: '',
+                  onPressed: onMessageUser,
+                ),
             ] else
               const Spacer(),
             shareButton,

--- a/mobile/lib/widgets/profile/profile_grid.dart
+++ b/mobile/lib/widgets/profile/profile_grid.dart
@@ -46,6 +46,7 @@ class ProfileGridView extends ConsumerStatefulWidget {
     this.onMore,
     this.onOpenClips,
     this.onMessageUser,
+    this.isMessageRestricted = false,
     this.onShareProfile,
     this.onBlockedTap,
     this.scrollController,
@@ -88,6 +89,9 @@ class ProfileGridView extends ConsumerStatefulWidget {
 
   /// Callback when "Message" button is tapped (other profiles only).
   final VoidCallback? onMessageUser;
+
+  /// Whether the Message affordance should be hidden for policy reasons.
+  final bool isMessageRestricted;
 
   /// Callback when share button is tapped.
   final void Function(BuildContext context)? onShareProfile;
@@ -669,6 +673,7 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
                         displayName: widget.displayName,
                         onOpenClips: widget.onOpenClips,
                         onMessageUser: widget.onMessageUser,
+                        isMessageRestricted: widget.isMessageRestricted,
                         onShareProfile: widget.onShareProfile,
                         onBlockedTap: widget.onBlockedTap,
                       ),

--- a/mobile/lib/widgets/profile/profile_header_widget.dart
+++ b/mobile/lib/widgets/profile/profile_header_widget.dart
@@ -67,6 +67,7 @@ class ProfileHeaderWidget extends ConsumerStatefulWidget {
     this.displayName,
     this.onOpenClips,
     this.onMessageUser,
+    this.isMessageRestricted = false,
     this.onShareProfile,
     this.onBlockedTap,
     super.key,
@@ -111,6 +112,9 @@ class ProfileHeaderWidget extends ConsumerStatefulWidget {
 
   /// Callback when "Message" button is tapped (other profiles only).
   final VoidCallback? onMessageUser;
+
+  /// Whether the Message affordance should be hidden for policy reasons.
+  final bool isMessageRestricted;
 
   /// Callback when share button is tapped.
   final void Function(BuildContext context)? onShareProfile;
@@ -393,6 +397,7 @@ class _ProfileHeaderWidgetState extends ConsumerState<ProfileHeaderWidget> {
             onEditProfile: widget.onEditProfile,
             onOpenClips: widget.onOpenClips,
             onMessageUser: widget.onMessageUser,
+            isMessageRestricted: widget.isMessageRestricted,
             onShareProfile: widget.onShareProfile,
             onBlockedTap: widget.onBlockedTap,
           ),

--- a/mobile/test/providers/dm_send_policy_test.dart
+++ b/mobile/test/providers/dm_send_policy_test.dart
@@ -89,6 +89,9 @@ void main() {
       final authService = _MockAuthService();
       when(() => authService.currentPublicKeyHex).thenReturn('a' * 64);
       when(
+        () => authService.authenticationSource,
+      ).thenReturn(AuthenticationSource.divineOAuth);
+      when(
         () => officials.isApprovedMinorDmRecipient(strangerHex),
       ).thenAnswer((_) async => false);
       when(
@@ -100,8 +103,8 @@ void main() {
           currentAuthStateProvider.overrideWithValue(AuthState.authenticated),
           sharedPreferencesProvider.overrideWithValue(prefs),
           authServiceProvider.overrideWithValue(authService),
-          // Keycast never answers (outage / suppressed by the restricted
-          // party). The policy must not wait on this to fail closed.
+          // Keycast never answers (outage / suppressed by the restricted party).
+          // Keycast accounts must not wait on this to fail closed.
           protectedMinorStatusProvider.overrideWith(
             (ref) => Completer<ProtectedMinorStatus>().future,
           ),
@@ -131,6 +134,9 @@ void main() {
       final prefs = await SharedPreferences.getInstance();
       final authService = _MockAuthService();
       when(() => authService.currentPublicKeyHex).thenReturn('a' * 64);
+      when(
+        () => authService.authenticationSource,
+      ).thenReturn(AuthenticationSource.divineOAuth);
       when(
         () => officials.isApprovedMinorDmRecipient(strangerHex),
       ).thenAnswer((_) async => false);

--- a/mobile/test/providers/is_dm_restricted_provider_test.dart
+++ b/mobile/test/providers/is_dm_restricted_provider_test.dart
@@ -30,12 +30,17 @@ void main() {
     prefs = await SharedPreferences.getInstance();
     authService = _MockAuthService();
     when(() => authService.currentPublicKeyHex).thenReturn(pubkey);
+    when(
+      () => authService.authenticationSource,
+    ).thenReturn(AuthenticationSource.divineOAuth);
   });
 
   ProviderContainer containerWith({
     required AuthState authState,
     Future<ProtectedMinorStatus> Function()? status,
+    AuthenticationSource authSource = AuthenticationSource.divineOAuth,
   }) {
+    when(() => authService.authenticationSource).thenReturn(authSource);
     final container = ProviderContainer(
       overrides: [
         currentAuthStateProvider.overrideWithValue(authState),
@@ -49,10 +54,10 @@ void main() {
     return container;
   }
 
-  test('restricted while status is unresolved and no verdict persisted', () {
-    // Cold start / keycast outage / suppressed check on a never-seen account:
-    // fail closed. The restricted party can trivially produce this state
-    // (airplane mode, cleared storage), so it must not lift the gate.
+  test('Keycast account is restricted while unresolved with no verdict', () {
+    // Cold start / keycast outage / suppressed check on a never-seen Keycast
+    // account: fail closed. The restricted party can trivially produce this
+    // state (airplane mode, cleared storage), so it must not lift the gate.
     final container = containerWith(
       authState: AuthState.authenticated,
       status: () => Completer<ProtectedMinorStatus>().future,
@@ -60,6 +65,22 @@ void main() {
 
     expect(container.read(isDmRestrictedProvider), isTrue);
   });
+
+  test(
+    'non-Keycast account is unrestricted when Keycast verdict is absent',
+    () {
+      // Self-custody accounts are outside Keycast's verified-minor signal. An
+      // absent Keycast verdict for them is structurally inapplicable, not a
+      // suppressible signal.
+      final container = containerWith(
+        authState: AuthState.authenticated,
+        authSource: AuthenticationSource.importedKeys,
+        status: () => Completer<ProtectedMinorStatus>().future,
+      );
+
+      expect(container.read(isDmRestrictedProvider), isFalse);
+    },
+  );
 
   test('unauthenticated with no verdict persisted is restricted', () {
     final container = containerWith(authState: AuthState.unauthenticated);
@@ -115,6 +136,22 @@ void main() {
 
     expect(container.read(isDmRestrictedProvider), isTrue);
   });
+
+  test(
+    'ever-Keycast pubkey remains restricted after imported-key reauth',
+    () async {
+      final store = ProtectedMinorStickyStore(prefs: prefs);
+      await store.markKeycastAccount(pubkey);
+
+      final container = containerWith(
+        authState: AuthState.authenticated,
+        authSource: AuthenticationSource.importedKeys,
+        status: () => Completer<ProtectedMinorStatus>().future,
+      );
+
+      expect(container.read(isDmRestrictedProvider), isTrue);
+    },
+  );
 
   test('an unknown resolution falls back to the persisted verdict', () async {
     final store = ProtectedMinorStickyStore(prefs: prefs);

--- a/mobile/test/providers/is_key_management_restricted_provider_test.dart
+++ b/mobile/test/providers/is_key_management_restricted_provider_test.dart
@@ -1,6 +1,6 @@
 // ABOUTME: Tests isKeyManagementRestrictedProvider (#182) — the fail-CLOSED gate
 // ABOUTME: for nsec export + key import/change. Delegates to the #176 DM seam, so
-// ABOUTME: an unresolved / suppressed protected-minor check must restrict.
+// ABOUTME: unresolved / suppressed Keycast checks must restrict.
 
 import 'dart:async';
 
@@ -29,6 +29,9 @@ void main() {
     prefs = await SharedPreferences.getInstance();
     authService = _MockAuthService();
     when(() => authService.currentPublicKeyHex).thenReturn(pubkey);
+    when(
+      () => authService.authenticationSource,
+    ).thenReturn(AuthenticationSource.divineOAuth);
   });
 
   ProviderContainer containerWith({
@@ -49,8 +52,8 @@ void main() {
   }
 
   test('restricted while the protected-minor check is unresolved', () {
-    // Fail closed: a suppressed/cold-start check on a never-seen account must
-    // hide the key-export/import affordances. This is exactly where the
+    // Fail closed: a suppressed/cold-start check on a never-seen Keycast
+    // account must hide the key-export/import affordances. This is where the
     // fail-OPEN isProtectedMinorProvider would (wrongly) return false.
     final container = containerWith(
       authState: AuthState.authenticated,

--- a/mobile/test/screens/other_profile_screen_test.dart
+++ b/mobile/test/screens/other_profile_screen_test.dart
@@ -1,0 +1,266 @@
+// ABOUTME: Widget tests for OtherProfileView integration behavior.
+// ABOUTME: Verifies screen-level provider reactivity for profile affordances.
+
+import 'dart:async';
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:comments_repository/comments_repository.dart';
+import 'package:content_blocklist_repository/content_blocklist_repository.dart';
+import 'package:content_policy/content_policy.dart';
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart' show StateProvider;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:likes_repository/likes_repository.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:openvine/blocs/other_profile/other_profile_bloc.dart';
+import 'package:openvine/features/feature_flags/models/feature_flag.dart';
+import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
+import 'package:openvine/features/people_lists/bloc/people_lists_bloc.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/official_accounts_providers.dart';
+import 'package:openvine/providers/protected_minor_providers.dart';
+import 'package:openvine/providers/user_profile_providers.dart';
+import 'package:openvine/screens/other_profile_screen.dart';
+import 'package:openvine/services/auth_service.dart' show AuthState;
+import 'package:openvine/services/official_accounts_service.dart';
+import 'package:openvine/services/video_event_service.dart';
+import 'package:reposts_repository/reposts_repository.dart';
+import 'package:videos_repository/videos_repository.dart';
+
+import '../helpers/test_provider_overrides.dart';
+
+class _MockOtherProfileBloc
+    extends MockBloc<OtherProfileEvent, OtherProfileState>
+    implements OtherProfileBloc {}
+
+class _MockPeopleListsBloc extends MockBloc<PeopleListsEvent, PeopleListsState>
+    implements PeopleListsBloc {}
+
+class _MockContentBlocklistRepository extends Mock
+    implements ContentBlocklistRepository {}
+
+class _MockLikesRepository extends Mock implements LikesRepository {}
+
+class _MockRepostsRepository extends Mock implements RepostsRepository {}
+
+class _MockCommentsRepository extends Mock implements CommentsRepository {}
+
+class _MockVideosRepository extends Mock implements VideosRepository {}
+
+class _MockVideoEventService extends Mock implements VideoEventService {}
+
+class _MockOfficials extends Mock implements OfficialAccountsService {}
+
+void main() {
+  const targetPubkey =
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+  const viewerPubkey =
+      'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+  late _MockOtherProfileBloc otherProfileBloc;
+  late _MockPeopleListsBloc peopleListsBloc;
+  late _MockContentBlocklistRepository blocklistRepository;
+  late _MockLikesRepository likesRepository;
+  late _MockRepostsRepository repostsRepository;
+  late _MockCommentsRepository commentsRepository;
+  late _MockVideosRepository videosRepository;
+  late _MockVideoEventService videoEventService;
+  late _MockOfficials officials;
+  late MockFollowRepository followRepository;
+  late MockNostrClient nostrClient;
+  late MockAuthService authService;
+
+  UserProfile profile() => UserProfile(
+    pubkey: targetPubkey,
+    displayName: 'Target User',
+    rawData: const {},
+    createdAt: DateTime(2026),
+    eventId: 'c' * 64,
+  );
+
+  AuthorFeedResult emptyAuthorFeed() => const AuthorFeedResult(
+    authorPubkey: targetPubkey,
+    totalCount: 0,
+    hasMore: false,
+  );
+
+  setUpAll(() {
+    registerFallbackValue(const OtherProfileLoadRequested());
+  });
+
+  setUp(() {
+    otherProfileBloc = _MockOtherProfileBloc();
+    peopleListsBloc = _MockPeopleListsBloc();
+    blocklistRepository = _MockContentBlocklistRepository();
+    likesRepository = _MockLikesRepository();
+    repostsRepository = _MockRepostsRepository();
+    commentsRepository = _MockCommentsRepository();
+    videosRepository = _MockVideosRepository();
+    videoEventService = _MockVideoEventService();
+    officials = _MockOfficials();
+    followRepository = createMockFollowRepository(
+      followingPubkeys: const [targetPubkey],
+    );
+    nostrClient = createMockNostrService();
+    authService = createMockAuthService();
+
+    final loadedState = OtherProfileLoaded(profile: profile(), isFresh: true);
+    whenListen(
+      otherProfileBloc,
+      const Stream<OtherProfileState>.empty(),
+      initialState: loadedState,
+    );
+    when(() => otherProfileBloc.state).thenReturn(loadedState);
+    when(() => otherProfileBloc.pubkey).thenReturn(targetPubkey);
+    when(() => otherProfileBloc.isBlocked).thenReturn(false);
+    when(() => otherProfileBloc.isFollowing).thenReturn(true);
+    whenListen(
+      peopleListsBloc,
+      const Stream<PeopleListsState>.empty(),
+      initialState: const PeopleListsState(),
+    );
+    when(() => peopleListsBloc.state).thenReturn(const PeopleListsState());
+
+    when(() => blocklistRepository.isBlocked(any())).thenReturn(false);
+    when(() => blocklistRepository.hasBlockedUs(any())).thenReturn(false);
+    when(() => blocklistRepository.hasMutedUs(any())).thenReturn(false);
+    when(() => blocklistRepository.shouldFilterFromFeeds(any())).thenReturn(
+      false,
+    );
+    when(() => blocklistRepository.currentState).thenReturn(
+      ContentPolicyState.empty(),
+    );
+    when(() => blocklistRepository.stateStream).thenAnswer(
+      (_) => const Stream<ContentPolicyState>.empty(),
+    );
+
+    when(
+      likesRepository.watchLikedEventIds,
+    ).thenAnswer((_) => const Stream<List<String>>.empty());
+    when(
+      repostsRepository.watchRepostedAddressableIds,
+    ).thenAnswer((_) => const Stream<Set<String>>.empty());
+
+    when(() => videoEventService.authorVideos(any())).thenReturn(
+      const <VideoEvent>[],
+    );
+    when(() => videoEventService.filterVideoList(any())).thenAnswer(
+      (invocation) => invocation.positionalArguments.first as List<VideoEvent>,
+    );
+    when(() => videoEventService.addListener(any())).thenReturn(null);
+    when(() => videoEventService.removeListener(any())).thenReturn(null);
+    when(() => videoEventService.addVideoUpdateListener(any())).thenReturn(
+      () {},
+    );
+    when(() => videoEventService.subscribeToUserVideos(any())).thenAnswer(
+      (_) async {},
+    );
+    when(
+      () => videosRepository.getAuthorFeed(
+        authorPubkey: any(named: 'authorPubkey'),
+        offset: any(named: 'offset'),
+        relaySeed: any(named: 'relaySeed'),
+        skipCache: any(named: 'skipCache'),
+      ),
+    ).thenAnswer((_) async => emptyAuthorFeed());
+
+    when(() => officials.isApprovedMinorDmRecipientSync(any())).thenReturn(
+      false,
+    );
+    when(() => nostrClient.publicKey).thenReturn(viewerPubkey);
+    when(() => authService.currentPublicKeyHex).thenReturn(viewerPubkey);
+    when(() => authService.authState).thenReturn(AuthState.authenticated);
+    when(() => authService.isAuthenticated).thenReturn(true);
+    when(() => authService.isAnonymous).thenReturn(false);
+    when(() => authService.hasExpiredOAuthSession).thenReturn(false);
+    when(() => authService.isRpcUpgradeInProgress).thenReturn(false);
+  });
+
+  Widget buildSubject({
+    required ProviderContainer container,
+  }) {
+    return UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        theme: VineTheme.theme,
+        home: MultiBlocProvider(
+          providers: [
+            BlocProvider<OtherProfileBloc>.value(value: otherProfileBloc),
+            BlocProvider<PeopleListsBloc>.value(value: peopleListsBloc),
+          ],
+          child: const OtherProfileView(pubkey: targetPubkey),
+        ),
+      ),
+    );
+  }
+
+  ProviderContainer createContainer(StateProvider<bool> restrictedProvider) {
+    return ProviderContainer(
+      overrides: [
+        ...getStandardTestOverrides(
+          mockAuthService: authService,
+          mockNostrService: nostrClient,
+          mockFollowRepository: followRepository,
+        ),
+        contentBlocklistRepositoryProvider.overrideWithValue(
+          blocklistRepository,
+        ),
+        likesRepositoryProvider.overrideWithValue(likesRepository),
+        repostsRepositoryProvider.overrideWithValue(repostsRepository),
+        commentsRepositoryProvider.overrideWithValue(commentsRepository),
+        videosRepositoryProvider.overrideWithValue(videosRepository),
+        videoEventServiceProvider.overrideWithValue(videoEventService),
+        officialAccountsServiceProvider.overrideWithValue(officials),
+        isDmRestrictedProvider.overrideWith(
+          (ref) => ref.watch(restrictedProvider),
+        ),
+        userProfileStatsReactiveProvider(targetPubkey).overrideWith(
+          (ref) => const Stream<ProfileStats?>.empty(),
+        ),
+        fetchUserProfileProvider(targetPubkey).overrideWith(
+          (ref) async => profile(),
+        ),
+        isFeatureEnabledProvider(FeatureFlag.videoReplies).overrideWith(
+          (ref) => false,
+        ),
+        isFeatureEnabledProvider(
+          FeatureFlag.profileMonetizationLinks,
+        ).overrideWith((ref) => false),
+        isFeatureEnabledProvider(FeatureFlag.curatedLists).overrideWith(
+          (ref) => false,
+        ),
+      ],
+    );
+  }
+
+  testWidgets(
+    'updates Message visibility when DM restriction flips while mounted',
+    (tester) async {
+      final restrictedProvider = StateProvider<bool>((ref) => true);
+      final container = createContainer(restrictedProvider);
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(buildSubject(container: container));
+      await tester.pump();
+
+      expect(find.text('Message'), findsNothing);
+
+      container.read(restrictedProvider.notifier).state = false;
+      await tester.pump();
+
+      expect(find.text('Message'), findsOneWidget);
+
+      container.read(restrictedProvider.notifier).state = true;
+      await tester.pump();
+
+      expect(find.text('Message'), findsNothing);
+    },
+  );
+}

--- a/mobile/test/services/protected_minor_sticky_store_test.dart
+++ b/mobile/test/services/protected_minor_sticky_store_test.dart
@@ -87,4 +87,25 @@ void main() {
       expect(store.lastKnownFor(otherPubkey), isNull);
     });
   });
+
+  group('wasKeycastAccountFor', () {
+    test('unmarked account reads false', () {
+      expect(store.wasKeycastAccountFor(pubkey), false);
+      expect(store.wasKeycastAccountFor(null), false);
+    });
+
+    test('markKeycastAccount persists per account', () async {
+      await store.markKeycastAccount(pubkey);
+
+      expect(store.wasKeycastAccountFor(pubkey), true);
+      expect(store.wasKeycastAccountFor(otherPubkey), false);
+    });
+
+    test('persists across instances', () async {
+      await store.markKeycastAccount(pubkey);
+
+      final fresh = ProtectedMinorStickyStore(prefs: prefs);
+      expect(fresh.wasKeycastAccountFor(pubkey), true);
+    });
+  });
 }

--- a/mobile/test/widgets/profile/profile_action_buttons_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_action_buttons_widget_test.dart
@@ -40,9 +40,9 @@ void main() {
     ).thenReturn(ContentPolicyState.empty());
 
     when(() => followRepository.followingPubkeys).thenReturn(const []);
-    when(() => followRepository.followingStream).thenAnswer(
-      (_) => Stream<List<String>>.value(const []),
-    );
+    when(
+      () => followRepository.followingStream,
+    ).thenAnswer((_) => Stream<List<String>>.value(const []));
     when(() => followRepository.watchMyFollowingCached()).thenAnswer(
       (_) => Stream.value(
         const CacheResult.live(
@@ -52,7 +52,7 @@ void main() {
     );
   });
 
-  Widget buildWidget() {
+  Widget buildWidget({bool isMessageRestricted = false}) {
     return testMaterialApp(
       home: Scaffold(
         body: ProfileActionButtons(
@@ -60,6 +60,7 @@ void main() {
           isOwnProfile: false,
           displayName: 'Target User',
           onMessageUser: () {},
+          isMessageRestricted: isMessageRestricted,
           onShareProfile: (_) {},
         ),
       ),
@@ -76,9 +77,9 @@ void main() {
   testWidgets(
     'hides follow and message actions when target cannot be targeted',
     (tester) async {
-      when(() => blocklistRepository.hasBlockedUs(targetPubkey)).thenReturn(
-        true,
-      );
+      when(
+        () => blocklistRepository.hasBlockedUs(targetPubkey),
+      ).thenReturn(true);
       when(() => blocklistRepository.currentState).thenReturn(
         const ContentPolicyState(
           currentUserPubkey: viewerPubkey,
@@ -103,9 +104,9 @@ void main() {
   testWidgets(
     'keeps share right-aligned when already following target cannot be targeted',
     (tester) async {
-      when(() => blocklistRepository.hasBlockedUs(targetPubkey)).thenReturn(
-        true,
-      );
+      when(
+        () => blocklistRepository.hasBlockedUs(targetPubkey),
+      ).thenReturn(true);
       when(() => blocklistRepository.currentState).thenReturn(
         const ContentPolicyState(
           currentUserPubkey: viewerPubkey,
@@ -118,9 +119,9 @@ void main() {
       when(
         () => followRepository.followingPubkeys,
       ).thenReturn(const [targetPubkey]);
-      when(() => followRepository.followingStream).thenAnswer(
-        (_) => Stream<List<String>>.value(const [targetPubkey]),
-      );
+      when(
+        () => followRepository.followingStream,
+      ).thenAnswer((_) => Stream<List<String>>.value(const [targetPubkey]));
       when(() => followRepository.watchMyFollowingCached()).thenAnswer(
         (_) => Stream.value(
           const CacheResult.live(
@@ -139,4 +140,16 @@ void main() {
       expect(find.byType(Spacer), findsOneWidget);
     },
   );
+
+  testWidgets('hides only message action when DM policy restricts the viewer', (
+    tester,
+  ) async {
+    await tester.pumpWidget(buildWidget(isMessageRestricted: true));
+    await tester.pump();
+
+    expect(find.text('Follow'), findsOneWidget);
+    expect(find.text('Message'), findsNothing);
+    expect(find.byType(DivineButton), findsOneWidget);
+    expect(find.byType(DivineIconButton), findsOneWidget);
+  });
 }


### PR DESCRIPTION
## Summary
- Relax the protected-minor DM fail-closed fallback for pure self-custody accounts that Keycast can never return a verdict for
- Persist an ever-Keycast marker per pubkey so current or historical Keycast accounts still fail closed when no verdict is available
- Hide the profile Message affordance when protected-minor policy blocks it, while keeping the tap and route guards in place

Closes #6300

## Verification
- flutter test test/providers/is_dm_restricted_provider_test.dart test/services/protected_minor_sticky_store_test.dart test/widgets/profile/profile_action_buttons_widget_test.dart
- flutter analyze
- pre-push changed-file analyzer and tests passed