### PR TITLE
fix(support): resolve root-anchored comment notifications

### DIFF
--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -1068,12 +1068,7 @@ class NotificationRepository {
     if (raw.isEmpty) return [];
 
     final pubkeys = raw.map((n) => n.sourcePubkey).toSet().toList();
-    final eventIds = raw
-        .map((n) => n.referencedEventId)
-        .whereType<String>()
-        .where((id) => id.isNotEmpty)
-        .toSet()
-        .toList();
+    final eventIds = _videoMetadataEventIds(raw);
 
     final profilesFuture = _profileRepository.fetchBatchProfiles(
       pubkeys: pubkeys,
@@ -1161,13 +1156,30 @@ class NotificationRepository {
     return _VideoMetadataLookup(videosById: map, notFoundIds: notFoundIds);
   }
 
+  static List<String> _videoMetadataEventIds(List<RelayNotification> raw) {
+    final eventIds = <String>{};
+    for (final notification in raw) {
+      final referencedEventId = notification.referencedEventId;
+      if (referencedEventId != null && referencedEventId.isNotEmpty) {
+        eventIds.add(referencedEventId);
+      }
+
+      final kind = _mapNotificationKind(notification);
+      if (!_isVideoAnchoredKind(kind)) continue;
+      final anchorEventId = _videoAnchorEventId(kind, notification);
+      if (anchorEventId != null && anchorEventId.isNotEmpty) {
+        eventIds.add(anchorEventId);
+      }
+    }
+    return eventIds.toList();
+  }
+
   /// Builds [VideoNotification]s by grouping like/comment/repost
-  /// notifications by `(referencedEventId, kind)`.
+  /// notifications by `(video anchor event id, kind)`.
   ///
-  /// Threshold is 1 — every video-anchored notification with a non-null
-  /// `referencedEventId` becomes a [VideoNotification], even if only one
-  /// actor interacted. Notifications missing `referencedEventId` are
-  /// dropped.
+  /// Threshold is 1 — every notification with a non-empty video anchor becomes
+  /// a [VideoNotification], even if only one actor interacted. Comments can
+  /// anchor on `rootEventId` when the payload omits `referencedEventId`.
   ///
   /// Notifications whose referenced video is confirmed to belong to a
   /// different user are collected in [misattributed] for reclassification
@@ -1180,15 +1192,10 @@ class NotificationRepository {
     required Set<String> videoNotFoundIds,
     List<RelayNotification>? misattributed,
   }) {
-    bool isVideoAnchored(NotificationKind k) =>
-        k == NotificationKind.like ||
-        k == NotificationKind.comment ||
-        k == NotificationKind.repost;
-
     final groups = <_VideoGroupKey, List<RelayNotification>>{};
     for (final n in raw) {
       final kind = _mapNotificationKind(n);
-      if (!isVideoAnchored(kind)) continue;
+      if (!_isVideoAnchoredKind(kind)) continue;
       final eventId = _videoAnchorEventId(kind, n);
       if (eventId == null || eventId.isEmpty) continue;
       if (_hasKnownReferencedVideoOwnerMismatch(
@@ -1199,7 +1206,7 @@ class NotificationRepository {
         rootEventPubkey: n.rootEventPubkey,
       )) {
         _logReclassifiedOwnerMismatch(
-          notificationId: n.id,
+          notificationId: n.dedupeKey,
           sourcePubkey: n.sourcePubkey,
           referencedVideoEventId: eventId,
           referencedVideoOwnerPubkey: videosById[eventId]?.pubkey,
@@ -1278,6 +1285,11 @@ class NotificationRepository {
     }
     return result;
   }
+
+  static bool _isVideoAnchoredKind(NotificationKind kind) =>
+      kind == NotificationKind.like ||
+      kind == NotificationKind.comment ||
+      kind == NotificationKind.repost;
 
   /// Builds [ActorNotification]s for follow/mention/system kinds.
   ///
@@ -1444,8 +1456,8 @@ class NotificationRepository {
   /// video; a confirmed *different* owner is reclassified to an actor row
   /// upstream ([_groupVideoAnchored] / #4920) before this is reached. So
   /// ownership here is either confirmed-recipient or unconfirmable (a metadata
-  /// miss: stale/edited event id, fetch failure, or a comment with an empty
-  /// `referenced_event_id`). In both cases we synthesize the route rather than
+  /// miss: stale/edited event id or fetch failure). In both cases we synthesize
+  /// the route rather than
   /// dropping to the raw, often-stale `referencedEventId` — which is the #4730
   /// broken-link gap: once the recipient edits a video, its old event id no
   /// longer resolves, so the stable route is the only thing that reopens it.

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -953,15 +953,11 @@ void main() {
         expect(item.videoEventId, equals('video_x'));
       });
 
-      test('comment with empty referencedEventId synthesizes the addressable '
-          'id from the payload d-tag and keeps the root video event id '
-          '(#4730 broken-link fix)', () async {
+      test('comment with empty referencedEventId fetches root metadata and '
+          'keeps the root video event id (#6369)', () async {
         // NIP-22 comment whose referenced_event_id is empty carries the video
-        // via rootEventId. The page-load path fetches metadata by
-        // referenced_event_id only (not rootEventId), so ownership of the root
-        // video is unconfirmed here — but the notification is still about the
-        // recipient's own video, so the recipient-scoped route is synthesized
-        // from the payload d-tag instead of dropping to the rootEventId.
+        // via rootEventId. Fetching metadata for the same anchor used by
+        // grouping lets ownership and the stable d-tag come from the root.
         stubNotifications([
           makeNotification(
             id: 'c1',
@@ -975,6 +971,7 @@ void main() {
           ),
         ]);
         stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
+        stubVideoStats('video_root', makeVideoStats(id: 'video_root'));
 
         final page = await repository.getNotifications();
 
@@ -985,10 +982,11 @@ void main() {
           item.videoAddressableId,
           equals(
             '${NIP71VideoKinds.addressableShortVideo}:'
-            '$userPubkey:vine-id',
+            '$userPubkey:d_video_root',
           ),
         );
         expect(item.videoEventId, equals('video_root'));
+        verify(() => funnelcakeApiClient.getVideoStats('video_root')).called(1);
       });
 
       test(
@@ -1359,6 +1357,46 @@ void main() {
         final item = page.items.single as ActorNotification;
         expect(item.type, equals(NotificationKind.likeComment));
         expect(item.targetEventId, equals('foreign_video'));
+      });
+
+      test('comment anchored on a non-owned root video is reclassified as '
+          'reply instead of commented on your video (#6369)', () async {
+        stubNotifications([
+          makeNotification(
+            id: '',
+            sourceEventId: 'comment_evt_id',
+            sourceKind: 1111,
+            notificationType: 'mention',
+            referencedEventId: '',
+            rootEventId: 'foreign_root_video',
+            targetCommentId: 'target_comment_id',
+            referencedDTag: 'foreign-d-tag',
+            content: 'Reply from another creator',
+            isReferencedVideo: false,
+          ),
+        ]);
+        stubProfiles({
+          'pubkey_alice': makeProfile('pubkey_alice', displayName: 'Alice'),
+        });
+        stubVideoStats(
+          'foreign_root_video',
+          makeVideoStats(
+            id: 'foreign_root_video',
+            pubkey: 'other_owner_pubkey',
+          ),
+        );
+
+        final page = await repository.getNotifications();
+
+        expect(page.items, hasLength(1));
+        final item = page.items.single as ActorNotification;
+        expect(item.id, equals('comment_evt_id'));
+        expect(item.type, equals(NotificationKind.reply));
+        expect(item.targetEventId, equals('target_comment_id'));
+        expect(item.videoAddressableId, isNull);
+        verify(
+          () => funnelcakeApiClient.getVideoStats('foreign_root_video'),
+        ).called(1);
       });
 
       test(
@@ -2462,10 +2500,7 @@ void main() {
               (await hydrated.watchSnapshot().first).items.single
                   as VideoNotification;
           expect(item.id, equals('cached_like_1'));
-          expect(item.actors.map((a) => a.pubkey), [
-            'pubkey_bob',
-            'actor_pub',
-          ]);
+          expect(item.actors.map((a) => a.pubkey), ['pubkey_bob', 'actor_pub']);
           expect(item.totalCount, equals(2));
           expect(item.videoTitle, equals('Server title'));
           expect(


### PR DESCRIPTION
## Summary
- fetch video metadata for the same anchor event id used to group video notifications, including root_event_id anchored comments
- reclassify foreign-root comment notifications as reply rows instead of "commented on your video"
- log owner-mismatch reclassifications with the notification dedupe key so empty server ids remain traceable

## Verification
- cd mobile/packages/notification_repository && flutter test test/src/notification_repository_test.dart
- cd mobile && flutter analyze packages/notification_repository/lib packages/notification_repository/test/src/notification_repository_test.dart
- cd mobile && flutter analyze lib test integration_test
- pre-push checks: analyzer + changed notification_repository test

Closes #6369