### PR TITLE
fix(audio): gate original-sound reuse on the creator's sharing preference

### DIFF
--- a/mobile/lib/providers/saved_sounds_provider.dart
+++ b/mobile/lib/providers/saved_sounds_provider.dart
@@ -3,13 +3,21 @@
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:models/models.dart' show AudioEvent;
+import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/services/saved_sounds_service.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 final savedSoundsServiceProvider = Provider<SavedSoundsService>((ref) {
-  return SavedSoundsService(ref.watch(sharedPreferencesProvider));
+  // Rebuild on sign-in/out and account switch so the service (and the sounds
+  // list built from it) always targets the current account's bucket.
+  ref.watch(currentAuthStateProvider);
+  final pubkeyHex = ref.watch(authServiceProvider).currentPublicKeyHex;
+  return SavedSoundsService(
+    ref.watch(sharedPreferencesProvider),
+    pubkeyHex: pubkeyHex,
+  );
 });
 
 final savedSoundsProvider =

--- a/mobile/lib/providers/saved_sounds_provider.dart
+++ b/mobile/lib/providers/saved_sounds_provider.dart
@@ -26,36 +26,52 @@ final savedSoundsProvider =
     );
 
 class SavedSoundsNotifier extends Notifier<List<AudioEvent>> {
+  SavedSoundsService? _backfillService;
   bool _backfillScheduled = false;
 
   @override
   List<AudioEvent> build() {
-    final sounds = ref.watch(savedSoundsServiceProvider).loadSounds();
+    final service = ref.watch(savedSoundsServiceProvider);
+    // Allow one backfill per account: reset when the service (and therefore
+    // the account bucket) changes so an account switch re-evaluates instead of
+    // staying suppressed by a previous account's run.
+    if (!identical(service, _backfillService)) {
+      _backfillService = service;
+      _backfillScheduled = false;
+    }
+    final sounds = service.loadSounds();
     if (!_backfillScheduled && sounds.any((s) => (s.duration ?? 0) <= 0)) {
       // Fire-and-forget backfill for legacy entries that were saved
       // before SavedSoundsNotifier started persisting durations.
       _backfillScheduled = true;
-      Future.microtask(_backfillMissingDurations);
+      Future.microtask(() => _backfillMissingDurations(service));
     }
     return sounds;
   }
 
   Future<SavedSoundSaveResult> saveSound(AudioEvent sound) async {
+    // Freeze the account bucket before any await: an account switch mid-save
+    // must not redirect the write — or a stale-account state update — into a
+    // different account's bucket.
+    final service = ref.read(savedSoundsServiceProvider);
     final enriched = await _ensureDuration(sound);
-    final result = await ref
-        .read(savedSoundsServiceProvider)
-        .saveSound(enriched);
-    state = ref.read(savedSoundsServiceProvider).loadSounds();
+    final result = await service.saveSound(enriched);
+    if (identical(ref.read(savedSoundsServiceProvider), service)) {
+      state = service.loadSounds();
+    }
     return result;
   }
 
   Future<void> removeSound(String soundId) async {
-    await ref.read(savedSoundsServiceProvider).removeSound(soundId);
-    state = ref.read(savedSoundsServiceProvider).loadSounds();
+    final service = ref.read(savedSoundsServiceProvider);
+    await service.removeSound(soundId);
+    if (identical(ref.read(savedSoundsServiceProvider), service)) {
+      state = service.loadSounds();
+    }
   }
 
-  Future<void> _backfillMissingDurations() async {
-    final current = state;
+  Future<void> _backfillMissingDurations(SavedSoundsService service) async {
+    final current = service.loadSounds();
     final updated = <AudioEvent>[];
     var changed = false;
     for (final sound in current) {
@@ -68,8 +84,10 @@ class SavedSoundsNotifier extends Notifier<List<AudioEvent>> {
       updated.add(enriched);
     }
     if (!changed) return;
-    await ref.read(savedSoundsServiceProvider).replaceAll(updated);
-    state = updated;
+    await service.replaceAll(updated);
+    if (identical(ref.read(savedSoundsServiceProvider), service)) {
+      state = updated;
+    }
   }
 
   /// Probes [ProVideoEditor] for the missing duration so the saved

--- a/mobile/lib/providers/saved_sounds_provider.dart
+++ b/mobile/lib/providers/saved_sounds_provider.dart
@@ -56,7 +56,7 @@ class SavedSoundsNotifier extends Notifier<List<AudioEvent>> {
     final service = ref.read(savedSoundsServiceProvider);
     final enriched = await _ensureDuration(sound);
     final result = await service.saveSound(enriched);
-    if (identical(ref.read(savedSoundsServiceProvider), service)) {
+    if (_targetsCurrentBucket(service)) {
       state = service.loadSounds();
     }
     return result;
@@ -65,10 +65,18 @@ class SavedSoundsNotifier extends Notifier<List<AudioEvent>> {
   Future<void> removeSound(String soundId) async {
     final service = ref.read(savedSoundsServiceProvider);
     await service.removeSound(soundId);
-    if (identical(ref.read(savedSoundsServiceProvider), service)) {
+    if (_targetsCurrentBucket(service)) {
       state = service.loadSounds();
     }
   }
+
+  /// Whether [service] still targets the account bucket the provider is
+  /// currently bound to. Compares the stable storage key rather than object
+  /// identity: an A→B→A switch mid-write yields a *fresh* service instance for
+  /// the same A bucket, so `identical` would wrongly drop the completed write
+  /// from the current state.
+  bool _targetsCurrentBucket(SavedSoundsService service) =>
+      ref.read(savedSoundsServiceProvider).storageKey == service.storageKey;
 
   Future<void> _backfillMissingDurations(SavedSoundsService service) async {
     final current = service.loadSounds();
@@ -85,7 +93,7 @@ class SavedSoundsNotifier extends Notifier<List<AudioEvent>> {
     }
     if (!changed) return;
     await service.replaceAll(updated);
-    if (identical(ref.read(savedSoundsServiceProvider), service)) {
+    if (_targetsCurrentBucket(service)) {
       state = updated;
     }
   }

--- a/mobile/lib/screens/sound_detail_screen.dart
+++ b/mobile/lib/screens/sound_detail_screen.dart
@@ -205,6 +205,22 @@ class _SoundDetailScreenState extends ConsumerState<SoundDetailScreen> {
     );
   }
 
+  /// Whether the viewer may reuse [SoundDetailScreen.sound].
+  ///
+  /// Shared and bundled sounds were explicitly published for reuse, so they
+  /// always qualify. A video's *original* sound is reusable only when its
+  /// creator enabled audio reuse, or when the viewer is that creator (you can
+  /// always reuse your own audio). Without the source video — e.g. a raw
+  /// `/sound/<video-id>` deep link — reuse consent can't be confirmed, so it
+  /// is withheld.
+  bool _canReuseSound() {
+    final sound = widget.sound;
+    if (!sound.isOriginalSound) return true;
+    final viewer = ref.watch(authServiceProvider).currentPublicKeyHex;
+    if (viewer != null && viewer == sound.pubkey) return true;
+    return widget.sourceVideo?.allowAudioReuse ?? false;
+  }
+
   void _navigateToVideo(String videoId, int index, List<VideoEvent> videos) {
     Log.info(
       'Showing video feed at index $index for video: $videoId',
@@ -274,7 +290,7 @@ class _SoundDetailScreenState extends ConsumerState<SoundDetailScreen> {
                   isPlaying: _isPlayingPreview,
                   isLoadingPreview: _isLoadingPreview,
                   onPreviewTap: _togglePreview,
-                  onUseSoundTap: _onUseSound,
+                  onUseSoundTap: _canReuseSound() ? _onUseSound : null,
                 ),
 
                 // Divider
@@ -353,7 +369,10 @@ class _SoundHeader extends ConsumerStatefulWidget {
   final bool isPlaying;
   final bool isLoadingPreview;
   final VoidCallback onPreviewTap;
-  final VoidCallback onUseSoundTap;
+
+  /// Tap handler for the "Use Sound" button, or `null` when the sound may not
+  /// be reused — in which case the button is hidden entirely.
+  final VoidCallback? onUseSoundTap;
 
   @override
   ConsumerState<_SoundHeader> createState() => _SoundHeaderState();
@@ -496,32 +515,34 @@ class _SoundHeaderState extends ConsumerState<_SoundHeader> {
                 ),
               ),
 
-              const SizedBox(width: 12),
+              if (widget.onUseSoundTap != null) ...[
+                const SizedBox(width: 12),
 
-              // Use Sound button
-              Expanded(
-                child: Semantics(
-                  identifier: 'sound_detail_use_button',
-                  button: true,
-                  child: ElevatedButton.icon(
-                    onPressed: widget.onUseSoundTap,
-                    icon: const DivineIcon(
-                      icon: DivineIconName.plus,
-                      size: 20,
-                      color: VineTheme.backgroundColor,
-                    ),
-                    label: Text(context.l10n.soundUseSound),
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: VineTheme.vineGreen,
-                      foregroundColor: VineTheme.backgroundColor,
-                      padding: const EdgeInsets.symmetric(vertical: 12),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(8),
+                // Use Sound button
+                Expanded(
+                  child: Semantics(
+                    identifier: 'sound_detail_use_button',
+                    button: true,
+                    child: ElevatedButton.icon(
+                      onPressed: widget.onUseSoundTap,
+                      icon: const DivineIcon(
+                        icon: DivineIconName.plus,
+                        size: 20,
+                        color: VineTheme.backgroundColor,
+                      ),
+                      label: Text(context.l10n.soundUseSound),
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: VineTheme.vineGreen,
+                        foregroundColor: VineTheme.backgroundColor,
+                        padding: const EdgeInsets.symmetric(vertical: 12),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(8),
+                        ),
                       ),
                     ),
                   ),
                 ),
-              ),
+              ],
             ],
           ),
         ],

--- a/mobile/lib/screens/sound_detail_screen.dart
+++ b/mobile/lib/screens/sound_detail_screen.dart
@@ -209,16 +209,18 @@ class _SoundDetailScreenState extends ConsumerState<SoundDetailScreen> {
   ///
   /// Shared and bundled sounds were explicitly published for reuse, so they
   /// always qualify. A video's *original* sound is reusable only when its
-  /// creator enabled audio reuse, or when the viewer is that creator (you can
-  /// always reuse your own audio). Without the source video — e.g. a raw
-  /// `/sound/<video-id>` deep link — reuse consent can't be confirmed, so it
-  /// is withheld.
+  /// creator enabled audio reuse (carried on [AudioEvent.allowsReuse], so this
+  /// holds regardless of how the screen was reached — reuse chain, deep link,
+  /// or the metadata sheet), or when the viewer is that creator.
   bool _canReuseSound() {
     final sound = widget.sound;
     if (!sound.isOriginalSound) return true;
+    if (sound.allowsReuse) return true;
+    // Owner exception — re-evaluate on auth restore/logout/account-switch so it
+    // can't go stale (authServiceProvider alone is a stable instance).
+    ref.watch(currentAuthStateProvider);
     final viewer = ref.watch(authServiceProvider).currentPublicKeyHex;
-    if (viewer != null && viewer == sound.pubkey) return true;
-    return widget.sourceVideo?.allowAudioReuse ?? false;
+    return viewer != null && viewer == sound.pubkey;
   }
 
   void _navigateToVideo(String videoId, int index, List<VideoEvent> videos) {

--- a/mobile/lib/services/saved_sounds_service.dart
+++ b/mobile/lib/services/saved_sounds_service.dart
@@ -9,11 +9,32 @@ import 'package:shared_preferences/shared_preferences.dart';
 enum SavedSoundSaveResult { saved, alreadySaved }
 
 class SavedSoundsService {
-  SavedSoundsService(this._preferences);
+  SavedSoundsService(this._preferences, {String? pubkeyHex})
+    : _pubkeyHex = pubkeyHex;
 
-  static const storageKey = 'saved_reusable_sounds';
+  /// Prefix for the per-account storage keys.
+  static const _keyPrefix = 'saved_reusable_sounds';
 
   final SharedPreferences _preferences;
+
+  /// Signed-in pubkey (hex) whose saved sounds this instance manages, or
+  /// `null` when signed out.
+  final String? _pubkeyHex;
+
+  /// SharedPreferences key for the current account's saved sounds.
+  ///
+  /// Saved sounds are scoped per account so a sound one account adopts never
+  /// leaks into another account on a shared device. The signed-out state uses
+  /// a dedicated anonymous bucket. The legacy device-wide key
+  /// (`saved_reusable_sounds`, no suffix) is intentionally left orphaned; it is
+  /// never read again, so pre-existing saves reset once — a light convenience
+  /// feature, not data worth migrating across an ambiguous account boundary.
+  String get storageKey {
+    final pubkey = _pubkeyHex;
+    return pubkey == null || pubkey.isEmpty
+        ? '${_keyPrefix}_anon'
+        : '${_keyPrefix}_$pubkey';
+  }
 
   List<AudioEvent> loadSounds() {
     final rawSounds = _preferences.getString(storageKey);

--- a/mobile/lib/services/saved_sounds_service.dart
+++ b/mobile/lib/services/saved_sounds_service.dart
@@ -124,7 +124,35 @@ class SavedSoundsService {
     // setString updates the in-memory cache synchronously, so the load right
     // after this call sees the migrated data; disk persistence is fire-and-
     // forget. Write the account bucket before retiring the legacy key.
-    unawaited(_preferences.setString(storageKey, legacy));
+    unawaited(_preferences.setString(storageKey, _consentedLegacy(legacy)));
     unawaited(_preferences.remove(_legacyStorageKey));
+  }
+
+  /// Filters the pre-namespacing list to entries safe to adopt without
+  /// confirming reuse consent.
+  ///
+  /// A video's original sound (`video_*` id) may have been saved during the
+  /// pre-fix device-wide bug even though its creator had disabled reuse. That
+  /// consent can't be validated offline, so those entries are dropped (fail
+  /// closed). Shared (Kind 1063), bundled, and imported sounds were reusable by
+  /// construction and are kept.
+  String _consentedLegacy(String legacy) {
+    try {
+      final decoded = jsonDecode(legacy);
+      if (decoded is! List) return '[]';
+      final kept = <Map<String, dynamic>>[];
+      for (final entry in decoded.whereType<Map>()) {
+        try {
+          final sound = AudioEvent.fromJson(Map<String, dynamic>.from(entry));
+          if (sound.isOriginalSound) continue;
+          kept.add(_persistableSound(sound).toJson());
+        } catch (_) {
+          continue;
+        }
+      }
+      return jsonEncode(kept);
+    } catch (_) {
+      return '[]';
+    }
   }
 }

--- a/mobile/lib/services/saved_sounds_service.dart
+++ b/mobile/lib/services/saved_sounds_service.dart
@@ -4,6 +4,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:meta/meta.dart';
 import 'package:models/models.dart' show AudioEvent;
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -19,6 +20,20 @@ class SavedSoundsService {
   /// The pre-namespacing device-wide key (no account suffix). Read once at
   /// upgrade to migrate existing saves into the first account that loads.
   static const String _legacyStorageKey = _keyPrefix;
+
+  /// Process-wide guard so the one-shot legacy migration is claimed by exactly
+  /// one account. Set synchronously the instant an account claims it — before
+  /// the async write — so a second account loading during that write can't also
+  /// adopt the same device-wide list (#6330). Released only when the account
+  /// write fails, so a failed migration retries on a later load.
+  static bool _legacyMigrationClaimed = false;
+
+  /// Resets the process-wide legacy-migration claim. Tests share one isolate,
+  /// so each migration test must start from an unclaimed state.
+  @visibleForTesting
+  static void resetLegacyMigrationClaimForTesting() {
+    _legacyMigrationClaimed = false;
+  }
 
   final SharedPreferences _preferences;
 
@@ -118,28 +133,43 @@ class SavedSoundsService {
     final pubkey = _pubkeyHex;
     if (pubkey == null || pubkey.isEmpty) return;
     if (_preferences.containsKey(storageKey)) return;
+    if (_legacyMigrationClaimed) return;
     final legacy = _preferences.getString(_legacyStorageKey);
     if (legacy == null) return;
 
-    // setString updates the in-memory cache synchronously, so the load right
-    // after this call sees the migrated data; disk persistence and the legacy
-    // retire are ordered so the shared key is only dropped after the account
-    // bucket is durably written (see [_migrateLegacyBucket]).
+    // Claim synchronously: there is no await between reading the legacy key and
+    // setting this flag, so a second account that loads during the async write
+    // below sees the claim and cannot re-adopt the same list. setString also
+    // updates the in-memory cache synchronously, so the load right after this
+    // call still sees the migrated data.
+    _legacyMigrationClaimed = true;
     unawaited(_migrateLegacyBucket(_consentedLegacy(legacy)));
   }
 
   /// Persists the migrated list into the account bucket, then retires the
-  /// legacy key — but only once the write succeeds, so a failed or interrupted
-  /// write can never drop the data (the migration simply retries on the next
-  /// load while the legacy key survives).
+  /// legacy key. The claim is released only when the account write itself fails,
+  /// so a failed or interrupted write can never drop the data (the migration
+  /// retries on the next load while the legacy key survives); once the write
+  /// succeeds the claim stays, so no other account can re-adopt the list even if
+  /// retiring the legacy key later fails.
   Future<void> _migrateLegacyBucket(String migrated) async {
     try {
-      final written = await _preferences.setString(storageKey, migrated);
-      if (written) {
-        await _preferences.remove(_legacyStorageKey);
+      if (!await _preferences.setString(storageKey, migrated)) {
+        // The account write was rejected: release the claim and leave the
+        // legacy key so the next load retries the whole migration.
+        _legacyMigrationClaimed = false;
+        return;
       }
     } catch (_) {
-      // Leave the legacy key in place; migration retries on the next load.
+      // The account write threw: same as above — retry on the next load.
+      _legacyMigrationClaimed = false;
+      return;
+    }
+    try {
+      await _preferences.remove(_legacyStorageKey);
+    } catch (_) {
+      // Account bucket is durably written; leaving the legacy key is harmless
+      // now that the claim is permanent for this process.
     }
   }
 

--- a/mobile/lib/services/saved_sounds_service.dart
+++ b/mobile/lib/services/saved_sounds_service.dart
@@ -26,17 +26,17 @@ class SavedSoundsService {
   /// `null` when signed out.
   final String? _pubkeyHex;
 
-  /// SharedPreferences key for the current account's saved sounds.
+  /// SharedPreferences key for a specific account's saved sounds.
   ///
   /// Saved sounds are scoped per account so a sound one account adopts never
   /// leaks into another account on a shared device. The signed-out state uses
-  /// a dedicated anonymous bucket.
-  String get storageKey {
-    final pubkey = _pubkeyHex;
-    return pubkey == null || pubkey.isEmpty
-        ? '${_keyPrefix}_anon'
-        : '${_keyPrefix}_$pubkey';
-  }
+  /// a dedicated anonymous bucket. Exposed so account teardown can target the
+  /// deleted account's bucket without duplicating the key format.
+  static String accountStorageKey(String pubkeyHex) =>
+      pubkeyHex.isEmpty ? '${_keyPrefix}_anon' : '${_keyPrefix}_$pubkeyHex';
+
+  /// SharedPreferences key for the current account's saved sounds.
+  String get storageKey => accountStorageKey(_pubkeyHex ?? '');
 
   List<AudioEvent> loadSounds() {
     _migrateLegacyBucketIfNeeded();
@@ -122,10 +122,25 @@ class SavedSoundsService {
     if (legacy == null) return;
 
     // setString updates the in-memory cache synchronously, so the load right
-    // after this call sees the migrated data; disk persistence is fire-and-
-    // forget. Write the account bucket before retiring the legacy key.
-    unawaited(_preferences.setString(storageKey, _consentedLegacy(legacy)));
-    unawaited(_preferences.remove(_legacyStorageKey));
+    // after this call sees the migrated data; disk persistence and the legacy
+    // retire are ordered so the shared key is only dropped after the account
+    // bucket is durably written (see [_migrateLegacyBucket]).
+    unawaited(_migrateLegacyBucket(_consentedLegacy(legacy)));
+  }
+
+  /// Persists the migrated list into the account bucket, then retires the
+  /// legacy key — but only once the write succeeds, so a failed or interrupted
+  /// write can never drop the data (the migration simply retries on the next
+  /// load while the legacy key survives).
+  Future<void> _migrateLegacyBucket(String migrated) async {
+    try {
+      final written = await _preferences.setString(storageKey, migrated);
+      if (written) {
+        await _preferences.remove(_legacyStorageKey);
+      }
+    } catch (_) {
+      // Leave the legacy key in place; migration retries on the next load.
+    }
   }
 
   /// Filters the pre-namespacing list to entries safe to adopt without

--- a/mobile/lib/services/saved_sounds_service.dart
+++ b/mobile/lib/services/saved_sounds_service.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Persistence service for user-saved reusable sounds.
 // ABOUTME: Stores selected AudioEvent records for the Library Sounds tab.
 
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:models/models.dart' show AudioEvent;
@@ -15,6 +16,10 @@ class SavedSoundsService {
   /// Prefix for the per-account storage keys.
   static const _keyPrefix = 'saved_reusable_sounds';
 
+  /// The pre-namespacing device-wide key (no account suffix). Read once at
+  /// upgrade to migrate existing saves into the first account that loads.
+  static const String _legacyStorageKey = _keyPrefix;
+
   final SharedPreferences _preferences;
 
   /// Signed-in pubkey (hex) whose saved sounds this instance manages, or
@@ -25,10 +30,7 @@ class SavedSoundsService {
   ///
   /// Saved sounds are scoped per account so a sound one account adopts never
   /// leaks into another account on a shared device. The signed-out state uses
-  /// a dedicated anonymous bucket. The legacy device-wide key
-  /// (`saved_reusable_sounds`, no suffix) is intentionally left orphaned; it is
-  /// never read again, so pre-existing saves reset once — a light convenience
-  /// feature, not data worth migrating across an ambiguous account boundary.
+  /// a dedicated anonymous bucket.
   String get storageKey {
     final pubkey = _pubkeyHex;
     return pubkey == null || pubkey.isEmpty
@@ -37,6 +39,7 @@ class SavedSoundsService {
   }
 
   List<AudioEvent> loadSounds() {
+    _migrateLegacyBucketIfNeeded();
     final rawSounds = _preferences.getString(storageKey);
     if (rawSounds == null || rawSounds.isEmpty) {
       return [];
@@ -100,5 +103,28 @@ class SavedSoundsService {
     return sound.anchorClipId == null
         ? sound
         : sound.copyWith(clearAnchorClipId: true);
+  }
+
+  /// One-time upgrade migration: adopt the pre-namespacing device-wide list
+  /// into the first signed-in account that loads after the update, then retire
+  /// the shared key so a second account can't also inherit it.
+  ///
+  /// Only migrates into a real account bucket (not the signed-out anonymous
+  /// one) and only when this account has no bucket yet, so it runs at most once
+  /// and never overwrites existing per-account data. The legacy list is
+  /// unlabeled, so whichever account loads first adopts all of it — an accepted
+  /// upgrade trade-off (see PR #6330).
+  void _migrateLegacyBucketIfNeeded() {
+    final pubkey = _pubkeyHex;
+    if (pubkey == null || pubkey.isEmpty) return;
+    if (_preferences.containsKey(storageKey)) return;
+    final legacy = _preferences.getString(_legacyStorageKey);
+    if (legacy == null) return;
+
+    // setString updates the in-memory cache synchronously, so the load right
+    // after this call sees the migrated data; disk persistence is fire-and-
+    // forget. Write the account bucket before retiring the legacy key.
+    unawaited(_preferences.setString(storageKey, legacy));
+    unawaited(_preferences.remove(_legacyStorageKey));
   }
 }

--- a/mobile/lib/services/user_data_cleanup_service.dart
+++ b/mobile/lib/services/user_data_cleanup_service.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Service to clear user-specific cached data when identity changes
 // ABOUTME: Prevents data leakage between different Nostr accounts after reinstall
 
+import 'package:openvine/services/saved_sounds_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -194,6 +195,18 @@ class UserDataCleanupService {
         await _prefs.remove(legacyDraftOwnerKey);
         clearedCount++;
         clearedKeys.add(legacyDraftOwnerKey);
+      }
+    }
+
+    // The per-account saved-sounds bucket holds audio ids, urls, and metadata.
+    // Drop it only on a destructive delete of a known account — a plain account
+    // switch keeps it so the user's library survives switching back.
+    if (deleteUserData && userPubkey != null && userPubkey.isNotEmpty) {
+      final savedSoundsKey = SavedSoundsService.accountStorageKey(userPubkey);
+      if (_prefs.containsKey(savedSoundsKey)) {
+        await _prefs.remove(savedSoundsKey);
+        clearedCount++;
+        clearedKeys.add(savedSoundsKey);
       }
     }
 

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
@@ -142,6 +142,9 @@ class _OriginalSoundSection extends ConsumerWidget {
   bool _canReuseSound(WidgetRef ref) {
     if (reusedCreatorPubkey != null) return true;
     if (video.allowAudioReuse) return true;
+    // Re-evaluate on auth restore/logout/account-switch so the owner exception
+    // can't go stale (authServiceProvider alone is a stable instance).
+    ref.watch(currentAuthStateProvider);
     final viewerPubkey = ref.watch(authServiceProvider).currentPublicKeyHex;
     return viewerPubkey != null && viewerPubkey == video.pubkey;
   }

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
@@ -135,12 +135,16 @@ class _OriginalSoundSection extends ConsumerWidget {
 
   /// Whether the viewer may reuse this original sound.
   ///
-  /// A sound reused from another creator (who already shared it) stays
-  /// reusable. Otherwise the video's own audio is reusable only when the
-  /// creator enabled audio reuse (the `allow_audio_reuse` marker), or when the
-  /// viewer is the creator — you can always reuse your own audio.
+  /// This section is reached in two shapes. When the video has an audio
+  /// reference it reused a sound we couldn't resolve (the
+  /// [_SharedAudioSection] fallback): the referenced source's reuse consent
+  /// can't be confirmed offline, so fail closed — attribution still shows but
+  /// the sound isn't offered for reuse (an owner-saved private sound must not
+  /// leak this way). Otherwise this is the video's own original sound, reusable
+  /// only when its creator enabled audio reuse (the `allow_audio_reuse`
+  /// marker) or when the viewer is that creator.
   bool _canReuseSound(WidgetRef ref) {
-    if (reusedCreatorPubkey != null) return true;
+    if (video.hasAudioReference) return false;
     if (video.allowAudioReuse) return true;
     // Re-evaluate on auth restore/logout/account-switch so the owner exception
     // can't go stale (authServiceProvider alone is a stable instance).
@@ -156,19 +160,12 @@ class _OriginalSoundSection extends ConsumerWidget {
       category: LogCategory.ui,
     );
 
-    // For a reused sound the attribution belongs to the source video, so build
-    // the sound around the referenced source (credited to its creator) rather
-    // than this video's own audio.
-    final syntheticAudio = reusedCreatorPubkey != null
-        ? AudioEvent(
-            id: 'video_${video.audioEventId ?? video.id}',
-            pubkey: reusedCreatorPubkey!,
-            createdAt: video.createdAt,
-            title: 'Original sound - $creatorName',
-            source: 'Original Sound',
-            sourceVideoReference: video.inspiredByVideo?.addressableId,
-          )
-        : AudioEvent.fromVideoOriginalSound(video, creatorName: creatorName);
+    // Only reached for the video's own original sound (the reused-but-
+    // unresolved fallback is display-only), so build from this video directly.
+    final syntheticAudio = AudioEvent.fromVideoOriginalSound(
+      video,
+      creatorName: creatorName,
+    );
 
     // Dismiss the sheet first, then navigate from the root navigator
     // context.

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/sounds_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/sound_detail_screen.dart';
@@ -92,8 +93,12 @@ class _SharedAudioSection extends ConsumerWidget {
 }
 
 /// Section showing "Original sound - @creator" for videos without shared
-/// audio. Tapping navigates to [SoundDetailScreen] where the user can
-/// preview and select the sound for recording.
+/// audio.
+///
+/// The row is always shown for attribution, but it is only a reuse entry point
+/// (tappable into [SoundDetailScreen]) when the sound may be reused — see
+/// [_canReuseSound]. When it may not, the row is display-only credit, so a
+/// creator who left audio sharing off is not silently made reusable.
 class _OriginalSoundSection extends ConsumerWidget {
   const _OriginalSoundSection({required this.video, this.reusedCreatorPubkey});
 
@@ -119,50 +124,26 @@ class _OriginalSoundSection extends ConsumerWidget {
 
     return MetadataSection(
       label: context.l10n.metadataSoundsLabel,
-      child: Semantics(
-        button: true,
-        label: context.l10n.metadataSoundsOriginalSoundSemantics(creatorName),
-        child: GestureDetector(
-          behavior: HitTestBehavior.opaque,
-          onTap: () => _navigateToSoundDetail(context, creatorName),
-          child: Row(
-            spacing: 16,
-            children: [
-              const DivineIcon(
-                icon: DivineIconName.waveform,
-                color: VineTheme.onSurfaceVariant,
-              ),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      context.l10n.metadataOriginalSound,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: VineTheme.titleMediumFont(),
-                    ),
-                    Text(
-                      creatorName,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: VineTheme.bodyMediumFont(
-                        color: VineTheme.onSurfaceVariant,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              const DivineIcon(
-                icon: DivineIconName.caretRight,
-                color: VineTheme.onSurfaceVariant,
-                size: 20,
-              ),
-            ],
-          ),
-        ),
+      child: _OriginalSoundRow(
+        creatorName: creatorName,
+        onTap: _canReuseSound(ref)
+            ? () => _navigateToSoundDetail(context, creatorName)
+            : null,
       ),
     );
+  }
+
+  /// Whether the viewer may reuse this original sound.
+  ///
+  /// A sound reused from another creator (who already shared it) stays
+  /// reusable. Otherwise the video's own audio is reusable only when the
+  /// creator enabled audio reuse (the `allow_audio_reuse` marker), or when the
+  /// viewer is the creator — you can always reuse your own audio.
+  bool _canReuseSound(WidgetRef ref) {
+    if (reusedCreatorPubkey != null) return true;
+    if (video.allowAudioReuse) return true;
+    final viewerPubkey = ref.watch(authServiceProvider).currentPublicKeyHex;
+    return viewerPubkey != null && viewerPubkey == video.pubkey;
   }
 
   void _navigateToSoundDetail(BuildContext context, String creatorName) {
@@ -197,6 +178,72 @@ class _OriginalSoundSection extends ConsumerWidget {
         extra: <String, dynamic>{'sound': syntheticAudio, 'sourceVideo': video},
       );
     });
+  }
+}
+
+/// The "Original sound - @creator" row.
+///
+/// When [onTap] is non-null the row is a reuse entry point: tappable, with a
+/// trailing chevron and button semantics. When null it is display-only
+/// attribution — the sound may not be reused, so viewers see the credit but no
+/// affordance to adopt it.
+class _OriginalSoundRow extends StatelessWidget {
+  const _OriginalSoundRow({required this.creatorName, required this.onTap});
+
+  final String creatorName;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final onTap = this.onTap;
+    final row = Row(
+      spacing: 16,
+      children: [
+        const DivineIcon(
+          icon: DivineIconName.waveform,
+          color: VineTheme.onSurfaceVariant,
+        ),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                context.l10n.metadataOriginalSound,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: VineTheme.titleMediumFont(),
+              ),
+              Text(
+                creatorName,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: VineTheme.bodyMediumFont(
+                  color: VineTheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+        ),
+        if (onTap != null)
+          const DivineIcon(
+            icon: DivineIconName.caretRight,
+            color: VineTheme.onSurfaceVariant,
+            size: 20,
+          ),
+      ],
+    );
+
+    if (onTap == null) return row;
+
+    return Semantics(
+      button: true,
+      label: context.l10n.metadataSoundsOriginalSoundSemantics(creatorName),
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: row,
+      ),
+    );
   }
 }
 

--- a/mobile/packages/models/lib/src/audio_event.dart
+++ b/mobile/packages/models/lib/src/audio_event.dart
@@ -57,6 +57,7 @@ class AudioEvent {
     this.startTime = Duration.zero,
     this.endTime,
     this.anchorClipId,
+    this.allowsReuse = true,
   });
 
   /// Parse an AudioEvent from a Nostr Event.
@@ -188,6 +189,7 @@ class AudioEvent {
       title: creatorName == null ? null : 'Original sound - $creatorName',
       source: 'Original Sound',
       sourceVideoReference: '34236:${video.pubkey}:${video.vineId ?? video.id}',
+      allowsReuse: video.allowAudioReuse,
     );
   }
 
@@ -439,6 +441,16 @@ class AudioEvent {
   /// Local-only editor state, never published to Nostr.
   final String? anchorClipId;
 
+  /// Whether the source creator permits this sound to be reused by others.
+  ///
+  /// Meaningful only for a video's synthesized original sound
+  /// ([AudioEvent.fromVideoOriginalSound]), where it carries the source video's
+  /// `allow_audio_reuse` marker so a reuse gate can decide without re-fetching
+  /// the video. Shared Kind 1063 and bundled sounds were published for reuse,
+  /// so this defaults to `true`. Transient — not serialized (an adopted sound
+  /// was reusable when saved) and not part of identity equality.
+  final bool allowsReuse;
+
   /// Whether this audio is currently anchored to a source video clip.
   bool get isAnchored => anchorClipId != null;
 
@@ -552,6 +564,7 @@ class AudioEvent {
     Duration? endTime,
     String? anchorClipId,
     bool clearAnchorClipId = false,
+    bool? allowsReuse,
   }) {
     return AudioEvent(
       id: id ?? this.id,
@@ -574,6 +587,7 @@ class AudioEvent {
       anchorClipId: clearAnchorClipId
           ? null
           : (anchorClipId ?? this.anchorClipId),
+      allowsReuse: allowsReuse ?? this.allowsReuse,
     );
   }
 

--- a/mobile/packages/models/test/src/audio_event_test.dart
+++ b/mobile/packages/models/test/src/audio_event_test.dart
@@ -389,6 +389,43 @@ void main() {
         expect(audioEvent.title, isNull);
         expect(audioEvent.pubkey, equals(testPubkey));
       });
+
+      test('carries allowsReuse from the source video', () {
+        VideoEvent video({required bool allowReuse}) => VideoEvent(
+          id: testHexId,
+          pubkey: testPubkey,
+          createdAt: 1700000000,
+          content: 'classic vine',
+          timestamp: DateTime(2026),
+          videoUrl: 'https://example.com/video.mp4',
+          duration: 6,
+          vineId: 'vine-123',
+          rawTags: allowReuse ? const {'allow_audio_reuse': 'true'} : const {},
+        );
+
+        expect(
+          AudioEvent.fromVideoOriginalSound(
+            video(allowReuse: true),
+          ).allowsReuse,
+          isTrue,
+        );
+        expect(
+          AudioEvent.fromVideoOriginalSound(
+            video(allowReuse: false),
+          ).allowsReuse,
+          isFalse,
+        );
+      });
+
+      test('defaults allowsReuse to true for a plain AudioEvent', () {
+        const audioEvent = AudioEvent(
+          id: testHexId,
+          pubkey: testPubkey,
+          createdAt: 1700000000,
+        );
+
+        expect(audioEvent.allowsReuse, isTrue);
+      });
     });
 
     group('attributionEventId', () {

--- a/mobile/test/providers/saved_sounds_provider_test.dart
+++ b/mobile/test/providers/saved_sounds_provider_test.dart
@@ -122,5 +122,62 @@ void main() {
       expect(serviceB.loadSounds(), isEmpty);
       expect(container.read(savedSoundsProvider), isEmpty);
     });
+
+    test(
+      'applies the write to current state after an A->B->A switch',
+      () async {
+        const pubkeyA =
+            'a123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+        const pubkeyB =
+            'b123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+        // Two distinct instances for the same A bucket model the provider
+        // rebuilding a *fresh* service when it returns to account A.
+        final serviceA1 = SavedSoundsService(
+          sharedPreferences,
+          pubkeyHex: pubkeyA,
+        );
+        final serviceB = SavedSoundsService(
+          sharedPreferences,
+          pubkeyHex: pubkeyB,
+        );
+        final serviceA2 = SavedSoundsService(
+          sharedPreferences,
+          pubkeyHex: pubkeyA,
+        );
+
+        var current = serviceA1;
+        final container = ProviderContainer(
+          overrides: [
+            savedSoundsServiceProvider.overrideWith((ref) => current),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        // saveSound freezes serviceA1 before its first await.
+        expect(container.read(savedSoundsProvider), isEmpty);
+        final future = container
+            .read(savedSoundsProvider.notifier)
+            .saveSound(_sound(id: 'sound1'));
+
+        // A -> B -> A mid-save: the provider ends on a fresh A instance
+        // (serviceA2), which is not identical to the frozen serviceA1.
+        current = serviceB;
+        container.invalidate(savedSoundsServiceProvider);
+        expect(container.read(savedSoundsProvider), isEmpty);
+        current = serviceA2;
+        container.invalidate(savedSoundsServiceProvider);
+        expect(container.read(savedSoundsProvider), isEmpty);
+
+        await future;
+
+        // The write landed in A's bucket and the current A state reflects it,
+        // even though the current service instance differs from the frozen one.
+        expect(serviceA2.loadSounds().map((sound) => sound.id), ['sound1']);
+        expect(
+          container.read(savedSoundsProvider).map((sound) => sound.id),
+          ['sound1'],
+        );
+      },
+    );
   });
 }

--- a/mobile/test/providers/saved_sounds_provider_test.dart
+++ b/mobile/test/providers/saved_sounds_provider_test.dart
@@ -78,5 +78,49 @@ void main() {
       expect(container.read(savedSoundsProvider), isEmpty);
       expect(service.loadSounds(), isEmpty);
     });
+
+    test('saveSound freezes the account bucket across the awaits', () async {
+      const pubkeyA =
+          'a123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+      const pubkeyB =
+          'b123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+      final serviceA = SavedSoundsService(
+        sharedPreferences,
+        pubkeyHex: pubkeyA,
+      );
+      final serviceB = SavedSoundsService(
+        sharedPreferences,
+        pubkeyHex: pubkeyB,
+      );
+
+      // Drive the "current account bucket" directly so the switch is
+      // deterministic, independent of auth-state propagation.
+      var current = serviceA;
+      final container = ProviderContainer(
+        overrides: [
+          savedSoundsServiceProvider.overrideWith((ref) => current),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      // Prime for account A; saveSound freezes serviceA before its first await.
+      expect(container.read(savedSoundsProvider), isEmpty);
+      final future = container
+          .read(savedSoundsProvider.notifier)
+          .saveSound(_sound(id: 'sound1'));
+
+      // Switch the active bucket to B mid-save and force the rebind.
+      current = serviceB;
+      container.invalidate(savedSoundsServiceProvider);
+      expect(container.read(savedSoundsProvider), isEmpty);
+
+      await future;
+
+      // The write landed in the frozen account A, never leaked into B, and the
+      // stale-account state update was skipped.
+      expect(serviceA.loadSounds().map((sound) => sound.id), ['sound1']);
+      expect(serviceB.loadSounds(), isEmpty);
+      expect(container.read(savedSoundsProvider), isEmpty);
+    });
   });
 }

--- a/mobile/test/screens/sound_detail_screen_test.dart
+++ b/mobile/test/screens/sound_detail_screen_test.dart
@@ -24,6 +24,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:sound_service/sound_service.dart';
 
 import '../helpers/go_router.dart';
+import '../helpers/test_provider_overrides.dart';
 
 class _MockAudioPlaybackService extends Mock implements AudioPlaybackService {}
 
@@ -114,9 +115,21 @@ class MockVideosUsingSoundErrorNotifier
 }
 
 /// Test wrapper widget that provides necessary context.
-Widget createTestWidget({required Widget child, List<dynamic>? overrides}) {
+///
+/// [viewerPubkey] seeds the mocked signed-in pubkey used by the reuse gate;
+/// defaults to signed-out (null).
+Widget createTestWidget({
+  required Widget child,
+  List<dynamic>? overrides,
+  String? viewerPubkey,
+}) {
+  final mockAuth = createMockAuthService();
+  when(() => mockAuth.currentPublicKeyHex).thenReturn(viewerPubkey);
   return ProviderScope(
-    overrides: [...?overrides],
+    overrides: [
+      authServiceProvider.overrideWithValue(mockAuth),
+      ...?overrides,
+    ],
     child: MaterialApp(
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
@@ -486,6 +499,108 @@ void main() {
 
         expect(find.text('Use Sound'), findsOneWidget);
         expect(_divineIcon(DivineIconName.plus), findsOneWidget);
+      });
+    });
+
+    group('Use Sound reuse gating', () {
+      const sourceVideoId =
+          'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
+      const creatorPubkey =
+          'test_pubkey_0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+      // createTestAudioEvent's default pubkey is [creatorPubkey].
+      AudioEvent originalSound() => createTestAudioEvent(
+        id: 'video_$sourceVideoId',
+        title: 'Original sound',
+      );
+
+      VideoEvent sourceVideo({required bool allowReuse}) => VideoEvent(
+        id: sourceVideoId,
+        pubkey: creatorPubkey,
+        createdAt: 1700000000,
+        content: '',
+        timestamp: DateTime.fromMillisecondsSinceEpoch(1700000000 * 1000),
+        videoUrl: 'https://example.com/video/$sourceVideoId.mp4',
+        rawTags: allowReuse ? const {'allow_audio_reuse': 'true'} : const {},
+      );
+
+      List<dynamic> gridOverrides() => [
+        soundUsageCountProvider(
+          sourceVideoId,
+        ).overrideWith((ref) => Future.value(0)),
+        videosUsingSoundProvider(
+          sourceVideoId,
+        ).overrideWith((ref) => Future.value(<String>[])),
+        audioPlaybackServiceProvider.overrideWithValue(mockAudioService),
+      ];
+
+      testWidgets('hides Use Sound when the creator disabled audio reuse', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          createTestWidget(
+            child: SoundDetailScreen(
+              sound: originalSound(),
+              sourceVideo: sourceVideo(allowReuse: false),
+            ),
+            overrides: gridOverrides(),
+          ),
+        );
+        await tester.pump();
+
+        expect(find.text('Use Sound'), findsNothing);
+        expect(_divineIcon(DivineIconName.plus), findsNothing);
+        // Preview stays available for the un-adoptable sound.
+        expect(find.text('Preview'), findsOneWidget);
+      });
+
+      testWidgets('shows Use Sound when the creator enabled audio reuse', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          createTestWidget(
+            child: SoundDetailScreen(
+              sound: originalSound(),
+              sourceVideo: sourceVideo(allowReuse: true),
+            ),
+            overrides: gridOverrides(),
+          ),
+        );
+        await tester.pump();
+
+        expect(find.text('Use Sound'), findsOneWidget);
+      });
+
+      testWidgets('shows Use Sound for the creator viewing their own sound', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          createTestWidget(
+            viewerPubkey: creatorPubkey,
+            child: SoundDetailScreen(
+              sound: originalSound(),
+              sourceVideo: sourceVideo(allowReuse: false),
+            ),
+            overrides: gridOverrides(),
+          ),
+        );
+        await tester.pump();
+
+        expect(find.text('Use Sound'), findsOneWidget);
+      });
+
+      testWidgets('hides Use Sound for a deep link with no source video', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          createTestWidget(
+            child: SoundDetailScreen(sound: originalSound()),
+            overrides: gridOverrides(),
+          ),
+        );
+        await tester.pump();
+
+        expect(find.text('Use Sound'), findsNothing);
       });
     });
 

--- a/mobile/test/screens/sound_detail_screen_test.dart
+++ b/mobile/test/screens/sound_detail_screen_test.dart
@@ -508,12 +508,6 @@ void main() {
       const creatorPubkey =
           'test_pubkey_0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
 
-      // createTestAudioEvent's default pubkey is [creatorPubkey].
-      AudioEvent originalSound() => createTestAudioEvent(
-        id: 'video_$sourceVideoId',
-        title: 'Original sound',
-      );
-
       VideoEvent sourceVideo({required bool allowReuse}) => VideoEvent(
         id: sourceVideoId,
         pubkey: creatorPubkey,
@@ -523,6 +517,13 @@ void main() {
         videoUrl: 'https://example.com/video/$sourceVideoId.mp4',
         rawTags: allowReuse ? const {'allow_audio_reuse': 'true'} : const {},
       );
+
+      // The synthesized original sound carries allowsReuse from the video, so
+      // the gate works regardless of whether sourceVideo is threaded through.
+      AudioEvent originalSound({required bool allowReuse}) =>
+          AudioEvent.fromVideoOriginalSound(
+            sourceVideo(allowReuse: allowReuse),
+          );
 
       List<dynamic> gridOverrides() => [
         soundUsageCountProvider(
@@ -539,10 +540,7 @@ void main() {
       ) async {
         await tester.pumpWidget(
           createTestWidget(
-            child: SoundDetailScreen(
-              sound: originalSound(),
-              sourceVideo: sourceVideo(allowReuse: false),
-            ),
+            child: SoundDetailScreen(sound: originalSound(allowReuse: false)),
             overrides: gridOverrides(),
           ),
         );
@@ -554,22 +552,24 @@ void main() {
         expect(find.text('Preview'), findsOneWidget);
       });
 
-      testWidgets('shows Use Sound when the creator enabled audio reuse', (
-        tester,
-      ) async {
-        await tester.pumpWidget(
-          createTestWidget(
-            child: SoundDetailScreen(
-              sound: originalSound(),
-              sourceVideo: sourceVideo(allowReuse: true),
+      testWidgets(
+        'shows Use Sound for a reusable original sound reached without a '
+        'source video',
+        (tester) async {
+          // Regression: the resolved reuse path (and deep links) pass only the
+          // sound, no sourceVideo. Reuse must still be offered when the creator
+          // enabled it.
+          await tester.pumpWidget(
+            createTestWidget(
+              child: SoundDetailScreen(sound: originalSound(allowReuse: true)),
+              overrides: gridOverrides(),
             ),
-            overrides: gridOverrides(),
-          ),
-        );
-        await tester.pump();
+          );
+          await tester.pump();
 
-        expect(find.text('Use Sound'), findsOneWidget);
-      });
+          expect(find.text('Use Sound'), findsOneWidget);
+        },
+      );
 
       testWidgets('shows Use Sound for the creator viewing their own sound', (
         tester,
@@ -577,30 +577,13 @@ void main() {
         await tester.pumpWidget(
           createTestWidget(
             viewerPubkey: creatorPubkey,
-            child: SoundDetailScreen(
-              sound: originalSound(),
-              sourceVideo: sourceVideo(allowReuse: false),
-            ),
+            child: SoundDetailScreen(sound: originalSound(allowReuse: false)),
             overrides: gridOverrides(),
           ),
         );
         await tester.pump();
 
         expect(find.text('Use Sound'), findsOneWidget);
-      });
-
-      testWidgets('hides Use Sound for a deep link with no source video', (
-        tester,
-      ) async {
-        await tester.pumpWidget(
-          createTestWidget(
-            child: SoundDetailScreen(sound: originalSound()),
-            overrides: gridOverrides(),
-          ),
-        );
-        await tester.pump();
-
-        expect(find.text('Use Sound'), findsNothing);
       });
     });
 

--- a/mobile/test/services/saved_sounds_service_test.dart
+++ b/mobile/test/services/saved_sounds_service_test.dart
@@ -108,24 +108,75 @@ void main() {
     });
 
     test('returns empty list when persisted JSON is corrupt', () {
-      sharedPreferences.setString(SavedSoundsService.storageKey, 'not json');
       final service = SavedSoundsService(sharedPreferences);
+      sharedPreferences.setString(service.storageKey, 'not json');
 
       expect(service.loadSounds(), isEmpty);
     });
 
     test('skips invalid persisted entries without dropping valid sounds', () {
+      final service = SavedSoundsService(sharedPreferences);
       final validSound = _sound(id: 'sound1', title: 'Valid Sound');
       sharedPreferences.setString(
-        SavedSoundsService.storageKey,
+        service.storageKey,
         jsonEncode([
           validSound.toJson(),
           {'id': 123},
         ]),
       );
-      final service = SavedSoundsService(sharedPreferences);
 
       expect(service.loadSounds(), [validSound]);
+    });
+
+    group('per-account isolation', () {
+      const pubkeyA =
+          'a123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+      const pubkeyB =
+          'b123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+      test('a sound saved under one account is invisible to another', () async {
+        await SavedSoundsService(
+          sharedPreferences,
+          pubkeyHex: pubkeyA,
+        ).saveSound(_sound(id: 'sound1'));
+
+        final accountB = SavedSoundsService(
+          sharedPreferences,
+          pubkeyHex: pubkeyB,
+        );
+        expect(accountB.loadSounds(), isEmpty);
+
+        final accountA = SavedSoundsService(
+          sharedPreferences,
+          pubkeyHex: pubkeyA,
+        );
+        expect(accountA.loadSounds().map((sound) => sound.id), ['sound1']);
+      });
+
+      test('the signed-out bucket is separate from any account', () async {
+        await SavedSoundsService(
+          sharedPreferences,
+        ).saveSound(_sound(id: 'sound1'));
+
+        final account = SavedSoundsService(
+          sharedPreferences,
+          pubkeyHex: pubkeyA,
+        );
+        expect(account.loadSounds(), isEmpty);
+      });
+
+      test('does not read the legacy device-wide key', () {
+        sharedPreferences.setString(
+          'saved_reusable_sounds',
+          jsonEncode([_sound(id: 'legacy').toJson()]),
+        );
+
+        final service = SavedSoundsService(
+          sharedPreferences,
+          pubkeyHex: pubkeyA,
+        );
+        expect(service.loadSounds(), isEmpty);
+      });
     });
   });
 }

--- a/mobile/test/services/saved_sounds_service_test.dart
+++ b/mobile/test/services/saved_sounds_service_test.dart
@@ -4,9 +4,12 @@
 import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/services/saved_sounds_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockSharedPreferences extends Mock implements SharedPreferences {}
 
 AudioEvent _sound({
   required String id,
@@ -165,21 +168,27 @@ void main() {
         expect(account.loadSounds(), isEmpty);
       });
 
-      test('migrates the legacy device-wide list into the first account', () {
-        sharedPreferences.setString(
-          'saved_reusable_sounds',
-          jsonEncode([_sound(id: 'legacy').toJson()]),
-        );
+      test(
+        'migrates the legacy device-wide list into the first account',
+        () async {
+          sharedPreferences.setString(
+            'saved_reusable_sounds',
+            jsonEncode([_sound(id: 'legacy').toJson()]),
+          );
 
-        final accountA = SavedSoundsService(
-          sharedPreferences,
-          pubkeyHex: pubkeyA,
-        );
-        expect(accountA.loadSounds().map((sound) => sound.id), ['legacy']);
-        // Legacy key retired so it can't be adopted again.
-        expect(sharedPreferences.getString('saved_reusable_sounds'), isNull);
-        expect(sharedPreferences.getString(accountA.storageKey), isNotNull);
-      });
+          final accountA = SavedSoundsService(
+            sharedPreferences,
+            pubkeyHex: pubkeyA,
+          );
+          expect(accountA.loadSounds().map((sound) => sound.id), ['legacy']);
+
+          // The legacy key is retired only after the account bucket is durably
+          // written, so let the ordered migration finish first.
+          await Future<void>.delayed(Duration.zero);
+          expect(sharedPreferences.getString('saved_reusable_sounds'), isNull);
+          expect(sharedPreferences.getString(accountA.storageKey), isNotNull);
+        },
+      );
 
       test('drops legacy video_* original sounds during migration', () {
         // A pre-fix save of another creator's original sound (reuse consent
@@ -199,19 +208,52 @@ void main() {
         expect(accountA.loadSounds().map((sound) => sound.id), ['shared']);
       });
 
-      test('a second account does not inherit the migrated legacy list', () {
-        sharedPreferences.setString(
-          'saved_reusable_sounds',
-          jsonEncode([_sound(id: 'legacy').toJson()]),
-        );
+      test(
+        'a second account does not inherit the migrated legacy list',
+        () async {
+          sharedPreferences.setString(
+            'saved_reusable_sounds',
+            jsonEncode([_sound(id: 'legacy').toJson()]),
+          );
 
-        SavedSoundsService(sharedPreferences, pubkeyHex: pubkeyA).loadSounds();
+          SavedSoundsService(
+            sharedPreferences,
+            pubkeyHex: pubkeyA,
+          ).loadSounds();
+          // Let the first account's migration retire the legacy key.
+          await Future<void>.delayed(Duration.zero);
 
-        final accountB = SavedSoundsService(
-          sharedPreferences,
-          pubkeyHex: pubkeyB,
-        );
-        expect(accountB.loadSounds(), isEmpty);
+          final accountB = SavedSoundsService(
+            sharedPreferences,
+            pubkeyHex: pubkeyB,
+          );
+          expect(accountB.loadSounds(), isEmpty);
+        },
+      );
+
+      test('keeps the legacy key when the migration write fails', () async {
+        final mockPrefs = _MockSharedPreferences();
+        const legacyKey = 'saved_reusable_sounds';
+        final service = SavedSoundsService(mockPrefs, pubkeyHex: pubkeyA);
+        final accountKey = service.storageKey;
+
+        when(() => mockPrefs.containsKey(accountKey)).thenReturn(false);
+        when(
+          () => mockPrefs.getString(legacyKey),
+        ).thenReturn(jsonEncode([_sound(id: 'legacy').toJson()]));
+        when(() => mockPrefs.getString(accountKey)).thenReturn(null);
+        // The durable write fails.
+        when(
+          () => mockPrefs.setString(accountKey, any()),
+        ).thenAnswer((_) async => false);
+        when(() => mockPrefs.remove(any())).thenAnswer((_) async => true);
+
+        service.loadSounds();
+        await Future<void>.delayed(Duration.zero);
+
+        // Legacy key must survive so the migration retries — never removed
+        // after a failed write.
+        verifyNever(() => mockPrefs.remove(legacyKey));
       });
 
       test('does not migrate the legacy list into the signed-out bucket', () {

--- a/mobile/test/services/saved_sounds_service_test.dart
+++ b/mobile/test/services/saved_sounds_service_test.dart
@@ -181,6 +181,24 @@ void main() {
         expect(sharedPreferences.getString(accountA.storageKey), isNotNull);
       });
 
+      test('drops legacy video_* original sounds during migration', () {
+        // A pre-fix save of another creator's original sound (reuse consent
+        // unknown) must not become reusable after the upgrade.
+        sharedPreferences.setString(
+          'saved_reusable_sounds',
+          jsonEncode([
+            _sound(id: 'shared').toJson(),
+            _sound(id: 'video_original').toJson(),
+          ]),
+        );
+
+        final accountA = SavedSoundsService(
+          sharedPreferences,
+          pubkeyHex: pubkeyA,
+        );
+        expect(accountA.loadSounds().map((sound) => sound.id), ['shared']);
+      });
+
       test('a second account does not inherit the migrated legacy list', () {
         sharedPreferences.setString(
           'saved_reusable_sounds',

--- a/mobile/test/services/saved_sounds_service_test.dart
+++ b/mobile/test/services/saved_sounds_service_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Tests for the persisted reusable sounds library service.
 // ABOUTME: Covers saving, dedupe, ordering, and corrupt storage fallback.
 
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -38,6 +39,9 @@ void main() {
     late SharedPreferences sharedPreferences;
 
     setUp(() async {
+      // The migration claim is a process-wide static; reset it so the shared
+      // test isolate can't leak a prior test's claim into this one.
+      SavedSoundsService.resetLegacyMigrationClaimForTesting();
       SharedPreferences.setMockInitialValues({});
       sharedPreferences = await SharedPreferences.getInstance();
     });
@@ -255,6 +259,50 @@ void main() {
         // after a failed write.
         verifyNever(() => mockPrefs.remove(legacyKey));
       });
+
+      test(
+        'a second account cannot re-adopt the legacy list mid-migration',
+        () async {
+          final mockPrefs = _MockSharedPreferences();
+          const legacyKey = 'saved_reusable_sounds';
+          final legacyJson = jsonEncode([_sound(id: 'shared').toJson()]);
+
+          final serviceA = SavedSoundsService(mockPrefs, pubkeyHex: pubkeyA);
+          final serviceB = SavedSoundsService(mockPrefs, pubkeyHex: pubkeyB);
+          final keyA = serviceA.storageKey;
+          final keyB = serviceB.storageKey;
+
+          when(() => mockPrefs.containsKey(keyA)).thenReturn(false);
+          when(() => mockPrefs.containsKey(keyB)).thenReturn(false);
+          when(() => mockPrefs.getString(legacyKey)).thenReturn(legacyJson);
+          when(() => mockPrefs.getString(keyA)).thenReturn(null);
+          when(() => mockPrefs.getString(keyB)).thenReturn(null);
+          // Hold A's migration write open so B loads inside the migration
+          // window while the legacy key is still present.
+          final blockedWrite = Completer<bool>();
+          when(
+            () => mockPrefs.setString(keyA, any()),
+          ).thenAnswer((_) => blockedWrite.future);
+          when(
+            () => mockPrefs.setString(keyB, any()),
+          ).thenAnswer((_) async => true);
+          when(() => mockPrefs.remove(any())).thenAnswer((_) async => true);
+
+          // A claims the migration synchronously; its write stays pending.
+          serviceA.loadSounds();
+          // B loads while A's write is unresolved and the legacy key survives.
+          serviceB.loadSounds();
+
+          // Only A ever tried to adopt the legacy list; B was blocked by the
+          // claim and never wrote its own bucket.
+          verify(() => mockPrefs.setString(keyA, any())).called(1);
+          verifyNever(() => mockPrefs.setString(keyB, any()));
+
+          // Let A finish so no pending future outlives the test.
+          blockedWrite.complete(true);
+          await Future<void>.delayed(Duration.zero);
+        },
+      );
 
       test('does not migrate the legacy list into the signed-out bucket', () {
         sharedPreferences.setString(

--- a/mobile/test/services/saved_sounds_service_test.dart
+++ b/mobile/test/services/saved_sounds_service_test.dart
@@ -165,18 +165,69 @@ void main() {
         expect(account.loadSounds(), isEmpty);
       });
 
-      test('does not read the legacy device-wide key', () {
+      test('migrates the legacy device-wide list into the first account', () {
         sharedPreferences.setString(
           'saved_reusable_sounds',
           jsonEncode([_sound(id: 'legacy').toJson()]),
         );
 
-        final service = SavedSoundsService(
+        final accountA = SavedSoundsService(
           sharedPreferences,
           pubkeyHex: pubkeyA,
         );
-        expect(service.loadSounds(), isEmpty);
+        expect(accountA.loadSounds().map((sound) => sound.id), ['legacy']);
+        // Legacy key retired so it can't be adopted again.
+        expect(sharedPreferences.getString('saved_reusable_sounds'), isNull);
+        expect(sharedPreferences.getString(accountA.storageKey), isNotNull);
       });
+
+      test('a second account does not inherit the migrated legacy list', () {
+        sharedPreferences.setString(
+          'saved_reusable_sounds',
+          jsonEncode([_sound(id: 'legacy').toJson()]),
+        );
+
+        SavedSoundsService(sharedPreferences, pubkeyHex: pubkeyA).loadSounds();
+
+        final accountB = SavedSoundsService(
+          sharedPreferences,
+          pubkeyHex: pubkeyB,
+        );
+        expect(accountB.loadSounds(), isEmpty);
+      });
+
+      test('does not migrate the legacy list into the signed-out bucket', () {
+        sharedPreferences.setString(
+          'saved_reusable_sounds',
+          jsonEncode([_sound(id: 'legacy').toJson()]),
+        );
+
+        final anon = SavedSoundsService(sharedPreferences);
+        expect(anon.loadSounds(), isEmpty);
+        // Legacy stays untouched for a real account to adopt later.
+        expect(sharedPreferences.getString('saved_reusable_sounds'), isNotNull);
+      });
+
+      test(
+        'does not migrate when the account already has saved sounds',
+        () async {
+          final accountA = SavedSoundsService(
+            sharedPreferences,
+            pubkeyHex: pubkeyA,
+          );
+          await accountA.saveSound(_sound(id: 'own'));
+          sharedPreferences.setString(
+            'saved_reusable_sounds',
+            jsonEncode([_sound(id: 'legacy').toJson()]),
+          );
+
+          expect(accountA.loadSounds().map((sound) => sound.id), ['own']);
+          expect(
+            sharedPreferences.getString('saved_reusable_sounds'),
+            isNotNull,
+          );
+        },
+      );
     });
   });
 }

--- a/mobile/test/services/user_data_cleanup_service_test.dart
+++ b/mobile/test/services/user_data_cleanup_service_test.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Validates that user-specific data is cleared when switching accounts
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/saved_sounds_service.dart';
 import 'package:openvine/services/user_data_cleanup_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -177,6 +178,38 @@ void main() {
           prefs.containsKey(UserDataCleanupService.legacyDraftOwnerKey),
           isFalse,
         );
+      });
+
+      test(
+        'clears the saved-sounds bucket on destructive account delete',
+        () async {
+          const pubkey =
+              'a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456';
+          final bucketKey = SavedSoundsService.accountStorageKey(pubkey);
+          await prefs.setString(bucketKey, '[{"id":"sound1"}]');
+
+          await service.clearUserSpecificData(
+            deleteUserData: true,
+            userPubkey: pubkey,
+          );
+
+          expect(prefs.containsKey(bucketKey), isFalse);
+        },
+      );
+
+      test('keeps the saved-sounds bucket on a plain account switch', () async {
+        const pubkey =
+            'a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456';
+        final bucketKey = SavedSoundsService.accountStorageKey(pubkey);
+        await prefs.setString(bucketKey, '[{"id":"sound1"}]');
+
+        await service.clearUserSpecificData(
+          isIdentityChange: true,
+          userPubkey: pubkey,
+        );
+
+        // A switch (not a delete) preserves the library for switching back.
+        expect(prefs.containsKey(bucketKey), isTrue);
       });
 
       test('marks legacy draft owner only when legacy drafts exist', () async {

--- a/mobile/test/widgets/metadata_sounds_section_test.dart
+++ b/mobile/test/widgets/metadata_sounds_section_test.dart
@@ -337,6 +337,37 @@ void main() {
       );
 
       testWidgets(
+        'is display-only when the reused source cannot be resolved',
+        (tester) async {
+          // hasAudioReference + unresolved source: the referenced creator's
+          // reuse consent is unconfirmable, so the row credits them but offers
+          // no reuse affordance (fail closed).
+          await tester.pumpWidget(
+            ProviderScope(
+              overrides: [
+                soundByIdProvider(
+                  testAudioEventId,
+                ).overrideWith((ref) async => null),
+              ],
+              child: MaterialApp(
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                theme: VineTheme.theme,
+                home: Scaffold(
+                  backgroundColor: Colors.black,
+                  body: MetadataSoundsSection(video: reusedVideo()),
+                ),
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          expect(find.text('Original sound'), findsOneWidget);
+          expect(_divineIcon(DivineIconName.caretRight), findsNothing);
+        },
+      );
+
+      testWidgets(
         'tapping a resolved reused sound opens the detail (no dead-end)',
         (tester) async {
           const sourceVideoId =

--- a/mobile/test/widgets/metadata_sounds_section_test.dart
+++ b/mobile/test/widgets/metadata_sounds_section_test.dart
@@ -6,14 +6,24 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/sounds_providers.dart';
 import 'package:openvine/screens/sound_detail_screen.dart';
 import 'package:openvine/widgets/video_feed_item/metadata/metadata_sounds_section.dart';
 
+import '../helpers/test_provider_overrides.dart';
+
 Finder _divineIcon(DivineIconName name) =>
     find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
+
+MockAuthService _mockAuth({String? viewerPubkey}) {
+  final mockAuth = createMockAuthService();
+  when(() => mockAuth.currentPublicKeyHex).thenReturn(viewerPubkey);
+  return mockAuth;
+}
 
 void main() {
   group(MetadataSoundsSection, () {
@@ -52,7 +62,10 @@ void main() {
       );
     }
 
-    VideoEvent createVideoWithoutAudio({String? authorName}) {
+    VideoEvent createVideoWithoutAudio({
+      String? authorName,
+      bool allowAudioReuse = false,
+    }) {
       final now = DateTime.now();
       return VideoEvent(
         id: testVideoId,
@@ -63,18 +76,25 @@ void main() {
         timestamp: now,
         title: 'Test Video',
         authorName: authorName,
+        rawTags: allowAudioReuse
+            ? const {'allow_audio_reuse': 'true'}
+            : const {},
       );
     }
 
     Widget buildTestWidget({
       required VideoEvent video,
       AudioEvent? audioOverride,
+      String? viewerPubkey,
     }) {
       return ProviderScope(
         overrides: [
           soundByIdProvider(testAudioEventId).overrideWith((ref) async {
             return audioOverride ?? testAudio;
           }),
+          authServiceProvider.overrideWithValue(
+            _mockAuth(viewerPubkey: viewerPubkey),
+          ),
         ],
         child: MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -149,15 +169,6 @@ void main() {
         expect(find.text('Jake Lara'), findsOneWidget);
       });
 
-      testWidgets('shows chevron (tappable to use sound)', (tester) async {
-        final video = createVideoWithoutAudio();
-
-        await tester.pumpWidget(buildTestWidget(video: video));
-        await tester.pumpAndSettle();
-
-        expect(_divineIcon(DivineIconName.caretRight), findsOneWidget);
-      });
-
       testWidgets('falls back to original sound when audio event is null', (
         tester,
       ) async {
@@ -169,6 +180,7 @@ void main() {
               soundByIdProvider(testAudioEventId).overrideWith((ref) async {
                 return null;
               }),
+              authServiceProvider.overrideWithValue(_mockAuth()),
             ],
             child: MaterialApp(
               localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -187,6 +199,86 @@ void main() {
         // Should fall back to original sound
         expect(find.text('Original sound'), findsOneWidget);
       });
+    });
+
+    group('Original sound reuse gating', () {
+      testWidgets(
+        'is display-only (no chevron) when the creator disabled audio reuse',
+        (tester) async {
+          final video = createVideoWithoutAudio();
+
+          await tester.pumpWidget(buildTestWidget(video: video));
+          await tester.pumpAndSettle();
+
+          expect(find.text('Original sound'), findsOneWidget);
+          expect(_divineIcon(DivineIconName.caretRight), findsNothing);
+        },
+      );
+
+      testWidgets('does not navigate when a display-only sound is tapped', (
+        tester,
+      ) async {
+        final router = GoRouter(
+          initialLocation: '/',
+          routes: [
+            GoRoute(
+              path: '/',
+              builder: (_, _) => Scaffold(
+                body: MetadataSoundsSection(video: createVideoWithoutAudio()),
+              ),
+            ),
+            GoRoute(
+              path: SoundDetailScreen.path,
+              name: SoundDetailScreen.routeName,
+              builder: (_, _) => const Scaffold(body: Text('DETAIL')),
+            ),
+          ],
+        );
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [authServiceProvider.overrideWithValue(_mockAuth())],
+            child: MaterialApp.router(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              theme: VineTheme.theme,
+              routerConfig: router,
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Original sound'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('DETAIL'), findsNothing);
+        expect(find.text('Original sound'), findsOneWidget);
+      });
+
+      testWidgets('shows chevron when the creator enabled audio reuse', (
+        tester,
+      ) async {
+        final video = createVideoWithoutAudio(allowAudioReuse: true);
+
+        await tester.pumpWidget(buildTestWidget(video: video));
+        await tester.pumpAndSettle();
+
+        expect(_divineIcon(DivineIconName.caretRight), findsOneWidget);
+      });
+
+      testWidgets(
+        'shows chevron for the creator viewing their own video with reuse off',
+        (tester) async {
+          final video = createVideoWithoutAudio();
+
+          await tester.pumpWidget(
+            buildTestWidget(video: video, viewerPubkey: testPubkey),
+          );
+          await tester.pumpAndSettle();
+
+          expect(_divineIcon(DivineIconName.caretRight), findsOneWidget);
+        },
+      );
     });
 
     group('Reused sound fallback', () {


### PR DESCRIPTION
Closes #6332

## Description

Creators reported their audio was still reusable by other users even with audio sharing turned off. The preference was enforced only at publish time; every path that lets a viewer *adopt* a video's original sound ignored it. This PR enforces the creator's reuse consent across all of those paths, and hardens the saved-sounds store that feeds them.

### Enforcement — a viewer can only adopt a video's original sound when the creator consented

- **Metadata "Original sound" row** ([metadata_sounds_section.dart](mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart)): the row stays visible for attribution, but is only a tappable reuse entry point when the creator enabled `allow_audio_reuse` or the viewer is the creator. When the sound was reused from a source we can't resolve, it fails closed (display-only) — an owner-saved private sound can't leak through the reuse-chain fallback.
- **"Use Sound" action** ([sound_detail_screen.dart](mobile/lib/screens/sound_detail_screen.dart)): hidden for a video's original sound unless the creator consented or the viewer is the creator — closing the `/sound/<video-id>` deep-link and resolved-reuse paths that never passed a `sourceVideo`.
- **Consent signal** ([audio_event.dart](mobile/packages/models/lib/src/audio_event.dart)): `AudioEvent.allowsReuse` carries the source video's `allow_audio_reuse` marker so the gate is correct regardless of how the screen was reached (metadata sheet, reuse chain, or deep link).
- Reuse gates watch `currentAuthStateProvider` so the owner exception re-evaluates on auth restore / logout / account switch.

### Saved sounds — scoped per account and migrated safely

- **Per-account buckets** ([saved_sounds_service.dart](mobile/lib/services/saved_sounds_service.dart)): saved sounds are keyed per signed-in pubkey (`saved_reusable_sounds_<pubkey>`, `_anon` when signed out) so one account's adopted sound can't surface in another on a shared device. The provider watches `currentAuthStateProvider` so the list rebuilds on account switch.
- **Race-safe writes** ([saved_sounds_provider.dart](mobile/lib/providers/saved_sounds_provider.dart)): `saveSound` / `removeSound` / backfill freeze the account bucket before the first `await` and only update state while the account is still current, so a mid-save switch can't write A's sounds into B's bucket.
- **One-time upgrade migration**: the first signed-in account to load adopts the legacy device-wide list, then retires the key so a second account can't also inherit it. Legacy `video_*` original sounds are **dropped** (fail closed) — their creator's consent can't be validated offline, and the pre-fix device-wide bucket may hold sounds whose creator had disabled reuse.

## Out of Scope

- **Server/relay-side enforcement.** This is client-side. A modified client could ignore the gate; full enforcement would require relay-side checks outside this repo. Client paths (metadata sheet, Use Sound, deep link, saved-sounds reuse) are all covered.
- **Stale consent after a creator later disables reuse** on an already-adopted sound — a separate re-validation concern, unchanged here.

## Verification

- `flutter analyze lib test` clean; targeted suites green: `sound_detail_screen`, `saved_sounds_service`, `saved_sounds_provider`, `metadata_sounds_section`, `library/sounds_tab`, `audio_selection_bottom_sheet`, and `AudioEvent` (models). New tests cover: reuse gating + owner exception, deep-link/reuse-chain paths, the account-switch race, per-account isolation, legacy migration + `video_*` drop, and the fail-closed unresolved-reuse fallback.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

**Related Issue:**