### PR TITLE
fix(feed): cap playback length with native clipping

### DIFF
--- a/mobile/lib/constants/app_constants.dart
+++ b/mobile/lib/constants/app_constants.dart
@@ -55,6 +55,23 @@ class AppConstants {
   static const int followingVideoThreshold = 5;
 
   // ============================================================================
+  // FEED PLAYBACK
+  // ============================================================================
+
+  /// Hard cap on how long any feed video plays before it loops.
+  ///
+  /// Nothing in the feed plays longer than a Vine, including kind-34236 events
+  /// published by other Nostr clients that point at arbitrarily long files.
+  /// The cap is applied as a native clip end (`VideoClip.end`), so the loop
+  /// point stays inside the platform player — a Dart-side seek-to-zero is what
+  /// produced the audible loop seam in #5544.
+  ///
+  /// Deliberately above `VideoEditorConstants.maxDuration` (6.3s, the
+  /// *recording* limit): classic Vine assets measure 6.500–6.533s, and capping
+  /// at the recording limit would clip their musical loop point (#6421).
+  static const Duration maxFeedPlaybackDuration = Duration(seconds: 7);
+
+  // ============================================================================
   // VIDEO PROCESSING
   // ============================================================================
 

--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -15,6 +15,7 @@ import 'package:openvine/blocs/video_interactions/video_interactions_bloc.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_state.dart';
 import 'package:openvine/blocs/video_volume/video_volume_cubit.dart';
+import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
@@ -364,9 +365,12 @@ class FeedVideosState extends ConsumerState<FeedVideos> with RouteAware {
           _resumeAutoAdvanceAfterSwipe();
           widget.onActiveVideoChanged?.call(video, index);
         },
-        // Do not pass maxLoopDuration here. Feed playback should loop at the
-        // asset boundary; restarting with a Dart seek at the 6.3s recording
-        // limit creates an audible seam.
+        // Nothing in the feed plays longer than a Vine, not even a 60s file a
+        // foreign Nostr client points at. The cap is a native clip end, so the
+        // loop point stays in the platform player — deliberately NOT
+        // maxLoopDuration, whose Dart seek at the 6.3s recording limit both
+        // truncated classic Vines and created an audible seam (#5544, #6421).
+        maxPlaybackDuration: AppConstants.maxFeedPlaybackDuration,
         onVideoLoopCompleted: _handleAutoAdvanceCompleted,
         shouldPortraitExpand: widget.shouldPortraitExpand,
         canAutoPlay: _canAutoPlayVideo,

--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
@@ -391,7 +391,18 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             let startTime = CMTime(value: startMs, timescale: 1000)
             let endTime: CMTime
             if let endMs {
-                endTime = CMTime(value: endMs.int64Value, timescale: 1000)
+                // Clamp to the asset: insertTimeRange silently inserts only the
+                // media that exists, so an endMs past the source would leave
+                // clipDuration (and therefore the reported totalDuration)
+                // longer than what actually plays. The feed relies on this —
+                // it caps every clip at maxFeedPlaybackDuration without knowing
+                // the source length up front. ExoPlayer clamps the equivalent
+                // ClippingConfiguration itself.
+                let requestedEnd = CMTime(value: endMs.int64Value, timescale: 1000)
+                endTime =
+                    (assetDuration.isNumeric && CMTimeCompare(requestedEnd, assetDuration) > 0)
+                    ? assetDuration
+                    : requestedEnd
             } else {
                 endTime = assetDuration
             }

--- a/mobile/packages/divine_video_player/lib/src/video_clip.dart
+++ b/mobile/packages/divine_video_player/lib/src/video_clip.dart
@@ -106,10 +106,11 @@ class VideoClip {
 
   /// End position within the source video.
   ///
-  /// When `null`, the clip plays to the end of the source. On the Android and
-  /// Apple backends an [end] past the source duration is clamped to it, so a
-  /// caller capping playback without knowing the source length still gets the
-  /// natural end for shorter sources.
+  /// When `null`, the clip plays to the end of the source. On the Android,
+  /// Apple and web backends an [end] past the source duration is clamped to
+  /// it, so a caller capping playback without knowing the source length still
+  /// gets the natural end for shorter sources. The Linux backend does not
+  /// clamp and reports the requested length.
   final Duration? end;
 
   /// Audio volume for this clip (0.0 = muted, 1.0 = full volume).

--- a/mobile/packages/divine_video_player/lib/src/video_clip.dart
+++ b/mobile/packages/divine_video_player/lib/src/video_clip.dart
@@ -106,7 +106,10 @@ class VideoClip {
 
   /// End position within the source video.
   ///
-  /// When `null`, the clip plays to the end of the source.
+  /// When `null`, the clip plays to the end of the source. On the Android and
+  /// Apple backends an [end] past the source duration is clamped to it, so a
+  /// caller capping playback without knowing the source length still gets the
+  /// natural end for shorter sources.
   final Duration? end;
 
   /// Audio volume for this clip (0.0 = muted, 1.0 = full volume).

--- a/mobile/packages/divine_video_player/lib/src/web/web_clip_duration.dart
+++ b/mobile/packages/divine_video_player/lib/src/web/web_clip_duration.dart
@@ -1,0 +1,34 @@
+import 'dart:math' as math;
+
+/// Resolves the playback duration the web backend reports for a clip, in
+/// seconds.
+///
+/// [sourceDurationSeconds] is the `<video>` element's own duration, which is
+/// `NaN` until the browser has loaded metadata and `Infinity` for a live
+/// stream.
+///
+/// A [clipEndSeconds] past the source is clamped to the source, matching the
+/// Android and Apple backends, so a caller capping playback without knowing
+/// the source length still reports the natural end for shorter sources.
+/// Without the clamp a blind cap makes every shorter video report the cap as
+/// its duration, which breaks any consumer that arms on `duration - epsilon`.
+double resolveClipDurationSeconds({
+  required double clipStartSeconds,
+  required double? clipEndSeconds,
+  required double sourceDurationSeconds,
+}) {
+  final hasSourceDuration =
+      !sourceDurationSeconds.isNaN && sourceDurationSeconds.isFinite;
+
+  final double? endSeconds;
+  if (clipEndSeconds == null) {
+    endSeconds = hasSourceDuration ? sourceDurationSeconds : null;
+  } else {
+    endSeconds = hasSourceDuration
+        ? math.min(clipEndSeconds, sourceDurationSeconds)
+        : clipEndSeconds;
+  }
+  if (endSeconds == null) return 0;
+
+  return math.max(0, endSeconds - clipStartSeconds);
+}

--- a/mobile/packages/divine_video_player/lib/src/web/web_video_player_backend_web.dart
+++ b/mobile/packages/divine_video_player/lib/src/web/web_video_player_backend_web.dart
@@ -10,6 +10,7 @@ import 'dart:ui_web' as ui_web;
 import 'package:divine_video_player/src/audio_track.dart' as divine;
 import 'package:divine_video_player/src/video_clip.dart';
 import 'package:divine_video_player/src/video_player_state.dart';
+import 'package:divine_video_player/src/web/web_clip_duration.dart';
 import 'package:divine_video_player/src/web/web_video_player_backend.dart';
 import 'package:flutter/widgets.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -419,17 +420,14 @@ class HtmlVideoElementBackend implements WebVideoPlayerBackend {
     final position = Duration(
       microseconds: math.max(0, (positionSeconds * 1e6).round()),
     );
-    final rawDurationSeconds = element.duration;
-    final hasDuration =
-        !rawDurationSeconds.isNaN && rawDurationSeconds.isFinite;
     final clipEnd = _clipEnd;
-    final effectiveDurationSeconds = clipEnd != null
-        ? _toSeconds(clipEnd) - _toSeconds(_clipStart)
-        : hasDuration
-        ? rawDurationSeconds - _toSeconds(_clipStart)
-        : 0.0;
+    final effectiveDurationSeconds = resolveClipDurationSeconds(
+      clipStartSeconds: _toSeconds(_clipStart),
+      clipEndSeconds: clipEnd == null ? null : _toSeconds(clipEnd),
+      sourceDurationSeconds: element.duration,
+    );
     final duration = Duration(
-      microseconds: math.max(0, (effectiveDurationSeconds * 1e6).round()),
+      microseconds: (effectiveDurationSeconds * 1e6).round(),
     );
 
     var bufferedPosition = position;

--- a/mobile/packages/divine_video_player/test/src/apple_clip_end_clamp_contract_test.dart
+++ b/mobile/packages/divine_video_player/test/src/apple_clip_end_clamp_contract_test.dart
@@ -1,0 +1,80 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// `insertTimeRange` silently inserts only the media that exists, so an
+/// out-of-range clip end never truncates playback — but it does inflate the
+/// `clipDuration` the Swift side derives from the *requested* end, and that
+/// value becomes the reported `totalDuration`. Callers that cap playback
+/// without knowing the source length (the feed's `maxFeedPlaybackDuration`)
+/// depend on the clamp: without it every shorter video reports the cap as its
+/// duration, corrupting the progress fraction and the loop-completion timing
+/// that arms on `duration - endThreshold`.
+///
+/// ExoPlayer clamps the equivalent `ClippingConfiguration` inside
+/// `ClippingTimeline`, so the guarantee documented on `VideoClip.end` holds on
+/// Android without repo code. On Apple it is this branch and nothing else, and
+/// it has no Dart runtime surface — the package's CI runs Dart and Kotlin
+/// tests only, so a refactor that drops it keeps every other test green.
+void main() {
+  group('Apple native clip-end clamp contract', () {
+    test('clamps a requested clip end to the asset duration', () {
+      final source = _appleSourceFile().readAsStringSync();
+
+      expect(
+        source,
+        contains('CMTimeCompare(requestedEnd, assetDuration) > 0'),
+        reason:
+            'A requested end past the asset must resolve to the asset '
+            'duration, not to the requested value.',
+      );
+      expect(
+        source,
+        contains('assetDuration.isNumeric'),
+        reason:
+            'A non-numeric asset duration (indefinite/unloaded) cannot be '
+            'compared against, so the requested end has to stand there.',
+      );
+    });
+
+    test('clamps before deriving the clip duration', () {
+      final source = _appleSourceFile().readAsStringSync();
+
+      final clamp = source.indexOf(
+        'CMTimeCompare(requestedEnd, assetDuration) > 0',
+      );
+      final clipDuration = source.indexOf(
+        'CMTimeSubtract(endTime, startTime)',
+      );
+
+      expect(clamp, greaterThanOrEqualTo(0));
+      expect(clipDuration, greaterThanOrEqualTo(0));
+      expect(
+        clamp,
+        lessThan(clipDuration),
+        reason:
+            'clipDuration feeds the reported totalDuration, so it must be '
+            'derived from the clamped end rather than the requested one.',
+      );
+    });
+  });
+}
+
+/// The iOS and macOS players share a single Darwin source tree
+/// (`darwin/divine_video_player/Sources/`), so the clamp contract is asserted
+/// once.
+File _appleSourceFile() {
+  final packageRelative = File(
+    'darwin/divine_video_player/Sources/divine_video_player/'
+    'DivineVideoPlayerInstance.swift',
+  );
+  if (packageRelative.existsSync()) {
+    return packageRelative;
+  }
+
+  return File(
+    'packages/divine_video_player/'
+    'darwin/divine_video_player/Sources/divine_video_player/'
+    'DivineVideoPlayerInstance.swift',
+  );
+}

--- a/mobile/packages/divine_video_player/test/src/web_clip_duration_test.dart
+++ b/mobile/packages/divine_video_player/test/src/web_clip_duration_test.dart
@@ -1,0 +1,109 @@
+import 'package:divine_video_player/src/web/web_clip_duration.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('resolveClipDurationSeconds', () {
+    test('reports the source length when no clip end is set', () {
+      expect(
+        resolveClipDurationSeconds(
+          clipStartSeconds: 0,
+          clipEndSeconds: null,
+          sourceDurationSeconds: 3.2,
+        ),
+        3.2,
+      );
+    });
+
+    test('clamps a clip end past the source to the source length', () {
+      expect(
+        resolveClipDurationSeconds(
+          clipStartSeconds: 0,
+          clipEndSeconds: 7,
+          sourceDurationSeconds: 3.2,
+        ),
+        3.2,
+        reason:
+            'The feed caps every clip blindly; without the clamp a 3.2s video '
+            'reports the 7s cap and no consumer arming on duration - epsilon '
+            'ever fires.',
+      );
+    });
+
+    test('keeps a clip end inside the source', () {
+      expect(
+        resolveClipDurationSeconds(
+          clipStartSeconds: 0,
+          clipEndSeconds: 7,
+          sourceDurationSeconds: 60,
+        ),
+        7,
+      );
+    });
+
+    test('subtracts the clip start from the resolved end', () {
+      expect(
+        resolveClipDurationSeconds(
+          clipStartSeconds: 1,
+          clipEndSeconds: 3,
+          sourceDurationSeconds: 60,
+        ),
+        2,
+      );
+      expect(
+        resolveClipDurationSeconds(
+          clipStartSeconds: 1,
+          clipEndSeconds: null,
+          sourceDurationSeconds: 3,
+        ),
+        2,
+      );
+    });
+
+    test('uses the requested end while the source duration is unknown', () {
+      expect(
+        resolveClipDurationSeconds(
+          clipStartSeconds: 0,
+          clipEndSeconds: 7,
+          sourceDurationSeconds: double.nan,
+        ),
+        7,
+        reason:
+            'element.duration is NaN until metadata loads; reporting zero '
+            'there would flap the duration on every refresh before playback.',
+      );
+    });
+
+    test('uses the requested end for a live source', () {
+      expect(
+        resolveClipDurationSeconds(
+          clipStartSeconds: 0,
+          clipEndSeconds: 7,
+          sourceDurationSeconds: double.infinity,
+        ),
+        7,
+      );
+    });
+
+    test('reports zero when neither a clip end nor a source length exists', () {
+      expect(
+        resolveClipDurationSeconds(
+          clipStartSeconds: 0,
+          clipEndSeconds: null,
+          sourceDurationSeconds: double.nan,
+        ),
+        0,
+      );
+    });
+
+    test('never reports a negative duration for a start past the end', () {
+      expect(
+        resolveClipDurationSeconds(
+          clipStartSeconds: 5,
+          clipEndSeconds: 2,
+          sourceDurationSeconds: 60,
+        ),
+        0,
+      );
+    });
+  });
+}

--- a/mobile/packages/infinite_video_feed/lib/src/utils/source_loader.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/utils/source_loader.dart
@@ -34,6 +34,10 @@ class SourceLoadAborted implements Exception {
 /// Returns a record of `(source, attemptIndex)` for the URL that opened.
 /// Logs each failure via [log] and re-throws the last error when every
 /// source fails.
+///
+/// [maxPlaybackDuration] becomes the clip's end position, so the native
+/// player stops (and loops) there. Sources shorter than the cap are
+/// unaffected — both backends clamp the clip end to the real duration.
 Future<(String, int)> setSourceWithFallbacks({
   required int index,
   required DivineVideoPlayerController controller,
@@ -41,6 +45,7 @@ Future<(String, int)> setSourceWithFallbacks({
   required void Function(String) log,
   Map<String, String>? Function(String source)? httpHeadersForSource,
   bool Function()? isLoadCurrent,
+  Duration? maxPlaybackDuration,
   SourceLoadDelay delay = Future<void>.delayed,
 }) async {
   Object? lastError;
@@ -59,6 +64,7 @@ Future<(String, int)> setSourceWithFallbacks({
       await controller.setSource(
         VideoClip.network(
           source,
+          end: maxPlaybackDuration,
           httpHeaders: httpHeadersForSource?.call(source) ?? const {},
         ),
       );
@@ -101,6 +107,7 @@ Future<(String, int)> setSourceWithFallbacks({
             await controller.setSource(
               VideoClip.network(
                 source,
+                end: maxPlaybackDuration,
                 httpHeaders: httpHeadersForSource?.call(source) ?? const {},
               ),
             );

--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -53,6 +53,7 @@ class InfiniteVideoFeed extends StatefulWidget {
     this.releaseCurrentWhenInactive = false,
     this.prefetchCount = 8,
     this.shouldPortraitExpand = true,
+    this.maxPlaybackDuration,
     this.maxLoopDuration,
     this.onActiveVideoChanged,
     this.onNearEnd,
@@ -231,10 +232,24 @@ class InfiniteVideoFeed extends StatefulWidget {
   /// Defaults to `true`.
   final bool shouldPortraitExpand;
 
+  /// Hard cap on how long each video plays before the native player loops.
+  ///
+  /// Applied as the clip end position ([VideoClip.end]) on every source the
+  /// feed opens, so the loop point lives in the platform player: Android
+  /// clips the `MediaItem` and repeats it, iOS trims the composition the
+  /// `AVPlayerLooper` loops over. A source shorter than the cap plays to its
+  /// natural end — both backends clamp the clip end to the real duration.
+  ///
+  /// When `null`, every source plays to its full length.
+  final Duration? maxPlaybackDuration;
+
   /// Seeks active playback back to zero once this position is reached.
   ///
   /// When `null`, timeline-length loop enforcement is disabled and native
   /// looping behavior applies.
+  ///
+  /// Prefer [maxPlaybackDuration] for length enforcement: a Dart-side seek
+  /// produces an audible seam at the loop point (#5544).
   final Duration? maxLoopDuration;
 
   /// Called when the active video changes.
@@ -1146,7 +1161,12 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
 
       if (fromCache) {
         try {
-          await controller.setSource(VideoClip.file(cachedFile.path));
+          await controller.setSource(
+            VideoClip.file(
+              cachedFile.path,
+              end: widget.maxPlaybackDuration,
+            ),
+          );
           if (!guardInitOwnership('setSource(cache)')) return;
           _loadedFromCache.add(index);
           // Register network sources with prestart so a runtime parseError
@@ -1184,6 +1204,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
             log: _log,
             httpHeadersForSource: httpHeadersForSource,
             isLoadCurrent: ownsInit,
+            maxPlaybackDuration: widget.maxPlaybackDuration,
           );
           if (!guardInitOwnership('setSourceWithFallbacks(cache)')) return;
           _sources.register(index, playbackSources, openedSourceIdx);
@@ -1204,6 +1225,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
           log: _log,
           httpHeadersForSource: httpHeadersForSource,
           isLoadCurrent: ownsInit,
+          maxPlaybackDuration: widget.maxPlaybackDuration,
         );
         if (!guardInitOwnership('setSourceWithFallbacks(network)')) return;
         _sources.register(index, playbackSources, openedSourceIdx);
@@ -1363,6 +1385,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
       await controller.setSource(
         VideoClip.network(
           nextSource,
+          end: widget.maxPlaybackDuration,
           httpHeaders: _httpHeadersByIndex[index] ?? const {},
         ),
       );
@@ -1458,6 +1481,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
       await controller.setSource(
         VideoClip.network(
           source,
+          end: widget.maxPlaybackDuration,
           httpHeaders: _httpHeadersByIndex[index] ?? const {},
         ),
       );

--- a/mobile/packages/infinite_video_feed/test/src/utils/source_loader_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/utils/source_loader_test.dart
@@ -26,7 +26,49 @@ void main() {
 
       expect(result, equals(('urlA', 0)));
       expect(controller.lastSource?.httpHeaders, isEmpty);
+      // No cap requested — the package must not invent one of its own.
+      expect(controller.lastSource?.end, isNull);
       expect(logs, isEmpty);
+    });
+
+    test('caps every source in the chain at maxPlaybackDuration', () async {
+      final clips = <VideoClip>[];
+      final controller = _RecordingControllerWithOneFailure(clips.add);
+      addTearDown(controller.dispose);
+
+      const cap = Duration(seconds: 7);
+      final result = await setSourceWithFallbacks(
+        index: 0,
+        controller: controller,
+        sources: ['optimizedUrl', 'rawUrl'],
+        log: logs.add,
+        maxPlaybackDuration: cap,
+      );
+
+      expect(result, equals(('rawUrl', 1)));
+      expect(clips.map((clip) => clip.end), equals([cap, cap]));
+    });
+
+    test('keeps the cap on a source retried after HTTP 202', () async {
+      final clips = <VideoClip>[];
+      final controller = _RecordingControllerWithFailures(
+        clips.add,
+        failures: [Exception('CoreMediaErrorDomain error -12667 - HTTP 202')],
+      );
+      addTearDown(controller.dispose);
+
+      const cap = Duration(seconds: 7);
+      final result = await setSourceWithFallbacks(
+        index: 0,
+        controller: controller,
+        sources: ['processingUrl'],
+        log: logs.add,
+        maxPlaybackDuration: cap,
+        delay: (_) async {},
+      );
+
+      expect(result, equals(('processingUrl', 0)));
+      expect(clips.map((clip) => clip.end), equals([cap, cap]));
     });
 
     test('passes headers for the selected source', () async {

--- a/mobile/test/widgets/video_feed_item/feed_looping_contract_test.dart
+++ b/mobile/test/widgets/video_feed_item/feed_looping_contract_test.dart
@@ -1,6 +1,8 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/constants/app_constants.dart';
+import 'package:openvine/constants/video_editor_constants.dart';
 
 void main() {
   test('feed playback uses native looping instead of 6.3s seek enforcement', () {
@@ -19,6 +21,69 @@ void main() {
       reason:
           'Feed playback must not restart long videos with a Dart seek at the '
           '6.3s recording limit; seek-based restarts create audible seams.',
+    );
+  });
+
+  test('feed playback caps video length via a native clip end', () {
+    final feedVideosSource = File(
+      'lib/widgets/video_feed_item/feed_videos.dart',
+    ).readAsStringSync();
+
+    expect(
+      feedVideosSource,
+      contains('maxPlaybackDuration: AppConstants.maxFeedPlaybackDuration'),
+      reason:
+          'Without the cap a 60s file referenced by a foreign client plays in '
+          'full in the feed.',
+    );
+  });
+
+  test('every feed source is opened with the cap applied', () {
+    // Cache hit, first load, source failover and processing retry each re-open
+    // the player, so a missed site lets a long video escape the cap on that
+    // path alone.
+    const capArgumentByFile = {
+      'packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart':
+          'end: widget.maxPlaybackDuration',
+      'packages/infinite_video_feed/lib/src/utils/source_loader.dart':
+          'end: maxPlaybackDuration',
+    };
+
+    for (final entry in capArgumentByFile.entries) {
+      final source = File(entry.key).readAsStringSync();
+      final clipCount = RegExp(
+        r'VideoClip\.(network|file)\(',
+      ).allMatches(source).length;
+
+      expect(
+        clipCount,
+        greaterThan(0),
+        reason: 'No clips found in ${entry.key}',
+      );
+      expect(
+        entry.value.allMatches(source),
+        hasLength(clipCount),
+        reason: '${entry.key} opens a clip without applying the cap.',
+      );
+    }
+  });
+
+  test('the cap clears classic Vine assets and is not the recording limit', () {
+    // Longest classic Vine measured with ffprobe on media.divine.video (#6421).
+    // Capping below this would cut the musical loop point off every one of
+    // them.
+    const longestClassicVine = Duration(milliseconds: 6533);
+
+    expect(
+      AppConstants.maxFeedPlaybackDuration,
+      greaterThan(longestClassicVine),
+    );
+    expect(
+      AppConstants.maxFeedPlaybackDuration,
+      greaterThan(VideoEditorConstants.maxDuration),
+      reason:
+          'maxDuration is the 6.3s recording limit, not a playback cap; '
+          'reusing it truncates classic Vines.',
     );
   });
 }

--- a/mobile/test/widgets/video_feed_item/feed_looping_contract_test.dart
+++ b/mobile/test/widgets/video_feed_item/feed_looping_contract_test.dart
@@ -6,12 +6,12 @@ import 'package:openvine/constants/video_editor_constants.dart';
 
 void main() {
   test('feed playback uses native looping instead of 6.3s seek enforcement', () {
-    final feedVideosSource = File(
+    final feedVideosSource = _dartCodeOnly(
       'lib/widgets/video_feed_item/feed_videos.dart',
-    ).readAsStringSync();
-    final pooledPlayerSource = File(
+    );
+    final pooledPlayerSource = _dartCodeOnly(
       'packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart',
-    ).readAsStringSync();
+    );
 
     expect(pooledPlayerSource, contains('setLooping(looping: true)'));
     expect(feedVideosSource, isNot(contains('maxLoopDuration:')));
@@ -24,24 +24,13 @@ void main() {
     );
   });
 
-  test('feed playback caps video length via a native clip end', () {
-    final feedVideosSource = File(
-      'lib/widgets/video_feed_item/feed_videos.dart',
-    ).readAsStringSync();
-
-    expect(
-      feedVideosSource,
-      contains('maxPlaybackDuration: AppConstants.maxFeedPlaybackDuration'),
-      reason:
-          'Without the cap a 60s file referenced by a foreign client plays in '
-          'full in the feed.',
-    );
-  });
-
   test('every feed source is opened with the cap applied', () {
     // Cache hit, first load, source failover and processing retry each re-open
     // the player, so a missed site lets a long video escape the cap on that
-    // path alone.
+    // path alone. The app-side wiring is asserted behaviourally in
+    // feed_videos_test.dart; only the package clip sites are pinned here,
+    // because the feed builds those clips around a controller no widget test
+    // can observe.
     const capArgumentByFile = {
       'packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart':
           'end: widget.maxPlaybackDuration',
@@ -50,10 +39,11 @@ void main() {
     };
 
     for (final entry in capArgumentByFile.entries) {
-      final source = File(entry.key).readAsStringSync();
-      final clipCount = RegExp(
-        r'VideoClip\.(network|file)\(',
-      ).allMatches(source).length;
+      final source = _dartCodeOnly(entry.key);
+      // Matches every construction form, including the unnamed
+      // `VideoClip(uri: ...)` constructor and the `asset` / `memory` helpers.
+      // A form this missed would drop out of both counts and hold parity.
+      final clipCount = RegExp('VideoClip[.(]').allMatches(source).length;
 
       expect(
         clipCount,
@@ -86,4 +76,20 @@ void main() {
           'reusing it truncates classic Vines.',
     );
   });
+}
+
+/// Reads [path] with comments and string-literal bodies removed, so no
+/// assertion here can be satisfied — or defeated — by commented-out code.
+///
+/// Shares the design-system ratchets' filter rather than re-deriving one; it
+/// already handles nested block comments, raw and triple-quoted strings, and a
+/// `//` inside a URL.
+String _dartCodeOnly(String path) {
+  final result = Process.runSync('awk', [
+    '-f',
+    File('scripts/lib/dart_code_only.awk').absolute.path,
+    path,
+  ]);
+  expect(result.exitCode, 0, reason: result.stderr.toString());
+  return result.stdout as String;
 }

--- a/mobile/test/widgets/video_feed_item/feed_videos_test.dart
+++ b/mobile/test/widgets/video_feed_item/feed_videos_test.dart
@@ -18,6 +18,7 @@ import 'package:openvine/blocs/video_interactions/video_interactions_bloc.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_state.dart';
 import 'package:openvine/blocs/video_volume/video_volume_cubit.dart';
+import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag_state.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
@@ -1162,6 +1163,35 @@ void main() {
         ).called(1);
       },
     );
+  });
+
+  group('playback length cap', () {
+    testWidgets('caps InfiniteVideoFeed playback at the feed cap', (
+      tester,
+    ) async {
+      final video = _makeVideo();
+
+      await _pumpFeedVideos(tester, videos: [video]);
+      await tester.pump();
+
+      final feed = tester.widget<InfiniteVideoFeed>(
+        find.byType(InfiniteVideoFeed),
+      );
+      expect(
+        feed.maxPlaybackDuration,
+        AppConstants.maxFeedPlaybackDuration,
+        reason:
+            'Without the cap a 60s file referenced by a foreign Nostr client '
+            'plays in full in the feed.',
+      );
+      expect(
+        feed.maxLoopDuration,
+        isNull,
+        reason:
+            'Length enforcement is a native clip end; a Dart seek back to zero '
+            'creates the audible loop seam #5544 reported.',
+      );
+    });
   });
 
   group('activity wiring', () {


### PR DESCRIPTION
## Description

Restores the feed-side guarantee that nothing plays longer than a Vine, implemented as **native clipping** rather than the Dart-side `seekTo(Duration.zero)` that #5551 removed.

**Why the rule went missing.** The old `maxLoopDuration: VideoEditorConstants.maxDuration` did two jobs at once: it enforced the product rule (no 30/60s videos in the feed, including kind-34236 events from foreign clients pointing at arbitrarily long files) and it implemented that rule as a Dart seek. The seek was the direct cause of the audible loop seam in #5544, so #5551 removed the whole setting — and the product rule left with it. There is no duration guard anywhere in the app today; a 60s file referenced by another Nostr client plays in full.

**Why clipping works where the seek didn't.** The loop point now lives in the native player rather than in a Dart roundtrip, so there is no seam to produce. Android sets `MediaItem.ClippingConfiguration.endPositionMs` and `REPEAT_MODE_ALL` repeats the clipped item; iOS trims the `AVMutableComposition` via `insertTimeRange` and `AVPlayerLooper` loops the trimmed composition. Both were already plumbed through the method channel as `startMs`/`endMs` — this PR only starts using them from the feed.

**Why 7s and not 6.3s.** `VideoEditorConstants.maxDuration` is the *recording* limit and stays 6.3s. Classic Vine assets are not 6.3s — measured with `ffprobe` on `media.divine.video` they run 6.500–6.533s. Re-clipping at the recording limit would cut ~200ms off every classic Vine and destroy the musical loop point on exactly the beatbox content #5544 and #6386 complain about. The new `AppConstants.maxFeedPlaybackDuration` is a separate, named playback constant set to 7s.

**Why the cap applies to every source, not just non-Divine ones.** The issue floated capping only foreign sources. Divine's own export is already bounded at 6.3s (`renderVideo(maxOutputDuration:)`) and classic Vines are ≤6.533s, so a 7s cap is a no-op for both. A source-conditional branch would buy nothing and leave a hole for anything that slips past the source check.

**Why all four open paths.** First load, cache hit, source failover and the HTTP-202 processing retry each re-open the player independently, so a missed site would let a long video escape the cap on that path alone. The contract test counts `VideoClip` constructions against cap applications, so a future path cannot skip it silently.

**Why the Swift change.** ExoPlayer clamps `endPositionMs` to the real duration itself (`ClippingTimeline`: `if (endUs > window.durationUs) endUs = window.durationUs`). AVFoundation clamps what `insertTimeRange` actually inserts, but the Swift side computed `clipDuration` from the *requested* end regardless — so every 6.533s Vine would have reported a 7.0s duration while looping at 6.533s, desyncing every duration readout. `endTime` is now clamped to the asset duration, matching ExoPlayer.

`maxLoopDuration` and its seek path are untouched and still unused by the feed; the existing contract assertion that `feed_videos.dart` contains no `maxLoopDuration:` stays green.

**Related Issue:** Closes #6421

## Out of Scope

- Removing the now-unused `maxLoopDuration` parameter and `subscribeToLoopEnforcement` from `infinite_video_feed`. Pre-existing dead-in-production code, unrelated to this fix, and deleting it would touch 16 test references in the package.
- The Linux (`media_kit`) backend does not clamp a clip end past the source duration, so it reports the requested length. Linux is a dev-only desktop target that CI does not build, and clamping there would cost a duration probe per clip on the editor path. Documented on `VideoClip.end` as an Android/Apple guarantee instead.

## Verification

- `flutter analyze lib test integration_test` — clean (app), plus both touched packages.
- `dart format` — clean.
- `infinite_video_feed`: full suite, 231 tests, **100.00% line coverage** (the package's CI gate).
- `divine_video_player`: full suite, 257 tests. Coverage 99.49%, byte-identical to the same run on a clean tree — the four uncovered lines are pre-existing const-constructor declarations.
- App: `test/widgets/video_feed_item/` + `test/screens/feed/`, 460 tests.
- New tests: cap threading through the fallback chain and the HTTP-202 retry (`source_loader_test.dart`); cap wired in `feed_videos.dart`, applied at every clip site, and clearing classic Vine length (`feed_looping_contract_test.dart`).
- Negative check: removed one `end:` application on purpose and confirmed the new contract test goes red.
- Confirmed ExoPlayer's clamp by disassembling `ClippingMediaSource$ClippingTimeline` from the media3 1.10.0 AAR rather than trusting the docs.

### Manual test plan (pending — draft until these pass)

- [ ] Real Samsung Galaxy device: a >7s video from an external Nostr client stops at 7s and loops from there, with no rebuffer at the loop point.
- [ ] iOS: same video caps and loops, `AVPlayerLooper` still gapless over the trimmed composition.
- [ ] Both platforms: a classic beatbox Vine plays to its natural end, loop point unchanged versus the current build, no truncation.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
