### PR TITLE
chore(deps): bump pro_image_editor to 13.2.3 for layer-align fix

### DIFF
--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1783,10 +1783,10 @@ packages:
     dependency: "direct main"
     description:
       name: pro_image_editor
-      sha256: "51252686737dcba47133d1a928b52fcba876c57ee81428cabeb22571520e9efd"
+      sha256: "80f3677566c29eec012ce3aafa7c06bc009c838fd733c72fa909579bf56b17df"
       url: "https://pub.dev"
     source: hosted
-    version: "13.2.0"
+    version: "13.2.3"
   pro_video_editor:
     dependency: "direct main"
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -319,7 +319,7 @@ dependencies:
   firebase_messaging: ^16.1.1
   audio_session: ^0.2.2
   pro_video_editor: ^2.6.0
-  pro_image_editor: ^13.2.0
+  pro_image_editor: ^13.2.3
   flutter_colorpicker: ^1.1.0
   file_picker: ^10.3.7
   sensors_plus: ^7.0.0


### PR DESCRIPTION
Closes #6383

## What

Bumps `pro_image_editor` from `13.2.0` → `13.2.3`.

## Why

Overlapping layers that shared the same position in the image editor were **trapped by their coincident snapping/alignment guides** — the guides kept re-snapping the layer to the stack, so you couldn't drag an overlapping layer away. `13.2.3` re-arms snapping only once the layer has moved clear, so a layer can now be dragged out of a coincident stack.

The bump also brings the two intermediate fixes:

- **13.2.2** — ignores the spurious scale-end Flutter fires when a finger is added/removed mid-gesture, which previously corrupted the history stack and crashed on iOS with a `_dependents.isEmpty` assertion (upstream #850).
- **13.2.1** — text-editor rounded background no longer grows/reflows the moment editing completes (upstream #849).

All three are `FIX`-only releases within the same major — no API changes, so no call-site edits were needed.