### PR TITLE
perf(dev): add `mise run test` so local runs match CI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -232,8 +232,16 @@ blanks yourself and hope review will sort it out later.
 cd mobile
 flutter pub get
 flutter analyze
-flutter test
+flutter test test/path/to/foo_test.dart     # one file or directory
+mise run test           # whole suite, the way CI runs it
 ```
+
+Use `flutter test test/path/to/foo_test.dart` while iterating on a specific
+file, and `mise run test` for the full suite. `mise run test` wraps `very_good test
+--optimization`, which is what Mobile CI runs: it bundles the untagged test
+files into a single isolate instead of compiling and spinning one per file.
+Measured on an identical 31-file / 277-test subset, same machine, back to
+back: **60s for `flutter test`, 17s for the optimized run**.
 
 Useful app entry paths from `mobile/`:
 
@@ -269,7 +277,8 @@ Core checks:
 ```bash
 cd mobile
 flutter analyze
-flutter test
+flutter test test/path/to/foo_test.dart     # while iterating
+mise run test           # before pushing — whole suite, as CI runs it
 ```
 
 Additional expectations:

--- a/mobile/.gitignore
+++ b/mobile/.gitignore
@@ -82,6 +82,7 @@ test*.mp4
 test/goldens/**/failures/
 packages/*/test/**/failures/
 integration_test/test_bundle.dart
+test/.test_optimizer.dart
 
 # fastlane screenshot pipeline artifacts (generated per run)
 ios/fastlane/report.xml

--- a/mobile/docs/TEST_PERFORMANCE.md
+++ b/mobile/docs/TEST_PERFORMANCE.md
@@ -4,6 +4,31 @@ The app test suite is large enough that fixed startup costs and hidden waits
 matter. Use `scripts/test_timing_baseline.sh` before and after test-speed
 changes so improvements are measured instead of guessed.
 
+## Running the suite locally
+
+Use `mise run test` from `mobile/` for a full local run. It wraps the same
+`very_good test --optimization --concurrency=4` command Mobile CI uses, so a
+local pass means the same thing a CI pass does.
+
+Plain `flutter test` compiles and spins a fresh isolate **per file**; the
+optimizer bundles the untagged files into one. Measured head-to-head on an
+identical subset (31 files / 277 tests, selected round-robin so it spans
+directories, same machine, back to back):
+
+| Command | Wall | Tests |
+|---|---:|---:|
+| `flutter test --concurrency=4` | 60s | 277 |
+| `very_good test --optimization --concurrency=4` | 17s | 277 |
+
+About 1.4s per file of isolate and compile overhead that the optimizer
+amortises away. Keep using `flutter test <path>` while iterating on one
+file — the optimizer has no subset flag, so it is all-or-nothing.
+
+Note the optimized full suite can expose pre-existing seed- and load-sensitive
+failures on a developer machine; #6372 tracks that cleanup. If a red run is not
+obviously tied to your diff, capture the failing seed and rerun once before
+root-causing against the merged-isolate state below.
+
 ## Baseline Commands
 
 Run from `mobile/`:

--- a/mobile/mise.toml
+++ b/mobile/mise.toml
@@ -88,3 +88,38 @@ run = "bash ../local_stack/emulator.sh --headless"
 [tasks.emulator_wipe]
 description = "Launch Android emulator with -wipe-data (nuclear option for storage issues)"
 run = "bash ../local_stack/emulator.sh --wipe"
+
+[tasks.test]
+description = "Run the full app test suite the way CI does (merged-isolate optimizer)"
+run = """
+set -eu
+# Plain `flutter test` compiles and spins a fresh isolate per file; the VGV
+# optimizer bundles the untagged files into one. Measured on an identical
+# 31-file / 277-test subset: 60s plain vs 17s optimized.
+VERY_GOOD_CLI_VERSION=1.3.0
+PUB_CACHE_BIN="${PUB_CACHE:-$HOME/.pub-cache}/bin"
+VERY_GOOD_BIN=""
+if command -v very_good >/dev/null 2>&1; then
+  VERY_GOOD_BIN="$(command -v very_good)"
+elif [ -x "$PUB_CACHE_BIN/very_good" ]; then
+  VERY_GOOD_BIN="$PUB_CACHE_BIN/very_good"
+fi
+
+VERY_GOOD_CURRENT_VERSION=""
+if [ -n "$VERY_GOOD_BIN" ]; then
+  VERY_GOOD_CURRENT_VERSION="$("$VERY_GOOD_BIN" --version | awk 'NR == 1 { print $1 }')"
+fi
+
+if [ "$VERY_GOOD_CURRENT_VERSION" != "$VERY_GOOD_CLI_VERSION" ]; then
+  echo "Installing very_good_cli $VERY_GOOD_CLI_VERSION (pinned to match Mobile CI)..."
+  dart pub global activate very_good_cli "$VERY_GOOD_CLI_VERSION"
+  VERY_GOOD_BIN="$PUB_CACHE_BIN/very_good"
+fi
+
+flutter pub get
+PATH="$PUB_CACHE_BIN:$PATH" "$VERY_GOOD_BIN" test \
+  --optimization \
+  --concurrency=4 \
+  --exclude-tags integration \
+  --test-randomize-ordering-seed random
+"""


### PR DESCRIPTION
Closes #6377

## Why

`CONTRIBUTING.md` tells developers to run `flutter test` for the suite. That compiles and spins a **fresh isolate per test file** across 1,226 files. CI runs `very_good test --optimization`, which bundles the untagged files into one isolate. Nothing pointed developers at the faster command, and nothing made "green locally" mean the same thing as "green in CI".

## Measured

Head-to-head on an identical subset — 31 files / 277 tests, selected round-robin so it spans directories, same machine, back to back:

| Command | Wall | Tests |
|---|---:|---:|
| `flutter test --concurrency=4` | **60s** | 277 |
| `very_good test --optimization --concurrency=4` | **17s** | 277 |

**3.5× on identical work** — roughly 1.4s per file of isolate and compile overhead the optimizer amortises away.

Method (uses the shard selector from #6375 to hold the file set constant):

```bash
cd mobile
bash scripts/ci/select_test_shard.sh --total 40 --index 0 --force
mise exec -- flutter test --concurrency=4 --exclude-tags integration     # 60s
mise exec -- very_good test --optimization --concurrency=4 --exclude-tags integration  # 17s
git checkout -- test
```

## What changed

- **`mobile/mise.toml`** — new `mise run test` task wrapping the command Mobile CI runs. It runs `flutter pub get`, enforces the pinned `very_good_cli 1.3.0` even when another `very_good` is already on `PATH`, and then invokes the optimized suite with CI flags.
- **`mobile/.gitignore`** — ignores `test/.test_optimizer.dart`, the temporary optimizer bundle file, so a crashed or hard-killed run cannot leave an accidental staged artifact.
- **`CONTRIBUTING.md`** — both the day-to-day and testing-expectations blocks now distinguish `flutter test test/path/to/foo_test.dart` (while iterating on one file) from `mise run test` (whole suite, before pushing), with the measured numbers.
- **`mobile/docs/TEST_PERFORMANCE.md`** — the comparison and its method, next to the existing merged-isolate notes. The local instability note now points at #6372 and asks developers to capture the failing seed before root-causing.

The task takes no path argument on purpose: `very_good test` has no subset flag, so it is all-or-nothing. `flutter test test/path/to/foo_test.dart` stays the right tool for a single file, and the docs say so rather than leaving people to discover it.

## Correctness

Docs and a task wrapper. No app code, gates, ratchets, or workflows are touched. The task now mirrors CI setup (`flutter pub get` + pinned Very Good CLI) before running the same optimized test flags as `mobile_ci.yaml`.

## Verification

- `mise run test` in a fresh takeover worktree detected the existing `very_good_cli 1.1.1`, installed `very_good_cli 1.3.0`, ran `flutter pub get`, and launched the optimized randomized suite.
- Full optimized run reached the real suite and completed with one pre-existing temp-directory cleanup failure in `test/providers/personal_event_cache_service_provider_test.dart` (`Directory not empty`). The same test file passed when rerun directly with the same seed: `flutter test test/providers/personal_event_cache_service_provider_test.dart --test-randomize-ordering-seed=26429946`.
- `git check-ignore -v mobile/test/.test_optimizer.dart` confirms the optimizer artifact is ignored.
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)