### PR TITLE
feat(clip-reuse): preserve imported clip provenance

### DIFF
--- a/mobile/lib/models/divine_video_clip.dart
+++ b/mobile/lib/models/divine_video_clip.dart
@@ -40,6 +40,10 @@ class DivineVideoClip {
     this.proofManifestJson,
     this.deletedAt,
     this.transition,
+    this.sourceAuthorPubkey,
+    this.sourceEventId,
+    this.sourceAddressableId,
+    this.sourceRelayHint,
   }) : assert(
          video != null || stopMotionFrames != null,
          'A clip must have either a video file or stop-motion frames',
@@ -136,6 +140,19 @@ class DivineVideoClip {
   /// tail into the first clip's head so a looping player restarts seamlessly.
   /// Drives both the live editor preview and the final rendered composition.
   final ClipTransition? transition;
+
+  /// Original video author's pubkey when this local clip was imported from an
+  /// existing published video.
+  final String? sourceAuthorPubkey;
+
+  /// Original source event id for imported clips.
+  final String? sourceEventId;
+
+  /// Addressable kind 34236 coordinate for the source video when available.
+  final String? sourceAddressableId;
+
+  /// Relay hint for fetching the source video or author attribution.
+  final String? sourceRelayHint;
 
   double get durationInSeconds => duration.inMilliseconds / 1000.0;
 
@@ -302,6 +319,14 @@ class DivineVideoClip {
     DateTime? deletedAt,
     ClipTransition? transition,
     bool clearTransition = false,
+    String? sourceAuthorPubkey,
+    bool clearSourceAuthorPubkey = false,
+    String? sourceEventId,
+    bool clearSourceEventId = false,
+    String? sourceAddressableId,
+    bool clearSourceAddressableId = false,
+    String? sourceRelayHint,
+    bool clearSourceRelayHint = false,
   }) {
     final isNewLogicalClip = id != null && id != this.id;
 
@@ -347,6 +372,18 @@ class DivineVideoClip {
           : (proofManifestJson ?? this.proofManifestJson),
       deletedAt: deletedAt ?? this.deletedAt,
       transition: clearTransition ? null : (transition ?? this.transition),
+      sourceAuthorPubkey: clearSourceAuthorPubkey
+          ? null
+          : (sourceAuthorPubkey ?? this.sourceAuthorPubkey),
+      sourceEventId: clearSourceEventId
+          ? null
+          : (sourceEventId ?? this.sourceEventId),
+      sourceAddressableId: clearSourceAddressableId
+          ? null
+          : (sourceAddressableId ?? this.sourceAddressableId),
+      sourceRelayHint: clearSourceRelayHint
+          ? null
+          : (sourceRelayHint ?? this.sourceRelayHint),
     );
   }
 
@@ -389,6 +426,11 @@ class DivineVideoClip {
         'reversedVideoPath': p.basename(reversedVideoPath!),
       if (proofManifestJson != null) 'proofManifestJson': proofManifestJson,
       if (transition != null) 'transition': transition!.toMap(),
+      if (sourceAuthorPubkey != null) 'sourceAuthorPubkey': sourceAuthorPubkey,
+      if (sourceEventId != null) 'sourceEventId': sourceEventId,
+      if (sourceAddressableId != null)
+        'sourceAddressableId': sourceAddressableId,
+      if (sourceRelayHint != null) 'sourceRelayHint': sourceRelayHint,
     };
   }
 
@@ -503,6 +545,10 @@ class DivineVideoClip {
       ),
       proofManifestJson: json['proofManifestJson'] as String?,
       transition: _transitionFromJson(json['transition']),
+      sourceAuthorPubkey: json['sourceAuthorPubkey'] as String?,
+      sourceEventId: json['sourceEventId'] as String?,
+      sourceAddressableId: json['sourceAddressableId'] as String?,
+      sourceRelayHint: json['sourceRelayHint'] as String?,
     );
   }
 

--- a/mobile/lib/services/video_clip_import_service.dart
+++ b/mobile/lib/services/video_clip_import_service.dart
@@ -162,6 +162,10 @@ class VideoClipImportService {
         originalAspectRatio: actualRatio ?? 1,
         targetAspectRatio: _targetAspectRatioFor(video, actualRatio),
         ghostFramePath: ghostFramePath,
+        sourceAuthorPubkey: video.pubkey,
+        sourceEventId: video.id,
+        sourceAddressableId: video.addressableId,
+        sourceRelayHint: video.sourceRelay,
       );
 
       await _clipLibraryService.saveClip(clip);

--- a/mobile/lib/services/video_editor/video_editor_clip_library_save_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_clip_library_save_service.dart
@@ -91,6 +91,12 @@ class VideoEditorClipLibrarySaveService {
       thumbnailPath: thumbnail?.path ?? clip.thumbnailPath,
       thumbnailTimestamp: thumbnail?.timestamp,
       lensMetadata: clip.lensMetadata,
+      // A flatten re-renders the same logical clip, so its imported-source
+      // attribution carries over unchanged.
+      sourceAuthorPubkey: clip.sourceAuthorPubkey,
+      sourceEventId: clip.sourceEventId,
+      sourceAddressableId: clip.sourceAddressableId,
+      sourceRelayHint: clip.sourceRelayHint,
     );
   }
 

--- a/mobile/lib/services/video_editor/video_editor_merge_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_merge_service.dart
@@ -46,6 +46,10 @@ class VideoEditorMergeService {
     );
 
     final first = clips.first;
+    // Imported-source attribution only survives a merge when every input
+    // shares the same source; a mix of sources has no single author to
+    // credit, so the merged clip keeps none.
+    final keepSource = clips.every((clip) => _sameSource(clip, first));
     return DivineVideoClip(
       id: 'merged_${DateTime.now().microsecondsSinceEpoch}',
       video: EditorVideo.file(outputPath),
@@ -55,6 +59,16 @@ class VideoEditorMergeService {
       originalAspectRatio: first.originalAspectRatio,
       thumbnailPath: first.thumbnailPath,
       lensMetadata: first.lensMetadata,
+      sourceAuthorPubkey: keepSource ? first.sourceAuthorPubkey : null,
+      sourceEventId: keepSource ? first.sourceEventId : null,
+      sourceAddressableId: keepSource ? first.sourceAddressableId : null,
+      sourceRelayHint: keepSource ? first.sourceRelayHint : null,
     );
   }
+
+  static bool _sameSource(DivineVideoClip a, DivineVideoClip b) =>
+      a.sourceAuthorPubkey == b.sourceAuthorPubkey &&
+      a.sourceEventId == b.sourceEventId &&
+      a.sourceAddressableId == b.sourceAddressableId &&
+      a.sourceRelayHint == b.sourceRelayHint;
 }

--- a/mobile/test/models/divine_video_clip_test.dart
+++ b/mobile/test/models/divine_video_clip_test.dart
@@ -123,9 +123,9 @@ void main() {
     });
 
     test('keeps the stills when the flag is not set', () {
-      final copy = stopMotionClip(['/a.jpg']).copyWith(
-        video: editor.EditorVideo.file(File('/rendered.mp4')),
-      );
+      final copy = stopMotionClip([
+        '/a.jpg',
+      ]).copyWith(video: editor.EditorVideo.file(File('/rendered.mp4')));
 
       expect(copy.stopMotionFrames, hasLength(1));
     });
@@ -149,9 +149,9 @@ void main() {
     });
 
     test('round-trips through JSON and defaults to zero when absent', () {
-      final shifted = clip('/videos/clip.mp4').copyWith(
-        sourceStartOffset: const Duration(milliseconds: 3210),
-      );
+      final shifted = clip(
+        '/videos/clip.mp4',
+      ).copyWith(sourceStartOffset: const Duration(milliseconds: 3210));
 
       final restored = DivineVideoClip.fromJson(shifted.toJson(), '/videos');
       expect(
@@ -184,15 +184,12 @@ void main() {
     });
 
     test('round-trips through JSON and defaults to zero when absent', () {
-      final floored = clip('/videos/clip.mp4').copyWith(
-        minTrimStart: const Duration(milliseconds: 2500),
-      );
+      final floored = clip(
+        '/videos/clip.mp4',
+      ).copyWith(minTrimStart: const Duration(milliseconds: 2500));
 
       final restored = DivineVideoClip.fromJson(floored.toJson(), '/videos');
-      expect(
-        restored.minTrimStart,
-        equals(const Duration(milliseconds: 2500)),
-      );
+      expect(restored.minTrimStart, equals(const Duration(milliseconds: 2500)));
 
       // Old drafts/history entries have no key — must default to zero.
       final legacy = DivineVideoClip.fromJson(
@@ -200,6 +197,72 @@ void main() {
         '/videos',
       );
       expect(legacy.minTrimStart, equals(Duration.zero));
+    });
+  });
+
+  group('DivineVideoClip source provenance', () {
+    test('round-trips through JSON when populated', () {
+      final source = clip('/videos/clip.mp4').copyWith(
+        sourceAuthorPubkey: 'source-author-pubkey',
+        sourceEventId: 'source-event-id',
+        sourceAddressableId: '34236:source-author-pubkey:source-d-tag',
+        sourceRelayHint: 'wss://relay.divine.video',
+      );
+
+      final json = source.toJson();
+      expect(json['sourceAuthorPubkey'], 'source-author-pubkey');
+      expect(json['sourceEventId'], 'source-event-id');
+      expect(
+        json['sourceAddressableId'],
+        '34236:source-author-pubkey:source-d-tag',
+      );
+      expect(json['sourceRelayHint'], 'wss://relay.divine.video');
+
+      final restored = DivineVideoClip.fromJson(json, '/videos');
+      expect(restored.sourceAuthorPubkey, source.sourceAuthorPubkey);
+      expect(restored.sourceEventId, source.sourceEventId);
+      expect(restored.sourceAddressableId, source.sourceAddressableId);
+      expect(restored.sourceRelayHint, source.sourceRelayHint);
+    });
+
+    test('defaults to null for legacy JSON and omits empty keys', () {
+      final json = clip('/videos/clip.mp4').toJson();
+      expect(json.containsKey('sourceAuthorPubkey'), isFalse);
+      expect(json.containsKey('sourceEventId'), isFalse);
+      expect(json.containsKey('sourceAddressableId'), isFalse);
+      expect(json.containsKey('sourceRelayHint'), isFalse);
+
+      final restored = DivineVideoClip.fromJson(json, '/videos');
+      expect(restored.sourceAuthorPubkey, isNull);
+      expect(restored.sourceEventId, isNull);
+      expect(restored.sourceAddressableId, isNull);
+      expect(restored.sourceRelayHint, isNull);
+    });
+
+    test('survives copyWith and can be cleared explicitly', () {
+      final source = clip('/videos/clip.mp4').copyWith(
+        sourceAuthorPubkey: 'source-author-pubkey',
+        sourceEventId: 'source-event-id',
+        sourceAddressableId: '34236:source-author-pubkey:source-d-tag',
+        sourceRelayHint: 'wss://relay.divine.video',
+      );
+
+      final copied = source.copyWith(duration: const Duration(seconds: 6));
+      expect(copied.sourceAuthorPubkey, source.sourceAuthorPubkey);
+      expect(copied.sourceEventId, source.sourceEventId);
+      expect(copied.sourceAddressableId, source.sourceAddressableId);
+      expect(copied.sourceRelayHint, source.sourceRelayHint);
+
+      final cleared = copied.copyWith(
+        clearSourceAuthorPubkey: true,
+        clearSourceEventId: true,
+        clearSourceAddressableId: true,
+        clearSourceRelayHint: true,
+      );
+      expect(cleared.sourceAuthorPubkey, isNull);
+      expect(cleared.sourceEventId, isNull);
+      expect(cleared.sourceAddressableId, isNull);
+      expect(cleared.sourceRelayHint, isNull);
     });
   });
 
@@ -215,9 +278,9 @@ void main() {
       // A 5s clip split at 2s: start half [0,2s], end half [2s,5s] on the same
       // file with minTrimStart 2s. Summing budgetDuration must recover the
       // original 5s, not 2s + 5s = 7s.
-      final startHalf = clip('/videos/clip.mp4').copyWith(
-        duration: const Duration(seconds: 2),
-      );
+      final startHalf = clip(
+        '/videos/clip.mp4',
+      ).copyWith(duration: const Duration(seconds: 2));
       final endHalf = clip('/videos/clip.mp4').copyWith(
         trimStart: const Duration(seconds: 2),
         minTrimStart: const Duration(seconds: 2),

--- a/mobile/test/services/video_clip_import_service_test.dart
+++ b/mobile/test/services/video_clip_import_service_test.dart
@@ -20,6 +20,7 @@ const _defaultVineId = 'vine-123';
 
 models.VideoEvent _video({
   String id = 'classic-vine-event-id',
+  String pubkey = 'classic-vine-author-pubkey',
   String? videoUrl = 'https://cdn.example.com/classic.mp4',
   int? duration = 6,
   String? dimensions = '480x480',
@@ -28,10 +29,11 @@ models.VideoEvent _video({
   String? title,
   String content = 'classic vine',
   String? textTrackContent,
+  String? sourceRelay = 'wss://relay.divine.video',
 }) {
   return models.VideoEvent(
     id: id,
-    pubkey: 'classic-vine-author-pubkey',
+    pubkey: pubkey,
     createdAt: 1451606400,
     content: content,
     timestamp: DateTime.fromMillisecondsSinceEpoch(
@@ -45,6 +47,7 @@ models.VideoEvent _video({
     rawTags: rawTags,
     vineId: vineId,
     textTrackContent: textTrackContent,
+    sourceRelay: sourceRelay,
   );
 }
 
@@ -76,10 +79,7 @@ void main() {
   });
 
   VideoClipImportService buildService({
-    Future<File?> Function({
-      required String url,
-      required String cacheKey,
-    })?
+    Future<File?> Function({required String url, required String cacheKey})?
     downloadVideo,
     Future<VideoClipThumbnail?> Function({
       required String videoPath,
@@ -151,17 +151,26 @@ void main() {
     expect(success.clip.ghostFramePath, endsWith('ghost.jpg'));
     expect(success.clip.requireVideo.file!.path, startsWith(docsDir.path));
     expect(success.clip.libraryTitle, 'classic vine');
+    expect(success.clip.sourceAuthorPubkey, 'classic-vine-author-pubkey');
+    expect(success.clip.sourceEventId, 'classic-vine-event-id');
+    expect(
+      success.clip.sourceAddressableId,
+      '34236:classic-vine-author-pubkey:vine-123',
+    );
+    expect(success.clip.sourceRelayHint, 'wss://relay.divine.video');
     expect(
       File(success.clip.requireVideo.file!.path).readAsBytesSync(),
       sourceVideo.readAsBytesSync(),
     );
 
     final captured =
-        verify(
-              () => clipLibraryService.saveClip(captureAny()),
-            ).captured.single
+        verify(() => clipLibraryService.saveClip(captureAny())).captured.single
             as DivineVideoClip;
     expect(captured.id, success.clip.id);
+    expect(captured.sourceAuthorPubkey, success.clip.sourceAuthorPubkey);
+    expect(captured.sourceEventId, success.clip.sourceEventId);
+    expect(captured.sourceAddressableId, success.clip.sourceAddressableId);
+    expect(captured.sourceRelayHint, success.clip.sourceRelayHint);
   });
 
   test('uses an explicit user title when importing to the library', () async {
@@ -252,6 +261,7 @@ First useful caption
     final result = await service.importToLibrary(
       _video(
         id: 'own-video-event-id',
+        pubkey: 'own-video-author-pubkey',
         rawTags: const {'platform': 'divine'},
         vineId: null,
       ),
@@ -260,6 +270,10 @@ First useful caption
     expect(result, isA<VideoClipImportSuccess>());
     final success = result as VideoClipImportSuccess;
     expect(success.clip.id, startsWith('own_video_own-video-event-id_'));
+    expect(success.clip.sourceAuthorPubkey, 'own-video-author-pubkey');
+    expect(success.clip.sourceEventId, 'own-video-event-id');
+    expect(success.clip.sourceAddressableId, isNull);
+    expect(success.clip.sourceRelayHint, 'wss://relay.divine.video');
     verify(() => clipLibraryService.saveClip(any())).called(1);
   });
 
@@ -293,69 +307,60 @@ First useful caption
     },
   );
 
-  test(
-    'falls back to ProVideoEditor metadata for square own videos without '
-    'dimensions',
-    () async {
-      final service = buildService(
-        readVideoMetadata: (video) async => VideoMetadata(
-          duration: const Duration(seconds: 6),
-          extension: 'mp4',
-          fileSize: 1024,
-          resolution: const Size(720, 720),
-          rotation: 0,
-          bitrate: 1000,
-        ),
-      );
+  test('falls back to ProVideoEditor metadata for square own videos without '
+      'dimensions', () async {
+    final service = buildService(
+      readVideoMetadata: (video) async => VideoMetadata(
+        duration: const Duration(seconds: 6),
+        extension: 'mp4',
+        fileSize: 1024,
+        resolution: const Size(720, 720),
+        rotation: 0,
+        bitrate: 1000,
+      ),
+    );
 
-      final result = await service.importToLibrary(
-        _video(
-          id: 'own-square',
-          rawTags: const {'platform': 'divine'},
-          vineId: null,
-          dimensions: null,
-        ),
-      );
+    final result = await service.importToLibrary(
+      _video(
+        id: 'own-square',
+        rawTags: const {'platform': 'divine'},
+        vineId: null,
+        dimensions: null,
+      ),
+    );
 
-      final success = result as VideoClipImportSuccess;
-      expect(success.clip.targetAspectRatio, models.AspectRatio.square);
-      expect(success.clip.originalAspectRatio, 1);
-    },
-  );
+    final success = result as VideoClipImportSuccess;
+    expect(success.clip.targetAspectRatio, models.AspectRatio.square);
+    expect(success.clip.originalAspectRatio, 1);
+  });
 
-  test(
-    'maps landscape own video to square target ratio',
-    () async {
-      final service = buildService(
-        readVideoMetadata: (video) async => VideoMetadata(
-          duration: const Duration(seconds: 6),
-          extension: 'mp4',
-          fileSize: 1024,
-          resolution: const Size(1920, 1080),
-          rotation: 0,
-          bitrate: 1000,
-        ),
-      );
+  test('maps landscape own video to square target ratio', () async {
+    final service = buildService(
+      readVideoMetadata: (video) async => VideoMetadata(
+        duration: const Duration(seconds: 6),
+        extension: 'mp4',
+        fileSize: 1024,
+        resolution: const Size(1920, 1080),
+        rotation: 0,
+        bitrate: 1000,
+      ),
+    );
 
-      final result = await service.importToLibrary(
-        _video(
-          id: 'own-landscape',
-          rawTags: const {'platform': 'divine'},
-          vineId: null,
-          dimensions: null,
-        ),
-      );
+    final result = await service.importToLibrary(
+      _video(
+        id: 'own-landscape',
+        rawTags: const {'platform': 'divine'},
+        vineId: null,
+        dimensions: null,
+      ),
+    );
 
-      final success = result as VideoClipImportSuccess;
-      // Landscape videos (ratio > 1.0) satisfy _squareishMinAspectRatio and
-      // intentionally map to square to match the clip library's crop policy.
-      expect(success.clip.targetAspectRatio, models.AspectRatio.square);
-      expect(
-        success.clip.originalAspectRatio,
-        closeTo(1920 / 1080, 0.001),
-      );
-    },
-  );
+    final success = result as VideoClipImportSuccess;
+    // Landscape videos (ratio > 1.0) satisfy _squareishMinAspectRatio and
+    // intentionally map to square to match the clip library's crop policy.
+    expect(success.clip.targetAspectRatio, models.AspectRatio.square);
+    expect(success.clip.originalAspectRatio, closeTo(1920 / 1080, 0.001));
+  });
 
   test(
     'swaps width and height when metadata reports a 90 degree rotation',

--- a/mobile/test/services/video_editor/video_editor_clip_library_save_service_test.dart
+++ b/mobile/test/services/video_editor/video_editor_clip_library_save_service_test.dart
@@ -359,6 +359,40 @@ void main() {
       expect(result, isNull);
     });
 
+    test(
+      'carries the imported-source attribution onto the saved clip',
+      () async {
+        VideoEditorRenderService.renderVideoOverride =
+            ({
+              required clips,
+              required usePersistentStorage,
+              aspectRatio,
+              parameters,
+              taskId,
+              maxOutputDuration,
+            }) async => '/documents/divine_1.mp4';
+
+        final result =
+            await VideoEditorClipLibrarySaveService.flattenClipForLibrary(
+              clip: _createClip().copyWith(
+                sourceAuthorPubkey: 'source-author-pubkey',
+                sourceEventId: 'source-event-id',
+                sourceAddressableId: '34236:source-author-pubkey:source-d-tag',
+                sourceRelayHint: 'wss://relay.divine.video',
+              ),
+              renderId: 'save-1',
+            );
+
+        expect(result!.sourceAuthorPubkey, equals('source-author-pubkey'));
+        expect(result.sourceEventId, equals('source-event-id'));
+        expect(
+          result.sourceAddressableId,
+          equals('34236:source-author-pubkey:source-d-tag'),
+        );
+        expect(result.sourceRelayHint, equals('wss://relay.divine.video'));
+      },
+    );
+
     group('cleanupFlattenedClip', () {
       late Directory tempDir;
 

--- a/mobile/test/services/video_editor/video_editor_merge_service_test.dart
+++ b/mobile/test/services/video_editor/video_editor_merge_service_test.dart
@@ -183,5 +183,72 @@ void main() {
 
       expect(result, isNull);
     });
+
+    test(
+      'preserves provenance when every clip shares the same source',
+      () async {
+        VideoEditorRenderService.renderVideoOverride =
+            ({
+              required clips,
+              required usePersistentStorage,
+              aspectRatio,
+              parameters,
+              taskId,
+              maxOutputDuration,
+            }) async => '/documents/merged.mp4';
+
+        DivineVideoClip sameSourceClip(String id) =>
+            _createClip(id: id).copyWith(
+              sourceAuthorPubkey: 'source-author-pubkey',
+              sourceEventId: 'source-event-id',
+              sourceAddressableId: '34236:source-author-pubkey:source-d-tag',
+              sourceRelayHint: 'wss://relay.divine.video',
+            );
+
+        final result = await VideoEditorMergeService.mergeClips(
+          clips: [sameSourceClip('a'), sameSourceClip('b')],
+          renderId: 'merge-1',
+        );
+
+        expect(result!.sourceAuthorPubkey, equals('source-author-pubkey'));
+        expect(result.sourceEventId, equals('source-event-id'));
+        expect(
+          result.sourceAddressableId,
+          equals('34236:source-author-pubkey:source-d-tag'),
+        );
+        expect(result.sourceRelayHint, equals('wss://relay.divine.video'));
+      },
+    );
+
+    test('drops provenance when clips come from different sources', () async {
+      VideoEditorRenderService.renderVideoOverride =
+          ({
+            required clips,
+            required usePersistentStorage,
+            aspectRatio,
+            parameters,
+            taskId,
+            maxOutputDuration,
+          }) async => '/documents/merged.mp4';
+
+      final result = await VideoEditorMergeService.mergeClips(
+        clips: [
+          _createClip(id: 'a').copyWith(
+            sourceAuthorPubkey: 'author-a',
+            sourceEventId: 'event-a',
+          ),
+          _createClip(id: 'b').copyWith(
+            sourceAuthorPubkey: 'author-b',
+            sourceEventId: 'event-b',
+          ),
+        ],
+        renderId: 'merge-1',
+      );
+
+      expect(result!.sourceAuthorPubkey, isNull);
+      expect(result.sourceEventId, isNull);
+      expect(result.sourceAddressableId, isNull);
+      expect(result.sourceRelayHint, isNull);
+    });
   });
 }


### PR DESCRIPTION
## Summary

- add nullable source provenance fields to DivineVideoClip and persist them in the existing clip JSON payload
- populate imported clips with source author, event id, addressable id, and relay hint from VideoEvent
- cover populated and legacy JSON round trips plus classic Vine and own-video import provenance

## Verification

- flutter test test/models/divine_video_clip_test.dart test/services/video_clip_import_service_test.dart
- flutter analyze
- pre-push hook: analyzer and changed-file tests passed

Closes #6320
Refs #6315