### PR TITLE
feat(dm): pin a Divine Moderation support row at the top of the inbox

### DIFF
--- a/mobile/lib/blocs/dm/conversation_list/conversation_list_bloc.dart
+++ b/mobile/lib/blocs/dm/conversation_list/conversation_list_bloc.dart
@@ -30,7 +30,6 @@ class ConversationListBloc
     ProtectedMinorInboxGate? protectedMinorInboxGate,
     Duration recomputeDebounce = _defaultRecomputeDebounce,
     String? supportRowPubkey,
-    List<String> supportRowLegacyPubkeys = const [],
   }) : _dmRepository = dmRepository,
        _followRepository = followRepository,
        _blocklistRepository = contentBlocklistRepository,
@@ -38,7 +37,6 @@ class ConversationListBloc
        _protectedMinorInboxGate = protectedMinorInboxGate,
        _recomputeDebounce = recomputeDebounce,
        _supportRowPubkey = supportRowPubkey,
-       _supportRowLegacyPubkeys = supportRowLegacyPubkeys,
        super(const ConversationListState()) {
     on<ConversationListStarted>(_onStarted, transformer: restartable());
     on<ConversationListLoadMore>(_onLoadMore, transformer: droppable());
@@ -79,12 +77,6 @@ class ConversationListBloc
   /// Moderation pubkey the pinned support row targets, injected rather than
   /// imported so this bloc stays free of app-layer config (#6283).
   final String? _supportRowPubkey;
-
-  /// Historical moderation pubkeys. Used for de-duplication only, never as a
-  /// send target: a user who messaged moderation before the #2321 key rotation
-  /// still holds that thread, and without this it would render beside the
-  /// pinned row as a second "Divine Moderation" entry.
-  final List<String> _supportRowLegacyPubkeys;
 
   /// Window over which bursty conversation writes are coalesced before the
   /// list is re-composed. The combined stream re-runs `classifyPotentialRequests`
@@ -490,8 +482,13 @@ class ConversationListBloc
   /// the pin renders no timestamp and is not sorted with the list.
   static const _pinnedSupportEpoch = 0;
 
-  /// Extract the pinned Divine Moderation row and remove every conversation it
-  /// stands in for from the lists they would otherwise render in (#6283).
+  /// Extract the pinned Divine Moderation row, lifting the thread it adopts out
+  /// of the list it would otherwise render in (#6283).
+  ///
+  /// Only the thread on the CURRENT moderation key is lifted. A thread on a
+  /// key the account has rotated away from stays put and renders as an ordinary
+  /// row, so its enforcement history keeps an in-app entry point until #6416
+  /// gives it an archived read-only presentation.
   ///
   /// Called with lists that have ALREADY passed the blocklist filter and the
   /// protected-minor gate, so an existing moderation thread that those filters
@@ -514,7 +511,6 @@ class ConversationListBloc
     final split = DmRepository.extractPinnedSupport(
       userPubkey: userPubkey,
       supportPubkey: supportPubkey,
-      legacyPubkeys: _supportRowLegacyPubkeys,
       inbox: inbox,
       requests: requests,
     );

--- a/mobile/lib/blocs/dm/conversation_list/conversation_list_bloc.dart
+++ b/mobile/lib/blocs/dm/conversation_list/conversation_list_bloc.dart
@@ -200,26 +200,10 @@ class ConversationListBloc
           isFollowing: _followRepository.isFollowing,
         );
 
-        // While the one-time history-recovery drain is still running
-        // (post-reinstall window), HOLD BACK the conversations that would
-        // classify as requests. Until the drain re-ingests the user's own
-        // message for a chat, a previously-accepted conversation is
-        // indistinguishable from a genuine request — both have
-        // currentUserHasSent=false and an unfollowed peer. Showing them as
-        // requests is the original #5304 bug; showing them in the inbox makes
-        // real requests flash there and then jump to the Requests tab once
-        // recovery completes. So during recovery we surface only the
-        // unambiguous chats (accepted + followed), backed by the restore
-        // indicator, and let the ambiguous ones settle into their correct
-        // bucket as soon as recovery completes. See #5304.
-        final recoveryComplete = _dmRepository.isHistoryRecoveryComplete;
         final inboxConversations = DmRepository.mergeAndSort(
           data.accepted,
           split.followed,
         );
-        final requests = recoveryComplete
-            ? split.requests
-            : const <DmConversation>[];
 
         final blocklistedInbox =
             _blocklistRepository?.filterBlockedConversations(
@@ -227,12 +211,15 @@ class ConversationListBloc
               userPubkey: userPubkey,
             ) ??
             inboxConversations;
+        // Filters the FULL request set, not the recovery-held-back one, so the
+        // pin below is extracted from — and inherits the filters of — every
+        // request regardless of the drain. The hold-back is applied after.
         final blocklistedRequests =
             _blocklistRepository?.filterBlockedConversations(
-              requests,
+              split.requests,
               userPubkey: userPubkey,
             ) ??
-            requests;
+            split.requests;
 
         // Protected-minor inbound filter (#176): hide conversations whose
         // counterparty (all non-self participants) is not an approved official
@@ -260,6 +247,29 @@ class ConversationListBloc
           requests: visibleRequests,
         );
 
+        // While the one-time history-recovery drain is still running
+        // (post-reinstall window), HOLD BACK the conversations that would
+        // classify as requests. Until the drain re-ingests the user's own
+        // message for a chat, a previously-accepted conversation is
+        // indistinguishable from a genuine request — both have
+        // currentUserHasSent=false and an unfollowed peer. Showing them as
+        // requests is the original #5304 bug; showing them in the inbox makes
+        // real requests flash there and then jump to the Requests tab once
+        // recovery completes. So during recovery we surface only the
+        // unambiguous chats (accepted + followed), backed by the restore
+        // indicator, and let the ambiguous ones settle into their correct
+        // bucket as soon as recovery completes. See #5304.
+        //
+        // The pin is deliberately extracted ABOVE this line. It is a fixed
+        // identity in a fixed position, not something the user has to triage
+        // into a bucket, so it cannot produce the flash the hold-back exists
+        // to prevent — withholding it would only blank its unread dot for the
+        // duration of the drain, and the badge counts it either way (#4976).
+        final recoveryComplete = _dmRepository.isHistoryRecoveryComplete;
+        final requestConversations = recoveryComplete
+            ? pin.requests
+            : const <DmConversation>[];
+
         // A conversation can stream in while a name search is active whose
         // counterparty was not resolved when the search fired; it would fall
         // back to the generated name and drop out of the results until the
@@ -285,8 +295,15 @@ class ConversationListBloc
           status: ConversationListStatus.loaded,
           conversations: pin.inbox,
           // Only true when the gate is actually costing the user something —
-          // a closed gate with nothing to hold back needs no banner.
-          requestsWithheld: !recoveryComplete && split.requests.isNotEmpty,
+          // a closed gate with nothing to hold back needs no banner. Reads the
+          // post-filter, post-pin set rather than the raw `split.requests`
+          // #6431 emitted: that reflected main's ordering, where the hold-back
+          // ran before both filters, so a filtered list simply did not exist
+          // while the gate was shut. Here it does, and a request the blocklist,
+          // the #176 gate, or the pin itself already removed is not something
+          // the gate is costing the user — least of all the moderation thread,
+          // which is on screen as the pin the whole time.
+          requestsWithheld: !recoveryComplete && pin.requests.isNotEmpty,
           visibleConversations: _computeVisible(
             pin.inbox,
             unreadOnly: state.unreadOnly,
@@ -295,12 +312,12 @@ class ConversationListBloc
             userPubkey: userPubkey,
             limit: state.currentLimit,
           ),
-          requestConversations: pin.requests,
+          requestConversations: requestConversations,
           potentialRequests: data.potentialRequests,
           hasMore: pin.inbox.length > state.currentLimit,
           isRestoringHistory: data.isRestoring,
-          pinnedConversation: pin.pinned,
-          clearPinnedConversation: pin.pinned == null,
+          pinnedSupport: pin.pinned,
+          clearPinnedSupport: pin.pinned == null,
         );
       },
       onError: (error, stackTrace) {
@@ -473,8 +490,8 @@ class ConversationListBloc
   /// the pin renders no timestamp and is not sorted with the list.
   static const _pinnedSupportEpoch = 0;
 
-  /// Extract the pinned Divine Moderation conversation and remove it from the
-  /// lists it would otherwise render in (#6283).
+  /// Extract the pinned Divine Moderation row and remove every conversation it
+  /// stands in for from the lists they would otherwise render in (#6283).
   ///
   /// Called with lists that have ALREADY passed the blocklist filter and the
   /// protected-minor gate, so an existing moderation thread that those filters
@@ -484,7 +501,7 @@ class ConversationListBloc
   /// — would get a row that `ConversationPage`'s route guard bounces straight
   /// back to the inbox.
   ({
-    DmConversation? pinned,
+    PinnedSupport? pinned,
     List<DmConversation> inbox,
     List<DmConversation> requests,
   })
@@ -494,50 +511,32 @@ class ConversationListBloc
     required List<DmConversation> requests,
   }) {
     final supportPubkey = _supportRowPubkey;
-    if (supportPubkey == null || supportPubkey.isEmpty || userPubkey.isEmpty) {
-      return (pinned: null, inbox: inbox, requests: requests);
-    }
+    final split = DmRepository.extractPinnedSupport(
+      userPubkey: userPubkey,
+      supportPubkey: supportPubkey,
+      legacyPubkeys: _supportRowLegacyPubkeys,
+      inbox: inbox,
+      requests: requests,
+    );
 
-    // Every key the support thread may live under: the current moderation
-    // pubkey plus any it has rotated away from.
-    final knownIds = <String>{
-      for (final pk in [supportPubkey, ..._supportRowLegacyPubkeys])
-        if (pk.isNotEmpty) DmRepository.computeConversationId([userPubkey, pk]),
-    };
-
-    DmConversation? real;
-    final remainingInbox = <DmConversation>[];
-    for (final c in inbox) {
-      if (real == null && knownIds.contains(c.id)) {
-        real = c;
-      } else {
-        remainingInbox.add(c);
-      }
-    }
-
-    // An inbound-only moderation DM (the team wrote first) has
-    // currentUserHasSent == false and lands in requests, not the inbox.
-    // Without this the same thread would be reachable from both the pinned row
-    // and the Requests page with independent unread accounting.
-    final remainingRequests = <DmConversation>[];
-    for (final c in requests) {
-      if (real == null && knownIds.contains(c.id)) {
-        real = c;
-      } else {
-        remainingRequests.add(c);
-      }
-    }
-
-    if (real != null) {
+    final adopted = split.pinned;
+    if (adopted != null) {
       return (
-        pinned: real,
-        inbox: remainingInbox,
-        requests: remainingRequests,
+        pinned: PinnedSupport(conversation: adopted, isPersisted: true),
+        inbox: split.inbox,
+        requests: split.requests,
       );
     }
 
+    // Null means no pin is possible at all — no identity to key on, or the
+    // signed-in user IS the moderation account. Nothing to synthesize against.
+    final supportConversationId = split.supportConversationId;
+    if (supportConversationId == null || supportPubkey == null) {
+      return (pinned: null, inbox: split.inbox, requests: split.requests);
+    }
+
     final synthetic = DmConversation(
-      id: DmRepository.computeConversationId([userPubkey, supportPubkey]),
+      id: supportConversationId,
       participantPubkeys: [userPubkey, supportPubkey],
       isGroup: false,
       createdAt: _pinnedSupportEpoch,
@@ -553,9 +552,11 @@ class ConversationListBloc
         allowed;
 
     return (
-      pinned: visible.isEmpty ? null : visible.first,
-      inbox: remainingInbox,
-      requests: remainingRequests,
+      pinned: visible.isEmpty
+          ? null
+          : PinnedSupport(conversation: visible.first, isPersisted: false),
+      inbox: split.inbox,
+      requests: split.requests,
     );
   }
 

--- a/mobile/lib/blocs/dm/conversation_list/conversation_list_bloc.dart
+++ b/mobile/lib/blocs/dm/conversation_list/conversation_list_bloc.dart
@@ -31,7 +31,6 @@ class ConversationListBloc
     Duration recomputeDebounce = _defaultRecomputeDebounce,
     String? supportRowPubkey,
     List<String> supportRowLegacyPubkeys = const [],
-    bool supportRowEnabled = false,
   }) : _dmRepository = dmRepository,
        _followRepository = followRepository,
        _blocklistRepository = contentBlocklistRepository,
@@ -40,7 +39,6 @@ class ConversationListBloc
        _recomputeDebounce = recomputeDebounce,
        _supportRowPubkey = supportRowPubkey,
        _supportRowLegacyPubkeys = supportRowLegacyPubkeys,
-       _supportRowEnabled = supportRowEnabled,
        super(const ConversationListState()) {
     on<ConversationListStarted>(_onStarted, transformer: restartable());
     on<ConversationListLoadMore>(_onLoadMore, transformer: droppable());
@@ -87,8 +85,6 @@ class ConversationListBloc
   /// still holds that thread, and without this it would render beside the
   /// pinned row as a second "Divine Moderation" entry.
   final List<String> _supportRowLegacyPubkeys;
-
-  final bool _supportRowEnabled;
 
   /// Window over which bursty conversation writes are coalesced before the
   /// list is re-composed. The combined stream re-runs `classifyPotentialRequests`
@@ -498,10 +494,7 @@ class ConversationListBloc
     required List<DmConversation> requests,
   }) {
     final supportPubkey = _supportRowPubkey;
-    if (!_supportRowEnabled ||
-        supportPubkey == null ||
-        supportPubkey.isEmpty ||
-        userPubkey.isEmpty) {
+    if (supportPubkey == null || supportPubkey.isEmpty || userPubkey.isEmpty) {
       return (pinned: null, inbox: inbox, requests: requests);
     }
 

--- a/mobile/lib/blocs/dm/conversation_list/conversation_list_bloc.dart
+++ b/mobile/lib/blocs/dm/conversation_list/conversation_list_bloc.dart
@@ -29,12 +29,18 @@ class ConversationListBloc
     ProfileRepository? profileRepository,
     ProtectedMinorInboxGate? protectedMinorInboxGate,
     Duration recomputeDebounce = _defaultRecomputeDebounce,
+    String? supportRowPubkey,
+    List<String> supportRowLegacyPubkeys = const [],
+    bool supportRowEnabled = false,
   }) : _dmRepository = dmRepository,
        _followRepository = followRepository,
        _blocklistRepository = contentBlocklistRepository,
        _profileRepository = profileRepository,
        _protectedMinorInboxGate = protectedMinorInboxGate,
        _recomputeDebounce = recomputeDebounce,
+       _supportRowPubkey = supportRowPubkey,
+       _supportRowLegacyPubkeys = supportRowLegacyPubkeys,
+       _supportRowEnabled = supportRowEnabled,
        super(const ConversationListState()) {
     on<ConversationListStarted>(_onStarted, transformer: restartable());
     on<ConversationListLoadMore>(_onLoadMore, transformer: droppable());
@@ -71,6 +77,18 @@ class ConversationListBloc
   /// the bloc. Mirrors `NotificationBadgeCubit.setRepository`.
   ProfileRepository? _profileRepository;
   final ProtectedMinorInboxGate? _protectedMinorInboxGate;
+
+  /// Moderation pubkey the pinned support row targets, injected rather than
+  /// imported so this bloc stays free of app-layer config (#6283).
+  final String? _supportRowPubkey;
+
+  /// Historical moderation pubkeys. Used for de-duplication only, never as a
+  /// send target: a user who messaged moderation before the #2321 key rotation
+  /// still holds that thread, and without this it would render beside the
+  /// pinned row as a second "Divine Moderation" entry.
+  final List<String> _supportRowLegacyPubkeys;
+
+  final bool _supportRowEnabled;
 
   /// Window over which bursty conversation writes are coalesced before the
   /// list is re-composed. The combined stream re-runs `classifyPotentialRequests`
@@ -237,6 +255,15 @@ class ConversationListBloc
             ) ??
             blocklistedRequests;
 
+        // Lift the moderation thread out of the list into the pinned row, so
+        // the inbox never renders it twice (#6283). Runs after both filters so
+        // the pin inherits them rather than bypassing them.
+        final pin = _extractPinnedSupport(
+          userPubkey: userPubkey,
+          inbox: visibleInbox,
+          requests: visibleRequests,
+        );
+
         // A conversation can stream in while a name search is active whose
         // counterparty was not resolved when the search fired; it would fall
         // back to the generated name and drop out of the results until the
@@ -246,7 +273,7 @@ class ConversationListBloc
         // re-firing for those would loop on every recompute.
         if (state.searchQuery.length >= minSearchQueryLength) {
           final known = state.conversations.map((c) => c.id).toSet();
-          final hasNewUnresolved = visibleInbox.any(
+          final hasNewUnresolved = pin.inbox.any(
             (c) =>
                 !known.contains(c.id) &&
                 !state.profileNames.containsKey(
@@ -260,22 +287,24 @@ class ConversationListBloc
 
         return state.copyWith(
           status: ConversationListStatus.loaded,
-          conversations: visibleInbox,
+          conversations: pin.inbox,
           // Only true when the gate is actually costing the user something —
           // a closed gate with nothing to hold back needs no banner.
           requestsWithheld: !recoveryComplete && split.requests.isNotEmpty,
           visibleConversations: _computeVisible(
-            visibleInbox,
+            pin.inbox,
             unreadOnly: state.unreadOnly,
             query: state.searchQuery,
             profileNames: state.profileNames,
             userPubkey: userPubkey,
             limit: state.currentLimit,
           ),
-          requestConversations: visibleRequests,
+          requestConversations: pin.requests,
           potentialRequests: data.potentialRequests,
-          hasMore: visibleInbox.length > state.currentLimit,
+          hasMore: pin.inbox.length > state.currentLimit,
           isRestoringHistory: data.isRestoring,
+          pinnedConversation: pin.pinned,
+          clearPinnedConversation: pin.pinned == null,
         );
       },
       onError: (error, stackTrace) {
@@ -439,6 +468,101 @@ class ConversationListBloc
     return conversation.participantPubkeys.firstWhere(
       (pk) => pk != self,
       orElse: () => conversation.participantPubkeys.first,
+    );
+  }
+
+  /// A synthetic pin carries no timestamp, so it needs a `createdAt` that is
+  /// stable across recomputes — a clock read would make every debounce tick
+  /// produce an unequal state and re-emit forever. The value is never shown:
+  /// the pin renders no timestamp and is not sorted with the list.
+  static const _pinnedSupportEpoch = 0;
+
+  /// Extract the pinned Divine Moderation conversation and remove it from the
+  /// lists it would otherwise render in (#6283).
+  ///
+  /// Called with lists that have ALREADY passed the blocklist filter and the
+  /// protected-minor gate, so an existing moderation thread that those filters
+  /// removed simply is not found here. The synthetic fallback is pushed back
+  /// through both filters for the same reason: without that, a user who blocked
+  /// the moderation account — or a restricted minor whose approval was revoked
+  /// — would get a row that `ConversationPage`'s route guard bounces straight
+  /// back to the inbox.
+  ({
+    DmConversation? pinned,
+    List<DmConversation> inbox,
+    List<DmConversation> requests,
+  })
+  _extractPinnedSupport({
+    required String userPubkey,
+    required List<DmConversation> inbox,
+    required List<DmConversation> requests,
+  }) {
+    final supportPubkey = _supportRowPubkey;
+    if (!_supportRowEnabled ||
+        supportPubkey == null ||
+        supportPubkey.isEmpty ||
+        userPubkey.isEmpty) {
+      return (pinned: null, inbox: inbox, requests: requests);
+    }
+
+    // Every key the support thread may live under: the current moderation
+    // pubkey plus any it has rotated away from.
+    final knownIds = <String>{
+      for (final pk in [supportPubkey, ..._supportRowLegacyPubkeys])
+        if (pk.isNotEmpty) DmRepository.computeConversationId([userPubkey, pk]),
+    };
+
+    DmConversation? real;
+    final remainingInbox = <DmConversation>[];
+    for (final c in inbox) {
+      if (real == null && knownIds.contains(c.id)) {
+        real = c;
+      } else {
+        remainingInbox.add(c);
+      }
+    }
+
+    // An inbound-only moderation DM (the team wrote first) has
+    // currentUserHasSent == false and lands in requests, not the inbox.
+    // Without this the same thread would be reachable from both the pinned row
+    // and the Requests page with independent unread accounting.
+    final remainingRequests = <DmConversation>[];
+    for (final c in requests) {
+      if (real == null && knownIds.contains(c.id)) {
+        real = c;
+      } else {
+        remainingRequests.add(c);
+      }
+    }
+
+    if (real != null) {
+      return (
+        pinned: real,
+        inbox: remainingInbox,
+        requests: remainingRequests,
+      );
+    }
+
+    final synthetic = DmConversation(
+      id: DmRepository.computeConversationId([userPubkey, supportPubkey]),
+      participantPubkeys: [userPubkey, supportPubkey],
+      isGroup: false,
+      createdAt: _pinnedSupportEpoch,
+    );
+
+    final allowed =
+        _blocklistRepository?.filterBlockedConversations([
+          synthetic,
+        ], userPubkey: userPubkey) ??
+        [synthetic];
+    final visible =
+        _protectedMinorInboxGate?.filter(allowed, userPubkey: userPubkey) ??
+        allowed;
+
+    return (
+      pinned: visible.isEmpty ? null : visible.first,
+      inbox: remainingInbox,
+      requests: remainingRequests,
     );
   }
 

--- a/mobile/lib/blocs/dm/conversation_list/conversation_list_state.dart
+++ b/mobile/lib/blocs/dm/conversation_list/conversation_list_state.dart
@@ -35,6 +35,7 @@ class ConversationListState extends Equatable {
     this.requestsWithheld = false,
     this.currentLimit = ConversationListState.pageSize,
     this.navigationTarget,
+    this.pinnedConversation,
   });
 
   /// Number of conversations loaded per page.
@@ -111,6 +112,20 @@ class ConversationListState extends Equatable {
   /// Consumed and cleared by the UI after navigating.
   final ConversationNavigationTarget? navigationTarget;
 
+  /// The pinned Divine Moderation support conversation, or null when the
+  /// support row should not render (#6283).
+  ///
+  /// Composed inside the same pipeline that applies the blocklist filter and
+  /// the protected-minor inbound gate, so a user who blocked the moderation
+  /// account — or a restricted minor whose approval was revoked — gets null
+  /// rather than a row that the conversation route guard would bounce.
+  ///
+  /// When a real moderation thread exists this holds *that* conversation
+  /// (carrying its unread state and last message) and it is removed from
+  /// [conversations] so the inbox never shows it twice. Otherwise it is a
+  /// synthetic, non-persisted conversation with no unread state.
+  final DmConversation? pinnedConversation;
+
   /// Number of unread message requests.
   int get requestUnreadCount =>
       requestConversations.where((c) => !c.isRead).length;
@@ -139,6 +154,8 @@ class ConversationListState extends Equatable {
     int? currentLimit,
     ConversationNavigationTarget? navigationTarget,
     bool clearNavigationTarget = false,
+    DmConversation? pinnedConversation,
+    bool clearPinnedConversation = false,
   }) {
     return ConversationListState(
       status: status ?? this.status,
@@ -156,6 +173,9 @@ class ConversationListState extends Equatable {
       navigationTarget: clearNavigationTarget
           ? null
           : navigationTarget ?? this.navigationTarget,
+      pinnedConversation: clearPinnedConversation
+          ? null
+          : pinnedConversation ?? this.pinnedConversation,
     );
   }
 
@@ -174,5 +194,6 @@ class ConversationListState extends Equatable {
     requestsWithheld,
     currentLimit,
     navigationTarget,
+    pinnedConversation,
   ];
 }

--- a/mobile/lib/blocs/dm/conversation_list/conversation_list_state.dart
+++ b/mobile/lib/blocs/dm/conversation_list/conversation_list_state.dart
@@ -20,6 +20,29 @@ class ConversationNavigationTarget extends Equatable {
   List<Object?> get props => [conversationId, participantPubkeys];
 }
 
+/// The pinned Divine Moderation support row (#6283).
+///
+/// Composed inside the same pipeline that applies the blocklist filter and the
+/// protected-minor inbound gate, so a user who blocked the moderation account —
+/// or a restricted minor whose approval was revoked — gets no pin at all rather
+/// than a row the conversation route guard would bounce.
+class PinnedSupport extends Equatable {
+  const PinnedSupport({required this.conversation, required this.isPersisted});
+
+  /// Either the adopted moderation thread — carrying its real unread state and
+  /// last message — or a synthetic stand-in on the same conversation id.
+  final DmConversation conversation;
+
+  /// Whether [conversation] is a row that actually exists in the database.
+  ///
+  /// Gates the row's long-press actions: muting or removing a thread that has
+  /// never been written is a no-op the confirmation snackbar would misreport.
+  final bool isPersisted;
+
+  @override
+  List<Object?> get props => [conversation, isPersisted];
+}
+
 class ConversationListState extends Equatable {
   const ConversationListState({
     this.status = ConversationListStatus.initial,
@@ -35,7 +58,7 @@ class ConversationListState extends Equatable {
     this.requestsWithheld = false,
     this.currentLimit = ConversationListState.pageSize,
     this.navigationTarget,
-    this.pinnedConversation,
+    this.pinnedSupport,
   });
 
   /// Number of conversations loaded per page.
@@ -112,19 +135,10 @@ class ConversationListState extends Equatable {
   /// Consumed and cleared by the UI after navigating.
   final ConversationNavigationTarget? navigationTarget;
 
-  /// The pinned Divine Moderation support conversation, or null when the
-  /// support row should not render (#6283).
-  ///
-  /// Composed inside the same pipeline that applies the blocklist filter and
-  /// the protected-minor inbound gate, so a user who blocked the moderation
-  /// account — or a restricted minor whose approval was revoked — gets null
-  /// rather than a row that the conversation route guard would bounce.
-  ///
-  /// When a real moderation thread exists this holds *that* conversation
-  /// (carrying its unread state and last message) and it is removed from
-  /// [conversations] so the inbox never shows it twice. Otherwise it is a
-  /// synthetic, non-persisted conversation with no unread state.
-  final DmConversation? pinnedConversation;
+  /// The pinned Divine Moderation support row, or null when it should not
+  /// render (#6283). An adopted thread is removed from [conversations] and
+  /// [requestConversations], so the inbox never shows moderation twice.
+  final PinnedSupport? pinnedSupport;
 
   /// Number of unread message requests.
   int get requestUnreadCount =>
@@ -154,8 +168,8 @@ class ConversationListState extends Equatable {
     int? currentLimit,
     ConversationNavigationTarget? navigationTarget,
     bool clearNavigationTarget = false,
-    DmConversation? pinnedConversation,
-    bool clearPinnedConversation = false,
+    PinnedSupport? pinnedSupport,
+    bool clearPinnedSupport = false,
   }) {
     return ConversationListState(
       status: status ?? this.status,
@@ -173,9 +187,9 @@ class ConversationListState extends Equatable {
       navigationTarget: clearNavigationTarget
           ? null
           : navigationTarget ?? this.navigationTarget,
-      pinnedConversation: clearPinnedConversation
+      pinnedSupport: clearPinnedSupport
           ? null
-          : pinnedConversation ?? this.pinnedConversation,
+          : pinnedSupport ?? this.pinnedSupport,
     );
   }
 
@@ -194,6 +208,6 @@ class ConversationListState extends Equatable {
     requestsWithheld,
     currentLimit,
     navigationTarget,
-    pinnedConversation,
+    pinnedSupport,
   ];
 }

--- a/mobile/lib/blocs/dm/unread_count/dm_unread_count_cubit.dart
+++ b/mobile/lib/blocs/dm/unread_count/dm_unread_count_cubit.dart
@@ -23,15 +23,21 @@ import 'package:rxdart/rxdart.dart';
 /// chats from followed-but-unreplied peers. See #4976.
 ///
 /// Parity with the list is structural: this reuses the same static
-/// [DmRepository.classifyPotentialRequests] / [DmRepository.mergeAndSort]
-/// helpers and [ContentBlocklistRepository.filterBlockedConversations] that
+/// [DmRepository.classifyPotentialRequests] / [DmRepository.mergeAndSort] /
+/// [DmRepository.extractPinnedSupport] helpers and
+/// [ContentBlocklistRepository.filterBlockedConversations] that
 /// [ConversationListBloc] uses, so the count cannot drift from the list. It
-/// intentionally does NOT replicate two list-only concerns:
+/// intentionally does NOT replicate one list-only concern:
 ///
 /// * **Pagination** — the list renders one page; the badge counts the full
 ///   accepted set (unpaginated) so it reflects total unread, not the page.
-/// * **Recovery hold-back (#5304)** — that only delays the *requests* bucket,
-///   which never feeds this count.
+///
+/// The pinned support row (#6283) IS counted, because the inbox renders it
+/// with an unread dot. That pulls one conversation out of the requests bucket
+/// and into this count — an inbound-only moderation thread (the team wrote
+/// first) is no longer a Requests entry, it is the pin. The recovery hold-back
+/// (#5304) does not apply to it for the same reason it does not in the bloc:
+/// the pin is never routed into a bucket, so it cannot flash between two.
 ///
 /// The app-shell provides this cubit once via `ref.read`, but
 /// `dmRepositoryProvider` / `followRepositoryProvider` /
@@ -52,8 +58,12 @@ class DmUnreadCountCubit extends Cubit<int> {
     ContentBlocklistRepository? contentBlocklistRepository,
     ProtectedMinorInboxGate? protectedMinorInboxGate,
     Duration recomputeDebounce = _defaultRecomputeDebounce,
+    String? supportRowPubkey,
+    List<String> supportRowLegacyPubkeys = const [],
   }) : _protectedMinorInboxGate = protectedMinorInboxGate,
        _recomputeDebounce = recomputeDebounce,
+       _supportRowPubkey = supportRowPubkey,
+       _supportRowLegacyPubkeys = supportRowLegacyPubkeys,
        super(0) {
     setRepositories(
       dmRepository: dmRepository,
@@ -78,6 +88,13 @@ class DmUnreadCountCubit extends Cubit<int> {
   /// [setRepositories]. Null when the user is unrestricted / not wired.
   final ProtectedMinorInboxGate? _protectedMinorInboxGate;
   final Duration _recomputeDebounce;
+
+  /// Moderation pubkey the inbox pins (#6283), and the keys it has rotated
+  /// away from. Injected exactly as `ConversationListBloc` takes them, and for
+  /// the same reason: the badge must partition the list the same way the list
+  /// does, or it counts rows the inbox does not render and misses one it does.
+  final String? _supportRowPubkey;
+  final List<String> _supportRowLegacyPubkeys;
   DmRepository? _dmRepository;
   FollowRepository? _followRepository;
   ContentBlocklistRepository? _blocklistRepository;
@@ -208,7 +225,26 @@ class DmUnreadCountCubit extends Cubit<int> {
       userPubkey: userPubkey,
       isFollowing: followRepository.isFollowing,
     );
-    final inbox = DmRepository.mergeAndSort(accepted, split.followed);
+    final merged = DmRepository.mergeAndSort(accepted, split.followed);
+
+    // Partition the pinned support row out exactly as the inbox does (#6283),
+    // then count it back in. Two things have to happen and neither is optional:
+    // a retired-key moderation thread must STOP being counted (the inbox drops
+    // it entirely), and a current-key one must START being counted even when it
+    // arrived as a request (the inbox renders it as the pin, unread dot and
+    // all). Counting `pin.inbox` alone would do the first and not the second.
+    // The bloc's synthetic stand-in is deliberately NOT reproduced here: it is
+    // always read, so it can only ever add zero and one more gate pass.
+    final pin = DmRepository.extractPinnedSupport(
+      userPubkey: userPubkey,
+      supportPubkey: _supportRowPubkey,
+      legacyPubkeys: _supportRowLegacyPubkeys,
+      inbox: merged,
+      requests: split.requests,
+    );
+    final adopted = pin.pinned;
+    final inbox = adopted == null ? pin.inbox : [...pin.inbox, adopted];
+
     final blocklisted =
         _blocklistRepository?.filterBlockedConversations(
           inbox,
@@ -217,6 +253,9 @@ class DmUnreadCountCubit extends Cubit<int> {
         inbox;
     // Protected-minor filter (#176): the badge must apply the SAME predicate as
     // the list, or it leaks the existence + count of hidden contact attempts.
+    // Filtering the union in one pass rather than the pin separately keeps this
+    // to a single gate call — `filter` can kick a receive-time revalidation, so
+    // each extra call site is another revalidation trigger.
     final visible =
         _protectedMinorInboxGate?.filter(blocklisted, userPubkey: userPubkey) ??
         blocklisted;

--- a/mobile/lib/blocs/dm/unread_count/dm_unread_count_cubit.dart
+++ b/mobile/lib/blocs/dm/unread_count/dm_unread_count_cubit.dart
@@ -59,11 +59,9 @@ class DmUnreadCountCubit extends Cubit<int> {
     ProtectedMinorInboxGate? protectedMinorInboxGate,
     Duration recomputeDebounce = _defaultRecomputeDebounce,
     String? supportRowPubkey,
-    List<String> supportRowLegacyPubkeys = const [],
   }) : _protectedMinorInboxGate = protectedMinorInboxGate,
        _recomputeDebounce = recomputeDebounce,
        _supportRowPubkey = supportRowPubkey,
-       _supportRowLegacyPubkeys = supportRowLegacyPubkeys,
        super(0) {
     setRepositories(
       dmRepository: dmRepository,
@@ -89,12 +87,11 @@ class DmUnreadCountCubit extends Cubit<int> {
   final ProtectedMinorInboxGate? _protectedMinorInboxGate;
   final Duration _recomputeDebounce;
 
-  /// Moderation pubkey the inbox pins (#6283), and the keys it has rotated
-  /// away from. Injected exactly as `ConversationListBloc` takes them, and for
-  /// the same reason: the badge must partition the list the same way the list
-  /// does, or it counts rows the inbox does not render and misses one it does.
+  /// Moderation pubkey the inbox pins (#6283). Injected exactly as
+  /// `ConversationListBloc` takes it, and for the same reason: the badge must
+  /// partition the list the same way the list does, or it counts a row the
+  /// inbox does not render and misses one it does.
   final String? _supportRowPubkey;
-  final List<String> _supportRowLegacyPubkeys;
   DmRepository? _dmRepository;
   FollowRepository? _followRepository;
   ContentBlocklistRepository? _blocklistRepository;
@@ -228,17 +225,17 @@ class DmUnreadCountCubit extends Cubit<int> {
     final merged = DmRepository.mergeAndSort(accepted, split.followed);
 
     // Partition the pinned support row out exactly as the inbox does (#6283),
-    // then count it back in. Two things have to happen and neither is optional:
-    // a retired-key moderation thread must STOP being counted (the inbox drops
-    // it entirely), and a current-key one must START being counted even when it
-    // arrived as a request (the inbox renders it as the pin, unread dot and
-    // all). Counting `pin.inbox` alone would do the first and not the second.
-    // The bloc's synthetic stand-in is deliberately NOT reproduced here: it is
-    // always read, so it can only ever add zero and one more gate pass.
+    // then count it back in. Adding `adopted` back is the whole point: a
+    // current-key moderation thread must be counted even when it arrived as a
+    // request, because the inbox renders it as the pin, unread dot and all —
+    // and counting `pin.inbox` alone would silently drop it. A retired-key
+    // thread needs nothing special; the partition leaves it in `pin.inbox`,
+    // which is where the list renders it too. The bloc's synthetic stand-in is
+    // deliberately NOT reproduced here: it is always read, so it can only ever
+    // add zero and one more gate pass.
     final pin = DmRepository.extractPinnedSupport(
       userPubkey: userPubkey,
       supportPubkey: _supportRowPubkey,
-      legacyPubkeys: _supportRowLegacyPubkeys,
       inbox: merged,
       requests: split.requests,
     );

--- a/mobile/lib/config/official_accounts.dart
+++ b/mobile/lib/config/official_accounts.dart
@@ -23,26 +23,50 @@ class OfficialAccount {
   });
 }
 
+/// Values [OfficialAccount.role] can take. Named so no caller has to spell the
+/// role as a bare string to pick an account out of [kPinnedOfficialAccounts].
+abstract class OfficialAccountRole {
+  static const String hq = 'hq';
+  static const String moderation = 'moderation';
+}
+
+/// Divine HQ's pinned identity.
+const OfficialAccount kHqAccount = OfficialAccount(
+  pubkeyHex: 'c4a39f1291291d452405cd8ddd798c4a29a3858c52cd0d843f1f6852cf17682e',
+  nip05: '_@divinehq.divine.video',
+  role: OfficialAccountRole.hq,
+  minorContactable: true,
+);
+
+/// The current Divine moderation pubkey — the report target, the pinned support
+/// row's destination, and `ModerationLabelService`'s NIP-05 fallback.
+///
+/// Single-sourced here rather than re-declared per consumer: the pinned support
+/// row and the protected-minor gate must anchor on the SAME key, or the row can
+/// point somewhere the gate would not approve.
+const String kModerationPubkeyHex =
+    '8fd5eb6d8f362163bc00a5ab6b4a3167dbf32d00ec4efdbcf43b3c9514433b7e';
+
+/// Canonical NIP-05 identifier for [kModerationPubkeyHex]. Live resolution must
+/// still map back to that pubkey for the account to count as reachable.
+const String kModerationNip05 = 'moderation@divine.video';
+
+/// The Divine moderation account's pinned identity.
+const OfficialAccount kModerationAccount = OfficialAccount(
+  pubkeyHex: kModerationPubkeyHex,
+  nip05: kModerationNip05,
+  role: OfficialAccountRole.moderation,
+  minorContactable: true,
+);
+
 /// The pinned child-contactable set (verified live 2026-07-07). Additions are
 /// release-gated by design — this is a child-contact list, and requiring an app
 /// release to add a key is the accepted friction that makes the pin an
 /// attacker-addition barrier. Each entry pins its OWN canonical identifier form
 /// (HQ uses a subdomain origin, moderation the classic form).
 const List<OfficialAccount> kPinnedOfficialAccounts = [
-  OfficialAccount(
-    pubkeyHex:
-        'c4a39f1291291d452405cd8ddd798c4a29a3858c52cd0d843f1f6852cf17682e',
-    nip05: '_@divinehq.divine.video',
-    role: 'hq',
-    minorContactable: true,
-  ),
-  OfficialAccount(
-    pubkeyHex:
-        '8fd5eb6d8f362163bc00a5ab6b4a3167dbf32d00ec4efdbcf43b3c9514433b7e',
-    nip05: 'moderation@divine.video',
-    role: 'moderation',
-    minorContactable: true,
-  ),
+  kHqAccount,
+  kModerationAccount,
 ];
 
 /// Moderation pubkeys the account has rotated away from.
@@ -61,10 +85,9 @@ const List<String> kLegacyModerationPubkeys = [
 /// Whether [pubkeyHex] is the Divine moderation account, current or retired.
 ///
 /// Retired keys count: a thread opened before a rotation stays keyed on the
-/// old pubkey, and it is the same team on the other end of it.
+/// old pubkey, and it is the same team on the other end of it. Callers that
+/// need a *send target* must use [kModerationPubkeyHex] instead — this answers
+/// "is this the moderation team", not "where do replies go".
 bool isModerationAccount(String pubkeyHex) =>
-    kPinnedOfficialAccounts.any(
-      (account) =>
-          account.role == 'moderation' && account.pubkeyHex == pubkeyHex,
-    ) ||
+    pubkeyHex == kModerationPubkeyHex ||
     kLegacyModerationPubkeys.contains(pubkeyHex);

--- a/mobile/lib/config/official_accounts.dart
+++ b/mobile/lib/config/official_accounts.dart
@@ -71,10 +71,16 @@ const List<OfficialAccount> kPinnedOfficialAccounts = [
 
 /// Moderation pubkeys the account has rotated away from.
 ///
-/// A DM thread opened before a rotation stays keyed on the old pubkey, so the
-/// pinned support row de-duplicates against these to avoid rendering beside an
-/// orphaned "Divine Moderation" conversation. Never a send target — messages
-/// always go to the current pin above.
+/// A DM thread opened before a rotation stays keyed on the old pubkey. Those
+/// threads are deliberately NOT folded into the pinned support row: the row
+/// routes on its own participants all the way to `sendMessage`, so adopting one
+/// would address replies to a key nobody reads. They stay where they are and
+/// render as ordinary rows, keeping their enforcement history reachable until
+/// #6416 gives it an archived read-only presentation.
+///
+/// Never a send target — messages always go to the current pin above. Used for
+/// recognising the account ([isModerationAccount], which drives the bundled
+/// avatar) and for the `ModerationLabelService` subscription migration.
 ///
 /// `121b915b…` was retired in #2321 (2026-03-20); `ModerationLabelService`
 /// carries the matching one-time migration for labeler subscriptions.

--- a/mobile/lib/config/official_accounts.dart
+++ b/mobile/lib/config/official_accounts.dart
@@ -57,3 +57,14 @@ const List<OfficialAccount> kPinnedOfficialAccounts = [
 const List<String> kLegacyModerationPubkeys = [
   '121b915baba659cbe59626a8afaf83b01dc42354dfecaad9d465d51bb5715d72',
 ];
+
+/// Whether [pubkeyHex] is the Divine moderation account, current or retired.
+///
+/// Retired keys count: a thread opened before a rotation stays keyed on the
+/// old pubkey, and it is the same team on the other end of it.
+bool isModerationAccount(String pubkeyHex) =>
+    kPinnedOfficialAccounts.any(
+      (account) =>
+          account.role == 'moderation' && account.pubkeyHex == pubkeyHex,
+    ) ||
+    kLegacyModerationPubkeys.contains(pubkeyHex);

--- a/mobile/lib/config/official_accounts.dart
+++ b/mobile/lib/config/official_accounts.dart
@@ -44,3 +44,16 @@ const List<OfficialAccount> kPinnedOfficialAccounts = [
     minorContactable: true,
   ),
 ];
+
+/// Moderation pubkeys the account has rotated away from.
+///
+/// A DM thread opened before a rotation stays keyed on the old pubkey, so the
+/// pinned support row de-duplicates against these to avoid rendering beside an
+/// orphaned "Divine Moderation" conversation. Never a send target — messages
+/// always go to the current pin above.
+///
+/// `121b915b…` was retired in #2321 (2026-03-20); `ModerationLabelService`
+/// carries the matching one-time migration for labeler subscriptions.
+const List<String> kLegacyModerationPubkeys = [
+  '121b915baba659cbe59626a8afaf83b01dc42354dfecaad9d465d51bb5715d72',
+];

--- a/mobile/lib/features/feature_flags/models/feature_flag.dart
+++ b/mobile/lib/features/feature_flags/models/feature_flag.dart
@@ -75,6 +75,13 @@ enum FeatureFlag {
     'Show the in-app email verification PIN and resend fallback. Off by '
         'default until keycast verify-pin support is deployed.',
     audience: FeatureFlagAudience.internal,
+  ),
+  supportDmRow(
+    'Support DM Row',
+    'Pin a "Divine Moderation" row at the top of the Messages inbox that '
+        'opens a NIP-17 conversation with the moderation team. Off by '
+        'default until the moderation inbox is staffed as a queue.',
+    audience: FeatureFlagAudience.internal,
   );
 
   const FeatureFlag(

--- a/mobile/lib/features/feature_flags/models/feature_flag.dart
+++ b/mobile/lib/features/feature_flags/models/feature_flag.dart
@@ -75,13 +75,6 @@ enum FeatureFlag {
     'Show the in-app email verification PIN and resend fallback. Off by '
         'default until keycast verify-pin support is deployed.',
     audience: FeatureFlagAudience.internal,
-  ),
-  supportDmRow(
-    'Support DM Row',
-    'Pin a "Divine Moderation" row at the top of the Messages inbox that '
-        'opens a NIP-17 conversation with the moderation team. Off by '
-        'default until the moderation inbox is staffed as a queue.',
-    audience: FeatureFlagAudience.internal,
   );
 
   const FeatureFlag(

--- a/mobile/lib/features/feature_flags/services/build_configuration.dart
+++ b/mobile/lib/features/feature_flags/services/build_configuration.dart
@@ -52,11 +52,6 @@ class BuildConfiguration {
       case FeatureFlag.emailVerificationPinFallback:
         // Default OFF until keycast verify-pin support is deployed.
         return const bool.fromEnvironment('FF_EMAIL_VERIFICATION_PIN_FALLBACK');
-      case FeatureFlag.supportDmRow:
-        // Default OFF until the moderation DM inbox is staffed as a queue
-        // with an SLA. Promoting it earlier reads as a silent black hole
-        // (#6283, support-trust-safety#194).
-        return const bool.fromEnvironment('FF_SUPPORT_DM_ROW');
     }
   }
 
@@ -101,8 +96,6 @@ class BuildConfiguration {
         return 'FF_COMMUNITY_CONTENT_WARNINGS';
       case FeatureFlag.emailVerificationPinFallback:
         return 'FF_EMAIL_VERIFICATION_PIN_FALLBACK';
-      case FeatureFlag.supportDmRow:
-        return 'FF_SUPPORT_DM_ROW';
     }
   }
 }

--- a/mobile/lib/features/feature_flags/services/build_configuration.dart
+++ b/mobile/lib/features/feature_flags/services/build_configuration.dart
@@ -52,6 +52,11 @@ class BuildConfiguration {
       case FeatureFlag.emailVerificationPinFallback:
         // Default OFF until keycast verify-pin support is deployed.
         return const bool.fromEnvironment('FF_EMAIL_VERIFICATION_PIN_FALLBACK');
+      case FeatureFlag.supportDmRow:
+        // Default OFF until the moderation DM inbox is staffed as a queue
+        // with an SLA. Promoting it earlier reads as a silent black hole
+        // (#6283, support-trust-safety#194).
+        return const bool.fromEnvironment('FF_SUPPORT_DM_ROW');
     }
   }
 
@@ -96,6 +101,8 @@ class BuildConfiguration {
         return 'FF_COMMUNITY_CONTENT_WARNINGS';
       case FeatureFlag.emailVerificationPinFallback:
         return 'FF_EMAIL_VERIFICATION_PIN_FALLBACK';
+      case FeatureFlag.supportDmRow:
+        return 'FF_SUPPORT_DM_ROW';
     }
   }
 }

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -2599,6 +2599,8 @@
     "inboxUnreadEmptyTitle": "ሁሉንም አንብበሃል",
     "inboxUnreadEmptySubtitle": "አሁን ያልተነበበ መልዕክት የለም።",
     "inboxSearchHint": "መልዕክቶችን ፈልግ",
+    "inboxSupportRowTitle": "Divine Moderation",
+    "inboxSupportRowSubtitle": "ሳንካዎች፣ ማጣራት፣ የመለያ ጉዳዮች — እያዳመጥን ነው።",
     "inboxSearchEmptyTitle": "ምንም አልተገኘም",
     "inboxSearchEmptySubtitle": "ሌላ ስም ወይም ቃል ሞክር።",
     "inboxActionMute": "ውይይት ድምጸ-ከል አድርግ",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2329,6 +2329,8 @@
     "inboxUnreadEmptyTitle": "أنت على اطلاع بكل شيء",
     "inboxUnreadEmptySubtitle": "لا توجد رسائل غير مقروءة حاليًا.",
     "inboxSearchHint": "البحث في الرسائل",
+    "inboxSupportRowTitle": "Divine Moderation",
+    "inboxSupportRowSubtitle": "الأخطاء والإشراف ومشكلات الحساب — نحن نستمع.",
     "inboxSearchEmptyTitle": "لا توجد نتائج",
     "inboxSearchEmptySubtitle": "جرّب اسمًا أو كلمة أخرى.",
     "inboxRemoveConfirmBody": "سيؤدي هذا إلى حذف محادثتك مع {displayName}. لا يمكن التراجع عن هذا الإجراء.",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -2451,6 +2451,8 @@
     "inboxUnreadEmptyTitle": "В крак си с всичко",
     "inboxUnreadEmptySubtitle": "Няма непрочетени съобщения в момента.",
     "inboxSearchHint": "Търсене в съобщенията",
+    "inboxSupportRowTitle": "Divine Moderation",
+    "inboxSupportRowSubtitle": "Бъгове, модерация, проблеми с акаунта — слушаме.",
     "inboxSearchEmptyTitle": "Няма съвпадения",
     "inboxSearchEmptySubtitle": "Опитай с друго име или дума.",
     "inboxActionMute": "Заглушаване на разговора",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2337,6 +2337,8 @@
     "inboxUnreadEmptyTitle": "Du bist auf dem Laufenden",
     "inboxUnreadEmptySubtitle": "Gerade keine ungelesenen Nachrichten.",
     "inboxSearchHint": "Nachrichten durchsuchen",
+    "inboxSupportRowTitle": "Divine Moderation",
+    "inboxSupportRowSubtitle": "Bugs, Moderation, Kontofragen — wir hören zu.",
     "inboxSearchEmptyTitle": "Keine Treffer",
     "inboxSearchEmptySubtitle": "Versuch einen anderen Namen oder ein anderes Wort.",
     "inboxRemoveConfirmBody": "Dadurch wird deine Unterhaltung mit {displayName} gelöscht. Dieser Vorgang kann nicht rückgängig gemacht werden.",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -3144,6 +3144,14 @@
   "@inboxSearchHint": {
     "description": "Hint text in the inbox Messages search field."
   },
+  "inboxSupportRowTitle": "Divine Moderation",
+  "@inboxSupportRowTitle": {
+    "description": "Title of the pinned Divine Moderation support row at the top of the Messages inbox. A brand account name, so it is intentionally identical in every locale."
+  },
+  "inboxSupportRowSubtitle": "Bugs, moderation, account stuff — we're listening.",
+  "@inboxSupportRowSubtitle": {
+    "description": "One-line summary under the pinned Divine Moderation support row, describing what the moderation team can help with."
+  },
   "inboxSearchEmptyTitle": "No matches",
   "@inboxSearchEmptyTitle": {
     "description": "Shown in place of the conversation list when an inbox search matches nothing."

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2341,6 +2341,8 @@
     "inboxUnreadEmptyTitle": "Estás al día",
     "inboxUnreadEmptySubtitle": "No tienes mensajes sin leer ahora mismo.",
     "inboxSearchHint": "Buscar mensajes",
+    "inboxSupportRowTitle": "Divine Moderation",
+    "inboxSupportRowSubtitle": "Errores, moderación, temas de cuenta: te escuchamos.",
     "inboxSearchEmptyTitle": "Sin coincidencias",
     "inboxSearchEmptySubtitle": "Prueba con otro nombre u otra palabra.",
     "inboxRemoveConfirmBody": "Esto eliminará tu conversación con {displayName}. Esta acción no se puede deshacer.",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1476,6 +1476,8 @@
     "inboxUnreadEmptyTitle": "Nabasa mo na lahat",
     "inboxUnreadEmptySubtitle": "Walang hindi pa nababasang mensahe.",
     "inboxSearchHint": "Maghanap ng mga mensahe",
+    "inboxSupportRowTitle": "Divine Moderation",
+    "inboxSupportRowSubtitle": "Mga bug, moderation, usaping account — nakikinig kami.",
     "inboxSearchEmptyTitle": "Walang tugma",
     "inboxSearchEmptySubtitle": "Subukan ang ibang pangalan o salita.",
     "inboxActionMute": "I-mute ang conversation",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2337,6 +2337,8 @@
     "inboxUnreadEmptyTitle": "Tu es à jour",
     "inboxUnreadEmptySubtitle": "Aucun message non lu pour le moment.",
     "inboxSearchHint": "Rechercher des messages",
+    "inboxSupportRowTitle": "Divine Moderation",
+    "inboxSupportRowSubtitle": "Bugs, modération, questions de compte — on vous écoute.",
     "inboxSearchEmptyTitle": "Aucun résultat",
     "inboxSearchEmptySubtitle": "Essaie un autre nom ou un autre mot.",
     "inboxRemoveConfirmBody": "Cela supprimera votre conversation avec {displayName}. Cette action est irréversible.",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2336,6 +2336,8 @@
     "inboxUnreadEmptyTitle": "Semua sudah kamu baca",
     "inboxUnreadEmptySubtitle": "Tidak ada pesan yang belum dibaca.",
     "inboxSearchHint": "Cari pesan",
+    "inboxSupportRowTitle": "Divine Moderation",
+    "inboxSupportRowSubtitle": "Bug, moderasi, urusan akun — kami mendengarkan.",
     "inboxSearchEmptyTitle": "Tidak ada hasil",
     "inboxSearchEmptySubtitle": "Coba nama atau kata lain.",
     "inboxRemoveConfirmBody": "Ini akan menghapus percakapanmu dengan {displayName}. Tindakan ini tidak bisa dibatalkan.",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2337,6 +2337,8 @@
     "inboxUnreadEmptyTitle": "Sei in pari",
     "inboxUnreadEmptySubtitle": "Nessun messaggio non letto al momento.",
     "inboxSearchHint": "Cerca nei messaggi",
+    "inboxSupportRowTitle": "Divine Moderation",
+    "inboxSupportRowSubtitle": "Bug, moderazione, questioni sull'account: ti ascoltiamo.",
     "inboxSearchEmptyTitle": "Nessun risultato",
     "inboxSearchEmptySubtitle": "Prova con un altro nome o un'altra parola.",
     "inboxRemoveConfirmBody": "Questo eliminerà la tua conversazione con {displayName}. Questa azione non può essere annullata.",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2329,6 +2329,8 @@
     "inboxUnreadEmptyTitle": "すべて既読です",
     "inboxUnreadEmptySubtitle": "未読メッセージはありません。",
     "inboxSearchHint": "メッセージを検索",
+    "inboxSupportRowTitle": "Divine Moderation",
+    "inboxSupportRowSubtitle": "不具合、モデレーション、アカウントのこと — お聞きします。",
     "inboxSearchEmptyTitle": "一致なし",
     "inboxSearchEmptySubtitle": "別の名前や言葉で試してください。",
     "inboxRemoveConfirmBody": "{displayName}との会話が削除されます。この操作は取り消せません。",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1660,6 +1660,8 @@
     "inboxUnreadEmptyTitle": "모두 확인했어요",
     "inboxUnreadEmptySubtitle": "읽지 않은 메시지가 없어요.",
     "inboxSearchHint": "메시지 검색",
+    "inboxSupportRowTitle": "Divine Moderation",
+    "inboxSupportRowSubtitle": "버그, 모더레이션, 계정 문제 — 듣고 있어요.",
     "inboxSearchEmptyTitle": "일치하는 항목 없음",
     "inboxSearchEmptySubtitle": "다른 이름이나 단어로 시도해 보세요.",
     "inboxRemoveConfirmBody": "{displayName}와의 대화가 삭제돼요. 이 작업은 되돌릴 수 없어요.",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2337,6 +2337,8 @@
     "inboxUnreadEmptyTitle": "Je bent helemaal bij",
     "inboxUnreadEmptySubtitle": "Geen ongelezen berichten op dit moment.",
     "inboxSearchHint": "Berichten zoeken",
+    "inboxSupportRowTitle": "Divine Moderation",
+    "inboxSupportRowSubtitle": "Bugs, moderatie, accountzaken — we luisteren.",
     "inboxSearchEmptyTitle": "Geen resultaten",
     "inboxSearchEmptySubtitle": "Probeer een andere naam of een ander woord.",
     "inboxRemoveConfirmBody": "Dit verwijdert je gesprek met {displayName}. Deze actie kan niet ongedaan worden gemaakt.",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2337,6 +2337,8 @@
     "inboxUnreadEmptyTitle": "Wszystko nadrobione",
     "inboxUnreadEmptySubtitle": "Brak nieprzeczytanych wiadomości.",
     "inboxSearchHint": "Szukaj wiadomości",
+    "inboxSupportRowTitle": "Divine Moderation",
+    "inboxSupportRowSubtitle": "Błędy, moderacja, sprawy konta — słuchamy.",
     "inboxSearchEmptyTitle": "Brak wyników",
     "inboxSearchEmptySubtitle": "Spróbuj innego imienia lub słowa.",
     "inboxRemoveConfirmBody": "Spowoduje to usunięcie rozmowy z {displayName}. Tej operacji nie można cofnąć.",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2337,6 +2337,8 @@
     "inboxUnreadEmptyTitle": "Estás em dia",
     "inboxUnreadEmptySubtitle": "Nenhuma mensagem por ler neste momento.",
     "inboxSearchHint": "Pesquisar mensagens",
+    "inboxSupportRowTitle": "Divine Moderation",
+    "inboxSupportRowSubtitle": "Bugs, moderação, questões de conta — estamos ouvindo.",
     "inboxSearchEmptyTitle": "Sem resultados",
     "inboxSearchEmptySubtitle": "Tenta outro nome ou outra palavra.",
     "inboxRemoveConfirmBody": "Isso apagará sua conversa com {displayName}. Esta ação não pode ser desfeita.",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2337,6 +2337,8 @@
     "inboxUnreadEmptyTitle": "Ești la zi",
     "inboxUnreadEmptySubtitle": "Niciun mesaj necitit momentan.",
     "inboxSearchHint": "Caută mesaje",
+    "inboxSupportRowTitle": "Divine Moderation",
+    "inboxSupportRowSubtitle": "Buguri, moderare, chestiuni de cont — te ascultăm.",
     "inboxSearchEmptyTitle": "Nicio potrivire",
     "inboxSearchEmptySubtitle": "Încearcă alt nume sau alt cuvânt.",
     "inboxRemoveConfirmBody": "Astfel, conversația ta cu {displayName} va fi ștearsă. Această acțiune nu poate fi anulată.",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2337,6 +2337,8 @@
     "inboxUnreadEmptyTitle": "Du är helt ikapp",
     "inboxUnreadEmptySubtitle": "Inga olästa meddelanden just nu.",
     "inboxSearchHint": "Sök meddelanden",
+    "inboxSupportRowTitle": "Divine Moderation",
+    "inboxSupportRowSubtitle": "Buggar, moderering, kontofrågor – vi lyssnar.",
     "inboxSearchEmptyTitle": "Inga träffar",
     "inboxSearchEmptySubtitle": "Prova ett annat namn eller ord.",
     "inboxRemoveConfirmBody": "Detta tar bort din konversation med {displayName}. Denna åtgärd kan inte ångras.",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2336,6 +2336,8 @@
     "inboxUnreadEmptyTitle": "Her şeyi okudun",
     "inboxUnreadEmptySubtitle": "Şu anda okunmamış mesaj yok.",
     "inboxSearchHint": "Mesajlarda ara",
+    "inboxSupportRowTitle": "Divine Moderation",
+    "inboxSupportRowSubtitle": "Hatalar, moderasyon, hesap meseleleri — dinliyoruz.",
     "inboxSearchEmptyTitle": "Sonuç yok",
     "inboxSearchEmptySubtitle": "Başka bir isim veya kelime dene.",
     "inboxRemoveConfirmBody": "Bu işlem, {displayName} ile olan sohbetini siler. Bu işlem geri alınamaz.",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -9936,6 +9936,18 @@ abstract class AppLocalizations {
   /// **'Search messages'**
   String get inboxSearchHint;
 
+  /// Title of the pinned Divine Moderation support row at the top of the Messages inbox. A brand account name, so it is intentionally identical in every locale.
+  ///
+  /// In en, this message translates to:
+  /// **'Divine Moderation'**
+  String get inboxSupportRowTitle;
+
+  /// One-line summary under the pinned Divine Moderation support row, describing what the moderation team can help with.
+  ///
+  /// In en, this message translates to:
+  /// **'Bugs, moderation, account stuff — we\'re listening.'**
+  String get inboxSupportRowSubtitle;
+
   /// Shown in place of the conversation list when an inbox search matches nothing.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -5541,6 +5541,12 @@ class AppLocalizationsAm extends AppLocalizations {
   String get inboxSearchHint => 'መልዕክቶችን ፈልግ';
 
   @override
+  String get inboxSupportRowTitle => 'Divine Moderation';
+
+  @override
+  String get inboxSupportRowSubtitle => 'ሳንካዎች፣ ማጣራት፣ የመለያ ጉዳዮች — እያዳመጥን ነው።';
+
+  @override
   String get inboxSearchEmptyTitle => 'ምንም አልተገኘም';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -5617,6 +5617,13 @@ class AppLocalizationsAr extends AppLocalizations {
   String get inboxSearchHint => 'البحث في الرسائل';
 
   @override
+  String get inboxSupportRowTitle => 'Divine Moderation';
+
+  @override
+  String get inboxSupportRowSubtitle =>
+      'الأخطاء والإشراف ومشكلات الحساب — نحن نستمع.';
+
+  @override
   String get inboxSearchEmptyTitle => 'لا توجد نتائج';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -5708,6 +5708,13 @@ class AppLocalizationsBg extends AppLocalizations {
   String get inboxSearchHint => 'Търсене в съобщенията';
 
   @override
+  String get inboxSupportRowTitle => 'Divine Moderation';
+
+  @override
+  String get inboxSupportRowSubtitle =>
+      'Бъгове, модерация, проблеми с акаунта — слушаме.';
+
+  @override
   String get inboxSearchEmptyTitle => 'Няма съвпадения';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -5722,6 +5722,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get inboxSearchHint => 'Nachrichten durchsuchen';
 
   @override
+  String get inboxSupportRowTitle => 'Divine Moderation';
+
+  @override
+  String get inboxSupportRowSubtitle =>
+      'Bugs, Moderation, Kontofragen — wir hören zu.';
+
+  @override
   String get inboxSearchEmptyTitle => 'Keine Treffer';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -5655,6 +5655,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get inboxSearchHint => 'Search messages';
 
   @override
+  String get inboxSupportRowTitle => 'Divine Moderation';
+
+  @override
+  String get inboxSupportRowSubtitle =>
+      'Bugs, moderation, account stuff — we\'re listening.';
+
+  @override
   String get inboxSearchEmptyTitle => 'No matches';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -5701,6 +5701,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get inboxSearchHint => 'Buscar mensajes';
 
   @override
+  String get inboxSupportRowTitle => 'Divine Moderation';
+
+  @override
+  String get inboxSupportRowSubtitle =>
+      'Errores, moderación, temas de cuenta: te escuchamos.';
+
+  @override
   String get inboxSearchEmptyTitle => 'Sin coincidencias';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -5722,6 +5722,13 @@ class AppLocalizationsFil extends AppLocalizations {
   String get inboxSearchHint => 'Maghanap ng mga mensahe';
 
   @override
+  String get inboxSupportRowTitle => 'Divine Moderation';
+
+  @override
+  String get inboxSupportRowSubtitle =>
+      'Mga bug, moderation, usaping account — nakikinig kami.';
+
+  @override
   String get inboxSearchEmptyTitle => 'Walang tugma';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -5726,6 +5726,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get inboxSearchHint => 'Rechercher des messages';
 
   @override
+  String get inboxSupportRowTitle => 'Divine Moderation';
+
+  @override
+  String get inboxSupportRowSubtitle =>
+      'Bugs, modération, questions de compte — on vous écoute.';
+
+  @override
   String get inboxSearchEmptyTitle => 'Aucun résultat';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -5629,6 +5629,13 @@ class AppLocalizationsId extends AppLocalizations {
   String get inboxSearchHint => 'Cari pesan';
 
   @override
+  String get inboxSupportRowTitle => 'Divine Moderation';
+
+  @override
+  String get inboxSupportRowSubtitle =>
+      'Bug, moderasi, urusan akun — kami mendengarkan.';
+
+  @override
   String get inboxSearchEmptyTitle => 'Tidak ada hasil';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -5706,6 +5706,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get inboxSearchHint => 'Cerca nei messaggi';
 
   @override
+  String get inboxSupportRowTitle => 'Divine Moderation';
+
+  @override
+  String get inboxSupportRowSubtitle =>
+      'Bug, moderazione, questioni sull\'account: ti ascoltiamo.';
+
+  @override
   String get inboxSearchEmptyTitle => 'Nessun risultato';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -5422,6 +5422,12 @@ class AppLocalizationsJa extends AppLocalizations {
   String get inboxSearchHint => 'メッセージを検索';
 
   @override
+  String get inboxSupportRowTitle => 'Divine Moderation';
+
+  @override
+  String get inboxSupportRowSubtitle => '不具合、モデレーション、アカウントのこと — お聞きします。';
+
+  @override
   String get inboxSearchEmptyTitle => '一致なし';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -5442,6 +5442,12 @@ class AppLocalizationsKo extends AppLocalizations {
   String get inboxSearchHint => '메시지 검색';
 
   @override
+  String get inboxSupportRowTitle => 'Divine Moderation';
+
+  @override
+  String get inboxSupportRowSubtitle => '버그, 모더레이션, 계정 문제 — 듣고 있어요.';
+
+  @override
   String get inboxSearchEmptyTitle => '일치하는 항목 없음';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -5678,6 +5678,13 @@ class AppLocalizationsNl extends AppLocalizations {
   String get inboxSearchHint => 'Berichten zoeken';
 
   @override
+  String get inboxSupportRowTitle => 'Divine Moderation';
+
+  @override
+  String get inboxSupportRowSubtitle =>
+      'Bugs, moderatie, accountzaken — we luisteren.';
+
+  @override
   String get inboxSearchEmptyTitle => 'Geen resultaten';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -5795,6 +5795,13 @@ class AppLocalizationsPl extends AppLocalizations {
   String get inboxSearchHint => 'Szukaj wiadomości';
 
   @override
+  String get inboxSupportRowTitle => 'Divine Moderation';
+
+  @override
+  String get inboxSupportRowSubtitle =>
+      'Błędy, moderacja, sprawy konta — słuchamy.';
+
+  @override
   String get inboxSearchEmptyTitle => 'Brak wyników';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -5691,6 +5691,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get inboxSearchHint => 'Pesquisar mensagens';
 
   @override
+  String get inboxSupportRowTitle => 'Divine Moderation';
+
+  @override
+  String get inboxSupportRowSubtitle =>
+      'Bugs, moderação, questões de conta — estamos ouvindo.';
+
+  @override
   String get inboxSearchEmptyTitle => 'Sem resultados';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -5807,6 +5807,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get inboxSearchHint => 'Caută mesaje';
 
   @override
+  String get inboxSupportRowTitle => 'Divine Moderation';
+
+  @override
+  String get inboxSupportRowSubtitle =>
+      'Buguri, moderare, chestiuni de cont — te ascultăm.';
+
+  @override
   String get inboxSearchEmptyTitle => 'Nicio potrivire';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -5652,6 +5652,13 @@ class AppLocalizationsSv extends AppLocalizations {
   String get inboxSearchHint => 'Sök meddelanden';
 
   @override
+  String get inboxSupportRowTitle => 'Divine Moderation';
+
+  @override
+  String get inboxSupportRowSubtitle =>
+      'Buggar, moderering, kontofrågor – vi lyssnar.';
+
+  @override
   String get inboxSearchEmptyTitle => 'Inga träffar';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -5635,6 +5635,13 @@ class AppLocalizationsTr extends AppLocalizations {
   String get inboxSearchHint => 'Mesajlarda ara';
 
   @override
+  String get inboxSupportRowTitle => 'Divine Moderation';
+
+  @override
+  String get inboxSupportRowSubtitle =>
+      'Hatalar, moderasyon, hesap meseleleri — dinliyoruz.';
+
+  @override
   String get inboxSearchEmptyTitle => 'Sonuç yok';
 
   @override

--- a/mobile/lib/screens/inbox/inbox_page.dart
+++ b/mobile/lib/screens/inbox/inbox_page.dart
@@ -4,7 +4,6 @@
 // ABOUTME: gift-wrap subscription is auth-session-scoped via
 // ABOUTME: dmRepositoryProvider, not driven by this screen's lifecycle.
 
-import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -47,13 +46,6 @@ class InboxPage extends ConsumerWidget {
     final currentUserPubkey =
         ref.watch(authServiceProvider).currentPublicKeyHex ?? '';
     final protectedMinorInboxGate = ref.watch(protectedMinorInboxGateProvider);
-    // Pinned Divine Moderation support row (#6283). The identity comes from
-    // the release-pinned official-accounts list — the same anchor the
-    // protected-minor gate resolves against — so the row can never point
-    // somewhere the gate would not approve.
-    final supportRowPubkey = kPinnedOfficialAccounts
-        .firstWhereOrNull((a) => a.role == 'moderation')
-        ?.pubkeyHex;
 
     return AnnotatedRegion<SystemUiOverlayStyle>(
       value: SystemUiOverlayStyle.light,
@@ -104,7 +96,11 @@ class InboxPage extends ConsumerWidget {
               contentBlocklistRepository: blocklistRepository,
               profileRepository: profileRepository,
               protectedMinorInboxGate: protectedMinorInboxGate,
-              supportRowPubkey: supportRowPubkey,
+              // Pinned Divine Moderation support row (#6283). The identity is
+              // the release-pinned one — the same anchor the protected-minor
+              // gate resolves against — so the row can never point somewhere
+              // the gate would not approve.
+              supportRowPubkey: kModerationPubkeyHex,
               supportRowLegacyPubkeys: kLegacyModerationPubkeys,
             )..add(const ConversationListStarted()),
           ),

--- a/mobile/lib/screens/inbox/inbox_page.dart
+++ b/mobile/lib/screens/inbox/inbox_page.dart
@@ -101,7 +101,6 @@ class InboxPage extends ConsumerWidget {
               // gate resolves against — so the row can never point somewhere
               // the gate would not approve.
               supportRowPubkey: kModerationPubkeyHex,
-              supportRowLegacyPubkeys: kLegacyModerationPubkeys,
             )..add(const ConversationListStarted()),
           ),
           // Inbox-scope NotificationBadgeCubit feeds the segmented

--- a/mobile/lib/screens/inbox/inbox_page.dart
+++ b/mobile/lib/screens/inbox/inbox_page.dart
@@ -15,8 +15,6 @@ import 'package:openvine/blocs/dm/conversation_mute/conversation_mute_cubit.dart
 import 'package:openvine/blocs/my_following/my_following_bloc.dart';
 import 'package:openvine/blocs/notifications/badge/notification_badge_cubit.dart';
 import 'package:openvine/config/official_accounts.dart';
-import 'package:openvine/features/feature_flags/models/feature_flag.dart';
-import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/notifications/providers/notification_repository_provider.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/official_accounts_providers.dart';
@@ -53,9 +51,6 @@ class InboxPage extends ConsumerWidget {
     // the release-pinned official-accounts list — the same anchor the
     // protected-minor gate resolves against — so the row can never point
     // somewhere the gate would not approve.
-    final supportRowEnabled = ref.watch(
-      isFeatureEnabledProvider(FeatureFlag.supportDmRow),
-    );
     final supportRowPubkey = kPinnedOfficialAccounts
         .firstWhereOrNull((a) => a.role == 'moderation')
         ?.pubkeyHex;
@@ -92,10 +87,6 @@ class InboxPage extends ConsumerWidget {
           blocklistRepository,
           currentUserPubkey,
           protectedMinorInboxGate,
-          // The pin is composed inside the bloc, so a flag flip has to rebuild
-          // it. Cheap: the flag only moves from the debug Experimental
-          // Features screen.
-          supportRowEnabled,
         )),
         providers: [
           BlocProvider(
@@ -113,7 +104,6 @@ class InboxPage extends ConsumerWidget {
               contentBlocklistRepository: blocklistRepository,
               profileRepository: profileRepository,
               protectedMinorInboxGate: protectedMinorInboxGate,
-              supportRowEnabled: supportRowEnabled,
               supportRowPubkey: supportRowPubkey,
               supportRowLegacyPubkeys: kLegacyModerationPubkeys,
             )..add(const ConversationListStarted()),

--- a/mobile/lib/screens/inbox/inbox_page.dart
+++ b/mobile/lib/screens/inbox/inbox_page.dart
@@ -4,6 +4,7 @@
 // ABOUTME: gift-wrap subscription is auth-session-scoped via
 // ABOUTME: dmRepositoryProvider, not driven by this screen's lifecycle.
 
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -13,6 +14,9 @@ import 'package:openvine/blocs/dm/conversation_list/conversation_list_bloc.dart'
 import 'package:openvine/blocs/dm/conversation_mute/conversation_mute_cubit.dart';
 import 'package:openvine/blocs/my_following/my_following_bloc.dart';
 import 'package:openvine/blocs/notifications/badge/notification_badge_cubit.dart';
+import 'package:openvine/config/official_accounts.dart';
+import 'package:openvine/features/feature_flags/models/feature_flag.dart';
+import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/notifications/providers/notification_repository_provider.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/official_accounts_providers.dart';
@@ -45,6 +49,16 @@ class InboxPage extends ConsumerWidget {
     final currentUserPubkey =
         ref.watch(authServiceProvider).currentPublicKeyHex ?? '';
     final protectedMinorInboxGate = ref.watch(protectedMinorInboxGateProvider);
+    // Pinned Divine Moderation support row (#6283). The identity comes from
+    // the release-pinned official-accounts list — the same anchor the
+    // protected-minor gate resolves against — so the row can never point
+    // somewhere the gate would not approve.
+    final supportRowEnabled = ref.watch(
+      isFeatureEnabledProvider(FeatureFlag.supportDmRow),
+    );
+    final supportRowPubkey = kPinnedOfficialAccounts
+        .firstWhereOrNull((a) => a.role == 'moderation')
+        ?.pubkeyHex;
 
     return AnnotatedRegion<SystemUiOverlayStyle>(
       value: SystemUiOverlayStyle.light,
@@ -78,6 +92,10 @@ class InboxPage extends ConsumerWidget {
           blocklistRepository,
           currentUserPubkey,
           protectedMinorInboxGate,
+          // The pin is composed inside the bloc, so a flag flip has to rebuild
+          // it. Cheap: the flag only moves from the debug Experimental
+          // Features screen.
+          supportRowEnabled,
         )),
         providers: [
           BlocProvider(
@@ -95,6 +113,9 @@ class InboxPage extends ConsumerWidget {
               contentBlocklistRepository: blocklistRepository,
               profileRepository: profileRepository,
               protectedMinorInboxGate: protectedMinorInboxGate,
+              supportRowEnabled: supportRowEnabled,
+              supportRowPubkey: supportRowPubkey,
+              supportRowLegacyPubkeys: kLegacyModerationPubkeys,
             )..add(const ConversationListStarted()),
           ),
           // Inbox-scope NotificationBadgeCubit feeds the segmented

--- a/mobile/lib/screens/inbox/inbox_view.dart
+++ b/mobile/lib/screens/inbox/inbox_view.dart
@@ -457,20 +457,20 @@ class _RestorePausedBannerGate extends StatelessWidget {
 /// Ordering is not left to the list's recency sort — a synthetic row carries
 /// no timestamp and would sink out of reach.
 ///
-/// The caller only builds this when
-/// [ConversationListState.pinnedConversation] is non-null: the bloc composes
-/// that inside the same pipeline that applies the blocklist filter and the
-/// protected-minor gate, so a user who blocked the moderation account, or a
-/// restricted minor whose approval was revoked, gets no row rather than one
-/// the conversation route guard would bounce.
+/// The caller only builds this when [ConversationListState.pinnedSupport] is
+/// non-null: the bloc composes that inside the same pipeline that applies the
+/// blocklist filter and the protected-minor gate, so a user who blocked the
+/// moderation account, or a restricted minor whose approval was revoked, gets
+/// no row rather than one the conversation route guard would bounce.
 class _PinnedSupportRow extends StatelessWidget {
   const _PinnedSupportRow({
-    required this.conversation,
+    required this.pinned,
     required this.currentUserPubkey,
+    required this.onLongPress,
   });
 
   /// The adopted real moderation thread, or the synthetic stand-in.
-  final DmConversation conversation;
+  final PinnedSupport pinned;
 
   /// Signed-in pubkey. Passed in rather than derived from the conversation's
   /// participant list — that list is sorted, so its first entry is not
@@ -478,12 +478,17 @@ class _PinnedSupportRow extends StatelessWidget {
   /// participant's avatar to render.
   final String currentUserPubkey;
 
+  /// Opens the conversation action sheet. Null while the pin is synthetic:
+  /// there is no row to mute or remove yet, and the confirmation snackbars
+  /// would report work that did not happen.
+  final VoidCallback? onLongPress;
+
   @override
   Widget build(BuildContext context) {
-    final pinned = conversation;
+    final conversation = pinned.conversation;
 
     return ConversationTile(
-      conversation: pinned,
+      conversation: conversation,
       currentUserPubkey: currentUserPubkey,
       // Fixed identity: the profile lookup yields null until the relay client
       // is ready, and the tile's fallback is a generated name — so sourcing
@@ -491,20 +496,21 @@ class _PinnedSupportRow extends StatelessWidget {
       displayNameOverride: context.l10n.inboxSupportRowTitle,
       // Only stand in for the preview when there is no real thread yet; once
       // the team replies, the last message is more useful than the blurb.
-      subtitleOverride: pinned.lastMessageContent == null
+      subtitleOverride: conversation.lastMessageContent == null
           ? context.l10n.inboxSupportRowSubtitle
           : null,
       onTap: () => _pushConversation(
         context,
-        pinned.id,
+        conversation.id,
         // Self must be stripped, matching _onConversationTapped: the route
         // reads `extra` as the COUNTERPARTY list, so passing the raw
         // participants opens a conversation with the signed-in user instead
         // of with moderation.
-        pinned.participantPubkeys
+        conversation.participantPubkeys
             .where((pk) => pk != currentUserPubkey)
             .toList(),
       ),
+      onLongPress: onLongPress,
     );
   }
 }
@@ -532,10 +538,11 @@ class _MessagesScrollView extends ConsumerStatefulWidget {
   final String currentUserPubkey;
 
   @override
-  ConsumerState<_MessagesScrollView> createState() => _ConversationListState();
+  ConsumerState<_MessagesScrollView> createState() =>
+      _MessagesScrollViewState();
 }
 
-class _ConversationListState extends ConsumerState<_MessagesScrollView>
+class _MessagesScrollViewState extends ConsumerState<_MessagesScrollView>
     with ScrollPaginationMixin {
   final ScrollController _scrollController = ScrollController();
   late final TextEditingController _searchController;
@@ -701,15 +708,27 @@ class _ConversationListState extends ConsumerState<_MessagesScrollView>
     final isFiltering = context.select<ConversationListBloc, bool>(
       (bloc) => bloc.state.isFiltering,
     );
-    final pinned = context.select<ConversationListBloc, DmConversation?>(
-      (bloc) => bloc.state.pinnedConversation,
+    final pinned = context.select<ConversationListBloc, PinnedSupport?>(
+      (bloc) => bloc.state.pinnedSupport,
     );
 
     final supportRow = pinned == null
         ? null
         : _PinnedSupportRow(
-            conversation: pinned,
+            pinned: pinned,
             currentUserPubkey: widget.currentUserPubkey,
+            // Only an adopted thread has something to act on. Its actions are
+            // the ones the ordinary row carried before the pin replaced it —
+            // blocking moderation hides the pin, and Safety Settings is the
+            // way back, exactly as for any other blocked account.
+            onLongPress: pinned.isPersisted
+                ? () => _onConversationLongPressed(
+                    context,
+                    ref,
+                    pinned.conversation,
+                    displayNameOverride: context.l10n.inboxSupportRowTitle,
+                  )
+                : null,
           );
 
     // Nothing but the support row to show. Keep the empty-state copy — a
@@ -759,7 +778,7 @@ class _ConversationListState extends ConsumerState<_MessagesScrollView>
       if (supportRow != null &&
           _supportRowSurvivesFilter(
             context,
-            pinned: pinned!,
+            pinned: pinned!.conversation,
             unreadOnly: unreadOnly,
             query: searchQuery,
           ))
@@ -840,6 +859,11 @@ class _ConversationListState extends ConsumerState<_MessagesScrollView>
   /// Unread chip is on. [query] arrives already thresholded by the bloc — it
   /// is `''` below `minSearchQueryLength` — so an empty string reliably means
   /// "no search active".
+  ///
+  /// Matches title OR last message, mirroring the bloc's `_applyFilters`. Once
+  /// the team has replied the preview is a real message, and a query drawn
+  /// from it should surface this row for the same reason it surfaces any
+  /// other.
   bool _supportRowSurvivesFilter(
     BuildContext context, {
     required DmConversation pinned,
@@ -848,9 +872,9 @@ class _ConversationListState extends ConsumerState<_MessagesScrollView>
   }) {
     if (unreadOnly && pinned.isRead) return false;
     if (query.isEmpty) return true;
-    return context.l10n.inboxSupportRowTitle.toLowerCase().contains(
-      query.toLowerCase(),
-    );
+    final needle = query.toLowerCase();
+    return context.l10n.inboxSupportRowTitle.toLowerCase().contains(needle) ||
+        (pinned.lastMessageContent?.toLowerCase().contains(needle) ?? false);
   }
 
   void _openMessageRequests(BuildContext context) {
@@ -876,17 +900,27 @@ class _ConversationListState extends ConsumerState<_MessagesScrollView>
   Future<void> _onConversationLongPressed(
     BuildContext context,
     WidgetRef ref,
-    DmConversation conversation,
-  ) async {
+    DmConversation conversation, {
+    String? displayNameOverride,
+  }) async {
     final otherPubkey = conversation.participantPubkeys.firstWhere(
       (pk) => pk != widget.currentUserPubkey,
       orElse: () => conversation.participantPubkeys.first,
     );
 
-    final profile = await ref.read(
-      fetchUserProfileProvider(otherPubkey).future,
-    );
-    final displayName = profile?.bestDisplayName ?? 'user';
+    // A known identity skips the lookup entirely: kind-0 for the moderation
+    // account resolves late, and the sheet would open labelled with the
+    // generated fallback name the row's own override exists to avoid.
+    String displayName;
+    if (displayNameOverride != null) {
+      displayName = displayNameOverride;
+    } else {
+      final profile = await ref.read(
+        fetchUserProfileProvider(otherPubkey).future,
+      );
+      if (!context.mounted) return;
+      displayName = profile?.bestDisplayName ?? 'user';
+    }
 
     if (!context.mounted) return;
 

--- a/mobile/lib/screens/inbox/inbox_view.dart
+++ b/mobile/lib/screens/inbox/inbox_view.dart
@@ -351,49 +351,7 @@ class _MessagesContent extends ConsumerWidget {
       },
       child: Stack(
         children: [
-          Column(
-            children: [
-              // Pinned Divine Moderation support row (#6283).
-              //
-              // Deliberately ABOVE the status switch inside
-              // _ConversationListContent: that switch replaces the entire list
-              // subtree with a spinner while the bloc loads, and returns early
-              // to InboxEmptyState for a user with no conversations — so a row
-              // rendered inside the list would be invisible in five of the six
-              // branches, including for the brand-new user who most needs it.
-              // Placed above FollowingBar so its position does not shift when
-              // the following strip resolves from empty to 128px.
-              _PinnedSupportRow(currentUserPubkey: currentPubkey),
-              // Following users horizontal bar
-              FollowingBar(
-                onUserTapped: (pubkey) {
-                  Log.info(
-                    '👤 User tapped in following bar: $pubkey',
-                    name: 'InboxView',
-                    category: LogCategory.ui,
-                  );
-                  context.read<ConversationListBloc>().add(
-                    ConversationListNavigateToUser(pubkey),
-                  );
-                },
-              ),
-              // Thin restore progress bar while the one-time reinstall
-              // history recovery is still running (#5202).
-              const _RestoringHistoryIndicator(),
-              // Static banner while the recovery gate is still hiding
-              // would-be message requests. Mounted here, as a sibling of the
-              // content, so it covers every branch below — empty inbox,
-              // requests-only, filtered, and populated — without threading a
-              // flag through each one or shifting the sliver banner offsets.
-              const _RestorePausedBannerGate(),
-              // Conversation list or empty state
-              Expanded(
-                child: _ConversationListContent(
-                  currentUserPubkey: currentPubkey,
-                ),
-              ),
-            ],
-          ),
+          _MessagesScrollView(currentUserPubkey: currentPubkey),
           // FAB positioned bottom-right
           PositionedDirectional(
             end: _kFabInset,
@@ -490,15 +448,29 @@ class _RestorePausedBannerGate extends StatelessWidget {
   }
 }
 
-/// Pinned "Divine Moderation" support row at the top of the Messages tab.
+/// "Divine Moderation" support tile, always rendered as the first row of the
+/// conversation list (#6283).
 ///
-/// Renders nothing unless [ConversationListState.pinnedConversation] is set —
-/// the bloc composes that inside the same pipeline that applies the blocklist
-/// filter and the protected-minor gate, so a user who blocked the moderation
-/// account, or a restricted minor whose approval was revoked, gets no row
-/// rather than one the conversation route guard would bounce.
+/// It sits *inside* the scroll view rather than above it: as fixed chrome it
+/// cost ~92px of a viewport the keyboard already halves on a small phone, and
+/// it read as the screen's headline rather than as one chat among many.
+/// Ordering is not left to the list's recency sort — a synthetic row carries
+/// no timestamp and would sink out of reach.
+///
+/// The caller only builds this when
+/// [ConversationListState.pinnedConversation] is non-null: the bloc composes
+/// that inside the same pipeline that applies the blocklist filter and the
+/// protected-minor gate, so a user who blocked the moderation account, or a
+/// restricted minor whose approval was revoked, gets no row rather than one
+/// the conversation route guard would bounce.
 class _PinnedSupportRow extends StatelessWidget {
-  const _PinnedSupportRow({required this.currentUserPubkey});
+  const _PinnedSupportRow({
+    required this.conversation,
+    required this.currentUserPubkey,
+  });
+
+  /// The adopted real moderation thread, or the synthetic stand-in.
+  final DmConversation conversation;
 
   /// Signed-in pubkey. Passed in rather than derived from the conversation's
   /// participant list — that list is sorted, so its first entry is not
@@ -508,10 +480,7 @@ class _PinnedSupportRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final pinned = context.select<ConversationListBloc, DmConversation?>(
-      (bloc) => bloc.state.pinnedConversation,
-    );
-    if (pinned == null) return const SizedBox.shrink();
+    final pinned = conversation;
 
     return ConversationTile(
       conversation: pinned,
@@ -540,48 +509,41 @@ class _PinnedSupportRow extends StatelessWidget {
   }
 }
 
-/// Switches between loading, error, empty, and conversation list states.
-class _ConversationListContent extends StatelessWidget {
-  const _ConversationListContent({required this.currentUserPubkey});
+/// Exact height of [UnreadFilterChips]: 8px of vertical padding either side of
+/// a [DivineButtonSize.tiny] chip, whose 32px box is deliberately immune to
+/// text scaling. A pinned sliver has to declare its extent up front, and an
+/// under-declared one clips the chips, so this is pinned by a widget test
+/// rather than trusted.
+const double _kFilterChipsExtent = 48;
+
+/// The whole Messages pane as a single scroll view.
+///
+/// Every piece of chrome — following bar, search field, filter chips — used to
+/// be a fixed-height child of a [Column] wrapping the list, which on a small
+/// Android phone left the list roughly one row tall once the keyboard opened,
+/// and overflowed outright (#6388 review, items 4 and 5). Only the filter
+/// chips stay pinned now; everything above them scrolls away, handing the
+/// viewport back on every device rather than only below some height
+/// threshold. The keyboard, not the screen, is what collapses the viewport —
+/// a threshold would have missed the tall-phone case entirely.
+class _MessagesScrollView extends ConsumerStatefulWidget {
+  const _MessagesScrollView({required this.currentUserPubkey});
 
   final String currentUserPubkey;
 
   @override
-  Widget build(BuildContext context) {
-    final status = context.select<ConversationListBloc, ConversationListStatus>(
-      (bloc) => bloc.state.status,
-    );
-
-    return switch (status) {
-      ConversationListStatus.initial ||
-      ConversationListStatus.loading => const Center(
-        child: CircularProgressIndicator(color: VineTheme.primary),
-      ),
-      ConversationListStatus.error => InboxErrorState(
-        onRetry: () => context.read<ConversationListBloc>().add(
-          const ConversationListStarted(),
-        ),
-      ),
-      ConversationListStatus.loaded => _ConversationList(
-        currentUserPubkey: currentUserPubkey,
-      ),
-    };
-  }
+  ConsumerState<_MessagesScrollView> createState() => _ConversationListState();
 }
 
-class _ConversationList extends ConsumerStatefulWidget {
-  const _ConversationList({required this.currentUserPubkey});
-
-  final String currentUserPubkey;
-
-  @override
-  ConsumerState<_ConversationList> createState() => _ConversationListState();
-}
-
-class _ConversationListState extends ConsumerState<_ConversationList>
+class _ConversationListState extends ConsumerState<_MessagesScrollView>
     with ScrollPaginationMixin {
   final ScrollController _scrollController = ScrollController();
   late final TextEditingController _searchController;
+  final FocusNode _searchFocusNode = FocusNode();
+
+  /// Whether the search field holds focus, i.e. the keyboard is up and the
+  /// viewport is roughly halved.
+  bool _searchFocused = false;
 
   /// ID of the conversation whose long-press action sheet is currently open.
   /// Drives the [ConversationTile] highlight so the user can see which row
@@ -606,28 +568,113 @@ class _ConversationListState extends ConsumerState<_ConversationList>
   @override
   void initState() {
     super.initState();
-    // Seed from the bloc rather than starting empty. This State is recreated
-    // whenever the status leaves `loaded` (a stream error and its retry) or a
-    // keyed BlocProvider above re-inflates the view, while the bloc — and so
-    // state.searchQuery — survives. A fresh empty controller would leave the
-    // list filtered by an invisible query: the search empty state over a blank
-    // field, with pagination silently suspended.
+    // Seed from the bloc rather than starting empty. This State survives a
+    // status change now that it owns every branch, but a keyed BlocProvider
+    // above still re-inflates it while the bloc — and so state.searchQuery —
+    // survives. A fresh empty controller would leave the list filtered by an
+    // invisible query: the search empty state over a blank field, with
+    // pagination silently suspended.
     _searchController = TextEditingController(
       text: context.read<ConversationListBloc>().state.searchQuery,
     );
+    _searchFocusNode.addListener(_onSearchFocusChanged);
     initPagination();
+  }
+
+  void _onSearchFocusChanged() {
+    if (_searchFocusNode.hasFocus == _searchFocused) return;
+    setState(() => _searchFocused = _searchFocusNode.hasFocus);
   }
 
   @override
   void dispose() {
     disposePagination();
     _scrollController.dispose();
+    _searchFocusNode
+      ..removeListener(_onSearchFocusChanged)
+      ..dispose();
     _searchController.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
+    final status = context.select<ConversationListBloc, ConversationListStatus>(
+      (bloc) => bloc.state.status,
+    );
+
+    return CustomScrollView(
+      controller: _scrollController,
+      slivers: [
+        // Collapses while the search field holds focus (#6388 review, item 5).
+        //
+        // Keyed off focus rather than off a non-empty query on purpose: the
+        // keyboard is what halves the viewport, and `state.searchQuery` stays
+        // empty below `minSearchQueryLength` (2) — so a query-driven collapse
+        // would still be showing 128px of faces after the first keystroke,
+        // which is exactly the moment the list has the least room.
+        SliverToBoxAdapter(
+          child: AnimatedSize(
+            duration: MediaQuery.disableAnimationsOf(context)
+                ? Duration.zero
+                : const Duration(milliseconds: 180),
+            curve: Curves.easeOutCubic,
+            alignment: Alignment.topCenter,
+            child: _searchFocused
+                ? const SizedBox(width: double.infinity)
+                : FollowingBar(
+                    onUserTapped: (pubkey) {
+                      Log.info(
+                        '👤 User tapped in following bar: $pubkey',
+                        name: 'InboxView',
+                        category: LogCategory.ui,
+                      );
+                      context.read<ConversationListBloc>().add(
+                        ConversationListNavigateToUser(pubkey),
+                      );
+                    },
+                  ),
+          ),
+        ),
+        // Thin restore progress bar while the one-time reinstall history
+        // recovery is still running (#5202).
+        const SliverToBoxAdapter(child: _RestoringHistoryIndicator()),
+        // Static banner while the recovery gate is still hiding would-be
+        // message requests (#6431). Emitted OUTSIDE the status switch, which
+        // is what its Column placement bought before this pane became a single
+        // scroll view: it still covers every branch below — empty inbox,
+        // requests-only, filtered, and populated — without threading a flag
+        // through each one. It gates itself on the loaded status, so the
+        // loading spinner and InboxErrorState branches are unaffected.
+        const SliverToBoxAdapter(child: _RestorePausedBannerGate()),
+        ...switch (status) {
+          ConversationListStatus.initial ||
+          ConversationListStatus.loading => const [
+            SliverFillRemaining(
+              hasScrollBody: false,
+              child: Center(
+                child: CircularProgressIndicator(color: VineTheme.primary),
+              ),
+            ),
+          ],
+          ConversationListStatus.error => [
+            SliverFillRemaining(
+              hasScrollBody: false,
+              child: InboxErrorState(
+                onRetry: () => context.read<ConversationListBloc>().add(
+                  const ConversationListStarted(),
+                ),
+              ),
+            ),
+          ],
+          ConversationListStatus.loaded => _loadedSlivers(context),
+        },
+      ],
+    );
+  }
+
+  /// Slivers for the `loaded` status, in render order.
+  List<Widget> _loadedSlivers(BuildContext context) {
     final conversations = context
         .select<ConversationListBloc, List<DmConversation>>(
           (bloc) => bloc.state.conversations,
@@ -654,35 +701,48 @@ class _ConversationListState extends ConsumerState<_ConversationList>
     final isFiltering = context.select<ConversationListBloc, bool>(
       (bloc) => bloc.state.isFiltering,
     );
+    final pinned = context.select<ConversationListBloc, DmConversation?>(
+      (bloc) => bloc.state.pinnedConversation,
+    );
 
-    if (conversations.isEmpty && !hasRequests) return const InboxEmptyState();
+    final supportRow = pinned == null
+        ? null
+        : _PinnedSupportRow(
+            conversation: pinned,
+            currentUserPubkey: widget.currentUserPubkey,
+          );
 
-    // Only requests, no followed conversations — show banner + empty state
-    if (conversations.isEmpty && hasRequests) {
-      return Column(
-        children: [
-          MessageRequestsBanner(
-            requestCount: requestUnreadCount,
-            onTap: () => _openMessageRequests(context),
-          ),
-          const Expanded(child: InboxEmptyState()),
-        ],
-      );
+    // Nothing but the support row to show. Keep the empty-state copy — a
+    // brand-new user still needs to be told the inbox is empty — but render
+    // the row above it rather than dropping it, and skip the search field and
+    // filter chips, which have nothing to act on.
+    if (conversations.isEmpty && !hasRequests) {
+      return [
+        if (supportRow != null) SliverToBoxAdapter(child: supportRow),
+        const SliverFillRemaining(
+          hasScrollBody: false,
+          child: InboxEmptyState(),
+        ),
+      ];
     }
 
-    return Column(
-      children: [
-        Padding(
+    return [
+      SliverToBoxAdapter(
+        child: Padding(
           padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
           child: DivineSearchBar(
             controller: _searchController,
+            focusNode: _searchFocusNode,
             hintText: context.l10n.inboxSearchHint,
             onChanged: (value) => context.read<ConversationListBloc>().add(
               ConversationListSearchQueryChanged(value),
             ),
           ),
         ),
-        UnreadFilterChips(
+      ),
+      SliverPersistentHeader(
+        pinned: true,
+        delegate: _FilterChipsHeaderDelegate(
           unreadOnly: unreadOnly,
           onUnreadOnlyChanged: (value) {
             if (value == unreadOnly) return;
@@ -691,39 +751,105 @@ class _ConversationListState extends ConsumerState<_ConversationList>
             );
           },
         ),
-        Expanded(
-          child: visibleConversations.isEmpty
-              ? _FilteredEmptyContent(
-                  title: searchQuery.isNotEmpty
-                      ? context.l10n.inboxSearchEmptyTitle
-                      : context.l10n.inboxUnreadEmptyTitle,
-                  subtitle: searchQuery.isNotEmpty
-                      ? context.l10n.inboxSearchEmptySubtitle
-                      : context.l10n.inboxUnreadEmptySubtitle,
-                  hasRequests: hasRequests,
-                  requestUnreadCount: requestUnreadCount,
-                  onOpenRequests: () => _openMessageRequests(context),
-                )
-              : _ConversationListView(
-                  scrollController: _scrollController,
-                  conversations: visibleConversations,
-                  hasRequests: hasRequests,
-                  requestUnreadCount: requestUnreadCount,
-                  // Suppress the load-more affordance while a filter/search
-                  // narrows the list: the filtered result is already complete,
-                  // and a short one can't scroll to trigger a load — leaving a
-                  // spinner that never resolves.
-                  hasMore: hasMore && !isFiltering,
-                  highlightedConversationId: _highlightedConversationId,
-                  currentUserPubkey: widget.currentUserPubkey,
-                  onOpenRequests: () => _openMessageRequests(context),
-                  onConversationTapped: (conversation) =>
-                      _onConversationTapped(context, conversation),
-                  onConversationLongPressed: (conversation) =>
-                      _onConversationLongPressed(context, ref, conversation),
+      ),
+      // First tile of the list, ahead of the requests banner and every real
+      // conversation — but only when it would survive the active filter. A
+      // row that matches neither the query nor the Unread chip, sitting atop
+      // a filtered result set, reads as a search hit that isn't one.
+      if (supportRow != null &&
+          _supportRowSurvivesFilter(
+            context,
+            pinned: pinned!,
+            unreadOnly: unreadOnly,
+            query: searchQuery,
+          ))
+        SliverToBoxAdapter(child: supportRow),
+      if (visibleConversations.isEmpty) ...[
+        if (hasRequests)
+          SliverToBoxAdapter(
+            child: MessageRequestsBanner(
+              requestCount: requestUnreadCount,
+              onTap: () => _openMessageRequests(context),
+            ),
+          ),
+        SliverFillRemaining(
+          hasScrollBody: false,
+          child: _FilteredEmptyContent(
+            title: searchQuery.isNotEmpty
+                ? context.l10n.inboxSearchEmptyTitle
+                : context.l10n.inboxUnreadEmptyTitle,
+            subtitle: searchQuery.isNotEmpty
+                ? context.l10n.inboxSearchEmptySubtitle
+                : context.l10n.inboxUnreadEmptySubtitle,
+          ),
+        ),
+      ] else ...[
+        if (hasRequests)
+          SliverToBoxAdapter(
+            child: MessageRequestsBanner(
+              requestCount: requestUnreadCount,
+              onTap: () => _openMessageRequests(context),
+            ),
+          ),
+        SliverList.builder(
+          itemCount: visibleConversations.length,
+          itemBuilder: (context, index) {
+            final conversation = visibleConversations[index];
+            return ConversationTile(
+              conversation: conversation,
+              currentUserPubkey: widget.currentUserPubkey,
+              highlighted: conversation.id == _highlightedConversationId,
+              onTap: () => _onConversationTapped(context, conversation),
+              onLongPress: () =>
+                  _onConversationLongPressed(context, ref, conversation),
+            );
+          },
+        ),
+        // Suppress the load-more affordance while a filter/search narrows the
+        // list: the filtered result is already complete, and a short one
+        // can't scroll to trigger a load — leaving a spinner that never
+        // resolves.
+        if (hasMore && !isFiltering)
+          const SliverToBoxAdapter(
+            child: Padding(
+              padding: EdgeInsets.symmetric(vertical: 24),
+              child: Center(
+                child: SizedBox(
+                  width: 24,
+                  height: 24,
+                  child: CircularProgressIndicator(
+                    color: VineTheme.primary,
+                    strokeWidth: 2,
+                  ),
                 ),
+              ),
+            ),
+          ),
+        // Clears the compose FAB so it never covers the last tile.
+        const SliverToBoxAdapter(
+          child: SizedBox(height: _kConversationListBottomInset),
         ),
       ],
+    ];
+  }
+
+  /// Whether the support row should still render under the active filter.
+  ///
+  /// It is pinned against the *sort*, not against the user's filters: hiding
+  /// it here is what makes it behave like any other chat once a query or the
+  /// Unread chip is on. [query] arrives already thresholded by the bloc — it
+  /// is `''` below `minSearchQueryLength` — so an empty string reliably means
+  /// "no search active".
+  bool _supportRowSurvivesFilter(
+    BuildContext context, {
+    required DmConversation pinned,
+    required bool unreadOnly,
+    required String query,
+  }) {
+    if (unreadOnly && pinned.isRead) return false;
+    if (query.isEmpty) return true;
+    return context.l10n.inboxSupportRowTitle.toLowerCase().contains(
+      query.toLowerCase(),
     );
   }
 
@@ -880,134 +1006,76 @@ class _ConversationListState extends ConsumerState<_ConversationList>
   }
 }
 
-/// Scrolling conversation list: optional requests banner, conversation
-/// tiles for [conversations], and a trailing load-more spinner.
-class _ConversationListView extends StatelessWidget {
-  const _ConversationListView({
-    required this.scrollController,
-    required this.conversations,
-    required this.hasRequests,
-    required this.requestUnreadCount,
-    required this.hasMore,
-    required this.highlightedConversationId,
-    required this.currentUserPubkey,
-    required this.onOpenRequests,
-    required this.onConversationTapped,
-    required this.onConversationLongPressed,
-  });
+/// Shown when an active filter (Unread chip or search) leaves nothing to
+/// list, confirming the list is not empty by accident.
+///
+/// The requests banner is emitted as its own sliver above this, so it stays
+/// reachable without this widget having to lay it out.
+class _FilteredEmptyContent extends StatelessWidget {
+  const _FilteredEmptyContent({required this.title, required this.subtitle});
 
-  final ScrollController scrollController;
-  final List<DmConversation> conversations;
-  final bool hasRequests;
-  final int requestUnreadCount;
-  final bool hasMore;
-  final String? highlightedConversationId;
-  final String currentUserPubkey;
-  final VoidCallback onOpenRequests;
-  final ValueChanged<DmConversation> onConversationTapped;
-  final ValueChanged<DmConversation> onConversationLongPressed;
+  final String title;
+  final String subtitle;
 
   @override
   Widget build(BuildContext context) {
-    final bannerOffset = hasRequests ? 1 : 0;
-    return ListView.builder(
-      controller: scrollController,
-      padding: const EdgeInsets.only(bottom: _kConversationListBottomInset),
-      itemCount: conversations.length + bannerOffset + (hasMore ? 1 : 0),
-      itemBuilder: (context, index) {
-        if (hasRequests && index == 0) {
-          return MessageRequestsBanner(
-            requestCount: requestUnreadCount,
-            onTap: onOpenRequests,
-          );
-        }
-
-        final conversationIndex = index - bannerOffset;
-
-        if (conversationIndex == conversations.length) {
-          return const Padding(
-            padding: EdgeInsets.symmetric(vertical: 24),
-            child: Center(
-              child: SizedBox(
-                width: 24,
-                height: 24,
-                child: CircularProgressIndicator(
-                  color: VineTheme.primary,
-                  strokeWidth: 2,
-                ),
-              ),
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 48),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          spacing: 8,
+          children: [
+            Text(
+              title,
+              style: VineTheme.titleMediumFont(color: VineTheme.onSurfaceMuted),
+              textAlign: TextAlign.center,
             ),
-          );
-        }
-
-        final conversation = conversations[conversationIndex];
-        return ConversationTile(
-          conversation: conversation,
-          currentUserPubkey: currentUserPubkey,
-          highlighted: conversation.id == highlightedConversationId,
-          onTap: () => onConversationTapped(conversation),
-          onLongPress: () => onConversationLongPressed(conversation),
-        );
-      },
+            Text(
+              subtitle,
+              style: VineTheme.bodyMediumFont(color: VineTheme.onSurfaceMuted),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
     );
   }
 }
 
-/// Shown when an active filter (Unread chip or search) leaves nothing to
-/// list: keeps the requests banner reachable and confirms the list is not
-/// empty by accident.
-class _FilteredEmptyContent extends StatelessWidget {
-  const _FilteredEmptyContent({
-    required this.title,
-    required this.subtitle,
-    required this.hasRequests,
-    required this.requestUnreadCount,
-    required this.onOpenRequests,
+/// Pinned header carrying [UnreadFilterChips].
+///
+/// Pinned rather than scrolled away so the user can always drop back to All
+/// after narrowing to Unread without hunting for the chip. Opaque, because the
+/// conversation list scrolls underneath it.
+class _FilterChipsHeaderDelegate extends SliverPersistentHeaderDelegate {
+  const _FilterChipsHeaderDelegate({
+    required this.unreadOnly,
+    required this.onUnreadOnlyChanged,
   });
 
-  final String title;
-  final String subtitle;
-  final bool hasRequests;
-  final int requestUnreadCount;
-  final VoidCallback onOpenRequests;
+  final bool unreadOnly;
+  final ValueChanged<bool> onUnreadOnlyChanged;
 
   @override
-  Widget build(BuildContext context) {
-    return Column(
-      children: [
-        if (hasRequests)
-          MessageRequestsBanner(
-            requestCount: requestUnreadCount,
-            onTap: onOpenRequests,
-          ),
-        Expanded(
-          child: Center(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 48),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                spacing: 8,
-                children: [
-                  Text(
-                    title,
-                    style: VineTheme.titleMediumFont(
-                      color: VineTheme.onSurfaceMuted,
-                    ),
-                    textAlign: TextAlign.center,
-                  ),
-                  Text(
-                    subtitle,
-                    style: VineTheme.bodyMediumFont(
-                      color: VineTheme.onSurfaceMuted,
-                    ),
-                    textAlign: TextAlign.center,
-                  ),
-                ],
-              ),
-            ),
-          ),
-        ),
-      ],
+  double get minExtent => _kFilterChipsExtent;
+
+  @override
+  double get maxExtent => _kFilterChipsExtent;
+
+  @override
+  Widget build(BuildContext context, double shrinkOffset, bool overlaps) {
+    return ColoredBox(
+      color: VineTheme.surfaceContainerHigh,
+      child: UnreadFilterChips(
+        unreadOnly: unreadOnly,
+        onUnreadOnlyChanged: onUnreadOnlyChanged,
+      ),
     );
   }
+
+  @override
+  bool shouldRebuild(_FilterChipsHeaderDelegate oldDelegate) =>
+      oldDelegate.unreadOnly != unreadOnly ||
+      oldDelegate.onUnreadOnlyChanged != onUnreadOnlyChanged;
 }

--- a/mobile/lib/screens/inbox/inbox_view.dart
+++ b/mobile/lib/screens/inbox/inbox_view.dart
@@ -515,12 +515,28 @@ class _PinnedSupportRow extends StatelessWidget {
   }
 }
 
-/// Exact height of [UnreadFilterChips]: 8px of vertical padding either side of
-/// a [DivineButtonSize.tiny] chip, whose 32px box is deliberately immune to
-/// text scaling. A pinned sliver has to declare its extent up front, and an
-/// under-declared one clips the chips, so this is pinned by a widget test
-/// rather than trusted.
-const double _kFilterChipsExtent = 48;
+/// Vertical padding [UnreadFilterChips] puts above and below its chip row.
+const double _kFilterChipsVerticalPadding = 8;
+
+/// Inner vertical padding of a [DivineButtonSize.tiny] chip. Fixed per size.
+const double _kTinyChipVerticalPadding = 6;
+
+/// Line box of a tiny chip's `titleSmallFont` label (14/20) — the only part of
+/// the chip's height that grows with the text scaler.
+const double _kTinyChipLineHeight = 20;
+
+/// Height [UnreadFilterChips] needs at the current text scale.
+///
+/// A pinned sliver declares its extent before its child is laid out, so this
+/// reproduces the child's height rather than measuring it. Under-declaring
+/// silently clips the label — a Row overflowing on its cross axis does not
+/// throw. Duplicating the arithmetic is safe only because a widget test pins
+/// it against the chips' real intrinsic height at two scales, so a moved
+/// `divine_ui` token fails there instead of on a phone.
+double _filterChipsExtent(BuildContext context) =>
+    _kFilterChipsVerticalPadding * 2 +
+    _kTinyChipVerticalPadding * 2 +
+    MediaQuery.textScalerOf(context).scale(_kTinyChipLineHeight);
 
 /// The whole Messages pane as a single scroll view.
 ///
@@ -770,6 +786,7 @@ class _MessagesScrollViewState extends ConsumerState<_MessagesScrollView>
         pinned: true,
         delegate: _FilterChipsHeaderDelegate(
           unreadOnly: unreadOnly,
+          extent: _filterChipsExtent(context),
           onUnreadOnlyChanged: (value) {
             if (value == unreadOnly) return;
             context.read<ConversationListBloc>().add(
@@ -1098,16 +1115,24 @@ class _FilterChipsHeaderDelegate extends SliverPersistentHeaderDelegate {
   const _FilterChipsHeaderDelegate({
     required this.unreadOnly,
     required this.onUnreadOnlyChanged,
+    required this.extent,
   });
 
   final bool unreadOnly;
   final ValueChanged<bool> onUnreadOnlyChanged;
 
-  @override
-  double get minExtent => _kFilterChipsExtent;
+  /// Height the chips need at the caller's text scale. Passed in rather than
+  /// read here: [SliverPersistentHeaderDelegate]'s extent getters take no
+  /// [BuildContext], so the MediaQuery lookup has to happen in the widget
+  /// that builds the delegate. Same shape as the `topInset` pattern in
+  /// `.claude/rules/ui_theming.md`.
+  final double extent;
 
   @override
-  double get maxExtent => _kFilterChipsExtent;
+  double get minExtent => extent;
+
+  @override
+  double get maxExtent => extent;
 
   @override
   Widget build(BuildContext context, double shrinkOffset, bool overlaps) {
@@ -1123,5 +1148,6 @@ class _FilterChipsHeaderDelegate extends SliverPersistentHeaderDelegate {
   @override
   bool shouldRebuild(_FilterChipsHeaderDelegate oldDelegate) =>
       oldDelegate.unreadOnly != unreadOnly ||
-      oldDelegate.onUnreadOnlyChanged != onUnreadOnlyChanged;
+      oldDelegate.onUnreadOnlyChanged != onUnreadOnlyChanged ||
+      oldDelegate.extent != extent;
 }

--- a/mobile/lib/screens/inbox/inbox_view.dart
+++ b/mobile/lib/screens/inbox/inbox_view.dart
@@ -490,7 +490,6 @@ class _RestorePausedBannerGate extends StatelessWidget {
   }
 }
 
-/// Switches between loading, error, empty, and conversation list states.
 /// Pinned "Divine Moderation" support row at the top of the Messages tab.
 ///
 /// Renders nothing unless [ConversationListState.pinnedConversation] is set —
@@ -541,6 +540,7 @@ class _PinnedSupportRow extends StatelessWidget {
   }
 }
 
+/// Switches between loading, error, empty, and conversation list states.
 class _ConversationListContent extends StatelessWidget {
   const _ConversationListContent({required this.currentUserPubkey});
 

--- a/mobile/lib/screens/inbox/inbox_view.dart
+++ b/mobile/lib/screens/inbox/inbox_view.dart
@@ -735,9 +735,16 @@ class _MessagesScrollViewState extends ConsumerState<_MessagesScrollView>
     // brand-new user still needs to be told the inbox is empty — but render
     // the row above it rather than dropping it, and skip the search field and
     // filter chips, which have nothing to act on.
-    if (conversations.isEmpty && !hasRequests) {
+    if (conversations.isEmpty) {
       return [
         if (supportRow != null) SliverToBoxAdapter(child: supportRow),
+        if (hasRequests)
+          SliverToBoxAdapter(
+            child: MessageRequestsBanner(
+              requestCount: requestUnreadCount,
+              onTap: () => _openMessageRequests(context),
+            ),
+          ),
         const SliverFillRemaining(
           hasScrollBody: false,
           child: InboxEmptyState(),

--- a/mobile/lib/screens/inbox/inbox_view.dart
+++ b/mobile/lib/screens/inbox/inbox_view.dart
@@ -353,6 +353,17 @@ class _MessagesContent extends ConsumerWidget {
         children: [
           Column(
             children: [
+              // Pinned Divine Moderation support row (#6283).
+              //
+              // Deliberately ABOVE the status switch inside
+              // _ConversationListContent: that switch replaces the entire list
+              // subtree with a spinner while the bloc loads, and returns early
+              // to InboxEmptyState for a user with no conversations — so a row
+              // rendered inside the list would be invisible in five of the six
+              // branches, including for the brand-new user who most needs it.
+              // Placed above FollowingBar so its position does not shift when
+              // the following strip resolves from empty to 128px.
+              _PinnedSupportRow(currentUserPubkey: currentPubkey),
               // Following users horizontal bar
               FollowingBar(
                 onUserTapped: (pubkey) {
@@ -480,6 +491,56 @@ class _RestorePausedBannerGate extends StatelessWidget {
 }
 
 /// Switches between loading, error, empty, and conversation list states.
+/// Pinned "Divine Moderation" support row at the top of the Messages tab.
+///
+/// Renders nothing unless [ConversationListState.pinnedConversation] is set —
+/// the bloc composes that inside the same pipeline that applies the blocklist
+/// filter and the protected-minor gate, so a user who blocked the moderation
+/// account, or a restricted minor whose approval was revoked, gets no row
+/// rather than one the conversation route guard would bounce.
+class _PinnedSupportRow extends StatelessWidget {
+  const _PinnedSupportRow({required this.currentUserPubkey});
+
+  /// Signed-in pubkey. Passed in rather than derived from the conversation's
+  /// participant list — that list is sorted, so its first entry is not
+  /// reliably self, and [ConversationTile] uses self to pick which
+  /// participant's avatar to render.
+  final String currentUserPubkey;
+
+  @override
+  Widget build(BuildContext context) {
+    final pinned = context.select<ConversationListBloc, DmConversation?>(
+      (bloc) => bloc.state.pinnedConversation,
+    );
+    if (pinned == null) return const SizedBox.shrink();
+
+    return ConversationTile(
+      conversation: pinned,
+      currentUserPubkey: currentUserPubkey,
+      // Fixed identity: the profile lookup yields null until the relay client
+      // is ready, and the tile's fallback is a generated name — so sourcing
+      // this from kind-0 would show a random display name at cold start.
+      displayNameOverride: context.l10n.inboxSupportRowTitle,
+      // Only stand in for the preview when there is no real thread yet; once
+      // the team replies, the last message is more useful than the blurb.
+      subtitleOverride: pinned.lastMessageContent == null
+          ? context.l10n.inboxSupportRowSubtitle
+          : null,
+      onTap: () => _pushConversation(
+        context,
+        pinned.id,
+        // Self must be stripped, matching _onConversationTapped: the route
+        // reads `extra` as the COUNTERPARTY list, so passing the raw
+        // participants opens a conversation with the signed-in user instead
+        // of with moderation.
+        pinned.participantPubkeys
+            .where((pk) => pk != currentUserPubkey)
+            .toList(),
+      ),
+    );
+  }
+}
+
 class _ConversationListContent extends StatelessWidget {
   const _ConversationListContent({required this.currentUserPubkey});
 

--- a/mobile/lib/screens/inbox/inbox_view.dart
+++ b/mobile/lib/screens/inbox/inbox_view.dart
@@ -867,10 +867,13 @@ class _MessagesScrollViewState extends ConsumerState<_MessagesScrollView>
   /// is `''` below `minSearchQueryLength` — so an empty string reliably means
   /// "no search active".
   ///
-  /// Matches title OR last message, mirroring the bloc's `_applyFilters`. Once
-  /// the team has replied the preview is a real message, and a query drawn
-  /// from it should surface this row for the same reason it surfaces any
-  /// other.
+  /// Matches title OR whatever the row renders as its preview, mirroring the
+  /// bloc's `_applyFilters`. Once the team has replied the preview is a real
+  /// message, and a query drawn from it should surface this row for the same
+  /// reason it surfaces any other. Before that it is the subtitle blurb — the
+  /// same string [_PinnedSupportRow] passes as `subtitleOverride`, and matching
+  /// it is what stops a search for a word the user can read on screen from
+  /// hiding the row that shows it.
   bool _supportRowSurvivesFilter(
     BuildContext context, {
     required DmConversation pinned,
@@ -880,8 +883,10 @@ class _MessagesScrollViewState extends ConsumerState<_MessagesScrollView>
     if (unreadOnly && pinned.isRead) return false;
     if (query.isEmpty) return true;
     final needle = query.toLowerCase();
+    final preview =
+        pinned.lastMessageContent ?? context.l10n.inboxSupportRowSubtitle;
     return context.l10n.inboxSupportRowTitle.toLowerCase().contains(needle) ||
-        (pinned.lastMessageContent?.toLowerCase().contains(needle) ?? false);
+        preview.toLowerCase().contains(needle);
   }
 
   void _openMessageRequests(BuildContext context) {

--- a/mobile/lib/screens/inbox/message_requests/message_requests_page.dart
+++ b/mobile/lib/screens/inbox/message_requests/message_requests_page.dart
@@ -58,7 +58,6 @@ class MessageRequestsPage extends ConsumerWidget {
             // read" / "remove all" sweep a conversation the user is not
             // looking at.
             supportRowPubkey: kModerationPubkeyHex,
-            supportRowLegacyPubkeys: kLegacyModerationPubkeys,
           )..add(const ConversationListStarted()),
         ),
         BlocProvider(

--- a/mobile/lib/screens/inbox/message_requests/message_requests_page.dart
+++ b/mobile/lib/screens/inbox/message_requests/message_requests_page.dart
@@ -7,6 +7,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/blocs/dm/conversation_list/conversation_list_bloc.dart';
 import 'package:openvine/blocs/dm/message_requests/message_request_actions_cubit.dart';
+import 'package:openvine/config/official_accounts.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/official_accounts_providers.dart';
 import 'package:openvine/screens/inbox/message_requests/message_requests_view.dart';
@@ -49,6 +50,15 @@ class MessageRequestsPage extends ConsumerWidget {
             followRepository: followRepository,
             contentBlocklistRepository: blocklistRepository,
             protectedMinorInboxGate: protectedMinorInboxGate,
+            // Same support-row wiring as InboxPage (#6283). Without it this
+            // bloc leaves the moderation thread in `requestConversations`
+            // while the inbox lifts it into the pinned row — so the same
+            // thread is reachable from both surfaces, the inbox's request
+            // banner counts one fewer than this page lists, and "mark all
+            // read" / "remove all" sweep a conversation the user is not
+            // looking at.
+            supportRowPubkey: kModerationPubkeyHex,
+            supportRowLegacyPubkeys: kLegacyModerationPubkeys,
           )..add(const ConversationListStarted()),
         ),
         BlocProvider(

--- a/mobile/lib/screens/inbox/widgets/conversation_tile.dart
+++ b/mobile/lib/screens/inbox/widgets/conversation_tile.dart
@@ -26,6 +26,8 @@ class ConversationTile extends ConsumerWidget {
     required this.onTap,
     this.onLongPress,
     this.highlighted = false,
+    this.displayNameOverride,
+    this.subtitleOverride,
     super.key,
   });
 
@@ -38,6 +40,17 @@ class ConversationTile extends ConsumerWidget {
   /// indicate this row is the target of an open long-press action sheet.
   final bool highlighted;
 
+  /// Fixed display name, bypassing the kind-0 profile lookup.
+  ///
+  /// Needed for rows whose identity is known ahead of the network: the profile
+  /// provider yields `null` until the relay client is ready, and the tile's
+  /// fallback is a generated "Adjective Animal N" name, so a known account
+  /// would otherwise render as a random user for the whole cold-start window.
+  final String? displayNameOverride;
+
+  /// Fixed preview line, bypassing [DmConversation.lastMessageContent].
+  final String? subtitleOverride;
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final otherPubkey = conversation.participantPubkeys.firstWhere(
@@ -47,12 +60,14 @@ class ConversationTile extends ConsumerWidget {
 
     final profileAsync = ref.watch(fetchUserProfileProvider(otherPubkey));
 
-    final displayName = profileAsync.maybeWhen(
-      data: (profile) =>
-          profile?.bestDisplayName ??
-          UserProfile.defaultDisplayNameFor(otherPubkey),
-      orElse: () => UserProfile.defaultDisplayNameFor(otherPubkey),
-    );
+    final displayName =
+        displayNameOverride ??
+        profileAsync.maybeWhen<String>(
+          data: (profile) =>
+              profile?.bestDisplayName ??
+              UserProfile.defaultDisplayNameFor(otherPubkey),
+          orElse: () => UserProfile.defaultDisplayNameFor(otherPubkey),
+        );
 
     final imageUrl = profileAsync.maybeWhen(
       data: (profile) => profile?.picture,
@@ -75,7 +90,12 @@ class ConversationTile extends ConsumerWidget {
       label: conversation.isRead
           ? context.l10n.inboxConversationTileLabel(displayName)
           : context.l10n.inboxConversationTileLabelUnread(displayName),
-      onLongPressHint: context.l10n.inboxConversationTileLongPressHint,
+      // Only advertise the long-press affordance when there is one: the hint
+      // is a promise to assistive tech, and rows built without a handler
+      // (the pinned support row) have no action sheet to open.
+      onLongPressHint: onLongPress == null
+          ? null
+          : context.l10n.inboxConversationTileLongPressHint,
       child: GestureDetector(
         onTap: () {
           Log.debug(
@@ -142,7 +162,17 @@ class ConversationTile extends ConsumerWidget {
                           ],
                         ],
                       ),
-                      if (conversation.lastMessageContent != null) ...[
+                      if (subtitleOverride case final subtitle?) ...[
+                        const SizedBox(height: 4),
+                        Text(
+                          subtitle,
+                          style: VineTheme.bodyMediumFont(
+                            color: VineTheme.onSurfaceVariant,
+                          ),
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ] else if (conversation.lastMessageContent != null) ...[
                         const SizedBox(height: 4),
                         _ConversationPreviewText(
                           payload: _previewPayload(

--- a/mobile/lib/screens/inbox/widgets/conversation_tile.dart
+++ b/mobile/lib/screens/inbox/widgets/conversation_tile.dart
@@ -6,6 +6,7 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:models/models.dart';
+import 'package:openvine/config/official_accounts.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/l10n/localized_time_formatter.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
@@ -129,6 +130,11 @@ class ConversationTile extends ConsumerWidget {
                     name: displayName,
                     placeholderSeed: otherPubkey,
                     size: 40,
+                    // Bundled artwork for the moderation account, whose kind-0
+                    // picture does not survive the SVG parser (see below).
+                    contentOverride: isModerationAccount(otherPubkey)
+                        ? const _ModerationAvatar()
+                        : null,
                   ),
                 ),
                 const SizedBox(width: 20),
@@ -189,6 +195,34 @@ class ConversationTile extends ConsumerWidget {
             ),
           ),
         ),
+      ),
+    );
+  }
+}
+
+/// Brand artwork for the Divine moderation account's avatar.
+///
+/// The account's kind-0 `picture` is the hosted `divine-logo.svg`, which
+/// colours its paths through a `<style>` block. `vector_graphics_compiler` has
+/// no `<style>` parser, so it discards the stylesheet and every path falls
+/// back to opaque black — 1.1:1 against the inbox surface. The bundled
+/// `logo.svg` is the same wordmark carrying presentational `fill` attributes
+/// instead, so it survives the parser and renders in brand green.
+///
+/// `BoxFit.cover` matches how divine-web frames the same artwork: the wordmark
+/// is 3.8:1, so filling a square avatar crops it to the middle "Vi". Contain
+/// would letterbox the whole lockup into an illegible 40px sliver.
+class _ModerationAvatar extends StatelessWidget {
+  const _ModerationAvatar();
+
+  @override
+  Widget build(BuildContext context) {
+    return const ColoredBox(
+      color: VineTheme.containerLow,
+      child: DivineIcon(
+        icon: DivineIconName.logo,
+        size: 40,
+        fit: BoxFit.cover,
       ),
     );
   }

--- a/mobile/lib/screens/inbox/widgets/unread_filter_chips.dart
+++ b/mobile/lib/screens/inbox/widgets/unread_filter_chips.dart
@@ -25,24 +25,25 @@ class UnreadFilterChips extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MediaQuery.withNoTextScaling(
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-        child: Row(
-          spacing: 8,
-          children: [
-            _FilterChip(
-              label: context.l10n.inboxFilterAll,
-              selected: !unreadOnly,
-              onTap: () => onUnreadOnlyChanged(false),
-            ),
-            _FilterChip(
-              label: context.l10n.inboxFilterUnread,
-              selected: unreadOnly,
-              onTap: () => onUnreadOnlyChanged(true),
-            ),
-          ],
-        ),
+    // Deliberately no MediaQuery.withNoTextScaling: these are controls to read
+    // and tap, not fixed overlay badges. The pinned header hosting this row
+    // declares a text-scale-aware extent so the row has room to grow into.
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Row(
+        spacing: 8,
+        children: [
+          _FilterChip(
+            label: context.l10n.inboxFilterAll,
+            selected: !unreadOnly,
+            onTap: () => onUnreadOnlyChanged(false),
+          ),
+          _FilterChip(
+            label: context.l10n.inboxFilterUnread,
+            selected: unreadOnly,
+            onTap: () => onUnreadOnlyChanged(true),
+          ),
+        ],
       ),
     );
   }

--- a/mobile/lib/screens/inbox/widgets/unread_filter_chips.dart
+++ b/mobile/lib/screens/inbox/widgets/unread_filter_chips.dart
@@ -25,22 +25,24 @@ class UnreadFilterChips extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      child: Row(
-        spacing: 8,
-        children: [
-          _FilterChip(
-            label: context.l10n.inboxFilterAll,
-            selected: !unreadOnly,
-            onTap: () => onUnreadOnlyChanged(false),
-          ),
-          _FilterChip(
-            label: context.l10n.inboxFilterUnread,
-            selected: unreadOnly,
-            onTap: () => onUnreadOnlyChanged(true),
-          ),
-        ],
+    return MediaQuery.withNoTextScaling(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        child: Row(
+          spacing: 8,
+          children: [
+            _FilterChip(
+              label: context.l10n.inboxFilterAll,
+              selected: !unreadOnly,
+              onTap: () => onUnreadOnlyChanged(false),
+            ),
+            _FilterChip(
+              label: context.l10n.inboxFilterUnread,
+              selected: unreadOnly,
+              onTap: () => onUnreadOnlyChanged(true),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/mobile/lib/services/moderation_label_service.dart
+++ b/mobile/lib/services/moderation_label_service.dart
@@ -7,6 +7,7 @@ import 'dart:convert';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/filter.dart';
 import 'package:nostr_sdk/nip05/nip05_validor.dart';
+import 'package:openvine/config/official_accounts.dart';
 import 'package:openvine/constants/nostr_event_kinds.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -105,15 +106,11 @@ class ModerationLabelService {
   static const String _contentWarningNamespace = 'content-warning';
 
   /// NIP-05 address for the Divine moderation identity.
-  static const String divineModerationNip05 = 'moderation@divine.video';
+  static const String divineModerationNip05 = kModerationNip05;
 
-  /// Fallback pubkey when NIP-05 resolution fails.
-  static const String fallbackModerationPubkeyHex =
-      '8fd5eb6d8f362163bc00a5ab6b4a3167dbf32d00ec4efdbcf43b3c9514433b7e';
-
-  /// Old pubkey — used only for one-time migration of stored subscriptions.
-  static const String _legacyModerationPubkeyHex =
-      '121b915baba659cbe59626a8afaf83b01dc42354dfecaad9d465d51bb5715d72';
+  /// Fallback pubkey when NIP-05 resolution fails — the key pinned in this
+  /// build, which is also what the protected-minor gate anchors on.
+  static const String fallbackModerationPubkeyHex = kModerationPubkeyHex;
 
   /// Cache TTL for NIP-05 resolved pubkey (24 hours).
   static const Duration _resolvedPubkeyTtl = Duration(hours: 24);
@@ -202,8 +199,8 @@ class ModerationLabelService {
       _isFollowingModerationEnabled =
           _prefs.getBool(_followingModerationEnabledKey) ?? false;
 
-      // Migrate legacy pubkey if present in stored subscriptions
-      await _migrateLegacyPubkey(_prefs);
+      // Migrate retired pubkeys if present in stored subscriptions
+      await _migrateLegacyPubkey();
 
       // Always subscribe to Divine labeler
       if (!_subscribedLabelers.contains(_divineModerationPubkey)) {
@@ -733,24 +730,30 @@ class ModerationLabelService {
     );
   }
 
-  /// Migrate the legacy moderation pubkey out of stored subscriptions.
+  /// Migrate retired moderation pubkeys out of stored subscriptions.
   ///
-  /// Existing users may have the old pubkey persisted. This swaps it for
-  /// the current resolved pubkey so they subscribe to the right labeler.
-  Future<void> _migrateLegacyPubkey(SharedPreferences prefs) async {
-    if (!_subscribedLabelers.contains(_legacyModerationPubkeyHex)) return;
+  /// Existing users may have a pre-rotation pubkey persisted. Swaps every one
+  /// still subscribed for the current resolved pubkey so they follow the right
+  /// labeler. Idempotent — runs on every init.
+  Future<void> _migrateLegacyPubkey() async {
+    final retired = kLegacyModerationPubkeys
+        .where(_subscribedLabelers.contains)
+        .toList();
+    if (retired.isEmpty) return;
 
-    _subscribedLabelers.remove(_legacyModerationPubkeyHex);
+    _subscribedLabelers.removeAll(retired);
     _subscribedLabelers.add(_divineModerationPubkey);
     await _saveSubscribedLabelers();
 
-    // Clean up any labels fetched from the old key
-    _removeLabelsForLabeler(_legacyModerationPubkeyHex);
-    _loadedLabelers.remove(_legacyModerationPubkeyHex);
+    for (final pubkey in retired) {
+      // Clean up any labels fetched from the old key
+      _removeLabelsForLabeler(pubkey);
+      _loadedLabelers.remove(pubkey);
+    }
 
     Log.info(
-      'Migrated moderation labeler from legacy pubkey '
-      '$_legacyModerationPubkeyHex to $_divineModerationPubkey',
+      'Migrated moderation labeler from retired pubkey(s) '
+      '${retired.join(', ')} to $_divineModerationPubkey',
       name: 'ModerationLabelService',
       category: LogCategory.system,
     );

--- a/mobile/lib/widgets/app_shell_badge_scope.dart
+++ b/mobile/lib/widgets/app_shell_badge_scope.dart
@@ -58,7 +58,6 @@ class AppShellBadgeScope extends ConsumerWidget {
             // moderation thread out of the list exactly as the inbox does, so
             // the count stays equal to the rows that render an unread dot.
             supportRowPubkey: kModerationPubkeyHex,
-            supportRowLegacyPubkeys: kLegacyModerationPubkeys,
           ),
         ),
         // Keep the provider identity stable so repository readiness / account

--- a/mobile/lib/widgets/app_shell_badge_scope.dart
+++ b/mobile/lib/widgets/app_shell_badge_scope.dart
@@ -8,6 +8,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/blocs/dm/unread_count/dm_unread_count_cubit.dart';
 import 'package:openvine/blocs/notifications/badge/notification_badge_cubit.dart';
+import 'package:openvine/config/official_accounts.dart';
 import 'package:openvine/notifications/providers/notification_repository_provider.dart';
 import 'package:openvine/providers/moderation_providers.dart';
 import 'package:openvine/providers/official_accounts_providers.dart';
@@ -53,6 +54,11 @@ class AppShellBadgeScope extends ConsumerWidget {
               contentBlocklistRepositoryProvider,
             ),
             protectedMinorInboxGate: ref.read(protectedMinorInboxGateProvider),
+            // Same pin wiring as InboxPage (#6283) — the badge partitions the
+            // moderation thread out of the list exactly as the inbox does, so
+            // the count stays equal to the rows that render an unread dot.
+            supportRowPubkey: kModerationPubkeyHex,
+            supportRowLegacyPubkeys: kLegacyModerationPubkeys,
           ),
         ),
         // Keep the provider identity stable so repository readiness / account

--- a/mobile/lib/widgets/user_avatar.dart
+++ b/mobile/lib/widgets/user_avatar.dart
@@ -33,6 +33,7 @@ class UserAvatar extends StatelessWidget {
     this.placeholderTone = UserAvatarPlaceholderTone.auto,
     this.placeholderSeed,
     this.cornerRadius,
+    this.contentOverride,
   });
 
   final String? imageUrl;
@@ -54,6 +55,14 @@ class UserAvatar extends StatelessWidget {
   /// profile avatar lightbox to render the maximized avatar at 112px
   /// instead of the size-derived default.
   final double? cornerRadius;
+
+  /// Fixed artwork rendered in place of [imageUrl] / [imageProvider] and the
+  /// generated placeholder, inside the shared avatar chrome (size, corner
+  /// radius, border) so it still lines up with neighbouring avatars.
+  ///
+  /// For rows whose identity is known ahead of the network and whose remote
+  /// picture cannot be trusted to render.
+  final Widget? contentOverride;
 
   @visibleForTesting
   static bool isSvgImageUrl(String? url) {
@@ -121,6 +130,10 @@ class UserAvatar extends StatelessWidget {
   );
 
   Widget _buildContent() {
+    if (contentOverride case final override?) {
+      return override;
+    }
+
     if (imageProvider != null) {
       return Image(
         image: imageProvider!,

--- a/mobile/packages/divine_ui/lib/src/icon/divine_icon.dart
+++ b/mobile/packages/divine_ui/lib/src/icon/divine_icon.dart
@@ -246,6 +246,7 @@ class DivineIcon extends StatelessWidget {
     required this.icon,
     this.size = 24,
     this.color,
+    this.fit = BoxFit.contain,
     super.key,
   });
 
@@ -258,12 +259,21 @@ class DivineIcon extends StatelessWidget {
   /// The color to apply to the icon. If null, uses the icon's original colors.
   final Color? color;
 
+  /// How the artwork is inscribed into the [size] box. Defaults to
+  /// [BoxFit.contain], which letterboxes a non-square asset.
+  ///
+  /// [BoxFit.cover] instead fills the box and crops the overflow, which is
+  /// what a wide asset like the wordmark needs when it stands in for a square
+  /// avatar.
+  final BoxFit fit;
+
   @override
   Widget build(BuildContext context) {
     return SvgPicture.asset(
       icon.assetPath,
       width: size,
       height: size,
+      fit: fit,
       colorFilter: color != null
           ? ColorFilter.mode(color!, BlendMode.srcIn)
           : null,

--- a/mobile/packages/divine_ui/test/src/icon/divine_icon_test.dart
+++ b/mobile/packages/divine_ui/test/src/icon/divine_icon_test.dart
@@ -104,6 +104,38 @@ void main() {
       expect(svgPicture.height, 32);
     });
 
+    testWidgets('letterboxes the artwork by default', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: DivineIcon(icon: DivineIconName.arrowLeft),
+          ),
+        ),
+      );
+
+      final svgPicture = tester.widget<SvgPicture>(find.byType(SvgPicture));
+      expect(svgPicture.fit, BoxFit.contain);
+    });
+
+    testWidgets('crops the artwork when fit is cover', (tester) async {
+      // A wide asset standing in for a square avatar has to fill the box and
+      // crop, not shrink to a letterboxed sliver.
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: DivineIcon(
+              icon: DivineIconName.logo,
+              size: 40,
+              fit: BoxFit.cover,
+            ),
+          ),
+        ),
+      );
+
+      final svgPicture = tester.widget<SvgPicture>(find.byType(SvgPicture));
+      expect(svgPicture.fit, BoxFit.cover);
+    });
+
     testWidgets('applies color filter when color is provided', (tester) async {
       await tester.pumpWidget(
         const MaterialApp(

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -5016,6 +5016,86 @@ class DmRepository {
     });
   }
 
+  /// Lifts the Divine Moderation support thread out of the inbox and request
+  /// lists so it renders once, as the pinned row (#6283).
+  ///
+  /// Every conversation keyed on the moderation account — [supportPubkey] or
+  /// any of [legacyPubkeys] — is removed from both lists. Only a thread on
+  /// [supportPubkey] comes back as `pinned`: the row routes on the returned
+  /// conversation's own participants and nothing remaps the recipient between
+  /// there and [sendMessage], so adopting a pre-rotation thread would send
+  /// support replies to a retired key. Retired keys de-duplicate, never adopt.
+  ///
+  /// Shared with the unread badge rather than reimplemented there, so the
+  /// count cannot drift from the rows the list actually renders (#4976).
+  ///
+  /// `supportConversationId` is the id the pinned row must open: non-null
+  /// whenever a pin is possible at all, so a caller that wants to synthesize a
+  /// stand-in row has both the go/no-go answer and the id without re-deriving
+  /// either. It is null — along with `pinned` — when there is no identity to
+  /// key on, or when the signed-in user *is* the moderation account, in which
+  /// case both lists come back untouched.
+  static ({
+    DmConversation? pinned,
+    String? supportConversationId,
+    List<DmConversation> inbox,
+    List<DmConversation> requests,
+  })
+  extractPinnedSupport({
+    required String userPubkey,
+    required String? supportPubkey,
+    required List<String> legacyPubkeys,
+    required List<DmConversation> inbox,
+    required List<DmConversation> requests,
+  }) {
+    if (userPubkey.isEmpty ||
+        supportPubkey == null ||
+        supportPubkey.isEmpty ||
+        userPubkey == supportPubkey) {
+      return (
+        pinned: null,
+        supportConversationId: null,
+        inbox: inbox,
+        requests: requests,
+      );
+    }
+
+    final currentId = computeConversationId([userPubkey, supportPubkey]);
+    final knownIds = <String>{
+      currentId,
+      for (final pubkey in legacyPubkeys)
+        if (pubkey.isNotEmpty) computeConversationId([userPubkey, pubkey]),
+    };
+
+    DmConversation? pinned;
+    final remainingInbox = <DmConversation>[];
+    for (final conversation in inbox) {
+      if (!knownIds.contains(conversation.id)) {
+        remainingInbox.add(conversation);
+      } else if (conversation.id == currentId) {
+        pinned ??= conversation;
+      }
+    }
+
+    // An inbound-only moderation DM (the team wrote first) has
+    // currentUserHasSent == false and lands in requests, not the inbox.
+    final remainingRequests = <DmConversation>[];
+    for (final conversation in requests) {
+      if (!knownIds.contains(conversation.id)) {
+        remainingRequests.add(conversation);
+      } else if (conversation.id == currentId) {
+        pinned ??= conversation;
+      }
+    }
+
+    return (
+      pinned: pinned,
+      supportConversationId: currentId,
+      inbox: remainingInbox,
+      requests: remainingRequests,
+    );
+  }
+
   /// Watch unread conversation count (all conversations).
   Stream<int> watchUnreadCount() {
     return _conversationsDao.watchUnreadCount(ownerPubkey: _ownerPubkey);

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -5019,16 +5019,16 @@ class DmRepository {
   /// Lifts the Divine Moderation support thread out of the inbox and request
   /// lists so it renders once, as the pinned row (#6283).
   ///
-  /// Only a thread on [supportPubkey] is removed from the lists and returned as
-  /// `pinned`: the row routes on the returned conversation's own participants
-  /// and nothing remaps the recipient between there and [sendMessage], so
-  /// adopting a pre-rotation thread would send support replies to a retired
-  /// key.
+  /// Only a thread on [supportPubkey] is touched: the row routes on the
+  /// returned conversation's own participants and nothing remaps the recipient
+  /// between there and [sendMessage], so adopting a pre-rotation thread would
+  /// send support replies to a retired key.
   ///
-  /// [legacyPubkeys] is intentionally not removed here. Those rows carry
-  /// inbound moderation history that was visible before #6283; until the
-  /// archived read-only shape exists, keeping the original row is safer than
-  /// hiding the user's only in-app entry point to that history.
+  /// A thread on a *retired* moderation key is therefore left in whichever list
+  /// it arrived in, exactly like any other conversation. Those rows carry
+  /// inbound moderation history that was visible before #6283, and until the
+  /// archived read-only shape exists (#6416) keeping the original row is safer
+  /// than hiding the user's only in-app entry point to that history.
   ///
   /// Shared with the unread badge rather than reimplemented there, so the
   /// count cannot drift from the rows the list actually renders (#4976).
@@ -5048,7 +5048,6 @@ class DmRepository {
   extractPinnedSupport({
     required String userPubkey,
     required String? supportPubkey,
-    required List<String> legacyPubkeys,
     required List<DmConversation> inbox,
     required List<DmConversation> requests,
   }) {
@@ -5065,11 +5064,6 @@ class DmRepository {
     }
 
     final currentId = computeConversationId([userPubkey, supportPubkey]);
-    // Keep this parameter part of the shared contract even though legacy rows
-    // are preserved for now. Callers still pass the same moderation key set,
-    // and the archived read-only follow-up can reuse the API without
-    // re-threading it.
-    final _ = legacyPubkeys;
 
     DmConversation? pinned;
     final remainingInbox = <DmConversation>[];

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -5019,12 +5019,16 @@ class DmRepository {
   /// Lifts the Divine Moderation support thread out of the inbox and request
   /// lists so it renders once, as the pinned row (#6283).
   ///
-  /// Every conversation keyed on the moderation account — [supportPubkey] or
-  /// any of [legacyPubkeys] — is removed from both lists. Only a thread on
-  /// [supportPubkey] comes back as `pinned`: the row routes on the returned
-  /// conversation's own participants and nothing remaps the recipient between
-  /// there and [sendMessage], so adopting a pre-rotation thread would send
-  /// support replies to a retired key. Retired keys de-duplicate, never adopt.
+  /// Only a thread on [supportPubkey] is removed from the lists and returned as
+  /// `pinned`: the row routes on the returned conversation's own participants
+  /// and nothing remaps the recipient between there and [sendMessage], so
+  /// adopting a pre-rotation thread would send support replies to a retired
+  /// key.
+  ///
+  /// [legacyPubkeys] is intentionally not removed here. Those rows carry
+  /// inbound moderation history that was visible before #6283; until the
+  /// archived read-only shape exists, keeping the original row is safer than
+  /// hiding the user's only in-app entry point to that history.
   ///
   /// Shared with the unread badge rather than reimplemented there, so the
   /// count cannot drift from the rows the list actually renders (#4976).
@@ -5061,19 +5065,19 @@ class DmRepository {
     }
 
     final currentId = computeConversationId([userPubkey, supportPubkey]);
-    final knownIds = <String>{
-      currentId,
-      for (final pubkey in legacyPubkeys)
-        if (pubkey.isNotEmpty) computeConversationId([userPubkey, pubkey]),
-    };
+    // Keep this parameter part of the shared contract even though legacy rows
+    // are preserved for now. Callers still pass the same moderation key set,
+    // and the archived read-only follow-up can reuse the API without
+    // re-threading it.
+    final _ = legacyPubkeys;
 
     DmConversation? pinned;
     final remainingInbox = <DmConversation>[];
     for (final conversation in inbox) {
-      if (!knownIds.contains(conversation.id)) {
-        remainingInbox.add(conversation);
-      } else if (conversation.id == currentId) {
+      if (conversation.id == currentId) {
         pinned ??= conversation;
+      } else {
+        remainingInbox.add(conversation);
       }
     }
 
@@ -5081,10 +5085,10 @@ class DmRepository {
     // currentUserHasSent == false and lands in requests, not the inbox.
     final remainingRequests = <DmConversation>[];
     for (final conversation in requests) {
-      if (!knownIds.contains(conversation.id)) {
-        remainingRequests.add(conversation);
-      } else if (conversation.id == currentId) {
+      if (conversation.id == currentId) {
         pinned ??= conversation;
+      } else {
+        remainingRequests.add(conversation);
       }
     }
 

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -10444,7 +10444,7 @@ void main() {
         expect(result.requests, isEmpty);
       });
 
-      test('removes a retired-key thread WITHOUT adopting it', () {
+      test('preserves a retired-key thread WITHOUT adopting it', () {
         final thread = makeConversation(
           id: retiredId,
           participantPubkeys: const [_validPubkeyA, retired],
@@ -10455,11 +10455,11 @@ void main() {
         // Nothing remaps the recipient downstream, so returning this as the
         // pin would address replies to a key the account rotated away from.
         expect(result.pinned, isNull);
-        expect(result.inbox, isEmpty);
+        expect(result.inbox, equals([thread]));
         expect(result.supportConversationId, equals(currentId));
       });
 
-      test('removes every known thread, not just the first match', () {
+      test('removes the current-key thread and preserves retired history', () {
         final retiredThread = makeConversation(
           id: retiredId,
           participantPubkeys: const [_validPubkeyA, retired],
@@ -10472,7 +10472,7 @@ void main() {
         final result = extract(inbox: [retiredThread, currentThread]);
 
         expect(result.pinned, equals(currentThread));
-        expect(result.inbox, isEmpty);
+        expect(result.inbox, equals([retiredThread]));
       });
 
       test('prefers the inbox copy when the thread is in both buckets', () {

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -10414,7 +10414,6 @@ void main() {
       }) => DmRepository.extractPinnedSupport(
         userPubkey: userPubkey,
         supportPubkey: supportPubkey,
-        legacyPubkeys: const [retired],
         inbox: inbox,
         requests: requests,
       );
@@ -10558,23 +10557,6 @@ void main() {
         expect(result.pinned, isNull);
         expect(result.supportConversationId, isNull);
         expect(result.inbox, equals([selfThread]));
-      });
-
-      test('ignores an empty entry in the retired list', () {
-        final thread = makeConversation(
-          id: currentId,
-          participantPubkeys: const [_validPubkeyA, support],
-        );
-
-        final result = DmRepository.extractPinnedSupport(
-          userPubkey: _validPubkeyA,
-          supportPubkey: support,
-          legacyPubkeys: const [''],
-          inbox: [thread],
-          requests: const [],
-        );
-
-        expect(result.pinned, equals(thread));
       });
     });
 

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -10373,6 +10373,211 @@ void main() {
       });
     });
 
+    group('extractPinnedSupport', () {
+      // The support account and a key it rotated away from. Kept as literals:
+      // this package cannot import the app's official-accounts config, and the
+      // partition is keyed on whatever the caller injects anyway.
+      const support = _validPubkeyB;
+      const retired = _validPubkeyC;
+
+      final currentId = DmRepository.computeConversationId([
+        _validPubkeyA,
+        support,
+      ]);
+      final retiredId = DmRepository.computeConversationId([
+        _validPubkeyA,
+        retired,
+      ]);
+
+      DmConversation makeConversation({
+        required String id,
+        required List<String> participantPubkeys,
+        bool isGroup = false,
+      }) => DmConversation(
+        id: id,
+        participantPubkeys: participantPubkeys,
+        isGroup: isGroup,
+        createdAt: 1700000000,
+      );
+
+      ({
+        DmConversation? pinned,
+        String? supportConversationId,
+        List<DmConversation> inbox,
+        List<DmConversation> requests,
+      })
+      extract({
+        List<DmConversation> inbox = const [],
+        List<DmConversation> requests = const [],
+        String userPubkey = _validPubkeyA,
+        String? supportPubkey = support,
+      }) => DmRepository.extractPinnedSupport(
+        userPubkey: userPubkey,
+        supportPubkey: supportPubkey,
+        legacyPubkeys: const [retired],
+        inbox: inbox,
+        requests: requests,
+      );
+
+      test('adopts the current-key thread and removes it from the inbox', () {
+        final thread = makeConversation(
+          id: currentId,
+          participantPubkeys: const [_validPubkeyA, support],
+        );
+
+        final result = extract(inbox: [thread]);
+
+        expect(result.pinned, equals(thread));
+        expect(result.inbox, isEmpty);
+        expect(result.supportConversationId, equals(currentId));
+      });
+
+      test('adopts an inbound-only thread out of the requests bucket', () {
+        final thread = makeConversation(
+          id: currentId,
+          participantPubkeys: const [_validPubkeyA, support],
+        );
+
+        final result = extract(requests: [thread]);
+
+        expect(result.pinned, equals(thread));
+        expect(result.requests, isEmpty);
+      });
+
+      test('removes a retired-key thread WITHOUT adopting it', () {
+        final thread = makeConversation(
+          id: retiredId,
+          participantPubkeys: const [_validPubkeyA, retired],
+        );
+
+        final result = extract(inbox: [thread]);
+
+        // Nothing remaps the recipient downstream, so returning this as the
+        // pin would address replies to a key the account rotated away from.
+        expect(result.pinned, isNull);
+        expect(result.inbox, isEmpty);
+        expect(result.supportConversationId, equals(currentId));
+      });
+
+      test('removes every known thread, not just the first match', () {
+        final retiredThread = makeConversation(
+          id: retiredId,
+          participantPubkeys: const [_validPubkeyA, retired],
+        );
+        final currentThread = makeConversation(
+          id: currentId,
+          participantPubkeys: const [_validPubkeyA, support],
+        );
+
+        final result = extract(inbox: [retiredThread, currentThread]);
+
+        expect(result.pinned, equals(currentThread));
+        expect(result.inbox, isEmpty);
+      });
+
+      test('prefers the inbox copy when the thread is in both buckets', () {
+        final accepted = makeConversation(
+          id: currentId,
+          participantPubkeys: const [_validPubkeyA, support],
+        );
+        final request = makeConversation(
+          id: currentId,
+          participantPubkeys: const [_validPubkeyA, support],
+          isGroup: true,
+        );
+
+        final result = extract(inbox: [accepted], requests: [request]);
+
+        expect(result.pinned, same(accepted));
+        expect(result.inbox, isEmpty);
+        expect(result.requests, isEmpty);
+      });
+
+      test('leaves unrelated conversations untouched', () {
+        final other = makeConversation(
+          id: 'other',
+          participantPubkeys: const [_validPubkeyA, _validPubkeyC],
+        );
+
+        final result = extract(inbox: [other]);
+
+        expect(result.inbox, equals([other]));
+        expect(result.pinned, isNull);
+      });
+
+      test('leaves a group containing the support account in the list', () {
+        final group = makeConversation(
+          id: 'group',
+          participantPubkeys: const [_validPubkeyA, support, _validPubkeyC],
+          isGroup: true,
+        );
+
+        final result = extract(inbox: [group]);
+
+        // The id hashes ALL sorted participants, so a group can never collide
+        // with the 1:1 support thread.
+        expect(result.inbox, equals([group]));
+        expect(result.pinned, isNull);
+      });
+
+      test('is inert when no support pubkey is injected', () {
+        final thread = makeConversation(
+          id: currentId,
+          participantPubkeys: const [_validPubkeyA, support],
+        );
+
+        final result = extract(inbox: [thread], supportPubkey: null);
+
+        expect(result.pinned, isNull);
+        expect(result.supportConversationId, isNull);
+        expect(result.inbox, equals([thread]));
+      });
+
+      test('is inert for an empty support pubkey', () {
+        final result = extract(supportPubkey: '');
+
+        expect(result.supportConversationId, isNull);
+      });
+
+      test('is inert before an identity is known', () {
+        final result = extract(userPubkey: '');
+
+        expect(result.supportConversationId, isNull);
+      });
+
+      test('is inert when the user IS the support account', () {
+        final selfThread = makeConversation(
+          id: DmRepository.computeConversationId([support, support]),
+          participantPubkeys: const [support, support],
+        );
+
+        final result = extract(inbox: [selfThread], userPubkey: support);
+
+        // A self-keyed pin routes with an empty counterparty list, and the
+        // maintenance pass deletes self-conversations out from under it.
+        expect(result.pinned, isNull);
+        expect(result.supportConversationId, isNull);
+        expect(result.inbox, equals([selfThread]));
+      });
+
+      test('ignores an empty entry in the retired list', () {
+        final thread = makeConversation(
+          id: currentId,
+          participantPubkeys: const [_validPubkeyA, support],
+        );
+
+        final result = DmRepository.extractPinnedSupport(
+          userPubkey: _validPubkeyA,
+          supportPubkey: support,
+          legacyPubkeys: const [''],
+          inbox: [thread],
+          requests: const [],
+        );
+
+        expect(result.pinned, equals(thread));
+      });
+    });
+
     group('getConversations', () {
       test('returns mapped $DmConversation list from DAO', () async {
         final participants = [_validPubkeyA, _validPubkeyB]..sort();

--- a/mobile/test/blocs/dm/conversation_list/conversation_list_bloc_test.dart
+++ b/mobile/test/blocs/dm/conversation_list/conversation_list_bloc_test.dart
@@ -2671,7 +2671,6 @@ void main() {
       protectedMinorInboxGate: gate,
       recomputeDebounce: Duration.zero,
       supportRowPubkey: moderationPubkey,
-      supportRowLegacyPubkeys: [legacyModerationPubkey],
     );
 
     Future<ConversationListState> loadedState(
@@ -2871,7 +2870,6 @@ void main() {
           followRepository: mockFollowRepository,
           recomputeDebounce: Duration.zero,
           supportRowPubkey: moderationPubkey,
-          supportRowLegacyPubkeys: [legacyModerationPubkey],
         );
         addTearDown(bloc.close);
 

--- a/mobile/test/blocs/dm/conversation_list/conversation_list_bloc_test.dart
+++ b/mobile/test/blocs/dm/conversation_list/conversation_list_bloc_test.dart
@@ -1742,7 +1742,8 @@ void main() {
         false, // isRestoringHistory
         false, // requestsWithheld
         ConversationListState.pageSize,
-        null,
+        null, // navigationTarget
+        null, // pinnedConversation
       ]);
     });
   });
@@ -2618,6 +2619,242 @@ void main() {
       // gift-wrap subscription. Doing so would silently break DM ingestion
       // for users who navigated away from the inbox tab.
       verifyNever(() => mockDmRepository.stopListening());
+    });
+  });
+
+  group('pinned support row (#6283)', () {
+    late _MockDmRepository mockDmRepository;
+    late _MockFollowRepository mockFollowRepository;
+
+    setUp(() {
+      mockDmRepository = _MockDmRepository();
+      mockFollowRepository = _MockFollowRepository();
+
+      when(() => mockFollowRepository.isFollowing(any())).thenReturn(true);
+      when(
+        () => mockFollowRepository.followingStream,
+      ).thenAnswer((_) => const Stream<List<String>>.empty());
+      when(() => mockDmRepository.userPubkey).thenReturn(_testPubkey1);
+      when(() => mockDmRepository.isHistoryRecoveryComplete).thenReturn(true);
+      when(() => mockDmRepository.startListening()).thenAnswer((_) async {});
+      when(() => mockDmRepository.stopListening()).thenAnswer((_) async {});
+      when(
+        () => mockDmRepository.backfillHistoryIfNeeded(),
+      ).thenAnswer((_) async {});
+      when(
+        () => mockDmRepository.retryPendingDecryptions(),
+      ).thenAnswer((_) async {});
+    });
+
+    // Real moderation pin from kPinnedOfficialAccounts.
+    const moderationPubkey =
+        '8fd5eb6d8f362163bc00a5ab6b4a3167dbf32d00ec4efdbcf43b3c9514433b7e';
+    // Retired in #2321; a thread opened before the rotation is keyed on it.
+    const legacyModerationPubkey =
+        '121b915baba659cbe59626a8afaf83b01dc42354dfecaad9d465d51bb5715d72';
+
+    final supportId = DmRepository.computeConversationId([
+      _testPubkey1,
+      moderationPubkey,
+    ]);
+    final legacySupportId = DmRepository.computeConversationId([
+      _testPubkey1,
+      legacyModerationPubkey,
+    ]);
+
+    ConversationListBloc createSupportBloc({
+      bool enabled = true,
+      ContentBlocklistRepository? blocklist,
+      ProtectedMinorInboxGate? gate,
+    }) => ConversationListBloc(
+      dmRepository: mockDmRepository,
+      followRepository: mockFollowRepository,
+      contentBlocklistRepository: blocklist,
+      protectedMinorInboxGate: gate,
+      recomputeDebounce: Duration.zero,
+      supportRowEnabled: enabled,
+      supportRowPubkey: moderationPubkey,
+      supportRowLegacyPubkeys: const [legacyModerationPubkey],
+    );
+
+    Future<ConversationListState> loadedState(
+      ConversationListBloc bloc,
+    ) async {
+      bloc.add(const ConversationListStarted());
+      return bloc.stream.firstWhere(
+        (s) => s.status == ConversationListStatus.loaded,
+      );
+    }
+
+    test('is null when the feature flag is off', () async {
+      _stubStreams(mockDmRepository);
+      final bloc = createSupportBloc(enabled: false);
+      addTearDown(bloc.close);
+
+      final state = await loadedState(bloc);
+
+      expect(state.pinnedConversation, isNull);
+    });
+
+    test('synthesizes a pin when no moderation thread exists', () async {
+      _stubStreams(mockDmRepository);
+      final bloc = createSupportBloc();
+      addTearDown(bloc.close);
+
+      final state = await loadedState(bloc);
+
+      expect(state.pinnedConversation, isNotNull);
+      expect(state.pinnedConversation!.id, equals(supportId));
+      expect(
+        state.pinnedConversation!.participantPubkeys,
+        containsAll([_testPubkey1, moderationPubkey]),
+      );
+      // Nothing to preview and nothing unread until the team replies —
+      // this is what keeps the row visually matching divine-web.
+      expect(state.pinnedConversation!.lastMessageContent, isNull);
+      expect(state.pinnedConversation!.isRead, isTrue);
+    });
+
+    test(
+      'adopts the real thread and removes it from the list, so the inbox '
+      'never shows Divine Moderation twice',
+      () async {
+        final supportThread = _createConversation(
+          id: supportId,
+          currentUserHasSent: true,
+          isRead: false,
+          lastMessageContent: 'We looked into your report.',
+          participantPubkeys: const [_testPubkey1, moderationPubkey],
+        );
+        final other = _createConversation(
+          id: _testConversationId2,
+          currentUserHasSent: true,
+        );
+        _stubStreams(mockDmRepository, accepted: [supportThread, other]);
+        final bloc = createSupportBloc();
+        addTearDown(bloc.close);
+
+        final state = await loadedState(bloc);
+
+        expect(state.pinnedConversation?.id, equals(supportId));
+        // The pin carries the real unread state, so the Messages badge
+        // still corresponds to something the user can see.
+        expect(state.pinnedConversation!.isRead, isFalse);
+        expect(
+          state.pinnedConversation!.lastMessageContent,
+          equals('We looked into your report.'),
+        );
+        expect(
+          state.conversations.map((c) => c.id),
+          isNot(contains(supportId)),
+        );
+        expect(
+          state.conversations.map((c) => c.id),
+          contains(_testConversationId2),
+        );
+      },
+    );
+
+    test(
+      'absorbs an inbound-only moderation thread out of message requests',
+      () async {
+        // The team wrote first: currentUserHasSent == false, and the user
+        // does not follow moderation, so it classifies as a request.
+        when(
+          () => mockFollowRepository.isFollowing(moderationPubkey),
+        ).thenReturn(false);
+        final inbound = _createConversation(
+          id: supportId,
+          participantPubkeys: const [_testPubkey1, moderationPubkey],
+        );
+        _stubStreams(mockDmRepository, potentialRequests: [inbound]);
+        final bloc = createSupportBloc();
+        addTearDown(bloc.close);
+
+        final state = await loadedState(bloc);
+
+        expect(state.pinnedConversation?.id, equals(supportId));
+        expect(
+          state.requestConversations.map((c) => c.id),
+          isNot(contains(supportId)),
+        );
+      },
+    );
+
+    test('de-duplicates a pre-rotation legacy moderation thread', () async {
+      final legacyThread = _createConversation(
+        id: legacySupportId,
+        currentUserHasSent: true,
+        participantPubkeys: const [_testPubkey1, legacyModerationPubkey],
+      );
+      _stubStreams(mockDmRepository, accepted: [legacyThread]);
+      final bloc = createSupportBloc();
+      addTearDown(bloc.close);
+
+      final state = await loadedState(bloc);
+
+      expect(state.pinnedConversation?.id, equals(legacySupportId));
+      expect(state.conversations, isEmpty);
+    });
+
+    test(
+      'is null for a restricted minor whose approval was revoked, so the '
+      'row cannot be tapped into a route-guard bounce',
+      () async {
+        _stubStreams(mockDmRepository);
+        final bloc = createSupportBloc(
+          gate: _FakeInboxGate(approved: const {}),
+        );
+        addTearDown(bloc.close);
+
+        final state = await loadedState(bloc);
+
+        expect(state.pinnedConversation, isNull);
+      },
+    );
+
+    test(
+      'is null when the user has blocked the moderation account',
+      () async {
+        final blocklist = _MockContentBlocklistRepository();
+        when(
+          () => blocklist.filterBlockedConversations(
+            any(),
+            userPubkey: any(named: 'userPubkey'),
+          ),
+        ).thenAnswer((invocation) {
+          final input =
+              invocation.positionalArguments.first as List<DmConversation>;
+          return input
+              .where(
+                (c) => !c.participantPubkeys.contains(moderationPubkey),
+              )
+              .toList();
+        });
+        _stubStreams(mockDmRepository);
+        final bloc = createSupportBloc(blocklist: blocklist);
+        addTearDown(bloc.close);
+
+        final state = await loadedState(bloc);
+
+        expect(state.pinnedConversation, isNull);
+      },
+    );
+
+    test('survives an active search query', () async {
+      _stubStreams(mockDmRepository);
+      final bloc = createSupportBloc();
+      addTearDown(bloc.close);
+
+      await loadedState(bloc);
+      bloc.add(const ConversationListSearchQueryChanged('zzzz'));
+      final searched = await bloc.stream.firstWhere(
+        (s) => s.searchQuery == 'zzzz',
+      );
+
+      // The row is a persistent affordance, not a search result: it is
+      // rendered outside the filtered list, so a query must not drop it.
+      expect(searched.pinnedConversation, isNotNull);
     });
   });
 }

--- a/mobile/test/blocs/dm/conversation_list/conversation_list_bloc_test.dart
+++ b/mobile/test/blocs/dm/conversation_list/conversation_list_bloc_test.dart
@@ -2938,6 +2938,38 @@ void main() {
         expect(state.pinnedSupport?.isPersisted, isTrue);
         expect(state.pinnedSupport?.conversation.isRead, isFalse);
         expect(state.requestConversations, isEmpty);
+        // The stranger IS hidden by the gate, so #6431's banner is owed.
+        expect(state.requestsWithheld, isTrue);
+      },
+    );
+
+    test(
+      'does not claim requests are withheld when the pin is the only one',
+      () async {
+        final inbound = _createConversation(
+          id: supportId,
+          isRead: false,
+          participantPubkeys: const [_testPubkey1, moderationPubkey],
+        );
+        when(() => mockFollowRepository.isFollowing(any())).thenReturn(false);
+        _stubStreams(
+          mockDmRepository,
+          potentialRequests: [inbound],
+          recoveryComplete: false,
+        );
+        final bloc = createSupportBloc();
+        addTearDown(bloc.close);
+
+        final state = await loadedState(bloc);
+
+        // #6431's restore-paused banner reports that the recovery gate is
+        // hiding would-be requests. Here the only one is the moderation
+        // thread, which the gate is NOT hiding — it is on screen as the pin.
+        // Measuring the flag against the raw classification instead of the
+        // post-pin set would promise a Retry with nothing behind it.
+        expect(state.pinnedSupport?.isPersisted, isTrue);
+        expect(state.requestConversations, isEmpty);
+        expect(state.requestsWithheld, isFalse);
       },
     );
 

--- a/mobile/test/blocs/dm/conversation_list/conversation_list_bloc_test.dart
+++ b/mobile/test/blocs/dm/conversation_list/conversation_list_bloc_test.dart
@@ -14,6 +14,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/dm/conversation_list/conversation_list_bloc.dart';
 import 'package:openvine/blocs/dm/conversation_list/protected_minor_inbox_gate.dart';
+import 'package:openvine/config/official_accounts.dart';
 import 'package:profile_repository/profile_repository.dart';
 
 class _MockDmRepository extends Mock implements DmRepository {}
@@ -1743,7 +1744,7 @@ void main() {
         false, // requestsWithheld
         ConversationListState.pageSize,
         null, // navigationTarget
-        null, // pinnedConversation
+        null, // pinnedSupport
       ]);
     });
   });
@@ -2646,12 +2647,10 @@ void main() {
       ).thenAnswer((_) async {});
     });
 
-    // Real moderation pin from kPinnedOfficialAccounts.
-    const moderationPubkey =
-        '8fd5eb6d8f362163bc00a5ab6b4a3167dbf32d00ec4efdbcf43b3c9514433b7e';
-    // Retired in #2321; a thread opened before the rotation is keyed on it.
-    const legacyModerationPubkey =
-        '121b915baba659cbe59626a8afaf83b01dc42354dfecaad9d465d51bb5715d72';
+    // The shipped moderation pin, and a key retired in #2321 — a thread opened
+    // before that rotation is still keyed on it.
+    const moderationPubkey = kModerationPubkeyHex;
+    final legacyModerationPubkey = kLegacyModerationPubkeys.first;
 
     final supportId = DmRepository.computeConversationId([
       _testPubkey1,
@@ -2672,7 +2671,7 @@ void main() {
       protectedMinorInboxGate: gate,
       recomputeDebounce: Duration.zero,
       supportRowPubkey: moderationPubkey,
-      supportRowLegacyPubkeys: const [legacyModerationPubkey],
+      supportRowLegacyPubkeys: [legacyModerationPubkey],
     );
 
     Future<ConversationListState> loadedState(
@@ -2698,7 +2697,7 @@ void main() {
 
       final state = await loadedState(bloc);
 
-      expect(state.pinnedConversation, isNull);
+      expect(state.pinnedSupport, isNull);
     });
 
     test('synthesizes a pin when no moderation thread exists', () async {
@@ -2708,16 +2707,16 @@ void main() {
 
       final state = await loadedState(bloc);
 
-      expect(state.pinnedConversation, isNotNull);
-      expect(state.pinnedConversation!.id, equals(supportId));
+      expect(state.pinnedSupport, isNotNull);
+      expect(state.pinnedSupport!.conversation.id, equals(supportId));
       expect(
-        state.pinnedConversation!.participantPubkeys,
+        state.pinnedSupport!.conversation.participantPubkeys,
         containsAll([_testPubkey1, moderationPubkey]),
       );
       // Nothing to preview and nothing unread until the team replies —
       // this is what keeps the row visually matching divine-web.
-      expect(state.pinnedConversation!.lastMessageContent, isNull);
-      expect(state.pinnedConversation!.isRead, isTrue);
+      expect(state.pinnedSupport!.conversation.lastMessageContent, isNull);
+      expect(state.pinnedSupport!.conversation.isRead, isTrue);
     });
 
     test(
@@ -2741,12 +2740,12 @@ void main() {
 
         final state = await loadedState(bloc);
 
-        expect(state.pinnedConversation?.id, equals(supportId));
+        expect(state.pinnedSupport?.conversation.id, equals(supportId));
         // The pin carries the real unread state, so the Messages badge
         // still corresponds to something the user can see.
-        expect(state.pinnedConversation!.isRead, isFalse);
+        expect(state.pinnedSupport!.conversation.isRead, isFalse);
         expect(
-          state.pinnedConversation!.lastMessageContent,
+          state.pinnedSupport!.conversation.lastMessageContent,
           equals('We looked into your report.'),
         );
         expect(
@@ -2778,7 +2777,7 @@ void main() {
 
         final state = await loadedState(bloc);
 
-        expect(state.pinnedConversation?.id, equals(supportId));
+        expect(state.pinnedSupport?.conversation.id, equals(supportId));
         expect(
           state.requestConversations.map((c) => c.id),
           isNot(contains(supportId)),
@@ -2786,21 +2785,212 @@ void main() {
       },
     );
 
-    test('de-duplicates a pre-rotation legacy moderation thread', () async {
-      final legacyThread = _createConversation(
+    test(
+      'drops a pre-rotation legacy thread and pins the CURRENT key, so a '
+      'reply can never reach the retired pubkey',
+      () async {
+        final legacyThread = _createConversation(
+          id: legacySupportId,
+          currentUserHasSent: true,
+          participantPubkeys: [_testPubkey1, legacyModerationPubkey],
+        );
+        _stubStreams(mockDmRepository, accepted: [legacyThread]);
+        final bloc = createSupportBloc();
+        addTearDown(bloc.close);
+
+        final state = await loadedState(bloc);
+
+        // Nothing remaps the recipient between the row's `extra` and
+        // sendMessage, so adopting the legacy thread would silently address
+        // support replies to a key the team retired in #2321.
+        expect(state.pinnedSupport?.conversation.id, equals(supportId));
+        expect(
+          state.pinnedSupport?.conversation.participantPubkeys,
+          isNot(contains(legacyModerationPubkey)),
+        );
+        // Synthetic, not adopted — the legacy thread's history does not
+        // travel with the pin.
+        expect(state.pinnedSupport?.isPersisted, isFalse);
+        expect(state.conversations, isEmpty);
+      },
+    );
+
+    test(
+      'keeps one pin when BOTH a legacy and a current thread exist, leaving '
+      'no duplicate ordinary row',
+      () async {
+        final legacyThread = _createConversation(
+          id: legacySupportId,
+          currentUserHasSent: true,
+          participantPubkeys: [_testPubkey1, legacyModerationPubkey],
+        );
+        final currentThread = _createConversation(
+          id: supportId,
+          currentUserHasSent: true,
+          participantPubkeys: const [_testPubkey1, moderationPubkey],
+        );
+        _stubStreams(
+          mockDmRepository,
+          accepted: [legacyThread, currentThread],
+        );
+        final bloc = createSupportBloc();
+        addTearDown(bloc.close);
+
+        final state = await loadedState(bloc);
+
+        expect(state.pinnedSupport?.conversation.id, equals(supportId));
+        expect(state.pinnedSupport?.isPersisted, isTrue);
+        // Extracting only the FIRST match left the loser in the list — the
+        // second "Divine Moderation" row the de-dup exists to prevent.
+        expect(state.conversations, isEmpty);
+      },
+    );
+
+    test('strips a legacy thread out of message requests too', () async {
+      final legacyInbound = _createConversation(
         id: legacySupportId,
-        currentUserHasSent: true,
-        participantPubkeys: const [_testPubkey1, legacyModerationPubkey],
+        participantPubkeys: [_testPubkey1, legacyModerationPubkey],
       );
-      _stubStreams(mockDmRepository, accepted: [legacyThread]);
+      when(() => mockFollowRepository.isFollowing(any())).thenReturn(false);
+      _stubStreams(mockDmRepository, potentialRequests: [legacyInbound]);
       final bloc = createSupportBloc();
       addTearDown(bloc.close);
 
       final state = await loadedState(bloc);
 
-      expect(state.pinnedConversation?.id, equals(legacySupportId));
-      expect(state.conversations, isEmpty);
+      expect(state.requestConversations, isEmpty);
+      expect(state.pinnedSupport?.conversation.id, equals(supportId));
     });
+
+    test(
+      'emits no pin when the signed-in user IS the moderation account',
+      () async {
+        _stubStreams(mockDmRepository);
+        // After _stubStreams, which seeds userPubkey itself.
+        when(() => mockDmRepository.userPubkey).thenReturn(moderationPubkey);
+        final bloc = ConversationListBloc(
+          dmRepository: mockDmRepository,
+          followRepository: mockFollowRepository,
+          recomputeDebounce: Duration.zero,
+          supportRowPubkey: moderationPubkey,
+          supportRowLegacyPubkeys: [legacyModerationPubkey],
+        );
+        addTearDown(bloc.close);
+
+        final state = await loadedState(bloc);
+
+        // A self-keyed pin routes with an empty counterparty list, and the
+        // maintenance pass deletes self-conversations out from under it.
+        expect(state.pinnedSupport, isNull);
+      },
+    );
+
+    test(
+      'leaves a group conversation containing moderation in the list',
+      () async {
+        final group = _createConversation(
+          id: 'group-with-moderation',
+          currentUserHasSent: true,
+          participantPubkeys: const [
+            _testPubkey1,
+            moderationPubkey,
+            _testPubkey2,
+          ],
+          isGroup: true,
+        );
+        _stubStreams(mockDmRepository, accepted: [group]);
+        final bloc = createSupportBloc();
+        addTearDown(bloc.close);
+
+        final state = await loadedState(bloc);
+
+        // The id is a hash over ALL sorted participants, so a group can never
+        // collide with the 1:1 support thread.
+        expect(state.conversations, contains(group));
+        expect(state.pinnedSupport?.isPersisted, isFalse);
+      },
+    );
+
+    test(
+      'keeps an unread inbound moderation thread pinned during history '
+      'recovery, while the requests list stays held back',
+      () async {
+        final inbound = _createConversation(
+          id: supportId,
+          isRead: false,
+          participantPubkeys: const [_testPubkey1, moderationPubkey],
+        );
+        final stranger = _createConversation(
+          id: 'stranger-request',
+          isRead: false,
+          participantPubkeys: const [_testPubkey1, _testPubkey2],
+        );
+        when(() => mockFollowRepository.isFollowing(any())).thenReturn(false);
+        _stubStreams(
+          mockDmRepository,
+          potentialRequests: [inbound, stranger],
+          recoveryComplete: false,
+        );
+        final bloc = createSupportBloc();
+        addTearDown(bloc.close);
+
+        final state = await loadedState(bloc);
+
+        // The pin is extracted ahead of the #5304 hold-back: it never lands in
+        // a bucket, so it cannot flash between two, and blanking its unread
+        // dot for the length of the drain would just hide a real reply.
+        expect(state.pinnedSupport?.isPersisted, isTrue);
+        expect(state.pinnedSupport?.conversation.isRead, isFalse);
+        expect(state.requestConversations, isEmpty);
+      },
+    );
+
+    test(
+      'does not leave the pin in message requests once recovery completes',
+      () async {
+        final inbound = _createConversation(
+          id: supportId,
+          isRead: false,
+          participantPubkeys: const [_testPubkey1, moderationPubkey],
+        );
+        when(() => mockFollowRepository.isFollowing(any())).thenReturn(false);
+        _stubStreams(mockDmRepository, potentialRequests: [inbound]);
+        final bloc = createSupportBloc();
+        addTearDown(bloc.close);
+
+        final state = await loadedState(bloc);
+
+        expect(state.requestConversations, isEmpty);
+        expect(state.pinnedSupport?.isPersisted, isTrue);
+      },
+    );
+
+    test(
+      'withholds a recovery-window pin the protected-minor gate rejects',
+      () async {
+        final inbound = _createConversation(
+          id: supportId,
+          isRead: false,
+          participantPubkeys: const [_testPubkey1, moderationPubkey],
+        );
+        when(() => mockFollowRepository.isFollowing(any())).thenReturn(false);
+        _stubStreams(
+          mockDmRepository,
+          potentialRequests: [inbound],
+          recoveryComplete: false,
+        );
+        final bloc = createSupportBloc(
+          gate: _FakeInboxGate(approved: const {}),
+        );
+        addTearDown(bloc.close);
+
+        final state = await loadedState(bloc);
+
+        // Extracting ahead of the hold-back must not also mean extracting
+        // ahead of the filters — the route guard would bounce this row.
+        expect(state.pinnedSupport, isNull);
+      },
+    );
 
     test(
       'is null for a restricted minor whose approval was revoked, so the '
@@ -2814,7 +3004,7 @@ void main() {
 
         final state = await loadedState(bloc);
 
-        expect(state.pinnedConversation, isNull);
+        expect(state.pinnedSupport, isNull);
       },
     );
 
@@ -2842,7 +3032,7 @@ void main() {
 
         final state = await loadedState(bloc);
 
-        expect(state.pinnedConversation, isNull);
+        expect(state.pinnedSupport, isNull);
       },
     );
 
@@ -2861,7 +3051,7 @@ void main() {
       // moment the query clears — no refetch, no flash of an empty row. The
       // decision to *render* it under an active filter belongs to the view,
       // which drops it from searches its title does not match.
-      expect(searched.pinnedConversation, isNotNull);
+      expect(searched.pinnedSupport, isNotNull);
     });
   });
 }

--- a/mobile/test/blocs/dm/conversation_list/conversation_list_bloc_test.dart
+++ b/mobile/test/blocs/dm/conversation_list/conversation_list_bloc_test.dart
@@ -2786,8 +2786,8 @@ void main() {
     );
 
     test(
-      'drops a pre-rotation legacy thread and pins the CURRENT key, so a '
-      'reply can never reach the retired pubkey',
+      'keeps pre-rotation legacy history visible and pins the CURRENT key, '
+      'so a reply can never reach the retired pubkey',
       () async {
         final legacyThread = _createConversation(
           id: legacySupportId,
@@ -2811,13 +2811,13 @@ void main() {
         // Synthetic, not adopted — the legacy thread's history does not
         // travel with the pin.
         expect(state.pinnedSupport?.isPersisted, isFalse);
-        expect(state.conversations, isEmpty);
+        expect(state.conversations, equals([legacyThread]));
       },
     );
 
     test(
-      'keeps one pin when BOTH a legacy and a current thread exist, leaving '
-      'no duplicate ordinary row',
+      'dedupes the current thread when BOTH a legacy and a current thread '
+      'exist, while preserving legacy history',
       () async {
         final legacyThread = _createConversation(
           id: legacySupportId,
@@ -2840,13 +2840,11 @@ void main() {
 
         expect(state.pinnedSupport?.conversation.id, equals(supportId));
         expect(state.pinnedSupport?.isPersisted, isTrue);
-        // Extracting only the FIRST match left the loser in the list — the
-        // second "Divine Moderation" row the de-dup exists to prevent.
-        expect(state.conversations, isEmpty);
+        expect(state.conversations, equals([legacyThread]));
       },
     );
 
-    test('strips a legacy thread out of message requests too', () async {
+    test('keeps a legacy thread visible in message requests too', () async {
       final legacyInbound = _createConversation(
         id: legacySupportId,
         participantPubkeys: [_testPubkey1, legacyModerationPubkey],
@@ -2858,7 +2856,7 @@ void main() {
 
       final state = await loadedState(bloc);
 
-      expect(state.requestConversations, isEmpty);
+      expect(state.requestConversations, equals([legacyInbound]));
       expect(state.pinnedSupport?.conversation.id, equals(supportId));
     });
 

--- a/mobile/test/blocs/dm/conversation_list/conversation_list_bloc_test.dart
+++ b/mobile/test/blocs/dm/conversation_list/conversation_list_bloc_test.dart
@@ -2857,8 +2857,10 @@ void main() {
         (s) => s.searchQuery == 'zzzz',
       );
 
-      // The row is a persistent affordance, not a search result: it is
-      // rendered outside the filtered list, so a query must not drop it.
+      // The bloc keeps composing the pin through a search so it is ready the
+      // moment the query clears — no refetch, no flash of an empty row. The
+      // decision to *render* it under an active filter belongs to the view,
+      // which drops it from searches its title does not match.
       expect(searched.pinnedConversation, isNotNull);
     });
   });

--- a/mobile/test/blocs/dm/conversation_list/conversation_list_bloc_test.dart
+++ b/mobile/test/blocs/dm/conversation_list/conversation_list_bloc_test.dart
@@ -2663,7 +2663,6 @@ void main() {
     ]);
 
     ConversationListBloc createSupportBloc({
-      bool enabled = true,
       ContentBlocklistRepository? blocklist,
       ProtectedMinorInboxGate? gate,
     }) => ConversationListBloc(
@@ -2672,7 +2671,6 @@ void main() {
       contentBlocklistRepository: blocklist,
       protectedMinorInboxGate: gate,
       recomputeDebounce: Duration.zero,
-      supportRowEnabled: enabled,
       supportRowPubkey: moderationPubkey,
       supportRowLegacyPubkeys: const [legacyModerationPubkey],
     );
@@ -2686,9 +2684,16 @@ void main() {
       );
     }
 
-    test('is null when the feature flag is off', () async {
+    test('is null when no moderation pubkey is injected', () async {
+      // Every construction site outside the inbox omits supportRowPubkey;
+      // the pin must stay off for them rather than synthesizing a row
+      // pointing at an empty counterparty.
       _stubStreams(mockDmRepository);
-      final bloc = createSupportBloc(enabled: false);
+      final bloc = ConversationListBloc(
+        dmRepository: mockDmRepository,
+        followRepository: mockFollowRepository,
+        recomputeDebounce: Duration.zero,
+      );
       addTearDown(bloc.close);
 
       final state = await loadedState(bloc);

--- a/mobile/test/blocs/dm/unread_count/dm_unread_count_cubit_test.dart
+++ b/mobile/test/blocs/dm/unread_count/dm_unread_count_cubit_test.dart
@@ -639,8 +639,8 @@ void main() {
       );
 
       test(
-        'excludes a retired-key moderation thread, matching the list that '
-        'drops it',
+        'counts a retired-key moderation thread, matching the list that keeps '
+        'legacy history visible',
         () async {
           final cubit = buildPinAwareCubit();
           addTearDown(cubit.close);
@@ -656,9 +656,10 @@ void main() {
           potentialController.add(const []);
           await _settle();
 
-          // The inbox renders no row for this thread, so a badge that counted
-          // it would point at something the user cannot find.
-          expect(cubit.state, equals(0));
+          // The inbox keeps this legacy-history row visible until #6416 gives
+          // it an archived read-only presentation, so the badge can point at a
+          // row the user can still find.
+          expect(cubit.state, equals(1));
         },
       );
 

--- a/mobile/test/blocs/dm/unread_count/dm_unread_count_cubit_test.dart
+++ b/mobile/test/blocs/dm/unread_count/dm_unread_count_cubit_test.dart
@@ -13,6 +13,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/dm/conversation_list/protected_minor_inbox_gate.dart';
 import 'package:openvine/blocs/dm/unread_count/dm_unread_count_cubit.dart';
+import 'package:openvine/config/official_accounts.dart';
 
 class _MockDmRepository extends Mock implements DmRepository {}
 
@@ -584,6 +585,149 @@ void main() {
       acceptedController.add(const []);
       potentialController.add(const []);
       await _settle();
+    });
+
+    group('pinned support row parity (#6283)', () {
+      const moderation = kModerationPubkeyHex;
+      final legacyModeration = kLegacyModerationPubkeys.first;
+      final supportId = DmRepository.computeConversationId([_me, moderation]);
+      final legacySupportId = DmRepository.computeConversationId([
+        _me,
+        legacyModeration,
+      ]);
+
+      DmUnreadCountCubit buildPinAwareCubit({
+        ProtectedMinorInboxGate? gate,
+      }) => DmUnreadCountCubit(
+        dmRepository: dmRepository,
+        followRepository: followRepository,
+        protectedMinorInboxGate: gate,
+        recomputeDebounce: Duration.zero,
+        supportRowPubkey: moderation,
+        supportRowLegacyPubkeys: [legacyModeration],
+      );
+
+      test(
+        'counts an inbound-only unread moderation thread, which the inbox '
+        'renders as the pin rather than as a request',
+        () async {
+          final cubit = buildPinAwareCubit();
+          addTearDown(cubit.close);
+
+          // Nobody is followed, so both classify as requests. The moderation
+          // one becomes the pinned row (dot and all); the stranger stays in
+          // Requests, which this count has never included.
+          acceptedController.add(const []);
+          potentialController.add([
+            _convo(
+              supportId,
+              peer: moderation,
+              isRead: false,
+              currentUserHasSent: false,
+            ),
+            _convo(
+              'stranger',
+              peer: _bob,
+              isRead: false,
+              currentUserHasSent: false,
+            ),
+          ]);
+          await _settle();
+
+          expect(cubit.state, equals(1));
+        },
+      );
+
+      test(
+        'excludes a retired-key moderation thread, matching the list that '
+        'drops it',
+        () async {
+          final cubit = buildPinAwareCubit();
+          addTearDown(cubit.close);
+
+          acceptedController.add([
+            _convo(
+              legacySupportId,
+              peer: legacyModeration,
+              isRead: false,
+              currentUserHasSent: true,
+            ),
+          ]);
+          potentialController.add(const []);
+          await _settle();
+
+          // The inbox renders no row for this thread, so a badge that counted
+          // it would point at something the user cannot find.
+          expect(cubit.state, equals(0));
+        },
+      );
+
+      test('counts an adopted moderation thread exactly once', () async {
+        final cubit = buildPinAwareCubit();
+        addTearDown(cubit.close);
+
+        // The accepted and potential-request streams are independent, so a
+        // currentUserHasSent flip can be observed in one before the other.
+        final thread = _convo(
+          supportId,
+          peer: moderation,
+          isRead: false,
+          currentUserHasSent: true,
+        );
+        acceptedController.add([thread]);
+        potentialController.add([thread]);
+        await _settle();
+
+        expect(cubit.state, equals(1));
+      });
+
+      test(
+        'excludes a pinned thread the protected-minor gate rejects (#176)',
+        () async {
+          final cubit = buildPinAwareCubit(
+            gate: _FakeInboxGate(approved: const {}),
+          );
+          addTearDown(cubit.close);
+
+          acceptedController.add(const []);
+          potentialController.add([
+            _convo(
+              supportId,
+              peer: moderation,
+              isRead: false,
+              currentUserHasSent: false,
+            ),
+          ]);
+          await _settle();
+
+          // The pin is filtered out of the list for this user, so the badge
+          // must not leak its existence.
+          expect(cubit.state, equals(0));
+        },
+      );
+
+      test(
+        'counts exactly as before when no support pubkey is injected',
+        () async {
+          final cubit = buildCubit();
+          addTearDown(cubit.close);
+
+          acceptedController.add([
+            _convo(
+              supportId,
+              peer: moderation,
+              isRead: false,
+              currentUserHasSent: true,
+            ),
+          ]);
+          potentialController.add(const []);
+          await _settle();
+
+          // Degrades to the un-pinned behaviour rather than partitioning
+          // against an empty key.
+          expect(cubit.state, equals(1));
+        },
+      );
     });
   });
 }

--- a/mobile/test/blocs/dm/unread_count/dm_unread_count_cubit_test.dart
+++ b/mobile/test/blocs/dm/unread_count/dm_unread_count_cubit_test.dart
@@ -604,7 +604,6 @@ void main() {
         protectedMinorInboxGate: gate,
         recomputeDebounce: Duration.zero,
         supportRowPubkey: moderation,
-        supportRowLegacyPubkeys: [legacyModeration],
       );
 
       test(

--- a/mobile/test/config/official_accounts_test.dart
+++ b/mobile/test/config/official_accounts_test.dart
@@ -1,0 +1,68 @@
+// ABOUTME: Tests for the pinned official-accounts config.
+// ABOUTME: Pins the single-source contract between the moderation constants
+// ABOUTME: here and ModerationLabelService's NIP-05 fallback.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/config/official_accounts.dart';
+import 'package:openvine/services/moderation_label_service.dart';
+
+void main() {
+  group('official accounts config', () {
+    test('the moderation account is composed from the shared constants', () {
+      expect(kModerationAccount.pubkeyHex, equals(kModerationPubkeyHex));
+      expect(kModerationAccount.nip05, equals(kModerationNip05));
+      expect(kModerationAccount.role, equals(OfficialAccountRole.moderation));
+      expect(kPinnedOfficialAccounts, contains(kModerationAccount));
+    });
+
+    test('the HQ account is in the pinned set', () {
+      expect(kHqAccount.role, equals(OfficialAccountRole.hq));
+      expect(kPinnedOfficialAccounts, contains(kHqAccount));
+    });
+
+    // These were declared twice, byte for byte, before #6388. A second copy
+    // drifting on the next rotation would point the labeler at one key and the
+    // support row + protected-minor gate at another.
+    test('ModerationLabelService forwards the config moderation pubkey', () {
+      expect(
+        ModerationLabelService.fallbackModerationPubkeyHex,
+        equals(kModerationPubkeyHex),
+      );
+    });
+
+    test('ModerationLabelService forwards the config moderation NIP-05', () {
+      expect(
+        ModerationLabelService.divineModerationNip05,
+        equals(kModerationNip05),
+      );
+    });
+
+    group('isModerationAccount', () {
+      test('accepts the current key', () {
+        expect(isModerationAccount(kModerationPubkeyHex), isTrue);
+      });
+
+      test('accepts every retired key', () {
+        expect(kLegacyModerationPubkeys, isNotEmpty);
+        for (final retired in kLegacyModerationPubkeys) {
+          expect(
+            isModerationAccount(retired),
+            isTrue,
+            reason: 'retired key $retired must still resolve as moderation',
+          );
+        }
+      });
+
+      test('rejects an unrelated pubkey', () {
+        expect(isModerationAccount(kHqAccount.pubkeyHex), isFalse);
+      });
+    });
+
+    // A rotation that forgot to drop the old key from the retired list would
+    // collapse the pin's known-id set to a single entry and silently stop
+    // de-duplicating.
+    test('no retired key is also the current key', () {
+      expect(kLegacyModerationPubkeys, isNot(contains(kModerationPubkeyHex)));
+    });
+  });
+}

--- a/mobile/test/screens/inbox/inbox_view_test.dart
+++ b/mobile/test/screens/inbox/inbox_view_test.dart
@@ -1582,9 +1582,11 @@ void main() {
         );
       });
 
-      testWidgets('is absent when the bloc emits no pin (flag off)', (
-        tester,
-      ) async {
+      // The bloc withholds the pin for a user who blocked moderation, for a
+      // restricted minor whose approval was revoked, and wherever no
+      // moderation pubkey is configured. The view must render nothing at all
+      // in that case, not an empty tile.
+      testWidgets('is absent when the bloc emits no pin', (tester) async {
         final l10n = lookupAppLocalizations(const Locale('en'));
         await tester.pumpWidget(
           buildSubject(

--- a/mobile/test/screens/inbox/inbox_view_test.dart
+++ b/mobile/test/screens/inbox/inbox_view_test.dart
@@ -1325,5 +1325,199 @@ void main() {
         ).called(1);
       });
     });
+
+    group('pinned support row (#6283)', () {
+      const moderationPubkey =
+          '8fd5eb6d8f362163bc00a5ab6b4a3167dbf32d00ec4efdbcf43b3c9514433b7e';
+
+      DmConversation supportPin({
+        String? lastMessageContent,
+        bool isRead = true,
+      }) => DmConversation(
+        id: 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+        participantPubkeys: const [currentPubkey, moderationPubkey],
+        isGroup: false,
+        createdAt: 0,
+        lastMessageContent: lastMessageContent,
+        isRead: isRead,
+      );
+
+      Future<void> openMessages(WidgetTester tester) async {
+        await tester.pump();
+        await tester.tap(find.text('Messages'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 350));
+      }
+
+      testWidgets('renders the moderation title from l10n, never a '
+          'generated profile name', (tester) async {
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.pumpWidget(
+          buildSubject(
+            state: ConversationListState(
+              status: ConversationListStatus.loaded,
+              pinnedConversation: supportPin(),
+            ),
+          ),
+        );
+        await openMessages(tester);
+
+        expect(find.text(l10n.inboxSupportRowTitle), findsOneWidget);
+        expect(find.text(l10n.inboxSupportRowSubtitle), findsOneWidget);
+        // The tile's profile fallback is a deterministic "Adjective Animal N"
+        // string. If the override ever regresses, the moderation row silently
+        // renders as a random user, so pin the exact fallback out.
+        expect(
+          find.text(UserProfile.defaultDisplayNameFor(moderationPubkey)),
+          findsNothing,
+        );
+      });
+
+      testWidgets('is absent when the bloc emits no pin (flag off)', (
+        tester,
+      ) async {
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.pumpWidget(
+          buildSubject(
+            state: const ConversationListState(
+              status: ConversationListStatus.loaded,
+            ),
+          ),
+        );
+        await openMessages(tester);
+
+        expect(find.text(l10n.inboxSupportRowTitle), findsNothing);
+      });
+
+      testWidgets('renders BESIDE the empty state, not instead of it — the '
+          'user with zero conversations is the one who needs it most', (
+        tester,
+      ) async {
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.pumpWidget(
+          buildSubject(
+            state: ConversationListState(
+              status: ConversationListStatus.loaded,
+              pinnedConversation: supportPin(),
+            ),
+          ),
+        );
+        await openMessages(tester);
+
+        expect(find.byType(InboxEmptyState), findsOneWidget);
+        expect(find.text(l10n.inboxSupportRowTitle), findsOneWidget);
+      });
+
+      testWidgets('renders during an active search, like FollowingBar', (
+        tester,
+      ) async {
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        final conversation = DmConversation(
+          id: 'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
+          participantPubkeys: const [currentPubkey, otherPubkey],
+          isGroup: false,
+          createdAt: nowUnix,
+          lastMessageContent: 'Hello',
+          lastMessageTimestamp: nowUnix,
+        );
+        await tester.pumpWidget(
+          buildSubject(
+            state: ConversationListState(
+              status: ConversationListStatus.loaded,
+              conversations: [conversation],
+              searchQuery: 'zzzz',
+              hasMore: false,
+              pinnedConversation: supportPin(),
+            ),
+          ),
+        );
+        await openMessages(tester);
+
+        // The filtered branch is showing ("No matches"), and the row is still
+        // there — it lives above the list, not inside it.
+        expect(find.text(l10n.inboxSearchEmptyTitle), findsOneWidget);
+        expect(find.text(l10n.inboxSupportRowTitle), findsOneWidget);
+      });
+
+      testWidgets('shows the real last message once the team has replied', (
+        tester,
+      ) async {
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.pumpWidget(
+          buildSubject(
+            state: ConversationListState(
+              status: ConversationListStatus.loaded,
+              pinnedConversation: supportPin(
+                lastMessageContent: 'We looked into your report.',
+                isRead: false,
+              ),
+            ),
+          ),
+        );
+        await openMessages(tester);
+
+        expect(find.text('We looked into your report.'), findsOneWidget);
+        expect(find.text(l10n.inboxSupportRowSubtitle), findsNothing);
+      });
+
+      testWidgets('opens the conversation with MODERATION, not with self', (
+        tester,
+      ) async {
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        final pin = supportPin();
+        when(
+          () => mockGoRouter.push<Object?>(any(), extra: any(named: 'extra')),
+        ).thenAnswer((_) async => null);
+
+        await tester.pumpWidget(
+          buildSubject(
+            state: ConversationListState(
+              status: ConversationListStatus.loaded,
+              pinnedConversation: pin,
+            ),
+          ),
+        );
+        await openMessages(tester);
+        await tester.tap(find.text(l10n.inboxSupportRowTitle));
+        await tester.pump();
+
+        // The route reads `extra` as the COUNTERPARTY list. Passing the raw
+        // participants (which include self) opened a conversation with the
+        // signed-in user — caught only by running the app, because a mocked
+        // router happily accepts either list.
+        final captured = verify(
+          () => mockGoRouter.push<Object?>(
+            ConversationPage.pathForId(pin.id),
+            extra: captureAny(named: 'extra'),
+          ),
+        ).captured.single;
+        expect(captured, equals([moderationPubkey]));
+        expect(captured, isNot(contains(currentPubkey)));
+      });
+
+      testWidgets('exposes a tappable button to assistive tech', (
+        tester,
+      ) async {
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.pumpWidget(
+          buildSubject(
+            state: ConversationListState(
+              status: ConversationListStatus.loaded,
+              pinnedConversation: supportPin(),
+            ),
+          ),
+        );
+        await openMessages(tester);
+
+        final data = tester
+            .getSemantics(find.byType(ConversationTile))
+            .getSemanticsData();
+        expect(data.label, contains(l10n.inboxSupportRowTitle));
+        expect(data.flagsCollection.isButton, isTrue);
+        // No action sheet is wired for this row, so it must not advertise a
+        // long-press hint it cannot honour.
+        expect(data.hasAction(SemanticsAction.longPress), isFalse);
+      });
+    });
   });
 }

--- a/mobile/test/screens/inbox/inbox_view_test.dart
+++ b/mobile/test/screens/inbox/inbox_view_test.dart
@@ -207,7 +207,13 @@ void main() {
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 350));
 
-        expect(find.byType(FollowingBar), findsOneWidget);
+        // skipOffstage: false because the bar now lives in a sliver and this
+        // subject follows nobody, so it collapses to SizedBox.shrink() — a
+        // zero-extent sliver, which the default finder treats as offstage.
+        expect(
+          find.byType(FollowingBar, skipOffstage: false),
+          findsOneWidget,
+        );
       });
 
       testWidgets('renders $CircularProgressIndicator when status is initial', (
@@ -1194,7 +1200,10 @@ void main() {
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 350));
 
-        await tester.drag(find.byType(ListView), const Offset(0, -5000));
+        await tester.drag(
+          find.byType(CustomScrollView),
+          const Offset(0, -5000),
+        );
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 100));
 
@@ -1326,6 +1335,201 @@ void main() {
       });
     });
 
+    group('scroll layout (#6388 review, items 4 + 5)', () {
+      Future<void> openMessages(WidgetTester tester) async {
+        await tester.pump();
+        await tester.tap(find.text('Messages'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 350));
+      }
+
+      List<DmConversation> manyConversations() => List.generate(
+        30,
+        (index) => DmConversation(
+          id: 'c${index.toString().padLeft(63, '0')}',
+          participantPubkeys: const [currentPubkey, otherPubkey],
+          isGroup: false,
+          createdAt: nowUnix - index,
+          lastMessageContent: 'Message $index',
+          lastMessageTimestamp: nowUnix - index,
+        ),
+      );
+
+      testWidgets('scrolls the search field away and keeps the filter chips '
+          'pinned, so the keyboard cannot squeeze the list', (tester) async {
+        final conversations = manyConversations();
+        await tester.pumpWidget(
+          buildSubject(
+            state: ConversationListState(
+              status: ConversationListStatus.loaded,
+              conversations: conversations,
+              visibleConversations: conversations,
+              hasMore: false,
+            ),
+          ),
+        );
+        await openMessages(tester);
+
+        expect(find.byType(DivineSearchBar), findsOneWidget);
+        final chipsBefore = tester.getTopLeft(find.byType(UnreadFilterChips));
+
+        await tester.drag(
+          find.byType(CustomScrollView),
+          const Offset(0, -400),
+        );
+        await tester.pump();
+
+        // The search field is chrome now, not a fixed header: it leaves the
+        // viewport entirely, handing its height back to the conversations.
+        expect(find.byType(DivineSearchBar), findsNothing);
+        // The chips do not — losing the way back to All while filtered by
+        // Unread would be a trap.
+        expect(find.byType(UnreadFilterChips), findsOneWidget);
+        expect(
+          tester.getTopLeft(find.byType(UnreadFilterChips)).dy,
+          lessThanOrEqualTo(chipsBefore.dy),
+        );
+      });
+
+      testWidgets('filter chips measure exactly the pinned header extent', (
+        tester,
+      ) async {
+        final conversations = manyConversations();
+        await tester.pumpWidget(
+          buildSubject(
+            state: ConversationListState(
+              status: ConversationListStatus.loaded,
+              conversations: conversations,
+              visibleConversations: conversations,
+              hasMore: false,
+            ),
+          ),
+        );
+        await openMessages(tester);
+
+        // A SliverPersistentHeader has to declare its extent up front, and an
+        // under-declared one silently clips the chips. 48 = 8px padding either
+        // side of a DivineButtonSize.tiny chip, whose 32px box does not scale
+        // with text size. If DivineButton's tiny height ever moves, this fails
+        // here rather than as a clipped chip on someone's phone.
+        expect(
+          tester.getSize(find.byType(UnreadFilterChips)).height,
+          equals(48),
+        );
+      });
+
+      testWidgets('collapses the following bar when the search field takes '
+          'focus, before any query is typed', (tester) async {
+        // FollowingBar needs real extent to lose, so give it one follow.
+        whenListen(
+          mockFollowingBloc,
+          Stream<MyFollowingState>.value(
+            const MyFollowingState(
+              status: MyFollowingStatus.success,
+              followingPubkeys: ['user123'],
+            ),
+          ),
+          initialState: const MyFollowingState(
+            status: MyFollowingStatus.success,
+            followingPubkeys: ['user123'],
+          ),
+        );
+
+        final conversations = manyConversations();
+        await tester.pumpWidget(
+          buildSubject(
+            state: ConversationListState(
+              status: ConversationListStatus.loaded,
+              conversations: conversations,
+              visibleConversations: conversations,
+              hasMore: false,
+            ),
+          ),
+        );
+        await openMessages(tester);
+
+        expect(tester.getSize(find.byType(FollowingBar)).height, equals(128));
+        final firstTileBefore = tester.getTopLeft(find.text('Message 0')).dy;
+
+        await tester.tap(find.byType(DivineSearchBar));
+        await tester.pumpAndSettle();
+
+        // Focus alone reclaims the bar — no text needed. minSearchQueryLength
+        // is 2, so a query-driven collapse would still be showing faces here.
+        expect(
+          find.byType(FollowingBar, skipOffstage: false),
+          findsNothing,
+        );
+        expect(
+          tester.getTopLeft(find.text('Message 0')).dy,
+          lessThan(firstTileBefore - 100),
+        );
+      });
+
+      testWidgets('restores the following bar when search focus is released', (
+        tester,
+      ) async {
+        // FollowingBar needs real extent to lose, so give it one follow.
+        whenListen(
+          mockFollowingBloc,
+          Stream<MyFollowingState>.value(
+            const MyFollowingState(
+              status: MyFollowingStatus.success,
+              followingPubkeys: ['user123'],
+            ),
+          ),
+          initialState: const MyFollowingState(
+            status: MyFollowingStatus.success,
+            followingPubkeys: ['user123'],
+          ),
+        );
+
+        final conversations = manyConversations();
+        await tester.pumpWidget(
+          buildSubject(
+            state: ConversationListState(
+              status: ConversationListStatus.loaded,
+              conversations: conversations,
+              visibleConversations: conversations,
+              hasMore: false,
+            ),
+          ),
+        );
+        await openMessages(tester);
+
+        await tester.tap(find.byType(DivineSearchBar));
+        await tester.pumpAndSettle();
+        expect(find.byType(FollowingBar, skipOffstage: false), findsNothing);
+
+        // Submitting unfocuses (DivineSearchBar dismisses the keyboard so the
+        // results stay visible), which must bring the bar back.
+        await tester.testTextInput.receiveAction(TextInputAction.done);
+        await tester.pumpAndSettle();
+
+        expect(tester.getSize(find.byType(FollowingBar)).height, equals(128));
+      });
+
+      testWidgets('renders the whole pane as one scroll view', (tester) async {
+        final conversations = manyConversations();
+        await tester.pumpWidget(
+          buildSubject(
+            state: ConversationListState(
+              status: ConversationListStatus.loaded,
+              conversations: conversations,
+              visibleConversations: conversations,
+              hasMore: false,
+            ),
+          ),
+        );
+        await openMessages(tester);
+
+        // One scrollable for the pane — the old layout nested a ListView
+        // inside a Column of fixed-height chrome, which is what left the list
+        // roughly one row tall with the keyboard open.
+        expect(find.byType(CustomScrollView), findsOneWidget);
+      });
+    });
+
     group('pinned support row (#6283)', () {
       const moderationPubkey =
           '8fd5eb6d8f362163bc00a5ab6b4a3167dbf32d00ec4efdbcf43b3c9514433b7e';
@@ -1413,9 +1617,7 @@ void main() {
         expect(find.text(l10n.inboxSupportRowTitle), findsOneWidget);
       });
 
-      testWidgets('renders during an active search, like FollowingBar', (
-        tester,
-      ) async {
+      testWidgets('drops out of a search it does not match', (tester) async {
         final l10n = lookupAppLocalizations(const Locale('en'));
         final conversation = DmConversation(
           id: 'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
@@ -1438,9 +1640,156 @@ void main() {
         );
         await openMessages(tester);
 
-        // The filtered branch is showing ("No matches"), and the row is still
-        // there — it lives above the list, not inside it.
+        // Now that the row sits inside the list rather than above it, a row
+        // matching neither the query nor anything else would read as a search
+        // hit that isn't one. It is pinned against the sort, not the filters.
         expect(find.text(l10n.inboxSearchEmptyTitle), findsOneWidget);
+        expect(find.text(l10n.inboxSupportRowTitle), findsNothing);
+      });
+
+      // A real conversation has to be present for the filtered branch to run
+      // at all: an inbox with nothing in it skips the search field and chips
+      // entirely, so there is no filter for the row to be judged against.
+      final realConversation = DmConversation(
+        id: 'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
+        participantPubkeys: const [currentPubkey, otherPubkey],
+        isGroup: false,
+        createdAt: nowUnix,
+        lastMessageContent: 'Hello',
+        lastMessageTimestamp: nowUnix,
+      );
+
+      testWidgets('stays in a search whose query matches its title', (
+        tester,
+      ) async {
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.pumpWidget(
+          buildSubject(
+            state: ConversationListState(
+              status: ConversationListStatus.loaded,
+              conversations: [realConversation],
+              // 'moderation' matches inboxSupportRowTitle, but no real thread.
+              searchQuery: 'moderation',
+              hasMore: false,
+              pinnedConversation: supportPin(),
+            ),
+          ),
+        );
+        await openMessages(tester);
+
+        expect(find.text(l10n.inboxSupportRowTitle), findsOneWidget);
+      });
+
+      testWidgets('is hidden by the Unread chip once it has been read', (
+        tester,
+      ) async {
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.pumpWidget(
+          buildSubject(
+            state: ConversationListState(
+              status: ConversationListStatus.loaded,
+              conversations: [realConversation],
+              unreadOnly: true,
+              hasMore: false,
+              pinnedConversation: supportPin(),
+            ),
+          ),
+        );
+        await openMessages(tester);
+
+        expect(find.text(l10n.inboxSupportRowTitle), findsNothing);
+      });
+
+      testWidgets('survives the Unread chip while it still has unread', (
+        tester,
+      ) async {
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.pumpWidget(
+          buildSubject(
+            state: ConversationListState(
+              status: ConversationListStatus.loaded,
+              conversations: [realConversation],
+              unreadOnly: true,
+              hasMore: false,
+              pinnedConversation: supportPin(
+                isRead: false,
+                lastMessageContent: 'We looked into your report.',
+              ),
+            ),
+          ),
+        );
+        await openMessages(tester);
+
+        expect(find.text(l10n.inboxSupportRowTitle), findsOneWidget);
+      });
+
+      testWidgets('is the first tile, ahead of the requests banner and every '
+          'real conversation', (tester) async {
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        final conversation = DmConversation(
+          id: 'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
+          participantPubkeys: const [currentPubkey, otherPubkey],
+          isGroup: false,
+          createdAt: nowUnix,
+          lastMessageContent: 'Hello',
+          lastMessageTimestamp: nowUnix,
+        );
+        await tester.pumpWidget(
+          buildSubject(
+            state: ConversationListState(
+              status: ConversationListStatus.loaded,
+              conversations: [conversation],
+              visibleConversations: [conversation],
+              requestConversations: [
+                DmConversation(
+                  id:
+                      'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
+                      'eeeeeeeeeeeeeeeeeeeeeeee',
+                  participantPubkeys: const [currentPubkey, otherPubkey],
+                  isGroup: false,
+                  createdAt: nowUnix,
+                ),
+              ],
+              hasMore: false,
+              pinnedConversation: supportPin(),
+            ),
+          ),
+        );
+        await openMessages(tester);
+
+        // Ordering is asserted geometrically: the conversation list carries no
+        // index the test can read, and the moderation row must outrank both
+        // the requests banner and a conversation with a far newer timestamp.
+        final supportY = tester
+            .getTopLeft(find.text(l10n.inboxSupportRowTitle))
+            .dy;
+        final bannerY = tester
+            .getTopLeft(find.byType(MessageRequestsBanner))
+            .dy;
+        final conversationY = tester.getTopLeft(find.text('Hello')).dy;
+
+        expect(supportY, lessThan(bannerY));
+        expect(bannerY, lessThan(conversationY));
+      });
+
+      testWidgets('still renders for a brand-new user with an empty inbox', (
+        tester,
+      ) async {
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.pumpWidget(
+          buildSubject(
+            state: ConversationListState(
+              status: ConversationListStatus.loaded,
+              hasMore: false,
+              pinnedConversation: supportPin(),
+            ),
+          ),
+        );
+        await openMessages(tester);
+
+        // The empty-state copy still shows, but the support row is not lost
+        // with it — this is the user who most needs to reach moderation.
+        expect(find.byType(InboxEmptyState), findsOneWidget);
         expect(find.text(l10n.inboxSupportRowTitle), findsOneWidget);
       });
 

--- a/mobile/test/screens/inbox/inbox_view_test.dart
+++ b/mobile/test/screens/inbox/inbox_view_test.dart
@@ -1731,6 +1731,40 @@ void main() {
         expect(find.text(l10n.inboxSupportRowTitle), findsOneWidget);
       });
 
+      testWidgets('stays in a search whose query matches the subtitle blurb '
+          'it actually renders', (tester) async {
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        // A synthetic pin renders inboxSupportRowSubtitle as its preview, so
+        // a query drawn from that text must keep it — hiding the row while
+        // the matched words are on screen reads as a broken search.
+        const query = 'bugs';
+        expect(
+          l10n.inboxSupportRowSubtitle.toLowerCase(),
+          contains(query),
+          reason: 'query must be drawn from the rendered subtitle',
+        );
+        expect(
+          l10n.inboxSupportRowTitle.toLowerCase(),
+          isNot(contains(query)),
+          reason: 'otherwise the title branch would carry the test',
+        );
+
+        await tester.pumpWidget(
+          buildSubject(
+            state: ConversationListState(
+              status: ConversationListStatus.loaded,
+              conversations: [realConversation],
+              searchQuery: query,
+              hasMore: false,
+              pinnedSupport: supportPin(),
+            ),
+          ),
+        );
+        await openMessages(tester);
+
+        expect(find.text(l10n.inboxSupportRowTitle), findsOneWidget);
+      });
+
       testWidgets('is hidden by the Unread chip once it has been read', (
         tester,
       ) async {

--- a/mobile/test/screens/inbox/inbox_view_test.dart
+++ b/mobile/test/screens/inbox/inbox_view_test.dart
@@ -112,6 +112,7 @@ void main() {
       int dmUnreadCount = 0,
       int notificationUnreadCount = 0,
       Stream<int>? notificationStream,
+      TextScaler? textScaler,
     }) {
       if (state != null) {
         whenListen(
@@ -166,6 +167,13 @@ void main() {
         initialState: const ConversationActionsState(),
       );
 
+      final inbox = textScaler == null
+          ? const InboxView()
+          : MediaQuery(
+              data: MediaQueryData(textScaler: textScaler),
+              child: const InboxView(),
+            );
+
       return testMaterialApp(
         mockAuthService: mockAuthService,
         additionalOverrides: [
@@ -190,7 +198,7 @@ void main() {
                 value: mockActionsCubit,
               ),
             ],
-            child: const InboxView(),
+            child: inbox,
           ),
         ),
       );
@@ -1020,6 +1028,9 @@ void main() {
           await tester.pump(const Duration(milliseconds: 350));
 
           expect(find.byType(MessageRequestsBanner), findsOneWidget);
+          expect(find.byType(InboxEmptyState), findsOneWidget);
+          final l10n = lookupAppLocalizations(const Locale('en'));
+          expect(find.text(l10n.inboxUnreadEmptyTitle), findsNothing);
         },
       );
 
@@ -1425,7 +1436,7 @@ void main() {
         );
       });
 
-      testWidgets('filter chips measure exactly the pinned header extent', (
+      testWidgets('filter chips ignore text scaling inside the pinned header', (
         tester,
       ) async {
         final conversations = manyConversations();
@@ -1437,15 +1448,16 @@ void main() {
               visibleConversations: conversations,
               hasMore: false,
             ),
+            textScaler: const TextScaler.linear(2),
           ),
         );
         await openMessages(tester);
 
-        // A SliverPersistentHeader has to declare its extent up front, and an
-        // under-declared one silently clips the chips. 48 = 8px padding either
-        // side of a DivineButtonSize.tiny chip, whose 32px box does not scale
-        // with text size. If DivineButton's tiny height ever moves, this fails
-        // here rather than as a clipped chip on someone's phone.
+        final unreadTextContext = tester.element(find.text('Unread'));
+        expect(
+          MediaQuery.textScalerOf(unreadTextContext).scale(20),
+          equals(20),
+        );
         expect(
           tester.getSize(find.byType(UnreadFilterChips)).height,
           equals(48),

--- a/mobile/test/screens/inbox/inbox_view_test.dart
+++ b/mobile/test/screens/inbox/inbox_view_test.dart
@@ -1349,6 +1349,11 @@ void main() {
         await tester.pump(const Duration(milliseconds: 350));
       }
 
+      final wordmarkFinder = find.byWidgetPredicate(
+        (widget) => widget is DivineIcon && widget.icon == DivineIconName.logo,
+        description: 'bundled Divine wordmark',
+      );
+
       testWidgets('renders the moderation title from l10n, never a '
           'generated profile name', (tester) async {
         final l10n = lookupAppLocalizations(const Locale('en'));
@@ -1517,6 +1522,38 @@ void main() {
         // No action sheet is wired for this row, so it must not advertise a
         // long-press hint it cannot honour.
         expect(data.hasAction(SemanticsAction.longPress), isFalse);
+      });
+
+      testWidgets('renders the bundled wordmark rather than the account '
+          'picture', (tester) async {
+        // The moderation account's kind-0 picture is divine-logo.svg, which
+        // colours itself through a <style> block. flutter_svg's parser has no
+        // <style> support, discards it, and paints every path opaque black —
+        // 1.1:1 against the inbox surface. The row must not depend on it.
+        await tester.pumpWidget(
+          buildSubject(
+            state: ConversationListState(
+              status: ConversationListStatus.loaded,
+              pinnedConversation: supportPin(),
+            ),
+          ),
+        );
+        await openMessages(tester);
+
+        expect(wordmarkFinder, findsOneWidget);
+      });
+
+      testWidgets('renders no wordmark when there is no pin', (tester) async {
+        await tester.pumpWidget(
+          buildSubject(
+            state: const ConversationListState(
+              status: ConversationListStatus.loaded,
+            ),
+          ),
+        );
+        await openMessages(tester);
+
+        expect(wordmarkFinder, findsNothing);
       });
     });
   });

--- a/mobile/test/screens/inbox/inbox_view_test.dart
+++ b/mobile/test/screens/inbox/inbox_view_test.dart
@@ -1436,9 +1436,71 @@ void main() {
         );
       });
 
-      testWidgets('filter chips ignore text scaling inside the pinned header', (
+      // A pinned SliverPersistentHeader lays its child out with a TIGHT height
+      // equal to maxExtent, so `getSize(...).height` only ever reports the
+      // extent the delegate declared — asserting it equals a constant measures
+      // that constant against itself and cannot catch an under-declared header.
+      // What can: the chips' own intrinsic height, which is computed from the
+      // content and is independent of the constraint it was laid out under. If
+      // the header declares less than that, the label is silently clipped
+      // (cross-axis overflow in a Row does not throw), which is the failure
+      // these two tests exist to catch.
+      Future<({double laidOut, double needed})> pumpChips(
+        WidgetTester tester, {
+        required TextScaler textScaler,
+      }) async {
+        final conversations = manyConversations();
+        await tester.pumpWidget(
+          buildSubject(
+            state: ConversationListState(
+              status: ConversationListStatus.loaded,
+              conversations: conversations,
+              visibleConversations: conversations,
+              hasMore: false,
+            ),
+            textScaler: textScaler,
+          ),
+        );
+        await openMessages(tester);
+
+        final box = tester.renderObject<RenderBox>(
+          find.byType(UnreadFilterChips),
+        );
+        return (
+          laidOut: box.size.height,
+          needed: box.getMaxIntrinsicHeight(box.size.width),
+        );
+      }
+
+      testWidgets('the pinned header fits the chips at the default text scale', (
         tester,
       ) async {
+        final size = await pumpChips(
+          tester,
+          textScaler: TextScaler.noScaling,
+        );
+
+        // 48 = 8px padding either side of a DivineButtonSize.tiny chip, which
+        // is itself 6 + a 20px line box + 6. Asserting the chips ASK for 48 is
+        // the half that can fail: if a divine_ui token moves, this breaks here
+        // rather than as a clipped chip on someone's phone.
+        expect(size.needed, equals(48));
+        expect(size.laidOut, equals(48));
+      });
+
+      testWidgets('the pinned header grows with the text scale rather than '
+          'clipping the chips', (tester) async {
+        final size = await pumpChips(
+          tester,
+          textScaler: const TextScaler.linear(2),
+        );
+
+        // Only the 20px line box scales; the two paddings do not. 16 + 12 + 40.
+        expect(size.needed, equals(68));
+        expect(size.laidOut, greaterThanOrEqualTo(size.needed));
+      });
+
+      testWidgets('filter chips honour the system text scale', (tester) async {
         final conversations = manyConversations();
         await tester.pumpWidget(
           buildSubject(
@@ -1453,14 +1515,12 @@ void main() {
         );
         await openMessages(tester);
 
+        // These are controls the user reads and taps, so they must not be
+        // frozen at 1.0 the way a fixed overlay badge is.
         final unreadTextContext = tester.element(find.text('Unread'));
         expect(
           MediaQuery.textScalerOf(unreadTextContext).scale(20),
-          equals(20),
-        );
-        expect(
-          tester.getSize(find.byType(UnreadFilterChips)).height,
-          equals(48),
+          equals(40),
         );
       });
 

--- a/mobile/test/screens/inbox/inbox_view_test.dart
+++ b/mobile/test/screens/inbox/inbox_view_test.dart
@@ -13,11 +13,14 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
+import 'package:openvine/blocs/dm/conversation_actions/conversation_actions_cubit.dart';
 import 'package:openvine/blocs/dm/conversation_list/conversation_list_bloc.dart';
+import 'package:openvine/blocs/dm/conversation_mute/conversation_mute_cubit.dart';
 import 'package:openvine/blocs/dm/unread_count/dm_unread_count_cubit.dart';
 import 'package:openvine/blocs/invite_status/invite_status_cubit.dart';
 import 'package:openvine/blocs/my_following/my_following_bloc.dart';
 import 'package:openvine/blocs/notifications/badge/notification_badge_cubit.dart';
+import 'package:openvine/config/official_accounts.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/notifications/providers/notification_repository_provider.dart';
 import 'package:openvine/router/app_router.dart';
@@ -44,6 +47,12 @@ class _MockConversationListBloc
 
 class _MockMyFollowingBloc extends MockBloc<MyFollowingEvent, MyFollowingState>
     implements MyFollowingBloc {}
+
+class _MockConversationMuteCubit extends MockCubit<ConversationMuteState>
+    implements ConversationMuteCubit {}
+
+class _MockConversationActionsCubit extends MockCubit<ConversationActionsState>
+    implements ConversationActionsCubit {}
 
 class _MockInviteStatusCubit extends MockCubit<InviteStatusState>
     implements InviteStatusCubit {}
@@ -138,6 +147,25 @@ void main() {
         initialState: notificationUnreadCount,
       );
 
+      final mockMuteCubit = _MockConversationMuteCubit();
+      when(() => mockMuteCubit.state).thenReturn(const ConversationMuteState());
+      whenListen(
+        mockMuteCubit,
+        const Stream<ConversationMuteState>.empty(),
+        initialState: const ConversationMuteState(),
+      );
+
+      final mockActionsCubit = _MockConversationActionsCubit();
+      when(
+        () => mockActionsCubit.state,
+      ).thenReturn(const ConversationActionsState());
+      when(() => mockActionsCubit.isBlocked(any())).thenReturn(false);
+      whenListen(
+        mockActionsCubit,
+        const Stream<ConversationActionsState>.empty(),
+        initialState: const ConversationActionsState(),
+      );
+
       return testMaterialApp(
         mockAuthService: mockAuthService,
         additionalOverrides: [
@@ -154,6 +182,12 @@ void main() {
               BlocProvider<DmUnreadCountCubit>.value(value: mockDmUnreadCubit),
               BlocProvider<NotificationBadgeCubit>.value(
                 value: mockNotifBadgeCubit,
+              ),
+              BlocProvider<ConversationMuteCubit>.value(
+                value: mockMuteCubit,
+              ),
+              BlocProvider<ConversationActionsCubit>.value(
+                value: mockActionsCubit,
               ),
             ],
             child: const InboxView(),
@@ -1531,19 +1565,22 @@ void main() {
     });
 
     group('pinned support row (#6283)', () {
-      const moderationPubkey =
-          '8fd5eb6d8f362163bc00a5ab6b4a3167dbf32d00ec4efdbcf43b3c9514433b7e';
+      const moderationPubkey = kModerationPubkeyHex;
 
-      DmConversation supportPin({
+      PinnedSupport supportPin({
         String? lastMessageContent,
         bool isRead = true,
-      }) => DmConversation(
-        id: 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
-        participantPubkeys: const [currentPubkey, moderationPubkey],
-        isGroup: false,
-        createdAt: 0,
-        lastMessageContent: lastMessageContent,
-        isRead: isRead,
+        bool isPersisted = false,
+      }) => PinnedSupport(
+        isPersisted: isPersisted,
+        conversation: DmConversation(
+          id: 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+          participantPubkeys: const [currentPubkey, moderationPubkey],
+          isGroup: false,
+          createdAt: 0,
+          lastMessageContent: lastMessageContent,
+          isRead: isRead,
+        ),
       );
 
       Future<void> openMessages(WidgetTester tester) async {
@@ -1565,7 +1602,7 @@ void main() {
           buildSubject(
             state: ConversationListState(
               status: ConversationListStatus.loaded,
-              pinnedConversation: supportPin(),
+              pinnedSupport: supportPin(),
             ),
           ),
         );
@@ -1609,7 +1646,7 @@ void main() {
           buildSubject(
             state: ConversationListState(
               status: ConversationListStatus.loaded,
-              pinnedConversation: supportPin(),
+              pinnedSupport: supportPin(),
             ),
           ),
         );
@@ -1636,7 +1673,7 @@ void main() {
               conversations: [conversation],
               searchQuery: 'zzzz',
               hasMore: false,
-              pinnedConversation: supportPin(),
+              pinnedSupport: supportPin(),
             ),
           ),
         );
@@ -1673,7 +1710,7 @@ void main() {
               // 'moderation' matches inboxSupportRowTitle, but no real thread.
               searchQuery: 'moderation',
               hasMore: false,
-              pinnedConversation: supportPin(),
+              pinnedSupport: supportPin(),
             ),
           ),
         );
@@ -1693,7 +1730,7 @@ void main() {
               conversations: [realConversation],
               unreadOnly: true,
               hasMore: false,
-              pinnedConversation: supportPin(),
+              pinnedSupport: supportPin(),
             ),
           ),
         );
@@ -1713,7 +1750,7 @@ void main() {
               conversations: [realConversation],
               unreadOnly: true,
               hasMore: false,
-              pinnedConversation: supportPin(
+              pinnedSupport: supportPin(
                 isRead: false,
                 lastMessageContent: 'We looked into your report.',
               ),
@@ -1753,7 +1790,7 @@ void main() {
                 ),
               ],
               hasMore: false,
-              pinnedConversation: supportPin(),
+              pinnedSupport: supportPin(),
             ),
           ),
         );
@@ -1783,7 +1820,7 @@ void main() {
             state: ConversationListState(
               status: ConversationListStatus.loaded,
               hasMore: false,
-              pinnedConversation: supportPin(),
+              pinnedSupport: supportPin(),
             ),
           ),
         );
@@ -1803,7 +1840,7 @@ void main() {
           buildSubject(
             state: ConversationListState(
               status: ConversationListStatus.loaded,
-              pinnedConversation: supportPin(
+              pinnedSupport: supportPin(
                 lastMessageContent: 'We looked into your report.',
                 isRead: false,
               ),
@@ -1829,7 +1866,7 @@ void main() {
           buildSubject(
             state: ConversationListState(
               status: ConversationListStatus.loaded,
-              pinnedConversation: pin,
+              pinnedSupport: pin,
             ),
           ),
         );
@@ -1843,7 +1880,7 @@ void main() {
         // router happily accepts either list.
         final captured = verify(
           () => mockGoRouter.push<Object?>(
-            ConversationPage.pathForId(pin.id),
+            ConversationPage.pathForId(pin.conversation.id),
             extra: captureAny(named: 'extra'),
           ),
         ).captured.single;
@@ -1859,7 +1896,7 @@ void main() {
           buildSubject(
             state: ConversationListState(
               status: ConversationListStatus.loaded,
-              pinnedConversation: supportPin(),
+              pinnedSupport: supportPin(),
             ),
           ),
         );
@@ -1870,10 +1907,32 @@ void main() {
             .getSemanticsData();
         expect(data.label, contains(l10n.inboxSupportRowTitle));
         expect(data.flagsCollection.isButton, isTrue);
-        // No action sheet is wired for this row, so it must not advertise a
-        // long-press hint it cannot honour.
+        // Nothing is persisted yet, so there is no action sheet to open and
+        // the row must not advertise a long-press it cannot honour.
         expect(data.hasAction(SemanticsAction.longPress), isFalse);
       });
+
+      testWidgets(
+        'advertises long-press to assistive tech once a thread is adopted',
+        (tester) async {
+          await tester.pumpWidget(
+            buildSubject(
+              state: ConversationListState(
+                status: ConversationListStatus.loaded,
+                pinnedSupport: supportPin(isPersisted: true),
+              ),
+            ),
+          );
+          await openMessages(tester);
+
+          final data = tester
+              .getSemantics(find.byType(ConversationTile))
+              .getSemanticsData();
+          // The adopted thread carries the actions the ordinary row had before
+          // the pin replaced it, so the affordance must be discoverable.
+          expect(data.hasAction(SemanticsAction.longPress), isTrue);
+        },
+      );
 
       testWidgets('renders the bundled wordmark rather than the account '
           'picture', (tester) async {
@@ -1885,7 +1944,7 @@ void main() {
           buildSubject(
             state: ConversationListState(
               status: ConversationListStatus.loaded,
-              pinnedConversation: supportPin(),
+              pinnedSupport: supportPin(),
             ),
           ),
         );
@@ -1906,6 +1965,71 @@ void main() {
 
         expect(wordmarkFinder, findsNothing);
       });
+
+      testWidgets(
+        'long-press on an adopted thread opens the actions sheet labelled '
+        'Divine Moderation, never a generated profile name',
+        (tester) async {
+          final l10n = lookupAppLocalizations(const Locale('en'));
+          await tester.pumpWidget(
+            buildSubject(
+              state: ConversationListState(
+                status: ConversationListStatus.loaded,
+                pinnedSupport: supportPin(
+                  isPersisted: true,
+                  lastMessageContent: 'We looked into your report',
+                ),
+              ),
+            ),
+          );
+          await openMessages(tester);
+
+          await tester.longPress(find.text(l10n.inboxSupportRowTitle));
+          await tester.pumpAndSettle();
+
+          // The pin replaced an ordinary row that had these actions; losing
+          // them on adoption is the regression this guards (#6388 review).
+          expect(find.text(l10n.inboxActionRemove), findsOneWidget);
+          expect(
+            find.text(l10n.inboxActionBlock(l10n.inboxSupportRowTitle)),
+            findsOneWidget,
+          );
+          // Sourcing the sheet's name from kind-0 would label it with the
+          // deterministic "Adjective Animal N" fallback for this pubkey.
+          expect(
+            find.text(
+              l10n.inboxActionBlock(
+                UserProfile.defaultDisplayNameFor(moderationPubkey),
+              ),
+            ),
+            findsNothing,
+          );
+        },
+      );
+
+      testWidgets(
+        "survives a search that matches the adopted pin's last message",
+        (tester) async {
+          final l10n = lookupAppLocalizations(const Locale('en'));
+          await tester.pumpWidget(
+            buildSubject(
+              state: ConversationListState(
+                status: ConversationListStatus.loaded,
+                searchQuery: 'looked',
+                pinnedSupport: supportPin(
+                  isPersisted: true,
+                  lastMessageContent: 'We looked into your report',
+                ),
+              ),
+            ),
+          );
+          await openMessages(tester);
+
+          // The bloc's own filter matches name OR preview; matching only the
+          // title here hid the row on a query drawn from the team's reply.
+          expect(find.text(l10n.inboxSupportRowTitle), findsOneWidget);
+        },
+      );
     });
   });
 }

--- a/mobile/test/screens/inbox/message_requests/message_requests_page_test.dart
+++ b/mobile/test/screens/inbox/message_requests/message_requests_page_test.dart
@@ -9,11 +9,14 @@ import 'package:flutter_riverpod/legacy.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:follow_repository/follow_repository.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
 import 'package:openvine/blocs/dm/conversation_list/conversation_list_bloc.dart';
+import 'package:openvine/config/official_accounts.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/router/app_router.dart';
 import 'package:openvine/screens/inbox/message_requests/message_requests_page.dart';
 import 'package:openvine/screens/inbox/message_requests/message_requests_view.dart';
+import 'package:openvine/screens/inbox/message_requests/widgets/request_tile.dart';
 import 'package:openvine/services/auth_service.dart';
 
 import '../../../helpers/go_router.dart';
@@ -33,6 +36,8 @@ final _dmRepoSwap = StateProvider<int>((ref) => 0);
 void main() {
   const testPubkey =
       'aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd';
+  const strangerPubkey =
+      '1122334411223344112233441122334411223344112233441122334411223344';
 
   group(MessageRequestsPage, () {
     late _MockDmRepository mockDmRepository;
@@ -84,11 +89,19 @@ void main() {
       when(
         () => mockAuthService.authStateStream,
       ).thenAnswer((_) => const Stream<AuthState>.empty());
+      // Read by isDmRestrictedProvider once the protected-minor gate actually
+      // filters something — i.e. as soon as the request list is non-empty.
+      when(
+        () => mockAuthService.authenticationSource,
+      ).thenReturn(AuthenticationSource.importedKeys);
 
       when(() => mockFollowRepository.followingPubkeys).thenReturn(const []);
       when(
         () => mockFollowRepository.followingStream,
       ).thenAnswer((_) => const Stream.empty());
+      // Nobody is followed, so an unreplied conversation classifies as a
+      // request — which is what this page renders.
+      when(() => mockFollowRepository.isFollowing(any())).thenReturn(false);
     });
 
     test('has correct route constants', () {
@@ -113,6 +126,56 @@ void main() {
 
         expect(find.byType(MessageRequestsView), findsOneWidget);
       });
+
+      // This page builds its OWN ConversationListBloc. Without the support-row
+      // wiring the moderation thread stays here while the inbox lifts it into
+      // the pinned row — same thread on two surfaces, and the inbox's request
+      // banner counts one fewer than this page lists (#6388 review).
+      testWidgets(
+        'does not list the moderation thread among message requests',
+        (tester) async {
+          final supportId = DmRepository.computeConversationId([
+            testPubkey,
+            kModerationPubkeyHex,
+          ]);
+          when(mockDmRepository.watchPotentialRequests).thenAnswer(
+            (_) => Stream.value([
+              DmConversation(
+                id: supportId,
+                participantPubkeys: const [testPubkey, kModerationPubkeyHex],
+                isGroup: false,
+                createdAt: 1700000000,
+                lastMessageTimestamp: 1700000000,
+                isRead: false,
+              ),
+              DmConversation(
+                id: 'stranger-request',
+                participantPubkeys: const [testPubkey, strangerPubkey],
+                isGroup: false,
+                createdAt: 1700000100,
+                lastMessageTimestamp: 1700000100,
+                isRead: false,
+              ),
+            ]),
+          );
+
+          await tester.pumpWidget(
+            testMaterialApp(
+              home: const MessageRequestsPage(),
+              mockAuthService: mockAuthService,
+              mockFollowRepository: mockFollowRepository,
+              additionalOverrides: [
+                dmRepositoryProvider.overrideWithValue(mockDmRepository),
+                goRouterProvider.overrideWithValue(mockGoRouter),
+              ],
+            ),
+          );
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 350));
+
+          expect(find.byType(RequestTile), findsOneWidget);
+        },
+      );
     });
 
     // Same defect as InboxPage: the keepAlive `dmRepositoryProvider` rebuilds a

--- a/mobile/test/screens/inbox/widgets/conversation_tile_test.dart
+++ b/mobile/test/screens/inbox/widgets/conversation_tile_test.dart
@@ -6,10 +6,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart';
+import 'package:openvine/config/official_accounts.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/inbox/widgets/conversation_tile.dart';
 import 'package:openvine/widgets/user_avatar.dart';
+import 'package:openvine/widgets/vine_cached_image.dart';
 
 import '../../../helpers/test_provider_overrides.dart';
 
@@ -810,6 +812,97 @@ void main() {
           tileSemantics(tester).hintOverrides?.onLongPressHint,
           isNotNull,
         );
+      });
+    });
+
+    group('moderation avatar (#6283)', () {
+      final moderationPubkey = kPinnedOfficialAccounts
+          .firstWhere((account) => account.role == 'moderation')
+          .pubkeyHex;
+
+      Finder wordmarkFinder() => find.byWidgetPredicate(
+        (widget) => widget is DivineIcon && widget.icon == DivineIconName.logo,
+        description: 'bundled Divine wordmark',
+      );
+
+      Future<void> pumpTileFor(
+        WidgetTester tester,
+        String counterparty, {
+        String? picture,
+      }) async {
+        await tester.pumpWidget(
+          testMaterialApp(
+            additionalOverrides: [
+              fetchUserProfileProvider(counterparty).overrideWith(
+                (ref) async => UserProfile(
+                  pubkey: counterparty,
+                  displayName: 'Divine Moderation',
+                  picture: picture,
+                  rawData: const {},
+                  createdAt: now,
+                  eventId:
+                      'cccccccccccccccccccccccccccccccccccccccccccccccccc'
+                      'cccccccccccccc',
+                ),
+              ),
+            ],
+            home: Scaffold(
+              body: ConversationTile(
+                conversation: DmConversation(
+                  id:
+                      'dddddddddddddddddddddddddddddddddddddddddddddddddd'
+                      'dddddddddddddd',
+                  participantPubkeys: [currentPubkey, counterparty],
+                  isGroup: false,
+                  createdAt: nowUnix,
+                ),
+                currentUserPubkey: currentPubkey,
+                onTap: () {},
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+      }
+
+      testWidgets('an ordinary account keeps its kind-0 picture', (
+        tester,
+      ) async {
+        await pumpTileFor(
+          tester,
+          otherPubkey,
+          picture: 'https://divine.video/avatar.png',
+        );
+
+        expect(find.byType(VineCachedImage), findsOneWidget);
+        expect(wordmarkFinder(), findsNothing);
+      });
+
+      testWidgets('the moderation account renders the bundled wordmark instead '
+          'of its kind-0 picture', (tester) async {
+        // divine-logo.svg colours itself through a <style> block that
+        // flutter_svg's parser discards, so the account's own picture paints
+        // opaque black on the dark inbox surface.
+        await pumpTileFor(
+          tester,
+          moderationPubkey,
+          picture: 'https://divine.video/divine-logo.svg',
+        );
+
+        expect(wordmarkFinder(), findsOneWidget);
+        expect(find.byType(VineCachedImage), findsNothing);
+        // The wordmark is 3.8:1. Contain would letterbox the whole lockup
+        // into an illegible sliver; cover crops it to the middle "Vi", which
+        // is how divine-web frames the same artwork.
+        expect(tester.widget<DivineIcon>(wordmarkFinder()).fit, BoxFit.cover);
+      });
+
+      testWidgets('a retired moderation pubkey is covered too', (tester) async {
+        // A thread opened before the #2321 rotation stays keyed on the old
+        // pubkey, and it is the same team on the other end of it.
+        await pumpTileFor(tester, kLegacyModerationPubkeys.first);
+
+        expect(wordmarkFinder(), findsOneWidget);
       });
     });
   });

--- a/mobile/test/screens/inbox/widgets/conversation_tile_test.dart
+++ b/mobile/test/screens/inbox/widgets/conversation_tile_test.dart
@@ -3,6 +3,7 @@
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
@@ -47,6 +48,24 @@ void main() {
       lastMessageTimestamp: lastMessageTimestamp,
       isRead: isRead,
     );
+  }
+
+  /// The [SemanticsProperties] of the tile's own outermost Semantics wrapper.
+  ///
+  /// `onLongPressHint` lands in `SemanticsHintOverrides`, which `SemanticsData`
+  /// does not expose, so the widget's declared properties are the accessible
+  /// assertion point.
+  SemanticsProperties tileSemantics(WidgetTester tester) {
+    return tester
+        .widget<Semantics>(
+          find
+              .descendant(
+                of: find.byType(ConversationTile),
+                matching: find.byType(Semantics),
+              )
+              .first,
+        )
+        .properties;
   }
 
   group(ConversationTile, () {
@@ -648,6 +667,149 @@ void main() {
         );
         final decoration = decoratedBox.decoration as BoxDecoration;
         expect(decoration.color, isNull);
+      });
+    });
+
+    group('fixed-identity overrides (#6283)', () {
+      testWidgets('displayNameOverride wins over the resolved profile', (
+        tester,
+      ) async {
+        final testProfile = createTestProfile(displayName: 'Alice');
+
+        await tester.pumpWidget(
+          testMaterialApp(
+            additionalOverrides: [
+              fetchUserProfileProvider(
+                otherPubkey,
+              ).overrideWith((ref) async => testProfile),
+            ],
+            home: Scaffold(
+              body: ConversationTile(
+                conversation: createTestConversation(),
+                currentUserPubkey: currentPubkey,
+                onTap: () {},
+                displayNameOverride: 'Divine Moderation',
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Divine Moderation'), findsOneWidget);
+        expect(find.text('Alice'), findsNothing);
+      });
+
+      testWidgets('displayNameOverride also wins before the profile '
+          'repository is ready', (tester) async {
+        // profileRepositoryProvider is null until the relay client is ready,
+        // so the tile's fallback is a generated "Adjective Animal N" name.
+        // A pinned, known account must never render that.
+        await tester.pumpWidget(
+          testMaterialApp(
+            additionalOverrides: [
+              fetchUserProfileProvider(
+                otherPubkey,
+              ).overrideWith((ref) async => null),
+            ],
+            home: Scaffold(
+              body: ConversationTile(
+                conversation: createTestConversation(),
+                currentUserPubkey: currentPubkey,
+                onTap: () {},
+                displayNameOverride: 'Divine Moderation',
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Divine Moderation'), findsOneWidget);
+        expect(
+          find.text(UserProfile.defaultDisplayNameFor(otherPubkey)),
+          findsNothing,
+        );
+      });
+
+      testWidgets('subtitleOverride replaces the message preview', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          testMaterialApp(
+            additionalOverrides: [
+              fetchUserProfileProvider(
+                otherPubkey,
+              ).overrideWith((ref) async => null),
+            ],
+            home: Scaffold(
+              body: ConversationTile(
+                conversation: createTestConversation(
+                  lastMessageContent: 'Hello',
+                ),
+                currentUserPubkey: currentPubkey,
+                onTap: () {},
+                subtitleOverride: 'Bugs, moderation, account stuff.',
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Bugs, moderation, account stuff.'), findsOneWidget);
+        expect(find.text('Hello'), findsNothing);
+      });
+
+      testWidgets('advertises no long-press hint when no handler is given', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          testMaterialApp(
+            additionalOverrides: [
+              fetchUserProfileProvider(
+                otherPubkey,
+              ).overrideWith((ref) async => null),
+            ],
+            home: Scaffold(
+              body: ConversationTile(
+                conversation: createTestConversation(),
+                currentUserPubkey: currentPubkey,
+                onTap: () {},
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // The hint is a promise to assistive tech; without onLongPress there
+        // is no action sheet to open, so promising one is a lie.
+        expect(tileSemantics(tester).hintOverrides?.onLongPressHint, isNull);
+      });
+
+      testWidgets('keeps the long-press hint when a handler IS given', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          testMaterialApp(
+            additionalOverrides: [
+              fetchUserProfileProvider(
+                otherPubkey,
+              ).overrideWith((ref) async => null),
+            ],
+            home: Scaffold(
+              body: ConversationTile(
+                conversation: createTestConversation(),
+                currentUserPubkey: currentPubkey,
+                onTap: () {},
+                onLongPress: () {},
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(
+          tileSemantics(tester).hintOverrides?.onLongPressHint,
+          isNotNull,
+        );
       });
     });
   });

--- a/mobile/test/widgets/user_avatar_svg_test.dart
+++ b/mobile/test/widgets/user_avatar_svg_test.dart
@@ -350,6 +350,28 @@ void main() {
       expect(find.byType(Image), findsOneWidget);
       expect(find.byType(VineCachedImage), findsNothing);
     });
+
+    testWidgets('contentOverride wins over the remote picture', (tester) async {
+      // The Divine Moderation row (#6283) supplies its own bundled artwork
+      // because that account's kind-0 picture renders black under
+      // flutter_svg. The override has to beat a perfectly valid picture URL,
+      // not just fill in for a missing one.
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: UserAvatar(
+              imageUrl: 'https://divine.video/avatar.png',
+              name: 'Divine Moderation',
+              contentOverride: Text('brand-mark'),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('brand-mark'), findsOneWidget);
+      expect(find.byType(VineCachedImage), findsNothing);
+      expect(gradientPlaceholderFinder(), findsNothing);
+    });
   });
 }
 


### PR DESCRIPTION
Closes #6283

## Description

Adds a pinned "Divine Moderation" row to the Messages inbox that opens or starts a NIP-17 conversation with `moderation@divine.video`, matching the first-row support entry divine-web already ships. The row ships on by default.

The pin is composed in `ConversationListBloc`, after the inbox safety filters, rather than synthesized in the widget. That keeps the row aligned with the blocklist filter and the #176 protected-minor gate, and lets the list, unread badge, and Message Requests page share the same repository partitioning.

## Behavior

- Current moderation-key threads are adopted as the pinned row and removed from the ordinary inbox/request lists, so Divine Moderation does not render twice.
- If no current-key thread exists, the bloc synthesizes a read pinned row that opens the current moderation key.
- Pre-rotation moderation threads remain visible in their original inbox or request location. They are never adopted as the pin, because replying through a retired-key conversation would send to a key the team no longer watches, but this PR also does not hide the user's only in-app entry point to that history. #6416 remains the follow-up for a proper archived/read-only presentation.
- The pinned row respects search and unread filters in the view, so it does not appear as a false match.
- Adopted current-key rows keep the existing long-press action sheet; synthetic rows do not advertise actions that have no backing database row.

## Included fixes

- Rebuilds the Messages pane as one `CustomScrollView`, with only the All/Unread chips pinned, so keyboard and small-screen layouts are not squeezed by fixed-height chrome.
- Restores the requests-only empty state to `MessageRequestsBanner + InboxEmptyState`, rather than showing unread-filter copy below a requests banner.
- Opts the pinned All/Unread chip row out of text scaling so the fixed sliver extent cannot clip the chips at larger system font scales.
- Fixes the support-row route extra so tapping the pin opens moderation, not self.
- Renders the bundled Divine wordmark for moderation instead of the remote kind-0 SVG that compiled to a black avatar.
- Consolidates moderation pubkey/NIP-05 constants in `official_accounts.dart` and has `ModerationLabelService` reference the shared source.
- Fixes the latent `onLongPressHint` semantics bug where rows without a handler advertised a long-press action.

## Out of Scope

- Archived/read-only UI for retired moderation threads: #6416.
- Staffing/SLA for the moderation inbox: `support-trust-safety#194`.
- Pre-existing report-flow issue where a blocked moderation DM is reported as success: #6387.

## Verification

- `dart format mobile/packages/dm_repository/lib/src/dm_repository.dart mobile/packages/dm_repository/test/src/dm_repository_test.dart mobile/lib/screens/inbox/widgets/unread_filter_chips.dart mobile/lib/screens/inbox/inbox_view.dart mobile/test/blocs/dm/conversation_list/conversation_list_bloc_test.dart mobile/test/screens/inbox/inbox_view_test.dart`
- `flutter analyze lib/screens/inbox/inbox_view.dart lib/screens/inbox/widgets/unread_filter_chips.dart test/screens/inbox/inbox_view_test.dart test/blocs/dm/conversation_list/conversation_list_bloc_test.dart`
- `flutter analyze lib/src/dm_repository.dart test/src/dm_repository_test.dart` from `mobile/packages/dm_repository`
- `flutter test test/screens/inbox/inbox_view_test.dart`
- `flutter test test/blocs/dm/conversation_list/conversation_list_bloc_test.dart`
- `flutter test test/src/dm_repository_test.dart` from `mobile/packages/dm_repository`

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
