### PR TITLE
fix(notifications): keep bech32 npub tokens intact in reply/comment previews

### DIFF
--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -46,6 +46,15 @@ final RegExp _npubIdentifierPattern = RegExp(
   caseSensitive: false,
 );
 
+/// A bech32 Nostr reference embedded in note content, e.g. `npub1…` or
+/// `nostr:nprofile1…`. Matches the same token shape the UI linkifier decodes
+/// (npub/nprofile/note/nevent/naddr), so comment previews never slice a token
+/// mid-string and defeat downstream npub → display-name resolution.
+final RegExp _bech32ReferencePattern = RegExp(
+  '(?:nostr:)?(?:npub|nprofile|note|nevent|naddr)1[0-9a-z]+',
+  caseSensitive: false,
+);
+
 /// Retry policy for the first-page notifications fetch.
 ///
 /// Retries only transient server faults — HTTP `5xx` and request timeouts
@@ -1775,16 +1784,44 @@ class NotificationRepository {
     return n.referencedEventId;
   }
 
-  /// Truncates comment text to [_maxCommentLength] characters.
+  /// Truncates comment text to roughly [_maxCommentLength] characters.
   ///
   /// Only applies to comment and reply notifications.
+  ///
+  /// The cut avoids splitting a bech32 Nostr reference (`npub1…`,
+  /// `nprofile1…`, `note1…`, `nevent1…`, `naddr1…`) mid-token. A sliced token
+  /// can no longer be decoded, so the row widget falls back to rendering the
+  /// raw `npub1…` string verbatim instead of resolving it to a display name.
+  /// Keeping the token intact lets the UI linkifier resolve it to `@<name>`.
   static String? _truncateComment(String? content, NotificationKind kind) {
     if (content == null) return null;
     if (kind != NotificationKind.comment && kind != NotificationKind.reply) {
       return null;
     }
     if (content.length <= _maxCommentLength) return content;
-    return '${content.substring(0, _maxCommentLength)}...';
+
+    final cut = _bech32AwareCut(content, _maxCommentLength);
+    return cut < content.length ? '${content.substring(0, cut)}...' : content;
+  }
+
+  /// Returns the largest end index `<= [limit]` that does not fall inside a
+  /// bech32 Nostr reference.
+  ///
+  /// If a reference straddles [limit] but starts at or before it, the cut is
+  /// pulled back to the reference's start so the whole token is omitted from
+  /// the preview rather than split. If the content *begins* with a reference
+  /// that itself reaches or exceeds [limit] (e.g. a reply whose body is just
+  /// an npub), the token's full extent is returned so the UI can resolve it —
+  /// ellipsizing would otherwise leave an undecodable fragment.
+  static int _bech32AwareCut(String content, int limit) {
+    for (final match in _bech32ReferencePattern.allMatches(content)) {
+      final startsBeforeOrAtLimit = match.start < limit;
+      final endsAfterLimit = match.end > limit;
+      if (!startsBeforeOrAtLimit || !endsAfterLimit) continue;
+      if (match.start == 0) return match.end;
+      return match.start;
+    }
+    return limit;
   }
 }
 

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -46,12 +46,14 @@ final RegExp _npubIdentifierPattern = RegExp(
   caseSensitive: false,
 );
 
-/// A bech32 Nostr reference embedded in note content, e.g. `npub1…` or
-/// `nostr:nprofile1…`. Matches the same token shape the UI linkifier decodes
-/// (npub/nprofile/note/nevent/naddr), so comment previews never slice a token
-/// mid-string and defeat downstream npub → display-name resolution.
+/// A bech32 Nostr reference embedded in note content, e.g. `npub1...` or
+/// `nostr:nprofile1...`.
+///
+/// Keep this boundary rule aligned with
+/// `LinkifiedTextSpanBuilder._combinedRegex` so the repository only protects
+/// token spans the UI can decode.
 final RegExp _bech32ReferencePattern = RegExp(
-  '(?:nostr:)?(?:npub|nprofile|note|nevent|naddr)1[0-9a-z]+',
+  r'(?<![A-Za-z0-9])(?:nostr:)?(?:npub|nprofile|note|nevent|naddr)1[a-z0-9]+\b',
   caseSensitive: false,
 );
 
@@ -1784,15 +1786,17 @@ class NotificationRepository {
     return n.referencedEventId;
   }
 
-  /// Truncates comment text to roughly [_maxCommentLength] characters.
+  /// Truncates comment text to [_maxCommentLength] characters, except for
+  /// bounded leading Nostr references that the UI can resolve.
   ///
   /// Only applies to comment and reply notifications.
   ///
-  /// The cut avoids splitting a bech32 Nostr reference (`npub1…`,
-  /// `nprofile1…`, `note1…`, `nevent1…`, `naddr1…`) mid-token. A sliced token
-  /// can no longer be decoded, so the row widget falls back to rendering the
-  /// raw `npub1…` string verbatim instead of resolving it to a display name.
-  /// Keeping the token intact lets the UI linkifier resolve it to `@<name>`.
+  /// The cut avoids splitting a bech32 Nostr reference (`npub1...`,
+  /// `nprofile1...`, `note1...`, `nevent1...`, `naddr1...`) mid-token. A
+  /// sliced token can no longer be decoded, so the row widget falls back to
+  /// rendering the raw `npub1...` string verbatim instead of resolving it.
+  /// Keeping a bounded leading token intact lets the UI linkifier resolve it to
+  /// `@<name>`.
   static String? _truncateComment(String? content, NotificationKind kind) {
     if (content == null) return null;
     if (kind != NotificationKind.comment && kind != NotificationKind.reply) {
@@ -1801,27 +1805,41 @@ class NotificationRepository {
     if (content.length <= _maxCommentLength) return content;
 
     final cut = _bech32AwareCut(content, _maxCommentLength);
-    return cut < content.length ? '${content.substring(0, cut)}...' : content;
+    if (cut >= content.length) return content;
+    return '${content.substring(0, cut).trimRight()}...';
   }
 
-  /// Returns the largest end index `<= [limit]` that does not fall inside a
-  /// bech32 Nostr reference.
+  /// Returns a bounded cut index that does not split a bech32 Nostr reference.
   ///
-  /// If a reference straddles [limit] but starts at or before it, the cut is
-  /// pulled back to the reference's start so the whole token is omitted from
-  /// the preview rather than split. If the content *begins* with a reference
-  /// that itself reaches or exceeds [limit] (e.g. a reply whose body is just
-  /// an npub), the token's full extent is returned so the UI can resolve it —
-  /// ellipsizing would otherwise leave an undecodable fragment.
+  /// If a reference straddles [limit], the cut is pulled back to the
+  /// reference's start so the token is omitted from the preview rather than
+  /// split. If the content before that token is only whitespace or
+  /// punctuation, and keeping the full token stays within the preview bound,
+  /// the token's end is returned so the UI can resolve it.
   static int _bech32AwareCut(String content, int limit) {
+    final maxBech32PreviewLength = limit * 4;
     for (final match in _bech32ReferencePattern.allMatches(content)) {
       final startsBeforeOrAtLimit = match.start < limit;
       final endsAfterLimit = match.end > limit;
       if (!startsBeforeOrAtLimit || !endsAfterLimit) continue;
-      if (match.start == 0) return match.end;
+      final canKeepLeadingToken =
+          match.end <= maxBech32PreviewLength &&
+          _hasOnlyWhitespaceOrPunctuationBefore(content, match.start);
+      if (canKeepLeadingToken) return match.end;
       return match.start;
     }
     return limit;
+  }
+
+  static bool _hasOnlyWhitespaceOrPunctuationBefore(String content, int end) {
+    for (var index = 0; index < end; index += 1) {
+      final codeUnit = content.codeUnitAt(index);
+      final isAsciiDigit = codeUnit >= 0x30 && codeUnit <= 0x39;
+      final isAsciiUppercase = codeUnit >= 0x41 && codeUnit <= 0x5A;
+      final isAsciiLowercase = codeUnit >= 0x61 && codeUnit <= 0x7A;
+      if (isAsciiDigit || isAsciiUppercase || isAsciiLowercase) return false;
+    }
+    return true;
   }
 }
 

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -2028,6 +2028,57 @@ void main() {
       );
 
       test(
+        'keeps a bech32 npub intact when it spans the 50-char cut',
+        () async {
+          // Regression: a reply whose content begins with a raw npub longer
+          // than the 50-char preview cap must keep the token intact so the
+          // row widget can decode it to a display name. Slicing it
+          // mid-bech32 destroyed the checksum and the row fell back to
+          // rendering a raw "npub1..." fragment verbatim.
+          const npub =
+              'npub180cvv07tjdrrgpa9jzd0cdkej42kwsaxq9rz7gvdpjx6nz004f9uulstw6';
+          stubNotifications([
+            makeNotification(
+              notificationType: 'comment',
+              sourceKind: 1,
+              content: npub,
+            ),
+          ]);
+          stubProfiles({});
+
+          final page = await repository.getNotifications();
+          final item = page.items.single as VideoNotification;
+          expect(item.commentText, equals(npub));
+        },
+      );
+
+      test(
+        'omits a bech32 reference straddling the cut instead of splitting it',
+        () async {
+          // 'Reply to ' (9 chars) + npub (63) + ' more' straddles the
+          // 50-char limit: the npub starts at index 9 and ends at 72. The
+          // cut pulls back to the token's start so the preview shows only
+          // the leading text, never a sliced npub fragment.
+          const npub =
+              'npub180cvv07tjdrrgpa9jzd0cdkej42kwsaxq9rz7gvdpjx6nz004f9uulstw6';
+          const content = 'Reply to $npub more';
+          stubNotifications([
+            makeNotification(
+              notificationType: 'comment',
+              sourceKind: 1,
+              content: content,
+            ),
+          ]);
+          stubProfiles({});
+
+          final page = await repository.getNotifications();
+          final item = page.items.single as VideoNotification;
+          expect(item.commentText, equals('Reply to ...'));
+          expect(item.commentText, isNot(contains('npub1')));
+        },
+      );
+
+      test(
         'like / repost on video leaves commentText null (no body text)',
         () async {
           // Default makeNotification is a reaction (kind 7) on a video,

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -2028,7 +2028,7 @@ void main() {
       );
 
       test(
-        'keeps a bech32 npub intact when it spans the 50-char cut',
+        'keeps a bounded leading bech32 npub intact when it spans the cut',
         () async {
           // Regression: a reply whose content begins with a raw npub longer
           // than the 50-char preview cap must keep the token intact so the
@@ -2053,6 +2053,27 @@ void main() {
       );
 
       test(
+        'keeps a bech32 npub after leading whitespace or punctuation',
+        () async {
+          const npub =
+              'npub180cvv07tjdrrgpa9jzd0cdkej42kwsaxq9rz7gvdpjx6nz004f9uulstw6';
+          const content = ' @$npub';
+          stubNotifications([
+            makeNotification(
+              notificationType: 'comment',
+              sourceKind: 1,
+              content: content,
+            ),
+          ]);
+          stubProfiles({});
+
+          final page = await repository.getNotifications();
+          final item = page.items.single as VideoNotification;
+          expect(item.commentText, equals(content));
+        },
+      );
+
+      test(
         'omits a bech32 reference straddling the cut instead of splitting it',
         () async {
           // 'Reply to ' (9 chars) + npub (63) + ' more' straddles the
@@ -2073,8 +2094,47 @@ void main() {
 
           final page = await repository.getNotifications();
           final item = page.items.single as VideoNotification;
-          expect(item.commentText, equals('Reply to ...'));
+          expect(item.commentText, equals('Reply to...'));
           expect(item.commentText, isNot(contains('npub1')));
+        },
+      );
+
+      test(
+        'does not preserve unbounded leading token-shaped content',
+        () async {
+          final content = 'npub1${'a' * 5000}';
+          stubNotifications([
+            makeNotification(
+              notificationType: 'comment',
+              sourceKind: 1,
+              content: content,
+            ),
+          ]);
+          stubProfiles({});
+
+          final page = await repository.getNotifications();
+          final item = page.items.single as VideoNotification;
+          expect(item.commentText, equals('...'));
+          expect(item.commentText!.length, lessThanOrEqualTo(53));
+        },
+      );
+
+      test(
+        'does not treat embedded alphanumeric bech32-looking text as a token',
+        () async {
+          final content = 'prefixnpub1${'a' * 60}';
+          stubNotifications([
+            makeNotification(
+              notificationType: 'comment',
+              sourceKind: 1,
+              content: content,
+            ),
+          ]);
+          stubProfiles({});
+
+          final page = await repository.getNotifications();
+          final item = page.items.single as VideoNotification;
+          expect(item.commentText, equals('${content.substring(0, 50)}...'));
         },
       );
 


### PR DESCRIPTION
Closes #6346

## What & why

Notification reply/comment quotes were showing raw, sliced `npub1...` strings instead of resolved names. `_truncateComment` capped previews at 50 chars with a blind substring, so embedded bech32 Nostr references could be cut mid-token before the UI linkifier had a chance to decode them.

## Fix

Make `_truncateComment` bech32-token-aware without letting remote notification content bypass the preview cap:

- align the repository token boundary with `LinkifiedTextSpanBuilder` so only UI-decodable token spans are protected;
- when a token straddles the 50-char cut, omit the token instead of slicing it;
- when the preview is only whitespace/punctuation plus a bounded Nostr reference, keep the whole token so the UI can resolve it;
- reject unbounded token-shaped content by dropping that token rather than persisting thousands of remote-controlled characters;
- trim trailing whitespace before adding the ellipsis.

Current `main` also includes the dedicated `notification_repository` CI workflow, so the package tests now run in CI after this rebase.

## Verification

- `mise exec -- dart format --output=none --set-exit-if-changed packages/notification_repository/lib/src/notification_repository.dart packages/notification_repository/test/src/notification_repository_test.dart`
- `mise exec -- flutter analyze packages/notification_repository`
- `mise exec -- flutter test test/src/notification_repository_test.dart` from `mobile/packages/notification_repository` - 131 pass
- pre-push hook: no merge conflicts with main, analyzer clean, changed-file notification_repository tests pass

## Regression tests added

1. Reply body is just a bounded `npub1...` token and stays decodable.
2. Leading whitespace/punctuation before `npub1...` still keeps the token intact.
3. `Reply to <npub> more` omits the straddling token and avoids a sliced `npub1` fragment.
4. Oversized leading token-shaped content is not persisted unbounded.
5. Alphanumeric-embedded `prefixnpub1...` text is not treated as a linkifier token.