### PR TITLE
fix(feed): guard tuning-undo against unmounted context

### DIFF
--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -542,6 +542,10 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
   }
 
   void _undoTuning(String feedTuningEventId, String videoId) {
+    // The Undo receipt lives in the app-level ScaffoldMessenger, so it can
+    // fire after this screen was popped and its State unmounted — touching
+    // `context` then throws a null-check on the dead element. Bail if gone.
+    if (!mounted) return;
     final bloc = context.read<FullscreenFeedBloc>()
       ..add(FullscreenFeedTuningUndoRequested(feedTuningEventId));
     final videos = bloc.state.videos;

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -248,6 +248,10 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
   }
 
   void _undoTuning(String feedTuningEventId, String videoId) {
+    // The Undo receipt lives in the app-level ScaffoldMessenger, so it can
+    // fire after this screen was popped and its State unmounted — touching
+    // `context` then throws a null-check on the dead element. Bail if gone.
+    if (!mounted) return;
     final bloc = context.read<VideoFeedBloc>()
       ..add(VideoFeedTuningUndoRequested(feedTuningEventId));
     final videos = bloc.state.videos;

--- a/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
+++ b/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
@@ -10,6 +10,7 @@ import 'package:bloc_test/bloc_test.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:divine_video_player/divine_video_player.dart'
     show DivineVideoPlayerController;
+import 'package:feed_tuning_repository/feed_tuning_repository.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -1526,6 +1527,74 @@ void main() {
           () => mockBloc.add(const FullscreenFeedIndexChanged(1)),
         );
       });
+    });
+
+    group('feed-tuning undo', () {
+      testWidgets(
+        'does not crash when Undo is tapped after the screen unmounts',
+        (tester) async {
+          // Regression for a FATAL Crashlytics crash: the tuning receipt lives
+          // in the app-level ScaffoldMessenger and outlives this screen.
+          // Popping the feed while the receipt is visible, then tapping Undo,
+          // called `context.read` on the unmounted State — a null-check on the
+          // dead element.
+          const initialState = FullscreenFeedState();
+          final controller = StreamController<FullscreenFeedState>();
+          addTearDown(controller.close);
+          when(() => mockBloc.state).thenReturn(initialState);
+          whenListen(mockBloc, controller.stream, initialState: initialState);
+
+          final showContent = ValueNotifier<bool>(true);
+          addTearDown(showContent.dispose);
+
+          await tester.pumpWidget(
+            testMaterialApp(
+              mockProfileRepository: mockProfileRepository,
+              mockNip05VerificationService: mockNip05VerificationService,
+              // A persistent Scaffold keeps a registered target on the
+              // app-level messenger after the feed unmounts — mirroring the
+              // underlying route that remains when the fullscreen feed pops.
+              home: Scaffold(
+                body: ValueListenableBuilder<bool>(
+                  valueListenable: showContent,
+                  builder: (context, show, _) =>
+                      show ? buildContent() : const SizedBox.shrink(),
+                ),
+              ),
+            ),
+          );
+          await tester.pump();
+
+          controller.add(
+            initialState.copyWith(
+              lastTuningAction: const FullscreenFeedTuningAction(
+                videoId: testVideoId1,
+                direction: FeedTuningDirection.less,
+                sequence: 1,
+                publishedEventId: 'published-tuning-event-id',
+              ),
+            ),
+          );
+          await tester.pump();
+          await tester.pump(const Duration(seconds: 1)); // reveal animation
+
+          final undoLabel = lookupAppLocalizations(
+            const Locale('en'),
+          ).feedTuningUndo;
+          expect(find.text(undoLabel), findsOneWidget);
+
+          // Pop the feed: unmount FullscreenFeedContent while the
+          // messenger-owned receipt stays on screen.
+          showContent.value = false;
+          await tester.pump();
+          expect(find.text(undoLabel), findsOneWidget);
+
+          await tester.tap(find.text(undoLabel));
+          await tester.pump();
+
+          expect(tester.takeException(), isNull);
+        },
+      );
     });
   });
 }

--- a/mobile/test/screens/feed/video_feed_page_test.dart
+++ b/mobile/test/screens/feed/video_feed_page_test.dart
@@ -827,6 +827,87 @@ void main() {
       },
     );
 
+    testWidgets(
+      'does not crash when Undo is tapped after the feed unmounts',
+      (tester) async {
+        // Regression for a FATAL Crashlytics crash: the tuning receipt lives
+        // in the app-level ScaffoldMessenger and outlives this screen. Popping
+        // the feed while the receipt is visible, then tapping Undo, called
+        // `context.read` on the unmounted State — a null-check on the dead
+        // element.
+        final videos = [
+          createTestVideoEvent(id: 'video-0'),
+          createTestVideoEvent(id: 'video-1'),
+        ];
+        final initialState = VideoFeedBlocState(
+          status: VideoFeedStatus.success,
+          videos: videos,
+        );
+        final tunedState = initialState.copyWith(
+          lastTuningAction: VideoFeedTuningAction(
+            videoId: videos.first.id,
+            direction: FeedTuningDirection.less,
+            sequence: 1,
+            publishedEventId: 'published-tuning-event-id',
+          ),
+        );
+        final controller = StreamController<VideoFeedBlocState>();
+        addTearDown(controller.close);
+        when(() => videoFeedBloc.state).thenReturn(initialState);
+        whenListen(
+          videoFeedBloc,
+          controller.stream,
+          initialState: initialState,
+        );
+
+        final showFeed = ValueNotifier<bool>(true);
+        addTearDown(showFeed.dispose);
+
+        await tester.pumpWidget(
+          testMaterialApp(
+            home: MultiBlocProvider(
+              providers: [
+                BlocProvider<VideoFeedBloc>.value(value: videoFeedBloc),
+                BlocProvider<VideoPlaybackStatusCubit>(
+                  create: (_) => VideoPlaybackStatusCubit(),
+                ),
+                BlocProvider<VideoVolumeCubit>.value(value: videoVolumeCubit),
+              ],
+              child: Scaffold(
+                body: ValueListenableBuilder<bool>(
+                  valueListenable: showFeed,
+                  builder: (context, show, _) =>
+                      show ? const VideoFeedView() : const SizedBox.shrink(),
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        when(() => videoFeedBloc.state).thenReturn(tunedState);
+        controller.add(tunedState);
+        await tester.pump();
+        await tester.pump(const Duration(seconds: 1)); // reveal animation
+
+        final undoLabel = lookupAppLocalizations(
+          const Locale('en'),
+        ).feedTuningUndo;
+        expect(find.text(undoLabel), findsOneWidget);
+
+        // Pop the feed: unmount VideoFeedView while the messenger-owned
+        // receipt stays on screen.
+        showFeed.value = false;
+        await tester.pump();
+        expect(find.text(undoLabel), findsOneWidget);
+
+        await tester.tap(find.text(undoLabel));
+        await tester.pump();
+
+        expect(tester.takeException(), isNull);
+      },
+    );
+
     testWidgets('requests auto-refresh when app returns from background', (
       tester,
     ) async {


### PR DESCRIPTION
Closes #6354

## Description

Fixes a FATAL Crashlytics crash (`6f6338d4`, iOS, v1.0.16–1.0.17, still OPEN): `Null check operator used on a null value` in `_FullscreenFeedContentState._undoTuning`, blamed on `State.context` (`framework.dart:959`).

The feed-tuning **Undo** receipt is shown through the app-level `ScaffoldMessenger`, which lives above the feed route and outlives it. When the user navigates away, the feed's `State` is disposed but the receipt stays on screen for its 4-second window. Tapping **Undo** then runs `_undoTuning` → `context.read<...>()` on the unmounted `State` (`_element!` is null) → crash. The v1.0.16 variant is the same crash via the old `SnackBarAction` path, so it is not tied to the recent snackbar-rendering change.

The fix is a `mounted` guard before touching `context`, matching the pattern already used elsewhere in the same file (`_handlePendingSkip`, `_syncFeedActive`). The home feed's `_undoTuning` shares the identical latent bug — the same shared, messenger-scoped receipt — so it gets the same guard.

**Related Issue:** 

## Out of Scope

Making the undo actually fire after the screen is gone (the feed BLoC is scoped to the screen and is closed on dispose, so there is nothing to dispatch to). A silent no-op is the correct behavior here; lifting undo to a screen-independent layer is a separate, larger change.

## Verification

- `flutter analyze lib test integration_test` — clean on all four files.
- `flutter test test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart test/screens/feed/video_feed_page_test.dart` — green.
- Added one regression test per screen (unmount the feed while the receipt is visible, then tap Undo → no exception). Confirmed both **fail without the guard** and pass with it.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)