### PR TITLE
fix(video-recorder): stop an over-swipe on the mode wheel making every capture square

### DIFF
--- a/mobile/docs/QA_RECORDER_MODE_AND_ASPECT.md
+++ b/mobile/docs/QA_RECORDER_MODE_AND_ASPECT.md
@@ -1,0 +1,175 @@
+# Device QA — recorder mode wheel & capture aspect ratio
+
+Manual test guide for the camera mode wheel, the shape it imposes on captures,
+and the post/metadata screen it selects. Written for #6200 (portrait videos
+previewing as square) and the related #6148 / #6163 (blank post screen), but
+kept topic-scoped because this whole area is sticky, cross-screen, and easy to
+regress.
+
+**Run this on a real device.** The defects here depend on fling physics and on
+`SharedPreferences` surviving an app restart — neither reproduces reliably in a
+simulator or in widget tests.
+
+---
+
+## 1. What was actually wrong
+
+One value — the **last-used recorder mode**, persisted as
+`camera_last_used_recorder_mode` — controlled three unrelated things:
+
+1. which mode the camera opens in,
+2. the **aspect ratio** stamped onto every clip you record,
+3. which **entire post screen UI** you get after recording.
+
+The mode wheel could select a mode you never scrolled onto: an over-fling
+resolved to the first or last slot. Because the mode is persisted and re-applied
+on every cold start, **one careless swipe changed your recording shape
+permanently** — closing and reopening the app did not clear it.
+
+In the 1.0.16 build both end slots were hazards:
+
+| over-swipe | mode selected | what you saw |
+|---|---|---|
+| hard **left** | `Upload` | post screen renders nothing — black, no back button, had to force-quit |
+| hard **right** | `Classic` | portrait recordings previewed as **square** |
+
+The exported/published video was still correct portrait — only the preview lied.
+That is why affected users' posted videos look fine on the relay.
+
+---
+
+## 2. Before you start
+
+**Build**: this branch, on a physical iPhone and (ideally) a physical Android
+device. iOS 26.x is where it was reported.
+
+**Resetting state between runs — read this, it is the main gotcha.**
+The mode is sticky. If a test leaves you in `Classic`, the next test starts in
+`Classic`. To get back to a known state, do one of:
+
+- open the camera and **tap** (do not swipe) the `Capture` label, or
+- delete and reinstall the app for a genuinely clean slate.
+
+Record which mode you are in at the start of every test below. If a result looks
+wrong, check the mode first.
+
+**Recording shape reference**: `Classic` is the 1:1 Vine format and is *supposed*
+to be square. Every other mode should give you portrait unless you deliberately
+toggle the shape in Capture mode.
+
+---
+
+## 3. Test matrix
+
+### T1 — the wheel cannot jump to an end slot *(the core fix)*
+
+1. Open the camera. Tap `Capture` so you start from a known slot.
+2. **Fling the mode wheel hard to the right** (a fast flick, not a slow drag).
+3. Observe which mode ends up selected.
+4. Repeat with a **hard fling to the left**.
+5. Repeat both from every other starting mode.
+
+**Expected**: each fling advances **one slot at a time**. You never land on the
+far end of the wheel from a single gesture.
+**Pre-fix**: a hard fling jumped straight to the last (or first) mode.
+
+> Tapping a mode label directly should still jump anywhere instantly — that path
+> is deliberately unrestricted. Verify tapping a distant mode still works.
+
+### T2 — switching modes does not silently change your shape
+
+> The shape toggle in `Capture` mode (the square/portrait crop icon) is
+> **disabled once you have recorded clips** — it only works on an empty
+> timeline. Discard any clips before starting this test, or the control will
+> look broken.
+
+1. In `Capture` mode with no clips recorded, tap the crop icon to select
+   **square**.
+2. Switch to `Lip Sync`, then back to `Capture`.
+
+**Expected**: still square — your explicit choice survived.
+**Pre-fix**: every mode change reset the shape to the mode's default.
+
+3. Now from `Capture` (portrait), switch to `Classic`.
+
+**Expected**: square — Classic legitimately forces 1:1.
+
+4. Switch from `Classic` back to `Capture`.
+
+**Expected**: back to portrait. Classic's square must not leak into Capture.
+
+### T3 — the shape does not survive a restart it shouldn't
+
+1. Put the wheel on `Capture` with portrait selected.
+2. Force-quit the app completely (swipe it away, not just background it).
+3. Reopen and go to the camera.
+
+**Expected**: still `Capture`, still portrait.
+**Pre-fix**: if the persisted mode was `Classic`, every launch silently re-forced
+square, with no way to notice except the viewfinder shape.
+
+### T4 — portrait recording previews as portrait *(the reported bug)*
+
+1. In `Capture` mode with portrait selected, record a short video.
+2. Continue to the post/metadata screen.
+3. Tap the preview (eye) control if present.
+
+**Expected**: the video is previewed **portrait**, matching the viewfinder and
+matching what gets published. No square letterbox or square crop anywhere in the
+flow — viewfinder, editor, cover picker, post screen, full-screen preview.
+
+4. Now switch to `Classic`, record, and go to the post screen.
+
+**Expected**: previewed **square** — correct for Classic.
+
+### T5 — no blank post screen *(#6148 / #6163)*
+
+1. Try to reach the post/metadata screen from every mode: `Capture`, `Lip Sync`,
+   `Stop Motion`, `Classic`, and after restoring a saved draft from the Library.
+
+**Expected**: you always get a real post screen with a visible app bar and a way
+back. Never a blank/black screen that traps you.
+**Pre-fix**: with `Upload` persisted, the post screen rendered nothing and the
+only escape was force-quitting the app.
+
+### T6 — "Square only" feed filter actually filters *(#3882)*
+
+1. Settings → General Settings → video shape → **"Square videos only"**
+   (*"Keep feeds in the classic square format"*).
+2. Return to the feed and scroll a good distance (For You, and the other tabs).
+
+**Expected**: portrait videos are actually hidden; you see square content only.
+**Pre-fix**: the setting did nothing at all — the app never received video
+dimensions from the API, so it could not tell the shapes apart.
+
+3. Switch back to **"Square and portrait"** (*"Show the full mix of Divine
+   videos"*) and confirm portrait videos return.
+
+> This one needs network. It is the only test here that depends on live API
+> responses rather than local state.
+
+### T7 — publishing is unchanged (regression guard)
+
+1. Record and publish one portrait video and one Classic (square) video.
+2. Check both on another client or the web app.
+
+**Expected**: the portrait one is portrait (1080×1920), the Classic one is
+square. Publishing behaviour must not have changed — only the preview was ever
+wrong.
+
+---
+
+## 4. What to report
+
+For any failure, capture:
+
+- the **mode** the wheel was on and how you got there (tap vs swipe direction),
+- whether the app had been **force-quit** since that mode was chosen,
+- a **screenshot or screen recording** — for shape bugs the width of the video
+  box distinguishes the surfaces, and the app's own logs cannot tell us which
+  screen you were on,
+- the exported video, if it disagrees with the preview.
+
+A screenshot is worth more than a log export here: the bug-report log capture
+keeps only errors and warnings from before the last few seconds, so it does not
+record which screen was on-screen when you noticed the problem.

--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -1519,10 +1519,19 @@ class VideoRecorderBloc
 
     final previousMode = state.recorderMode;
     final previousFrames = state.stopMotionFrames;
+    // Only a mode that dictates its own shape may rewrite the aspect ratio —
+    // and leaving such a mode restores the incoming mode's default. Between two
+    // unconstrained modes the user's own choice is preserved. Stamping it
+    // unconditionally meant every mode change (including the saved-mode replay
+    // on each cold start) re-imposed the mode's aspect (#6200).
+    final nextAspectRatio =
+        mode.constrainsAspectRatio || previousMode.constrainsAspectRatio
+        ? mode.defaultAspectRatio
+        : state.aspectRatio;
     emit(
       state.copyWith(
         recorderMode: mode,
-        aspectRatio: mode.defaultAspectRatio,
+        aspectRatio: nextAspectRatio,
         showGridLines: _gridLinesEnabledFor(mode),
         timerDuration: mode.supportsCountdownTimer
             ? state.timerDuration

--- a/mobile/lib/models/video_recorder/video_recorder_mode.dart
+++ b/mobile/lib/models/video_recorder/video_recorder_mode.dart
@@ -74,6 +74,15 @@ enum VideoRecorderMode {
     .classic => .square,
   };
 
+  /// Whether the mode itself dictates the capture shape, overriding whatever
+  /// the user last chose.
+  ///
+  /// Only Classic does: it is the 1:1 Vine format by definition. Every other
+  /// mode leaves the shape to the user's aspect-ratio toggle, so switching
+  /// between them must not silently rewrite it — that is what turned an
+  /// accidental Classic selection into a permanently square capture (#6200).
+  bool get constrainsAspectRatio => this == classic;
+
   /// Whether this mode captures still photos (stop-motion) instead of
   /// recording video. Drives the shutter behavior and capture UI.
   bool get capturesStills => this == stopMotion;

--- a/mobile/lib/widgets/video_metadata/modes/classic/video_metadata_classic_preview_thumbnail.dart
+++ b/mobile/lib/widgets/video_metadata/modes/classic/video_metadata_classic_preview_thumbnail.dart
@@ -103,8 +103,12 @@ class _VideoMetadataClassicPreviewThumbnailState
       ),
     );
 
+    // Size from the clip, not from the mode. This stack is selected by the
+    // persisted recorder mode, which can disagree with the clip that is
+    // actually being posted — a hardcoded 1:1 box then previews a portrait
+    // recording as a square (#6200).
     return AspectRatio(
-      aspectRatio: 1,
+      aspectRatio: clip.targetAspectRatio.value,
       child: clip.thumbnailPath == null
           ? const Center(
               child: DivineIcon(

--- a/mobile/lib/widgets/video_recorder/video_recorder_mode_selector.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_mode_selector.dart
@@ -132,12 +132,11 @@ class _VideoRecorderModeSelectorWheelState
     // Both end slots are hazards: `upload` renders a blank metadata screen and
     // `classic` pins capture to square, and the choice is persisted (#6200).
     // Tap-to-select does not come through here, so it can still jump anywhere.
-    final lowerBound = _selectedIndex > 0 ? _selectedIndex - 1 : 0;
     final lastIndex = _snapOffsets.length - 1;
-    final upperBound = _selectedIndex < lastIndex
-        ? _selectedIndex + 1
-        : lastIndex;
-    targetIndex = targetIndex.clamp(lowerBound, upperBound);
+    targetIndex = targetIndex.clamp(
+      (_selectedIndex - 1).clamp(0, lastIndex),
+      (_selectedIndex + 1).clamp(0, lastIndex),
+    );
     _lastScrollDelta = 0;
     // Defer to the next frame — animateTo called directly inside a scroll
     // notification callback is silently ignored by Flutter's scroll system.

--- a/mobile/lib/widgets/video_recorder/video_recorder_mode_selector.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_mode_selector.dart
@@ -126,6 +126,18 @@ class _VideoRecorderModeSelectorWheelState
       final ceilDist = (offset - _snapOffsets[ceilIndex]).abs();
       targetIndex = floorDist <= ceilDist ? floorIndex : ceilIndex;
     }
+    // One gesture advances at most one slot. An over-fling matches no snap
+    // offset, so floorIndex/ceilIndex keep their initial values — 0 and the
+    // last index — and the wheel selects a mode the user never scrolled onto.
+    // Both end slots are hazards: `upload` renders a blank metadata screen and
+    // `classic` pins capture to square, and the choice is persisted (#6200).
+    // Tap-to-select does not come through here, so it can still jump anywhere.
+    final lowerBound = _selectedIndex > 0 ? _selectedIndex - 1 : 0;
+    final lastIndex = _snapOffsets.length - 1;
+    final upperBound = _selectedIndex < lastIndex
+        ? _selectedIndex + 1
+        : lastIndex;
+    targetIndex = targetIndex.clamp(lowerBound, upperBound);
     _lastScrollDelta = 0;
     // Defer to the next frame — animateTo called directly inside a scroll
     // notification callback is silently ignored by Flutter's scroll system.

--- a/mobile/packages/infinite_video_feed/test/src/widgets/video_item_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/widgets/video_item_test.dart
@@ -115,6 +115,55 @@ void main() {
       expect(fittedBox.fit, equals(BoxFit.cover));
     });
 
+    testWidgets('uses BoxFit.cover for a portrait ratio when portrait expand', (
+      tester,
+    ) async {
+      // The suite had square and landscape fixtures but no portrait one, so
+      // letterboxing every portrait video left all 229 tests green. Portrait
+      // is the app's dominant shape — it needs the explicit case (#6200).
+      final controller = FakeController();
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: VideoItemWidget(controller: controller),
+        ),
+      );
+
+      controller.pushState(
+        const DivineVideoPlayerState(videoWidth: 1080, videoHeight: 1920),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      final fittedBox = tester.widget<FittedBox>(find.byType(FittedBox));
+      expect(fittedBox.fit, equals(BoxFit.cover));
+    });
+
+    testWidgets('a near-square ratio still covers', (tester) async {
+      // The square branch keys off exact equality with 1.0, so pin the
+      // boundary: one pixel off square must still cover, not letterbox.
+      final controller = FakeController();
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: VideoItemWidget(controller: controller),
+        ),
+      );
+
+      controller.pushState(
+        const DivineVideoPlayerState(videoWidth: 1079, videoHeight: 1080),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      final fittedBox = tester.widget<FittedBox>(find.byType(FittedBox));
+      expect(fittedBox.fit, equals(BoxFit.cover));
+    });
+
     testWidgets('uses BoxFit.contain when shouldPortraitExpand is false', (
       tester,
     ) async {

--- a/mobile/packages/models/lib/src/video_stats.dart
+++ b/mobile/packages/models/lib/src/video_stats.dart
@@ -6,6 +6,11 @@ import 'package:meta/meta.dart';
 import 'package:models/src/engagement_count_parser.dart';
 import 'package:models/src/video_event.dart';
 
+/// imeta keys whose value may be encoded positionally
+/// (`['imeta', 'dim', '1080x1920']`) rather than space-separated
+/// (`['imeta', 'dim 1080x1920']`). Both encodings appear in the wild.
+const _positionalImetaKeys = {'blurhash', 'dim'};
+
 /// Video with engagement metrics from Funnelcake API.
 ///
 /// This model represents the combined event data and stats returned
@@ -229,9 +234,13 @@ class VideoStats {
             blurhashFromTag = tagValue;
           }
           if (tagName == 'imeta') {
-            // Extract blurhash from imeta. Two formats are seen in the wild:
+            // Extract blurhash and dim from imeta. Two formats are seen in the
+            // wild:
             //   - space-separated: ['imeta', 'blurhash <hash>', ...]
             //   - positional:      ['imeta', 'blurhash', '<hash>', ...]
+            // divine and funnelcake only ever emit `dim` inside imeta — there
+            // is no top-level `dim` tag on any REST endpoint — so missing this
+            // leaves every REST-hydrated video without width/height (#3882).
             for (var i = 1; i < tag.length; i++) {
               final element = tag[i].toString();
               final spaceIndex = element.indexOf(' ');
@@ -240,19 +249,23 @@ class VideoStats {
               if (spaceIndex > 0) {
                 key = element.substring(0, spaceIndex);
                 value = element.substring(spaceIndex + 1);
-              } else if (element == 'blurhash' && i + 1 < tag.length) {
+              } else if (_positionalImetaKeys.contains(element) &&
+                  i + 1 < tag.length) {
                 key = element;
                 value = tag[i + 1].toString();
               }
-              if (key == 'blurhash' &&
-                  blurhashFromTag == null &&
-                  value != null &&
-                  value.isNotEmpty) {
+              if (value == null || value.isEmpty) continue;
+              if (key == 'blurhash' && blurhashFromTag == null) {
                 blurhashFromTag = value;
+              }
+              if (key == 'dim' && dimensions == null) {
+                dimensions = value;
               }
             }
           }
-          if ((tagName == 'dim' || tagName == 'size') && dimensions == null) {
+          // `size` is a byte count, not a WxH string — it must never populate
+          // dimensions (divine-web keeps them separate too).
+          if (tagName == 'dim' && dimensions == null) {
             dimensions = tagValue;
           }
           if (tagName == 'summary' && summaryFromTag == null) {

--- a/mobile/packages/models/lib/src/video_stats.dart
+++ b/mobile/packages/models/lib/src/video_stats.dart
@@ -238,9 +238,10 @@ class VideoStats {
             // wild:
             //   - space-separated: ['imeta', 'blurhash <hash>', ...]
             //   - positional:      ['imeta', 'blurhash', '<hash>', ...]
-            // divine and funnelcake only ever emit `dim` inside imeta — there
-            // is no top-level `dim` tag on any REST endpoint — so missing this
-            // leaves every REST-hydrated video without width/height (#3882).
+            // Every funnelcake endpoint the app calls carries `dim` inside
+            // imeta and none emits a top-level `dim` tag, so without this
+            // every REST-hydrated video lost its width/height (#3882). The
+            // top-level branch below stays as a fallback for relay events.
             for (var i = 1; i < tag.length; i++) {
               final element = tag[i].toString();
               final spaceIndex = element.indexOf(' ');

--- a/mobile/packages/models/test/src/video_stats_test.dart
+++ b/mobile/packages/models/test/src/video_stats_test.dart
@@ -377,14 +377,16 @@ void main() {
         expect(stats.loops, equals(5000));
       });
 
-      test('extracts dimensions from size tag when dim tag is absent', () {
+      test('does not treat a size tag as dimensions', () {
+        // NIP-92 `size` is a byte count, not WxH. Accepting it as dimensions
+        // fed a file size into width/height parsing.
         final json = {
           'id': 'test-id',
           'pubkey': 'test-pubkey',
           'created_at': 1700000000,
           'kind': 34236,
           'tags': [
-            ['size', '480x480'],
+            ['size', '6169367'],
           ],
           'thumbnail': 'https://example.com/thumb.jpg',
           'video_url': 'https://example.com/video.mp4',
@@ -396,7 +398,7 @@ void main() {
 
         final stats = VideoStats.fromJson(json);
 
-        expect(stats.dimensions, equals('480x480'));
+        expect(stats.dimensions, isNull);
       });
 
       test('parses dimensions from direct REST fields', () {
@@ -816,6 +818,101 @@ void main() {
 
         expect(stats.kind, equals(34236));
       });
+    });
+
+    group('dimensions from imeta tag', () {
+      Map<String, dynamic> jsonWithTags(List<List<dynamic>> tags) => {
+        'event': {
+          'id': 'event-id',
+          'pubkey': 'event-pubkey',
+          'created_at': 1700000000,
+          'kind': 34236,
+          'd_tag': 'video-1',
+          'title': 'Test',
+          'thumbnail': 'https://example.com/thumb.jpg',
+          'video_url': 'https://example.com/video.mp4',
+          'tags': tags,
+        },
+        'reactions': 0,
+        'comments': 0,
+        'reposts': 0,
+        'engagement_score': 0,
+      };
+
+      test('extracts dim from space-separated imeta format', () {
+        final stats = VideoStats.fromJson(
+          jsonWithTags([
+            [
+              'imeta',
+              'url https://example.com/video.mp4',
+              'dim 1080x1920',
+            ],
+          ]),
+        );
+
+        expect(stats.dimensions, equals('1080x1920'));
+      });
+
+      test('extracts dim from positional imeta format', () {
+        final stats = VideoStats.fromJson(
+          jsonWithTags([
+            [
+              'imeta',
+              'url',
+              'https://example.com/video.mp4',
+              'dim',
+              '1080x1920',
+            ],
+          ]),
+        );
+
+        expect(stats.dimensions, equals('1080x1920'));
+      });
+
+      test('imeta size does not populate dimensions', () {
+        final stats = VideoStats.fromJson(
+          jsonWithTags([
+            ['imeta', 'url https://example.com/video.mp4', 'size 6169367'],
+          ]),
+        );
+
+        expect(stats.dimensions, isNull);
+      });
+
+      test(
+        'production funnelcake payload yields a portrait VideoEvent',
+        () {
+          // Verbatim tag shape returned by
+          // GET /api/users/{pubkey}/recommendations — funnelcake emits `dim`
+          // ONLY inside imeta, with no top-level `dim` tag and no `dimensions`
+          // field. Missing this left every REST-hydrated video with
+          // width/height null, so isPortrait was always false (#3882).
+          final stats = VideoStats.fromJson(
+            jsonWithTags([
+              ['d', 'video-1'],
+              [
+                'imeta',
+                'url https://media.divine.video/abc',
+                'm video/mp4',
+                'image https://media.divine.video/thumb',
+                'dim 1080x1920',
+                'size 6169367',
+                'x abc',
+                'blurhash vHHoI6xu-;WB~qRjIUofM{ayM{fQt7of',
+              ],
+              ['duration', '6'],
+            ]),
+          );
+
+          expect(stats.dimensions, equals('1080x1920'));
+          expect(stats.blurhash, equals('vHHoI6xu-;WB~qRjIUofM{ayM{fQt7of'));
+
+          final video = stats.toVideoEvent();
+          expect(video.width, equals(1080));
+          expect(video.height, equals(1920));
+          expect(video.isPortrait, isTrue);
+        },
+      );
     });
 
     group('blurhash from imeta tag', () {

--- a/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
+++ b/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
@@ -2041,6 +2041,50 @@ void main() {
       );
 
       blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'keeps the chosen shape when moving between unconstrained modes',
+        // Only Classic dictates a shape. Stamping mode.defaultAspectRatio on
+        // every switch discarded the user's own choice — and, because the mode
+        // is replayed from prefs on each cold start, re-imposed it forever
+        // (#6200).
+        build: () => buildBloc()
+          ..emit(
+            const VideoRecorderBlocState(
+              aspectRatio: model.AspectRatio.square,
+            ),
+          ),
+        act: (bloc) => bloc.add(
+          const VideoRecorderRecorderModeSet(VideoRecorderMode.lipSync),
+        ),
+        expect: () => const [
+          VideoRecorderBlocState(
+            recorderMode: VideoRecorderMode.lipSync,
+            aspectRatio: model.AspectRatio.square,
+          ),
+        ],
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'leaving classic restores the incoming mode default',
+        build: () => buildBloc()
+          ..emit(
+            const VideoRecorderBlocState(
+              recorderMode: VideoRecorderMode.classic,
+              aspectRatio: model.AspectRatio.square,
+              showGridLines: true,
+            ),
+          ),
+        act: (bloc) => bloc.add(
+          const VideoRecorderRecorderModeSet(VideoRecorderMode.capture),
+        ),
+        expect: () => const [VideoRecorderBlocState()],
+        verify: (bloc) {
+          // Spelled out because vertical is the state default, so the
+          // expectation above would otherwise read as asserting nothing.
+          expect(bloc.state.aspectRatio, equals(model.AspectRatio.vertical));
+        },
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
         'transitions involving upload preserve clips and editor',
         build: buildBloc,
         act: (bloc) => bloc.add(

--- a/mobile/test/models/video_recorder/video_recorder_mode_test.dart
+++ b/mobile/test/models/video_recorder/video_recorder_mode_test.dart
@@ -146,5 +146,65 @@ void main() {
         expect(VideoRecorderMode.upload.capturesStills, isFalse);
       });
     });
+
+    group('constrainsAspectRatio', () {
+      test('is true only for classic', () {
+        // Classic is the 1:1 Vine format by definition. Every other mode must
+        // leave the shape to the user's toggle, so switching between them
+        // cannot silently rewrite it (#6200).
+        expect(VideoRecorderMode.classic.constrainsAspectRatio, isTrue);
+        expect(VideoRecorderMode.capture.constrainsAspectRatio, isFalse);
+        expect(VideoRecorderMode.lipSync.constrainsAspectRatio, isFalse);
+        expect(VideoRecorderMode.stopMotion.constrainsAspectRatio, isFalse);
+        expect(VideoRecorderMode.upload.constrainsAspectRatio, isFalse);
+      });
+
+      test('every mode that constrains the shape declares its own default', () {
+        for (final mode in VideoRecorderMode.values) {
+          if (!mode.constrainsAspectRatio) continue;
+          expect(
+            mode.defaultAspectRatio,
+            equals(model.AspectRatio.square),
+            reason:
+                '${mode.name} constrains the aspect ratio, so its default must '
+                'be the shape it enforces',
+          );
+        }
+      });
+    });
+
+    group('shape-constraining modes', () {
+      // The mode wheel renders VideoRecorderMode.values verbatim, and its end
+      // entries are where an over-fling lands. Reordering the enum silently
+      // moved `classic` (square) into the last slot in 1.0.16, which is how
+      // #6200 shipped — nothing in the suite noticed.
+      //
+      // The guarantee is NOT that a square mode never sits at an end (the
+      // wheel's order is a product decision). It is that reaching such a mode
+      // always takes a deliberate gesture, which is pinned in
+      // video_recorder_mode_selector_test.dart. What belongs here is the
+      // narrower invariant: exactly one mode may impose a shape, so a reorder
+      // cannot quietly add another square trap.
+      test('classic is the only mode allowed to impose a shape', () {
+        final constraining = VideoRecorderMode.values
+            .where((m) => m.constrainsAspectRatio)
+            .toList();
+
+        expect(constraining, equals([VideoRecorderMode.classic]));
+      });
+
+      test('every non-constraining mode defaults to vertical', () {
+        for (final mode in VideoRecorderMode.values) {
+          if (mode.constrainsAspectRatio) continue;
+          expect(
+            mode.defaultAspectRatio,
+            equals(model.AspectRatio.vertical),
+            reason:
+                '${mode.name} does not impose a shape, so its default must be '
+                'the portrait capture default',
+          );
+        }
+      });
+    });
   });
 }

--- a/mobile/test/screens/video_metadata_preview_screen_test.dart
+++ b/mobile/test/screens/video_metadata_preview_screen_test.dart
@@ -27,13 +27,16 @@ class _MockVideoPublishNotifier extends VideoPublishNotifier {
   VideoPublishProviderState build() => _initialState;
 }
 
-DivineVideoClip _createTestClip({String id = 'test-clip'}) {
+DivineVideoClip _createTestClip({
+  String id = 'test-clip',
+  models.AspectRatio targetAspectRatio = models.AspectRatio.square,
+}) {
   return DivineVideoClip(
     id: id,
     video: EditorVideo.file('test.mp4'),
     duration: const Duration(seconds: 10),
     recordedAt: DateTime.now(),
-    targetAspectRatio: models.AspectRatio.square,
+    targetAspectRatio: targetAspectRatio,
     originalAspectRatio: 9 / 16,
   );
 }
@@ -119,6 +122,53 @@ void main() {
         ),
       );
     }
+
+    group('aspect ratio', () {
+      // No test asserted the rendered AspectRatio, so hardcoding this screen
+      // square left all 17 of its tests green — the exact defect users
+      // reported (#6200). Geometry rather than a golden: golden.sh renders
+      // with fonts CI does not provide.
+      Future<double> pumpAndReadAspectRatio(
+        WidgetTester tester,
+        models.AspectRatio target,
+      ) async {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+              const MethodChannel('divine_video_player/player_0'),
+              (call) async => null,
+            );
+        addTearDown(() {
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+              .setMockMethodCallHandler(
+                const MethodChannel('divine_video_player/player_0'),
+                null,
+              );
+        });
+
+        await tester.pumpWidget(
+          buildTestWidget(clip: _createTestClip(targetAspectRatio: target)),
+        );
+        await tester.pump(const Duration(milliseconds: 400));
+
+        return tester
+            .widget<AspectRatio>(find.byType(AspectRatio).first)
+            .aspectRatio;
+      }
+
+      testWidgets('previews a vertical clip at 9:16', (tester) async {
+        expect(
+          await pumpAndReadAspectRatio(tester, models.AspectRatio.vertical),
+          equals(9 / 16),
+        );
+      });
+
+      testWidgets('previews a square clip at 1:1', (tester) async {
+        expect(
+          await pumpAndReadAspectRatio(tester, models.AspectRatio.square),
+          equals(1.0),
+        );
+      });
+    });
 
     test('can be instantiated', () {
       expect(

--- a/mobile/test/widgets/video_metadata/modes/classic/video_metadata_classic_preview_thumbnail_test.dart
+++ b/mobile/test/widgets/video_metadata/modes/classic/video_metadata_classic_preview_thumbnail_test.dart
@@ -152,6 +152,62 @@ void main() {
       });
     });
 
+    group('aspect ratio', () {
+      // Geometry, not goldens: golden.sh renders with real fonts that CI does
+      // not provide, so matchesGoldenFile is guaranteed-red here.
+      Future<double> pumpAndReadAspectRatio(
+        WidgetTester tester,
+        models.AspectRatio target,
+      ) async {
+        final clip = DivineVideoClip(
+          id: 'test-clip',
+          video: EditorVideo.file('test.mp4'),
+          duration: const Duration(seconds: 10),
+          recordedAt: DateTime.now(),
+          thumbnailPath: 'test_thumbnail.jpg',
+          targetAspectRatio: target,
+          originalAspectRatio: 9 / 16,
+        );
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              sharedPreferencesProvider.overrideWithValue(prefs),
+              clipManagerProvider.overrideWith(
+                () => _MockClipManagerNotifier([clip]),
+              ),
+            ],
+            child: const MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(body: VideoMetadataClassicPreviewThumbnail()),
+            ),
+          ),
+        );
+
+        return tester
+            .widget<AspectRatio>(find.byType(AspectRatio).first)
+            .aspectRatio;
+      }
+
+      testWidgets('sizes a vertical clip 9:16, not square', (tester) async {
+        // The stack is chosen by the persisted recorder mode, which can
+        // disagree with the clip being posted. A hardcoded 1:1 box previewed
+        // a portrait recording as a square (#6200).
+        expect(
+          await pumpAndReadAspectRatio(tester, models.AspectRatio.vertical),
+          equals(9 / 16),
+        );
+      });
+
+      testWidgets('sizes a square clip 1:1', (tester) async {
+        expect(
+          await pumpAndReadAspectRatio(tester, models.AspectRatio.square),
+          equals(1.0),
+        );
+      });
+    });
+
     group('player initialization', () {
       testWidgets(
         'initializes player when finalRenderedClip becomes non-null',

--- a/mobile/test/widgets/video_recorder/video_recorder_mode_selector_test.dart
+++ b/mobile/test/widgets/video_recorder/video_recorder_mode_selector_test.dart
@@ -127,6 +127,77 @@ void main() {
         expect(modeChanges, isNot(contains(VideoRecorderMode.classic)));
       });
 
+      testWidgets('a hard fling forward does not jump to the last mode', (
+        tester,
+      ) async {
+        // The -60px drag guard above does not exercise a fling. An over-fling
+        // matches no snap offset, so floorIndex/ceilIndex kept their initial
+        // values (0 and the last index) and the wheel selected a mode the user
+        // never scrolled onto. Both end slots are hazards: the first renders a
+        // blank post screen and the last pins capture to square (#6200).
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+              return null;
+            });
+        addTearDown(() {
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+              .setMockMethodCallHandler(SystemChannels.platform, null);
+        });
+
+        await pumpSelector(tester, mode: VideoRecorderMode.capture);
+
+        await tester.fling(
+          find.byType(ListView),
+          const Offset(-600, 0),
+          6000,
+        );
+        await tester.pumpAndSettle();
+
+        expect(modeChanges, isNot(contains(VideoRecorderMode.values.last)));
+
+        // The user-visible harm: an over-fling must never silently switch the
+        // capture shape. Classic is the only mode that imposes one, and it is
+        // more than one slot from Capture.
+        expect(
+          modeChanges.where((m) => m.constrainsAspectRatio),
+          isEmpty,
+          reason: 'a single fling must not reach a shape-imposing mode',
+        );
+      });
+
+      testWidgets('a hard fling backward does not jump to the first mode', (
+        tester,
+      ) async {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+              return null;
+            });
+        addTearDown(() {
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+              .setMockMethodCallHandler(SystemChannels.platform, null);
+        });
+
+        await pumpSelector(tester, mode: VideoRecorderMode.values.last);
+
+        await tester.fling(find.byType(ListView), const Offset(600, 0), 6000);
+        await tester.pumpAndSettle();
+
+        expect(modeChanges, isNot(contains(VideoRecorderMode.values.first)));
+      });
+
+      testWidgets('tapping a distant mode still selects it directly', (
+        tester,
+      ) async {
+        // The fling bound must not restrict tap-to-select, which does not go
+        // through the snap path.
+        await pumpSelector(tester, mode: VideoRecorderMode.values.first);
+
+        await tester.tap(find.text(VideoRecorderMode.values.last.label));
+        await tester.pumpAndSettle();
+
+        expect(modeChanges, contains(VideoRecorderMode.values.last));
+      });
+
       testWidgets('uses ShaderMask for fade-out edges', (tester) async {
         await pumpSelector(tester);
 


### PR DESCRIPTION
## Description

Portrait recordings previewed as square. The published video was always correct — the reporter's live events are 98/100 `dim 1080x1920`, and everything they posted after filing is still 1080×1920 — so this was a capture-state and preview defect, not a media one.

**Root cause.** `VideoRecorderMode`'s declaration order changed in 1.0.16, moving `classic` — the only mode whose `defaultAspectRatio` is square — from the middle of the mode wheel to the last slot. `_snapToNearest` initialises `floorIndex = 0` and `ceilIndex = length - 1` and then looks for the offsets bracketing the scroll position; an over-fling passes every offset, so neither loop matches and those initial values survive. The wheel selects an end-slot mode the user never scrolled onto, and the choice is persisted. `_setMode` then stamps `state.aspectRatio = mode.defaultAspectRatio` and clears the clip manager, so the clip-derived override that follows sees an empty list. Every cold start replays the saved mode and re-imposes it — one careless swipe made every recording square, permanently.

Four layers, so one hole doesn't sink it:

| | Change |
|---|---|
| Gesture | a single fling advances at most one slot; tap-to-select still jumps anywhere |
| State | only Classic may dictate a shape (`constrainsAspectRatio`); between unconstrained modes the user's own choice survives |
| Render | the classic preview sizes from the clip instead of a hardcoded `AspectRatio(1)` |
| Data | `VideoStats.fromJson` reads `dim` out of `imeta` |

**#3882** is the data half. funnelcake emits `dim` only inside `imeta` — no top-level `dim` tag and no `dimensions` field on any endpoint the app calls (verified against production on `/users/{pk}/recommendations`, `/users/{pk}/videos`, `/videos/{id}`, `/videos/{id}/stats`). The imeta parser only extracted `blurhash`, so every REST-hydrated `VideoEvent` had `dimensions == null` and `isPortrait` false. That is why the "Square only" setting never filtered anything: `shouldHideVideo` returns false whenever width or height is null. Also stopped accepting a `size` tag as dimensions — NIP-92 `size` is a byte count, and divine-web keeps the two separate.

**Related Issue:** Closes #6200, Closes #3882

## Out of Scope

- **The mode wheel's order.** `classic` still sits in the last slot; that's a product decision, and the clamp is what makes the slot safe.
- **`DivineVideoClip.fromJson`'s `orElse: () => AspectRatio.square`.** It is the wrong way round versus the enum's own doc and versus divine-web, but it is effectively unreachable — `toJson` writes the key unconditionally on a non-nullable field, no writer bypasses it, no migration rewrites it, and the enum was never renamed. Flipping it would also mean deliberately re-speccing `recording_clip_test.dart:456`. Worth doing, separately.
- **funnelcake exposing a `dimensions` field.** The mobile-side parse works against today's API and needs no deploy.
- **#6148 / #6163.** Same family — the wheel's other end selects `upload`, which rendered `SizedBox.shrink()`. Both were closed as "addressed by #6199", which touches 0 of its 20 files in that path. Evidence posted on both; reopening is Liz's call. #6396 already fixed that branch.

## Verification

- `flutter analyze lib test integration_test` — clean
- `flutter test` in `packages/models` (816) and `packages/infinite_video_feed` (231, was 229)
- Targeted: recorder mode + selector + bloc + preview screen + classic metadata (193)
- Every new assertion was **checked against the pre-fix behaviour and confirmed to fail**. Two of them were mutation-proven gaps: letterboxing every portrait video left all 229 feed tests green, and hardcoding the post-preview square left all 17 of its tests green. The preview screen's own fixture encoded the bug shape — a portrait source with a square target — and asserted nothing about it.
- No goldens: `golden.sh` renders with fonts CI doesn't provide, so these are geometry assertions.
- **Not yet tested on a device.** `docs/QA_RECORDER_MODE_AND_ASPECT.md` in this PR is the device plan — these defects depend on fling physics and on `SharedPreferences` surviving a restart, so neither reproduces in a simulator or a widget test.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 📝 Documentation
