### PR TITLE
fix(video-editor): recover from export encoder-init failures

### DIFF
--- a/mobile/lib/constants/video_editor_constants.dart
+++ b/mobile/lib/constants/video_editor_constants.dart
@@ -191,6 +191,26 @@ class VideoEditorConstants {
   /// Video quality for recording and editing
   static const DivineVideoQuality quality = DivineVideoQuality.fhd;
 
+  /// Fallback export quality used after the device rejects the primary
+  /// [quality] with a `RenderEncoderException`.
+  ///
+  /// A 720p canvas needs far fewer encoder resources than 1080p, so a
+  /// codec-limited device that cannot allocate an [quality] encoder can still
+  /// finish the export at this reduced tier instead of losing the edit.
+  static const DivineVideoQuality encoderFallbackQuality =
+      DivineVideoQuality.hd;
+
+  /// Settle delay between export encoder attempts after a
+  /// `RenderEncoderException`.
+  ///
+  /// Encoder-init failures on codec-limited devices are usually transient
+  /// contention: the preview decoder the editor just released (the #5522
+  /// decoder-release gate) — or another app codec — has not been reclaimed by
+  /// the OS media server yet. The plugin's own in-process fallback chain runs
+  /// every attempt within a few hundred ms, so it cannot outlast that window;
+  /// waiting before the Dart-level retry lets the codec free up.
+  static const encoderRetrySettleDelay = Duration(milliseconds: 800);
+
   /// Hero animation tag for the back button in the video editor.
   static const heroBackButtonId = 'Video-Editor-Back-Button';
 

--- a/mobile/lib/services/video_editor/video_editor_render_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_render_service.dart
@@ -283,6 +283,8 @@ class VideoEditorRenderService {
   static final _compositeProgressController =
       StreamController<ProgressModel>.broadcast();
 
+  static final Set<String> _cancelledTaskIds = <String>{};
+
   @visibleForTesting
   static double proofModeProgressBudgetForClipCount(int clipCount) {
     final normalizedClipCount = clipCount < 1 ? 1 : clipCount;
@@ -311,7 +313,12 @@ class VideoEditorRenderService {
   @visibleForTesting
   static void resetActiveNativeTaskIdsForTesting() {
     NativeRenderTaskRegistry.reset();
+    _cancelledTaskIds.clear();
   }
+
+  @visibleForTesting
+  static bool isTaskCancellationRequestedForTesting(String taskId) =>
+      _cancelledTaskIds.contains(taskId);
 
   @visibleForTesting
   static void emitCompositeProgressForTesting({
@@ -1002,7 +1009,10 @@ class VideoEditorRenderService {
       ),
     );
 
-    await _cancelAndRender(outputPath, task);
+    await renderWithEncoderFallback(
+      baseTask: task,
+      encode: (attemptTask) => _cancelAndRender(outputPath, attemptTask),
+    );
 
     Log.debug(
       '✅ Clip ${clip.id} normalized to: $outputPath',
@@ -1119,8 +1129,8 @@ class VideoEditorRenderService {
 
     await renderWithEncoderFallback(
       baseTask: task,
-      aspectRatio: aspectRatio,
       encode: (attemptTask) => _cancelAndRender(outputPath, attemptTask),
+      fallbackAspectRatio: aspectRatio,
     );
 
     return outputPath;
@@ -1137,7 +1147,8 @@ class VideoEditorRenderService {
   /// — or another app codec — has not been reclaimed by the OS media server
   /// yet, and the plugin runs every attempt within a few hundred ms, so it
   /// cannot outlast that window. We retry at the Dart level with a
-  /// [settleDelay] (letting the codec free up), then once more at
+  /// [settleDelay] (letting the codec free up). When [fallbackAspectRatio] is
+  /// provided, it then retries once more at
   /// [VideoEditorConstants.encoderFallbackQuality] for devices genuinely at
   /// their 1080p encoder ceiling. Only if every attempt fails does the
   /// exception propagate to the UI's retry affordance (#6058).
@@ -1147,37 +1158,39 @@ class VideoEditorRenderService {
   @visibleForTesting
   static Future<void> renderWithEncoderFallback({
     required VideoRenderData baseTask,
-    required model.AspectRatio aspectRatio,
     required Future<void> Function(VideoRenderData task) encode,
+    model.AspectRatio? fallbackAspectRatio,
     Duration settleDelay = VideoEditorConstants.encoderRetrySettleDelay,
   }) async {
     const fallbackQuality = VideoEditorConstants.encoderFallbackQuality;
-    final reducedTask = baseTask.copyWith(
-      qualityConfig: VideoQualityConfig.custom(
-        bitrate: fallbackQuality.bitrate,
-        resolution: fallbackQuality.resolutionForAspectRatio(aspectRatio),
-      ),
-    );
+    final reducedTask = fallbackAspectRatio == null
+        ? null
+        : baseTask.copyWith(
+            qualityConfig: VideoQualityConfig.custom(
+              bitrate: fallbackQuality.bitrate,
+              resolution: fallbackQuality.resolutionForAspectRatio(
+                fallbackAspectRatio,
+              ),
+            ),
+          );
 
     final attempts = <({VideoRenderData task, Duration settle, bool reduced})>[
       (task: baseTask, settle: Duration.zero, reduced: false),
       (task: baseTask, settle: settleDelay, reduced: false),
-      (task: reducedTask, settle: settleDelay, reduced: true),
+      if (reducedTask != null)
+        (task: reducedTask, settle: settleDelay, reduced: true),
     ];
 
+    _cancelledTaskIds.remove(baseTask.id);
     for (var i = 0; i < attempts.length; i++) {
       final attempt = attempts[i];
-      // No native task is tracked during this settle window, so a teardown
-      // cancel (cancelActiveNativeTasks, AppLifecycleState.detached only) is a
-      // no-op here; the next attempt still starts and then fails/cancels
-      // against the torn-down state. A user cancel mid-encode throws
-      // RenderCanceledException, which isn't caught below and aborts the loop
-      // immediately.
       if (attempt.settle > Duration.zero) {
         await Future<void>.delayed(attempt.settle);
       }
+      _throwIfCancellationRequested(baseTask.id);
       try {
         await encode(attempt.task);
+        _throwIfCancellationRequested(baseTask.id);
         return;
       } on RenderEncoderException catch (e) {
         final isLast = i == attempts.length - 1;
@@ -1190,6 +1203,12 @@ class VideoEditorRenderService {
         );
         if (isLast) rethrow;
       }
+    }
+  }
+
+  static void _throwIfCancellationRequested(String taskId) {
+    if (_cancelledTaskIds.remove(taskId)) {
+      throw const RenderCanceledException();
     }
   }
 
@@ -1302,6 +1321,11 @@ class VideoEditorRenderService {
   }
 
   static Future<void> cancelTask(String id) async {
+    _cancelledTaskIds.add(id);
+    await _cancelNativeTaskOnly(id);
+  }
+
+  static Future<void> _cancelNativeTaskOnly(String id) async {
     try {
       Log.info(
         '⏹️ Cancelling video render',
@@ -1336,7 +1360,8 @@ class VideoEditorRenderService {
     // #4801 diagnostics while clean renders stay quiet.
     NativeLogLevel? nativeLogLevel = NativeLogLevel.warning,
   }) async {
-    await cancelTask(task.id);
+    _cancelledTaskIds.remove(task.id);
+    await _cancelNativeTaskOnly(task.id);
     return NativeRenderTaskRegistry.track(task.id, () {
       return ProVideoEditor.instance.renderVideoToFile(
         outputPath,

--- a/mobile/lib/services/video_editor/video_editor_render_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_render_service.dart
@@ -1117,9 +1117,74 @@ class VideoEditorRenderService {
           : null,
     );
 
-    await _cancelAndRender(outputPath, task);
+    await renderWithEncoderFallback(
+      baseTask: task,
+      aspectRatio: aspectRatio,
+      encode: (attemptTask) => _cancelAndRender(outputPath, attemptTask),
+    );
 
     return outputPath;
+  }
+
+  /// Runs the export [encode] for [baseTask], recovering from device
+  /// encoder-init failures (`RenderEncoderException`).
+  ///
+  /// The exception signals that `pro_video_editor`'s own in-process fallback
+  /// chain (operating-rate cap/removal, software encoder, profile downgrade)
+  /// could not initialise an encoder. On codec-limited devices that is usually
+  /// transient contention rather than a true format incompatibility: the
+  /// preview decoder the editor just released (the #5522 decoder-release gate)
+  /// — or another app codec — has not been reclaimed by the OS media server
+  /// yet, and the plugin runs every attempt within a few hundred ms, so it
+  /// cannot outlast that window. We retry at the Dart level with a
+  /// [settleDelay] (letting the codec free up), then once more at
+  /// [VideoEditorConstants.encoderFallbackQuality] for devices genuinely at
+  /// their 1080p encoder ceiling. Only if every attempt fails does the
+  /// exception propagate to the UI's retry affordance (#6058).
+  ///
+  /// The happy path pays no extra latency: the first attempt runs immediately
+  /// and only failures incur a settle.
+  @visibleForTesting
+  static Future<void> renderWithEncoderFallback({
+    required VideoRenderData baseTask,
+    required model.AspectRatio aspectRatio,
+    required Future<void> Function(VideoRenderData task) encode,
+    Duration settleDelay = VideoEditorConstants.encoderRetrySettleDelay,
+  }) async {
+    const fallbackQuality = VideoEditorConstants.encoderFallbackQuality;
+    final reducedTask = baseTask.copyWith(
+      qualityConfig: VideoQualityConfig.custom(
+        bitrate: fallbackQuality.bitrate,
+        resolution: fallbackQuality.resolutionForAspectRatio(aspectRatio),
+      ),
+    );
+
+    final attempts = <({VideoRenderData task, Duration settle, bool reduced})>[
+      (task: baseTask, settle: Duration.zero, reduced: false),
+      (task: baseTask, settle: settleDelay, reduced: false),
+      (task: reducedTask, settle: settleDelay, reduced: true),
+    ];
+
+    for (var i = 0; i < attempts.length; i++) {
+      final attempt = attempts[i];
+      if (attempt.settle > Duration.zero) {
+        await Future<void>.delayed(attempt.settle);
+      }
+      try {
+        await encode(attempt.task);
+        return;
+      } on RenderEncoderException catch (e) {
+        final isLast = i == attempts.length - 1;
+        Log.warning(
+          '⚠️ Export encoder init failed on attempt ${i + 1}/${attempts.length}'
+          '${attempt.reduced ? ' (reduced resolution)' : ''}'
+          '${isLast ? '' : '; retrying'}: $e',
+          name: _logName,
+          category: .video,
+        );
+        if (isLast) rethrow;
+      }
+    }
   }
 
   /// Builds the [ImageLayer]s composited over the exported video from the

--- a/mobile/lib/services/video_editor/video_editor_render_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_render_service.dart
@@ -1167,6 +1167,12 @@ class VideoEditorRenderService {
 
     for (var i = 0; i < attempts.length; i++) {
       final attempt = attempts[i];
+      // No native task is tracked during this settle window, so a teardown
+      // cancel (cancelActiveNativeTasks, AppLifecycleState.detached only) is a
+      // no-op here; the next attempt still starts and then fails/cancels
+      // against the torn-down state. A user cancel mid-encode throws
+      // RenderCanceledException, which isn't caught below and aborts the loop
+      // immediately.
       if (attempt.settle > Duration.zero) {
         await Future<void>.delayed(attempt.settle);
       }

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerPlugin.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerPlugin.kt
@@ -168,11 +168,16 @@ class DivineVideoPlayerPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, 
             }
             "dispose" -> {
                 val id = call.argument<Int>("id")!!
+                // Release the native player first, then log — the log then
+                // truthfully marks codec-release completion. Emitting it before
+                // release makes teardown look finished while the hardware codec
+                // is still held, which misreads export encoder-init races on
+                // codec-limited devices (the #5522 decoder-release gate).
+                PlayerRegistry.remove(id)?.dispose()
                 DivineVideoPlayerLog.info(
                     "Player $id disposed",
                     name = "DivineVideoPlayer.Lifecycle",
                 )
-                PlayerRegistry.remove(id)?.dispose()
                 result.success(null)
             }
             "preload" -> {

--- a/mobile/test/services/video_editor/video_editor_render_service_test.dart
+++ b/mobile/test/services/video_editor/video_editor_render_service_test.dart
@@ -9,12 +9,22 @@ import 'dart:ui' show Offset, Size;
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart' as model;
+import 'package:openvine/constants/video_editor_constants.dart';
+import 'package:openvine/extensions/aspect_ratio_extensions.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/video_editor/transition_geometry.dart';
 import 'package:openvine/services/video_editor/video_editor_render_service.dart';
 import 'package:pro_image_editor/pro_image_editor.dart' as pie;
 import 'package:pro_video_editor/pro_video_editor.dart'
-    show ClipTransition, ClipTransitionType, EditorVideo;
+    show
+        ClipTransition,
+        ClipTransitionType,
+        EditorVideo,
+        RenderCanceledException,
+        RenderEncoderException,
+        VideoQualityConfig,
+        VideoRenderData,
+        VideoSegment;
 
 void main() {
   DivineVideoClip clip(
@@ -239,6 +249,134 @@ void main() {
 
       expect(filters.single.startTime, isNull);
       expect(filters.single.endTime, isNull);
+    });
+  });
+
+  group('renderWithEncoderFallback', () {
+    const aspectRatio = model.AspectRatio.vertical;
+    final baseResolution = VideoEditorConstants.quality
+        .resolutionForAspectRatio(aspectRatio);
+    final fallbackResolution = VideoEditorConstants.encoderFallbackQuality
+        .resolutionForAspectRatio(aspectRatio);
+
+    VideoRenderData baseTask() => VideoRenderData(
+      id: 'render-task',
+      videoSegments: [
+        VideoSegment(
+          video: EditorVideo.file('${Directory.systemTemp.path}/a.mp4'),
+        ),
+      ],
+      qualityConfig: VideoQualityConfig.custom(
+        bitrate: VideoEditorConstants.quality.bitrate,
+        resolution: baseResolution,
+      ),
+    );
+
+    /// An encode that throws [RenderEncoderException] for its first
+    /// [failuresBeforeSuccess] calls, then succeeds, recording every task it
+    /// was handed.
+    ({
+      Future<void> Function(VideoRenderData) encode,
+      List<VideoRenderData> calls,
+    })
+    flakyEncoder({required int failuresBeforeSuccess}) {
+      final calls = <VideoRenderData>[];
+      Future<void> encode(VideoRenderData task) async {
+        calls.add(task);
+        if (calls.length <= failuresBeforeSuccess) {
+          throw const RenderEncoderException('encoder init failed');
+        }
+      }
+
+      return (encode: encode, calls: calls);
+    }
+
+    test('encodes once at full resolution when the first attempt '
+        'succeeds', () async {
+      final harness = flakyEncoder(failuresBeforeSuccess: 0);
+
+      await VideoEditorRenderService.renderWithEncoderFallback(
+        baseTask: baseTask(),
+        aspectRatio: aspectRatio,
+        encode: harness.encode,
+        settleDelay: Duration.zero,
+      );
+
+      expect(harness.calls, hasLength(1));
+      expect(harness.calls.single.qualityConfig?.resolution, baseResolution);
+    });
+
+    test('retries at full resolution after a single encoder failure', () async {
+      final harness = flakyEncoder(failuresBeforeSuccess: 1);
+
+      await VideoEditorRenderService.renderWithEncoderFallback(
+        baseTask: baseTask(),
+        aspectRatio: aspectRatio,
+        encode: harness.encode,
+        settleDelay: Duration.zero,
+      );
+
+      expect(harness.calls, hasLength(2));
+      expect(
+        harness.calls.map((t) => t.qualityConfig?.resolution),
+        everyElement(baseResolution),
+      );
+    });
+
+    test('falls back to the reduced resolution on the third attempt', () async {
+      final harness = flakyEncoder(failuresBeforeSuccess: 2);
+
+      await VideoEditorRenderService.renderWithEncoderFallback(
+        baseTask: baseTask(),
+        aspectRatio: aspectRatio,
+        encode: harness.encode,
+        settleDelay: Duration.zero,
+      );
+
+      expect(harness.calls, hasLength(3));
+      expect(harness.calls[0].qualityConfig?.resolution, baseResolution);
+      expect(harness.calls[1].qualityConfig?.resolution, baseResolution);
+      expect(harness.calls[2].qualityConfig?.resolution, fallbackResolution);
+      expect(
+        harness.calls[2].qualityConfig?.bitrate,
+        VideoEditorConstants.encoderFallbackQuality.bitrate,
+      );
+    });
+
+    test('rethrows after every attempt fails', () async {
+      final harness = flakyEncoder(failuresBeforeSuccess: 3);
+
+      await expectLater(
+        VideoEditorRenderService.renderWithEncoderFallback(
+          baseTask: baseTask(),
+          aspectRatio: aspectRatio,
+          encode: harness.encode,
+          settleDelay: Duration.zero,
+        ),
+        throwsA(isA<RenderEncoderException>()),
+      );
+
+      expect(harness.calls, hasLength(3));
+    });
+
+    test('does not retry non-encoder failures', () async {
+      var calls = 0;
+      Future<void> encode(VideoRenderData task) async {
+        calls++;
+        throw const RenderCanceledException();
+      }
+
+      await expectLater(
+        VideoEditorRenderService.renderWithEncoderFallback(
+          baseTask: baseTask(),
+          aspectRatio: aspectRatio,
+          encode: encode,
+          settleDelay: Duration.zero,
+        ),
+        throwsA(isA<RenderCanceledException>()),
+      );
+
+      expect(calls, 1);
     });
   });
 }

--- a/mobile/test/services/video_editor/video_editor_render_service_test.dart
+++ b/mobile/test/services/video_editor/video_editor_render_service_test.dart
@@ -3,10 +3,12 @@
 // ABOUTME: timeline mapping applied to layers, tune adjustments and filters at
 // ABOUTME: export.
 
+import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 import 'dart:ui' show Offset, Size;
 
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart' as model;
 import 'package:openvine/constants/video_editor_constants.dart';
@@ -377,6 +379,38 @@ void main() {
       );
 
       expect(calls, 1);
+    });
+
+    test('runs the first attempt immediately and waits settleDelay '
+        'before each retry', () {
+      fakeAsync((async) {
+        const settle = VideoEditorConstants.encoderRetrySettleDelay;
+        final harness = flakyEncoder(failuresBeforeSuccess: 2);
+
+        unawaited(
+          VideoEditorRenderService.renderWithEncoderFallback(
+            baseTask: baseTask(),
+            aspectRatio: aspectRatio,
+            encode: harness.encode,
+          ),
+        );
+
+        // First attempt pays no delay.
+        async.flushMicrotasks();
+        expect(harness.calls, hasLength(1));
+
+        // The retry waits out the full settle window before firing.
+        async.elapse(settle - const Duration(milliseconds: 1));
+        expect(harness.calls, hasLength(1));
+        async.elapse(const Duration(milliseconds: 1));
+        expect(harness.calls, hasLength(2));
+
+        // The reduced-resolution attempt waits another settle window.
+        async.elapse(settle - const Duration(milliseconds: 1));
+        expect(harness.calls, hasLength(2));
+        async.elapse(const Duration(milliseconds: 1));
+        expect(harness.calls, hasLength(3));
+      });
     });
   });
 }

--- a/mobile/test/services/video_editor/video_editor_render_service_test.dart
+++ b/mobile/test/services/video_editor/video_editor_render_service_test.dart
@@ -255,6 +255,8 @@ void main() {
   });
 
   group('renderWithEncoderFallback', () {
+    tearDown(VideoEditorRenderService.resetActiveNativeTaskIdsForTesting);
+
     const aspectRatio = model.AspectRatio.vertical;
     final baseResolution = VideoEditorConstants.quality
         .resolutionForAspectRatio(aspectRatio);
@@ -299,8 +301,8 @@ void main() {
 
       await VideoEditorRenderService.renderWithEncoderFallback(
         baseTask: baseTask(),
-        aspectRatio: aspectRatio,
         encode: harness.encode,
+        fallbackAspectRatio: aspectRatio,
         settleDelay: Duration.zero,
       );
 
@@ -313,8 +315,8 @@ void main() {
 
       await VideoEditorRenderService.renderWithEncoderFallback(
         baseTask: baseTask(),
-        aspectRatio: aspectRatio,
         encode: harness.encode,
+        fallbackAspectRatio: aspectRatio,
         settleDelay: Duration.zero,
       );
 
@@ -330,8 +332,8 @@ void main() {
 
       await VideoEditorRenderService.renderWithEncoderFallback(
         baseTask: baseTask(),
-        aspectRatio: aspectRatio,
         encode: harness.encode,
+        fallbackAspectRatio: aspectRatio,
         settleDelay: Duration.zero,
       );
 
@@ -351,8 +353,8 @@ void main() {
       await expectLater(
         VideoEditorRenderService.renderWithEncoderFallback(
           baseTask: baseTask(),
-          aspectRatio: aspectRatio,
           encode: harness.encode,
+          fallbackAspectRatio: aspectRatio,
           settleDelay: Duration.zero,
         ),
         throwsA(isA<RenderEncoderException>()),
@@ -371,14 +373,102 @@ void main() {
       await expectLater(
         VideoEditorRenderService.renderWithEncoderFallback(
           baseTask: baseTask(),
-          aspectRatio: aspectRatio,
           encode: encode,
+          fallbackAspectRatio: aspectRatio,
           settleDelay: Duration.zero,
         ),
         throwsA(isA<RenderCanceledException>()),
       );
 
       expect(calls, 1);
+    });
+
+    test(
+      'uses only the settle retry when reduced fallback is disabled',
+      () async {
+        final harness = flakyEncoder(failuresBeforeSuccess: 2);
+
+        await expectLater(
+          VideoEditorRenderService.renderWithEncoderFallback(
+            baseTask: baseTask(),
+            encode: harness.encode,
+            settleDelay: Duration.zero,
+          ),
+          throwsA(isA<RenderEncoderException>()),
+        );
+
+        expect(harness.calls, hasLength(2));
+        expect(
+          harness.calls.map((t) => t.qualityConfig?.resolution),
+          everyElement(baseResolution),
+        );
+      },
+    );
+
+    test('honors cancellation recorded during the settle window', () {
+      fakeAsync((async) {
+        const settle = VideoEditorConstants.encoderRetrySettleDelay;
+        final harness = flakyEncoder(failuresBeforeSuccess: 1);
+        Object? caught;
+
+        unawaited(
+          VideoEditorRenderService.renderWithEncoderFallback(
+            baseTask: baseTask(),
+            encode: harness.encode,
+            fallbackAspectRatio: aspectRatio,
+          ).catchError((Object error) {
+            caught = error;
+          }),
+        );
+
+        async.flushMicrotasks();
+        expect(harness.calls, hasLength(1));
+
+        unawaited(VideoEditorRenderService.cancelTask('render-task'));
+        expect(
+          VideoEditorRenderService.isTaskCancellationRequestedForTesting(
+            'render-task',
+          ),
+          isTrue,
+        );
+
+        async.elapse(settle);
+        async.flushMicrotasks();
+
+        expect(caught, isA<RenderCanceledException>());
+        expect(harness.calls, hasLength(1));
+        expect(
+          VideoEditorRenderService.isTaskCancellationRequestedForTesting(
+            'render-task',
+          ),
+          isFalse,
+        );
+      });
+    });
+
+    test('honors cancellation recorded while encode is running', () async {
+      var calls = 0;
+
+      await expectLater(
+        VideoEditorRenderService.renderWithEncoderFallback(
+          baseTask: baseTask(),
+          encode: (task) async {
+            calls++;
+            unawaited(VideoEditorRenderService.cancelTask(task.id));
+          },
+          fallbackAspectRatio: aspectRatio,
+          settleDelay: Duration.zero,
+        ),
+        throwsA(isA<RenderCanceledException>()),
+      );
+
+      expect(calls, 1);
+      expect(
+        VideoEditorRenderService.isTaskCancellationRequestedForTesting(
+          'render-task',
+        ),
+        isFalse,
+      );
     });
 
     test('runs the first attempt immediately and waits settleDelay '
@@ -390,8 +480,8 @@ void main() {
         unawaited(
           VideoEditorRenderService.renderWithEncoderFallback(
             baseTask: baseTask(),
-            aspectRatio: aspectRatio,
             encode: harness.encode,
+            fallbackAspectRatio: aspectRatio,
           ),
         );
 


### PR DESCRIPTION
Closes #6385

## Description

Multi-clip exports could fail outright with `RenderEncoderException` (`ERROR_CODE_ENCODER_INIT_FAILED`) on codec-limited devices, dropping the whole edit to a draft with only a `Video render cancelled or failed` warning.

Device logs told the real story: the encoder failed every fallback attempt (operating-rate cap/removal, software encoder, profile downgrade) within ~250 ms, right after the editor's preview decoder was released, and `DECODING_RESOURCES_RECLAIMED` errors showed up during editing. That points to transient MediaCodec contention / genuine device codec pressure, not a real format incompatibility. The plugin's own in-process fallback chain runs all its attempts in that same narrow window, so it can never outlast the codec-reclaim latency.

The fix, in `renderWithEncoderFallback`:

- Attempt 1: immediately, full config. The happy path pays zero extra latency.
- Attempt 2: after a settle delay, same config. Defeats the codec-reclaim race.
- Attempt 3: for final composite exports only, after another settle delay at reduced resolution (FHD -> HD/720p). Covers devices genuinely at their 1080p encoder ceiling.
- Mixed-resolution normalization encodes now use the settle retry too, without forcing a reduced final export canvas.
- User/teardown cancels recorded during a settle window or an active encode abort the retry loop instead of starting or accepting a later encode.
- Non-encoder failures, including `RenderCanceledException`, are not retried.

Native log accuracy: the Android `dispose` handler emitted its lifecycle log before the actual `release()`, so teardown looked finished while the hardware codec could still be held. This moves the log after release so it marks codec-release completion truthfully.

The primary UI-side "release the preview decoder before the export encoder" ordering already exists (the #5522 decoder-release gate); this PR is the recovery path for residual device-pressure failures that the gate cannot prevent.

## Out of Scope

- Product/analytics treatment for silent 720p fallback frequency. This PR keeps the existing save-the-edit behavior and logs retry attempts; export-quality telemetry can be added with the broader analytics work.
- Deeper coordination between export start and navigation-observer decoder teardown. The retry/cancel handling here keeps the fix local to the render pipeline.

## Verification

- `flutter test test/services/video_editor/video_editor_render_service_test.dart` — 20/20 pass
- `flutter analyze lib/services/video_editor/video_editor_render_service.dart test/services/video_editor/video_editor_render_service_test.dart` — No issues found
- Pre-push hook: changed-file analyzer and `test/services/video_editor/video_editor_render_service_test.dart` — pass

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)