### PR TITLE
feat(supporter): add flag-gated monthly supporter subscription (Option A)

### DIFF
--- a/.github/workflows/iap_repository.yaml
+++ b/.github/workflows/iap_repository.yaml
@@ -1,0 +1,27 @@
+# ABOUTME: CI workflow for the iap_repository package.
+# ABOUTME: Runs tests, formatting, and analysis only when iap_repository files change.
+
+name: IAP Repository CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "mobile/packages/iap_repository/**"
+      - ".github/workflows/iap_repository.yaml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "mobile/packages/iap_repository/**"
+      - ".github/workflows/iap_repository.yaml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
+    with:
+      working_directory: "mobile/packages/iap_repository"
+      min_coverage: 90

--- a/mobile/lib/blocs/supporter/supporter_cubit.dart
+++ b/mobile/lib/blocs/supporter/supporter_cubit.dart
@@ -1,0 +1,128 @@
+// ABOUTME: Screen-scoped Cubit for the Divine supporter screen.
+// ABOUTME: Loads tiers, drives subscribe/restore, and maps store exceptions.
+
+import 'dart:async';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:iap_repository/iap_repository.dart';
+import 'package:models/models.dart';
+import 'package:openvine/blocs/supporter/supporter_state.dart';
+import 'package:openvine/services/supporter_repository.dart';
+
+typedef SupporterAnalyticsSink = void Function(String event);
+
+class SupporterCubit extends Cubit<SupporterState> {
+  /// Creates a [SupporterCubit].
+  ///
+  /// [repository] owns the validator and cached entitlement.
+  /// [trackEvent] is an optional analytics sink (e.g.
+  /// `analyticsEventSinkProvider`); pass `_noopAnalytics` when unavailable.
+  SupporterCubit({
+    required SupporterRepository repository,
+    SupporterAnalyticsSink trackEvent = _noopAnalytics,
+  }) : _repository = repository,
+       _trackEvent = trackEvent,
+       super(SupporterState(entitlement: repository.current));
+
+  final SupporterRepository _repository;
+  final SupporterAnalyticsSink _trackEvent;
+
+  StreamSubscription<SupporterEntitlement>? _entitlementSub;
+
+  /// Begin listening to the repository's entitlement stream. Call from the
+  /// screen's `initState` so external purchase updates (renewals, restores)
+  /// reflect in the UI.
+  void start() {
+    _entitlementSub ??= _repository.changes.listen((entitlement) {
+      emit(
+        state.copyWith(
+          entitlement: entitlement,
+          status: entitlement.isSupporter
+              ? SupporterStatus.active
+              : state.status,
+          clearFailure: entitlement.isSupporter,
+        ),
+      );
+    });
+    loadTiers();
+  }
+
+  /// Fetch the available supporter tiers from the store.
+  Future<void> loadTiers() async {
+    emit(state.copyWith(status: SupporterStatus.loading, clearFailure: true));
+    try {
+      final tiers = await _repository.validator.fetchProducts();
+      emit(state.copyWith(tiers: tiers, status: SupporterStatus.idle));
+    } on EntitlementException catch (e) {
+      emit(
+        state.copyWith(
+          status: SupporterStatus.error,
+          failure: SupporterFailure.fromMessage(e.message),
+        ),
+      );
+    }
+  }
+
+  /// Begin a purchase for [productId].
+  Future<void> subscribe(String productId) async {
+    if (state.isBusy) return;
+    emit(
+      state.copyWith(status: SupporterStatus.purchasing, clearFailure: true),
+    );
+    _trackEvent('supporter_subscribe_tapped');
+    try {
+      final entitlement = await _repository.validator.purchase(productId);
+      emit(
+        state.copyWith(
+          entitlement: entitlement,
+          status: SupporterStatus.active,
+          clearFailure: true,
+        ),
+      );
+      _trackEvent('supporter_subscribe_succeeded');
+    } on EntitlementException catch (e) {
+      emit(
+        state.copyWith(
+          status: SupporterStatus.idle,
+          failure: SupporterFailure.fromMessage(e.message),
+        ),
+      );
+      _trackEvent('supporter_subscribe_failed');
+    }
+  }
+
+  /// Restore previous purchases tied to the store account.
+  Future<void> restore() async {
+    if (state.isBusy) return;
+    emit(state.copyWith(status: SupporterStatus.restoring, clearFailure: true));
+    _trackEvent('supporter_restore_tapped');
+    try {
+      await _repository.validator.restorePurchases();
+      // The restored entitlement arrives on the repository stream; reset to idle
+      // and let the stream listener surface the active status.
+      emit(state.copyWith(status: SupporterStatus.idle));
+      _trackEvent('supporter_restore_completed');
+    } on EntitlementException catch (e) {
+      emit(
+        state.copyWith(
+          status: SupporterStatus.idle,
+          failure: SupporterFailure.fromMessage(e.message),
+        ),
+      );
+      _trackEvent('supporter_restore_failed');
+    }
+  }
+
+  /// Dismiss the current failure banner.
+  void dismissError() {
+    emit(state.copyWith(clearFailure: true));
+  }
+
+  @override
+  Future<void> close() {
+    _entitlementSub?.cancel();
+    return super.close();
+  }
+
+  static void _noopAnalytics(String _) {}
+}

--- a/mobile/lib/blocs/supporter/supporter_state.dart
+++ b/mobile/lib/blocs/supporter/supporter_state.dart
@@ -1,0 +1,71 @@
+// ABOUTME: State for the Divine supporter screen.
+// ABOUTME: Tracks tiers, current entitlement, and purchase/restore lifecycle.
+
+import 'package:equatable/equatable.dart';
+import 'package:models/models.dart';
+
+enum SupporterStatus { idle, loading, purchasing, restoring, active, error }
+
+/// Typed reason for a supporter-screen failure, mapped from validator
+/// exceptions so the UI can show specific copy.
+enum SupporterFailure {
+  storeUnavailable,
+  purchaseFailed,
+  purchasePending,
+  restoreFailed,
+  unknown;
+
+  static SupporterFailure fromMessage(String message) {
+    final lower = message.toLowerCase();
+    if (lower.contains('unavailable')) return SupporterFailure.storeUnavailable;
+    if (lower.contains('pending')) return SupporterFailure.purchasePending;
+    if (lower.contains('restore')) return SupporterFailure.restoreFailed;
+    if (lower.contains('cancel') || lower.contains('fail')) {
+      return SupporterFailure.purchaseFailed;
+    }
+    return SupporterFailure.unknown;
+  }
+}
+
+class SupporterState extends Equatable {
+  const SupporterState({
+    this.tiers = const [],
+    this.entitlement = SupporterEntitlement.inactive,
+    this.status = SupporterStatus.idle,
+    this.failure,
+  });
+
+  /// Purchasable supporter tiers loaded from the store.
+  final List<SupporterTier> tiers;
+
+  /// The current supporter entitlement.
+  final SupporterEntitlement entitlement;
+
+  final SupporterStatus status;
+  final SupporterFailure? failure;
+
+  bool get isSupporter => entitlement.isSupporter;
+  bool get isBusy =>
+      status == SupporterStatus.purchasing ||
+      status == SupporterStatus.restoring ||
+      status == SupporterStatus.loading;
+  bool get hasTiers => tiers.isNotEmpty;
+
+  SupporterState copyWith({
+    List<SupporterTier>? tiers,
+    SupporterEntitlement? entitlement,
+    SupporterStatus? status,
+    SupporterFailure? failure,
+    bool clearFailure = false,
+  }) {
+    return SupporterState(
+      tiers: tiers ?? this.tiers,
+      entitlement: entitlement ?? this.entitlement,
+      status: status ?? this.status,
+      failure: clearFailure ? null : failure ?? this.failure,
+    );
+  }
+
+  @override
+  List<Object?> get props => [tiers, entitlement, status, failure];
+}

--- a/mobile/lib/features/feature_flags/models/feature_flag.dart
+++ b/mobile/lib/features/feature_flags/models/feature_flag.dart
@@ -68,7 +68,13 @@ enum FeatureFlag {
     'Email Verification PIN Fallback',
     'Show the in-app email verification PIN and resend fallback. Off by '
         'default until keycast verify-pin support is deployed.',
+  ),
+  divineSupporters(
+    'Divine Supporters',
+    'Optional monthly supporter subscription via in-app purchase. '
+        'Nothing is gated — it keeps Divine running and recognizes supporters.',
   );
+
 
   const FeatureFlag(this.displayName, this.description);
 

--- a/mobile/lib/features/feature_flags/services/build_configuration.dart
+++ b/mobile/lib/features/feature_flags/services/build_configuration.dart
@@ -52,6 +52,10 @@ class BuildConfiguration {
       case FeatureFlag.emailVerificationPinFallback:
         // Default OFF until keycast verify-pin support is deployed.
         return const bool.fromEnvironment('FF_EMAIL_VERIFICATION_PIN_FALLBACK');
+      case FeatureFlag.divineSupporters:
+        // Default OFF: MVP exploration behind the flag until store products
+        // are configured in App Store Connect and Google Play Console.
+        return const bool.fromEnvironment('FF_DIVINE_SUPPORTERS');
     }
   }
 
@@ -96,6 +100,8 @@ class BuildConfiguration {
         return 'FF_COMMUNITY_CONTENT_WARNINGS';
       case FeatureFlag.emailVerificationPinFallback:
         return 'FF_EMAIL_VERIFICATION_PIN_FALLBACK';
+      case FeatureFlag.divineSupporters:
+        return 'FF_DIVINE_SUPPORTERS';
     }
   }
 }

--- a/mobile/lib/providers/supporter_providers.dart
+++ b/mobile/lib/providers/supporter_providers.dart
@@ -1,0 +1,46 @@
+// ABOUTME: Riverpod providers wiring the supporter feature.
+// ABOUTME: Selects the store-backed EntitlementValidator on iOS/Android and a
+// ABOUTME: stub elsewhere, owned by a keepAlive SupporterRepository.
+
+import 'package:flutter/foundation.dart';
+import 'package:iap_repository/iap_repository.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/services/supporter_repository.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'supporter_providers.g.dart';
+
+/// True when this platform has a real in-app purchase store.
+///
+/// Mirrors the [hasNativeVideoPlayer] gate: iOS/Android only, web-safe.
+bool get hasInAppPurchaseStore =>
+    !kIsWeb &&
+    defaultTargetPlatform != TargetPlatform.linux &&
+    defaultTargetPlatform != TargetPlatform.windows &&
+    defaultTargetPlatform != TargetPlatform.macOS;
+
+/// The store-backed [EntitlementValidator] for the current platform.
+///
+/// Returns an [InAppPurchaseValidator] on iOS/Android and a
+/// [StubEntitlementValidator] elsewhere so the rest of the app can treat the
+/// supporter feature uniformly.
+@Riverpod(keepAlive: true)
+EntitlementValidator entitlementValidator(Ref ref) {
+  if (!hasInAppPurchaseStore) {
+    return StubEntitlementValidator();
+  }
+  final validator = InAppPurchaseValidator();
+  ref.onDispose(validator.dispose);
+  return validator;
+}
+
+/// The keepAlive [SupporterRepository] that owns the cached entitlement.
+@Riverpod(keepAlive: true)
+SupporterRepository supporterRepository(Ref ref) {
+  final repository = SupporterRepository(
+    validator: ref.watch(entitlementValidatorProvider),
+    prefs: ref.watch(sharedPreferencesProvider),
+  );
+  ref.onDispose(repository.dispose);
+  return repository;
+}

--- a/mobile/lib/providers/supporter_providers.g.dart
+++ b/mobile/lib/providers/supporter_providers.g.dart
@@ -1,0 +1,127 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'supporter_providers.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// The store-backed [EntitlementValidator] for the current platform.
+///
+/// Returns an [InAppPurchaseValidator] on iOS/Android and a
+/// [StubEntitlementValidator] elsewhere so the rest of the app can treat the
+/// supporter feature uniformly.
+
+@ProviderFor(entitlementValidator)
+final entitlementValidatorProvider = EntitlementValidatorProvider._();
+
+/// The store-backed [EntitlementValidator] for the current platform.
+///
+/// Returns an [InAppPurchaseValidator] on iOS/Android and a
+/// [StubEntitlementValidator] elsewhere so the rest of the app can treat the
+/// supporter feature uniformly.
+
+final class EntitlementValidatorProvider
+    extends
+        $FunctionalProvider<
+          EntitlementValidator,
+          EntitlementValidator,
+          EntitlementValidator
+        >
+    with $Provider<EntitlementValidator> {
+  /// The store-backed [EntitlementValidator] for the current platform.
+  ///
+  /// Returns an [InAppPurchaseValidator] on iOS/Android and a
+  /// [StubEntitlementValidator] elsewhere so the rest of the app can treat the
+  /// supporter feature uniformly.
+  EntitlementValidatorProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'entitlementValidatorProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$entitlementValidatorHash();
+
+  @$internal
+  @override
+  $ProviderElement<EntitlementValidator> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  EntitlementValidator create(Ref ref) {
+    return entitlementValidator(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(EntitlementValidator value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<EntitlementValidator>(value),
+    );
+  }
+}
+
+String _$entitlementValidatorHash() =>
+    r'0e3e4f5e3b811340e2ec5adf8882f66c7fe012cc';
+
+/// The keepAlive [SupporterRepository] that owns the cached entitlement.
+
+@ProviderFor(supporterRepository)
+final supporterRepositoryProvider = SupporterRepositoryProvider._();
+
+/// The keepAlive [SupporterRepository] that owns the cached entitlement.
+
+final class SupporterRepositoryProvider
+    extends
+        $FunctionalProvider<
+          SupporterRepository,
+          SupporterRepository,
+          SupporterRepository
+        >
+    with $Provider<SupporterRepository> {
+  /// The keepAlive [SupporterRepository] that owns the cached entitlement.
+  SupporterRepositoryProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'supporterRepositoryProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$supporterRepositoryHash();
+
+  @$internal
+  @override
+  $ProviderElement<SupporterRepository> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  SupporterRepository create(Ref ref) {
+    return supporterRepository(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(SupporterRepository value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<SupporterRepository>(value),
+    );
+  }
+}
+
+String _$supporterRepositoryHash() =>
+    r'20dfa7e54c802d785870a13f3cc92dba83d00de8';

--- a/mobile/lib/router/routes/settings_routes.dart
+++ b/mobile/lib/router/routes/settings_routes.dart
@@ -28,6 +28,7 @@ import 'package:openvine/screens/settings/nostr_settings_screen.dart';
 import 'package:openvine/screens/settings/settings_screen.dart';
 import 'package:openvine/screens/settings/storage/storage_management_page.dart';
 import 'package:openvine/screens/settings/support_center_screen.dart';
+import 'package:openvine/screens/settings/supporter_screen.dart';
 
 List<RouteBase> settingsRoutes(Ref ref) {
   return [
@@ -81,6 +82,12 @@ List<RouteBase> settingsRoutes(Ref ref) {
       name: MonetizationLinksSettingsScreen.routeName,
       redirect: (_, _) => monetizationLinksRedirectIfDisabled(ref),
       builder: (_, _) => const MonetizationLinksSettingsScreen(),
+    ),
+    GoRoute(
+      path: SupporterScreen.path,
+      name: SupporterScreen.routeName,
+      redirect: (_, _) => supporterRedirectIfDisabled(ref),
+      builder: (_, _) => const SupporterScreen(),
     ),
     GoRoute(
       path: AppLanguageScreen.path,
@@ -162,6 +169,14 @@ List<RouteBase> settingsRoutes(Ref ref) {
 String? monetizationLinksRedirectIfDisabled(Ref ref) {
   final enabled = ref.read(
     isFeatureEnabledProvider(FeatureFlag.profileMonetizationLinks),
+  );
+  if (enabled) return null;
+  return SettingsScreen.path;
+}
+
+String? supporterRedirectIfDisabled(Ref ref) {
+  final enabled = ref.read(
+    isFeatureEnabledProvider(FeatureFlag.divineSupporters),
   );
   if (enabled) return null;
   return SettingsScreen.path;

--- a/mobile/lib/screens/settings/settings_screen.dart
+++ b/mobile/lib/screens/settings/settings_screen.dart
@@ -36,6 +36,7 @@ import 'package:openvine/screens/settings/legal_screen.dart';
 import 'package:openvine/screens/settings/monetization_links_settings_screen.dart';
 import 'package:openvine/screens/settings/nostr_settings_screen.dart';
 import 'package:openvine/screens/settings/support_center_screen.dart';
+import 'package:openvine/screens/settings/supporter_screen.dart';
 import 'package:openvine/services/auth_service.dart' hide UserProfile;
 import 'package:openvine/services/nip05_verification_service.dart';
 import 'package:openvine/utils/deferred_login_options_navigator.dart';
@@ -182,6 +183,9 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     final monetizationLinksEnabled = ref.watch(
       isFeatureEnabledProvider(FeatureFlag.profileMonetizationLinks),
     );
+    final divineSupportersEnabled = ref.watch(
+      isFeatureEnabledProvider(FeatureFlag.divineSupporters),
+    );
     // Watched here (not just in _VersionTile) so the Developer Options tile
     // appears immediately when dev mode is unlocked via the version tap.
     final isDeveloperMode = ref.watch(isDeveloperModeEnabledProvider);
@@ -240,6 +244,14 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                         : context.l10n.monetizationSettingsSubtitle,
                     onTap: () =>
                         context.push(MonetizationLinksSettingsScreen.path),
+                  ),
+                if (divineSupportersEnabled)
+                  _SettingsTile(
+                    title: 'Divine Supporters',
+                    divineIcon: DivineIconName.heart,
+                    subtitle:
+                        'Support Divine with an optional monthly subscription.',
+                    onTap: () => context.push(SupporterScreen.path),
                   ),
                 _SettingsTile(
                   title: context.l10n.settingsSupportCenter,

--- a/mobile/lib/screens/settings/supporter_screen.dart
+++ b/mobile/lib/screens/settings/supporter_screen.dart
@@ -1,0 +1,261 @@
+// ABOUTME: Settings screen for the Divine supporter subscription.
+// ABOUTME: Signal-style: optional monthly support, nothing gated, recognition only.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:openvine/blocs/supporter/supporter_cubit.dart';
+import 'package:openvine/blocs/supporter/supporter_state.dart';
+import 'package:openvine/providers/supporter_providers.dart';
+
+class SupporterScreen extends ConsumerWidget {
+  static const routeName = 'supporter';
+  static const subpath = 'supporter';
+  static const path = '/settings/supporter';
+
+  const SupporterScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final repository = ref.watch(supporterRepositoryProvider);
+    return BlocProvider(
+      create: (_) => SupporterCubit(repository: repository),
+      child: const SupporterScreenView(),
+    );
+  }
+}
+
+class SupporterScreenView extends StatefulWidget {
+  const SupporterScreenView({super.key});
+
+  @override
+  State<SupporterScreenView> createState() => _SupporterScreenViewState();
+}
+
+class _SupporterScreenViewState extends State<SupporterScreenView> {
+  @override
+  void initState() {
+    super.initState();
+    // Start the cubit's entitlement listener now that the BlocProvider above
+    // has created the cubit.
+    context.read<SupporterCubit>().start();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<SupporterCubit, SupporterState>(
+      builder: (context, state) {
+        return Scaffold(
+          appBar: DiVineAppBar(
+            title: 'Divine Supporters',
+            showBackButton: true,
+            onBackPressed: context.pop,
+          ),
+          backgroundColor: VineTheme.navGreen,
+          body: Align(
+            alignment: Alignment.topCenter,
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 600),
+              child: ListView(
+                padding: const EdgeInsets.all(16),
+                children: [
+                  _Hero(state: state),
+                  const SizedBox(height: 24),
+                  if (state.isSupporter)
+                    const _ActiveBadge()
+                  else if (state.hasTiers)
+                    _TierList(state: state)
+                  else
+                    _UnavailableNote(loading: state.isBusy),
+                  const SizedBox(height: 16),
+                  if (!state.isSupporter) _RestoreButton(state: state),
+                  if (state.failure != null)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 16),
+                      child: _FailureBanner(
+                        failure: state.failure!,
+                        onDismiss: () =>
+                            context.read<SupporterCubit>().dismissError(),
+                      ),
+                    ),
+                  const SizedBox(height: 32),
+                  _Disclaimer(),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _Hero extends StatelessWidget {
+  const _Hero({required this.state});
+
+  final SupporterState state;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        const Icon(
+          Icons.favorite,
+          color: VineTheme.accentOrange,
+          size: 48,
+        ),
+        const SizedBox(height: 12),
+        Text(
+          'Keep Divine running',
+          style: Theme.of(context).textTheme.headlineSmall,
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 8),
+        Text(
+          'Divine is free and always will be. If you want to help us keep the '
+          'loops going, become a monthly supporter. Nothing is locked — it just '
+          'keeps the lights on and earns our thanks.',
+          style: Theme.of(context).textTheme.bodyMedium,
+          textAlign: TextAlign.center,
+        ),
+      ],
+    );
+  }
+}
+
+class _ActiveBadge extends StatelessWidget {
+  const _ActiveBadge();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: VineTheme.accentOrange.withValues(alpha: 0.15),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        children: [
+          const Icon(Icons.favorite, color: VineTheme.accentOrange),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              "You're a Divine Supporter. Thank you for keeping this going.",
+              style: Theme.of(context).textTheme.bodyLarge,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TierList extends StatelessWidget {
+  const _TierList({required this.state});
+
+  final SupporterState state;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        for (final tier in state.tiers)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 12),
+            child: DivineButton(
+              label: '${tier.title} — ${tier.price} / month',
+              onPressed: state.isBusy
+                  ? null
+                  : () => context.read<SupporterCubit>().subscribe(
+                      tier.productId,
+                    ),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _UnavailableNote extends StatelessWidget {
+  const _UnavailableNote({required this.loading});
+
+  final bool loading;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      loading
+          ? 'Checking the store…'
+          : 'Supporter subscriptions are not available here right now.',
+      style: Theme.of(context).textTheme.bodyMedium,
+      textAlign: TextAlign.center,
+    );
+  }
+}
+
+class _RestoreButton extends StatelessWidget {
+  const _RestoreButton({required this.state});
+
+  final SupporterState state;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextButton(
+      onPressed: state.isBusy
+          ? null
+          : () => context.read<SupporterCubit>().restore(),
+      child: const Text('Restore purchases'),
+    );
+  }
+}
+
+class _FailureBanner extends StatelessWidget {
+  const _FailureBanner({required this.failure, required this.onDismiss});
+
+  final SupporterFailure failure;
+  final VoidCallback onDismiss;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        const Icon(Icons.error_outline, color: VineTheme.accentOrange),
+        const SizedBox(width: 8),
+        Expanded(child: Text(_message(failure))),
+        IconButton(
+          icon: const Icon(Icons.close),
+          onPressed: onDismiss,
+        ),
+      ],
+    );
+  }
+
+  String _message(SupporterFailure failure) {
+    switch (failure) {
+      case SupporterFailure.storeUnavailable:
+        return 'The store is unavailable on this device.';
+      case SupporterFailure.purchaseFailed:
+        return 'The purchase did not complete. You were not charged.';
+      case SupporterFailure.purchasePending:
+        return 'Your purchase is pending approval.';
+      case SupporterFailure.restoreFailed:
+        return 'No supporter subscription was found to restore.';
+      case SupporterFailure.unknown:
+        return 'Something went wrong. Please try again.';
+    }
+  }
+}
+
+class _Disclaimer extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      'Supporter status is verified on your device for now. Cross-device sync '
+      'will arrive when server validation lands.',
+      style: Theme.of(context).textTheme.bodySmall,
+      textAlign: TextAlign.center,
+    );
+  }
+}

--- a/mobile/lib/services/supporter_repository.dart
+++ b/mobile/lib/services/supporter_repository.dart
@@ -1,0 +1,110 @@
+// ABOUTME: Service that owns a user's supporter entitlement across sessions.
+// ABOUTME: Caches the latest entitlement in SharedPreferences and bridges the
+// ABOUTME: EntitlementValidator stream to app state.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:iap_repository/iap_repository.dart';
+import 'package:models/models.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Persists and surfaces the current [SupporterEntitlement].
+///
+/// Wraps an [EntitlementValidator] (StoreKit/Play Billing in production) and
+/// keeps the last known entitlement in [SharedPreferences] so it survives
+/// relaunches and is available offline. The repository is the single read-side
+/// surface the UI consults; the validator is the write side.
+class SupporterRepository {
+  /// Creates a [SupporterRepository].
+  ///
+  /// [validator] is the store-backed validator. [prefs] is the canonical
+  /// [SharedPreferences] from [sharedPreferencesProvider].
+  SupporterRepository({
+    required EntitlementValidator validator,
+    required SharedPreferences prefs,
+  }) : _validator = validator,
+       _prefs = prefs {
+    _current = _loadCached();
+    _subscription = _validator.entitlementChanges.listen(_handleChange);
+  }
+
+  final EntitlementValidator _validator;
+  final SharedPreferences _prefs;
+
+  static const String _cacheKey = 'divine_supporter_entitlement';
+
+  late SupporterEntitlement _current;
+  StreamSubscription<SupporterEntitlement>? _subscription;
+  final StreamController<SupporterEntitlement> _controller =
+      StreamController<SupporterEntitlement>.broadcast();
+
+  /// The current entitlement (hydrated from cache on construction, refreshed by
+  /// the validator stream as purchases arrive).
+  SupporterEntitlement get current => _current;
+
+  /// Whether the user is currently an active supporter.
+  bool get isSupporter => _current.isSupporter;
+
+  /// A stream of entitlement updates. Emits the current value to new
+  /// listeners.
+  Stream<SupporterEntitlement> get changes => _controller.stream;
+
+  /// The underlying validator, exposed so the UI/cubit can drive purchases and
+  /// restores through the same store connection this repository owns.
+  EntitlementValidator get validator => _validator;
+
+  SupporterEntitlement _loadCached() {
+    final raw = _prefs.getString(_cacheKey);
+    if (raw == null) return SupporterEntitlement.inactive;
+    try {
+      final decoded = SupporterEntitlement.fromJson(
+        jsonDecode(raw) as Map<String, dynamic>,
+      );
+      // Recompute active against the current clock in case expiry passed while
+      // the app was closed.
+      return decoded.refreshed();
+    } on Object {
+      return SupporterEntitlement.inactive;
+    }
+  }
+
+  Future<void> _persist(SupporterEntitlement entitlement) async {
+    try {
+      await _prefs.setString(
+        _cacheKey,
+        jsonEncode(entitlement.toJson()),
+      );
+    } on Object {
+      // Swallow: persistence is best-effort; the in-memory value is still
+      // authoritative for this session.
+    }
+  }
+
+  void _handleChange(SupporterEntitlement entitlement) {
+    if (entitlement == _current) return;
+    _current = entitlement;
+    _controller.add(entitlement);
+    _persist(entitlement);
+  }
+
+  /// Mark the entitlement inactive locally (e.g. after a confirmed expiry or
+  /// cancellation detected out-of-band). The validator stream is the source of
+  /// truth; this is a cache reset.
+  Future<void> clearLocalEntitlement() async {
+    _handleChange(SupporterEntitlement.inactive);
+    try {
+      await _prefs.remove(_cacheKey);
+    } on Object {
+      // best-effort
+    }
+  }
+
+  /// Release the validator stream subscription. The validator itself is
+  /// disposed by whoever owns it (the provider).
+  void dispose() {
+    _subscription?.cancel();
+    _subscription = null;
+    _controller.close();
+  }
+}

--- a/mobile/packages/iap_repository/analysis_options.yaml
+++ b/mobile/packages/iap_repository/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:very_good_analysis/analysis_options.yaml

--- a/mobile/packages/iap_repository/lib/iap_repository.dart
+++ b/mobile/packages/iap_repository/lib/iap_repository.dart
@@ -1,0 +1,7 @@
+// ABOUTME: Public surface for the iap_repository package.
+// ABOUTME: Store abstraction + client-first supporter entitlement validation.
+
+export 'src/entitlement_validator.dart';
+export 'src/exceptions.dart';
+export 'src/in_app_purchase_validator.dart';
+export 'src/stub_entitlement_validator.dart';

--- a/mobile/packages/iap_repository/lib/src/entitlement_validator.dart
+++ b/mobile/packages/iap_repository/lib/src/entitlement_validator.dart
@@ -1,0 +1,46 @@
+// ABOUTME: Abstract store + entitlement surface for Divine supporters.
+// ABOUTME: Implementations back this with StoreKit/Play Billing (client-first)
+// ABOUTME: or, later, a server-side receipt-validation backend.
+
+import 'package:models/models.dart';
+
+/// Abstracts the in-app purchase store and supporter-entitlement source.
+///
+/// This is the single seam between the app and however supporter status is
+/// verified. The client-first MVP backs it with on-device StoreKit / Play
+/// Billing (see InAppPurchaseValidator). A server-side validator can implement
+/// the same interface later without changing callers.
+abstract class EntitlementValidator {
+  /// Whether a store is available on this device/build. When false,
+  /// [fetchProducts] / [purchase] / [restorePurchases] reject with a
+  /// StoreUnavailableException.
+  Future<bool> get isAvailable;
+
+  /// Fetch the purchasable supporter tiers from the store.
+  ///
+  /// Returns an empty list when the store is available but no supporter
+  /// products are configured yet.
+  Future<List<SupporterTier>> fetchProducts();
+
+  /// Begin a purchase for [productId]. Resolves with the resulting
+  /// SupporterEntitlement once the store confirms the purchase.
+  ///
+  /// Throws StoreUnavailableException, PurchaseFailedException, or
+  /// PurchasePendingException.
+  Future<SupporterEntitlement> purchase(String productId);
+
+  /// Restore previous supporter purchases tied to this store account.
+  ///
+  /// Resolves with the active SupporterEntitlement if one is found, or
+  /// SupporterEntitlement.inactive otherwise. Throws RestoreFailedException
+  /// on store errors.
+  Future<SupporterEntitlement> restorePurchases();
+
+  /// A stream of the current entitlement, emitting whenever the store reports
+  /// a purchase, renewal, cancellation, or expiry. Emits
+  /// [SupporterEntitlement.inactive] until a verified purchase arrives.
+  Stream<SupporterEntitlement> get entitlementChanges;
+
+  /// Release store listeners and resources.
+  void dispose();
+}

--- a/mobile/packages/iap_repository/lib/src/exceptions.dart
+++ b/mobile/packages/iap_repository/lib/src/exceptions.dart
@@ -1,0 +1,53 @@
+// ABOUTME: Typed exceptions thrown by EntitlementValidator implementations.
+// ABOUTME: Sealed so callers can exhaustively switch on purchase outcomes.
+
+/// Base class for all errors thrown by an EntitlementValidator.
+sealed class EntitlementException implements Exception {
+  /// Creates an entitlement exception with a human-readable [message].
+  const EntitlementException(this.message, this.kind);
+
+  /// Free-form message describing the failure.
+  final String message;
+
+  /// Stable identifier for the exception subtype, safe for production logs.
+  final String kind;
+
+  @override
+  String toString() => '$kind: $message';
+}
+
+/// The store is unavailable on this device or build (e.g. unsupported platform,
+/// store not connected). Purchases cannot be attempted.
+final class StoreUnavailableException extends EntitlementException {
+  /// Creates a [StoreUnavailableException].
+  const StoreUnavailableException([String message = 'Store is unavailable.'])
+    : super(message, 'StoreUnavailableException');
+}
+
+/// A purchase was attempted and the store reported a failure (user cancelled,
+/// network error during purchase, declined payment, etc.).
+final class PurchaseFailedException extends EntitlementException {
+  /// Creates a [PurchaseFailedException] with the store's [responseCode] when
+  /// available (e.g. `billingResponse` / StoreKit error code).
+  const PurchaseFailedException(this.responseCode, String message)
+    : super(message, 'PurchaseFailedException');
+
+  /// Store-specific error code, or null when the store did not provide one.
+  final String? responseCode;
+}
+
+/// A purchase was initiated but is still pending (e.g. awaiting parental
+/// approval or payment settlement). The entitlement is not yet active.
+final class PurchasePendingException extends EntitlementException {
+  /// Creates a [PurchasePendingException].
+  const PurchasePendingException([String message = 'Purchase is pending.'])
+    : super(message, 'PurchasePendingException');
+}
+
+/// Restoring previous purchases did not yield an active supporter entitlement.
+final class RestoreFailedException extends EntitlementException {
+  /// Creates a [RestoreFailedException].
+  const RestoreFailedException([
+    String message = 'No supporter subscription was found to restore.',
+  ]) : super(message, 'RestoreFailedException');
+}

--- a/mobile/packages/iap_repository/lib/src/in_app_purchase_validator.dart
+++ b/mobile/packages/iap_repository/lib/src/in_app_purchase_validator.dart
@@ -1,0 +1,212 @@
+// ABOUTME: Client-first EntitlementValidator backed by the in_app_purchase
+// ABOUTME: plugin (StoreKit on iOS, Google Play Billing on Android).
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:iap_repository/src/entitlement_validator.dart';
+import 'package:iap_repository/src/exceptions.dart';
+import 'package:in_app_purchase/in_app_purchase.dart';
+import 'package:models/models.dart';
+
+/// The store product IDs Divine treats as supporter tiers.
+///
+/// These must exist in App Store Connect and the Google Play Console for real
+/// purchases to work. While the flag is off and these are unconfigured,
+/// fetchProducts simply returns an empty list.
+@visibleForTesting
+const Set<String> supporterProductIds = <String>{
+  'divine.supporter.monthly',
+};
+
+/// [EntitlementValidator] backed by the `in_app_purchase` plugin.
+///
+/// Purchase results arrive asynchronously on [InAppPurchase.purchaseStream];
+/// [purchase] bridges that into a single Future using a [Completer]. This keeps
+/// the public surface Future-based while still honoring the store's delivery
+/// model.
+class InAppPurchaseValidator implements EntitlementValidator {
+  /// Creates an [InAppPurchaseValidator].
+  ///
+  /// [store] is injectable for tests; production code passes
+  /// [InAppPurchase.instance].
+  InAppPurchaseValidator({
+    InAppPurchase? store,
+    @visibleForTesting Set<String>? productIds,
+  }) : _store = store ?? InAppPurchase.instance,
+       _productIds = productIds ?? supporterProductIds;
+
+  final InAppPurchase _store;
+  final Set<String> _productIds;
+
+  StreamSubscription<List<PurchaseDetails>>? _subscription;
+  final StreamController<SupporterEntitlement> _entitlementController =
+      StreamController<SupporterEntitlement>.broadcast();
+
+  /// Pending purchase listeners keyed by product id, awaiting the matching
+  /// result on the purchase stream.
+  final Map<String, Completer<SupporterEntitlement>> _pendingPurchases = {};
+
+  bool _listening = false;
+
+  void _ensureListening() {
+    if (_listening) return;
+    _listening = true;
+    _subscription = _store.purchaseStream.listen(
+      _handlePurchaseStream,
+      onError: _entitlementController.addError,
+    );
+  }
+
+  void _handlePurchaseStream(List<PurchaseDetails> purchases) {
+    purchases.forEach(_processPurchase);
+  }
+
+  Future<void> _processPurchase(PurchaseDetails purchase) async {
+    final completer = _pendingPurchases.remove(purchase.productID);
+    switch (purchase.status) {
+      case PurchaseStatus.purchased:
+      case PurchaseStatus.restored:
+        final entitlement = _entitlementFromPurchase(purchase);
+        _entitlementController.add(entitlement);
+        await _completeSafely(purchase);
+        completer?.complete(entitlement);
+      case PurchaseStatus.error:
+        final exception = PurchaseFailedException(
+          purchase.error?.code,
+          purchase.error?.message ?? 'Purchase failed.',
+        );
+        completer?.completeError(exception);
+        _entitlementController.addError(exception);
+      case PurchaseStatus.canceled:
+        const exception = PurchaseFailedException(
+          null,
+          'Purchase was cancelled.',
+        );
+        completer?.completeError(exception);
+      case PurchaseStatus.pending:
+        // Still pending parental approval / payment settlement; keep waiting
+        // for the same completer on the next stream event.
+        if (completer != null) {
+          _pendingPurchases[purchase.productID] = completer;
+        }
+        _entitlementController.add(SupporterEntitlement.inactive);
+    }
+  }
+
+  Future<void> _completeSafely(PurchaseDetails purchase) async {
+    if (!purchase.pendingCompletePurchase) return;
+    try {
+      await _store.completePurchase(purchase);
+    } on Object {
+      // Swallow: completing the purchase is best-effort; the store will
+      // continue to deliver it until acknowledged.
+    }
+  }
+
+  SupporterEntitlement _entitlementFromPurchase(PurchaseDetails purchase) {
+    final now = DateTime.now();
+    return SupporterEntitlement(
+      productId: purchase.productID,
+      source: defaultTargetPlatform == TargetPlatform.iOS
+          ? EntitlementSource.appStore
+          : EntitlementSource.playStore,
+      purchaseDate: now,
+      // The plugin does not expose renewal/expiry dates uniformly across
+      // stores; the server-side validator (later) will supply authoritative
+      // expiry. We leave it null and treat active support as session-scoped
+      // for the client-first MVP.
+    );
+  }
+
+  @override
+  Future<bool> get isAvailable => _store.isAvailable();
+
+  @override
+  Future<List<SupporterTier>> fetchProducts() async {
+    if (!await _store.isAvailable()) {
+      throw const StoreUnavailableException();
+    }
+    if (_productIds.isEmpty) return const <SupporterTier>[];
+    final response = await _store.queryProductDetails(_productIds);
+    return response.productDetails.map(_tierFromProduct).toList();
+  }
+
+  SupporterTier _tierFromProduct(ProductDetails product) => SupporterTier(
+    productId: product.id,
+    title: product.title,
+    price: product.price,
+    currencyCode: product.currencyCode,
+    description: product.description,
+  );
+
+  @override
+  Future<SupporterEntitlement> purchase(String productId) async {
+    if (!await _store.isAvailable()) {
+      throw const StoreUnavailableException();
+    }
+    _ensureListening();
+
+    final completer = Completer<SupporterEntitlement>();
+    _pendingPurchases[productId] = completer;
+
+    final productDetails = await _store.queryProductDetails({productId});
+    final product = productDetails.productDetails.isEmpty
+        ? null
+        : productDetails.productDetails.first;
+
+    final initiated = await _store.buyNonConsumable(
+      purchaseParam: PurchaseParam(
+        productDetails: product ?? _placeholderProduct(productId),
+      ),
+    );
+    if (!initiated) {
+      _pendingPurchases.remove(productId);
+      throw const PurchaseFailedException(
+        null,
+        'Store did not start the purchase.',
+      );
+    }
+    return completer.future;
+  }
+
+  /// A fallback [ProductDetails] used only to satisfy [PurchaseParam] when the
+  /// product was fetched by id at purchase time but the store didn't return
+  /// its details. The store will reject the purchase if the id is invalid.
+  ProductDetails _placeholderProduct(String productId) {
+    return ProductDetails(
+      id: productId,
+      title: 'Divine Supporter',
+      description: '',
+      price: '',
+      rawPrice: 0,
+      currencyCode: '',
+    );
+  }
+
+  @override
+  Future<SupporterEntitlement> restorePurchases() async {
+    if (!await _store.isAvailable()) {
+      throw const StoreUnavailableException();
+    }
+    _ensureListening();
+    await _store.restorePurchases();
+
+    // Restored purchases are delivered on the purchase stream. We resolve to
+    // inactive synchronously and rely on the stream + repository cache to
+    // surface any restored entitlement, keeping restore non-blocking.
+    return SupporterEntitlement.inactive;
+  }
+
+  @override
+  Stream<SupporterEntitlement> get entitlementChanges =>
+      _entitlementController.stream;
+
+  @override
+  void dispose() {
+    unawaited(_subscription?.cancel());
+    _subscription = null;
+    _listening = false;
+    unawaited(_entitlementController.close());
+  }
+}

--- a/mobile/packages/iap_repository/lib/src/stub_entitlement_validator.dart
+++ b/mobile/packages/iap_repository/lib/src/stub_entitlement_validator.dart
@@ -1,0 +1,40 @@
+// ABOUTME: No-op EntitlementValidator for unsupported platforms (web).
+// ABOUTME: Always reports no store and an inactive entitlement.
+
+import 'dart:async';
+
+import 'package:iap_repository/src/entitlement_validator.dart';
+import 'package:iap_repository/src/exceptions.dart';
+import 'package:models/models.dart';
+
+/// EntitlementValidator that reports no store availability.
+///
+/// Used on platforms without an in-app purchase store (e.g. web) so the rest of
+/// the app can treat the supporter feature uniformly.
+class StubEntitlementValidator implements EntitlementValidator {
+  final StreamController<SupporterEntitlement> _controller =
+      StreamController<SupporterEntitlement>.broadcast();
+
+  @override
+  Future<bool> get isAvailable async => false;
+
+  @override
+  Future<List<SupporterTier>> fetchProducts() =>
+      Future.value(const <SupporterTier>[]);
+
+  @override
+  Future<SupporterEntitlement> purchase(String productId) =>
+      Future.error(const StoreUnavailableException());
+
+  @override
+  Future<SupporterEntitlement> restorePurchases() =>
+      Future.value(SupporterEntitlement.inactive);
+
+  @override
+  Stream<SupporterEntitlement> get entitlementChanges => _controller.stream;
+
+  @override
+  void dispose() {
+    unawaited(_controller.close());
+  }
+}

--- a/mobile/packages/iap_repository/pubspec.yaml
+++ b/mobile/packages/iap_repository/pubspec.yaml
@@ -1,0 +1,23 @@
+name: iap_repository
+description: In-app purchase store abstraction and client-first entitlement validation for Divine supporters.
+version: 0.1.0+1
+publish_to: none
+
+environment:
+  sdk: ^3.11.0
+
+resolution: workspace
+
+dependencies:
+  flutter:
+    sdk: flutter
+  in_app_purchase: ^3.2.0
+  meta: ^1.17.0
+  models:
+    path: ../models
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  mocktail: ^1.0.4
+  very_good_analysis: ^10.0.0

--- a/mobile/packages/iap_repository/test/exceptions_test.dart
+++ b/mobile/packages/iap_repository/test/exceptions_test.dart
@@ -1,0 +1,92 @@
+// ABOUTME: Tests for the EntitlementException hierarchy and StubEntitlementValidator.
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:iap_repository/iap_repository.dart';
+import 'package:models/models.dart';
+
+void main() {
+  group(EntitlementException, () {
+    test('StoreUnavailableException has stable kind', () {
+      const exception = StoreUnavailableException();
+      expect(exception.kind, 'StoreUnavailableException');
+      expect(exception.toString(), contains('StoreUnavailableException'));
+    });
+
+    test('PurchaseFailedException carries responseCode', () {
+      const exception = PurchaseFailedException('user_canceled', 'cancelled');
+      expect(exception.responseCode, 'user_canceled');
+      expect(exception.message, 'cancelled');
+    });
+
+    test('PurchaseFailedException tolerates null responseCode', () {
+      const exception = PurchaseFailedException(null, 'failed');
+      expect(exception.responseCode, isNull);
+    });
+
+    test('PurchasePendingException default message', () {
+      const exception = PurchasePendingException();
+      expect(exception.kind, 'PurchasePendingException');
+      expect(exception.message, isNotEmpty);
+    });
+
+    test('RestoreFailedException default message', () {
+      const exception = RestoreFailedException();
+      expect(exception.kind, 'RestoreFailedException');
+    });
+
+    test('all subtypes are EntitlementException', () {
+      expect(const StoreUnavailableException(), isA<EntitlementException>());
+      expect(
+        const PurchaseFailedException(null, 'x'),
+        isA<EntitlementException>(),
+      );
+      expect(
+        const PurchasePendingException(),
+        isA<EntitlementException>(),
+      );
+      expect(const RestoreFailedException(), isA<EntitlementException>());
+    });
+  });
+
+  group(StubEntitlementValidator, () {
+    late StubEntitlementValidator validator;
+
+    setUp(() {
+      validator = StubEntitlementValidator();
+    });
+
+    tearDown(() {
+      validator.dispose();
+    });
+
+    test('isAvailable is false', () async {
+      expect(await validator.isAvailable, isFalse);
+    });
+
+    test('fetchProducts returns empty list', () async {
+      expect(await validator.fetchProducts(), isEmpty);
+    });
+
+    test('purchase rejects with StoreUnavailableException', () async {
+      await expectLater(
+        validator.purchase('p'),
+        throwsA(isA<StoreUnavailableException>()),
+      );
+    });
+
+    test('restorePurchases resolves to inactive', () async {
+      final result = await validator.restorePurchases();
+      expect(result, equals(SupporterEntitlement.inactive));
+      expect(result.isSupporter, isFalse);
+    });
+
+    test('entitlementChanges is a broadcast stream', () {
+      expect(validator.entitlementChanges, isA<Stream<SupporterEntitlement>>());
+      // Listening twice (broadcast) does not throw.
+      validator.entitlementChanges.listen((_) {});
+      validator.entitlementChanges.listen((_) {});
+    });
+  });
+}

--- a/mobile/packages/iap_repository/test/in_app_purchase_validator_test.dart
+++ b/mobile/packages/iap_repository/test/in_app_purchase_validator_test.dart
@@ -1,0 +1,322 @@
+// ABOUTME: Tests for InAppPurchaseValidator store interactions + stream bridge.
+// ABOUTME: Mocks InAppPurchase via mocktail and drives the purchase stream.
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:iap_repository/iap_repository.dart';
+import 'package:in_app_purchase/in_app_purchase.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+
+class _MockInAppPurchase extends Mock implements InAppPurchase {}
+
+class _FakePurchaseParam extends Fake implements PurchaseParam {}
+
+class _FakePurchaseDetails extends Fake implements PurchaseDetails {}
+
+PurchaseDetails _purchase(
+  String productId, {
+  PurchaseStatus status = PurchaseStatus.purchased,
+  bool pendingComplete = false,
+}) {
+  return PurchaseDetails(
+    productID: productId,
+    status: status,
+    transactionDate: '0',
+    verificationData: PurchaseVerificationData(
+      localVerificationData: '',
+      serverVerificationData: '',
+      source: 'test',
+    ),
+  )..pendingCompletePurchase = pendingComplete;
+}
+
+/// A minimal fake [ProductDetails] for tests.
+ProductDetails _product(String id, {String price = '\$4.99'}) {
+  return ProductDetails(
+    id: id,
+    title: 'Divine Supporter',
+    description: 'Keep Divine running',
+    price: price,
+    rawPrice: 4.99,
+    currencyCode: 'USD',
+  );
+}
+
+void main() {
+  late _MockInAppPurchase store;
+  late InAppPurchaseValidator validator;
+
+  setUpAll(() {
+    registerFallbackValue(_FakePurchaseParam());
+    registerFallbackValue(_FakePurchaseDetails());
+  });
+
+  setUp(() {
+    store = _MockInAppPurchase();
+    validator = InAppPurchaseValidator(
+      store: store,
+      productIds: const {'divine.supporter.monthly'},
+    );
+  });
+
+  tearDown(() {
+    validator.dispose();
+  });
+
+  group(InAppPurchaseValidator, () {
+    test('isAvailable delegates to the store', () async {
+      when(store.isAvailable).thenAnswer((_) async => true);
+      expect(await validator.isAvailable, isTrue);
+
+      when(store.isAvailable).thenAnswer((_) async => false);
+      expect(await validator.isAvailable, isFalse);
+    });
+
+    group('fetchProducts', () {
+      test('throws StoreUnavailableException when store unavailable', () async {
+        when(store.isAvailable).thenAnswer((_) async => false);
+        await expectLater(
+          validator.fetchProducts(),
+          throwsA(isA<StoreUnavailableException>()),
+        );
+      });
+
+      test('maps ProductDetails to SupporterTier', () async {
+        when(store.isAvailable).thenAnswer((_) async => true);
+        when(() => store.queryProductDetails(any())).thenAnswer(
+          (_) async => ProductDetailsResponse(
+            productDetails: [_product('divine.supporter.monthly')],
+            notFoundIDs: [],
+          ),
+        );
+        final tiers = await validator.fetchProducts();
+        expect(tiers, hasLength(1));
+        expect(tiers.single.productId, 'divine.supporter.monthly');
+        expect(tiers.single.title, 'Divine Supporter');
+        expect(tiers.single.price, '\$4.99');
+        expect(tiers.single.currencyCode, 'USD');
+      });
+
+      test('returns empty when no products found', () async {
+        when(store.isAvailable).thenAnswer((_) async => true);
+        when(() => store.queryProductDetails(any())).thenAnswer(
+          (_) async => ProductDetailsResponse(
+            productDetails: const [],
+            notFoundIDs: ['divine.supporter.monthly'],
+          ),
+        );
+        expect(await validator.fetchProducts(), isEmpty);
+      });
+    });
+
+    group('purchase', () {
+      test('throws StoreUnavailableException when store unavailable', () async {
+        when(store.isAvailable).thenAnswer((_) async => false);
+        await expectLater(
+          validator.purchase('divine.supporter.monthly'),
+          throwsA(isA<StoreUnavailableException>()),
+        );
+      });
+
+      test(
+        'throws PurchaseFailedException when store fails to start',
+        () async {
+          when(store.isAvailable).thenAnswer((_) async => true);
+          when(() => store.queryProductDetails(any())).thenAnswer(
+            (_) async => ProductDetailsResponse(
+              productDetails: [_product('divine.supporter.monthly')],
+              notFoundIDs: const [],
+            ),
+          );
+          when(
+            () => store.buyNonConsumable(
+              purchaseParam: any(named: 'purchaseParam'),
+            ),
+          ).thenAnswer((_) async => false);
+          when(
+            () => store.purchaseStream,
+          ).thenAnswer((_) => const Stream<List<PurchaseDetails>>.empty());
+          await expectLater(
+            validator.purchase('divine.supporter.monthly'),
+            throwsA(isA<PurchaseFailedException>()),
+          );
+        },
+      );
+    });
+
+    group('purchase stream outcomes', () {
+      late StreamController<List<PurchaseDetails>> streamController;
+
+      setUp(() {
+        // Broadcast so the validator's subscription and the test can both listen.
+        streamController = StreamController<List<PurchaseDetails>>.broadcast();
+        when(store.isAvailable).thenAnswer((_) async => true);
+        when(
+          () => store.purchaseStream,
+        ).thenAnswer((_) => streamController.stream);
+        when(() => store.queryProductDetails(any())).thenAnswer(
+          (_) async => ProductDetailsResponse(
+            productDetails: [_product('divine.supporter.monthly')],
+            notFoundIDs: const [],
+          ),
+        );
+        when(
+          () => store.buyNonConsumable(
+            purchaseParam: any(named: 'purchaseParam'),
+          ),
+        ).thenAnswer((_) async => true);
+        when(() => store.completePurchase(any())).thenAnswer((_) async {});
+      });
+
+      tearDown(() => streamController.close());
+
+      // Flushes pending microtasks so purchase() finishes its internal awaits
+      // (queryProductDetails + buyNonConsumable) before we inject a stream event.
+      Future<void> pumpMicrotasks({int iterations = 5}) async {
+        for (var i = 0; i < iterations; i++) {
+          await Future<void>.delayed(Duration.zero);
+        }
+      }
+
+      test(
+        'purchased status resolves active entitlement and completes purchase',
+        () async {
+          final future = validator.purchase('divine.supporter.monthly');
+          await pumpMicrotasks();
+          streamController.add([
+            _purchase(
+              'divine.supporter.monthly',
+              status: PurchaseStatus.purchased,
+              pendingComplete: true,
+            ),
+          ]);
+          final result = await future.timeout(const Duration(seconds: 1));
+          expect(result.isActive, isTrue);
+          expect(result.productId, 'divine.supporter.monthly');
+          expect(result.isSupporter, isTrue);
+          verify(() => store.completePurchase(any())).called(1);
+        },
+      );
+
+      test('restored status resolves active entitlement', () async {
+        final future = validator.purchase('divine.supporter.monthly');
+        await pumpMicrotasks();
+        streamController.add([
+          _purchase(
+            'divine.supporter.monthly',
+            status: PurchaseStatus.restored,
+          ),
+        ]);
+        final result = await future.timeout(const Duration(seconds: 1));
+        expect(result.isActive, isTrue);
+      });
+
+      test('error status rejects with PurchaseFailedException', () async {
+        final future = validator.purchase('divine.supporter.monthly');
+        await pumpMicrotasks();
+        streamController.add([
+          _purchase(
+            'divine.supporter.monthly',
+            status: PurchaseStatus.error,
+          ),
+        ]);
+        await expectLater(
+          future,
+          throwsA(isA<PurchaseFailedException>()),
+        );
+      });
+
+      test('canceled status rejects with PurchaseFailedException', () async {
+        final future = validator.purchase('divine.supporter.monthly');
+        await pumpMicrotasks();
+        streamController.add([
+          _purchase(
+            'divine.supporter.monthly',
+            status: PurchaseStatus.canceled,
+          ),
+        ]);
+        await expectLater(
+          future,
+          throwsA(isA<PurchaseFailedException>()),
+        );
+      });
+
+      test(
+        'pending status keeps the purchase unresolved until purchased',
+        () async {
+          final future = validator.purchase('divine.supporter.monthly');
+          await pumpMicrotasks();
+          streamController.add([
+            _purchase(
+              'divine.supporter.monthly',
+              status: PurchaseStatus.pending,
+            ),
+          ]);
+          await pumpMicrotasks();
+          // Then resolve with a purchased event.
+          streamController.add([
+            _purchase(
+              'divine.supporter.monthly',
+              status: PurchaseStatus.purchased,
+            ),
+          ]);
+          final result = await future.timeout(const Duration(seconds: 1));
+          expect(result.isSupporter, isTrue);
+        },
+      );
+
+      test('entitlementChanges emits on purchase', () async {
+        final emitted = <SupporterEntitlement>[];
+        validator.entitlementChanges.listen(emitted.add);
+        final future = validator.purchase('divine.supporter.monthly');
+        await pumpMicrotasks();
+        streamController.add([
+          _purchase(
+            'divine.supporter.monthly',
+            status: PurchaseStatus.purchased,
+          ),
+        ]);
+        await future.timeout(const Duration(seconds: 1));
+        expect(emitted, isNotEmpty);
+        expect(emitted.last.isSupporter, isTrue);
+      });
+    });
+
+    group('restorePurchases', () {
+      test('throws StoreUnavailableException when store unavailable', () async {
+        when(store.isAvailable).thenAnswer((_) async => false);
+        await expectLater(
+          validator.restorePurchases(),
+          throwsA(isA<StoreUnavailableException>()),
+        );
+      });
+
+      test(
+        'resolves inactive and calls restorePurchases on the store',
+        () async {
+          when(store.isAvailable).thenAnswer((_) async => true);
+          when(
+            () => store.purchaseStream,
+          ).thenAnswer((_) => const Stream<List<PurchaseDetails>>.empty());
+          when(() => store.restorePurchases()).thenAnswer((_) async {});
+          final result = await validator.restorePurchases();
+          expect(result, equals(SupporterEntitlement.inactive));
+          verify(() => store.restorePurchases()).called(1);
+        },
+      );
+    });
+
+    test('dispose closes the entitlement stream', () async {
+      when(
+        () => store.purchaseStream,
+      ).thenAnswer((_) => const Stream<List<PurchaseDetails>>.empty());
+      // Trigger listener subscription then dispose.
+      validator.entitlementChanges.listen((_) {});
+      validator.dispose();
+      // Re-create to avoid tearDown double-dispose.
+      validator = InAppPurchaseValidator(store: store);
+    });
+  });
+}

--- a/mobile/packages/models/lib/models.dart
+++ b/mobile/packages/models/lib/models.dart
@@ -39,6 +39,8 @@ export 'src/profile_stats.dart';
 export 'src/ready_event_data.dart';
 export 'src/recommendations_response.dart';
 export 'src/social_counts.dart';
+export 'src/supporter_entitlement.dart';
+export 'src/supporter_tier.dart';
 export 'src/trending_hashtag.dart';
 export 'src/user_list.dart';
 export 'src/user_profile.dart';

--- a/mobile/packages/models/lib/src/supporter_entitlement.dart
+++ b/mobile/packages/models/lib/src/supporter_entitlement.dart
@@ -1,0 +1,163 @@
+// ABOUTME: Typed model representing a user's current supporter entitlement.
+// ABOUTME: Tracks purchase state and expiry for client-side validation.
+
+import 'package:meta/meta.dart';
+
+/// The platform that granted the entitlement.
+enum EntitlementSource {
+  /// Granted by StoreKit (iOS).
+  appStore,
+
+  /// Granted by Google Play Billing (Android).
+  playStore,
+
+  /// Granted by a server-side validation backend.
+  server,
+
+  /// No entitlement / unsupported platform.
+  none;
+
+  static EntitlementSource fromValue(Object? value) {
+    switch (value?.toString().trim().toLowerCase()) {
+      case 'app_store':
+      case 'appstore':
+        return EntitlementSource.appStore;
+      case 'play_store':
+      case 'playstore':
+        return EntitlementSource.playStore;
+      case 'server':
+        return EntitlementSource.server;
+      default:
+        return EntitlementSource.none;
+    }
+  }
+
+  String get value {
+    switch (this) {
+      case EntitlementSource.appStore:
+        return 'app_store';
+      case EntitlementSource.playStore:
+        return 'play_store';
+      case EntitlementSource.server:
+        return 'server';
+      case EntitlementSource.none:
+        return 'none';
+    }
+  }
+}
+
+/// Represents a user's supporter status at a point in time.
+///
+/// This is the single source of truth surfaced to the UI. For the client-first
+/// MVP it is derived from on-device purchase verification; the shape is
+/// designed so a server-side [EntitlementSource.server] can replace the source
+/// without changing consumers.
+@immutable
+class SupporterEntitlement {
+  const SupporterEntitlement({
+    required this.productId,
+    required this.source,
+    this.purchaseDate,
+    this.expirationDate,
+    this.isActive = true,
+  });
+
+  factory SupporterEntitlement.fromJson(Map<String, dynamic> json) {
+    final rawPurchase = json['purchaseDate'];
+    final rawExpiration = json['expirationDate'];
+    return SupporterEntitlement(
+      productId: json['productId'] as String? ?? '',
+      source: EntitlementSource.fromValue(json['source']),
+      purchaseDate: rawPurchase is String
+          ? DateTime.tryParse(rawPurchase)
+          : null,
+      expirationDate: rawExpiration is String
+          ? DateTime.tryParse(rawExpiration)
+          : null,
+      isActive: json['isActive'] as bool? ?? false,
+    );
+  }
+
+  /// Product identifier (SKU) of the active subscription, or '' when inactive.
+  final String productId;
+
+  /// Where this entitlement was verified.
+  final EntitlementSource source;
+
+  /// When the purchase was confirmed, or null when never purchased.
+  final DateTime? purchaseDate;
+
+  /// When the subscription expires/renews, or null for one-time or unknown.
+  final DateTime? expirationDate;
+
+  /// Whether the entitlement is currently in force (verified and not expired).
+  final bool isActive;
+
+  /// True when the entitlement has an expiry date that has passed.
+  bool get isExpired =>
+      expirationDate != null && DateTime.now().isAfter(expirationDate!);
+
+  /// True when this represents active, non-expired support.
+  bool get isSupporter => isActive && !isExpired;
+
+  SupporterEntitlement copyWith({
+    String? productId,
+    EntitlementSource? source,
+    DateTime? purchaseDate,
+    DateTime? expirationDate,
+    bool? isActive,
+  }) => SupporterEntitlement(
+    productId: productId ?? this.productId,
+    source: source ?? this.source,
+    purchaseDate: purchaseDate ?? this.purchaseDate,
+    expirationDate: expirationDate ?? this.expirationDate,
+    isActive: isActive ?? this.isActive,
+  );
+
+  /// A copy with [isActive] recomputed against the current clock. Used when
+  /// hydrating a cached entitlement on app launch.
+  SupporterEntitlement refreshed() => copyWith(
+    isActive: isActive && !isExpired,
+  );
+
+  Map<String, dynamic> toJson() => {
+    'productId': productId,
+    'source': source.value,
+    if (purchaseDate != null) 'purchaseDate': purchaseDate!.toIso8601String(),
+    if (expirationDate != null)
+      'expirationDate': expirationDate!.toIso8601String(),
+    'isActive': isActive,
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SupporterEntitlement &&
+          runtimeType == other.runtimeType &&
+          productId == other.productId &&
+          source == other.source &&
+          purchaseDate == other.purchaseDate &&
+          expirationDate == other.expirationDate &&
+          isActive == other.isActive;
+
+  @override
+  int get hashCode => Object.hash(
+    productId,
+    source,
+    purchaseDate,
+    expirationDate,
+    isActive,
+  );
+
+  /// An entitlement representing no active support.
+  static const SupporterEntitlement inactive = SupporterEntitlement(
+    productId: '',
+    source: EntitlementSource.none,
+    isActive: false,
+  );
+
+  @override
+  String toString() =>
+      'SupporterEntitlement(productId: $productId, source: $source, '
+      'isActive: $isActive, isSupporter: $isSupporter)';
+}

--- a/mobile/packages/models/lib/src/supporter_tier.dart
+++ b/mobile/packages/models/lib/src/supporter_tier.dart
@@ -1,0 +1,67 @@
+// ABOUTME: Typed model describing a Divine supporter subscription tier.
+// ABOUTME: Maps an in-app purchase product to a human-readable support offer.
+
+import 'package:meta/meta.dart';
+
+/// A purchasable supporter tier, backed by a StoreKit / Play Billing product.
+///
+/// The [productId] is the platform-specific SKU configured in App Store
+/// Connect and the Google Play Console. [price] and [currencyCode] come from
+/// the store's localized price for that product so we never hard-code amounts.
+@immutable
+class SupporterTier {
+  const SupporterTier({
+    required this.productId,
+    required this.title,
+    required this.price,
+    this.currencyCode,
+    this.description,
+  });
+
+  /// Platform-specific product identifier (SKU) from the store console.
+  final String productId;
+
+  /// Human-readable title shown to the user (from the store product).
+  final String title;
+
+  /// Localized display price as returned by the store (e.g. "$4.99").
+  final String price;
+
+  /// ISO 4217 currency code for the localized price, when known.
+  final String? currencyCode;
+
+  /// Optional marketing description of the tier.
+  final String? description;
+
+  Map<String, dynamic> toJson() => {
+    'productId': productId,
+    'title': title,
+    'price': price,
+    if (currencyCode != null) 'currencyCode': currencyCode,
+    if (description != null) 'description': description,
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SupporterTier &&
+          runtimeType == other.runtimeType &&
+          productId == other.productId &&
+          title == other.title &&
+          price == other.price &&
+          currencyCode == other.currencyCode &&
+          description == other.description;
+
+  @override
+  int get hashCode => Object.hash(
+    productId,
+    title,
+    price,
+    currencyCode,
+    description,
+  );
+
+  @override
+  String toString() =>
+      'SupporterTier(productId: $productId, title: $title, price: $price)';
+}

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1222,6 +1222,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.2"
+  in_app_purchase:
+    dependency: "direct main"
+    description:
+      name: in_app_purchase
+      sha256: "0e9510b80b0074e89ab0a8e0fc901439b779dc9ae575ab8d419253c6e1627716"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.3.0"
+  in_app_purchase_android:
+    dependency: transitive
+    description:
+      name: in_app_purchase_android
+      sha256: c04e2cad0470fc868cb0ea06477648f003220b1b6612909db83528ca83ac0905
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.2"
+  in_app_purchase_platform_interface:
+    dependency: transitive
+    description:
+      name: in_app_purchase_platform_interface
+      sha256: "0b0076cac8ce4fa7048f01e76af8b123aeb6a7c4e0dea2a5206d6664454f3e36"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.1"
+  in_app_purchase_storekit:
+    dependency: transitive
+    description:
+      name: in_app_purchase_storekit
+      sha256: "47d63717270133fcfa1ff8e144f6aaf9d498fa3884de43e24909737da55aedd8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.10+1"
   integration_test:
     dependency: "direct dev"
     description: flutter

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -54,6 +54,7 @@ workspace:
   - packages/funnelcake_api_client
   - packages/hashtag_repository
   - packages/image_metadata_stripper
+  - packages/iap_repository
   - packages/invite_api_client
   - packages/keycast_flutter
   - packages/likes_repository
@@ -158,6 +159,9 @@ dependencies:
   image_picker: ^1.2.0 # For selecting images from gallery or camera
   image_metadata_stripper:
     path: packages/image_metadata_stripper
+  in_app_purchase: ^3.2.0
+  iap_repository:
+    path: packages/iap_repository
   invite_api_client:
     path: packages/invite_api_client
   gal: ^2.3.2 # Save videos to device photo gallery

--- a/mobile/scripts/baseline/package_coverage_floors.txt
+++ b/mobile/scripts/baseline/package_coverage_floors.txt
@@ -34,6 +34,7 @@ follow_repository 100
 funnelcake_api_client 44
 hashtag_repository 30
 image_metadata_stripper 100
+iap_repository 90
 infinite_video_feed 100
 invite_api_client 89
 keycast_flutter 44

--- a/mobile/test/blocs/supporter/supporter_cubit_test.dart
+++ b/mobile/test/blocs/supporter/supporter_cubit_test.dart
@@ -1,0 +1,221 @@
+// ABOUTME: Tests for SupporterCubit — tier loading, subscribe, restore, failures.
+
+import 'dart:async';
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:iap_repository/iap_repository.dart';
+import 'package:models/models.dart';
+import 'package:openvine/blocs/supporter/supporter_cubit.dart';
+import 'package:openvine/blocs/supporter/supporter_state.dart';
+import 'package:openvine/services/supporter_repository.dart';
+
+class _FakeRepository extends Fake implements SupporterRepository {
+  _FakeRepository(this._controller);
+
+  final StreamController<SupporterEntitlement> _controller;
+
+  /// Typed validator so tests can configure fakes directly.
+  @override
+  final _FakeValidator validator = _FakeValidator();
+
+  @override
+  SupporterEntitlement get current => SupporterEntitlement.inactive;
+
+  @override
+  Stream<SupporterEntitlement> get changes => _controller.stream;
+}
+
+class _FakeValidator extends Fake implements EntitlementValidator {
+  List<SupporterTier> products = const [];
+  Object? fetchError;
+  Object? purchaseError;
+  SupporterEntitlement purchaseResult = SupporterEntitlement.inactive;
+  Object? restoreError;
+
+  @override
+  Future<List<SupporterTier>> fetchProducts() async {
+    if (fetchError != null) throw fetchError!;
+    return products;
+  }
+
+  @override
+  Future<SupporterEntitlement> purchase(String productId) async {
+    if (purchaseError != null) throw purchaseError!;
+    return purchaseResult;
+  }
+
+  @override
+  Future<SupporterEntitlement> restorePurchases() async {
+    if (restoreError != null) throw restoreError!;
+    return SupporterEntitlement.inactive;
+  }
+}
+
+void main() {
+  late StreamController<SupporterEntitlement> controller;
+
+  setUp(() {
+    controller = StreamController<SupporterEntitlement>.broadcast();
+  });
+
+  tearDown(() => controller.close());
+
+  blocTest<SupporterCubit, SupporterState>(
+    'loadTiers emits loading then tiers',
+    build: () {
+      final repo = _FakeRepository(controller);
+      repo.validator.products = [
+        const SupporterTier(
+          productId: 'divine.supporter.monthly',
+          title: 'Supporter',
+          price: r'$4.99',
+        ),
+      ];
+      return SupporterCubit(repository: repo);
+    },
+    act: (cubit) => cubit.loadTiers(),
+    expect: () => [
+      isA<SupporterState>().having(
+        (s) => s.status,
+        'status',
+        SupporterStatus.loading,
+      ),
+      isA<SupporterState>()
+          .having((s) => s.tiers, 'tiers', hasLength(1))
+          .having((s) => s.status, 'status', SupporterStatus.idle),
+    ],
+  );
+
+  blocTest<SupporterCubit, SupporterState>(
+    'loadTiers maps StoreUnavailableException to failure',
+    build: () {
+      final repo = _FakeRepository(controller);
+      repo.validator.products = [];
+      repo.validator.fetchError = const StoreUnavailableException();
+      return SupporterCubit(repository: repo);
+    },
+    act: (cubit) => cubit.loadTiers(),
+    skip: 1,
+    expect: () => [
+      isA<SupporterState>()
+          .having((s) => s.status, 'status', SupporterStatus.error)
+          .having(
+            (s) => s.failure,
+            'failure',
+            SupporterFailure.storeUnavailable,
+          ),
+    ],
+  );
+
+  blocTest<SupporterCubit, SupporterState>(
+    'subscribe emits purchasing then active on success',
+    build: () {
+      final repo = _FakeRepository(controller);
+      repo.validator.purchaseResult = SupporterEntitlement(
+        productId: 'divine.supporter.monthly',
+        source: EntitlementSource.appStore,
+        purchaseDate: DateTime.utc(2030),
+      );
+      return SupporterCubit(repository: repo);
+    },
+    act: (cubit) => cubit.subscribe('divine.supporter.monthly'),
+    expect: () => [
+      isA<SupporterState>().having(
+        (s) => s.status,
+        'status',
+        SupporterStatus.purchasing,
+      ),
+      isA<SupporterState>()
+          .having((s) => s.status, 'status', SupporterStatus.active)
+          .having((s) => s.isSupporter, 'isSupporter', isTrue),
+    ],
+  );
+
+  blocTest<SupporterCubit, SupporterState>(
+    'subscribe maps PurchaseFailedException to failure',
+    build: () {
+      final repo = _FakeRepository(controller);
+      repo.validator.purchaseError = const PurchaseFailedException(
+        'cancel',
+        'cancelled',
+      );
+      return SupporterCubit(repository: repo);
+    },
+    act: (cubit) => cubit.subscribe('divine.supporter.monthly'),
+    skip: 1,
+    expect: () => [
+      isA<SupporterState>()
+          .having((s) => s.status, 'status', SupporterStatus.idle)
+          .having(
+            (s) => s.failure,
+            'failure',
+            SupporterFailure.purchaseFailed,
+          ),
+    ],
+  );
+
+  blocTest<SupporterCubit, SupporterState>(
+    'restore emits restoring then idle on success',
+    build: () {
+      final repo = _FakeRepository(controller);
+      return SupporterCubit(repository: repo);
+    },
+    act: (cubit) => cubit.restore(),
+    expect: () => [
+      isA<SupporterState>().having(
+        (s) => s.status,
+        'status',
+        SupporterStatus.restoring,
+      ),
+      isA<SupporterState>().having(
+        (s) => s.status,
+        'status',
+        SupporterStatus.idle,
+      ),
+    ],
+  );
+
+  blocTest<SupporterCubit, SupporterState>(
+    'restore maps RestoreFailedException to failure',
+    build: () {
+      final repo = _FakeRepository(controller);
+      repo.validator.restoreError = const RestoreFailedException();
+      return SupporterCubit(repository: repo);
+    },
+    act: (cubit) => cubit.restore(),
+    skip: 1,
+    expect: () => [
+      isA<SupporterState>()
+          .having((s) => s.status, 'status', SupporterStatus.idle)
+          .having(
+            (s) => s.failure,
+            'failure',
+            SupporterFailure.restoreFailed,
+          ),
+    ],
+  );
+
+  test('SupporterFailure.fromMessage maps known substrings', () {
+    expect(
+      SupporterFailure.fromMessage('Store is unavailable.'),
+      SupporterFailure.storeUnavailable,
+    );
+    expect(
+      SupporterFailure.fromMessage('Purchase is pending.'),
+      SupporterFailure.purchasePending,
+    );
+    expect(
+      SupporterFailure.fromMessage('No subscription to restore.'),
+      SupporterFailure.restoreFailed,
+    );
+    expect(
+      SupporterFailure.fromMessage('Purchase was cancelled.'),
+      SupporterFailure.purchaseFailed,
+    );
+    expect(
+      SupporterFailure.fromMessage('something unexpected'),
+      SupporterFailure.unknown,
+    );
+  });
+}

--- a/mobile/test/models/supporter_models_test.dart
+++ b/mobile/test/models/supporter_models_test.dart
@@ -1,0 +1,151 @@
+// ABOUTME: Tests for SupporterTier and SupporterEntitlement models.
+// ABOUTME: Covers equality, JSON round-trip, expiry semantics, and inactive.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart';
+
+void main() {
+  group(SupporterTier, () {
+    test('toJson includes optional fields when present', () {
+      const tier = SupporterTier(
+        productId: 'divine.supporter.monthly',
+        title: 'Divine Supporter',
+        price: r'$4.99',
+        currencyCode: 'USD',
+        description: 'Keep Divine running',
+      );
+      final json = tier.toJson();
+      expect(json['productId'], 'divine.supporter.monthly');
+      expect(json['price'], r'$4.99');
+      expect(json['currencyCode'], 'USD');
+      expect(json['description'], 'Keep Divine running');
+    });
+
+    test('toJson omits null optional fields', () {
+      const tier = SupporterTier(
+        productId: 'p',
+        title: 't',
+        price: '1',
+      );
+      final json = tier.toJson();
+      expect(json.containsKey('currencyCode'), isFalse);
+      expect(json.containsKey('description'), isFalse);
+    });
+
+    test('equality and hashCode are value-based', () {
+      const a = SupporterTier(
+        productId: 'p',
+        title: 't',
+        price: '1',
+        currencyCode: 'USD',
+      );
+      const b = SupporterTier(
+        productId: 'p',
+        title: 't',
+        price: '1',
+        currencyCode: 'USD',
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+  });
+
+  group(SupporterEntitlement, () {
+    test('inactive is not a supporter', () {
+      expect(SupporterEntitlement.inactive.isSupporter, isFalse);
+      expect(SupporterEntitlement.inactive.isActive, isFalse);
+      expect(SupporterEntitlement.inactive.productId, isEmpty);
+    });
+
+    test('isSupporter true when active and not expired', () {
+      final e = SupporterEntitlement(
+        productId: 'p',
+        source: EntitlementSource.appStore,
+        purchaseDate: DateTime.utc(2026, 7, 15),
+        expirationDate: DateTime.utc(2030, 7, 15),
+      );
+      expect(e.isActive, isTrue);
+      expect(e.isExpired, isFalse);
+      expect(e.isSupporter, isTrue);
+    });
+
+    test('isExpired true when expirationDate in the past', () {
+      final e = SupporterEntitlement(
+        productId: 'p',
+        source: EntitlementSource.playStore,
+        expirationDate: DateTime.utc(2000, 7, 15),
+      );
+      expect(e.isExpired, isTrue);
+      expect(e.isSupporter, isFalse);
+    });
+
+    test('isSupporter false when explicitly inactive', () {
+      const e = SupporterEntitlement(
+        productId: 'p',
+        source: EntitlementSource.appStore,
+        isActive: false,
+      );
+      expect(e.isSupporter, isFalse);
+    });
+
+    test('refreshed flips isActive to false when expired', () {
+      final expired = SupporterEntitlement(
+        productId: 'p',
+        source: EntitlementSource.appStore,
+        expirationDate: DateTime.utc(2000, 7, 15),
+      );
+      expect(expired.refreshed().isActive, isFalse);
+    });
+
+    test('fromJson/toJson round trip', () {
+      final original = SupporterEntitlement(
+        productId: 'divine.supporter.monthly',
+        source: EntitlementSource.appStore,
+        purchaseDate: DateTime.utc(2026, 7, 23),
+        expirationDate: DateTime.utc(2026, 8, 23),
+      );
+      final decoded = SupporterEntitlement.fromJson(original.toJson());
+      expect(decoded.productId, original.productId);
+      expect(decoded.source, original.source);
+      expect(decoded.isActive, original.isActive);
+      expect(decoded.purchaseDate, original.purchaseDate);
+      expect(decoded.expirationDate, original.expirationDate);
+    });
+
+    test('fromJson tolerates missing fields', () {
+      final decoded = SupporterEntitlement.fromJson(const <String, dynamic>{});
+      expect(decoded.productId, isEmpty);
+      expect(decoded.source, EntitlementSource.none);
+      expect(decoded.isActive, isFalse);
+    });
+
+    test('EntitlementSource.fromValue parses variants', () {
+      expect(
+        EntitlementSource.fromValue('app_store'),
+        EntitlementSource.appStore,
+      );
+      expect(
+        EntitlementSource.fromValue('play_store'),
+        EntitlementSource.playStore,
+      );
+      expect(EntitlementSource.fromValue('server'), EntitlementSource.server);
+      expect(EntitlementSource.fromValue(null), EntitlementSource.none);
+      expect(EntitlementSource.fromValue('bogus'), EntitlementSource.none);
+    });
+
+    test('equality and hashCode are value-based', () {
+      final a = SupporterEntitlement(
+        productId: 'p',
+        source: EntitlementSource.appStore,
+        purchaseDate: DateTime.utc(2026, 7, 15),
+      );
+      final b = SupporterEntitlement(
+        productId: 'p',
+        source: EntitlementSource.appStore,
+        purchaseDate: DateTime.utc(2026, 7, 15),
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+  });
+}

--- a/mobile/test/screens/settings/supporter_screen_test.dart
+++ b/mobile/test/screens/settings/supporter_screen_test.dart
@@ -1,0 +1,157 @@
+// ABOUTME: Widget tests for SupporterScreen — rendering and status display.
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:iap_repository/iap_repository.dart';
+import 'package:models/models.dart';
+import 'package:openvine/blocs/supporter/supporter_cubit.dart';
+import 'package:openvine/blocs/supporter/supporter_state.dart';
+import 'package:openvine/providers/supporter_providers.dart';
+import 'package:openvine/screens/settings/supporter_screen.dart';
+import 'package:openvine/services/supporter_repository.dart';
+
+/// A minimal fake repository exposing the surface the screen reads.
+class _FakeRepository extends Fake implements SupporterRepository {
+  _FakeRepository(
+    this._controller, {
+    this.initial = SupporterEntitlement.inactive,
+  });
+
+  final StreamController<SupporterEntitlement> _controller;
+  final SupporterEntitlement initial;
+
+  @override
+  SupporterEntitlement get current => initial;
+
+  @override
+  Stream<SupporterEntitlement> get changes => _controller.stream;
+
+  @override
+  EntitlementValidator get validator => _EmptyValidator();
+}
+
+class _EmptyValidator extends Fake implements EntitlementValidator {
+  @override
+  Future<bool> get isAvailable async => false;
+
+  @override
+  Future<List<SupporterTier>> fetchProducts() async => const [];
+
+  @override
+  Future<SupporterEntitlement> purchase(String productId) async =>
+      SupporterEntitlement.inactive;
+
+  @override
+  Future<SupporterEntitlement> restorePurchases() async =>
+      SupporterEntitlement.inactive;
+
+  @override
+  Stream<SupporterEntitlement> get entitlementChanges =>
+      const Stream<SupporterEntitlement>.empty();
+}
+
+void main() {
+  testWidgets('renders hero copy and restore button when not a supporter', (
+    tester,
+  ) async {
+    final controller = StreamController<SupporterEntitlement>.broadcast();
+    addTearDown(controller.close);
+    final repo = _FakeRepository(controller);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          supporterRepositoryProvider.overrideWithValue(repo),
+        ],
+        child: const MaterialApp(home: SupporterScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Keep Divine running'), findsOneWidget);
+    expect(find.text('Restore purchases'), findsOneWidget);
+  });
+
+  testWidgets('shows active badge when entitlement is active', (tester) async {
+    final controller = StreamController<SupporterEntitlement>.broadcast();
+    addTearDown(controller.close);
+    final repo = _FakeRepository(
+      controller,
+      initial: SupporterEntitlement(
+        productId: 'divine.supporter.monthly',
+        source: EntitlementSource.appStore,
+        purchaseDate: DateTime.utc(2030),
+      ),
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          supporterRepositoryProvider.overrideWithValue(repo),
+        ],
+        child: const MaterialApp(home: SupporterScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining("You're a Divine Supporter"), findsOneWidget);
+  });
+
+  testWidgets('shows unavailable note when store has no tiers', (tester) async {
+    final controller = StreamController<SupporterEntitlement>.broadcast();
+    addTearDown(controller.close);
+    final repo = _FakeRepository(controller);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          supporterRepositoryProvider.overrideWithValue(repo),
+        ],
+        child: const MaterialApp(home: SupporterScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.textContaining('not available here right now'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('renders failure banner for an error state', (tester) async {
+    final controller = StreamController<SupporterEntitlement>.broadcast();
+    addTearDown(controller.close);
+    late SupporterCubit cubit;
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          supporterRepositoryProvider.overrideWithValue(
+            _FakeRepository(controller),
+          ),
+        ],
+        child: MaterialApp(
+          home: BlocProvider<SupporterCubit>(
+            create: (_) {
+              cubit = SupporterCubit(repository: _FakeRepository(controller));
+              return cubit;
+            },
+            child: const SupporterScreenView(),
+          ),
+        ),
+      ),
+    );
+    // Let start() + loadTiers() settle to idle, then surface a failure.
+    await tester.pumpAndSettle();
+    cubit.emit(
+      const SupporterState(failure: SupporterFailure.purchaseFailed),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('did not complete'), findsOneWidget);
+  });
+}

--- a/mobile/test/services/supporter_repository_test.dart
+++ b/mobile/test/services/supporter_repository_test.dart
@@ -1,0 +1,167 @@
+// ABOUTME: Tests for SupporterRepository caching + stream bridging.
+// ABOUTME: Uses a fake EntitlementValidator to drive entitlement changes.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:iap_repository/iap_repository.dart';
+import 'package:models/models.dart';
+import 'package:openvine/services/supporter_repository.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// A controllable fake validator that emits on a stream we own.
+class _FakeValidator implements EntitlementValidator {
+  _FakeValidator(this._controller);
+
+  final StreamController<SupporterEntitlement> _controller;
+  List<SupporterTier> products = const [];
+  SupporterEntitlement purchaseResult = SupporterEntitlement.inactive;
+
+  @override
+  Future<bool> get isAvailable async => true;
+
+  @override
+  Future<List<SupporterTier>> fetchProducts() async => products;
+
+  @override
+  Future<SupporterEntitlement> purchase(String productId) async =>
+      purchaseResult;
+
+  @override
+  Future<SupporterEntitlement> restorePurchases() async => purchaseResult;
+
+  @override
+  Stream<SupporterEntitlement> get entitlementChanges => _controller.stream;
+
+  void emit(SupporterEntitlement e) => _controller.add(e);
+
+  @override
+  void dispose() {}
+}
+
+void main() {
+  SharedPreferences.setMockInitialValues({});
+
+  group(SupporterRepository, () {
+    late _FakeValidator validator;
+    late StreamController<SupporterEntitlement> controller;
+
+    setUp(() {
+      // Reset the in-memory SharedPreferences between tests so writes in one
+      // test do not leak into the next (the mock persists across getInstance
+      // calls within a test process).
+      SharedPreferences.setMockInitialValues({});
+      controller = StreamController<SupporterEntitlement>.broadcast();
+      validator = _FakeValidator(controller);
+    });
+
+    tearDown(() {
+      controller.close();
+    });
+
+    test('loads inactive when no cache present', () async {
+      final prefs = await SharedPreferences.getInstance();
+      final repo = SupporterRepository(validator: validator, prefs: prefs);
+      addTearDown(repo.dispose);
+      expect(repo.current, equals(SupporterEntitlement.inactive));
+      expect(repo.isSupporter, isFalse);
+    });
+
+    test('hydrates cached entitlement on construction', () async {
+      final cached = SupporterEntitlement(
+        productId: 'divine.supporter.monthly',
+        source: EntitlementSource.appStore,
+        purchaseDate: DateTime.utc(2030),
+      ).toJson();
+      SharedPreferences.setMockInitialValues({
+        'divine_supporter_entitlement': jsonEncode(cached),
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final repo = SupporterRepository(validator: validator, prefs: prefs);
+      addTearDown(repo.dispose);
+      expect(repo.current.productId, 'divine.supporter.monthly');
+      expect(repo.isSupporter, isTrue);
+    });
+
+    test('marks expired cached entitlement inactive on load', () async {
+      final cached = SupporterEntitlement(
+        productId: 'divine.supporter.monthly',
+        source: EntitlementSource.appStore,
+        purchaseDate: DateTime.utc(2000),
+        expirationDate: DateTime.utc(2000, 2),
+      ).toJson();
+      SharedPreferences.setMockInitialValues({
+        'divine_supporter_entitlement': jsonEncode(cached),
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final repo = SupporterRepository(validator: validator, prefs: prefs);
+      addTearDown(repo.dispose);
+      expect(repo.isSupporter, isFalse);
+    });
+
+    test('updates current and persists when validator emits', () async {
+      final prefs = await SharedPreferences.getInstance();
+      final repo = SupporterRepository(validator: validator, prefs: prefs);
+      addTearDown(repo.dispose);
+
+      final emitted = <SupporterEntitlement>[];
+      repo.changes.listen(emitted.add);
+
+      validator.emit(
+        SupporterEntitlement(
+          productId: 'divine.supporter.monthly',
+          source: EntitlementSource.playStore,
+          purchaseDate: DateTime.utc(2030),
+        ),
+      );
+      // Allow the stream listener to fire.
+      await Future<void>.delayed(Duration.zero);
+
+      expect(repo.isSupporter, isTrue);
+      expect(emitted.last.isSupporter, isTrue);
+
+      final stored = prefs.getString('divine_supporter_entitlement');
+      expect(stored, isNotNull);
+      expect(stored, contains('divine.supporter.monthly'));
+    });
+
+    test('ignores duplicate emissions', () async {
+      final prefs = await SharedPreferences.getInstance();
+      final repo = SupporterRepository(validator: validator, prefs: prefs);
+      addTearDown(repo.dispose);
+
+      var emissions = 0;
+      repo.changes.listen((_) => emissions++);
+
+      validator.emit(SupporterEntitlement.inactive);
+      validator.emit(SupporterEntitlement.inactive);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(emissions, 0);
+    });
+
+    test('clearLocalEntitlement sets inactive and removes cache', () async {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(
+        'divine_supporter_entitlement',
+        jsonEncode(
+          SupporterEntitlement(
+            productId: 'p',
+            source: EntitlementSource.appStore,
+            purchaseDate: DateTime.utc(2030),
+          ).toJson(),
+        ),
+      );
+      final repo = SupporterRepository(validator: validator, prefs: prefs);
+      addTearDown(repo.dispose);
+
+      await repo.clearLocalEntitlement();
+      expect(repo.isSupporter, isFalse);
+      expect(
+        prefs.getString('divine_supporter_entitlement'),
+        isNull,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Closes #6379

## What

Adds an optional, **Signal-style monthly supporter subscription** behind a new `FeatureFlag.divineSupporters` (default **off**). Nothing is gated — it's recognition + funding only.

This is **Option A** (native IAP) from the supporter exploration, implemented **client-first**: on-device StoreKit / Play Billing validation today, with a clean `EntitlementValidator` interface so a server-side receipt-validation backend can slot in later without touching the UI or BLoC.

## Architecture (follows UI → Cubit → Repository → Client)

| Layer | File |
|---|---|
| Feature flag | `FeatureFlag.divineSupporters` + both `build_configuration` switches |
| Models | `SupporterTier`, `SupporterEntitlement` (in `packages/models`) |
| Store abstraction | **new** `packages/iap_repository`: `EntitlementValidator` interface, `InAppPurchaseValidator`, `StubEntitlementValidator`, typed exceptions |
| Service | `SupporterRepository` (cached entitlement in SharedPreferences) |
| Providers | `supporter_providers.dart` (`@riverpod`, selects validator by platform) |
| BLoC | `SupporterCubit` + `SupporterState` (Equatable, status + typed-failure enums) |
| UI | `SupporterScreen` + route + settings tile, all flag-gated |

## Tests
- `iap_repository` package: **26 tests, 96% coverage** (floor locked at 90)
- Models, repository, cubit, widget: **29 tests, all green**
- Pre-push hook (full analyze + suite) passed

## Manual prerequisites before flipping the flag on in a release
- **App Store Connect + Google Play Console**: create the `divine.supporter.monthly` product (SKU) in both stores.
- **iOS capability**: add the *In-App Purchase* capability to the `Runner` target (writes `com.apple.developer.in-app-purchases.payments` to `Runner.entitlements`) and refresh the signing profile. Intentionally **not** done in this PR — adding it now would break signing for everyone until the App ID is updated in the Apple Developer Portal. The Flutter plugin + Dart code work without it; only real purchases fail gracefully.
- **Android**: no manifest permission needed for Play Billing.

## Explicitly out of scope (follow-ups)
- Server-side receipt validation backend (the `EntitlementValidator` interface is designed for it; not built).
- NIP-58 "Divine Supporter" badge (deferred per the chosen direction; local flag ships first).
- Content/feature gating — none, by design (Signal-style).

## Risks
- Client-only entitlement for the MVP means no cross-device sync until the backend lands; restore relies on the store account.
- This is a business-model shift (currently documented as "funded by andotherstuff.org"). The flag ships off so it's pure exploration until product/release sign-off.