### PR TITLE
fix(profile): avoid disposed refs in profile streams

### DIFF
--- a/.github/ci-timing-budgets.json
+++ b/.github/ci-timing-budgets.json
@@ -3,11 +3,10 @@
     "Wall-clock budgets for Mobile CI jobs, in seconds. Enforced by the",
     "'Check CI timing budget' step in the mobile-ci gate job.",
     "",
-    "Keys must cover each mobile-ci gate job name exactly. Runtime matching",
-    "also treats a key as a matrix-job prefix, but the committed file stays",
-    "pinned to the workflow's declared names so job renames are reviewed.",
-    "A budgeted job that did not run (skipped, or renamed) is reported and",
-    "skipped, never inferred as a pass. A job with no budget entry is ignored.",
+    "Keys match a job name exactly, or as a prefix — 'Tests' covers both",
+    "'Tests' and a future 'Tests (shard N/4)'. A budgeted job that did not",
+    "run (skipped, or renamed) is reported and skipped, never inferred as a",
+    "pass. A job with no budget entry is ignored.",
     "",
     "warn  - exceeded => GitHub warning annotation on the PR. Set near the",
     "        job's observed p90 so ordinary drift surfaces early.",
@@ -24,10 +23,7 @@
   ],
   "jobs": {
     "Detect App CI Scope": { "warn": 40, "fail": 90 },
-    "Tests (shard ${{ strategy.job-index }}/${{ strategy.job-total }})": {
-      "warn": 600,
-      "fail": 780
-    },
+    "Tests": { "warn": 600, "fail": 780 },
     "Generated Files": { "warn": 260, "fail": 420 },
     "Analyze": { "warn": 150, "fail": 300 },
     "Format": { "warn": 90, "fail": 180 },

--- a/.github/ci-timing-budgets.json
+++ b/.github/ci-timing-budgets.json
@@ -3,10 +3,11 @@
     "Wall-clock budgets for Mobile CI jobs, in seconds. Enforced by the",
     "'Check CI timing budget' step in the mobile-ci gate job.",
     "",
-    "Keys match a job name exactly, or as a prefix — 'Tests' covers both",
-    "'Tests' and a future 'Tests (shard N/4)'. A budgeted job that did not",
-    "run (skipped, or renamed) is reported and skipped, never inferred as a",
-    "pass. A job with no budget entry is ignored.",
+    "Keys must cover each mobile-ci gate job name exactly. Runtime matching",
+    "also treats a key as a matrix-job prefix, but the committed file stays",
+    "pinned to the workflow's declared names so job renames are reviewed.",
+    "A budgeted job that did not run (skipped, or renamed) is reported and",
+    "skipped, never inferred as a pass. A job with no budget entry is ignored.",
     "",
     "warn  - exceeded => GitHub warning annotation on the PR. Set near the",
     "        job's observed p90 so ordinary drift surfaces early.",
@@ -23,7 +24,10 @@
   ],
   "jobs": {
     "Detect App CI Scope": { "warn": 40, "fail": 90 },
-    "Tests": { "warn": 600, "fail": 780 },
+    "Tests (shard ${{ strategy.job-index }}/${{ strategy.job-total }})": {
+      "warn": 600,
+      "fail": 780
+    },
     "Generated Files": { "warn": 260, "fail": 420 },
     "Analyze": { "warn": 150, "fail": 300 },
     "Format": { "warn": 90, "fail": 180 },

--- a/mobile/lib/providers/user_profile_providers.dart
+++ b/mobile/lib/providers/user_profile_providers.dart
@@ -6,32 +6,38 @@ import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:models/models.dart';
 import 'package:openvine/providers/repository_providers.dart';
+import 'package:profile_repository/profile_repository.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'user_profile_providers.g.dart';
 
 // ignore: specify_nonobvious_property_types
 final userProfileStatsReactiveProvider =
-    StreamProvider.family<ProfileStats?, String>((ref, pubkey) async* {
+    StreamProvider.family<ProfileStats?, String>((ref, pubkey) {
       // Counts come from a public funnelcake REST call + Drift; they need only
       // an identity-known session, not the full nostrReady relay-connect settle.
       // Using the identity-known-gated stats repo lets counts render as soon as
       // REST returns instead of stalling on "—" until relays connect (#5863).
       final repo = ref.watch(profileStatsRepositoryProvider);
       if (repo == null) {
-        return;
+        return const Stream<ProfileStats?>.empty();
       }
 
-      unawaited(
-        repo
-            .fetchFreshProfile(pubkey: pubkey)
-            .catchError((Object _, StackTrace _) => null),
-      );
-
-      await for (final stats in repo.watchProfileStats(pubkey: pubkey)) {
-        yield stats;
-      }
+      return _watchProfileStats(repo, pubkey);
     });
+
+Stream<ProfileStats?> _watchProfileStats(
+  ProfileRepository repo,
+  String pubkey,
+) async* {
+  unawaited(
+    repo
+        .fetchFreshProfile(pubkey: pubkey)
+        .catchError((Object _, StackTrace _) => null),
+  );
+
+  yield* repo.watchProfileStats(pubkey: pubkey);
+}
 
 /// Reactive profile provider backed by Drift's watchProfile stream.
 ///
@@ -43,10 +49,19 @@ final userProfileStatsReactiveProvider =
 /// Consumers get `AsyncValue<UserProfile?>` — same API as the old
 /// FutureProvider, so widget code changes are minimal.
 @riverpod
-Stream<UserProfile?> userProfileReactive(Ref ref, String pubkey) async* {
+Stream<UserProfile?> userProfileReactive(Ref ref, String pubkey) {
   final repo = ref.watch(profileRepositoryProvider);
-  if (repo == null) return;
+  if (repo == null) {
+    return const Stream<UserProfile?>.empty();
+  }
 
+  return _watchUserProfile(repo, pubkey);
+}
+
+Stream<UserProfile?> _watchUserProfile(
+  ProfileRepository repo,
+  String pubkey,
+) async* {
   // Kick off a background fetch if nothing is cached yet.
   final cached = await repo.getCachedProfile(pubkey: pubkey);
   if (cached == null) {

--- a/mobile/lib/providers/user_profile_providers.g.dart
+++ b/mobile/lib/providers/user_profile_providers.g.dart
@@ -93,7 +93,7 @@ final class UserProfileReactiveProvider
 }
 
 String _$userProfileReactiveHash() =>
-    r'b0df16fa99256495c86d9dc1980ac7312d71a6bd';
+    r'f0c15277edfd883bf7d28cb94b19822f01f94934';
 
 /// Reactive profile provider backed by Drift's watchProfile stream.
 ///

--- a/mobile/test/providers/user_profile_providers_test.dart
+++ b/mobile/test/providers/user_profile_providers_test.dart
@@ -4,6 +4,7 @@
 import 'dart:async';
 
 import 'package:db_client/db_client.dart' hide ProfileStats;
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:funnelcake_api_client/funnelcake_api_client.dart';
@@ -47,6 +48,203 @@ void main() {
   const pubkey =
       'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 
+  group('userProfileReactiveProvider', () {
+    late _MockProfileRepository profileRepository;
+    late ProviderContainer container;
+
+    setUp(() {
+      profileRepository = _MockProfileRepository();
+      container = ProviderContainer(
+        overrides: [
+          profileRepositoryProvider.overrideWithValue(profileRepository),
+        ],
+      );
+      addTearDown(container.dispose);
+    });
+
+    test(
+      'does not touch a disposed Ref after immediate invalidation',
+      () async {
+        when(
+          () => profileRepository.getCachedProfile(pubkey: pubkey),
+        ).thenAnswer((_) async => null);
+        when(
+          () => profileRepository.fetchFreshProfile(pubkey: pubkey),
+        ).thenAnswer((_) async => null);
+        when(
+          () => profileRepository.watchProfile(pubkey: pubkey),
+        ).thenAnswer((_) => const Stream<UserProfile?>.empty());
+
+        final uncaughtErrors = await _captureUncaughtErrors(() async {
+          final sub = container.listen(
+            userProfileReactiveProvider(pubkey),
+            (_, _) {},
+            fireImmediately: true,
+          );
+
+          container.invalidate(userProfileReactiveProvider(pubkey));
+          sub.close();
+          await Future<void>.delayed(Duration.zero);
+        });
+
+        expect(uncaughtErrors, isEmpty);
+      },
+    );
+
+    test('emits cached stream value before live updates', () async {
+      final liveController = StreamController<UserProfile?>();
+      addTearDown(liveController.close);
+      final cachedProfile = _profile(pubkey, name: 'cached');
+      final liveProfile = _profile(pubkey, name: 'live');
+
+      when(
+        () => profileRepository.getCachedProfile(pubkey: pubkey),
+      ).thenAnswer((_) async => cachedProfile);
+      when(
+        () => profileRepository.watchProfile(pubkey: pubkey),
+      ).thenAnswer((_) => liveController.stream);
+
+      final emitted = <AsyncValue<UserProfile?>>[];
+      final sub = container.listen(
+        userProfileReactiveProvider(pubkey),
+        (_, next) => emitted.add(next),
+        fireImmediately: true,
+      );
+      addTearDown(sub.close);
+
+      await untilCalled(
+        () => profileRepository.watchProfile(pubkey: pubkey),
+      );
+      await Future<void>.delayed(Duration.zero);
+      liveController.add(cachedProfile);
+      await Future<void>.delayed(Duration.zero);
+      liveController.add(liveProfile);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(emitted.where((value) => value.hasValue).map((v) => v.value), [
+        cachedProfile,
+        liveProfile,
+      ]);
+      verifyNever(() => profileRepository.fetchFreshProfile(pubkey: pubkey));
+    });
+
+    test('fetches fresh profile once when cache is empty', () async {
+      final liveController = StreamController<UserProfile?>();
+      addTearDown(liveController.close);
+
+      when(
+        () => profileRepository.getCachedProfile(pubkey: pubkey),
+      ).thenAnswer((_) async => null);
+      when(
+        () => profileRepository.fetchFreshProfile(pubkey: pubkey),
+      ).thenAnswer((_) async => null);
+      when(
+        () => profileRepository.watchProfile(pubkey: pubkey),
+      ).thenAnswer((_) => liveController.stream);
+
+      final sub = container.listen(
+        userProfileReactiveProvider(pubkey),
+        (_, _) {},
+        fireImmediately: true,
+      );
+      addTearDown(sub.close);
+
+      await Future<void>.delayed(Duration.zero);
+
+      verify(
+        () => profileRepository.fetchFreshProfile(pubkey: pubkey),
+      ).called(1);
+    });
+
+    test('cancels the underlying profile stream when disposed', () async {
+      var wasCancelled = false;
+      final liveController = StreamController<UserProfile?>(
+        onCancel: () {
+          wasCancelled = true;
+        },
+      );
+      addTearDown(liveController.close);
+
+      when(
+        () => profileRepository.getCachedProfile(pubkey: pubkey),
+      ).thenAnswer((_) async => _profile(pubkey));
+      when(
+        () => profileRepository.watchProfile(pubkey: pubkey),
+      ).thenAnswer((_) => liveController.stream);
+
+      final sub = container.listen(
+        userProfileReactiveProvider(pubkey),
+        (_, _) {},
+        fireImmediately: true,
+      );
+
+      await Future<void>.delayed(Duration.zero);
+      sub.close();
+      container.invalidate(userProfileReactiveProvider(pubkey));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(wasCancelled, isTrue);
+    });
+
+    test('completes safely when profile repository is unavailable', () async {
+      final emptyContainer = ProviderContainer(
+        overrides: [
+          profileRepositoryProvider.overrideWithValue(null),
+        ],
+      );
+      addTearDown(emptyContainer.dispose);
+
+      final emitted = <AsyncValue<UserProfile?>>[];
+      final sub = emptyContainer.listen(
+        userProfileReactiveProvider(pubkey),
+        (_, next) => emitted.add(next),
+        fireImmediately: true,
+      );
+      addTearDown(sub.close);
+
+      await Future<void>.delayed(Duration.zero);
+
+      expect(emitted, isNotEmpty);
+      expect(emitted.last, isA<AsyncLoading<UserProfile?>>());
+    });
+  });
+
+  group('userProfileStatsReactiveProvider lifecycle', () {
+    test(
+      'does not touch a disposed Ref after immediate invalidation',
+      () async {
+        final profileRepository = _MockProfileRepository();
+        final container = ProviderContainer(
+          overrides: [
+            profileStatsRepositoryProvider.overrideWithValue(profileRepository),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        when(
+          () => profileRepository.fetchFreshProfile(pubkey: pubkey),
+        ).thenAnswer((_) async => null);
+        when(
+          () => profileRepository.watchProfileStats(pubkey: pubkey),
+        ).thenAnswer((_) => const Stream<ProfileStats?>.empty());
+
+        final uncaughtErrors = await _captureUncaughtErrors(() async {
+          final sub = container.listen(
+            userProfileStatsReactiveProvider(pubkey),
+            (_, _) {},
+            fireImmediately: true,
+          );
+
+          container.invalidate(userProfileStatsReactiveProvider(pubkey));
+          sub.close();
+          await Future<void>.delayed(Duration.zero);
+        });
+
+        expect(uncaughtErrors, isEmpty);
+      },
+    );
+  });
+
   group('userProfileStatsReactiveProvider', () {
     late _MockProfileRepository profileRepository;
     late StreamController<ProfileStats?> statsController;
@@ -79,7 +277,6 @@ void main() {
         (_, next) => emitted.add(next),
         fireImmediately: true,
       );
-      addTearDown(sub.close);
 
       await Future<void>.delayed(Duration.zero);
 
@@ -101,6 +298,10 @@ void main() {
       await Future<void>.delayed(Duration.zero);
 
       expect(emitted.last.value, stats);
+      sub.close();
+      container.invalidate(userProfileStatsReactiveProvider(pubkey));
+      await Future<void>.delayed(Duration.zero);
+      await statsController.close();
     });
 
     test(
@@ -143,7 +344,6 @@ void main() {
           (_, _) {},
           fireImmediately: true,
         );
-        addTearDown(sub.close);
 
         await Future<void>.delayed(Duration.zero);
         expect(fetchCount, 1);
@@ -159,6 +359,10 @@ void main() {
         await Future<void>.delayed(Duration.zero);
 
         expect(fetchCount, 1);
+        sub.close();
+        streamContainer.invalidate(userProfileStatsReactiveProvider(pubkey));
+        await Future<void>.delayed(Duration.zero);
+        await statsController.close();
       },
     );
   });
@@ -253,4 +457,42 @@ void main() {
       },
     );
   });
+}
+
+UserProfile _profile(String pubkey, {String name = 'profile'}) {
+  final eventId = switch (name) {
+    'cached' =>
+      'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+    'live' =>
+      'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+    _ => 'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
+  };
+
+  return UserProfile(
+    pubkey: pubkey,
+    name: name,
+    rawData: {'name': name},
+    createdAt: DateTime.utc(2026),
+    eventId: eventId,
+  );
+}
+
+Future<List<Object>> _captureUncaughtErrors(
+  Future<void> Function() body,
+) async {
+  final errors = <Object>[];
+  final previousFlutterError = FlutterError.onError;
+  FlutterError.onError = (details) {
+    errors.add(details.exception);
+  };
+
+  try {
+    await runZonedGuarded(body, (error, _) {
+      errors.add(error);
+    });
+  } finally {
+    FlutterError.onError = previousFlutterError;
+  }
+
+  return errors;
 }


### PR DESCRIPTION
Closes #6274

## Summary
- Capture profile repositories synchronously before returning profile/stat streams so deferred stream bodies never read disposed refs.
- Move profile/stat async stream work into Ref-free helpers while preserving null-repo empty-stream behavior and background fetch behavior.
- Add regression tests for immediate invalidation/disposal plus profile stream, fetch, cancellation, and null-repo behavior.

## Verification
- flutter test test/providers/user_profile_providers_test.dart
- flutter analyze lib test
- flutter test test/widgets/settings_screen_test.dart test/widgets/video_feed_item/video_overlay_actions_description_test.dart test/widgets/video_feed_item/video_author_info_section_test.dart test/widgets/video_metadata/video_metadata_collaborators_input_test.dart test/widgets/profile/profile_header_widget_test.dart
- push hook: analysis, generated-file verification, changed-file tests