### PR TITLE
perf(test): stop upload-draft failure tests sleeping 62s of real backoff

### DIFF
--- a/mobile/test/services/upload_manager_from_draft_test.dart
+++ b/mobile/test/services/upload_manager_from_draft_test.dart
@@ -75,7 +75,15 @@ void main() {
           thumbnailUrl: 'https://media.divine.video/test-video-id-thumb.jpg',
         ),
       );
-      uploadManager = UploadManager(blossomService: mockBlossomService);
+      uploadManager = UploadManager(
+        blossomService: mockBlossomService,
+        // The default config sleeps 2+4+8+16+32s of real time before giving
+        // up, so each failure-path test below burned ~62s. Only the retry
+        // *count* matters here — the backoff arithmetic itself is covered by
+        // upload_retry_policy_test.dart. maxRetries stays at the production
+        // default so exhaustion still takes the same number of attempts.
+        retryConfig: const UploadRetryConfig(initialDelay: Duration.zero),
+      );
       await uploadManager.initialize();
     });
 


### PR DESCRIPTION
## Why

Per-test durations recovered from the Mobile CI log (run 30142684388, diffing consecutive reporter timestamps in the `Run Flutter tests` step) showed the distribution is extremely top-heavy: the ten slowest tests own ~35% of the 558s test step, and two of them cost **62 seconds each**.

Both live in `upload_manager_from_draft_test.dart` and drive `UploadManager` to retry exhaustion:

- `cleans failed non-resumable transient stop-motion renders`
- `throws when upload finishes in failed state instead of returning a completed upload`

`UploadRetryConfig` defaults to `maxRetries: 5`, `initialDelay: 2s`, `backoffMultiplier: 2.0`, and `UploadRetryPolicy._waitForBackoff` sleeps that in wall-clock time. 2 + 4 + 8 + 16 + 32 = **62s per test**, twice.

The `Tests` job is Mobile CI's critical path (every other job runs in parallel underneath it), so this is 124s straight off PR latency.

## What changed

One line: the shared `setUp` now constructs `UploadManager` with `retryConfig: const UploadRetryConfig(initialDelay: Duration.zero)`.

## Measured

| | Before | After |
|---|---:|---:|
| Whole file, isolated (`flutter test <file>`) | 3m08s | **18s** |
| Test execution within the file (reporter clock) | 188s | **4s** |

Method: `cd mobile && time mise exec -- flutter test test/services/upload_manager_from_draft_test.dart --reporter expanded`, same machine, back to back.

## Correctness

This removes waiting, not checking.

- `maxRetries` stays at the production default of 5, so exhaustion still takes the same six attempts through the same code path. Only the sleep between them is zeroed.
- The backoff arithmetic itself is not what these tests assert — they assert that the upload ends `failed`, that `startUploadFromDraft` throws, and that the transient render file is cleaned up. The `initialDelay`/`backoffMultiplier`/`maxDelay` computation is covered by `test/services/upload/upload_retry_policy_test.dart`, which is untouched.
- **Verified the tests can still fail.** Replacing the retry-exhaustion `rethrow` in `UploadRetryPolicy.performWithRetry` with `return` turns the file red (`+5 -2`, both failure-path tests failing on `expectLater(..., throwsA(...))`); restoring it turns them green again.

No test was deleted, skipped, or had an assertion weakened. No ratchet baseline shifts.

## Verification

- `mise exec -- flutter analyze lib test integration_test` — `No issues found! (ran in 134.3s)`
- `mise exec -- flutter test test/services/upload_manager_from_draft_test.dart` — 7/7 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)