### PR TITLE
fix(dm): harden NIP-17 against unauthenticated rumor fields and unsigned seals

### DIFF
--- a/mobile/packages/dm_repository/lib/src/dm_decryption_worker.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_decryption_worker.dart
@@ -94,7 +94,7 @@ Future<DecryptedRumorResult> _decryptOne(
   }
 
   // C16/NIP-44: validate the outer gift wrap (kind 1059) signature before
-  // decrypting. Defense-in-depth — diVine relays verify on publish, but an
+  // decrypting. Defense-in-depth — Divine relays verify on publish, but an
   // untrusted relay or local cache could serve a forged/tampered wrap.
   if (!verifyGiftWrapPart(giftWrap)) {
     return DecryptedRumorResult.failure(
@@ -156,19 +156,13 @@ Future<DecryptedRumorResult> _decryptOne(
   // (it signed the seal), so it is the authoritative author, and the id is
   // derived rather than trusted: it becomes the `direct_messages` primary
   // key and the reaction upsert key, so accepting a claimed one lets a
-  // sender overwrite another user's row. Rebuilding through the Event
-  // constructor recomputes the canonical NIP-01 id from the rumor's own
-  // fields — for a well-formed sender it equals the claimed id, so there is
-  // no observable divergence. Mirrors GiftWrapUtil.getRumorEvent and
-  // DmRepository._rumorFromSlot, which already build rumors this way.
+  // sender overwrite another user's row. Parse only the authenticated/needed
+  // fields; claimed `id` and `pubkey` may be absent. Mirrors
+  // GiftWrapUtil.getRumorEvent and DmRepository._rumorFromSlot.
   try {
-    final parsed = Event.fromJson(rumorJson);
-    final rumor = Event(
-      sealEvent.pubkey,
-      parsed.kind,
-      parsed.tags,
-      parsed.content,
-      createdAt: parsed.createdAt,
+    final rumor = rebuildUnsignedRumorFromJson(
+      rumorJson,
+      authenticatedPubkey: sealEvent.pubkey,
     );
     return DecryptedRumorResult.success(rumor.toJson());
   } on Object catch (e) {

--- a/mobile/packages/dm_repository/lib/src/dm_decryption_worker.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_decryption_worker.dart
@@ -151,31 +151,25 @@ Future<DecryptedRumorResult> _decryptOne(
     );
   }
 
-  // NIP-17 sender verification: the rumor's claimed author is NOT
-  // cryptographically authenticated — the seal's pubkey IS (it signed
-  // the seal). When they differ, attribute the message to the seal's
-  // authenticated pubkey to prevent impersonation. This mirrors the
-  // logic in GiftWrapUtil.getRumorEvent.
-  final rumorPubkey = rumorJson['pubkey'];
-  final spoofedAuthor =
-      rumorPubkey is String && rumorPubkey != sealEvent.pubkey;
-
-  // Round-trip through Event to normalize shape and re-emit toJson so
-  // the main isolate receives exactly what Event.fromJson expects back.
+  // NIP-59 leaves the rumor unsigned, so NOTHING in it is authenticated —
+  // not its `pubkey` and not its `id`. The seal's pubkey IS authenticated
+  // (it signed the seal), so it is the authoritative author, and the id is
+  // derived rather than trusted: it becomes the `direct_messages` primary
+  // key and the reaction upsert key, so accepting a claimed one lets a
+  // sender overwrite another user's row. Rebuilding through the Event
+  // constructor recomputes the canonical NIP-01 id from the rumor's own
+  // fields — for a well-formed sender it equals the claimed id, so there is
+  // no observable divergence. Mirrors GiftWrapUtil.getRumorEvent and
+  // DmRepository._rumorFromSlot, which already build rumors this way.
   try {
-    var rumor = Event.fromJson(rumorJson);
-    if (spoofedAuthor) {
-      // C4: rebuild with the seal's authenticated pubkey so the rumor id
-      // is RECOMPUTED to match (Event.fromJson would otherwise carry over
-      // the spoofed id). The rebuilt rumor is unsigned, per NIP-59.
-      rumor = Event(
-        sealEvent.pubkey,
-        rumor.kind,
-        rumor.tags,
-        rumor.content,
-        createdAt: rumor.createdAt,
-      );
-    }
+    final parsed = Event.fromJson(rumorJson);
+    final rumor = Event(
+      sealEvent.pubkey,
+      parsed.kind,
+      parsed.tags,
+      parsed.content,
+      createdAt: parsed.createdAt,
+    );
     return DecryptedRumorResult.success(rumor.toJson());
   } on Object catch (e) {
     return DecryptedRumorResult.failure(

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1691,22 +1691,20 @@ class DmRepository {
       final rumor = rumorEvent;
 
       // A NIP-59 rumor is unsigned, so `created_at` is chosen freely by the
-      // sender. Refuse an implausibly future-dated one before any kind
-      // routing — this seam covers kinds 14/15, reactions and deletions
-      // alike. Persisting it would advance the sync cursor past now and
-      // blackhole every later subscription (and pin the thread to the top of
-      // the inbox forever). Ledger the wrap so it is not re-decrypted on
-      // every launch; the sender can always resend with an honest timestamp.
+      // sender. Keep the message, but clamp the timestamp used for local
+      // ordering/cursors so a bad clock cannot blackhole future subscriptions
+      // or pin the thread above honest messages forever.
       final nowSec = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      final persistedCreatedAt = rumor.createdAt > nowSec
+          ? nowSec
+          : rumor.createdAt;
       if (rumor.createdAt > nowSec + DmSyncState.maxFutureSkewSeconds) {
         Log.warning(
-          'Rejected DM (kind ${rumor.kind}) from ${rumor.pubkey}: rumor '
-          'created_at ${rumor.createdAt} is beyond the accepted skew of '
+          'Clamped DM (kind ${rumor.kind}) from ${rumor.pubkey}: rumor '
+          'created_at ${rumor.createdAt} is beyond the expected skew of '
           '${DmSyncState.maxFutureSkewSeconds}s (now $nowSec)',
           category: LogCategory.system,
         );
-        await _recordProcessedWrap(giftWrapEvent.id);
-        return;
       }
 
       // NIP-17 spec line 14 explicitly permits kind 7 reactions inside
@@ -1823,7 +1821,7 @@ class DmRepository {
         conversationId: conversationId,
         senderPubkey: rumor.pubkey,
         content: rumor.content,
-        createdAt: rumor.createdAt,
+        createdAt: persistedCreatedAt,
         ownerPubkey: _userPubkey,
       );
       if (isDuplicate) {
@@ -1849,7 +1847,7 @@ class DmRepository {
           conversationId: conversationId,
           senderPubkey: rumor.pubkey,
           content: rumor.content,
-          createdAt: rumor.createdAt,
+          createdAt: persistedCreatedAt,
           giftWrapId: giftWrapEvent.id,
           messageKind: rumor.kind,
           replyToId: replyToId,
@@ -1878,9 +1876,9 @@ class DmRepository {
           id: conversationId,
           participantPubkeys: jsonEncode(participants),
           isGroup: isGroup,
-          createdAt: existing?.createdAt ?? rumor.createdAt,
+          createdAt: existing?.createdAt ?? persistedCreatedAt,
           lastMessageContent: previewContent,
-          lastMessageTimestamp: rumor.createdAt,
+          lastMessageTimestamp: persistedCreatedAt,
           lastMessageSenderPubkey: rumor.pubkey,
           subject: subject,
           isRead: isSentByMe,
@@ -1891,10 +1889,10 @@ class DmRepository {
         );
       });
 
-      // Advance sync boundaries using the rumor's REAL created_at. The
-      // outer gift wrap randomizes its own created_at within a ~2 day
-      // window (NIP-17) so it must not be used for boundary tracking.
-      await _syncState?.recordSeen(_userPubkey, createdAt: rumor.createdAt);
+      // Advance sync boundaries from the bounded local timestamp. The outer
+      // gift wrap randomizes its own created_at within a ~2 day window
+      // (NIP-17) so it must not be used for boundary tracking.
+      await _syncState?.recordSeen(_userPubkey, createdAt: persistedCreatedAt);
 
       Log.debug(
         'Persisted DM (kind ${rumor.kind}) in conversation '
@@ -2213,9 +2211,9 @@ class DmRepository {
   ///
   /// The id is recomputed by the constructor from [GiftWrapUnwrapSlot.sender] —
   /// always the canonical NIP-01 id for the authenticated sender, the same
-  /// recompute [GiftWrapUtil.getRumorEvent] performs on its sender-mismatch
-  /// branch. For a well-formed sender (every diVine client embeds the canonical
-  /// id) it equals the claimed id, so there is no observable divergence; for a
+  /// unconditional recompute [GiftWrapUtil.getRumorEvent] performs locally.
+  /// For a well-formed sender (every Divine client embeds the canonical id) it
+  /// equals the claimed id, so there is no observable divergence; for a
   /// non-canonical claimed id the recompute is the more correct, interoperable
   /// choice (the DB primary key is the rumor id).
   Event? _rumorFromSlot(GiftWrapUnwrapSlot slot) {

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -755,44 +755,52 @@ class DmRepository {
     _reconnectTimer = null;
     if (_giftWrapSubscription != null || _subscribing || !isInitialized) return;
 
-    // Count-based windowing: first open fetches a bounded backlog
-    // (limit:50), later opens fetch only recent events via a `since:`
-    // filter. The 2-day overlap absorbs NIP-17 randomized created_at
-    // jitter (gift wraps tweak their outer created_at within a ~2 day
-    // window). See docs/plans/2026-04-05-dm-scaling-fix-design.md.
-    final newest = _syncState?.newestSyncedAt(_userPubkey);
-    final isFirstOpen = newest == null;
-    final filter = nostr_filter.Filter(
-      kinds: [
-        EventKind.giftWrap,
-        EventKind.directMessage,
-        EventKind.eventDeletion,
-      ],
-      p: [_userPubkey],
-      limit: isFirstOpen ? 50 : null,
-      since: isFirstOpen ? null : (newest - 2 * 86400),
-    );
-
-    Log.info(
-      'Starting DM subscription for pubkey $_userPubkey '
-      '(connected relays: '
-      '${_nostrClient.connectedRelayCount}/'
-      '${_nostrClient.configuredRelayCount}, '
-      'filter: ${filter.toJson()})',
-      category: LogCategory.system,
-    );
-
-    // Resolve the user's OWN kind-10050 inbox relays and target the live
-    // subscription at them — as BOTH tempRelays (to add connections outside
-    // the default pool) AND targetRelays — so gift wraps a NIP-17 sender
-    // delivered to relays outside divine's default pool are read. A `null`
-    // result (no kind-10050 / resolve failure) preserves the prior
-    // default-pool behavior. Memoized per session, so the resolve (bounded by
-    // the queryEvents ~5s timeout) only delays the FIRST open. `_subscribing`
-    // guards the await window against a concurrent startListening opening a
-    // duplicate subscription. See #4974.
+    // Claim the subscribe slot BEFORE the first await. `_subscribing` is what
+    // stops a concurrent startListening() from opening a duplicate
+    // subscription, so every suspension point below must be inside it — the
+    // re-entrancy check above is only sound while the code between it and this
+    // assignment stays synchronous. The `finally` below always releases it.
     _subscribing = true;
     try {
+      // Heal boundaries a pre-guard build may have poisoned with an
+      // unauthenticated rumor timestamp before deriving `since:` from them —
+      // otherwise an already-affected install stays silently blackholed.
+      await _syncState?.repairPoisonedBoundaries(_userPubkey);
+
+      // Count-based windowing: first open fetches a bounded backlog
+      // (limit:50), later opens fetch only recent events via a `since:`
+      // filter. The 2-day overlap absorbs NIP-17 randomized created_at
+      // jitter (gift wraps tweak their outer created_at within a ~2 day
+      // window). See docs/plans/2026-04-05-dm-scaling-fix-design.md.
+      final newest = _syncState?.newestSyncedAt(_userPubkey);
+      final isFirstOpen = newest == null;
+      final filter = nostr_filter.Filter(
+        kinds: [
+          EventKind.giftWrap,
+          EventKind.directMessage,
+          EventKind.eventDeletion,
+        ],
+        p: [_userPubkey],
+        limit: isFirstOpen ? 50 : null,
+        since: isFirstOpen ? null : (newest - 2 * 86400),
+      );
+
+      Log.info(
+        'Starting DM subscription for pubkey $_userPubkey '
+        '(connected relays: '
+        '${_nostrClient.connectedRelayCount}/'
+        '${_nostrClient.configuredRelayCount}, '
+        'filter: ${filter.toJson()})',
+        category: LogCategory.system,
+      );
+
+      // Resolve the user's OWN kind-10050 inbox relays and target the live
+      // subscription at them — as BOTH tempRelays (to add connections outside
+      // the default pool) AND targetRelays — so gift wraps a NIP-17 sender
+      // delivered to relays outside divine's default pool are read. A `null`
+      // result (no kind-10050 / resolve failure) preserves the prior
+      // default-pool behavior. Memoized per session, so the resolve (bounded
+      // by the queryEvents ~5s timeout) only delays the FIRST open. See #4974.
       // Capture the session token before the await: `filter` was built with
       // the current `_userPubkey`, so if an account switch lands during the
       // resolve we must NOT open a subscription targeting the previous user.
@@ -1681,6 +1689,25 @@ class DmRepository {
       // Bind to a final local so the non-null type promotes inside the
       // runInTransaction closure below (a nullable parameter would not).
       final rumor = rumorEvent;
+
+      // A NIP-59 rumor is unsigned, so `created_at` is chosen freely by the
+      // sender. Refuse an implausibly future-dated one before any kind
+      // routing — this seam covers kinds 14/15, reactions and deletions
+      // alike. Persisting it would advance the sync cursor past now and
+      // blackhole every later subscription (and pin the thread to the top of
+      // the inbox forever). Ledger the wrap so it is not re-decrypted on
+      // every launch; the sender can always resend with an honest timestamp.
+      final nowSec = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      if (rumor.createdAt > nowSec + DmSyncState.maxFutureSkewSeconds) {
+        Log.warning(
+          'Rejected DM (kind ${rumor.kind}) from ${rumor.pubkey}: rumor '
+          'created_at ${rumor.createdAt} is beyond the accepted skew of '
+          '${DmSyncState.maxFutureSkewSeconds}s (now $nowSec)',
+          category: LogCategory.system,
+        );
+        await _recordProcessedWrap(giftWrapEvent.id);
+        return;
+      }
 
       // NIP-17 spec line 14 explicitly permits kind 7 reactions inside
       // the gift-wrap envelope. Reaction deletions are also wrapped by

--- a/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
@@ -45,6 +45,34 @@ class DmSyncState {
   /// under "Message requests".
   static const int currentDrainVersion = 3;
 
+  /// Maximum clock skew, in seconds, tolerated on a self-asserted DM
+  /// `created_at` before it is treated as implausible.
+  ///
+  /// A NIP-59 inner rumor is unsigned — only the kind-13 seal and kind-1059
+  /// wrap are cryptographically bound — so its `created_at` is chosen freely
+  /// by whoever sent the wrap. Unbounded, one rumor stamped far in the future
+  /// permanently blackholes the inbox: it advances [newestSyncedAt], and
+  /// `DmRepository.startListening` derives the live subscription's `since:`
+  /// from it, so no relay ever returns anything again.
+  ///
+  /// One hour is deliberately far below the 2-day `since:` overlap window: a
+  /// timestamp saturating this allowance still yields
+  /// `since = (now + 1h) - 2d = now - 47h`, comfortably in the past, so even
+  /// the maximum accepted skew cannot push the cursor past now. It also
+  /// absorbs any realistic consumer-device clock error.
+  static const int maxFutureSkewSeconds = 3600;
+
+  /// Lower bound for a plausible Nostr `created_at` (2020-01-01T00:00:00Z).
+  ///
+  /// Guards the opposite end of the same unauthenticated field. The history
+  /// drain seeds its `until:` cursor from [oldestSyncedAt]; a rumor stamped
+  /// below the outer floor of all relay-retained history makes the first page
+  /// come back empty, which the drain reads as exhaustion and latches
+  /// `historyDrainComplete` with zero recovery. Nostr did not exist before
+  /// this instant, so no legitimate DM predates it and real history is never
+  /// truncated.
+  static const int minPlausibleCreatedAt = 1577836800;
+
   /// Returns the newest (highest) `created_at` unix timestamp we have
   /// successfully processed for [pubkey], or `null` if nothing has been
   /// processed yet.
@@ -59,15 +87,71 @@ class DmSyncState {
   /// successfully processed for [pubkey]. Advances `newestSyncedAt`
   /// upward and `oldestSyncedAt` downward monotonically — older events
   /// never roll back `newest`, and newer events never roll back `oldest`.
+  ///
+  /// [createdAt] is caller-supplied and, for a NIP-59 rumor, unauthenticated,
+  /// so each boundary is bounded independently before it is persisted: the
+  /// newest is capped at now ([maxFutureSkewSeconds]) and the oldest floored
+  /// at [minPlausibleCreatedAt]. The two bounds are applied separately rather
+  /// than clamping one value, because they defend two different failure modes
+  /// and must not interact on a device whose own clock is wrong.
+  ///
+  /// This is defence in depth: `DmRepository` already refuses to persist a
+  /// rumor dated beyond the skew allowance, so a well-behaved caller never
+  /// reaches the cap here.
   Future<void> recordSeen(String pubkey, {required int createdAt}) async {
+    final nowSec = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+    final cappedNewest = createdAt > nowSec + maxFutureSkewSeconds
+        ? nowSec
+        : createdAt;
     final newest = newestSyncedAt(pubkey);
-    if (newest == null || createdAt > newest) {
-      await _prefs.setInt('$_newestPrefix$pubkey', createdAt);
+    if (newest == null || cappedNewest > newest) {
+      await _prefs.setInt('$_newestPrefix$pubkey', cappedNewest);
     }
+
+    final flooredOldest = createdAt < minPlausibleCreatedAt
+        ? minPlausibleCreatedAt
+        : createdAt;
     final oldest = oldestSyncedAt(pubkey);
-    if (oldest == null || createdAt < oldest) {
-      await _prefs.setInt('$_oldestPrefix$pubkey', createdAt);
+    if (oldest == null || flooredOldest < oldest) {
+      await _prefs.setInt('$_oldestPrefix$pubkey', flooredOldest);
     }
+  }
+
+  /// Repairs sync boundaries left out of bounds by an earlier build for
+  /// [pubkey], and re-arms the history drain when it finds any.
+  ///
+  /// The guards in [recordSeen] only protect writes made from this build
+  /// onward. An install that already persisted a poisoned boundary stays
+  /// blackholed forever otherwise — the failure is silent, so the user has no
+  /// way to attribute it and no recovery short of a reinstall or account
+  /// switch. Called once per subscription start, before the `since:` filter
+  /// is derived.
+  ///
+  /// Clearing the completion flag and resume cursor matches
+  /// [upgradeDrainVersionIfNeeded]: while the poisoned boundary was in place
+  /// the subscription filtered out real history, so the one-time drain must
+  /// run again to recover whatever the relays still hold.
+  Future<void> repairPoisonedBoundaries(String pubkey) async {
+    final nowSec = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    var repaired = false;
+
+    final newest = newestSyncedAt(pubkey);
+    if (newest != null && newest > nowSec + maxFutureSkewSeconds) {
+      await _prefs.setInt('$_newestPrefix$pubkey', nowSec);
+      repaired = true;
+    }
+
+    final oldest = oldestSyncedAt(pubkey);
+    if (oldest != null && oldest < minPlausibleCreatedAt) {
+      await _prefs.setInt('$_oldestPrefix$pubkey', minPlausibleCreatedAt);
+      repaired = true;
+    }
+
+    if (!repaired) return;
+
+    await _prefs.remove('$_drainCompletePrefix$pubkey');
+    await _prefs.remove('$_drainCursorPrefix$pubkey');
   }
 
   /// Whether the one-time full-history drain has completed for [pubkey].

--- a/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
@@ -46,7 +46,8 @@ class DmSyncState {
   static const int currentDrainVersion = 3;
 
   /// Maximum clock skew, in seconds, tolerated on a self-asserted DM
-  /// `created_at` before it is treated as implausible.
+  /// `created_at` before callers should stop treating it as an honest send
+  /// time.
   ///
   /// A NIP-59 inner rumor is unsigned — only the kind-13 seal and kind-1059
   /// wrap are cryptographically bound — so its `created_at` is chosen freely
@@ -55,12 +56,12 @@ class DmSyncState {
   /// `DmRepository.startListening` derives the live subscription's `since:`
   /// from it, so no relay ever returns anything again.
   ///
-  /// One hour is deliberately far below the 2-day `since:` overlap window: a
-  /// timestamp saturating this allowance still yields
-  /// `since = (now + 1h) - 2d = now - 47h`, comfortably in the past, so even
-  /// the maximum accepted skew cannot push the cursor past now. It also
-  /// absorbs any realistic consumer-device clock error.
-  static const int maxFutureSkewSeconds = 3600;
+  /// Twenty-four hours is still safely inside the 2-day `since:` overlap
+  /// window: a timestamp saturating this allowance still yields
+  /// `since = (now + 24h) - 2d = now - 24h`, in the past, so the maximum
+  /// tolerated skew cannot push the cursor past now. It also avoids silently
+  /// dropping messages from devices with a badly drifted clock.
+  static const int maxFutureSkewSeconds = 86400;
 
   /// Lower bound for a plausible Nostr `created_at` (2020-01-01T00:00:00Z).
   ///
@@ -89,32 +90,27 @@ class DmSyncState {
   /// never roll back `newest`, and newer events never roll back `oldest`.
   ///
   /// [createdAt] is caller-supplied and, for a NIP-59 rumor, unauthenticated,
-  /// so each boundary is bounded independently before it is persisted: the
-  /// newest is capped at now ([maxFutureSkewSeconds]) and the oldest floored
-  /// at [minPlausibleCreatedAt]. The two bounds are applied separately rather
-  /// than clamping one value, because they defend two different failure modes
-  /// and must not interact on a device whose own clock is wrong.
+  /// so each boundary is bounded independently before it is persisted. The
+  /// two bounds are applied separately rather than clamping one value, because
+  /// they defend two different failure modes and must not interact on a device
+  /// whose own clock is wrong.
   ///
-  /// This is defence in depth: `DmRepository` already refuses to persist a
-  /// rumor dated beyond the skew allowance, so a well-behaved caller never
-  /// reaches the cap here.
+  /// This is defence in depth: `DmRepository` already bounds the timestamp it
+  /// persists for NIP-17 rumors, so a well-behaved caller should reach these
+  /// clamps only through legacy state or direct callers.
   Future<void> recordSeen(String pubkey, {required int createdAt}) async {
     final nowSec = DateTime.now().millisecondsSinceEpoch ~/ 1000;
 
-    final cappedNewest = createdAt > nowSec + maxFutureSkewSeconds
-        ? nowSec
-        : createdAt;
+    final cappedNewest = createdAt.clamp(minPlausibleCreatedAt, nowSec);
     final newest = newestSyncedAt(pubkey);
     if (newest == null || cappedNewest > newest) {
       await _prefs.setInt('$_newestPrefix$pubkey', cappedNewest);
     }
 
-    final flooredOldest = createdAt < minPlausibleCreatedAt
-        ? minPlausibleCreatedAt
-        : createdAt;
+    final cappedOldest = createdAt.clamp(minPlausibleCreatedAt, nowSec);
     final oldest = oldestSyncedAt(pubkey);
-    if (oldest == null || flooredOldest < oldest) {
-      await _prefs.setInt('$_oldestPrefix$pubkey', flooredOldest);
+    if (oldest == null || cappedOldest < oldest) {
+      await _prefs.setInt('$_oldestPrefix$pubkey', cappedOldest);
     }
   }
 
@@ -128,30 +124,33 @@ class DmSyncState {
   /// switch. Called once per subscription start, before the `since:` filter
   /// is derived.
   ///
-  /// Clearing the completion flag and resume cursor matches
-  /// [upgradeDrainVersionIfNeeded]: while the poisoned boundary was in place
-  /// the subscription filtered out real history, so the one-time drain must
-  /// run again to recover whatever the relays still hold.
+  /// Clearing the completion flag and seeding the resume cursor at now
+  /// re-drains down through the window the poisoned live subscription missed;
+  /// removing the cursor would seed from [oldestSyncedAt] and only revisit
+  /// older history the user already has.
   Future<void> repairPoisonedBoundaries(String pubkey) async {
     final nowSec = DateTime.now().millisecondsSinceEpoch ~/ 1000;
     var repaired = false;
 
     final newest = newestSyncedAt(pubkey);
-    if (newest != null && newest > nowSec + maxFutureSkewSeconds) {
+    if (newest != null && newest > nowSec) {
       await _prefs.setInt('$_newestPrefix$pubkey', nowSec);
       repaired = true;
     }
 
     final oldest = oldestSyncedAt(pubkey);
-    if (oldest != null && oldest < minPlausibleCreatedAt) {
-      await _prefs.setInt('$_oldestPrefix$pubkey', minPlausibleCreatedAt);
+    if (oldest != null && (oldest < minPlausibleCreatedAt || oldest > nowSec)) {
+      await _prefs.setInt(
+        '$_oldestPrefix$pubkey',
+        oldest < minPlausibleCreatedAt ? minPlausibleCreatedAt : nowSec,
+      );
       repaired = true;
     }
 
     if (!repaired) return;
 
     await _prefs.remove('$_drainCompletePrefix$pubkey');
-    await _prefs.remove('$_drainCursorPrefix$pubkey');
+    await _prefs.setInt('$_drainCursorPrefix$pubkey', nowSec);
   }
 
   /// Whether the one-time full-history drain has completed for [pubkey].

--- a/mobile/packages/dm_repository/lib/src/gift_wrap_build_worker.dart
+++ b/mobile/packages/dm_repository/lib/src/gift_wrap_build_worker.dart
@@ -24,7 +24,7 @@ class BuildGiftWrapRequest {
   /// Hex-encoded sender private key used for NIP-44 ECDH and Schnorr signing.
   final String privateKeyHex;
 
-  /// The unsigned kind-14 rumor as `Event.toJson`; its id is preserved.
+  /// The unsigned kind-14 rumor; receivers derive its id after unwrap.
   final Map<String, dynamic> rumorJson;
 
   /// Recipient public keys (hex) to wrap [rumorJson] for, one wrap each.

--- a/mobile/packages/dm_repository/test/src/dm_decryption_worker_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_decryption_worker_test.dart
@@ -525,5 +525,78 @@ void main() {
       expect(results[0].isSuccess, isFalse);
       expect(results[0].error, isNotNull);
     });
+
+    group('inner rumor id is derived, never trusted', () {
+      // A NIP-59 rumor is unsigned, so its claimed `id` is attacker-chosen —
+      // and it becomes the direct_messages primary key and the reaction
+      // upsert key downstream.
+      test(
+        'a claimed non-canonical id is replaced by the canonical one',
+        () async {
+          final recipientPriv = generatePrivateKey();
+          final recipientPub = getPublicKey(recipientPriv);
+          final senderPriv = generatePrivateKey();
+          final senderPub = getPublicKey(senderPriv);
+
+          final rumor = _buildRumor(
+            senderPubkey: senderPub,
+            recipientPubkey: recipientPub,
+            content: 'overwrite me',
+          );
+          final canonicalId = rumor.id;
+          rumor.id = 'f' * 64;
+
+          final gift = await _buildGiftWrap(
+            rumor: rumor,
+            senderPrivateKey: senderPriv,
+            recipientPubkey: recipientPub,
+          );
+
+          final results = await decryptGiftWrapBatch(
+            DecryptBatchRequest(
+              events: [gift.toJson()],
+              privateKeyHex: recipientPriv,
+            ),
+          );
+
+          expect(results, hasLength(1));
+          expect(results[0].isSuccess, isTrue);
+          final decrypted = Event.fromJson(results[0].rumor!);
+          expect(decrypted.id, isNot(equals('f' * 64)));
+          expect(decrypted.id, equals(canonicalId));
+          expect(decrypted.isValid, isTrue);
+          expect(decrypted.content, equals('overwrite me'));
+        },
+      );
+
+      test('an honest sender sees no divergence in the id', () async {
+        final recipientPriv = generatePrivateKey();
+        final recipientPub = getPublicKey(recipientPriv);
+        final senderPriv = generatePrivateKey();
+        final senderPub = getPublicKey(senderPriv);
+
+        final rumor = _buildRumor(
+          senderPubkey: senderPub,
+          recipientPubkey: recipientPub,
+          content: 'round trip',
+        );
+
+        final gift = await _buildGiftWrap(
+          rumor: rumor,
+          senderPrivateKey: senderPriv,
+          recipientPubkey: recipientPub,
+        );
+
+        final results = await decryptGiftWrapBatch(
+          DecryptBatchRequest(
+            events: [gift.toJson()],
+            privateKeyHex: recipientPriv,
+          ),
+        );
+
+        expect(results[0].isSuccess, isTrue);
+        expect(Event.fromJson(results[0].rumor!).id, equals(rumor.id));
+      });
+    });
   });
 }

--- a/mobile/packages/dm_repository/test/src/dm_decryption_worker_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_decryption_worker_test.dart
@@ -19,12 +19,14 @@ Future<Event> _buildGiftWrap({
   required Event rumor,
   required String senderPrivateKey,
   required String recipientPubkey,
+  void Function(Map<String, dynamic> rumorMap)? mutateRumorMap,
 }) async {
   final senderPubkey = getPublicKey(senderPrivateKey);
 
   // Seal: encrypt the unsigned rumor to the recipient using the
   // sender's key, then sign with the sender's key.
   final rumorMap = rumor.toJson()..remove('sig');
+  mutateRumorMap?.call(rumorMap);
   final sealKey = NIP44V2.shareSecret(senderPrivateKey, recipientPubkey);
   final sealContent = await NIP44V2.encrypt(jsonEncode(rumorMap), sealKey);
   final sealEvent = Event(
@@ -494,6 +496,42 @@ void main() {
         expect(Event.fromJson(results[0].rumor!).isValid, isTrue);
       },
     );
+
+    test('omitted claimed rumor id and pubkey still decrypts', () async {
+      final recipientPriv = generatePrivateKey();
+      final recipientPub = getPublicKey(recipientPriv);
+      final senderPriv = generatePrivateKey();
+      final senderPub = getPublicKey(senderPriv);
+      final rumor = _buildRumor(
+        senderPubkey: senderPub,
+        recipientPubkey: recipientPub,
+        content: 'minimal rumor',
+      );
+
+      final giftWrap = await _buildGiftWrap(
+        rumor: rumor,
+        senderPrivateKey: senderPriv,
+        recipientPubkey: recipientPub,
+        mutateRumorMap: (rumorMap) {
+          rumorMap
+            ..remove('id')
+            ..remove('pubkey');
+        },
+      );
+
+      final results = await decryptGiftWrapBatch(
+        DecryptBatchRequest(
+          events: [giftWrap.toJson()],
+          privateKeyHex: recipientPriv,
+        ),
+      );
+
+      expect(results, hasLength(1));
+      expect(results[0].isSuccess, isTrue);
+      expect(results[0].rumor!['id'], equals(rumor.id));
+      expect(results[0].rumor!['pubkey'], equals(senderPub));
+      expect(results[0].rumor!['content'], equals('minimal rumor'));
+    });
 
     test('wrong private key yields failure entry for every event', () async {
       final alicePriv = generatePrivateKey();

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -11072,7 +11072,7 @@ void main() {
       Event futureDatedRumor() => Event.fromJson({
         'id': _rumorEventId,
         'pubkey': _validPubkeyB,
-        // Year 2100 — unconditionally beyond the accepted skew.
+        // Year 2100 — unconditionally beyond the local ordering clamp.
         'created_at': 4102444800,
         'kind': EventKind.privateDirectMessage,
         'tags': [
@@ -11083,10 +11083,58 @@ void main() {
       });
 
       test(
-        'a future-dated rumor is rejected, ledgered, and never advances the '
-        'sync cursor',
+        'a future-dated rumor is persisted with a clamped timestamp and never '
+        'advances the sync cursor past now',
         () async {
           final syncState = _FakeDmSyncState();
+          when(
+            () => mockDirectMessagesDao.insertMessage(
+              id: any(named: 'id'),
+              conversationId: any(named: 'conversationId'),
+              senderPubkey: any(named: 'senderPubkey'),
+              content: any(named: 'content'),
+              createdAt: any(named: 'createdAt'),
+              giftWrapId: any(named: 'giftWrapId'),
+              messageKind: any(named: 'messageKind'),
+              replyToId: any(named: 'replyToId'),
+              subject: any(named: 'subject'),
+              tagsJson: any(named: 'tagsJson'),
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              sendBatchId: any(named: 'sendBatchId'),
+            ),
+          ).thenAnswer((_) async {});
+          when(
+            () => mockConversationsDao.getConversation(
+              any(),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockConversationsDao.upsertConversation(
+              id: any(named: 'id'),
+              participantPubkeys: any(named: 'participantPubkeys'),
+              isGroup: any(named: 'isGroup'),
+              createdAt: any(named: 'createdAt'),
+              lastMessageContent: any(named: 'lastMessageContent'),
+              lastMessageTimestamp: any(named: 'lastMessageTimestamp'),
+              lastMessageSenderPubkey: any(named: 'lastMessageSenderPubkey'),
+              subject: any(named: 'subject'),
+              isRead: any(named: 'isRead'),
+              currentUserHasSent: any(named: 'currentUserHasSent'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              dmProtocol: any(named: 'dmProtocol'),
+            ),
+          ).thenAnswer((_) async {});
           final repository = createRepository(
             processedGiftWrapsDao: ledger,
             syncState: syncState,
@@ -11098,23 +11146,37 @@ void main() {
           await Future<void>.delayed(Duration.zero);
           await Future<void>.delayed(Duration.zero);
 
-          // Never persisted...
-          verifyNever(
+          final insertCall = verify(
             () => mockDirectMessagesDao.insertMessage(
               id: any(named: 'id'),
               conversationId: any(named: 'conversationId'),
               senderPubkey: any(named: 'senderPubkey'),
               content: any(named: 'content'),
-              createdAt: any(named: 'createdAt'),
+              createdAt: captureAny(named: 'createdAt'),
               giftWrapId: any(named: 'giftWrapId'),
               messageKind: any(named: 'messageKind'),
+              replyToId: any(named: 'replyToId'),
+              subject: any(named: 'subject'),
+              tagsJson: any(named: 'tagsJson'),
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
               ownerPubkey: any(named: 'ownerPubkey'),
+              sendBatchId: any(named: 'sendBatchId'),
             ),
-          );
-          // ...and critically, the cursor is untouched.
-          expect(syncState.recorded, isEmpty);
-          // Ledgered so it is not re-decrypted on every launch.
-          expect(ledger.recorded, contains(_giftWrapEventId));
+          )..called(1);
+          final insertedCreatedAt = insertCall.captured.single as int;
+          final nowSec = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+          expect(insertedCreatedAt, closeTo(nowSec, 5));
+          expect(syncState.recorded.single.createdAt, closeTo(nowSec, 5));
+          expect(ledger.recorded, isNot(contains(_giftWrapEventId)));
 
           await controller.close();
           await repository.stopListening();

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -315,6 +315,7 @@ class _FakeDmSyncState implements DmSyncState {
   final List<String> markedCompletePubkeys = <String>[];
   final List<int> persistedDrainCursors = <int>[];
   final List<String> upgradedPubkeys = <String>[];
+  final List<String> repairedPubkeys = <String>[];
   final List<({String pubkey, int createdAt})> recorded =
       <({String pubkey, int createdAt})>[];
 
@@ -349,6 +350,18 @@ class _FakeDmSyncState implements DmSyncState {
     drainCompleteOverride = false;
     drainCursorOverride = null;
     drainVersionOverride = DmSyncState.currentDrainVersion;
+  }
+
+  @override
+  Future<void> repairPoisonedBoundaries(String pubkey) async {
+    repairedPubkeys.add(pubkey);
+    final nowSec = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    final newest = newestOverride;
+    if (newest != null && newest > nowSec + DmSyncState.maxFutureSkewSeconds) {
+      newestOverride = nowSec;
+      drainCompleteOverride = false;
+      drainCursorOverride = null;
+    }
   }
 
   @override
@@ -11046,6 +11059,110 @@ void main() {
 
           expect(decryptCount, 2);
           expect(ledger.recorded, isNot(contains(_giftWrapEventId)));
+
+          await controller.close();
+          await repository.stopListening();
+        },
+      );
+
+      // A NIP-59 rumor is unsigned, so `created_at` is chosen freely by
+      // whoever sent the wrap. Left unbounded, one such rumor advances the
+      // sync cursor past now and every later subscription returns nothing —
+      // the inbox is silently blackholed until reinstall.
+      Event futureDatedRumor() => Event.fromJson({
+        'id': _rumorEventId,
+        'pubkey': _validPubkeyB,
+        // Year 2100 — unconditionally beyond the accepted skew.
+        'created_at': 4102444800,
+        'kind': EventKind.privateDirectMessage,
+        'tags': [
+          ['p', _validPubkeyA],
+        ],
+        'content': 'blackhole',
+        'sig': '',
+      });
+
+      test(
+        'a future-dated rumor is rejected, ledgered, and never advances the '
+        'sync cursor',
+        () async {
+          final syncState = _FakeDmSyncState();
+          final repository = createRepository(
+            processedGiftWrapsDao: ledger,
+            syncState: syncState,
+            rumorDecryptor: (_, _) async => futureDatedRumor(),
+          );
+          await repository.startListening();
+
+          controller.add(giftWrap());
+          await Future<void>.delayed(Duration.zero);
+          await Future<void>.delayed(Duration.zero);
+
+          // Never persisted...
+          verifyNever(
+            () => mockDirectMessagesDao.insertMessage(
+              id: any(named: 'id'),
+              conversationId: any(named: 'conversationId'),
+              senderPubkey: any(named: 'senderPubkey'),
+              content: any(named: 'content'),
+              createdAt: any(named: 'createdAt'),
+              giftWrapId: any(named: 'giftWrapId'),
+              messageKind: any(named: 'messageKind'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          );
+          // ...and critically, the cursor is untouched.
+          expect(syncState.recorded, isEmpty);
+          // Ledgered so it is not re-decrypted on every launch.
+          expect(ledger.recorded, contains(_giftWrapEventId));
+
+          await controller.close();
+          await repository.stopListening();
+        },
+      );
+
+      test(
+        'the skew guard does not reject an honestly-dated rumor',
+        () async {
+          // Same wrap, same pipeline — only the rumor timestamp differs. The
+          // rumor must reach its kind handler instead of being short-circuited.
+          final nowSec = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+          final honest = Event.fromJson({
+            'id': _rumorEventId,
+            'pubkey': _validPubkeyB,
+            'created_at': nowSec - 60,
+            'kind': EventKind.reaction,
+            'tags': [
+              ['e', _giftWrapEventId2],
+              ['p', _validPubkeyA],
+            ],
+            'content': '❤️',
+            'sig': '',
+          });
+          when(
+            () => mockReactionsRepository.persistIncoming(
+              rumorEvent: any(named: 'rumorEvent'),
+              giftWrapId: _giftWrapEventId,
+            ),
+          ).thenAnswer((_) async => DmReactionWrapOutcome.processed);
+
+          final repository = createRepository(
+            processedGiftWrapsDao: ledger,
+            reactionsRepository: mockReactionsRepository,
+            rumorDecryptor: (_, _) async => honest,
+          );
+          await repository.startListening();
+
+          controller.add(giftWrap());
+          await Future<void>.delayed(Duration.zero);
+          await Future<void>.delayed(Duration.zero);
+
+          verify(
+            () => mockReactionsRepository.persistIncoming(
+              rumorEvent: any(named: 'rumorEvent'),
+              giftWrapId: _giftWrapEventId,
+            ),
+          ).called(1);
 
           await controller.close();
           await repository.stopListening();

--- a/mobile/packages/dm_repository/test/src/dm_sync_state_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_sync_state_test.dart
@@ -13,6 +13,16 @@ void main() {
     const pkA = 'npub1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
     const pkB = 'npub1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
 
+    // Ascending plausible Nostr timestamps (Nov 2023). The boundary
+    // assertions below only care about relative order, but `recordSeen`
+    // floors anything before [DmSyncState.minPlausibleCreatedAt], so the
+    // fixtures have to be times a real event could carry.
+    const tsOldest = 1700000000;
+    const tsMid = 1700000500;
+    const tsNewer = 1700001000;
+    const tsNewest = 1700002000;
+    const tsOther = 1700003000;
+
     setUp(() async {
       SharedPreferences.setMockInitialValues(<String, Object>{});
       prefs = await SharedPreferences.getInstance();
@@ -31,10 +41,10 @@ void main() {
     test(
       'recordSeen sets both newest and oldest for the first event',
       () async {
-        await state.recordSeen(pkA, createdAt: 1000);
+        await state.recordSeen(pkA, createdAt: tsOldest);
 
-        expect(state.newestSyncedAt(pkA), equals(1000));
-        expect(state.oldestSyncedAt(pkA), equals(1000));
+        expect(state.newestSyncedAt(pkA), equals(tsOldest));
+        expect(state.oldestSyncedAt(pkA), equals(tsOldest));
       },
     );
 
@@ -42,10 +52,10 @@ void main() {
       'recordSeen advances newest monotonically — lower createdAt does '
       'not overwrite',
       () async {
-        await state.recordSeen(pkA, createdAt: 2000);
-        await state.recordSeen(pkA, createdAt: 1500);
+        await state.recordSeen(pkA, createdAt: tsNewer);
+        await state.recordSeen(pkA, createdAt: tsMid);
 
-        expect(state.newestSyncedAt(pkA), equals(2000));
+        expect(state.newestSyncedAt(pkA), equals(tsNewer));
       },
     );
 
@@ -53,11 +63,11 @@ void main() {
       'recordSeen advances oldest monotonically downward — higher '
       'createdAt does not overwrite oldest',
       () async {
-        await state.recordSeen(pkA, createdAt: 1000);
-        await state.recordSeen(pkA, createdAt: 2000);
+        await state.recordSeen(pkA, createdAt: tsOldest);
+        await state.recordSeen(pkA, createdAt: tsNewer);
 
-        expect(state.oldestSyncedAt(pkA), equals(1000));
-        expect(state.newestSyncedAt(pkA), equals(2000));
+        expect(state.oldestSyncedAt(pkA), equals(tsOldest));
+        expect(state.newestSyncedAt(pkA), equals(tsNewer));
       },
     );
 
@@ -65,18 +75,18 @@ void main() {
       "recordSeen scopes state per pubkey — one user's boundary does "
       'not bleed into another',
       () async {
-        await state.recordSeen(pkA, createdAt: 1000);
-        await state.recordSeen(pkA, createdAt: 2000);
+        await state.recordSeen(pkA, createdAt: tsOldest);
+        await state.recordSeen(pkA, createdAt: tsNewer);
 
         expect(state.newestSyncedAt(pkB), isNull);
         expect(state.oldestSyncedAt(pkB), isNull);
 
-        await state.recordSeen(pkB, createdAt: 5000);
+        await state.recordSeen(pkB, createdAt: tsOther);
 
-        expect(state.newestSyncedAt(pkA), equals(2000));
-        expect(state.oldestSyncedAt(pkA), equals(1000));
-        expect(state.newestSyncedAt(pkB), equals(5000));
-        expect(state.oldestSyncedAt(pkB), equals(5000));
+        expect(state.newestSyncedAt(pkA), equals(tsNewer));
+        expect(state.oldestSyncedAt(pkA), equals(tsOldest));
+        expect(state.newestSyncedAt(pkB), equals(tsOther));
+        expect(state.oldestSyncedAt(pkB), equals(tsOther));
       },
     );
 
@@ -84,16 +94,16 @@ void main() {
       'clear removes both newest and oldest for the given pubkey and '
       'leaves others intact',
       () async {
-        await state.recordSeen(pkA, createdAt: 1000);
-        await state.recordSeen(pkA, createdAt: 2000);
-        await state.recordSeen(pkB, createdAt: 3000);
+        await state.recordSeen(pkA, createdAt: tsOldest);
+        await state.recordSeen(pkA, createdAt: tsNewer);
+        await state.recordSeen(pkB, createdAt: tsNewest);
 
         await state.clear(pkA);
 
         expect(state.newestSyncedAt(pkA), isNull);
         expect(state.oldestSyncedAt(pkA), isNull);
-        expect(state.newestSyncedAt(pkB), equals(3000));
-        expect(state.oldestSyncedAt(pkB), equals(3000));
+        expect(state.newestSyncedAt(pkB), equals(tsNewest));
+        expect(state.oldestSyncedAt(pkB), equals(tsNewest));
       },
     );
 
@@ -101,9 +111,9 @@ void main() {
       'clearAll removes sync state for every pubkey and leaves '
       'non-dm keys intact',
       () async {
-        await state.recordSeen(pkA, createdAt: 1000);
-        await state.recordSeen(pkA, createdAt: 2000);
-        await state.recordSeen(pkB, createdAt: 3000);
+        await state.recordSeen(pkA, createdAt: tsOldest);
+        await state.recordSeen(pkA, createdAt: tsNewer);
+        await state.recordSeen(pkB, createdAt: tsNewest);
         await prefs.setString('unrelated_key', 'keep_me');
 
         await state.clearAll();
@@ -318,6 +328,109 @@ void main() {
         expect(state.dmRelayListPublished(pkB), isFalse);
         expect(prefs.getString('unrelated_key'), equals('keep_me'));
       });
+    });
+
+    group('unauthenticated rumor timestamps', () {
+      // A NIP-59 rumor is unsigned, so `created_at` is attacker-chosen.
+      // Absolute out-of-bounds values keep these deterministic without
+      // needing to control the wall clock.
+      const year2100 = 4102444800;
+      const epochOne = 1;
+
+      int nowSec() => DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+      test('recordSeen caps a far-future createdAt at now', () async {
+        await state.recordSeen(pkA, createdAt: year2100);
+
+        final newest = state.newestSyncedAt(pkA);
+        expect(newest, isNotNull);
+        expect(newest, lessThan(year2100));
+        expect(newest, closeTo(nowSec(), 5));
+      });
+
+      test(
+        'a capped createdAt cannot push the live since: filter past now',
+        () async {
+          await state.recordSeen(pkA, createdAt: year2100);
+
+          // DmRepository.startListening derives `since` this way; if it ever
+          // lands in the future the relay returns nothing and the inbox is
+          // silently blackholed.
+          final since = state.newestSyncedAt(pkA)! - 2 * 86400;
+          expect(since, lessThan(nowSec()));
+        },
+      );
+
+      test('recordSeen floors an implausibly old createdAt', () async {
+        await state.recordSeen(pkA, createdAt: epochOne);
+
+        expect(
+          state.oldestSyncedAt(pkA),
+          equals(DmSyncState.minPlausibleCreatedAt),
+        );
+      });
+
+      test('recordSeen leaves an in-range createdAt untouched', () async {
+        final honest = nowSec() - 60;
+
+        await state.recordSeen(pkA, createdAt: honest);
+
+        expect(state.newestSyncedAt(pkA), equals(honest));
+        expect(state.oldestSyncedAt(pkA), equals(honest));
+      });
+
+      test(
+        'repairPoisonedBoundaries heals a cursor persisted by an older build '
+        'and re-arms the drain',
+        () async {
+          // Simulate a pre-guard build having written the poisoned value.
+          await prefs.setInt('dm.newestSyncedAt.$pkA', year2100);
+          await state.markHistoryDrainComplete(pkA);
+          expect(state.historyDrainComplete(pkA), isTrue);
+
+          await state.repairPoisonedBoundaries(pkA);
+
+          expect(state.newestSyncedAt(pkA), closeTo(nowSec(), 5));
+          expect(state.historyDrainComplete(pkA), isFalse);
+        },
+      );
+
+      test('repairPoisonedBoundaries heals an implausibly old floor', () async {
+        await prefs.setInt('dm.oldestSyncedAt.$pkA', epochOne);
+
+        await state.repairPoisonedBoundaries(pkA);
+
+        expect(
+          state.oldestSyncedAt(pkA),
+          equals(DmSyncState.minPlausibleCreatedAt),
+        );
+      });
+
+      test(
+        'repairPoisonedBoundaries is a no-op for healthy boundaries',
+        () async {
+          final honest = nowSec() - 3600;
+          await state.recordSeen(pkA, createdAt: honest);
+          await state.markHistoryDrainComplete(pkA);
+
+          await state.repairPoisonedBoundaries(pkA);
+
+          expect(state.newestSyncedAt(pkA), equals(honest));
+          expect(state.oldestSyncedAt(pkA), equals(honest));
+          // A healthy install must not be forced through a re-drain.
+          expect(state.historyDrainComplete(pkA), isTrue);
+        },
+      );
+
+      test(
+        'repairPoisonedBoundaries is a no-op when nothing is stored',
+        () async {
+          await state.repairPoisonedBoundaries(pkA);
+
+          expect(state.newestSyncedAt(pkA), isNull);
+          expect(state.oldestSyncedAt(pkA), isNull);
+        },
+      );
     });
   });
 }

--- a/mobile/packages/dm_repository/test/src/dm_sync_state_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_sync_state_test.dart
@@ -348,6 +348,27 @@ void main() {
         expect(newest, closeTo(nowSec(), 5));
       });
 
+      test('recordSeen caps oldest for a first far-future createdAt', () async {
+        await state.recordSeen(pkA, createdAt: year2100);
+
+        final oldest = state.oldestSyncedAt(pkA);
+        expect(oldest, isNotNull);
+        expect(oldest, lessThan(year2100));
+        expect(oldest, closeTo(nowSec(), 5));
+      });
+
+      test(
+        'recordSeen floors newest for a first implausibly old createdAt',
+        () async {
+          await state.recordSeen(pkA, createdAt: epochOne);
+
+          expect(
+            state.newestSyncedAt(pkA),
+            equals(DmSyncState.minPlausibleCreatedAt),
+          );
+        },
+      );
+
       test(
         'a capped createdAt cannot push the live since: filter past now',
         () async {
@@ -386,12 +407,14 @@ void main() {
           // Simulate a pre-guard build having written the poisoned value.
           await prefs.setInt('dm.newestSyncedAt.$pkA', year2100);
           await state.markHistoryDrainComplete(pkA);
+          await state.setHistoryDrainCursor(pkA, tsOldest);
           expect(state.historyDrainComplete(pkA), isTrue);
 
           await state.repairPoisonedBoundaries(pkA);
 
           expect(state.newestSyncedAt(pkA), closeTo(nowSec(), 5));
           expect(state.historyDrainComplete(pkA), isFalse);
+          expect(state.historyDrainCursor(pkA), closeTo(nowSec(), 5));
         },
       );
 
@@ -405,6 +428,18 @@ void main() {
           equals(DmSyncState.minPlausibleCreatedAt),
         );
       });
+
+      test(
+        'repairPoisonedBoundaries heals an implausibly future oldest',
+        () async {
+          await prefs.setInt('dm.oldestSyncedAt.$pkA', year2100);
+
+          await state.repairPoisonedBoundaries(pkA);
+
+          expect(state.oldestSyncedAt(pkA), closeTo(nowSec(), 5));
+          expect(state.historyDrainCursor(pkA), closeTo(nowSec(), 5));
+        },
+      );
 
       test(
         'repairPoisonedBoundaries is a no-op for healthy boundaries',

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -38,6 +38,43 @@ class _RpcExceptionDouble implements Exception {
   String toString() => 'RpcException: $message';
 }
 
+/// Encrypts normally but returns `null` from [signEvent], reproducing what
+/// every remote signer does when signing is declined: an Amber user dismissing
+/// the approval prompt, a NIP-46 bunker RPC timing out, a NIP-07 rejection.
+class _RefusesToSignSigner implements NostrSigner {
+  _RefusesToSignSigner(this._delegate);
+
+  final LocalNostrSigner _delegate;
+
+  @override
+  Future<Event?> signEvent(Event event) async => null;
+
+  @override
+  Future<String?> getPublicKey() => _delegate.getPublicKey();
+
+  @override
+  Future<Map<dynamic, dynamic>?> getRelays() => _delegate.getRelays();
+
+  @override
+  Future<String?> encrypt(String pubkey, String plaintext) =>
+      _delegate.encrypt(pubkey, plaintext);
+
+  @override
+  Future<String?> decrypt(String pubkey, String ciphertext) =>
+      _delegate.decrypt(pubkey, ciphertext);
+
+  @override
+  Future<String?> nip44Encrypt(String pubkey, String plaintext) =>
+      _delegate.nip44Encrypt(pubkey, plaintext);
+
+  @override
+  Future<String?> nip44Decrypt(String pubkey, String ciphertext) =>
+      _delegate.nip44Decrypt(pubkey, ciphertext);
+
+  @override
+  void close() => _delegate.close();
+}
+
 /// Denies every recipient — stands in for a protected minor's policy where the
 /// counterparty is not in the approved official set.
 Future<DmSendPolicyDecision> _denyAllPolicy(String recipientPubkey) async =>
@@ -1505,6 +1542,43 @@ void main() {
         expect(result.error, isNotNull);
         verifyNever(() => mockNostrClient.publishEvent(any()));
       });
+
+      test(
+        'sendRumor fails, and publishes nothing, when the signer declines to '
+        'sign the seal',
+        () async {
+          // End-to-end through the REAL GiftWrapUtil: a declining signer used
+          // to yield a seal with an empty sig, wrapped under a valid ephemeral
+          // key, which relays accepted and the caller recorded as delivered —
+          // while every recipient dropped it. The send must fail instead, so
+          // the durable queue row survives and the sweep re-drives it.
+          final decliningService = NIP17MessageService(
+            signer: _RefusesToSignSigner(LocalNostrSigner(_testPrivateKey)),
+            senderPublicKey: getPublicKey(_testPrivateKey),
+            nostrService: mockNostrClient,
+          );
+
+          final rumor = decliningService.buildRumor(
+            recipientPubkey: _recipientPubkey,
+            content: 'must not ship unsigned',
+          );
+
+          final result = await decliningService.sendRumor(
+            rumorEvent: rumor,
+            recipientPubkey: _recipientPubkey,
+          );
+
+          expect(result.success, isFalse);
+          expect(result.error, isNotNull);
+          verifyNever(() => mockNostrClient.publishEvent(any()));
+          verifyNever(
+            () => mockNostrClient.publishEventAwaitOk(
+              any(),
+              timeout: any(named: 'timeout'),
+            ),
+          );
+        },
+      );
 
       test('returns failure when the gift-wrap builder throws', () async {
         final throwingBuilderService = NIP17MessageService(

--- a/mobile/packages/nostr_sdk/lib/nip59/gift_wrap_util.dart
+++ b/mobile/packages/nostr_sdk/lib/nip59/gift_wrap_util.dart
@@ -36,6 +36,28 @@ bool verifyGiftWrapPartJson(Map<String, dynamic> eventJson) {
 /// `getRumorEvent` verifies inline on the calling isolate, unchanged.
 typedef GiftWrapPartVerifier = Future<bool> Function(Event event);
 
+/// Rebuilds an unsigned NIP-59 rumor from its plaintext JSON using the
+/// authenticated seal pubkey as author.
+///
+/// NIP-59 leaves the inner rumor unsigned, so its claimed `id` and `pubkey`
+/// are not authenticated and may be absent. Read only the fields that define
+/// the canonical event body, and let [Event] derive the id from those fields.
+Event rebuildUnsignedRumorFromJson(
+  Map<String, dynamic> rumorJson, {
+  required String authenticatedPubkey,
+}) {
+  final tags = (rumorJson['tags'] as List<dynamic>)
+      .map((tag) => (tag as List<dynamic>).map((e) => e as String).toList())
+      .toList();
+  return Event(
+    authenticatedPubkey,
+    rumorJson['kind'] as int,
+    tags,
+    rumorJson['content'] as String,
+    createdAt: rumorJson['created_at'] as int,
+  );
+}
+
 class GiftWrapUtil {
   static final math.Random _secureRandom = math.Random.secure();
 
@@ -71,7 +93,7 @@ class GiftWrapUtil {
     GiftWrapPartVerifier? verifyPart,
   }) async {
     // C16/NIP-44: validate the outer gift wrap (kind 1059) signature before
-    // decrypting. Defense-in-depth — diVine relays already verify, but an
+    // decrypting. Defense-in-depth — Divine relays already verify, but an
     // untrusted relay or local cache could serve a forged/tampered wrap.
     final outerValid = verifyPart != null
         ? await verifyPart(e)
@@ -110,8 +132,8 @@ class GiftWrapUtil {
       return null;
     }
 
-    var jsonObj = jsonDecode(sourceText);
-    var innerEvent = Event.fromJson(jsonObj);
+    final jsonObj = jsonDecode(sourceText) as Map<String, dynamic>;
+    final claimedPubkey = jsonObj['pubkey'];
 
     // The inner rumor is intentionally NOT signature-checked: NIP-59 requires
     // it to be unsigned, and its claimed authorship is never trusted for
@@ -123,10 +145,10 @@ class GiftWrapUtil {
     // Some Nostr clients in the wild produce mismatched pubkeys. Rather than
     // rejecting the message entirely, we accept it but attribute it to the
     // seal's authenticated pubkey to prevent impersonation.
-    if (rumorEvent.pubkey != innerEvent.pubkey) {
+    if (claimedPubkey is String && rumorEvent.pubkey != claimedPubkey) {
       log(
         'GiftWrap sender pubkey mismatch: seal=${rumorEvent.pubkey} '
-        'rumor=${innerEvent.pubkey}. Using seal pubkey as authoritative sender.',
+        'rumor=$claimedPubkey. Using seal pubkey as authoritative sender.',
       );
     }
 
@@ -143,12 +165,9 @@ class GiftWrapUtil {
     // and for a non-canonical one the recompute is the more correct choice.
     // DmRepository._rumorFromSlot already builds rumors exactly this way.
     // The rebuilt rumor is unsigned, per NIP-59.
-    return Event(
-      rumorEvent.pubkey,
-      innerEvent.kind,
-      innerEvent.tags,
-      innerEvent.content,
-      createdAt: innerEvent.createdAt,
+    return rebuildUnsignedRumorFromJson(
+      jsonObj,
+      authenticatedPubkey: rumorEvent.pubkey,
     );
   }
 
@@ -228,9 +247,8 @@ class GiftWrapUtil {
 /// The seal's pubkey is DERIVED from [senderPrivateKeyHex] rather than passed
 /// in: it must correspond to the signing key, or both the recipient's NIP-44
 /// ECDH (which keys on the seal pubkey) and the seal's Schnorr verification
-/// fail. [rumorJson] is the unsigned kind-14 rumor as [Event.toJson]; its `sig`
-/// is stripped before sealing and its id is preserved (receiver-side gift-wrap
-/// dedup keys on it).
+/// fail. [rumorJson] is the unsigned kind-14 rumor; its `sig` is stripped
+/// before sealing, and receivers derive the rumor id after unwrap.
 ///
 /// Returns the signed kind-1059 gift wrap. Pure (no I/O, no signer object),
 /// so it is safe to run inside an isolate — the same crypto primitives already

--- a/mobile/packages/nostr_sdk/lib/nip59/gift_wrap_util.dart
+++ b/mobile/packages/nostr_sdk/lib/nip59/gift_wrap_util.dart
@@ -128,19 +128,28 @@ class GiftWrapUtil {
         'GiftWrap sender pubkey mismatch: seal=${rumorEvent.pubkey} '
         'rumor=${innerEvent.pubkey}. Using seal pubkey as authoritative sender.',
       );
-      // C4: rebuild the rumor with the seal's authenticated pubkey so the
-      // event id is RECOMPUTED to match (Event.fromJson would otherwise carry
-      // over the spoofed id). The rebuilt rumor is unsigned, per NIP-59.
-      return Event(
-        rumorEvent.pubkey,
-        innerEvent.kind,
-        innerEvent.tags,
-        innerEvent.content,
-        createdAt: innerEvent.createdAt,
-      );
     }
 
-    return innerEvent;
+    // Rebuild unconditionally through the Event constructor so BOTH
+    // unauthenticated fields are handled at one seam: the pubkey becomes the
+    // seal's (authenticated) one, and the id is DERIVED rather than trusted.
+    //
+    // Because the rumor is unsigned, nothing binds its claimed `id` to its
+    // body — yet that id becomes the `direct_messages` primary key and the
+    // reaction upsert key, so a sender who claims an id already in use can
+    // silently overwrite another user's row. The constructor recomputes the
+    // canonical NIP-01 id from the rumor's own fields; for a well-formed
+    // sender it equals the claimed id, so there is no observable divergence,
+    // and for a non-canonical one the recompute is the more correct choice.
+    // DmRepository._rumorFromSlot already builds rumors exactly this way.
+    // The rebuilt rumor is unsigned, per NIP-59.
+    return Event(
+      rumorEvent.pubkey,
+      innerEvent.kind,
+      innerEvent.tags,
+      innerEvent.content,
+      createdAt: innerEvent.createdAt,
+    );
   }
 
   static Future<Event?> getGiftWrapEvent(

--- a/mobile/packages/nostr_sdk/lib/nip59/gift_wrap_util.dart
+++ b/mobile/packages/nostr_sdk/lib/nip59/gift_wrap_util.dart
@@ -182,6 +182,19 @@ class GiftWrapUtil {
     );
     await nostr.signEvent(sealEvent);
 
+    // [Nostr.signEvent] is a no-op when the signer returns null, which is a
+    // reachable outcome for every remote signer: an Amber user dismissing the
+    // approval prompt, a NIP-46 bunker RPC timing out, a NIP-07 rejection.
+    // Without this check the seal ships with an empty `sig`, the wrap around
+    // it is signed with a valid ephemeral key so relays accept it, the send
+    // reports as delivered — and every recipient drops it at the seal
+    // signature check. Returning null routes the caller to a retryable
+    // failure that keeps its durable queue row instead.
+    if (sealEvent.sig.isEmpty) {
+      log('GiftWrap seal was not signed; refusing to publish an unsigned DM.');
+      return null;
+    }
+
     var randomPrivateKey = generatePrivateKey();
     var randomPubkey = getPublicKey(randomPrivateKey);
     var randomKey = NIP44V2.shareSecret(randomPrivateKey, receiverPublicKey);
@@ -246,6 +259,10 @@ Future<Event?> buildGiftWrapFromHex({
     sealEventContent,
     createdAt: sealCreatedAt,
   );
+  // No unsigned-seal guard is needed here: [Event.sign] only no-ops when the
+  // key fails `keyIsValid`, and `getPublicKey` above rejects exactly those
+  // keys by throwing first. The throw propagates to the caller as a failed
+  // build, which is the same safe outcome. Pinned by a test.
   sealEvent.sign(senderPrivateKeyHex);
 
   final randomPrivateKey = generatePrivateKey();

--- a/mobile/packages/nostr_sdk/test/nip59/build_gift_wrap_from_hex_test.dart
+++ b/mobile/packages/nostr_sdk/test/nip59/build_gift_wrap_from_hex_test.dart
@@ -48,7 +48,8 @@ void main() {
       expect(decrypted!.content, equals('secret message'));
       expect(decrypted.pubkey, equals(senderPubkey));
       expect(decrypted.kind, equals(EventKind.privateDirectMessage));
-      // Rumor id is preserved — receiver-side gift-wrap dedup keys on it.
+      // Receivers derive the rumor id after unwrap, so only the wrap id is
+      // relevant for gift-wrap dedup.
       expect(decrypted.id, equals(rumor.id));
     });
 

--- a/mobile/packages/nostr_sdk/test/nip59/gift_wrap_util_test.dart
+++ b/mobile/packages/nostr_sdk/test/nip59/gift_wrap_util_test.dart
@@ -203,5 +203,90 @@ void main() {
       expect(rumor!.content, equals('still delivered'));
       expect(rumor.pubkey, equals(senderPubkey));
     });
+
+    group('inner rumor id is derived, never trusted', () {
+      // NIP-59 leaves the rumor unsigned, so nothing binds its claimed `id`
+      // to its body — yet that id becomes the direct_messages primary key
+      // and the reaction upsert key. A sender who claims an id already in
+      // use could otherwise silently overwrite another user's row.
+      test(
+        'a claimed non-canonical id is replaced by the canonical one',
+        () async {
+          final tampered = Event(
+            senderPubkey,
+            EventKind.privateDirectMessage,
+            const <List<String>>[],
+            'secret message',
+          );
+          final canonicalId = tampered.id;
+          // Claim an id that does not match the body at all.
+          tampered.id = 'f' * 64;
+
+          final wrap = await buildGiftWrap(
+            rumor: tampered,
+            senderPrivateKey: senderPrivateKey,
+            recipientPubkey: getPublicKey(recipientPrivateKey),
+          );
+
+          final rumor = await GiftWrapUtil.getRumorEvent(recipientNostr, wrap);
+
+          expect(rumor, isNotNull);
+          expect(rumor!.id, isNot(equals('f' * 64)));
+          expect(rumor.id, equals(canonicalId));
+          expect(rumor.isValid, isTrue);
+          // Body is untouched — only the id is re-derived.
+          expect(rumor.content, equals('secret message'));
+          expect(rumor.pubkey, equals(senderPubkey));
+        },
+      );
+
+      test('an honest sender sees no divergence in the id', () async {
+        final honest = Event(
+          senderPubkey,
+          EventKind.privateDirectMessage,
+          const <List<String>>[
+            ['p', 'abc'],
+          ],
+          'round trip',
+        );
+        final wrap = await buildGiftWrap(
+          rumor: honest,
+          senderPrivateKey: senderPrivateKey,
+          recipientPubkey: getPublicKey(recipientPrivateKey),
+        );
+
+        final rumor = await GiftWrapUtil.getRumorEvent(recipientNostr, wrap);
+
+        // Our own send path builds rumors through the same constructor, so
+        // the self-wrap round trip and outgoing-queue key stay consistent.
+        expect(rumor!.id, equals(honest.id));
+      });
+
+      test('a spoofed author is re-attributed AND its id re-derived from the '
+          'seal pubkey', () async {
+        final impostorPubkey = getPublicKey(generatePrivateKey());
+        final spoofed = Event(
+          impostorPubkey,
+          EventKind.privateDirectMessage,
+          const <List<String>>[],
+          'i am someone else',
+        );
+        final spoofedId = spoofed.id;
+
+        final wrap = await buildGiftWrap(
+          rumor: spoofed,
+          // Sealed and signed by the real sender, claiming another author.
+          senderPrivateKey: senderPrivateKey,
+          recipientPubkey: getPublicKey(recipientPrivateKey),
+        );
+
+        final rumor = await GiftWrapUtil.getRumorEvent(recipientNostr, wrap);
+
+        expect(rumor, isNotNull);
+        expect(rumor!.pubkey, equals(senderPubkey));
+        expect(rumor.id, isNot(equals(spoofedId)));
+        expect(rumor.isValid, isTrue);
+      });
+    });
   });
 }

--- a/mobile/packages/nostr_sdk/test/nip59/gift_wrap_util_test.dart
+++ b/mobile/packages/nostr_sdk/test/nip59/gift_wrap_util_test.dart
@@ -67,10 +67,12 @@ void main() {
     required String senderPrivateKey,
     required String recipientPubkey,
     bool keepRumorSig = false,
+    void Function(Map<String, dynamic> rumorMap)? mutateRumorMap,
   }) async {
     final senderPubkey = getPublicKey(senderPrivateKey);
     final rumorMap = rumor.toJson();
     if (!keepRumorSig) rumorMap.remove('sig');
+    mutateRumorMap?.call(rumorMap);
     final sealKey = NIP44V2.shareSecret(senderPrivateKey, recipientPubkey);
     final sealContent = await NIP44V2.encrypt(jsonEncode(rumorMap), sealKey);
     final sealEvent = Event(
@@ -323,6 +325,34 @@ void main() {
         expect(rumor!.pubkey, equals(senderPubkey));
         expect(rumor.id, isNot(equals(spoofedId)));
         expect(rumor.isValid, isTrue);
+      });
+
+      test('an omitted claimed id and pubkey still unwraps', () async {
+        final honest = Event(
+          senderPubkey,
+          EventKind.privateDirectMessage,
+          const <List<String>>[
+            ['p', 'abc'],
+          ],
+          'minimal rumor',
+        );
+        final expectedId = honest.id;
+        final wrap = await buildGiftWrap(
+          rumor: honest,
+          senderPrivateKey: senderPrivateKey,
+          recipientPubkey: getPublicKey(recipientPrivateKey),
+          mutateRumorMap: (rumorMap) {
+            rumorMap.remove('id');
+            rumorMap.remove('pubkey');
+          },
+        );
+
+        final rumor = await GiftWrapUtil.getRumorEvent(recipientNostr, wrap);
+
+        expect(rumor, isNotNull);
+        expect(rumor!.id, equals(expectedId));
+        expect(rumor.pubkey, equals(senderPubkey));
+        expect(rumor.content, equals('minimal rumor'));
       });
     });
   });

--- a/mobile/packages/nostr_sdk/test/nip59/gift_wrap_util_test.dart
+++ b/mobile/packages/nostr_sdk/test/nip59/gift_wrap_util_test.dart
@@ -9,6 +9,43 @@ import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 
+/// A signer that encrypts normally but refuses to sign, returning `null` from
+/// [signEvent] exactly as a remote signer does when the user dismisses the
+/// Amber approval prompt, a NIP-46 bunker RPC times out, or NIP-07 rejects.
+class _RefusesToSignSigner implements NostrSigner {
+  _RefusesToSignSigner(this._delegate);
+
+  final LocalNostrSigner _delegate;
+
+  @override
+  Future<Event?> signEvent(Event event) async => null;
+
+  @override
+  Future<String?> getPublicKey() => _delegate.getPublicKey();
+
+  @override
+  Future<Map<dynamic, dynamic>?> getRelays() => _delegate.getRelays();
+
+  @override
+  Future<String?> encrypt(String pubkey, String plaintext) =>
+      _delegate.encrypt(pubkey, plaintext);
+
+  @override
+  Future<String?> decrypt(String pubkey, String ciphertext) =>
+      _delegate.decrypt(pubkey, ciphertext);
+
+  @override
+  Future<String?> nip44Encrypt(String pubkey, String plaintext) =>
+      _delegate.nip44Encrypt(pubkey, plaintext);
+
+  @override
+  Future<String?> nip44Decrypt(String pubkey, String ciphertext) =>
+      _delegate.nip44Decrypt(pubkey, ciphertext);
+
+  @override
+  void close() => _delegate.close();
+}
+
 void main() {
   Relay dummyRelay(String url) => RelayBase(url, RelayStatus(url));
 
@@ -287,6 +324,85 @@ void main() {
         expect(rumor.id, isNot(equals(spoofedId)));
         expect(rumor.isValid, isTrue);
       });
+    });
+  });
+
+  group('getGiftWrapEvent refuses to ship an unsigned seal', () {
+    late String senderPrivateKey;
+    late String recipientPubkey;
+
+    setUp(() {
+      senderPrivateKey = generatePrivateKey();
+      recipientPubkey = getPublicKey(generatePrivateKey());
+    });
+
+    Event rumorFor(String senderPubkey) =>
+        Event(senderPubkey, EventKind.privateDirectMessage, <List<String>>[
+          ['p', recipientPubkey],
+        ], 'never delivered');
+
+    test('returns null when the signer declines to sign the seal', () async {
+      final signer = _RefusesToSignSigner(LocalNostrSigner(senderPrivateKey));
+      final nostr = Nostr(signer, const [], dummyRelay);
+      await nostr.refreshPublicKey();
+
+      final wrap = await GiftWrapUtil.getGiftWrapEvent(
+        nostr,
+        rumorFor(getPublicKey(senderPrivateKey)),
+        recipientPubkey,
+      );
+
+      // A wrap here would be signed by a valid ephemeral key, so relays would
+      // accept it and the send would report delivered — while every recipient
+      // dropped it at the seal signature check.
+      expect(wrap, isNull);
+    });
+
+    test('still builds a signed wrap when the signer cooperates', () async {
+      final nostr = Nostr(
+        LocalNostrSigner(senderPrivateKey),
+        const [],
+        dummyRelay,
+      );
+      await nostr.refreshPublicKey();
+
+      final wrap = await GiftWrapUtil.getGiftWrapEvent(
+        nostr,
+        rumorFor(getPublicKey(senderPrivateKey)),
+        recipientPubkey,
+      );
+
+      expect(wrap, isNotNull);
+      expect(verifyGiftWrapPart(wrap!), isTrue);
+    });
+
+    test(
+      'buildGiftWrapFromHex fails loudly on a key Event.sign would no-op on',
+      () async {
+        // Event.sign silently no-ops when keyIsValid is false, which would
+        // otherwise produce the same unsigned seal as a declining signer. On
+        // this path getPublicKey rejects those keys first, so the build throws
+        // instead of returning a wrap — no unsigned DM can escape either way.
+        expect(
+          () => buildGiftWrapFromHex(
+            senderPrivateKeyHex: 'not-a-valid-private-key',
+            rumorJson: rumorFor(getPublicKey(generatePrivateKey())).toJson(),
+            receiverPublicKey: recipientPubkey,
+          ),
+          throwsArgumentError,
+        );
+      },
+    );
+
+    test('buildGiftWrapFromHex still builds for a valid key', () async {
+      final wrap = await buildGiftWrapFromHex(
+        senderPrivateKeyHex: senderPrivateKey,
+        rumorJson: rumorFor(getPublicKey(senderPrivateKey)).toJson(),
+        receiverPublicKey: recipientPubkey,
+      );
+
+      expect(wrap, isNotNull);
+      expect(verifyGiftWrapPart(wrap!), isTrue);
     });
   });
 }


### PR DESCRIPTION
## Description

A NIP-59 inner rumor is **unsigned**. Only the kind-13 seal and the kind-1059 wrap are cryptographically bound, so receiver code cannot trust rumor fields such as `id`, `pubkey`, or `created_at`.

This PR hardens the NIP-17 DM path against three silent failure modes:

### 1. Future-dated rumors could poison DM sync cursors

`recordSeen` advanced `newestSyncedAt` to any rumor `created_at`, and `startListening` derives the live subscription's `since:` from that value. One DM stamped far in the future could move the cursor past now and make later subscriptions return nothing.

The fix now bounds both sync boundaries independently before persisting:

- `newestSyncedAt` is clamped to the plausible range instead of accepting future values.
- `oldestSyncedAt` is clamped to the same plausible range so a fresh install cannot seed history drain with epoch or far-future values.
- `repairPoisonedBoundaries` heals both poisoned boundaries.
- When repair re-arms the history drain, it seeds `historyDrainCursor` to now so the one-time drain walks down through the missed window instead of jumping straight to already-synced old history.

Future-dated NIP-17 rumors are still delivered. The repository clamps the timestamp used for local persistence, conversation ordering, dedup windows, and sync cursor updates instead of dropping and ledgering the wrap. A warning is logged when the rumor is beyond the expected 24-hour skew, but the message is preserved.

### 2. Attacker-chosen rumor fields became local identity

`Event.fromJson` copies `data['id']` and `data['pubkey']` through verbatim. For unsigned rumors, that let unauthenticated input become the direct-message primary key, reaction upsert key, and displayed sender.

Both local unwrap paths now rebuild the inner rumor unconditionally from the authenticated seal pubkey and the canonical rumor body fields. The shared rebuild helper also parses only `kind`, `tags`, `content`, and `created_at`, so legitimate senders that omit unauthenticated `id` or `pubkey` no longer fail unwrap.

### 3. Unsigned seals could report as delivered

`Nostr.signEvent` can return null when a remote signer declines or times out. The gift-wrap builder now refuses to build the kind-1059 wrap unless the kind-13 seal has a signature, so the send stays retryable instead of publishing a wrapper that recipients will drop.

**Related Issue:** Relates to #4974

## Out of Scope

Other findings from the same audit, deliberately not included to keep this reviewable:

- kind-10050 DM relay list is still not advertised (backend-gated on the relay accepting kind 10050, #4974)
- "delete for everyone" still publishes a plaintext kind-5 naming both parties
- the first message of a new thread still publishes a plaintext NIP-04 kind-4 copy
- reactions still publish to the default pool while OK-confirming
- `stopListening()` still does not stop an in-flight history drain
- the Keycast server-batch unwrap path still performs no client-side verification

## Verification

Original author verification:

- `dm_repository`: package tests passed with coverage above gate
- `nostr_sdk`: package tests passed
- `db_client`: package tests passed
- `test/blocs/dm`: tests passed
- `flutter analyze lib test`: no issues

Takeover verification on the final diff:

- `mobile/packages/dm_repository`: `flutter analyze lib test`
- `mobile/packages/dm_repository`: `flutter test` (534 tests)
- `mobile/packages/nostr_sdk`: `flutter analyze lib test`
- `mobile/packages/nostr_sdk`: `flutter test` (396 tests)
- pre-push hook: no merge conflicts with `main`, analyzer passed, changed-file tests passed (448 tests)
- `git diff --check`

No generated-code inputs touched, no ARB changes, no golden changes.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
