### PR TITLE
fix(video-editor): keep stop-motion audio covering the composition

### DIFF
--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
@@ -5,6 +5,7 @@ import 'package:models/models.dart' show AudioEvent;
 import 'package:openvine/constants/video_editor_timeline_constants.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/stop_motion/stop_motion_frame_ops.dart';
+import 'package:openvine/models/video_editor/composition_duration.dart';
 import 'package:openvine/models/video_editor/editor_overlay_snapshot.dart';
 import 'package:openvine/observability/reportable_error.dart';
 import 'package:openvine/services/audio_extraction_service.dart';

--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_state.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_state.dart
@@ -213,8 +213,7 @@ class ClipEditorState extends Equatable {
   final Set<int> selectedFrameIndexes;
 
   /// Total wall-clock duration of all clips (respecting trim and playback speed).
-  Duration get totalDuration =>
-      clips.fold(Duration.zero, (sum, clip) => sum + clip.playbackDuration);
+  Duration get totalDuration => compositionDuration(clips);
 
   /// Creates a copy with the given fields replaced.
   ClipEditorState copyWith({

--- a/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart
+++ b/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart
@@ -644,28 +644,45 @@ class TimelineOverlayBloc
 
     final tracksById = {for (final track in state.audioTracks) track.id: track};
 
+    // The preview player builds each sound's window from the overlay item, and
+    // only re-reads it when audioTracksPlayerRevision moves — the track list
+    // itself is untouched here, so Equatable would otherwise let the player
+    // keep the window it was handed before this re-clamp.
+    var soundWindowChanged = false;
     final updated = <TimelineOverlayItem>[];
     for (final item in state.items) {
-      if (item.startTime >= totalDuration) continue;
+      final isSound = item.type == TimelineOverlayType.sound;
+      if (item.startTime >= totalDuration) {
+        soundWindowChanged = soundWindowChanged || isSound;
+        continue;
+      }
 
-      final track = item.type == TimelineOverlayType.sound
-          ? tracksById[item.id]
-          : null;
+      final track = isSound ? tracksById[item.id] : null;
       final clampedEnd = _clampEnd(
         track == null ? item.endTime : _soundWindowEnd(track, totalDuration),
         totalDuration,
       );
-      if (clampedEnd <= item.startTime) continue;
+      if (clampedEnd <= item.startTime) {
+        soundWindowChanged = soundWindowChanged || isSound;
+        continue;
+      }
 
-      updated.add(
-        clampedEnd == item.endTime ? item : item.copyWith(endTime: clampedEnd),
-      );
+      if (clampedEnd == item.endTime) {
+        updated.add(item);
+        continue;
+      }
+      soundWindowChanged = soundWindowChanged || isSound;
+      updated.add(item.copyWith(endTime: clampedEnd));
     }
 
     emit(
       state.copyWith(
         items: _recalculateRows(updated),
         timelineMarkers: _clampMarkers(state.timelineMarkers, totalDuration),
+        audioTracksPlayerRevision:
+            soundWindowChanged && !event.isClipTrimDragging
+            ? state.audioTracksPlayerRevision + 1
+            : state.audioTracksPlayerRevision,
       ),
     );
   }

--- a/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart
+++ b/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart
@@ -270,7 +270,7 @@ class TimelineOverlayBloc
       startTime: hasWindow ? track.startTime : .zero,
       // No valid window → span the whole video. [total] is guaranteed > 0 by
       // _onUpdateItems (transient-zero is substituted with maxDuration there).
-      endTime: hasWindow ? _clampEnd(endTime, total) : total,
+      endTime: _clampEnd(_soundWindowEnd(track, total), total),
       label: track.title ?? track.pubkey,
       maxDuration: sourceDuration != null
           ? sourceDuration - track.startOffset
@@ -627,6 +627,14 @@ class TimelineOverlayBloc
   /// Clamp every overlay item so its visible region fits within
   /// [0, totalDuration]. Items that end up with zero visible duration
   /// are removed.
+  ///
+  /// A sound bar is re-derived from its [AudioEvent] rather than only clamped,
+  /// because a clamp cannot undo itself. Undo/redo builds the bars against the
+  /// total that was current *before* the navigation — the restored clips only
+  /// reach [ClipEditorBloc] afterwards — so redoing an edit that lengthened the
+  /// composition hands this handler a bar already truncated to the old, shorter
+  /// end. Clamping it again would leave the sound playing short under a longer
+  /// video (#6401).
   void _onTotalDurationChanged(
     TimelineOverlayTotalDurationChanged event,
     Emitter<TimelineOverlayState> emit,
@@ -634,11 +642,19 @@ class TimelineOverlayBloc
     final totalDuration = event.totalDuration;
     if (totalDuration <= Duration.zero) return;
 
+    final tracksById = {for (final track in state.audioTracks) track.id: track};
+
     final updated = <TimelineOverlayItem>[];
     for (final item in state.items) {
       if (item.startTime >= totalDuration) continue;
 
-      final clampedEnd = _clampEnd(item.endTime, totalDuration);
+      final track = item.type == TimelineOverlayType.sound
+          ? tracksById[item.id]
+          : null;
+      final clampedEnd = _clampEnd(
+        track == null ? item.endTime : _soundWindowEnd(track, totalDuration),
+        totalDuration,
+      );
       if (clampedEnd <= item.startTime) continue;
 
       updated.add(
@@ -723,6 +739,14 @@ class TimelineOverlayBloc
   /// Returns [endTime] clamped to [totalDuration].
   static Duration _clampEnd(Duration endTime, Duration totalDuration) =>
       endTime > totalDuration ? totalDuration : endTime;
+
+  /// Unclamped end a sound bar for [track] should span to: the track's own
+  /// composition window, or the whole video when that window is missing or
+  /// inverted (see [_soundItem] for why a persisted track can carry one).
+  static Duration _soundWindowEnd(AudioEvent track, Duration total) {
+    final endTime = track.endTime;
+    return endTime != null && endTime > track.startTime ? endTime : total;
+  }
 
   void _onWaveformLoaded(
     TimelineOverlayWaveformLoaded event,

--- a/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_event.dart
+++ b/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_event.dart
@@ -159,12 +159,24 @@ class TimelineOverlayCollapseToggled extends TimelineOverlayEvent {
 /// Dispatched when clip trimming or removal shortens the total
 /// video duration.
 class TimelineOverlayTotalDurationChanged extends TimelineOverlayEvent {
-  const TimelineOverlayTotalDurationChanged(this.totalDuration);
+  const TimelineOverlayTotalDurationChanged(
+    this.totalDuration, {
+    this.isClipTrimDragging = false,
+  });
 
   final Duration totalDuration;
 
+  /// Whether a clip trim drag is still in flight.
+  ///
+  /// The total changes on every frame of that drag, so a sound bar covering
+  /// the end is re-clamped continuously. Re-scheduling the preview player's
+  /// native audio each time would churn it per frame, so the handler skips the
+  /// player bump while this is set. (Clip trims never re-sync the sound to the
+  /// new composition length, drag or not — a separate, pre-existing gap.)
+  final bool isClipTrimDragging;
+
   @override
-  List<Object?> get props => [totalDuration];
+  List<Object?> get props => [totalDuration, isClipTrimDragging];
 }
 
 /// Add a timeline marker at the given playhead [position].

--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -1791,7 +1791,7 @@ class VideoRecorderBloc
       frames: frames,
       originalAspectRatio: state.aspectRatio.value,
       targetAspectRatio: state.aspectRatio,
-      duration: _stopMotionPerFrame * frames.length,
+      duration: StopMotionFrameOps.totalDuration(frames),
       thumbnailPath: frames.first.path,
       lensMetadata: _cameraService.currentLensMetadata,
     );
@@ -1864,7 +1864,7 @@ class VideoRecorderBloc
       frames: frames,
       originalAspectRatio: state.aspectRatio.value,
       targetAspectRatio: state.aspectRatio,
-      duration: _stopMotionPerFrame * frames.length,
+      duration: StopMotionFrameOps.totalDuration(frames),
       thumbnailPath: frames.first.path,
       lensMetadata: _cameraService.currentLensMetadata,
     );

--- a/mobile/lib/extensions/video_editor_extensions.dart
+++ b/mobile/lib/extensions/video_editor_extensions.dart
@@ -167,11 +167,13 @@ extension VideoEditorExtensions on ProImageEditorState {
   /// edit over a soundless composition does not start writing an audio key
   /// into every history entry.
   ///
-  /// Use this from every commit that lengthens the composition by restretching
-  /// or adding stop-motion content — the frame-list commit and the
-  /// camera/clips-picker sync. Deliberately *not* folded into [setClipState]
-  /// itself: that is the generic clip writer, and duplicate/un-trim/speed edits
-  /// would then extend a sound one-way (nothing ever shortens it again), while
+  /// Use this from every commit that can lengthen the composition — the
+  /// stop-motion frame-list commit, the camera/clips-picker sync, duplicating
+  /// a clip, slowing a clip down, and dragging a trim handle back out. The
+  /// grow is one-way: a later shrink leaves the window overhanging, and the
+  /// sound strip's trim handle is the affordance for pulling it back.
+  /// Deliberately *not* folded into [setClipState] itself: that is the
+  /// generic clip writer with no previous-clip list to compare against, and
   /// the transition path measures its output with `TransitionTimelineMap`
   /// rather than a plain sum of playback durations.
   void setLengthenedClipState({

--- a/mobile/lib/extensions/video_editor_extensions.dart
+++ b/mobile/lib/extensions/video_editor_extensions.dart
@@ -158,6 +158,46 @@ extension VideoEditorExtensions on ProImageEditorState {
     setState(() {});
   }
 
+  /// Persists a clip-list change that can make the composition longer, growing
+  /// any audio window that covered the old end onto the new one (#6401).
+  ///
+  /// [previousClips] is the composition as it stood *before* the edit, so the
+  /// grow can tell a window that ran to the end from one the user trimmed
+  /// short. Falls back to a plain [setClipState] when no window moved, so an
+  /// edit over a soundless composition does not start writing an audio key
+  /// into every history entry.
+  ///
+  /// Use this from every commit that lengthens the composition by restretching
+  /// or adding stop-motion content — the frame-list commit and the
+  /// camera/clips-picker sync. Deliberately *not* folded into [setClipState]
+  /// itself: that is the generic clip writer, and duplicate/un-trim/speed edits
+  /// would then extend a sound one-way (nothing ever shortens it again), while
+  /// the transition path measures its output with `TransitionTimelineMap`
+  /// rather than a plain sum of playback durations.
+  void setLengthenedClipState({
+    required List<DivineVideoClip> previousClips,
+    required List<DivineVideoClip> clips,
+    List<Duration>? timelineMarkers,
+  }) {
+    final currentTracks = stateManager.audioTracks;
+    final grownTracks = growAudioToCompositionEnd(
+      rebaseAnchoredAudioForClipState(clips, currentTracks),
+      previousDuration: compositionDuration(previousClips),
+      duration: compositionDuration(clips),
+      maxDuration: VideoEditorConstants.maxDuration,
+    );
+
+    if (identical(grownTracks, currentTracks)) {
+      setClipState(clips, timelineMarkers: timelineMarkers);
+      return;
+    }
+    setClipAndAudioState(
+      clips: clips,
+      audioTracks: grownTracks,
+      timelineMarkers: timelineMarkers,
+    );
+  }
+
   /// Persists clip trim and order state in the editor's history metadata.
   ///
   /// When [skipUpdateHistory] is `false` (default), creates a new history

--- a/mobile/lib/extensions/video_editor_extensions.dart
+++ b/mobile/lib/extensions/video_editor_extensions.dart
@@ -2,6 +2,7 @@ import 'package:models/models.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/extensions/video_editor_history_extensions.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/video_editor/composition_duration.dart';
 import 'package:openvine/models/video_editor/editor_overlay_snapshot.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart';
 import 'package:pro_image_editor/pro_image_editor.dart' hide AudioTrack;

--- a/mobile/lib/models/video_editor/composition_duration.dart
+++ b/mobile/lib/models/video_editor/composition_duration.dart
@@ -1,0 +1,5 @@
+import 'package:openvine/models/divine_video_clip.dart';
+
+/// Total wall-clock duration [clips] occupy on the editor timeline.
+Duration compositionDuration(List<DivineVideoClip> clips) =>
+    clips.fold(Duration.zero, (sum, clip) => sum + clip.playbackDuration);

--- a/mobile/lib/screens/video_editor/video_editor_screen.dart
+++ b/mobile/lib/screens/video_editor/video_editor_screen.dart
@@ -463,13 +463,27 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen>
 
   /// Syncs the current clip list from [clipManagerProvider] into the
   /// [ClipEditorBloc] and appends a history entry to the pro_image_editor.
+  ///
+  /// Both callers add content — stills shot from the editor's camera, a
+  /// stop-motion set merged in from the clips picker — so the composition can
+  /// end up longer than the one a sound was clamped to when it was added.
+  /// [VideoEditorExtensions.setLengthenedClipState] carries a window that ran
+  /// to the old end onto the new one (#6401); a window the user trimmed short
+  /// is left alone.
   void _syncClipsToEditor({required ClipEditorBloc clipEditorBloc}) {
+    // Read before the dispatch: this is the composition the audio windows were
+    // last clamped against.
+    final previousClips = clipEditorBloc.state.clips;
+
     // Sync the updated clip list into the editor BLoC.
     final updatedClips = ref.read(clipManagerProvider).clips;
     clipEditorBloc.add(ClipEditorInitialized(updatedClips));
 
     if (_editor != null) {
-      _editor!.setClipState(updatedClips);
+      _editor!.setLengthenedClipState(
+        previousClips: previousClips,
+        clips: updatedClips,
+      );
     }
   }
 

--- a/mobile/lib/widgets/video_editor/stop_motion/stop_motion_frame_commands.dart
+++ b/mobile/lib/widgets/video_editor/stop_motion/stop_motion_frame_commands.dart
@@ -6,7 +6,9 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
 import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
+import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/extensions/video_editor_extensions.dart';
+import 'package:openvine/extensions/video_editor_history_extensions.dart';
 import 'package:openvine/models/stop_motion/stop_motion_frame_ops.dart';
 import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
@@ -16,9 +18,10 @@ import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timel
 /// Commits a new stop-motion frame list for the single stop-motion clip
 /// [clipId].
 ///
-/// Updates the [ClipEditorBloc], rebases timeline markers, and writes the change
-/// to editor history (undo/redo) — mirroring the clip-level edit commit in
-/// `TimelineClipControls` (`_deleteClip` / `_setPlaybackSpeed`). A no-op edit
+/// Updates the [ClipEditorBloc], rebases timeline markers, stretches audio that
+/// ran to the end of the composition onto the new (longer) end, and writes the
+/// change to editor history (undo/redo) — mirroring the clip-level edit commit
+/// in `TimelineClipControls` (`_deleteClip` / `_setPlaybackSpeed`). A no-op edit
 /// (the frame-ops helpers return the source list unchanged) is skipped so it
 /// never records an empty history entry.
 ///
@@ -53,9 +56,27 @@ void commitStopMotionFrames(
     markers: overlayBloc.state.timelineMarkers,
   );
 
+  // A hold change restretches the whole composition, so a sound that covered it
+  // has to grow with it (#6401).
+  final currentTracks = editor.stateManager.audioTracks;
+  final grownTracks = growAudioToCompositionEnd(
+    rebaseAnchoredAudioForClipState(newClips, currentTracks),
+    previousDuration: compositionDuration(state.clips),
+    duration: compositionDuration(newClips),
+    maxDuration: VideoEditorConstants.maxDuration,
+  );
+
   bloc.add(ClipEditorClipUpdated(clipId: clipId, clip: updated));
   overlayBloc.add(TimelineMarkersRebased(rebasedMarkers));
-  editor.setClipState(newClips, timelineMarkers: rebasedMarkers);
+  if (identical(grownTracks, currentTracks)) {
+    editor.setClipState(newClips, timelineMarkers: rebasedMarkers);
+  } else {
+    editor.setClipAndAudioState(
+      clips: newClips,
+      audioTracks: grownTracks,
+      timelineMarkers: rebasedMarkers,
+    );
+  }
 }
 
 List<StopMotionClipFrame>? _stopMotionFrames(

--- a/mobile/lib/widgets/video_editor/stop_motion/stop_motion_frame_commands.dart
+++ b/mobile/lib/widgets/video_editor/stop_motion/stop_motion_frame_commands.dart
@@ -6,9 +6,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
 import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
-import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/extensions/video_editor_extensions.dart';
-import 'package:openvine/extensions/video_editor_history_extensions.dart';
 import 'package:openvine/models/stop_motion/stop_motion_frame_ops.dart';
 import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
@@ -56,27 +54,15 @@ void commitStopMotionFrames(
     markers: overlayBloc.state.timelineMarkers,
   );
 
-  // A hold change restretches the whole composition, so a sound that covered it
-  // has to grow with it (#6401).
-  final currentTracks = editor.stateManager.audioTracks;
-  final grownTracks = growAudioToCompositionEnd(
-    rebaseAnchoredAudioForClipState(newClips, currentTracks),
-    previousDuration: compositionDuration(state.clips),
-    duration: compositionDuration(newClips),
-    maxDuration: VideoEditorConstants.maxDuration,
-  );
-
   bloc.add(ClipEditorClipUpdated(clipId: clipId, clip: updated));
   overlayBloc.add(TimelineMarkersRebased(rebasedMarkers));
-  if (identical(grownTracks, currentTracks)) {
-    editor.setClipState(newClips, timelineMarkers: rebasedMarkers);
-  } else {
-    editor.setClipAndAudioState(
-      clips: newClips,
-      audioTracks: grownTracks,
-      timelineMarkers: rebasedMarkers,
-    );
-  }
+  // A hold change restretches the whole composition, so a sound that covered it
+  // has to grow with it (#6401).
+  editor.setLengthenedClipState(
+    previousClips: state.clips,
+    clips: newClips,
+    timelineMarkers: rebasedMarkers,
+  );
 }
 
 List<StopMotionClipFrame>? _stopMotionFrames(

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart
@@ -202,7 +202,14 @@ class _TimelineClipControlsState extends State<TimelineClipControls> {
     bloc.add(ClipEditorClipUpdated(clipId: clip.id, clip: updated));
     overlayBloc.add(TimelineMarkersRebased(rebasedMarkers));
 
-    editor.setClipState(newClips, timelineMarkers: rebasedMarkers);
+    // Slowing a clip down lengthens the composition, so a sound that covered
+    // the old end has to grow with it (#6401); a speed-up passes through
+    // unchanged.
+    editor.setLengthenedClipState(
+      previousClips: currentClips,
+      clips: newClips,
+      timelineMarkers: rebasedMarkers,
+    );
   }
 
   void _requestExtractAudio(BuildContext context) {
@@ -331,7 +338,13 @@ class _TimelineClipControlsState extends State<TimelineClipControls> {
       ..add(const ClipEditorEditingStopped());
 
     overlayBloc.add(TimelineMarkersRebased(rebasedMarkers));
-    editor.setClipState(newClips, timelineMarkers: rebasedMarkers);
+    // Appending the copy lengthens the composition, so a sound that covered
+    // the old end has to grow with it (#6401).
+    editor.setLengthenedClipState(
+      previousClips: state.clips,
+      clips: newClips,
+      timelineMarkers: rebasedMarkers,
+    );
   }
 
   void _splitClip(BuildContext context) {

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart
@@ -542,8 +542,12 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
       overlayBloc.add(TimelineMarkersRebased(rebasedMarkers));
       clipEditorBloc.add(const ClipEditorTrimDragEnded());
 
-      editor.setClipState(
-        clipEditorBloc.state.clips,
+      // Dragging a trim handle back out lengthens the composition, so a sound
+      // that covered the old end has to grow with it (#6401); a trim that
+      // only shortened the clip passes through unchanged.
+      editor.setLengthenedClipState(
+        previousClips: _clipTrimStartClips ?? clipEditorBloc.state.clips,
+        clips: clipEditorBloc.state.clips,
         timelineMarkers: rebasedMarkers,
       );
       _clipTrimStartClips = null;

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart
@@ -189,7 +189,10 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
             // shortening while a trim gesture is active.
             final overlayBloc = context.read<TimelineOverlayBloc>();
             overlayBloc.add(
-              TimelineOverlayTotalDurationChanged(state.totalDuration),
+              TimelineOverlayTotalDurationChanged(
+                state.totalDuration,
+                isClipTrimDragging: state.isTrimDragging,
+              ),
             );
             final rebasedMarkers = _rebasedClipTrimMarkers(state.clips);
             if (rebasedMarkers != null) {

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart
@@ -250,13 +250,20 @@ const _audioWindowResolution = Duration(milliseconds: 1);
 /// stretches nine stills from 0.375s to 6.375s published a 6.375s video muxed
 /// with a 0.375s audio track (#6401).
 ///
-/// Only tracks that reached [previousDuration] follow the new end; a window the
-/// user deliberately trimmed shorter keeps its length. The new end is bounded
-/// by the audio the track still has left after its [AudioEvent.startOffset] and
-/// by [maxDuration], matching the ceiling the track would have been given had
-/// the sound been added at the new composition length. Windows are never
-/// shortened here — a composition that shrank is clamped for display by the
-/// timeline and for output by the render.
+/// Only tracks whose window *ended at* [previousDuration] follow the new end.
+/// A window the user deliberately trimmed shorter keeps its length, and so does
+/// one that overhangs the old end — after a shrink-then-grow (lower the hold,
+/// raise it again) a trimmed window sits past the shorter composition, and a
+/// one-sided "did it reach the end" test would read that overhang as coverage
+/// and silently undo the trim. The cost of the symmetric test is that a window
+/// left overhanging a shrunken composition keeps its old end instead of being
+/// re-extended; the sound strip's trim handle is the affordance for that.
+///
+/// The new end is bounded by the audio the track still has left after its
+/// [AudioEvent.startOffset] and by [maxDuration], matching the ceiling the
+/// track would have been given had the sound been added at the new composition
+/// length. Windows are never shortened here — a composition that shrank is
+/// clamped for display by the timeline and for output by the render.
 ///
 /// Returns the original list instance when nothing moved.
 List<AudioEvent> growAudioToCompositionEnd(
@@ -273,9 +280,10 @@ List<AudioEvent> growAudioToCompositionEnd(
   for (final track in audioTracks) {
     final endTime = track.endTime;
     // No window: the track already plays to its own end, and the render clamps
-    // that to the video.
+    // that to the video. A window that ends anywhere but the old composition
+    // end — short of it or past it — was placed by the user, not by the clamp.
     if (endTime == null ||
-        endTime + _audioWindowResolution < previousDuration) {
+        (endTime - previousDuration).abs() > _audioWindowResolution) {
       result.add(track);
       continue;
     }

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart
@@ -229,10 +229,6 @@ List<AudioEvent> rebaseAnchoredAudioForClipState(
   return changed ? result : audioTracks;
 }
 
-/// Total wall-clock duration [clips] occupy on the timeline.
-Duration compositionDuration(List<DivineVideoClip> clips) =>
-    clips.fold(Duration.zero, (sum, clip) => sum + clip.playbackDuration);
-
 /// Granularity an audio window survives a history/draft round-trip at.
 ///
 /// [AudioEvent] serializes its window in whole milliseconds while a stop-motion
@@ -313,7 +309,7 @@ Duration? _audioSourceEnd(AudioEvent track) {
   final duration = track.duration;
   if (duration == null || duration <= 0) return null;
   final remaining =
-      Duration(milliseconds: (duration * 1000).round()) - track.startOffset;
+      Duration(milliseconds: (duration * 1000).toInt()) - track.startOffset;
   if (remaining <= Duration.zero) return null;
   return track.startTime + remaining;
 }

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart
@@ -229,6 +229,87 @@ List<AudioEvent> rebaseAnchoredAudioForClipState(
   return changed ? result : audioTracks;
 }
 
+/// Total wall-clock duration [clips] occupy on the timeline.
+Duration compositionDuration(List<DivineVideoClip> clips) =>
+    clips.fold(Duration.zero, (sum, clip) => sum + clip.playbackDuration);
+
+/// Granularity an audio window survives a history/draft round-trip at.
+///
+/// [AudioEvent] serializes its window in whole milliseconds while a stop-motion
+/// composition is microsecond-accurate (a 1/24s hold is 41667µs), so a window
+/// restored from history sits up to a millisecond short of the composition end
+/// it was clamped to. Comparisons against the composition end carry that slack.
+const _audioWindowResolution = Duration(milliseconds: 1);
+
+/// Stretches audio windows that ran to the end of the composition so they keep
+/// covering it after an edit made the composition longer.
+///
+/// A sound is added with its window clamped to the composition end (see
+/// `_openMusicLibrary`). Growing the composition afterwards used to leave that
+/// window frozen at the old, shorter end — a stop-motion hold change that
+/// stretches nine stills from 0.375s to 6.375s published a 6.375s video muxed
+/// with a 0.375s audio track (#6401).
+///
+/// Only tracks that reached [previousDuration] follow the new end; a window the
+/// user deliberately trimmed shorter keeps its length. The new end is bounded
+/// by the audio the track still has left after its [AudioEvent.startOffset] and
+/// by [maxDuration], matching the ceiling the track would have been given had
+/// the sound been added at the new composition length. Windows are never
+/// shortened here — a composition that shrank is clamped for display by the
+/// timeline and for output by the render.
+///
+/// Returns the original list instance when nothing moved.
+List<AudioEvent> growAudioToCompositionEnd(
+  List<AudioEvent> audioTracks, {
+  required Duration previousDuration,
+  required Duration duration,
+  required Duration maxDuration,
+}) {
+  if (audioTracks.isEmpty || duration <= previousDuration) return audioTracks;
+
+  final ceiling = duration < maxDuration ? duration : maxDuration;
+  var changed = false;
+  final result = <AudioEvent>[];
+  for (final track in audioTracks) {
+    final endTime = track.endTime;
+    // No window: the track already plays to its own end, and the render clamps
+    // that to the video.
+    if (endTime == null ||
+        endTime + _audioWindowResolution < previousDuration) {
+      result.add(track);
+      continue;
+    }
+
+    final sourceEnd = _audioSourceEnd(track);
+    final newEnd = sourceEnd != null && sourceEnd < ceiling
+        ? sourceEnd
+        : ceiling;
+    if (newEnd <= endTime) {
+      result.add(track);
+      continue;
+    }
+    changed = true;
+    result.add(track.copyWith(endTime: newEnd));
+  }
+
+  return changed ? result : audioTracks;
+}
+
+/// Timeline position at which [track] runs out of source audio, or `null` when
+/// its source length is unknown.
+///
+/// A non-positive duration counts as unknown, matching the sound timeline item
+/// and the duration-heal path, so a persisted-but-zero duration cannot collapse
+/// a window instead of leaving it uncapped.
+Duration? _audioSourceEnd(AudioEvent track) {
+  final duration = track.duration;
+  if (duration == null || duration <= 0) return null;
+  final remaining =
+      Duration(milliseconds: (duration * 1000).round()) - track.startOffset;
+  if (remaining <= Duration.zero) return null;
+  return track.startTime + remaining;
+}
+
 _TimelineMarkerAnchor? _timelineMarkerAnchorForPosition(
   List<DivineVideoClip> clips,
   Duration marker,

--- a/mobile/test/blocs/video_editor/timeline_overlay/timeline_overlay_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/timeline_overlay/timeline_overlay_bloc_test.dart
@@ -1538,6 +1538,72 @@ void main() {
       );
 
       blocTest<TimelineOverlayBloc, TimelineOverlayState>(
+        'restores a sound bar the redo reconcile clamped against a stale total',
+        build: TimelineOverlayBloc.new,
+        // Redo of a stop-motion hold change: the history entry carries the
+        // grown 4.5s window, but the reconcile reads the total off
+        // ClipEditorBloc *before* the restored clips land there, so the bar is
+        // built against the pre-redo 3s. The timeline then reports the real
+        // total — the bar has to follow it back out, or the sound plays 3s
+        // under a 4.5s video (#6401).
+        act: (bloc) => bloc
+          ..add(
+            TimelineOverlayItemsUpdate(
+              layers: const <Layer>[],
+              filters: const <FilterState>[],
+              audioTracks: [
+                _audioEvent(
+                  id: 'sound-1',
+                  start: Duration.zero,
+                  end: const Duration(milliseconds: 4500),
+                ),
+              ],
+              totalVideoDuration: const Duration(seconds: 3),
+            ),
+          )
+          ..add(
+            const TimelineOverlayTotalDurationChanged(
+              Duration(milliseconds: 4500),
+            ),
+          ),
+        verify: (bloc) {
+          final sound = bloc.state.items.firstWhere((i) => i.id == 'sound-1');
+          expect(sound.endTime, const Duration(milliseconds: 4500));
+        },
+      );
+
+      blocTest<TimelineOverlayBloc, TimelineOverlayState>(
+        'does not stretch a sound past the window the user trimmed it to',
+        build: TimelineOverlayBloc.new,
+        // Same growth, but this track's own window is 1.5s. Following the
+        // total must never invent coverage the AudioEvent does not have.
+        act: (bloc) => bloc
+          ..add(
+            TimelineOverlayItemsUpdate(
+              layers: const <Layer>[],
+              filters: const <FilterState>[],
+              audioTracks: [
+                _audioEvent(
+                  id: 'sound-1',
+                  start: Duration.zero,
+                  end: const Duration(milliseconds: 1500),
+                ),
+              ],
+              totalVideoDuration: const Duration(seconds: 3),
+            ),
+          )
+          ..add(
+            const TimelineOverlayTotalDurationChanged(
+              Duration(milliseconds: 4500),
+            ),
+          ),
+        verify: (bloc) {
+          final sound = bloc.state.items.firstWhere((i) => i.id == 'sound-1');
+          expect(sound.endTime, const Duration(milliseconds: 1500));
+        },
+      );
+
+      blocTest<TimelineOverlayBloc, TimelineOverlayState>(
         'clamps markers to the provided total duration',
         build: TimelineOverlayBloc.new,
         seed: () => const TimelineOverlayState(

--- a/mobile/test/blocs/video_editor/timeline_overlay/timeline_overlay_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/timeline_overlay/timeline_overlay_bloc_test.dart
@@ -1569,6 +1569,66 @@ void main() {
         verify: (bloc) {
           final sound = bloc.state.items.firstWhere((i) => i.id == 'sound-1');
           expect(sound.endTime, const Duration(milliseconds: 4500));
+          // The bar alone is not enough: the preview player builds its window
+          // from the item and is only re-synced when this counter moves, so
+          // without the bump the sound keeps playing the truncated 3s.
+          expect(bloc.state.audioTracksPlayerRevision, 1);
+        },
+      );
+
+      blocTest<TimelineOverlayBloc, TimelineOverlayState>(
+        'does not re-sync the player mid clip-trim drag',
+        build: TimelineOverlayBloc.new,
+        // The total changes every frame of the drag, so bumping here would
+        // tear down and reschedule native audio per frame. The bar still
+        // follows; only the player bump waits.
+        act: (bloc) => bloc
+          ..add(
+            TimelineOverlayItemsUpdate(
+              layers: const <Layer>[],
+              filters: const <FilterState>[],
+              audioTracks: [
+                _audioEvent(
+                  id: 'sound-1',
+                  start: Duration.zero,
+                  end: const Duration(seconds: 6),
+                ),
+              ],
+              totalVideoDuration: const Duration(seconds: 6),
+            ),
+          )
+          ..add(
+            const TimelineOverlayTotalDurationChanged(
+              Duration(seconds: 3),
+              isClipTrimDragging: true,
+            ),
+          ),
+        verify: (bloc) {
+          final sound = bloc.state.items.firstWhere((i) => i.id == 'sound-1');
+          expect(sound.endTime, const Duration(seconds: 3));
+          expect(bloc.state.audioTracksPlayerRevision, 0);
+        },
+      );
+
+      blocTest<TimelineOverlayBloc, TimelineOverlayState>(
+        'does not re-sync the player when no sound window moved',
+        build: TimelineOverlayBloc.new,
+        // A layer clamp must not churn the native audio tracks.
+        seed: () => TimelineOverlayState(
+          items: [
+            _item(
+              id: 'layer-1',
+              type: TimelineOverlayType.layer,
+              start: const Duration(seconds: 2),
+              end: const Duration(seconds: 10),
+            ),
+          ],
+        ),
+        act: (bloc) => bloc.add(
+          const TimelineOverlayTotalDurationChanged(Duration(seconds: 5)),
+        ),
+        verify: (bloc) {
+          expect(bloc.state.audioTracksPlayerRevision, 0);
         },
       );
 

--- a/mobile/test/extensions/video_editor_extensions_test.dart
+++ b/mobile/test/extensions/video_editor_extensions_test.dart
@@ -16,10 +16,13 @@ class _MockProImageEditorState extends Mock implements ProImageEditorState {
 
 class _MockStateManager extends Mock implements StateManager {}
 
-DivineVideoClip _clip(String id) => DivineVideoClip(
+DivineVideoClip _clip(
+  String id, {
+  Duration duration = const Duration(seconds: 3),
+}) => DivineVideoClip(
   id: id,
   video: EditorVideo.file('/tmp/$id.mp4'),
-  duration: const Duration(seconds: 3),
+  duration: duration,
   recordedAt: DateTime(2026),
   targetAspectRatio: .vertical,
   originalAspectRatio: 9 / 16,
@@ -106,6 +109,88 @@ void main() {
         meta[VideoEditorConstants.clipsStateHistoryKey],
         isA<List<dynamic>>().having((clips) => clips.length, 'length', 1),
       );
+    });
+
+    group('setLengthenedClipState', () {
+      // #6401 on the content-added path: a sound clamped to a 3s composition
+      // when it was added, then the user shoots more stills from the editor's
+      // camera (or merges a set in from the clips picker) and the composition
+      // becomes 6s. Without the grow, publish muxes a 6s video with 3s audio.
+      const covering = AudioEvent(
+        id: 'sound-1',
+        pubkey: 'bundled',
+        createdAt: 0,
+        url: 'asset://sounds/loop.mp3',
+        duration: 30,
+        endTime: Duration(seconds: 3),
+      );
+
+      List<AudioEvent> capturedAudio() {
+        final meta =
+            verify(
+                  () => editor.addHistory(meta: captureAny(named: 'meta')),
+                ).captured.single
+                as Map<String, dynamic>;
+        final raw =
+            meta[VideoEditorConstants.audioStateHistoryKey] as List<dynamic>;
+        return raw
+            .cast<Map<String, dynamic>>()
+            .map(AudioEvent.fromJson)
+            .toList();
+      }
+
+      test('grows a sound that covered the old end onto the added clip', () {
+        when(() => stateManager.activeMeta).thenReturn({
+          VideoEditorConstants.audioStateHistoryKey: [covering.toJson()],
+        });
+
+        editor.setLengthenedClipState(
+          previousClips: [_clip('clip-1')],
+          clips: [_clip('clip-1'), _clip('clip-2')],
+        );
+
+        expect(capturedAudio().single.endTime, const Duration(seconds: 6));
+      });
+
+      test('leaves a sound the user trimmed short of the old end', () {
+        const trimmed = AudioEvent(
+          id: 'sound-1',
+          pubkey: 'bundled',
+          createdAt: 0,
+          url: 'asset://sounds/loop.mp3',
+          duration: 30,
+          endTime: Duration(seconds: 1),
+        );
+        when(() => stateManager.activeMeta).thenReturn({
+          VideoEditorConstants.audioStateHistoryKey: [trimmed.toJson()],
+        });
+
+        editor.setLengthenedClipState(
+          previousClips: [_clip('clip-1')],
+          clips: [_clip('clip-1'), _clip('clip-2')],
+        );
+
+        expect(capturedAudio().single.endTime, const Duration(seconds: 1));
+      });
+
+      test('writes no audio key when the composition has no sound', () {
+        when(() => stateManager.activeMeta).thenReturn({});
+
+        editor.setLengthenedClipState(
+          previousClips: [_clip('clip-1')],
+          clips: [_clip('clip-1'), _clip('clip-2')],
+        );
+
+        final meta =
+            verify(
+                  () => editor.addHistory(meta: captureAny(named: 'meta')),
+                ).captured.single
+                as Map<String, dynamic>;
+        expect(
+          meta.containsKey(VideoEditorConstants.audioStateHistoryKey),
+          isFalse,
+        );
+      });
     });
 
     test('setClipState updates current markers when skipping history', () {

--- a/mobile/test/widgets/video_editor/stop_motion/stop_motion_frame_commands_test.dart
+++ b/mobile/test/widgets/video_editor/stop_motion/stop_motion_frame_commands_test.dart
@@ -1,0 +1,219 @@
+// ABOUTME: Widget tests for the stop-motion frame-list commit command.
+// ABOUTME: Verifies audio that covered the composition follows a hold change.
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart' as model;
+import 'package:models/models.dart' show AudioEvent;
+import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
+import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
+import 'package:openvine/constants/video_editor_constants.dart';
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/stop_motion/stop_motion_frame_ops.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
+import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
+import 'package:openvine/widgets/video_editor/stop_motion/stop_motion_frame_commands.dart';
+import 'package:pro_image_editor/pro_image_editor.dart';
+
+class _MockClipEditorBloc extends MockBloc<ClipEditorEvent, ClipEditorState>
+    implements ClipEditorBloc {}
+
+class _MockTimelineOverlayBloc
+    extends MockBloc<TimelineOverlayEvent, TimelineOverlayState>
+    implements TimelineOverlayBloc {}
+
+class _MockProImageEditorState extends Mock implements ProImageEditorState {
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
+      '_MockProImageEditorState';
+}
+
+class _MockStateManager extends Mock implements StateManager {}
+
+void main() {
+  group(commitStopMotionFrames, () {
+    const clipId = 'clip_sm_1';
+    const frameCount = 9;
+
+    late _MockClipEditorBloc bloc;
+    late _MockTimelineOverlayBloc overlayBloc;
+    late _MockProImageEditorState editor;
+    late _MockStateManager stateManager;
+
+    setUpAll(() {
+      registerFallbackValue(const ClipEditorEditingStopped());
+      registerFallbackValue(const TimelineMarkersRebased([]));
+    });
+
+    List<StopMotionClipFrame> framesHeldFor(int framesPerImage) => [
+      for (var i = 0; i < frameCount; i++)
+        StopMotionClipFrame(
+          path: '/tmp/frame_$i.jpg',
+          duration: StopMotionFrameOps.framesPerImageToDuration(framesPerImage),
+        ),
+    ];
+
+    DivineVideoClip clipWith(List<StopMotionClipFrame> frames) =>
+        DivineVideoClip(
+          id: clipId,
+          stopMotionFrames: frames,
+          duration: StopMotionFrameOps.totalDuration(frames),
+          recordedAt: DateTime(2026),
+          targetAspectRatio: model.AspectRatio.vertical,
+          originalAspectRatio: 9 / 16,
+        );
+
+    setUp(() {
+      bloc = _MockClipEditorBloc();
+      overlayBloc = _MockTimelineOverlayBloc();
+      editor = _MockProImageEditorState();
+      stateManager = _MockStateManager();
+
+      when(() => overlayBloc.state).thenReturn(const TimelineOverlayState());
+      when(() => editor.stateManager).thenReturn(stateManager);
+      when(
+        () => editor.addHistory(
+          layers: any(named: 'layers'),
+          filters: any(named: 'filters'),
+          meta: any(named: 'meta'),
+          newLayer: any(named: 'newLayer'),
+          transformConfigs: any(named: 'transformConfigs'),
+          tuneAdjustments: any(named: 'tuneAdjustments'),
+          blur: any(named: 'blur'),
+          heroScreenshotRequired: any(named: 'heroScreenshotRequired'),
+          blockCaptureScreenshot: any(named: 'blockCaptureScreenshot'),
+        ),
+      ).thenAnswer((_) {});
+      when(() => editor.setState(any())).thenAnswer((invocation) {
+        (invocation.positionalArguments.single as VoidCallback)();
+      });
+    });
+
+    Future<void> commit(
+      WidgetTester tester, {
+      required List<StopMotionClipFrame> frames,
+    }) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: VideoEditorScope(
+            editorKey: GlobalKey<ProImageEditorState>(),
+            editorOverride: editor,
+            removeAreaKey: GlobalKey(),
+            originalClipAspectRatio: 9 / 16,
+            bodySizeNotifier: ValueNotifier(const Size(400, 600)),
+            zoomMatrixNotifier: ValueNotifier(Matrix4.identity()),
+            fromLibrary: false,
+            onOpenCamera: () {},
+            onOpenClipsEditor: () {},
+            onAddStickers: () {},
+            onOpenMusicLibrary: () {},
+            onOpenVoiceOver: () {},
+            onAddEditTextLayer: ([layer]) async => null,
+            child: MultiBlocProvider(
+              providers: [
+                BlocProvider<ClipEditorBloc>.value(value: bloc),
+                BlocProvider<TimelineOverlayBloc>.value(value: overlayBloc),
+              ],
+              child: Builder(
+                builder: (context) => TextButton(
+                  onPressed: () => commitStopMotionFrames(
+                    context,
+                    clipId: clipId,
+                    frames: frames,
+                  ),
+                  child: const Text('commit'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('commit'));
+      await tester.pump();
+    }
+
+    List<AudioEvent> capturedAudio() {
+      final meta =
+          verify(
+                () => editor.addHistory(
+                  layers: any(named: 'layers'),
+                  filters: any(named: 'filters'),
+                  meta: captureAny(named: 'meta'),
+                  newLayer: any(named: 'newLayer'),
+                  transformConfigs: any(named: 'transformConfigs'),
+                  tuneAdjustments: any(named: 'tuneAdjustments'),
+                  blur: any(named: 'blur'),
+                  heroScreenshotRequired: any(named: 'heroScreenshotRequired'),
+                  blockCaptureScreenshot: any(
+                    named: 'blockCaptureScreenshot',
+                  ),
+                ),
+              ).captured.single
+              as Map<String, dynamic>;
+      final raw =
+          meta[VideoEditorConstants.audioStateHistoryKey] as List<dynamic>;
+      return raw.cast<Map<String, dynamic>>().map(AudioEvent.fromJson).toList();
+    }
+
+    testWidgets('stretches a sound that covered the composition when a longer '
+        'hold restretches it', (tester) async {
+      // #6401: nine stills at the default hold are 375ms, and a sound added
+      // there is clamped to 375ms. Holding each still for 12 output frames
+      // makes the video 4.5s — the sound has to grow with it, or publish muxes
+      // a 4.5s video with a 375ms audio track.
+      final captured = framesHeldFor(StopMotionFrameOps.defaultFramesPerImage);
+      final sound = AudioEvent(
+        id: 'sound-1',
+        pubkey: 'bundled',
+        createdAt: 0,
+        url: 'asset://sounds/loop.mp3',
+        duration: 30,
+        endTime: StopMotionFrameOps.totalDuration(captured),
+      );
+      when(() => stateManager.activeMeta).thenReturn({
+        VideoEditorConstants.audioStateHistoryKey: [sound.toJson()],
+      });
+      when(
+        () => bloc.state,
+      ).thenReturn(ClipEditorState(clips: [clipWith(captured)]));
+
+      await commit(tester, frames: framesHeldFor(12));
+
+      expect(
+        capturedAudio().single.endTime,
+        const Duration(milliseconds: 4500),
+      );
+    });
+
+    testWidgets('leaves a sound the user trimmed short of the composition', (
+      tester,
+    ) async {
+      final captured = framesHeldFor(StopMotionFrameOps.defaultFramesPerImage);
+      const sound = AudioEvent(
+        id: 'sound-1',
+        pubkey: 'bundled',
+        createdAt: 0,
+        url: 'asset://sounds/loop.mp3',
+        duration: 30,
+        endTime: Duration(milliseconds: 200),
+      );
+      when(() => stateManager.activeMeta).thenReturn({
+        VideoEditorConstants.audioStateHistoryKey: [sound.toJson()],
+      });
+      when(
+        () => bloc.state,
+      ).thenReturn(ClipEditorState(clips: [clipWith(captured)]));
+
+      await commit(tester, frames: framesHeldFor(12));
+
+      // The clip edit is still committed; only the audio window is untouched.
+      expect(
+        capturedAudio().single.endTime,
+        const Duration(milliseconds: 200),
+      );
+    });
+  });
+}

--- a/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls_test.dart
@@ -2,18 +2,23 @@
 // ABOUTME: Verifies visible actions and done-event dispatch.
 
 import 'package:bloc_test/bloc_test.dart';
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart' as model;
+import 'package:models/models.dart' show AudioEvent;
 import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
 import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
+import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
+import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_clip_speed_sheet.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_timeline_controls.dart';
 import 'package:pro_image_editor/features/main_editor/services/sizes_manager.dart'
@@ -547,6 +552,178 @@ void main() {
         expect(event.overlays, isNotNull);
       },
     );
+
+    // #6401 on the clip-edit paths: duplicate and speed-down lengthen the
+    // composition, and a sound clamped to the old end has to follow it.
+    group('sound follows composition growth', () {
+      late _MockProImageEditorState editor;
+      late _MockStateManager stateManager;
+      late _MockTimelineOverlayBloc overlayBloc;
+
+      const coveringSound = AudioEvent(
+        id: 'sound-1',
+        pubkey: 'bundled',
+        createdAt: 0,
+        url: 'asset://sounds/loop.mp3',
+        duration: 30,
+        endTime: Duration(seconds: 3),
+      );
+
+      setUp(() {
+        editor = _MockProImageEditorState();
+        stateManager = _MockStateManager();
+        overlayBloc = _MockTimelineOverlayBloc();
+
+        when(() => overlayBloc.state).thenReturn(const TimelineOverlayState());
+        when(
+          () => overlayBloc.stream,
+        ).thenAnswer((_) => const Stream<TimelineOverlayState>.empty());
+        when(() => editor.stateManager).thenReturn(stateManager);
+        when(() => stateManager.activeMeta).thenReturn({
+          VideoEditorConstants.audioStateHistoryKey: [coveringSound.toJson()],
+        });
+        when(
+          () => editor.addHistory(
+            layers: any(named: 'layers'),
+            filters: any(named: 'filters'),
+            meta: any(named: 'meta'),
+            newLayer: any(named: 'newLayer'),
+            transformConfigs: any(named: 'transformConfigs'),
+            tuneAdjustments: any(named: 'tuneAdjustments'),
+            blur: any(named: 'blur'),
+            heroScreenshotRequired: any(named: 'heroScreenshotRequired'),
+            blockCaptureScreenshot: any(named: 'blockCaptureScreenshot'),
+          ),
+        ).thenAnswer((_) {});
+        when(() => editor.setState(any())).thenAnswer((invocation) {
+          (invocation.positionalArguments.single as VoidCallback)();
+        });
+      });
+
+      Future<VideoEditorTimelineControls> pumpWithEditor(
+        WidgetTester tester, {
+        required ClipEditorState state,
+      }) async {
+        when(() => bloc.state).thenReturn(state);
+        // The speed sheet confirms via context.pop, so the harness needs a
+        // GoRouter rather than a plain MaterialApp.
+        await tester.pumpWidget(
+          ProviderScope(
+            child: MaterialApp.router(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              routerConfig: GoRouter(
+                routes: [
+                  GoRoute(
+                    path: '/',
+                    builder: (context, state) => Scaffold(
+                      body: VideoEditorScope(
+                        editorKey: GlobalKey<ProImageEditorState>(),
+                        editorOverride: editor,
+                        removeAreaKey: GlobalKey(),
+                        originalClipAspectRatio: 9 / 16,
+                        bodySizeNotifier: ValueNotifier(const Size(400, 600)),
+                        zoomMatrixNotifier: ValueNotifier(Matrix4.identity()),
+                        fromLibrary: false,
+                        onOpenCamera: () {},
+                        onOpenClipsEditor: () {},
+                        onAddStickers: () {},
+                        onOpenMusicLibrary: () {},
+                        onOpenVoiceOver: () {},
+                        onAddEditTextLayer: ([layer]) async => null,
+                        child: MultiBlocProvider(
+                          providers: [
+                            BlocProvider<ClipEditorBloc>.value(value: bloc),
+                            BlocProvider<TimelineOverlayBloc>.value(
+                              value: overlayBloc,
+                            ),
+                          ],
+                          child: TimelineClipControls(
+                            playheadPosition: ValueNotifier(Duration.zero),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+        return tester.widget<VideoEditorTimelineControls>(
+          find.byType(VideoEditorTimelineControls),
+        );
+      }
+
+      List<AudioEvent> capturedAudio() {
+        final meta =
+            verify(
+                  () => editor.addHistory(
+                    layers: any(named: 'layers'),
+                    filters: any(named: 'filters'),
+                    meta: captureAny(named: 'meta'),
+                    newLayer: any(named: 'newLayer'),
+                    transformConfigs: any(named: 'transformConfigs'),
+                    tuneAdjustments: any(named: 'tuneAdjustments'),
+                    blur: any(named: 'blur'),
+                    heroScreenshotRequired: any(
+                      named: 'heroScreenshotRequired',
+                    ),
+                    blockCaptureScreenshot: any(
+                      named: 'blockCaptureScreenshot',
+                    ),
+                  ),
+                ).captured.single
+                as Map<String, dynamic>;
+        final raw =
+            meta[VideoEditorConstants.audioStateHistoryKey] as List<dynamic>;
+        return raw
+            .cast<Map<String, dynamic>>()
+            .map(AudioEvent.fromJson)
+            .toList();
+      }
+
+      testWidgets('duplicate grows a sound that covered the composition onto '
+          'the appended copy', (tester) async {
+        final controls = await pumpWithEditor(
+          tester,
+          state: ClipEditorState(clips: [clip('clip-1')]),
+        );
+
+        controls.onDuplicated!();
+        await tester.pump();
+
+        expect(capturedAudio().single.endTime, const Duration(seconds: 6));
+      });
+
+      testWidgets('slowing a clip down grows a sound that covered the '
+          'composition onto the stretched end', (tester) async {
+        final controls = await pumpWithEditor(
+          tester,
+          state: ClipEditorState(clips: [clip('clip-1')]),
+        );
+
+        controls.onSpeed!();
+        await tester.pumpAndSettle();
+
+        // Drag the sheet's slider to half speed and confirm.
+        tester.widget<DivineSlider>(find.byType(DivineSlider)).onChanged!(0.5);
+        await tester.pump();
+        await tester.tap(
+          find.descendant(
+            of: find.byType(VideoEditorClipSpeedSheet),
+            matching: find.byWidgetPredicate(
+              (widget) =>
+                  widget is DivineIconButton &&
+                  widget.icon == DivineIconName.check,
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(capturedAudio().single.endTime, const Duration(seconds: 6));
+      });
+    });
 
     testWidgets('Save shows a spinner while this clip is being saved', (
       tester,

--- a/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
@@ -1363,6 +1363,77 @@ void main() {
         isTrue,
       );
     });
+
+    test('keeps a trimmed window after the composition shrank under it', () {
+      // Trim to 1.5s over a 3s composition, drop the hold so the composition
+      // is 1.125s (the window now overhangs, because nothing shortens it),
+      // then raise the hold to 4.5s. The overhang is not coverage — reading it
+      // as "reached the old end" would grow the window and eat the trim.
+      final track = _audio(
+        id: 'sound',
+        startTime: Duration.zero,
+        endTime: const Duration(milliseconds: 1500),
+        duration: 30,
+      );
+
+      final tracks = [track];
+      expect(
+        identical(
+          grow(
+            tracks,
+            previousDuration: const Duration(milliseconds: 1125),
+            duration: const Duration(milliseconds: 4500),
+          ),
+          tracks,
+        ),
+        isTrue,
+      );
+    });
+
+    test('stops where the source ends without clawing the window back', () {
+      // A 1s sound with 0.8s trimmed off its head runs out at 200ms — behind
+      // the window's 375ms end, e.g. after the duration-heal path corrected a
+      // too-long source length. Growing must not shorten the window to 200ms.
+      final track = _audio(
+        id: 'sound',
+        startTime: Duration.zero,
+        endTime: shortComposition,
+        startOffset: const Duration(milliseconds: 800),
+        duration: 1,
+      );
+
+      final tracks = [track];
+      expect(identical(grow(tracks), tracks), isTrue);
+    });
+
+    test('carries skipped tracks through in order while one grows', () {
+      final covering = _audio(
+        id: 'music',
+        startTime: Duration.zero,
+        endTime: shortComposition,
+        duration: 30,
+      );
+      final trimmed = _audio(
+        id: 'voice-over',
+        startTime: Duration.zero,
+        endTime: const Duration(milliseconds: 200),
+        duration: 30,
+      );
+      const unbounded = AudioEvent(
+        id: 'ambience',
+        pubkey: '',
+        createdAt: 0,
+        url: '/tmp/ambience.wav',
+        duration: 30,
+      );
+
+      final result = grow([covering, trimmed, unbounded]);
+
+      expect(result, hasLength(3));
+      expect(result[0].endTime, maxDuration);
+      expect(identical(result[1], trimmed), isTrue);
+      expect(identical(result[2], unbounded), isTrue);
+    });
   });
 
   group(stopMotionInitialPixelsPerSecond, () {

--- a/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
@@ -1236,6 +1236,135 @@ void main() {
     });
   });
 
+  group(growAudioToCompositionEnd, () {
+    // The #6401 shape: nine stills at the default 1/24s hold (375ms) with a
+    // sound clamped to that end, then a hold change stretching them to 6.375s.
+    const shortComposition = Duration(milliseconds: 375);
+    const longComposition = Duration(milliseconds: 6375);
+    const maxDuration = Duration(seconds: 6, milliseconds: 300);
+
+    List<AudioEvent> grow(
+      List<AudioEvent> tracks, {
+      Duration previousDuration = shortComposition,
+      Duration duration = longComposition,
+    }) => growAudioToCompositionEnd(
+      tracks,
+      previousDuration: previousDuration,
+      duration: duration,
+      maxDuration: maxDuration,
+    );
+
+    test('stretches a window that ran to the old composition end', () {
+      final track = _audio(
+        id: 'sound',
+        startTime: Duration.zero,
+        endTime: shortComposition,
+        duration: 30,
+      );
+
+      expect(grow([track]).single.endTime, maxDuration);
+    });
+
+    test('follows the end across the millisecond the window persists at', () {
+      // Nine 1/24s holds are 375003µs, but the window round-trips through
+      // editor history as whole milliseconds. Comparing it against the exact
+      // composition end would read the truncation as a deliberate trim.
+      final track = _audio(
+        id: 'sound',
+        startTime: Duration.zero,
+        endTime: const Duration(milliseconds: 375),
+        duration: 30,
+      );
+
+      expect(
+        grow(
+          [track],
+          previousDuration: const Duration(microseconds: 375003),
+        ).single.endTime,
+        maxDuration,
+      );
+    });
+
+    test('stops where the sound runs out of source content', () {
+      // A 2s sound cannot cover the 6.375s composition.
+      final track = _audio(
+        id: 'sound',
+        startTime: Duration.zero,
+        endTime: shortComposition,
+        duration: 2,
+      );
+
+      expect(grow([track]).single.endTime, const Duration(seconds: 2));
+    });
+
+    test('measures the remaining source from the track start and offset', () {
+      // A 2s sound, 0.5s of it already trimmed off the head, dropped 1s into
+      // the timeline: it can play until 1s + (2s - 0.5s) = 2.5s.
+      final track = _audio(
+        id: 'sound',
+        startTime: const Duration(seconds: 1),
+        endTime: shortComposition + const Duration(seconds: 1),
+        startOffset: const Duration(milliseconds: 500),
+        duration: 2,
+      );
+
+      expect(
+        grow(
+          [track],
+          previousDuration: shortComposition + const Duration(seconds: 1),
+        ).single.endTime,
+        const Duration(milliseconds: 2500),
+      );
+    });
+
+    test('leaves a window the user trimmed shorter than the composition', () {
+      final track = _audio(
+        id: 'sound',
+        startTime: Duration.zero,
+        endTime: const Duration(milliseconds: 200),
+        duration: 30,
+      );
+
+      final tracks = [track];
+      expect(identical(grow(tracks), tracks), isTrue);
+    });
+
+    test('leaves an unbounded window to the render clamp', () {
+      const track = AudioEvent(
+        id: 'sound',
+        pubkey: '',
+        createdAt: 0,
+        url: '/tmp/sound.wav',
+        duration: 30,
+      );
+
+      final tracks = [track];
+      expect(identical(grow(tracks), tracks), isTrue);
+    });
+
+    test('never shortens a window when the composition shrank', () {
+      final track = _audio(
+        id: 'sound',
+        startTime: Duration.zero,
+        endTime: longComposition,
+        duration: 30,
+      );
+
+      final tracks = [track];
+      expect(
+        identical(
+          grow(
+            tracks,
+            previousDuration: longComposition,
+            duration: shortComposition,
+          ),
+          tracks,
+        ),
+        isTrue,
+      );
+    });
+  });
+
   group(stopMotionInitialPixelsPerSecond, () {
     List<StopMotionClipFrame> framesOf(int count, Duration hold) => [
       for (var i = 0; i < count; i++)

--- a/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_test.dart
@@ -12,10 +12,12 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart' show AudioEvent;
 import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
 import 'package:openvine/blocs/video_editor/filter_editor/video_editor_filter_bloc.dart';
 import 'package:openvine/blocs/video_editor/main_editor/video_editor_main_bloc.dart';
 import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
+import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/constants/video_editor_timeline_constants.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/divine_video_clip.dart';
@@ -76,6 +78,14 @@ class _MockVideoEditorFilterBloc
     extends MockBloc<VideoEditorFilterEvent, VideoEditorFilterState>
     implements VideoEditorFilterBloc {}
 
+class _MockProImageEditorState extends Mock implements ProImageEditorState {
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
+      '_MockProImageEditorState';
+}
+
+class _MockStateManager extends Mock implements StateManager {}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -128,6 +138,7 @@ void main() {
     Widget buildWidget({
       VideoEditorMainState? mainState,
       ClipEditorState? clipState,
+      ProImageEditorState? editor,
     }) {
       if (mainState != null) {
         when(() => mockMainBloc.state).thenReturn(mainState);
@@ -143,6 +154,7 @@ void main() {
           home: Scaffold(
             body: VideoEditorScope(
               editorKey: GlobalKey<ProImageEditorState>(),
+              editorOverride: editor,
               removeAreaKey: GlobalKey(),
               originalClipAspectRatio: 9 / 16,
               bodySizeNotifier: ValueNotifier(const Size(400, 600)),
@@ -658,6 +670,107 @@ void main() {
           find.byType(VideoEditorTimelineInteractiveBody),
         );
         expect(body.pixelsPerSecond, TimelineConstants.pixelsPerSecond);
+      });
+    });
+
+    // #6401 on the trim path: dragging a trim handle back out lengthens the
+    // composition, and a sound clamped to the trimmed end has to follow it.
+    group('trim-extension sound growth', () {
+      late _MockProImageEditorState editor;
+      late _MockStateManager stateManager;
+
+      const coveringSound = AudioEvent(
+        id: 'sound-1',
+        pubkey: 'bundled',
+        createdAt: 0,
+        url: 'asset://sounds/loop.mp3',
+        duration: 30,
+        endTime: Duration(seconds: 2),
+      );
+
+      setUp(() {
+        editor = _MockProImageEditorState();
+        stateManager = _MockStateManager();
+
+        when(() => editor.stateManager).thenReturn(stateManager);
+        when(() => stateManager.activeMeta).thenReturn({
+          VideoEditorConstants.audioStateHistoryKey: [coveringSound.toJson()],
+        });
+        when(
+          () => editor.addHistory(
+            layers: any(named: 'layers'),
+            filters: any(named: 'filters'),
+            meta: any(named: 'meta'),
+            newLayer: any(named: 'newLayer'),
+            transformConfigs: any(named: 'transformConfigs'),
+            tuneAdjustments: any(named: 'tuneAdjustments'),
+            blur: any(named: 'blur'),
+            heroScreenshotRequired: any(named: 'heroScreenshotRequired'),
+            blockCaptureScreenshot: any(named: 'blockCaptureScreenshot'),
+          ),
+        ).thenAnswer((_) {});
+        when(() => editor.setState(any())).thenAnswer((invocation) {
+          (invocation.positionalArguments.single as VoidCallback)();
+        });
+      });
+
+      testWidgets('extending a trim grows a sound that covered the trimmed '
+          'end onto the restored end', (tester) async {
+        // A 3s clip trimmed to 2s; the sound covers the 2s composition.
+        final trimmed = _createTestClip(
+          id: 'a',
+          seconds: 3,
+        ).copyWith(trimEnd: const Duration(seconds: 1));
+        when(
+          () => mockClipBloc.state,
+        ).thenReturn(ClipEditorState(clips: [trimmed]));
+
+        await tester.pumpWidget(buildWidget(editor: editor));
+        await tester.pump();
+
+        final strip = tester.widget<VideoEditorTimelineClipStrip>(
+          find.byType(VideoEditorTimelineClipStrip),
+        );
+
+        // Drag start captures the trimmed composition as the previous clips.
+        strip.onTrimDragChanged!(true);
+        await tester.pump();
+
+        // The user drags the end handle back out to the full 3s; the bloc
+        // state now carries the restored clip.
+        when(() => mockClipBloc.state).thenReturn(
+          ClipEditorState(clips: [_createTestClip(id: 'a', seconds: 3)]),
+        );
+        strip.onTrimDragChanged!(false);
+        await tester.pump();
+
+        final meta =
+            verify(
+                  () => editor.addHistory(
+                    layers: any(named: 'layers'),
+                    filters: any(named: 'filters'),
+                    meta: captureAny(named: 'meta'),
+                    newLayer: any(named: 'newLayer'),
+                    transformConfigs: any(named: 'transformConfigs'),
+                    tuneAdjustments: any(named: 'tuneAdjustments'),
+                    blur: any(named: 'blur'),
+                    heroScreenshotRequired: any(
+                      named: 'heroScreenshotRequired',
+                    ),
+                    blockCaptureScreenshot: any(
+                      named: 'blockCaptureScreenshot',
+                    ),
+                  ),
+                ).captured.single
+                as Map<String, dynamic>;
+        final raw =
+            meta[VideoEditorConstants.audioStateHistoryKey] as List<dynamic>;
+        final audio = raw
+            .cast<Map<String, dynamic>>()
+            .map(AudioEvent.fromJson)
+            .toList();
+
+        expect(audio.single.endTime, const Duration(seconds: 3));
       });
     });
   });


### PR DESCRIPTION
## Description

A stop-motion video published with a sound got an audio track truncated to `frameCount × (1/24s)` — 9 stills published a 6.37s video muxed with a 0.375s audio track (#6401).

Two things had to be true for that:

**Capture stored a duration that ignored the frame holds.** `_appendStopMotionFrame` / the ingest path cached the clip with `_stopMotionPerFrame * frames.length`, not the summed holds. When the user then added a sound, `_openMusicLibrary` clamped its `endTime` to that stale, shorter composition end — baking a 0.375s audio window. Capture now stores `StopMotionFrameOps.totalDuration(frames)`, which is the same value today (all holds are the default) but is the correct contract and stops the clamp from ever reading a fictional end.

**A hold change restretched the video but not the sound.** `commitStopMotionFrames` recomputed the clip duration from the new holds and rebased anchored audio, but preserved each audio window's span verbatim. Stretching nine stills from 0.375s to 6.375s left the sound frozen at 0.375s. The commit now runs the rebased tracks through `growAudioToCompositionEnd`, which extends any window that reached the *old* composition end onto the new one.

Design choices worth calling out:

- **Only tracks that reached the old end grow.** A window the user deliberately trimmed shorter is theirs; growing it would silently undo the trim.
- **Never shortened here.** A composition that shrank is already clamped for display by the timeline and for output by the render, so shortening would be a second, lossy source of truth.
- **The new end is bounded twice** — by the source audio remaining after the track's `startOffset`, and by `VideoEditorConstants.maxDuration`. That is the same ceiling the track would have been given had the sound been added at the new composition length, so a grown window and a freshly-added one land in the same place.
- **The "reached the old end" comparison carries 1ms of slack.** `AudioEvent` serializes its window in whole milliseconds, but a stop-motion composition is microsecond-accurate (nine 1/24s holds are 375003µs). Without the slack, a window that round-tripped through editor history reads as a deliberate trim and stops following the composition.
- **`identical` short-circuit on the commit path.** When nothing moved, the commit keeps calling `setClipState` instead of `setClipAndAudioState`, so a frame edit with no audio doesn't start writing audio into every history entry.

**Related Issue:** Closes #6401

## Out of Scope

The issue's proposed defense-in-depth item 2 (recompute the ceiling from frame holds inside `_openMusicLibrary` / `_healMissingAudioDurations`) is not included. With capture storing the summed-holds duration, `clip.duration` is no longer stale at the point those paths read it, so the extra recomputation would be dead weight rather than a second line of defense.

## Verification

- `flutter test test/widgets/video_editor/stop_motion/stop_motion_frame_commands_test.dart test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart` — 114 passing, including a new widget test that commits a hold change over a clip with a sound and asserts the persisted window grew to 4.5s, plus one asserting a user-trimmed window is left alone.
- `flutter test test/blocs/video_recorder/video_recorder_bloc_test.dart` — 221 passing (pre-push hook).
- `flutter analyze lib test integration_test` — no issues.
- `dart format` — clean.

Not yet verified on device — the audio-follows-holds path still wants a manual publish check on a real stop-motion capture before this leaves draft.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
