### PR TITLE
fix(video-editor): give a recorded clip its media's length

### DIFF
--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -33,6 +33,7 @@ import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/services/haptic_service.dart';
 import 'package:openvine/services/performance_monitoring_service.dart';
+import 'package:openvine/services/video_editor/clip_media_duration.dart';
 import 'package:openvine/services/video_recorder/camera/camera_base_service.dart';
 import 'package:openvine/services/video_thumbnail_service.dart';
 import 'package:path/path.dart' as p;
@@ -1089,9 +1090,10 @@ class VideoRecorderBloc
       final metadata = await ProVideoEditor.instance.getMetadata(
         EditorVideo.file(File(workCopyPath)),
       );
-      clipManager.updateClipDuration(clip.id, metadata.duration);
+      final clipDuration = commonTrackEnd(metadata) ?? metadata.duration;
+      clipManager.updateClipDuration(clip.id, clipDuration);
       Log.debug(
-        '📊 Video duration: ${metadata.duration.inMilliseconds}ms',
+        '📊 Video duration: ${clipDuration.inMilliseconds}ms',
         name: 'VideoRecorderBloc',
         category: LogCategory.video,
       );

--- a/mobile/lib/providers/clip_manager_provider.dart
+++ b/mobile/lib/providers/clip_manager_provider.dart
@@ -18,6 +18,7 @@ import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/providers/video_publish_provider.dart';
 import 'package:openvine/services/file_cleanup_service.dart';
 import 'package:openvine/services/native_proofmode_service.dart';
+import 'package:openvine/services/video_editor/clip_media_duration.dart';
 import 'package:openvine/services/video_editor/video_editor_render_service.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -236,6 +237,7 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
             }
 
             refreshClip(clip);
+            unawaited(_alignClipToRecordedMedia(clip.id));
           },
         ),
       );
@@ -262,7 +264,64 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
     // This runs after trimming (if any) completes via the processingCompleter.
     unawaited(_generateClipProof(clip));
 
+    // A trimmed clip is realigned once its re-render lands, above.
+    if (!isClipTooLong) {
+      unawaited(_alignClipToRecordedMedia(clip.id));
+    }
+
     return clip;
+  }
+
+  /// Replaces a recorded clip's stopwatch length with the point where its media
+  /// tracks both still have content.
+  ///
+  /// The recorder times how long the button was held, but an mp4's declared
+  /// length is its *longest* track, and capture stops the audio and video
+  /// writers independently — so a recording's tail routinely carries picture
+  /// with no sound. Leaving that tail in the clip's length puts the whole
+  /// editor timeline out of step with the media: trims, layer windows and
+  /// transitions are authored against a stretch the export cannot fill, and the
+  /// feed's looping player replays the silence every cycle (#6386).
+  ///
+  /// Only ever shortens, and only within [clipTrackEndTolerance] — a clip that
+  /// genuinely outlasts its audio keeps its full length.
+  Future<void> _alignClipToRecordedMedia(String clipId) async {
+    final clip = getClipById(clipId);
+    final video = clip?.video;
+    if (clip == null || video == null) return;
+
+    final VideoMetadata metadata;
+    try {
+      metadata = await ProVideoEditor.instance.getMetadata(video);
+    } catch (e) {
+      // Keep the recorded length: a clip that cannot be probed is still
+      // editable, it just keeps the seam it was captured with.
+      Log.warning(
+        '⚠️ Could not read media length for clip $clipId: $e',
+        name: 'ClipManagerNotifier',
+        category: .video,
+      );
+      return;
+    }
+
+    if (!ref.mounted) return;
+
+    final trackEnd = commonTrackEnd(metadata);
+    if (trackEnd == null) return;
+
+    final current = getClipById(clipId);
+    if (current == null || current.duration <= trackEnd) return;
+
+    final aligned = current.copyWith(duration: trackEnd);
+    refreshClip(aligned);
+    unawaited(saveClipToLibrary(aligned));
+
+    Log.debug(
+      '✂️ Aligned clip $clipId to its common track end: '
+      '${current.duration.inMilliseconds}ms → ${trackEnd.inMilliseconds}ms',
+      name: 'ClipManagerNotifier',
+      category: .video,
+    );
   }
 
   /// Adds a frames-based stop-motion clip to the manager.

--- a/mobile/lib/providers/clip_manager_provider.dart
+++ b/mobile/lib/providers/clip_manager_provider.dart
@@ -18,9 +18,8 @@ import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/providers/video_publish_provider.dart';
 import 'package:openvine/services/file_cleanup_service.dart';
 import 'package:openvine/services/native_proofmode_service.dart';
-import 'package:openvine/services/video_editor/clip_media_duration.dart';
 import 'package:openvine/services/video_editor/video_editor_render_service.dart';
-import 'package:pro_video_editor/pro_video_editor.dart';
+import 'package:pro_video_editor/pro_video_editor.dart' show EditorVideo;
 import 'package:unified_logger/unified_logger.dart';
 
 final clipManagerProvider =
@@ -237,7 +236,6 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
             }
 
             refreshClip(clip);
-            unawaited(_alignClipToRecordedMedia(clip.id));
           },
         ),
       );
@@ -264,64 +262,7 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
     // This runs after trimming (if any) completes via the processingCompleter.
     unawaited(_generateClipProof(clip));
 
-    // A trimmed clip is realigned once its re-render lands, above.
-    if (!isClipTooLong) {
-      unawaited(_alignClipToRecordedMedia(clip.id));
-    }
-
     return clip;
-  }
-
-  /// Replaces a recorded clip's stopwatch length with the point where its media
-  /// tracks both still have content.
-  ///
-  /// The recorder times how long the button was held, but an mp4's declared
-  /// length is its *longest* track, and capture stops the audio and video
-  /// writers independently — so a recording's tail routinely carries picture
-  /// with no sound. Leaving that tail in the clip's length puts the whole
-  /// editor timeline out of step with the media: trims, layer windows and
-  /// transitions are authored against a stretch the export cannot fill, and the
-  /// feed's looping player replays the silence every cycle (#6386).
-  ///
-  /// Only ever shortens, and only within [clipTrackEndTolerance] — a clip that
-  /// genuinely outlasts its audio keeps its full length.
-  Future<void> _alignClipToRecordedMedia(String clipId) async {
-    final clip = getClipById(clipId);
-    final video = clip?.video;
-    if (clip == null || video == null) return;
-
-    final VideoMetadata metadata;
-    try {
-      metadata = await ProVideoEditor.instance.getMetadata(video);
-    } catch (e) {
-      // Keep the recorded length: a clip that cannot be probed is still
-      // editable, it just keeps the seam it was captured with.
-      Log.warning(
-        '⚠️ Could not read media length for clip $clipId: $e',
-        name: 'ClipManagerNotifier',
-        category: .video,
-      );
-      return;
-    }
-
-    if (!ref.mounted) return;
-
-    final trackEnd = commonTrackEnd(metadata);
-    if (trackEnd == null) return;
-
-    final current = getClipById(clipId);
-    if (current == null || current.duration <= trackEnd) return;
-
-    final aligned = current.copyWith(duration: trackEnd);
-    refreshClip(aligned);
-    unawaited(saveClipToLibrary(aligned));
-
-    Log.debug(
-      '✂️ Aligned clip $clipId to its common track end: '
-      '${current.duration.inMilliseconds}ms → ${trackEnd.inMilliseconds}ms',
-      name: 'ClipManagerNotifier',
-      category: .video,
-    );
   }
 
   /// Adds a frames-based stop-motion clip to the manager.

--- a/mobile/lib/services/video_editor/clip_media_duration.dart
+++ b/mobile/lib/services/video_editor/clip_media_duration.dart
@@ -1,0 +1,33 @@
+// ABOUTME: Derives a recorded clip's true length from its media tracks
+// ABOUTME: so the editor timeline matches the file the export is built from
+
+import 'package:pro_video_editor/pro_video_editor.dart';
+
+/// How far a clip's audio may fall short of its video before the gap counts as
+/// content rather than a track-end mismatch.
+///
+/// Capture stops the audio and video writers independently, so the two tracks
+/// end a fraction of a second apart; a survey of published mp4s put the worst
+/// case at ~0.4s. A larger gap means the clip is genuinely meant to outlast its
+/// audio — a stop-motion still held past a short sound, or a source with a
+/// broken audio track — and shortening it would swallow content.
+const clipTrackEndTolerance = Duration(milliseconds: 500);
+
+/// The point where every track of a recorded clip still has content, or `null`
+/// when the clip's recorded length should be kept as it is.
+///
+/// An mp4's container duration is its *longest* track, so a clip whose audio
+/// writer stopped first declares a length whose tail has picture but no sound.
+/// Treating that declared length as the clip's length puts the editor timeline
+/// out of step with the media: trims, layer anchors and transitions are all
+/// authored against a tail that the export cannot fill.
+///
+/// Returns `null` when there is nothing to correct — no audio track, tracks
+/// already ending together, or a shortfall beyond [clipTrackEndTolerance].
+Duration? commonTrackEnd(VideoMetadata metadata) {
+  final audioDuration = metadata.audioDuration;
+  if (audioDuration == null) return null;
+  if (audioDuration >= metadata.duration) return null;
+  if (metadata.duration - audioDuration > clipTrackEndTolerance) return null;
+  return audioDuration;
+}

--- a/mobile/lib/services/video_editor/clip_media_duration.dart
+++ b/mobile/lib/services/video_editor/clip_media_duration.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Derives a recorded clip's true length from its media tracks
 // ABOUTME: so the editor timeline matches the file the export is built from
 
+import 'package:openvine/services/video_editor/video_editor_split_service.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 
 /// How far a clip's audio may fall short of its video before the gap counts as
@@ -12,6 +13,10 @@ import 'package:pro_video_editor/pro_video_editor.dart';
 /// audio — a stop-motion still held past a short sound, or a source with a
 /// broken audio track — and shortening it would swallow content.
 const clipTrackEndTolerance = Duration(milliseconds: 500);
+
+/// Shorter common track ends are treated as unusable metadata, matching the
+/// editor's minimum editable clip duration.
+const Duration minCommonTrackEnd = VideoEditorSplitService.minClipDuration;
 
 /// The point where every track of a recorded clip still has content, or `null`
 /// when the clip's recorded length should be kept as it is.
@@ -27,6 +32,7 @@ const clipTrackEndTolerance = Duration(milliseconds: 500);
 Duration? commonTrackEnd(VideoMetadata metadata) {
   final audioDuration = metadata.audioDuration;
   if (audioDuration == null) return null;
+  if (audioDuration < minCommonTrackEnd) return null;
   if (audioDuration >= metadata.duration) return null;
   if (metadata.duration - audioDuration > clipTrackEndTolerance) return null;
   return audioDuration;

--- a/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
+++ b/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
@@ -1602,6 +1602,130 @@ void main() {
       late PathProviderPlatform originalPathProvider;
 
       blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'saves the common track end after detached enrichment settles',
+        setUp: () {
+          docsDir = Directory.systemTemp.createTempSync('rec_enrich_docs');
+          originalPathProvider = PathProviderPlatform.instance;
+          PathProviderPlatform.instance = MockPathProviderPlatform()
+            ..setApplicationDocumentsPath(docsDir.path)
+            ..setTemporaryPath(docsDir.path);
+
+          final editor = _MockProVideoEditor();
+          when(() => editor.getMetadata(any())).thenAnswer(
+            (_) async => VideoMetadata(
+              duration: const Duration(milliseconds: 6033),
+              audioDuration: const Duration(milliseconds: 5998),
+              extension: 'mp4',
+              fileSize: 1024,
+              resolution: const Size(720, 1280),
+              rotation: 0,
+              bitrate: 2000000,
+            ),
+          );
+          when(() => editor.getThumbnails(any())).thenAnswer(
+            (_) async => [
+              Uint8List.fromList(const [1, 2, 3]),
+            ],
+          );
+          when(
+            () => editor.getSingleThumbnail(any()),
+          ).thenAnswer((_) async => Uint8List.fromList(const [1, 2, 3]));
+          originalProVideoEditor = ProVideoEditor.instance;
+          ProVideoEditor.instance = editor;
+
+          recordingFile = File('${docsDir.path}/recording.mp4')
+            ..writeAsStringSync('recorded clip');
+          final recorded = _MockEditorVideo();
+          when(
+            recorded.safeFilePath,
+          ).thenAnswer((_) async => recordingFile.path);
+          when(
+            () => cameraService.stopRecording(),
+          ).thenAnswer((_) async => recorded);
+
+          var currentClip = DivineVideoClip(
+            id: 'aligned-clip',
+            video: recorded,
+            duration: const Duration(milliseconds: 6033),
+            recordedAt: DateTime(2024),
+            targetAspectRatio: model.AspectRatio.vertical,
+            originalAspectRatio: 9 / 16,
+          );
+          when(
+            () => clipManager.addClip(
+              video: any(named: 'video'),
+              originalAspectRatio: any(named: 'originalAspectRatio'),
+              targetAspectRatio: any(named: 'targetAspectRatio'),
+              lensMetadata: any(named: 'lensMetadata'),
+              limitClipDuration: any(named: 'limitClipDuration'),
+            ),
+          ).thenReturn(currentClip);
+          when(() => clipManager.updateClipDuration(any(), any())).thenAnswer((
+            invocation,
+          ) {
+            currentClip = currentClip.copyWith(
+              duration: invocation.positionalArguments[1] as Duration,
+            );
+          });
+          when(
+            () => clipManager.updateThumbnail(
+              clipId: any(named: 'clipId'),
+              thumbnailPath: any(named: 'thumbnailPath'),
+              thumbnailTimestamp: any(named: 'thumbnailTimestamp'),
+            ),
+          ).thenAnswer((_) {});
+          when(
+            () => clipManager.updateGhostFrame(
+              clipId: any(named: 'clipId'),
+              ghostFramePath: any(named: 'ghostFramePath'),
+            ),
+          ).thenAnswer((_) {});
+          var clipsReadCount = 0;
+          when(() => clipManager.clips).thenAnswer((_) {
+            clipsReadCount += 1;
+            // Skip preloading in this unit test; the final enrichment lookup
+            // still sees the clip after the duration update.
+            return clipsReadCount == 1 ? const [] : [currentClip];
+          });
+          when(
+            () => clipManager.saveClipToLibrary(any()),
+          ).thenAnswer((_) async => true);
+        },
+        tearDown: () {
+          ProVideoEditor.instance = originalProVideoEditor;
+          PathProviderPlatform.instance = originalPathProvider;
+          if (docsDir.existsSync()) docsDir.deleteSync(recursive: true);
+        },
+        build: () => buildBloc()
+          ..emit(
+            const VideoRecorderBlocState(
+              recordingState: VideoRecorderState.recording,
+            ),
+          ),
+        act: (bloc) async {
+          bloc.add(const VideoRecorderRecordingStopRequested());
+          await pumpEventQueue(times: 100);
+        },
+        verify: (_) {
+          verify(
+            () => clipManager.updateClipDuration(
+              'aligned-clip',
+              const Duration(milliseconds: 5998),
+            ),
+          ).called(1);
+          final savedClips = verify(
+            () => clipManager.saveClipToLibrary(captureAny()),
+          ).captured.cast<DivineVideoClip>();
+          expect(savedClips, hasLength(2));
+          expect(
+            savedClips.last.duration,
+            equals(const Duration(milliseconds: 5998)),
+          );
+          expect(File('${recordingFile.path}.work.mp4').existsSync(), isFalse);
+        },
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
         'skips the enriched save and still deletes the work copy when the clip '
         'is gone before the metadata save — the work copy must not leak',
         setUp: () {

--- a/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
+++ b/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
@@ -1595,7 +1595,7 @@ void main() {
       );
     });
 
-    group('detached enrichment → clip removed mid-enrichment', () {
+    group('detached enrichment', () {
       late Directory docsDir;
       late File recordingFile;
       late ProVideoEditor originalProVideoEditor;

--- a/mobile/test/providers/clip_manager_provider_test.dart
+++ b/mobile/test/providers/clip_manager_provider_test.dart
@@ -1,8 +1,6 @@
 // ABOUTME: Tests for ClipManagerProvider - Riverpod state management
 // ABOUTME: Validates state updates and provider lifecycle
 
-import 'dart:ui';
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -14,17 +12,12 @@ import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/services/clip_library_service.dart';
 import 'package:openvine/services/draft_storage_service.dart';
-import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class _MockDraftStorageService extends Mock implements DraftStorageService {}
 
 class _MockClipLibraryService extends Mock implements ClipLibraryService {}
-
-class _MockProVideoEditor extends Mock
-    with MockPlatformInterfaceMixin
-    implements ProVideoEditor {}
 
 void main() {
   group('ClipManagerProvider', () {
@@ -43,7 +36,6 @@ void main() {
           originalAspectRatio: 9 / 16,
         ),
       );
-      registerFallbackValue(EditorVideo.file('/fallback.mp4'));
     });
 
     setUp(() async {
@@ -953,123 +945,5 @@ void main() {
         ).called(1);
       });
     });
-
-    group('aligning a recorded clip to its media', () {
-      late ProVideoEditor originalEditor;
-      late _MockProVideoEditor editor;
-
-      setUp(() {
-        originalEditor = ProVideoEditor.instance;
-        editor = _MockProVideoEditor();
-        ProVideoEditor.instance = editor;
-        when(() => mockClipLibraryService.saveClip(any())).thenAnswer(
-          (_) async {},
-        );
-      });
-
-      tearDown(() {
-        ProVideoEditor.instance = originalEditor;
-      });
-
-      /// Adds a clip and lets the fire-and-forget alignment settle.
-      Future<DivineVideoClip> addAndSettle(ClipManagerNotifier notifier) async {
-        final clip = notifier.addClip(
-          limitClipDuration: false,
-          video: EditorVideo.file('/path/to/video.mp4'),
-          duration: const Duration(milliseconds: 3000),
-          targetAspectRatio: .vertical,
-          originalAspectRatio: 9 / 16,
-        );
-        await pumpEventQueue();
-        return clip;
-      }
-
-      test(
-        'shortens the clip to where both tracks still have content',
-        () async {
-          when(() => editor.getMetadata(any())).thenAnswer(
-            (_) async => _metadata(
-              duration: const Duration(milliseconds: 3000),
-              audioDuration: const Duration(milliseconds: 2931),
-            ),
-          );
-          final notifier = container.read(clipManagerProvider.notifier);
-
-          await addAndSettle(notifier);
-
-          expect(
-            container.read(clipManagerProvider).clips.single.duration,
-            equals(const Duration(milliseconds: 2931)),
-          );
-        },
-      );
-
-      test('persists the aligned length to the library', () async {
-        when(() => editor.getMetadata(any())).thenAnswer(
-          (_) async => _metadata(
-            duration: const Duration(milliseconds: 3000),
-            audioDuration: const Duration(milliseconds: 2931),
-          ),
-        );
-        final notifier = container.read(clipManagerProvider.notifier);
-
-        await addAndSettle(notifier);
-
-        final captured =
-            verify(
-                  () => mockClipLibraryService.saveClip(captureAny()),
-                ).captured.single
-                as DivineVideoClip;
-        expect(captured.duration, equals(const Duration(milliseconds: 2931)));
-      });
-
-      test('leaves a clip that genuinely outlasts its audio', () async {
-        when(() => editor.getMetadata(any())).thenAnswer(
-          (_) async => _metadata(
-            duration: const Duration(milliseconds: 3000),
-            audioDuration: const Duration(milliseconds: 800),
-          ),
-        );
-        final notifier = container.read(clipManagerProvider.notifier);
-
-        await addAndSettle(notifier);
-
-        expect(
-          container.read(clipManagerProvider).clips.single.duration,
-          equals(const Duration(milliseconds: 3000)),
-        );
-        verifyNever(() => mockClipLibraryService.saveClip(any()));
-      });
-
-      test(
-        'keeps the recorded length when the media cannot be probed',
-        () async {
-          when(
-            () => editor.getMetadata(any()),
-          ).thenThrow(Exception('unreadable'));
-          final notifier = container.read(clipManagerProvider.notifier);
-
-          await addAndSettle(notifier);
-
-          expect(
-            container.read(clipManagerProvider).clips.single.duration,
-            equals(const Duration(milliseconds: 3000)),
-          );
-        },
-      );
-    });
   });
 }
-
-VideoMetadata _metadata({
-  required Duration duration,
-  Duration? audioDuration,
-}) => VideoMetadata(
-  duration: duration,
-  audioDuration: audioDuration,
-  extension: 'mp4',
-  fileSize: 1024,
-  resolution: const Size(720, 1280),
-  rotation: 0,
-  bitrate: 2000000,
-);

--- a/mobile/test/providers/clip_manager_provider_test.dart
+++ b/mobile/test/providers/clip_manager_provider_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Tests for ClipManagerProvider - Riverpod state management
 // ABOUTME: Validates state updates and provider lifecycle
 
+import 'dart:ui';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -12,12 +14,17 @@ import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/services/clip_library_service.dart';
 import 'package:openvine/services/draft_storage_service.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class _MockDraftStorageService extends Mock implements DraftStorageService {}
 
 class _MockClipLibraryService extends Mock implements ClipLibraryService {}
+
+class _MockProVideoEditor extends Mock
+    with MockPlatformInterfaceMixin
+    implements ProVideoEditor {}
 
 void main() {
   group('ClipManagerProvider', () {
@@ -36,6 +43,7 @@ void main() {
           originalAspectRatio: 9 / 16,
         ),
       );
+      registerFallbackValue(EditorVideo.file('/fallback.mp4'));
     });
 
     setUp(() async {
@@ -945,5 +953,123 @@ void main() {
         ).called(1);
       });
     });
+
+    group('aligning a recorded clip to its media', () {
+      late ProVideoEditor originalEditor;
+      late _MockProVideoEditor editor;
+
+      setUp(() {
+        originalEditor = ProVideoEditor.instance;
+        editor = _MockProVideoEditor();
+        ProVideoEditor.instance = editor;
+        when(() => mockClipLibraryService.saveClip(any())).thenAnswer(
+          (_) async {},
+        );
+      });
+
+      tearDown(() {
+        ProVideoEditor.instance = originalEditor;
+      });
+
+      /// Adds a clip and lets the fire-and-forget alignment settle.
+      Future<DivineVideoClip> addAndSettle(ClipManagerNotifier notifier) async {
+        final clip = notifier.addClip(
+          limitClipDuration: false,
+          video: EditorVideo.file('/path/to/video.mp4'),
+          duration: const Duration(milliseconds: 3000),
+          targetAspectRatio: .vertical,
+          originalAspectRatio: 9 / 16,
+        );
+        await pumpEventQueue();
+        return clip;
+      }
+
+      test(
+        'shortens the clip to where both tracks still have content',
+        () async {
+          when(() => editor.getMetadata(any())).thenAnswer(
+            (_) async => _metadata(
+              duration: const Duration(milliseconds: 3000),
+              audioDuration: const Duration(milliseconds: 2931),
+            ),
+          );
+          final notifier = container.read(clipManagerProvider.notifier);
+
+          await addAndSettle(notifier);
+
+          expect(
+            container.read(clipManagerProvider).clips.single.duration,
+            equals(const Duration(milliseconds: 2931)),
+          );
+        },
+      );
+
+      test('persists the aligned length to the library', () async {
+        when(() => editor.getMetadata(any())).thenAnswer(
+          (_) async => _metadata(
+            duration: const Duration(milliseconds: 3000),
+            audioDuration: const Duration(milliseconds: 2931),
+          ),
+        );
+        final notifier = container.read(clipManagerProvider.notifier);
+
+        await addAndSettle(notifier);
+
+        final captured =
+            verify(
+                  () => mockClipLibraryService.saveClip(captureAny()),
+                ).captured.single
+                as DivineVideoClip;
+        expect(captured.duration, equals(const Duration(milliseconds: 2931)));
+      });
+
+      test('leaves a clip that genuinely outlasts its audio', () async {
+        when(() => editor.getMetadata(any())).thenAnswer(
+          (_) async => _metadata(
+            duration: const Duration(milliseconds: 3000),
+            audioDuration: const Duration(milliseconds: 800),
+          ),
+        );
+        final notifier = container.read(clipManagerProvider.notifier);
+
+        await addAndSettle(notifier);
+
+        expect(
+          container.read(clipManagerProvider).clips.single.duration,
+          equals(const Duration(milliseconds: 3000)),
+        );
+        verifyNever(() => mockClipLibraryService.saveClip(any()));
+      });
+
+      test(
+        'keeps the recorded length when the media cannot be probed',
+        () async {
+          when(
+            () => editor.getMetadata(any()),
+          ).thenThrow(Exception('unreadable'));
+          final notifier = container.read(clipManagerProvider.notifier);
+
+          await addAndSettle(notifier);
+
+          expect(
+            container.read(clipManagerProvider).clips.single.duration,
+            equals(const Duration(milliseconds: 3000)),
+          );
+        },
+      );
+    });
   });
 }
+
+VideoMetadata _metadata({
+  required Duration duration,
+  Duration? audioDuration,
+}) => VideoMetadata(
+  duration: duration,
+  audioDuration: audioDuration,
+  extension: 'mp4',
+  fileSize: 1024,
+  resolution: const Size(720, 1280),
+  rotation: 0,
+  bitrate: 2000000,
+);

--- a/mobile/test/services/video_editor/clip_media_duration_test.dart
+++ b/mobile/test/services/video_editor/clip_media_duration_test.dart
@@ -75,5 +75,17 @@ void main() {
 
       expect(commonTrackEnd(result), isNull);
     });
+
+    test(
+      'ignores degenerate audio tracks below the editable duration floor',
+      () {
+        final result = _metadata(
+          duration: const Duration(milliseconds: 400),
+          audioDuration: Duration.zero,
+        );
+
+        expect(commonTrackEnd(result), isNull);
+      },
+    );
   });
 }

--- a/mobile/test/services/video_editor/clip_media_duration_test.dart
+++ b/mobile/test/services/video_editor/clip_media_duration_test.dart
@@ -1,0 +1,79 @@
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/video_editor/clip_media_duration.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
+
+VideoMetadata _metadata({
+  required Duration duration,
+  Duration? audioDuration,
+}) => VideoMetadata(
+  duration: duration,
+  audioDuration: audioDuration,
+  extension: 'mp4',
+  fileSize: 1024,
+  resolution: const Size(720, 1280),
+  rotation: 0,
+  bitrate: 2000000,
+);
+
+void main() {
+  group('commonTrackEnd', () {
+    test('returns the audio end when the audio writer stopped first', () {
+      final result = _metadata(
+        duration: const Duration(milliseconds: 3000),
+        audioDuration: const Duration(milliseconds: 2931),
+      );
+
+      expect(
+        commonTrackEnd(result),
+        equals(const Duration(milliseconds: 2931)),
+      );
+    });
+
+    test('returns null when both tracks already end together', () {
+      final result = _metadata(
+        duration: const Duration(milliseconds: 3000),
+        audioDuration: const Duration(milliseconds: 3000),
+      );
+
+      expect(commonTrackEnd(result), isNull);
+    });
+
+    test('returns null for a clip with no audio track', () {
+      final result = _metadata(duration: const Duration(milliseconds: 3000));
+
+      expect(commonTrackEnd(result), isNull);
+    });
+
+    test('trims a shortfall exactly at the tolerance', () {
+      final result = _metadata(
+        duration: const Duration(milliseconds: 3000),
+        audioDuration: const Duration(milliseconds: 2500),
+      );
+
+      expect(
+        commonTrackEnd(result),
+        equals(const Duration(milliseconds: 2500)),
+      );
+    });
+
+    test('leaves a clip that outlasts its audio beyond the tolerance', () {
+      final result = _metadata(
+        duration: const Duration(milliseconds: 3000),
+        audioDuration: const Duration(milliseconds: 2499),
+      );
+
+      expect(commonTrackEnd(result), isNull);
+    });
+
+    test('leaves a stop-motion still held past a short sound', () {
+      final result = _metadata(
+        duration: const Duration(seconds: 6),
+        audioDuration: const Duration(milliseconds: 800),
+      );
+
+      expect(commonTrackEnd(result), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Description

A recorded clip's length came from a stopwatch — how long the record button was held. The media it produces is a different number: capture stops the audio and video writers independently, so an mp4's two tracks end tens of milliseconds apart, and the container declares the *longer* one. The clip's tail therefore carries picture with no sound.

Every editor anchor is authored against that tail — trims, layer time windows, transitions, filter windows — and the export cannot fill it. What the feed's looping player replays every cycle is that stretch of silence, which is the seam in #6386. On a multi-clip export the same gap sits at every clip join, not only at the loop point.

This sets a recorded clip's length to the point where both its tracks still have content during the recorder's existing metadata enrichment pass. The editor timeline then matches the media, and the export follows from the existing per-segment `endTime` without any special-casing.

- `commonTrackEnd(VideoMetadata)` returns the common track end, or `null` when there is nothing to correct: no audio track, tracks already ending together, or a shortfall beyond 500 ms.
- `VideoRecorderBloc._enrichAndSaveClip` applies it while reusing the metadata probe the recorder already performs for duration, thumbnail, ghost frame, and the enriched library save. The recorder still shows the clip instantly, then the detached enrichment writes the aligned duration once.
- Only ever shortens. A clip that genuinely outlasts its audio — a stop-motion still held past a short sound, a source with a broken audio track — keeps its full length.

### Why not fix this at export time

The first version of this PR passed a `trimToCommonTrackEnd` flag into the native renderer and bumped `pro_video_editor` to 2.10.0. That worked on the seam but was the wrong layer, for two reasons.

It fixed the symptom after the whole editor had already worked with the wrong number, so the export no longer matched what the user saw. Measured on a two-clip export whose clips each carried a 300 ms gap: the trim shortened each clip, so clip 2 started at 2.70 s instead of 3.00 s — but an overlay anchored to clip 2 still fired at 3.00 s, **300 ms late**. The drift accumulates over the preceding clips, and colour filters drift with it.

And it was Apple-only. `trimToCommonTrackEnd` is implemented under `darwin/` and has no Android counterpart in 2.10.0 — measured on a Galaxy S25, a 300 ms gap rendered to the same 284 ms with and without the flag. Correcting the clip's length is platform-independent.

Fixing it at the source removes both problems and the dependency bump: `pro_video_editor` stays at 2.9.0.

## Out of Scope

**Already-recorded clips.** Only affects new recordings; clips already sitting in a draft keep their stored length. The player-side clamp from #6430, merged 2026-07-28, covers what is already published — Blossom is content-addressed, so a re-encode is a different file and a different event.

**Imported and remixed clips.** `VideoClipImportService` takes its duration from the source Nostr event, not from the file. Those are already-published videos that cannot be repaired in place, and #6430 covers their playback.

**Stop-motion clips.** They have no captured audio track; their length is authored from the frames, and `commonTrackEnd` returns `null` for them.

## Verification

- `flutter analyze lib test integration_test` — clean
- `flutter test test/providers/clip_manager_provider_test.dart test/services/video_editor/ test/blocs/video_recorder/ test/services/upload_manager_from_draft_test.dart` — 393 passed
- 7 tests for `commonTrackEnd`, including the degenerate-track floor guard
- Recorder stop-path regression coverage that drives detached enrichment through the final library save and asserts the aligned duration survives

### Device verification

Driven from a throwaway `integration_test` against the real render path.

**Real capture, iPad Air 11-inch (M4), iOS 26.5.2** — container vs. audio-track duration:

| | container | audio | gap |
|---|---|---|---|
| the recording itself | 6033 ms | 5998 ms | 35 ms |
| export from the recorded length | 6033 ms | 5998 ms | 35 ms |
| export from the aligned length | 6000 ms | 5998 ms | **2 ms** |

The residual 2 ms is one AAC access unit. The export is 33 ms shorter — the stretch that had no audio under it.

**Real capture, Galaxy S25, Android 16** — the alignment fires here too (`audioDuration` is implemented on Android), but this recording's gap was 25 ms, which is *shorter than one video frame* at 30 fps. A video cannot end between two frames, so there was nothing to cut and the export is unchanged:

| | container | audio | gap |
|---|---|---|---|
| the recording itself | 6166 ms | 6141 ms | 25 ms |
| export from the recorded length | 6166 ms | 6122 ms | 44 ms |
| export from the aligned length | 6166 ms | 6122 ms | 44 ms |

Feeding the same device a crafted 300 ms gap — comfortably more than one frame — shows the mechanism working on Android:

| | container | audio | gap |
|---|---|---|---|
| source | 3000 ms | 2700 ms | 300 ms |
| export from the declared length | 3000 ms | 2716 ms | 284 ms |
| export from the aligned length | **2700 ms** | 2693 ms | **7 ms** |

So the fix is platform-independent, unlike the export-side flag it replaces. What it cannot remove is a gap below one frame duration (~33 ms at 30 fps), or the ±20 ms of AAC framing the Android encoder adds on its own — the residual 44 ms above is that framing, not the capture gap.

**Crafted 300 ms gap, macOS 26.5.2** — container vs. audio-track duration of the export:

| | video | audio | delta |
|---|---|---|---|
| single clip | 2.700 s | 2.700 s | **0 ms** |
| two clips | 5.400 s | 5.400 s | **0 ms** |
| two clips + overlay | 5.400 s | 5.400 s | **0 ms** |

Sampling the audio envelope in 50 ms windows across the two-clip export shows continuous sound to 5.41 s — no hole at the clip join, which the un-aligned export had at 2.70–3.00 s.

Overlay anchored to the second clip, measured by sampling the rendered frames:

| | clip 2 starts at | overlay appears at | drift |
|---|---|---|---|
| export-side trim (previous approach) | 2.70 s | 3.00 s | +300 ms |
| capture-side alignment (this PR) | 2.70 s | 2.70 s | **0 ms** |

**Closes:** #none — #6386 was closed by the player-side fix #6430; this is the capture-side counterpart for new recordings.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore


