### PR TITLE
fix(sound-publishing): keep sound attribution on published posts

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -641,6 +641,7 @@
     "videoFollowButtonFollowing": "በመከተል ላይ",
     "videoFollowButtonFollow": "ተከተል",
     "audioAttributionOriginalSound": "ኦሪጅናል ድምጽ",
+    "audioAttributionUnavailableSound": "Sound unavailable",
     "videoInspiredByAttribution": "በ@{creatorName} የተነሳሳ",
     "@videoInspiredByAttribution": {
         "placeholders": {

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -641,7 +641,7 @@
     "videoFollowButtonFollowing": "በመከተል ላይ",
     "videoFollowButtonFollow": "ተከተል",
     "audioAttributionOriginalSound": "ኦሪጅናል ድምጽ",
-    "audioAttributionUnavailableSound": "Sound unavailable",
+    "audioAttributionUnavailableSound": "ድምጽ አይገኝም",
     "videoInspiredByAttribution": "በ@{creatorName} የተነሳሳ",
     "@videoInspiredByAttribution": {
         "placeholders": {

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -559,6 +559,7 @@
     "videoFollowButtonFollowing": "متابع",
     "videoFollowButtonFollow": "متابعة",
     "audioAttributionOriginalSound": "صوت أصلي",
+    "audioAttributionUnavailableSound": "Sound unavailable",
     "videoInspiredByAttribution": "مستوحى من @{creatorName}",
     "@videoInspiredByAttribution": {
         "placeholders": {

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -559,7 +559,7 @@
     "videoFollowButtonFollowing": "متابع",
     "videoFollowButtonFollow": "متابعة",
     "audioAttributionOriginalSound": "صوت أصلي",
-    "audioAttributionUnavailableSound": "Sound unavailable",
+    "audioAttributionUnavailableSound": "الصوت غير متاح",
     "videoInspiredByAttribution": "مستوحى من @{creatorName}",
     "@videoInspiredByAttribution": {
         "placeholders": {

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -588,7 +588,7 @@
     "videoFollowButtonFollowing": "Следване",
     "videoFollowButtonFollow": "Следвай",
     "audioAttributionOriginalSound": "Оригинален звук",
-    "audioAttributionUnavailableSound": "Sound unavailable",
+    "audioAttributionUnavailableSound": "Звукът е недостъпен",
     "videoInspiredByAttribution": "Вдъхновен от @{creatorName}",
     "@videoInspiredByAttribution": {
         "placeholders": {

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -588,6 +588,7 @@
     "videoFollowButtonFollowing": "Следване",
     "videoFollowButtonFollow": "Следвай",
     "audioAttributionOriginalSound": "Оригинален звук",
+    "audioAttributionUnavailableSound": "Sound unavailable",
     "videoInspiredByAttribution": "Вдъхновен от @{creatorName}",
     "@videoInspiredByAttribution": {
         "placeholders": {

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -559,7 +559,7 @@
     "videoFollowButtonFollowing": "Gefolgt",
     "videoFollowButtonFollow": "Folgen",
     "audioAttributionOriginalSound": "Originalton",
-    "audioAttributionUnavailableSound": "Sound unavailable",
+    "audioAttributionUnavailableSound": "Ton nicht verfügbar",
     "videoInspiredByAttribution": "Inspiriert von @{creatorName}",
     "@videoInspiredByAttribution": {
         "placeholders": {

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -559,6 +559,7 @@
     "videoFollowButtonFollowing": "Gefolgt",
     "videoFollowButtonFollow": "Folgen",
     "audioAttributionOriginalSound": "Originalton",
+    "audioAttributionUnavailableSound": "Sound unavailable",
     "videoInspiredByAttribution": "Inspiriert von @{creatorName}",
     "@videoInspiredByAttribution": {
         "placeholders": {

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -739,6 +739,10 @@
   "videoFollowButtonFollowing": "Following",
   "videoFollowButtonFollow": "Follow",
   "audioAttributionOriginalSound": "Original sound",
+  "audioAttributionUnavailableSound": "Sound unavailable",
+  "@audioAttributionUnavailableSound": {
+    "description": "Neutral label shown when a video references a shared sound event that cannot currently be fetched. Must not imply the video author's original sound."
+  },
   "videoInspiredByAttribution": "Inspired by @{creatorName}",
   "@videoInspiredByAttribution": {
     "placeholders": {

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -559,6 +559,7 @@
     "videoFollowButtonFollowing": "Siguiendo",
     "videoFollowButtonFollow": "Seguir",
     "audioAttributionOriginalSound": "Sonido original",
+    "audioAttributionUnavailableSound": "Sound unavailable",
     "videoInspiredByAttribution": "Inspirado en @{creatorName}",
     "@videoInspiredByAttribution": {
         "placeholders": {

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -559,7 +559,7 @@
     "videoFollowButtonFollowing": "Siguiendo",
     "videoFollowButtonFollow": "Seguir",
     "audioAttributionOriginalSound": "Sonido original",
-    "audioAttributionUnavailableSound": "Sound unavailable",
+    "audioAttributionUnavailableSound": "Sonido no disponible",
     "videoInspiredByAttribution": "Inspirado en @{creatorName}",
     "@videoInspiredByAttribution": {
         "placeholders": {

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -394,6 +394,7 @@
     "videoFollowButtonFollowing": "Sinusundan",
     "videoFollowButtonFollow": "Sundan",
     "audioAttributionOriginalSound": "Original sound",
+    "audioAttributionUnavailableSound": "Sound unavailable",
     "videoInspiredByAttribution": "Inspirasyon mula kay @{creatorName}",
     "videoCollaboratorWithOne": "kasama si @{name}",
     "videoCollaboratorWithMore": "kasama si @{name} +{count}",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -394,7 +394,7 @@
     "videoFollowButtonFollowing": "Sinusundan",
     "videoFollowButtonFollow": "Sundan",
     "audioAttributionOriginalSound": "Original sound",
-    "audioAttributionUnavailableSound": "Sound unavailable",
+    "audioAttributionUnavailableSound": "Hindi available ang sound",
     "videoInspiredByAttribution": "Inspirasyon mula kay @{creatorName}",
     "videoCollaboratorWithOne": "kasama si @{name}",
     "videoCollaboratorWithMore": "kasama si @{name} +{count}",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -559,6 +559,7 @@
     "videoFollowButtonFollowing": "Abonné",
     "videoFollowButtonFollow": "Suivre",
     "audioAttributionOriginalSound": "Son original",
+    "audioAttributionUnavailableSound": "Sound unavailable",
     "videoInspiredByAttribution": "Inspiré par @{creatorName}",
     "@videoInspiredByAttribution": {
         "placeholders": {

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -559,7 +559,7 @@
     "videoFollowButtonFollowing": "Abonné",
     "videoFollowButtonFollow": "Suivre",
     "audioAttributionOriginalSound": "Son original",
-    "audioAttributionUnavailableSound": "Sound unavailable",
+    "audioAttributionUnavailableSound": "Son indisponible",
     "videoInspiredByAttribution": "Inspiré par @{creatorName}",
     "@videoInspiredByAttribution": {
         "placeholders": {

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -559,7 +559,7 @@
     "videoFollowButtonFollowing": "Mengikuti",
     "videoFollowButtonFollow": "Ikuti",
     "audioAttributionOriginalSound": "Suara asli",
-    "audioAttributionUnavailableSound": "Sound unavailable",
+    "audioAttributionUnavailableSound": "Suara tidak tersedia",
     "videoInspiredByAttribution": "Terinspirasi oleh @{creatorName}",
     "@videoInspiredByAttribution": {
         "placeholders": {

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -559,6 +559,7 @@
     "videoFollowButtonFollowing": "Mengikuti",
     "videoFollowButtonFollow": "Ikuti",
     "audioAttributionOriginalSound": "Suara asli",
+    "audioAttributionUnavailableSound": "Sound unavailable",
     "videoInspiredByAttribution": "Terinspirasi oleh @{creatorName}",
     "@videoInspiredByAttribution": {
         "placeholders": {

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -559,7 +559,7 @@
     "videoFollowButtonFollowing": "Segui già",
     "videoFollowButtonFollow": "Segui",
     "audioAttributionOriginalSound": "Audio originale",
-    "audioAttributionUnavailableSound": "Sound unavailable",
+    "audioAttributionUnavailableSound": "Audio non disponibile",
     "videoInspiredByAttribution": "Ispirato da @{creatorName}",
     "@videoInspiredByAttribution": {
         "placeholders": {

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -559,6 +559,7 @@
     "videoFollowButtonFollowing": "Segui già",
     "videoFollowButtonFollow": "Segui",
     "audioAttributionOriginalSound": "Audio originale",
+    "audioAttributionUnavailableSound": "Sound unavailable",
     "videoInspiredByAttribution": "Ispirato da @{creatorName}",
     "@videoInspiredByAttribution": {
         "placeholders": {

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -559,6 +559,7 @@
     "videoFollowButtonFollowing": "フォロー中",
     "videoFollowButtonFollow": "フォロー",
     "audioAttributionOriginalSound": "オリジナルサウンド",
+    "audioAttributionUnavailableSound": "Sound unavailable",
     "videoInspiredByAttribution": "@{creatorName} にインスパイアされた",
     "@videoInspiredByAttribution": {
         "placeholders": {

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -559,7 +559,7 @@
     "videoFollowButtonFollowing": "フォロー中",
     "videoFollowButtonFollow": "フォロー",
     "audioAttributionOriginalSound": "オリジナルサウンド",
-    "audioAttributionUnavailableSound": "Sound unavailable",
+    "audioAttributionUnavailableSound": "サウンドが見つからないよ",
     "videoInspiredByAttribution": "@{creatorName} にインスパイアされた",
     "@videoInspiredByAttribution": {
         "placeholders": {

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -364,6 +364,7 @@
     "videoFollowButtonFollowing": "팔로잉",
     "videoFollowButtonFollow": "팔로우",
     "audioAttributionOriginalSound": "오리지널 사운드",
+    "audioAttributionUnavailableSound": "Sound unavailable",
     "videoInspiredByAttribution": "@{creatorName}님에게 영감받아",
     "videoCollaboratorWithOne": "@{name}님과 함께",
     "videoCollaboratorWithMore": "@{name}님 외 +{count}명과 함께",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -364,7 +364,7 @@
     "videoFollowButtonFollowing": "팔로잉",
     "videoFollowButtonFollow": "팔로우",
     "audioAttributionOriginalSound": "오리지널 사운드",
-    "audioAttributionUnavailableSound": "Sound unavailable",
+    "audioAttributionUnavailableSound": "사운드를 사용할 수 없어요",
     "videoInspiredByAttribution": "@{creatorName}님에게 영감받아",
     "videoCollaboratorWithOne": "@{name}님과 함께",
     "videoCollaboratorWithMore": "@{name}님 외 +{count}명과 함께",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -559,6 +559,7 @@
     "videoFollowButtonFollowing": "Volgend",
     "videoFollowButtonFollow": "Volgen",
     "audioAttributionOriginalSound": "Origineel geluid",
+    "audioAttributionUnavailableSound": "Sound unavailable",
     "videoInspiredByAttribution": "Geïnspireerd door @{creatorName}",
     "@videoInspiredByAttribution": {
         "placeholders": {

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -559,7 +559,7 @@
     "videoFollowButtonFollowing": "Volgend",
     "videoFollowButtonFollow": "Volgen",
     "audioAttributionOriginalSound": "Origineel geluid",
-    "audioAttributionUnavailableSound": "Sound unavailable",
+    "audioAttributionUnavailableSound": "Geluid niet beschikbaar",
     "videoInspiredByAttribution": "Geïnspireerd door @{creatorName}",
     "@videoInspiredByAttribution": {
         "placeholders": {

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -559,6 +559,7 @@
     "videoFollowButtonFollowing": "Obserwujesz",
     "videoFollowButtonFollow": "Obserwuj",
     "audioAttributionOriginalSound": "Oryginalny dźwięk",
+    "audioAttributionUnavailableSound": "Sound unavailable",
     "videoInspiredByAttribution": "Zainspirowane przez @{creatorName}",
     "@videoInspiredByAttribution": {
         "placeholders": {

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -559,7 +559,7 @@
     "videoFollowButtonFollowing": "Obserwujesz",
     "videoFollowButtonFollow": "Obserwuj",
     "audioAttributionOriginalSound": "Oryginalny dźwięk",
-    "audioAttributionUnavailableSound": "Sound unavailable",
+    "audioAttributionUnavailableSound": "Dźwięk niedostępny",
     "videoInspiredByAttribution": "Zainspirowane przez @{creatorName}",
     "@videoInspiredByAttribution": {
         "placeholders": {

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -559,7 +559,7 @@
     "videoFollowButtonFollowing": "Seguindo",
     "videoFollowButtonFollow": "Seguir",
     "audioAttributionOriginalSound": "Som original",
-    "audioAttributionUnavailableSound": "Sound unavailable",
+    "audioAttributionUnavailableSound": "Som indisponível",
     "videoInspiredByAttribution": "Inspirado em @{creatorName}",
     "@videoInspiredByAttribution": {
         "placeholders": {

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -559,6 +559,7 @@
     "videoFollowButtonFollowing": "Seguindo",
     "videoFollowButtonFollow": "Seguir",
     "audioAttributionOriginalSound": "Som original",
+    "audioAttributionUnavailableSound": "Sound unavailable",
     "videoInspiredByAttribution": "Inspirado em @{creatorName}",
     "@videoInspiredByAttribution": {
         "placeholders": {

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -559,6 +559,7 @@
     "videoFollowButtonFollowing": "Urmărit",
     "videoFollowButtonFollow": "Urmărește",
     "audioAttributionOriginalSound": "Sunet original",
+    "audioAttributionUnavailableSound": "Sound unavailable",
     "videoInspiredByAttribution": "Inspirat de @{creatorName}",
     "@videoInspiredByAttribution": {
         "placeholders": {

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -559,7 +559,7 @@
     "videoFollowButtonFollowing": "Urmărit",
     "videoFollowButtonFollow": "Urmărește",
     "audioAttributionOriginalSound": "Sunet original",
-    "audioAttributionUnavailableSound": "Sound unavailable",
+    "audioAttributionUnavailableSound": "Sunet indisponibil",
     "videoInspiredByAttribution": "Inspirat de @{creatorName}",
     "@videoInspiredByAttribution": {
         "placeholders": {

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -559,7 +559,7 @@
     "videoFollowButtonFollowing": "Följer",
     "videoFollowButtonFollow": "Följ",
     "audioAttributionOriginalSound": "Originalljud",
-    "audioAttributionUnavailableSound": "Sound unavailable",
+    "audioAttributionUnavailableSound": "Ljud otillgängligt",
     "videoInspiredByAttribution": "Inspirerad av @{creatorName}",
     "@videoInspiredByAttribution": {
         "placeholders": {

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -559,6 +559,7 @@
     "videoFollowButtonFollowing": "Följer",
     "videoFollowButtonFollow": "Följ",
     "audioAttributionOriginalSound": "Originalljud",
+    "audioAttributionUnavailableSound": "Sound unavailable",
     "videoInspiredByAttribution": "Inspirerad av @{creatorName}",
     "@videoInspiredByAttribution": {
         "placeholders": {

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -559,7 +559,7 @@
     "videoFollowButtonFollowing": "Takip ediliyor",
     "videoFollowButtonFollow": "Takip et",
     "audioAttributionOriginalSound": "Orijinal ses",
-    "audioAttributionUnavailableSound": "Sound unavailable",
+    "audioAttributionUnavailableSound": "Ses kullanılamıyor",
     "videoInspiredByAttribution": "@{creatorName} tarafından ilham alındı",
     "@videoInspiredByAttribution": {
         "placeholders": {

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -559,6 +559,7 @@
     "videoFollowButtonFollowing": "Takip ediliyor",
     "videoFollowButtonFollow": "Takip et",
     "audioAttributionOriginalSound": "Orijinal ses",
+    "audioAttributionUnavailableSound": "Sound unavailable",
     "videoInspiredByAttribution": "@{creatorName} tarafından ilham alındı",
     "@videoInspiredByAttribution": {
         "placeholders": {

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -2668,6 +2668,12 @@ abstract class AppLocalizations {
   /// **'Original sound'**
   String get audioAttributionOriginalSound;
 
+  /// Neutral label shown when a video references a shared sound event that cannot currently be fetched. Must not imply the video author's original sound.
+  ///
+  /// In en, this message translates to:
+  /// **'Sound unavailable'**
+  String get audioAttributionUnavailableSound;
+
   /// No description provided for @videoInspiredByAttribution.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -1456,7 +1456,7 @@ class AppLocalizationsAm extends AppLocalizations {
   String get audioAttributionOriginalSound => 'ኦሪጅናል ድምጽ';
 
   @override
-  String get audioAttributionUnavailableSound => 'Sound unavailable';
+  String get audioAttributionUnavailableSound => 'ድምጽ አይገኝም';
 
   @override
   String videoInspiredByAttribution(String creatorName) {

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -1456,6 +1456,9 @@ class AppLocalizationsAm extends AppLocalizations {
   String get audioAttributionOriginalSound => 'ኦሪጅናል ድምጽ';
 
   @override
+  String get audioAttributionUnavailableSound => 'Sound unavailable';
+
+  @override
   String videoInspiredByAttribution(String creatorName) {
     return 'በ@$creatorName የተነሳሳ';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -1482,7 +1482,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get audioAttributionOriginalSound => 'صوت أصلي';
 
   @override
-  String get audioAttributionUnavailableSound => 'Sound unavailable';
+  String get audioAttributionUnavailableSound => 'الصوت غير متاح';
 
   @override
   String videoInspiredByAttribution(String creatorName) {

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -1482,6 +1482,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get audioAttributionOriginalSound => 'صوت أصلي';
 
   @override
+  String get audioAttributionUnavailableSound => 'Sound unavailable';
+
+  @override
   String videoInspiredByAttribution(String creatorName) {
     return 'مستوحى من @$creatorName';
   }

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -1515,6 +1515,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get audioAttributionOriginalSound => 'Оригинален звук';
 
   @override
+  String get audioAttributionUnavailableSound => 'Sound unavailable';
+
+  @override
   String videoInspiredByAttribution(String creatorName) {
     return 'Вдъхновен от @$creatorName';
   }

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -1515,7 +1515,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get audioAttributionOriginalSound => 'Оригинален звук';
 
   @override
-  String get audioAttributionUnavailableSound => 'Sound unavailable';
+  String get audioAttributionUnavailableSound => 'Звукът е недостъпен';
 
   @override
   String videoInspiredByAttribution(String creatorName) {

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -1511,7 +1511,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get audioAttributionOriginalSound => 'Originalton';
 
   @override
-  String get audioAttributionUnavailableSound => 'Sound unavailable';
+  String get audioAttributionUnavailableSound => 'Ton nicht verfügbar';
 
   @override
   String videoInspiredByAttribution(String creatorName) {

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -1511,6 +1511,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get audioAttributionOriginalSound => 'Originalton';
 
   @override
+  String get audioAttributionUnavailableSound => 'Sound unavailable';
+
+  @override
   String videoInspiredByAttribution(String creatorName) {
     return 'Inspiriert von @$creatorName';
   }

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -1493,6 +1493,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get audioAttributionOriginalSound => 'Original sound';
 
   @override
+  String get audioAttributionUnavailableSound => 'Sound unavailable';
+
+  @override
   String videoInspiredByAttribution(String creatorName) {
     return 'Inspired by @$creatorName';
   }

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -1513,7 +1513,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get audioAttributionOriginalSound => 'Sonido original';
 
   @override
-  String get audioAttributionUnavailableSound => 'Sound unavailable';
+  String get audioAttributionUnavailableSound => 'Sonido no disponible';
 
   @override
   String videoInspiredByAttribution(String creatorName) {

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -1513,6 +1513,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get audioAttributionOriginalSound => 'Sonido original';
 
   @override
+  String get audioAttributionUnavailableSound => 'Sound unavailable';
+
+  @override
   String videoInspiredByAttribution(String creatorName) {
     return 'Inspirado en @$creatorName';
   }

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -1520,7 +1520,7 @@ class AppLocalizationsFil extends AppLocalizations {
   String get audioAttributionOriginalSound => 'Original sound';
 
   @override
-  String get audioAttributionUnavailableSound => 'Sound unavailable';
+  String get audioAttributionUnavailableSound => 'Hindi available ang sound';
 
   @override
   String videoInspiredByAttribution(String creatorName) {

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -1520,6 +1520,9 @@ class AppLocalizationsFil extends AppLocalizations {
   String get audioAttributionOriginalSound => 'Original sound';
 
   @override
+  String get audioAttributionUnavailableSound => 'Sound unavailable';
+
+  @override
   String videoInspiredByAttribution(String creatorName) {
     return 'Inspirasyon mula kay @$creatorName';
   }

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -1520,6 +1520,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get audioAttributionOriginalSound => 'Son original';
 
   @override
+  String get audioAttributionUnavailableSound => 'Sound unavailable';
+
+  @override
   String videoInspiredByAttribution(String creatorName) {
     return 'Inspiré par @$creatorName';
   }

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -1520,7 +1520,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get audioAttributionOriginalSound => 'Son original';
 
   @override
-  String get audioAttributionUnavailableSound => 'Sound unavailable';
+  String get audioAttributionUnavailableSound => 'Son indisponible';
 
   @override
   String videoInspiredByAttribution(String creatorName) {

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -1470,6 +1470,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get audioAttributionOriginalSound => 'Suara asli';
 
   @override
+  String get audioAttributionUnavailableSound => 'Sound unavailable';
+
+  @override
   String videoInspiredByAttribution(String creatorName) {
     return 'Terinspirasi oleh @$creatorName';
   }

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -1470,7 +1470,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get audioAttributionOriginalSound => 'Suara asli';
 
   @override
-  String get audioAttributionUnavailableSound => 'Sound unavailable';
+  String get audioAttributionUnavailableSound => 'Suara tidak tersedia';
 
   @override
   String videoInspiredByAttribution(String creatorName) {

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -1515,6 +1515,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get audioAttributionOriginalSound => 'Audio originale';
 
   @override
+  String get audioAttributionUnavailableSound => 'Sound unavailable';
+
+  @override
   String videoInspiredByAttribution(String creatorName) {
     return 'Ispirato da @$creatorName';
   }

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -1515,7 +1515,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get audioAttributionOriginalSound => 'Audio originale';
 
   @override
-  String get audioAttributionUnavailableSound => 'Sound unavailable';
+  String get audioAttributionUnavailableSound => 'Audio non disponibile';
 
   @override
   String videoInspiredByAttribution(String creatorName) {

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -1402,6 +1402,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get audioAttributionOriginalSound => 'オリジナルサウンド';
 
   @override
+  String get audioAttributionUnavailableSound => 'Sound unavailable';
+
+  @override
   String videoInspiredByAttribution(String creatorName) {
     return '@$creatorName にインスパイアされた';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -1402,7 +1402,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get audioAttributionOriginalSound => 'オリジナルサウンド';
 
   @override
-  String get audioAttributionUnavailableSound => 'Sound unavailable';
+  String get audioAttributionUnavailableSound => 'サウンドが見つからないよ';
 
   @override
   String videoInspiredByAttribution(String creatorName) {

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -1411,6 +1411,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get audioAttributionOriginalSound => '오리지널 사운드';
 
   @override
+  String get audioAttributionUnavailableSound => 'Sound unavailable';
+
+  @override
   String videoInspiredByAttribution(String creatorName) {
     return '@$creatorName님에게 영감받아';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -1411,7 +1411,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get audioAttributionOriginalSound => '오리지널 사운드';
 
   @override
-  String get audioAttributionUnavailableSound => 'Sound unavailable';
+  String get audioAttributionUnavailableSound => '사운드를 사용할 수 없어요';
 
   @override
   String videoInspiredByAttribution(String creatorName) {

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -1503,7 +1503,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get audioAttributionOriginalSound => 'Origineel geluid';
 
   @override
-  String get audioAttributionUnavailableSound => 'Sound unavailable';
+  String get audioAttributionUnavailableSound => 'Geluid niet beschikbaar';
 
   @override
   String videoInspiredByAttribution(String creatorName) {

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -1503,6 +1503,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get audioAttributionOriginalSound => 'Origineel geluid';
 
   @override
+  String get audioAttributionUnavailableSound => 'Sound unavailable';
+
+  @override
   String videoInspiredByAttribution(String creatorName) {
     return 'Geïnspireerd door @$creatorName';
   }

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -1518,6 +1518,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get audioAttributionOriginalSound => 'Oryginalny dźwięk';
 
   @override
+  String get audioAttributionUnavailableSound => 'Sound unavailable';
+
+  @override
   String videoInspiredByAttribution(String creatorName) {
     return 'Zainspirowane przez @$creatorName';
   }

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -1518,7 +1518,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get audioAttributionOriginalSound => 'Oryginalny dźwięk';
 
   @override
-  String get audioAttributionUnavailableSound => 'Sound unavailable';
+  String get audioAttributionUnavailableSound => 'Dźwięk niedostępny';
 
   @override
   String videoInspiredByAttribution(String creatorName) {

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -1511,7 +1511,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get audioAttributionOriginalSound => 'Som original';
 
   @override
-  String get audioAttributionUnavailableSound => 'Sound unavailable';
+  String get audioAttributionUnavailableSound => 'Som indisponível';
 
   @override
   String videoInspiredByAttribution(String creatorName) {

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -1511,6 +1511,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get audioAttributionOriginalSound => 'Som original';
 
   @override
+  String get audioAttributionUnavailableSound => 'Sound unavailable';
+
+  @override
   String videoInspiredByAttribution(String creatorName) {
     return 'Inspirado em @$creatorName';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -1532,6 +1532,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get audioAttributionOriginalSound => 'Sunet original';
 
   @override
+  String get audioAttributionUnavailableSound => 'Sound unavailable';
+
+  @override
   String videoInspiredByAttribution(String creatorName) {
     return 'Inspirat de @$creatorName';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -1532,7 +1532,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get audioAttributionOriginalSound => 'Sunet original';
 
   @override
-  String get audioAttributionUnavailableSound => 'Sound unavailable';
+  String get audioAttributionUnavailableSound => 'Sunet indisponibil';
 
   @override
   String videoInspiredByAttribution(String creatorName) {

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -1489,7 +1489,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get audioAttributionOriginalSound => 'Originalljud';
 
   @override
-  String get audioAttributionUnavailableSound => 'Sound unavailable';
+  String get audioAttributionUnavailableSound => 'Ljud otillgängligt';
 
   @override
   String videoInspiredByAttribution(String creatorName) {

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -1489,6 +1489,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get audioAttributionOriginalSound => 'Originalljud';
 
   @override
+  String get audioAttributionUnavailableSound => 'Sound unavailable';
+
+  @override
   String videoInspiredByAttribution(String creatorName) {
     return 'Inspirerad av @$creatorName';
   }

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -1475,7 +1475,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get audioAttributionOriginalSound => 'Orijinal ses';
 
   @override
-  String get audioAttributionUnavailableSound => 'Sound unavailable';
+  String get audioAttributionUnavailableSound => 'Ses kullanılamıyor';
 
   @override
   String videoInspiredByAttribution(String creatorName) {

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -1475,6 +1475,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get audioAttributionOriginalSound => 'Orijinal ses';
 
   @override
+  String get audioAttributionUnavailableSound => 'Sound unavailable';
+
+  @override
   String videoInspiredByAttribution(String creatorName) {
     return '@$creatorName tarafından ilham alındı';
   }

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -1376,11 +1376,18 @@ class VideoEventPublisher {
       }
 
       // Handle audio reuse: extract audio, upload, publish Kind 1063 event
-      // Then add e tag linking video to audio event
-      // Skip if we already referenced a selected audio event above
+      // Then add e tag linking video to audio event.
+      //
+      // Skip only when the selected audio was actually referenced above. A
+      // selection that yielded no Nostr reference (bundled sound,
+      // external-provider sound) is the user's own audio to offer — the same
+      // rule [VideoEditorProviderState.reusesExternalAudio] uses to keep the
+      // "Publish this sound" toggle visible — so gating on the raw selection
+      // instead silently dropped both this event and the `allow_audio_reuse`
+      // marker, leaving the video with no audio metadata at all (#6185).
       String? audioEventId;
       if (allowAudioReuse &&
-          !hasSelectedAudioEventId &&
+          reusableSelectedAudioEventId == null &&
           upload.localVideoPath.isNotEmpty) {
         tags.add(['allow_audio_reuse', 'true']);
         Log.info(

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -1378,16 +1378,16 @@ class VideoEventPublisher {
       // Handle audio reuse: extract audio, upload, publish Kind 1063 event
       // Then add e tag linking video to audio event.
       //
-      // Skip only when the selected audio was actually referenced above. A
-      // selection that yielded no Nostr reference (bundled sound,
-      // external-provider sound) is the user's own audio to offer — the same
-      // rule [VideoEditorProviderState.reusesExternalAudio] uses to keep the
-      // "Publish this sound" toggle visible — so gating on the raw selection
-      // instead silently dropped both this event and the `allow_audio_reuse`
-      // marker, leaving the video with no audio metadata at all (#6185).
+      // Skip when the selected audio was actually referenced above. Bundled
+      // sounds yield no Nostr reference, so opting into reuse should publish the
+      // rendered video audio as the user's reusable Kind 1063. External-provider
+      // catalog sounds are also not referenceable, but they carry their own
+      // provider/license metadata and must not be republished as the user's
+      // reusable sound.
       String? audioEventId;
       if (allowAudioReuse &&
           reusableSelectedAudioEventId == null &&
+          selectedAudio?.isExternalProviderSound != true &&
           upload.localVideoPath.isNotEmpty) {
         tags.add(['allow_audio_reuse', 'true']);
         Log.info(

--- a/mobile/lib/widgets/video_feed_item/audio_attribution_credit.dart
+++ b/mobile/lib/widgets/video_feed_item/audio_attribution_credit.dart
@@ -8,12 +8,17 @@ class AudioAttributionCredit {
   const AudioAttributionCredit._();
 
   /// The reused sound's original creator, carried on the video via its
-  /// inspired-by source (reusing a sound auto-populates inspired-by from the
-  /// source video). Null when absent, so the video's own author is credited.
+  /// inspired-by source. Null when absent, so the video's own author is
+  /// credited.
   ///
   /// Only call this for a video that actually references a sound. Inspired-by
   /// is a general credit, so on a video with no audio reference it says
   /// nothing about who made the sound.
+  ///
+  /// Even then it is a best-effort credit rather than a guarantee:
+  /// `getActiveDraft` auto-populates inspired-by from the selected sound's
+  /// source video only when the draft has none set, so one set for an
+  /// unrelated reason is left in place and would be credited here.
   static String? reusedCreatorPubkeyFor(VideoEvent video) {
     final pubkey = video.inspiredByVideo?.creatorPubkey;
     return (pubkey != null && pubkey.isNotEmpty) ? pubkey : null;

--- a/mobile/lib/widgets/video_feed_item/audio_attribution_credit.dart
+++ b/mobile/lib/widgets/video_feed_item/audio_attribution_credit.dart
@@ -1,52 +1,41 @@
-// ABOUTME: Shared helpers for unresolved audio attribution credit.
-// ABOUTME: Keeps feed-row and metadata-sheet fallback credit logic in sync.
+// ABOUTME: Shared helper for audio attribution creator credit.
+// ABOUTME: Keeps feed-row and metadata-sheet credit logic in sync.
 
 import 'package:models/models.dart';
 
-/// Resolved display credit for an audio attribution fallback.
+/// Shared creator-credit selection for the two visible sound surfaces.
 class AudioAttributionCredit {
-  const AudioAttributionCredit({
-    required this.creatorPubkey,
-    required this.creatorName,
-    required this.creditsReusedCreator,
-  });
+  const AudioAttributionCredit._();
 
-  final String creatorPubkey;
-  final String creatorName;
-  final bool creditsReusedCreator;
-}
-
-/// Shared credit selection for videos whose referenced sound cannot be fetched.
-class UnresolvedAudioAttributionCredit {
-  const UnresolvedAudioAttributionCredit._();
-
-  /// The reused sound's original creator, carried via inspired-by when a sound
-  /// selection auto-populated that field. Null means the best available credit
-  /// is the video's author.
+  /// The reused sound's original creator, carried on the video via its
+  /// inspired-by source (reusing a sound auto-populates inspired-by from the
+  /// source video). Null when absent, so the video's own author is credited.
+  ///
+  /// Only call this for a video that actually references a sound. Inspired-by
+  /// is a general credit, so on a video with no audio reference it says
+  /// nothing about who made the sound.
   static String? reusedCreatorPubkeyFor(VideoEvent video) {
     final pubkey = video.inspiredByVideo?.creatorPubkey;
     return (pubkey != null && pubkey.isNotEmpty) ? pubkey : null;
   }
 
-  static AudioAttributionCredit resolve({
+  /// The name to credit for [video]'s sound.
+  ///
+  /// [reusedCreatorPubkey] is the reused sound's creator, or null when the
+  /// video has no reused sound. Callers pass it explicitly — a null must stay
+  /// "no reused creator" so a video carrying inspired-by for an unrelated
+  /// reason still credits its own author.
+  ///
+  /// [creatorProfile] is the profile of whoever that resolves to, so the
+  /// generated-name fallbacks below are only reached before it loads.
+  static String creatorNameFor({
     required VideoEvent video,
     required UserProfile? creatorProfile,
-    String? reusedCreatorPubkey,
-  }) {
-    final resolvedReusedCreatorPubkey =
-        reusedCreatorPubkey ?? reusedCreatorPubkeyFor(video);
-    final creatorPubkey = resolvedReusedCreatorPubkey ?? video.pubkey;
-    final creatorName =
-        creatorProfile?.bestDisplayName ??
-        (resolvedReusedCreatorPubkey != null
-            ? UserProfile.defaultDisplayNameFor(creatorPubkey)
-            : video.displayAuthorName ??
-                  UserProfile.generatedNameFor(video.pubkey));
-
-    return AudioAttributionCredit(
-      creatorPubkey: creatorPubkey,
-      creatorName: creatorName,
-      creditsReusedCreator: resolvedReusedCreatorPubkey != null,
-    );
-  }
+    required String? reusedCreatorPubkey,
+  }) =>
+      creatorProfile?.bestDisplayName ??
+      (reusedCreatorPubkey != null
+          ? UserProfile.defaultDisplayNameFor(reusedCreatorPubkey)
+          : video.displayAuthorName ??
+                UserProfile.generatedNameFor(video.pubkey));
 }

--- a/mobile/lib/widgets/video_feed_item/audio_attribution_credit.dart
+++ b/mobile/lib/widgets/video_feed_item/audio_attribution_credit.dart
@@ -1,0 +1,52 @@
+// ABOUTME: Shared helpers for unresolved audio attribution credit.
+// ABOUTME: Keeps feed-row and metadata-sheet fallback credit logic in sync.
+
+import 'package:models/models.dart';
+
+/// Resolved display credit for an audio attribution fallback.
+class AudioAttributionCredit {
+  const AudioAttributionCredit({
+    required this.creatorPubkey,
+    required this.creatorName,
+    required this.creditsReusedCreator,
+  });
+
+  final String creatorPubkey;
+  final String creatorName;
+  final bool creditsReusedCreator;
+}
+
+/// Shared credit selection for videos whose referenced sound cannot be fetched.
+class UnresolvedAudioAttributionCredit {
+  const UnresolvedAudioAttributionCredit._();
+
+  /// The reused sound's original creator, carried via inspired-by when a sound
+  /// selection auto-populated that field. Null means the best available credit
+  /// is the video's author.
+  static String? reusedCreatorPubkeyFor(VideoEvent video) {
+    final pubkey = video.inspiredByVideo?.creatorPubkey;
+    return (pubkey != null && pubkey.isNotEmpty) ? pubkey : null;
+  }
+
+  static AudioAttributionCredit resolve({
+    required VideoEvent video,
+    required UserProfile? creatorProfile,
+    String? reusedCreatorPubkey,
+  }) {
+    final resolvedReusedCreatorPubkey =
+        reusedCreatorPubkey ?? reusedCreatorPubkeyFor(video);
+    final creatorPubkey = resolvedReusedCreatorPubkey ?? video.pubkey;
+    final creatorName =
+        creatorProfile?.bestDisplayName ??
+        (resolvedReusedCreatorPubkey != null
+            ? UserProfile.defaultDisplayNameFor(creatorPubkey)
+            : video.displayAuthorName ??
+                  UserProfile.generatedNameFor(video.pubkey));
+
+    return AudioAttributionCredit(
+      creatorPubkey: creatorPubkey,
+      creatorName: creatorName,
+      creditsReusedCreator: resolvedReusedCreatorPubkey != null,
+    );
+  }
+}

--- a/mobile/lib/widgets/video_feed_item/audio_attribution_row.dart
+++ b/mobile/lib/widgets/video_feed_item/audio_attribution_row.dart
@@ -134,20 +134,23 @@ class _UnresolvedAudioAttribution extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final creatorPubkey =
-        UnresolvedAudioAttributionCredit.reusedCreatorPubkeyFor(video) ??
-        video.pubkey;
+    // Only reached with an audio reference, so inspired-by (when present) is
+    // the reused sound's source rather than an unrelated credit.
+    final reusedCreatorPubkey = AudioAttributionCredit.reusedCreatorPubkeyFor(
+      video,
+    );
+    final creatorPubkey = reusedCreatorPubkey ?? video.pubkey;
     final creatorProfile = ref
         .watch(userProfileReactiveProvider(creatorPubkey))
         .value;
-    final credit = UnresolvedAudioAttributionCredit.resolve(
-      video: video,
-      creatorProfile: creatorProfile,
-    );
 
     return _AudioAttributionPill(
       soundName: context.l10n.audioAttributionUnavailableSound,
-      creatorName: credit.creatorName,
+      creatorName: AudioAttributionCredit.creatorNameFor(
+        video: video,
+        creatorProfile: creatorProfile,
+        reusedCreatorPubkey: reusedCreatorPubkey,
+      ),
     );
   }
 }

--- a/mobile/lib/widgets/video_feed_item/audio_attribution_row.dart
+++ b/mobile/lib/widgets/video_feed_item/audio_attribution_row.dart
@@ -134,8 +134,8 @@ class _UnresolvedAudioAttribution extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // Only reached with an audio reference, so inspired-by (when present) is
-    // the reused sound's source rather than an unrelated credit.
+    // Only reached with an audio reference, so inspired-by is the best
+    // available credit for the sound here.
     final reusedCreatorPubkey = AudioAttributionCredit.reusedCreatorPubkeyFor(
       video,
     );

--- a/mobile/lib/widgets/video_feed_item/audio_attribution_row.dart
+++ b/mobile/lib/widgets/video_feed_item/audio_attribution_row.dart
@@ -15,10 +15,12 @@ import 'package:unified_logger/unified_logger.dart';
 
 /// A tappable row showing audio attribution on every video in the feed.
 ///
-/// Two display modes:
+/// Three display modes:
 /// - **Shared audio**: `♪ Sound name · Creator` → taps to [SoundDetailScreen]
 /// - **Original sound**: `♪ Original sound - @creator` → taps to
 ///   [OriginalSoundDetailScreen]
+/// - **Unresolved reference**: `♪ Original sound · Creator`, display-only —
+///   the video reuses a sound whose event can't be fetched (#6185)
 class AudioAttributionRow extends ConsumerWidget {
   /// Creates an AudioAttributionRow.
   const AudioAttributionRow({required this.video, super.key});
@@ -46,7 +48,7 @@ class AudioAttributionRow extends ConsumerWidget {
             name: 'AudioAttributionRow',
             category: LogCategory.ui,
           );
-          return const SizedBox.shrink();
+          return _UnresolvedAudioAttribution(video: video);
         }
 
         return _AudioAttributionContent(audio: audio);
@@ -58,7 +60,7 @@ class AudioAttributionRow extends ConsumerWidget {
           name: 'AudioAttributionRow',
           category: LogCategory.ui,
         );
-        return const SizedBox.shrink();
+        return _UnresolvedAudioAttribution(video: video);
       },
     );
   }
@@ -88,49 +90,14 @@ class _AudioAttributionContent extends ConsumerWidget {
           UserProfile.defaultDisplayNameFor(audio.pubkey);
     }
 
-    return Semantics(
-      identifier: 'audio_attribution_row',
-      button: true,
-      label: context.l10n.audioAttributionRowSemanticLabel(
+    return _AudioAttributionPill(
+      soundName: soundName,
+      creatorName: creatorName,
+      semanticLabel: context.l10n.audioAttributionRowSemanticLabel(
         soundName,
         creatorName,
       ),
-      child: GestureDetector(
-        onTap: () => _navigateToSoundDetail(context, audio),
-        child: Container(
-          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-          decoration: BoxDecoration(
-            color: VineTheme.backgroundColor.withValues(alpha: 0.3),
-            borderRadius: BorderRadius.circular(4),
-          ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            spacing: 4,
-            children: [
-              const DivineIcon(
-                icon: DivineIconName.musicNote,
-                size: 14,
-                color: VineTheme.vineGreen,
-              ),
-              Flexible(
-                child: Text(
-                  '$soundName · $creatorName',
-                  style: VineTheme.labelMediumFont().copyWith(
-                    shadows: [const Shadow(blurRadius: 4)],
-                  ),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ),
-              const DivineIcon(
-                icon: DivineIconName.caretRight,
-                size: 14,
-                color: VineTheme.onSurfaceVariant,
-              ),
-            ],
-          ),
-        ),
-      ),
+      onTap: () => _navigateToSoundDetail(context, audio),
     );
   }
 
@@ -144,6 +111,117 @@ class _AudioAttributionContent extends ConsumerWidget {
     context.pushWithVideoPause(
       SoundDetailScreen.pathForId(audio.id),
       extra: audio,
+    );
+  }
+}
+
+/// Display-only credit shown when the referenced audio event can't be
+/// resolved — an unreachable relay, or a source video whose event id was
+/// replaced by an edit.
+///
+/// The video *did* reuse a sound, so collapsing to nothing drops the credit
+/// entirely and reads to the publisher as "my sound never got attached"
+/// (#6185). Mirrors `MetadataSoundsSection`'s fallback: credit the reused
+/// sound's original creator when the video carries one, otherwise the video's
+/// own author. Stays display-only — reuse consent can't be confirmed without
+/// the source event, so this must not become a reuse entry point.
+class _UnresolvedAudioAttribution extends ConsumerWidget {
+  const _UnresolvedAudioAttribution({required this.video});
+
+  final VideoEvent video;
+
+  /// The reused sound's original creator, carried on the video via its
+  /// inspired-by source (a reused sound auto-populates inspired-by from the
+  /// source video). Null when absent, so the video's own author is credited.
+  String? get _reusedCreatorPubkey {
+    final pubkey = video.inspiredByVideo?.creatorPubkey;
+    return (pubkey != null && pubkey.isNotEmpty) ? pubkey : null;
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final reusedCreatorPubkey = _reusedCreatorPubkey;
+    final creatorPubkey = reusedCreatorPubkey ?? video.pubkey;
+    final creatorProfile = ref
+        .watch(userProfileReactiveProvider(creatorPubkey))
+        .value;
+    final creatorName =
+        creatorProfile?.bestDisplayName ??
+        (reusedCreatorPubkey != null
+            ? UserProfile.defaultDisplayNameFor(creatorPubkey)
+            : video.displayAuthorName ??
+                  UserProfile.generatedNameFor(video.pubkey));
+
+    return _AudioAttributionPill(
+      soundName: context.l10n.audioAttributionOriginalSound,
+      creatorName: creatorName,
+    );
+  }
+}
+
+/// The attribution pill itself: music note, `Sound · Creator`, and — only when
+/// [onTap] is set — a trailing chevron and button semantics.
+class _AudioAttributionPill extends StatelessWidget {
+  const _AudioAttributionPill({
+    required this.soundName,
+    required this.creatorName,
+    this.semanticLabel,
+    this.onTap,
+  });
+
+  final String soundName;
+  final String creatorName;
+
+  /// Screen-reader label for the tappable form. Null for the display-only
+  /// form, where the rendered text is already the whole content.
+  final String? semanticLabel;
+
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final onTap = this.onTap;
+
+    final pill = Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: VineTheme.backgroundColor.withValues(alpha: 0.3),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        spacing: 4,
+        children: [
+          const DivineIcon(
+            icon: DivineIconName.musicNote,
+            size: 14,
+            color: VineTheme.vineGreen,
+          ),
+          Flexible(
+            child: Text(
+              '$soundName · $creatorName',
+              style: VineTheme.labelMediumFont().copyWith(
+                shadows: [const Shadow(blurRadius: 4)],
+              ),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          if (onTap != null)
+            const DivineIcon(
+              icon: DivineIconName.caretRight,
+              size: 14,
+              color: VineTheme.onSurfaceVariant,
+            ),
+        ],
+      ),
+    );
+
+    return Semantics(
+      identifier: 'audio_attribution_row',
+      button: onTap != null,
+      label: semanticLabel,
+      child: onTap == null ? pill : GestureDetector(onTap: onTap, child: pill),
     );
   }
 }

--- a/mobile/lib/widgets/video_feed_item/audio_attribution_row.dart
+++ b/mobile/lib/widgets/video_feed_item/audio_attribution_row.dart
@@ -11,6 +11,7 @@ import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/original_sound_detail_screen.dart';
 import 'package:openvine/screens/sound_detail_screen.dart';
 import 'package:openvine/utils/pause_aware_modals.dart';
+import 'package:openvine/widgets/video_feed_item/audio_attribution_credit.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// A tappable row showing audio attribution on every video in the feed.
@@ -19,7 +20,7 @@ import 'package:unified_logger/unified_logger.dart';
 /// - **Shared audio**: `♪ Sound name · Creator` → taps to [SoundDetailScreen]
 /// - **Original sound**: `♪ Original sound - @creator` → taps to
 ///   [OriginalSoundDetailScreen]
-/// - **Unresolved reference**: `♪ Original sound · Creator`, display-only —
+/// - **Unresolved reference**: `♪ Sound unavailable · Creator`, display-only —
 ///   the video reuses a sound whose event can't be fetched (#6185)
 class AudioAttributionRow extends ConsumerWidget {
   /// Creates an AudioAttributionRow.
@@ -119,42 +120,34 @@ class _AudioAttributionContent extends ConsumerWidget {
 /// resolved — an unreachable relay, or a source video whose event id was
 /// replaced by an edit.
 ///
-/// The video *did* reuse a sound, so collapsing to nothing drops the credit
+/// The video *did* reuse a sound, so collapsing to nothing drops the signal
 /// entirely and reads to the publisher as "my sound never got attached"
-/// (#6185). Mirrors `MetadataSoundsSection`'s fallback: credit the reused
-/// sound's original creator when the video carries one, otherwise the video's
-/// own author. Stays display-only — reuse consent can't be confirmed without
-/// the source event, so this must not become a reuse entry point.
+/// (#6185). The credit selection mirrors `MetadataSoundsSection`, but the
+/// sound label stays neutral because the referenced event may be a named shared
+/// sound rather than the author's original sound. Stays display-only — reuse
+/// consent can't be confirmed without the source event, so this must not become
+/// a reuse entry point.
 class _UnresolvedAudioAttribution extends ConsumerWidget {
   const _UnresolvedAudioAttribution({required this.video});
 
   final VideoEvent video;
 
-  /// The reused sound's original creator, carried on the video via its
-  /// inspired-by source (a reused sound auto-populates inspired-by from the
-  /// source video). Null when absent, so the video's own author is credited.
-  String? get _reusedCreatorPubkey {
-    final pubkey = video.inspiredByVideo?.creatorPubkey;
-    return (pubkey != null && pubkey.isNotEmpty) ? pubkey : null;
-  }
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final reusedCreatorPubkey = _reusedCreatorPubkey;
-    final creatorPubkey = reusedCreatorPubkey ?? video.pubkey;
+    final creatorPubkey =
+        UnresolvedAudioAttributionCredit.reusedCreatorPubkeyFor(video) ??
+        video.pubkey;
     final creatorProfile = ref
         .watch(userProfileReactiveProvider(creatorPubkey))
         .value;
-    final creatorName =
-        creatorProfile?.bestDisplayName ??
-        (reusedCreatorPubkey != null
-            ? UserProfile.defaultDisplayNameFor(creatorPubkey)
-            : video.displayAuthorName ??
-                  UserProfile.generatedNameFor(video.pubkey));
+    final credit = UnresolvedAudioAttributionCredit.resolve(
+      video: video,
+      creatorProfile: creatorProfile,
+    );
 
     return _AudioAttributionPill(
-      soundName: context.l10n.audioAttributionOriginalSound,
-      creatorName: creatorName,
+      soundName: context.l10n.audioAttributionUnavailableSound,
+      creatorName: credit.creatorName,
     );
   }
 }

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
@@ -11,6 +11,7 @@ import 'package:openvine/providers/sounds_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/sound_detail_screen.dart';
 import 'package:openvine/utils/pause_aware_modals.dart';
+import 'package:openvine/widgets/video_feed_item/audio_attribution_credit.dart';
 import 'package:openvine/widgets/video_feed_item/metadata/metadata_section.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -57,7 +58,8 @@ class _SharedAudioSection extends ConsumerWidget {
           // reusing user.
           return _OriginalSoundSection(
             video: video,
-            reusedCreatorPubkey: _reusedCreatorPubkey,
+            reusedCreatorPubkey:
+                UnresolvedAudioAttributionCredit.reusedCreatorPubkeyFor(video),
           );
         }
         return MetadataSection(
@@ -77,18 +79,11 @@ class _SharedAudioSection extends ConsumerWidget {
         );
         return _OriginalSoundSection(
           video: video,
-          reusedCreatorPubkey: _reusedCreatorPubkey,
+          reusedCreatorPubkey:
+              UnresolvedAudioAttributionCredit.reusedCreatorPubkeyFor(video),
         );
       },
     );
-  }
-
-  /// The reused sound's original creator, carried on the video via its
-  /// inspired-by source (a reused sound auto-populates inspired-by from the
-  /// source video). Null when absent, so the fallback keeps its default.
-  String? get _reusedCreatorPubkey {
-    final pubkey = video.inspiredByVideo?.creatorPubkey;
-    return (pubkey != null && pubkey.isNotEmpty) ? pubkey : null;
   }
 }
 
@@ -115,19 +110,18 @@ class _OriginalSoundSection extends ConsumerWidget {
     final creatorProfile = ref
         .watch(userProfileReactiveProvider(creatorPubkey))
         .value;
-    final creatorName =
-        creatorProfile?.bestDisplayName ??
-        (reusedCreatorPubkey != null
-            ? UserProfile.defaultDisplayNameFor(creatorPubkey)
-            : video.displayAuthorName ??
-                  UserProfile.generatedNameFor(video.pubkey));
+    final credit = UnresolvedAudioAttributionCredit.resolve(
+      video: video,
+      creatorProfile: creatorProfile,
+      reusedCreatorPubkey: reusedCreatorPubkey,
+    );
 
     return MetadataSection(
       label: context.l10n.metadataSoundsLabel,
       child: _OriginalSoundRow(
-        creatorName: creatorName,
+        creatorName: credit.creatorName,
         onTap: _canReuseSound(ref)
-            ? () => _navigateToSoundDetail(context, creatorName)
+            ? () => _navigateToSoundDetail(context, credit.creatorName)
             : null,
       ),
     );

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
@@ -58,8 +58,9 @@ class _SharedAudioSection extends ConsumerWidget {
           // reusing user.
           return _OriginalSoundSection(
             video: video,
-            reusedCreatorPubkey:
-                UnresolvedAudioAttributionCredit.reusedCreatorPubkeyFor(video),
+            reusedCreatorPubkey: AudioAttributionCredit.reusedCreatorPubkeyFor(
+              video,
+            ),
           );
         }
         return MetadataSection(
@@ -79,8 +80,9 @@ class _SharedAudioSection extends ConsumerWidget {
         );
         return _OriginalSoundSection(
           video: video,
-          reusedCreatorPubkey:
-              UnresolvedAudioAttributionCredit.reusedCreatorPubkeyFor(video),
+          reusedCreatorPubkey: AudioAttributionCredit.reusedCreatorPubkeyFor(
+            video,
+          ),
         );
       },
     );
@@ -110,7 +112,7 @@ class _OriginalSoundSection extends ConsumerWidget {
     final creatorProfile = ref
         .watch(userProfileReactiveProvider(creatorPubkey))
         .value;
-    final credit = UnresolvedAudioAttributionCredit.resolve(
+    final creatorName = AudioAttributionCredit.creatorNameFor(
       video: video,
       creatorProfile: creatorProfile,
       reusedCreatorPubkey: reusedCreatorPubkey,
@@ -119,9 +121,9 @@ class _OriginalSoundSection extends ConsumerWidget {
     return MetadataSection(
       label: context.l10n.metadataSoundsLabel,
       child: _OriginalSoundRow(
-        creatorName: credit.creatorName,
+        creatorName: creatorName,
         onTap: _canReuseSound(ref)
-            ? () => _navigateToSoundDetail(context, credit.creatorName)
+            ? () => _navigateToSoundDetail(context, creatorName)
             : null,
       ),
     );

--- a/mobile/test/services/video_event_publisher_test.dart
+++ b/mobile/test/services/video_event_publisher_test.dart
@@ -553,10 +553,10 @@ void main() {
       ).thenAnswer((_) async {});
     });
 
-    PendingUpload createUpload() {
+    PendingUpload createUpload({String localVideoPath = ''}) {
       return PendingUpload(
         id: 'upload-id',
-        localVideoPath: '',
+        localVideoPath: localVideoPath,
         nostrPubkey: testPubkey,
         status: UploadStatus.readyToPublish,
         createdAt: DateTime.now(),
@@ -688,6 +688,62 @@ void main() {
               'wss://relay.divine.video',
               'audio',
             ]),
+            isTrue,
+          );
+        },
+      );
+
+      test(
+        'does not re-publish the video audio when a source is referenced',
+        () async {
+          stubSignAndPublish();
+
+          final reusedSound = AudioEvent(
+            id: 'video_$sourceVideoId',
+            pubkey: sourceCreator,
+            createdAt: 1700000000,
+          );
+
+          final result = await publisher.publishVideoEvent(
+            upload: createUpload(localVideoPath: '/tmp/divine-video-6185.mp4'),
+            allowAudioReuse: true,
+            selectedAudio: reusedSound,
+            selectedAudioEventId: reusedSound.id,
+          );
+
+          expect(result, isTrue);
+          expect(
+            _containsTag(capturedTags, const ['allow_audio_reuse', 'true']),
+            isFalse,
+          );
+        },
+      );
+
+      test(
+        'honors audio reuse when the selection is not referenceable',
+        () async {
+          stubSignAndPublish();
+
+          // A bundled sound has no Nostr event to reference, so the video's own
+          // audio is the user's to offer and "Publish this sound" must still
+          // take effect instead of being silently dropped (#6185).
+          const bundledSound = AudioEvent(
+            id: '${AudioEvent.bundledMarker}_oh_no_no_no_crowd',
+            pubkey: AudioEvent.bundledMarker,
+            createdAt: 0,
+            url: 'asset://assets/sounds/oh-no-no-no-crowd.mp3',
+          );
+
+          final result = await publisher.publishVideoEvent(
+            upload: createUpload(localVideoPath: '/tmp/divine-video-6185.mp4'),
+            allowAudioReuse: true,
+            selectedAudio: bundledSound,
+            selectedAudioEventId: bundledSound.id,
+          );
+
+          expect(result, isTrue);
+          expect(
+            _containsTag(capturedTags, const ['allow_audio_reuse', 'true']),
             isTrue,
           );
         },

--- a/mobile/test/services/video_event_publisher_test.dart
+++ b/mobile/test/services/video_event_publisher_test.dart
@@ -10,7 +10,8 @@ import 'package:crypto/crypto.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:models/models.dart' show AudioEvent, audioEventKind;
+import 'package:models/models.dart'
+    show AudioEvent, AudioExternalSource, AudioLicenseMetadata, audioEventKind;
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/filter.dart';
@@ -18,6 +19,7 @@ import 'package:nostr_sdk/relay/publish_outcome.dart';
 import 'package:nostr_sdk/relay/relay_pool.dart';
 import 'package:openvine/constants/nip71_migration.dart';
 import 'package:openvine/models/pending_upload.dart';
+import 'package:openvine/services/audio_extraction_service.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/saved_sounds_service.dart';
 import 'package:openvine/services/upload_manager.dart';
@@ -33,6 +35,9 @@ class _MockAuthService extends Mock implements AuthService {}
 class _MockVideoEventService extends Mock implements VideoEventService {}
 
 class _MockBlossomUploadService extends Mock implements BlossomUploadService {}
+
+class _MockAudioExtractionService extends Mock
+    implements AudioExtractionService {}
 
 class _MockSavedSoundsService extends Mock implements SavedSoundsService {}
 
@@ -720,9 +725,19 @@ void main() {
       );
 
       test(
-        'honors audio reuse when the selection is not referenceable',
+        'honors audio reuse for bundled sounds',
         () async {
-          stubSignAndPublish();
+          final blossomUploadService = _MockBlossomUploadService();
+          final audioExtractionService = _MockAudioExtractionService();
+          final signedEvents = <Event>[];
+          publisher = VideoEventPublisher(
+            uploadManager: uploadManager,
+            nostrService: nostrClient,
+            authService: authService,
+            videoEventService: videoEventService,
+            blossomUploadService: blossomUploadService,
+            audioExtractionService: audioExtractionService,
+          );
 
           // A bundled sound has no Nostr event to reference, so the video's own
           // audio is the user's to offer and "Publish this sound" must still
@@ -732,6 +747,67 @@ void main() {
             pubkey: AudioEvent.bundledMarker,
             createdAt: 0,
             url: 'asset://assets/sounds/oh-no-no-no-crowd.mp3',
+          );
+
+          const audioPath = '/tmp/divine-video-6185.m4a';
+          when(
+            () => audioExtractionService.extractAudio(
+              videoPath: '/tmp/divine-video-6185.mp4',
+            ),
+          ).thenAnswer(
+            (_) async => const AudioExtractionResult(
+              audioFilePath: audioPath,
+              duration: 6,
+              fileSize: 12345,
+              sha256Hash:
+                  'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+              mimeType: 'audio/m4a',
+            ),
+          );
+          when(
+            () => audioExtractionService.cleanupAudioFile(audioPath),
+          ).thenAnswer((_) async {});
+          when(
+            () => blossomUploadService.uploadAudio(
+              audioFile: any(named: 'audioFile'),
+              mimeType: 'audio/m4a',
+            ),
+          ).thenAnswer(
+            (_) async => const BlossomUploadResult(
+              success: true,
+              url: 'https://cdn.example.com/audio.m4a',
+              fallbackUrl: 'https://cdn.example.com/audio.m4a',
+              videoId:
+                  'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            ),
+          );
+          when(
+            () => authService.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer((invocation) async {
+            final kind = invocation.namedArguments[#kind] as int;
+            final content = invocation.namedArguments[#content] as String;
+            final tags = invocation.namedArguments[#tags] as List<List<String>>;
+            final event = Event(testPubkey, kind, tags, content);
+            signedEvents.add(event);
+            capturedTags = tags;
+            return event;
+          });
+          when(
+            () => nostrClient.publishEventAwaitOk(
+              any(),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer(
+            (invocation) async => PublishOutcome(
+              eventId: (invocation.positionalArguments.first as Event).id,
+              acceptedBy: const ['wss://relay.divine.video'],
+              rejectedBy: const {},
+              noResponseFrom: const [],
+            ),
           );
 
           final result = await publisher.publishVideoEvent(
@@ -745,6 +821,69 @@ void main() {
           expect(
             _containsTag(capturedTags, const ['allow_audio_reuse', 'true']),
             isTrue,
+          );
+          final audioEvent = signedEvents.singleWhere(
+            (event) => event.kind == audioEventKind,
+          );
+          final videoEvent = signedEvents.singleWhere(
+            (event) => event.kind != audioEventKind,
+          );
+          expect(
+            _containsTag(audioEvent.tags, const [
+              'url',
+              'https://cdn.example.com/audio.m4a',
+            ]),
+            isTrue,
+          );
+          expect(
+            _containsTag(videoEvent.tags, [
+              'e',
+              audioEvent.id,
+              'wss://relay.divine.video',
+              'audio',
+            ]),
+            isTrue,
+          );
+        },
+      );
+
+      test(
+        'does not publish external-provider audio as reusable user audio',
+        () async {
+          stubSignAndPublish();
+
+          const externalProviderSound = AudioEvent(
+            id: 'freesound:12345',
+            pubkey: AudioEvent.externalProviderMarker,
+            createdAt: 0,
+            url: 'https://cdn.example.com/freesound-preview.mp3',
+            externalSource: AudioExternalSource(
+              provider: 'freesound',
+              providerSoundId: '12345',
+              providerName: 'Freesound',
+              creatorName: 'Catalog Artist',
+              license: AudioLicenseMetadata(
+                type: 'cc-by',
+                name: 'Creative Commons Attribution',
+                url: 'https://creativecommons.org/licenses/by/4.0/',
+                allowsCommercialUse: true,
+                allowsDerivatives: true,
+                requiresAttribution: true,
+              ),
+            ),
+          );
+
+          final result = await publisher.publishVideoEvent(
+            upload: createUpload(localVideoPath: '/tmp/divine-video-6185.mp4'),
+            allowAudioReuse: true,
+            selectedAudio: externalProviderSound,
+            selectedAudioEventId: externalProviderSound.id,
+          );
+
+          expect(result, isTrue);
+          expect(
+            _containsTag(capturedTags, const ['allow_audio_reuse', 'true']),
+            isFalse,
           );
         },
       );

--- a/mobile/test/widgets/audio_attribution_row_test.dart
+++ b/mobile/test/widgets/audio_attribution_row_test.dart
@@ -68,12 +68,14 @@ void main() {
       required VideoEvent video,
       AudioEvent? audioOverride,
       bool resolvesAudio = true,
+      Object? audioError,
       List<dynamic> additionalOverrides = const [],
     }) {
       return ProviderScope(
         overrides: [
           if (video.hasAudioReference)
             soundByIdProvider(testAudioEventId).overrideWith((ref) async {
+              if (audioError != null) throw audioError;
               return resolvesAudio ? audioOverride ?? testAudio : null;
             }),
           ...additionalOverrides,
@@ -197,22 +199,23 @@ void main() {
     // referenced event can't be fetched the credit must degrade rather than
     // vanish (#6185).
     group('Unresolvable audio reference', () {
-      testWidgets('credits the video author when the audio event is null', (
+      testWidgets('shows a neutral label when the audio event is null', (
         tester,
       ) async {
         final l10n = lookupAppLocalizations(const Locale('en'));
 
         await tester.pumpWidget(
-          buildTestWidget(
-            video: createVideoWithAudio(),
-            resolvesAudio: false,
-          ),
+          buildTestWidget(video: createVideoWithAudio(), resolvesAudio: false),
         );
         await tester.pumpAndSettle();
 
         expect(
-          find.textContaining(l10n.audioAttributionOriginalSound),
+          find.textContaining(l10n.audioAttributionUnavailableSound),
           findsOneWidget,
+        );
+        expect(
+          find.textContaining(l10n.audioAttributionOriginalSound),
+          findsNothing,
         );
       });
 
@@ -239,12 +242,35 @@ void main() {
         );
       });
 
-      testWidgets('is not a reuse entry point', (tester) async {
+      testWidgets('uses the same display-only fallback on provider errors', (
+        tester,
+      ) async {
+        final l10n = lookupAppLocalizations(const Locale('en'));
+
         await tester.pumpWidget(
           buildTestWidget(
             video: createVideoWithAudio(),
-            resolvesAudio: false,
+            audioError: StateError('relay unavailable'),
           ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(
+          find.textContaining(l10n.audioAttributionUnavailableSound),
+          findsOneWidget,
+        );
+        expect(
+          find.descendant(
+            of: find.byType(AudioAttributionRow),
+            matching: find.byType(GestureDetector),
+          ),
+          findsNothing,
+        );
+      });
+
+      testWidgets('is not a reuse entry point', (tester) async {
+        await tester.pumpWidget(
+          buildTestWidget(video: createVideoWithAudio(), resolvesAudio: false),
         );
         await tester.pumpAndSettle();
 
@@ -271,10 +297,7 @@ void main() {
         tester,
       ) async {
         await tester.pumpWidget(
-          buildTestWidget(
-            video: createVideoWithAudio(),
-            resolvesAudio: false,
-          ),
+          buildTestWidget(video: createVideoWithAudio(), resolvesAudio: false),
         );
         await tester.pumpAndSettle();
 

--- a/mobile/test/widgets/audio_attribution_row_test.dart
+++ b/mobile/test/widgets/audio_attribution_row_test.dart
@@ -19,6 +19,8 @@ void main() {
         'pubkey123456789abcdef0123456789abcdef0123456789abcdef0123456789ab';
     const testVideoId =
         'video0123456789abcdef0123456789abcdef0123456789abcdef0123456789ab';
+    const sourceCreatorPubkey =
+        'source123456789abcdef0123456789abcdef0123456789abcdef0123456789ab';
 
     late AudioEvent testAudio;
 
@@ -34,7 +36,7 @@ void main() {
       );
     });
 
-    VideoEvent createVideoWithAudio() {
+    VideoEvent createVideoWithAudio({InspiredByInfo? inspiredByVideo}) {
       final now = DateTime.now();
       return VideoEvent(
         id: testVideoId,
@@ -45,6 +47,7 @@ void main() {
         timestamp: now,
         title: 'Test Video',
         audioEventId: testAudioEventId,
+        inspiredByVideo: inspiredByVideo,
       );
     }
 
@@ -64,13 +67,14 @@ void main() {
     Widget buildTestWidget({
       required VideoEvent video,
       AudioEvent? audioOverride,
+      bool resolvesAudio = true,
       List<dynamic> additionalOverrides = const [],
     }) {
       return ProviderScope(
         overrides: [
           if (video.hasAudioReference)
             soundByIdProvider(testAudioEventId).overrideWith((ref) async {
-              return audioOverride ?? testAudio;
+              return resolvesAudio ? audioOverride ?? testAudio : null;
             }),
           ...additionalOverrides,
         ],
@@ -187,31 +191,103 @@ void main() {
         );
         expect(text.style?.color, equals(VineTheme.whiteText));
       });
+    });
 
-      testWidgets('renders nothing when audio event is null', (tester) async {
-        final video = createVideoWithAudio();
+    // The video carries an audio reference, so it did reuse a sound. When the
+    // referenced event can't be fetched the credit must degrade rather than
+    // vanish (#6185).
+    group('Unresolvable audio reference', () {
+      testWidgets('credits the video author when the audio event is null', (
+        tester,
+      ) async {
+        final l10n = lookupAppLocalizations(const Locale('en'));
 
         await tester.pumpWidget(
-          ProviderScope(
-            overrides: [
-              soundByIdProvider(testAudioEventId).overrideWith((ref) async {
-                return null;
-              }),
-            ],
-            child: MaterialApp(
-              theme: VineTheme.theme,
-              home: Scaffold(
-                backgroundColor: Colors.black,
-                body: AudioAttributionRow(video: video),
-              ),
-            ),
+          buildTestWidget(
+            video: createVideoWithAudio(),
+            resolvesAudio: false,
           ),
         );
-
         await tester.pumpAndSettle();
 
-        // Should render nothing when audio can't be found
-        expect(find.textContaining('Original sound'), findsNothing);
+        expect(
+          find.textContaining(l10n.audioAttributionOriginalSound),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('credits the reused sound creator when inspired-by is set', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildTestWidget(
+            video: createVideoWithAudio(
+              inspiredByVideo: const InspiredByInfo(
+                addressableId: '34236:$sourceCreatorPubkey:vine-xyz',
+              ),
+            ),
+            resolvesAudio: false,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(
+          find.textContaining(
+            UserProfile.defaultDisplayNameFor(sourceCreatorPubkey),
+          ),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('is not a reuse entry point', (tester) async {
+        await tester.pumpWidget(
+          buildTestWidget(
+            video: createVideoWithAudio(),
+            resolvesAudio: false,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(
+          find.descendant(
+            of: find.byType(AudioAttributionRow),
+            matching: find.byType(GestureDetector),
+          ),
+          findsNothing,
+        );
+
+        final semantics = tester.widget<Semantics>(
+          find
+              .descendant(
+                of: find.byType(AudioAttributionRow),
+                matching: find.byType(Semantics),
+              )
+              .first,
+        );
+        expect(semantics.properties.button, isFalse);
+      });
+
+      testWidgets('renders no caret, since there is nowhere to navigate', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildTestWidget(
+            video: createVideoWithAudio(),
+            resolvesAudio: false,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final divineIcons = tester.widgetList<DivineIcon>(
+          find.descendant(
+            of: find.byType(AudioAttributionRow),
+            matching: find.byType(DivineIcon),
+          ),
+        );
+        expect(
+          divineIcons.any((icon) => icon.icon == DivineIconName.caretRight),
+          isFalse,
+        );
       });
     });
 

--- a/mobile/test/widgets/metadata_sounds_section_test.dart
+++ b/mobile/test/widgets/metadata_sounds_section_test.dart
@@ -65,6 +65,7 @@ void main() {
     VideoEvent createVideoWithoutAudio({
       String? authorName,
       bool allowAudioReuse = false,
+      InspiredByInfo? inspiredBy,
     }) {
       final now = DateTime.now();
       return VideoEvent(
@@ -76,6 +77,7 @@ void main() {
         timestamp: now,
         title: 'Test Video',
         authorName: authorName,
+        inspiredByVideo: inspiredBy,
         rawTags: allowAudioReuse
             ? const {'allow_audio_reuse': 'true'}
             : const {},
@@ -167,6 +169,32 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.text('Jake Lara'), findsOneWidget);
+      });
+
+      testWidgets('credits the author when inspired-by is not a reused sound', (
+        tester,
+      ) async {
+        // Inspired-by is a general credit, not a sound reference. With no
+        // audio reference the video has its own original sound, so the credit
+        // must stay with its author rather than the inspired-by creator.
+        const inspiredCreatorPubkey =
+            'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210';
+        final video = createVideoWithoutAudio(
+          authorName: 'Jake Lara',
+          inspiredBy: const InspiredByInfo(
+            addressableId: '34236:$inspiredCreatorPubkey:vine-xyz',
+          ),
+        );
+
+        await tester.pumpWidget(buildTestWidget(video: video));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Original sound'), findsOneWidget);
+        expect(find.text('Jake Lara'), findsOneWidget);
+        expect(
+          find.text(UserProfile.defaultDisplayNameFor(inspiredCreatorPubkey)),
+          findsNothing,
+        );
       });
 
       testWidgets('falls back to original sound when audio event is null', (


### PR DESCRIPTION
## Description

Two silent drops left a reused sound invisible at the bottom of a published post.

**Publish — `VideoEventPublisher`.** The "publish this sound" branch was gated on whether a sound was *selected* (`hasSelectedAudioEventId`), not on whether that selection actually produced a Nostr reference. A bundled sound yields no referenceable event, so the published video came out with **no `["e", …, "audio"]` tag, no `allow_audio_reuse` marker, and no Kind 1063** — the toggle was a no-op, which matches the reporter's "even after disabling and re-enabling 'Publish this sound'". Bundled selections now publish the rendered video audio as the user's reusable Kind 1063. External-provider catalog sounds are explicitly excluded from that branch so Freesound/Openverse-style selections are not republished as the user's reusable audio without their provider/license metadata.

**Feed — `AudioAttributionRow`.** The row collapsed to `SizedBox.shrink()` whenever the referenced audio event could not be fetched (unreachable relay, or a source video whose event id was replaced by an edit), so a *correctly tagged* video still showed nothing. It now degrades to a display-only `♪ Sound unavailable · Creator` pill, crediting the reused sound's original creator when the video carries one (via inspired-by), otherwise the video's author. The neutral label avoids claiming the referenced shared sound was the video author's original sound. It stays non-tappable: reuse consent can't be confirmed without the source event, so it must not become a reuse entry point.

The tappable and display-only forms now share one `_AudioAttributionPill`; the chevron and button semantics appear only on the tappable form. The unresolved-credit fallback is shared with `MetadataSoundsSection` so the two visible sound surfaces cannot drift.

**Scoping the shared credit.** That shared helper takes `reusedCreatorPubkey` as a required parameter rather than deriving it from the video, because a null has to stay "this video has no reused sound". `MetadataSoundsSection` depends on that: a video with no audio reference has its own original sound, and inspired-by is a general credit that says nothing about who made it. Deriving it instead credited the inspired-by creator on any video carrying one for an unrelated reason, wherever the author's profile had not loaded yet. Even with an audio reference present the credit is best-effort — `getActiveDraft` only auto-populates inspired-by from the sound's source video when the draft has none set — which is recorded on the helper.

**Related Issue:** Closes #6185

### Note on the original report

The report is dated 2026-07-19 against 1.0.16 (2026-07-11). #6066 (merged 2026-07-13, first shipped in 1.0.17 on 2026-07-22) added `AudioEvent.attributionEventId` and the editor-track attribution fallback, which fix the two drops that were live on 1.0.16: a reused original sound's `video_<eventId>` id failed the 64-hex check and the tag was dropped, and a sound added through the editor's music library never reached `draft.selectedSound` at all. On 1.0.17+ that repro should already produce a sound row — and step 3 of it is no longer reachable, because the "Publish this sound" toggle is now hidden for reused sounds. This PR closes the paths that remain on `main`.

## Out of Scope

- Bundled sounds still carry no per-sound feed attribution: their ids aren't event ids, so nothing referenceable can go in an `e` tag. With this PR a bundled-sound video that opts into reuse publishes its own Kind 1063 and gets the generic row; naming the bundled sound itself would need a separate tag shape.
- External-provider catalog sounds are not republished as reusable user audio. Preserving provider/license/creator metadata for those sounds would need a separate protocol shape.
- "Publish this sound" is still inert when the video references another creator's sound; the metadata toggle is deliberately hidden in that case (#6066).

## Verification

- `flutter analyze lib test` — clean.
- `flutter test test/l10n/arb_consistency_test.dart test/widgets/metadata_sounds_section_test.dart test/widgets/audio_attribution_row_test.dart test/services/video_event_publisher_test.dart` — 61 passing.
- The credit regression test was run against `origin/main`'s copy of `metadata_sounds_section.dart` (passes) and against the version that derived the reused creator (fails), so it pins the behavior rather than the refactor.
- Pre-commit and pre-push hooks reran format, analyzer, and changed-file tests before each push.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

