### PR TITLE
chore(git): ignore zcode session files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,6 +173,7 @@ docs/superpowers/specs/.clearance-*/
 
 # Ephemeral working context / session notes — never tracked (any depth)
 .context/
+.zcode/
 
 # Playwright MCP scratch output
 **/.playwright-mcp/


### PR DESCRIPTION
Closes #6340

## Summary
- ignore the repository-local `.zcode/` directory
- keep Codex/Zed session plans out of Git status and commits

## Verification
- `git check-ignore -v .zcode/plans/example.md`
- `git diff --check origin/main...HEAD`