### PR TITLE
fix(support): consume observed video deletions

### DIFF
--- a/mobile/lib/blocs/profile_feed/profile_feed_cubit.dart
+++ b/mobile/lib/blocs/profile_feed/profile_feed_cubit.dart
@@ -720,7 +720,7 @@ class ProfileFeedCubit extends Bloc<ProfileFeedEvent, ProfileFeedState> {
   List<VideoEvent> _withoutTombstones(List<VideoEvent> videos) {
     if (videos.isEmpty) return videos;
     return videos
-        .where((v) => !_videoEventService.isVideoEventLocallyDeleted(v))
+        .where((v) => !_videoEventService.isVideoEventKnownDeleted(v))
         .toList();
   }
 

--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -174,7 +174,7 @@ VideoEventService videoEventService(Ref ref) {
       stackTrace: stackTrace,
     );
   }
-  service.seedLocalDeletionTombstones(
+  service.seedKnownDeletionTombstones(
     eventIds: persistedDeletions.map((deletion) => deletion.originalEventId),
     addressableIds: persistedDeletions
         .map((deletion) => deletion.addressableId)

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -269,7 +269,7 @@ final class VideoEventServiceProvider
   }
 }
 
-String _$videoEventServiceHash() => r'4f32c751466a87eaef78b39472c339d306a57be8';
+String _$videoEventServiceHash() => r'7507831fe85efacc79d4b974a06fd19a0bb8dec7';
 
 /// Video event publisher for publishing video events to Nostr relays
 

--- a/mobile/lib/screens/video_detail_screen.dart
+++ b/mobile/lib/screens/video_detail_screen.dart
@@ -306,7 +306,7 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
 
     if (_video == null ||
         videoEventService.shouldHideVideo(_video!) ||
-        videoEventService.isVideoEventLocallyDeleted(_video!)) {
+        videoEventService.isVideoEventKnownDeleted(_video!)) {
       return Scaffold(
         backgroundColor: VineTheme.backgroundColor,
         appBar: _buildExitAppBar(context),

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -228,9 +228,10 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   final Map<SubscriptionType, bool> _isFollowingFeed = {};
   final Map<SubscriptionType, bool> _includeReposts = {};
 
-  // Track locally deleted videos to prevent resurrection from pagination
-  final Set<String> _locallyDeletedVideoIds = {};
-  final Set<String> _locallyDeletedVideoCoordinateKeys = {};
+  // Track known deleted videos to prevent resurrection from pagination.
+  // Includes local user deletions and observed remote NIP-09 deletes.
+  final Set<String> _knownDeletedVideoIds = {};
+  final Set<String> _knownDeletedVideoCoordinateKeys = {};
 
   // Broadcasts video ids the moment they are removed (deletion / future
   // block / mute). Subscribers — fullscreen feed bloc, profile feed
@@ -242,6 +243,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
 
   static const int _maxRetryAttempts = 3;
   static const Duration _retryDelay = Duration(seconds: 10);
+  static const int _eventDeletionKind = 5;
 
   // Optional services for enhanced functionality
   ContentBlocklistRepository? _blocklistRepository;
@@ -380,7 +382,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   ///
   /// Used in response to block / mute events. Unlike
   /// [removeVideoCompletely], this does NOT add ids to
-  /// [_locallyDeletedVideoIds] — block / mute are reversible and the
+  /// [_knownDeletedVideoIds] — block / mute are reversible and the
   /// existing pagination filters (via [shouldHideVideo] /
   /// [filterVideoList]) already guarantee that an unblocked author's
   /// videos can come back on the next refresh. We only need the
@@ -997,7 +999,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   /// - `_eventLists` (all subscription types: homeFeed, discovery, etc.)
   /// - `_authorBuckets` (used by profile feeds)
   /// - `_hashtagBuckets` (used by hashtag feeds)
-  /// - Marks as locally deleted to prevent pagination resurrection
+  /// - Marks as known deleted to prevent pagination resurrection
   ///
   /// This mirrors the `updateVideoEvent()` pattern for comprehensive state updates.
   /// Call this after successfully publishing a NIP-09 delete event.
@@ -1018,7 +1020,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   void removeVideoEventCompletely(VideoEvent video) {
     _removeVideoCompletely(
       primaryEventId: video.id,
-      coordinateKey: _localDeletionCoordinateKey(video),
+      coordinateKey: _knownDeletionCoordinateKey(video),
       logIdentity: video.addressableId ?? video.id,
     );
   }
@@ -1034,7 +1036,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     bool shouldRemove(VideoEvent video) =>
         video.id == primaryEventId ||
         (coordinateKey != null &&
-            _localDeletionCoordinateKey(video) == coordinateKey);
+            _knownDeletionCoordinateKey(video) == coordinateKey);
 
     // Remove from all subscription types (mirrors updateVideoEvent pattern)
     for (final entry in _eventLists.entries) {
@@ -1093,15 +1095,15 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       }
     }
 
-    // Mark as locally deleted to prevent pagination resurrection.
+    // Mark as known deleted to prevent pagination resurrection.
     //
     // Semantics: removal is permanent for the lifetime of this service.
     // Even if subsequent relay queries return the same event id, or another
     // event id for the same addressable video, it will be filtered out.
-    _locallyDeletedVideoIds.add(primaryEventId);
-    _locallyDeletedVideoIds.addAll(removedVideoIds);
+    _knownDeletedVideoIds.add(primaryEventId);
+    _knownDeletedVideoIds.addAll(removedVideoIds);
     if (coordinateKey != null) {
-      _locallyDeletedVideoCoordinateKeys.add(coordinateKey);
+      _knownDeletedVideoCoordinateKeys.add(coordinateKey);
     }
 
     // Emit on the side-channel BEFORE notifyListeners so that subscribers
@@ -1144,22 +1146,29 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     removeVideoCompletely(videoId);
   }
 
-  /// Check if a video has been locally deleted
+  /// Check if a video has a known deletion tombstone.
   /// Used to filter out deleted videos from pagination results
-  bool isVideoLocallyDeleted(String videoId) {
-    return _locallyDeletedVideoIds.contains(videoId);
+  bool isVideoKnownDeleted(String videoId) {
+    return _knownDeletedVideoIds.contains(videoId);
   }
 
-  /// Hydrate local deletion tombstones from persisted delete history.
+  /// Backwards-compatible alias for callers that have not migrated from the
+  /// original local-only deletion naming.
+  bool isVideoLocallyDeleted(String videoId) {
+    return isVideoKnownDeleted(videoId);
+  }
+
+  /// Hydrate known deletion tombstones from persisted delete history or
+  /// observed remote deletes.
   ///
   /// [addressableIds] must use the NIP-33 `kind:pubkey:d-tag` format. The
   /// service keeps its own compact lookup key private so callers do not couple
   /// to the in-memory implementation.
-  void seedLocalDeletionTombstones({
+  void seedKnownDeletionTombstones({
     Iterable<String> eventIds = const [],
     Iterable<String> addressableIds = const [],
   }) {
-    _locallyDeletedVideoIds.addAll(eventIds.where((id) => id.isNotEmpty));
+    _knownDeletedVideoIds.addAll(eventIds.where((id) => id.isNotEmpty));
 
     for (final addressableId in addressableIds) {
       final parsed = AId.fromString(addressableId);
@@ -1169,8 +1178,8 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
           parsed.dTag.isEmpty) {
         continue;
       }
-      _locallyDeletedVideoCoordinateKeys.add(
-        _localDeletionCoordinateKeyFromParts(
+      _knownDeletedVideoCoordinateKeys.add(
+        _knownDeletionCoordinateKeyFromParts(
           pubkey: parsed.pubkey,
           stableId: parsed.dTag,
         ),
@@ -1178,25 +1187,178 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     }
   }
 
+  /// Backwards-compatible alias for local delete-history hydration.
+  void seedLocalDeletionTombstones({
+    Iterable<String> eventIds = const [],
+    Iterable<String> addressableIds = const [],
+  }) {
+    seedKnownDeletionTombstones(
+      eventIds: eventIds,
+      addressableIds: addressableIds,
+    );
+  }
+
   /// Check whether this concrete video or its addressable identity has been
-  /// locally deleted.
-  bool isVideoEventLocallyDeleted(VideoEvent video) {
-    return _locallyDeletedVideoIds.contains(video.id) ||
-        _locallyDeletedVideoCoordinateKeys.contains(
-          _localDeletionCoordinateKey(video),
+  /// deleted by a known local or remote NIP-09 delete.
+  bool isVideoEventKnownDeleted(VideoEvent video) {
+    return _knownDeletedVideoIds.contains(video.id) ||
+        _knownDeletedVideoCoordinateKeys.contains(
+          _knownDeletionCoordinateKey(video),
         );
   }
 
-  String _localDeletionCoordinateKey(VideoEvent video) =>
-      _localDeletionCoordinateKeyFromParts(
+  /// Backwards-compatible alias for callers that have not migrated from the
+  /// original local-only deletion naming.
+  bool isVideoEventLocallyDeleted(VideoEvent video) {
+    return isVideoEventKnownDeleted(video);
+  }
+
+  String _knownDeletionCoordinateKey(VideoEvent video) =>
+      _knownDeletionCoordinateKeyFromParts(
         pubkey: video.pubkey,
         stableId: video.stableId,
       );
 
-  String _localDeletionCoordinateKeyFromParts({
+  String _knownDeletionCoordinateKeyFromParts({
     required String pubkey,
     required String stableId,
   }) => '${pubkey.toLowerCase()}:$stableId';
+
+  void _handleObservedDeletionEvent(Event deletionEvent) {
+    if (deletionEvent.kind != _eventDeletionKind) return;
+
+    final deletionPubkey = deletionEvent.pubkey.toLowerCase();
+    final requestedEventIds = <String>{};
+    final coordinateKeys = <String>{};
+    final addressableIds = <String>{};
+
+    for (final tag in deletionEvent.tags) {
+      if (tag.length < 2) continue;
+
+      final tagName = tag[0];
+      final tagValue = tag[1];
+      if (tagName == 'e' && tagValue.isNotEmpty) {
+        requestedEventIds.add(tagValue.toLowerCase());
+      } else if (tagName == 'a' && tagValue.isNotEmpty) {
+        final parsed = AId.fromString(tagValue);
+        if (parsed == null ||
+            parsed.kind != NIP71VideoKinds.addressableShortVideo ||
+            parsed.pubkey.toLowerCase() != deletionPubkey ||
+            parsed.dTag.isEmpty) {
+          continue;
+        }
+
+        addressableIds.add(tagValue);
+        coordinateKeys.add(
+          _knownDeletionCoordinateKeyFromParts(
+            pubkey: parsed.pubkey,
+            stableId: parsed.dTag,
+          ),
+        );
+      }
+    }
+
+    if (requestedEventIds.isEmpty && coordinateKeys.isEmpty) return;
+
+    final validatedEventIds = <String>{};
+    for (final video in _allCachedVideos()) {
+      if (video.pubkey.toLowerCase() != deletionPubkey) continue;
+
+      final matchesRequestedId = requestedEventIds.contains(
+        video.id.toLowerCase(),
+      );
+      final matchesCoordinate = coordinateKeys.contains(
+        _knownDeletionCoordinateKey(video),
+      );
+
+      if (matchesRequestedId || matchesCoordinate) {
+        validatedEventIds.add(video.id);
+      }
+    }
+
+    if (validatedEventIds.isEmpty && coordinateKeys.isEmpty) return;
+
+    seedKnownDeletionTombstones(
+      eventIds: validatedEventIds,
+      addressableIds: addressableIds,
+    );
+
+    _removeKnownDeletedVideos(
+      eventIds: validatedEventIds,
+      coordinateKeys: coordinateKeys,
+      logIdentity: deletionEvent.id,
+    );
+  }
+
+  Iterable<VideoEvent> _allCachedVideos() sync* {
+    for (final videos in _eventLists.values) {
+      yield* videos;
+    }
+    for (final videos in _authorBuckets.values) {
+      yield* videos;
+    }
+    for (final videos in _hashtagBuckets.values) {
+      yield* videos;
+    }
+  }
+
+  void _removeKnownDeletedVideos({
+    required Set<String> eventIds,
+    required Set<String> coordinateKeys,
+    required String logIdentity,
+  }) {
+    var removedCount = 0;
+    final removedVideoIds = <String>{};
+
+    bool shouldRemove(VideoEvent video) =>
+        eventIds.contains(video.id) ||
+        coordinateKeys.contains(_knownDeletionCoordinateKey(video));
+
+    for (final entry in _eventLists.entries) {
+      final initialLength = entry.value.length;
+      entry.value.removeWhere((video) {
+        final remove = shouldRemove(video);
+        if (remove) removedVideoIds.add(video.id);
+        return remove;
+      });
+      removedCount += initialLength - entry.value.length;
+    }
+
+    for (final entry in _authorBuckets.entries) {
+      final initialLength = entry.value.length;
+      entry.value.removeWhere((video) {
+        final remove = shouldRemove(video);
+        if (remove) removedVideoIds.add(video.id);
+        return remove;
+      });
+      removedCount += initialLength - entry.value.length;
+    }
+
+    for (final entry in _hashtagBuckets.entries) {
+      final initialLength = entry.value.length;
+      entry.value.removeWhere((video) {
+        final remove = shouldRemove(video);
+        if (remove) removedVideoIds.add(video.id);
+        return remove;
+      });
+      removedCount += initialLength - entry.value.length;
+    }
+
+    if (!_removedVideoIdsController.isClosed) {
+      for (final id in removedVideoIds) {
+        _removedVideoIdsController.add(id);
+      }
+    }
+
+    Log.info(
+      removedCount > 0
+          ? 'Applied observed video deletion $logIdentity to $removedCount cached location(s)'
+          : 'Recorded observed video deletion $logIdentity tombstone',
+      name: 'VideoEventService',
+      category: LogCategory.video,
+    );
+    notifyListeners();
+  }
 
   /// Emits a video id whenever the service has marked it removed —
   /// today this is user-initiated deletion via [removeVideoCompletely];
@@ -1205,7 +1367,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   /// Subscribers should treat each event as "drop this id from any open
   /// surface immediately." The stream is broadcast and does not buffer,
   /// so newcomers only receive future emissions; the canonical source of
-  /// truth is still the service state plus [isVideoLocallyDeleted].
+  /// truth is still the service state plus [isVideoKnownDeleted].
   Stream<String> get removedVideoIds => _removedVideoIdsController.stream;
 
   /// Load cached events from database (cache-first strategy)
@@ -1603,6 +1765,17 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       _activeGroupFilters[subscriptionType] = group;
 
       final filters = <Filter>[videoFilter];
+      if (authors != null && authors.isNotEmpty) {
+        filters.add(
+          Filter(
+            kinds: [_eventDeletionKind],
+            authors: authors,
+            since: effectiveSince,
+            until: effectiveUntil,
+            limit: limit,
+          ),
+        );
+      }
 
       // Optionally add repost filter if enabled
       if (includeReposts) {
@@ -2309,6 +2482,11 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
         paginationState.markEventSeen(event.id);
       }
 
+      if (event.kind == _eventDeletionKind) {
+        _handleObservedDeletionEvent(event);
+        return;
+      }
+
       if (!NIP71VideoKinds.isVideoKind(event.kind) && event.kind != 16) {
         // Cache non-video events in appropriate services instead of discarding
         if (event.kind == 0 && _profileRepository != null) {
@@ -2587,6 +2765,11 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
         name: 'VideoEventService',
         category: LogCategory.video,
       );
+
+      if (event.kind == _eventDeletionKind) {
+        _handleObservedDeletionEvent(event);
+        return;
+      }
 
       if (!NIP71VideoKinds.isVideoKind(event.kind) && event.kind != 16) {
         Log.warning(
@@ -2933,6 +3116,12 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
         authors: [pubkey],
         until: until,
         limit: (limit * 0.2).round(), // 20% of limit for reposts
+      ),
+      Filter(
+        kinds: [_eventDeletionKind],
+        authors: [pubkey],
+        until: until,
+        limit: limit,
       ),
     ];
 
@@ -4430,10 +4619,10 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     SubscriptionType subscriptionType, {
     bool isHistorical = false,
   }) {
-    // CRITICAL: Filter out locally deleted videos to prevent pagination resurrection
-    if (isVideoEventLocallyDeleted(videoEvent)) {
+    // CRITICAL: Filter out known deleted videos to prevent pagination resurrection.
+    if (isVideoEventKnownDeleted(videoEvent)) {
       Log.debug(
-        'Filtering out locally deleted video ${videoEvent.id} from $subscriptionType feed',
+        'Filtering out known deleted video ${videoEvent.id} from $subscriptionType feed',
         name: 'VideoEventService',
         category: LogCategory.video,
       );

--- a/mobile/test/blocs/profile_feed/profile_feed_cubit_test.dart
+++ b/mobile/test/blocs/profile_feed/profile_feed_cubit_test.dart
@@ -102,7 +102,7 @@ class _Harness {
     when(
       () => ves.filterVideoList(any()),
     ).thenAnswer((i) => i.positionalArguments[0] as List<VideoEvent>);
-    when(() => ves.isVideoEventLocallyDeleted(any())).thenReturn(false);
+    when(() => ves.isVideoEventKnownDeleted(any())).thenReturn(false);
     when(() => ves.subscribeToUserVideos(any())).thenAnswer((_) async {});
     when(() => ves.unsubscribeFromUserVideos(any())).thenAnswer((_) async {});
     when(
@@ -730,7 +730,7 @@ void main() {
         _video('b', createdAt: 2000),
       ]);
       when(
-        () => h.ves.isVideoEventLocallyDeleted(
+        () => h.ves.isVideoEventKnownDeleted(
           any(that: isA<VideoEvent>().having((v) => v.id, 'id', 'b')),
         ),
       ).thenReturn(true);
@@ -882,12 +882,35 @@ void main() {
 
     test('tombstoned videos are excluded from emitted state', () async {
       when(
-        () => h.ves.isVideoEventLocallyDeleted(
+        () => h.ves.isVideoEventKnownDeleted(
           any(that: isA<VideoEvent>().having((v) => v.id, 'id', 'a')),
         ),
       ).thenReturn(true);
       final cubit = await buildReady(_result([_video('a'), _video('b')]));
       addTearDown(cubit.close);
+
+      expect(cubit.state.videos.map((v) => v.id), ['b']);
+    });
+
+    test('service tombstone removes an already-loaded REST video', () async {
+      final originalAudit = ProfileFeedCubit.relaySnapshotAudit;
+      ProfileFeedCubit.relaySnapshotAudit = const Duration(milliseconds: 20);
+      addTearDown(() => ProfileFeedCubit.relaySnapshotAudit = originalAudit);
+
+      final cubit = await buildReady(_result([_video('a'), _video('b')]));
+      addTearDown(cubit.close);
+      expect(cubit.state.videos.map((v) => v.id), ['a', 'b']);
+
+      when(
+        () => h.ves.isVideoEventKnownDeleted(
+          any(that: isA<VideoEvent>().having((v) => v.id, 'id', 'a')),
+        ),
+      ).thenReturn(true);
+      when(() => h.ves.authorVideos(_author)).thenReturn(const <VideoEvent>[]);
+
+      h.onChanged!();
+      await Future<void>.delayed(const Duration(milliseconds: 60));
+      await pumpEventQueue();
 
       expect(cubit.state.videos.map((v) => v.id), ['b']);
     });
@@ -901,7 +924,7 @@ void main() {
           createdAt: 5000,
         );
         when(
-          () => h.ves.isVideoEventLocallyDeleted(
+          () => h.ves.isVideoEventKnownDeleted(
             any(
               that: isA<VideoEvent>()
                   .having((v) => v.id, 'id', 'new-event-id-from-rest')

--- a/mobile/test/screens/video_detail_screen_test.dart
+++ b/mobile/test/screens/video_detail_screen_test.dart
@@ -88,7 +88,7 @@ void main() {
         () => mockVideoEventService.shouldHideVideo(any()),
       ).thenReturn(false);
       when(
-        () => mockVideoEventService.isVideoEventLocallyDeleted(any()),
+        () => mockVideoEventService.isVideoEventKnownDeleted(any()),
       ).thenReturn(false);
     });
 
@@ -630,7 +630,7 @@ void main() {
           ),
         ).thenAnswer((_) async => video);
         when(
-          () => mockVideoEventService.isVideoEventLocallyDeleted(video),
+          () => mockVideoEventService.isVideoEventKnownDeleted(video),
         ).thenReturn(true);
 
         await tester.pumpWidget(buildSubject(videoId: 'deleted_video_id'));

--- a/mobile/test/services/video_event_service_deletion_test.dart
+++ b/mobile/test/services/video_event_service_deletion_test.dart
@@ -36,6 +36,16 @@ VideoEvent _videoEvent({
   return VideoEvent.fromNostrEvent(event);
 }
 
+Event _deletionEvent({
+  required String id,
+  required String pubkey,
+  required List<List<String>> tags,
+}) {
+  return Event(pubkey, 5, tags, 'delete', createdAt: 1001)
+    ..id = id
+    ..sig = 'sig-$id';
+}
+
 void main() {
   setUpAll(() {
     registerFallbackValue(<Filter>[]);
@@ -51,9 +61,7 @@ void main() {
       subscriptionManager = _MockSubscriptionManager();
       when(() => nostrClient.isInitialized).thenReturn(true);
       when(() => nostrClient.connectedRelayCount).thenReturn(1);
-      when(
-        () => nostrClient.publicKey,
-      ).thenReturn(
+      when(() => nostrClient.publicKey).thenReturn(
         'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
       );
       when(
@@ -168,6 +176,149 @@ void main() {
       expect(service.isVideoLocallyDeleted('vid-1'), isTrue);
       expect(service.isVideoLocallyDeleted('vid-2'), isFalse);
     });
+
+    test(
+      'observed author deletion removes a matching cached profile video',
+      () async {
+        const author =
+            'c3dd74d68e414f0305db9f7dc96ec32e616502e6ccf5bbf5739de19a96b67f3e';
+        const videoId =
+            '1111111111111111111111111111111111111111111111111111111111111111';
+        const deletionId =
+            '2222222222222222222222222222222222222222222222222222222222222222';
+        final emitted = <String>[];
+        final sub = service.removedVideoIds.listen(emitted.add);
+
+        final video = _videoEvent(
+          id: videoId,
+          pubkey: author,
+          dTag: 'deleted-vine-id',
+        );
+        service.addVideoEventForTesting(
+          video,
+          SubscriptionType.profile,
+          isHistorical: false,
+        );
+
+        service.handleEventForTesting(
+          _deletionEvent(
+            id: deletionId,
+            pubkey: author,
+            tags: [
+              ['e', videoId],
+              ['k', '34236'],
+            ],
+          ),
+          SubscriptionType.profile,
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        expect(service.authorVideos(author), isEmpty);
+        expect(service.isVideoKnownDeleted(videoId), isTrue);
+        expect(emitted, contains(videoId));
+        await sub.cancel();
+      },
+    );
+
+    test('observed deletion from a different pubkey is ignored', () async {
+      const author =
+          'c3dd74d68e414f0305db9f7dc96ec32e616502e6ccf5bbf5739de19a96b67f3e';
+      const attacker =
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      const videoId =
+          '3333333333333333333333333333333333333333333333333333333333333333';
+      const deletionId =
+          '4444444444444444444444444444444444444444444444444444444444444444';
+      final emitted = <String>[];
+      final sub = service.removedVideoIds.listen(emitted.add);
+
+      final video = _videoEvent(
+        id: videoId,
+        pubkey: author,
+        dTag: 'protected-vine-id',
+      );
+      service.addVideoEventForTesting(
+        video,
+        SubscriptionType.profile,
+        isHistorical: false,
+      );
+
+      service.handleEventForTesting(
+        _deletionEvent(
+          id: deletionId,
+          pubkey: attacker,
+          tags: [
+            ['e', videoId],
+            ['a', '34236:$author:protected-vine-id'],
+            ['k', '34236'],
+          ],
+        ),
+        SubscriptionType.profile,
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(service.authorVideos(author).map((v) => v.id), contains(videoId));
+      expect(service.isVideoKnownDeleted(videoId), isFalse);
+      expect(emitted, isEmpty);
+      await sub.cancel();
+    });
+
+    test(
+      'observed addressable deletion tombstones replacement event ids',
+      () async {
+        const author =
+            'c3dd74d68e414f0305db9f7dc96ec32e616502e6ccf5bbf5739de19a96b67f3e';
+        const olderId =
+            '5555555555555555555555555555555555555555555555555555555555555555';
+        const replacementId =
+            '6666666666666666666666666666666666666666666666666666666666666666';
+        const deletionId =
+            '7777777777777777777777777777777777777777777777777777777777777777';
+        final emitted = <String>[];
+        final sub = service.removedVideoIds.listen(emitted.add);
+
+        final older = _videoEvent(
+          id: olderId,
+          pubkey: author,
+          dTag: 'same-addressable-video',
+        );
+        final replacement = _videoEvent(
+          id: replacementId,
+          pubkey: author,
+          dTag: 'same-addressable-video',
+        );
+        service
+          ..addVideoEventForTesting(
+            older,
+            SubscriptionType.profile,
+            isHistorical: false,
+          )
+          ..addVideoEventForTesting(
+            replacement,
+            SubscriptionType.discovery,
+            isHistorical: false,
+          );
+
+        service.handleEventForTesting(
+          _deletionEvent(
+            id: deletionId,
+            pubkey: author,
+            tags: [
+              ['a', '34236:$author:same-addressable-video'],
+              ['k', '34236'],
+            ],
+          ),
+          SubscriptionType.profile,
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        expect(service.authorVideos(author), isEmpty);
+        expect(service.isVideoEventKnownDeleted(older), isTrue);
+        expect(service.isVideoEventKnownDeleted(replacement), isTrue);
+        expect(emitted, containsAll(<String>[olderId, replacementId]));
+        await sub.cancel();
+      },
+    );
 
     test('dispose closes the stream', () async {
       final sub = service.removedVideoIds.listen((_) {});

--- a/mobile/test/services/video_event_service_eose_empty_test.dart
+++ b/mobile/test/services/video_event_service_eose_empty_test.dart
@@ -218,7 +218,7 @@ void main() {
 
         expect(
           capturedCalls,
-          hasLength(2),
+          hasLength(3),
           reason:
               'Each subscription filter is probed separately so the local '
               'cache is consulted (queryEvents only reads cache for '
@@ -245,13 +245,23 @@ void main() {
           probeFilters.map((filter) => filter.authors).toList(),
           everyElement(equals([_profileAuthor])),
         );
-        expect(
-          probeFilters.first.kinds,
-          equals(NIP71VideoKinds.getAllVideoKinds()),
+        final videoFilter = probeFilters.singleWhere(
+          (filter) =>
+              filter.kinds != null &&
+              filter.kinds!.length ==
+                  NIP71VideoKinds.getAllVideoKinds().length &&
+              filter.kinds!.every(NIP71VideoKinds.getAllVideoKinds().contains),
         );
-        expect(probeFilters.first.limit, 100);
-        expect(probeFilters.last.kinds, equals([16]));
-        expect(probeFilters.last.limit, 50);
+        final repostFilter = probeFilters.singleWhere(
+          (filter) => filter.kinds != null && filter.kinds!.singleOrNull == 16,
+        );
+        final deletionFilter = probeFilters.singleWhere(
+          (filter) => filter.kinds != null && filter.kinds!.singleOrNull == 5,
+        );
+
+        expect(videoFilter.limit, 100);
+        expect(repostFilter.limit, 50);
+        expect(deletionFilter.limit, 100);
       },
     );
 

--- a/mobile/test/widgets/profile/profile_video_feed_view_test.dart
+++ b/mobile/test/widgets/profile/profile_video_feed_view_test.dart
@@ -117,7 +117,7 @@ void main() {
         () => videoEventService.filterVideoList(any()),
       ).thenAnswer((i) => i.positionalArguments.first as List<VideoEvent>);
       when(
-        () => videoEventService.isVideoEventLocallyDeleted(any()),
+        () => videoEventService.isVideoEventKnownDeleted(any()),
       ).thenReturn(false);
       when(
         () => videoEventService.subscribeToUserVideos(any()),


### PR DESCRIPTION
## Summary

- subscribe to scoped NIP-09 kind-5 delete events for observed author/video feed subscriptions
- apply signer-validated remote delete tombstones to cached video lists, author buckets, hashtag buckets, and removal listeners
- rename production tombstone semantics from local deletion to known deletion while keeping compatibility aliases
- update profile and detail surfaces to filter against known deletion tombstones

## Related issues

- Part of divinevideo/divine-mobile#6341
- Backend REST/index follow-up: divinevideo/divine-funnelcake#694

This PR fixes the mobile relay/live-state side of #6341. It intentionally does not close #6341 because For You / Popular and REST-backed author cold loads still require divinevideo/divine-funnelcake#694.

## Verification

- `flutter test test/services/video_event_service_deletion_test.dart test/blocs/profile_feed/profile_feed_cubit_test.dart test/screens/video_detail_screen_test.dart`
- `flutter test test/services/video_event_service_subscribe_race_test.dart test/services/video_event_service_online_retry_test.dart test/services/subscription_deduplication_test.dart`
- `flutter analyze`
- pre-push checks: analyzer, generated-file verification, changed-file tests

## Notes

A stale local command included `test/services/subscription_manager_filter_test.dart`, which does not exist in this tree; rerunning the existing subscription-related test files passed.