### PR TITLE
fix(news-feed): ignore iOS back swipe for tuning

### DIFF
--- a/mobile/lib/widgets/feed_tuning/feed_tuning_swipe_overlay.dart
+++ b/mobile/lib/widgets/feed_tuning/feed_tuning_swipe_overlay.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:feed_tuning_repository/feed_tuning_repository.dart';
@@ -7,6 +8,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
 import 'package:flutter/services.dart';
 import 'package:openvine/l10n/l10n.dart';
+
+// Mirrors Flutter's private _kBackGestureWidth in cupertino/route.dart.
+const double _platformBackGestureWidth = 20;
 
 /// Horizontal-swipe detector over the fullscreen feed that lets the user tune
 /// recommendations: swipe right = "more like this", swipe left = "less like
@@ -68,6 +72,7 @@ class _FeedTuningSwipeOverlayState extends State<FeedTuningSwipeOverlay> {
 
   void _onPointerDown(PointerDownEvent event) {
     if (_activeDragPointer != null) return;
+    if (_isPlatformBackGestureStart(event.position)) return;
     _activeDragPointer = event.pointer;
     _dragOffset = Offset.zero;
     _dragIntent = _DragIntent.undecided;
@@ -90,6 +95,7 @@ class _FeedTuningSwipeOverlayState extends State<FeedTuningSwipeOverlay> {
 
   void _onPointerPanZoomStart(PointerPanZoomStartEvent event) {
     if (_activeDragPointer != null) return;
+    if (_isPlatformBackGestureStart(event.position)) return;
     _activeDragPointer = event.pointer;
     _dragOffset = Offset.zero;
     _dragIntent = _DragIntent.undecided;
@@ -137,9 +143,41 @@ class _FeedTuningSwipeOverlayState extends State<FeedTuningSwipeOverlay> {
     final committed =
         _dragIntent == _DragIntent.horizontal &&
         _passedThreshold &&
-        direction != null;
+        direction != null &&
+        !_isRouteTransitionInProgress;
     _reset();
     if (committed) widget.onTuned(direction);
+  }
+
+  bool get _isRouteTransitionInProgress {
+    final animation = ModalRoute.of(context)?.animation;
+    return animation != null && animation.status != AnimationStatus.completed;
+  }
+
+  bool _isPlatformBackGestureStart(Offset globalPosition) {
+    if (Theme.of(context).platform != TargetPlatform.iOS) return false;
+
+    final route = ModalRoute.of(context);
+    if (route is! PageRoute<dynamic> || !route.popGestureEnabled) return false;
+
+    final renderObject = context.findRenderObject();
+    if (renderObject is! RenderBox) return false;
+
+    final localPosition = renderObject.globalToLocal(globalPosition);
+    final textDirection = Directionality.of(context);
+    final padding = MediaQuery.paddingOf(context);
+    final backGestureWidth = switch (textDirection) {
+      TextDirection.ltr => math.max(padding.left, _platformBackGestureWidth),
+      TextDirection.rtl => math.max(padding.right, _platformBackGestureWidth),
+    };
+
+    return switch (textDirection) {
+      TextDirection.ltr =>
+        localPosition.dx >= 0 && localPosition.dx <= backGestureWidth,
+      TextDirection.rtl =>
+        localPosition.dx >= renderObject.size.width - backGestureWidth &&
+            localPosition.dx <= renderObject.size.width,
+    };
   }
 
   void _onPointerSignal(PointerSignalEvent event) {

--- a/mobile/lib/widgets/feed_tuning/feed_tuning_swipe_overlay.dart
+++ b/mobile/lib/widgets/feed_tuning/feed_tuning_swipe_overlay.dart
@@ -143,15 +143,9 @@ class _FeedTuningSwipeOverlayState extends State<FeedTuningSwipeOverlay> {
     final committed =
         _dragIntent == _DragIntent.horizontal &&
         _passedThreshold &&
-        direction != null &&
-        !_isRouteTransitionInProgress;
+        direction != null;
     _reset();
     if (committed) widget.onTuned(direction);
-  }
-
-  bool get _isRouteTransitionInProgress {
-    final animation = ModalRoute.of(context)?.animation;
-    return animation != null && animation.status != AnimationStatus.completed;
   }
 
   bool _isPlatformBackGestureStart(Offset globalPosition) {

--- a/mobile/test/widgets/feed_tuning/feed_tuning_swipe_overlay_test.dart
+++ b/mobile/test/widgets/feed_tuning/feed_tuning_swipe_overlay_test.dart
@@ -9,14 +9,10 @@ import 'package:openvine/widgets/feed_tuning/feed_tuning_swipe_overlay.dart';
 void main() {
   final l10n = lookupAppLocalizations(const Locale('en'));
 
-  Future<List<FeedTuningDirection>> pumpOverlay(
-    WidgetTester tester, {
-    TargetPlatform? platform,
-  }) async {
+  Future<List<FeedTuningDirection>> pumpOverlay(WidgetTester tester) async {
     final tuned = <FeedTuningDirection>[];
     await tester.pumpWidget(
       MaterialApp(
-        theme: platform == null ? null : ThemeData(platform: platform),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
         home: Scaffold(

--- a/mobile/test/widgets/feed_tuning/feed_tuning_swipe_overlay_test.dart
+++ b/mobile/test/widgets/feed_tuning/feed_tuning_swipe_overlay_test.dart
@@ -9,10 +9,14 @@ import 'package:openvine/widgets/feed_tuning/feed_tuning_swipe_overlay.dart';
 void main() {
   final l10n = lookupAppLocalizations(const Locale('en'));
 
-  Future<List<FeedTuningDirection>> pumpOverlay(WidgetTester tester) async {
+  Future<List<FeedTuningDirection>> pumpOverlay(
+    WidgetTester tester, {
+    TargetPlatform? platform,
+  }) async {
     final tuned = <FeedTuningDirection>[];
     await tester.pumpWidget(
       MaterialApp(
+        theme: platform == null ? null : ThemeData(platform: platform),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
         home: Scaffold(
@@ -164,6 +168,67 @@ void main() {
         containsAll(<int>[moreId, lessId]),
       );
       handle.dispose();
+    });
+  });
+
+  group('platform back gesture', () {
+    testWidgets('iOS back swipe pops without tuning', (tester) async {
+      final tuned = await pumpPushedOverlay(tester);
+
+      await tester.dragFrom(const Offset(5, 300), const Offset(500, 0));
+      await tester.pumpAndSettle();
+
+      expect(tuned, isEmpty);
+      expect(find.text('home'), findsOneWidget);
+    });
+
+    testWidgets('iOS center swipe still tunes more on pushed route', (
+      tester,
+    ) async {
+      final tuned = await pumpPushedOverlay(tester);
+
+      await tester.dragFrom(const Offset(200, 300), const Offset(220, 0));
+      await tester.pumpAndSettle();
+
+      expect(tuned, [FeedTuningDirection.more]);
+      expect(find.byType(FeedTuningSwipeOverlay), findsOneWidget);
+    });
+
+    testWidgets('iOS RTL back swipe pops without tuning', (tester) async {
+      final tuned = await pumpPushedOverlay(
+        tester,
+        textDirection: TextDirection.rtl,
+      );
+
+      await tester.dragFrom(const Offset(795, 300), const Offset(-500, 0));
+      await tester.pumpAndSettle();
+
+      expect(tuned, isEmpty);
+      expect(find.text('home'), findsOneWidget);
+    });
+
+    testWidgets('iOS root-route edge swipe can still tune', (tester) async {
+      final tuned = await pumpFullscreenRootOverlay(tester);
+
+      await tester.dragFrom(const Offset(5, 300), const Offset(220, 0));
+      await tester.pumpAndSettle();
+
+      expect(tuned, [FeedTuningDirection.more]);
+    });
+
+    testWidgets('non-iOS pushed route edge swipe can still tune', (
+      tester,
+    ) async {
+      final tuned = await pumpPushedOverlay(
+        tester,
+        platform: TargetPlatform.android,
+      );
+
+      await tester.dragFrom(const Offset(5, 300), const Offset(220, 0));
+      await tester.pumpAndSettle();
+
+      expect(tuned, [FeedTuningDirection.more]);
+      expect(find.byType(FeedTuningSwipeOverlay), findsOneWidget);
     });
   });
 
@@ -328,3 +393,76 @@ void main() {
 }
 
 void _noop(FeedTuningDirection _) {}
+
+Future<List<FeedTuningDirection>> pumpFullscreenRootOverlay(
+  WidgetTester tester, {
+  TargetPlatform platform = TargetPlatform.iOS,
+}) async {
+  final tuned = <FeedTuningDirection>[];
+  await tester.pumpWidget(
+    MaterialApp(
+      theme: ThemeData(platform: platform),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: FeedTuningSwipeOverlay(
+          onTuned: tuned.add,
+          child: const SizedBox.expand(),
+        ),
+      ),
+    ),
+  );
+  return tuned;
+}
+
+Future<List<FeedTuningDirection>> pumpPushedOverlay(
+  WidgetTester tester, {
+  TargetPlatform platform = TargetPlatform.iOS,
+  TextDirection textDirection = TextDirection.ltr,
+}) async {
+  final tuned = <FeedTuningDirection>[];
+  await tester.pumpWidget(
+    MaterialApp(
+      theme: ThemeData(platform: platform),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      builder: (context, child) {
+        return Directionality(
+          textDirection: textDirection,
+          child: child ?? const SizedBox.shrink(),
+        );
+      },
+      home: Builder(
+        builder: (context) {
+          return Scaffold(
+            body: Center(
+              child: TextButton(
+                onPressed: () {
+                  Navigator.of(context).push<void>(
+                    MaterialPageRoute<void>(
+                      builder: (_) {
+                        return Scaffold(
+                          body: FeedTuningSwipeOverlay(
+                            onTuned: tuned.add,
+                            child: const SizedBox.expand(),
+                          ),
+                        );
+                      },
+                    ),
+                  );
+                },
+                child: const Text('home'),
+              ),
+            ),
+          );
+        },
+      ),
+    ),
+  );
+
+  await tester.tap(find.text('home'));
+  await tester.pumpAndSettle();
+  expect(find.byType(FeedTuningSwipeOverlay), findsOneWidget);
+
+  return tuned;
+}


### PR DESCRIPTION
## Summary
- ignore feed-tuning drags that start in Flutter's iOS leading-edge back gesture strip on poppable routes
- keep center swipes, root-route tuning, non-iOS pushed route tuning, vertical paging, trackpad pan, pointer scroll, and semantics behavior intact
- add regression coverage for iOS back swipe, RTL leading edge, root route, and non-iOS pushed routes

## Verification
- flutter test test/widgets/feed_tuning/feed_tuning_swipe_overlay_test.dart
- flutter analyze lib test integration_test
- pre-push hook: analyzer + changed widget test suite

Closes #6390