### PR TITLE
fix(nostr): auth awaited relay publishes

### DIFF
--- a/mobile/packages/nostr_sdk/lib/relay/publish_outcome.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/publish_outcome.dart
@@ -72,6 +72,8 @@ class PublishTracker {
     required this.eventId,
     this.eventKind,
     this.diagnosticTag,
+    this.message,
+    this.deadline,
     required this.expectedRelays,
     required Duration timeout,
   }) {
@@ -86,6 +88,12 @@ class PublishTracker {
 
   /// Caller-supplied tag for temporary publish diagnostics, when enabled.
   final String? diagnosticTag;
+
+  /// Original EVENT frame for SDK-internal retry paths.
+  final List<dynamic>? message;
+
+  /// Hard publish deadline shared with SDK-internal retry paths.
+  final DateTime? deadline;
 
   /// Relay URLs we expect responses from.
   final Set<String> expectedRelays;

--- a/mobile/packages/nostr_sdk/lib/relay/publish_outcome.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/publish_outcome.dart
@@ -99,6 +99,7 @@ class PublishTracker {
   final Set<String> expectedRelays;
 
   final Map<String, String> _rejected = {};
+  final Map<String, String> _deferredRejections = {};
   final Set<String> _accepted = {};
   final Completer<PublishOutcome> _completer = Completer<PublishOutcome>();
   late final Timer _timer;
@@ -109,6 +110,7 @@ class PublishTracker {
   /// Call when the relay returned `OK true`.
   void onAccepted(String relayUrl) {
     if (_closed) return;
+    _deferredRejections.remove(relayUrl);
     _accepted.add(relayUrl);
     // First confirmation is enough for deletion-style operations; we still
     // collect the remaining responses but complete immediately.
@@ -118,13 +120,33 @@ class PublishTracker {
   /// Call when the relay returned `OK false` with a reason.
   void onRejected(String relayUrl, String reason) {
     if (_closed) return;
+    _deferredRejections.remove(relayUrl);
     _rejected[relayUrl] = reason;
     _maybeCompleteIfAllAnswered();
+  }
+
+  /// Record a relay rejection that should be reported if the publish times out,
+  /// without counting the relay as answered yet.
+  void deferRejection(String relayUrl, String reason) {
+    if (_closed ||
+        _accepted.contains(relayUrl) ||
+        _rejected.containsKey(relayUrl)) {
+      return;
+    }
+    _deferredRejections[relayUrl] = reason;
+  }
+
+  /// Clear a previously deferred rejection when the relay is retried or
+  /// otherwise no longer represents the original rejection.
+  void clearDeferredRejection(String relayUrl) {
+    if (_closed) return;
+    _deferredRejections.remove(relayUrl);
   }
 
   /// Call when a relay disconnected or otherwise cannot be awaited further.
   void onRelayUnavailable(String relayUrl) {
     if (_closed) return;
+    _deferredRejections.remove(relayUrl);
     expectedRelays.remove(relayUrl);
     _maybeCompleteIfAllAnswered();
   }
@@ -145,15 +167,21 @@ class PublishTracker {
     if (_closed) return;
     _closed = true;
     _timer.cancel();
+    final effectiveRejected = Map<String, String>.from(_rejected);
+    if (_accepted.isEmpty) {
+      effectiveRejected.addAll(_deferredRejections);
+    }
     final noResponse = expectedRelays
-        .where((r) => !_accepted.contains(r) && !_rejected.containsKey(r))
+        .where(
+          (r) => !_accepted.contains(r) && !effectiveRejected.containsKey(r),
+        )
         .toList(growable: false);
     _completer.complete(
       PublishOutcome(
         eventId: eventId,
         eventKind: eventKind,
         acceptedBy: _accepted.toList(growable: false),
-        rejectedBy: Map<String, String>.unmodifiable(_rejected),
+        rejectedBy: Map<String, String>.unmodifiable(effectiveRejected),
         noResponseFrom: noResponse,
       ),
     );

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -23,6 +23,20 @@ import 'relay_base.dart';
 import 'relay_type.dart';
 import 'signature_verification_policy.dart';
 
+class _AuthRequiredPublishRetry {
+  const _AuthRequiredPublishRetry({
+    required this.message,
+    required this.tracker,
+    required this.reason,
+    required this.deadline,
+  });
+
+  final List<dynamic> message;
+  final PublishTracker tracker;
+  final String reason;
+  final DateTime deadline;
+}
+
 class RelayPool {
   // avoid to send these events to cache relay
   static List<int> cacheAvoidEvents = [
@@ -89,6 +103,14 @@ class RelayPool {
 
   /// Track publishes awaiting OK confirmations (per event id).
   final Map<String, PublishTracker> _pendingPublishes = {};
+
+  /// Awaited publishes that were rejected before the relay completed NIP-42.
+  ///
+  /// Keyed by event id, then relay url. These are retried once after the
+  /// corresponding relay confirms AUTH, bounded by the publish's original
+  /// deadline.
+  final Map<String, Map<String, _AuthRequiredPublishRetry>>
+  _authRequiredPublishRetries = {};
 
   Relay Function(String) tempRelayGener;
 
@@ -165,6 +187,119 @@ class RelayPool {
 
   void _logPublishDiagnostic(String diagnosticTag, String message) {
     log('$diagnosticTag relay diagnostic: $message');
+  }
+
+  bool _isExplicitAuthRequiredReason(String message) {
+    final lower = message.trim().toLowerCase();
+    return lower.startsWith('auth-required');
+  }
+
+  bool _isRestrictedReason(String message) {
+    return message.trim().toLowerCase().startsWith('restricted');
+  }
+
+  bool _shouldRetryPublishAfterAuth({
+    required Relay relay,
+    required String eventId,
+    required String message,
+  }) {
+    final retriesForEvent = _authRequiredPublishRetries[eventId];
+    if (retriesForEvent != null && retriesForEvent.containsKey(relay.url)) {
+      return false;
+    }
+    if (_isExplicitAuthRequiredReason(message)) return true;
+    return _isRestrictedReason(message) && !relay.relayStatus.authed;
+  }
+
+  void _trackAuthRequiredPublish({
+    required Relay relay,
+    required List<dynamic> message,
+    required PublishTracker tracker,
+    required String reason,
+    required DateTime deadline,
+  }) {
+    relay.relayStatus.alwaysAuth = true;
+    final retry = _AuthRequiredPublishRetry(
+      message: message,
+      tracker: tracker,
+      reason: reason,
+      deadline: deadline,
+    );
+    _authRequiredPublishRetries.putIfAbsent(
+      tracker.eventId,
+      () => <String, _AuthRequiredPublishRetry>{},
+    )[relay.url] = retry;
+  }
+
+  void _removeAuthRequiredPublish(String eventId, String relayUrl) {
+    final retriesForEvent = _authRequiredPublishRetries[eventId];
+    if (retriesForEvent == null) return;
+    retriesForEvent.remove(relayUrl);
+    if (retriesForEvent.isEmpty) {
+      _authRequiredPublishRetries.remove(eventId);
+    }
+  }
+
+  Future<void> _retryAuthRequiredPublishesForRelay(Relay relay) async {
+    final retryEntries = <MapEntry<String, _AuthRequiredPublishRetry>>[];
+    for (final entry in _authRequiredPublishRetries.entries) {
+      final retry = entry.value[relay.url];
+      if (retry != null) {
+        retryEntries.add(MapEntry(entry.key, retry));
+      }
+    }
+
+    for (final entry in retryEntries) {
+      final eventId = entry.key;
+      final retry = entry.value;
+      if (!DateTime.now().isBefore(retry.deadline)) {
+        retry.tracker.onRejected(relay.url, retry.reason);
+        _removeAuthRequiredPublish(eventId, relay.url);
+        continue;
+      }
+
+      final timeout = retry.deadline.difference(DateTime.now());
+      if (timeout <= Duration.zero) {
+        retry.tracker.onRejected(relay.url, retry.reason);
+        _removeAuthRequiredPublish(eventId, relay.url);
+        continue;
+      }
+
+      log(
+        '🔐 Re-publishing auth-required EVENT after AUTH '
+        'eventId=$eventId relay=${relay.url}',
+      );
+      final sent = await relay
+          .send(
+            retry.message,
+            skipReconnect: true,
+            queueIfFailed: false,
+            deadline: retry.deadline,
+          )
+          .timeout(timeout, onTimeout: () => false);
+      if (!sent) {
+        retry.tracker.onRelayUnavailable(relay.url);
+        _removeAuthRequiredPublish(eventId, relay.url);
+      }
+    }
+  }
+
+  void _rejectAuthRequiredPublishesForRelay(Relay relay, String authMessage) {
+    final retryEntries = <MapEntry<String, _AuthRequiredPublishRetry>>[];
+    for (final entry in _authRequiredPublishRetries.entries) {
+      final retry = entry.value[relay.url];
+      if (retry != null) {
+        retryEntries.add(MapEntry(entry.key, retry));
+      }
+    }
+
+    for (final entry in retryEntries) {
+      entry.value.tracker.onRejected(
+        relay.url,
+        authMessage.isEmpty ? entry.value.reason : authMessage,
+      );
+      _removeAuthRequiredPublish(entry.key, relay.url);
+    }
   }
 
   Future<bool> add(
@@ -275,20 +410,12 @@ class RelayPool {
       var message = subscription.toJson();
       if ((sendAfterAuth || relay.relayStatus.alwaysAuth) &&
           !relay.relayStatus.authed) {
-        // For vine.hol.is, send the query to trigger AUTH challenge
-        if (relay.url.contains('vine.hol.is')) {
-          log('🔐 vine.hol.is query - sending to trigger AUTH challenge');
-          final result = await relay
-              .send(message, forceSend: true)
-              .timeout(perRelaySendTimeout, onTimeout: () => false);
-          if (result) {
-            relay.saveQuery(subscription);
-            return true;
-          }
-        } else {
-          // Save query before — message will be sent after auth completes
+        log('🔐 Auth-required query - sending to trigger AUTH challenge');
+        final result = await relay
+            .send(message, forceSend: true)
+            .timeout(perRelaySendTimeout, onTimeout: () => false);
+        if (result) {
           relay.saveQuery(subscription);
-          relay.pendingAuthedMessages.add(message);
           return true;
         }
       } else {
@@ -735,6 +862,7 @@ class RelayPool {
       final publishTracker = _pendingPublishes[eventId];
       if (publishTracker != null) {
         if (success) {
+          _removeAuthRequiredPublish(eventId, relay.url);
           publishTracker.onAccepted(relay.url);
           final diagnosticTag = publishTracker.diagnosticTag;
           if (diagnosticTag != null) {
@@ -744,7 +872,37 @@ class RelayPool {
               'eventId=$eventId relay=${relay.url}',
             );
           }
+        } else if (_shouldRetryPublishAfterAuth(
+          relay: relay,
+          eventId: eventId,
+          message: message,
+        )) {
+          final originalMessage = publishTracker.message;
+          final deadline = publishTracker.deadline;
+          if (originalMessage == null || deadline == null) {
+            publishTracker.onRejected(relay.url, message);
+          } else {
+            _trackAuthRequiredPublish(
+              relay: relay,
+              message: originalMessage,
+              tracker: publishTracker,
+              reason: message,
+              deadline: deadline,
+            );
+            final diagnosticTag = publishTracker.diagnosticTag;
+            if (diagnosticTag != null) {
+              _logPublishDiagnostic(
+                diagnosticTag,
+                'OK auth-required kind=${publishTracker.eventKind} '
+                'eventId=$eventId relay=${relay.url} reason=$message',
+              );
+            }
+            if (relay.relayStatus.authed) {
+              await _retryAuthRequiredPublishesForRelay(relay);
+            }
+          }
         } else {
+          _removeAuthRequiredPublish(eventId, relay.url);
           publishTracker.onRejected(relay.url, message);
           final diagnosticTag = publishTracker.diagnosticTag;
           if (diagnosticTag != null) {
@@ -791,9 +949,11 @@ class RelayPool {
               '${relay.url}',
             );
           }
+          await _retryAuthRequiredPublishesForRelay(relay);
         } else {
           relay.relayStatus.authed = false;
           log('🔐 AUTH failed for ${relay.url}: $message');
+          _rejectAuthRequiredPublishesForRelay(relay, message);
         }
       }
     } else if (messageType == "NOTICE") {
@@ -811,6 +971,7 @@ class RelayPool {
         log('🔐 AUTH challenge received from ${relay.url}');
         final challenge = _stringAt(relay, json, 1, 'AUTH challenge');
         if (challenge == null) return;
+        relay.relayStatus.alwaysAuth = true;
         final challengePreview = challenge.length > 16
             ? challenge.substring(0, 16)
             : challenge;
@@ -1011,17 +1172,13 @@ class RelayPool {
       log(subscribeMsg);
       if ((sendAfterAuth || relay.relayStatus.alwaysAuth) &&
           !relay.relayStatus.authed) {
-        // For vine.hol.is, send the subscription to trigger AUTH challenge
-        if (relay.url.contains('vine.hol.is')) {
-          log(
-            '🔐 vine.hol.is subscription - sending to trigger AUTH challenge',
-          );
-          var result = await relay.send(message, forceSend: true);
-          if (result) {
-            return true;
-          }
-        } else {
-          relay.pendingAuthedMessages.add(message);
+        log(
+          '🔐 Auth-required subscription - sending to trigger AUTH challenge',
+        );
+        final result = await relay
+            .send(message, forceSend: true)
+            .timeout(perRelaySendTimeout, onTimeout: () => false);
+        if (result) {
           return true;
         }
       } else {
@@ -1332,22 +1489,20 @@ class RelayPool {
             '🔐 Relay ${relay.url} requires auth (alwaysAuth=${relay.relayStatus.alwaysAuth}, authed=${relay.relayStatus.authed})',
           );
 
-          // For vine.hol.is, we need to send one message to trigger AUTH challenge
-          // Many relays only send AUTH challenges when they receive a message that needs auth
-          if (relay.url.contains('vine.hol.is')) {
+          // Many relays only send AUTH challenges after a frame that needs
+          // auth. Deadline-bound publishes cannot sit in the auth queue, so
+          // send once inside the deadline and let the OK/AUTH handlers retry
+          // the EVENT if the relay accepts after NIP-42 completes.
+          if (deadline != null) {
             log(
-              '🔐 vine.hol.is detected - sending message to trigger AUTH challenge',
+              '🔐 Deadline-bound auth publish - sending to trigger AUTH challenge',
             );
-            // Auth-trigger path intentionally does NOT pass skipReconnect:
-            // the AUTH handshake requires a real send. Per-relay timeout
-            // still applies so a stuck auth-trigger send cannot block the
-            // rest of the fan-out.
             var timedOut = false;
             var result = await relay
                 .send(
                   message,
                   forceSend: true,
-                  queueIfFailed: deadline == null,
+                  queueIfFailed: false,
                   deadline: deadline,
                 )
                 .timeout(
@@ -1373,25 +1528,15 @@ class RelayPool {
               'auth-trigger send kind=$eventKind eventId=$eventId '
               'relay=${relay.url} sent=$result',
             );
-            // Don't queue this message since we're sending it
           } else {
-            // Deadline-bound sends intentionally do not queue for AUTH: a queued
-            // frame could publish after the caller already returned failure.
-            if (deadline == null) {
-              log('🔐 Queueing message for authentication: ${message[0]}');
-              relay.pendingAuthedMessages.add(message);
-              sentTo.add(relay.url);
-              attemptedRelayUrls.add(relay.url);
-              onSent?.call(relay.url);
-              logDiagnostic(
-                'queued for auth kind=$eventKind eventId=$eventId relay=${relay.url}',
-              );
-            } else {
-              logDiagnostic(
-                'auth queue skipped kind=$eventKind eventId=$eventId relay=${relay.url} '
-                'reason=deadlineBoundSend',
-              );
-            }
+            log('🔐 Queueing message for authentication: ${message[0]}');
+            relay.pendingAuthedMessages.add(message);
+            sentTo.add(relay.url);
+            attemptedRelayUrls.add(relay.url);
+            onSent?.call(relay.url);
+            logDiagnostic(
+              'queued for auth kind=$eventKind eventId=$eventId relay=${relay.url}',
+            );
           }
           log(
             '🔐 Pending authed messages count: ${relay.pendingAuthedMessages.length}',
@@ -1522,21 +1667,24 @@ class RelayPool {
     if (existing != null) {
       return existing.future;
     }
+    final sentAt = DateTime.now();
+    final deadline = sentAt.add(timeout);
     final tracker = PublishTracker(
       eventId: eventId,
       eventKind: eventKind ?? _eventKindFromMessage(message),
       diagnosticTag: diagnosticTag,
+      message: message,
+      deadline: deadline,
       expectedRelays: <String>{},
       timeout: timeout,
     );
     _pendingPublishes[eventId] = tracker;
 
-    final sentAt = DateTime.now();
     final sentTo = await _sendCollect(
       message,
       tempRelays: tempRelays,
       targetRelays: targetRelays,
-      deadline: sentAt.add(timeout),
+      deadline: deadline,
       diagnosticTag: diagnosticTag,
       onSent: (relayUrl) => tracker.expectedRelays.add(relayUrl),
     );
@@ -1570,7 +1718,10 @@ class RelayPool {
               _repairSilentRelays(outcome.noResponseFrom, sentAt);
             }
           })
-          .whenComplete(() => _pendingPublishes.remove(eventId)),
+          .whenComplete(() {
+            _pendingPublishes.remove(eventId);
+            _authRequiredPublishRetries.remove(eventId);
+          }),
     );
     return tracker.future;
   }

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -231,6 +231,7 @@ class RelayPool {
     required DateTime deadline,
   }) {
     relay.relayStatus.alwaysAuth = true;
+    tracker.deferRejection(relay.url, reason);
     final retry = _AuthRequiredPublishRetry(
       message: message,
       tracker: tracker,
@@ -287,6 +288,7 @@ class RelayPool {
         '🔐 Re-publishing auth-required EVENT after AUTH '
         'eventId=$eventId relay=${relay.url}',
       );
+      retry.tracker.clearDeferredRejection(relay.url);
       final sent = await relay
           .send(
             retry.message,
@@ -421,13 +423,17 @@ class RelayPool {
       if ((sendAfterAuth || relay.relayStatus.alwaysAuth) &&
           !relay.relayStatus.authed) {
         log('🔐 Auth-required query - sending to trigger AUTH challenge');
+        relay.saveQuery(subscription);
         final result = await relay
             .send(message, forceSend: true)
             .timeout(perRelaySendTimeout, onTimeout: () => false);
-        if (result) {
-          relay.saveQuery(subscription);
-          return true;
+        if (!result) {
+          log(
+            '🔐 Auth-required query trigger send failed; query remains saved '
+            'for replay after reconnect/auth: ${subscription.id} ${relay.url}',
+          );
         }
+        return true;
       } else {
         // Skip reconnect during query fan-out to avoid blocking
         // other relays while one dead relay tries exponential backoff.
@@ -1020,9 +1026,13 @@ class RelayPool {
               '🔐 Pending ${relay.pendingAuthedMessages.length} messages for after auth confirmation',
             );
           }
+        } else {
+          log('🔐 AUTH signing returned null for ${relay.url}');
+          _rejectAuthRequiredPublishesForRelay(relay, '');
         }
       } catch (err, stackTrace) {
         log('🔐 AUTH handling failed for ${relay.url}: $err\n$stackTrace');
+        _rejectAuthRequiredPublishesForRelay(relay, '');
       }
     } else if (messageType == 'COUNT') {
       // NIP-45 COUNT response

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -24,7 +24,7 @@ import 'relay_type.dart';
 import 'signature_verification_policy.dart';
 
 class _AuthRequiredPublishRetry {
-  const _AuthRequiredPublishRetry({
+  _AuthRequiredPublishRetry({
     required this.message,
     required this.tracker,
     required this.reason,
@@ -35,6 +35,11 @@ class _AuthRequiredPublishRetry {
   final PublishTracker tracker;
   final String reason;
   final DateTime deadline;
+
+  /// Set once the EVENT has been re-sent after AUTH. A single tracked entry
+  /// lingers as the dedup marker until the relay answers OK, so later
+  /// AUTH/OK triggers must not push the same frame again.
+  bool resent = false;
 }
 
 class RelayPool {
@@ -208,7 +213,14 @@ class RelayPool {
       return false;
     }
     if (_isExplicitAuthRequiredReason(message)) return true;
-    return _isRestrictedReason(message) && !relay.relayStatus.authed;
+    // A bare "restricted" reason is NIP-01's generic members-only rejection
+    // and is only auth-retryable when the relay actually speaks NIP-42 (it
+    // sent an AUTH challenge, so alwaysAuth is set) and has not authed yet.
+    // Without that guard a permanent allow-list rejection would be tracked
+    // and hang until the publish deadline instead of failing fast.
+    return _isRestrictedReason(message) &&
+        relay.relayStatus.alwaysAuth &&
+        !relay.relayStatus.authed;
   }
 
   void _trackAuthRequiredPublish({
@@ -240,7 +252,9 @@ class RelayPool {
     }
   }
 
-  Future<void> _retryAuthRequiredPublishesForRelay(Relay relay) async {
+  List<MapEntry<String, _AuthRequiredPublishRetry>> _retryEntriesForRelay(
+    Relay relay,
+  ) {
     final retryEntries = <MapEntry<String, _AuthRequiredPublishRetry>>[];
     for (final entry in _authRequiredPublishRetries.entries) {
       final retry = entry.value[relay.url];
@@ -248,15 +262,16 @@ class RelayPool {
         retryEntries.add(MapEntry(entry.key, retry));
       }
     }
+    return retryEntries;
+  }
 
-    for (final entry in retryEntries) {
+  Future<void> _retryAuthRequiredPublishesForRelay(Relay relay) async {
+    for (final entry in _retryEntriesForRelay(relay)) {
       final eventId = entry.key;
       final retry = entry.value;
-      if (!DateTime.now().isBefore(retry.deadline)) {
-        retry.tracker.onRejected(relay.url, retry.reason);
-        _removeAuthRequiredPublish(eventId, relay.url);
-        continue;
-      }
+      // A resent entry lingers only as the dedup marker; do not push it again
+      // on a later AUTH/OK trigger for this relay.
+      if (retry.resent) continue;
 
       final timeout = retry.deadline.difference(DateTime.now());
       if (timeout <= Duration.zero) {
@@ -265,6 +280,9 @@ class RelayPool {
         continue;
       }
 
+      // Mark before the await: onMessage delivery is fire-and-forget, so a
+      // re-entrant OK/AUTH frame must not resend this in-flight EVENT.
+      retry.resent = true;
       log(
         '🔐 Re-publishing auth-required EVENT after AUTH '
         'eventId=$eventId relay=${relay.url}',
@@ -285,15 +303,7 @@ class RelayPool {
   }
 
   void _rejectAuthRequiredPublishesForRelay(Relay relay, String authMessage) {
-    final retryEntries = <MapEntry<String, _AuthRequiredPublishRetry>>[];
-    for (final entry in _authRequiredPublishRetries.entries) {
-      final retry = entry.value[relay.url];
-      if (retry != null) {
-        retryEntries.add(MapEntry(entry.key, retry));
-      }
-    }
-
-    for (final entry in retryEntries) {
+    for (final entry in _retryEntriesForRelay(relay)) {
       entry.value.tracker.onRejected(
         relay.url,
         authMessage.isEmpty ? entry.value.reason : authMessage,
@@ -948,6 +958,14 @@ class RelayPool {
               '🔐 AUTH post-auth: NO subscriptions saved for '
               '${relay.url}',
             );
+          }
+
+          // Re-issue one-shot queries. Their pre-auth REQ was sent to trigger
+          // the challenge and may have been CLOSED with auth-required, so the
+          // saved query still needs to run once the relay accepts us.
+          for (final query in relay.getQueries()) {
+            log('🔐 AUTH post-auth: re-sending query ${query.id} ${relay.url}');
+            relay.send(query.toJson());
           }
           await _retryAuthRequiredPublishesForRelay(relay);
         } else {

--- a/mobile/packages/nostr_sdk/test/integration/relay_auth_test.dart
+++ b/mobile/packages/nostr_sdk/test/integration/relay_auth_test.dart
@@ -47,6 +47,13 @@ class MockRelay extends RelayBase {
   void clearSentMessages() {
     sentMessages.clear();
   }
+
+  Future<void> deliver(List<dynamic> message) async {
+    final result = onMessage?.call(this, message);
+    if (result is Future) {
+      await result;
+    }
+  }
 }
 
 void main() {
@@ -158,35 +165,19 @@ void main() {
       expect(relay.sentMessages.length, equals(1));
       expect(relay.sentMessages.first[0], equals('REQ'));
 
-      // Simulate successful authentication
-      relay.relayStatus.authed = true;
-
-      // Manually trigger post-AUTH subscription replay (normally done after
-      // AUTH OK handling in RelayPool).
-      for (final subscription in relay.getSubscriptions()) {
-        await relay.send(subscription.toJson());
-      }
-
+      await relay.deliver(['AUTH', relay.authChallenge]);
       expect(relay.sentMessages.length, equals(2));
+      expect(relay.sentMessages.last[0], equals('AUTH'));
+      final authEvent = relay.sentMessages.last[1] as Map<String, dynamic>;
+      final authEventId = authEvent['id'];
+      expect(authEventId, isA<String>());
+
+      await relay.deliver(['OK', authEventId, true, '']);
+
+      expect(relay.sentMessages.length, equals(3));
       expect(relay.sentMessages.last[0], equals('REQ'));
       expect(relay.pendingAuthedMessages.isEmpty, isTrue);
-    });
-
-    test('Auth challenge functionality basic test', () async {
-      final relayUrl = 'wss://auth.relay.com';
-      final relay = MockRelay(relayUrl);
-
-      await nostr.relayPool.add(relay);
-      nostr.setRelayAlwaysAuth(relayUrl, true);
-
-      // Send subscription that should be queued for auth
-      nostr.subscribe([
-        Filter(kinds: [EventKind.textNote]).toJson(),
-      ], (event) {});
-
-      expect(relay.sentMessages, hasLength(1));
-      expect(relay.sentMessages.first[0], equals('REQ'));
-      expect(relay.pendingAuthedMessages, isEmpty);
+      expect(relay.relayStatus.authed, isTrue);
     });
 
     test('Mixed relay configuration - some with alwaysAuth', () async {

--- a/mobile/packages/nostr_sdk/test/integration/relay_auth_test.dart
+++ b/mobile/packages/nostr_sdk/test/integration/relay_auth_test.dart
@@ -47,13 +47,6 @@ class MockRelay extends RelayBase {
   void clearSentMessages() {
     sentMessages.clear();
   }
-
-  void sendPendingMessages() {
-    while (pendingAuthedMessages.isNotEmpty) {
-      final message = pendingAuthedMessages.removeAt(0);
-      send(message);
-    }
-  }
 }
 
 void main() {

--- a/mobile/packages/nostr_sdk/test/integration/relay_auth_test.dart
+++ b/mobile/packages/nostr_sdk/test/integration/relay_auth_test.dart
@@ -110,7 +110,7 @@ void main() {
       expect(config['wss://relay3.com'], isTrue);
     });
 
-    test('Messages queued when relay requires alwaysAuth', () async {
+    test('Subscriptions trigger AUTH when relay requires alwaysAuth', () async {
       final relayUrl = 'wss://auth.relay.com';
       final relay = MockRelay(relayUrl);
       relay.shouldSendAuthChallenge = true;
@@ -118,16 +118,13 @@ void main() {
       await nostr.relayPool.add(relay);
       nostr.setRelayAlwaysAuth(relayUrl, true);
 
-      // Subscribe should be queued for authentication
-      // ignore: unused_local_variable - subscription created to test queueing behavior
-      final subscription = nostr.subscribe([
+      nostr.subscribe([
         Filter(kinds: [EventKind.textNote]).toJson(),
       ], (event) {});
 
-      // Message should be in pending auth messages, not sent yet
-      expect(relay.sentMessages.isEmpty, isTrue);
-      expect(relay.pendingAuthedMessages.isNotEmpty, isTrue);
-      expect(relay.pendingAuthedMessages.first[0], equals('REQ'));
+      expect(relay.sentMessages, hasLength(1));
+      expect(relay.sentMessages.first[0], equals('REQ'));
+      expect(relay.pendingAuthedMessages, isEmpty);
     });
 
     test('Events queued when relay requires alwaysAuth', () async {
@@ -153,7 +150,7 @@ void main() {
       expect(relay.pendingAuthedMessages.first[0], equals('EVENT'));
     });
 
-    test('Messages sent after authentication when alwaysAuth is true', () async {
+    test('Subscriptions are re-sent after authentication succeeds', () async {
       final relayUrl = 'wss://auth.relay.com';
       final relay = MockRelay(relayUrl);
 
@@ -165,18 +162,20 @@ void main() {
         Filter(kinds: [EventKind.textNote]).toJson(),
       ], (event) {});
 
-      expect(relay.sentMessages.isEmpty, isTrue);
-      expect(relay.pendingAuthedMessages.length, equals(1));
+      expect(relay.sentMessages.length, equals(1));
+      expect(relay.sentMessages.first[0], equals('REQ'));
 
       // Simulate successful authentication
       relay.relayStatus.authed = true;
 
-      // Manually trigger sending of pending messages (normally done after AUTH response)
-      relay.sendPendingMessages();
+      // Manually trigger post-AUTH subscription replay (normally done after
+      // AUTH OK handling in RelayPool).
+      for (final subscription in relay.getSubscriptions()) {
+        await relay.send(subscription.toJson());
+      }
 
-      // Now the message should be sent
-      expect(relay.sentMessages.length, equals(1));
-      expect(relay.sentMessages.first[0], equals('REQ'));
+      expect(relay.sentMessages.length, equals(2));
+      expect(relay.sentMessages.last[0], equals('REQ'));
       expect(relay.pendingAuthedMessages.isEmpty, isTrue);
     });
 
@@ -192,9 +191,9 @@ void main() {
         Filter(kinds: [EventKind.textNote]).toJson(),
       ], (event) {});
 
-      // Message should be queued for authentication
-      expect(relay.pendingAuthedMessages.isNotEmpty, isTrue);
-      expect(relay.pendingAuthedMessages.first[0], equals('REQ'));
+      expect(relay.sentMessages, hasLength(1));
+      expect(relay.sentMessages.first[0], equals('REQ'));
+      expect(relay.pendingAuthedMessages, isEmpty);
     });
 
     test('Mixed relay configuration - some with alwaysAuth', () async {

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_auth_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_auth_test.dart
@@ -2,6 +2,8 @@
 // ABOUTME: Ensures NIP-42 AUTH challenges do not crash when the cached
 // ABOUTME: public key is empty (post-signOut, mid-init, account switch).
 
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:nostr_sdk/relay/client_connected.dart';
@@ -76,11 +78,27 @@ class _AuthFakeRelay extends Relay {
 }
 
 void main() {
-  group('RelayPool AUTH branch empty-pubkey guard', () {
-    const testPrivateKey =
-        '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12';
-    const challenge = 'abcdef0123456789abcdef0123456789';
+  const testPrivateKey =
+      '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12';
+  const challenge =
+      'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
 
+  List<List<dynamic>> sentMessagesOfType(_AuthFakeRelay relay, String type) {
+    return relay.sentMessages
+        .where((m) => m.isNotEmpty && m.first == type)
+        .toList(growable: false);
+  }
+
+  String sentAuthEventId(_AuthFakeRelay relay) {
+    final authMessages = sentMessagesOfType(relay, 'AUTH');
+    expect(authMessages, hasLength(1));
+    final authEvent = authMessages.single[1] as Map<String, dynamic>;
+    final id = authEvent['id'];
+    expect(id, isA<String>());
+    return id as String;
+  }
+
+  group('RelayPool AUTH branch empty-pubkey guard', () {
     Relay dummyTempRelay(String url) => RelayBase(url, RelayStatus(url));
 
     test(
@@ -112,9 +130,7 @@ void main() {
           isNotEmpty,
           reason: 'AUTH handler should refresh the cached pubkey from signer',
         );
-        final sentAuth = fakeRelay.sentMessages
-            .where((m) => m.isNotEmpty && m.first == 'AUTH')
-            .toList();
+        final sentAuth = sentMessagesOfType(fakeRelay, 'AUTH');
         expect(
           sentAuth,
           hasLength(1),
@@ -138,10 +154,145 @@ void main() {
 
       // No AUTH response should have been produced since no key is
       // available to sign one.
-      final sentAuth = fakeRelay.sentMessages
-          .where((m) => m.isNotEmpty && m.first == 'AUTH')
-          .toList();
+      final sentAuth = sentMessagesOfType(fakeRelay, 'AUTH');
       expect(sentAuth, isEmpty);
+    });
+  });
+
+  group('RelayPool auth-required publish retry', () {
+    late LocalNostrSigner signer;
+    late Nostr nostr;
+    late _AuthFakeRelay relay;
+
+    setUp(() async {
+      signer = LocalNostrSigner(testPrivateKey);
+      nostr = Nostr(signer, [], (url) => RelayBase(url, RelayStatus(url)));
+      await nostr.refreshPublicKey();
+      relay = _AuthFakeRelay('wss://auth-required.example');
+      final added = await nostr.relayPool.add(relay);
+      expect(added, isTrue);
+    });
+
+    test('republishes an awaited EVENT once after NIP-42 succeeds', () async {
+      const eventId =
+          '1111111111111111111111111111111111111111111111111111111111111111';
+      final outcomeFuture = nostr.relayPool.sendEventAwaitOk(
+        [
+          'EVENT',
+          {'id': eventId, 'kind': EventKind.giftWrap},
+        ],
+        eventId: eventId,
+        eventKind: EventKind.giftWrap,
+        targetRelays: [relay.url],
+        timeout: const Duration(seconds: 1),
+      );
+
+      expect(sentMessagesOfType(relay, 'EVENT'), hasLength(1));
+
+      await relay.deliver([
+        'OK',
+        eventId,
+        false,
+        'auth-required: you must auth',
+      ]);
+      var completed = false;
+      unawaited(outcomeFuture.then((_) => completed = true));
+      await Future<void>.delayed(Duration.zero);
+      expect(
+        completed,
+        isFalse,
+        reason: 'auth-required rejection should wait for AUTH retry',
+      );
+
+      await relay.deliver(['AUTH', challenge]);
+      final authEventId = sentAuthEventId(relay);
+      await relay.deliver(['OK', authEventId, true, '']);
+
+      expect(
+        sentMessagesOfType(relay, 'EVENT'),
+        hasLength(2),
+        reason: 'the original EVENT should be retried once after AUTH',
+      );
+
+      await relay.deliver(['OK', eventId, true, '']);
+      final outcome = await outcomeFuture;
+
+      expect(outcome.confirmed, isTrue);
+      expect(outcome.acceptedBy, equals([relay.url]));
+      expect(outcome.rejectedBy, isEmpty);
+    });
+
+    test('republishes when AUTH OK arrives before EVENT rejection', () async {
+      const eventId =
+          '3333333333333333333333333333333333333333333333333333333333333333';
+      final outcomeFuture = nostr.relayPool.sendEventAwaitOk(
+        [
+          'EVENT',
+          {'id': eventId, 'kind': EventKind.giftWrap},
+        ],
+        eventId: eventId,
+        eventKind: EventKind.giftWrap,
+        targetRelays: [relay.url],
+        timeout: const Duration(seconds: 1),
+      );
+
+      await relay.deliver(['AUTH', challenge]);
+      final authEventId = sentAuthEventId(relay);
+      await relay.deliver(['OK', authEventId, true, '']);
+      await relay.deliver([
+        'OK',
+        eventId,
+        false,
+        'auth-required: you must auth',
+      ]);
+
+      expect(sentMessagesOfType(relay, 'EVENT'), hasLength(2));
+
+      await relay.deliver(['OK', eventId, true, '']);
+      final outcome = await outcomeFuture;
+
+      expect(outcome.confirmed, isTrue);
+      expect(outcome.acceptedBy, equals([relay.url]));
+    });
+
+    test('does not loop when the post-auth EVENT is still rejected', () async {
+      const eventId =
+          '2222222222222222222222222222222222222222222222222222222222222222';
+      final outcomeFuture = nostr.relayPool.sendEventAwaitOk(
+        [
+          'EVENT',
+          {'id': eventId, 'kind': EventKind.giftWrap},
+        ],
+        eventId: eventId,
+        eventKind: EventKind.giftWrap,
+        targetRelays: [relay.url],
+        timeout: const Duration(seconds: 1),
+      );
+
+      await relay.deliver([
+        'OK',
+        eventId,
+        false,
+        'auth-required: you must auth',
+      ]);
+      await relay.deliver(['AUTH', challenge]);
+      final authEventId = sentAuthEventId(relay);
+      await relay.deliver(['OK', authEventId, true, '']);
+      await relay.deliver(['OK', eventId, false, 'restricted: members only']);
+
+      final outcome = await outcomeFuture;
+
+      expect(outcome.failed, isTrue);
+      expect(outcome.acceptedBy, isEmpty);
+      expect(
+        outcome.rejectedBy,
+        equals({relay.url: 'restricted: members only'}),
+      );
+      expect(
+        sentMessagesOfType(relay, 'EVENT'),
+        hasLength(2),
+        reason: 'post-auth rejection should not trigger another republish',
+      );
     });
   });
 }

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_auth_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_auth_test.dart
@@ -42,6 +42,10 @@ class _AuthFakeRelay extends Relay {
 
   final List<List<dynamic>> sentMessages = [];
 
+  /// When true, [send] records the frame but reports transport failure, so the
+  /// post-auth resend path (`onRelayUnavailable`) can be exercised.
+  bool failSends = false;
+
   @override
   Future<bool> doConnect() async {
     relayStatus.connected = ClientConnected.connected;
@@ -62,7 +66,7 @@ class _AuthFakeRelay extends Relay {
     DateTime? deadline,
   }) async {
     sentMessages.add(message);
-    return true;
+    return !failSends;
   }
 
   /// Drive an inbound message through the handler registered by RelayPool,
@@ -255,7 +259,7 @@ void main() {
       expect(outcome.acceptedBy, equals([relay.url]));
     });
 
-    test('does not loop when the post-auth EVENT is still rejected', () async {
+    test('does not loop when the relay keeps rejecting after AUTH', () async {
       const eventId =
           '2222222222222222222222222222222222222222222222222222222222222222';
       final outcomeFuture = nostr.relayPool.sendEventAwaitOk(
@@ -278,7 +282,11 @@ void main() {
       await relay.deliver(['AUTH', challenge]);
       final authEventId = sentAuthEventId(relay);
       await relay.deliver(['OK', authEventId, true, '']);
-      await relay.deliver(['OK', eventId, false, 'restricted: members only']);
+      // A second auth-required after AUTH would re-trigger a retry if the
+      // dedup marker were missing; the tracked entry must suppress it. Using
+      // an auth-required reason here (not "restricted") isolates the dedup
+      // guard as the sole reason the second republish does not happen.
+      await relay.deliver(['OK', eventId, false, 'auth-required: still no']);
 
       final outcome = await outcomeFuture;
 
@@ -286,13 +294,133 @@ void main() {
       expect(outcome.acceptedBy, isEmpty);
       expect(
         outcome.rejectedBy,
-        equals({relay.url: 'restricted: members only'}),
+        equals({relay.url: 'auth-required: still no'}),
       );
       expect(
         sentMessagesOfType(relay, 'EVENT'),
         hasLength(2),
-        reason: 'post-auth rejection should not trigger another republish',
+        reason: 'the dedup marker must prevent a second post-auth republish',
       );
     });
+
+    test('fails fast on restricted rejection with no AUTH offered', () async {
+      const eventId =
+          '4444444444444444444444444444444444444444444444444444444444444444';
+      final outcomeFuture = nostr.relayPool.sendEventAwaitOk(
+        [
+          'EVENT',
+          {'id': eventId, 'kind': EventKind.giftWrap},
+        ],
+        eventId: eventId,
+        eventKind: EventKind.giftWrap,
+        targetRelays: [relay.url],
+        timeout: const Duration(seconds: 1),
+      );
+
+      // The relay never sends an AUTH challenge (alwaysAuth stays false), so a
+      // bare "restricted" is a permanent members-only rejection, not NIP-42.
+      await relay.deliver([
+        'OK',
+        eventId,
+        false,
+        'restricted: not on allow list',
+      ]);
+
+      final outcome = await outcomeFuture;
+
+      expect(outcome.failed, isTrue);
+      expect(
+        outcome.rejectedBy,
+        equals({relay.url: 'restricted: not on allow list'}),
+      );
+      expect(
+        sentMessagesOfType(relay, 'EVENT'),
+        hasLength(1),
+        reason: 'a members-only relay that never offers AUTH must not retry',
+      );
+    });
+
+    test('rejects the publish when the relay AUTH fails', () async {
+      const eventId =
+          '5555555555555555555555555555555555555555555555555555555555555555';
+      final outcomeFuture = nostr.relayPool.sendEventAwaitOk(
+        [
+          'EVENT',
+          {'id': eventId, 'kind': EventKind.giftWrap},
+        ],
+        eventId: eventId,
+        eventKind: EventKind.giftWrap,
+        targetRelays: [relay.url],
+        timeout: const Duration(seconds: 1),
+      );
+
+      await relay.deliver([
+        'OK',
+        eventId,
+        false,
+        'auth-required: you must auth',
+      ]);
+      await relay.deliver(['AUTH', challenge]);
+      final authEventId = sentAuthEventId(relay);
+      await relay.deliver([
+        'OK',
+        authEventId,
+        false,
+        'auth failed: bad signature',
+      ]);
+
+      final outcome = await outcomeFuture;
+
+      expect(outcome.failed, isTrue);
+      expect(
+        outcome.rejectedBy,
+        equals({relay.url: 'auth failed: bad signature'}),
+      );
+      expect(
+        sentMessagesOfType(relay, 'EVENT'),
+        hasLength(1),
+        reason: 'a failed AUTH must not retry the EVENT',
+      );
+    });
+
+    test(
+      'marks the relay unavailable when the post-auth resend fails',
+      () async {
+        const eventId =
+            '6666666666666666666666666666666666666666666666666666666666666666';
+        final outcomeFuture = nostr.relayPool.sendEventAwaitOk(
+          [
+            'EVENT',
+            {'id': eventId, 'kind': EventKind.giftWrap},
+          ],
+          eventId: eventId,
+          eventKind: EventKind.giftWrap,
+          targetRelays: [relay.url],
+          timeout: const Duration(seconds: 1),
+        );
+
+        await relay.deliver([
+          'OK',
+          eventId,
+          false,
+          'auth-required: you must auth',
+        ]);
+        await relay.deliver(['AUTH', challenge]);
+        final authEventId = sentAuthEventId(relay);
+        relay.failSends = true;
+        await relay.deliver(['OK', authEventId, true, '']);
+
+        final outcome = await outcomeFuture;
+
+        expect(outcome.failed, isTrue);
+        expect(outcome.acceptedBy, isEmpty);
+        expect(outcome.rejectedBy, isEmpty);
+        expect(
+          sentMessagesOfType(relay, 'EVENT'),
+          hasLength(2),
+          reason: 'the resend is attempted once before giving up',
+        );
+      },
+    );
   });
 }

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_auth_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_auth_test.dart
@@ -161,6 +161,22 @@ void main() {
       final sentAuth = sentMessagesOfType(fakeRelay, 'AUTH');
       expect(sentAuth, isEmpty);
     });
+
+    test('marks relay alwaysAuth after AUTH challenge', () async {
+      final signer = LocalNostrSigner(testPrivateKey);
+      final nostr = Nostr(signer, [], dummyTempRelay);
+      await nostr.refreshPublicKey();
+
+      final fakeRelay = _AuthFakeRelay('wss://auth-fake.example');
+      final added = await nostr.relayPool.add(fakeRelay);
+      expect(added, isTrue);
+      expect(fakeRelay.relayStatus.alwaysAuth, isFalse);
+
+      await fakeRelay.deliver(['AUTH', challenge]);
+
+      expect(fakeRelay.relayStatus.alwaysAuth, isTrue);
+      expect(sentMessagesOfType(fakeRelay, 'AUTH'), hasLength(1));
+    });
   });
 
   group('RelayPool auth-required publish retry', () {
@@ -224,7 +240,29 @@ void main() {
       expect(outcome.confirmed, isTrue);
       expect(outcome.acceptedBy, equals([relay.url]));
       expect(outcome.rejectedBy, isEmpty);
+      expect(relay.relayStatus.alwaysAuth, isTrue);
     });
+
+    test(
+      'registers auth-required query even when trigger send fails',
+      () async {
+        relay.relayStatus.alwaysAuth = true;
+        relay.failSends = true;
+        final subscription = Subscription([
+          Filter(kinds: [EventKind.textNote]).toJson(),
+        ], (_) {});
+
+        final result = await nostr.relayPool.relayDoQuery(
+          relay,
+          subscription,
+          false,
+        );
+
+        expect(result, isTrue);
+        expect(relay.checkQuery(subscription.id), isTrue);
+        expect(sentMessagesOfType(relay, 'REQ'), hasLength(1));
+      },
+    );
 
     test('republishes when AUTH OK arrives before EVENT rejection', () async {
       const eventId =
@@ -381,6 +419,81 @@ void main() {
         hasLength(1),
         reason: 'a failed AUTH must not retry the EVENT',
       );
+    });
+
+    test('reports auth-required reason when relay never challenges', () async {
+      const eventId =
+          '7777777777777777777777777777777777777777777777777777777777777777';
+      final outcomeFuture = nostr.relayPool.sendEventAwaitOk(
+        [
+          'EVENT',
+          {'id': eventId, 'kind': EventKind.giftWrap},
+        ],
+        eventId: eventId,
+        eventKind: EventKind.giftWrap,
+        targetRelays: [relay.url],
+        timeout: const Duration(milliseconds: 10),
+      );
+
+      await relay.deliver([
+        'OK',
+        eventId,
+        false,
+        'auth-required: you must auth',
+      ]);
+
+      final outcome = await outcomeFuture;
+
+      expect(outcome.failed, isTrue);
+      expect(
+        outcome.rejectedBy,
+        equals({relay.url: 'auth-required: you must auth'}),
+      );
+      expect(outcome.noResponseFrom, isEmpty);
+    });
+
+    test('rejects with stored reason when AUTH cannot be signed', () async {
+      const eventId =
+          '8888888888888888888888888888888888888888888888888888888888888888';
+      final unauthenticatedNostr = Nostr(
+        _NullKeySigner(),
+        [],
+        (url) => RelayBase(url, RelayStatus(url)),
+      );
+      final unauthenticatedRelay = _AuthFakeRelay(
+        'wss://auth-required-no-key.example',
+      );
+      final added = await unauthenticatedNostr.relayPool.add(
+        unauthenticatedRelay,
+      );
+      expect(added, isTrue);
+      final outcomeFuture = unauthenticatedNostr.relayPool.sendEventAwaitOk(
+        [
+          'EVENT',
+          {'id': eventId, 'kind': EventKind.giftWrap},
+        ],
+        eventId: eventId,
+        eventKind: EventKind.giftWrap,
+        targetRelays: [unauthenticatedRelay.url],
+        timeout: const Duration(seconds: 1),
+      );
+
+      await unauthenticatedRelay.deliver([
+        'OK',
+        eventId,
+        false,
+        'auth-required: you must auth',
+      ]);
+      await unauthenticatedRelay.deliver(['AUTH', challenge]);
+
+      final outcome = await outcomeFuture;
+
+      expect(outcome.failed, isTrue);
+      expect(
+        outcome.rejectedBy,
+        equals({unauthenticatedRelay.url: 'auth-required: you must auth'}),
+      );
+      expect(sentMessagesOfType(unauthenticatedRelay, 'AUTH'), isEmpty);
     });
 
     test(


### PR DESCRIPTION
Closes #6360

## Summary
- retry deadline-bound awaited publishes once after NIP-42 AUTH succeeds
- detect auth-required/restricted relay responses generically instead of relying on relay-specific special cases
- keep members-only post-auth rejections terminal so sends do not loop indefinitely

## Tests
- flutter test test/unit/relay_pool_auth_test.dart
- flutter test test/integration/relay_auth_test.dart
- flutter test test/unit/relay_pool_concurrency_test.dart
- flutter test
- flutter analyze
- flutter test test/src/nip17_message_service_test.dart test/src/dm_repository_test.dart
- flutter analyze lib test integration_test