### PR TITLE
fix(follow): self-heal invalid cached pubkeys

### DIFF
--- a/mobile/lib/widgets/profile/follow_from_profile_button.dart
+++ b/mobile/lib/widgets/profile/follow_from_profile_button.dart
@@ -147,16 +147,26 @@ class FollowFromProfileButtonView extends StatelessWidget {
       );
     }
 
-    return BlocSelector<MyFollowingBloc, MyFollowingState, bool>(
-      selector: (state) => state.isFollowing(pubkey),
-      builder: (context, isFollowing) {
-        if (isFollowing) {
-          return _FollowingButton(
-            onPressed: () => _showUnfollowConfirmation(context),
-          );
-        }
-        return _FollowButton(onPressed: () => _follow(context));
+    return BlocListener<MyFollowingBloc, MyFollowingState>(
+      listenWhen: (previous, current) =>
+          current.status == MyFollowingStatus.toggleFailure &&
+          previous.status != MyFollowingStatus.toggleFailure,
+      listener: (context, state) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(context.l10n.followersUpdateFollowFailed)),
+        );
       },
+      child: BlocSelector<MyFollowingBloc, MyFollowingState, bool>(
+        selector: (state) => state.isFollowing(pubkey),
+        builder: (context, isFollowing) {
+          if (isFollowing) {
+            return _FollowingButton(
+              onPressed: () => _showUnfollowConfirmation(context),
+            );
+          }
+          return _FollowButton(onPressed: () => _follow(context));
+        },
+      ),
     );
   }
 

--- a/mobile/packages/follow_repository/lib/src/follow_repository.dart
+++ b/mobile/packages/follow_repository/lib/src/follow_repository.dart
@@ -1567,11 +1567,17 @@ class FollowRepository {
 
         if (cached != null) {
           final decoded = jsonDecode(cached) as List<dynamic>;
-          _followingPubkeys = _sanitizePubkeys(
-            decoded.cast<String>(),
+          final cachedPubkeys = decoded.cast<String>();
+          final sanitizedPubkeys = _sanitizePubkeys(
+            cachedPubkeys,
             source: 'LocalStorage',
           );
+          _followingPubkeys = sanitizedPubkeys;
           _emitFollowingList();
+
+          if (sanitizedPubkeys.length != cachedPubkeys.length) {
+            await _saveToLocalStorage();
+          }
 
           Log.info(
             'Loaded cached following list: '

--- a/mobile/packages/follow_repository/test/src/follow_repository_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_test.dart
@@ -566,6 +566,22 @@ void main() {
         expect(repository.isFollowing(invalidPubkey), isFalse);
       });
 
+      test('persists the sanitized list after loading invalid local storage '
+          'entries', () async {
+        SharedPreferences.setMockInitialValues({
+          'following_list_$testCurrentUserPubkey':
+              '["$invalidPubkey", "$testTargetPubkey"]',
+        });
+
+        await repository.initialize();
+
+        final prefs = await SharedPreferences.getInstance();
+        expect(
+          prefs.getString('following_list_$testCurrentUserPubkey'),
+          '["$testTargetPubkey"]',
+        );
+      });
+
       test('follow succeeds and publishes a clean list when the cached '
           'list holds an invalid pubkey', () async {
         SharedPreferences.setMockInitialValues({

--- a/mobile/test/screens/other_profile_screen_test.dart
+++ b/mobile/test/screens/other_profile_screen_test.dart
@@ -168,6 +168,9 @@ void main() {
     when(
       () => videoEventService.isVideoEventLocallyDeleted(any()),
     ).thenReturn(false);
+    when(
+      () => videoEventService.isVideoEventKnownDeleted(any()),
+    ).thenReturn(false);
     when(() => videoEventService.addListener(any())).thenReturn(null);
     when(() => videoEventService.removeListener(any())).thenReturn(null);
     when(

--- a/mobile/test/services/upload_manager_error_handling_test.dart
+++ b/mobile/test/services/upload_manager_error_handling_test.dart
@@ -52,8 +52,6 @@ void main() {
     uploadManager = UploadManager(blossomService: mockBlossomService);
 
     mockConnectivity('wifi');
-
-    await uploadManager.initialize();
   });
 
   tearDown(() async {

--- a/mobile/test/widgets/profile/follow_from_profile_button_test.dart
+++ b/mobile/test/widgets/profile/follow_from_profile_button_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Tests for FollowFromProfileButton widget using MyFollowingBloc
 // ABOUTME: Validates follow/unfollow button state, tap behavior, and visibility logic
 
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
@@ -245,6 +247,34 @@ void main() {
         await tester.pumpAndSettle();
 
         verifyNever(() => mockMyFollowingBloc.add(any()));
+      });
+
+      testWidgets('shows localized snackbar when follow toggle fails', (
+        tester,
+      ) async {
+        final otherPubkey = validPubkey('other');
+        final states = StreamController<MyFollowingState>();
+        addTearDown(states.close);
+        whenListen(
+          mockMyFollowingBloc,
+          states.stream,
+          initialState: const MyFollowingState(
+            status: MyFollowingStatus.success,
+          ),
+        );
+
+        await tester.pumpWidget(createTestWidget(pubkey: otherPubkey));
+        await tester.pump();
+
+        states.add(
+          const MyFollowingState(status: MyFollowingStatus.toggleFailure),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 250));
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(find.text(l10n.followersUpdateFollowFailed), findsOneWidget);
+        expect(find.byType(SnackBar), findsOneWidget);
       });
     });
 


### PR DESCRIPTION
## Summary
- persist sanitized following lists after invalid cached pubkeys are dropped from SharedPreferences
- show the existing localized follow-failure snackbar from the profile follow button
- add regression coverage for poisoned local storage cleanup and profile toggle failure feedback

## Verification
- flutter test test/src/follow_repository_test.dart (from mobile/packages/follow_repository)
- flutter test test/widgets/profile/follow_from_profile_button_test.dart (from mobile)
- flutter analyze lib test (from mobile/packages/follow_repository)
- flutter analyze lib test integration_test (from mobile)
- pre-push hook: analyzer and changed-file tests

Closes #6121