### PR TITLE
fix(support): gate internal feature flags

### DIFF
--- a/.github/ci-timing-budgets.json
+++ b/.github/ci-timing-budgets.json
@@ -3,7 +3,8 @@
     "Wall-clock budgets for Mobile CI jobs, in seconds. Enforced by the",
     "'Check CI timing budget' step in the mobile-ci gate job.",
     "",
-    "Keys match a job name exactly, or as a prefix. A budgeted job that did not",
+    "Keys match a job name exactly, or as a prefix — 'Tests' covers both",
+    "'Tests' and a future 'Tests (shard N/4)'. A budgeted job that did not",
     "run (skipped, or renamed) is reported and skipped, never inferred as a",
     "pass. A job with no budget entry is ignored.",
     "",
@@ -22,10 +23,7 @@
   ],
   "jobs": {
     "Detect App CI Scope": { "warn": 40, "fail": 90 },
-    "Tests (shard ${{ strategy.job-index }}/${{ strategy.job-total }})": {
-      "warn": 600,
-      "fail": 780
-    },
+    "Tests": { "warn": 600, "fail": 780 },
     "Generated Files": { "warn": 260, "fail": 420 },
     "Analyze": { "warn": 150, "fail": 300 },
     "Format": { "warn": 90, "fail": 180 },

--- a/mobile/lib/features/feature_flags/models/feature_flag.dart
+++ b/mobile/lib/features/feature_flags/models/feature_flag.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Feature flag enum defining available feature flags for Divine
 // ABOUTME: Provides type-safe flag definitions with display names and descriptions
 
+enum FeatureFlagAudience { user, internal }
+
 enum FeatureFlag {
   enhancedAnalytics(
     'Enhanced Analytics',
@@ -39,6 +41,7 @@ enum FeatureFlag {
     'Self-advertise your NIP-17 kind-10050 DM inbox relays on login so '
         'compliant senders deliver where divine reads. Keep off until the '
         'backend relay accepts kind-10050.',
+    audience: FeatureFlagAudience.internal,
   ),
   feedTuning(
     'Feed Tuning Swipes',
@@ -53,25 +56,36 @@ enum FeatureFlag {
   lightMode(
     'Light Mode',
     'Enable the experimental System, Light, and Dark appearance settings.',
+    audience: FeatureFlagAudience.internal,
   ),
   adaptiveMediaChrome(
     'Adaptive Media Chrome',
     'Use light controls around fullscreen video when Light Mode is enabled.',
+    audience: FeatureFlagAudience.internal,
   ),
   communityContentWarnings(
     'Community Content Warnings',
     'Suggest content-warning labels on videos and blur videos whose labels '
         'crossed the community threshold. Off by default pending T&S '
         'rollout sign-off.',
+    audience: FeatureFlagAudience.internal,
   ),
   emailVerificationPinFallback(
     'Email Verification PIN Fallback',
     'Show the in-app email verification PIN and resend fallback. Off by '
         'default until keycast verify-pin support is deployed.',
+    audience: FeatureFlagAudience.internal,
   );
 
-  const FeatureFlag(this.displayName, this.description);
+  const FeatureFlag(
+    this.displayName,
+    this.description, {
+    this.audience = FeatureFlagAudience.user,
+  });
 
   final String displayName;
   final String description;
+  final FeatureFlagAudience audience;
+
+  bool get isInternal => audience == FeatureFlagAudience.internal;
 }

--- a/mobile/lib/features/feature_flags/providers/feature_flag_providers.dart
+++ b/mobile/lib/features/feature_flags/providers/feature_flag_providers.dart
@@ -4,6 +4,7 @@
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/services/build_configuration.dart';
 import 'package:openvine/features/feature_flags/services/feature_flag_service.dart';
+import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -20,8 +21,13 @@ BuildConfiguration buildConfiguration(Ref ref) {
 FeatureFlagService featureFlagService(Ref ref) {
   final prefs = ref.watch(sharedPreferencesProvider);
   final buildConfig = ref.watch(buildConfigurationProvider);
+  final canOverrideInternalFlags = ref.watch(isDeveloperModeEnabledProvider);
 
-  final service = FeatureFlagService(prefs, buildConfig);
+  final service = FeatureFlagService(
+    prefs,
+    buildConfig,
+    canOverrideInternalFlags: () => canOverrideInternalFlags,
+  );
   // Load persisted overrides from SharedPreferences
   service.initialize();
   return service;

--- a/mobile/lib/features/feature_flags/providers/feature_flag_providers.dart
+++ b/mobile/lib/features/feature_flags/providers/feature_flag_providers.dart
@@ -21,15 +21,24 @@ BuildConfiguration buildConfiguration(Ref ref) {
 FeatureFlagService featureFlagService(Ref ref) {
   final prefs = ref.watch(sharedPreferencesProvider);
   final buildConfig = ref.watch(buildConfigurationProvider);
-  final canOverrideInternalFlags = ref.watch(isDeveloperModeEnabledProvider);
+  final environmentService = ref.watch(environmentServiceProvider);
 
   final service = FeatureFlagService(
     prefs,
     buildConfig,
-    canOverrideInternalFlags: () => canOverrideInternalFlags,
+    canOverrideInternalFlags: () => environmentService.isDeveloperModeEnabled,
   );
   // Load persisted overrides from SharedPreferences
   service.initialize();
+
+  // Re-resolve every flag when developer mode flips, rather than watching it
+  // and rebuilding: this provider's instance is captured by ref.read in
+  // SettingsScreen.initState, and a new identity here would strand that
+  // capture on an orphaned service.
+  void onEnvironmentChanged() => service.initialize();
+  environmentService.addListener(onEnvironmentChanged);
+  ref.onDispose(() => environmentService.removeListener(onEnvironmentChanged));
+
   return service;
 }
 

--- a/mobile/lib/features/feature_flags/providers/feature_flag_providers.g.dart
+++ b/mobile/lib/features/feature_flags/providers/feature_flag_providers.g.dart
@@ -112,7 +112,7 @@ final class FeatureFlagServiceProvider
 }
 
 String _$featureFlagServiceHash() =>
-    r'bd34ff1d65498b7f8d5ddccd7de35a6a76ce53af';
+    r'f663b9f0232f24e115143321b82371ae100822ba';
 
 /// Feature flag state provider (reactive to service changes)
 

--- a/mobile/lib/features/feature_flags/providers/feature_flag_providers.g.dart
+++ b/mobile/lib/features/feature_flags/providers/feature_flag_providers.g.dart
@@ -112,7 +112,7 @@ final class FeatureFlagServiceProvider
 }
 
 String _$featureFlagServiceHash() =>
-    r'd33155b88044c601621da0725982b9bd17c811e8';
+    r'bd34ff1d65498b7f8d5ddccd7de35a6a76ce53af';
 
 /// Feature flag state provider (reactive to service changes)
 

--- a/mobile/lib/features/feature_flags/screens/feature_flag_screen.dart
+++ b/mobile/lib/features/feature_flags/screens/feature_flag_screen.dart
@@ -8,6 +8,7 @@ import 'package:go_router/go_router.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/services/cache_recovery_service.dart';
 
 class FeatureFlagScreen extends ConsumerWidget {
@@ -17,6 +18,10 @@ class FeatureFlagScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final service = ref.watch(featureFlagServiceProvider);
     final state = ref.watch(featureFlagStateProvider);
+    final showInternalFlags = ref.watch(isDeveloperModeEnabledProvider);
+    final visibleFlags = FeatureFlag.values
+        .where((flag) => !flag.isInternal || showInternalFlags)
+        .toList(growable: false);
 
     return Scaffold(
       appBar: DiVineAppBar(
@@ -48,9 +53,9 @@ class FeatureFlagScreen extends ConsumerWidget {
                 // Feature Flags List
                 Expanded(
                   child: ListView.builder(
-                    itemCount: FeatureFlag.values.length,
+                    itemCount: visibleFlags.length,
                     itemBuilder: (context, index) {
-                      final flag = FeatureFlag.values[index];
+                      final flag = visibleFlags[index];
                       final isEnabled = state[flag] ?? false;
                       final hasUserOverride = service.hasUserOverride(flag);
 

--- a/mobile/lib/features/feature_flags/services/feature_flag_service.dart
+++ b/mobile/lib/features/feature_flags/services/feature_flag_service.dart
@@ -34,21 +34,20 @@ class FeatureFlagService extends ChangeNotifier {
   }
 
   /// Initialize the service by loading persisted flag values
+  ///
+  /// A persisted override for an internal flag is ignored, not deleted, while
+  /// internal access is off — so the user's choice is honoured again if the
+  /// flag is later promoted back to [FeatureFlagAudience.user] or internal
+  /// access is restored.
   Future<void> initialize() async {
     final flags = <FeatureFlag, bool>{};
 
     for (final flag in FeatureFlag.values) {
-      final key = _getPreferenceKey(flag);
-      final savedValue = _prefs.getBool(key);
+      final savedValue = _prefs.getBool(_getPreferenceKey(flag));
 
-      if (_canUsePersistedOverride(flag, savedValue)) {
-        flags[flag] = savedValue!;
-      } else {
-        if (savedValue != null) {
-          await _removeInternalOverride(key, flag);
-        }
-        flags[flag] = _buildConfig.getDefault(flag);
-      }
+      flags[flag] = _canUsePersistedOverride(flag, savedValue)
+          ? savedValue!
+          : _buildConfig.getDefault(flag);
     }
 
     _currentState = FeatureFlagState(flags);
@@ -61,11 +60,11 @@ class FeatureFlagService extends ChangeNotifier {
   }
 
   /// Set a feature flag value and persist it
+  ///
+  /// Internal flags are read-only without internal access: the flag resolves
+  /// back to its build default and nothing is written or removed.
   Future<void> setFlag(FeatureFlag flag, bool value) async {
-    final key = _getPreferenceKey(flag);
-
     if (!_canOverrideFlag(flag)) {
-      await _removeInternalOverride(key, flag);
       _currentState = _currentState.copyWith(
         flag,
         _buildConfig.getDefault(flag),
@@ -73,6 +72,8 @@ class FeatureFlagService extends ChangeNotifier {
       notifyListeners();
       return;
     }
+
+    final key = _getPreferenceKey(flag);
 
     try {
       await _prefs.setBool(key, value);
@@ -140,6 +141,9 @@ class FeatureFlagService extends ChangeNotifier {
   }
 
   /// Check if a flag has a user override (is different from build default)
+  ///
+  /// Always false for an internal flag without internal access: any persisted
+  /// value is retained on disk but not applied.
   bool hasUserOverride(FeatureFlag flag) {
     if (!_canOverrideFlag(flag)) return false;
 
@@ -172,19 +176,5 @@ class FeatureFlagService extends ChangeNotifier {
 
   bool _canOverrideFlag(FeatureFlag flag) {
     return !flag.isInternal || _canOverrideInternalFlags();
-  }
-
-  Future<void> _removeInternalOverride(String key, FeatureFlag flag) async {
-    if (!flag.isInternal) return;
-
-    try {
-      await _prefs.remove(key);
-    } catch (e) {
-      Log.warning(
-        'Failed to remove internal feature flag override $flag: $e',
-        name: 'FeatureFlagService',
-        category: LogCategory.system,
-      );
-    }
   }
 }

--- a/mobile/lib/features/feature_flags/services/feature_flag_service.dart
+++ b/mobile/lib/features/feature_flags/services/feature_flag_service.dart
@@ -9,13 +9,20 @@ import 'package:unified_logger/unified_logger.dart';
 
 /// Service managing feature flag state with change notifications for Riverpod reactivity
 class FeatureFlagService extends ChangeNotifier {
-  FeatureFlagService(this._prefs, this._buildConfig) {
+  FeatureFlagService(
+    this._prefs,
+    this._buildConfig, {
+    bool Function()? canOverrideInternalFlags,
+  }) : _canOverrideInternalFlags = canOverrideInternalFlags ?? _denyInternal {
     _initializeWithDefaults();
   }
 
   final SharedPreferences _prefs;
   final BuildConfiguration _buildConfig;
+  final bool Function() _canOverrideInternalFlags;
   late FeatureFlagState _currentState;
+
+  static bool _denyInternal() => false;
 
   /// Initialize with build defaults (called in constructor)
   void _initializeWithDefaults() {
@@ -34,9 +41,12 @@ class FeatureFlagService extends ChangeNotifier {
       final key = _getPreferenceKey(flag);
       final savedValue = _prefs.getBool(key);
 
-      if (savedValue != null) {
-        flags[flag] = savedValue;
+      if (_canUsePersistedOverride(flag, savedValue)) {
+        flags[flag] = savedValue!;
       } else {
+        if (savedValue != null) {
+          await _removeInternalOverride(key, flag);
+        }
         flags[flag] = _buildConfig.getDefault(flag);
       }
     }
@@ -53,6 +63,16 @@ class FeatureFlagService extends ChangeNotifier {
   /// Set a feature flag value and persist it
   Future<void> setFlag(FeatureFlag flag, bool value) async {
     final key = _getPreferenceKey(flag);
+
+    if (!_canOverrideFlag(flag)) {
+      await _removeInternalOverride(key, flag);
+      _currentState = _currentState.copyWith(
+        flag,
+        _buildConfig.getDefault(flag),
+      );
+      notifyListeners();
+      return;
+    }
 
     try {
       await _prefs.setBool(key, value);
@@ -121,6 +141,8 @@ class FeatureFlagService extends ChangeNotifier {
 
   /// Check if a flag has a user override (is different from build default)
   bool hasUserOverride(FeatureFlag flag) {
+    if (!_canOverrideFlag(flag)) return false;
+
     final key = _getPreferenceKey(flag);
     return _prefs.containsKey(key);
   }
@@ -141,5 +163,28 @@ class FeatureFlagService extends ChangeNotifier {
   /// Generate preference key for a flag
   String _getPreferenceKey(FeatureFlag flag) {
     return 'ff_${flag.name}';
+  }
+
+  bool _canUsePersistedOverride(FeatureFlag flag, bool? savedValue) {
+    if (savedValue == null) return false;
+    return _canOverrideFlag(flag);
+  }
+
+  bool _canOverrideFlag(FeatureFlag flag) {
+    return !flag.isInternal || _canOverrideInternalFlags();
+  }
+
+  Future<void> _removeInternalOverride(String key, FeatureFlag flag) async {
+    if (!flag.isInternal) return;
+
+    try {
+      await _prefs.remove(key);
+    } catch (e) {
+      Log.warning(
+        'Failed to remove internal feature flag override $flag: $e',
+        name: 'FeatureFlagService',
+        category: LogCategory.system,
+      );
+    }
   }
 }

--- a/mobile/lib/features/feature_flags/services/feature_flag_service.dart
+++ b/mobile/lib/features/feature_flags/services/feature_flag_service.dart
@@ -122,16 +122,18 @@ class FeatureFlagService extends ChangeNotifier {
     final flags = <FeatureFlag, bool>{};
 
     for (final flag in FeatureFlag.values) {
-      final key = _getPreferenceKey(flag);
-      try {
-        await _prefs.remove(key);
-      } catch (e) {
-        // Handle storage errors gracefully - log and continue
-        Log.warning(
-          'Failed to reset feature flag $flag: $e',
-          name: 'FeatureFlagService',
-          category: LogCategory.system,
-        );
+      if (_canOverrideFlag(flag)) {
+        final key = _getPreferenceKey(flag);
+        try {
+          await _prefs.remove(key);
+        } catch (e) {
+          // Handle storage errors gracefully - log and continue
+          Log.warning(
+            'Failed to reset feature flag $flag: $e',
+            name: 'FeatureFlagService',
+            category: LogCategory.system,
+          );
+        }
       }
       flags[flag] = _buildConfig.getDefault(flag);
     }

--- a/mobile/test/core/feature_flag_test.dart
+++ b/mobile/test/core/feature_flag_test.dart
@@ -47,5 +47,32 @@ void main() {
         );
       }
     });
+
+    test('should classify staged rollout flags as internal', () {
+      expect(FeatureFlag.lightMode.audience, FeatureFlagAudience.internal);
+      expect(
+        FeatureFlag.adaptiveMediaChrome.audience,
+        FeatureFlagAudience.internal,
+      );
+      expect(
+        FeatureFlag.publishDmRelayList.audience,
+        FeatureFlagAudience.internal,
+      );
+      expect(
+        FeatureFlag.communityContentWarnings.audience,
+        FeatureFlagAudience.internal,
+      );
+      expect(
+        FeatureFlag.emailVerificationPinFallback.audience,
+        FeatureFlagAudience.internal,
+      );
+    });
+
+    test('should leave user-facing flags visible to users', () {
+      expect(FeatureFlag.curatedLists.audience, FeatureFlagAudience.user);
+      expect(FeatureFlag.blueskyPublishing.audience, FeatureFlagAudience.user);
+      expect(FeatureFlag.videoReplies.audience, FeatureFlagAudience.user);
+      expect(FeatureFlag.feedTuning.audience, FeatureFlagAudience.user);
+    });
   });
 }

--- a/mobile/test/features/feature_flags/feature_flag_workflow_test.dart
+++ b/mobile/test/features/feature_flags/feature_flag_workflow_test.dart
@@ -309,9 +309,14 @@ void main() {
       await tester.tap(resetButton);
       await tester.pumpAndSettle();
 
-      // Verify all flags were reset
+      // Verify visible/user-facing flags were reset without deleting hidden
+      // internal overrides.
       for (final flag in FeatureFlag.values) {
-        verify(() => mockPrefs.remove('ff_${flag.name}')).called(1);
+        if (flag.isInternal) {
+          verifyNever(() => mockPrefs.remove('ff_${flag.name}'));
+        } else {
+          verify(() => mockPrefs.remove('ff_${flag.name}')).called(1);
+        }
       }
 
       // Simulate SharedPreferences after reset

--- a/mobile/test/providers/feature_flag_provider_test.dart
+++ b/mobile/test/providers/feature_flag_provider_test.dart
@@ -7,6 +7,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/features/feature_flags/services/feature_flag_service.dart';
+import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -140,6 +141,45 @@ void main() {
       expect(newEnabled, isTrue);
 
       container.dispose();
+    });
+
+    test('gates internal flag overrides on developer mode', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'ff_lightMode': true,
+        'ff_enhancedAnalytics': true,
+      });
+      final prefs = await SharedPreferences.getInstance();
+
+      final container = ProviderContainer(
+        overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+      );
+      addTearDown(container.dispose);
+
+      final environment = container.read(environmentServiceProvider);
+      await environment.initialize(sharedPreferences: prefs);
+
+      final service = container.read(featureFlagServiceProvider);
+      await service.initialize();
+
+      expect(service.isEnabled(FeatureFlag.lightMode), isFalse);
+      expect(service.isEnabled(FeatureFlag.enhancedAnalytics), isTrue);
+      expect(prefs.getBool('ff_lightMode'), isTrue);
+
+      await environment.enableDeveloperMode();
+      await pumpEventQueue();
+
+      expect(
+        identical(container.read(featureFlagServiceProvider), service),
+        isTrue,
+        reason: 'a new instance would strand every ref.read capture',
+      );
+      expect(service.isEnabled(FeatureFlag.lightMode), isTrue);
+
+      await environment.disableDeveloperMode();
+      await pumpEventQueue();
+
+      expect(service.isEnabled(FeatureFlag.lightMode), isFalse);
+      expect(prefs.getBool('ff_lightMode'), isTrue);
     });
   });
 }

--- a/mobile/test/screens/feature_flag_screen_test.dart
+++ b/mobile/test/screens/feature_flag_screen_test.dart
@@ -9,6 +9,7 @@ import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/features/feature_flags/screens/feature_flag_screen.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -34,9 +35,12 @@ void main() {
       }
     });
 
-    Widget buildSubject() {
+    Widget buildSubject({bool isDeveloperMode = false}) {
       return ProviderScope(
-        overrides: [sharedPreferencesProvider.overrideWithValue(mockPrefs)],
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(mockPrefs),
+          isDeveloperModeEnabledProvider.overrideWithValue(isDeveloperMode),
+        ],
         child: const MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
@@ -67,6 +71,50 @@ void main() {
 
       final listViewWidth = tester.getSize(find.byType(ListView).first).width;
       expect(listViewWidth, moreOrLessEquals(600));
+    });
+
+    testWidgets('hides internal flags when developer mode is off', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(800, 2000);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(buildSubject());
+      await initializeFeatureFlags(tester);
+
+      expect(
+        find.text(FeatureFlag.enhancedAnalytics.displayName),
+        findsOneWidget,
+      );
+      expect(find.text(FeatureFlag.lightMode.displayName), findsNothing);
+      expect(
+        find.text(FeatureFlag.publishDmRelayList.displayName),
+        findsNothing,
+      );
+    });
+
+    testWidgets('shows internal flags when developer mode is on', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(800, 2000);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(buildSubject(isDeveloperMode: true));
+      await initializeFeatureFlags(tester);
+
+      expect(
+        find.text(FeatureFlag.enhancedAnalytics.displayName),
+        findsOneWidget,
+      );
+      expect(find.text(FeatureFlag.lightMode.displayName), findsOneWidget);
+      expect(
+        find.text(FeatureFlag.publishDmRelayList.displayName),
+        findsOneWidget,
+      );
     });
 
     testWidgets('should display all flags', (tester) async {

--- a/mobile/test/screens/feature_flag_screen_test.dart
+++ b/mobile/test/screens/feature_flag_screen_test.dart
@@ -264,9 +264,13 @@ void main() {
       await tester.tap(resetButton);
       await tester.pumpAndSettle();
 
-      // Verify that remove was called for all flags
+      // Verify that only visible/user-facing flags were reset.
       for (final flag in FeatureFlag.values) {
-        verify(() => mockPrefs.remove('ff_${flag.name}')).called(1);
+        if (flag.isInternal) {
+          verifyNever(() => mockPrefs.remove('ff_${flag.name}'));
+        } else {
+          verify(() => mockPrefs.remove('ff_${flag.name}')).called(1);
+        }
       }
     });
 

--- a/mobile/test/services/feature_flag_service_test.dart
+++ b/mobile/test/services/feature_flag_service_test.dart
@@ -64,7 +64,7 @@ void main() {
       });
 
       test(
-        'drops persisted internal flag overrides when internal access is off',
+        'ignores persisted internal flag overrides when internal access is off',
         () async {
           when(() => mockPrefs.getBool('ff_lightMode')).thenReturn(true);
           when(() => mockPrefs.containsKey('ff_lightMode')).thenReturn(true);
@@ -73,7 +73,9 @@ void main() {
 
           expect(service.isEnabled(FeatureFlag.lightMode), isFalse);
           expect(service.hasUserOverride(FeatureFlag.lightMode), isFalse);
-          verify(() => mockPrefs.remove('ff_lightMode')).called(1);
+          // Ignored, not deleted — the choice is honoured again if the flag is
+          // promoted back to a user audience or internal access is restored.
+          verifyNever(() => mockPrefs.remove('ff_lightMode'));
         },
       );
 
@@ -131,7 +133,7 @@ void main() {
           await service.setFlag(FeatureFlag.lightMode, true);
 
           verifyNever(() => mockPrefs.setBool('ff_lightMode', true));
-          verify(() => mockPrefs.remove('ff_lightMode')).called(1);
+          verifyNever(() => mockPrefs.remove('ff_lightMode'));
           expect(service.isEnabled(FeatureFlag.lightMode), isFalse);
         },
       );

--- a/mobile/test/services/feature_flag_service_test.dart
+++ b/mobile/test/services/feature_flag_service_test.dart
@@ -187,9 +187,28 @@ void main() {
         await service.resetAllFlags();
 
         for (final flag in FeatureFlag.values) {
-          verify(() => mockPrefs.remove('ff_${flag.name}')).called(1);
+          if (flag.isInternal) {
+            verifyNever(() => mockPrefs.remove('ff_${flag.name}'));
+          } else {
+            verify(() => mockPrefs.remove('ff_${flag.name}')).called(1);
+          }
         }
       });
+
+      test(
+        'preserves internal flag overrides when resetting all without access',
+        () async {
+          when(() => mockPrefs.getBool('ff_lightMode')).thenReturn(true);
+          when(() => mockPrefs.containsKey('ff_lightMode')).thenReturn(true);
+
+          await service.initialize();
+          await service.resetAllFlags();
+
+          verifyNever(() => mockPrefs.remove('ff_lightMode'));
+          expect(service.isEnabled(FeatureFlag.lightMode), isFalse);
+          expect(service.hasUserOverride(FeatureFlag.lightMode), isFalse);
+        },
+      );
     });
 
     group('state queries', () {

--- a/mobile/test/services/feature_flag_service_test.dart
+++ b/mobile/test/services/feature_flag_service_test.dart
@@ -62,6 +62,60 @@ void main() {
 
         expect(service.isEnabled(FeatureFlag.enhancedAnalytics), isTrue);
       });
+
+      test(
+        'drops persisted internal flag overrides when internal access is off',
+        () async {
+          when(() => mockPrefs.getBool('ff_lightMode')).thenReturn(true);
+          when(() => mockPrefs.containsKey('ff_lightMode')).thenReturn(true);
+
+          await service.initialize();
+
+          expect(service.isEnabled(FeatureFlag.lightMode), isFalse);
+          expect(service.hasUserOverride(FeatureFlag.lightMode), isFalse);
+          verify(() => mockPrefs.remove('ff_lightMode')).called(1);
+        },
+      );
+
+      test(
+        'preserves internal flag overrides when internal access is on',
+        () async {
+          service = FeatureFlagService(
+            mockPrefs,
+            const BuildConfiguration(),
+            canOverrideInternalFlags: () => true,
+          );
+          when(() => mockPrefs.getBool('ff_lightMode')).thenReturn(true);
+          when(() => mockPrefs.containsKey('ff_lightMode')).thenReturn(true);
+
+          await service.initialize();
+
+          expect(service.isEnabled(FeatureFlag.lightMode), isTrue);
+          expect(service.hasUserOverride(FeatureFlag.lightMode), isTrue);
+          verifyNever(() => mockPrefs.remove('ff_lightMode'));
+        },
+      );
+
+      test(
+        'keeps user-facing flag overrides when internal access is off',
+        () async {
+          when(
+            () => mockPrefs.getBool('ff_enhancedAnalytics'),
+          ).thenReturn(true);
+          when(
+            () => mockPrefs.containsKey('ff_enhancedAnalytics'),
+          ).thenReturn(true);
+
+          await service.initialize();
+
+          expect(service.isEnabled(FeatureFlag.enhancedAnalytics), isTrue);
+          expect(
+            service.hasUserOverride(FeatureFlag.enhancedAnalytics),
+            isTrue,
+          );
+          verifyNever(() => mockPrefs.remove('ff_enhancedAnalytics'));
+        },
+      );
     });
 
     group('flag management', () {
@@ -70,6 +124,33 @@ void main() {
 
         verify(() => mockPrefs.setBool('ff_enhancedAnalytics', true)).called(1);
       });
+
+      test(
+        'should not persist internal flags when internal access is off',
+        () async {
+          await service.setFlag(FeatureFlag.lightMode, true);
+
+          verifyNever(() => mockPrefs.setBool('ff_lightMode', true));
+          verify(() => mockPrefs.remove('ff_lightMode')).called(1);
+          expect(service.isEnabled(FeatureFlag.lightMode), isFalse);
+        },
+      );
+
+      test(
+        'should persist internal flags when internal access is on',
+        () async {
+          service = FeatureFlagService(
+            mockPrefs,
+            const BuildConfiguration(),
+            canOverrideInternalFlags: () => true,
+          );
+
+          await service.setFlag(FeatureFlag.lightMode, true);
+
+          verify(() => mockPrefs.setBool('ff_lightMode', true)).called(1);
+          expect(service.isEnabled(FeatureFlag.lightMode), isTrue);
+        },
+      );
 
       test('should notify listeners on flag change', () async {
         // SKIP: Service refactored to use Riverpod instead of ChangeNotifier
@@ -128,10 +209,7 @@ void main() {
         ).thenReturn(true);
 
         expect(service.hasUserOverride(FeatureFlag.enhancedAnalytics), isTrue);
-        expect(
-          service.hasUserOverride(FeatureFlag.accountSwitching),
-          isFalse,
-        );
+        expect(service.hasUserOverride(FeatureFlag.accountSwitching), isFalse);
       });
 
       test('should provide flag metadata', () {

--- a/mobile/test/tools/check_ci_timing_budget_test.dart
+++ b/mobile/test/tools/check_ci_timing_budget_test.dart
@@ -17,12 +17,15 @@ import 'package:path/path.dart' as p;
 void main() {
   group('check_ci_timing_budget.py', () {
     late Directory sandbox;
+    late String repoRoot;
     late String scriptPath;
 
     setUp(() {
       sandbox = Directory.systemTemp.createTempSync('ci_timing_budget_');
+      repoRoot = repositoryRoot();
       scriptPath = p.join(
-        Directory.current.path,
+        repoRoot,
+        'mobile',
         'scripts',
         'ci',
         'check_ci_timing_budget.py',
@@ -229,11 +232,7 @@ void main() {
       'the committed budget file is well formed and covers the gate jobs',
       () {
         final committed = File(
-          p.join(
-            Directory.current.parent.path,
-            '.github',
-            'ci-timing-budgets.json',
-          ),
+          p.join(repoRoot, '.github', 'ci-timing-budgets.json'),
         );
         expect(committed.existsSync(), isTrue);
 
@@ -273,11 +272,7 @@ void main() {
       // exactly — but silently drops every shard out of enforcement at run
       // time, so the well-formedness test above cannot see it.
       final committed = File(
-        p.join(
-          Directory.current.parent.path,
-          '.github',
-          'ci-timing-budgets.json',
-        ),
+        p.join(repoRoot, '.github', 'ci-timing-budgets.json'),
       ).readAsStringSync();
 
       final result = Process.runSync('python3', [
@@ -296,12 +291,7 @@ void main() {
 
     test('budget file edits require app CI', () {
       final workflow = File(
-        p.join(
-          Directory.current.parent.path,
-          '.github',
-          'workflows',
-          'mobile_ci.yaml',
-        ),
+        p.join(repoRoot, '.github', 'workflows', 'mobile_ci.yaml'),
       ).readAsStringSync();
 
       expect(workflow, contains('.github/ci-timing-budgets.json)'));
@@ -309,10 +299,19 @@ void main() {
   });
 }
 
+String repositoryRoot() {
+  final result = Process.runSync('git', [
+    'rev-parse',
+    '--show-toplevel',
+  ], workingDirectory: Directory.current.path);
+  expect(result.exitCode, 0, reason: '${result.stdout}${result.stderr}');
+  return (result.stdout as String).trim();
+}
+
 List<String> mobileCiGateJobNames() {
   final workflow = File(
     p.join(
-      Directory.current.parent.path,
+      repositoryRoot(),
       '.github',
       'workflows',
       'mobile_ci.yaml',

--- a/mobile/test/tools/check_ci_timing_budget_test.dart
+++ b/mobile/test/tools/check_ci_timing_budget_test.dart
@@ -266,6 +266,34 @@ void main() {
       },
     );
 
+    test('the committed budget still catches a slow rendered shard', () {
+      // The gate reads job names from the GitHub API, where a matrix name is
+      // already rendered ('Tests (shard 0/4)'). Keying the budget on the raw
+      // template instead is self-consistent — budgetNameForGateJob matches it
+      // exactly — but silently drops every shard out of enforcement at run
+      // time, so the well-formedness test above cannot see it.
+      final committed = File(
+        p.join(
+          Directory.current.parent.path,
+          '.github',
+          'ci-timing-budgets.json',
+        ),
+      ).readAsStringSync();
+
+      final result = Process.runSync('python3', [
+        scriptPath,
+        '--budgets',
+        writeJson('committed.json', jsonDecode(committed) as Object),
+        '--jobs-json',
+        writeJson('shards.json', {
+          'jobs': [job('Tests (shard 0/4)', 3000)],
+        }),
+      ]);
+
+      expect(result.exitCode, 1, reason: '${result.stdout}${result.stderr}');
+      expect(result.stdout, contains('Tests (shard 0/4)'));
+    });
+
     test('budget file edits require app CI', () {
       final workflow = File(
         p.join(

--- a/mobile/test/widgets/video_feed_item/actions/help_classify_action_button_test.dart
+++ b/mobile/test/widgets/video_feed_item/actions/help_classify_action_button_test.dart
@@ -133,7 +133,11 @@ void main() {
       // read has to go through the reactive provider chain.
       SharedPreferences.setMockInitialValues(<String, Object>{});
       final prefs = await SharedPreferences.getInstance();
-      final service = FeatureFlagService(prefs, const BuildConfiguration());
+      final service = FeatureFlagService(
+        prefs,
+        const BuildConfiguration(),
+        canOverrideInternalFlags: () => true,
+      );
       await service.initialize();
       addTearDown(service.dispose);
 

--- a/mobile/test/widgets/video_feed_item/feed_videos_test.dart
+++ b/mobile/test/widgets/video_feed_item/feed_videos_test.dart
@@ -906,7 +906,11 @@ void main() {
           'ff_communityContentWarnings': true,
         });
         final prefs = await SharedPreferences.getInstance();
-        final flags = FeatureFlagService(prefs, const BuildConfiguration());
+        final flags = FeatureFlagService(
+          prefs,
+          const BuildConfiguration(),
+          canOverrideInternalFlags: () => true,
+        );
         await flags.initialize();
         addTearDown(flags.dispose);
 
@@ -969,7 +973,11 @@ void main() {
           'ff_communityContentWarnings': false,
         });
         final prefs = await SharedPreferences.getInstance();
-        final flags = FeatureFlagService(prefs, const BuildConfiguration());
+        final flags = FeatureFlagService(
+          prefs,
+          const BuildConfiguration(),
+          canOverrideInternalFlags: () => true,
+        );
         await flags.initialize();
         addTearDown(flags.dispose);
 


### PR DESCRIPTION
## Summary
- add audience metadata to feature flags and mark unfinished staged-rollout flags as internal
- hide internal flags on the Experimental Features screen unless developer mode is enabled
- ignore persisted internal flag overrides while internal access is off, preserving them for later promotion or developer-mode access
- update the Mobile CI timing budget key for the sharded test matrix and keep affected runtime-toggle tests aligned with internal flag access

## Verification
- flutter test test/services/feature_flag_service_test.dart test/screens/feature_flag_screen_test.dart test/tools/check_ci_timing_budget_test.dart test/features/feature_flags/feature_flag_workflow_test.dart
- flutter test test/widgets/video_feed_item/feed_videos_test.dart test/widgets/video_feed_item/actions/help_classify_action_button_test.dart
- flutter analyze lib test integration_test
- pre-push checks: analyzer, generated files, changed-file tests
- GitHub Actions green on e93a1cd6f8

Refs #6404