### PR TITLE
fix(video-editor): preserve draft metadata mode

### DIFF
--- a/mobile/lib/router/routes/video_routes.dart
+++ b/mobile/lib/router/routes/video_routes.dart
@@ -130,7 +130,11 @@ List<RouteBase> videoRoutes() {
     GoRoute(
       path: VideoMetadataScreen.path,
       name: VideoMetadataScreen.routeName,
-      builder: (_, st) => const VideoMetadataScreen(),
+      builder: (_, st) => VideoMetadataScreen(
+        draftMode: VideoMetadataScreen.draftModeFromName(
+          st.uri.queryParameters[VideoMetadataScreen.draftModeQueryParameter],
+        ),
+      ),
     ),
     GoRoute(
       path: '${VideoMetadataEditScreen.path}/:videoId',

--- a/mobile/lib/screens/video_metadata/video_metadata_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_screen.dart
@@ -21,13 +21,43 @@ enum _C2paMissingChoice { regenerate, skip }
 /// expiration settings.
 class VideoMetadataScreen extends ConsumerStatefulWidget {
   /// Creates a video metadata editing screen.
-  const VideoMetadataScreen({super.key});
+  const VideoMetadataScreen({this.draftMode, super.key});
 
   /// Route name for this screen.
   static const routeName = 'video-metadata';
 
   /// Path for this route.
   static const path = '/video-metadata';
+
+  /// Query parameter carrying the composition mode from the draft editor.
+  static const draftModeQueryParameter = 'mode';
+
+  /// Builds the metadata location for a draft editor composition.
+  ///
+  /// Drafts always use the capture metadata flow. Stop-motion drafts retain
+  /// their distinct mode so future mode-specific behavior can branch without
+  /// consulting the unrelated last-used recorder preference.
+  static String pathForDraft({required bool isStopMotion}) {
+    final mode = isStopMotion
+        ? VideoRecorderMode.stopMotion
+        : VideoRecorderMode.capture;
+    return Uri(
+      path: path,
+      queryParameters: {draftModeQueryParameter: mode.name},
+    ).toString();
+  }
+
+  /// Parses the only recorder modes valid for an editor draft.
+  static VideoRecorderMode? draftModeFromName(String? name) => switch (name) {
+    'capture' => VideoRecorderMode.capture,
+    'stopMotion' => VideoRecorderMode.stopMotion,
+    _ => null,
+  };
+
+  /// Mode derived from the draft composition by the video editor.
+  ///
+  /// When absent, direct recorder flows retain the persisted recorder mode.
+  final VideoRecorderMode? draftMode;
 
   @override
   ConsumerState<VideoMetadataScreen> createState() =>
@@ -120,11 +150,13 @@ class _VideoMetadataScreenState extends ConsumerState<VideoMetadataScreen> {
 
     // The recorder bloc is screen-scoped and this screen is a separate route,
     // so read the mode the recorder persisted rather than the (absent) bloc.
-    final recorderMode = VideoRecorderMode.fromName(
-      ref
-          .watch(sharedPreferencesProvider)
-          .getString(VideoRecorderMode.persistenceKey),
-    );
+    final recorderMode =
+        widget.draftMode ??
+        VideoRecorderMode.fromName(
+          ref
+              .watch(sharedPreferencesProvider)
+              .getString(VideoRecorderMode.persistenceKey),
+        );
 
     // Cancel video render when user navigates back
     return PopScope(
@@ -137,15 +169,14 @@ class _VideoMetadataScreenState extends ConsumerState<VideoMetadataScreen> {
         child: switch (recorderMode) {
           // Lip-sync shares capture's editor + metadata flow. Stop-motion
           // produces a normal video clip, so it shares the same capture-mode
-          // metadata UI.
+          // metadata UI. Upload cannot navigate here directly; treating it as
+          // capture is a safe fallback for restored legacy draft routes that
+          // do not carry the draft mode query parameter.
           .capture ||
           .stopMotion ||
-          .lipSync => const VideoMetadataCaptureStack(),
+          .lipSync ||
+          .upload => const VideoMetadataCaptureStack(),
           .classic => const VideoMetadataClassicStack(),
-          // Deliberately unreachable: upload mode has no record button, so no
-          // clips can be created and the user cannot navigate to the metadata
-          // screen while in this mode. Required only for switch exhaustiveness.
-          .upload => const SizedBox.shrink(),
         },
       ),
     );

--- a/mobile/lib/screens/video_metadata/video_metadata_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_screen.dart
@@ -169,9 +169,9 @@ class _VideoMetadataScreenState extends ConsumerState<VideoMetadataScreen> {
         child: switch (recorderMode) {
           // Lip-sync shares capture's editor + metadata flow. Stop-motion
           // produces a normal video clip, so it shares the same capture-mode
-          // metadata UI. Upload cannot navigate here directly; treating it as
-          // capture is a safe fallback for restored legacy draft routes that
-          // do not carry the draft mode query parameter.
+          // metadata UI. Upload has no video editor, so recorder navigation
+          // pushes this route without a mode query. A restored draft uses the
+          // capture stack even when upload is the persisted recorder mode.
           .capture ||
           .stopMotion ||
           .lipSync ||

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -1899,7 +1899,11 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     final awaitCover = VideoEditorScope.of(context).awaitPushCoverTransition;
     final gate = _decoderReleaseGate = Completer<void>();
     _isMetadataRouteActive = true;
-    final navigation = context.push(VideoMetadataScreen.path);
+    final navigation = context.push(
+      VideoMetadataScreen.pathForDraft(
+        isStopMotion: _isStopMotionComposition,
+      ),
+    );
     try {
       await (awaitCover?.call() ??
           awaitPushTransition(

--- a/mobile/test/router/routes/restored_route_extras_test.dart
+++ b/mobile/test/router/routes/restored_route_extras_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart';
+import 'package:openvine/models/video_recorder/video_recorder_mode.dart';
 import 'package:openvine/router/routes/profile_routes.dart';
 import 'package:openvine/router/routes/video_routes.dart';
 import 'package:openvine/router/widgets/other_profile_screen_router.dart';
@@ -11,6 +12,7 @@ import 'package:openvine/screens/sound_detail_screen.dart';
 import 'package:openvine/screens/subtitle_editor/subtitle_editor_screen.dart';
 import 'package:openvine/screens/video_editor/video_editor_screen.dart';
 import 'package:openvine/screens/video_metadata/video_metadata_edit_screen.dart';
+import 'package:openvine/screens/video_metadata/video_metadata_screen.dart';
 
 class _FakeGoRouterState extends Fake implements GoRouterState {
   _FakeGoRouterState({
@@ -171,6 +173,53 @@ void main() {
       expect(draft.draftId, 'draft-1');
       expect(draft.fromLibrary, isTrue);
       expect(malformed.fromLibrary, isFalse);
+    });
+
+    testWidgets('video metadata route restores draft recorder modes', (
+      tester,
+    ) async {
+      final route = _routeNamed(videoRoutes(), VideoMetadataScreen.routeName);
+      late VideoMetadataScreen capture;
+      late VideoMetadataScreen stopMotion;
+      late VideoMetadataScreen unsupported;
+
+      await _buildWithContext(tester, (context) {
+        capture =
+            route.builder!(
+                  context,
+                  _FakeGoRouterState(
+                    location: VideoMetadataScreen.pathForDraft(
+                      isStopMotion: false,
+                    ),
+                    pathParameters: const {},
+                  ),
+                )
+                as VideoMetadataScreen;
+        stopMotion =
+            route.builder!(
+                  context,
+                  _FakeGoRouterState(
+                    location: VideoMetadataScreen.pathForDraft(
+                      isStopMotion: true,
+                    ),
+                    pathParameters: const {},
+                  ),
+                )
+                as VideoMetadataScreen;
+        unsupported =
+            route.builder!(
+                  context,
+                  _FakeGoRouterState(
+                    location: '${VideoMetadataScreen.path}?mode=upload',
+                    pathParameters: const {},
+                  ),
+                )
+                as VideoMetadataScreen;
+      });
+
+      expect(capture.draftMode, VideoRecorderMode.capture);
+      expect(stopMotion.draftMode, VideoRecorderMode.stopMotion);
+      expect(unsupported.draftMode, isNull);
     });
 
     testWidgets('video edit routes tolerate decoded maps and no extra', (

--- a/mobile/test/screens/video_metadata_screen_test.dart
+++ b/mobile/test/screens/video_metadata_screen_test.dart
@@ -53,7 +53,7 @@ void main() {
     // it without any BlocProvider on purpose: a regression to reading the bloc
     // would throw a ProviderNotFoundException and fail here (the crash hm21
     // hit in classic mode).
-    Widget buildScreen() {
+    Widget buildScreen({VideoRecorderMode? draftMode}) {
       return ProviderScope(
         overrides: [
           sharedPreferencesProvider.overrideWithValue(prefs),
@@ -66,10 +66,10 @@ void main() {
             ),
           ),
         ],
-        child: const MaterialApp(
+        child: MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
-          home: VideoMetadataScreen(),
+          home: VideoMetadataScreen(draftMode: draftMode),
         ),
       );
     }
@@ -446,6 +446,38 @@ void main() {
     });
 
     group('recorder mode switch', () {
+      testWidgets('persisted upload mode falls back to capture metadata', (
+        tester,
+      ) async {
+        await prefs.setString(
+          VideoRecorderMode.persistenceKey,
+          VideoRecorderMode.upload.name,
+        );
+
+        await tester.pumpWidget(buildScreen());
+        await tester.pumpAndSettle();
+
+        expect(find.byType(VideoMetadataCaptureStack), findsOneWidget);
+        expect(find.text('Post details'), findsOneWidget);
+      });
+
+      testWidgets('draft stop-motion mode overrides a persisted classic mode', (
+        tester,
+      ) async {
+        await prefs.setString(
+          VideoRecorderMode.persistenceKey,
+          VideoRecorderMode.classic.name,
+        );
+
+        await tester.pumpWidget(
+          buildScreen(draftMode: VideoRecorderMode.stopMotion),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byType(VideoMetadataCaptureStack), findsOneWidget);
+        expect(find.byType(VideoMetadataClassicStack), findsNothing);
+      });
+
       testWidgets('renders $VideoMetadataCaptureStack when mode is capture', (
         tester,
       ) async {


### PR DESCRIPTION
Closes #6397

## Summary

- derive the metadata flow from the editor composition when leaving a draft
- carry `capture` or `stopMotion` through a restorable route query parameter
- render capture metadata as the safe fallback for legacy routes with a persisted `upload` mode
- cover draft-mode restoration and metadata rendering with regression tests

## Root cause

`VideoMetadataScreen` used the globally persisted last recorder mode. Reopening a draft after the user had last selected Upload resolved that mode to `upload`, whose metadata branch rendered an empty widget. This produced the reported black screen even though routing and final video rendering succeeded.

## User impact

Normal drafts now always open Capture post details, while stop-motion drafts retain Stop Motion mode. A stale Upload preference can no longer produce a black metadata screen.

## Validation

- `flutter test test/widgets/video_editor/main_editor/video_editor_canvas_test.dart test/screens/video_metadata_screen_test.dart test/router/routes/restored_route_extras_test.dart`
- `flutter analyze lib test integration_test`
- `scripts/golden.sh verify`
- `bash scripts/check_raw_textstyle_ceiling.sh`
- `bash scripts/check_raw_colors_ceiling.sh`
- `bash scripts/check_material_button_ceiling.sh`
- `bash scripts/check_raw_dialog_ceiling.sh`
- pre-push analyzer and affected-test checks
