### PR TITLE
feat(profile): long-press own video tile for edit/delete actions

### DIFF
--- a/mobile/lib/widgets/profile/profile_videos_grid.dart
+++ b/mobile/lib/widgets/profile/profile_videos_grid.dart
@@ -12,13 +12,17 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/background_publish/background_publish_bloc.dart';
+import 'package:openvine/blocs/owner_video_actions/owner_video_actions_cubit.dart';
 import 'package:openvine/blocs/profile_feed/profile_feed_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/mixins/grid_prefetch_mixin.dart';
 import 'package:openvine/mixins/scroll_pagination_mixin.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
+import 'package:openvine/screens/video_metadata/video_metadata_edit_screen.dart';
+import 'package:openvine/utils/delete_failure_localization.dart';
 import 'package:openvine/utils/video_identity.dart';
+import 'package:openvine/widgets/owner_video_delete_confirmation_dialog.dart';
 import 'package:openvine/widgets/profile/pending_collaborator_invite_banner_cubit.dart';
 import 'package:openvine/widgets/profile/profile_tab_empty_state.dart';
 import 'package:openvine/widgets/profile/profile_tab_loading_more_sliver.dart';
@@ -112,6 +116,9 @@ class _ProfileVideosGridState extends ConsumerState<ProfileVideosGrid>
     with GridPrefetchMixin, ScrollPaginationMixin {
   List<VideoEvent>? _lastPrefetchedVideos;
 
+  /// Created lazily on the first own-video delete; closed in [dispose].
+  OwnerVideoActionsCubit? _ownerVideoActionsCubit;
+
   /// Resolved from [PrimaryScrollController] provided by [NestedScrollView].
   ScrollController? _primaryScrollController;
 
@@ -151,6 +158,7 @@ class _ProfileVideosGridState extends ConsumerState<ProfileVideosGrid>
 
   @override
   void dispose() {
+    _ownerVideoActionsCubit?.close();
     disposePagination();
     super.dispose();
   }
@@ -173,6 +181,63 @@ class _ProfileVideosGridState extends ConsumerState<ProfileVideosGrid>
 
   void _triggerLoadMore() {
     context.read<ProfileFeedCubit>().add(const ProfileFeedLoadMoreRequested());
+  }
+
+  Future<void> _showOwnVideoActions(VideoEvent video) async {
+    await VineBottomSheet.show<void>(
+      context: context,
+      scrollable: false,
+      expanded: false,
+      title: Text(
+        context.l10n.videoGridOptionsTitle,
+        style: VineTheme.titleMediumFont(),
+      ),
+      body: _OwnVideoActionsSheetBody(
+        onEditVideo: () => _editVideo(video),
+        onDeleteVideo: () => _confirmDeleteVideo(video),
+      ),
+    );
+  }
+
+  void _editVideo(VideoEvent video) {
+    context.push(VideoMetadataEditScreen.pathFor(video.id), extra: video);
+  }
+
+  Future<void> _confirmDeleteVideo(VideoEvent video) async {
+    final confirmed = await showOwnerVideoDeleteConfirmationDialog(context);
+    if (!confirmed || !mounted) return;
+
+    final cubit = _ownerVideoActionsCubit ??= OwnerVideoActionsCubit(
+      contentDeletionServiceFuture: ref.read(
+        contentDeletionServiceProvider.future,
+      ),
+      videoEventService: ref.read(videoEventServiceProvider),
+    );
+    await cubit.deleteVideo(video);
+
+    if (!mounted) return;
+
+    final state = cubit.state;
+    final messenger = ScaffoldMessenger.of(context);
+    if (state.deleteStatus == OwnerVideoDeleteStatus.success) {
+      // The service marks the video locally deleted; a refresh drops the
+      // tile from the grid without waiting for relay propagation.
+      context.read<ProfileFeedCubit>().add(const ProfileFeedRefreshRequested());
+      messenger.showSnackBar(
+        DivineSnackbarContainer.snackBar(
+          context.l10n.shareMenuVideoDeletionRequested,
+        ),
+      );
+    } else {
+      messenger.showSnackBar(
+        DivineSnackbarContainer.snackBar(
+          state.deleteResult == null
+              ? context.l10n.shareMenuDeleteFailedGeneric
+              : localizedDeleteFailureMessage(context, state.deleteResult!),
+          error: true,
+        ),
+      );
+    }
   }
 
   void _onVideoTapped(
@@ -345,6 +410,9 @@ class _ProfileVideosGridState extends ConsumerState<ProfileVideosGrid>
                   videoEvent: eventEntry.videoEvent,
                   userIdHex: widget.userIdHex,
                   index: index,
+                  onLongPress: isOwnProfile
+                      ? () => _showOwnVideoActions(eventEntry.videoEvent)
+                      : null,
                   onTap: () {
                     // Adjust index to account for uploading videos at the top
                     final publishedIndex = index - uploadingCount;
@@ -423,12 +491,16 @@ class _VideoGridTile extends StatelessWidget {
     required this.userIdHex,
     required this.index,
     required this.onTap,
+    this.onLongPress,
   });
 
   final VideoEvent videoEvent;
   final String userIdHex;
   final int index;
   final VoidCallback onTap;
+
+  /// Opens the own-video actions sheet; null on other users' profiles.
+  final VoidCallback? onLongPress;
 
   @override
   Widget build(BuildContext context) => Semantics(
@@ -437,6 +509,7 @@ class _VideoGridTile extends StatelessWidget {
     button: true,
     child: GestureDetector(
       onTap: onTap,
+      onLongPress: onLongPress,
       child: ClipRRect(
         borderRadius: BorderRadius.circular(4),
         child: DecoratedBox(
@@ -449,6 +522,87 @@ class _VideoGridTile extends StatelessWidget {
       ),
     ),
   );
+}
+
+/// Edit/Delete actions shown when long-pressing an own video tile.
+class _OwnVideoActionsSheetBody extends StatelessWidget {
+  const _OwnVideoActionsSheetBody({
+    required this.onEditVideo,
+    required this.onDeleteVideo,
+  });
+
+  final VoidCallback onEditVideo;
+  final VoidCallback onDeleteVideo;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        _OwnVideoActionTile(
+          icon: DivineIconName.pencilSimple,
+          iconColor: VineTheme.vineGreen,
+          title: context.l10n.videoGridEditVideo,
+          subtitle: context.l10n.videoGridEditVideoSubtitle,
+          onTap: onEditVideo,
+        ),
+        _OwnVideoActionTile(
+          icon: DivineIconName.trash,
+          iconColor: VineTheme.error,
+          title: context.l10n.videoGridDeleteVideo,
+          subtitle: context.l10n.videoGridDeleteVideoSubtitle,
+          onTap: onDeleteVideo,
+        ),
+        SizedBox(height: MediaQuery.viewPaddingOf(context).bottom + 16),
+      ],
+    );
+  }
+}
+
+class _OwnVideoActionTile extends StatelessWidget {
+  const _OwnVideoActionTile({
+    required this.icon,
+    required this.iconColor,
+    required this.title,
+    required this.subtitle,
+    required this.onTap,
+  });
+
+  final DivineIconName icon;
+  final Color iconColor;
+  final String title;
+  final String subtitle;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    // The sheet paints its own background; a transparent Material keeps
+    // ListTile's ink effects visible without double-painting a surface.
+    return Material(
+      type: MaterialType.transparency,
+      child: ListTile(
+        leading: Container(
+          width: 40,
+          height: 40,
+          alignment: Alignment.center,
+          decoration: BoxDecoration(
+            color: VineTheme.cardBackground,
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: DivineIcon(icon: icon, color: iconColor, size: 20),
+        ),
+        title: Text(title, style: VineTheme.titleMediumFont()),
+        subtitle: Text(
+          subtitle,
+          style: VineTheme.bodySmallFont(color: VineTheme.secondaryText),
+        ),
+        onTap: () {
+          Navigator.of(context).pop();
+          onTap();
+        },
+      ),
+    );
+  }
 }
 
 class _PendingCollaboratorInviteBanner extends ConsumerWidget {

--- a/mobile/lib/widgets/profile/profile_videos_grid.dart
+++ b/mobile/lib/widgets/profile/profile_videos_grid.dart
@@ -274,7 +274,9 @@ class _ProfileVideosGridState extends ConsumerState<ProfileVideosGrid>
       return true;
     }());
     final authService = ref.read(authServiceProvider);
-    final isOwnProfile = authService.currentPublicKeyHex == widget.userIdHex;
+    final currentUserPubkey = authService.currentPublicKeyHex;
+    final isOwnProfile =
+        currentUserPubkey != null && currentUserPubkey == widget.userIdHex;
 
     // Subscribe to the *shape* of the active upload list (id + title +
     // thumbnailPath per upload). Progress is intentionally excluded so that
@@ -410,7 +412,9 @@ class _ProfileVideosGridState extends ConsumerState<ProfileVideosGrid>
                   videoEvent: eventEntry.videoEvent,
                   userIdHex: widget.userIdHex,
                   index: index,
-                  onLongPress: isOwnProfile
+                  onLongPress:
+                      currentUserPubkey != null &&
+                          currentUserPubkey == eventEntry.videoEvent.pubkey
                       ? () => _showOwnVideoActions(eventEntry.videoEvent)
                       : null,
                   onTap: () {
@@ -507,6 +511,10 @@ class _VideoGridTile extends StatelessWidget {
     identifier: 'video_thumbnail_$index',
     label: context.l10n.profileVideoThumbnailLabel(index + 1),
     button: true,
+    onLongPress: onLongPress,
+    onLongPressHint: onLongPress == null
+        ? null
+        : context.l10n.videoGridOptionsTitle,
     child: GestureDetector(
       onTap: onTap,
       onLongPress: onLongPress,

--- a/mobile/test/widgets/profile/profile_videos_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_videos_grid_test.dart
@@ -17,6 +17,7 @@ import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/divine_video_draft.dart';
 import 'package:openvine/providers/social_providers.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
+import 'package:openvine/screens/video_metadata/video_metadata_edit_screen.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/video_publish/video_publish_service.dart';
 import 'package:openvine/widgets/profile/profile_videos_grid.dart';
@@ -313,6 +314,157 @@ void main() {
           expect(args.initialVideoId, videos[1].id);
           expect(args.initialStableId, videos[1].stableId);
           expect(args.seedVideos, videos);
+        },
+      );
+
+      testWidgets(
+        'long-pressing an own video tile shows edit and delete actions',
+        (tester) async {
+          when(() => mockAuth.currentPublicKeyHex).thenReturn(_ownPubkey);
+          final videos = _createTestVideos(pubkey: _ownPubkey);
+          final l10n = lookupAppLocalizations(const Locale('en'));
+
+          await tester.pumpWidget(
+            buildSubject(userIdHex: _ownPubkey, videos: videos),
+          );
+
+          await tester.longPress(find.bySemanticsLabel('Video thumbnail 1'));
+          await tester.pumpAndSettle();
+
+          expect(find.text(l10n.videoGridEditVideo), findsOneWidget);
+          expect(find.text(l10n.videoGridDeleteVideo), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        "long-pressing a tile on another user's profile shows no actions",
+        (tester) async {
+          when(() => mockAuth.currentPublicKeyHex).thenReturn(_ownPubkey);
+          final videos = _createTestVideos(pubkey: _otherPubkey);
+          final l10n = lookupAppLocalizations(const Locale('en'));
+          final profileFeedCubit = _stubbedProfileFeedCubit();
+          // Without a long-press handler the gesture falls through to the
+          // tap navigation, so the harness needs the fullscreen route.
+          final router = GoRouter(
+            routes: [
+              GoRoute(
+                path: '/',
+                builder: (context, state) => testProviderScope(
+                  mockAuthService: mockAuth,
+                  child: BlocProvider<BackgroundPublishBloc>.value(
+                    value: mockBloc,
+                    child: Scaffold(
+                      body: BlocProvider<ProfileFeedCubit>.value(
+                        value: profileFeedCubit,
+                        child: ProfileVideosGrid(
+                          videos: videos,
+                          userIdHex: _otherPubkey,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              GoRoute(
+                path: PooledFullscreenVideoFeedScreen.path,
+                builder: (context, state) => const SizedBox.shrink(),
+              ),
+            ],
+          );
+
+          await tester.pumpWidget(
+            MaterialApp.router(
+              routerConfig: router,
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+            ),
+          );
+
+          await tester.longPress(find.bySemanticsLabel('Video thumbnail 1'));
+          await tester.pumpAndSettle();
+
+          expect(find.text(l10n.videoGridEditVideo), findsNothing);
+          expect(find.text(l10n.videoGridDeleteVideo), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'tapping Edit Video in the actions sheet opens the metadata editor',
+        (tester) async {
+          when(() => mockAuth.currentPublicKeyHex).thenReturn(_ownPubkey);
+          final videos = _createTestVideos(pubkey: _ownPubkey);
+          final l10n = lookupAppLocalizations(const Locale('en'));
+          String? capturedVideoId;
+          final profileFeedCubit = _stubbedProfileFeedCubit();
+          final router = GoRouter(
+            routes: [
+              GoRoute(
+                path: '/',
+                builder: (context, state) => testProviderScope(
+                  mockAuthService: mockAuth,
+                  child: BlocProvider<BackgroundPublishBloc>.value(
+                    value: mockBloc,
+                    child: Scaffold(
+                      body: BlocProvider<ProfileFeedCubit>.value(
+                        value: profileFeedCubit,
+                        child: ProfileVideosGrid(
+                          videos: videos,
+                          userIdHex: _ownPubkey,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              GoRoute(
+                path: '${VideoMetadataEditScreen.path}/:videoId',
+                builder: (context, state) {
+                  capturedVideoId = state.pathParameters['videoId'];
+                  return const SizedBox.shrink();
+                },
+              ),
+            ],
+          );
+
+          await tester.pumpWidget(
+            MaterialApp.router(
+              routerConfig: router,
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+            ),
+          );
+
+          await tester.longPress(find.bySemanticsLabel('Video thumbnail 1'));
+          await tester.pumpAndSettle();
+          await tester.tap(find.text(l10n.videoGridEditVideo));
+          await tester.pumpAndSettle();
+
+          expect(capturedVideoId, videos[0].id);
+        },
+      );
+
+      testWidgets(
+        'tapping Delete Video in the actions sheet asks for confirmation',
+        (tester) async {
+          when(() => mockAuth.currentPublicKeyHex).thenReturn(_ownPubkey);
+          final videos = _createTestVideos(pubkey: _ownPubkey);
+          final l10n = lookupAppLocalizations(const Locale('en'));
+
+          await tester.pumpWidget(
+            buildSubject(userIdHex: _ownPubkey, videos: videos),
+          );
+
+          await tester.longPress(find.bySemanticsLabel('Video thumbnail 1'));
+          await tester.pumpAndSettle();
+          await tester.tap(find.text(l10n.videoGridDeleteVideo));
+          await tester.pumpAndSettle();
+
+          expect(find.text(l10n.shareMenuDeleteConfirmation), findsOneWidget);
+
+          await tester.tap(find.text(l10n.shareMenuCancel));
+          await tester.pumpAndSettle();
+
+          expect(find.text(l10n.shareMenuDeleteConfirmation), findsNothing);
         },
       );
 

--- a/mobile/test/widgets/profile/profile_videos_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_videos_grid_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:ui' show SemanticsAction;
 
 import 'package:bloc_test/bloc_test.dart';
 import 'package:db_client/db_client.dart';
@@ -335,6 +336,78 @@ void main() {
           expect(find.text(l10n.videoGridDeleteVideo), findsOneWidget);
         },
       );
+
+      testWidgets(
+        'long-pressing a non-owned tile on own profile shows no actions',
+        (tester) async {
+          when(() => mockAuth.currentPublicKeyHex).thenReturn(_ownPubkey);
+          final videos = _createTestVideos(pubkey: _otherPubkey);
+          final l10n = lookupAppLocalizations(const Locale('en'));
+          final profileFeedCubit = _stubbedProfileFeedCubit();
+          final router = GoRouter(
+            routes: [
+              GoRoute(
+                path: '/',
+                builder: (context, state) => testProviderScope(
+                  mockAuthService: mockAuth,
+                  child: BlocProvider<BackgroundPublishBloc>.value(
+                    value: mockBloc,
+                    child: Scaffold(
+                      body: BlocProvider<ProfileFeedCubit>.value(
+                        value: profileFeedCubit,
+                        child: ProfileVideosGrid(
+                          videos: videos,
+                          userIdHex: _ownPubkey,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              GoRoute(
+                path: PooledFullscreenVideoFeedScreen.path,
+                builder: (context, state) => const SizedBox.shrink(),
+              ),
+            ],
+          );
+
+          await tester.pumpWidget(
+            MaterialApp.router(
+              routerConfig: router,
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+            ),
+          );
+
+          await tester.longPress(find.bySemanticsLabel('Video thumbnail 1'));
+          await tester.pumpAndSettle();
+
+          expect(find.text(l10n.videoGridEditVideo), findsNothing);
+          expect(find.text(l10n.videoGridDeleteVideo), findsNothing);
+        },
+      );
+
+      testWidgets('own video tile exposes long-press semantics', (
+        tester,
+      ) async {
+        when(() => mockAuth.currentPublicKeyHex).thenReturn(_ownPubkey);
+        final videos = _createTestVideos(pubkey: _ownPubkey);
+        final handle = tester.ensureSemantics();
+
+        await tester.pumpWidget(
+          buildSubject(userIdHex: _ownPubkey, videos: videos),
+        );
+
+        final node = tester.getSemantics(
+          find.bySemanticsLabel('Video thumbnail 1'),
+        );
+        expect(
+          node.getSemanticsData().hasAction(SemanticsAction.longPress),
+          isTrue,
+        );
+
+        handle.dispose();
+      });
 
       testWidgets(
         "long-pressing a tile on another user's profile shows no actions",


### PR DESCRIPTION
## Summary

Closes #6326
Relates to #6327

Long-pressing a video tile on your own profile's Videos tab now opens an actions sheet with Edit Video and Delete Video. Previously the profile grid had no edit/delete affordance; you had to open the video fullscreen and use the three-dot menu or share sheet.

- Long-press is wired only for videos owned by the signed-in user; other profiles and any non-owned tile keep existing tap-to-open behavior.
- The tile exposes a long-press semantics action so assistive technology can discover the owner action affordance.
- Sheet uses the sanctioned VineBottomSheet.show, VineTheme fonts/colors, DivineIcon, and existing l10n keys, with no ARB changes.
- Edit pushes the existing VideoMetadataEditScreen.pathFor(video.id) route.
- Delete reuses showOwnerVideoDeleteConfirmationDialog + OwnerVideoActionsCubit, then dispatches ProfileFeedRefreshRequested so the tile disappears immediately after local deletion state updates.

## Test plan

- flutter test test/widgets/profile/profile_videos_grid_test.dart
- flutter analyze lib test integration_test

Covered widget paths include:

- long-press on own tile shows Edit/Delete actions
- long-press on another user's profile shows no actions
- long-press on a non-owned tile on the own profile shows no actions
- own video tiles expose long-press semantics
- Edit action navigates to the metadata editor with the right video id
- Delete action shows the confirmation dialog; Cancel dismisses

## Manual test plan

- Own profile -> Videos tab -> long-press a tile -> sheet with Edit/Delete
- Edit -> metadata editor opens for that video
- Delete -> confirm -> tile disappears, "deletion requested" snackbar
- Other user's profile -> long-press -> opens video fullscreen unchanged

Generated with Claude Code; takeover hardening by Codex.
