### PR TITLE
fix(support): clarify restricted video errors

### DIFF
--- a/mobile/lib/blocs/video_playback_status/video_playback_status_state.dart
+++ b/mobile/lib/blocs/video_playback_status/video_playback_status_state.dart
@@ -158,10 +158,15 @@ class VideoPlaybackStatusState extends Equatable {
 /// Null defaults to [PlaybackStatus.generic] because a missing error type
 /// still represents a non-ready state that should replace the normal
 /// overlay.
-PlaybackStatus playbackStatusFromError(VideoErrorType? errorType) {
+PlaybackStatus playbackStatusFromError(
+  VideoErrorType? errorType, {
+  bool isModerationSource = true,
+}) {
   return switch (errorType) {
     VideoErrorType.ageRestricted => PlaybackStatus.ageRestricted,
-    VideoErrorType.forbidden => PlaybackStatus.forbidden,
+    VideoErrorType.forbidden when isModerationSource =>
+      PlaybackStatus.forbidden,
+    VideoErrorType.forbidden => PlaybackStatus.generic,
     VideoErrorType.notFound => PlaybackStatus.notFound,
     VideoErrorType.generic => PlaybackStatus.generic,
     null => PlaybackStatus.generic,

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -631,7 +631,7 @@
     "videoErrorVerifyAge": "ዕድሜን ያረጋግጡ",
     "videoErrorRetry": "እንደገና ይሞክሩ",
     "videoErrorContentRestricted": "ይዘት ተገድቧል",
-    "videoErrorContentRestrictedBody": "ይህ ቪዲዮ በቅብብሎሽ ተገድቧል።",
+    "videoErrorContentRestrictedBody": "This video was removed for breaking our content rules.",
     "videoErrorVerifyAgeBody": "ይህን ቪዲዮ ለማየት እድሜዎን ያረጋግጡ።",
     "videoErrorSkip": "ዝለል",
     "videoErrorVerifyAgeButton": "ዕድሜን ያረጋግጡ",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -549,7 +549,7 @@
     "videoErrorVerifyAge": "تحقق من العمر",
     "videoErrorRetry": "إعادة المحاولة",
     "videoErrorContentRestricted": "المحتوى مقيّد",
-    "videoErrorContentRestrictedBody": "تم تقييد هذا الفيديو من طرف المحول.",
+    "videoErrorContentRestrictedBody": "This video was removed for breaking our content rules.",
     "videoErrorVerifyAgeBody": "تحقّق من عمرك لعرض هذا الفيديو.",
     "videoErrorSkip": "تخطّي",
     "videoErrorVerifyAgeButton": "تحقّق من العمر",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -578,7 +578,7 @@
     "videoErrorVerifyAge": "Потвърди възрастта",
     "videoErrorRetry": "Опитай пак",
     "videoErrorContentRestricted": "Ограничено съдържание",
-    "videoErrorContentRestrictedBody": "Това видео беше ограничено от релето.",
+    "videoErrorContentRestrictedBody": "This video was removed for breaking our content rules.",
     "videoErrorVerifyAgeBody": "Потвърди възрастта си, за да гледаш това видео.",
     "videoErrorSkip": "Пропусни",
     "videoErrorVerifyAgeButton": "Потвърди възрастта",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -549,7 +549,7 @@
     "videoErrorVerifyAge": "Alter verifizieren",
     "videoErrorRetry": "Erneut versuchen",
     "videoErrorContentRestricted": "Inhalt eingeschränkt",
-    "videoErrorContentRestrictedBody": "Dieses Video wurde vom Relay eingeschränkt.",
+    "videoErrorContentRestrictedBody": "This video was removed for breaking our content rules.",
     "videoErrorVerifyAgeBody": "Verifiziere dein Alter, um dieses Video zu sehen.",
     "videoErrorSkip": "Überspringen",
     "videoErrorVerifyAgeButton": "Alter verifizieren",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -698,7 +698,10 @@
   "videoErrorVerifyAge": "Verify Age",
   "videoErrorRetry": "Retry",
   "videoErrorContentRestricted": "Content restricted",
-  "videoErrorContentRestrictedBody": "This video was restricted by the relay.",
+  "videoErrorContentRestrictedBody": "This video was removed for breaking our content rules.",
+  "@videoErrorContentRestrictedBody": {
+    "description": "Body copy for videos blocked by platform moderation, quarantine, or a media-server 403. Do not mention Nostr relays or user relay settings."
+  },
   "videoErrorVerifyAgeBody": "Verify your age to view this video.",
   "videoErrorSkip": "Skip",
   "videoErrorVerifyAgeButton": "Verify age",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -549,7 +549,7 @@
     "videoErrorVerifyAge": "Verificar edad",
     "videoErrorRetry": "Reintentar",
     "videoErrorContentRestricted": "Contenido restringido",
-    "videoErrorContentRestrictedBody": "Este video fue restringido por el relay.",
+    "videoErrorContentRestrictedBody": "This video was removed for breaking our content rules.",
     "videoErrorVerifyAgeBody": "Verificá tu edad para ver este video.",
     "videoErrorSkip": "Saltar",
     "videoErrorVerifyAgeButton": "Verificar edad",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -384,7 +384,7 @@
     "videoErrorVerifyAge": "I-verify ang Edad",
     "videoErrorRetry": "Subukan ulit",
     "videoErrorContentRestricted": "Restricted ang content",
-    "videoErrorContentRestrictedBody": "Pinigilan ng relay ang video na ito.",
+    "videoErrorContentRestrictedBody": "This video was removed for breaking our content rules.",
     "videoErrorVerifyAgeBody": "I-verify ang edad mo para mapanood ang video na ito.",
     "videoErrorSkip": "Laktawan",
     "videoErrorVerifyAgeButton": "I-verify ang edad",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -549,7 +549,7 @@
     "videoErrorVerifyAge": "Vérifier l'âge",
     "videoErrorRetry": "Réessayer",
     "videoErrorContentRestricted": "Contenu restreint",
-    "videoErrorContentRestrictedBody": "Cette vidéo a été restreinte par le relay.",
+    "videoErrorContentRestrictedBody": "This video was removed for breaking our content rules.",
     "videoErrorVerifyAgeBody": "Vérifie ton âge pour voir cette vidéo.",
     "videoErrorSkip": "Passer",
     "videoErrorVerifyAgeButton": "Vérifier l'âge",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -549,7 +549,7 @@
     "videoErrorVerifyAge": "Verifikasi Usia",
     "videoErrorRetry": "Coba Lagi",
     "videoErrorContentRestricted": "Konten dibatasi",
-    "videoErrorContentRestrictedBody": "Video ini dibatasi oleh relay.",
+    "videoErrorContentRestrictedBody": "This video was removed for breaking our content rules.",
     "videoErrorVerifyAgeBody": "Verifikasi usiamu untuk melihat video ini.",
     "videoErrorSkip": "Lewati",
     "videoErrorVerifyAgeButton": "Verifikasi usia",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -549,7 +549,7 @@
     "videoErrorVerifyAge": "Verifica età",
     "videoErrorRetry": "Riprova",
     "videoErrorContentRestricted": "Contenuto con restrizioni",
-    "videoErrorContentRestrictedBody": "Questo video è stato limitato dal relay.",
+    "videoErrorContentRestrictedBody": "This video was removed for breaking our content rules.",
     "videoErrorVerifyAgeBody": "Verifica la tua età per vedere questo video.",
     "videoErrorSkip": "Salta",
     "videoErrorVerifyAgeButton": "Verifica età",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -549,7 +549,7 @@
     "videoErrorVerifyAge": "年齢を確認",
     "videoErrorRetry": "もう一回",
     "videoErrorContentRestricted": "コンテンツが制限されてる",
-    "videoErrorContentRestrictedBody": "この動画はリレーによって制限されたよ。",
+    "videoErrorContentRestrictedBody": "This video was removed for breaking our content rules.",
     "videoErrorVerifyAgeBody": "この動画を見るには年齢確認が必要だよ。",
     "videoErrorSkip": "スキップ",
     "videoErrorVerifyAgeButton": "年齢を確認",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -354,7 +354,7 @@
     "videoErrorVerifyAge": "나이 인증",
     "videoErrorRetry": "다시 시도",
     "videoErrorContentRestricted": "콘텐츠 제한됨",
-    "videoErrorContentRestrictedBody": "이 영상은 릴레이에 의해 제한됐어요.",
+    "videoErrorContentRestrictedBody": "This video was removed for breaking our content rules.",
     "videoErrorVerifyAgeBody": "이 영상을 보려면 나이를 인증해주세요.",
     "videoErrorSkip": "건너뛰기",
     "videoErrorVerifyAgeButton": "나이 인증",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -549,7 +549,7 @@
     "videoErrorVerifyAge": "Leeftijd verifiëren",
     "videoErrorRetry": "Opnieuw",
     "videoErrorContentRestricted": "Inhoud beperkt",
-    "videoErrorContentRestrictedBody": "Deze video is beperkt door de relay.",
+    "videoErrorContentRestrictedBody": "This video was removed for breaking our content rules.",
     "videoErrorVerifyAgeBody": "Verifieer je leeftijd om deze video te bekijken.",
     "videoErrorSkip": "Overslaan",
     "videoErrorVerifyAgeButton": "Leeftijd verifiëren",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -549,7 +549,7 @@
     "videoErrorVerifyAge": "Zweryfikuj wiek",
     "videoErrorRetry": "Spróbuj ponownie",
     "videoErrorContentRestricted": "Treść ograniczona",
-    "videoErrorContentRestrictedBody": "Ten film został ograniczony przez przekaźnik.",
+    "videoErrorContentRestrictedBody": "This video was removed for breaking our content rules.",
     "videoErrorVerifyAgeBody": "Zweryfikuj swój wiek, żeby zobaczyć ten film.",
     "videoErrorSkip": "Pomiń",
     "videoErrorVerifyAgeButton": "Zweryfikuj wiek",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -549,7 +549,7 @@
     "videoErrorVerifyAge": "Verificar idade",
     "videoErrorRetry": "Tentar novamente",
     "videoErrorContentRestricted": "Conteúdo restrito",
-    "videoErrorContentRestrictedBody": "Este vídeo foi restringido pelo relay.",
+    "videoErrorContentRestrictedBody": "This video was removed for breaking our content rules.",
     "videoErrorVerifyAgeBody": "Verifique sua idade para ver este vídeo.",
     "videoErrorSkip": "Pular",
     "videoErrorVerifyAgeButton": "Verificar idade",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -549,7 +549,7 @@
     "videoErrorVerifyAge": "Verifică vârsta",
     "videoErrorRetry": "Reîncearcă",
     "videoErrorContentRestricted": "Conținut restricționat",
-    "videoErrorContentRestrictedBody": "Acest videoclip a fost restricționat de relay.",
+    "videoErrorContentRestrictedBody": "This video was removed for breaking our content rules.",
     "videoErrorVerifyAgeBody": "Verifică-ți vârsta ca să vezi acest videoclip.",
     "videoErrorSkip": "Sari peste",
     "videoErrorVerifyAgeButton": "Verifică vârsta",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -549,7 +549,7 @@
     "videoErrorVerifyAge": "Verifiera ålder",
     "videoErrorRetry": "Försök igen",
     "videoErrorContentRestricted": "Innehåll begränsat",
-    "videoErrorContentRestrictedBody": "Den här videon har begränsats av relen.",
+    "videoErrorContentRestrictedBody": "This video was removed for breaking our content rules.",
     "videoErrorVerifyAgeBody": "Verifiera din ålder för att se den här videon.",
     "videoErrorSkip": "Hoppa över",
     "videoErrorVerifyAgeButton": "Verifiera ålder",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -549,7 +549,7 @@
     "videoErrorVerifyAge": "Yaşı Doğrula",
     "videoErrorRetry": "Tekrar Dene",
     "videoErrorContentRestricted": "İçerik kısıtlandı",
-    "videoErrorContentRestrictedBody": "Bu video röle tarafından kısıtlanmış.",
+    "videoErrorContentRestrictedBody": "This video was removed for breaking our content rules.",
     "videoErrorVerifyAgeBody": "Bu videoyu görüntülemek için yaşını doğrula.",
     "videoErrorSkip": "Atla",
     "videoErrorVerifyAgeButton": "Yaşı doğrula",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -2566,10 +2566,10 @@ abstract class AppLocalizations {
   /// **'Content restricted'**
   String get videoErrorContentRestricted;
 
-  /// No description provided for @videoErrorContentRestrictedBody.
+  /// Body copy for videos blocked by platform moderation, quarantine, or a media-server 403. Do not mention Nostr relays or user relay settings.
   ///
   /// In en, this message translates to:
-  /// **'This video was restricted by the relay.'**
+  /// **'This video was removed for breaking our content rules.'**
   String get videoErrorContentRestrictedBody;
 
   /// No description provided for @videoErrorVerifyAgeBody.

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -1400,7 +1400,8 @@ class AppLocalizationsAm extends AppLocalizations {
   String get videoErrorContentRestricted => 'ይዘት ተገድቧል';
 
   @override
-  String get videoErrorContentRestrictedBody => 'ይህ ቪዲዮ በቅብብሎሽ ተገድቧል።';
+  String get videoErrorContentRestrictedBody =>
+      'This video was removed for breaking our content rules.';
 
   @override
   String get videoErrorVerifyAgeBody => 'ይህን ቪዲዮ ለማየት እድሜዎን ያረጋግጡ።';

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -1426,7 +1426,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get videoErrorContentRestrictedBody =>
-      'تم تقييد هذا الفيديو من طرف المحول.';
+      'This video was removed for breaking our content rules.';
 
   @override
   String get videoErrorVerifyAgeBody => 'تحقّق من عمرك لعرض هذا الفيديو.';

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -1458,7 +1458,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get videoErrorContentRestrictedBody =>
-      'Това видео беше ограничено от релето.';
+      'This video was removed for breaking our content rules.';
 
   @override
   String get videoErrorVerifyAgeBody =>

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -1454,7 +1454,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get videoErrorContentRestrictedBody =>
-      'Dieses Video wurde vom Relay eingeschränkt.';
+      'This video was removed for breaking our content rules.';
 
   @override
   String get videoErrorVerifyAgeBody =>

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -1437,7 +1437,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get videoErrorContentRestrictedBody =>
-      'This video was restricted by the relay.';
+      'This video was removed for breaking our content rules.';
 
   @override
   String get videoErrorVerifyAgeBody => 'Verify your age to view this video.';

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -1457,7 +1457,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get videoErrorContentRestrictedBody =>
-      'Este video fue restringido por el relay.';
+      'This video was removed for breaking our content rules.';
 
   @override
   String get videoErrorVerifyAgeBody => 'Verificá tu edad para ver este video.';

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -1463,7 +1463,7 @@ class AppLocalizationsFil extends AppLocalizations {
 
   @override
   String get videoErrorContentRestrictedBody =>
-      'Pinigilan ng relay ang video na ito.';
+      'This video was removed for breaking our content rules.';
 
   @override
   String get videoErrorVerifyAgeBody =>

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -1463,7 +1463,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get videoErrorContentRestrictedBody =>
-      'Cette vidéo a été restreinte par le relay.';
+      'This video was removed for breaking our content rules.';
 
   @override
   String get videoErrorVerifyAgeBody =>

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -1413,7 +1413,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get videoErrorContentRestrictedBody =>
-      'Video ini dibatasi oleh relay.';
+      'This video was removed for breaking our content rules.';
 
   @override
   String get videoErrorVerifyAgeBody =>

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -1458,7 +1458,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get videoErrorContentRestrictedBody =>
-      'Questo video è stato limitato dal relay.';
+      'This video was removed for breaking our content rules.';
 
   @override
   String get videoErrorVerifyAgeBody =>

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -1347,7 +1347,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get videoErrorContentRestricted => 'コンテンツが制限されてる';
 
   @override
-  String get videoErrorContentRestrictedBody => 'この動画はリレーによって制限されたよ。';
+  String get videoErrorContentRestrictedBody =>
+      'This video was removed for breaking our content rules.';
 
   @override
   String get videoErrorVerifyAgeBody => 'この動画を見るには年齢確認が必要だよ。';

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -1356,7 +1356,8 @@ class AppLocalizationsKo extends AppLocalizations {
   String get videoErrorContentRestricted => '콘텐츠 제한됨';
 
   @override
-  String get videoErrorContentRestrictedBody => '이 영상은 릴레이에 의해 제한됐어요.';
+  String get videoErrorContentRestrictedBody =>
+      'This video was removed for breaking our content rules.';
 
   @override
   String get videoErrorVerifyAgeBody => '이 영상을 보려면 나이를 인증해주세요.';

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -1446,7 +1446,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get videoErrorContentRestrictedBody =>
-      'Deze video is beperkt door de relay.';
+      'This video was removed for breaking our content rules.';
 
   @override
   String get videoErrorVerifyAgeBody =>

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -1461,7 +1461,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get videoErrorContentRestrictedBody =>
-      'Ten film został ograniczony przez przekaźnik.';
+      'This video was removed for breaking our content rules.';
 
   @override
   String get videoErrorVerifyAgeBody =>

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -1454,7 +1454,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get videoErrorContentRestrictedBody =>
-      'Este vídeo foi restringido pelo relay.';
+      'This video was removed for breaking our content rules.';
 
   @override
   String get videoErrorVerifyAgeBody =>

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -1475,7 +1475,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get videoErrorContentRestrictedBody =>
-      'Acest videoclip a fost restricționat de relay.';
+      'This video was removed for breaking our content rules.';
 
   @override
   String get videoErrorVerifyAgeBody =>

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -1432,7 +1432,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get videoErrorContentRestrictedBody =>
-      'Den här videon har begränsats av relen.';
+      'This video was removed for breaking our content rules.';
 
   @override
   String get videoErrorVerifyAgeBody =>

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -1418,7 +1418,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get videoErrorContentRestrictedBody =>
-      'Bu video röle tarafından kısıtlanmış.';
+      'This video was removed for breaking our content rules.';
 
   @override
   String get videoErrorVerifyAgeBody =>

--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -203,6 +203,10 @@ class FeedVideosState extends ConsumerState<FeedVideos> with RouteAware {
       _feedKey.currentState?.retryAt(index, httpHeaders: httpHeaders) ??
       Future.value(false);
 
+  void _skipPooledVideoAt(int index) {
+    unawaited(_feedKey.currentState?.animateToPage(index + 1));
+  }
+
   @override
   void didUpdateWidget(covariant FeedVideos oldWidget) {
     super.didUpdateWidget(oldWidget);
@@ -456,6 +460,7 @@ class FeedVideosState extends ConsumerState<FeedVideos> with RouteAware {
             index: index,
             resolveSha256: VideoModerationStatusService.resolveSha256,
             onRetry: onRetry,
+            onSkip: () => _skipPooledVideoAt(index),
             retryPlayback: (httpHeaders) =>
                 _retryPooledVideoAt(index, httpHeaders),
             errorType: errorType,
@@ -739,14 +744,14 @@ class __OverlayState extends ConsumerState<_Overlay> {
     // prefetching if it flips on for an already-mounted overlay (initState's
     // prefetch is a no-op while the flag is off). #5720 M3.
     ref.watch(isFeatureEnabledProvider(FeatureFlag.communityContentWarnings));
-    ref.listen(
-      isFeatureEnabledProvider(FeatureFlag.communityContentWarnings),
-      (previous, next) {
-        if (next && previous != true) {
-          _prefetchCommunityLabels();
-        }
-      },
-    );
+    ref.listen(isFeatureEnabledProvider(FeatureFlag.communityContentWarnings), (
+      previous,
+      next,
+    ) {
+      if (next && previous != true) {
+        _prefetchCommunityLabels();
+      }
+    });
 
     // Merge community-suggested warnings (#4771) into the creator/trusted
     // warn labels so a crossed-threshold community label drives the same
@@ -1201,6 +1206,13 @@ class _FeedLoadingOrRestrictedOverlayView extends ConsumerWidget {
                   resolveSha256: VideoModerationStatusService.resolveSha256,
                   // Retry is hidden for moderation-restricted content.
                   onRetry: () {},
+                  onSkip: () {
+                    unawaited(
+                      context
+                          .findAncestorStateOfType<InfiniteVideoFeedState>()
+                          ?.animateToPage(index + 1),
+                    );
+                  },
                   retryPlayback: (httpHeaders) =>
                       context
                           .findAncestorStateOfType<InfiniteVideoFeedState>()

--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -435,18 +435,25 @@ class FeedVideosState extends ConsumerState<FeedVideos> with RouteAware {
             return const SizedBox.shrink();
           }
           final video = widget.videos[index];
+          final cubit = context.read<VideoPlaybackStatusCubit>();
 
           // Dedupe at the call site so `errorBuilder` rebuilds don't
           // schedule a post-frame callback every frame. See
           // _lastReportedError doc above.
           if (_lastReportedError[video.id] != errorType) {
             _lastReportedError[video.id] = errorType;
-            // Capture the cubit eagerly so the post-frame callback doesn't
+            // Capture the status eagerly so the post-frame callback doesn't
             // walk the ancestor tree on a potentially-deactivated element.
-            final cubit = context.read<VideoPlaybackStatusCubit>();
+            final playbackStatus = playbackStatusFromError(
+              errorType,
+              isModerationSource:
+                  VideoModerationStatusService.shouldCheckModeration(
+                    video.videoUrl,
+                  ),
+            );
             WidgetsBinding.instance.addPostFrameCallback((_) {
               if (!mounted) return;
-              cubit.report(video.id, playbackStatusFromError(errorType));
+              cubit.report(video.id, playbackStatus);
             });
           }
           // Mirror the BoxFit logic of VideoLoadingPlaceholder /
@@ -459,7 +466,11 @@ class FeedVideosState extends ConsumerState<FeedVideos> with RouteAware {
             video: video,
             index: index,
             resolveSha256: VideoModerationStatusService.resolveSha256,
-            onRetry: onRetry,
+            onRetry: () {
+              _lastReportedError.remove(video.id);
+              cubit.report(video.id, PlaybackStatus.ready);
+              onRetry();
+            },
             onSkip: () => _skipPooledVideoAt(index),
             retryPlayback: (httpHeaders) =>
                 _retryPooledVideoAt(index, httpHeaders),

--- a/mobile/lib/widgets/video_feed_item/moderated_content_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/moderated_content_overlay.dart
@@ -104,20 +104,3 @@ class ModeratedContentOverlay extends StatelessWidget {
     );
   }
 }
-
-/// User-facing copy for [ModeratedContentOverlay].
-///
-/// Kept as static constants so tests can reference the same values the
-/// widget renders, preventing drift when copy changes. When l10n lands,
-/// these become the keys fed into the localizer.
-@visibleForTesting
-class ModeratedContentOverlayStrings {
-  const ModeratedContentOverlayStrings._();
-
-  static const String forbiddenTitle = 'Content restricted';
-  static const String forbiddenBody = 'This video was restricted by the relay.';
-  static const String ageRestrictedTitle = 'Age-restricted content';
-  static const String ageRestrictedBody = 'Verify your age to view this video.';
-  static const String skipLabel = 'Skip';
-  static const String verifyAgeLabel = 'Verify age';
-}

--- a/mobile/lib/widgets/video_feed_item/pooled_video_error_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/pooled_video_error_overlay.dart
@@ -29,6 +29,7 @@ class PooledVideoErrorOverlay extends ConsumerStatefulWidget {
     required this.video,
     required this.onRetry,
     required this.errorType,
+    this.onSkip,
     this.onVerifyAge,
     this.isVerifying = false,
     this.shouldPortraitExpand = true,
@@ -38,6 +39,7 @@ class PooledVideoErrorOverlay extends ConsumerStatefulWidget {
 
   final VideoEvent video;
   final VoidCallback onRetry;
+  final VoidCallback? onSkip;
   final VoidCallback? onVerifyAge;
 
   /// Whether an age-verification retry is in flight. Shows the Verify age
@@ -153,7 +155,12 @@ class _PooledVideoErrorOverlayState
         ? context.l10n.videoErrorContentRestrictedBody
         : null;
     final showVerifyAge = isAgeRestricted && widget.onVerifyAge != null;
-    final showRetry = !isModerationRestricted && !showVerifyAge;
+    final showSkip =
+        isModerationRestricted && !isAgeRestricted && widget.onSkip != null;
+    final showRetry =
+        (!isModerationRestricted || (isAgeRestricted && !showVerifyAge)) &&
+        !showSkip &&
+        !showVerifyAge;
     _maybeAutoRetryAgeRestricted(showVerifyAge: showVerifyAge);
 
     return Stack(
@@ -213,6 +220,13 @@ class _PooledVideoErrorOverlayState
                     type: DivineButtonType.tertiary,
                     size: DivineButtonSize.small,
                     onPressed: widget.onRetry,
+                  ),
+                if (showSkip)
+                  DivineButton(
+                    label: context.l10n.videoErrorSkip,
+                    type: DivineButtonType.tertiary,
+                    size: DivineButtonSize.small,
+                    onPressed: widget.onSkip,
                   ),
               ],
             ),

--- a/mobile/lib/widgets/video_feed_item/pooled_video_error_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/pooled_video_error_overlay.dart
@@ -17,7 +17,10 @@ import 'package:openvine/widgets/vine_cached_image.dart';
 /// Error overlay for videos playing through the pooled video player.
 ///
 /// Shows different UI based on the [VideoErrorType] from the controller:
-/// - [VideoErrorType.forbidden]: Shield icon + "Content restricted" (no retry)
+/// - [VideoErrorType.forbidden] for Divine URLs: Shield icon +
+///   "Content restricted" (no retry)
+/// - [VideoErrorType.forbidden] for third-party URLs: Error icon +
+///   "Video playback error" + Retry
 /// - [VideoErrorType.notFound] with moderation status: Shield icon +
 ///   "Content restricted" (no retry)
 /// - [VideoErrorType.ageRestricted]: Lock icon + "Age-restricted content" +
@@ -118,7 +121,7 @@ class _PooledVideoErrorOverlayState
         moderationStatus != null &&
         moderationStatus.ageRestricted;
     final isModerationRestricted =
-        type == VideoErrorType.forbidden ||
+        (type == VideoErrorType.forbidden && isDivineUrl) ||
         (shouldEnrichNotFoundWithModeration &&
             moderationStatus != null &&
             moderationStatus.isUnavailableDueToModeration);
@@ -143,8 +146,10 @@ class _PooledVideoErrorOverlayState
         context.l10n.videoErrorContentRestricted,
       (VideoErrorType.notFound, false, false) =>
         context.l10n.videoErrorNotFound,
-      (VideoErrorType.forbidden, false, _) =>
+      (VideoErrorType.forbidden, false, true) =>
         context.l10n.videoErrorContentRestricted,
+      (VideoErrorType.forbidden, false, false) =>
+        context.l10n.videoErrorPlayback,
       (VideoErrorType.ageRestricted, false, _) =>
         context.l10n.videoErrorAgeRestricted,
       (VideoErrorType.generic, false, _) => context.l10n.videoErrorPlayback,

--- a/mobile/lib/widgets/video_feed_item/verifying_aware_video_error_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/verifying_aware_video_error_overlay.dart
@@ -31,6 +31,7 @@ class VerifyingAwareVideoErrorOverlay extends ConsumerWidget {
     required this.errorType,
     required this.shouldPortraitExpand,
     required this.isSquare,
+    this.onSkip,
     super.key,
   });
 
@@ -41,6 +42,9 @@ class VerifyingAwareVideoErrorOverlay extends ConsumerWidget {
 
   /// Called when the user taps Retry. Hidden for moderation-restricted content.
   final VoidCallback onRetry;
+
+  /// Called when the user taps Skip for moderation-restricted content.
+  final VoidCallback? onSkip;
 
   /// Reloads playback for the retried item with the signed viewer-auth headers.
   final FutureOr<bool> Function(Map<String, String>) retryPlayback;
@@ -60,6 +64,7 @@ class VerifyingAwareVideoErrorOverlay extends ConsumerWidget {
       builder: (context, isVerifying) => PooledVideoErrorOverlay(
         video: video,
         onRetry: onRetry,
+        onSkip: onSkip,
         onVerifyAge: () => retryAgeRestrictedPooledVideo(
           context: context,
           ref: ref,

--- a/mobile/test/blocs/video_playback_status/video_playback_status_cubit_test.dart
+++ b/mobile/test/blocs/video_playback_status/video_playback_status_cubit_test.dart
@@ -281,6 +281,16 @@ void main() {
         );
         expect(playbackStatusFromError(null), PlaybackStatus.generic);
       });
+
+      test('maps third-party forbidden errors to generic playback status', () {
+        expect(
+          playbackStatusFromError(
+            VideoErrorType.forbidden,
+            isModerationSource: false,
+          ),
+          PlaybackStatus.generic,
+        );
+      });
     });
   });
 }

--- a/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
+++ b/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
@@ -115,6 +115,14 @@ class _NativePlayerHarness {
     }
   }
 
+  Future<void> sendEvent(int playerId, Map<Object?, Object?> event) async {
+    await tester.binding.defaultBinaryMessenger.handlePlatformMessage(
+      'divine_video_player/player_$playerId/events',
+      _codec.encodeSuccessEnvelope(event),
+      (_) {},
+    );
+  }
+
   Future<void> dispose() async {
     tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
       _globalChannel,
@@ -1124,6 +1132,54 @@ void main() {
             () =>
                 mockBloc.add(any(that: isA<FullscreenFeedVideoUnavailable>())),
           );
+        },
+      );
+
+      testWidgets(
+        'keeps third-party forbidden playback errors retryable in pooled feed',
+        (tester) async {
+          final nativePlayer = _NativePlayerHarness(tester)..install();
+          addTearDown(nativePlayer.dispose);
+          final l10n = lookupAppLocalizations(const Locale('en'));
+          final video = createTestVideoEvent(
+            id: testVideoId1,
+            pubkey: testPubkey,
+            videoUrl: 'https://cdn.example.com/video.mp4',
+          );
+
+          await tester.pumpWidget(
+            buildSubject(
+              state: FullscreenFeedState(
+                status: FullscreenFeedStatus.ready,
+                videos: [video],
+              ),
+            ),
+          );
+          await tester.pump();
+          await tester.pump();
+
+          await nativePlayer.sendEvent(0, const <Object?, Object?>{
+            'status': 'error',
+            'errorCode': 'network_error',
+            'errorMessage': 'HTTP 403 Forbidden',
+          });
+          await tester.pump();
+          await tester.pump();
+
+          final cubit = BlocProvider.of<VideoPlaybackStatusCubit>(
+            tester.element(find.byType(FullscreenFeedContent)),
+          );
+          expect(cubit.state.statusFor(video.id), PlaybackStatus.generic);
+          expect(find.byType(ModeratedContentOverlay), findsNothing);
+          expect(find.text(l10n.videoErrorPlayback), findsOneWidget);
+          expect(find.text(l10n.videoErrorContentRestricted), findsNothing);
+          expect(find.text(l10n.videoErrorRetry), findsOneWidget);
+
+          await tester.tap(find.text(l10n.videoErrorRetry));
+          await tester.pump();
+
+          expect(cubit.state.statusFor(video.id), PlaybackStatus.ready);
+          expect(find.byType(ModeratedContentOverlay), findsNothing);
         },
       );
 

--- a/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
+++ b/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
@@ -1206,15 +1206,15 @@ void main() {
           cubit.report(video.id, PlaybackStatus.ageRestricted);
           await tester.pump();
 
+          final l10n = lookupAppLocalizations(const Locale('en'));
+
           expect(find.byType(ModeratedContentOverlay), findsOneWidget);
           expect(
-            find.text(ModeratedContentOverlayStrings.verifyAgeLabel),
+            find.text(l10n.videoErrorVerifyAgeButton),
             findsOneWidget,
           );
 
-          await tester.tap(
-            find.text(ModeratedContentOverlayStrings.verifyAgeLabel),
-          );
+          await tester.tap(find.text(l10n.videoErrorVerifyAgeButton));
           await tester.pump();
           await tester.pump();
 
@@ -1299,9 +1299,9 @@ void main() {
           cubit.report(video.id, PlaybackStatus.ageRestricted);
           await tester.pump();
 
-          await tester.tap(
-            find.text(ModeratedContentOverlayStrings.verifyAgeLabel),
-          );
+          final l10n = lookupAppLocalizations(const Locale('en'));
+
+          await tester.tap(find.text(l10n.videoErrorVerifyAgeButton));
           await tester.pump();
           await tester.pump();
 

--- a/mobile/test/widgets/pooled_video_error_overlay_test.dart
+++ b/mobile/test/widgets/pooled_video_error_overlay_test.dart
@@ -146,6 +146,33 @@ void main() {
 
         expect(find.text(l10n.videoErrorRetry), findsNothing);
       });
+
+      testWidgets(
+        'shows retryable playback error for third-party video URLs',
+        (tester) async {
+          await tester.pumpWidget(
+            buildWidget(
+              errorType: VideoErrorType.forbidden,
+              video: thirdPartyVideo,
+              onSkip: () => skipPressed = true,
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          expect(_findDivineIcon(DivineIconName.warningCircle), findsOneWidget);
+          expect(find.text(l10n.videoErrorPlayback), findsOneWidget);
+          expect(find.text(l10n.videoErrorContentRestricted), findsNothing);
+          expect(find.text(l10n.videoErrorContentRestrictedBody), findsNothing);
+          expect(find.text(l10n.videoErrorSkip), findsNothing);
+          expect(find.text(l10n.videoErrorRetry), findsOneWidget);
+
+          await tester.tap(find.text(l10n.videoErrorRetry));
+          await tester.pump();
+
+          expect(retryPressed, isTrue);
+          expect(skipPressed, isFalse);
+        },
+      );
     });
 
     group('ageRestricted', () {

--- a/mobile/test/widgets/pooled_video_error_overlay_test.dart
+++ b/mobile/test/widgets/pooled_video_error_overlay_test.dart
@@ -25,6 +25,7 @@ void main() {
     late VideoEvent divineVideo;
     late VideoEvent thirdPartyVideo;
     late bool retryPressed;
+    late bool skipPressed;
     late bool verifyAgePressed;
     late AppLocalizations l10n;
 
@@ -42,6 +43,7 @@ void main() {
         videoUrl: 'https://cdn.example.com/video.mp4',
       );
       retryPressed = false;
+      skipPressed = false;
       verifyAgePressed = false;
       l10n = lookupAppLocalizations(const Locale('en'));
     });
@@ -50,12 +52,14 @@ void main() {
       VideoErrorType? errorType,
       VideoEvent? video,
       VoidCallback? onVerifyAge,
+      VoidCallback? onSkip,
       bool isVerifying = false,
       VideoPlaybackStatusCubit? playbackStatusCubit,
     }) {
       final overlay = PooledVideoErrorOverlay(
         video: video ?? divineVideo,
         onRetry: () => retryPressed = true,
+        onSkip: onSkip,
         onVerifyAge: onVerifyAge,
         errorType: errorType,
         isVerifying: isVerifying,
@@ -89,11 +93,13 @@ void main() {
       required VideoModerationStatus moderationStatus,
       VideoEvent? video,
       VoidCallback? onVerifyAge,
+      VoidCallback? onSkip,
       VideoPlaybackStatusCubit? playbackStatusCubit,
     }) {
       final overlay = PooledVideoErrorOverlay(
         video: video ?? divineVideo,
         onRetry: () => retryPressed = true,
+        onSkip: onSkip,
         onVerifyAge: onVerifyAge,
         errorType: errorType,
       );
@@ -295,6 +301,33 @@ void main() {
         },
       );
 
+      testWidgets('shows Skip when moderation status indicates blocked', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildWidgetWithModeration(
+            errorType: VideoErrorType.notFound,
+            moderationStatus: const VideoModerationStatus(
+              moderated: true,
+              blocked: true,
+              quarantined: false,
+              ageRestricted: false,
+              needsReview: false,
+              aiGenerated: false,
+            ),
+            onSkip: () => skipPressed = true,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text(l10n.videoErrorSkip), findsOneWidget);
+
+        await tester.tap(find.text(l10n.videoErrorSkip));
+        await tester.pump();
+
+        expect(skipPressed, isTrue);
+      });
+
       testWidgets(
         'shows shield icon when moderation status indicates quarantined',
         (tester) async {
@@ -345,6 +378,35 @@ void main() {
           await tester.tap(find.text(l10n.videoErrorVerifyAgeButton));
 
           expect(verifyAgePressed, isTrue);
+        },
+      );
+
+      testWidgets(
+        'shows retry when moderation age restriction has no verify action',
+        (tester) async {
+          await tester.pumpWidget(
+            buildWidgetWithModeration(
+              errorType: VideoErrorType.notFound,
+              moderationStatus: const VideoModerationStatus(
+                moderated: true,
+                blocked: false,
+                quarantined: false,
+                ageRestricted: true,
+                needsReview: false,
+                aiGenerated: false,
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          expect(find.text(l10n.videoErrorAgeRestricted), findsOneWidget);
+          expect(find.text(l10n.videoErrorVerifyAgeButton), findsNothing);
+          expect(find.text(l10n.videoErrorRetry), findsOneWidget);
+
+          await tester.tap(find.text(l10n.videoErrorRetry));
+          await tester.pump();
+
+          expect(retryPressed, isTrue);
         },
       );
 

--- a/mobile/test/widgets/video_feed_item/moderated_content_overlay_test.dart
+++ b/mobile/test/widgets/video_feed_item/moderated_content_overlay_test.dart
@@ -40,18 +40,9 @@ void main() {
     ) async {
       await pumpOverlay(tester, status: PlaybackStatus.forbidden);
 
-      expect(
-        find.text(ModeratedContentOverlayStrings.forbiddenTitle),
-        findsOneWidget,
-      );
-      expect(
-        find.text(ModeratedContentOverlayStrings.skipLabel),
-        findsOneWidget,
-      );
-      expect(
-        find.text(ModeratedContentOverlayStrings.verifyAgeLabel),
-        findsNothing,
-      );
+      expect(find.text(enL10n.videoErrorContentRestricted), findsOneWidget);
+      expect(find.text(enL10n.videoErrorSkip), findsOneWidget);
+      expect(find.text(enL10n.videoErrorVerifyAgeButton), findsNothing);
     });
 
     testWidgets('renders age-restricted message and Verify age button', (
@@ -63,18 +54,9 @@ void main() {
         onVerifyAge: () {},
       );
 
-      expect(
-        find.text(ModeratedContentOverlayStrings.ageRestrictedTitle),
-        findsOneWidget,
-      );
-      expect(
-        find.text(ModeratedContentOverlayStrings.verifyAgeLabel),
-        findsOneWidget,
-      );
-      expect(
-        find.text(ModeratedContentOverlayStrings.skipLabel),
-        findsOneWidget,
-      );
+      expect(find.text(enL10n.videoErrorAgeRestricted), findsOneWidget);
+      expect(find.text(enL10n.videoErrorVerifyAgeButton), findsOneWidget);
+      expect(find.text(enL10n.videoErrorSkip), findsOneWidget);
     });
 
     testWidgets('calls onSkip when Skip is tapped', (tester) async {
@@ -84,7 +66,7 @@ void main() {
         status: PlaybackStatus.forbidden,
         onSkip: () => skipped++,
       );
-      await tester.tap(find.text(ModeratedContentOverlayStrings.skipLabel));
+      await tester.tap(find.text(enL10n.videoErrorSkip));
       await tester.pumpAndSettle();
 
       expect(skipped, equals(1));
@@ -97,9 +79,7 @@ void main() {
         status: PlaybackStatus.ageRestricted,
         onVerifyAge: () => verified++,
       );
-      await tester.tap(
-        find.text(ModeratedContentOverlayStrings.verifyAgeLabel),
-      );
+      await tester.tap(find.text(enL10n.videoErrorVerifyAgeButton));
       await tester.pumpAndSettle();
 
       expect(verified, equals(1));
@@ -119,9 +99,7 @@ void main() {
         expect(find.byType(CircularProgressIndicator), findsOneWidget);
 
         // Disabled while verifying — a tap must be a no-op.
-        await tester.tap(
-          find.text(ModeratedContentOverlayStrings.verifyAgeLabel),
-        );
+        await tester.tap(find.text(enL10n.videoErrorVerifyAgeButton));
         await tester.pump();
         expect(verified, equals(0));
       },
@@ -137,7 +115,7 @@ void main() {
         onSkip: () => skipped++,
         onVerifyAge: () {},
       );
-      await tester.tap(find.text(ModeratedContentOverlayStrings.skipLabel));
+      await tester.tap(find.text(enL10n.videoErrorSkip));
       await tester.pumpAndSettle();
 
       expect(skipped, equals(1));


### PR DESCRIPTION
## Summary

- replaces the misleading “restricted by the relay” message with platform-moderation copy and regenerates l10n
- adds a Skip affordance for pooled moderation-restricted video cards
- falls moderation-derived age restrictions back to Retry when no Verify age handler is available
- removes stale `ModeratedContentOverlayStrings` test copy and uses `AppLocalizations` lookups instead

## Verification

- `flutter gen-l10n`
- `flutter test test/widgets/pooled_video_error_overlay_test.dart test/widgets/video_feed_item/moderated_content_overlay_test.dart test/l10n/arb_consistency_test.dart`
- `flutter test test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart`
- `flutter analyze`
- pre-push changed-file analyze/tests passed

## Follow-ups

- Backend root cause: divinevideo/divine-funnelcake#681
- Reviewed non-English translations: #6323

Closes #6322
