### PR TITLE
test(auth): settle the wordmark SVG before asserting image semantics

### DIFF
--- a/mobile/test/widgets/auth/auth_hero_section_test.dart
+++ b/mobile/test/widgets/auth/auth_hero_section_test.dart
@@ -149,6 +149,11 @@ void main() {
       ) async {
         final semantics = tester.ensureSemantics();
         await tester.pumpWidget(createTestWidget());
+        // flutter_svg attaches the semantics label immediately but only flags
+        // the node as an image once the picture finishes decoding — which
+        // isn't guaranteed on the first frame (it varies with SVG-cache warmth
+        // and platform in the merged-isolate suite). Settle before counting.
+        await tester.pumpAndSettle();
 
         expect(_imageSemanticsNodeCount(tester), equals(1));
         expect(find.bySemanticsLabel(AppConfig.appName), findsOneWidget);


### PR DESCRIPTION
Closes #6334

## Description

`AuthHeroSection`'s "exports only the wordmark image to semantics" test counts image-semantics nodes right after `pumpWidget`. flutter_svg attaches the semantics **label** immediately but only flags the node as an **image** once the picture finishes decoding — which isn't guaranteed on the first frame and varies with SVG-cache warmth and platform.

Under `very_good --optimization` (one merged isolate), test ordering can run this assertion before anything warms the wordmark SVG, so on CI (Linux) the count comes back `0` (`Expected: <1>, Actual: <0>`) while the file passes locally and in isolation. It has flaked several PRs across different random seeds.

Fix: `pumpAndSettle` before counting, so the assertion no longer depends on decode timing or bundle ordering. No production change.

**Related Issue:** 

## Verification

- `flutter analyze` clean; `flutter test test/widgets/auth/auth_hero_section_test.dart` — 11/11 pass.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)