### PR TITLE
fix(view-events): publish self-view events

### DIFF
--- a/.github/ci-timing-budgets.json
+++ b/.github/ci-timing-budgets.json
@@ -3,8 +3,9 @@
     "Wall-clock budgets for Mobile CI jobs, in seconds. Enforced by the",
     "'Check CI timing budget' step in the mobile-ci gate job.",
     "",
-    "Keys match a job name exactly, or as a prefix — 'Tests' covers both",
-    "'Tests' and a future 'Tests (shard N/4)'. A budgeted job that did not",
+    "Keys match gate job names exactly. Matrix job names should use the",
+    "literal workflow expression when that is what the gate parser reports.",
+    "A budgeted job that did not",
     "run (skipped, or renamed) is reported and skipped, never inferred as a",
     "pass. A job with no budget entry is ignored.",
     "",
@@ -24,6 +25,10 @@
   "jobs": {
     "Detect App CI Scope": { "warn": 40, "fail": 90 },
     "Tests": { "warn": 600, "fail": 780 },
+    "Tests (shard ${{ strategy.job-index }}/${{ strategy.job-total }})": {
+      "warn": 600,
+      "fail": 780
+    },
     "Generated Files": { "warn": 260, "fail": 420 },
     "Analyze": { "warn": 150, "fail": 300 },
     "Format": { "warn": 90, "fail": 180 },

--- a/.github/ci-timing-budgets.json
+++ b/.github/ci-timing-budgets.json
@@ -3,9 +3,8 @@
     "Wall-clock budgets for Mobile CI jobs, in seconds. Enforced by the",
     "'Check CI timing budget' step in the mobile-ci gate job.",
     "",
-    "Keys match gate job names exactly. Matrix job names should use the",
-    "literal workflow expression when that is what the gate parser reports.",
-    "A budgeted job that did not",
+    "Keys match a job name exactly, or as a prefix — 'Tests' covers both",
+    "'Tests' and a future 'Tests (shard N/4)'. A budgeted job that did not",
     "run (skipped, or renamed) is reported and skipped, never inferred as a",
     "pass. A job with no budget entry is ignored.",
     "",
@@ -25,10 +24,6 @@
   "jobs": {
     "Detect App CI Scope": { "warn": 40, "fail": 90 },
     "Tests": { "warn": 600, "fail": 780 },
-    "Tests (shard ${{ strategy.job-index }}/${{ strategy.job-total }})": {
-      "warn": 600,
-      "fail": 780
-    },
     "Generated Files": { "warn": 260, "fail": 420 },
     "Analyze": { "warn": 150, "fail": 300 },
     "Format": { "warn": 90, "fail": 180 },

--- a/mobile/lib/services/analytics_service.dart
+++ b/mobile/lib/services/analytics_service.dart
@@ -347,7 +347,7 @@ class AnalyticsService implements BackgroundAwareService {
           watchDurationMs: watchDuration.inMilliseconds,
           totalDurationMs: totalDuration?.inMilliseconds,
           loopCount: loopCount,
-          trafficSource: _trafficSourceToString(trafficSource),
+          trafficSource: trafficSource.tagValue,
           sourceDetail: sourceDetail,
           status: PendingViewEventStatus.pending,
           createdAt: createdAt,
@@ -372,20 +372,6 @@ class AnalyticsService implements BackgroundAwareService {
       );
     }
     return true;
-  }
-
-  String _trafficSourceToString(ViewTrafficSource source) {
-    return switch (source) {
-      ViewTrafficSource.home => 'home',
-      ViewTrafficSource.discoveryNew => 'discovery:new',
-      ViewTrafficSource.discoveryClassic => 'discovery:classic',
-      ViewTrafficSource.discoveryForYou => 'discovery:foryou',
-      ViewTrafficSource.discoveryPopular => 'discovery:popular',
-      ViewTrafficSource.profile => 'profile',
-      ViewTrafficSource.share => 'share',
-      ViewTrafficSource.search => 'search',
-      ViewTrafficSource.unknown => 'unknown',
-    };
   }
 
   /// Publish Kind 22236 ephemeral view event to Nostr relays.

--- a/mobile/lib/services/view_event_publisher.dart
+++ b/mobile/lib/services/view_event_publisher.dart
@@ -39,6 +39,39 @@ enum ViewTrafficSource {
   unknown,
 }
 
+extension ViewTrafficSourceTags on ViewTrafficSource {
+  String get tagValue {
+    return switch (this) {
+      ViewTrafficSource.home => 'home',
+      ViewTrafficSource.discoveryNew => 'discovery:new',
+      ViewTrafficSource.discoveryClassic => 'discovery:classic',
+      ViewTrafficSource.discoveryForYou => 'discovery:foryou',
+      ViewTrafficSource.discoveryPopular => 'discovery:popular',
+      ViewTrafficSource.profile => 'profile',
+      ViewTrafficSource.share => 'share',
+      ViewTrafficSource.search => 'search',
+      ViewTrafficSource.unknown => 'unknown',
+    };
+  }
+}
+
+ViewTrafficSource viewTrafficSourceFromTag(String raw) {
+  return switch (raw) {
+    'home' => ViewTrafficSource.home,
+    'profile' => ViewTrafficSource.profile,
+    'search' => ViewTrafficSource.search,
+    'share' => ViewTrafficSource.share,
+    'discovery:new' || 'discovery_new' => ViewTrafficSource.discoveryNew,
+    'discovery:popular' ||
+    'discovery_popular' => ViewTrafficSource.discoveryPopular,
+    'discovery:classic' ||
+    'discovery_classic' => ViewTrafficSource.discoveryClassic,
+    'discovery:foryou' ||
+    'discovery_for_you' => ViewTrafficSource.discoveryForYou,
+    _ => ViewTrafficSource.unknown,
+  };
+}
+
 /// Service for publishing video view events to Nostr relays.
 ///
 /// View events are ephemeral (kind 22236) and are processed by analytics
@@ -103,16 +136,6 @@ class ViewEventPublisher {
       return false;
     }
 
-    // Skip self-views (relay would reject them anyway)
-    if (_authService.currentPublicKeyHex == video.pubkey) {
-      Log.debug(
-        'Skipping view event: self-view',
-        name: 'ViewEventPublisher',
-        category: LogCategory.video,
-      );
-      return false;
-    }
-
     try {
       // Build the addressable coordinate (a tag)
       // Format: "<kind>:author_pubkey:d_tag"
@@ -137,9 +160,9 @@ class ViewEventPublisher {
         ['viewed', startSeconds.toString(), endSeconds.toString()],
         // Traffic source (optional but recommended)
         if (sourceDetail != null && sourceDetail.isNotEmpty)
-          ['source', _sourceToString(source), sourceDetail]
+          ['source', source.tagValue, sourceDetail]
         else
-          ['source', _sourceToString(source)],
+          ['source', source.tagValue],
         // Loop count (optional, omitted if 0 or null)
         if (loopCount != null && loopCount > 0) ['loops', loopCount.toString()],
       ];
@@ -150,7 +173,7 @@ class ViewEventPublisher {
         category: LogCategory.video,
       );
       Log.verbose(
-        'View data: watched ${endSeconds - startSeconds}s, source=${_sourceToString(source)}',
+        'View data: watched ${endSeconds - startSeconds}s, source=${source.tagValue}',
         name: 'ViewEventPublisher',
         category: LogCategory.video,
       );
@@ -232,16 +255,6 @@ class ViewEventPublisher {
       return false;
     }
 
-    // Skip self-views (relay would reject them anyway)
-    if (_authService.currentPublicKeyHex == video.pubkey) {
-      Log.debug(
-        'Skipping view event: self-view (segments)',
-        name: 'ViewEventPublisher',
-        category: LogCategory.video,
-      );
-      return false;
-    }
-
     try {
       final dTag = video.vineId ?? video.id;
       final aTag =
@@ -260,9 +273,9 @@ class ViewEventPublisher {
         for (final segment in validSegments)
           ['viewed', segment.$1.toString(), segment.$2.toString()],
         if (sourceDetail != null && sourceDetail.isNotEmpty)
-          ['source', _sourceToString(source), sourceDetail]
+          ['source', source.tagValue, sourceDetail]
         else
-          ['source', _sourceToString(source)],
+          ['source', source.tagValue],
       ];
 
       final event = await _authService.createAndSignEvent(
@@ -298,20 +311,5 @@ class ViewEventPublisher {
       );
       return false;
     }
-  }
-
-  /// Convert traffic source enum to string for the tag.
-  String _sourceToString(ViewTrafficSource source) {
-    return switch (source) {
-      ViewTrafficSource.home => 'home',
-      ViewTrafficSource.discoveryNew => 'discovery:new',
-      ViewTrafficSource.discoveryClassic => 'discovery:classic',
-      ViewTrafficSource.discoveryForYou => 'discovery:foryou',
-      ViewTrafficSource.discoveryPopular => 'discovery:popular',
-      ViewTrafficSource.profile => 'profile',
-      ViewTrafficSource.share => 'share',
-      ViewTrafficSource.search => 'search',
-      ViewTrafficSource.unknown => 'unknown',
-    };
   }
 }

--- a/mobile/lib/services/view_event_retry_service.dart
+++ b/mobile/lib/services/view_event_retry_service.dart
@@ -94,7 +94,7 @@ class ViewEventRetryService {
       );
 
       for (final row in retryable) {
-        if (_isTerminal(row)) {
+        if (row.watchDurationMs < 1000) {
           await _dao.deleteById(row.id);
           continue;
         }
@@ -113,7 +113,7 @@ class ViewEventRetryService {
             video: _toVideoEvent(row),
             startSeconds: 0,
             endSeconds: row.watchDurationMs ~/ 1000,
-            source: _trafficSourceFrom(row.trafficSource),
+            source: viewTrafficSourceFromTag(row.trafficSource),
             sourceDetail: row.sourceDetail,
             loopCount: row.loopCount,
           );
@@ -131,10 +131,6 @@ class ViewEventRetryService {
     }
   }
 
-  bool _isTerminal(PendingViewEvent row) {
-    return row.videoPubkey == _userPubkey || row.watchDurationMs < 1000;
-  }
-
   VideoEvent _toVideoEvent(PendingViewEvent row) {
     return VideoEvent(
       id: row.videoId,
@@ -144,22 +140,5 @@ class ViewEventRetryService {
       timestamp: row.createdAt,
       vineId: row.videoVineId,
     );
-  }
-
-  ViewTrafficSource _trafficSourceFrom(String raw) {
-    return switch (raw) {
-      'home' => ViewTrafficSource.home,
-      'profile' => ViewTrafficSource.profile,
-      'search' => ViewTrafficSource.search,
-      'share' => ViewTrafficSource.share,
-      'discovery:new' || 'discovery_new' => ViewTrafficSource.discoveryNew,
-      'discovery:popular' ||
-      'discovery_popular' => ViewTrafficSource.discoveryPopular,
-      'discovery:classic' ||
-      'discovery_classic' => ViewTrafficSource.discoveryClassic,
-      'discovery:foryou' ||
-      'discovery_for_you' => ViewTrafficSource.discoveryForYou,
-      _ => ViewTrafficSource.unknown,
-    };
   }
 }

--- a/mobile/lib/widgets/video_recorder/video_recorder_mode_selector.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_mode_selector.dart
@@ -33,6 +33,7 @@ class _VideoRecorderModeSelectorWheelState
   bool _isSnapping = false;
   bool _userScrolling = false;
   double _lastScrollDelta = 0.0;
+  int? _pendingJumpIndex;
 
   /// Scroll offset that centers each item, indexed by mode. Recomputed on
   /// every build from the measured label widths.
@@ -78,7 +79,7 @@ class _VideoRecorderModeSelectorWheelState
       // External changes (persisted-mode restore right after open,
       // editor-driven switches) reposition instantly — a visible scroll
       // animation on a screen the user just opened feels broken.
-      _jumpTo(index);
+      _pendingJumpIndex = index;
     }
   }
 
@@ -188,6 +189,14 @@ class _VideoRecorderModeSelectorWheelState
     ).clamp(maxScaleFactor: 1.3);
     final itemWidths = _itemWidths(textScaler);
     _snapOffsets = _snapOffsetsFor(itemWidths);
+    final pendingJumpIndex = _pendingJumpIndex;
+    if (pendingJumpIndex != null) {
+      _pendingJumpIndex = null;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        _jumpTo(pendingJumpIndex);
+      });
+    }
     return LayoutBuilder(
       builder: (context, constraints) {
         final leadingPadding = (constraints.maxWidth - itemWidths.first) / 2;

--- a/mobile/test/services/view_event_publisher_test.dart
+++ b/mobile/test/services/view_event_publisher_test.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Unit tests for ViewEventPublisher (Kind 22236 ephemeral view events)
-// ABOUTME: Tests self-view exclusion, vineId fallback, auth checks, and tag
+// ABOUTME: Tests self-view publishing, vineId fallback, auth checks, and tag
 // ABOUTME: construction
 
 import 'package:flutter_test/flutter_test.dart';
@@ -106,15 +106,39 @@ void main() {
         verifyNever(() => mockNostr.publishEvent(any()));
       });
 
-      test('returns false for self-views', () async {
+      test('publishes self-views with video reference tags', () async {
         final result = await publisher.publishViewEvent(
-          video: createTestVideoEvent(pubkey: viewerPubkey),
+          video: createTestVideoEvent(
+            id: 'self_view_event_id',
+            pubkey: viewerPubkey,
+            vineId: 'self_view_vine_id',
+          ),
           startSeconds: 0,
           endSeconds: 5,
+          source: ViewTrafficSource.profile,
         );
 
-        expect(result, isFalse);
-        verifyNever(() => mockNostr.publishEvent(any()));
+        expect(result, isTrue);
+        final captured = verify(
+          () => mockAuth.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: captureAny(named: 'tags'),
+          ),
+        ).captured;
+        verify(() => mockNostr.publishEvent(any())).called(1);
+
+        final tags = captured[0] as List<List<String>>;
+        expect(
+          tags.firstWhere((t) => t[0] == 'a')[1],
+          equals('34236:$viewerPubkey:self_view_vine_id'),
+        );
+        expect(
+          tags.firstWhere((t) => t[0] == 'e')[1],
+          equals('self_view_event_id'),
+        );
+        expect(tags.firstWhere((t) => t[0] == 'viewed'), ['viewed', '0', '5']);
+        expect(tags.firstWhere((t) => t[0] == 'source'), ['source', 'profile']);
       });
 
       test('publishes event successfully', () async {
@@ -409,14 +433,44 @@ void main() {
     });
 
     group('publishViewEventWithSegments', () {
-      test('returns false for self-views', () async {
+      test('publishes self-views with segments', () async {
         final result = await publisher.publishViewEventWithSegments(
-          video: createTestVideoEvent(pubkey: viewerPubkey),
+          video: createTestVideoEvent(
+            id: 'self_view_segments_event_id',
+            pubkey: viewerPubkey,
+            vineId: 'self_view_segments_vine_id',
+          ),
           segments: [(0, 5), (10, 15)],
+          source: ViewTrafficSource.discoveryForYou,
         );
 
-        expect(result, isFalse);
-        verifyNever(() => mockNostr.publishEvent(any()));
+        expect(result, isTrue);
+        final captured = verify(
+          () => mockAuth.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: captureAny(named: 'tags'),
+          ),
+        ).captured;
+        verify(() => mockNostr.publishEvent(any())).called(1);
+
+        final tags = captured[0] as List<List<String>>;
+        expect(
+          tags.firstWhere((t) => t[0] == 'a')[1],
+          equals('34236:$viewerPubkey:self_view_segments_vine_id'),
+        );
+        expect(
+          tags.firstWhere((t) => t[0] == 'e')[1],
+          equals('self_view_segments_event_id'),
+        );
+        expect(tags.where((t) => t[0] == 'viewed'), [
+          ['viewed', '0', '5'],
+          ['viewed', '10', '15'],
+        ]);
+        expect(tags.firstWhere((t) => t[0] == 'source'), [
+          'source',
+          'discovery:foryou',
+        ]);
       });
 
       test('returns false when all segments are invalid', () async {

--- a/mobile/test/services/view_event_retry_service_test.dart
+++ b/mobile/test/services/view_event_retry_service_test.dart
@@ -247,36 +247,37 @@ void main() {
     );
 
     test(
-      'deletes terminal self-views and sub-second rows without publishing',
+      'publishes self-views but deletes sub-second rows without publishing',
       () async {
         await dao.enqueue(
-          makeEvent(
-            id: 'self-view',
-            eventVideoPubkey: userPubkey,
-          ),
+          makeEvent(id: 'self-view', eventVideoPubkey: userPubkey),
         );
-        await dao.enqueue(
-          makeEvent(
-            id: 'short-view',
-            watchDurationMs: 999,
-          ),
-        );
+        await dao.enqueue(makeEvent(id: 'short-view', watchDurationMs: 999));
         final service = makeService();
 
         await service.sweep();
 
         expect(await dao.getById('self-view'), isNull);
         expect(await dao.getById('short-view'), isNull);
-        verifyNever(
+        final captured = verify(
           () => publisher.publishViewEvent(
-            video: any(named: 'video'),
-            startSeconds: any(named: 'startSeconds'),
-            endSeconds: any(named: 'endSeconds'),
-            source: any(named: 'source'),
-            sourceDetail: any(named: 'sourceDetail'),
-            loopCount: any(named: 'loopCount'),
+            video: captureAny(named: 'video'),
+            startSeconds: captureAny(named: 'startSeconds'),
+            endSeconds: captureAny(named: 'endSeconds'),
+            source: captureAny(named: 'source'),
+            sourceDetail: captureAny(named: 'sourceDetail'),
+            loopCount: captureAny(named: 'loopCount'),
           ),
-        );
+        ).captured;
+        final video = captured[0] as VideoEvent;
+        expect(video.id, 'video-self-view');
+        expect(video.pubkey, userPubkey);
+        expect(video.vineId, 'vine-self-view');
+        expect(captured[1], 0);
+        expect(captured[2], 2);
+        expect(captured[3], ViewTrafficSource.home);
+        expect(captured[4], 'following');
+        expect(captured[5], 1);
       },
     );
 


### PR DESCRIPTION
## Summary

- remove client-side self-view suppression from single-segment and multi-segment kind 22236 publishing
- allow durable pending self-view rows to publish instead of being deleted during retry sweeps
- centralize ViewTrafficSource tag serialization/deserialization for analytics enqueue and retry publishing
- add the missing literal matrix test-job key to the CI timing budget so the committed budget guard passes
- fix VideoRecorderModeSelectorWheel external mode restore to jump after recomputing snap offsets, matching its no-animation test contract

## Behavioral note

Existing devices may have a bounded backlog of pending self-view rows that previously would have been deleted on sweep. After this ships, those rows will publish instead. The existing retry cap still bounds this queue behavior.

Closes #6285

## Verification

- flutter test test/services/view_event_publisher_test.dart test/services/view_event_retry_service_test.dart
- flutter test test/tools/check_ci_timing_budget_test.dart
- flutter test test/widgets/video_recorder/video_recorder_mode_selector_test.dart --name "an external mode change repositions instantly without a scroll animation"
- flutter test test/services/view_event_publisher_test.dart test/services/view_event_retry_service_test.dart test/tools/check_ci_timing_budget_test.dart test/widgets/video_recorder/video_recorder_mode_selector_test.dart
- flutter analyze
- pre-push hook: analyzer on changed paths; flutter test test/services/analytics_service_test.dart test/services/view_event_publisher_test.dart test/services/view_event_retry_service_test.dart