### PR TITLE
feat(review): prompt engaged store-installed creators to rate the app

### DIFF
--- a/docs/superpowers/plans/2026-07-26-app-review-lifecycle-hardening.md
+++ b/docs/superpowers/plans/2026-07-26-app-review-lifecycle-hardening.md
@@ -1,0 +1,231 @@
+# App Review Lifecycle Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent in-app review prompts from surviving account/lifecycle changes and make eligibility use refreshed profile statistics.
+
+**Architecture:** Keep the existing coordinator widget and Cubit boundary. Pass a live account/lifecycle predicate through the Cubit, make Cubit shutdown cancellation-safe, and introduce a feature-local bounded stats loader that refreshes before reading Drift.
+
+**Tech Stack:** Flutter, Riverpod, flutter_bloc, ProfileRepository, flutter_test
+
+---
+
+### Task 1: Make Cubit evaluation cancellation-safe
+
+**Files:**
+- Modify: `mobile/test/features/app_review/app_review_coordinator_cubit_test.dart`
+- Modify: `mobile/lib/features/app_review/app_review_coordinator_cubit.dart`
+
+- [ ] **Step 1: Write failing lifecycle tests**
+
+Add a test that starts `evaluate`, closes the Cubit while the fake frame
+scheduler is pending, completes the scheduler, and expects the evaluation to
+complete without a platform request. Add a second test whose active predicate
+changes to false while a completer-backed `isAvailable` call is pending and
+expects no cooldown or request.
+
+```dart
+test('stops cleanly when closed during frame wait', () async {
+  final evaluation = cubit.evaluate(
+    inputs: inputs(),
+    isActive: () => true,
+  );
+  await cubit.close();
+  frameScheduler.complete();
+
+  await expectLater(evaluation, completes);
+  expect(platform.requests, 0);
+});
+```
+
+- [ ] **Step 2: Run tests and verify the post-close case fails**
+
+Run:
+
+```bash
+cd mobile
+mise exec -- flutter test test/features/app_review/app_review_coordinator_cubit_test.dart
+```
+
+Expected: failure from emitting after `close()` or from the missing
+`isActive` API.
+
+- [ ] **Step 3: Implement the minimal Cubit guards**
+
+Rename the callback to `isActive`, return immediately when `isClosed`, check
+both `isClosed` and `isActive()` after async boundaries, and guard the final
+emit:
+
+```dart
+bool canContinue() => !isClosed && isActive();
+
+if (isClosed || state) return;
+emit(true);
+try {
+  await _evaluate(inputs: inputs, isActive: isActive);
+} finally {
+  if (!isClosed) emit(false);
+}
+```
+
+- [ ] **Step 4: Run the Cubit tests and verify they pass**
+
+Run the command from Step 2. Expected: all Cubit tests pass.
+
+### Task 2: Refresh profile stats before reading the cache
+
+**Files:**
+- Create: `mobile/lib/features/app_review/app_review_profile_stats_loader.dart`
+- Create: `mobile/test/features/app_review/app_review_profile_stats_loader_test.dart`
+- Modify: `mobile/lib/features/app_review/app_review_coordinator.dart`
+
+- [ ] **Step 1: Write failing loader tests**
+
+Create tests proving the watcher is not subscribed until the refresh completes,
+the refreshed row is returned, and refresh errors/timeouts return null.
+
+```dart
+final refresh = Completer<void>();
+var refreshed = false;
+final result = loader.load(
+  refresh: () async {
+    await refresh.future;
+    refreshed = true;
+  },
+  watch: () => Stream.value(refreshed ? freshStats : staleStats),
+);
+
+expect(refreshed, isFalse);
+refresh.complete();
+expect(await result, freshStats);
+```
+
+- [ ] **Step 2: Run the loader test and verify it fails**
+
+Run:
+
+```bash
+cd mobile
+mise exec -- flutter test test/features/app_review/app_review_profile_stats_loader_test.dart
+```
+
+Expected: compile failure because `AppReviewProfileStatsLoader` does not exist.
+
+- [ ] **Step 3: Implement the bounded refresh-first loader**
+
+Create `AppReviewProfileStatsLoader` with a three-second default timeout:
+
+```dart
+Future<ProfileStats?> load({
+  required Future<void> Function() refresh,
+  required Stream<ProfileStats?> Function() watch,
+}) async {
+  try {
+    return await (() async {
+      await refresh();
+      return watch().whereType<ProfileStats>().first;
+    })().timeout(timeout);
+  } on Object {
+    return null;
+  }
+}
+```
+
+Update the coordinator to call the loader with
+`fetchFreshProfile(pubkey: pubkey)` before `watchProfileStats`.
+
+- [ ] **Step 4: Run the loader and coordinator tests**
+
+Run:
+
+```bash
+cd mobile
+mise exec -- flutter test \
+  test/features/app_review/app_review_profile_stats_loader_test.dart \
+  test/features/app_review/app_review_coordinator_cubit_test.dart
+```
+
+Expected: all tests pass.
+
+### Task 3: Bind the coordinator to the active account
+
+**Files:**
+- Modify: `mobile/lib/features/app_review/app_review_coordinator.dart`
+- Modify: `mobile/test/features/app_review/app_review_coordinator_cubit_test.dart`
+
+- [ ] **Step 1: Add the live active-context predicate**
+
+Implement a widget helper that returns true only while the original pubkey is
+still authenticated, the widget is mounted, and the app remains foreground:
+
+```dart
+bool _isActiveFor(String pubkey) {
+  if (!mounted || !ref.read(appForegroundProvider)) return false;
+  final authService = ref.read(authServiceProvider);
+  return authService.authState == AuthState.authenticated &&
+      authService.currentPublicKeyHex == pubkey;
+}
+```
+
+Check it after profile-stat loading and pass it through `evaluate`.
+
+- [ ] **Step 2: Run focused review tests**
+
+Run:
+
+```bash
+cd mobile
+mise exec -- flutter test \
+  test/features/app_review/app_review_coordinator_cubit_test.dart \
+  test/features/app_review/app_review_profile_stats_loader_test.dart \
+  test/services/app_review_prompt_service_test.dart
+```
+
+Expected: all tests pass.
+
+### Task 4: Verify and publish
+
+**Files:**
+- Verify all files changed by Tasks 1–3.
+
+- [ ] **Step 1: Run formatting and guardrails**
+
+```bash
+cd mobile
+mise exec -- dart format --output=none --set-exit-if-changed \
+  lib/features/app_review \
+  test/features/app_review
+bash scripts/check_process_global_mutations.sh
+```
+
+Expected: both commands exit zero.
+
+- [ ] **Step 2: Run analysis**
+
+```bash
+cd mobile
+mise exec -- flutter analyze
+```
+
+Expected: no issues found.
+
+- [ ] **Step 3: Commit and push**
+
+Stage only the design, plan, app-review production files, and their tests.
+Commit with:
+
+```bash
+git commit -m "fix(review): cancel stale prompt evaluations"
+git push origin HEAD:feat/in-app-review-prompt
+```
+
+- [ ] **Step 4: Monitor PR checks**
+
+Run:
+
+```bash
+gh pr checks 6399 --repo divinevideo/divine-mobile --watch
+```
+
+Expected: every required check passes on the pushed head.
+

--- a/docs/superpowers/specs/2026-07-26-app-review-lifecycle-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-26-app-review-lifecycle-hardening-design.md
@@ -1,0 +1,41 @@
+# App Review Lifecycle Hardening Design
+
+## Goal
+
+Keep an in-app review evaluation bound to the authenticated account and
+provider container that started it, and use refreshed profile statistics when
+deciding eligibility.
+
+## Design
+
+The existing `AppReviewCoordinator` and `AppReviewCoordinatorCubit` split stays
+in place. The widget will pass an `isActive` callback that checks all
+UI/account preconditions together: the widget is mounted, the app is in the
+foreground, authentication is still settled, and the active pubkey still
+matches the evaluation's pubkey. The Cubit will call that predicate after every
+async boundary and will also stop cleanly when its provider container closes.
+
+Profile-stat loading moves into a small feature-local loader. It will await the
+repository refresh before subscribing to Drift's current stats row, with one
+timeout around the combined operation. This prevents an existing cached row
+from winning the race against the refresh while preserving the bounded,
+fail-closed behavior.
+
+## Error Handling
+
+- A changed account, sign-out, background transition, or closed Cubit cancels
+  the evaluation without writing cooldown state or opening the native prompt.
+- Cubit shutdown never emits a final state after `close()`.
+- Profile refresh errors, stream errors, and timeouts return no stats, leaving
+  the user ineligible for that foreground cycle.
+
+## Tests
+
+- Close the Cubit while its frame wait is pending and verify the evaluation
+  completes without a platform request or post-close emit.
+- Change the active-context predicate while platform availability is pending
+  and verify no cooldown or native request occurs.
+- Verify the stats loader does not subscribe until refresh completes and then
+  returns the refreshed row.
+- Verify loader errors and timeouts fail closed.
+

--- a/mobile/android/app/src/main/kotlin/co/openvine/app/MainActivity.kt
+++ b/mobile/android/app/src/main/kotlin/co/openvine/app/MainActivity.kt
@@ -154,10 +154,12 @@ class MainActivity : FlutterActivity() {
         )
     }
 
-    /// Resolves the installer package name (e.g. "com.android.vending" for Play
-    /// Store, "com.zapstore.app" for Zapstore) so the Dart side can classify
-    /// the install source. Returns null for sideloaded APKs or on older Android
-    /// versions where the installer cannot be determined.
+    /**
+     * Resolves the installer package name (e.g. "com.android.vending" for Play
+     * Store, "com.zapstore.app" for Zapstore) so the Dart side can classify
+     * the install source. Returns null for sideloaded APKs or on older Android
+     * versions where the installer cannot be determined.
+     */
     @Suppress("DEPRECATION")
     private fun resolveInstallerPackageName(): String? {
         return try {

--- a/mobile/android/app/src/main/kotlin/co/openvine/app/MainActivity.kt
+++ b/mobile/android/app/src/main/kotlin/co/openvine/app/MainActivity.kt
@@ -46,6 +46,8 @@ class MainActivity : FlutterActivity() {
     companion object {
         private const val NAVIGATION_CHANNEL = "org.openvine/navigation"
         private const val NAV_TAG = "OpenVineNavigation"
+        private const val INSTALL_SOURCE_CHANNEL = "divine/install_source"
+        private const val INSTALL_SOURCE_TAG = "OpenVineInstallSource"
     }
 
     private var navigationChannel: MethodChannel? = null
@@ -76,6 +78,11 @@ class MainActivity : FlutterActivity() {
 
         // Set up navigation channel for back button handling
         setupNavigationChannel(flutterEngine)
+
+        // Set up install-source channel (Play Store / Zapstore / sideload).
+        // Drives the in-app review prompt's store-install gate and the
+        // AppUpdateRepository's download-URL resolution (#6296).
+        setupInstallSourceChannel(flutterEngine)
 
         // Set up NIP-55 Android Signer plugin
         nostrSignerPlugin = NostrSignerPlugin(this, flutterEngine)
@@ -145,6 +152,43 @@ class MainActivity : FlutterActivity() {
             isFinishing = { isFinishing },
             onFallback = { finish() },
         )
+    }
+
+    /// Resolves the installer package name (e.g. "com.android.vending" for Play
+    /// Store, "com.zapstore.app" for Zapstore) so the Dart side can classify
+    /// the install source. Returns null for sideloaded APKs or on older Android
+    /// versions where the installer cannot be determined.
+    @Suppress("DEPRECATION")
+    private fun resolveInstallerPackageName(): String? {
+        return try {
+            // Prefer getInstallSourceInfo (Play's documented API) on Tiramisu+.
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                packageManager
+                    .getInstallSourceInfo(packageName)
+                    .installingPackageName
+            } else {
+                packageManager.getInstallerPackageName(packageName)
+            }
+        } catch (e: PackageManager.NameNotFoundException) {
+            Log.d(INSTALL_SOURCE_TAG, "No installer package name available", e)
+            null
+        } catch (e: IllegalArgumentException) {
+            Log.d(INSTALL_SOURCE_TAG, "Installer lookup failed", e)
+            null
+        }
+    }
+
+    private fun setupInstallSourceChannel(flutterEngine: FlutterEngine) {
+        MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            INSTALL_SOURCE_CHANNEL,
+        ).setMethodCallHandler { call, result ->
+            when (call.method) {
+                "getInstallerPackageName" -> result.success(resolveInstallerPackageName())
+                else -> result.notImplemented()
+            }
+        }
+        Log.d(INSTALL_SOURCE_TAG, "Install source channel registered")
     }
 
     override fun onDestroy() {

--- a/mobile/ios/Runner/AppDelegate.swift
+++ b/mobile/ios/Runner/AppDelegate.swift
@@ -213,12 +213,11 @@ extension FlutterError: @retroactive Error {}
       switch call.method {
       case "isSandboxReceipt":
         // The receipt URL is nil in simulator/debug runs without a store
-        // receipt; treat that as "not sandbox" so debug builds don't get
-        // classified as TestFlight. Production App Store builds always have a
-        // receipt URL whose lastPathComponent is "receipt".
+        // receipt. Return nil so Dart fails closed to sideload instead of
+        // pretending an unknown receipt environment is the App Store.
         guard let receiptURL = Bundle.main.appStoreReceiptURL else {
-          NSLog("📦 InstallSource: no receipt URL — defaulting to App Store")
-          result(false)
+          NSLog("📦 InstallSource: no receipt URL — returning unknown")
+          result(nil)
           return
         }
         let isSandbox = receiptURL.lastPathComponent == "sandboxReceipt"

--- a/mobile/ios/Runner/AppDelegate.swift
+++ b/mobile/ios/Runner/AppDelegate.swift
@@ -72,6 +72,11 @@ extension FlutterError: @retroactive Error {}
     // Set up Zendesk platform channel
     setupZendeskChannel(with: engineBridge)
 
+    // Set up install-source channel (App Store / TestFlight / sideload).
+    // Drives the in-app review prompt's store-install gate and the
+    // AppUpdateRepository's download-URL resolution (#6296).
+    setupInstallSourceChannel(with: engineBridge)
+
     NSLog("✅ AppDelegate: Implicit Flutter engine initialized with UIScene lifecycle")
   }
 
@@ -190,6 +195,42 @@ extension FlutterError: @retroactive Error {}
     }
 
     NSLog("✅ ProofMode: Platform channel registered with LibProofMode")
+  }
+
+  /// Install-source platform channel.
+  ///
+  /// iOS distinguishes install source by the app store receipt URL: TestFlight
+  /// builds ship a `sandboxReceipt`, App Store builds ship a `receipt`. The
+  /// Dart side maps `isSandbox` → testFlight/appStore via the shared
+  /// `resolveIosInstallSource` resolver in app_update_repository.
+  private func setupInstallSourceChannel(with engineBridge: FlutterImplicitEngineBridge) {
+    let channel = FlutterMethodChannel(
+      name: "divine/install_source",
+      binaryMessenger: engineBridge.applicationRegistrar.messenger()
+    )
+
+    channel.setMethodCallHandler { (call, result) in
+      switch call.method {
+      case "isSandboxReceipt":
+        // The receipt URL is nil in simulator/debug runs without a store
+        // receipt; treat that as "not sandbox" so debug builds don't get
+        // classified as TestFlight. Production App Store builds always have a
+        // receipt URL whose lastPathComponent is "receipt".
+        guard let receiptURL = Bundle.main.appStoreReceiptURL else {
+          NSLog("📦 InstallSource: no receipt URL — defaulting to App Store")
+          result(false)
+          return
+        }
+        let isSandbox = receiptURL.lastPathComponent == "sandboxReceipt"
+        NSLog("📦 InstallSource: isSandbox=\(isSandbox) (\(receiptURL.lastPathComponent))")
+        result(isSandbox)
+
+      default:
+        result(FlutterMethodNotImplemented)
+      }
+    }
+
+    NSLog("✅ InstallSource: Platform channel registered")
   }
 
   private func setupZendeskChannel(with engineBridge: FlutterImplicitEngineBridge) {

--- a/mobile/lib/features/app_review/app_review_analytics.dart
+++ b/mobile/lib/features/app_review/app_review_analytics.dart
@@ -1,0 +1,68 @@
+// ABOUTME: Privacy-safe analytics helpers for the in-app review prompt.
+// ABOUTME: Buckets the video count and never logs pubkeys.
+
+import 'dart:async';
+
+import 'package:analytics/analytics.dart';
+import 'package:app_update_repository/app_update_repository.dart';
+
+/// Records that a user met all eligibility conditions and would have been
+/// prompted (the OS may still throttle this to no-op).
+void trackInAppReviewEligible({
+  required AnalyticsEventSink analytics,
+  required InstallSource installSource,
+  required int videoCount,
+  required int sessionCount,
+  required int daysSinceFirstLaunch,
+}) {
+  unawaited(
+    analytics.logEvent(
+      name: 'in_app_review_eligible',
+      parameters: {
+        'install_source': installSource.name,
+        'video_count_bucket': _videoCountBucket(videoCount),
+        'session_count': sessionCount,
+        'days_since_first_launch': daysSinceFirstLaunch,
+      },
+    ),
+  );
+}
+
+/// Records that the native review card was actually requested. The OS does
+/// not report whether the user rated or dismissed, so this is the terminal
+/// event of the prompt flow.
+void trackInAppReviewPrompted({required AnalyticsEventSink analytics}) {
+  unawaited(
+    analytics.logEvent(
+      name: 'in_app_review_prompted',
+      parameters: const {},
+    ),
+  );
+}
+
+/// Records that requesting the native review card threw. Used to monitor
+/// platform-API breakage without surfacing the raw exception to users.
+void trackInAppReviewRequestFailed({
+  required AnalyticsEventSink analytics,
+  required Object error,
+}) {
+  unawaited(
+    analytics.logEvent(
+      name: 'in_app_review_request_failed',
+      parameters: {'error_type': error.runtimeType.toString()},
+    ),
+  );
+}
+
+/// Buckets the video count so the analytics payload cannot be used to
+/// reconstruct an exact posting history. >10 is the only bucket the gate
+/// cares about, so coarser buckets above that preserve all signal.
+String _videoCountBucket(int count) {
+  if (count <= 0) return '0';
+  if (count <= 5) return '1-5';
+  if (count <= 10) return '6-10';
+  if (count <= 25) return '11-25';
+  if (count <= 50) return '26-50';
+  if (count <= 100) return '51-100';
+  return '100+';
+}

--- a/mobile/lib/features/app_review/app_review_analytics.dart
+++ b/mobile/lib/features/app_review/app_review_analytics.dart
@@ -21,8 +21,10 @@ void trackInAppReviewEligible({
       parameters: {
         'install_source': installSource.name,
         'video_count_bucket': _videoCountBucket(videoCount),
-        'session_count': sessionCount,
-        'days_since_first_launch': daysSinceFirstLaunch,
+        'session_count_bucket': _sessionCountBucket(sessionCount),
+        'days_since_first_launch_bucket': _daysSinceFirstLaunchBucket(
+          daysSinceFirstLaunch,
+        ),
       },
     ),
   );
@@ -33,10 +35,7 @@ void trackInAppReviewEligible({
 /// event of the prompt flow.
 void trackInAppReviewPrompted({required AnalyticsEventSink analytics}) {
   unawaited(
-    analytics.logEvent(
-      name: 'in_app_review_prompted',
-      parameters: const {},
-    ),
+    analytics.logEvent(name: 'in_app_review_prompted', parameters: const {}),
   );
 }
 
@@ -65,4 +64,22 @@ String _videoCountBucket(int count) {
   if (count <= 50) return '26-50';
   if (count <= 100) return '51-100';
   return '100+';
+}
+
+String _sessionCountBucket(int count) {
+  if (count <= 0) return '0';
+  if (count <= 5) return '1-5';
+  if (count <= 9) return '6-9';
+  if (count <= 20) return '10-20';
+  if (count <= 50) return '21-50';
+  return '50+';
+}
+
+String _daysSinceFirstLaunchBucket(int days) {
+  if (days <= 0) return '0';
+  if (days <= 6) return '1-6';
+  if (days <= 13) return '7-13';
+  if (days <= 30) return '14-30';
+  if (days <= 90) return '31-90';
+  return '90+';
 }

--- a/mobile/lib/features/app_review/app_review_coordinator.dart
+++ b/mobile/lib/features/app_review/app_review_coordinator.dart
@@ -5,23 +5,26 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:in_app_review/in_app_review.dart';
 import 'package:models/models.dart';
-import 'package:openvine/features/app_review/app_review_analytics.dart';
+import 'package:openvine/features/app_review/app_review_coordinator_cubit.dart';
 import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/app_foreground_provider.dart';
 import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/install_source_provider.dart';
+import 'package:openvine/providers/repository_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
-import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/services/app_engagement_store.dart';
 import 'package:openvine/services/app_review_prompt_service.dart';
 import 'package:openvine/services/auth_service.dart' show AuthState;
-import 'package:openvine/services/install_source_service.dart';
 
-/// Provides the [InstallSourceResolver]. Override in tests.
-final installSourceResolverProvider = Provider<InstallSourceResolver>(
-  (ref) => const InstallSourceService(),
+/// Provides the native in-app review platform facade.
+final appReviewPlatformProvider = Provider<AppReviewPlatform>(
+  (ref) => InAppReviewPlatform(),
+);
+
+/// Provides the scheduler used to wait for a stable frame before prompting.
+final appReviewFrameSchedulerProvider = Provider<AppReviewFrameScheduler>(
+  (ref) => const WidgetsAppReviewFrameScheduler(),
 );
 
 /// Provides the [AppReviewPromptService].
@@ -36,12 +39,26 @@ final appEngagementStoreProvider = Provider<AppEngagementStore>((ref) {
   return AppEngagementStore(sharedPreferences: prefs);
 });
 
-/// A zero-size widget that evaluates the review gate whenever auth settles,
-/// the current user's profile stats update, or the app returns to the
-/// foreground. Mount exactly once near the root of the widget tree.
+/// Provides the review-prompt coordinator cubit.
+final appReviewCoordinatorCubitProvider = Provider<AppReviewCoordinatorCubit>((
+  ref,
+) {
+  final cubit = AppReviewCoordinatorCubit(
+    service: ref.watch(appReviewPromptServiceProvider),
+    analytics: ref.watch(analyticsEventSinkProvider),
+    reviewPlatform: ref.watch(appReviewPlatformProvider),
+    frameScheduler: ref.watch(appReviewFrameSchedulerProvider),
+  );
+  ref.onDispose(cubit.close);
+  return cubit;
+});
+
+/// A zero-size widget that evaluates the review gate when the app returns to
+/// the foreground. Mount exactly once near the root of the widget tree.
 ///
-/// Renders nothing; its only job is to call [InAppReview.requestReview] when
-/// all eligibility conditions in [AppReviewPromptService.shouldShow] are met.
+/// Renders nothing; its only job is to dispatch the OS-native review request
+/// when all eligibility conditions in [AppReviewPromptService.shouldShow] are
+/// met.
 class AppReviewCoordinator extends ConsumerStatefulWidget {
   const AppReviewCoordinator({super.key, this.child});
 
@@ -54,128 +71,74 @@ class AppReviewCoordinator extends ConsumerStatefulWidget {
       _AppReviewCoordinatorState();
 }
 
-class _AppReviewCoordinatorState extends ConsumerState<AppReviewCoordinator>
-    with WidgetsBindingObserver {
-  final InAppReview _inAppReview = InAppReview.instance;
-  bool _evaluating = false;
-
-  @override
-  void initState() {
-    super.initState();
-    WidgetsBinding.instance.addObserver(this);
-  }
-
-  @override
-  void dispose() {
-    WidgetsBinding.instance.removeObserver(this);
-    super.dispose();
-  }
-
-  @override
-  void didChangeAppLifecycleState(AppLifecycleState state) {
-    // Re-evaluate when the user returns to the app: that's the "actively
-    // engaging" moment. Avoids prompting during background or transitions.
-    if (state == AppLifecycleState.resumed) {
-      _maybePrompt();
-    }
-  }
+class _AppReviewCoordinatorState extends ConsumerState<AppReviewCoordinator> {
+  bool? _wasForeground;
 
   @override
   Widget build(BuildContext context) {
-    // Subscribe to auth + foreground state + current user's stats so a change
-    // in any of them re-triggers evaluation. The actual gating work happens in
-    // _maybePrompt, gated to one in-flight evaluation at a time.
+    // Auth is watched so account swaps rebuild before the next foreground
+    // trigger. Foreground transitions are the only prompt moment.
     ref.watch(currentAuthStateProvider);
-    ref.watch(appForegroundProvider);
-    final pubkey = ref.watch(authServiceProvider).currentPublicKeyHex;
-    // Explicit annotation: the family StreamProvider's inferred type is
-    // non-obvious, and documenting it makes the subscription's shape clear.
-    AsyncValue<ProfileStats?>? statsValue;
-    if (pubkey != null) {
-      // Family provider: watching with the pubkey re-subscribes when the
-      // active account changes.
-      statsValue = ref.watch(userProfileStatsReactiveProvider(pubkey));
-    }
-    // Schedule evaluation after this build so any provider change (auth
-    // settle, stats load, foreground return) gets a chance to fire the gate.
-    if (statsValue != null && statsValue.hasValue) {
+    final isForeground = ref.watch(appForegroundProvider);
+    final wasForeground = _wasForeground;
+    _wasForeground = isForeground;
+    if (wasForeground == false && isForeground) {
       WidgetsBinding.instance.addPostFrameCallback((_) => _maybePrompt());
     }
     return widget.child ?? const SizedBox.shrink();
   }
 
   Future<void> _maybePrompt() async {
-    if (_evaluating) return;
-    _evaluating = true;
-    try {
-      await _evaluateAndPrompt();
-    } finally {
-      _evaluating = false;
-    }
-  }
-
-  Future<void> _evaluateAndPrompt() async {
     if (!mounted) return;
     final authService = ref.read(authServiceProvider);
     if (authService.authState != AuthState.authenticated) return;
     final pubkey = authService.currentPublicKeyHex;
     if (pubkey == null) return;
 
-    // Read the current stats from the live subscription. This avoids a second
-    // async round-trip to the DB and naturally waits until stats have loaded
-    // (the build method only schedules a prompt when statsValue.hasValue).
-    final statsValue = ref.read(userProfileStatsReactiveProvider(pubkey));
-    final stats = statsValue.value;
-    final videoCount = stats?.videoCount ?? 0;
-    if (videoCount <= AppReviewPromptService.defaultMinimumVideoCount) return;
-
     final engagement = ref.read(appEngagementStoreProvider);
     final service = ref.read(appReviewPromptServiceProvider);
     final installSource = ref.read(installSourceProvider);
-    final analytics = ref.read(analyticsEventSinkProvider);
-
-    final inputs = ReviewEligibilityInputs(
+    final localInputs = ReviewLocalEligibilityInputs(
       pubkey: pubkey,
-      videoCount: videoCount,
       installSource: installSource,
       sessionCount: engagement.sessionCount,
       daysSinceFirstLaunch: engagement.daysSinceFirstLaunch(),
     );
+    if (!service.shouldLoadProfileStats(localInputs)) return;
 
-    if (!service.shouldShow(inputs)) return;
-
-    trackInAppReviewEligible(
-      analytics: analytics,
-      installSource: installSource,
-      videoCount: videoCount,
-      sessionCount: inputs.sessionCount,
-      daysSinceFirstLaunch: inputs.daysSinceFirstLaunch,
-    );
-
-    // Record the cooldown BEFORE showing so a crash or OS throttle can't
-    // cause a tight re-prompt loop. The OS applies its own ~3/year ceiling on
-    // top of this.
-    await service.recordShown(pubkey);
-
-    // Wait for a stable frame so the native card layers over settled UI and
-    // never competes with a route transition (Apple/Google reject cards shown
-    // mid-transition).
+    final stats = await _loadProfileStats(pubkey);
     if (!mounted) return;
-    final frameCompleter = Completer<void>();
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!frameCompleter.isCompleted) frameCompleter.complete();
-    });
-    await frameCompleter.future;
+    await ref
+        .read(appReviewCoordinatorCubitProvider)
+        .evaluate(
+          inputs: ReviewEligibilityInputs(
+            pubkey: pubkey,
+            videoCount: stats?.videoCount ?? 0,
+            installSource: installSource,
+            sessionCount: localInputs.sessionCount,
+            daysSinceFirstLaunch: localInputs.daysSinceFirstLaunch,
+          ),
+          isMounted: () => mounted,
+        );
+  }
 
+  Future<ProfileStats?> _loadProfileStats(String pubkey) async {
+    final repository = ref.read(profileStatsRepositoryProvider);
+    if (repository == null) return null;
+    unawaited(
+      repository
+          .fetchFreshProfile(pubkey: pubkey)
+          .catchError((Object _, StackTrace _) => null),
+    );
     try {
-      // isAvailable guards desktop/web where the native card can't show.
-      if (!mounted) return;
-      if (!await _inAppReview.isAvailable()) return;
-      if (!mounted) return;
-      await _inAppReview.requestReview();
-      trackInAppReviewPrompted(analytics: analytics);
-    } catch (error) {
-      trackInAppReviewRequestFailed(analytics: analytics, error: error);
+      return await repository
+          .watchProfileStats(pubkey: pubkey)
+          .where((stats) => stats != null)
+          .cast<ProfileStats>()
+          .first
+          .timeout(const Duration(seconds: 3));
+    } on TimeoutException {
+      return null;
     }
   }
 }

--- a/mobile/lib/features/app_review/app_review_coordinator.dart
+++ b/mobile/lib/features/app_review/app_review_coordinator.dart
@@ -1,0 +1,181 @@
+// ABOUTME: Mounts once in the widget tree to evaluate the in-app review
+// ABOUTME: gate on auth settle, profile-stats load, and app foreground.
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:in_app_review/in_app_review.dart';
+import 'package:models/models.dart';
+import 'package:openvine/features/app_review/app_review_analytics.dart';
+import 'package:openvine/providers/analytics_providers.dart';
+import 'package:openvine/providers/app_foreground_provider.dart';
+import 'package:openvine/providers/auth_providers.dart';
+import 'package:openvine/providers/install_source_provider.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/providers/user_profile_providers.dart';
+import 'package:openvine/services/app_engagement_store.dart';
+import 'package:openvine/services/app_review_prompt_service.dart';
+import 'package:openvine/services/auth_service.dart' show AuthState;
+import 'package:openvine/services/install_source_service.dart';
+
+/// Provides the [InstallSourceResolver]. Override in tests.
+final installSourceResolverProvider = Provider<InstallSourceResolver>(
+  (ref) => const InstallSourceService(),
+);
+
+/// Provides the [AppReviewPromptService].
+final appReviewPromptServiceProvider = Provider<AppReviewPromptService>((ref) {
+  final prefs = ref.watch(sharedPreferencesProvider);
+  return AppReviewPromptService(sharedPreferences: prefs);
+});
+
+/// Provides the [AppEngagementStore].
+final appEngagementStoreProvider = Provider<AppEngagementStore>((ref) {
+  final prefs = ref.watch(sharedPreferencesProvider);
+  return AppEngagementStore(sharedPreferences: prefs);
+});
+
+/// A zero-size widget that evaluates the review gate whenever auth settles,
+/// the current user's profile stats update, or the app returns to the
+/// foreground. Mount exactly once near the root of the widget tree.
+///
+/// Renders nothing; its only job is to call [InAppReview.requestReview] when
+/// all eligibility conditions in [AppReviewPromptService.shouldShow] are met.
+class AppReviewCoordinator extends ConsumerStatefulWidget {
+  const AppReviewCoordinator({super.key, this.child});
+
+  /// The rest of the app tree. Included so the coordinator can wrap the app
+  /// without an extra nesting level.
+  final Widget? child;
+
+  @override
+  ConsumerState<AppReviewCoordinator> createState() =>
+      _AppReviewCoordinatorState();
+}
+
+class _AppReviewCoordinatorState extends ConsumerState<AppReviewCoordinator>
+    with WidgetsBindingObserver {
+  final InAppReview _inAppReview = InAppReview.instance;
+  bool _evaluating = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    // Re-evaluate when the user returns to the app: that's the "actively
+    // engaging" moment. Avoids prompting during background or transitions.
+    if (state == AppLifecycleState.resumed) {
+      _maybePrompt();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Subscribe to auth + foreground state + current user's stats so a change
+    // in any of them re-triggers evaluation. The actual gating work happens in
+    // _maybePrompt, gated to one in-flight evaluation at a time.
+    ref.watch(currentAuthStateProvider);
+    ref.watch(appForegroundProvider);
+    final pubkey = ref.watch(authServiceProvider).currentPublicKeyHex;
+    // Explicit annotation: the family StreamProvider's inferred type is
+    // non-obvious, and documenting it makes the subscription's shape clear.
+    AsyncValue<ProfileStats?>? statsValue;
+    if (pubkey != null) {
+      // Family provider: watching with the pubkey re-subscribes when the
+      // active account changes.
+      statsValue = ref.watch(userProfileStatsReactiveProvider(pubkey));
+    }
+    // Schedule evaluation after this build so any provider change (auth
+    // settle, stats load, foreground return) gets a chance to fire the gate.
+    if (statsValue != null && statsValue.hasValue) {
+      WidgetsBinding.instance.addPostFrameCallback((_) => _maybePrompt());
+    }
+    return widget.child ?? const SizedBox.shrink();
+  }
+
+  Future<void> _maybePrompt() async {
+    if (_evaluating) return;
+    _evaluating = true;
+    try {
+      await _evaluateAndPrompt();
+    } finally {
+      _evaluating = false;
+    }
+  }
+
+  Future<void> _evaluateAndPrompt() async {
+    if (!mounted) return;
+    final authService = ref.read(authServiceProvider);
+    if (authService.authState != AuthState.authenticated) return;
+    final pubkey = authService.currentPublicKeyHex;
+    if (pubkey == null) return;
+
+    // Read the current stats from the live subscription. This avoids a second
+    // async round-trip to the DB and naturally waits until stats have loaded
+    // (the build method only schedules a prompt when statsValue.hasValue).
+    final statsValue = ref.read(userProfileStatsReactiveProvider(pubkey));
+    final stats = statsValue.value;
+    final videoCount = stats?.videoCount ?? 0;
+    if (videoCount <= AppReviewPromptService.defaultMinimumVideoCount) return;
+
+    final engagement = ref.read(appEngagementStoreProvider);
+    final service = ref.read(appReviewPromptServiceProvider);
+    final installSource = ref.read(installSourceProvider);
+    final analytics = ref.read(analyticsEventSinkProvider);
+
+    final inputs = ReviewEligibilityInputs(
+      pubkey: pubkey,
+      videoCount: videoCount,
+      installSource: installSource,
+      sessionCount: engagement.sessionCount,
+      daysSinceFirstLaunch: engagement.daysSinceFirstLaunch(),
+    );
+
+    if (!service.shouldShow(inputs)) return;
+
+    trackInAppReviewEligible(
+      analytics: analytics,
+      installSource: installSource,
+      videoCount: videoCount,
+      sessionCount: inputs.sessionCount,
+      daysSinceFirstLaunch: inputs.daysSinceFirstLaunch,
+    );
+
+    // Record the cooldown BEFORE showing so a crash or OS throttle can't
+    // cause a tight re-prompt loop. The OS applies its own ~3/year ceiling on
+    // top of this.
+    await service.recordShown(pubkey);
+
+    // Wait for a stable frame so the native card layers over settled UI and
+    // never competes with a route transition (Apple/Google reject cards shown
+    // mid-transition).
+    if (!mounted) return;
+    final frameCompleter = Completer<void>();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!frameCompleter.isCompleted) frameCompleter.complete();
+    });
+    await frameCompleter.future;
+
+    try {
+      // isAvailable guards desktop/web where the native card can't show.
+      if (!mounted) return;
+      if (!await _inAppReview.isAvailable()) return;
+      if (!mounted) return;
+      await _inAppReview.requestReview();
+      trackInAppReviewPrompted(analytics: analytics);
+    } catch (error) {
+      trackInAppReviewRequestFailed(analytics: analytics, error: error);
+    }
+  }
+}

--- a/mobile/lib/features/app_review/app_review_coordinator.dart
+++ b/mobile/lib/features/app_review/app_review_coordinator.dart
@@ -1,12 +1,11 @@
 // ABOUTME: Mounts once in the widget tree to evaluate the in-app review
 // ABOUTME: gate on auth settle, profile-stats load, and app foreground.
 
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:models/models.dart';
 import 'package:openvine/features/app_review/app_review_coordinator_cubit.dart';
+import 'package:openvine/features/app_review/app_review_profile_stats_loader.dart';
 import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/app_foreground_provider.dart';
 import 'package:openvine/providers/auth_providers.dart';
@@ -72,6 +71,8 @@ class AppReviewCoordinator extends ConsumerStatefulWidget {
 }
 
 class _AppReviewCoordinatorState extends ConsumerState<AppReviewCoordinator> {
+  static const _profileStatsLoader = AppReviewProfileStatsLoader();
+
   bool? _wasForeground;
 
   @override
@@ -107,7 +108,7 @@ class _AppReviewCoordinatorState extends ConsumerState<AppReviewCoordinator> {
     if (!service.shouldLoadProfileStats(localInputs)) return;
 
     final stats = await _loadProfileStats(pubkey);
-    if (!mounted) return;
+    if (!_isActiveFor(pubkey)) return;
     await ref
         .read(appReviewCoordinatorCubitProvider)
         .evaluate(
@@ -118,27 +119,25 @@ class _AppReviewCoordinatorState extends ConsumerState<AppReviewCoordinator> {
             sessionCount: localInputs.sessionCount,
             daysSinceFirstLaunch: localInputs.daysSinceFirstLaunch,
           ),
-          isMounted: () => mounted,
+          isActive: () => _isActiveFor(pubkey),
         );
+  }
+
+  bool _isActiveFor(String pubkey) {
+    if (!mounted || !ref.read(appForegroundProvider)) return false;
+    final authService = ref.read(authServiceProvider);
+    return authService.authState == AuthState.authenticated &&
+        authService.currentPublicKeyHex == pubkey;
   }
 
   Future<ProfileStats?> _loadProfileStats(String pubkey) async {
     final repository = ref.read(profileStatsRepositoryProvider);
     if (repository == null) return null;
-    unawaited(
-      repository
-          .fetchFreshProfile(pubkey: pubkey)
-          .catchError((Object _, StackTrace _) => null),
+    return _profileStatsLoader.load(
+      refresh: () async {
+        await repository.fetchFreshProfile(pubkey: pubkey);
+      },
+      watch: () => repository.watchProfileStats(pubkey: pubkey),
     );
-    try {
-      return await repository
-          .watchProfileStats(pubkey: pubkey)
-          .where((stats) => stats != null)
-          .cast<ProfileStats>()
-          .first
-          .timeout(const Duration(seconds: 3));
-    } on TimeoutException {
-      return null;
-    }
   }
 }

--- a/mobile/lib/features/app_review/app_review_coordinator_cubit.dart
+++ b/mobile/lib/features/app_review/app_review_coordinator_cubit.dart
@@ -1,0 +1,128 @@
+// ABOUTME: Testable orchestration for the OS-native in-app review prompt.
+// ABOUTME: Owns platform availability, cooldown ordering, and analytics.
+
+import 'dart:async';
+
+import 'package:analytics/analytics.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:in_app_review/in_app_review.dart';
+import 'package:openvine/features/app_review/app_review_analytics.dart';
+import 'package:openvine/services/app_review_prompt_service.dart';
+
+/// Minimal platform facade around [InAppReview] for coordinator tests.
+abstract interface class AppReviewPlatform {
+  Future<bool> isAvailable();
+
+  Future<void> requestReview();
+}
+
+/// [InAppReview]-backed platform facade.
+class InAppReviewPlatform implements AppReviewPlatform {
+  InAppReviewPlatform({InAppReview? inAppReview})
+    : _inAppReview = inAppReview ?? InAppReview.instance;
+
+  final InAppReview _inAppReview;
+
+  @override
+  Future<bool> isAvailable() => _inAppReview.isAvailable();
+
+  @override
+  Future<void> requestReview() => _inAppReview.requestReview();
+}
+
+/// Waits until the UI has had a stable frame before showing the native card.
+abstract interface class AppReviewFrameScheduler {
+  Future<bool> waitForStableFrame();
+}
+
+/// Flutter binding backed frame scheduler.
+class WidgetsAppReviewFrameScheduler implements AppReviewFrameScheduler {
+  const WidgetsAppReviewFrameScheduler({
+    this.timeout = const Duration(seconds: 2),
+  });
+
+  final Duration timeout;
+
+  @override
+  Future<bool> waitForStableFrame() async {
+    final completer = Completer<void>();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!completer.isCompleted) completer.complete();
+    });
+    WidgetsBinding.instance.ensureVisualUpdate();
+
+    try {
+      await completer.future.timeout(timeout);
+      return true;
+    } on TimeoutException {
+      return false;
+    }
+  }
+}
+
+/// Coordinates one in-flight review evaluation at a time.
+class AppReviewCoordinatorCubit extends Cubit<bool> {
+  AppReviewCoordinatorCubit({
+    required AppReviewPromptService service,
+    required AnalyticsEventSink analytics,
+    required AppReviewPlatform reviewPlatform,
+    required AppReviewFrameScheduler frameScheduler,
+  }) : _service = service,
+       _analytics = analytics,
+       _reviewPlatform = reviewPlatform,
+       _frameScheduler = frameScheduler,
+       super(false);
+
+  final AppReviewPromptService _service;
+  final AnalyticsEventSink _analytics;
+  final AppReviewPlatform _reviewPlatform;
+  final AppReviewFrameScheduler _frameScheduler;
+
+  bool get isEvaluating => state;
+
+  Future<void> evaluate({
+    required ReviewEligibilityInputs inputs,
+    required bool Function() isMounted,
+  }) async {
+    if (state) return;
+    emit(true);
+    try {
+      await _evaluate(inputs: inputs, isMounted: isMounted);
+    } finally {
+      emit(false);
+    }
+  }
+
+  Future<void> _evaluate({
+    required ReviewEligibilityInputs inputs,
+    required bool Function() isMounted,
+  }) async {
+    if (!_service.shouldShow(inputs)) return;
+    if (!isMounted()) return;
+    if (!await _frameScheduler.waitForStableFrame()) return;
+    if (!isMounted()) return;
+
+    try {
+      if (!await _reviewPlatform.isAvailable()) return;
+      if (!isMounted()) return;
+
+      trackInAppReviewEligible(
+        analytics: _analytics,
+        installSource: inputs.installSource,
+        videoCount: inputs.videoCount,
+        sessionCount: inputs.sessionCount,
+        daysSinceFirstLaunch: inputs.daysSinceFirstLaunch,
+      );
+
+      // Start cooldown immediately before the native request. That avoids a
+      // tight re-prompt loop if the OS call crashes while not burning cooldown
+      // for unavailable platforms or an unmounted app.
+      await _service.recordShown(inputs.pubkey);
+      await _reviewPlatform.requestReview();
+      trackInAppReviewPrompted(analytics: _analytics);
+    } catch (error) {
+      trackInAppReviewRequestFailed(analytics: _analytics, error: error);
+    }
+  }
+}

--- a/mobile/lib/features/app_review/app_review_coordinator_cubit.dart
+++ b/mobile/lib/features/app_review/app_review_coordinator_cubit.dart
@@ -83,29 +83,31 @@ class AppReviewCoordinatorCubit extends Cubit<bool> {
 
   Future<void> evaluate({
     required ReviewEligibilityInputs inputs,
-    required bool Function() isMounted,
+    required bool Function() isActive,
   }) async {
-    if (state) return;
+    if (isClosed || state) return;
     emit(true);
     try {
-      await _evaluate(inputs: inputs, isMounted: isMounted);
+      await _evaluate(inputs: inputs, isActive: isActive);
     } finally {
-      emit(false);
+      if (!isClosed) emit(false);
     }
   }
 
   Future<void> _evaluate({
     required ReviewEligibilityInputs inputs,
-    required bool Function() isMounted,
+    required bool Function() isActive,
   }) async {
+    bool canContinue() => !isClosed && isActive();
+
     if (!_service.shouldShow(inputs)) return;
-    if (!isMounted()) return;
+    if (!canContinue()) return;
     if (!await _frameScheduler.waitForStableFrame()) return;
-    if (!isMounted()) return;
+    if (!canContinue()) return;
 
     try {
       if (!await _reviewPlatform.isAvailable()) return;
-      if (!isMounted()) return;
+      if (!canContinue()) return;
 
       trackInAppReviewEligible(
         analytics: _analytics,
@@ -119,6 +121,7 @@ class AppReviewCoordinatorCubit extends Cubit<bool> {
       // tight re-prompt loop if the OS call crashes while not burning cooldown
       // for unavailable platforms or an unmounted app.
       await _service.recordShown(inputs.pubkey);
+      if (!canContinue()) return;
       await _reviewPlatform.requestReview();
       trackInAppReviewPrompted(analytics: _analytics);
     } catch (error) {

--- a/mobile/lib/features/app_review/app_review_profile_stats_loader.dart
+++ b/mobile/lib/features/app_review/app_review_profile_stats_loader.dart
@@ -1,0 +1,30 @@
+// ABOUTME: Loads profile statistics for review eligibility after a refresh.
+// ABOUTME: Bounds the combined refresh/read operation and fails closed.
+
+import 'package:models/models.dart';
+
+/// Refreshes profile data before reading the current cached statistics row.
+class AppReviewProfileStatsLoader {
+  const AppReviewProfileStatsLoader({
+    this.timeout = const Duration(seconds: 3),
+  });
+
+  final Duration timeout;
+
+  Future<ProfileStats?> load({
+    required Future<void> Function() refresh,
+    required Stream<ProfileStats?> Function() watch,
+  }) async {
+    try {
+      return await (() async {
+        await refresh();
+        return watch()
+            .where((stats) => stats != null)
+            .cast<ProfileStats>()
+            .first;
+      })().timeout(timeout);
+    } on Object {
+      return null;
+    }
+  }
+}

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -44,6 +44,7 @@ import 'package:openvine/config/zendesk_config.dart';
 import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/features/app/startup/startup_coordinator.dart';
 import 'package:openvine/features/app/startup/startup_phase.dart';
+import 'package:openvine/features/app_review/app_review_coordinator.dart';
 import 'package:openvine/features/appearance/bloc/appearance_cubit.dart';
 import 'package:openvine/features/appearance/models/appearance_mode.dart';
 import 'package:openvine/features/appearance/providers/appearance_providers.dart';
@@ -66,6 +67,7 @@ import 'package:openvine/providers/deep_link_provider.dart';
 import 'package:openvine/providers/device_scope.dart';
 import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/foreground_idle_warmup_provider.dart';
+import 'package:openvine/providers/install_source_provider.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/service_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
@@ -82,6 +84,7 @@ import 'package:openvine/screens/profile_screen_router.dart';
 import 'package:openvine/screens/search_results/view/search_results_page.dart';
 import 'package:openvine/screens/video_detail_screen.dart';
 import 'package:openvine/screens/video_recorder_screen.dart';
+import 'package:openvine/services/app_engagement_store.dart';
 import 'package:openvine/services/back_button_handler.dart';
 import 'package:openvine/services/bandwidth_tracker_service.dart';
 import 'package:openvine/services/collaborator_invite_service.dart';
@@ -91,6 +94,7 @@ import 'package:openvine/services/database_corruption_service.dart';
 import 'package:openvine/services/database_encryption_bootstrap.dart';
 import 'package:openvine/services/deep_link_service.dart';
 import 'package:openvine/services/firebase_initialization.dart';
+import 'package:openvine/services/install_source_service.dart';
 import 'package:openvine/services/locale_preference_service.dart';
 import 'package:openvine/services/memory_pressure_handler.dart';
 import 'package:openvine/services/memory_telemetry_service.dart';
@@ -1428,12 +1432,24 @@ Future<void> _startOpenVineApp() async {
     corruptionService: databaseCorruptionService,
   );
   final accountSwitchController = AccountSwitchController();
+
+  // Resolve how this install was distributed (Play Store / App Store /
+  // TestFlight / Zapstore / sideload) via the native method channel, and
+  // record this cold start for the install-scoped engagement counter that the
+  // in-app review gate reads. Both are best-effort and fall back to safe
+  // defaults on web/desktop/unsupported native shells (#6296).
+  final installSource = await const InstallSourceService().resolve();
+  await AppEngagementStore(
+    sharedPreferences: sharedPreferences,
+  ).recordSession();
+
   final deviceScope = DeviceScope(
     database: deviceDatabase,
     sharedPreferences: sharedPreferences,
     switchController: accountSwitchController,
     dbCipherKey: dbCipherKey,
     databaseCorruptionService: databaseCorruptionService,
+    installSource: installSource,
   );
 
   // Create the initial account container to initialize services BEFORE runApp.
@@ -2599,9 +2615,15 @@ class _DivineAppState extends ConsumerState<DivineApp>
             localeListResolutionCallback: resolveAppUiLocale,
             // One gate above every route: once the local database reports
             // corruption there is no screen left that can work, so ask for the
-            // restart that repairs it instead of failing route by route.
-            builder: (context, child) =>
-                DatabaseCorruptionGate(child: child ?? const SizedBox.shrink()),
+            // restart that repairs it instead of failing route by route. The
+            // AppReviewCoordinator mounts here too: a zero-size widget that
+            // evaluates the in-app review gate on auth/stats/foreground changes
+            // and renders nothing itself.
+            builder: (context, child) => AppReviewCoordinator(
+              child: DatabaseCorruptionGate(
+                child: child ?? const SizedBox.shrink(),
+              ),
+            ),
           ),
         );
       }
@@ -2626,9 +2648,15 @@ class _DivineAppState extends ConsumerState<DivineApp>
             localeListResolutionCallback: resolveAppUiLocale,
             // One gate above every route: once the local database reports
             // corruption there is no screen left that can work, so ask for the
-            // restart that repairs it instead of failing route by route.
-            builder: (context, child) =>
-                DatabaseCorruptionGate(child: child ?? const SizedBox.shrink()),
+            // restart that repairs it instead of failing route by route. The
+            // AppReviewCoordinator mounts here too: a zero-size widget that
+            // evaluates the in-app review gate on auth/stats/foreground changes
+            // and renders nothing itself.
+            builder: (context, child) => AppReviewCoordinator(
+              child: DatabaseCorruptionGate(
+                child: child ?? const SizedBox.shrink(),
+              ),
+            ),
           ),
         ),
       );
@@ -2798,7 +2826,10 @@ class _DivineAppState extends ConsumerState<DivineApp>
                   appVersionClient: AppVersionClient(),
                   sharedPreferences: ref.read(sharedPreferencesProvider),
                   currentVersion: widget.packageInfo.version,
-                  installSource: InstallSource.sideload,
+                  // Real install source resolved at startup (Play / App Store
+                  // / TestFlight / Zapstore / sideload) — drives the correct
+                  // download URL for update nudges. Was hardcoded `sideload`.
+                  installSource: ref.read(installSourceProvider),
                 ),
               )..add(const AppUpdateCheckRequested()),
             ),

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -2616,11 +2616,10 @@ class _DivineAppState extends ConsumerState<DivineApp>
             // One gate above every route: once the local database reports
             // corruption there is no screen left that can work, so ask for the
             // restart that repairs it instead of failing route by route. The
-            // AppReviewCoordinator mounts here too: a zero-size widget that
-            // evaluates the in-app review gate on auth/stats/foreground changes
-            // and renders nothing itself.
-            builder: (context, child) => AppReviewCoordinator(
-              child: DatabaseCorruptionGate(
+            // review coordinator lives inside that gate so the recovery screen
+            // cannot be interrupted by an OS-native review card.
+            builder: (context, child) => DatabaseCorruptionGate(
+              child: AppReviewCoordinator(
                 child: child ?? const SizedBox.shrink(),
               ),
             ),
@@ -2649,11 +2648,10 @@ class _DivineAppState extends ConsumerState<DivineApp>
             // One gate above every route: once the local database reports
             // corruption there is no screen left that can work, so ask for the
             // restart that repairs it instead of failing route by route. The
-            // AppReviewCoordinator mounts here too: a zero-size widget that
-            // evaluates the in-app review gate on auth/stats/foreground changes
-            // and renders nothing itself.
-            builder: (context, child) => AppReviewCoordinator(
-              child: DatabaseCorruptionGate(
+            // review coordinator lives inside that gate so the recovery screen
+            // cannot be interrupted by an OS-native review card.
+            builder: (context, child) => DatabaseCorruptionGate(
+              child: AppReviewCoordinator(
                 child: child ?? const SizedBox.shrink(),
               ),
             ),

--- a/mobile/lib/providers/device_scope.dart
+++ b/mobile/lib/providers/device_scope.dart
@@ -1,12 +1,14 @@
 // ABOUTME: The device-scoped dependencies that must survive an account switch —
 // ABOUTME: shared across every ProviderContainer so a swap opens no new DB, etc.
 
+import 'package:app_update_repository/app_update_repository.dart';
 import 'package:db_client/db_client.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/providers/container_swap_host.dart';
 import 'package:openvine/providers/database_corruption_provider.dart';
 import 'package:openvine/providers/database_provider.dart';
 import 'package:openvine/providers/db_cipher_key_provider.dart';
+import 'package:openvine/providers/install_source_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/services/database_corruption_service.dart';
 // Override lives in riverpod's misc barrel; flutter_riverpod does not
@@ -45,6 +47,7 @@ class DeviceScope {
     required this.switchController,
     this.dbCipherKey,
     this.databaseCorruptionService,
+    this.installSource = InstallSource.sideload,
     this.accountOverrides = const [],
   });
 
@@ -71,6 +74,12 @@ class DeviceScope {
   /// uninstrumented (no cipher key).
   final DatabaseCorruptionService? databaseCorruptionService;
 
+  /// How this install was distributed (Play Store, App Store, TestFlight,
+  /// Zapstore, sideload). Resolved once during startup via
+  /// `InstallSourceService` and shared across every account container so the
+  /// in-app review gate and `AppUpdateRepository` see the same value.
+  final InstallSource installSource;
+
   /// Extra overrides applied to every account container.
   ///
   /// Production leaves this empty. Tests use it for container-wide fakes that
@@ -86,6 +95,7 @@ class DeviceScope {
     databaseCorruptionServiceProvider.overrideWithValue(
       databaseCorruptionService,
     ),
+    installSourceProvider.overrideWithValue(installSource),
     deviceScopeProvider.overrideWithValue(this),
     ...accountOverrides,
   ];

--- a/mobile/lib/providers/install_source_provider.dart
+++ b/mobile/lib/providers/install_source_provider.dart
@@ -1,0 +1,19 @@
+// ABOUTME: Riverpod provider for the device's resolved [InstallSource].
+// ABOUTME: Resolved once at startup and overridden in DeviceScope so every
+// ABOUTME: account container shares the same cheap read.
+
+import 'package:app_update_repository/app_update_repository.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// The [InstallSource] for this device install, resolved once during startup
+/// (see `main.dart`) and injected into every account container via
+/// [DeviceScope.overrides].
+///
+/// Throws by default; `main.dart` overrides it with the value resolved by
+/// [InstallSourceService] before `runApp`. Reading it before that is a
+/// programmer error, not a runtime condition to handle.
+final installSourceProvider = Provider<InstallSource>(
+  (ref) => throw StateError(
+    'installSourceProvider must be overridden at container creation',
+  ),
+);

--- a/mobile/lib/services/app_engagement_store.dart
+++ b/mobile/lib/services/app_engagement_store.dart
@@ -1,0 +1,60 @@
+// ABOUTME: SharedPreferences-backed install-scoped engagement counters used
+// ABOUTME: by the in-app review gate to confirm sustained app use.
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// SharedPreferences-backed, install-scoped engagement counters.
+///
+/// These track *device install* engagement (not per-user), since "is this
+/// person actively using the app" is an install-level signal that should
+/// survive account switches. The review gate consumes them alongside a
+/// per-user cooldown and a server-authoritative video count.
+class AppEngagementStore {
+  AppEngagementStore({
+    required SharedPreferences sharedPreferences,
+    DateTime Function()? now,
+  }) : _prefs = sharedPreferences,
+       _now = now ?? DateTime.now;
+
+  final SharedPreferences _prefs;
+  final DateTime Function() _now;
+
+  /// SharedPreferences keys.
+  static const sessionCountKey = 'app_session_count';
+  static const firstLaunchAtKey = 'app_first_launch_at';
+
+  /// Number of cold starts this install has recorded.
+  ///
+  /// Returns 0 before [recordSession] runs for the first time.
+  int get sessionCount => _prefs.getInt(sessionCountKey) ?? 0;
+
+  /// Wall-clock timestamp of the first cold start on this install, or `null`
+  /// if [recordSession] has never run.
+  DateTime? get firstLaunchAt {
+    final millis = _prefs.getInt(firstLaunchAtKey);
+    return millis == null ? null : DateTime.fromMillisecondsSinceEpoch(millis);
+  }
+
+  /// Whole days elapsed since the first cold start, or 0 if unset.
+  int daysSinceFirstLaunch({DateTime? now}) {
+    final first = firstLaunchAt;
+    if (first == null) return 0;
+    return (now ?? _now()).difference(first).inDays;
+  }
+
+  /// Records a single cold start: bumps the session counter and, if this is
+  /// the first launch, stamps the install's first-launch timestamp.
+  ///
+  /// Idempotent per cold start — call exactly once during startup, before
+  /// `runApp`. Safe to call again; it will over-count.
+  Future<void> recordSession() async {
+    final isFirstLaunch = !_prefs.containsKey(firstLaunchAtKey);
+    if (isFirstLaunch) {
+      await _prefs.setInt(
+        firstLaunchAtKey,
+        _now().millisecondsSinceEpoch,
+      );
+    }
+    await _prefs.setInt(sessionCountKey, sessionCount + 1);
+  }
+}

--- a/mobile/lib/services/app_review_prompt_service.dart
+++ b/mobile/lib/services/app_review_prompt_service.dart
@@ -35,6 +35,30 @@ class ReviewEligibilityInputs {
   final int daysSinceFirstLaunch;
 }
 
+/// Local-only inputs evaluated before opening the profile-stats stream.
+@immutable
+class ReviewLocalEligibilityInputs {
+  const ReviewLocalEligibilityInputs({
+    required this.pubkey,
+    required this.installSource,
+    required this.sessionCount,
+    required this.daysSinceFirstLaunch,
+  });
+
+  /// Hex pubkey of the currently signed-in account.
+  final String pubkey;
+
+  /// How this install was distributed.
+  final InstallSource installSource;
+
+  /// Cold-start count for this install (from [AppEngagementStore]).
+  final int sessionCount;
+
+  /// Whole days since the install's first cold start
+  /// (from [AppEngagementStore]).
+  final int daysSinceFirstLaunch;
+}
+
 /// Eligibility gate and per-user cooldown for the in-app review prompt.
 ///
 /// Design notes:
@@ -84,11 +108,27 @@ class AppReviewPromptService {
   static const defaultCooldown = Duration(days: 180);
 
   /// SharedPreferences key prefixes (pubkey-suffixed).
-  static const _dismissedAtPrefix = 'review_prompt_dismissed_at_';
-  static const _completedPrefix = 'review_prompt_completed_';
+  static const _attemptedAtPrefix = 'review_prompt_attempted_at_';
 
-  String _dismissedAtKey(String pubkey) => '$_dismissedAtPrefix$pubkey';
-  String _completedKey(String pubkey) => '$_completedPrefix$pubkey';
+  String _attemptedAtKey(String pubkey) => '$_attemptedAtPrefix$pubkey';
+
+  /// Returns `true` when the local, cheap criteria pass.
+  ///
+  /// Profile stats are fetched only after this succeeds so the app root does
+  /// not keep a Drift watch open for users who are clearly ineligible.
+  bool shouldLoadProfileStats(
+    ReviewLocalEligibilityInputs inputs, {
+    DateTime? now,
+  }) {
+    if (!_isStoreInstall(inputs.installSource)) return false;
+    if (!_hasSustainedUse(
+      sessionCount: inputs.sessionCount,
+      daysSinceFirstLaunch: inputs.daysSinceFirstLaunch,
+    )) {
+      return false;
+    }
+    return !_isInCooldown(inputs.pubkey, now: now);
+  }
 
   /// Returns `true` only when every eligibility condition is met and the
   /// per-user cooldown has elapsed.
@@ -104,31 +144,21 @@ class AppReviewPromptService {
   bool shouldShow(ReviewEligibilityInputs inputs, {DateTime? now}) {
     final referenceNow = now ?? _now();
 
-    // (1) Store installs only — TestFlight/Zapstore/sideload can't review.
-    if (inputs.installSource != InstallSource.playStore &&
-        inputs.installSource != InstallSource.appStore) {
-      return false;
-    }
+    if (!_isStoreInstall(inputs.installSource)) return false;
 
     // (2) Genuinely invested creator.
     if (inputs.videoCount <= minimumVideoCount) return false;
 
     // (3) Sustained use — either enough sessions or enough days on the install.
-    final sustainedUse =
-        inputs.sessionCount >= minimumSessionCount ||
-        inputs.daysSinceFirstLaunch >= minimumDaysSinceFirstLaunch;
-    if (!sustainedUse) return false;
-
-    // (4) Safety hatch: a future review API may report completion. Until then
-    //     the native card stays opaque and this flag is never set.
-    if (_prefs.getBool(_completedKey(inputs.pubkey)) ?? false) return false;
-
-    // (5) Per-user cooldown after the most recent prompt attempt.
-    final dismissedMillis = _prefs.getInt(_dismissedAtKey(inputs.pubkey));
-    if (dismissedMillis != null) {
-      final dismissedAt = DateTime.fromMillisecondsSinceEpoch(dismissedMillis);
-      if (referenceNow.difference(dismissedAt) < cooldown) return false;
+    if (!_hasSustainedUse(
+      sessionCount: inputs.sessionCount,
+      daysSinceFirstLaunch: inputs.daysSinceFirstLaunch,
+    )) {
+      return false;
     }
+
+    // (4) Per-user cooldown after the most recent prompt attempt.
+    if (_isInCooldown(inputs.pubkey, now: referenceNow)) return false;
 
     return true;
   }
@@ -138,20 +168,26 @@ class AppReviewPromptService {
   /// after every call to `InAppReview.requestReview()`, regardless of outcome.
   Future<void> recordShown(String pubkey, {DateTime? now}) async {
     final at = (now ?? _now()).millisecondsSinceEpoch;
-    await _prefs.setInt(_dismissedAtKey(pubkey), at);
+    await _prefs.setInt(_attemptedAtKey(pubkey), at);
   }
 
-  /// Marks a pubkey as having completed a review. Currently unused by the
-  /// coordinator (the native API is opaque); retained so a future,
-  /// observable review surface can flip it without changing this service's API.
-  Future<void> recordCompleted(String pubkey) async {
-    await _prefs.setBool(_completedKey(pubkey), true);
+  bool _isStoreInstall(InstallSource installSource) {
+    return installSource == InstallSource.playStore ||
+        installSource == InstallSource.appStore;
   }
 
-  /// Resets all review-prompt state for [pubkey]. Test-helper / future
-  /// debug-screen affordance; not called from production paths today.
-  Future<void> reset(String pubkey) async {
-    await _prefs.remove(_dismissedAtKey(pubkey));
-    await _prefs.remove(_completedKey(pubkey));
+  bool _hasSustainedUse({
+    required int sessionCount,
+    required int daysSinceFirstLaunch,
+  }) {
+    return sessionCount >= minimumSessionCount ||
+        daysSinceFirstLaunch >= minimumDaysSinceFirstLaunch;
+  }
+
+  bool _isInCooldown(String pubkey, {DateTime? now}) {
+    final attemptedMillis = _prefs.getInt(_attemptedAtKey(pubkey));
+    if (attemptedMillis == null) return false;
+    final attemptedAt = DateTime.fromMillisecondsSinceEpoch(attemptedMillis);
+    return (now ?? _now()).difference(attemptedAt) < cooldown;
   }
 }

--- a/mobile/lib/services/app_review_prompt_service.dart
+++ b/mobile/lib/services/app_review_prompt_service.dart
@@ -1,0 +1,157 @@
+// ABOUTME: Eligibility gate + persistence for the OS-native review prompt.
+// ABOUTME: Prompts only engaged, store-installed creators (>10 videos,
+// ABOUTME: sustained use), with a per-user cooldown after each prompt.
+
+import 'package:app_update_repository/app_update_repository.dart';
+import 'package:meta/meta.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Inputs evaluated by [AppReviewPromptService.shouldShow].
+@immutable
+class ReviewEligibilityInputs {
+  const ReviewEligibilityInputs({
+    required this.pubkey,
+    required this.videoCount,
+    required this.installSource,
+    required this.sessionCount,
+    required this.daysSinceFirstLaunch,
+  });
+
+  /// Hex pubkey of the currently signed-in account.
+  final String pubkey;
+
+  /// Server-authoritative count of videos this account has published
+  /// (from `ProfileStats.videoCount`).
+  final int videoCount;
+
+  /// How this install was distributed.
+  final InstallSource installSource;
+
+  /// Cold-start count for this install (from [AppEngagementStore]).
+  final int sessionCount;
+
+  /// Whole days since the install's first cold start
+  /// (from [AppEngagementStore]).
+  final int daysSinceFirstLaunch;
+}
+
+/// Eligibility gate and per-user cooldown for the in-app review prompt.
+///
+/// Design notes:
+/// - The native review card (`InAppReview.requestReview()`) is **opaque**: it
+///   never reports whether the user rated or dismissed. So "stop forever after
+///   they rate" isn't reliably detectable — we apply a [cooldown] after every
+///   prompt attempt and let the OS's own ~3/year throttle handle the rest.
+/// - Cooldown keys are pubkey-scoped so switching accounts resets eligibility
+///   cleanly (each account gets its own first impression).
+/// - Only Play Store and App Store installs are eligible; TestFlight,
+///   Zapstore, and sideloaded builds can't rate on the consumer stores.
+class AppReviewPromptService {
+  AppReviewPromptService({
+    required SharedPreferences sharedPreferences,
+    this.minimumVideoCount = defaultMinimumVideoCount,
+    this.minimumSessionCount = defaultMinimumSessionCount,
+    this.minimumDaysSinceFirstLaunch = defaultMinimumDaysSinceFirstLaunch,
+    this.cooldown = defaultCooldown,
+    DateTime Function()? now,
+  }) : _prefs = sharedPreferences,
+       _now = now ?? DateTime.now;
+
+  final SharedPreferences _prefs;
+  final DateTime Function() _now;
+
+  /// Video count required to be eligible. Default is >10 videos.
+  final int minimumVideoCount;
+
+  /// Cold-start count required to be eligible (unless [daysSinceFirstLaunch]
+  /// already exceeds [minimumDaysSinceFirstLaunch]).
+  final int minimumSessionCount;
+
+  /// Days-of-use required to be eligible (unless [sessionCount] already
+  /// exceeds [minimumSessionCount]).
+  final int minimumDaysSinceFirstLaunch;
+
+  /// Per-user cooldown applied after every prompt attempt.
+  final Duration cooldown;
+
+  /// Default eligibility thresholds.
+  static const defaultMinimumVideoCount = 10;
+  static const defaultMinimumSessionCount = 10;
+  static const defaultMinimumDaysSinceFirstLaunch = 14;
+
+  /// Default per-user cooldown (~6 months). The OS still applies its own
+  /// ~3-prompts/year throttle on top of this.
+  static const defaultCooldown = Duration(days: 180);
+
+  /// SharedPreferences key prefixes (pubkey-suffixed).
+  static const _dismissedAtPrefix = 'review_prompt_dismissed_at_';
+  static const _completedPrefix = 'review_prompt_completed_';
+
+  String _dismissedAtKey(String pubkey) => '$_dismissedAtPrefix$pubkey';
+  String _completedKey(String pubkey) => '$_completedPrefix$pubkey';
+
+  /// Returns `true` only when every eligibility condition is met and the
+  /// per-user cooldown has elapsed.
+  ///
+  /// Conditions (all required):
+  /// 1. Install source is Play Store or App Store.
+  /// 2. `videoCount` strictly exceeds [minimumVideoCount].
+  /// 3. Sustained use: `sessionCount >= minimumSessionCount`
+  ///    OR `daysSinceFirstLaunch >= minimumDaysSinceFirstLaunch`.
+  /// 4. No prior "completed" flag for this pubkey (safety hatch for the case
+  ///    where a future, more-transparent review API lets us detect a rating).
+  /// 5. The per-user cooldown has elapsed since the last prompt attempt.
+  bool shouldShow(ReviewEligibilityInputs inputs, {DateTime? now}) {
+    final referenceNow = now ?? _now();
+
+    // (1) Store installs only — TestFlight/Zapstore/sideload can't review.
+    if (inputs.installSource != InstallSource.playStore &&
+        inputs.installSource != InstallSource.appStore) {
+      return false;
+    }
+
+    // (2) Genuinely invested creator.
+    if (inputs.videoCount <= minimumVideoCount) return false;
+
+    // (3) Sustained use — either enough sessions or enough days on the install.
+    final sustainedUse =
+        inputs.sessionCount >= minimumSessionCount ||
+        inputs.daysSinceFirstLaunch >= minimumDaysSinceFirstLaunch;
+    if (!sustainedUse) return false;
+
+    // (4) Safety hatch: a future review API may report completion. Until then
+    //     the native card stays opaque and this flag is never set.
+    if (_prefs.getBool(_completedKey(inputs.pubkey)) ?? false) return false;
+
+    // (5) Per-user cooldown after the most recent prompt attempt.
+    final dismissedMillis = _prefs.getInt(_dismissedAtKey(inputs.pubkey));
+    if (dismissedMillis != null) {
+      final dismissedAt = DateTime.fromMillisecondsSinceEpoch(dismissedMillis);
+      if (referenceNow.difference(dismissedAt) < cooldown) return false;
+    }
+
+    return true;
+  }
+
+  /// Records that a prompt attempt was made (shown OR skipped by the OS), so
+  /// the per-user cooldown begins. The native card is opaque, so this fires
+  /// after every call to `InAppReview.requestReview()`, regardless of outcome.
+  Future<void> recordShown(String pubkey, {DateTime? now}) async {
+    final at = (now ?? _now()).millisecondsSinceEpoch;
+    await _prefs.setInt(_dismissedAtKey(pubkey), at);
+  }
+
+  /// Marks a pubkey as having completed a review. Currently unused by the
+  /// coordinator (the native API is opaque); retained so a future,
+  /// observable review surface can flip it without changing this service's API.
+  Future<void> recordCompleted(String pubkey) async {
+    await _prefs.setBool(_completedKey(pubkey), true);
+  }
+
+  /// Resets all review-prompt state for [pubkey]. Test-helper / future
+  /// debug-screen affordance; not called from production paths today.
+  Future<void> reset(String pubkey) async {
+    await _prefs.remove(_dismissedAtKey(pubkey));
+    await _prefs.remove(_completedKey(pubkey));
+  }
+}

--- a/mobile/lib/services/install_source_service.dart
+++ b/mobile/lib/services/install_source_service.dart
@@ -4,16 +4,7 @@
 import 'package:app_update_repository/app_update_repository.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
-
-/// Contract for resolving the app's [InstallSource].
-///
-/// Surfaces as an interface so tests can inject a deterministic source
-/// without going through the native method channel.
-abstract interface class InstallSourceResolver {
-  /// Resolves the install source. Returns [InstallSource.sideload] when the
-  /// platform does not expose install-source info (web, desktop, failures).
-  Future<InstallSource> resolve();
-}
+import 'package:unified_logger/unified_logger.dart';
 
 /// Method-channel-backed implementation.
 ///
@@ -21,7 +12,7 @@ abstract interface class InstallSourceResolver {
 /// (`com.android.vending` → Play Store, `com.zapstore.app` → Zapstore).
 /// iOS: inspects the app-store receipt URL (`sandboxReceipt` → TestFlight).
 /// On web/desktop/unsupported platforms it returns [InstallSource.sideload].
-class InstallSourceService implements InstallSourceResolver {
+class InstallSourceService {
   const InstallSourceService({MethodChannel? channel})
     : _channel = channel ?? const MethodChannel(_channelName);
 
@@ -29,7 +20,6 @@ class InstallSourceService implements InstallSourceResolver {
 
   final MethodChannel _channel;
 
-  @override
   Future<InstallSource> resolve() async {
     // Web and desktop builds have no native install-referrer channel.
     if (kIsWeb ||
@@ -46,16 +36,33 @@ class InstallSourceService implements InstallSourceResolver {
         return resolveAndroidInstallSource(installer);
       }
       // iOS.
-      final isSandbox =
-          await _channel.invokeMethod<bool>('isSandboxReceipt') ?? false;
+      final isSandbox = await _channel.invokeMethod<bool>('isSandboxReceipt');
+      if (isSandbox == null) {
+        Log.warning(
+          'Install source channel returned no iOS receipt environment; '
+          'falling back to sideload',
+          name: 'InstallSourceService',
+          category: LogCategory.system,
+        );
+        return InstallSource.sideload;
+      }
       return resolveIosInstallSource(isSandbox: isSandbox);
-    } on PlatformException catch (e, st) {
+    } on PlatformException catch (e) {
       // A missing channel (e.g. an older native shell) or a revoked installer
       // permission must never block app launch — fall back to sideload and let
       // the in-app review gate (which only matches Play/App Store) no-op.
-      debugPrint('InstallSourceService.resolve failed: $e\n$st');
+      Log.warning(
+        'Install source resolution failed: ${e.code}',
+        name: 'InstallSourceService',
+        category: LogCategory.system,
+      );
       return InstallSource.sideload;
-    } on MissingPluginException {
+    } on MissingPluginException catch (e) {
+      Log.warning(
+        'Install source channel missing; falling back to sideload: $e',
+        name: 'InstallSourceService',
+        category: LogCategory.system,
+      );
       return InstallSource.sideload;
     }
   }

--- a/mobile/lib/services/install_source_service.dart
+++ b/mobile/lib/services/install_source_service.dart
@@ -1,0 +1,62 @@
+// ABOUTME: Resolves how the app was installed (Play Store, App Store,
+// ABOUTME: TestFlight, Zapstore, sideload) via a native method channel.
+
+import 'package:app_update_repository/app_update_repository.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+/// Contract for resolving the app's [InstallSource].
+///
+/// Surfaces as an interface so tests can inject a deterministic source
+/// without going through the native method channel.
+abstract interface class InstallSourceResolver {
+  /// Resolves the install source. Returns [InstallSource.sideload] when the
+  /// platform does not expose install-source info (web, desktop, failures).
+  Future<InstallSource> resolve();
+}
+
+/// Method-channel-backed implementation.
+///
+/// Android: queries the installer package name
+/// (`com.android.vending` → Play Store, `com.zapstore.app` → Zapstore).
+/// iOS: inspects the app-store receipt URL (`sandboxReceipt` → TestFlight).
+/// On web/desktop/unsupported platforms it returns [InstallSource.sideload].
+class InstallSourceService implements InstallSourceResolver {
+  const InstallSourceService({MethodChannel? channel})
+    : _channel = channel ?? const MethodChannel(_channelName);
+
+  static const _channelName = 'divine/install_source';
+
+  final MethodChannel _channel;
+
+  @override
+  Future<InstallSource> resolve() async {
+    // Web and desktop builds have no native install-referrer channel.
+    if (kIsWeb ||
+        !(defaultTargetPlatform == TargetPlatform.android ||
+            defaultTargetPlatform == TargetPlatform.iOS)) {
+      return InstallSource.sideload;
+    }
+
+    try {
+      if (defaultTargetPlatform == TargetPlatform.android) {
+        final installer = await _channel.invokeMethod<String>(
+          'getInstallerPackageName',
+        );
+        return resolveAndroidInstallSource(installer);
+      }
+      // iOS.
+      final isSandbox =
+          await _channel.invokeMethod<bool>('isSandboxReceipt') ?? false;
+      return resolveIosInstallSource(isSandbox: isSandbox);
+    } on PlatformException catch (e, st) {
+      // A missing channel (e.g. an older native shell) or a revoked installer
+      // permission must never block app launch — fall back to sideload and let
+      // the in-app review gate (which only matches Play/App Store) no-op.
+      debugPrint('InstallSourceService.resolve failed: $e\n$st');
+      return InstallSource.sideload;
+    } on MissingPluginException {
+      return InstallSource.sideload;
+    }
+  }
+}

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1222,6 +1222,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.2"
+  in_app_review:
+    dependency: "direct main"
+    description:
+      name: in_app_review
+      sha256: "364db0c160b37fe7fad9cdaa18f968473924b17368869010af902760421b6bf8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.12"
+  in_app_review_platform_interface:
+    dependency: transitive
+    description:
+      name: in_app_review_platform_interface
+      sha256: fed2c755f2125caa9ae10495a3c163aa7fab5af3585a9c62ef4a6920c5b45f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.5"
   integration_test:
     dependency: "direct dev"
     description: flutter

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -306,6 +306,10 @@ dependencies:
   flutter_native_splash: ^2.4.7
   flutter_local_notifications: ^21.0.0
   package_info_plus: ^9.0.0
+  # Triggers the OS-native review card (SKStoreReviewController on iOS,
+  # Google Play in-app review on Android). Used by AppReviewCoordinator to
+  # ask engaged, store-installed creators to rate the app — no custom dialog.
+  in_app_review: ^2.0.12
   uuid: ^4.5.1
   app_links: ^6.4.1
   drift: ^2.34.0

--- a/mobile/test/features/app_review/app_review_analytics_test.dart
+++ b/mobile/test/features/app_review/app_review_analytics_test.dart
@@ -1,0 +1,142 @@
+// ABOUTME: Tests for app_review_analytics helpers. Verifies event names,
+// ABOUTME: privacy-safe bucketing, and that the video count is never logged
+// ABOUTME: exactly.
+
+import 'package:analytics/analytics.dart';
+import 'package:app_update_repository/app_update_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/features/app_review/app_review_analytics.dart';
+
+/// Records every event logged through the sink for assertion.
+class _RecordingSink implements AnalyticsEventSink {
+  final List<({String name, Map<String, Object> parameters})> events = [];
+
+  @override
+  Future<void> logEvent({
+    required String name,
+    required Map<String, Object> parameters,
+  }) async {
+    events.add((name: name, parameters: parameters));
+  }
+
+  @override
+  Future<void> logScreenView({
+    required String screenName,
+    String? screenClass,
+    Map<String, Object>? parameters,
+  }) async {}
+}
+
+void main() {
+  group('app_review_analytics', () {
+    late _RecordingSink sink;
+
+    setUp(() {
+      sink = _RecordingSink();
+    });
+
+    group('trackInAppReviewEligible', () {
+      test('logs the eligible event with install source and engagement', () {
+        trackInAppReviewEligible(
+          analytics: sink,
+          installSource: InstallSource.playStore,
+          videoCount: 50,
+          sessionCount: 20,
+          daysSinceFirstLaunch: 30,
+        );
+
+        expect(sink.events, hasLength(1));
+        expect(sink.events.single.name, 'in_app_review_eligible');
+        expect(sink.events.single.parameters['install_source'], 'playStore');
+        expect(sink.events.single.parameters['session_count'], 20);
+        expect(
+          sink.events.single.parameters['days_since_first_launch'],
+          30,
+        );
+      });
+
+      test('buckets the video count, never logs the exact value', () {
+        for (final count in [11, 15, 25, 50, 75, 100, 250]) {
+          trackInAppReviewEligible(
+            analytics: sink,
+            installSource: InstallSource.appStore,
+            videoCount: count,
+            sessionCount: 10,
+            daysSinceFirstLaunch: 14,
+          );
+        }
+
+        final buckets = sink.events
+            .map((e) => e.parameters['video_count_bucket'])
+            .toSet();
+
+        // No bucket may be a raw integer-string of the actual count.
+        for (final bucket in buckets) {
+          expect(
+            int.tryParse('$bucket'),
+            isNull,
+            reason: 'bucket "$bucket" leaks the exact video count',
+          );
+        }
+        expect(buckets, containsAll(['11-25', '26-50', '51-100', '100+']));
+      });
+
+      test('video_count_bucket boundaries', () {
+        String bucketFor(int count) {
+          trackInAppReviewEligible(
+            analytics: sink,
+            installSource: InstallSource.playStore,
+            videoCount: count,
+            sessionCount: 1,
+            daysSinceFirstLaunch: 1,
+          );
+          final last = sink.events.last.parameters['video_count_bucket'];
+          sink.events.clear();
+          return '$last';
+        }
+
+        expect(bucketFor(0), '0');
+        expect(bucketFor(3), '1-5');
+        expect(bucketFor(5), '1-5');
+        expect(bucketFor(8), '6-10');
+        expect(bucketFor(10), '6-10');
+        expect(bucketFor(11), '11-25');
+        expect(bucketFor(25), '11-25');
+        expect(bucketFor(26), '26-50');
+        expect(bucketFor(50), '26-50');
+        expect(bucketFor(51), '51-100');
+        expect(bucketFor(100), '51-100');
+        expect(bucketFor(101), '100+');
+      });
+    });
+
+    group('trackInAppReviewPrompted', () {
+      test('logs the prompted event', () {
+        trackInAppReviewPrompted(analytics: sink);
+
+        expect(sink.events, hasLength(1));
+        expect(sink.events.single.name, 'in_app_review_prompted');
+      });
+    });
+
+    group('trackInAppReviewRequestFailed', () {
+      test('logs only the error runtime type, never the message', () {
+        trackInAppReviewRequestFailed(
+          analytics: sink,
+          error: StateError('sensitive detail here'),
+        );
+
+        expect(sink.events, hasLength(1));
+        expect(sink.events.single.name, 'in_app_review_request_failed');
+        expect(
+          sink.events.single.parameters['error_type'],
+          'StateError',
+        );
+        // The raw message must never appear in the payload.
+        for (final value in sink.events.single.parameters.values) {
+          expect('$value', isNot(contains('sensitive detail')));
+        }
+      });
+    });
+  });
+}

--- a/mobile/test/features/app_review/app_review_analytics_test.dart
+++ b/mobile/test/features/app_review/app_review_analytics_test.dart
@@ -48,10 +48,10 @@ void main() {
         expect(sink.events, hasLength(1));
         expect(sink.events.single.name, 'in_app_review_eligible');
         expect(sink.events.single.parameters['install_source'], 'playStore');
-        expect(sink.events.single.parameters['session_count'], 20);
+        expect(sink.events.single.parameters['session_count_bucket'], '10-20');
         expect(
-          sink.events.single.parameters['days_since_first_launch'],
-          30,
+          sink.events.single.parameters['days_since_first_launch_bucket'],
+          '14-30',
         );
       });
 
@@ -108,6 +108,22 @@ void main() {
         expect(bucketFor(100), '51-100');
         expect(bucketFor(101), '100+');
       });
+
+      test('engagement counts are bucketed, never logged exactly', () {
+        trackInAppReviewEligible(
+          analytics: sink,
+          installSource: InstallSource.playStore,
+          videoCount: 50,
+          sessionCount: 47,
+          daysSinceFirstLaunch: 88,
+        );
+
+        final parameters = sink.events.single.parameters;
+        expect(parameters, isNot(contains('session_count')));
+        expect(parameters, isNot(contains('days_since_first_launch')));
+        expect(parameters['session_count_bucket'], '21-50');
+        expect(parameters['days_since_first_launch_bucket'], '31-90');
+      });
     });
 
     group('trackInAppReviewPrompted', () {
@@ -128,10 +144,7 @@ void main() {
 
         expect(sink.events, hasLength(1));
         expect(sink.events.single.name, 'in_app_review_request_failed');
-        expect(
-          sink.events.single.parameters['error_type'],
-          'StateError',
-        );
+        expect(sink.events.single.parameters['error_type'], 'StateError');
         // The raw message must never appear in the payload.
         for (final value in sink.events.single.parameters.values) {
           expect('$value', isNot(contains('sensitive detail')));

--- a/mobile/test/features/app_review/app_review_coordinator_cubit_test.dart
+++ b/mobile/test/features/app_review/app_review_coordinator_cubit_test.dart
@@ -31,6 +31,8 @@ class _RecordingSink implements AnalyticsEventSink {
 
 class _FakeReviewPlatform implements AppReviewPlatform {
   bool available = true;
+  Completer<bool>? availabilityCompleter;
+  Completer<void>? availabilityStarted;
   Object? requestError;
   int availabilityChecks = 0;
   int requests = 0;
@@ -39,6 +41,9 @@ class _FakeReviewPlatform implements AppReviewPlatform {
   @override
   Future<bool> isAvailable() async {
     availabilityChecks++;
+    availabilityStarted?.complete();
+    final pendingAvailability = availabilityCompleter;
+    if (pendingAvailability != null) return pendingAvailability.future;
     return available;
   }
 
@@ -118,7 +123,7 @@ void main() {
 
       final evaluation = cubit.evaluate(
         inputs: inputs(),
-        isMounted: () => true,
+        isActive: () => true,
       );
       frameScheduler.complete();
       await evaluation;
@@ -132,7 +137,7 @@ void main() {
     test('does not burn cooldown when the frame wait fails', () async {
       final evaluation = cubit.evaluate(
         inputs: inputs(),
-        isMounted: () => true,
+        isActive: () => true,
       );
       frameScheduler.complete(false);
       await evaluation;
@@ -148,7 +153,7 @@ void main() {
 
       final evaluation = cubit.evaluate(
         inputs: inputs(),
-        isMounted: () {
+        isActive: () {
           mountChecks++;
           if (mountChecks > 1) mounted = false;
           return mounted;
@@ -162,6 +167,32 @@ void main() {
       expect(prefs.getInt('review_prompt_attempted_at_$pubkey'), isNull);
     });
 
+    test(
+      'does not burn cooldown when account changes during availability check',
+      () async {
+        final availabilityCompleter = Completer<bool>();
+        final availabilityStarted = Completer<void>();
+        platform.availabilityCompleter = availabilityCompleter;
+        platform.availabilityStarted = availabilityStarted;
+        var isActive = true;
+
+        final evaluation = cubit.evaluate(
+          inputs: inputs(),
+          isActive: () => isActive,
+        );
+        frameScheduler.complete();
+        await availabilityStarted.future;
+
+        isActive = false;
+        availabilityCompleter.complete(true);
+        await evaluation;
+
+        expect(platform.requests, 0);
+        expect(prefs.getInt('review_prompt_attempted_at_$pubkey'), isNull);
+        expect(analytics.events, isEmpty);
+      },
+    );
+
     test('records cooldown immediately before requesting review', () async {
       final order = <String>[];
       platform.onRequest = () {
@@ -171,7 +202,7 @@ void main() {
 
       final evaluation = cubit.evaluate(
         inputs: inputs(),
-        isMounted: () => true,
+        isActive: () => true,
       );
       frameScheduler.complete();
       await evaluation;
@@ -191,7 +222,7 @@ void main() {
 
         final evaluation = cubit.evaluate(
           inputs: inputs(),
-          isMounted: () => true,
+          isActive: () => true,
         );
         frameScheduler.complete();
         await evaluation;
@@ -206,14 +237,29 @@ void main() {
     );
 
     test('ignores a second evaluation while one is in flight', () async {
-      final first = cubit.evaluate(inputs: inputs(), isMounted: () => true);
-      await cubit.evaluate(inputs: inputs(), isMounted: () => true);
+      final first = cubit.evaluate(inputs: inputs(), isActive: () => true);
+      await cubit.evaluate(inputs: inputs(), isActive: () => true);
 
       expect(frameScheduler.waits, 1);
       frameScheduler.complete();
       await first;
 
       expect(platform.requests, 1);
+    });
+
+    test('stops cleanly when closed during frame wait', () async {
+      final evaluation = cubit.evaluate(
+        inputs: inputs(),
+        isActive: () => true,
+      );
+
+      await cubit.close();
+      frameScheduler.complete();
+
+      await expectLater(evaluation, completes);
+      expect(platform.availabilityChecks, 0);
+      expect(platform.requests, 0);
+      expect(prefs.getInt('review_prompt_attempted_at_$pubkey'), isNull);
     });
   });
 }

--- a/mobile/test/features/app_review/app_review_coordinator_cubit_test.dart
+++ b/mobile/test/features/app_review/app_review_coordinator_cubit_test.dart
@@ -1,0 +1,219 @@
+// ABOUTME: Tests for the in-app review coordinator Cubit.
+// ABOUTME: Verifies prompt ordering, cooldown writes, mount checks, and guard.
+
+import 'dart:async';
+
+import 'package:analytics/analytics.dart';
+import 'package:app_update_repository/app_update_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/features/app_review/app_review_coordinator_cubit.dart';
+import 'package:openvine/services/app_review_prompt_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _RecordingSink implements AnalyticsEventSink {
+  final List<({String name, Map<String, Object> parameters})> events = [];
+
+  @override
+  Future<void> logEvent({
+    required String name,
+    required Map<String, Object> parameters,
+  }) async {
+    events.add((name: name, parameters: parameters));
+  }
+
+  @override
+  Future<void> logScreenView({
+    required String screenName,
+    String? screenClass,
+    Map<String, Object>? parameters,
+  }) async {}
+}
+
+class _FakeReviewPlatform implements AppReviewPlatform {
+  bool available = true;
+  Object? requestError;
+  int availabilityChecks = 0;
+  int requests = 0;
+  VoidCallback? onRequest;
+
+  @override
+  Future<bool> isAvailable() async {
+    availabilityChecks++;
+    return available;
+  }
+
+  @override
+  Future<void> requestReview() async {
+    requests++;
+    onRequest?.call();
+    final error = requestError;
+    if (error != null) throw error;
+  }
+}
+
+class _FakeFrameScheduler implements AppReviewFrameScheduler {
+  bool result = true;
+  final completer = Completer<bool>();
+  int waits = 0;
+
+  @override
+  Future<bool> waitForStableFrame() {
+    waits++;
+    if (completer.isCompleted) return Future.value(result);
+    return completer.future;
+  }
+
+  void complete([bool? value]) {
+    completer.complete(value ?? result);
+  }
+}
+
+typedef VoidCallback = void Function();
+
+void main() {
+  const pubkey = 'pubkey-a';
+
+  ReviewEligibilityInputs inputs({
+    int videoCount = 50,
+    InstallSource installSource = InstallSource.playStore,
+    int sessionCount = 20,
+    int daysSinceFirstLaunch = 30,
+  }) {
+    return ReviewEligibilityInputs(
+      pubkey: pubkey,
+      videoCount: videoCount,
+      installSource: installSource,
+      sessionCount: sessionCount,
+      daysSinceFirstLaunch: daysSinceFirstLaunch,
+    );
+  }
+
+  group(AppReviewCoordinatorCubit, () {
+    late SharedPreferences prefs;
+    late AppReviewPromptService service;
+    late _RecordingSink analytics;
+    late _FakeReviewPlatform platform;
+    late _FakeFrameScheduler frameScheduler;
+    late AppReviewCoordinatorCubit cubit;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      prefs = await SharedPreferences.getInstance();
+      service = AppReviewPromptService(sharedPreferences: prefs);
+      analytics = _RecordingSink();
+      platform = _FakeReviewPlatform();
+      frameScheduler = _FakeFrameScheduler();
+      cubit = AppReviewCoordinatorCubit(
+        service: service,
+        analytics: analytics,
+        reviewPlatform: platform,
+        frameScheduler: frameScheduler,
+      );
+    });
+
+    tearDown(() => cubit.close());
+
+    test('does not burn cooldown when native review is unavailable', () async {
+      platform.available = false;
+
+      final evaluation = cubit.evaluate(
+        inputs: inputs(),
+        isMounted: () => true,
+      );
+      frameScheduler.complete();
+      await evaluation;
+
+      expect(platform.availabilityChecks, 1);
+      expect(platform.requests, 0);
+      expect(prefs.getInt('review_prompt_attempted_at_$pubkey'), isNull);
+      expect(analytics.events, isEmpty);
+    });
+
+    test('does not burn cooldown when the frame wait fails', () async {
+      final evaluation = cubit.evaluate(
+        inputs: inputs(),
+        isMounted: () => true,
+      );
+      frameScheduler.complete(false);
+      await evaluation;
+
+      expect(platform.availabilityChecks, 0);
+      expect(platform.requests, 0);
+      expect(prefs.getInt('review_prompt_attempted_at_$pubkey'), isNull);
+    });
+
+    test('does not burn cooldown when unmounted after frame wait', () async {
+      var mounted = true;
+      var mountChecks = 0;
+
+      final evaluation = cubit.evaluate(
+        inputs: inputs(),
+        isMounted: () {
+          mountChecks++;
+          if (mountChecks > 1) mounted = false;
+          return mounted;
+        },
+      );
+      frameScheduler.complete();
+      await evaluation;
+
+      expect(platform.availabilityChecks, 0);
+      expect(platform.requests, 0);
+      expect(prefs.getInt('review_prompt_attempted_at_$pubkey'), isNull);
+    });
+
+    test('records cooldown immediately before requesting review', () async {
+      final order = <String>[];
+      platform.onRequest = () {
+        order.add('requestReview');
+        expect(prefs.getInt('review_prompt_attempted_at_$pubkey'), isNotNull);
+      };
+
+      final evaluation = cubit.evaluate(
+        inputs: inputs(),
+        isMounted: () => true,
+      );
+      frameScheduler.complete();
+      await evaluation;
+
+      expect(order, ['requestReview']);
+      expect(platform.requests, 1);
+      expect(analytics.events.map((event) => event.name), [
+        'in_app_review_eligible',
+        'in_app_review_prompted',
+      ]);
+    });
+
+    test(
+      'keeps cooldown when requestReview throws and tracks failure',
+      () async {
+        platform.requestError = StateError('platform failed');
+
+        final evaluation = cubit.evaluate(
+          inputs: inputs(),
+          isMounted: () => true,
+        );
+        frameScheduler.complete();
+        await evaluation;
+
+        expect(platform.requests, 1);
+        expect(prefs.getInt('review_prompt_attempted_at_$pubkey'), isNotNull);
+        expect(analytics.events.map((event) => event.name), [
+          'in_app_review_eligible',
+          'in_app_review_request_failed',
+        ]);
+      },
+    );
+
+    test('ignores a second evaluation while one is in flight', () async {
+      final first = cubit.evaluate(inputs: inputs(), isMounted: () => true);
+      await cubit.evaluate(inputs: inputs(), isMounted: () => true);
+
+      expect(frameScheduler.waits, 1);
+      frameScheduler.complete();
+      await first;
+
+      expect(platform.requests, 1);
+    });
+  });
+}

--- a/mobile/test/features/app_review/app_review_coordinator_test.dart
+++ b/mobile/test/features/app_review/app_review_coordinator_test.dart
@@ -1,0 +1,142 @@
+// ABOUTME: Widget tests for account-bound in-app review orchestration.
+// ABOUTME: Ensures an async evaluation cannot survive sign-out.
+
+import 'dart:async';
+
+import 'package:analytics/analytics.dart';
+import 'package:app_update_repository/app_update_repository.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:openvine/features/app_review/app_review_coordinator.dart';
+import 'package:openvine/features/app_review/app_review_coordinator_cubit.dart';
+import 'package:openvine/providers/analytics_providers.dart';
+import 'package:openvine/providers/app_foreground_provider.dart';
+import 'package:openvine/providers/auth_providers.dart';
+import 'package:openvine/providers/install_source_provider.dart';
+import 'package:openvine/providers/repository_providers.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/services/app_engagement_store.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:profile_repository/profile_repository.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockAuthService extends Mock implements AuthService {}
+
+class _MockProfileRepository extends Mock implements ProfileRepository {}
+
+class _RecordingReviewPlatform implements AppReviewPlatform {
+  int availabilityChecks = 0;
+  int requests = 0;
+
+  @override
+  Future<bool> isAvailable() async {
+    availabilityChecks++;
+    return true;
+  }
+
+  @override
+  Future<void> requestReview() async {
+    requests++;
+  }
+}
+
+class _ImmediateFrameScheduler implements AppReviewFrameScheduler {
+  @override
+  Future<bool> waitForStableFrame() async => true;
+}
+
+class _NoopAnalytics implements AnalyticsEventSink {
+  @override
+  Future<void> logEvent({
+    required String name,
+    required Map<String, Object> parameters,
+  }) async {}
+
+  @override
+  Future<void> logScreenView({
+    required String screenName,
+    String? screenClass,
+    Map<String, Object>? parameters,
+  }) async {}
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('does not prompt after the active account signs out', (
+    tester,
+  ) async {
+    const pubkey =
+        '1111111111111111111111111111111111111111111111111111111111111111';
+    var authState = AuthState.authenticated;
+    String? activePubkey = pubkey;
+    final authService = _MockAuthService();
+    when(() => authService.authState).thenAnswer((_) => authState);
+    when(
+      () => authService.currentPublicKeyHex,
+    ).thenAnswer((_) => activePubkey);
+
+    final statsController = StreamController<ProfileStats?>();
+    addTearDown(statsController.close);
+    final profileRepository = _MockProfileRepository();
+    when(
+      () => profileRepository.fetchFreshProfile(pubkey: pubkey),
+    ).thenAnswer((_) async => null);
+    when(
+      () => profileRepository.watchProfileStats(pubkey: pubkey),
+    ).thenAnswer((_) => statsController.stream);
+
+    SharedPreferences.setMockInitialValues(<String, Object>{
+      AppEngagementStore.sessionCountKey: 20,
+      AppEngagementStore.firstLaunchAtKey: DateTime(
+        2026,
+      ).millisecondsSinceEpoch,
+    });
+    final prefs = await SharedPreferences.getInstance();
+    final reviewPlatform = _RecordingReviewPlatform();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          analyticsEventSinkProvider.overrideWithValue(_NoopAnalytics()),
+          appReviewFrameSchedulerProvider.overrideWithValue(
+            _ImmediateFrameScheduler(),
+          ),
+          appReviewPlatformProvider.overrideWithValue(reviewPlatform),
+          authServiceProvider.overrideWithValue(authService),
+          currentAuthStateProvider.overrideWithValue(AuthState.authenticated),
+          installSourceProvider.overrideWithValue(InstallSource.playStore),
+          profileStatsRepositoryProvider.overrideWithValue(profileRepository),
+          sharedPreferencesProvider.overrideWithValue(prefs),
+        ],
+        child: const MaterialApp(home: AppReviewCoordinator()),
+      ),
+    );
+
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(AppReviewCoordinator)),
+    );
+    container.read(appForegroundProvider.notifier).setForeground(false);
+    await tester.pump();
+    container.read(appForegroundProvider.notifier).setForeground(true);
+    await tester.pump();
+
+    authState = AuthState.unauthenticated;
+    activePubkey = null;
+    statsController.add(
+      ProfileStats(
+        pubkey: pubkey,
+        videoCount: 50,
+        lastUpdated: DateTime(2026, 7, 26),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(reviewPlatform.availabilityChecks, 0);
+    expect(reviewPlatform.requests, 0);
+    expect(prefs.getInt('review_prompt_attempted_at_$pubkey'), isNull);
+  });
+}

--- a/mobile/test/features/app_review/app_review_profile_stats_loader_test.dart
+++ b/mobile/test/features/app_review/app_review_profile_stats_loader_test.dart
@@ -1,0 +1,74 @@
+// ABOUTME: Tests refresh-first profile-stat loading for review eligibility.
+// ABOUTME: Covers ordering and fail-closed error/timeout behavior.
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart';
+import 'package:openvine/features/app_review/app_review_profile_stats_loader.dart';
+
+void main() {
+  const pubkey =
+      '1111111111111111111111111111111111111111111111111111111111111111';
+  final staleStats = ProfileStats(
+    pubkey: pubkey,
+    videoCount: 10,
+    lastUpdated: DateTime(2026, 7, 25),
+  );
+  final freshStats = ProfileStats(
+    pubkey: pubkey,
+    videoCount: 11,
+    lastUpdated: DateTime(2026, 7, 26),
+  );
+
+  group(AppReviewProfileStatsLoader, () {
+    test('subscribes after refresh and returns the refreshed row', () async {
+      final refreshCompleter = Completer<void>();
+      var refreshed = false;
+      var watcherSubscriptions = 0;
+      const loader = AppReviewProfileStatsLoader();
+
+      final result = loader.load(
+        refresh: () async {
+          await refreshCompleter.future;
+          refreshed = true;
+        },
+        watch: () {
+          watcherSubscriptions++;
+          return Stream.value(refreshed ? freshStats : staleStats);
+        },
+      );
+
+      expect(watcherSubscriptions, 0);
+      refreshCompleter.complete();
+
+      expect(await result, same(freshStats));
+      expect(watcherSubscriptions, 1);
+    });
+
+    test('returns null when refresh fails', () async {
+      const loader = AppReviewProfileStatsLoader();
+
+      final result = await loader.load(
+        refresh: () => Future<void>.error(StateError('refresh failed')),
+        watch: () => Stream.value(freshStats),
+      );
+
+      expect(result, isNull);
+    });
+
+    test('returns null when the combined load times out', () async {
+      final refreshCompleter = Completer<void>();
+      const loader = AppReviewProfileStatsLoader(
+        timeout: Duration(milliseconds: 1),
+      );
+
+      final result = await loader.load(
+        refresh: () => refreshCompleter.future,
+        watch: () => Stream.value(freshStats),
+      );
+
+      expect(result, isNull);
+    });
+  });
+}

--- a/mobile/test/providers/device_scope_test.dart
+++ b/mobile/test/providers/device_scope_test.dart
@@ -1,12 +1,14 @@
 // ABOUTME: Tests that DeviceScope shares device singletons across containers so
 // ABOUTME: an account switch does not open a second DB connection.
 
+import 'package:app_update_repository/app_update_repository.dart';
 import 'package:db_client/db_client.dart';
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/providers/container_swap_host.dart';
 import 'package:openvine/providers/database_provider.dart';
 import 'package:openvine/providers/device_scope.dart';
+import 'package:openvine/providers/install_source_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -25,6 +27,7 @@ void main() {
       database: database,
       sharedPreferences: prefs,
       switchController: AccountSwitchController(),
+      installSource: InstallSource.playStore,
     );
   });
 
@@ -52,24 +55,31 @@ void main() {
     expect(b.read(sharedPreferencesProvider), same(prefs));
   });
 
-  test(
-    'disposing a container does not close the shared database',
-    () async {
-      final a = buildAccountContainer(deviceScope);
-      // Touch the DB through the container to prove it is live.
-      await a.read(databaseProvider).notificationsDao.getAllNotifications();
+  test('every container reads the same install source override', () {
+    final a = buildAccountContainer(deviceScope);
+    addTearDown(a.dispose);
+    final b = buildAccountContainer(deviceScope);
+    addTearDown(b.dispose);
 
-      a.dispose();
+    expect(a.read(installSourceProvider), InstallSource.playStore);
+    expect(b.read(installSourceProvider), InstallSource.playStore);
+  });
 
-      // The shared DB must still be usable from a new container after the
-      // old one was disposed — the override-with-value path never registered
-      // the factory's onDispose(db.close).
-      final b = buildAccountContainer(deviceScope);
-      addTearDown(b.dispose);
-      await expectLater(
-        b.read(databaseProvider).notificationsDao.getAllNotifications(),
-        completes,
-      );
-    },
-  );
+  test('disposing a container does not close the shared database', () async {
+    final a = buildAccountContainer(deviceScope);
+    // Touch the DB through the container to prove it is live.
+    await a.read(databaseProvider).notificationsDao.getAllNotifications();
+
+    a.dispose();
+
+    // The shared DB must still be usable from a new container after the
+    // old one was disposed — the override-with-value path never registered
+    // the factory's onDispose(db.close).
+    final b = buildAccountContainer(deviceScope);
+    addTearDown(b.dispose);
+    await expectLater(
+      b.read(databaseProvider).notificationsDao.getAllNotifications(),
+      completes,
+    );
+  });
 }

--- a/mobile/test/services/app_engagement_store_test.dart
+++ b/mobile/test/services/app_engagement_store_test.dart
@@ -1,0 +1,116 @@
+// ABOUTME: Tests for AppEngagementStore session counter + first-launch stamp.
+// ABOUTME: Verifies idempotent increment behavior and clock injection.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/app_engagement_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  group(AppEngagementStore, () {
+    late SharedPreferences prefs;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      prefs = await SharedPreferences.getInstance();
+    });
+
+    group('sessionCount', () {
+      test('is 0 before recordSession runs', () {
+        final store = AppEngagementStore(sharedPreferences: prefs);
+        expect(store.sessionCount, 0);
+      });
+
+      test('becomes 1 after the first recordSession', () async {
+        final store = AppEngagementStore(sharedPreferences: prefs);
+        await store.recordSession();
+        expect(store.sessionCount, 1);
+      });
+
+      test('increments across multiple recordSession calls', () async {
+        final store = AppEngagementStore(sharedPreferences: prefs);
+        await store.recordSession();
+        await store.recordSession();
+        await store.recordSession();
+        expect(store.sessionCount, 3);
+      });
+
+      test(
+        'reads a previously-persisted count on a new store instance',
+        () async {
+          await AppEngagementStore(sharedPreferences: prefs).recordSession();
+          await AppEngagementStore(sharedPreferences: prefs).recordSession();
+
+          // A fresh store (simulating a later cold start) reads the persisted count.
+          final laterStore = AppEngagementStore(sharedPreferences: prefs);
+          expect(laterStore.sessionCount, 2);
+        },
+      );
+    });
+
+    group('firstLaunchAt', () {
+      test('is null before recordSession runs', () {
+        final store = AppEngagementStore(sharedPreferences: prefs);
+        expect(store.firstLaunchAt, isNull);
+      });
+
+      test(
+        'is stamped on the first recordSession and never overwritten',
+        () async {
+          final first = DateTime(2026, 1, 15);
+          final store = AppEngagementStore(
+            sharedPreferences: prefs,
+            now: () => first,
+          );
+          await store.recordSession();
+          expect(store.firstLaunchAt, first);
+
+          // A later session with a different clock must NOT overwrite the stamp.
+          final laterStore = AppEngagementStore(
+            sharedPreferences: prefs,
+            now: () => DateTime(2026, 7, 25),
+          );
+          await laterStore.recordSession();
+          expect(laterStore.firstLaunchAt, first);
+        },
+      );
+    });
+
+    group('daysSinceFirstLaunch', () {
+      test('is 0 when no first-launch stamp exists', () {
+        final store = AppEngagementStore(sharedPreferences: prefs);
+        expect(store.daysSinceFirstLaunch(), 0);
+      });
+
+      test('computes whole days between first launch and now', () async {
+        final firstLaunch = DateTime(2026, 1, 15);
+        final store = AppEngagementStore(
+          sharedPreferences: prefs,
+          now: () => firstLaunch,
+        );
+        await store.recordSession();
+
+        final tenDaysLater = AppEngagementStore(
+          sharedPreferences: prefs,
+          now: () => firstLaunch.add(const Duration(days: 10, hours: 12)),
+        );
+        // 10.5 days floors to 10.
+        expect(tenDaysLater.daysSinceFirstLaunch(), 10);
+      });
+
+      test('honors an explicit now override', () async {
+        final firstLaunch = DateTime(2026, 1, 15);
+        final store = AppEngagementStore(
+          sharedPreferences: prefs,
+          now: () => firstLaunch,
+        );
+        await store.recordSession();
+
+        final evaluationNow = firstLaunch.add(const Duration(days: 30));
+        expect(
+          store.daysSinceFirstLaunch(now: evaluationNow),
+          30,
+        );
+      });
+    });
+  });
+}

--- a/mobile/test/services/app_review_prompt_service_test.dart
+++ b/mobile/test/services/app_review_prompt_service_test.dart
@@ -26,6 +26,20 @@ void main() {
     );
   }
 
+  ReviewLocalEligibilityInputs localInputs({
+    String pubkey = pubkey,
+    InstallSource installSource = InstallSource.playStore,
+    int sessionCount = 20,
+    int daysSinceFirstLaunch = 30,
+  }) {
+    return ReviewLocalEligibilityInputs(
+      pubkey: pubkey,
+      installSource: installSource,
+      sessionCount: sessionCount,
+      daysSinceFirstLaunch: daysSinceFirstLaunch,
+    );
+  }
+
   group(AppReviewPromptService, () {
     late SharedPreferences prefs;
 
@@ -82,26 +96,17 @@ void main() {
 
       test('returns false when videoCount equals the minimum (10)', () {
         final service = AppReviewPromptService(sharedPreferences: prefs);
-        expect(
-          service.shouldShow(eligibleInputs(videoCount: 10)),
-          isFalse,
-        );
+        expect(service.shouldShow(eligibleInputs(videoCount: 10)), isFalse);
       });
 
       test('returns false when videoCount is below the minimum', () {
         final service = AppReviewPromptService(sharedPreferences: prefs);
-        expect(
-          service.shouldShow(eligibleInputs(videoCount: 5)),
-          isFalse,
-        );
+        expect(service.shouldShow(eligibleInputs(videoCount: 5)), isFalse);
       });
 
       test('returns true when videoCount is one above the minimum', () {
         final service = AppReviewPromptService(sharedPreferences: prefs);
-        expect(
-          service.shouldShow(eligibleInputs(videoCount: 11)),
-          isTrue,
-        );
+        expect(service.shouldShow(eligibleInputs(videoCount: 11)), isTrue);
       });
 
       test(
@@ -142,10 +147,45 @@ void main() {
 
       test('returns false for videoCount of 0', () {
         final service = AppReviewPromptService(sharedPreferences: prefs);
+        expect(service.shouldShow(eligibleInputs(videoCount: 0)), isFalse);
+      });
+    });
+
+    group('shouldLoadProfileStats', () {
+      test('returns true when local criteria pass', () {
+        final service = AppReviewPromptService(sharedPreferences: prefs);
+        expect(service.shouldLoadProfileStats(localInputs()), isTrue);
+      });
+
+      test('returns false for non-store installs', () {
+        final service = AppReviewPromptService(sharedPreferences: prefs);
         expect(
-          service.shouldShow(eligibleInputs(videoCount: 0)),
+          service.shouldLoadProfileStats(
+            localInputs(installSource: InstallSource.sideload),
+          ),
           isFalse,
         );
+      });
+
+      test('returns false before sustained use', () {
+        final service = AppReviewPromptService(sharedPreferences: prefs);
+        expect(
+          service.shouldLoadProfileStats(
+            localInputs(sessionCount: 3, daysSinceFirstLaunch: 4),
+          ),
+          isFalse,
+        );
+      });
+
+      test('returns false during cooldown', () async {
+        final now = DateTime(2026, 7, 25);
+        final service = AppReviewPromptService(
+          sharedPreferences: prefs,
+          now: () => now,
+        );
+        await service.recordShown(pubkey);
+
+        expect(service.shouldLoadProfileStats(localInputs()), isFalse);
       });
     });
 
@@ -204,33 +244,6 @@ void main() {
       });
     });
 
-    group('completed flag', () {
-      test('returns false once recordCompleted is set', () async {
-        final service = AppReviewPromptService(sharedPreferences: prefs);
-        await service.recordCompleted(pubkey);
-
-        expect(service.shouldShow(eligibleInputs()), isFalse);
-      });
-
-      test(
-        'completed flag short-circuits even after the cooldown elapses',
-        () async {
-          final service = AppReviewPromptService(
-            sharedPreferences: prefs,
-            now: () => DateTime(2026, 1, 15),
-          );
-          await service.recordShown(pubkey);
-          await service.recordCompleted(pubkey);
-
-          final laterService = AppReviewPromptService(
-            sharedPreferences: prefs,
-            now: () => DateTime(2026, 12, 15),
-          );
-          expect(laterService.shouldShow(eligibleInputs()), isFalse);
-        },
-      );
-    });
-
     group('per-user key isolation', () {
       test('a cooldown on pubkey-a does not block pubkey-b', () async {
         final now = DateTime(2026, 7, 25);
@@ -240,28 +253,31 @@ void main() {
         );
         await service.recordShown('pubkey-a');
 
-        expect(
-          service.shouldShow(eligibleInputs(pubkey: 'pubkey-b')),
-          isTrue,
-        );
+        expect(service.shouldShow(eligibleInputs(pubkey: 'pubkey-b')), isTrue);
       });
 
-      test('reset clears the cooldown for that pubkey only', () async {
-        final now = DateTime(2026, 7, 25);
-        final service = AppReviewPromptService(
-          sharedPreferences: prefs,
-          now: () => now,
-        );
-        await service.recordShown('pubkey-a');
-        await service.recordShown('pubkey-b');
-        await service.reset('pubkey-a');
+      test(
+        'cooldown for pubkey-b does not affect pubkey-a after expiry',
+        () async {
+          final now = DateTime(2026, 7, 25);
+          final service = AppReviewPromptService(
+            sharedPreferences: prefs,
+            now: () => now,
+          );
+          await service.recordShown('pubkey-a');
+          await service.recordShown('pubkey-b');
 
-        expect(service.shouldShow(eligibleInputs()), isTrue);
-        expect(
-          service.shouldShow(eligibleInputs(pubkey: 'pubkey-b')),
-          isFalse,
-        );
-      });
+          final laterService = AppReviewPromptService(
+            sharedPreferences: prefs,
+            now: () => DateTime(2027, 1, 25),
+          );
+          expect(laterService.shouldShow(eligibleInputs()), isTrue);
+          expect(
+            laterService.shouldShow(eligibleInputs(pubkey: 'pubkey-b')),
+            isTrue,
+          );
+        },
+      );
     });
 
     group('recordShown uses the injected clock', () {
@@ -273,7 +289,7 @@ void main() {
         );
         await service.recordShown(pubkey);
 
-        final stored = prefs.getInt('review_prompt_dismissed_at_$pubkey');
+        final stored = prefs.getInt('review_prompt_attempted_at_$pubkey');
         expect(stored, fixed.millisecondsSinceEpoch);
       });
     });

--- a/mobile/test/services/app_review_prompt_service_test.dart
+++ b/mobile/test/services/app_review_prompt_service_test.dart
@@ -1,0 +1,281 @@
+// ABOUTME: Tests for AppReviewPromptService eligibility gate + cooldown.
+// ABOUTME: Covers every false branch, the all-true branch, cooldown expiry,
+// ABOUTME: and per-user key isolation.
+
+import 'package:app_update_repository/app_update_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/app_review_prompt_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  const pubkey = 'pubkey-a';
+
+  ReviewEligibilityInputs eligibleInputs({
+    String pubkey = pubkey,
+    int videoCount = 50,
+    InstallSource installSource = InstallSource.playStore,
+    int sessionCount = 20,
+    int daysSinceFirstLaunch = 30,
+  }) {
+    return ReviewEligibilityInputs(
+      pubkey: pubkey,
+      videoCount: videoCount,
+      installSource: installSource,
+      sessionCount: sessionCount,
+      daysSinceFirstLaunch: daysSinceFirstLaunch,
+    );
+  }
+
+  group(AppReviewPromptService, () {
+    late SharedPreferences prefs;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      prefs = await SharedPreferences.getInstance();
+    });
+
+    group('shouldShow', () {
+      test('returns true when every condition is met (Play Store)', () {
+        final service = AppReviewPromptService(sharedPreferences: prefs);
+        expect(service.shouldShow(eligibleInputs()), isTrue);
+      });
+
+      test('returns true when every condition is met (App Store)', () {
+        final service = AppReviewPromptService(sharedPreferences: prefs);
+        expect(
+          service.shouldShow(
+            eligibleInputs(installSource: InstallSource.appStore),
+          ),
+          isTrue,
+        );
+      });
+
+      test('returns false for TestFlight installs', () {
+        final service = AppReviewPromptService(sharedPreferences: prefs);
+        expect(
+          service.shouldShow(
+            eligibleInputs(installSource: InstallSource.testFlight),
+          ),
+          isFalse,
+        );
+      });
+
+      test('returns false for Zapstore installs', () {
+        final service = AppReviewPromptService(sharedPreferences: prefs);
+        expect(
+          service.shouldShow(
+            eligibleInputs(installSource: InstallSource.zapstore),
+          ),
+          isFalse,
+        );
+      });
+
+      test('returns false for sideloaded installs', () {
+        final service = AppReviewPromptService(sharedPreferences: prefs);
+        expect(
+          service.shouldShow(
+            eligibleInputs(installSource: InstallSource.sideload),
+          ),
+          isFalse,
+        );
+      });
+
+      test('returns false when videoCount equals the minimum (10)', () {
+        final service = AppReviewPromptService(sharedPreferences: prefs);
+        expect(
+          service.shouldShow(eligibleInputs(videoCount: 10)),
+          isFalse,
+        );
+      });
+
+      test('returns false when videoCount is below the minimum', () {
+        final service = AppReviewPromptService(sharedPreferences: prefs);
+        expect(
+          service.shouldShow(eligibleInputs(videoCount: 5)),
+          isFalse,
+        );
+      });
+
+      test('returns true when videoCount is one above the minimum', () {
+        final service = AppReviewPromptService(sharedPreferences: prefs);
+        expect(
+          service.shouldShow(eligibleInputs(videoCount: 11)),
+          isTrue,
+        );
+      });
+
+      test(
+        'returns true when sessions are sufficient even if days are low',
+        () {
+          final service = AppReviewPromptService(sharedPreferences: prefs);
+          expect(
+            service.shouldShow(
+              eligibleInputs(sessionCount: 10, daysSinceFirstLaunch: 1),
+            ),
+            isTrue,
+          );
+        },
+      );
+
+      test(
+        'returns true when days are sufficient even if sessions are low',
+        () {
+          final service = AppReviewPromptService(sharedPreferences: prefs);
+          expect(
+            service.shouldShow(
+              eligibleInputs(sessionCount: 1, daysSinceFirstLaunch: 14),
+            ),
+            isTrue,
+          );
+        },
+      );
+
+      test('returns false when neither sessions nor days are sufficient', () {
+        final service = AppReviewPromptService(sharedPreferences: prefs);
+        expect(
+          service.shouldShow(
+            eligibleInputs(sessionCount: 5, daysSinceFirstLaunch: 7),
+          ),
+          isFalse,
+        );
+      });
+
+      test('returns false for videoCount of 0', () {
+        final service = AppReviewPromptService(sharedPreferences: prefs);
+        expect(
+          service.shouldShow(eligibleInputs(videoCount: 0)),
+          isFalse,
+        );
+      });
+    });
+
+    group('cooldown', () {
+      test('returns false immediately after recordShown', () async {
+        final now = DateTime(2026, 7, 25);
+        final service = AppReviewPromptService(
+          sharedPreferences: prefs,
+          now: () => now,
+        );
+        await service.recordShown(pubkey);
+
+        expect(service.shouldShow(eligibleInputs()), isFalse);
+      });
+
+      test('returns true again after the default cooldown elapses', () async {
+        final shownAt = DateTime(2026, 1, 15);
+        final service = AppReviewPromptService(
+          sharedPreferences: prefs,
+          now: () => shownAt,
+        );
+        await service.recordShown(pubkey);
+
+        // Re-evaluate well past the 180-day default cooldown.
+        final laterService = AppReviewPromptService(
+          sharedPreferences: prefs,
+          now: () => DateTime(2026, 12, 15),
+        );
+        expect(laterService.shouldShow(eligibleInputs()), isTrue);
+      });
+
+      test('respects a custom cooldown via now injection', () async {
+        final shownAt = DateTime(2026, 1, 15);
+        final service = AppReviewPromptService(
+          sharedPreferences: prefs,
+          cooldown: const Duration(days: 30),
+          now: () => shownAt,
+        );
+        await service.recordShown(pubkey);
+
+        // 20 days later: still within the 30-day cooldown.
+        final within = AppReviewPromptService(
+          sharedPreferences: prefs,
+          cooldown: const Duration(days: 30),
+          now: () => DateTime(2026, 2, 4),
+        );
+        expect(within.shouldShow(eligibleInputs()), isFalse);
+
+        // 31 days later: past the cooldown.
+        final past = AppReviewPromptService(
+          sharedPreferences: prefs,
+          cooldown: const Duration(days: 30),
+          now: () => DateTime(2026, 2, 15),
+        );
+        expect(past.shouldShow(eligibleInputs()), isTrue);
+      });
+    });
+
+    group('completed flag', () {
+      test('returns false once recordCompleted is set', () async {
+        final service = AppReviewPromptService(sharedPreferences: prefs);
+        await service.recordCompleted(pubkey);
+
+        expect(service.shouldShow(eligibleInputs()), isFalse);
+      });
+
+      test(
+        'completed flag short-circuits even after the cooldown elapses',
+        () async {
+          final service = AppReviewPromptService(
+            sharedPreferences: prefs,
+            now: () => DateTime(2026, 1, 15),
+          );
+          await service.recordShown(pubkey);
+          await service.recordCompleted(pubkey);
+
+          final laterService = AppReviewPromptService(
+            sharedPreferences: prefs,
+            now: () => DateTime(2026, 12, 15),
+          );
+          expect(laterService.shouldShow(eligibleInputs()), isFalse);
+        },
+      );
+    });
+
+    group('per-user key isolation', () {
+      test('a cooldown on pubkey-a does not block pubkey-b', () async {
+        final now = DateTime(2026, 7, 25);
+        final service = AppReviewPromptService(
+          sharedPreferences: prefs,
+          now: () => now,
+        );
+        await service.recordShown('pubkey-a');
+
+        expect(
+          service.shouldShow(eligibleInputs(pubkey: 'pubkey-b')),
+          isTrue,
+        );
+      });
+
+      test('reset clears the cooldown for that pubkey only', () async {
+        final now = DateTime(2026, 7, 25);
+        final service = AppReviewPromptService(
+          sharedPreferences: prefs,
+          now: () => now,
+        );
+        await service.recordShown('pubkey-a');
+        await service.recordShown('pubkey-b');
+        await service.reset('pubkey-a');
+
+        expect(service.shouldShow(eligibleInputs()), isTrue);
+        expect(
+          service.shouldShow(eligibleInputs(pubkey: 'pubkey-b')),
+          isFalse,
+        );
+      });
+    });
+
+    group('recordShown uses the injected clock', () {
+      test('persists the injected now, not wall-clock time', () async {
+        final fixed = DateTime(2025, 6, 15, 10, 30);
+        final service = AppReviewPromptService(
+          sharedPreferences: prefs,
+          now: () => fixed,
+        );
+        await service.recordShown(pubkey);
+
+        final stored = prefs.getInt('review_prompt_dismissed_at_$pubkey');
+        expect(stored, fixed.millisecondsSinceEpoch);
+      });
+    });
+  });
+}

--- a/mobile/test/services/install_source_service_test.dart
+++ b/mobile/test/services/install_source_service_test.dart
@@ -1,0 +1,136 @@
+// ABOUTME: Tests for InstallSourceService method-channel mapping.
+// ABOUTME: Verifies the Android installer-name and iOS sandbox mappings, plus
+// ABOUTME: the sideload / failure fallbacks.
+
+import 'package:app_update_repository/app_update_repository.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/install_source_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const channelName = 'divine/install_source';
+
+  /// Installs a fake handler for [channelName] that returns [androidResult]
+  /// for `getInstallerPackageName` and [iosSandbox] for `isSandboxReceipt`.
+  void installFakeChannel({
+    String? androidResult,
+    bool iosSandbox = false,
+    Object? androidError,
+    Object? iosError,
+  }) {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(const MethodChannel(channelName), (
+          MethodCall call,
+        ) async {
+          if (call.method == 'getInstallerPackageName') {
+            if (androidError != null) throw androidError;
+            return androidResult;
+          }
+          if (call.method == 'isSandboxReceipt') {
+            if (iosError != null) throw iosError;
+            return iosSandbox;
+          }
+          return null;
+        });
+  }
+
+  /// Runs [body] with [defaultTargetPlatform] set to [platform], restoring the
+  /// real platform afterwards.
+  Future<void> withPlatform(
+    TargetPlatform platform,
+    Future<void> Function() body,
+  ) async {
+    final previous = debugDefaultTargetPlatformOverride;
+    debugDefaultTargetPlatformOverride = platform;
+    try {
+      await body();
+    } finally {
+      debugDefaultTargetPlatformOverride = previous;
+    }
+  }
+
+  group(InstallSourceService, () {
+    tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(const MethodChannel(channelName), null);
+    });
+
+    test('maps Android Play Store installer to playStore', () async {
+      await withPlatform(TargetPlatform.android, () async {
+        installFakeChannel(androidResult: 'com.android.vending');
+        final source = await const InstallSourceService().resolve();
+        expect(source, InstallSource.playStore);
+      });
+    });
+
+    test('maps Android Zapstore installer to zapstore', () async {
+      await withPlatform(TargetPlatform.android, () async {
+        installFakeChannel(androidResult: 'com.zapstore.app');
+        final source = await const InstallSourceService().resolve();
+        expect(source, InstallSource.zapstore);
+      });
+    });
+
+    test('maps an unknown Android installer to sideload', () async {
+      await withPlatform(TargetPlatform.android, () async {
+        installFakeChannel(androidResult: 'com.unknown.installer');
+        final source = await const InstallSourceService().resolve();
+        expect(source, InstallSource.sideload);
+      });
+    });
+
+    test('maps a null Android installer to sideload', () async {
+      await withPlatform(TargetPlatform.android, () async {
+        // installFakeChannel's default androidResult is null.
+        installFakeChannel();
+        final source = await const InstallSourceService().resolve();
+        expect(source, InstallSource.sideload);
+      });
+    });
+
+    test('falls back to sideload on Android PlatformException', () async {
+      await withPlatform(TargetPlatform.android, () async {
+        installFakeChannel(
+          androidError: PlatformException(code: 'UNAVAILABLE'),
+        );
+        final source = await const InstallSourceService().resolve();
+        expect(source, InstallSource.sideload);
+      });
+    });
+
+    test('maps iOS production receipt to appStore', () async {
+      await withPlatform(TargetPlatform.iOS, () async {
+        // installFakeChannel's default iosSandbox is false (production receipt).
+        installFakeChannel();
+        final source = await const InstallSourceService().resolve();
+        expect(source, InstallSource.appStore);
+      });
+    });
+
+    test('maps iOS sandbox receipt to testFlight', () async {
+      await withPlatform(TargetPlatform.iOS, () async {
+        installFakeChannel(iosSandbox: true);
+        final source = await const InstallSourceService().resolve();
+        expect(source, InstallSource.testFlight);
+      });
+    });
+
+    test('falls back to sideload on iOS PlatformException', () async {
+      await withPlatform(TargetPlatform.iOS, () async {
+        installFakeChannel(iosError: PlatformException(code: 'UNAVAILABLE'));
+        final source = await const InstallSourceService().resolve();
+        expect(source, InstallSource.sideload);
+      });
+    });
+
+    test('returns sideload on unsupported platforms (macOS)', () async {
+      await withPlatform(TargetPlatform.macOS, () async {
+        installFakeChannel(androidResult: 'com.android.vending');
+        final source = await const InstallSourceService().resolve();
+        expect(source, InstallSource.sideload);
+      });
+    });
+  });
+}

--- a/mobile/test/services/install_source_service_test.dart
+++ b/mobile/test/services/install_source_service_test.dart
@@ -16,7 +16,7 @@ void main() {
   /// for `getInstallerPackageName` and [iosSandbox] for `isSandboxReceipt`.
   void installFakeChannel({
     String? androidResult,
-    bool iosSandbox = false,
+    bool? iosSandbox = false,
     Object? androidError,
     Object? iosError,
   }) {
@@ -42,12 +42,11 @@ void main() {
     TargetPlatform platform,
     Future<void> Function() body,
   ) async {
-    final previous = debugDefaultTargetPlatformOverride;
     debugDefaultTargetPlatformOverride = platform;
     try {
       await body();
     } finally {
-      debugDefaultTargetPlatformOverride = previous;
+      debugDefaultTargetPlatformOverride = null;
     }
   }
 
@@ -117,9 +116,24 @@ void main() {
       });
     });
 
+    test('maps a null iOS receipt response to sideload', () async {
+      await withPlatform(TargetPlatform.iOS, () async {
+        installFakeChannel(iosSandbox: null);
+        final source = await const InstallSourceService().resolve();
+        expect(source, InstallSource.sideload);
+      });
+    });
+
     test('falls back to sideload on iOS PlatformException', () async {
       await withPlatform(TargetPlatform.iOS, () async {
         installFakeChannel(iosError: PlatformException(code: 'UNAVAILABLE'));
+        final source = await const InstallSourceService().resolve();
+        expect(source, InstallSource.sideload);
+      });
+    });
+
+    test('falls back to sideload when the native channel is missing', () async {
+      await withPlatform(TargetPlatform.iOS, () async {
         final source = await const InstallSourceService().resolve();
         expect(source, InstallSource.sideload);
       });


### PR DESCRIPTION
Closes #6400

## Summary

Asks only genuinely invested users to rate Divine via the OS-native review card (`SKStoreReviewController` on iOS, Google Play in-app review on Android). No custom dialog or copy; zero design-system surface and zero new arb strings.

## Eligibility

A user is prompted only when every condition holds:

1. Store install: Google Play or the iOS App Store. TestFlight, Zapstore, sideloaded, unknown, and unsupported shells are excluded.
2. Invested creator: strictly more than 10 published videos from `ProfileStats.videoCount`.
3. Sustained use: `>=10` cold starts OR `>=14` days since first launch.
4. Cooldown elapsed: at least ~6 months since the last prompt attempt for this account.

The prompt is evaluated on return-to-foreground, after cheap local gates pass. Profile stats are loaded on demand instead of keeping a root Drift watch alive for the whole app session.

## Install-Source Detection

This also replaces the previous `InstallSource.sideload` stub used by `AppUpdateRepository`:

- `InstallSourceService` resolves Android installer package name and iOS receipt environment through `divine/install_source`.
- Android maps Play Store and Zapstore installers, with unknown/null installers failing closed to sideload.
- iOS maps sandbox receipts to TestFlight and production receipts to App Store; missing/unknown receipt responses fail closed to sideload.
- `DeviceScope.installSource` shares the resolved source across account containers so review gating and update nudges use the same value.
- Platform failures and missing native channel fallbacks are observable via unified logging.

## Prompt Orchestration

- `AppReviewCoordinator` is a zero-size root widget that watches auth/foreground only and dispatches after a false-to-true foreground transition.
- `AppReviewCoordinatorCubit` owns the ordering: local gate, bounded stable-frame wait, `isAvailable()`, cooldown write, native request, analytics.
- Cooldown is written immediately before `requestReview()`, not before availability/mounted/frame checks, so unavailable platforms or unmounted UI cannot silently burn the 180-day cooldown.
- The coordinator is nested under `DatabaseCorruptionGate` so the database recovery screen cannot be interrupted by a native review card.

## Tests

Adds and updates tests for:

- Pure eligibility gate and local preflight.
- Engagement store counters.
- Install-source mapping, null receipt fallback, missing plugin fallback, and `DeviceScope.installSource` override.
- Analytics bucketing for video count, session count, and days since first launch.
- Coordinator Cubit ordering, frame failure, mounted checks, in-flight guard, unavailable platform behavior, request failure tracking, and cooldown write timing.

## Verification

- `flutter analyze`
- `flutter test test/features/app_review/app_review_analytics_test.dart test/features/app_review/app_review_coordinator_cubit_test.dart test/services/app_review_prompt_service_test.dart test/services/app_engagement_store_test.dart test/services/install_source_service_test.dart test/providers/device_scope_test.dart test/providers/swap_account_test.dart test/main_hashtag_deep_link_nav_action_test.dart test/main_notification_tap_routing_test.dart test/main_search_deep_link_nav_action_test.dart`
- `bash scripts/check_raw_logging.sh`
- `bash scripts/check_native_transport_security.sh`
