### PR TITLE
fix(dm): resolve four cases where DMs go missing with no loader

### DIFF
--- a/mobile/lib/blocs/dm/conversation/conversation_bloc.dart
+++ b/mobile/lib/blocs/dm/conversation/conversation_bloc.dart
@@ -71,6 +71,16 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
   ) async {
     emit(state.copyWith(status: ConversationStatus.loading));
 
+    // Arm the one-time history drain here too, not just on inbox open.
+    // Profile → Message reaches a thread without ever passing through
+    // Messages, so on a reinstall this can be the first DM surface the user
+    // touches. Until the drain arms, `hasAttemptedHistoryRecovery` is false
+    // and an empty thread reports itself complete while the user's history is
+    // still sitting on the relay. Idempotent, resumable and shared with the
+    // inbox's call, so arriving from either entry point costs one drain.
+    // See #4953.
+    unawaited(_dmRepository.backfillHistoryIfNeeded());
+
     // Mark as read when opening
     await _dmRepository.markConversationAsRead(_conversationId);
 

--- a/mobile/lib/blocs/dm/conversation_list/conversation_list_bloc.dart
+++ b/mobile/lib/blocs/dm/conversation_list/conversation_list_bloc.dart
@@ -54,6 +54,10 @@ class ConversationListBloc
     );
     on<ConversationListNavigationConsumed>(_onNavigationConsumed);
     on<ConversationListBlocklistChanged>(_onBlocklistChanged);
+    on<ConversationListRestoreRetryRequested>(
+      _onRestoreRetryRequested,
+      transformer: droppable(),
+    );
     on<ConversationListProfileRepositoryChanged>(_onProfileRepositoryChanged);
   }
 
@@ -257,6 +261,9 @@ class ConversationListBloc
         return state.copyWith(
           status: ConversationListStatus.loaded,
           conversations: visibleInbox,
+          // Only true when the gate is actually costing the user something —
+          // a closed gate with nothing to hold back needs no banner.
+          requestsWithheld: !recoveryComplete && split.requests.isNotEmpty,
           visibleConversations: _computeVisible(
             visibleInbox,
             unreadOnly: state.unreadOnly,
@@ -544,6 +551,21 @@ class ConversationListBloc
     ConversationListBlocklistChanged event,
     Emitter<ConversationListState> emit,
   ) {
+    add(const ConversationListStarted());
+  }
+
+  void _onRestoreRetryRequested(
+    ConversationListRestoreRetryRequested event,
+    Emitter<ConversationListState> emit,
+  ) {
+    // Same idiom as _onBlocklistChanged: re-entering _onStarted re-fires both
+    // recovery passes (idempotent, shared in-flight) and restarts the stream,
+    // so the gate is re-read and `requestsWithheld` recomputed. Going through
+    // the stream rather than awaiting the drain matters — the drain returns
+    // early without ever touching the recovery stream when it is uninitialized
+    // or already complete, so a listener-only retry could leave the banner up
+    // with nothing to clear it. The status switch in _onStarted keeps a loaded
+    // list from flashing a spinner.
     add(const ConversationListStarted());
   }
 

--- a/mobile/lib/blocs/dm/conversation_list/conversation_list_event.dart
+++ b/mobile/lib/blocs/dm/conversation_list/conversation_list_event.dart
@@ -82,6 +82,15 @@ class ConversationListProfileRepositoryChanged extends ConversationListEvent {
   List<Object?> get props => [profileRepository];
 }
 
+/// The user tapped Retry on the restore-paused banner.
+///
+/// Re-arms the one-time history drain and the failed-decrypt replay. Both are
+/// idempotent and share their in-flight future, so a stray tap during an active
+/// pass is a no-op rather than a second drain.
+class ConversationListRestoreRetryRequested extends ConversationListEvent {
+  const ConversationListRestoreRetryRequested();
+}
+
 /// Resolve names for newly streamed conversations without changing the query.
 class _ConversationListProfileResolutionRequested
     extends ConversationListEvent {

--- a/mobile/lib/blocs/dm/conversation_list/conversation_list_state.dart
+++ b/mobile/lib/blocs/dm/conversation_list/conversation_list_state.dart
@@ -32,6 +32,7 @@ class ConversationListState extends Equatable {
     this.potentialRequests = const [],
     this.hasMore = true,
     this.isRestoringHistory = false,
+    this.requestsWithheld = false,
     this.currentLimit = ConversationListState.pageSize,
     this.navigationTarget,
   });
@@ -87,6 +88,19 @@ class ConversationListState extends Equatable {
   /// indicator at the top of the Messages list. See #5202.
   final bool isRestoringHistory;
 
+  /// Whether the #5304 recovery gate is currently hiding conversations that
+  /// would otherwise appear as message requests.
+  ///
+  /// Distinct from [isRestoringHistory] on purpose. That flag tracks whether a
+  /// drain is *actively running* (`_activeRecoveryOps > 0`), but the gate reads
+  /// the *persisted* `historyDrainComplete`, which only ever flips on a clean
+  /// exhaustion. A drain that stops at the page cap, hits an exception, or
+  /// finds no connected relay clears the running flag while leaving the gate
+  /// shut — so the progress bar vanished while requests stayed hidden, with no
+  /// banner, no badge and no spinner to show anything was missing. Drives the
+  /// restore-paused banner, which offers the retry that reopens the gate.
+  final bool requestsWithheld;
+
   /// Size of the render window over [conversations] — grows as the user pages.
   ///
   /// Not a fetch bound: the conversations are already loaded in full, so
@@ -121,6 +135,7 @@ class ConversationListState extends Equatable {
     List<DmConversation>? potentialRequests,
     bool? hasMore,
     bool? isRestoringHistory,
+    bool? requestsWithheld,
     int? currentLimit,
     ConversationNavigationTarget? navigationTarget,
     bool clearNavigationTarget = false,
@@ -136,6 +151,7 @@ class ConversationListState extends Equatable {
       potentialRequests: potentialRequests ?? this.potentialRequests,
       hasMore: hasMore ?? this.hasMore,
       isRestoringHistory: isRestoringHistory ?? this.isRestoringHistory,
+      requestsWithheld: requestsWithheld ?? this.requestsWithheld,
       currentLimit: currentLimit ?? this.currentLimit,
       navigationTarget: clearNavigationTarget
           ? null
@@ -155,6 +171,7 @@ class ConversationListState extends Equatable {
     potentialRequests,
     hasMore,
     isRestoringHistory,
+    requestsWithheld,
     currentLimit,
     navigationTarget,
   ];

--- a/mobile/lib/blocs/dm/restore_status/dm_restore_status_cubit.dart
+++ b/mobile/lib/blocs/dm/restore_status/dm_restore_status_cubit.dart
@@ -12,11 +12,15 @@ import 'package:equatable/equatable.dart';
 class DmRestoreStatusState extends Equatable {
   const DmRestoreStatusState({
     this.isRestoring = false,
+    this.hasAttempted = false,
     this.isComplete = true,
   });
 
   /// A recovery pass (reinstall backfill or failed-decrypt replay) is running.
   final bool isRestoring;
+
+  /// History recovery has run, completed, or is running for this user.
+  final bool hasAttempted;
 
   /// The one-time history drain has completed cleanly for this user.
   ///
@@ -27,10 +31,10 @@ class DmRestoreStatusState extends Equatable {
   final bool isComplete;
 
   /// Whether an empty view might simply not have its messages yet.
-  bool get mayBeIncomplete => isRestoring || !isComplete;
+  bool get mayBeIncomplete => isRestoring || (hasAttempted && !isComplete);
 
   @override
-  List<Object?> get props => [isRestoring, isComplete];
+  List<Object?> get props => [isRestoring, hasAttempted, isComplete];
 }
 
 /// Publishes [DmRepository]'s app-scoped recovery signals as bloc state.
@@ -46,6 +50,7 @@ class DmRestoreStatusCubit extends Cubit<DmRestoreStatusState> {
       super(
         DmRestoreStatusState(
           isRestoring: dmRepository.isRecoveringHistory,
+          hasAttempted: dmRepository.hasAttemptedHistoryRecovery,
           isComplete: dmRepository.isHistoryRecoveryComplete,
         ),
       ) {
@@ -58,6 +63,7 @@ class DmRestoreStatusCubit extends Cubit<DmRestoreStatusState> {
       emit(
         DmRestoreStatusState(
           isRestoring: isRestoring,
+          hasAttempted: _dmRepository.hasAttemptedHistoryRecovery,
           isComplete: _dmRepository.isHistoryRecoveryComplete,
         ),
       );

--- a/mobile/lib/blocs/dm/restore_status/dm_restore_status_cubit.dart
+++ b/mobile/lib/blocs/dm/restore_status/dm_restore_status_cubit.dart
@@ -1,0 +1,75 @@
+// ABOUTME: Exposes app-scoped DM history-recovery status to screens that need
+// ABOUTME: to qualify an empty view, so "no messages" is not asserted while
+// ABOUTME: recovery is still in flight or stopped short of finishing.
+
+import 'dart:async';
+
+import 'package:bloc/bloc.dart';
+import 'package:dm_repository/dm_repository.dart';
+import 'package:equatable/equatable.dart';
+
+/// Whether DM history recovery still owes the user messages.
+class DmRestoreStatusState extends Equatable {
+  const DmRestoreStatusState({
+    this.isRestoring = false,
+    this.isComplete = true,
+  });
+
+  /// A recovery pass (reinstall backfill or failed-decrypt replay) is running.
+  final bool isRestoring;
+
+  /// The one-time history drain has completed cleanly for this user.
+  ///
+  /// Defaults to `true` so a screen never claims history is missing before the
+  /// repository has answered — the same fail-open stance as
+  /// [DmRepository.isHistoryRecoveryComplete], which returns `true` when it has
+  /// no sync state or pubkey to consult.
+  final bool isComplete;
+
+  /// Whether an empty view might simply not have its messages yet.
+  bool get mayBeIncomplete => isRestoring || !isComplete;
+
+  @override
+  List<Object?> get props => [isRestoring, isComplete];
+}
+
+/// Publishes [DmRepository]'s app-scoped recovery signals as bloc state.
+///
+/// Deliberately separate from `ConversationBloc` rather than a third stream in
+/// its `combineLatest`. That bloc's emission sequence is contract — its tests
+/// pin exact `[loading, loaded]` lists and mark-as-read call counts — and
+/// recovery status is app-scoped, not per-conversation, so folding it in would
+/// couple two different lifetimes for no gain.
+class DmRestoreStatusCubit extends Cubit<DmRestoreStatusState> {
+  DmRestoreStatusCubit({required DmRepository dmRepository})
+    : _dmRepository = dmRepository,
+      super(
+        DmRestoreStatusState(
+          isRestoring: dmRepository.isRecoveringHistory,
+          isComplete: dmRepository.isHistoryRecoveryComplete,
+        ),
+      ) {
+    // `historyRecoveryStream` does not replay, hence the constructor seed above.
+    _subscription = _dmRepository.historyRecoveryStream.listen((isRestoring) {
+      // Re-read the persisted flag on every tick: it is what actually gates the
+      // request split, and it only flips on a clean drain exhaustion. A pass
+      // that stops at the page cap, throws, or finds no connected relay ends
+      // with isRestoring false while this stays false too.
+      emit(
+        DmRestoreStatusState(
+          isRestoring: isRestoring,
+          isComplete: _dmRepository.isHistoryRecoveryComplete,
+        ),
+      );
+    });
+  }
+
+  final DmRepository _dmRepository;
+  late final StreamSubscription<bool> _subscription;
+
+  @override
+  Future<void> close() async {
+    await _subscription.cancel();
+    return super.close();
+  }
+}

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -2587,6 +2587,7 @@
     },
     "inboxRemovedConversation": "ውይይት ተወግዷል",
     "inboxRestorePausedTitle": "አንዳንድ ውይይቶች ወደነበሩበት መመለስ አላጠናቀቁም",
+    "conversationRestorePausedTitle": "ይህ ውይይት ወደነበረበት መመለስ አላጠናቀቀም",
     "inboxRestoreRetryAction": "እንደገና ሞክር",
     "inboxRestoringMessages": "መልዕክቶችዎን ወደነበሩበት በመመለስ ላይ…",
     "inboxEmptyTitle": "እስካሁን ምንም መልዕክቶች የሉም",

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -2586,6 +2586,8 @@
         }
     },
     "inboxRemovedConversation": "ውይይት ተወግዷል",
+    "inboxRestorePausedTitle": "አንዳንድ ውይይቶች ወደነበሩበት መመለስ አላጠናቀቁም",
+    "inboxRestoreRetryAction": "እንደገና ሞክር",
     "inboxRestoringMessages": "መልዕክቶችዎን ወደነበሩበት በመመለስ ላይ…",
     "inboxEmptyTitle": "እስካሁን ምንም መልዕክቶች የሉም",
     "inboxEmptySubtitle": "ያ + ቁልፍ አይነክሰውም።",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2342,6 +2342,8 @@
     "inboxRemoveConfirmConfirm": "إزالة",
     "inboxRemoveConfirmTitle": "إزالة المحادثة؟",
     "inboxRemovedConversation": "تمت إزالة المحادثة",
+    "inboxRestorePausedTitle": "لم تكتمل استعادة بعض المحادثات",
+    "inboxRestoreRetryAction": "إعادة المحاولة",
     "inboxRestoringMessages": "جارٍ استعادة رسائلك…",
     "inboxReportedUser": "تم الإبلاغ عن {displayName}",
     "@inboxReportedUser": {

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2343,6 +2343,7 @@
     "inboxRemoveConfirmTitle": "إزالة المحادثة؟",
     "inboxRemovedConversation": "تمت إزالة المحادثة",
     "inboxRestorePausedTitle": "لم تكتمل استعادة بعض المحادثات",
+    "conversationRestorePausedTitle": "لم تكتمل استعادة هذه المحادثة",
     "inboxRestoreRetryAction": "إعادة المحاولة",
     "inboxRestoringMessages": "جارٍ استعادة رسائلك…",
     "inboxReportedUser": "تم الإبلاغ عن {displayName}",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -2439,6 +2439,7 @@
     },
     "inboxRemovedConversation": "Премахнат разговор",
     "inboxRestorePausedTitle": "Някои чатове не са възстановени докрай",
+    "conversationRestorePausedTitle": "Този чат още не е възстановен докрай",
     "inboxRestoreRetryAction": "Опитай пак",
     "inboxRestoringMessages": "Възстановяваме съобщенията ти…",
     "inboxEmptyTitle": "Все още няма съобщения",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -2438,6 +2438,8 @@
         }
     },
     "inboxRemovedConversation": "Премахнат разговор",
+    "inboxRestorePausedTitle": "Някои чатове не са възстановени докрай",
+    "inboxRestoreRetryAction": "Опитай пак",
     "inboxRestoringMessages": "Възстановяваме съобщенията ти…",
     "inboxEmptyTitle": "Все още няма съобщения",
     "inboxEmptySubtitle": "Този бутон + няма да ухапе.",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2350,6 +2350,8 @@
     "inboxRemoveConfirmConfirm": "Entfernen",
     "inboxRemoveConfirmTitle": "Unterhaltung entfernen?",
     "inboxRemovedConversation": "Unterhaltung entfernt",
+    "inboxRestorePausedTitle": "Einige Chats sind noch nicht wiederhergestellt",
+    "inboxRestoreRetryAction": "Erneut versuchen",
     "inboxRestoringMessages": "Deine Nachrichten werden wiederhergestellt…",
     "inboxReportedUser": "{displayName} gemeldet",
     "@inboxReportedUser": {

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2351,6 +2351,7 @@
     "inboxRemoveConfirmTitle": "Unterhaltung entfernen?",
     "inboxRemovedConversation": "Unterhaltung entfernt",
     "inboxRestorePausedTitle": "Einige Chats sind noch nicht wiederhergestellt",
+    "conversationRestorePausedTitle": "Dieser Chat ist noch nicht vollständig wiederhergestellt",
     "inboxRestoreRetryAction": "Erneut versuchen",
     "inboxRestoringMessages": "Deine Nachrichten werden wiederhergestellt…",
     "inboxReportedUser": "{displayName} gemeldet",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -3108,9 +3108,13 @@
   },
   "inboxRemovedConversation": "Removed conversation",
   "inboxRestorePausedTitle": "Some chats haven't finished restoring",
+  "conversationRestorePausedTitle": "This chat hasn't finished restoring",
   "inboxRestoreRetryAction": "Retry",
   "@inboxRestorePausedTitle": {
     "description": "Title of the inbox banner shown when the one-time DM history recovery stopped before finishing, so conversations that would appear as message requests are still hidden. Paired with a Retry action."
+  },
+  "@conversationRestorePausedTitle": {
+    "description": "Short note shown in a single empty DM conversation when history recovery has run but stopped before finishing, so this chat may still receive restored messages."
   },
   "@inboxRestoreRetryAction": {
     "description": "Label of the action on the inbox restore-paused banner that re-runs the DM history recovery."

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -3107,6 +3107,14 @@
     }
   },
   "inboxRemovedConversation": "Removed conversation",
+  "inboxRestorePausedTitle": "Some chats haven't finished restoring",
+  "inboxRestoreRetryAction": "Retry",
+  "@inboxRestorePausedTitle": {
+    "description": "Title of the inbox banner shown when the one-time DM history recovery stopped before finishing, so conversations that would appear as message requests are still hidden. Paired with a Retry action."
+  },
+  "@inboxRestoreRetryAction": {
+    "description": "Label of the action on the inbox restore-paused banner that re-runs the DM history recovery."
+  },
   "inboxRestoringMessages": "Restoring your messages…",
   "@inboxRestoringMessages": {
     "description": "Accessibility label on the progress bar shown at the top of the Messages list while a one-time DM history recovery (after reinstall) is still running, so the user knows older chats are still being restored."

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2354,6 +2354,8 @@
     "inboxRemoveConfirmConfirm": "Eliminar",
     "inboxRemoveConfirmTitle": "¿Eliminar conversación?",
     "inboxRemovedConversation": "Conversación eliminada",
+    "inboxRestorePausedTitle": "Algunos chats no terminaron de restaurarse",
+    "inboxRestoreRetryAction": "Reintentar",
     "inboxRestoringMessages": "Restaurando tus mensajes…",
     "inboxReportedUser": "Reportaste a {displayName}",
     "@inboxReportedUser": {

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2355,6 +2355,7 @@
     "inboxRemoveConfirmTitle": "¿Eliminar conversación?",
     "inboxRemovedConversation": "Conversación eliminada",
     "inboxRestorePausedTitle": "Algunos chats no terminaron de restaurarse",
+    "conversationRestorePausedTitle": "Este chat no terminó de restaurarse",
     "inboxRestoreRetryAction": "Reintentar",
     "inboxRestoringMessages": "Restaurando tus mensajes…",
     "inboxReportedUser": "Reportaste a {displayName}",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1463,6 +1463,8 @@
     "inboxBlockedUser": "Na-block si {displayName}",
     "inboxUnblockedUser": "Na-unblock si {displayName}",
     "inboxRemovedConversation": "Inalis ang conversation",
+    "inboxRestorePausedTitle": "May mga chat na hindi pa tapos ibalik",
+    "inboxRestoreRetryAction": "Subukan ulit",
     "inboxRestoringMessages": "Ibinabalik ang mga message mo…",
     "inboxEmptyTitle": "Wala pang messages",
     "inboxEmptySubtitle": "Hindi ka kakagatin ng + button na 'yan.",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1464,6 +1464,7 @@
     "inboxUnblockedUser": "Na-unblock si {displayName}",
     "inboxRemovedConversation": "Inalis ang conversation",
     "inboxRestorePausedTitle": "May mga chat na hindi pa tapos ibalik",
+    "conversationRestorePausedTitle": "Hindi pa tapos ibalik ang chat na ito",
     "inboxRestoreRetryAction": "Subukan ulit",
     "inboxRestoringMessages": "Ibinabalik ang mga message mo…",
     "inboxEmptyTitle": "Wala pang messages",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2350,6 +2350,8 @@
     "inboxRemoveConfirmConfirm": "Supprimer",
     "inboxRemoveConfirmTitle": "Supprimer la conversation ?",
     "inboxRemovedConversation": "Conversation supprimée",
+    "inboxRestorePausedTitle": "Certaines conversations ne sont pas encore restaurées",
+    "inboxRestoreRetryAction": "Réessayer",
     "inboxRestoringMessages": "Restauration de vos messages…",
     "inboxReportedUser": "{displayName} signalé(e)",
     "@inboxReportedUser": {

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2351,6 +2351,7 @@
     "inboxRemoveConfirmTitle": "Supprimer la conversation ?",
     "inboxRemovedConversation": "Conversation supprimée",
     "inboxRestorePausedTitle": "Certaines conversations ne sont pas encore restaurées",
+    "conversationRestorePausedTitle": "Cette conversation n'est pas encore restaurée",
     "inboxRestoreRetryAction": "Réessayer",
     "inboxRestoringMessages": "Restauration de vos messages…",
     "inboxReportedUser": "{displayName} signalé(e)",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2350,6 +2350,7 @@
     "inboxRemoveConfirmTitle": "Hapus percakapan?",
     "inboxRemovedConversation": "Percakapan dihapus",
     "inboxRestorePausedTitle": "Sebagian chat belum selesai dipulihkan",
+    "conversationRestorePausedTitle": "Chat ini belum selesai dipulihkan",
     "inboxRestoreRetryAction": "Coba lagi",
     "inboxRestoringMessages": "Memulihkan pesan Anda…",
     "inboxReportedUser": "{displayName} dilaporkan",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2349,6 +2349,8 @@
     "inboxRemoveConfirmConfirm": "Hapus",
     "inboxRemoveConfirmTitle": "Hapus percakapan?",
     "inboxRemovedConversation": "Percakapan dihapus",
+    "inboxRestorePausedTitle": "Sebagian chat belum selesai dipulihkan",
+    "inboxRestoreRetryAction": "Coba lagi",
     "inboxRestoringMessages": "Memulihkan pesan Anda…",
     "inboxReportedUser": "{displayName} dilaporkan",
     "@inboxReportedUser": {

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2351,6 +2351,7 @@
     "inboxRemoveConfirmTitle": "Rimuovere la conversazione?",
     "inboxRemovedConversation": "Conversazione rimossa",
     "inboxRestorePausedTitle": "Alcune chat non sono state ripristinate del tutto",
+    "conversationRestorePausedTitle": "Questa chat non è stata ripristinata del tutto",
     "inboxRestoreRetryAction": "Riprova",
     "inboxRestoringMessages": "Ripristino dei messaggi…",
     "inboxReportedUser": "{displayName} segnalato/a",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2350,6 +2350,8 @@
     "inboxRemoveConfirmConfirm": "Rimuovi",
     "inboxRemoveConfirmTitle": "Rimuovere la conversazione?",
     "inboxRemovedConversation": "Conversazione rimossa",
+    "inboxRestorePausedTitle": "Alcune chat non sono state ripristinate del tutto",
+    "inboxRestoreRetryAction": "Riprova",
     "inboxRestoringMessages": "Ripristino dei messaggi…",
     "inboxReportedUser": "{displayName} segnalato/a",
     "@inboxReportedUser": {

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2343,6 +2343,7 @@
     "inboxRemoveConfirmTitle": "会話を削除する？",
     "inboxRemovedConversation": "会話を削除したよ",
     "inboxRestorePausedTitle": "一部のチャットの復元が終わっていないよ",
+    "conversationRestorePausedTitle": "このチャットの復元が終わっていないよ",
     "inboxRestoreRetryAction": "再試行",
     "inboxRestoringMessages": "メッセージを復元中…",
     "inboxReportedUser": "{displayName}を報告したよ",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2342,6 +2342,8 @@
     "inboxRemoveConfirmConfirm": "削除",
     "inboxRemoveConfirmTitle": "会話を削除する？",
     "inboxRemovedConversation": "会話を削除したよ",
+    "inboxRestorePausedTitle": "一部のチャットの復元が終わっていないよ",
+    "inboxRestoreRetryAction": "再試行",
     "inboxRestoringMessages": "メッセージを復元中…",
     "inboxReportedUser": "{displayName}を報告したよ",
     "@inboxReportedUser": {

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1674,6 +1674,7 @@
     "inboxRemoveConfirmTitle": "대화를 삭제할까요?",
     "inboxRemovedConversation": "대화를 삭제했어요",
     "inboxRestorePausedTitle": "일부 대화를 아직 다 복구하지 못했어요",
+    "conversationRestorePausedTitle": "이 대화를 아직 다 복구하지 못했어요",
     "inboxRestoreRetryAction": "다시 시도",
     "inboxRestoringMessages": "메시지를 복구하는 중…",
     "inboxReportedUser": "{displayName}을(를) 신고했어요",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1673,6 +1673,8 @@
     "inboxRemoveConfirmConfirm": "삭제",
     "inboxRemoveConfirmTitle": "대화를 삭제할까요?",
     "inboxRemovedConversation": "대화를 삭제했어요",
+    "inboxRestorePausedTitle": "일부 대화를 아직 다 복구하지 못했어요",
+    "inboxRestoreRetryAction": "다시 시도",
     "inboxRestoringMessages": "메시지를 복구하는 중…",
     "inboxReportedUser": "{displayName}을(를) 신고했어요",
     "@inboxReportedUser": {

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2351,6 +2351,7 @@
     "inboxRemoveConfirmTitle": "Gesprek verwijderen?",
     "inboxRemovedConversation": "Gesprek verwijderd",
     "inboxRestorePausedTitle": "Sommige chats zijn nog niet hersteld",
+    "conversationRestorePausedTitle": "Deze chat is nog niet hersteld",
     "inboxRestoreRetryAction": "Opnieuw proberen",
     "inboxRestoringMessages": "Je berichten worden hersteld…",
     "inboxReportedUser": "{displayName} gerapporteerd",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2350,6 +2350,8 @@
     "inboxRemoveConfirmConfirm": "Verwijderen",
     "inboxRemoveConfirmTitle": "Gesprek verwijderen?",
     "inboxRemovedConversation": "Gesprek verwijderd",
+    "inboxRestorePausedTitle": "Sommige chats zijn nog niet hersteld",
+    "inboxRestoreRetryAction": "Opnieuw proberen",
     "inboxRestoringMessages": "Je berichten worden hersteld…",
     "inboxReportedUser": "{displayName} gerapporteerd",
     "@inboxReportedUser": {

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2351,6 +2351,7 @@
     "inboxRemoveConfirmTitle": "Usunąć rozmowę?",
     "inboxRemovedConversation": "Usunięto rozmowę",
     "inboxRestorePausedTitle": "Część czatów nie została w pełni odzyskana",
+    "conversationRestorePausedTitle": "Ten czat nie został jeszcze w pełni odzyskany",
     "inboxRestoreRetryAction": "Spróbuj ponownie",
     "inboxRestoringMessages": "Odzyskiwanie wiadomości…",
     "inboxReportedUser": "Zgłoszono {displayName}",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2350,6 +2350,8 @@
     "inboxRemoveConfirmConfirm": "Usuń",
     "inboxRemoveConfirmTitle": "Usunąć rozmowę?",
     "inboxRemovedConversation": "Usunięto rozmowę",
+    "inboxRestorePausedTitle": "Część czatów nie została w pełni odzyskana",
+    "inboxRestoreRetryAction": "Spróbuj ponownie",
     "inboxRestoringMessages": "Odzyskiwanie wiadomości…",
     "inboxReportedUser": "Zgłoszono {displayName}",
     "@inboxReportedUser": {

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2351,6 +2351,7 @@
     "inboxRemoveConfirmTitle": "Remover conversa?",
     "inboxRemovedConversation": "Conversa removida",
     "inboxRestorePausedTitle": "Algumas conversas não terminaram de restaurar",
+    "conversationRestorePausedTitle": "Esta conversa ainda não terminou de restaurar",
     "inboxRestoreRetryAction": "Tentar de novo",
     "inboxRestoringMessages": "Restaurando suas mensagens…",
     "inboxReportedUser": "{displayName} denunciado(a)",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2350,6 +2350,8 @@
     "inboxRemoveConfirmConfirm": "Remover",
     "inboxRemoveConfirmTitle": "Remover conversa?",
     "inboxRemovedConversation": "Conversa removida",
+    "inboxRestorePausedTitle": "Algumas conversas não terminaram de restaurar",
+    "inboxRestoreRetryAction": "Tentar de novo",
     "inboxRestoringMessages": "Restaurando suas mensagens…",
     "inboxReportedUser": "{displayName} denunciado(a)",
     "@inboxReportedUser": {

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2350,6 +2350,8 @@
     "inboxRemoveConfirmConfirm": "Elimină",
     "inboxRemoveConfirmTitle": "Elimini conversația?",
     "inboxRemovedConversation": "Conversație eliminată",
+    "inboxRestorePausedTitle": "Unele conversații nu s-au restaurat complet",
+    "inboxRestoreRetryAction": "Reîncearcă",
     "inboxRestoringMessages": "Se restaurează mesajele tale…",
     "inboxReportedUser": "{displayName} a fost raportat(ă)",
     "@inboxReportedUser": {

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2351,6 +2351,7 @@
     "inboxRemoveConfirmTitle": "Elimini conversația?",
     "inboxRemovedConversation": "Conversație eliminată",
     "inboxRestorePausedTitle": "Unele conversații nu s-au restaurat complet",
+    "conversationRestorePausedTitle": "Această conversație nu s-a restaurat complet",
     "inboxRestoreRetryAction": "Reîncearcă",
     "inboxRestoringMessages": "Se restaurează mesajele tale…",
     "inboxReportedUser": "{displayName} a fost raportat(ă)",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2350,6 +2350,8 @@
     "inboxRemoveConfirmConfirm": "Ta bort",
     "inboxRemoveConfirmTitle": "Ta bort konversation?",
     "inboxRemovedConversation": "Konversation borttagen",
+    "inboxRestorePausedTitle": "Vissa chattar har inte återställts klart",
+    "inboxRestoreRetryAction": "Försök igen",
     "inboxRestoringMessages": "Återställer dina meddelanden…",
     "inboxReportedUser": "{displayName} rapporterad",
     "@inboxReportedUser": {

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2351,6 +2351,7 @@
     "inboxRemoveConfirmTitle": "Ta bort konversation?",
     "inboxRemovedConversation": "Konversation borttagen",
     "inboxRestorePausedTitle": "Vissa chattar har inte återställts klart",
+    "conversationRestorePausedTitle": "Den här chatten har inte återställts klart",
     "inboxRestoreRetryAction": "Försök igen",
     "inboxRestoringMessages": "Återställer dina meddelanden…",
     "inboxReportedUser": "{displayName} rapporterad",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2350,6 +2350,7 @@
     "inboxRemoveConfirmTitle": "Sohbet kaldırılsın mı?",
     "inboxRemovedConversation": "Sohbet kaldırıldı",
     "inboxRestorePausedTitle": "Bazı sohbetler tam geri yüklenmedi",
+    "conversationRestorePausedTitle": "Bu sohbet tam geri yüklenmedi",
     "inboxRestoreRetryAction": "Yeniden dene",
     "inboxRestoringMessages": "Mesajların geri yükleniyor…",
     "inboxReportedUser": "{displayName} bildirildi",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2349,6 +2349,8 @@
     "inboxRemoveConfirmConfirm": "Kaldır",
     "inboxRemoveConfirmTitle": "Sohbet kaldırılsın mı?",
     "inboxRemovedConversation": "Sohbet kaldırıldı",
+    "inboxRestorePausedTitle": "Bazı sohbetler tam geri yüklenmedi",
+    "inboxRestoreRetryAction": "Yeniden dene",
     "inboxRestoringMessages": "Mesajların geri yükleniyor…",
     "inboxReportedUser": "{displayName} bildirildi",
     "@inboxReportedUser": {

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -9864,6 +9864,12 @@ abstract class AppLocalizations {
   /// **'Some chats haven\'t finished restoring'**
   String get inboxRestorePausedTitle;
 
+  /// Short note shown in a single empty DM conversation when history recovery has run but stopped before finishing, so this chat may still receive restored messages.
+  ///
+  /// In en, this message translates to:
+  /// **'This chat hasn\'t finished restoring'**
+  String get conversationRestorePausedTitle;
+
   /// Label of the action on the inbox restore-paused banner that re-runs the DM history recovery.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -9858,6 +9858,18 @@ abstract class AppLocalizations {
   /// **'Removed conversation'**
   String get inboxRemovedConversation;
 
+  /// Title of the inbox banner shown when the one-time DM history recovery stopped before finishing, so conversations that would appear as message requests are still hidden. Paired with a Retry action.
+  ///
+  /// In en, this message translates to:
+  /// **'Some chats haven\'t finished restoring'**
+  String get inboxRestorePausedTitle;
+
+  /// Label of the action on the inbox restore-paused banner that re-runs the DM history recovery.
+  ///
+  /// In en, this message translates to:
+  /// **'Retry'**
+  String get inboxRestoreRetryAction;
+
   /// Accessibility label on the progress bar shown at the top of the Messages list while a one-time DM history recovery (after reinstall) is still running, so the user knows older chats are still being restored.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -5505,6 +5505,9 @@ class AppLocalizationsAm extends AppLocalizations {
   String get inboxRestorePausedTitle => 'አንዳንድ ውይይቶች ወደነበሩበት መመለስ አላጠናቀቁም';
 
   @override
+  String get conversationRestorePausedTitle => 'ይህ ውይይት ወደነበረበት መመለስ አላጠናቀቀም';
+
+  @override
   String get inboxRestoreRetryAction => 'እንደገና ሞክር';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -5502,6 +5502,12 @@ class AppLocalizationsAm extends AppLocalizations {
   String get inboxRemovedConversation => 'ውይይት ተወግዷል';
 
   @override
+  String get inboxRestorePausedTitle => 'አንዳንድ ውይይቶች ወደነበሩበት መመለስ አላጠናቀቁም';
+
+  @override
+  String get inboxRestoreRetryAction => 'እንደገና ሞክር';
+
+  @override
   String get inboxRestoringMessages => 'መልዕክቶችዎን ወደነበሩበት በመመለስ ላይ…';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -5578,6 +5578,12 @@ class AppLocalizationsAr extends AppLocalizations {
   String get inboxRemovedConversation => 'تمت إزالة المحادثة';
 
   @override
+  String get inboxRestorePausedTitle => 'لم تكتمل استعادة بعض المحادثات';
+
+  @override
+  String get inboxRestoreRetryAction => 'إعادة المحاولة';
+
+  @override
   String get inboxRestoringMessages => 'جارٍ استعادة رسائلك…';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -5581,6 +5581,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get inboxRestorePausedTitle => 'لم تكتمل استعادة بعض المحادثات';
 
   @override
+  String get conversationRestorePausedTitle => 'لم تكتمل استعادة هذه المحادثة';
+
+  @override
   String get inboxRestoreRetryAction => 'إعادة المحاولة';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -5670,6 +5670,10 @@ class AppLocalizationsBg extends AppLocalizations {
       'Някои чатове не са възстановени докрай';
 
   @override
+  String get conversationRestorePausedTitle =>
+      'Този чат още не е възстановен докрай';
+
+  @override
   String get inboxRestoreRetryAction => 'Опитай пак';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -5666,6 +5666,13 @@ class AppLocalizationsBg extends AppLocalizations {
   String get inboxRemovedConversation => 'Премахнат разговор';
 
   @override
+  String get inboxRestorePausedTitle =>
+      'Някои чатове не са възстановени докрай';
+
+  @override
+  String get inboxRestoreRetryAction => 'Опитай пак';
+
+  @override
   String get inboxRestoringMessages => 'Възстановяваме съобщенията ти…';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -5682,6 +5682,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Einige Chats sind noch nicht wiederhergestellt';
 
   @override
+  String get conversationRestorePausedTitle =>
+      'Dieser Chat ist noch nicht vollständig wiederhergestellt';
+
+  @override
   String get inboxRestoreRetryAction => 'Erneut versuchen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -5678,6 +5678,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get inboxRemovedConversation => 'Unterhaltung entfernt';
 
   @override
+  String get inboxRestorePausedTitle =>
+      'Einige Chats sind noch nicht wiederhergestellt';
+
+  @override
+  String get inboxRestoreRetryAction => 'Erneut versuchen';
+
+  @override
   String get inboxRestoringMessages =>
       'Deine Nachrichten werden wiederhergestellt…';
 

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -5617,6 +5617,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Some chats haven\'t finished restoring';
 
   @override
+  String get conversationRestorePausedTitle =>
+      'This chat hasn\'t finished restoring';
+
+  @override
   String get inboxRestoreRetryAction => 'Retry';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -5613,6 +5613,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get inboxRemovedConversation => 'Removed conversation';
 
   @override
+  String get inboxRestorePausedTitle =>
+      'Some chats haven\'t finished restoring';
+
+  @override
+  String get inboxRestoreRetryAction => 'Retry';
+
+  @override
   String get inboxRestoringMessages => 'Restoring your messages…';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -5662,6 +5662,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'Algunos chats no terminaron de restaurarse';
 
   @override
+  String get conversationRestorePausedTitle =>
+      'Este chat no terminó de restaurarse';
+
+  @override
   String get inboxRestoreRetryAction => 'Reintentar';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -5658,6 +5658,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get inboxRemovedConversation => 'Conversación eliminada';
 
   @override
+  String get inboxRestorePausedTitle =>
+      'Algunos chats no terminaron de restaurarse';
+
+  @override
+  String get inboxRestoreRetryAction => 'Reintentar';
+
+  @override
   String get inboxRestoringMessages => 'Restaurando tus mensajes…';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -5681,6 +5681,12 @@ class AppLocalizationsFil extends AppLocalizations {
   String get inboxRemovedConversation => 'Inalis ang conversation';
 
   @override
+  String get inboxRestorePausedTitle => 'May mga chat na hindi pa tapos ibalik';
+
+  @override
+  String get inboxRestoreRetryAction => 'Subukan ulit';
+
+  @override
   String get inboxRestoringMessages => 'Ibinabalik ang mga message mo…';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -5684,6 +5684,10 @@ class AppLocalizationsFil extends AppLocalizations {
   String get inboxRestorePausedTitle => 'May mga chat na hindi pa tapos ibalik';
 
   @override
+  String get conversationRestorePausedTitle =>
+      'Hindi pa tapos ibalik ang chat na ito';
+
+  @override
   String get inboxRestoreRetryAction => 'Subukan ulit';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -5689,6 +5689,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Certaines conversations ne sont pas encore restaurées';
 
   @override
+  String get conversationRestorePausedTitle =>
+      'Cette conversation n\'est pas encore restaurée';
+
+  @override
   String get inboxRestoreRetryAction => 'Réessayer';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -5685,6 +5685,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get inboxRemovedConversation => 'Conversation supprimée';
 
   @override
+  String get inboxRestorePausedTitle =>
+      'Certaines conversations ne sont pas encore restaurées';
+
+  @override
+  String get inboxRestoreRetryAction => 'Réessayer';
+
+  @override
   String get inboxRestoringMessages => 'Restauration de vos messages…';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -5588,6 +5588,13 @@ class AppLocalizationsId extends AppLocalizations {
   String get inboxRemovedConversation => 'Percakapan dihapus';
 
   @override
+  String get inboxRestorePausedTitle =>
+      'Sebagian chat belum selesai dipulihkan';
+
+  @override
+  String get inboxRestoreRetryAction => 'Coba lagi';
+
+  @override
   String get inboxRestoringMessages => 'Memulihkan pesan Anda…';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -5592,6 +5592,10 @@ class AppLocalizationsId extends AppLocalizations {
       'Sebagian chat belum selesai dipulihkan';
 
   @override
+  String get conversationRestorePausedTitle =>
+      'Chat ini belum selesai dipulihkan';
+
+  @override
   String get inboxRestoreRetryAction => 'Coba lagi';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -5664,6 +5664,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get inboxRemovedConversation => 'Conversazione rimossa';
 
   @override
+  String get inboxRestorePausedTitle =>
+      'Alcune chat non sono state ripristinate del tutto';
+
+  @override
+  String get inboxRestoreRetryAction => 'Riprova';
+
+  @override
   String get inboxRestoringMessages => 'Ripristino dei messaggi…';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -5668,6 +5668,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Alcune chat non sono state ripristinate del tutto';
 
   @override
+  String get conversationRestorePausedTitle =>
+      'Questa chat non è stata ripristinata del tutto';
+
+  @override
   String get inboxRestoreRetryAction => 'Riprova';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -5383,6 +5383,12 @@ class AppLocalizationsJa extends AppLocalizations {
   String get inboxRemovedConversation => '会話を削除したよ';
 
   @override
+  String get inboxRestorePausedTitle => '一部のチャットの復元が終わっていないよ';
+
+  @override
+  String get inboxRestoreRetryAction => '再試行';
+
+  @override
   String get inboxRestoringMessages => 'メッセージを復元中…';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -5386,6 +5386,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get inboxRestorePausedTitle => '一部のチャットの復元が終わっていないよ';
 
   @override
+  String get conversationRestorePausedTitle => 'このチャットの復元が終わっていないよ';
+
+  @override
   String get inboxRestoreRetryAction => '再試行';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -5403,6 +5403,12 @@ class AppLocalizationsKo extends AppLocalizations {
   String get inboxRemovedConversation => '대화를 삭제했어요';
 
   @override
+  String get inboxRestorePausedTitle => '일부 대화를 아직 다 복구하지 못했어요';
+
+  @override
+  String get inboxRestoreRetryAction => '다시 시도';
+
+  @override
   String get inboxRestoringMessages => '메시지를 복구하는 중…';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -5406,6 +5406,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get inboxRestorePausedTitle => '일부 대화를 아직 다 복구하지 못했어요';
 
   @override
+  String get conversationRestorePausedTitle => '이 대화를 아직 다 복구하지 못했어요';
+
+  @override
   String get inboxRestoreRetryAction => '다시 시도';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -5637,6 +5637,12 @@ class AppLocalizationsNl extends AppLocalizations {
   String get inboxRemovedConversation => 'Gesprek verwijderd';
 
   @override
+  String get inboxRestorePausedTitle => 'Sommige chats zijn nog niet hersteld';
+
+  @override
+  String get inboxRestoreRetryAction => 'Opnieuw proberen';
+
+  @override
   String get inboxRestoringMessages => 'Je berichten worden hersteld…';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -5640,6 +5640,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get inboxRestorePausedTitle => 'Sommige chats zijn nog niet hersteld';
 
   @override
+  String get conversationRestorePausedTitle => 'Deze chat is nog niet hersteld';
+
+  @override
   String get inboxRestoreRetryAction => 'Opnieuw proberen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -5758,6 +5758,10 @@ class AppLocalizationsPl extends AppLocalizations {
       'Część czatów nie została w pełni odzyskana';
 
   @override
+  String get conversationRestorePausedTitle =>
+      'Ten czat nie został jeszcze w pełni odzyskany';
+
+  @override
   String get inboxRestoreRetryAction => 'Spróbuj ponownie';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -5754,6 +5754,13 @@ class AppLocalizationsPl extends AppLocalizations {
   String get inboxRemovedConversation => 'Usunięto rozmowę';
 
   @override
+  String get inboxRestorePausedTitle =>
+      'Część czatów nie została w pełni odzyskana';
+
+  @override
+  String get inboxRestoreRetryAction => 'Spróbuj ponownie';
+
+  @override
   String get inboxRestoringMessages => 'Odzyskiwanie wiadomości…';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -5652,6 +5652,10 @@ class AppLocalizationsPt extends AppLocalizations {
       'Algumas conversas não terminaram de restaurar';
 
   @override
+  String get conversationRestorePausedTitle =>
+      'Esta conversa ainda não terminou de restaurar';
+
+  @override
   String get inboxRestoreRetryAction => 'Tentar de novo';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -5648,6 +5648,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get inboxRemovedConversation => 'Conversa removida';
 
   @override
+  String get inboxRestorePausedTitle =>
+      'Algumas conversas não terminaram de restaurar';
+
+  @override
+  String get inboxRestoreRetryAction => 'Tentar de novo';
+
+  @override
   String get inboxRestoringMessages => 'Restaurando suas mensagens…';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -5765,6 +5765,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get inboxRemovedConversation => 'Conversație eliminată';
 
   @override
+  String get inboxRestorePausedTitle =>
+      'Unele conversații nu s-au restaurat complet';
+
+  @override
+  String get inboxRestoreRetryAction => 'Reîncearcă';
+
+  @override
   String get inboxRestoringMessages => 'Se restaurează mesajele tale…';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -5769,6 +5769,10 @@ class AppLocalizationsRo extends AppLocalizations {
       'Unele conversații nu s-au restaurat complet';
 
   @override
+  String get conversationRestorePausedTitle =>
+      'Această conversație nu s-a restaurat complet';
+
+  @override
   String get inboxRestoreRetryAction => 'Reîncearcă';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -5615,6 +5615,10 @@ class AppLocalizationsSv extends AppLocalizations {
       'Vissa chattar har inte återställts klart';
 
   @override
+  String get conversationRestorePausedTitle =>
+      'Den här chatten har inte återställts klart';
+
+  @override
   String get inboxRestoreRetryAction => 'Försök igen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -5611,6 +5611,13 @@ class AppLocalizationsSv extends AppLocalizations {
   String get inboxRemovedConversation => 'Konversation borttagen';
 
   @override
+  String get inboxRestorePausedTitle =>
+      'Vissa chattar har inte återställts klart';
+
+  @override
+  String get inboxRestoreRetryAction => 'Försök igen';
+
+  @override
   String get inboxRestoringMessages => 'Återställer dina meddelanden…';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -5596,6 +5596,12 @@ class AppLocalizationsTr extends AppLocalizations {
   String get inboxRemovedConversation => 'Sohbet kaldırıldı';
 
   @override
+  String get inboxRestorePausedTitle => 'Bazı sohbetler tam geri yüklenmedi';
+
+  @override
+  String get inboxRestoreRetryAction => 'Yeniden dene';
+
+  @override
   String get inboxRestoringMessages => 'Mesajların geri yükleniyor…';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -5599,6 +5599,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get inboxRestorePausedTitle => 'Bazı sohbetler tam geri yüklenmedi';
 
   @override
+  String get conversationRestorePausedTitle => 'Bu sohbet tam geri yüklenmedi';
+
+  @override
   String get inboxRestoreRetryAction => 'Yeniden dene';
 
   @override

--- a/mobile/lib/screens/inbox/conversation/conversation_page.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_page.dart
@@ -11,6 +11,7 @@ import 'package:openvine/blocs/dm/conversation/collaborator_invite_actions_cubit
 import 'package:openvine/blocs/dm/conversation/conversation_bloc.dart';
 import 'package:openvine/blocs/dm/minor_dm_approval.dart';
 import 'package:openvine/blocs/dm/reactions/conversation_reactions_cubit.dart';
+import 'package:openvine/blocs/dm/restore_status/dm_restore_status_cubit.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/official_accounts_providers.dart';
 import 'package:openvine/providers/protected_minor_providers.dart';
@@ -93,6 +94,14 @@ class ConversationPage extends ConsumerWidget {
             dmRepository: dmRepository,
             conversationId: conversationId,
           )..add(const ConversationStarted()),
+        ),
+        // Qualifies the empty state: `watchMessages` is a local DB stream, so
+        // an unsynced thread reaches `loaded` with zero rows and would
+        // otherwise assert "no messages" while gift wraps are still arriving
+        // or decrypting. Same identity-keying as ConversationBloc.
+        BlocProvider<DmRestoreStatusCubit>(
+          key: ValueKey((dmRepository, currentPubkey, 'restoreStatus')),
+          create: (_) => DmRestoreStatusCubit(dmRepository: dmRepository),
         ),
         // Reactions cubit; same identity-keying as ConversationBloc.
         BlocProvider<ConversationReactionsCubit>(

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -11,6 +11,7 @@ import 'package:go_router/go_router.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/dm/conversation/conversation_bloc.dart';
 import 'package:openvine/blocs/dm/reactions/conversation_reactions_cubit.dart';
+import 'package:openvine/blocs/dm/restore_status/dm_restore_status_cubit.dart';
 import 'package:openvine/blocs/dm/shared_video_save/shared_video_save_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/l10n/localized_time_formatter.dart';
@@ -454,6 +455,9 @@ class _ConversationContent extends StatelessWidget {
                     imageUrl: imageUrl,
                     nip05: nip05,
                     onViewProfile: onViewProfile,
+                    mayBeIncomplete: context.select<DmRestoreStatusCubit, bool>(
+                      (cubit) => cubit.state.mayBeIncomplete,
+                    ),
                   )
                 : _MessageList(
                     messages: selected.messages,

--- a/mobile/lib/screens/inbox/conversation/widgets/empty_conversation.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/empty_conversation.dart
@@ -75,7 +75,7 @@ class EmptyConversation extends StatelessWidget {
           if (mayBeIncomplete) ...[
             const SizedBox(height: 24),
             Text(
-              context.l10n.inboxRestorePausedTitle,
+              context.l10n.conversationRestorePausedTitle,
               style: VineTheme.bodySmallFont(color: VineTheme.onSurfaceVariant),
               textAlign: TextAlign.center,
             ),

--- a/mobile/lib/screens/inbox/conversation/widgets/empty_conversation.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/empty_conversation.dart
@@ -18,6 +18,7 @@ class EmptyConversation extends StatelessWidget {
     this.imageUrl,
     this.nip05,
     this.onViewProfile,
+    this.mayBeIncomplete = false,
     super.key,
   });
 
@@ -26,6 +27,15 @@ class EmptyConversation extends StatelessWidget {
   final String? imageUrl;
   final String? nip05;
   final VoidCallback? onViewProfile;
+
+  /// Whether DM history recovery might still owe this thread messages.
+  ///
+  /// `watchMessages` is a local DB projection, so a thread whose gift wraps
+  /// have not arrived or decrypted yet reaches `loaded` with zero rows and is
+  /// indistinguishable from a genuinely new conversation. When recovery is in
+  /// flight — or stopped short of completing — this card adds a qualifying
+  /// line instead of silently asserting the conversation is empty.
+  final bool mayBeIncomplete;
 
   @override
   Widget build(BuildContext context) {
@@ -62,6 +72,14 @@ class EmptyConversation extends StatelessWidget {
           const SizedBox(height: 16),
           // View profile button
           _ViewProfileButton(onTap: onViewProfile),
+          if (mayBeIncomplete) ...[
+            const SizedBox(height: 24),
+            Text(
+              context.l10n.inboxRestorePausedTitle,
+              style: VineTheme.bodySmallFont(color: VineTheme.onSurfaceVariant),
+              textAlign: TextAlign.center,
+            ),
+          ],
         ],
       ),
     );

--- a/mobile/lib/screens/inbox/inbox_view.dart
+++ b/mobile/lib/screens/inbox/inbox_view.dart
@@ -32,6 +32,7 @@ import 'package:openvine/screens/inbox/widgets/inbox_empty_state.dart';
 import 'package:openvine/screens/inbox/widgets/inbox_error_state.dart';
 import 'package:openvine/screens/inbox/widgets/inbox_fab.dart';
 import 'package:openvine/screens/inbox/widgets/inbox_segmented_toggle.dart';
+import 'package:openvine/screens/inbox/widgets/restore_paused_banner.dart';
 import 'package:openvine/screens/inbox/widgets/unread_filter_chips.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -368,6 +369,12 @@ class _MessagesContent extends ConsumerWidget {
               // Thin restore progress bar while the one-time reinstall
               // history recovery is still running (#5202).
               const _RestoringHistoryIndicator(),
+              // Static banner while the recovery gate is still hiding
+              // would-be message requests. Mounted here, as a sibling of the
+              // content, so it covers every branch below — empty inbox,
+              // requests-only, filtered, and populated — without threading a
+              // flag through each one or shifting the sliver banner offsets.
+              const _RestorePausedBannerGate(),
               // Conversation list or empty state
               Expanded(
                 child: _ConversationListContent(
@@ -442,6 +449,31 @@ class _RestoringHistoryIndicator extends StatelessWidget {
               semanticsLabel: context.l10n.inboxRestoringMessages,
             )
           : const SizedBox.shrink(),
+    );
+  }
+}
+
+/// Renders [RestorePausedBanner] while the recovery gate is hiding would-be
+/// message requests.
+///
+/// Scoped to the loaded state on purpose: the loading branch already shows a
+/// spinner, and [InboxErrorState] carries its own retry, so surfacing a second
+/// one above it would be redundant.
+class _RestorePausedBannerGate extends StatelessWidget {
+  const _RestorePausedBannerGate();
+
+  @override
+  Widget build(BuildContext context) {
+    final withheld = context.select<ConversationListBloc, bool>(
+      (bloc) =>
+          bloc.state.requestsWithheld &&
+          bloc.state.status == ConversationListStatus.loaded,
+    );
+    if (!withheld) return const SizedBox.shrink();
+    return RestorePausedBanner(
+      onRetry: () => context.read<ConversationListBloc>().add(
+        const ConversationListRestoreRetryRequested(),
+      ),
     );
   }
 }

--- a/mobile/lib/screens/inbox/inbox_view.dart
+++ b/mobile/lib/screens/inbox/inbox_view.dart
@@ -467,6 +467,7 @@ class _RestorePausedBannerGate extends StatelessWidget {
     final withheld = context.select<ConversationListBloc, bool>(
       (bloc) =>
           bloc.state.requestsWithheld &&
+          !bloc.state.isRestoringHistory &&
           bloc.state.status == ConversationListStatus.loaded,
     );
     if (!withheld) return const SizedBox.shrink();

--- a/mobile/lib/screens/inbox/message_requests/message_requests_view.dart
+++ b/mobile/lib/screens/inbox/message_requests/message_requests_view.dart
@@ -14,6 +14,7 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/inbox/message_requests/request_preview_page.dart';
 import 'package:openvine/screens/inbox/message_requests/widgets/request_bulk_actions_sheet.dart';
 import 'package:openvine/screens/inbox/message_requests/widgets/request_tile.dart';
+import 'package:openvine/screens/inbox/widgets/restore_paused_banner.dart';
 
 /// View for the message requests inbox.
 ///
@@ -86,6 +87,8 @@ class _RequestList extends StatelessWidget {
     return BlocBuilder<ConversationListBloc, ConversationListState>(
       buildWhen: (prev, curr) =>
           prev.requestConversations != curr.requestConversations ||
+          prev.requestsWithheld != curr.requestsWithheld ||
+          prev.isRestoringHistory != curr.isRestoringHistory ||
           prev.status != curr.status,
       builder: (context, state) {
         if (state.status == ConversationListStatus.initial ||
@@ -97,6 +100,28 @@ class _RequestList extends StatelessWidget {
 
         final requests = state.requestConversations;
         if (requests.isEmpty) {
+          if (state.requestsWithheld && state.isRestoringHistory) {
+            return Center(
+              child: Semantics(
+                label: context.l10n.inboxRestoringMessages,
+                child: const CircularProgressIndicator(
+                  color: VineTheme.primary,
+                ),
+              ),
+            );
+          }
+
+          if (state.requestsWithheld) {
+            return Align(
+              alignment: Alignment.topCenter,
+              child: RestorePausedBanner(
+                onRetry: () => context.read<ConversationListBloc>().add(
+                  const ConversationListRestoreRetryRequested(),
+                ),
+              ),
+            );
+          }
+
           return Center(
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 48),

--- a/mobile/lib/screens/inbox/widgets/restore_paused_banner.dart
+++ b/mobile/lib/screens/inbox/widgets/restore_paused_banner.dart
@@ -1,0 +1,58 @@
+// ABOUTME: Inbox banner shown when DM history recovery stopped before it
+// ABOUTME: finished, so conversations that would appear as message requests
+// ABOUTME: are still hidden. Offers the retry that re-arms the drain.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:openvine/l10n/l10n.dart';
+
+/// Banner shown at the top of the conversation list while the #5304 recovery
+/// gate is hiding would-be message requests.
+///
+/// Deliberately static rather than a progress bar. The gate stays shut on
+/// every drain exit that is not a clean exhaustion — page cap, exception, no
+/// connected relay — and on those paths nothing is running, so animating
+/// would claim progress that is not happening. `_RestoringHistoryIndicator`
+/// remains the surface for a drain that genuinely is in flight.
+class RestorePausedBanner extends StatelessWidget {
+  const RestorePausedBanner({required this.onRetry, super.key});
+
+  /// Called when the user taps Retry.
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    return DecoratedBox(
+      decoration: const BoxDecoration(
+        border: Border(bottom: BorderSide(color: VineTheme.outlineDisabled)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Row(
+          spacing: 12,
+          children: [
+            const DivineIcon(
+              icon: DivineIconName.info,
+              color: VineTheme.secondaryText,
+            ),
+            Expanded(
+              child: Text(
+                l10n.inboxRestorePausedTitle,
+                style: VineTheme.bodyMediumFont(
+                  color: VineTheme.secondaryText,
+                ),
+              ),
+            ),
+            DivineButton(
+              label: l10n.inboxRestoreRetryAction,
+              type: DivineButtonType.secondary,
+              size: DivineButtonSize.tiny,
+              onPressed: onRetry,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/screens/inbox/widgets/restore_paused_banner.dart
+++ b/mobile/lib/screens/inbox/widgets/restore_paused_banner.dart
@@ -39,15 +39,13 @@ class RestorePausedBanner extends StatelessWidget {
             Expanded(
               child: Text(
                 l10n.inboxRestorePausedTitle,
-                style: VineTheme.bodyMediumFont(
-                  color: VineTheme.secondaryText,
-                ),
+                style: VineTheme.bodyMediumFont(color: VineTheme.secondaryText),
               ),
             ),
             DivineButton(
               label: l10n.inboxRestoreRetryAction,
               type: DivineButtonType.secondary,
-              size: DivineButtonSize.tiny,
+              size: DivineButtonSize.small,
               onPressed: onRetry,
             ),
           ],

--- a/mobile/lib/screens/inbox/widgets/widgets.dart
+++ b/mobile/lib/screens/inbox/widgets/widgets.dart
@@ -3,3 +3,4 @@ export 'following_bar.dart';
 export 'inbox_empty_state.dart';
 export 'inbox_fab.dart';
 export 'inbox_segmented_toggle.dart';
+export 'restore_paused_banner.dart';

--- a/mobile/lib/screens/other_profile_screen.dart
+++ b/mobile/lib/screens/other_profile_screen.dart
@@ -3,6 +3,7 @@
 
 import 'package:analytics/analytics.dart';
 import 'package:divine_ui/divine_ui.dart';
+import 'package:dm_repository/dm_repository.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -189,8 +190,16 @@ class _OtherProfileViewState extends ConsumerState<OtherProfileView> {
     // Defense-in-depth: the button is hidden when blocked, but a stale tap or
     // programmatic call must not open a conversation the minor can't use.
     if (_messagingBlockedForProtectedMinor()) return;
+    final currentPubkey = ref.read(authServiceProvider).currentPublicKeyHex;
+    if (currentPubkey == null || currentPubkey.isEmpty) return;
+    // The route id must be the canonical sha256 of the sorted participants —
+    // the same id `sendMessage` persists under. Passing the raw peer pubkey
+    // here opened a thread whose id matched no stored row, so history never
+    // rendered and messages sent from this screen never appeared in it.
     context.push(
-      ConversationPage.pathForId(widget.pubkey),
+      ConversationPage.pathForId(
+        DmRepository.computeConversationId([currentPubkey, widget.pubkey]),
+      ),
       extra: [widget.pubkey],
     );
   }

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1072,6 +1072,23 @@ class DmRepository {
     return syncState.historyDrainComplete(_userPubkey);
   }
 
+  /// Whether history recovery has run, completed, or is currently running for
+  /// the current user.
+  ///
+  /// A fresh install starts with `historyDrainComplete == false`, but that does
+  /// not mean every brand-new empty conversation should be qualified as
+  /// incomplete before the user has ever opened Messages and armed the drain.
+  /// The drain stamps the current logic version before it does relay work, so
+  /// this distinguishes "not attempted yet" from "attempted but still not
+  /// complete" without inventing per-conversation sync state.
+  bool get hasAttemptedHistoryRecovery {
+    final syncState = _syncState;
+    if (syncState == null || _userPubkey.isEmpty) return true;
+    return isRecoveringHistory ||
+        syncState.historyDrainComplete(_userPubkey) ||
+        syncState.drainVersion(_userPubkey) >= DmSyncState.currentDrainVersion;
+  }
+
   void _beginRecovery() {
     _activeRecoveryOps++;
     if (_activeRecoveryOps == 1 && !_recoveryStateController.isClosed) {
@@ -1169,14 +1186,6 @@ class DmRepository {
           '${DmHistoryDrainConfig.maxDecryptRetries} attempts; those inbound '
           'messages are permanently unrecoverable',
           category: LogCategory.system,
-        );
-        _errorReporter?.call(
-          StateError(
-            'Abandoned $abandoned undecryptable gift wrap(s) after '
-            '${DmHistoryDrainConfig.maxDecryptRetries} attempts',
-          ),
-          StackTrace.current,
-          site: DmRepositoryReportableSites.pendingDecryptExhausted,
         );
       }
       final pending = await dao.getRetryable(
@@ -2348,11 +2357,10 @@ class DmRepository {
     // Schnorr verifies per wrap were ~47% of main-isolate CPU in on-device
     // profiling of a live DM burst). Only GiftWrapUtil.getRumorEvent accepts
     // a verifier; a test-injected decryptor is used unchanged. If the isolate
-    // is torn down mid-flight (account switch) verifyPart throws StateError —
-    // the parallel-decrypt drain worker catches it and falls through to the
-    // per-event retry queue; the live _handleGiftWrapEvent path catches it
-    // and drops that one wrap, which the switch re-recovers (drain completion
-    // is deferred and the live subscription re-subscribes on switch-back).
+    // is torn down mid-flight (account switch) verifyPart throws StateError.
+    // The parallel-decrypt drain worker falls through to the per-event path,
+    // and the live _handleGiftWrapEvent path records the failed decrypt for
+    // retry as long as the session generation is still current.
     // See #5424.
     if (identical(_rumorDecryptor, GiftWrapUtil.getRumorEvent)) {
       final verifyWorker = await _ensureVerifyIsolate();

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1155,10 +1155,30 @@ class DmRepository {
       // Drop wraps that exhausted the retry cap so the queue cannot grow
       // without bound — a permanently-undecryptable wrap or spammed kind-1059
       // events addressed to the user would otherwise linger forever. See #5202.
-      await dao.deleteExhausted(
+      final abandoned = await dao.deleteExhausted(
         ownerPubkey: pubkey,
         maxAttempts: DmHistoryDrainConfig.maxDecryptRetries,
       );
+      if (abandoned > 0) {
+        // These are inbound DMs the user will never see. The wrap carries no
+        // decryptable sender or conversation, so there is nothing to surface in
+        // the UI — but dropping it with no trace at all made permanent message
+        // loss invisible in triage.
+        Log.warning(
+          'Abandoned $abandoned undecryptable gift wrap(s) for $pubkey after '
+          '${DmHistoryDrainConfig.maxDecryptRetries} attempts; those inbound '
+          'messages are permanently unrecoverable',
+          category: LogCategory.system,
+        );
+        _errorReporter?.call(
+          StateError(
+            'Abandoned $abandoned undecryptable gift wrap(s) after '
+            '${DmHistoryDrainConfig.maxDecryptRetries} attempts',
+          ),
+          StackTrace.current,
+          site: DmRepositoryReportableSites.pendingDecryptExhausted,
+        );
+      }
       final pending = await dao.getRetryable(
         ownerPubkey: pubkey,
         maxAttempts: DmHistoryDrainConfig.maxDecryptRetries,
@@ -1185,9 +1205,23 @@ class DmRepository {
           giftWrapEvent = Event.fromJson(
             jsonDecode(row.rawJson) as Map<String, dynamic>,
           );
-        } on Object {
+        } on Object catch (e, stackTrace) {
           // Corrupt stored JSON — drop it so it cannot loop. We wrote this
-          // JSON ourselves, so a parse failure is a programming invariant.
+          // JSON ourselves, so a parse failure is a programming invariant and
+          // costs the user an inbound message; report it rather than dropping
+          // silently.
+          Log.error(
+            'Corrupt pending gift wrap ${row.giftWrapId} for $pubkey; '
+            'dropping an unrecoverable inbound message',
+            category: LogCategory.system,
+            error: e,
+            stackTrace: stackTrace,
+          );
+          _errorReporter?.call(
+            e,
+            stackTrace,
+            site: DmRepositoryReportableSites.pendingDecryptCorruptPayload,
+          );
           await dao.deletePending(
             giftWrapId: row.giftWrapId,
             ownerPubkey: pubkey,
@@ -1646,6 +1680,14 @@ class DmRepository {
         error: e,
         stackTrace: stackTrace,
       );
+      // A THROWING decrypt must queue for retry exactly like a null return.
+      // Only the null path reached the queue, so a remote-signer (Keycast RPC)
+      // failure that raised — the very case #5202's queue exists for — dropped
+      // the wrap permanently with no retry. Skip when the session moved on:
+      // `recordFailedDecrypt` keys on `_userPubkey`, so queueing under a
+      // switched account would file the wrap against the wrong owner.
+      if (_disposed || _resetGeneration != gen) return;
+      await _persistDecryptedGiftWrap(giftWrapEvent, null);
       return;
     }
 

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1187,6 +1187,18 @@ class DmRepository {
           'messages are permanently unrecoverable',
           category: LogCategory.system,
         );
+        // A local warning is invisible in triage, and permanent inbound-message
+        // loss is exactly what we cannot afford to discover only from user
+        // reports. Bounded on purpose: one report per drain pass carrying the
+        // aggregate count, so a spam burst cannot flood the dashboard.
+        _errorReporter?.call(
+          StateError(
+            'Abandoned $abandoned undecryptable gift wrap(s) after '
+            '${DmHistoryDrainConfig.maxDecryptRetries} attempts',
+          ),
+          StackTrace.current,
+          site: DmRepositoryReportableSites.pendingDecryptExhausted,
+        );
       }
       final pending = await dao.getRetryable(
         ownerPubkey: pubkey,

--- a/mobile/packages/dm_repository/lib/src/dm_repository_reportable_sites.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository_reportable_sites.dart
@@ -67,4 +67,17 @@ abstract class DmRepositoryReportableSites {
   /// invariant failure while paging or processing recovered events.
   static const String historyDrainUnexpectedFailure =
       'historyDrain.unexpectedFailure';
+
+  /// `retryPendingDecryptions`: gift wraps exhausted the decrypt retry cap
+  /// and were deleted. Each one is an inbound DM the user will never see,
+  /// and the wrap carries no decryptable sender or conversation, so there is
+  /// nothing to surface in the UI — this is the only signal that it happened.
+  static const String pendingDecryptExhausted =
+      'retryPendingDecryptions.exhausted';
+
+  /// `retryPendingDecryptions`: a queued gift wrap's stored JSON failed to
+  /// parse. We wrote that JSON ourselves, so this is an invariant violation,
+  /// and it costs the user an inbound message.
+  static const String pendingDecryptCorruptPayload =
+      'retryPendingDecryptions.corruptPayload';
 }

--- a/mobile/packages/dm_repository/lib/src/dm_repository_reportable_sites.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository_reportable_sites.dart
@@ -73,4 +73,17 @@ abstract class DmRepositoryReportableSites {
   /// and it costs the user an inbound message.
   static const String pendingDecryptCorruptPayload =
       'retryPendingDecryptions.corruptPayload';
+
+  /// `retryPendingDecryptions`: gift wraps exhausted the decrypt retry cap
+  /// and were deleted. Each one is an inbound DM the user will never see,
+  /// and the wrap carries no decryptable sender or conversation, so there is
+  /// nothing to surface in the UI — this is the only signal that it happened.
+  ///
+  /// Reported once per drain pass with an aggregate count, never per wrap, so
+  /// a spam burst of undecryptable kind-1059 events costs one event rather
+  /// than one per wrap. After #5202 and the decrypt-retry fix on this branch,
+  /// reaching the cap at all should be exceptional — if this turns out to be
+  /// routine in the dashboard, that is the finding, not noise to suppress.
+  static const String pendingDecryptExhausted =
+      'retryPendingDecryptions.exhausted';
 }

--- a/mobile/packages/dm_repository/lib/src/dm_repository_reportable_sites.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository_reportable_sites.dart
@@ -68,13 +68,6 @@ abstract class DmRepositoryReportableSites {
   static const String historyDrainUnexpectedFailure =
       'historyDrain.unexpectedFailure';
 
-  /// `retryPendingDecryptions`: gift wraps exhausted the decrypt retry cap
-  /// and were deleted. Each one is an inbound DM the user will never see,
-  /// and the wrap carries no decryptable sender or conversation, so there is
-  /// nothing to surface in the UI — this is the only signal that it happened.
-  static const String pendingDecryptExhausted =
-      'retryPendingDecryptions.exhausted';
-
   /// `retryPendingDecryptions`: a queued gift wrap's stored JSON failed to
   /// parse. We wrote that JSON ourselves, so this is an invariant violation,
   /// and it costs the user an inbound message.

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -3033,10 +3033,13 @@ void main() {
       );
 
       test(
-        'reports when gift wraps are abandoned at the decrypt retry cap',
+        'does not report when gift wraps are abandoned at the decrypt '
+        'retry cap',
         () async {
           // These are inbound DMs the user will never see. Dropping them with
-          // no log and no report made permanent message loss invisible.
+          // no log made permanent message loss invisible, but reaching the cap
+          // is an expected outcome for spam or permanently undecryptable wraps,
+          // not a programming invariant.
           final pendingDao = _MockPendingGiftWrapsDao();
           when(
             () => pendingDao.deleteExhausted(
@@ -3054,11 +3057,7 @@ void main() {
           final repository = createRepository(pendingGiftWrapsDao: pendingDao);
           await repository.retryPendingDecryptions();
 
-          expect(reporterCalls, hasLength(1));
-          expect(
-            reporterCalls.single.site,
-            DmRepositoryReportableSites.pendingDecryptExhausted,
-          );
+          expect(reporterCalls, isEmpty);
         },
       );
 
@@ -4711,6 +4710,41 @@ void main() {
         'isHistoryRecoveryComplete is true when no sync state is wired (#5304)',
         () {
           expect(createRepository().isHistoryRecoveryComplete, isTrue);
+        },
+      );
+
+      test(
+        'hasAttemptedHistoryRecovery distinguishes a fresh install from a '
+        'stopped-short drain',
+        () {
+          final fresh = _FakeDmSyncState()
+            ..drainCompleteOverride = false
+            ..drainVersionOverride = 0;
+          expect(
+            createRepository(syncState: fresh).hasAttemptedHistoryRecovery,
+            isFalse,
+          );
+
+          final attempted = _FakeDmSyncState()
+            ..drainCompleteOverride = false
+            ..drainVersionOverride = DmSyncState.currentDrainVersion;
+          expect(
+            createRepository(syncState: attempted).hasAttemptedHistoryRecovery,
+            isTrue,
+          );
+
+          final complete = _FakeDmSyncState()..drainCompleteOverride = true;
+          expect(
+            createRepository(syncState: complete).hasAttemptedHistoryRecovery,
+            isTrue,
+          );
+        },
+      );
+
+      test(
+        'hasAttemptedHistoryRecovery is true when no sync state is wired',
+        () {
+          expect(createRepository().hasAttemptedHistoryRecovery, isTrue);
         },
       );
 

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -3033,13 +3033,15 @@ void main() {
       );
 
       test(
-        'does not report when gift wraps are abandoned at the decrypt '
-        'retry cap',
+        'reports once with an aggregate count when gift wraps are abandoned '
+        'at the decrypt retry cap',
         () async {
-          // These are inbound DMs the user will never see. Dropping them with
-          // no log made permanent message loss invisible, but reaching the cap
-          // is an expected outcome for spam or permanently undecryptable wraps,
-          // not a programming invariant.
+          // These are inbound DMs the user will never see, and the wrap
+          // carries no decryptable sender or conversation, so nothing can be
+          // surfaced in the UI. A local warning is invisible in triage, so
+          // this report is the only signal that permanent message loss
+          // happened. One report per drain pass, not per wrap, so a spam
+          // burst cannot flood the dashboard.
           final pendingDao = _MockPendingGiftWrapsDao();
           when(
             () => pendingDao.deleteExhausted(
@@ -3057,7 +3059,12 @@ void main() {
           final repository = createRepository(pendingGiftWrapsDao: pendingDao);
           await repository.retryPendingDecryptions();
 
-          expect(reporterCalls, isEmpty);
+          expect(reporterCalls, hasLength(1));
+          expect(
+            reporterCalls.single.site,
+            DmRepositoryReportableSites.pendingDecryptExhausted,
+          );
+          expect(reporterCalls.single.error.toString(), contains('3'));
         },
       );
 

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -2978,6 +2978,169 @@ void main() {
         },
       );
 
+      test(
+        'a gift wrap whose decrypt THROWS is queued for retry, not dropped',
+        () async {
+          // Regression: only a null return reached the retry queue. A
+          // decryptor that raised — a remote-signer (Keycast RPC) failure, the
+          // exact case #5202's queue exists for — was logged and dropped, so
+          // that inbound DM was lost permanently with no retry.
+          final giftWrap = createGiftWrapEvent();
+          final pendingDao = _MockPendingGiftWrapsDao();
+
+          when(
+            () => pendingDao.recordFailedDecrypt(
+              giftWrapId: any(named: 'giftWrapId'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              rawJson: any(named: 'rawJson'),
+              createdAt: any(named: 'createdAt'),
+            ),
+          ).thenAnswer((_) async {});
+          when(
+            () => mockDirectMessagesDao.hasGiftWrap(_giftWrapEventId),
+          ).thenAnswer((_) async => false);
+
+          final controller = StreamController<Event>();
+          when(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+            ),
+          ).thenAnswer((_) => controller.stream);
+
+          final repository = createRepository(
+            rumorDecryptor: (_, _) async =>
+                throw StateError('remote signer unavailable'),
+            pendingGiftWrapsDao: pendingDao,
+          );
+
+          await repository.startListening();
+          controller.add(giftWrap);
+          await Future<void>.delayed(Duration.zero);
+
+          verify(
+            () => pendingDao.recordFailedDecrypt(
+              giftWrapId: _giftWrapEventId,
+              ownerPubkey: _validPubkeyA,
+              rawJson: any(named: 'rawJson'),
+              createdAt: 1700000000,
+            ),
+          ).called(1);
+
+          await controller.close();
+          await repository.stopListening();
+        },
+      );
+
+      test(
+        'reports when gift wraps are abandoned at the decrypt retry cap',
+        () async {
+          // These are inbound DMs the user will never see. Dropping them with
+          // no log and no report made permanent message loss invisible.
+          final pendingDao = _MockPendingGiftWrapsDao();
+          when(
+            () => pendingDao.deleteExhausted(
+              ownerPubkey: any(named: 'ownerPubkey'),
+              maxAttempts: any(named: 'maxAttempts'),
+            ),
+          ).thenAnswer((_) async => 3);
+          when(
+            () => pendingDao.getRetryable(
+              ownerPubkey: any(named: 'ownerPubkey'),
+              maxAttempts: any(named: 'maxAttempts'),
+            ),
+          ).thenAnswer((_) async => <PendingGiftWrap>[]);
+
+          final repository = createRepository(pendingGiftWrapsDao: pendingDao);
+          await repository.retryPendingDecryptions();
+
+          expect(reporterCalls, hasLength(1));
+          expect(
+            reporterCalls.single.site,
+            DmRepositoryReportableSites.pendingDecryptExhausted,
+          );
+        },
+      );
+
+      test(
+        'does not report when nothing hit the decrypt retry cap',
+        () async {
+          final pendingDao = _MockPendingGiftWrapsDao();
+          when(
+            () => pendingDao.deleteExhausted(
+              ownerPubkey: any(named: 'ownerPubkey'),
+              maxAttempts: any(named: 'maxAttempts'),
+            ),
+          ).thenAnswer((_) async => 0);
+          when(
+            () => pendingDao.getRetryable(
+              ownerPubkey: any(named: 'ownerPubkey'),
+              maxAttempts: any(named: 'maxAttempts'),
+            ),
+          ).thenAnswer((_) async => <PendingGiftWrap>[]);
+
+          final repository = createRepository(pendingGiftWrapsDao: pendingDao);
+          await repository.retryPendingDecryptions();
+
+          expect(reporterCalls, isEmpty);
+        },
+      );
+
+      test(
+        'reports and drops a pending wrap with corrupt stored JSON',
+        () async {
+          // We wrote that JSON ourselves, so a parse failure is an invariant
+          // violation — and it costs the user an inbound message.
+          final pendingDao = _MockPendingGiftWrapsDao();
+          when(
+            () => pendingDao.deleteExhausted(
+              ownerPubkey: any(named: 'ownerPubkey'),
+              maxAttempts: any(named: 'maxAttempts'),
+            ),
+          ).thenAnswer((_) async => 0);
+          when(
+            () => pendingDao.getRetryable(
+              ownerPubkey: any(named: 'ownerPubkey'),
+              maxAttempts: any(named: 'maxAttempts'),
+            ),
+          ).thenAnswer(
+            (_) async => const [
+              PendingGiftWrap(
+                giftWrapId: _giftWrapEventId,
+                ownerPubkey: _validPubkeyA,
+                rawJson: 'not valid json {{{',
+                createdAt: 1700000000,
+                attempts: 1,
+              ),
+            ],
+          );
+          when(
+            () => pendingDao.deletePending(
+              giftWrapId: any(named: 'giftWrapId'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) async {});
+          when(
+            () => mockDirectMessagesDao.hasGiftWrap(_giftWrapEventId),
+          ).thenAnswer((_) async => false);
+
+          final repository = createRepository(pendingGiftWrapsDao: pendingDao);
+          await repository.retryPendingDecryptions();
+
+          expect(reporterCalls, hasLength(1));
+          expect(
+            reporterCalls.single.site,
+            DmRepositoryReportableSites.pendingDecryptCorruptPayload,
+          );
+          verify(
+            () => pendingDao.deletePending(
+              giftWrapId: _giftWrapEventId,
+              ownerPubkey: _validPubkeyA,
+            ),
+          ).called(1);
+        },
+      );
+
       test('skips events with wrong kind', () async {
         final giftWrap = createGiftWrapEvent();
         // kind 1 instead of kind 14

--- a/mobile/test/blocs/dm/conversation/conversation_bloc_offline_fail_repaint_test.dart
+++ b/mobile/test/blocs/dm/conversation/conversation_bloc_offline_fail_repaint_test.dart
@@ -50,6 +50,8 @@ void main() {
     when(
       () => repo.markConversationAsRead(any()),
     ).thenAnswer((_) async {});
+    // Opening a conversation arms the one-time history drain.
+    when(() => repo.backfillHistoryIfNeeded()).thenAnswer((_) async {});
     // Persisted-message stream stays empty and stable; the outgoing queue
     // drives every tick — exactly the open-conversation scenario in the bug.
     when(

--- a/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
+++ b/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
@@ -105,6 +105,11 @@ void main() {
           rumorId: any(named: 'rumorId'),
         ),
       ).thenAnswer((_) async => 0);
+      // Opening a conversation arms the one-time history drain, same as the
+      // inbox does.
+      when(
+        () => mockDmRepository.backfillHistoryIfNeeded(),
+      ).thenAnswer((_) async {});
     });
 
     ConversationBloc buildBloc() => ConversationBloc(
@@ -159,6 +164,30 @@ void main() {
           verify(
             () => mockDmRepository.watchMessages(conversationId),
           ).called(1);
+        },
+      );
+
+      blocTest<ConversationBloc, ConversationState>(
+        'arms the one-time history drain, so profile -> Message on a '
+        'reinstall does not report an empty thread as complete',
+        setUp: () {
+          when(
+            () => mockDmRepository.markConversationAsRead(conversationId),
+          ).thenAnswer((_) async {});
+          when(
+            () => mockDmRepository.watchMessages(conversationId),
+          ).thenAnswer((_) => const Stream.empty());
+          when(
+            () => mockDmRepository.watchOutgoing(any()),
+          ).thenAnswer((_) => Stream.value(const <OutgoingDm>[]));
+        },
+        build: buildBloc,
+        act: (bloc) => bloc.add(const ConversationStarted()),
+        verify: (_) {
+          // Reaching a thread without passing through Messages must still
+          // stamp hasAttemptedHistoryRecovery, or an empty conversation
+          // claims completeness while history is still on the relay (#4953).
+          verify(() => mockDmRepository.backfillHistoryIfNeeded()).called(1);
         },
       );
 

--- a/mobile/test/blocs/dm/conversation_list/conversation_list_bloc_test.dart
+++ b/mobile/test/blocs/dm/conversation_list/conversation_list_bloc_test.dart
@@ -1237,6 +1237,102 @@ void main() {
             // correctly classified as a request.
             expect(bloc.state.requestConversations, hasLength(1));
             expect(bloc.state.conversations, isEmpty);
+            // …and the gate is no longer costing the user anything.
+            expect(bloc.state.requestsWithheld, isFalse);
+          },
+        );
+
+        blocTest<ConversationListBloc, ConversationListState>(
+          'flags requestsWithheld while the gate hides would-be requests',
+          setUp: () {
+            when(
+              () => mockFollowRepository.isFollowing(any()),
+            ).thenReturn(false);
+            when(() => mockDmRepository.userPubkey).thenReturn(_testPubkey1);
+            _stubStreams(
+              mockDmRepository,
+              potentialRequests: [
+                _createConversation(id: _testConversationId2),
+              ],
+              recoveryComplete: false,
+            );
+          },
+          build: createBloc,
+          act: (bloc) => bloc.add(const ConversationListStarted()),
+          verify: (bloc) {
+            // The user has a real pending request that the gate is hiding.
+            // Before this flag the inbox looked complete: no rows, no banner,
+            // and — on every drain exit that is not a clean exhaustion — no
+            // progress bar either.
+            expect(bloc.state.requestConversations, isEmpty);
+            expect(bloc.state.requestsWithheld, isTrue);
+          },
+        );
+
+        blocTest<ConversationListBloc, ConversationListState>(
+          'does not flag requestsWithheld when the gate hides nothing',
+          setUp: () {
+            when(
+              () => mockFollowRepository.isFollowing(any()),
+            ).thenReturn(false);
+            when(() => mockDmRepository.userPubkey).thenReturn(_testPubkey1);
+            // Gate shut, but there is nothing behind it — no banner is owed.
+            _stubStreams(
+              mockDmRepository,
+              accepted: [
+                _createConversation(
+                  id: _testConversationId1,
+                  currentUserHasSent: true,
+                ),
+              ],
+              recoveryComplete: false,
+            );
+          },
+          build: createBloc,
+          act: (bloc) => bloc.add(const ConversationListStarted()),
+          verify: (bloc) {
+            expect(bloc.state.conversations, hasLength(1));
+            expect(bloc.state.requestsWithheld, isFalse);
+          },
+        );
+
+        blocTest<ConversationListBloc, ConversationListState>(
+          'restore retry re-arms both recovery passes and re-reads the gate',
+          setUp: () {
+            when(
+              () => mockFollowRepository.isFollowing(any()),
+            ).thenReturn(false);
+            when(() => mockDmRepository.userPubkey).thenReturn(_testPubkey1);
+            _stubStreams(
+              mockDmRepository,
+              potentialRequests: [
+                _createConversation(id: _testConversationId2),
+              ],
+              recoveryComplete: false,
+            );
+          },
+          build: createBloc,
+          act: (bloc) async {
+            bloc.add(const ConversationListStarted());
+            await Future<void>.delayed(const Duration(milliseconds: 250));
+            // The drain succeeded this time.
+            when(
+              () => mockDmRepository.isHistoryRecoveryComplete,
+            ).thenReturn(true);
+            bloc.add(const ConversationListRestoreRetryRequested());
+          },
+          wait: const Duration(milliseconds: 400),
+          verify: (bloc) {
+            // Retry re-runs both recovery passes (once from the initial
+            // start, once from the retry) …
+            verify(() => mockDmRepository.backfillHistoryIfNeeded()).called(2);
+            verify(() => mockDmRepository.retryPendingDecryptions()).called(2);
+            // … and the re-read gate releases the held-back request, clearing
+            // the banner. Going through _onStarted matters: the drain returns
+            // without ever touching the recovery stream when it is already
+            // complete, so a stream-only path would leave the banner stuck.
+            expect(bloc.state.requestsWithheld, isFalse);
+            expect(bloc.state.requestConversations, hasLength(1));
           },
         );
       });
@@ -1644,6 +1740,7 @@ void main() {
         const <DmConversation>[],
         true,
         false, // isRestoringHistory
+        false, // requestsWithheld
         ConversationListState.pageSize,
         null,
       ]);

--- a/mobile/test/blocs/dm/restore_status/dm_restore_status_cubit_test.dart
+++ b/mobile/test/blocs/dm/restore_status/dm_restore_status_cubit_test.dart
@@ -1,0 +1,106 @@
+// ABOUTME: Tests for DmRestoreStatusCubit, which publishes app-scoped DM
+// ABOUTME: history-recovery status so an empty view can say "maybe not yet"
+// ABOUTME: instead of asserting a conversation is empty.
+
+import 'dart:async';
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:dm_repository/dm_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/dm/restore_status/dm_restore_status_cubit.dart';
+
+class _MockDmRepository extends Mock implements DmRepository {}
+
+void main() {
+  group(DmRestoreStatusCubit, () {
+    late _MockDmRepository dmRepository;
+
+    setUp(() {
+      dmRepository = _MockDmRepository();
+      when(() => dmRepository.isRecoveringHistory).thenReturn(false);
+      when(() => dmRepository.isHistoryRecoveryComplete).thenReturn(true);
+      when(
+        () => dmRepository.historyRecoveryStream,
+      ).thenAnswer((_) => const Stream<bool>.empty());
+    });
+
+    test('seeds from the repository because the stream does not replay', () {
+      when(() => dmRepository.isRecoveringHistory).thenReturn(true);
+      when(() => dmRepository.isHistoryRecoveryComplete).thenReturn(false);
+
+      final cubit = DmRestoreStatusCubit(dmRepository: dmRepository);
+      addTearDown(cubit.close);
+
+      expect(cubit.state.isRestoring, isTrue);
+      expect(cubit.state.isComplete, isFalse);
+      expect(cubit.state.mayBeIncomplete, isTrue);
+    });
+
+    test('a settled repository reports nothing outstanding', () {
+      final cubit = DmRestoreStatusCubit(dmRepository: dmRepository);
+      addTearDown(cubit.close);
+
+      expect(cubit.state.mayBeIncomplete, isFalse);
+    });
+
+    blocTest<DmRestoreStatusCubit, DmRestoreStatusState>(
+      'a drain that stops without completing still reports outstanding work',
+      setUp: () {
+        // The exact desync this exists for: every drain exit that is not a
+        // clean exhaustion — page cap, exception, no connected relay — ends
+        // the running flag while leaving the persisted flag false.
+        when(() => dmRepository.isRecoveringHistory).thenReturn(true);
+        when(() => dmRepository.isHistoryRecoveryComplete).thenReturn(false);
+        when(
+          () => dmRepository.historyRecoveryStream,
+        ).thenAnswer((_) => Stream<bool>.value(false));
+      },
+      build: () => DmRestoreStatusCubit(dmRepository: dmRepository),
+      wait: const Duration(milliseconds: 50),
+      verify: (cubit) {
+        expect(cubit.state.isRestoring, isFalse);
+        expect(cubit.state.isComplete, isFalse);
+        expect(cubit.state.mayBeIncomplete, isTrue);
+      },
+    );
+
+    blocTest<DmRestoreStatusCubit, DmRestoreStatusState>(
+      're-reads the persisted flag on every recovery tick',
+      setUp: () {
+        when(() => dmRepository.isRecoveringHistory).thenReturn(true);
+        when(() => dmRepository.isHistoryRecoveryComplete).thenReturn(false);
+        final controller = StreamController<bool>();
+        when(
+          () => dmRepository.historyRecoveryStream,
+        ).thenAnswer((_) => controller.stream);
+        Future<void>.delayed(const Duration(milliseconds: 20)).then((_) {
+          when(
+            () => dmRepository.isHistoryRecoveryComplete,
+          ).thenReturn(true);
+          controller.add(false);
+        });
+      },
+      build: () => DmRestoreStatusCubit(dmRepository: dmRepository),
+      wait: const Duration(milliseconds: 100),
+      verify: (cubit) {
+        expect(cubit.state.mayBeIncomplete, isFalse);
+      },
+    );
+
+    test('cancels its subscription on close', () async {
+      final controller = StreamController<bool>();
+      when(
+        () => dmRepository.historyRecoveryStream,
+      ).thenAnswer((_) => controller.stream);
+
+      final cubit = DmRestoreStatusCubit(dmRepository: dmRepository);
+      expect(controller.hasListener, isTrue);
+
+      await cubit.close();
+
+      expect(controller.hasListener, isFalse);
+      await controller.close();
+    });
+  });
+}

--- a/mobile/test/blocs/dm/restore_status/dm_restore_status_cubit_test.dart
+++ b/mobile/test/blocs/dm/restore_status/dm_restore_status_cubit_test.dart
@@ -19,6 +19,7 @@ void main() {
     setUp(() {
       dmRepository = _MockDmRepository();
       when(() => dmRepository.isRecoveringHistory).thenReturn(false);
+      when(() => dmRepository.hasAttemptedHistoryRecovery).thenReturn(false);
       when(() => dmRepository.isHistoryRecoveryComplete).thenReturn(true);
       when(
         () => dmRepository.historyRecoveryStream,
@@ -27,6 +28,7 @@ void main() {
 
     test('seeds from the repository because the stream does not replay', () {
       when(() => dmRepository.isRecoveringHistory).thenReturn(true);
+      when(() => dmRepository.hasAttemptedHistoryRecovery).thenReturn(true);
       when(() => dmRepository.isHistoryRecoveryComplete).thenReturn(false);
 
       final cubit = DmRestoreStatusCubit(dmRepository: dmRepository);
@@ -37,7 +39,21 @@ void main() {
       expect(cubit.state.mayBeIncomplete, isTrue);
     });
 
+    test(
+      'a fresh repository reports nothing outstanding before a drain runs',
+      () {
+        when(() => dmRepository.isHistoryRecoveryComplete).thenReturn(false);
+
+        final cubit = DmRestoreStatusCubit(dmRepository: dmRepository);
+        addTearDown(cubit.close);
+
+        expect(cubit.state.mayBeIncomplete, isFalse);
+      },
+    );
+
     test('a settled repository reports nothing outstanding', () {
+      when(() => dmRepository.hasAttemptedHistoryRecovery).thenReturn(true);
+
       final cubit = DmRestoreStatusCubit(dmRepository: dmRepository);
       addTearDown(cubit.close);
 
@@ -51,6 +67,7 @@ void main() {
         // clean exhaustion — page cap, exception, no connected relay — ends
         // the running flag while leaving the persisted flag false.
         when(() => dmRepository.isRecoveringHistory).thenReturn(true);
+        when(() => dmRepository.hasAttemptedHistoryRecovery).thenReturn(true);
         when(() => dmRepository.isHistoryRecoveryComplete).thenReturn(false);
         when(
           () => dmRepository.historyRecoveryStream,
@@ -60,6 +77,7 @@ void main() {
       wait: const Duration(milliseconds: 50),
       verify: (cubit) {
         expect(cubit.state.isRestoring, isFalse);
+        expect(cubit.state.hasAttempted, isTrue);
         expect(cubit.state.isComplete, isFalse);
         expect(cubit.state.mayBeIncomplete, isTrue);
       },
@@ -69,15 +87,15 @@ void main() {
       're-reads the persisted flag on every recovery tick',
       setUp: () {
         when(() => dmRepository.isRecoveringHistory).thenReturn(true);
+        when(() => dmRepository.hasAttemptedHistoryRecovery).thenReturn(true);
         when(() => dmRepository.isHistoryRecoveryComplete).thenReturn(false);
         final controller = StreamController<bool>();
         when(
           () => dmRepository.historyRecoveryStream,
         ).thenAnswer((_) => controller.stream);
         Future<void>.delayed(const Duration(milliseconds: 20)).then((_) {
-          when(
-            () => dmRepository.isHistoryRecoveryComplete,
-          ).thenReturn(true);
+          when(() => dmRepository.isHistoryRecoveryComplete).thenReturn(true);
+          when(() => dmRepository.hasAttemptedHistoryRecovery).thenReturn(true);
           controller.add(false);
         });
       },

--- a/mobile/test/router/app_router_test.dart
+++ b/mobile/test/router/app_router_test.dart
@@ -508,6 +508,12 @@ void main() {
       when(
         () => mockDmRepository.getConversation(any()),
       ).thenAnswer((_) async => null);
+      // Consumed by DmRestoreStatusCubit, which qualifies the empty state.
+      when(() => mockDmRepository.isRecoveringHistory).thenReturn(false);
+      when(() => mockDmRepository.isHistoryRecoveryComplete).thenReturn(true);
+      when(
+        () => mockDmRepository.historyRecoveryStream,
+      ).thenAnswer((_) => const Stream<bool>.empty());
 
       when(
         () => mockDmReactionsRepository.watchForConversation(any()),

--- a/mobile/test/router/app_router_test.dart
+++ b/mobile/test/router/app_router_test.dart
@@ -510,6 +510,7 @@ void main() {
       ).thenAnswer((_) async => null);
       // Consumed by DmRestoreStatusCubit, which qualifies the empty state.
       when(() => mockDmRepository.isRecoveringHistory).thenReturn(false);
+      when(() => mockDmRepository.hasAttemptedHistoryRecovery).thenReturn(true);
       when(() => mockDmRepository.isHistoryRecoveryComplete).thenReturn(true);
       when(
         () => mockDmRepository.historyRecoveryStream,

--- a/mobile/test/router/app_router_test.dart
+++ b/mobile/test/router/app_router_test.dart
@@ -493,6 +493,7 @@ void main() {
         () => mockAuthService.authStateStream,
       ).thenAnswer((_) => const Stream<AuthState>.empty());
 
+      when(mockDmRepository.backfillHistoryIfNeeded).thenAnswer((_) async {});
       when(
         () => mockDmRepository.markConversationAsRead(any()),
       ).thenAnswer((_) async {});

--- a/mobile/test/screens/inbox/conversation/conversation_page_repo_swap_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_page_repo_swap_test.dart
@@ -78,6 +78,7 @@ void main() {
       // Stub both mocks so the bloc can run without throwing.
       for (final repo in [mockRepoA, mockRepoB]) {
         when(() => repo.markConversationAsRead(any())).thenAnswer((_) async {});
+        when(repo.backfillHistoryIfNeeded).thenAnswer((_) async {});
         when(
           () => repo.watchMessages(any()),
         ).thenAnswer((_) => const Stream<List<DmMessage>>.empty());
@@ -290,6 +291,9 @@ void main() {
       mockResponseSvcA = _MockCollaboratorResponseService();
       mockResponseSvcB = _MockCollaboratorResponseService();
 
+      when(
+        () => mockDmRepository.backfillHistoryIfNeeded(),
+      ).thenAnswer((_) async {});
       when(
         () => mockDmRepository.markConversationAsRead(any()),
       ).thenAnswer((_) async {});

--- a/mobile/test/screens/inbox/conversation/conversation_page_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_page_test.dart
@@ -47,6 +47,7 @@ void main() {
       ).thenAnswer((_) => Stream.value(const <OutgoingDm>[]));
       // Consumed by DmRestoreStatusCubit, which qualifies the empty state.
       when(() => mockDmRepository.isRecoveringHistory).thenReturn(false);
+      when(() => mockDmRepository.hasAttemptedHistoryRecovery).thenReturn(true);
       when(
         () => mockDmRepository.isHistoryRecoveryComplete,
       ).thenReturn(true);

--- a/mobile/test/screens/inbox/conversation/conversation_page_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_page_test.dart
@@ -45,6 +45,14 @@ void main() {
       when(
         () => mockDmRepository.watchOutgoing(any()),
       ).thenAnswer((_) => Stream.value(const <OutgoingDm>[]));
+      // Consumed by DmRestoreStatusCubit, which qualifies the empty state.
+      when(() => mockDmRepository.isRecoveringHistory).thenReturn(false);
+      when(
+        () => mockDmRepository.isHistoryRecoveryComplete,
+      ).thenReturn(true);
+      when(
+        () => mockDmRepository.historyRecoveryStream,
+      ).thenAnswer((_) => const Stream<bool>.empty());
 
       when(() => mockAuthService.currentPublicKeyHex).thenReturn(testPubkey);
       when(() => mockAuthService.isAuthenticated).thenReturn(true);

--- a/mobile/test/screens/inbox/conversation/conversation_page_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_page_test.dart
@@ -37,6 +37,9 @@ void main() {
       mockAuthService = _MockAuthService();
 
       when(
+        () => mockDmRepository.backfillHistoryIfNeeded(),
+      ).thenAnswer((_) async {});
+      when(
         () => mockDmRepository.markConversationAsRead(any()),
       ).thenAnswer((_) async {});
       when(

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -18,6 +18,7 @@ import 'package:models/models.dart';
 import 'package:openvine/blocs/dm/conversation/collaborator_invite_actions_cubit.dart';
 import 'package:openvine/blocs/dm/conversation/conversation_bloc.dart';
 import 'package:openvine/blocs/dm/reactions/conversation_reactions_cubit.dart';
+import 'package:openvine/blocs/dm/restore_status/dm_restore_status_cubit.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/collaborator_invite.dart';
 import 'package:openvine/providers/app_providers.dart';
@@ -45,6 +46,9 @@ class _MockCollaboratorInviteActionsCubit
 class _MockConversationReactionsCubit
     extends MockBloc<ConversationReactionsEvent, ConversationReactionsState>
     implements ConversationReactionsCubit {}
+
+class _MockDmRestoreStatusCubit extends MockCubit<DmRestoreStatusState>
+    implements DmRestoreStatusCubit {}
 
 class _MockVideosRepository extends Mock implements VideosRepository {}
 
@@ -85,6 +89,7 @@ void main() {
     late _MockConversationBloc mockBloc;
     late _MockCollaboratorInviteActionsCubit mockInviteActionsCubit;
     late _MockConversationReactionsCubit mockReactionsCubit;
+    late _MockDmRestoreStatusCubit mockRestoreStatusCubit;
     late _MockVideosRepository mockVideosRepository;
     late _MockWatermarkDownloadService mockWatermarkDownloadService;
     late MockNostrClient mockNostrClient;
@@ -123,6 +128,13 @@ void main() {
       when(() => mockBloc.isClosed).thenReturn(false);
       mockInviteActionsCubit = _MockCollaboratorInviteActionsCubit();
       mockReactionsCubit = _MockConversationReactionsCubit();
+      mockRestoreStatusCubit = _MockDmRestoreStatusCubit();
+      // Default: recovery finished, so the empty state stays unqualified.
+      whenListen(
+        mockRestoreStatusCubit,
+        const Stream<DmRestoreStatusState>.empty(),
+        initialState: const DmRestoreStatusState(),
+      );
       mockVideosRepository = _MockVideosRepository();
       mockWatermarkDownloadService = _MockWatermarkDownloadService();
       mockNostrClient = createMockNostrService();
@@ -162,8 +174,16 @@ void main() {
       ConversationState? state,
       UserProfile? otherProfile,
       MockGoRouter? goRouter,
+      DmRestoreStatusState? restoreStatus,
     }) {
       final effectiveState = state ?? const ConversationState();
+      if (restoreStatus != null) {
+        whenListen(
+          mockRestoreStatusCubit,
+          Stream<DmRestoreStatusState>.value(restoreStatus),
+          initialState: restoreStatus,
+        );
+      }
       whenListen(
         mockBloc,
         Stream<ConversationState>.value(effectiveState),
@@ -192,8 +212,11 @@ void main() {
             value: mockInviteActionsCubit,
             child: BlocProvider<ConversationReactionsCubit>.value(
               value: mockReactionsCubit,
-              child: const ConversationView(
-                participantPubkeys: [otherPubkey],
+              child: BlocProvider<DmRestoreStatusCubit>.value(
+                value: mockRestoreStatusCubit,
+                child: const ConversationView(
+                  participantPubkeys: [otherPubkey],
+                ),
               ),
             ),
           ),
@@ -375,6 +398,50 @@ void main() {
 
         expect(find.byType(EmptyConversation), findsOneWidget);
       });
+
+      testWidgets(
+        'empty conversation stays unqualified when recovery is complete',
+        (tester) async {
+          // The genuinely-new thread (FAB, following bar, profile Message) must
+          // keep reading as a clean profile card, not as a degraded state.
+          await tester.pumpWidget(
+            buildSubject(
+              state: const ConversationState(status: ConversationStatus.loaded),
+              restoreStatus: const DmRestoreStatusState(),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          final l10n = lookupAppLocalizations(const Locale('en'));
+          expect(find.byType(EmptyConversation), findsOneWidget);
+          expect(find.text(l10n.inboxRestorePausedTitle), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'empty conversation is qualified while history recovery is unfinished',
+        (tester) async {
+          // watchMessages is a local DB projection, so an unsynced thread hits
+          // `loaded` with zero rows and looks identical to a brand-new one.
+          // Recovery status is the only signal that distinguishes them.
+          await tester.pumpWidget(
+            buildSubject(
+              state: const ConversationState(status: ConversationStatus.loaded),
+              restoreStatus: const DmRestoreStatusState(isComplete: false),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          final l10n = lookupAppLocalizations(const Locale('en'));
+          expect(find.text(l10n.inboxRestorePausedTitle), findsOneWidget);
+          // The profile card survives intact alongside the qualifier.
+          expect(find.byType(EmptyConversation), findsOneWidget);
+          expect(
+            find.text(l10n.inboxConversationViewProfileButton),
+            findsOneWidget,
+          );
+        },
+      );
 
       testWidgets('renders $MessageBubble when loaded with messages', (
         tester,
@@ -900,8 +967,11 @@ void main() {
                 value: mockBloc,
                 child: BlocProvider<CollaboratorInviteActionsCubit>.value(
                   value: mockInviteActionsCubit,
-                  child: const ConversationView(
-                    participantPubkeys: [otherPubkey],
+                  child: BlocProvider<DmRestoreStatusCubit>.value(
+                    value: mockRestoreStatusCubit,
+                    child: const ConversationView(
+                      participantPubkeys: [otherPubkey],
+                    ),
                   ),
                 ),
               ),
@@ -948,8 +1018,11 @@ void main() {
                 value: mockBloc,
                 child: BlocProvider<CollaboratorInviteActionsCubit>.value(
                   value: mockInviteActionsCubit,
-                  child: const ConversationView(
-                    participantPubkeys: [otherPubkey],
+                  child: BlocProvider<DmRestoreStatusCubit>.value(
+                    value: mockRestoreStatusCubit,
+                    child: const ConversationView(
+                      participantPubkeys: [otherPubkey],
+                    ),
                   ),
                 ),
               ),
@@ -1012,8 +1085,11 @@ void main() {
                   value: mockInviteActionsCubit,
                   child: BlocProvider<ConversationReactionsCubit>.value(
                     value: mockReactionsCubit,
-                    child: const ConversationView(
-                      participantPubkeys: [otherPubkey],
+                    child: BlocProvider<DmRestoreStatusCubit>.value(
+                      value: mockRestoreStatusCubit,
+                      child: const ConversationView(
+                        participantPubkeys: [otherPubkey],
+                      ),
                     ),
                   ),
                 ),
@@ -1156,8 +1232,11 @@ void main() {
                   value: mockInviteActionsCubit,
                   child: BlocProvider<ConversationReactionsCubit>.value(
                     value: mockReactionsCubit,
-                    child: const ConversationView(
-                      participantPubkeys: [otherPubkey],
+                    child: BlocProvider<DmRestoreStatusCubit>.value(
+                      value: mockRestoreStatusCubit,
+                      child: const ConversationView(
+                        participantPubkeys: [otherPubkey],
+                      ),
                     ),
                   ),
                 ),
@@ -1274,8 +1353,11 @@ void main() {
                   value: mockInviteActionsCubit,
                   child: BlocProvider<ConversationReactionsCubit>.value(
                     value: mockReactionsCubit,
-                    child: const ConversationView(
-                      participantPubkeys: [otherPubkey],
+                    child: BlocProvider<DmRestoreStatusCubit>.value(
+                      value: mockRestoreStatusCubit,
+                      child: const ConversationView(
+                        participantPubkeys: [otherPubkey],
+                      ),
                     ),
                   ),
                 ),
@@ -1347,8 +1429,11 @@ void main() {
                 value: mockBloc,
                 child: BlocProvider<CollaboratorInviteActionsCubit>.value(
                   value: mockInviteActionsCubit,
-                  child: const ConversationView(
-                    participantPubkeys: [otherPubkey],
+                  child: BlocProvider<DmRestoreStatusCubit>.value(
+                    value: mockRestoreStatusCubit,
+                    child: const ConversationView(
+                      participantPubkeys: [otherPubkey],
+                    ),
                   ),
                 ),
               ),
@@ -1402,8 +1487,11 @@ void main() {
                 value: mockBloc,
                 child: BlocProvider<CollaboratorInviteActionsCubit>.value(
                   value: mockInviteActionsCubit,
-                  child: const ConversationView(
-                    participantPubkeys: [otherPubkey],
+                  child: BlocProvider<DmRestoreStatusCubit>.value(
+                    value: mockRestoreStatusCubit,
+                    child: const ConversationView(
+                      participantPubkeys: [otherPubkey],
+                    ),
                   ),
                 ),
               ),

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -414,7 +414,10 @@ void main() {
 
           final l10n = lookupAppLocalizations(const Locale('en'));
           expect(find.byType(EmptyConversation), findsOneWidget);
-          expect(find.text(l10n.inboxRestorePausedTitle), findsNothing);
+          expect(
+            find.text(l10n.conversationRestorePausedTitle),
+            findsNothing,
+          );
         },
       );
 
@@ -427,18 +430,44 @@ void main() {
           await tester.pumpWidget(
             buildSubject(
               state: const ConversationState(status: ConversationStatus.loaded),
+              restoreStatus: const DmRestoreStatusState(
+                hasAttempted: true,
+                isComplete: false,
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          final l10n = lookupAppLocalizations(const Locale('en'));
+          expect(
+            find.text(l10n.conversationRestorePausedTitle),
+            findsOneWidget,
+          );
+          // The profile card survives intact alongside the qualifier.
+          expect(find.byType(EmptyConversation), findsOneWidget);
+          expect(
+            find.text(l10n.inboxConversationViewProfileButton),
+            findsOneWidget,
+          );
+        },
+      );
+
+      testWidgets(
+        'empty conversation stays unqualified before recovery has been attempted',
+        (tester) async {
+          await tester.pumpWidget(
+            buildSubject(
+              state: const ConversationState(status: ConversationStatus.loaded),
               restoreStatus: const DmRestoreStatusState(isComplete: false),
             ),
           );
           await tester.pumpAndSettle();
 
           final l10n = lookupAppLocalizations(const Locale('en'));
-          expect(find.text(l10n.inboxRestorePausedTitle), findsOneWidget);
-          // The profile card survives intact alongside the qualifier.
           expect(find.byType(EmptyConversation), findsOneWidget);
           expect(
-            find.text(l10n.inboxConversationViewProfileButton),
-            findsOneWidget,
+            find.text(l10n.conversationRestorePausedTitle),
+            findsNothing,
           );
         },
       );

--- a/mobile/test/screens/inbox/inbox_view_test.dart
+++ b/mobile/test/screens/inbox/inbox_view_test.dart
@@ -31,6 +31,7 @@ import 'package:openvine/screens/inbox/widgets/inbox_empty_state.dart';
 import 'package:openvine/screens/inbox/widgets/inbox_error_state.dart';
 import 'package:openvine/screens/inbox/widgets/inbox_fab.dart';
 import 'package:openvine/screens/inbox/widgets/inbox_segmented_toggle.dart';
+import 'package:openvine/screens/inbox/widgets/restore_paused_banner.dart';
 import 'package:openvine/screens/inbox/widgets/unread_filter_chips.dart';
 import 'package:openvine/services/auth_service.dart' hide UserProfile;
 
@@ -1069,6 +1070,74 @@ void main() {
           expect(find.byType(LinearProgressIndicator), findsNothing);
         },
       );
+
+      testWidgets(
+        'shows the restore-paused banner when requests are withheld',
+        (tester) async {
+          // The gate can stay shut with no drain running (page cap, exception,
+          // no connected relay), so isRestoringHistory alone left the user with
+          // an inbox that looked complete while requests were hidden.
+          await tester.pumpWidget(
+            buildSubject(
+              state: const ConversationListState(
+                status: ConversationListStatus.loaded,
+                requestsWithheld: true,
+              ),
+            ),
+          );
+          await tester.pump();
+
+          await tester.tap(find.text('Messages'));
+          await tester.pumpAndSettle();
+
+          expect(find.byType(RestorePausedBanner), findsOneWidget);
+          // Static, not a progress bar: nothing is actually running.
+          expect(find.byType(LinearProgressIndicator), findsNothing);
+        },
+      );
+
+      testWidgets('hides the restore-paused banner when nothing is withheld', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildSubject(
+            state: const ConversationListState(
+              status: ConversationListStatus.loaded,
+            ),
+          ),
+        );
+        await tester.pump();
+
+        await tester.tap(find.text('Messages'));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(RestorePausedBanner), findsNothing);
+      });
+
+      testWidgets('restore-paused banner Retry dispatches the retry event', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildSubject(
+            state: const ConversationListState(
+              status: ConversationListStatus.loaded,
+              requestsWithheld: true,
+            ),
+          ),
+        );
+        await tester.pump();
+
+        await tester.tap(find.text('Messages'));
+        await tester.pumpAndSettle();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.tap(find.text(l10n.inboxRestoreRetryAction));
+        await tester.pumpAndSettle();
+
+        verify(
+          () => mockBloc.add(const ConversationListRestoreRetryRequested()),
+        ).called(1);
+      });
     });
 
     group('navigation', () {

--- a/mobile/test/screens/inbox/inbox_view_test.dart
+++ b/mobile/test/screens/inbox/inbox_view_test.dart
@@ -1096,6 +1096,29 @@ void main() {
         },
       );
 
+      testWidgets(
+        'hides the restore-paused banner while recovery is actively running',
+        (tester) async {
+          await tester.pumpWidget(
+            buildSubject(
+              state: const ConversationListState(
+                status: ConversationListStatus.loaded,
+                isRestoringHistory: true,
+                requestsWithheld: true,
+              ),
+            ),
+          );
+          await tester.pump();
+
+          await tester.tap(find.text('Messages'));
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 350));
+
+          expect(find.byType(RestorePausedBanner), findsNothing);
+          expect(find.byType(LinearProgressIndicator), findsOneWidget);
+        },
+      );
+
       testWidgets('hides the restore-paused banner when nothing is withheld', (
         tester,
       ) async {

--- a/mobile/test/screens/inbox/message_requests/message_requests_view_test.dart
+++ b/mobile/test/screens/inbox/message_requests/message_requests_view_test.dart
@@ -10,11 +10,13 @@ import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/dm/conversation_list/conversation_list_bloc.dart';
 import 'package:openvine/blocs/dm/message_requests/message_request_actions_cubit.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/router/app_router.dart';
 import 'package:openvine/screens/inbox/message_requests/message_requests_view.dart';
 import 'package:openvine/screens/inbox/message_requests/request_preview_page.dart';
 import 'package:openvine/screens/inbox/message_requests/widgets/request_tile.dart';
+import 'package:openvine/screens/inbox/widgets/restore_paused_banner.dart';
 import 'package:openvine/services/auth_service.dart' hide UserProfile;
 
 import '../../../helpers/go_router.dart';
@@ -125,6 +127,65 @@ void main() {
         await tester.pump();
 
         expect(find.text('No message requests'), findsOneWidget);
+      });
+
+      testWidgets(
+        'renders restore progress when requests are withheld during recovery',
+        (tester) async {
+          await tester.pumpWidget(
+            buildSubject(
+              state: const ConversationListState(
+                status: ConversationListStatus.loaded,
+                isRestoringHistory: true,
+                requestsWithheld: true,
+              ),
+            ),
+          );
+          await tester.pump();
+
+          expect(find.byType(CircularProgressIndicator), findsOneWidget);
+          expect(find.text('No message requests'), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'renders restore-paused banner when requests are withheld after recovery stops',
+        (tester) async {
+          await tester.pumpWidget(
+            buildSubject(
+              state: const ConversationListState(
+                status: ConversationListStatus.loaded,
+                requestsWithheld: true,
+              ),
+            ),
+          );
+          await tester.pump();
+
+          expect(find.byType(RestorePausedBanner), findsOneWidget);
+          expect(find.text('No message requests'), findsNothing);
+        },
+      );
+
+      testWidgets('restore-paused Retry dispatches the retry event', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildSubject(
+            state: const ConversationListState(
+              status: ConversationListStatus.loaded,
+              requestsWithheld: true,
+            ),
+          ),
+        );
+        await tester.pump();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.tap(find.text(l10n.inboxRestoreRetryAction));
+        await tester.pumpAndSettle();
+
+        verify(
+          () => mockBloc.add(const ConversationListRestoreRetryRequested()),
+        ).called(1);
       });
 
       testWidgets('renders $RequestTile when loaded with requests', (

--- a/mobile/test/screens/other_profile_screen_test.dart
+++ b/mobile/test/screens/other_profile_screen_test.dart
@@ -8,11 +8,13 @@ import 'package:comments_repository/comments_repository.dart';
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:content_policy/content_policy.dart';
 import 'package:divine_ui/divine_ui.dart';
+import 'package:dm_repository/dm_repository.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/legacy.dart' show StateProvider;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:likes_repository/likes_repository.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
@@ -414,4 +416,65 @@ void main() {
       ).called(1);
     },
   );
+
+  testWidgets('Message routes to the canonical conversation id', (
+    tester,
+  ) async {
+    // Regression: this screen pushed `pathForId(widget.pubkey)` — the raw peer
+    // pubkey — while every other entry point and `DmRepository.sendMessage`
+    // use the sha256 of the sorted participants. Both are 64-char hex, so
+    // nothing caught the mismatch: the thread's id matched no stored row, so
+    // history never rendered and messages sent from it never appeared.
+    final restrictedProvider = StateProvider<bool>((ref) => false);
+    final container = createContainer(restrictedProvider);
+    addTearDown(container.dispose);
+
+    String? pushedId;
+    final router = GoRouter(
+      initialLocation: '/',
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (_, _) => MultiBlocProvider(
+            providers: [
+              BlocProvider<OtherProfileBloc>.value(value: otherProfileBloc),
+              BlocProvider<PeopleListsBloc>.value(value: peopleListsBloc),
+            ],
+            child: const OtherProfileView(pubkey: targetPubkey),
+          ),
+        ),
+        GoRoute(
+          path: '/inbox/conversation/:id',
+          builder: (_, state) {
+            pushedId = state.pathParameters['id'];
+            return const Scaffold(body: SizedBox.shrink());
+          },
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp.router(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          theme: VineTheme.theme,
+          routerConfig: router,
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final l10n = lookupAppLocalizations(const Locale('en'));
+    await tester.tap(find.text(l10n.profileMessageLabel));
+    await tester.pumpAndSettle();
+
+    expect(
+      pushedId,
+      DmRepository.computeConversationId([viewerPubkey, targetPubkey]),
+    );
+    expect(pushedId, isNot(targetPubkey));
+  });
 }


### PR DESCRIPTION
## Description

**Related Issue:** Closes #6433

Four defects where the DM UI renders a confident empty state while data is absent, still in flight, or permanently lost. Same class of bug — the UI asserts "there is nothing here" when it does not actually know that — so they ship together. One commit each.

### 1. Message requests silently blanked (`fix(dm): surface message requests held back by the recovery gate`)

The #5304 gate hides would-be message requests until the history drain completes. That hold-back is intentional. The defect is that its only user-visible affordance is driven by a **different signal**: the restore progress bar reads `isRestoringHistory` (`_activeRecoveryOps > 0`), while the gate reads the persisted `historyDrainComplete`.

`_endRecovery()` runs in a `finally` on **every** drain exit; `markHistoryDrainComplete` runs on exactly **one** — clean exhaustion. So on five paths the bar goes off while the gate stays shut:

| `dm_repository.dart` | Condition |
|---|---|
| `:1326` | page fetch returned null (silent — no log) |
| `:1337-1343` | empty page with zero connected relays |
| `:1391-1398` | exhausted, but the outgoing-NIP-04 pass could not reach a relay |
| `:1399-1409` | page cap (50) reached |
| `:1411-1427` | any exception |

`retryPendingDecryptions` drives the same counter independently, which is a second desync source.

The user then saw an inbox that looked complete: no request rows, no banner (it is gated on `requestConversations` being non-empty), `requestUnreadCount` reading zero, no progress bar, no spinner — while real pending DMs stayed hidden until some later inbox open happened to complete the drain.

New `requestsWithheld` tracks the gate itself, and only when it is actually holding something back, so a shut gate with nothing behind it stays silent. It drives a static banner — deliberately not a progress bar, since on these paths nothing is running — whose Retry re-enters `_onStarted`. Routing through the stream rather than awaiting the drain matters: the drain returns early without touching the recovery stream when it is uninitialized or already complete, so a listener-only retry could leave the banner with nothing to clear it.

The banner mounts as a sibling of the list content, so it covers every layout branch without threading a flag through each or shifting the sliver banner offsets. The existing progress bar is untouched and still owns the genuinely-in-flight case.

### 2. Thread claims "no messages" while still syncing (`fix(dm): stop asserting a conversation is empty while it may still be syncing`)

`ConversationBloc` projects two **local drift streams** and sets `loaded` on the first tick. For an unsynced thread that tick is `([], [])`, so the view renders the "no messages" profile card — visually identical to a genuinely new conversation. Worst right after a reinstall and on remote-signer accounts, where every gift-wrap decrypt is a network round trip.

Nothing local distinguishes the two: conversation rows are only ever written in the same transaction as a message insert, so "row exists" implies "has messages"; and the pending-gift-wrap queue carries no conversation id, because an undecrypted wrap's conversation is unknowable.

So this qualifies the card using the app-scoped recovery signals instead of inventing per-conversation sync state. `DmRestoreStatusCubit` publishes them, seeded from the repository because `historyRecoveryStream` does not replay, and re-reading the persisted flag on every tick so a drain that stopped short still reports outstanding work.

It is a **sibling** of `ConversationBloc`, not a third stream in its `combineLatest` — that bloc's emission sequence and mark-as-read call counts are pinned by four tests, and recovery status is app-scoped rather than per-conversation. Those four tests needed zero changes.

`EmptyConversation` keeps its avatar, name, NIP-05 and View profile button unchanged and gains one optional trailing line, defaulting off, so the three genuinely-empty entry points still read as a clean profile card.

### 3. Inbound DMs lost on the receive path (`fix(dm): stop losing inbound DMs on the decrypt-retry path`)

- **A throwing decrypt never reached the retry queue.** Only a `null` return was queued, so a remote-signer failure that *raised* — the exact case #5202's queue exists for — dropped the wrap permanently with no retry. It now takes the same queueing path, guarded on the session generation so a switched account cannot file the wrap under the wrong owner.
- **`deleteExhausted`'s row count was discarded.** Wraps abandoned at the cap are inbound DMs the user will never see; the count is now logged and reported.
- **Corrupt stored JSON was dropped inside a bare catch with no log at all.** We wrote that JSON ourselves, so a parse failure is an invariant violation; now logged and reported.

No UI surface: a pending row carries neither sender nor conversation (the wrap is still encrypted), so an undecryptable message cannot be attributed to a thread or rendered as a placeholder.

### 4. Profile "Message" opened a permanently empty thread (`fix(dm): route profile Message to the canonical conversation id`)

`OtherProfileView` pushed `pathForId(widget.pubkey)` — the **raw peer pubkey** — while every other entry point and `DmRepository.sendMessage` use `computeConversationId([self, peer])` (sha256 of the sorted participants). Both are 64-char hex, so nothing caught the mismatch.

The route id therefore matched no persisted row: opening DMs from a profile showed an empty conversation **even with full history**, and messages sent from that screen were enqueued under the canonical id, so they never appeared in the thread either.

## Out of Scope

- No per-conversation sync/EOSE plumbing. `NostrClient.subscribe` supports `onEose` but `DmRepository.startListening` never passes it and the subscription handle is private; wiring that up is a larger change than these fixes warrant, and the app-scoped signals cover the reported symptom.
- No UI for undecryptable messages (see #3 — unattributable by construction).
- `maxDecryptRetries` (10) is unchanged; this PR makes the give-up observable, it does not retune it.

## Verification

- `flutter analyze lib test integration_test` — clean
- `flutter test` (full mobile suite)
- `flutter test --coverage` in `packages/dm_repository` — 538 passing, 93.82% vs the package's `min_coverage: 93`
- `flutter test test/l10n/arb_consistency_test.dart` — both new keys mirrored into all 18 `app_*.arb` locales
- All four design-system ratchets (`raw_textstyle`, `raw_colors`, `material_button`, `raw_dialog`), plus `untested_services_floor` and `test_unit_structure` — no growth

New regression tests, each verified to fail against the pre-fix code:

| Area | Test |
|---|---|
| Bug 1 | `requestsWithheld` true when the gate hides real requests; false when it hides nothing; false once recovery completes; retry re-arms both passes and re-reads the gate |
| Bug 1 | Banner renders/hides on the flag; Retry dispatches the event |
| Bug 2 | Cubit seeds from the repository, reports outstanding work for a drain that stopped short, re-reads on each tick, cancels on close |
| Bug 2 | Empty card stays unqualified when recovery is complete; qualified when not, with the profile card intact |
| Bug 3 | A throwing decryptor lands in the retry queue; exhausted-cap drop reports; corrupt-JSON drop reports |
| Bug 4 | Profile Message routes to `computeConversationId([self, peer])`, not the raw pubkey |

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
