### PR TITLE
fix(video-player): loop where both tracks still have content

### DIFF
--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
@@ -424,7 +424,7 @@ internal class DivineVideoPlayerInstance(
             // the seam. Clamping may only ever shorten: an earlier explicit
             // trim still wins.
             val commonEndMs = if (trimToCommonTrackEnd) {
-                commonTrackEndMs(uri)?.takeIf { it > startMs }
+                boundedCommonTrackEndMs(uri, startMs, endMs)
             } else {
                 null
             }
@@ -552,7 +552,11 @@ internal class DivineVideoPlayerInstance(
      * network round trip on the platform thread before playback can start, so
      * remote clips keep the container duration — and the seam — instead.
      */
-    private fun commonTrackEndMs(uri: String): Long? {
+    private fun boundedCommonTrackEndMs(
+        uri: String,
+        startMs: Long,
+        requestedEndMs: Long?,
+    ): Long? {
         val path = when {
             uri.startsWith("/") -> uri
             uri.startsWith("file://") -> Uri.parse(uri).path
@@ -575,7 +579,16 @@ internal class DivineVideoPlayerInstance(
                 }
             }
             // A clip without both track types has no mismatch to trim.
-            if (videoUs <= 0 || audioUs <= 0) null else minOf(videoUs, audioUs) / 1000
+            if (videoUs <= 0 || audioUs <= 0) {
+                null
+            } else {
+                boundedCommonTrackEndMs(
+                    startMs = startMs,
+                    requestedEndMs = requestedEndMs,
+                    videoEndMs = videoUs / 1000,
+                    audioEndMs = audioUs / 1000,
+                )
+            }
         } catch (e: Exception) {
             DivineVideoPlayerLog.warning(
                 "Player $playerId could not read track durations: $e",
@@ -585,6 +598,26 @@ internal class DivineVideoPlayerInstance(
         } finally {
             extractor.release()
         }
+    }
+
+    private fun boundedCommonTrackEndMs(
+        startMs: Long,
+        requestedEndMs: Long?,
+        videoEndMs: Long,
+        audioEndMs: Long,
+    ): Long? {
+        val containerEndMs = maxOf(videoEndMs, audioEndMs)
+        val playbackEndMs = minOf(requestedEndMs ?: containerEndMs, containerEndMs)
+        val commonEndMs = minOf(videoEndMs, audioEndMs)
+        val trimMs = playbackEndMs - commonEndMs
+        if (commonEndMs <= startMs || trimMs <= 0) return null
+
+        val playableDurationMs = playbackEndMs - startMs
+        if (playableDurationMs <= 0) return null
+
+        val relativeLimitMs = (playableDurationMs * MAX_COMMON_TRACK_END_TRIM_RATIO).toLong()
+        val trimLimitMs = minOf(MAX_COMMON_TRACK_END_TRIM_MS, relativeLimitMs)
+        return commonEndMs.takeIf { trimMs <= trimLimitMs }
     }
 
     private fun handleSeekTo(call: MethodCall, result: MethodChannel.Result) {
@@ -1293,6 +1326,10 @@ internal class DivineVideoPlayerInstance(
          * sensible lower bound the editor UI exposes.
          */
         private const val MIN_PLAYBACK_SPEED = 0.001f
+
+        /** Maximum tail considered an encoder/export track-end mismatch. */
+        private const val MAX_COMMON_TRACK_END_TRIM_MS = 500L
+        private const val MAX_COMMON_TRACK_END_TRIM_RATIO = 0.10
 
         /**
          * How many times an editing/preview player re-prepares after a

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
@@ -1,6 +1,8 @@
 package com.divinevideo.divine_video_player
 
 import android.content.Context
+import android.media.MediaExtractor
+import android.media.MediaFormat
 import android.net.Uri
 import android.os.Handler
 import android.os.Looper
@@ -415,6 +417,18 @@ internal class DivineVideoPlayerInstance(
             }
             val startMs = (map["startMs"] as? Number)?.toLong() ?: 0L
             val endMs = (map["endMs"] as? Number)?.toLong()
+            val trimToCommonTrackEnd = map["trimToCommonTrackEnd"] as? Boolean ?: false
+            // The container duration is the *longest* track, so ending there
+            // leaves a stretch where the shorter track has already run out —
+            // silence, or a frozen frame. On a looping player that stretch is
+            // the seam. Clamping may only ever shorten: an earlier explicit
+            // trim still wins.
+            val commonEndMs = if (trimToCommonTrackEnd) {
+                commonTrackEndMs(uri)?.takeIf { it > startMs }
+            } else {
+                null
+            }
+            val effectiveEndMs = listOfNotNull(endMs, commonEndMs).minOrNull()
             val clipVol = (map["volume"] as? Number)?.toFloat() ?: 1.0f
             val clipSpeed = ((map["playbackSpeed"] as? Number)?.toFloat() ?: 1.0f)
                 .coerceAtLeast(MIN_PLAYBACK_SPEED)
@@ -436,7 +450,7 @@ internal class DivineVideoPlayerInstance(
                     MediaItem.ClippingConfiguration.Builder()
                         .setStartPositionMs(startMs)
                         .apply {
-                            if (endMs != null) setEndPositionMs(endMs)
+                            if (effectiveEndMs != null) setEndPositionMs(effectiveEndMs)
                         }
                         .build(),
                 )
@@ -450,8 +464,8 @@ internal class DivineVideoPlayerInstance(
             // Offsets accumulate in playback time so the global timeline
             // matches what the editor UI shows (slow clips occupy more
             // space, fast clips less).
-            if (endMs != null) {
-                accumulated += sourceToPlaybackMs(endMs - startMs, clipSpeed)
+            if (effectiveEndMs != null) {
+                accumulated += sourceToPlaybackMs(effectiveEndMs - startMs, clipSpeed)
             }
         }
 
@@ -527,6 +541,50 @@ internal class DivineVideoPlayerInstance(
         // 10 s safety net — if STATE_READY never fires (e.g. corrupt file),
         // Dart is unblocked rather than hanging forever.
         mainHandler.postDelayed(setClipsTimeoutRunnable, SET_CLIPS_TIMEOUT_MS)
+    }
+
+    /**
+     * The point up to which *every* track of [uri] still has content, in
+     * milliseconds, or `null` when it cannot be determined without I/O that
+     * would delay playback.
+     *
+     * Only local files are probed. Reading a remote source's metadata means a
+     * network round trip on the platform thread before playback can start, so
+     * remote clips keep the container duration — and the seam — instead.
+     */
+    private fun commonTrackEndMs(uri: String): Long? {
+        val path = when {
+            uri.startsWith("/") -> uri
+            uri.startsWith("file://") -> Uri.parse(uri).path
+            else -> null
+        } ?: return null
+
+        val extractor = MediaExtractor()
+        return try {
+            extractor.setDataSource(path)
+            var videoUs = -1L
+            var audioUs = -1L
+            for (i in 0 until extractor.trackCount) {
+                val format = extractor.getTrackFormat(i)
+                val mime = format.getString(MediaFormat.KEY_MIME) ?: continue
+                if (!format.containsKey(MediaFormat.KEY_DURATION)) continue
+                val durationUs = format.getLong(MediaFormat.KEY_DURATION)
+                when {
+                    mime.startsWith("video/") && videoUs < 0 -> videoUs = durationUs
+                    mime.startsWith("audio/") && audioUs < 0 -> audioUs = durationUs
+                }
+            }
+            // A clip without both track types has no mismatch to trim.
+            if (videoUs <= 0 || audioUs <= 0) null else minOf(videoUs, audioUs) / 1000
+        } catch (e: Exception) {
+            DivineVideoPlayerLog.warning(
+                "Player $playerId could not read track durations: $e",
+                name = "DivineVideoPlayer.Load",
+            )
+            null
+        } finally {
+            extractor.release()
+        }
     }
 
     private fun handleSeekTo(call: MethodCall, result: MethodChannel.Result) {

--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
@@ -33,6 +33,8 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
 
     private static let setClipsTimeoutMs = 10_000
     private static let bufferingStallMs = 8_000
+    private static let maxCommonTrackEndTrimMs = 500.0
+    private static let maxCommonTrackEndTrimRatio = 0.10
 
     /// AVFoundation's asset-option key for per-asset HTTP request headers.
     ///
@@ -411,11 +413,23 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             // or a frozen frame. On a looping player that stretch is the seam.
             // Clamping may only ever shorten: an earlier explicit trim wins.
             if trimToCommonTrackEnd, let sourceAudioTrack = assetAudioTracks.first {
-                let videoRange = try await sourceVideoTrack.load(.timeRange)
-                let audioRange = try await sourceAudioTrack.load(.timeRange)
-                let commonEnd = CMTimeMinimum(videoRange.end, audioRange.end)
-                if commonEnd.isNumeric, CMTimeCompare(commonEnd, startTime) > 0 {
-                    endTime = CMTimeMinimum(endTime, commonEnd)
+                do {
+                    let videoRange = try await sourceVideoTrack.load(.timeRange)
+                    let audioRange = try await sourceAudioTrack.load(.timeRange)
+                    if let commonEnd = boundedCommonTrackEnd(
+                        startTime: startTime,
+                        requestedEnd: endTime,
+                        videoEnd: videoRange.end,
+                        audioEnd: audioRange.end
+                    ) {
+                        endTime = CMTimeMinimum(endTime, commonEnd)
+                    }
+                } catch {
+                    DivineVideoPlayerLog.shared.warning(
+                        "Player \(playerId) could not read track durations: "
+                            + "\(error.localizedDescription)",
+                        name: "DivineVideoPlayer.Load"
+                    )
                 }
             }
             let timeRange = CMTimeRange(start: startTime, end: endTime)
@@ -739,6 +753,39 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                 self.audioOverlayManager.resumeActive(speed: self.speed)
             }
         }
+    }
+
+    private func boundedCommonTrackEnd(
+        startTime: CMTime,
+        requestedEnd: CMTime,
+        videoEnd: CMTime,
+        audioEnd: CMTime
+    ) -> CMTime? {
+        let containerEnd = CMTimeMaximum(videoEnd, audioEnd)
+        let playbackEnd = CMTimeMinimum(requestedEnd, containerEnd)
+        let commonEnd = CMTimeMinimum(videoEnd, audioEnd)
+        guard commonEnd.isNumeric,
+              playbackEnd.isNumeric,
+              CMTimeCompare(commonEnd, startTime) > 0,
+              CMTimeCompare(playbackEnd, commonEnd) > 0
+        else {
+            return nil
+        }
+
+        let trimMs = CMTimeSubtract(playbackEnd, commonEnd).seconds * 1000
+        let playableDurationMs = CMTimeSubtract(playbackEnd, startTime).seconds * 1000
+        guard trimMs.isFinite,
+              playableDurationMs.isFinite,
+              playableDurationMs > 0
+        else {
+            return nil
+        }
+
+        let trimLimitMs = min(
+            Self.maxCommonTrackEndTrimMs,
+            playableDurationMs * Self.maxCommonTrackEndTrimRatio
+        )
+        return trimMs <= trimLimitMs ? commonEnd : nil
     }
 
     /// Calls `AVPlayer.preroll(atRate:)` only when the player is ready;

--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
@@ -342,6 +342,8 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             let clipVol = (clipMap["volume"] as? NSNumber)?.floatValue ?? 1.0
             let clipSpeed = (clipMap["playbackSpeed"] as? NSNumber)?.doubleValue ?? 1.0
             let httpHeaders = clipMap["httpHeaders"] as? [String: String]
+            let trimToCommonTrackEnd =
+                (clipMap["trimToCommonTrackEnd"] as? NSNumber)?.boolValue ?? false
 
             let url: URL
             if uri.hasPrefix("/") {
@@ -387,7 +389,7 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             let standardizedTransform = transform.standardized(for: naturalSize)
 
             let startTime = CMTime(value: startMs, timescale: 1000)
-            let endTime: CMTime
+            var endTime: CMTime
             if let endMs {
                 // Clamp to the asset: insertTimeRange silently inserts only the
                 // media that exists, so an endMs past the source would leave
@@ -403,6 +405,18 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                     : requestedEnd
             } else {
                 endTime = assetDuration
+            }
+            // The asset duration is the *longest* track, so ending there leaves
+            // a stretch where the shorter track has already run out — silence,
+            // or a frozen frame. On a looping player that stretch is the seam.
+            // Clamping may only ever shorten: an earlier explicit trim wins.
+            if trimToCommonTrackEnd, let sourceAudioTrack = assetAudioTracks.first {
+                let videoRange = try await sourceVideoTrack.load(.timeRange)
+                let audioRange = try await sourceAudioTrack.load(.timeRange)
+                let commonEnd = CMTimeMinimum(videoRange.end, audioRange.end)
+                if commonEnd.isNumeric, CMTimeCompare(commonEnd, startTime) > 0 {
+                    endTime = CMTimeMinimum(endTime, commonEnd)
+                }
             }
             let timeRange = CMTimeRange(start: startTime, end: endTime)
             let clipDuration = CMTimeSubtract(endTime, startTime)

--- a/mobile/packages/divine_video_player/lib/src/video_clip.dart
+++ b/mobile/packages/divine_video_player/lib/src/video_clip.dart
@@ -22,6 +22,7 @@ class VideoClip {
     this.volume = 1.0,
     this.playbackSpeed = 1.0,
     this.httpHeaders = const {},
+    this.trimToCommonTrackEnd = false,
   });
 
   /// Creates a [VideoClip] from a local file path.
@@ -32,6 +33,7 @@ class VideoClip {
     this.volume = 1.0,
     this.playbackSpeed = 1.0,
     this.httpHeaders = const {},
+    this.trimToCommonTrackEnd = false,
   }) : uri = path;
 
   /// Creates a [VideoClip] from a network URL.
@@ -42,6 +44,7 @@ class VideoClip {
     this.volume = 1.0,
     this.playbackSpeed = 1.0,
     this.httpHeaders = const {},
+    this.trimToCommonTrackEnd = false,
   }) : uri = url;
 
   /// Creates a [VideoClip] from a Flutter asset.
@@ -55,6 +58,7 @@ class VideoClip {
     double volume = 1.0,
     double playbackSpeed = 1.0,
     AssetBundle? bundle,
+    bool trimToCommonTrackEnd = false,
   }) async {
     final (data, dir) = await (
       (bundle ?? rootBundle).load(assetPath),
@@ -70,6 +74,7 @@ class VideoClip {
       end: end,
       volume: volume,
       playbackSpeed: playbackSpeed,
+      trimToCommonTrackEnd: trimToCommonTrackEnd,
     );
   }
 
@@ -84,6 +89,7 @@ class VideoClip {
     Duration? end,
     double volume = 1.0,
     double playbackSpeed = 1.0,
+    bool trimToCommonTrackEnd = false,
   }) async {
     final dir = await getTemporaryDirectory();
     final file = File('${dir.path}/divine_player_memory/$fileName');
@@ -95,6 +101,7 @@ class VideoClip {
       end: end,
       volume: volume,
       playbackSpeed: playbackSpeed,
+      trimToCommonTrackEnd: trimToCommonTrackEnd,
     );
   }
 
@@ -122,6 +129,26 @@ class VideoClip {
   /// HTTP headers to attach when [uri] resolves to a network source.
   final Map<String, String> httpHeaders;
 
+  /// Whether to end the clip where *all* of the source's tracks still have
+  /// content, instead of at the container duration.
+  ///
+  /// An mp4's declared duration is the longest of its tracks, and capture and
+  /// export pipelines routinely let the audio and video tracks end tens of
+  /// milliseconds apart. Playing to the container duration therefore ends on a
+  /// stretch where one track has already run out — silence, or a frozen last
+  /// frame. On a looping player that stretch is the loop seam.
+  ///
+  /// Set this for looping playback of a single clip. It shortens the clip by
+  /// the track mismatch (typically < 100 ms), so it is wrong for a clip in the
+  /// middle of a multi-clip timeline, where it would cut content rather than a
+  /// seam. Clamping only ever shortens: [end], when set, still wins if it is
+  /// earlier.
+  ///
+  /// Support is per-platform: Apple always honours it, Android honours it for
+  /// local files only (a remote source would need a blocking metadata read
+  /// before playback could start), and the web and Linux backends ignore it.
+  final bool trimToCommonTrackEnd;
+
   /// Serializes this clip for platform channel transport.
   Map<String, dynamic> toMap() {
     return {
@@ -131,6 +158,7 @@ class VideoClip {
       'volume': volume,
       'playbackSpeed': playbackSpeed,
       if (httpHeaders.isNotEmpty) 'httpHeaders': httpHeaders,
+      if (trimToCommonTrackEnd) 'trimToCommonTrackEnd': true,
     };
   }
 }

--- a/mobile/packages/divine_video_player/lib/src/video_clip.dart
+++ b/mobile/packages/divine_video_player/lib/src/video_clip.dart
@@ -138,11 +138,13 @@ class VideoClip {
   /// stretch where one track has already run out — silence, or a frozen last
   /// frame. On a looping player that stretch is the loop seam.
   ///
-  /// Set this for looping playback of a single clip. It shortens the clip by
-  /// the track mismatch (typically < 100 ms), so it is wrong for a clip in the
-  /// middle of a multi-clip timeline, where it would cut content rather than a
-  /// seam. Clamping only ever shortens: [end], when set, still wins if it is
-  /// earlier.
+  /// Set this for looping playback of a single clip. It shortens the clip only
+  /// when the track mismatch is small (currently at most 500 ms and at most
+  /// 10% of the playable duration), so obviously malformed assets keep their
+  /// container duration instead of collapsing into a tiny loop. It is wrong for
+  /// a clip in the middle of a multi-clip timeline, where it would cut content
+  /// rather than a seam. Clamping only ever shortens: [end], when set, still
+  /// wins if it is earlier.
   ///
   /// Support is per-platform: Apple always honours it, Android honours it for
   /// local files only (a remote source would need a blocking metadata read

--- a/mobile/packages/divine_video_player/test/src/loop_seam_trim_contract_test.dart
+++ b/mobile/packages/divine_video_player/test/src/loop_seam_trim_contract_test.dart
@@ -1,0 +1,110 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('loop seam trim contract', () {
+    test('Apple clamps the clip to the shorter of the two tracks', () {
+      final source = _appleSourceFile().readAsStringSync();
+
+      expect(
+        source,
+        contains('trimToCommonTrackEnd'),
+        reason:
+            'Apple must honour the flag; without it a looping clip replays '
+            'the tail where one track has already ended.',
+      );
+      expect(
+        source,
+        contains('CMTimeMinimum(videoRange.end, audioRange.end)'),
+        reason:
+            'The clip must end where both tracks still have content, not at '
+            'the asset duration, which is the longest track.',
+      );
+      expect(
+        source,
+        contains('CMTimeMinimum(endTime, commonEnd)'),
+        reason:
+            'Clamping may only ever shorten a clip — an explicit trim that '
+            'ends earlier still wins.',
+      );
+    });
+
+    test('Android clamps the clipping configuration, not just endMs', () {
+      final source = _androidSourceFile().readAsStringSync();
+
+      expect(
+        source,
+        contains('commonTrackEndMs'),
+        reason:
+            'Android must resolve the point where both tracks still have '
+            'content before building the clipping configuration.',
+      );
+      expect(
+        source,
+        contains('listOfNotNull(endMs, commonEndMs).minOrNull()'),
+        reason:
+            'Clamping may only ever shorten a clip — an explicit trim that '
+            'ends earlier still wins.',
+      );
+      expect(
+        source,
+        contains('setEndPositionMs(effectiveEndMs)'),
+        reason:
+            'The clamped end must reach ExoPlayer; setting the raw endMs '
+            'would leave the seam in place.',
+      );
+    });
+
+    test('Android probes local files only', () {
+      final source = _androidSourceFile().readAsStringSync();
+
+      expect(
+        source,
+        contains('MediaExtractor'),
+        reason:
+            'Per-track durations are not exposed by the ExoPlayer '
+            'timeline, which reports the longest track.',
+      );
+      expect(
+        source,
+        contains(RegExp(r'uri\.startsWith\("file://"\)')),
+        reason:
+            'Probing a remote source would block playback start on a network '
+            'round trip, so only local files may be read.',
+      );
+    });
+  });
+}
+
+File _appleSourceFile() {
+  final packageRelative = File(
+    'darwin/divine_video_player/Sources/divine_video_player/'
+    'DivineVideoPlayerInstance.swift',
+  );
+  if (packageRelative.existsSync()) {
+    return packageRelative;
+  }
+
+  return File(
+    'packages/divine_video_player/'
+    'darwin/divine_video_player/Sources/divine_video_player/'
+    'DivineVideoPlayerInstance.swift',
+  );
+}
+
+File _androidSourceFile() {
+  final packageRelative = File(
+    'android/src/main/kotlin/com/divinevideo/divine_video_player/'
+    'DivineVideoPlayerInstance.kt',
+  );
+  if (packageRelative.existsSync()) {
+    return packageRelative;
+  }
+
+  return File(
+    'packages/divine_video_player/'
+    'android/src/main/kotlin/com/divinevideo/divine_video_player/'
+    'DivineVideoPlayerInstance.kt',
+  );
+}

--- a/mobile/packages/divine_video_player/test/src/loop_seam_trim_contract_test.dart
+++ b/mobile/packages/divine_video_player/test/src/loop_seam_trim_contract_test.dart
@@ -16,10 +16,10 @@ void main() {
       );
       expect(
         source,
-        contains('CMTimeMinimum(videoRange.end, audioRange.end)'),
+        contains('boundedCommonTrackEnd('),
         reason:
-            'The clip must end where both tracks still have content, not at '
-            'the asset duration, which is the longest track.',
+            'The clip must end where both tracks still have content only when '
+            'the mismatch is small enough to be a seam, not a malformed asset.',
       );
       expect(
         source,
@@ -28,6 +28,27 @@ void main() {
             'Clamping may only ever shorten a clip — an explicit trim that '
             'ends earlier still wins.',
       );
+      expect(
+        source,
+        contains('catch {'),
+        reason:
+            'A failure to read optional track ranges must leave the clip '
+            'untrimmed rather than failing composition playback.',
+      );
+      expect(
+        source,
+        contains('maxCommonTrackEndTrimMs = 500.0'),
+        reason:
+            'The clamp must be bounded so stub audio tracks do not collapse a '
+            'normal-length video into a tiny loop.',
+      );
+      expect(
+        source,
+        contains('maxCommonTrackEndTrimRatio = 0.10'),
+        reason:
+            'The clamp must also be relative to playable duration so short '
+            'clips cannot lose an excessive fraction of content.',
+      );
     });
 
     test('Android clamps the clipping configuration, not just endMs', () {
@@ -35,7 +56,7 @@ void main() {
 
       expect(
         source,
-        contains('commonTrackEndMs'),
+        contains('boundedCommonTrackEndMs'),
         reason:
             'Android must resolve the point where both tracks still have '
             'content before building the clipping configuration.',
@@ -53,6 +74,20 @@ void main() {
         reason:
             'The clamped end must reach ExoPlayer; setting the raw endMs '
             'would leave the seam in place.',
+      );
+      expect(
+        source,
+        contains('MAX_COMMON_TRACK_END_TRIM_MS = 500L'),
+        reason:
+            'The clamp must be bounded so stub audio tracks do not collapse a '
+            'normal-length video into a tiny loop.',
+      );
+      expect(
+        source,
+        contains('MAX_COMMON_TRACK_END_TRIM_RATIO = 0.10'),
+        reason:
+            'The clamp must also be relative to playable duration so short '
+            'clips cannot lose an excessive fraction of content.',
       );
     });
 

--- a/mobile/packages/divine_video_player/test/src/video_clip_test.dart
+++ b/mobile/packages/divine_video_player/test/src/video_clip_test.dart
@@ -147,6 +147,25 @@ void main() {
           equals({'Authorization': 'Nostr token'}),
         );
       });
+
+      test('serializes trimToCommonTrackEnd only when opted in', () {
+        const plain = VideoClip(uri: 'test.mp4');
+        const trimmed = VideoClip(uri: 'test.mp4', trimToCommonTrackEnd: true);
+
+        expect(plain.toMap(), isNot(contains('trimToCommonTrackEnd')));
+        expect(trimmed.toMap()['trimToCommonTrackEnd'], isTrue);
+      });
+
+      test('carries trimToCommonTrackEnd through file and network', () {
+        const file = VideoClip.file('/a.mp4', trimToCommonTrackEnd: true);
+        const network = VideoClip.network(
+          'https://example.com/a.mp4',
+          trimToCommonTrackEnd: true,
+        );
+
+        expect(file.toMap()['trimToCommonTrackEnd'], isTrue);
+        expect(network.toMap()['trimToCommonTrackEnd'], isTrue);
+      });
     });
 
     group('asset', () {

--- a/mobile/packages/infinite_video_feed/lib/src/utils/source_loader.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/utils/source_loader.dart
@@ -66,6 +66,7 @@ Future<(String, int)> setSourceWithFallbacks({
           source,
           end: maxPlaybackDuration,
           httpHeaders: httpHeadersForSource?.call(source) ?? const {},
+          trimToCommonTrackEnd: true,
         ),
       );
       abortIfStale(source);
@@ -109,6 +110,7 @@ Future<(String, int)> setSourceWithFallbacks({
                 source,
                 end: maxPlaybackDuration,
                 httpHeaders: httpHeadersForSource?.call(source) ?? const {},
+                trimToCommonTrackEnd: true,
               ),
             );
             abortIfStale(source);

--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -1165,6 +1165,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
             VideoClip.file(
               cachedFile.path,
               end: widget.maxPlaybackDuration,
+              trimToCommonTrackEnd: true,
             ),
           );
           if (!guardInitOwnership('setSource(cache)')) return;
@@ -1387,6 +1388,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
           nextSource,
           end: widget.maxPlaybackDuration,
           httpHeaders: _httpHeadersByIndex[index] ?? const {},
+          trimToCommonTrackEnd: true,
         ),
       );
       if (index == _currentIndex && _isActive && _canAutoPlayAt(index)) {
@@ -1483,6 +1485,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
           source,
           end: widget.maxPlaybackDuration,
           httpHeaders: _httpHeadersByIndex[index] ?? const {},
+          trimToCommonTrackEnd: true,
         ),
       );
       if (!guardRetryOwnership('setSource')) return;

--- a/mobile/packages/infinite_video_feed/test/src/utils/source_loader_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/utils/source_loader_test.dart
@@ -71,6 +71,26 @@ void main() {
       expect(clips.map((clip) => clip.end), equals([cap, cap]));
     });
 
+    test('opts every source into loop-seam trimming', () async {
+      final controller = FakeController();
+      addTearDown(controller.dispose);
+
+      await setSourceWithFallbacks(
+        index: 0,
+        controller: controller,
+        sources: ['urlA'],
+        log: logs.add,
+      );
+
+      expect(
+        controller.lastSource?.trimToCommonTrackEnd,
+        isTrue,
+        reason:
+            'Feed playback loops, so a clip must end where both tracks still '
+            'have content rather than at the container duration.',
+      );
+    });
+
     test('passes headers for the selected source', () async {
       final controller = FakeController();
       addTearDown(controller.dispose);


### PR DESCRIPTION
## Description

An mp4's declared duration is its *longest* track, and capture and export pipelines routinely stop the audio and video tracks tens of milliseconds apart. Playing to the container duration therefore ends on a stretch where one track has already run out — silence, or a frozen last frame. On the feed's looping player that stretch is replayed every single cycle. That is the seam behind #6386.

I measured it before changing anything. `ffprobe` over 622 published Divine uploads and 58 archived Vines (audio track length minus video track length, which is exactly the seam):

| | OG Vines | Divine uploads |
|---|---|---|
| Δ >= 40 ms | 7/58 (12 %) | 62/362 iOS (17 %), 49/259 Android (19 %) |
| Δ >= 100 ms | 3/58 | iOS only |
| worst case | -280 ms | -379 ms |

So it is a property of the asset, not of the player — which is why it never reproduces on a random scroll through the feed, and why it needs a fix that does not depend on re-encoding. Published assets *cannot* be repaired anyway: Blossom is content-addressed and the sha256 is the identity, so a re-encode is a different file and a different event.

Clips can now opt into ending where every track still has content, and feed playback does. Clamping only ever shortens, and an explicit trim that ends earlier still wins.

The clamp is intentionally bounded so malformed assets fail open instead of collapsing into tiny loops. Native players trim only when the removed tail is at most 500 ms and at most 10% of the playable duration. That keeps the measured seam cases, while leaving the pathological `3df3a7a7…` asset at its container duration.

**Apple** takes the minimum of the two track ends when building the composition, then applies the bounded policy. If optional track-range loading fails, playback continues untrimmed rather than failing composition.

**Android** reads the per-track durations with `MediaExtractor` and passes the bounded minimum to the `ClippingConfiguration`. The ExoPlayer timeline only exposes the container duration (the longest track), and `Format` carries no duration, so there is no cheaper source for this. It is applied **to local files only**: probing a remote source means a network round trip on the platform thread before playback can start. The feed prefetches to disk, so the common path is local; an uncached first play keeps the old behaviour rather than paying a startup stall.

**Related Issue:** Closes #6386

## Out of Scope

**The export side.** iOS is not just inheriting bad source files, it also *creates* the mismatch: `VideoSequenceBuilder` in `pro_video_editor` clamps the clip range to the video track's range and then reuses that same range for the audio insert without intersecting the audio track. When the source audio is shorter, `insertTimeRange` silently truncates. That matches the measured signature exactly — 192 of 225 non-zero iOS deltas are "audio shorter", and the 38 % that land on exactly 0 ms are the clips whose audio fills the range anyway. Android's residual is different in kind: never exactly 0 (2 %), but bounded and sign-balanced (21 ms median, 121 ms worst) — Media3 Transformer per-track frame quantisation, not a defect.

The fix for that is hm21/pro_video_editor#182 (2.10.0, unreleased); wiring it here needs that release and a constraint bump. It only helps *new* uploads, so it does not overlap with this PR.

**One genuinely broken asset** turned up in the survey: `3df3a7a7…`, 6.37 s of video carrying 9 frames with 0.37 s of audio. This PR now treats that kind of mismatch as malformed and keeps the container duration.

## Verification

- `flutter analyze packages/divine_video_player/lib packages/divine_video_player/test packages/infinite_video_feed/lib packages/infinite_video_feed/test/src/utils/source_loader_test.dart` — clean
- `flutter test` in `packages/divine_video_player` — 262 passed
- `flutter test packages/divine_video_player/test/src/video_clip_test.dart packages/divine_video_player/test/src/loop_seam_trim_contract_test.dart` — passed after rebase
- `flutter test test/src/utils/source_loader_test.dart` in `packages/infinite_video_feed` — passed after rebase
- `swiftc -parse packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift` — clean
- pre-push hook (merge-conflict check, analyzer, changed-file tests) — passed

Android Kotlin compile was not locally runnable in this checkout: there is no Gradle wrapper, and the standalone plugin Gradle project cannot resolve Flutter's `dev.flutter.flutter-plugin-dependencies` plugin from the local Flutter SDK. CI's Android unit/build checks should cover this path.

Device verification still recommended before merge because the observable behavior is native playback. Best repro assets, worst first:

- `06c68e6645cfecd2a3a306f7ddff7bf0b289c5c1fbba1d10bbc05a338c35d2af` (-280 ms, audible gap)
- `91909f52ded5efd8b5d715daf673bdf849e2f47eaa86fd69fa6414d62ebdb60d` (-148 ms)
- `4804ef2c11b02d5d2aa14286e0fe1f5a4f673029f10f714fd7977d93b401c1af` (+108 ms, visible frozen frame)
- `3df3a7a7…` pathological short-audio asset, which should now keep its container duration

Worth checking alongside: that an editor trim still lands where the user set it, and that a stop-motion clip held past a short sound is not shortened.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
