### PR TITLE
perf(ci): cut 23s of full-history clone and 42s of apt off Mobile CI

### DIFF
--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -273,8 +273,12 @@ jobs:
           flutter-version: "3.44.0"
           channel: "stable"
           cache: true
-      # No `flutter pub get`: `dart format` is purely syntactic and never
-      # resolves package imports, so the ~10s resolve was dead weight.
+      - name: 📦 Install dependencies
+        # Required: `dart format` reads page width from analysis_options.yaml,
+        # which `include`s package:very_good_analysis. Without a resolved
+        # package config that include fails and the formatter silently falls
+        # back to its defaults, reformatting 529 files.
+        run: flutter pub get
       - name: ✨ Check formatting
         run: dart format --output=none --set-exit-if-changed lib test integration_test
   analyze:

--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -15,6 +15,9 @@ jobs:
   changes:
     name: Detect App CI Scope
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       app: ${{ steps.scope.outputs.app }}
       native: ${{ steps.scope.outputs.native }}
@@ -47,7 +50,7 @@ jobs:
             exit 0
           fi
 
-          gh api --paginate "/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
+          gh api --method GET --paginate -F per_page=100 "/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
             --jq '.[].filename' > /tmp/mobile-ci-changed-files.txt
           echo "Changed files:"
           cat /tmp/mobile-ci-changed-files.txt

--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -17,31 +17,48 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       app: ${{ steps.scope.outputs.app }}
+      native: ${{ steps.scope.outputs.native }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+      # No checkout: the changed-file list comes from the REST API. A
+      # `fetch-depth: 0` clone cost ~23s of this workflow's critical path
+      # (every other job `needs: changes`) to produce a list the API already
+      # has.
       - name: Detect whether app CI is required
         id: scope
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           if [ "${GITHUB_EVENT_NAME}" != "pull_request" ]; then
             echo "app=true" >> "$GITHUB_OUTPUT"
+            echo "native=true" >> "$GITHUB_OUTPUT"
             echo "Non-PR event; running full app CI."
             exit 0
           fi
 
-          git diff --name-only "$BASE_SHA" "$HEAD_SHA" > /tmp/mobile-ci-changed-files.txt
+          # The files endpoint caps at 3000 entries. A PR that large is not a
+          # scoped change, so fall open to the full matrix rather than
+          # under-running CI on a truncated list.
+          changed_total=$(gh api "/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.changed_files')
+          if [ "$changed_total" -gt 3000 ]; then
+            echo "app=true" >> "$GITHUB_OUTPUT"
+            echo "native=true" >> "$GITHUB_OUTPUT"
+            echo "PR touches $changed_total files (> 3000 API cap); running full app CI."
+            exit 0
+          fi
+
+          gh api --paginate "/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
+            --jq '.[].filename' > /tmp/mobile-ci-changed-files.txt
           echo "Changed files:"
           cat /tmp/mobile-ci-changed-files.txt
 
           app=false
+          native=false
           while IFS= read -r path; do
             case "$path" in
               .github/workflows/*)
                 app=true
+                native=true
                 ;;
               *.md|docs/*|brand-guidelines/*|mobile/docs/*)
                 # Docs-only changes do not need the full app test matrix.
@@ -59,14 +76,26 @@ jobs:
                 app=true
                 ;;
             esac
+            # The transport-security guard reads one Android XML plus three
+            # Info.plists and nothing else, so its verdict cannot change
+            # unless a native config or the guard itself changed. Matched at
+            # directory level (a superset of the guard's inputs) so the gate
+            # can't silently drift when the guard gains a fourth plist.
+            case "$path" in
+              mobile/android/*|mobile/ios/*|mobile/macos/*|mobile/scripts/check_native_transport_security.sh)
+                native=true
+                ;;
+            esac
           done < /tmp/mobile-ci-changed-files.txt
 
           echo "app=$app" >> "$GITHUB_OUTPUT"
+          echo "native=$native" >> "$GITHUB_OUTPUT"
           if [ "$app" = "true" ]; then
             echo "App CI required."
           else
             echo "Package-only/docs-only change; app CI jobs may be skipped."
           fi
+          echo "Native transport-security inputs changed: $native"
 
   generated-files:
     name: Generated Files
@@ -92,6 +121,13 @@ jobs:
       - name: 📦 Install dependencies
         run: flutter pub get
       - name: 🔒 Verify native transport security
+        # Skipped when no native config changed. The guard's only inputs are
+        # mobile/android/**, mobile/ios/**, mobile/macos/** and its own
+        # script; if none of those moved, its verdict is identical to the one
+        # main already recorded. Gating it also skips the apt install of
+        # libxml2-utils (~42s, of which `apt-get update` alone is ~28s), which
+        # is the single most expensive step in this job after codegen.
+        if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.native == 'true' }}
         run: |
           if ! command -v xmllint >/dev/null 2>&1; then
             sudo apt-get update -qq
@@ -237,8 +273,8 @@ jobs:
           flutter-version: "3.44.0"
           channel: "stable"
           cache: true
-      - name: 📦 Install dependencies
-        run: flutter pub get
+      # No `flutter pub get`: `dart format` is purely syntactic and never
+      # resolves package imports, so the ~10s resolve was dead weight.
       - name: ✨ Check formatting
         run: dart format --output=none --set-exit-if-changed lib test integration_test
   analyze:

--- a/PERF_BASELINE.md
+++ b/PERF_BASELINE.md
@@ -1,0 +1,231 @@
+# Build / test / dev-loop performance baseline
+
+Captured 2026-07-25 against `origin/main` @ `3152aee7f`. These are the numbers
+every later change is measured against. Re-measure with the commands in
+[How these were measured](#how-these-were-measured) before claiming a win.
+
+---
+
+## 1. CI (GitHub Actions)
+
+### Job durations
+
+p50/p90 over the 13 most recent successful `Mobile CI` runs (and, for the
+non-`Mobile CI` rows, over the most recent successful runs of their own
+workflow within the same window). `q_p50` is median queue wait — the gap
+between job creation and job start.
+
+| Job | Workflow | n | p50 | p90 | max | q_p50 |
+|---|---|---:|---:|---:|---:|---:|
+| Tests | Mobile CI | 13 | **599s** | 615s | 619s | 3s |
+| Build & Deploy to app.divine.video | Web production deploy | 2 | 225s | 225s | 225s | 4s |
+| Build Flutter Web Preview | PR preview build | 18 | 207s | 216s | 222s | 3s |
+| Generated Files | Mobile CI | 13 | **198s** | 230s | 233s | 3s |
+| Analyze | Mobile CI | 13 | 103s | 119s | 119s | 3s |
+| build / build (`divine_ui` VGV) | Divine UI CI | 23 | 100s | 157s | 170s | 3s |
+| Android Compile Check | service integration | 1 | 98s | 98s | 98s | 4s |
+| Format | Mobile CI | 13 | 52s | 61s | 64s | 3s |
+| Deploy PR Preview To Cloudflare | PR preview deploy | 21 | 36s | 41s | 42s | 3s |
+| Detect App CI Scope | Mobile CI | 13 | **26s** | 29s | 30s | 3s |
+| VGV Tag Gate | Mobile CI | 13 | 9s | 10s | 11s | 3s |
+| ensure-linked-issue | PR Issue Link | 4 | 6s | 6s | 6s | 3s |
+| mergeability | Mergeability Check | 20 | 4s | 6s | 7s | 3s |
+| semantic-pull-request | semantic_pr | 19 | 4s | 6s | 6s | 3s |
+| Mobile CI (gate) | Mobile CI | 13 | 3s | 4s | 4s | 3s |
+
+**Queue wait is 3–4s across the board. CI is not queue-bound** — every second
+of PR latency is real work.
+
+### Critical path
+
+Every `Mobile CI` job declares `needs: changes`, so the workflow's wall clock is:
+
+```
+Detect App CI Scope (26s)  ->  Tests (599s)   =  625s  (10m25s)
+```
+
+`Generated Files` (198s), `Analyze` (103s) and `Format` (52s) run in parallel
+under that ceiling and do not set PR latency today. They *become* the ceiling
+the moment `Tests` drops below them.
+
+### Per-step breakdown (run 30142684388, a representative PR run)
+
+**Detect App CI Scope — 26s total**
+
+| Step | Time |
+|---|---:|
+| `actions/checkout@v4` (`fetch-depth: 0`) | **23s** |
+| Detect whether app CI is required | 0s |
+
+23 seconds of full-history clone to produce a changed-file list, at the head of
+the critical path, on every run.
+
+**Tests — 615s total**
+
+| Step | Time |
+|---|---:|
+| Setup Flutter | 26s |
+| `flutter pub get` | 10s |
+| `dart pub global activate very_good_cli 1.3.0` | 9s |
+| **`very_good test --optimization --concurrency=4`** | **558s** |
+
+13,159 tests, 289 skipped, reported as `09:07` by the test runner.
+
+**Generated Files — 224s total**
+
+| Step | Time |
+|---|---:|
+| Setup Flutter | 17s |
+| `flutter pub get` | 12s |
+| **Verify native transport security** | **43s** |
+| 22 ratchet / boundary guards (combined) | ~40s |
+| **`dart run build_runner build`** | **101s** |
+| Verify l10n generated files | 3s |
+
+Of the 43s transport-security step, ~42s is `sudo apt-get update -qq` (28s) plus
+`apt-get install libxml2-utils` (14s). `xmllint` is genuinely absent from the
+`ubuntu-24.04` image; the actual guard runs in well under a second.
+
+**Analyze — 119s total:** Setup Flutter 27s, `pub get` 12s, `flutter analyze` 71s.
+
+**Format — 46s total:** Setup Flutter 17s, `pub get` 10s, `dart format` 11s.
+
+### Cache behaviour
+
+`subosito/flutter-action@v2` with `cache: true` is the only dependency cache and
+it does hit — Setup Flutter costs 17–27s rather than a full SDK download.
+`flutter pub get` at 10–12s is a warm pub cache. **No build_runner state is
+cached anywhere**, so the 101s codegen verification starts from an empty build
+graph on every run.
+
+### Package workflows
+
+All 57 package workflows under `.github/workflows/` carry `paths:` filters
+scoped to their own package plus their own workflow file, so a PR that touches
+no package code runs none of them. The six workflows without `paths:` filters
+are `mobile_ci.yaml`, `mobile_service_integration_tests.yaml`, `semantic_pr.yaml`,
+`pr_issue_link.yml`, `mergeability_check.yml`, and `mobile_pr_preview_deploy.yml`
+— all of which are intentionally repo-wide. **There is no path-filter waste to
+recover here.**
+
+`--coverage` is *not* collected in the `Mobile CI` Tests job. Package workflows
+do collect it, and they consume it (`min_coverage` gates), so it is not waste.
+
+---
+
+## 2. Test suite
+
+### Where the 558s goes
+
+Per-test durations were recovered from the CI log by diffing consecutive
+reporter timestamps in the `Run Flutter tests` step of run 30142684388.
+
+| Slice | Time | Share |
+|---|---:|---:|
+| Top 10 tests | 178s | 35.4% |
+| Top 25 tests | 192s | 38.3% |
+| Top 50 tests | 210s | 41.8% |
+| Top 100 tests | 240s | 47.8% |
+| Top 200 tests | 281s | 55.9% |
+| All 13,158 attributed | 502s | 100% |
+
+The distribution is extremely top-heavy: **the ten slowest tests own a third of
+the suite.**
+
+Caveat on attribution: the merged VGV bundle and the 18
+`skip_very_good_optimization` files interleave their reporter output, so a
+single large gap can be an artifact of a tagged suite's VM startup rather than
+a genuinely slow test. Every entry acted on below was re-confirmed by running
+its file in isolation.
+
+### Confirmed hot spots
+
+| Test | File | Measured |
+|---|---|---:|
+| `cleans failed non-resumable transient stop-motion renders` | `test/services/upload_manager_from_draft_test.dart` | **62s** |
+| `throws when upload finishes in failed state instead of returning a completed upload` | same file | **62s** |
+
+Both drive `UploadManager` to retry exhaustion. `UploadRetryConfig` defaults to
+`maxRetries: 5`, `initialDelay: 2s`, `backoffMultiplier: 2.0`, and
+`UploadRetryPolicy` sleeps that backoff in real time: 2+4+8+16+32 = **62s per
+test**. Isolated file run before the fix: **3m08s**.
+
+### Structural cost: the merged bundle is single-threaded
+
+CI runs `very_good test --optimization --concurrency=4` on a 4-vCPU runner. The
+optimizer collapses every untagged test file into **one** `.test_optimizer.dart`
+suite, i.e. one process. The 18 `skip_very_good_optimization` files run as
+separate suites alongside it. So for the overwhelming majority of the 558s,
+**one of the four available cores is doing the work** and the concurrency
+setting has nothing to schedule.
+
+### Existing test-hygiene ratchets (already in place, not regressions)
+
+The repo already freezes several of the things a perf audit would normally
+flag, so these are *not* available wins:
+
+- `scripts/baseline/future_delayed_tests.txt` — 35 files use `Future.delayed`
+  under `test/`, shrink-only (epic #4337).
+- `scripts/baseline/skip_tests.txt` — skipped-test count, shrink-only.
+- `test/vgv_tag_baseline.txt` — 18 `skip_very_good_optimization` files,
+  count may not increase.
+- `scripts/baseline/test_unit_files.txt` — `test/unit/` frozen per-file.
+
+Total explicit real-time sleep across `test/**` is **21.4s over 105
+`Future.delayed(Duration(...))` call sites** — real, but an order of magnitude
+smaller than the two 62s backoff waits above.
+
+---
+
+## 3. Dev loop (local)
+
+Apple Silicon dev machine, Flutter 3.44.0 via `mise exec --`, run from `mobile/`.
+
+| Operation | Time |
+|---|---:|
+| `flutter pub get`, warm workspace | 8.5s |
+| `dart format --output=none lib test integration_test` (2708 files) | 44.5s |
+| `flutter test <one 7-test service file>`, cold compile | 3m08s (18s after the backoff fix) |
+| `flutter test` (whole suite, **no** `--optimization`) | **projected ~5h** |
+
+That last row is the headline dev-loop finding. Plain `flutter test` compiles
+and spins a fresh isolate **per file** across 1,225 test files; a 50-minute
+sample completed 2,151 of ~13,159 tests. CI does the same suite in 9m07s
+because `very_good test --optimization` bundles them. A developer who types
+`flutter test` gets a ~30x worse experience than CI for the same work.
+
+### Repo shape (verified, not assumed)
+
+- `mobile/lib`: 1,400 Dart files
+- `mobile/test`: 1,225 `*_test.dart` files, largest buckets `widgets/` (289),
+  `services/` (280), `screens/` (185), `blocs/` (114)
+- `mobile/packages`: 57 packages, **all** declared `resolution: workspace` under
+  a single `workspace:` block in `mobile/pubspec.yaml` — one pub resolve for the
+  whole monorepo, not 57. No win available here.
+
+---
+
+## How these were measured
+
+```bash
+# CI job durations (p50/p90 across recent successful runs)
+gh run list --limit 300 --json databaseId,name,conclusion
+gh api /repos/divinevideo/divine-mobile/actions/runs/<id>/jobs \
+  --jq '.jobs[] | "\(.name)\t\((.completed_at|fromdate)-(.started_at|fromdate))"'
+
+# Per-step timings for one run
+gh api /repos/divinevideo/divine-mobile/actions/runs/<id>/jobs \
+  --jq '.jobs[] | select(.name=="Tests") | .steps[]
+        | "\(.name)\t\((.completed_at|fromdate)-(.started_at|fromdate))s"'
+
+# Per-test durations (diff consecutive reporter timestamps)
+gh run view <id> --log --job=<test-job-id> | grep "Run Flutter tests"
+
+# Local, CI-equivalent
+cd mobile
+mise exec -- very_good test --optimization --concurrency=4 \
+  --exclude-tags integration --test-randomize-ordering-seed random
+
+# Local, one file
+cd mobile && time mise exec -- flutter test <path> --reporter expanded
+```

--- a/PERF_BASELINE.md
+++ b/PERF_BASELINE.md
@@ -186,13 +186,39 @@ Apple Silicon dev machine, Flutter 3.44.0 via `mise exec --`, run from `mobile/`
 | `flutter pub get`, warm workspace | 8.5s |
 | `dart format --output=none lib test integration_test` (2708 files) | 44.5s |
 | `flutter test <one 7-test service file>`, cold compile | 3m08s (18s after the backoff fix) |
-| `flutter test` (whole suite, **no** `--optimization`) | **projected ~5h** |
+| Full suite, `very_good test --optimization --concurrency=4` | 5m08s – 7m12s |
 
-That last row is the headline dev-loop finding. Plain `flutter test` compiles
-and spins a fresh isolate **per file** across 1,225 test files; a 50-minute
-sample completed 2,151 of ~13,159 tests. CI does the same suite in 9m07s
-because `very_good test --optimization` bundles them. A developer who types
-`flutter test` gets a ~30x worse experience than CI for the same work.
+### Plain `flutter test` vs the optimized run
+
+Plain `flutter test` compiles and spins a fresh isolate **per file**;
+`very_good test --optimization` bundles the untagged files into one. Measured
+head-to-head on an identical subset — 31 files / 277 tests, selected by
+round-robin so it spans directories, same machine, back to back:
+
+| Command | Wall | Tests |
+|---|---:|---:|
+| `flutter test --concurrency=4` | **60s** | 277 |
+| `very_good test --optimization --concurrency=4` | **17s** | 277 |
+
+**3.5x on identical work**, i.e. roughly 1.4s of per-file isolate and compile
+overhead that the optimizer amortises away. `flutter test` is what
+`CONTRIBUTING.md` currently tells developers to run.
+
+The whole suite was not run to completion unoptimized; a partial run was
+abandoned after a 50-minute sample reached 2,151 of ~13,159 tests, but that
+sample was CPU-contended and is not a sound basis for a projection, so no
+full-suite plain figure is claimed here.
+
+### Full-suite run-to-run stability (local)
+
+The optimized full suite is **not reliably green on this machine**, on
+`main` as well as on branches. Across seven runs at
+`--test-randomize-ordering-seed 12345`, one `origin/main`-equivalent run
+failed on `personalEventCacheServiceProvider keeps queued events through
+transient non-auth states` (a known CI-only flake, #6280); other runs failed on
+`clips_library_bloc_test.dart` and `video_event_service_deduplication_test.dart`.
+Each failing test passes in isolation. Treat a single red local full-suite run
+as inconclusive and re-run before attributing it to a diff.
 
 ### Repo shape (verified, not assumed)
 
@@ -225,6 +251,12 @@ gh run view <id> --log --job=<test-job-id> | grep "Run Flutter tests"
 cd mobile
 mise exec -- very_good test --optimization --concurrency=4 \
   --exclude-tags integration --test-randomize-ordering-seed random
+
+# Plain vs optimized on an identical subset (uses the sharding selector)
+bash scripts/ci/select_test_shard.sh --total 40 --index 0 --force
+mise exec -- flutter test --concurrency=4 --exclude-tags integration
+mise exec -- very_good test --optimization --concurrency=4 --exclude-tags integration
+git checkout -- test        # restore
 
 # Local, one file
 cd mobile && time mise exec -- flutter test <path> --reporter expanded

--- a/docs/PERF_BASELINE.md
+++ b/docs/PERF_BASELINE.md
@@ -100,13 +100,15 @@ graph on every run.
 
 ### Package workflows
 
-All 57 package workflows under `.github/workflows/` carry `paths:` filters
-scoped to their own package plus their own workflow file, so a PR that touches
-no package code runs none of them. The six workflows without `paths:` filters
-are `mobile_ci.yaml`, `mobile_service_integration_tests.yaml`, `semantic_pr.yaml`,
-`pr_issue_link.yml`, `mergeability_check.yml`, and `mobile_pr_preview_deploy.yml`
-— all of which are intentionally repo-wide. **There is no path-filter waste to
-recover here.**
+`mobile/packages/` has 55 entries. The 54 package workflows currently present
+under `.github/workflows/` carry `paths:` filters scoped to their own package
+plus their own workflow file; `nostr_apps` is the existing package-CI exception
+tracked in `mobile/scripts/baseline/package_ci_exceptions.txt`. The two mobile
+web build/deploy workflows are also path-filtered to `mobile/**`. The six
+workflows without `paths:` filters are `mobile_ci.yaml`,
+`mobile_service_integration_tests.yaml`, `semantic_pr.yaml`, `pr_issue_link.yml`,
+`mergeability_check.yml`, and `mobile_pr_preview_deploy.yml` — all of which are
+intentionally repo-wide. **There is no path-filter waste to recover here.**
 
 `--coverage` is *not* collected in the `Mobile CI` Tests job. Package workflows
 do collect it, and they consume it (`min_coverage` gates), so it is not waste.
@@ -225,9 +227,9 @@ as inconclusive and re-run before attributing it to a diff.
 - `mobile/lib`: 1,400 Dart files
 - `mobile/test`: 1,225 `*_test.dart` files, largest buckets `widgets/` (289),
   `services/` (280), `screens/` (185), `blocs/` (114)
-- `mobile/packages`: 57 packages, **all** declared `resolution: workspace` under
+- `mobile/packages`: 55 entries, **all** declared `resolution: workspace` under
   a single `workspace:` block in `mobile/pubspec.yaml` — one pub resolve for the
-  whole monorepo, not 57. No win available here.
+  whole monorepo, not 55. No win available here.
 
 ---
 
@@ -252,11 +254,10 @@ cd mobile
 mise exec -- very_good test --optimization --concurrency=4 \
   --exclude-tags integration --test-randomize-ordering-seed random
 
-# Plain vs optimized on an identical subset (uses the sharding selector)
-bash scripts/ci/select_test_shard.sh --total 40 --index 0 --force
-mise exec -- flutter test --concurrency=4 --exclude-tags integration
-mise exec -- very_good test --optimization --concurrency=4 --exclude-tags integration
-git checkout -- test        # restore
+# Plain vs optimized on an identical subset
+git ls-files 'test/**/*_test.dart' | sort | awk 'NR % 40 == 1' > /tmp/mobile-perf-subset.txt
+mise exec -- flutter test --concurrency=4 --exclude-tags integration $(cat /tmp/mobile-perf-subset.txt)
+mise exec -- very_good test --optimization --concurrency=4 --exclude-tags integration $(cat /tmp/mobile-perf-subset.txt)
 
 # Local, one file
 cd mobile && time mise exec -- flutter test <path> --reporter expanded


### PR DESCRIPTION
Closes #6374

## Why

First PR of a measured pass over CI / test / dev-loop wall clock. It adds the baseline everything else is measured against (`docs/PERF_BASELINE.md`) and takes two pieces of pure waste that measurement turned up in `mobile_ci.yaml`.

Numbers come from run 30142684388 plus p50/p90 over the 13 most recent successful `Mobile CI` runs. Queue wait is 3–4s across every job, so CI is not queue-bound — all of this is real work.

## What changed

**1. `Detect App CI Scope` no longer clones the repo — 26s → 5s (measured on this PR)**

The job existed to run `git diff --name-only` between two SHAs, and paid `actions/checkout@v4` with `fetch-depth: 0` to do it:

| Step | Time |
|---|---:|
| `actions/checkout@v4` (full history) | **23s** |
| Detect whether app CI is required | 0s |

The REST API already has that list, so the job now runs with no checkout at all. Every other job declares `needs: changes`, so this sits at the head of the workflow's critical path on every single run.

**2. The transport-security guard is gated on native changes — saves ~42s when it doesn't apply**

`check_native_transport_security.sh` reads exactly one Android XML plus three `Info.plist` files. If none of them (nor the script) changed, its verdict is identical to the one `main` already recorded. The step is now gated on a new `native` output from the `changes` job, matched at directory level (`mobile/android/**`, `mobile/ios/**`, `mobile/macos/**`) so it is a superset of the guard's real inputs and can't drift if the guard gains a fourth plist.

The 43s step is almost entirely toolchain install — `xmllint` genuinely isn't on the `ubuntu-24.04` image:

```
03:41:45  sudo apt-get update -qq            # 28s
03:42:13  apt-get install libxml2-utils      # 14s
03:42:27  (guard itself runs in <1s)
```

## Measured impact

| | Before (p50) | After |
|---|---:|---:|
| `Detect App CI Scope` | 26s | **5s** (measured, this PR) |
| `Generated Files` (non-native PR) | 198s | ~156s (projected) |
| **Mobile CI critical path** | **625s** | **~604s** |

The critical-path saving is only the ~21s today, because `Tests` (599s p50) dwarfs everything else and runs in parallel with the rest. The `Generated Files` saving is runner-minutes now and becomes a critical-path saving as soon as `Tests` drops below it — which is what the sharding work does next.

Note this PR touches `.github/workflows/**`, which sets both `app=true` and `native=true`, so the transport guard still runs here and its skip path is not exercised by this PR's own run.

## A third change was attempted and reverted

I also removed `flutter pub get` from the `Format` job on the theory that `dart format` is purely syntactic. **CI proved that wrong on the first run** and the second commit restores it.

`dart format` reads its page width from `analysis_options.yaml`, which `include`s `package:very_good_analysis/analysis_options.yaml`. With no resolved package config the include fails —

```
Failed to resolve package URI "package:very_good_analysis/analysis_options.yaml"
...
Formatted 2708 files (529 changed) in 12.42 seconds.
```

— and the formatter silently falls back to its defaults. The sandbox I verified against had no `analysis_options` include, so it never reproduced this. Leaving the failure and its cause in the history rather than force-pushing it away.

## Correctness

No check is removed or weakened.

- The changed-file list is the same list, from a different source. The `pulls/{n}/files` endpoint caps at 3000 entries, so the job first reads `changed_files` and **falls open to the full matrix** above that cap rather than under-running CI on a truncated list.
- The transport guard still runs in full on every push to `main`, on every non-PR event, and on any PR touching native config or the guard itself. Skipping it when its inputs are byte-identical to `main` does not change what is enforced.

## Verification

`.github/workflows/mobile_ci.yaml` parses and the gate lands on the right step:

```
jobs: ['changes', 'generated-files', 'format', 'analyze', 'tests', 'vgv-tag-gate', 'mobile-ci']
changes outputs: {'app': ..., 'native': ...}
step[3]: 🔒 Verify native transport security | if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.native == 'true' }}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
