### PR TITLE
fix(blocklist): deliver a lifted block to the person who was blocked

### DIFF
--- a/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
@@ -1599,8 +1599,8 @@ class ContentBlocklistRepository {
 ///
 /// Once an author is known to block or mute us we additionally watch their
 /// list by author, which is the only filter their removal event can still
-/// match. Authors are kept watched after a lift so a later re-block is also
-/// observed immediately rather than waiting on discovery.
+/// match. Authors are kept watched after a lift so later list changes from a
+/// known author do not require tearing down and rebuilding the watch again.
 class _AuthorListWatch {
   _AuthorListWatch({required int kind, required String label})
     : _kind = kind,

--- a/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
@@ -120,6 +120,18 @@ class ContentBlocklistRepository {
   // Users who have blocked us (populated from kind 30000 events with d=block)
   final Set<String> _blockedByOthers = <String>{};
 
+  // Direct by-author watches on the lists of everyone who blocks or mutes
+  // us. The `#p = us` discovery filters cannot observe a block/mute being
+  // *lifted*; see [_AuthorListWatch] for why.
+  final _AuthorListWatch _blockAuthorWatch = _AuthorListWatch(
+    kind: 30000,
+    label: 'block-list',
+  );
+  final _AuthorListWatch _muteAuthorWatch = _AuthorListWatch(
+    kind: 10000,
+    label: 'mute-list',
+  );
+
   // Latest replaceable kind-30000 block-list event timestamp per author.
   // Prevent stale relay delivery order from resurrecting old block state.
   final Map<String, int> _latestBlockListEventCreatedAtByAuthor =
@@ -255,6 +267,9 @@ class ContentBlocklistRepository {
       _latestMuteListEventCreatedAtByAuthor.clear();
       _latestBlockListEventCreatedAtByAuthor.clear();
       _severedFollowers.clear();
+      // "Who blocks/mutes us" is meaningless for the incoming account.
+      _blockAuthorWatch.clear();
+      _muteAuthorWatch.clear();
       // Force fresh subscriptions filtered on the new pubkey. On a
       // same-client switch the old subscription's listener is
       // intentionally left in place (no handle is retained to cancel
@@ -1007,6 +1022,12 @@ class ContentBlocklistRepository {
     // Store references for Nostr publishing
     _nostrClient = nostrService;
 
+    // Any existing by-author watch was opened on the previous client.
+    _muteAuthorWatch.rebind(
+      client: nostrService,
+      onEvent: _handleMuteListEvent,
+    );
+
     Log.info(
       'Starting mutual mute list sync for pubkey: $ourPubkey',
       name: 'ContentBlocklistRepository',
@@ -1084,6 +1105,12 @@ class ContentBlocklistRepository {
 
     _signer = signer;
     _nostrClient = nostrService;
+
+    // Any existing by-author watch was opened on the previous client.
+    _blockAuthorWatch.rebind(
+      client: nostrService,
+      onEvent: _handleBlockListEvent,
+    );
 
     Log.info(
       'Starting block list sync for pubkey: $ourPubkey',
@@ -1295,6 +1322,13 @@ class ContentBlocklistRepository {
       // They muted us - add to blocklist
       if (!_mutualMuteBlocklist.contains(muterPubkey)) {
         _mutualMuteBlocklist.add(muterPubkey);
+        // Watch this author directly; the #p filter that just delivered
+        // this event can never deliver the unmute that follows it.
+        _muteAuthorWatch.add(
+          muterPubkey,
+          client: _nostrClient,
+          onEvent: _handleMuteListEvent,
+        );
         _emitChange(
           BlocklistChange(pubkey: muterPubkey, op: BlocklistOp.muted),
         );
@@ -1495,6 +1529,13 @@ class ContentBlocklistRepository {
     if (stillBlocked) {
       if (!_blockedByOthers.contains(blockerPubkey)) {
         _blockedByOthers.add(blockerPubkey);
+        // Watch this author directly; the #p filter that just delivered
+        // this event can never deliver the unblock that follows it.
+        _blockAuthorWatch.add(
+          blockerPubkey,
+          client: _nostrClient,
+          onEvent: _handleBlockListEvent,
+        );
         _emitChange(
           BlocklistChange(pubkey: blockerPubkey, op: BlocklistOp.blockedUs),
         );
@@ -1527,7 +1568,121 @@ class ContentBlocklistRepository {
     _mutualMuteSyncStarted = false;
     _mutualMuteSubscriptionId = null;
     _blockListSyncStarted = false;
+    _blockAuthorWatch.clear();
+    _muteAuthorWatch.clear();
     unawaited(_stateController.close());
     unawaited(_changesController.close());
+  }
+}
+
+/// Watches specific authors' replaceable list events *by author id*.
+///
+/// The repository discovers that someone blocked or muted us with a
+/// `#p = <us>` filter. That filter can only ever match a list that still
+/// tags us, so it sees the entry being added but never the replacement that
+/// removes it — a lifted block simply stops matching, and no event is
+/// delivered. The "they unblocked us" branches in
+/// [ContentBlocklistRepository._handleOthersBlockListEvent] and
+/// [ContentBlocklistRepository._handleMuteListEvent] were therefore
+/// unreachable in production: the blockee kept hiding the other party's DM
+/// conversation and profile forever.
+///
+/// Once an author is known to block or mute us we additionally watch their
+/// list by author, which is the only filter their removal event can still
+/// match. Authors are kept watched after a lift so a later re-block is also
+/// observed immediately rather than waiting on discovery.
+class _AuthorListWatch {
+  _AuthorListWatch({required int kind, required String label})
+    : _kind = kind,
+      _label = label;
+
+  final int _kind;
+  final String _label;
+  final Set<String> _authors = <String>{};
+
+  NostrClient? _boundClient;
+  StreamSubscription<Event>? _subscription;
+  String? _subscriptionId;
+  int _generation = 0;
+
+  /// Starts watching [author]'s list.
+  ///
+  /// Returns `false` when [author] was already watched, in which case the
+  /// existing subscription is left untouched.
+  bool add(
+    String author, {
+    required NostrClient? client,
+    required void Function(Event) onEvent,
+  }) {
+    if (!_authors.add(author)) return false;
+    _open(client: client, onEvent: onEvent);
+    return true;
+  }
+
+  /// Re-opens the watch against [client].
+  ///
+  /// Needed when the [NostrClient] is recreated (the old subscription lives
+  /// on a disposed client), and when the client only became available after
+  /// the first author was already watched.
+  void rebind({
+    required NostrClient? client,
+    required void Function(Event) onEvent,
+  }) {
+    if (_authors.isEmpty) return;
+    _open(client: client, onEvent: onEvent);
+  }
+
+  /// Drops every watched author — e.g. on identity change, where "who
+  /// blocks us" is meaningless for the new account.
+  void clear() {
+    _authors.clear();
+    _close();
+  }
+
+  void _open({
+    required NostrClient? client,
+    required void Function(Event) onEvent,
+  }) {
+    if (client == null) return;
+    _close();
+
+    final id = '$_label-author-watch-${++_generation}';
+    try {
+      _boundClient = client;
+      _subscriptionId = id;
+      _subscription = client
+          .subscribe([
+            Filter(authors: _authors.toList(), kinds: [_kind]),
+          ], subscriptionId: id)
+          .listen(onEvent);
+
+      Log.info(
+        'Watching ${_authors.length} $_label author(s) by author id',
+        name: 'ContentBlocklistRepository',
+        category: LogCategory.system,
+      );
+    } on Object catch (e) {
+      _boundClient = null;
+      _subscriptionId = null;
+      Log.error(
+        'Failed to open $_label author watch: $e',
+        name: 'ContentBlocklistRepository',
+        category: LogCategory.system,
+      );
+    }
+  }
+
+  void _close() {
+    unawaited(_subscription?.cancel());
+    _subscription = null;
+
+    final id = _subscriptionId;
+    final client = _boundClient;
+    _subscriptionId = null;
+    _boundClient = null;
+
+    if (id != null && client != null) {
+      unawaited(client.unsubscribe(id));
+    }
   }
 }

--- a/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
@@ -180,6 +180,14 @@ class ContentBlocklistRepository {
   BlockListSigner? _signer;
   NostrClient? _nostrClient;
 
+  // The client each background sync actually subscribed on. Tracked per
+  // sync path, not off the shared _nostrClient: the app starts both syncs
+  // in one turn (moderation_providers.dart), and neither body awaits, so
+  // whichever runs first would otherwise overwrite _nostrClient and hide
+  // the client swap from the other.
+  NostrClient? _mutualMuteSyncClient;
+  NostrClient? _blockListSyncClient;
+
   /// A synchronous snapshot of the current policy state.
   ContentPolicyState get currentState => _buildCurrentState();
 
@@ -1006,7 +1014,7 @@ class ContentBlocklistRepository {
 
     // If the NostrClient changed (e.g., account switch), the old subscription
     // was on a disposed client. Reset so we create a fresh subscription.
-    if (_mutualMuteSyncStarted && _nostrClient != nostrService) {
+    if (_mutualMuteSyncStarted && _mutualMuteSyncClient != nostrService) {
       _mutualMuteSyncStarted = false;
     }
 
@@ -1045,6 +1053,7 @@ class ContentBlocklistRepository {
       final subscription = nostrService.subscribe([mutualFilter, ownFilter]);
 
       _mutualMuteSyncStarted = true;
+      _mutualMuteSyncClient = nostrService;
       _mutualMuteSubscriptionId =
           'mutual-mute-${DateTime.now().millisecondsSinceEpoch}';
 
@@ -1090,7 +1099,7 @@ class ContentBlocklistRepository {
 
     // If the NostrClient changed (e.g., account switch), the old subscription
     // was on a disposed client. Reset so we create a fresh subscription.
-    if (_blockListSyncStarted && _nostrClient != nostrService) {
+    if (_blockListSyncStarted && _blockListSyncClient != nostrService) {
       _blockListSyncStarted = false;
     }
 
@@ -1132,6 +1141,7 @@ class ContentBlocklistRepository {
           .listen(_handleBlockListEvent);
 
       _blockListSyncStarted = true;
+      _blockListSyncClient = nostrService;
 
       // One-time migration (#4037): fold any legacy kind 30000 block list
       // into the standard kind 10000 mute list so pre-existing blocks

--- a/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
@@ -1614,19 +1614,16 @@ class _AuthorListWatch {
   StreamSubscription<Event>? _subscription;
   String? _subscriptionId;
   int _generation = 0;
+  bool _openScheduled = false;
 
-  /// Starts watching [author]'s list.
-  ///
-  /// Returns `false` when [author] was already watched, in which case the
-  /// existing subscription is left untouched.
-  bool add(
+  /// Starts watching [author]'s list. A no-op when already watched.
+  void add(
     String author, {
     required NostrClient? client,
     required void Function(Event) onEvent,
   }) {
-    if (!_authors.add(author)) return false;
-    _open(client: client, onEvent: onEvent);
-    return true;
+    if (!_authors.add(author)) return;
+    _scheduleOpen(client: client, onEvent: onEvent);
   }
 
   /// Re-opens the watch against [client].
@@ -1647,6 +1644,26 @@ class _AuthorListWatch {
   void clear() {
     _authors.clear();
     _close();
+  }
+
+  /// Coalesces a burst of [add] calls into a single subscription.
+  ///
+  /// The initial relay replay hands us every author who blocks us in quick
+  /// succession; opening per author would cost a REQ/CLOSE pair each and
+  /// re-deliver the already-watched authors every time. Deferred by a full
+  /// event-loop turn rather than a microtask because stream events reach us
+  /// one microtask apart, which is exactly what needs collapsing.
+  void _scheduleOpen({
+    required NostrClient? client,
+    required void Function(Event) onEvent,
+  }) {
+    if (client == null || _openScheduled) return;
+    _openScheduled = true;
+    Timer.run(() {
+      // Cleared by a rebind or clear() that ran before this fired.
+      if (!_openScheduled) return;
+      _open(client: client, onEvent: onEvent);
+    });
   }
 
   void _open({
@@ -1683,6 +1700,7 @@ class _AuthorListWatch {
   }
 
   void _close() {
+    _openScheduled = false;
     unawaited(_subscription?.cancel());
     _subscription = null;
 

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -3213,7 +3213,8 @@ void main() {
       List<List<String>> tags, {
       required int createdAt,
       required String id,
-    }) => Event(blockerPubkey, kind, tags, '', createdAt: createdAt)
+      String author = blockerPubkey,
+    }) => Event(author, kind, tags, '', createdAt: createdAt)
       ..id = id
       ..sig = 'signature';
 
@@ -3551,6 +3552,64 @@ void main() {
       await pumpEventQueue();
 
       expect(service.hasBlockedUs(blockerPubkey), isFalse);
+    });
+
+    test('a burst of discovered blockers opens a single watch', () async {
+      const otherBlockerPubkey =
+          '7f2a4c6e8b0d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b7d9f1a';
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+      // Both arrive in the same replay, as they do on a cold start.
+      for (final (author, id) in [
+        (blockerPubkey, 'block-event'),
+        (otherBlockerPubkey, 'other-block-event'),
+      ]) {
+        relay.publish(
+          listEvent(
+            30000,
+            [
+              ['d', 'block'],
+              ['p', ourPubkey],
+            ],
+            createdAt: now,
+            id: id,
+            author: author,
+          ),
+        );
+      }
+
+      await service.syncBlockListsInBackground(
+        mockNostrService,
+        mockSigner,
+        ourPubkey,
+      );
+      await pumpEventQueue();
+
+      expect(service.hasBlockedUs(blockerPubkey), isTrue);
+      expect(service.hasBlockedUs(otherBlockerPubkey), isTrue);
+
+      // The discovery subscription passes two filters; the by-author watch
+      // is the single-filter one.
+      final watchRequests =
+          verify(
+                () => mockNostrService.subscribe(
+                  captureAny(),
+                  subscriptionId: any(named: 'subscriptionId'),
+                ),
+              ).captured
+              .cast<List<Filter>>()
+              .where((filters) => filters.length == 1)
+              .toList();
+
+      expect(
+        watchRequests,
+        hasLength(1),
+        reason: 'both blockers must land in one REQ, not one each',
+      );
+      expect(
+        watchRequests.single.single.authors,
+        containsAll([blockerPubkey, otherBlockerPubkey]),
+      );
     });
   });
 }

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -3556,7 +3556,9 @@ void main() {
 /// This is the whole point of the group above. A stub that pipes every
 /// event into every listener cannot see the defect being guarded — the
 /// production filter is `#p = <us>`, and a lifted block publishes a list
-/// with no `p` tag, so the update stops matching and is never delivered.
+/// with no `p` tag, so the update stops matching. With [retainSuperseded]
+/// the stub goes further and reproduces what the deployed relay actually
+/// does: it keeps re-serving the last version that *did* carry the tag.
 class _FilterAwareRelay {
   /// [retainSuperseded] reproduces the behaviour observed on
   /// relay.divine.video: superseded versions of a replaceable/addressable
@@ -3593,7 +3595,9 @@ class _FilterAwareRelay {
   /// Stores [event] and fans it out to every matching subscription.
   ///
   /// Unless [retainSuperseded] is set, prior versions of the same
-  /// (author, kind) are dropped — the NIP-01 behaviour.
+  /// (author, kind) are dropped. Every test here uses a single `d` value
+  /// per kind, so that stands in for NIP-01's per-(author, kind, d)
+  /// replacement rule without needing the finer key.
   void publish(Event event) {
     if (!retainSuperseded) {
       _stored.removeWhere(
@@ -3624,11 +3628,14 @@ class _FilterAwareRelay {
   static List<Event> _newestPerCoordinate(Iterable<Event> events) {
     final newest = <String, Event>{};
     for (final event in events) {
-      final dTag = event.tags
-          .where((t) => t.length >= 2 && t[0] == 'd')
-          .map((t) => t[1])
-          .firstOrNull;
-      final coordinate = '${event.pubkey}:${event.kind}:${dTag ?? ''}';
+      var dTag = '';
+      for (final tag in event.tags) {
+        if (tag.length >= 2 && tag[0] == 'd') {
+          dTag = tag[1];
+          break;
+        }
+      }
+      final coordinate = '${event.pubkey}:${event.kind}:$dTag';
       final current = newest[coordinate];
       if (current == null || event.createdAt > current.createdAt) {
         newest[coordinate] = event;

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -3709,23 +3709,5 @@ class _FilterAwareRelay {
   }
 
   static bool _matchesAny(List<Filter> filters, Event event) =>
-      filters.any((filter) => _matches(filter, event));
-
-  static bool _matches(Filter filter, Event event) {
-    final kinds = filter.kinds;
-    if (kinds != null && !kinds.contains(event.kind)) return false;
-
-    final authors = filter.authors;
-    if (authors != null && !authors.contains(event.pubkey)) return false;
-
-    final p = filter.p;
-    if (p != null &&
-        !event.tags.any(
-          (tag) => tag.length >= 2 && tag[0] == 'p' && p.contains(tag[1]),
-        )) {
-      return false;
-    }
-
-    return true;
-  }
+      filters.any((filter) => filter.checkEvent(event));
 }

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -3496,11 +3496,17 @@ void main() {
           id: 'block-event',
         ),
       );
-      await service.syncBlockListsInBackground(
-        mockNostrService,
-        mockSigner,
-        ourPubkey,
-      );
+      // Start both syncs the way blocklistSyncBridge does. Mute sync runs
+      // first and neither body awaits, so a per-path client check is the
+      // only thing that can still see the swap on the block side.
+      await Future.wait([
+        service.syncMuteListsInBackground(mockNostrService, ourPubkey),
+        service.syncBlockListsInBackground(
+          mockNostrService,
+          mockSigner,
+          ourPubkey,
+        ),
+      ]);
       await pumpEventQueue();
       expect(service.hasBlockedUs(blockerPubkey), isTrue);
 
@@ -3521,11 +3527,10 @@ void main() {
       );
       when(() => newClient.unsubscribe(any())).thenAnswer((_) async {});
 
-      await service.syncBlockListsInBackground(
-        newClient,
-        mockSigner,
-        ourPubkey,
-      );
+      await Future.wait([
+        service.syncMuteListsInBackground(newClient, ourPubkey),
+        service.syncBlockListsInBackground(newClient, mockSigner, ourPubkey),
+      ]);
       await pumpEventQueue();
 
       // The watch on the old client is released rather than leaked.

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -3171,4 +3171,382 @@ void main() {
       expect(repo.currentState.blockedPubkeys, contains('persisted-hex'));
     });
   });
+
+  group('ContentBlocklistRepository - a lifted block reaches the blockee', () {
+    // Real pubkeys from the reported incident, untruncated.
+    const ourPubkey =
+        '613cb00feb0ecd7648a62740771cf60efaead56a0d19b2ac3d7b4f3c589e6fa3';
+    const blockerPubkey =
+        '9be8bd90d818407bcf574d11b1c57f104fd53f40fa767abc4a631ee2694b43a3';
+
+    late _FilterAwareRelay relay;
+    late _MockNostrClient mockNostrService;
+    late _MockBlockListSigner mockSigner;
+    late ContentBlocklistRepository service;
+
+    setUp(() {
+      relay = _FilterAwareRelay();
+      mockNostrService = _MockNostrClient();
+      mockSigner = _MockBlockListSigner();
+
+      when(
+        () => mockNostrService.subscribe(
+          any(),
+          subscriptionId: any(named: 'subscriptionId'),
+        ),
+      ).thenAnswer(
+        (invocation) => relay.subscribe(
+          invocation.positionalArguments.first as List<Filter>,
+        ),
+      );
+      when(() => mockNostrService.unsubscribe(any())).thenAnswer((_) async {});
+
+      service = ContentBlocklistRepository();
+    });
+
+    tearDown(() async {
+      await relay.close();
+    });
+
+    Event listEvent(
+      int kind,
+      List<List<String>> tags, {
+      required int createdAt,
+      required String id,
+    }) => Event(blockerPubkey, kind, tags, '', createdAt: createdAt)
+      ..id = id
+      ..sig = 'signature';
+
+    test(
+      'hasBlockedUs clears when the blocker republishes a kind-30000 list '
+      'that no longer tags us',
+      () async {
+        final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+        relay.publish(
+          listEvent(
+            30000,
+            [
+              ['d', 'block'],
+              ['p', ourPubkey],
+            ],
+            createdAt: now,
+            id: 'block-event',
+          ),
+        );
+
+        await service.syncBlockListsInBackground(
+          mockNostrService,
+          mockSigner,
+          ourPubkey,
+        );
+        await pumpEventQueue();
+        expect(service.hasBlockedUs(blockerPubkey), isTrue);
+
+        // The unblock replaces the list with one that has no 'p' tag at all,
+        // so it can never match the `#p = us` discovery filter. Only a
+        // by-author watch can deliver it.
+        relay.publish(
+          listEvent(
+            30000,
+            [
+              ['d', 'block'],
+              ['title', 'Block List'],
+            ],
+            createdAt: now + 60,
+            id: 'unblock-event',
+          ),
+        );
+        await pumpEventQueue();
+
+        expect(service.hasBlockedUs(blockerPubkey), isFalse);
+        expect(service.shouldFilterFromFeeds(blockerPubkey), isFalse);
+      },
+    );
+
+    test(
+      "the blocker's DM conversation reappears once the block is lifted",
+      () async {
+        final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+        final conversations = [
+          DmConversation(
+            id: 'conv-with-blocker',
+            participantPubkeys: const [ourPubkey, blockerPubkey],
+            isGroup: false,
+            createdAt: now,
+          ),
+        ];
+
+        relay.publish(
+          listEvent(
+            30000,
+            [
+              ['d', 'block'],
+              ['p', ourPubkey],
+            ],
+            createdAt: now,
+            id: 'block-event',
+          ),
+        );
+        await service.syncBlockListsInBackground(
+          mockNostrService,
+          mockSigner,
+          ourPubkey,
+        );
+        await pumpEventQueue();
+
+        expect(
+          service.filterBlockedConversations(
+            conversations,
+            userPubkey: ourPubkey,
+          ),
+          isEmpty,
+          reason: 'while blocked, the conversation is hidden',
+        );
+
+        relay.publish(
+          listEvent(
+            30000,
+            [
+              ['d', 'block'],
+            ],
+            createdAt: now + 60,
+            id: 'unblock-event',
+          ),
+        );
+        await pumpEventQueue();
+
+        expect(
+          service.filterBlockedConversations(
+            conversations,
+            userPubkey: ourPubkey,
+          ),
+          hasLength(1),
+          reason: 'the lifted block must un-hide the DM conversation',
+        );
+      },
+    );
+
+    test(
+      'hasMutedUs clears when the muter republishes a kind-10000 list that '
+      'no longer tags us',
+      () async {
+        final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+        relay.publish(
+          listEvent(
+            10000,
+            [
+              ['p', ourPubkey],
+            ],
+            createdAt: now,
+            id: 'mute-event',
+          ),
+        );
+
+        await service.syncMuteListsInBackground(mockNostrService, ourPubkey);
+        await pumpEventQueue();
+        expect(service.hasMutedUs(blockerPubkey), isTrue);
+
+        relay.publish(
+          listEvent(10000, [], createdAt: now + 60, id: 'unmute-event'),
+        );
+        await pumpEventQueue();
+
+        expect(service.hasMutedUs(blockerPubkey), isFalse);
+        expect(service.shouldFilterFromFeeds(blockerPubkey), isFalse);
+      },
+    );
+
+    test(
+      'a stale older list event does not resurrect a lifted block',
+      () async {
+        final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+        relay.publish(
+          listEvent(
+            30000,
+            [
+              ['d', 'block'],
+              ['p', ourPubkey],
+            ],
+            createdAt: now,
+            id: 'block-event',
+          ),
+        );
+        await service.syncBlockListsInBackground(
+          mockNostrService,
+          mockSigner,
+          ourPubkey,
+        );
+        await pumpEventQueue();
+
+        relay.publish(
+          listEvent(
+            30000,
+            [
+              ['d', 'block'],
+            ],
+            createdAt: now + 60,
+            id: 'unblock-event',
+          ),
+        );
+        await pumpEventQueue();
+        expect(service.hasBlockedUs(blockerPubkey), isFalse);
+
+        // A second relay replaying the superseded block must not win.
+        relay.publish(
+          listEvent(
+            30000,
+            [
+              ['d', 'block'],
+              ['p', ourPubkey],
+            ],
+            createdAt: now - 30,
+            id: 'stale-block-event',
+          ),
+        );
+        await pumpEventQueue();
+
+        expect(service.hasBlockedUs(blockerPubkey), isFalse);
+      },
+    );
+
+    test('the by-author watch follows a recreated NostrClient', () async {
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+      relay.publish(
+        listEvent(
+          30000,
+          [
+            ['d', 'block'],
+            ['p', ourPubkey],
+          ],
+          createdAt: now,
+          id: 'block-event',
+        ),
+      );
+      await service.syncBlockListsInBackground(
+        mockNostrService,
+        mockSigner,
+        ourPubkey,
+      );
+      await pumpEventQueue();
+      expect(service.hasBlockedUs(blockerPubkey), isTrue);
+
+      // The app recreates the NostrClient on auth flips and reconnects, so
+      // the existing watch is left holding a disposed client.
+      final newRelay = _FilterAwareRelay();
+      addTearDown(newRelay.close);
+      final newClient = _MockNostrClient();
+      when(
+        () => newClient.subscribe(
+          any(),
+          subscriptionId: any(named: 'subscriptionId'),
+        ),
+      ).thenAnswer(
+        (invocation) => newRelay.subscribe(
+          invocation.positionalArguments.first as List<Filter>,
+        ),
+      );
+      when(() => newClient.unsubscribe(any())).thenAnswer((_) async {});
+
+      await service.syncBlockListsInBackground(
+        newClient,
+        mockSigner,
+        ourPubkey,
+      );
+      await pumpEventQueue();
+
+      // The watch on the old client is released rather than leaked.
+      verify(() => mockNostrService.unsubscribe(any())).called(1);
+
+      // Only the new relay carries the unblock, so it can arrive solely
+      // through a watch that followed the client swap.
+      newRelay.publish(
+        listEvent(
+          30000,
+          [
+            ['d', 'block'],
+          ],
+          createdAt: now + 60,
+          id: 'unblock-event',
+        ),
+      );
+      await pumpEventQueue();
+
+      expect(service.hasBlockedUs(blockerPubkey), isFalse);
+    });
+  });
+}
+
+/// A relay stub that honours filters: a subscription only ever receives
+/// events it actually matches.
+///
+/// This is the whole point of the group above. A stub that pipes every
+/// event into every listener cannot see the defect being guarded — the
+/// production filter is `#p = <us>`, and a lifted block publishes a list
+/// with no `p` tag, so the update stops matching and is never delivered.
+class _FilterAwareRelay {
+  final List<({List<Filter> filters, StreamController<Event> controller})>
+  _subscriptions = [];
+  final List<Event> _stored = [];
+
+  Stream<Event> subscribe(List<Filter> filters) {
+    final controller = StreamController<Event>.broadcast();
+    _subscriptions.add((filters: filters, controller: controller));
+    // Relays replay stored matches on REQ. Deliver them asynchronously:
+    // the caller attaches its listener after this returns, and a broadcast
+    // controller discards anything added while it has no subscribers.
+    final replay = _stored.where((e) => _matchesAny(filters, e)).toList();
+    scheduleMicrotask(() {
+      for (final event in replay) {
+        if (!controller.isClosed) controller.add(event);
+      }
+    });
+    return controller.stream;
+  }
+
+  /// Stores [event] with replaceable semantics (one per author+kind, as the
+  /// relay does for kind 10000 and for kind 30000 at a fixed `d` tag) and
+  /// fans it out to every matching subscription.
+  void publish(Event event) {
+    _stored
+      ..removeWhere((e) => e.pubkey == event.pubkey && e.kind == event.kind)
+      ..add(event);
+    for (final subscription in _subscriptions) {
+      if (_matchesAny(subscription.filters, event) &&
+          !subscription.controller.isClosed) {
+        subscription.controller.add(event);
+      }
+    }
+  }
+
+  Future<void> close() async {
+    for (final subscription in _subscriptions) {
+      await subscription.controller.close();
+    }
+    _subscriptions.clear();
+  }
+
+  static bool _matchesAny(List<Filter> filters, Event event) =>
+      filters.any((filter) => _matches(filter, event));
+
+  static bool _matches(Filter filter, Event event) {
+    final kinds = filter.kinds;
+    if (kinds != null && !kinds.contains(event.kind)) return false;
+
+    final authors = filter.authors;
+    if (authors != null && !authors.contains(event.pubkey)) return false;
+
+    final p = filter.p;
+    if (p != null &&
+        !event.tags.any(
+          (tag) => tag.length >= 2 && tag[0] == 'p' && p.contains(tag[1]),
+        )) {
+      return false;
+    }
+
+    return true;
+  }
 }

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -3412,6 +3412,76 @@ void main() {
       },
     );
 
+    test(
+      'recovers on a cold start when the relay serves a superseded block '
+      'list to the #p filter',
+      () async {
+        // Reproduces relay.divine.video as measured: both versions of
+        // (author, kind 30000, d=block) stay stored, so the #p discovery
+        // filter keeps returning the last version that still tagged us
+        // while the author filter returns the current, empty one.
+        final staleRelay = _FilterAwareRelay(retainSuperseded: true);
+        addTearDown(staleRelay.close);
+
+        final staleClient = _MockNostrClient();
+        when(
+          () => staleClient.subscribe(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+          ),
+        ).thenAnswer(
+          (invocation) => staleRelay.subscribe(
+            invocation.positionalArguments.first as List<Filter>,
+          ),
+        );
+        when(() => staleClient.unsubscribe(any())).thenAnswer((_) async {});
+
+        final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+        staleRelay
+          ..publish(
+            listEvent(
+              30000,
+              [
+                ['d', 'block'],
+                ['p', ourPubkey],
+              ],
+              createdAt: now,
+              id: 'block-event',
+            ),
+          )
+          // The unblock supersedes it, but the old row is retained.
+          ..publish(
+            listEvent(
+              30000,
+              [
+                ['d', 'block'],
+                ['title', 'Block List'],
+              ],
+              createdAt: now + 600,
+              id: 'unblock-event',
+            ),
+          );
+
+        // Cold start: nothing in memory, everything re-derived from relay.
+        final coldService = ContentBlocklistRepository();
+        await coldService.syncBlockListsInBackground(
+          staleClient,
+          mockSigner,
+          ourPubkey,
+        );
+        await pumpEventQueue();
+
+        expect(
+          coldService.hasBlockedUs(blockerPubkey),
+          isFalse,
+          reason:
+              'the by-author watch must correct the stale #p delivery, or '
+              'the blockee stays blocked forever across restarts',
+        );
+        expect(coldService.shouldFilterFromFeeds(blockerPubkey), isFalse);
+      },
+    );
+
     test('the by-author watch follows a recreated NostrClient', () async {
       final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
 
@@ -3488,6 +3558,17 @@ void main() {
 /// production filter is `#p = <us>`, and a lifted block publishes a list
 /// with no `p` tag, so the update stops matching and is never delivered.
 class _FilterAwareRelay {
+  /// [retainSuperseded] reproduces the behaviour observed on
+  /// relay.divine.video: superseded versions of a replaceable/addressable
+  /// event stay stored, and "latest wins" is resolved *after* the filter
+  /// predicate. A tag query therefore returns the newest version that still
+  /// carries the tag — which, for a lifted block, is the stale one. NIP-01
+  /// says a relay should not do this, but the deployed relay does, so the
+  /// fix has to survive it.
+  _FilterAwareRelay({this.retainSuperseded = false});
+
+  final bool retainSuperseded;
+
   final List<({List<Filter> filters, StreamController<Event> controller})>
   _subscriptions = [];
   final List<Event> _stored = [];
@@ -3498,7 +3579,9 @@ class _FilterAwareRelay {
     // Relays replay stored matches on REQ. Deliver them asynchronously:
     // the caller attaches its listener after this returns, and a broadcast
     // controller discards anything added while it has no subscribers.
-    final replay = _stored.where((e) => _matchesAny(filters, e)).toList();
+    final replay = _newestPerCoordinate(
+      _stored.where((e) => _matchesAny(filters, e)),
+    );
     scheduleMicrotask(() {
       for (final event in replay) {
         if (!controller.isClosed) controller.add(event);
@@ -3507,13 +3590,17 @@ class _FilterAwareRelay {
     return controller.stream;
   }
 
-  /// Stores [event] with replaceable semantics (one per author+kind, as the
-  /// relay does for kind 10000 and for kind 30000 at a fixed `d` tag) and
-  /// fans it out to every matching subscription.
+  /// Stores [event] and fans it out to every matching subscription.
+  ///
+  /// Unless [retainSuperseded] is set, prior versions of the same
+  /// (author, kind) are dropped — the NIP-01 behaviour.
   void publish(Event event) {
-    _stored
-      ..removeWhere((e) => e.pubkey == event.pubkey && e.kind == event.kind)
-      ..add(event);
+    if (!retainSuperseded) {
+      _stored.removeWhere(
+        (e) => e.pubkey == event.pubkey && e.kind == event.kind,
+      );
+    }
+    _stored.add(event);
     for (final subscription in _subscriptions) {
       if (_matchesAny(subscription.filters, event) &&
           !subscription.controller.isClosed) {
@@ -3527,6 +3614,27 @@ class _FilterAwareRelay {
       await subscription.controller.close();
     }
     _subscriptions.clear();
+  }
+
+  /// Collapses [events] to the newest version per (author, kind, d-tag).
+  ///
+  /// Applied *after* the filter predicate, which is precisely how the
+  /// deployed relay resolves replaceable events — and why a `#p` query can
+  /// surface a superseded list.
+  static List<Event> _newestPerCoordinate(Iterable<Event> events) {
+    final newest = <String, Event>{};
+    for (final event in events) {
+      final dTag = event.tags
+          .where((t) => t.length >= 2 && t[0] == 'd')
+          .map((t) => t[1])
+          .firstOrNull;
+      final coordinate = '${event.pubkey}:${event.kind}:${dTag ?? ''}';
+      final current = newest[coordinate];
+      if (current == null || event.createdAt > current.createdAt) {
+        newest[coordinate] = event;
+      }
+    }
+    return newest.values.toList();
   }
 
   static bool _matchesAny(List<Filter> filters, Event event) =>


### PR DESCRIPTION
## Description

Unblocking someone never reaches the person who was unblocked. On their device the blocker's DM conversation stays hidden and their profile keeps showing **Account not available** — permanently, and **not cleared by restarting the app**.

Two independent defects stack, one per side.

### Client side (fixed here)

A blockee learns "X blocked me" only through a `#p = <us>` filter on X's kind-30000 block list (`content_blocklist_repository.dart:1096`), and the kind-10000 mute twin at `:1018`. A block is expressed by X's list *containing* `["p", "<us>"]`. An **unblock is expressed by the absence of that tag** — so the replacement event stops matching the filter and is never delivered. The "they unblocked us" branches in `_handleOthersBlockListEvent` and `_handleMuteListEvent` were unreachable in production.

The stale `_blockedByOthers` entry is a member of `_hideBuckets` (`:786`), so it feeds `shouldFilterFromFeeds` → `filterBlockedConversations` (`:943`, called from `conversation_list_bloc.dart:207` and `dm_unread_count_cubit.dart:213`) and gates `UserNotAvailableScreen` via `other_profile_screen_router.dart:50`. One stale bit hides both the conversation and the profile.

**Fix:** once an author is known to block or mute us, also watch their list *by author id* — the only filter their removal event can still match. The watch follows a recreated `NostrClient` (this app recreates it on auth flips and reconnects) and is dropped on identity change so it cannot leak across accounts.

### Relay side (not fixed here — needs a funnelcake change)

`relay.divine.video` retains superseded versions of replaceable/addressable events and resolves the NIP-01 coordinate collapse *after* the filter predicate, so a `#p` query keeps returning the last version that still carried the tag. Measured directly against production, same coordinate `(A, 30000, d=block)`:

```
{"kinds":[30000],"#p":[<blockee>]}                 -> created_at 1783998962, p=[<blockee>]   STALE
{"authors":[<blocker>],"kinds":[30000]}            -> created_at 1785149558, p=[]            CURRENT
{"kinds":[30000],"#p":[<blockee>],"#d":["block"]}  -> 0 events                               CORRECT
```

The two-tag form routes to the `Base` branch (`events_deduped FINAL`, keyed on the NIP-01 coordinate) and behaves correctly; the single-tag form routes to `TagTarget` with `skip_tag_filters: true` and collapses only over rows that already survived the tag predicate. Root cause is that `events_local` is `ReplacingMergeTree(indexed_at) ORDER BY (id)` — keyed on the physical event id, so superseded versions are never removed. NIP-01 makes latest-only storage a MUST for replaceable events, so this is a storage-layer violation, not just a REQ-return preference.

Consequence: the blockee re-derives the stale block on **every cold start**, which is why restarting does not help. This fix is verified to recover from that too — see the cold-start test.

Same-family prior art in divine-funnelcake: #494 (CLOSED) was this exact bug for kind-10000 mute lists on the REST path; #471 and #697 (both OPEN) are neighbouring dedup defects in the same file.

**Related Issue:** Closes #6435

## Out of Scope

- The relay-side dedup defect above. Needs a funnelcake fix; this PR is a client-side workaround that is correct independently of it.
- `unblockUser` is a silent no-op when the pubkey is not in `_runtimeBlocklist`.
- `_restoreBlocksFromRelay` (`:1447-1451`) merges relay `p` tags into `_runtimeBlocklist` and never removes, so a stale own-list copy can re-add a just-unblocked pubkey.
- Neither list publisher awaits a NIP-20 `OK`, so a failed publish is invisible.
- Separately noted while auditing the relay: it implements no NIP-42 AUTH and serves kind-1059 gift wraps to any unauthenticated `#p` query, contrary to NIP-59's guidance. That is how the measurements above were possible. Worth its own security triage.

## Verification

- `flutter test` in `mobile/packages/content_blocklist_repository` — 114/114 pass.
- `flutter test --coverage` — **100.00%** (541/541 lines), which this package's CI requires since its workflow sets no `min_coverage` override.
- All 6 new behaviour tests confirmed **red** against `origin/main`'s version of the lib file and **green** with the fix.
- 598 app-side tests across the 45 test files referencing `ContentBlocklistRepository` — all pass.
- `dart format` + `flutter analyze lib test` clean.
- Relay behaviour measured directly against `wss://relay.divine.video`, and the routing explanation confirmed by the one-tag vs two-tag experiment above.

Two notes on the tests. The pre-existing `content_blocklist_repository_test.dart:1524` already claimed to cover this ("removes blocker when updated event no longer contains our pubkey") but pushed the unblock into the same stubbed stream — a delivery the relay would never make. And the new stub deliberately reproduces the relay's non-conformant dedup rather than idealised NIP-01 semantics, so the fix is not being validated against a relay that does not exist.

Also confirmed against production that relay dedup does respect the `d` tag (22 authors return multiple distinct kind-30000 `d` tags, including one holding both `block` and `dm-contacts`), so watching by author cannot mask the `d=block` list behind another list from the same author.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
