### PR TITLE
fix(l10n): use root context for publish snackbar

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -2936,6 +2936,7 @@ class UploadFailureListener extends StatefulWidget {
 
 class _UploadFailureListenerState extends State<UploadFailureListener> {
   var _lastKnownFailedIds = <String>{};
+  var _lastKnownSucceededIds = <String>{};
   var _pendingSuccessCount = 0;
 
   @override
@@ -2948,12 +2949,16 @@ class _UploadFailureListenerState extends State<UploadFailureListener> {
 
         // Use the bloc's own recentlySucceededIds so we never confuse a
         // BackgroundPublishVanished removal with a true publish success.
-        final succeededCount = state.recentlySucceededIds.length;
+        final succeededIds = state.recentlySucceededIds.difference(
+          _lastKnownSucceededIds,
+        );
+        _lastKnownSucceededIds = state.recentlySucceededIds;
+        final succeededCount = succeededIds.length;
 
         if (succeededCount > 0) {
           if (authService.isAuthenticated) {
             // Show immediately — user is still in-app.
-            _showPublishSuccessSnackbar(context, succeededCount);
+            _showPublishSuccessSnackbar(succeededCount);
           } else {
             // Buffer for when auth is restored after re-auth redirect.
             _pendingSuccessCount += succeededCount;
@@ -2974,8 +2979,8 @@ class _UploadFailureListenerState extends State<UploadFailureListener> {
         }
 
         // Auth is now confirmed — flush buffered successes from re-auth window.
-        if (_pendingSuccessCount > 0) {
-          _showPublishSuccessSnackbar(context, _pendingSuccessCount);
+        if (_pendingSuccessCount > 0 &&
+            _showPublishSuccessSnackbar(_pendingSuccessCount)) {
           _pendingSuccessCount = 0;
         }
 
@@ -2985,7 +2990,7 @@ class _UploadFailureListenerState extends State<UploadFailureListener> {
         if (newFailedIds.isEmpty) return;
 
         final navContext = NavigatorKeys.root.currentContext;
-        if (navContext == null) return;
+        if (navContext == null || !navContext.mounted) return;
 
         final newFailures = state.uploads
             .where((u) => newFailedIds.contains(u.draft.id))
@@ -3000,15 +3005,16 @@ class _UploadFailureListenerState extends State<UploadFailureListener> {
 
 /// Shows a snackbar confirming that [count] background uploads completed.
 ///
-/// Uses [ScaffoldMessenger] via [NavigatorKeys.root] to reach the root
-/// [Scaffold] — this is required because the listener's [BuildContext] may
-/// not have a [Scaffold] ancestor when the snackbar fires during a re-auth
-/// redirect. The l10n strings are resolved from the passed-in [context]
-/// (the BlocListener's context), which always has localisation ancestors.
-void _showPublishSuccessSnackbar(BuildContext context, int count) {
+/// Returns `true` when the snackbar was shown.
+///
+/// Uses [NavigatorKeys.root] to resolve both localization and
+/// [ScaffoldMessenger] from inside the app tree. The listener itself is mounted
+/// above [MaterialApp], so its own [BuildContext] does not have localization or
+/// scaffold ancestors in production.
+bool _showPublishSuccessSnackbar(int count) {
   final navContext = NavigatorKeys.root.currentContext;
-  if (navContext == null || !navContext.mounted) return;
-  final l10n = context.l10n;
+  if (navContext == null || !navContext.mounted) return false;
+  final l10n = navContext.l10n;
   ScaffoldMessenger.of(navContext).showSnackBar(
     SnackBar(
       content: Text(
@@ -3019,6 +3025,7 @@ void _showPublishSuccessSnackbar(BuildContext context, int count) {
       behavior: SnackBarBehavior.floating,
     ),
   );
+  return true;
 }
 
 /// Shows failure bottom sheets one after another for each failed upload.

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -2957,8 +2957,12 @@ class _UploadFailureListenerState extends State<UploadFailureListener> {
 
         if (succeededCount > 0) {
           if (authService.isAuthenticated) {
-            // Show immediately — user is still in-app.
-            _showPublishSuccessSnackbar(succeededCount);
+            // Show immediately — user is still in-app. If the root navigator
+            // context is unavailable the snackbar would be silently dropped,
+            // so buffer it and replay once the context is ready.
+            if (!_showPublishSuccessSnackbar(succeededCount)) {
+              _pendingSuccessCount += succeededCount;
+            }
           } else {
             // Buffer for when auth is restored after re-auth redirect.
             _pendingSuccessCount += succeededCount;

--- a/mobile/test/widgets/upload_failure_listener_test.dart
+++ b/mobile/test/widgets/upload_failure_listener_test.dart
@@ -227,6 +227,45 @@ void main() {
     });
 
     testWidgets(
+      'buffers success shown while authenticated when root navigator is '
+      'unavailable, then replays it once the context appears',
+      (tester) async {
+        stubPublishBloc(const BackgroundPublishState());
+        when(() => authService.isAuthenticated).thenReturn(true);
+
+        await tester.pumpWidget(
+          _buildHarness(
+            publishBloc: publishBloc,
+            authService: authService,
+            wireRootNavigatorKey: false,
+          ),
+        );
+
+        // Success arrives while authenticated, but the root navigator
+        // context is unavailable — the snackbar cannot be shown yet.
+        publishStream.add(_succeededState('draft-authed-no-root'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(tester.takeException(), isNull);
+        expect(find.text(l10n.uploadPublishedCountMessage(1)), findsNothing);
+
+        // Root navigator context appears; the buffered success replays on
+        // the next state emission.
+        await tester.pumpWidget(
+          _buildHarness(publishBloc: publishBloc, authService: authService),
+        );
+        publishStream.add(const BackgroundPublishState());
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+
+        expect(tester.takeException(), isNull);
+        expect(find.text(l10n.uploadPublishedCountMessage(1)), findsOneWidget);
+      },
+    );
+
+    testWidgets(
       'does not throw or show snackbar when root navigator is unavailable',
       (tester) async {
         stubPublishBloc(const BackgroundPublishState());

--- a/mobile/test/widgets/upload_failure_listener_test.dart
+++ b/mobile/test/widgets/upload_failure_listener_test.dart
@@ -43,9 +43,9 @@ class _FakeDraft extends Fake implements DivineVideoDraft {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// Builds a minimal harness that wraps [UploadFailureListener] inside a
-/// [ProviderScope] (with [authServiceProvider] overridden) and a
-/// [BlocProvider] for [BackgroundPublishBloc].
+/// Builds a minimal harness matching production topology: [UploadFailureListener]
+/// wraps [MaterialApp], while [ProviderScope] and [BlocProvider] remain above
+/// the listener.
 ///
 /// The [MaterialApp] is keyed to [NavigatorKeys.root] so that
 /// [_showPublishSuccessSnackbar] can resolve its [ScaffoldMessenger] via
@@ -53,19 +53,21 @@ class _FakeDraft extends Fake implements DivineVideoDraft {
 Widget _buildHarness({
   required _MockBackgroundPublishBloc publishBloc,
   required _MockAuthService authService,
+  bool wireRootNavigatorKey = true,
 }) {
   return ProviderScope(
     overrides: [authServiceProvider.overrideWithValue(authService)],
-    child: MaterialApp(
-      // Wire the real NavigatorKeys.root so the snackbar helper can find the
-      // ScaffoldMessenger ancestor from NavigatorKeys.root.currentContext.
-      navigatorKey: NavigatorKeys.root,
-      localizationsDelegates: AppLocalizations.localizationsDelegates,
-      supportedLocales: AppLocalizations.supportedLocales,
-      home: BlocProvider<BackgroundPublishBloc>.value(
-        value: publishBloc,
-        child: const app.UploadFailureListener(
-          child: Scaffold(body: SizedBox.shrink()),
+    child: BlocProvider<BackgroundPublishBloc>.value(
+      value: publishBloc,
+      child: app.UploadFailureListener(
+        child: MaterialApp(
+          // Wire the real NavigatorKeys.root so the snackbar helper can find
+          // the ScaffoldMessenger and Localizations ancestors from
+          // NavigatorKeys.root.currentContext.
+          navigatorKey: wireRootNavigatorKey ? NavigatorKeys.root : null,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const Scaffold(body: SizedBox.shrink()),
         ),
       ),
     ),
@@ -73,17 +75,15 @@ Widget _buildHarness({
 }
 
 /// Creates a [BackgroundUpload] with result == null (in-progress).
-BackgroundUpload _inProgress(String id) => BackgroundUpload(
-  draft: _FakeDraft(id),
-  result: null,
-  progress: 0.5,
-);
+BackgroundUpload _inProgress(String id) =>
+    BackgroundUpload(draft: _FakeDraft(id), result: null, progress: 0.5);
 
-/// A [BackgroundPublishState] that carries a success signal for [id], with no
-/// remaining uploads — mirrors what the bloc emits on [PublishSuccess].
-BackgroundPublishState _succeededState(String id) => BackgroundPublishState(
-  recentlySucceededIds: {id},
-);
+/// A [BackgroundPublishState] that carries success signals, with no remaining
+/// uploads — mirrors what the bloc emits on [PublishSuccess].
+BackgroundPublishState _succeededState(String id, [String? secondId]) =>
+    BackgroundPublishState(
+      recentlySucceededIds: {id, ?secondId},
+    );
 
 /// A [BackgroundPublishState] where upload [id] disappeared without a success
 /// signal — mirrors what the bloc emits on [BackgroundPublishVanished].
@@ -130,13 +130,30 @@ void main() {
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 50));
 
+        expect(tester.takeException(), isNull);
         final l10n = lookupAppLocalizations(const Locale('en'));
-        expect(
-          find.text(l10n.uploadPublishedCountMessage(1)),
-          findsOneWidget,
-        );
+        expect(find.text(l10n.uploadPublishedCountMessage(1)), findsOneWidget);
       },
     );
+
+    testWidgets('shows plural snackbar when multiple uploads succeed', (
+      tester,
+    ) async {
+      stubPublishBloc(const BackgroundPublishState());
+      when(() => authService.isAuthenticated).thenReturn(true);
+
+      await tester.pumpWidget(
+        _buildHarness(publishBloc: publishBloc, authService: authService),
+      );
+
+      publishStream.add(_succeededState('draft-1', 'draft-2'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(tester.takeException(), isNull);
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      expect(find.text(l10n.uploadPublishedCountMessage(2)), findsOneWidget);
+    });
 
     testWidgets(
       'buffers success while unauthenticated then flushes on re-auth',
@@ -163,13 +180,98 @@ void main() {
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 50));
 
+        expect(tester.takeException(), isNull);
         // Buffered success must now be flushed.
-        expect(
-          find.text(l10n.uploadPublishedCountMessage(1)),
-          findsOneWidget,
-        );
+        expect(find.text(l10n.uploadPublishedCountMessage(1)), findsOneWidget);
       },
     );
+
+    testWidgets('keeps buffered success when root navigator is unavailable', (
+      tester,
+    ) async {
+      stubPublishBloc(const BackgroundPublishState());
+      when(() => authService.isAuthenticated).thenReturn(false);
+
+      await tester.pumpWidget(
+        _buildHarness(
+          publishBloc: publishBloc,
+          authService: authService,
+          wireRootNavigatorKey: false,
+        ),
+      );
+
+      publishStream.add(_succeededState('draft-buffered'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      expect(find.text(l10n.uploadPublishedCountMessage(1)), findsNothing);
+
+      when(() => authService.isAuthenticated).thenReturn(true);
+      publishStream.add(const BackgroundPublishState());
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(tester.takeException(), isNull);
+      expect(find.text(l10n.uploadPublishedCountMessage(1)), findsNothing);
+
+      await tester.pumpWidget(
+        _buildHarness(publishBloc: publishBloc, authService: authService),
+      );
+      publishStream.add(const BackgroundPublishState());
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(tester.takeException(), isNull);
+      expect(find.text(l10n.uploadPublishedCountMessage(1)), findsOneWidget);
+    });
+
+    testWidgets(
+      'does not throw or show snackbar when root navigator is unavailable',
+      (tester) async {
+        stubPublishBloc(const BackgroundPublishState());
+        when(() => authService.isAuthenticated).thenReturn(true);
+
+        await tester.pumpWidget(
+          _buildHarness(
+            publishBloc: publishBloc,
+            authService: authService,
+            wireRootNavigatorKey: false,
+          ),
+        );
+
+        publishStream.add(_succeededState('draft-no-root'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(tester.takeException(), isNull);
+        expect(find.text(l10n.uploadPublishedCountMessage(1)), findsNothing);
+      },
+    );
+
+    testWidgets('does not duplicate snackbar for replayed success state', (
+      tester,
+    ) async {
+      stubPublishBloc(const BackgroundPublishState());
+      when(() => authService.isAuthenticated).thenReturn(true);
+
+      await tester.pumpWidget(
+        _buildHarness(publishBloc: publishBloc, authService: authService),
+      );
+
+      final succeeded = _succeededState('draft-replayed');
+      publishStream.add(succeeded);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+      publishStream.add(succeeded);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(tester.takeException(), isNull);
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      expect(find.text(l10n.uploadPublishedCountMessage(1)), findsOneWidget);
+    });
 
     testWidgets(
       'does not show snackbar when upload vanishes via BackgroundPublishVanished',
@@ -192,6 +294,7 @@ void main() {
 
         // No snackbar must appear for a vanished upload.
         final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(tester.takeException(), isNull);
         expect(find.text(l10n.uploadPublishedCountMessage(1)), findsNothing);
         expect(find.text(l10n.uploadPublishedCountMessage(2)), findsNothing);
       },


### PR DESCRIPTION
## Summary
- resolve background publish success snackbar localization from the mounted root navigator context instead of the pre-MaterialApp listener context
- keep buffered publish success counts until the snackbar is actually shown
- update UploadFailureListener widget tests to mirror production topology and cover singular, plural, missing navigator, buffered flush, replay suppression, and vanished-upload suppression
- fix the CI timing-budget test so its committed-budget coverage check honors the guard's existing matrix-job prefix matching

Closes #6114

## Verification
- flutter test test/widgets/upload_failure_listener_test.dart
- flutter test test/tools/check_ci_timing_budget_test.dart
- flutter analyze lib/main.dart test/widgets/upload_failure_listener_test.dart test/tools/check_ci_timing_budget_test.dart
- flutter analyze lib test integration_test
- pre-push checks: analyzer plus changed-file tests