### PR TITLE
chore(deps): upgrade pro_video_editor to 2.9.0

### DIFF
--- a/mobile/lib/services/video_editor/video_editor_render_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_render_service.dart
@@ -1140,8 +1140,9 @@ class VideoEditorRenderService {
   /// encoder-init failures (`RenderEncoderException`).
   ///
   /// The exception signals that `pro_video_editor`'s own in-process fallback
-  /// chain (operating-rate cap/removal, software encoder, profile downgrade)
-  /// could not initialise an encoder. On codec-limited devices that is usually
+  /// chain (operating-rate cap/removal, profile downgrade, and a conditional
+  /// software encoder when the device has one usable for the target MIME) could
+  /// not initialise an encoder. On codec-limited devices that is usually
   /// transient contention rather than a true format incompatibility: the
   /// preview decoder the editor just released (the #5522 decoder-release gate)
   /// — or another app codec — has not been reclaimed by the OS media server

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1807,10 +1807,10 @@ packages:
     dependency: "direct main"
     description:
       name: pro_video_editor
-      sha256: aa05eb426dc98607dd6f776b4da9a5bb09c80c44e72138d299409d52a38b920d
+      sha256: ec977aa7d00678647c60d34b0dd2e91284e0305cd0688c1e305b930467d78dc7
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.0"
+    version: "2.9.0"
   process:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -322,7 +322,7 @@ dependencies:
   firebase_performance: ^0.11.1+4
   firebase_messaging: ^16.1.1
   audio_session: ^0.2.2
-  pro_video_editor: ^2.6.0
+  pro_video_editor: ^2.9.0
   pro_image_editor: ^13.2.3
   flutter_colorpicker: ^1.1.0
   file_picker: ^10.3.7


### PR DESCRIPTION
Closes #6420

## Description

Upgrades `pro_video_editor` from 2.6.0 to 2.9.0.

2.9.0 carries the Android-side half of the export-crash work that #6384 could only address from Dart. #6384 added the Dart-level settle-retry because the plugin's own in-process fallback chain ran every attempt within a few hundred ms and could not outlast codec-reclaim latency. Three things changed natively since:

- The software-encoder fallback no longer silently re-runs the hardware encoder under a `software-encoder` label. When the device has no usable software encoder the attempt is skipped with an explicit log line, so the fallback chain stops reporting attempts it never made.
- `RenderEncoderException` now carries `isTransient`, separating exhausted codec resources from a genuine format/encoder incompatibility.
- `ERROR_CODE_DECODER_INIT_FAILED` now maps into the codec-resource path when the cause is transient. That lets Divine's existing Dart settle-retry catch the starved preview-decoder case #6384 was written for; on 2.6.0 it surfaced as a generic `RENDER_ERROR` and skipped the retry.

The bump also picks up the intermediate releases: lossless split transmux on Android and passthrough split on Darwin (2.7.0), the fully-consumed clip-transition fix (2.7.1), and `mergeAudioToFile` (2.8.0).

The 2.7.0 Darwin releases also add all-P-frame / 1s-GOP settings to the bitrate-capped render and stop-motion encoders. That is expected to help Divine's short loop playback, but it should be eyeballed on iOS because PR CI does not build native iOS/macOS exports.

## Related Issue

- #6420

## Out of Scope

- Consuming `isTransient` in `VideoEditorRenderService.renderWithEncoderFallback`. The current retry chain treats every `RenderEncoderException` as retryable, which stays correct with 2.9.0: a permanent failure costs two extra attempts before surfacing. A naive `if (!e.isTransient) rethrow` is not the right follow-up because attempt 3 is not just a retry; it re-renders at `VideoEditorConstants.encoderFallbackQuality` for devices at their 1080p encoder ceiling (#6058). Short-circuiting permanent failures before that rung would make those devices lose edits instead of exporting at 720p.

## Verification

- `flutter pub get` — resolves to `pro_video_editor 2.9.0`, no other lock churn
- `flutter analyze lib test integration_test` — No issues found
- `flutter test test/services/video_editor/` — 233/233 pass
- Pre-push hook after takeover commit:
  - merge-conflict check against `main` — clean
  - changed-file analyzer — no issues found
  - `flutter test test/services/video_editor/video_editor_render_service_test.dart` — 20/20 pass

## Device Verification Before Merge

- [ ] iOS concat export
- [ ] iOS stop-motion export
- [ ] Max-duration overlap transition on a device or simulator

## Type of Change

- [x] Chore
