### PR TITLE
fix(notifications): fetch category tabs independently

### DIFF
--- a/mobile/lib/notifications/bloc/notification_feed_bloc.dart
+++ b/mobile/lib/notifications/bloc/notification_feed_bloc.dart
@@ -28,8 +28,10 @@ class NotificationFeedBloc
   NotificationFeedBloc({
     required NotificationRepository notificationRepository,
     required FollowRepository followRepository,
+    NotificationKind? filter,
   }) : _notificationRepository = notificationRepository,
        _followRepository = followRepository,
+       _filter = filter,
        super(const NotificationFeedState()) {
     on<_SnapshotChanged>(_onSnapshotChanged);
     on<NotificationFeedStarted>(_onStarted, transformer: droppable());
@@ -40,13 +42,14 @@ class NotificationFeedBloc
 
     // Project the repository's snapshot stream into BLoC state via a
     // private event so emit() stays inside an event handler.
-    _snapshotSubscription = _notificationRepository.watchSnapshot().listen(
-      (page) => add(_SnapshotChanged(page)),
-    );
+    _snapshotSubscription = _notificationRepository
+        .watchSnapshot(filter: _filter)
+        .listen((page) => add(_SnapshotChanged(page)));
   }
 
   final NotificationRepository _notificationRepository;
   final FollowRepository _followRepository;
+  final NotificationKind? _filter;
   late final StreamSubscription<NotificationPage> _snapshotSubscription;
 
   /// Override [ActorNotification.isFollowingBack] for follow-type rows so the
@@ -104,14 +107,16 @@ class NotificationFeedBloc
     emit(state.copyWith(isRefreshing: true));
 
     try {
-      await _notificationRepository.refresh();
+      await _notificationRepository.refreshFeed(_filter);
       emit(
         state.copyWith(
           status: NotificationFeedStatus.loaded,
           isRefreshing: false,
         ),
       );
-      await _markSeenOnOpen();
+      if (_filter == null) {
+        await _markSeenOnOpen();
+      }
     } on Exception catch (e, s) {
       // `NotificationRepository.refresh` propagates typed
       // `FunnelcakeException` (4xx/5xx/timeout; transient-retry
@@ -206,7 +211,7 @@ class NotificationFeedBloc
     emit(state.copyWith(isLoadingMore: true));
 
     try {
-      await _notificationRepository.loadNextPage();
+      await _notificationRepository.loadNextPageFor(_filter);
       emit(state.copyWith(isLoadingMore: false));
     } on Exception catch (e, s) {
       // `NotificationRepository.loadNextPage` (single-attempt
@@ -232,7 +237,7 @@ class NotificationFeedBloc
   ) async {
     emit(state.copyWith(isRefreshing: true));
     try {
-      await _notificationRepository.refresh();
+      await _notificationRepository.refreshFeed(_filter);
       emit(
         state.copyWith(
           status: NotificationFeedStatus.loaded,
@@ -342,7 +347,9 @@ class NotificationFeedBloc
   @override
   Future<void> close() async {
     await _snapshotSubscription.cancel();
-    _notificationRepository.resetPaginationDepth();
+    if (_filter == null) {
+      _notificationRepository.resetPaginationDepth();
+    }
     return super.close();
   }
 }

--- a/mobile/lib/notifications/bloc/notification_feed_bloc.dart
+++ b/mobile/lib/notifications/bloc/notification_feed_bloc.dart
@@ -53,6 +53,7 @@ class NotificationFeedBloc
   late final StreamSubscription<NotificationPage> _snapshotSubscription;
   int _emptyPageContinuations = 0;
   bool _loadMoreFailed = false;
+  bool _emptyPageContinuationPending = false;
 
   static const _maxEmptyPageContinuations = 3;
 
@@ -89,21 +90,45 @@ class NotificationFeedBloc
     _continuePastEmptyPageIfNeeded(notifications);
   }
 
+  /// Keeps an all-filtered-out page paginating instead of rendering as an
+  /// empty tab while the server still reports more rows.
+  ///
+  /// The repository emits the snapshot from inside `refreshFeed`, before it
+  /// completes, so on the first open this runs while `_onStarted` still
+  /// holds `isRefreshing: true` and `status: initial`. Dispatching a
+  /// load-more there would race the refresh's cursor reset, but simply
+  /// bailing strands the tab: no further snapshot follows, so it settles
+  /// empty with `hasMore: true` and never paginates. Defer instead, and
+  /// let [_flushPendingEmptyPageContinuation] pick it up once the refresh
+  /// handler has settled.
   void _continuePastEmptyPageIfNeeded(List<NotificationItem> notifications) {
     if (notifications.isNotEmpty || !state.hasMore) {
       _emptyPageContinuations = 0;
       _loadMoreFailed = false;
+      _emptyPageContinuationPending = false;
+      return;
+    }
+    if (_loadMoreFailed ||
+        _emptyPageContinuations >= _maxEmptyPageContinuations) {
       return;
     }
     if (state.status != NotificationFeedStatus.loaded ||
         state.isLoadingMore ||
-        state.isRefreshing ||
-        _loadMoreFailed ||
-        _emptyPageContinuations >= _maxEmptyPageContinuations) {
+        state.isRefreshing) {
+      _emptyPageContinuationPending = true;
       return;
     }
+    _emptyPageContinuationPending = false;
     _emptyPageContinuations += 1;
     add(const NotificationFeedLoadMore());
+  }
+
+  /// Re-runs a continuation that [_continuePastEmptyPageIfNeeded] had to
+  /// defer because a refresh was still in flight when the empty page landed.
+  void _flushPendingEmptyPageContinuation() {
+    if (!_emptyPageContinuationPending) return;
+    _emptyPageContinuationPending = false;
+    _continuePastEmptyPageIfNeeded(state.notifications);
   }
 
   /// Handle initial load.
@@ -126,6 +151,7 @@ class NotificationFeedBloc
   ) async {
     _emptyPageContinuations = 0;
     _loadMoreFailed = false;
+    _emptyPageContinuationPending = false;
     // Stale-while-revalidate: keep any hydrated/cached items rendered and
     // flag the in-flight refresh so the view shows a thin progress bar
     // instead of a blanking full-screen spinner.
@@ -139,6 +165,7 @@ class NotificationFeedBloc
           isRefreshing: false,
         ),
       );
+      _flushPendingEmptyPageContinuation();
       if (_filter == null) {
         await _markSeenOnOpen();
       }
@@ -264,6 +291,7 @@ class NotificationFeedBloc
   ) async {
     _emptyPageContinuations = 0;
     _loadMoreFailed = false;
+    _emptyPageContinuationPending = false;
     emit(state.copyWith(isRefreshing: true));
     try {
       await _notificationRepository.refreshFeed(_filter);
@@ -273,6 +301,7 @@ class NotificationFeedBloc
           isRefreshing: false,
         ),
       );
+      _flushPendingEmptyPageContinuation();
     } on Exception catch (e, s) {
       // `NotificationRepository.refresh` propagates typed
       // `FunnelcakeException` (4xx/5xx/timeout). Per

--- a/mobile/lib/notifications/bloc/notification_feed_bloc.dart
+++ b/mobile/lib/notifications/bloc/notification_feed_bloc.dart
@@ -254,11 +254,18 @@ class NotificationFeedBloc
   }
 
   /// Handle scroll pagination.
+  ///
+  /// Deliberately does NOT consult [_loadMoreFailed]: that flag only stops
+  /// the automatic empty-page continuation from re-arming. A load-more
+  /// failure emits no snapshot (`_markRefreshError` is first-page-only) and
+  /// surfaces no error affordance, so gating this handler on it would leave
+  /// a user who hit one transient 5xx at the bottom of the list unable to
+  /// paginate for the rest of the session.
   Future<void> _onLoadMore(
     NotificationFeedLoadMore event,
     Emitter<NotificationFeedState> emit,
   ) async {
-    if (!state.hasMore || state.isLoadingMore || _loadMoreFailed) return;
+    if (!state.hasMore || state.isLoadingMore) return;
 
     emit(state.copyWith(isLoadingMore: true));
 

--- a/mobile/lib/notifications/bloc/notification_feed_bloc.dart
+++ b/mobile/lib/notifications/bloc/notification_feed_bloc.dart
@@ -51,6 +51,10 @@ class NotificationFeedBloc
   final FollowRepository _followRepository;
   final NotificationKind? _filter;
   late final StreamSubscription<NotificationPage> _snapshotSubscription;
+  int _emptyPageContinuations = 0;
+  bool _loadMoreFailed = false;
+
+  static const _maxEmptyPageContinuations = 3;
 
   /// Override [ActorNotification.isFollowingBack] for follow-type rows so the
   /// flag tracks the authoritative follow state in [FollowRepository] rather
@@ -73,14 +77,33 @@ class NotificationFeedBloc
     _SnapshotChanged event,
     Emitter<NotificationFeedState> emit,
   ) {
+    final notifications = _applyFollowState(event.page.items);
     emit(
       state.copyWith(
-        notifications: _applyFollowState(event.page.items),
+        notifications: notifications,
         unreadCount: event.page.unreadCount,
         hasMore: event.page.hasMore,
         refreshError: event.page.lastRefreshError,
       ),
     );
+    _continuePastEmptyPageIfNeeded(notifications);
+  }
+
+  void _continuePastEmptyPageIfNeeded(List<NotificationItem> notifications) {
+    if (notifications.isNotEmpty || !state.hasMore) {
+      _emptyPageContinuations = 0;
+      _loadMoreFailed = false;
+      return;
+    }
+    if (state.status != NotificationFeedStatus.loaded ||
+        state.isLoadingMore ||
+        state.isRefreshing ||
+        _loadMoreFailed ||
+        _emptyPageContinuations >= _maxEmptyPageContinuations) {
+      return;
+    }
+    _emptyPageContinuations += 1;
+    add(const NotificationFeedLoadMore());
   }
 
   /// Handle initial load.
@@ -101,6 +124,8 @@ class NotificationFeedBloc
     NotificationFeedStarted event,
     Emitter<NotificationFeedState> emit,
   ) async {
+    _emptyPageContinuations = 0;
+    _loadMoreFailed = false;
     // Stale-while-revalidate: keep any hydrated/cached items rendered and
     // flag the in-flight refresh so the view shows a thin progress bar
     // instead of a blanking full-screen spinner.
@@ -206,7 +231,7 @@ class NotificationFeedBloc
     NotificationFeedLoadMore event,
     Emitter<NotificationFeedState> emit,
   ) async {
-    if (!state.hasMore || state.isLoadingMore) return;
+    if (!state.hasMore || state.isLoadingMore || _loadMoreFailed) return;
 
     emit(state.copyWith(isLoadingMore: true));
 
@@ -214,6 +239,7 @@ class NotificationFeedBloc
       await _notificationRepository.loadNextPageFor(_filter);
       emit(state.copyWith(isLoadingMore: false));
     } on Exception catch (e, s) {
+      _loadMoreFailed = true;
       // `NotificationRepository.loadNextPage` (single-attempt
       // paginate-load-more) propagates typed `FunnelcakeException`
       // (4xx/5xx/timeout). Per .claude/rules/error_handling.md they
@@ -221,6 +247,7 @@ class NotificationFeedBloc
       addError(e, s);
       emit(state.copyWith(isLoadingMore: false));
     } catch (e, s) {
+      _loadMoreFailed = true;
       // Errors (StateError, TypeError) — matrix-YES invariant.
       addError(
         Reportable(e, context: NotificationFeedBlocReportableSites.onLoadMore),
@@ -235,6 +262,8 @@ class NotificationFeedBloc
     NotificationFeedRefreshed event,
     Emitter<NotificationFeedState> emit,
   ) async {
+    _emptyPageContinuations = 0;
+    _loadMoreFailed = false;
     emit(state.copyWith(isRefreshing: true));
     try {
       await _notificationRepository.refreshFeed(_filter);
@@ -347,9 +376,7 @@ class NotificationFeedBloc
   @override
   Future<void> close() async {
     await _snapshotSubscription.cancel();
-    if (_filter == null) {
-      _notificationRepository.resetPaginationDepth();
-    }
+    _notificationRepository.resetPaginationDepth(filter: _filter);
     return super.close();
   }
 }

--- a/mobile/lib/notifications/bloc/notification_feed_bloc.dart
+++ b/mobile/lib/notifications/bloc/notification_feed_bloc.dart
@@ -272,6 +272,13 @@ class NotificationFeedBloc
     try {
       await _notificationRepository.loadNextPageFor(_filter);
       emit(state.copyWith(isLoadingMore: false));
+      // The page this call fetched lands on the snapshot while
+      // `isLoadingMore` is still true, so a page that filters down to
+      // nothing parks its continuation instead of dispatching it. Flush it
+      // here — otherwise only the first of [_maxEmptyPageContinuations]
+      // could ever fire, and a Comments feed whose pages are mostly video
+      // mentions would get one extra page of runway instead of three.
+      _flushPendingEmptyPageContinuation();
     } on Exception catch (e, s) {
       _loadMoreFailed = true;
       // `NotificationRepository.loadNextPage` (single-attempt

--- a/mobile/lib/notifications/view/inbox_notifications_page.dart
+++ b/mobile/lib/notifications/view/inbox_notifications_page.dart
@@ -6,8 +6,10 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:follow_repository/follow_repository.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart';
+import 'package:notification_repository/notification_repository.dart';
 import 'package:openvine/blocs/invite_status/invite_status_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/notifications/bloc/notification_feed_bloc.dart';
@@ -20,8 +22,7 @@ import 'package:openvine/screens/settings/invites_screen.dart';
 ///
 /// Wraps [NotificationsView] with the existing 5-tab UI (All / Likes /
 /// Comments / Follows / Reposts) and the invites banner shown on the All
-/// tab. Each tab passes a [NotificationKind] filter to the same view; the
-/// underlying [NotificationFeedBloc] is shared across tabs.
+/// tab. Each tab owns a feed BLoC with independent server-side pagination.
 class InboxNotificationsPage extends ConsumerWidget {
   /// Creates an [InboxNotificationsPage].
   const InboxNotificationsPage({super.key});
@@ -39,25 +40,21 @@ class InboxNotificationsPage extends ConsumerWidget {
     }
     final followRepository = ref.watch(followRepositoryProvider);
 
-    // Key on the watched dependency identities so the bloc rebuilds when
-    // either repository swaps (account switch, sign-out → sign-in, or
-    // provider invalidation). The upstream KeyedSubtree in `inbox_view.dart`
-    // already forces this subtree to remount on pubkey change today, but
-    // pinning the contract here keeps the page safe even if the inbox
-    // scaffold is restructured. See `.claude/rules/state_management.md`.
-    return BlocProvider(
-      key: ValueKey((notificationRepository, followRepository)),
-      create: (_) => NotificationFeedBloc(
-        notificationRepository: notificationRepository,
-        followRepository: followRepository,
-      )..add(const NotificationFeedStarted()),
-      child: const _InboxNotificationsScaffold(),
+    return _InboxNotificationsScaffold(
+      notificationRepository: notificationRepository,
+      followRepository: followRepository,
     );
   }
 }
 
 class _InboxNotificationsScaffold extends StatefulWidget {
-  const _InboxNotificationsScaffold();
+  const _InboxNotificationsScaffold({
+    required this.notificationRepository,
+    required this.followRepository,
+  });
+
+  final NotificationRepository notificationRepository;
+  final FollowRepository followRepository;
 
   @override
   State<_InboxNotificationsScaffold> createState() =>
@@ -127,12 +124,31 @@ class _InboxNotificationsScaffoldState
             Expanded(
               child: TabBarView(
                 controller: _tabController,
-                children: const [
-                  _AllTabContent(),
-                  NotificationsView(kindFilter: NotificationKind.like),
-                  NotificationsView(kindFilter: NotificationKind.comment),
-                  NotificationsView(kindFilter: NotificationKind.follow),
-                  NotificationsView(kindFilter: NotificationKind.repost),
+                children: [
+                  _AllTabContent(
+                    notificationRepository: widget.notificationRepository,
+                    followRepository: widget.followRepository,
+                  ),
+                  _NotificationTab(
+                    notificationRepository: widget.notificationRepository,
+                    followRepository: widget.followRepository,
+                    filter: NotificationKind.like,
+                  ),
+                  _NotificationTab(
+                    notificationRepository: widget.notificationRepository,
+                    followRepository: widget.followRepository,
+                    filter: NotificationKind.comment,
+                  ),
+                  _NotificationTab(
+                    notificationRepository: widget.notificationRepository,
+                    followRepository: widget.followRepository,
+                    filter: NotificationKind.follow,
+                  ),
+                  _NotificationTab(
+                    notificationRepository: widget.notificationRepository,
+                    followRepository: widget.followRepository,
+                    filter: NotificationKind.repost,
+                  ),
                 ],
               ),
             ),
@@ -143,17 +159,57 @@ class _InboxNotificationsScaffoldState
   }
 }
 
-/// All tab — invites banner above the unfiltered notifications list.
-class _AllTabContent extends StatelessWidget {
-  const _AllTabContent();
+class _NotificationTab extends StatelessWidget {
+  const _NotificationTab({
+    required this.notificationRepository,
+    required this.followRepository,
+    this.filter,
+    this.child = const NotificationsView(),
+  });
+
+  final NotificationRepository notificationRepository;
+  final FollowRepository followRepository;
+  final NotificationKind? filter;
+  final Widget child;
 
   @override
   Widget build(BuildContext context) {
-    return const Column(
-      children: [
-        _InvitesBanner(),
-        Expanded(child: NotificationsView()),
-      ],
+    // Key on the watched dependency identities plus filter so each tab's bloc
+    // rebuilds when repositories swap and keeps an independent pagination
+    // stream for its server-side category.
+    return BlocProvider(
+      key: ValueKey((notificationRepository, followRepository, filter)),
+      create: (_) => NotificationFeedBloc(
+        notificationRepository: notificationRepository,
+        followRepository: followRepository,
+        filter: filter,
+      )..add(const NotificationFeedStarted()),
+      child: child,
+    );
+  }
+}
+
+/// All tab — invites banner above the unfiltered notifications list.
+class _AllTabContent extends StatelessWidget {
+  const _AllTabContent({
+    required this.notificationRepository,
+    required this.followRepository,
+  });
+
+  final NotificationRepository notificationRepository;
+  final FollowRepository followRepository;
+
+  @override
+  Widget build(BuildContext context) {
+    return _NotificationTab(
+      notificationRepository: notificationRepository,
+      followRepository: followRepository,
+      child: const Column(
+        children: [
+          _InvitesBanner(),
+          Expanded(child: NotificationsView()),
+        ],
+      ),
     );
   }
 }

--- a/mobile/lib/notifications/view/inbox_notifications_page.dart
+++ b/mobile/lib/notifications/view/inbox_notifications_page.dart
@@ -125,9 +125,15 @@ class _InboxNotificationsScaffoldState
               child: TabBarView(
                 controller: _tabController,
                 children: [
-                  _AllTabContent(
+                  _NotificationTab(
                     notificationRepository: widget.notificationRepository,
                     followRepository: widget.followRepository,
+                    child: const Column(
+                      children: [
+                        _InvitesBanner(),
+                        Expanded(child: NotificationsView()),
+                      ],
+                    ),
                   ),
                   _NotificationTab(
                     notificationRepository: widget.notificationRepository,
@@ -159,7 +165,7 @@ class _InboxNotificationsScaffoldState
   }
 }
 
-class _NotificationTab extends StatelessWidget {
+class _NotificationTab extends StatefulWidget {
   const _NotificationTab({
     required this.notificationRepository,
     required this.followRepository,
@@ -173,43 +179,32 @@ class _NotificationTab extends StatelessWidget {
   final Widget child;
 
   @override
+  State<_NotificationTab> createState() => _NotificationTabState();
+}
+
+class _NotificationTabState extends State<_NotificationTab>
+    with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
+
+  @override
   Widget build(BuildContext context) {
+    super.build(context);
     // Key on the watched dependency identities plus filter so each tab's bloc
     // rebuilds when repositories swap and keeps an independent pagination
     // stream for its server-side category.
     return BlocProvider(
-      key: ValueKey((notificationRepository, followRepository, filter)),
+      key: ValueKey((
+        widget.notificationRepository,
+        widget.followRepository,
+        widget.filter,
+      )),
       create: (_) => NotificationFeedBloc(
-        notificationRepository: notificationRepository,
-        followRepository: followRepository,
-        filter: filter,
+        notificationRepository: widget.notificationRepository,
+        followRepository: widget.followRepository,
+        filter: widget.filter,
       )..add(const NotificationFeedStarted()),
-      child: child,
-    );
-  }
-}
-
-/// All tab — invites banner above the unfiltered notifications list.
-class _AllTabContent extends StatelessWidget {
-  const _AllTabContent({
-    required this.notificationRepository,
-    required this.followRepository,
-  });
-
-  final NotificationRepository notificationRepository;
-  final FollowRepository followRepository;
-
-  @override
-  Widget build(BuildContext context) {
-    return _NotificationTab(
-      notificationRepository: notificationRepository,
-      followRepository: followRepository,
-      child: const Column(
-        children: [
-          _InvitesBanner(),
-          Expanded(child: NotificationsView()),
-        ],
-      ),
+      child: widget.child,
     );
   }
 }

--- a/mobile/lib/notifications/view/notifications_view.dart
+++ b/mobile/lib/notifications/view/notifications_view.dart
@@ -27,15 +27,7 @@ import 'package:unified_logger/unified_logger.dart';
 @visibleForTesting
 class NotificationsView extends ConsumerStatefulWidget {
   /// Creates a [NotificationsView].
-  const NotificationsView({this.kindFilter, super.key});
-
-  /// When non-null, only notifications whose [NotificationItem.type] matches
-  /// the filter are rendered. Used by the inbox tabs scaffold.
-  ///
-  /// `like` matches both [VideoNotification]s of kind `like` and
-  /// [ActorNotification]s of kind `likeComment` so the Likes tab surfaces
-  /// reactions on both videos and comments.
-  final NotificationKind? kindFilter;
+  const NotificationsView({super.key});
 
   @override
   ConsumerState<NotificationsView> createState() => _NotificationsViewState();
@@ -43,6 +35,7 @@ class NotificationsView extends ConsumerStatefulWidget {
 
 class _NotificationsViewState extends ConsumerState<NotificationsView> {
   final ScrollController _scrollController = ScrollController();
+  bool _emptyLoadMoreQueued = false;
 
   /// Threshold (in pixels from bottom) to trigger load-more.
   static const _loadMoreThreshold = 200.0;
@@ -74,27 +67,20 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
     }
   }
 
-  /// Returns [items] filtered by [NotificationsView.kindFilter].
-  ///
-  /// `like` matches both video likes and comment likes so the Likes tab
-  /// surfaces reactions on either target.
-  List<NotificationItem> _applyFilter(List<NotificationItem> items) {
-    final filter = widget.kindFilter;
-    if (filter == null) return items;
-    return items.where((n) {
-      if (n.type == filter) return true;
-      if (filter == NotificationKind.like &&
-          n.type == NotificationKind.likeComment) {
-        return true;
-      }
-      if (filter == NotificationKind.comment &&
-          n is ActorNotification &&
-          n.type == NotificationKind.mention &&
-          n.hasCommentTarget) {
-        return true;
-      }
-      return false;
-    }).toList();
+  void _requestLoadMoreFromEmptyState(NotificationFeedState state) {
+    if (!state.hasMore ||
+        state.isLoadingMore ||
+        state.isRefreshing ||
+        _emptyLoadMoreQueued) {
+      return;
+    }
+    _emptyLoadMoreQueued = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      context.read<NotificationFeedBloc>().add(
+        const NotificationFeedLoadMore(),
+      );
+    });
   }
 
   @override
@@ -103,7 +89,11 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
       color: VineTheme.surfaceContainerHigh,
       child: BlocBuilder<NotificationFeedBloc, NotificationFeedState>(
         builder: (context, state) {
-          final visible = _applyFilter(state.notifications);
+          if (state.notifications.isNotEmpty ||
+              state.isLoadingMore ||
+              !state.hasMore) {
+            _emptyLoadMoreQueued = false;
+          }
 
           // Hard failure path. The bloc gates `failure` on
           // `notifications.isEmpty`, so we only land here when the cache
@@ -122,7 +112,7 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
           // background refresh never blanks the cached list. The inline
           // refresh-error banner handles the soft-failure affordance via
           // `state.refreshError`.
-          if (visible.isNotEmpty) {
+          if (state.notifications.isNotEmpty) {
             return Stack(
               children: [
                 RefreshIndicator(
@@ -134,7 +124,7 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
                     );
                   },
                   child: _NotificationList(
-                    notifications: visible,
+                    notifications: state.notifications,
                     isLoadingMore: state.isLoadingMore,
                     hasMore: state.hasMore,
                     scrollController: _scrollController,
@@ -182,6 +172,12 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
           // `onRefresh` returns.
           return Stack(
             children: [
+              Builder(
+                builder: (context) {
+                  _requestLoadMoreFromEmptyState(state);
+                  return const SizedBox.shrink();
+                },
+              ),
               RefreshIndicator(
                 color: VineTheme.onPrimary,
                 backgroundColor: VineTheme.vineGreen,
@@ -190,7 +186,7 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
                     const NotificationFeedRefreshed(),
                   );
                 },
-                child: const _ScrollableEmptyState(),
+                child: _ScrollableEmptyState(controller: _scrollController),
               ),
               Positioned(
                 top: 0,
@@ -443,12 +439,15 @@ class _RevalidationBar extends StatelessWidget {
 }
 
 class _ScrollableEmptyState extends StatelessWidget {
-  const _ScrollableEmptyState();
+  const _ScrollableEmptyState({required this.controller});
+
+  final ScrollController controller;
 
   @override
   Widget build(BuildContext context) {
     return LayoutBuilder(
       builder: (context, constraints) => SingleChildScrollView(
+        controller: controller,
         physics: const AlwaysScrollableScrollPhysics(),
         child: SizedBox(
           height: constraints.maxHeight,

--- a/mobile/lib/notifications/view/notifications_view.dart
+++ b/mobile/lib/notifications/view/notifications_view.dart
@@ -35,7 +35,6 @@ class NotificationsView extends ConsumerStatefulWidget {
 
 class _NotificationsViewState extends ConsumerState<NotificationsView> {
   final ScrollController _scrollController = ScrollController();
-  bool _emptyLoadMoreQueued = false;
 
   /// Threshold (in pixels from bottom) to trigger load-more.
   static const _loadMoreThreshold = 200.0;
@@ -67,34 +66,12 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
     }
   }
 
-  void _requestLoadMoreFromEmptyState(NotificationFeedState state) {
-    if (!state.hasMore ||
-        state.isLoadingMore ||
-        state.isRefreshing ||
-        _emptyLoadMoreQueued) {
-      return;
-    }
-    _emptyLoadMoreQueued = true;
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) return;
-      context.read<NotificationFeedBloc>().add(
-        const NotificationFeedLoadMore(),
-      );
-    });
-  }
-
   @override
   Widget build(BuildContext context) {
     return ColoredBox(
       color: VineTheme.surfaceContainerHigh,
       child: BlocBuilder<NotificationFeedBloc, NotificationFeedState>(
         builder: (context, state) {
-          if (state.notifications.isNotEmpty ||
-              state.isLoadingMore ||
-              !state.hasMore) {
-            _emptyLoadMoreQueued = false;
-          }
-
           // Hard failure path. The bloc gates `failure` on
           // `notifications.isEmpty`, so we only land here when the cache
           // is also empty.
@@ -172,12 +149,6 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
           // `onRefresh` returns.
           return Stack(
             children: [
-              Builder(
-                builder: (context) {
-                  _requestLoadMoreFromEmptyState(state);
-                  return const SizedBox.shrink();
-                },
-              ),
               RefreshIndicator(
                 color: VineTheme.onPrimary,
                 backgroundColor: VineTheme.vineGreen,

--- a/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
@@ -271,6 +271,7 @@ class FunnelcakeApiClient {
     int limit = 50,
     String? cursor,
     String? cursorId,
+    List<String>? types,
   }) {
     // Server timestamps are Unix seconds, not milliseconds.
     final effectiveBefore =
@@ -279,6 +280,7 @@ class FunnelcakeApiClient {
       'limit': '$limit',
       'before': effectiveBefore,
       'before_id': ?cursorId,
+      if (types != null && types.isNotEmpty) 'types': types.join(','),
     };
 
     return Uri.parse(
@@ -2415,6 +2417,7 @@ class FunnelcakeApiClient {
     int limit = 50,
     String? cursor,
     String? cursorId,
+    List<String>? types,
     Uri? requestUri,
     Map<String, String>? authHeaders,
   }) async {
@@ -2429,6 +2432,7 @@ class FunnelcakeApiClient {
           limit: limit,
           cursor: cursor,
           cursorId: cursorId,
+          types: types,
         );
 
     try {

--- a/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_notification_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_notification_test.dart
@@ -111,6 +111,38 @@ void main() {
         expect(url.queryParameters['before'], equals('cursor_abc'));
       });
 
+      test('passes notification types as comma-separated query', () async {
+        when(
+          () => mockHttpClient.get(
+            any(),
+            headers: any(named: 'headers'),
+          ),
+        ).thenAnswer(
+          (_) async => http.Response(
+            jsonEncode({
+              'notifications': <Map<String, dynamic>>[],
+              'unread_count': 0,
+              'has_more': false,
+            }),
+            200,
+          ),
+        );
+
+        await client.getNotifications(
+          pubkey: testPubkey,
+          types: const ['reaction', 'zap'],
+        );
+
+        final captured = verify(
+          () => mockHttpClient.get(
+            captureAny(),
+            headers: any(named: 'headers'),
+          ),
+        ).captured;
+        final url = captured.first as Uri;
+        expect(url.queryParameters['types'], equals('reaction,zap'));
+      });
+
       test('passes cursorId as before_id parameter', () async {
         when(
           () => mockHttpClient.get(
@@ -719,6 +751,15 @@ void main() {
           uri.queryParameters['before_id'],
           equals(stableCursorId),
         );
+      });
+
+      test('includes types when provided', () {
+        final uri = client.notificationsUri(
+          pubkey: testPubkey,
+          types: const ['follow'],
+        );
+
+        expect(uri.queryParameters['types'], equals('follow'));
       });
     });
   });

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -173,9 +173,14 @@ class NotificationRepository {
   final AuthHeadersProvider? _authHeadersProvider;
 
   final Map<NotificationKind?, _NotificationFeed> _feeds = {};
+  bool _closed = false;
 
-  _NotificationFeed _feedFor(NotificationKind? filter) =>
-      _feeds.putIfAbsent(filter, () => _NotificationFeed(filter: filter));
+  _NotificationFeed _feedFor(NotificationKind? filter) {
+    if (_closed) {
+      throw StateError('NotificationRepository is closed');
+    }
+    return _feeds.putIfAbsent(filter, () => _NotificationFeed(filter: filter));
+  }
 
   _NotificationFeed get _allFeed => _feedFor(null);
 
@@ -214,7 +219,9 @@ class NotificationRepository {
   /// Called when the repository is no longer needed (e.g. on auth flip
   /// when a new repository instance replaces this one).
   Future<void> close() async {
-    for (final feed in _liveFeeds) {
+    if (_closed) return;
+    _closed = true;
+    for (final feed in _liveFeeds.toList()) {
       await feed.snapshot.close();
     }
   }
@@ -225,7 +232,7 @@ class NotificationRepository {
   /// long-lived consumer (e.g. the refresh coordinator) may still hold it
   /// across an in-flight call. Such callers use this to classify the
   /// resulting [StateError] as expected account-switch noise.
-  bool get isClosed => _snapshot.isClosed;
+  bool get isClosed => _closed;
 
   /// Whether the snapshot currently holds more than the first page.
   ///
@@ -233,7 +240,8 @@ class NotificationRepository {
   /// user-visible paginated feed back to page 1. An explicit [refresh]
   /// (pull-to-refresh, page mount) still replaces the snapshot and resets
   /// this to `false`.
-  bool get hasPaginatedBeyondFirstPage => _allFeed.pagesLoaded > 1;
+  bool get hasPaginatedBeyondFirstPage =>
+      _liveFeeds.any((feed) => feed.pagesLoaded > 1);
 
   /// Releases the current page-depth guard after the feed UI is gone, and
   /// collapses any deep-scrolled accumulation back to the first page.
@@ -254,14 +262,15 @@ class NotificationRepository {
   /// reflects only the newest page's unread rows — the same bound the next
   /// `refresh()` would impose anyway, so this only brings that bound forward
   /// to feed-close instead of next-open.
-  void resetPaginationDepth() {
-    final current = _snapshot.value;
+  void resetPaginationDepth({NotificationKind? filter}) {
+    final feed = _feedFor(filter);
+    final current = feed.snapshot.value;
     if (current.items.length > _pageSize) {
-      _snapshot.add(
+      feed.snapshot.add(
         current.copyWith(items: current.items.take(_pageSize).toList()),
       );
     }
-    _allFeed.pagesLoaded = _snapshot.value.items.isEmpty ? 0 : 1;
+    feed.pagesLoaded = feed.snapshot.value.items.isEmpty ? 0 : 1;
   }
 
   /// Fetches the next page of notifications.
@@ -326,7 +335,10 @@ class NotificationRepository {
         ..lastCursor = response.nextCursor
         ..lastCursorId = response.nextCursorId;
 
-      final items = await _enrichAndGroup(response.notifications);
+      final items = await _enrichAndGroup(
+        response.notifications,
+        filter: filter,
+      );
       if (generation != feed.fetchGeneration) {
         return (page: feed.snapshot.value, applied: false);
       }
@@ -802,7 +814,7 @@ class NotificationRepository {
         NotificationKind.mention => const ['mention'],
         NotificationKind.likeComment => const ['reaction', 'zap'],
         NotificationKind.reply => const ['reply'],
-        NotificationKind.system => null,
+        NotificationKind.system => const ['list_add'],
       };
 
   static final math.Random _jitter = math.Random();
@@ -822,11 +834,25 @@ class NotificationRepository {
   /// when the refresh was superseded by another first-page fetch before it
   /// could apply.
   Future<bool> refreshApplied() {
-    return _refreshResult().then((result) => result.applied);
+    return _refreshAppliedForLiveFeeds();
   }
 
   Future<({NotificationPage page, bool applied})> _refreshResult() {
     return _refreshResultFor(null);
+  }
+
+  Future<bool> _refreshAppliedForLiveFeeds() async {
+    final feeds = _liveFeeds.toList();
+    if (feeds.isEmpty) {
+      return _refreshResult().then((result) => result.applied);
+    }
+
+    var applied = false;
+    for (final feed in feeds) {
+      final result = await _refreshResultFor(feed.filter);
+      applied = applied || result.applied;
+    }
+    return applied;
   }
 
   Future<({NotificationPage page, bool applied})> _refreshResultFor(
@@ -1239,8 +1265,9 @@ class NotificationRepository {
   /// Enriches raw relay notifications with profile + video metadata, then
   /// groups them into [VideoNotification]s and [ActorNotification]s.
   Future<List<NotificationItem>> _enrichAndGroup(
-    List<RelayNotification> raw,
-  ) async {
+    List<RelayNotification> raw, {
+    NotificationKind? filter,
+  }) async {
     if (raw.isEmpty) return [];
 
     final pubkeys = raw.map((n) => n.sourcePubkey).toSet().toList();
@@ -1266,7 +1293,25 @@ class NotificationRepository {
 
     final items = <NotificationItem>[...videos, ...actors, ...reclassified]
       ..sort((a, b) => b.timestamp.compareTo(a.timestamp));
-    return _applyBlockFilter(items);
+    return _applyBlockFilter(_applyFeedFilter(items, filter));
+  }
+
+  List<NotificationItem> _applyFeedFilter(
+    List<NotificationItem> items,
+    NotificationKind? filter,
+  ) {
+    if (filter != NotificationKind.comment) return items;
+    return items.where(_belongsInCommentsFeed).toList();
+  }
+
+  bool _belongsInCommentsFeed(NotificationItem item) {
+    if (item.type == NotificationKind.comment ||
+        item.type == NotificationKind.reply) {
+      return true;
+    }
+    return item is ActorNotification &&
+        item.type == NotificationKind.mention &&
+        item.hasCommentTarget;
   }
 
   /// Filters notifications from blocked/muted users.

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -1038,7 +1038,8 @@ class NotificationRepository {
       }
     }
 
-    final appended = <NotificationItem>[];
+    // Appends land in `result` itself so the indices in `followIndex` stay
+    // valid for the `result[idx] = …` merges below.
     for (final item in incoming) {
       if (item is VideoNotification) {
         final idx = videoGroupIndex[(item.videoEventId, item.type)];
@@ -1070,14 +1071,14 @@ class NotificationRepository {
       // omitted source_event_id). Preserves the original by-id dedupe
       // contract.
       if (allIds.contains(item.id)) continue;
-      appended.add(item);
+      result.add(item);
       allSourceEventIds.addAll(item.sourceEventIds);
       allIds.add(item.id);
       if (item is ActorNotification && item.type == NotificationKind.follow) {
-        followIndex[item.actor.pubkey] = result.length + appended.length - 1;
+        followIndex[item.actor.pubkey] = result.length - 1;
       }
     }
-    return [...result, ...appended];
+    return result;
   }
 
   static ActorNotification _mergeAppendedFollow(

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -234,14 +234,17 @@ class NotificationRepository {
   /// resulting [StateError] as expected account-switch noise.
   bool get isClosed => _closed;
 
-  /// Whether the snapshot currently holds more than the first page.
+  /// Whether every live feed is paginated beyond its first page.
   ///
   /// Resume-driven liveness triggers consult this to avoid collapsing a
-  /// user-visible paginated feed back to page 1. An explicit [refresh]
-  /// (pull-to-refresh, page mount) still replaces the snapshot and resets
-  /// this to `false`.
+  /// user-visible paginated feed back to page 1. [refreshApplied] already
+  /// skips the individual feeds that would collapse, so this only reports
+  /// `true` when no live feed is refreshable at all — otherwise one tab
+  /// scrolled two pages deep would suppress resume refreshes for every
+  /// other tab as well. An explicit [refresh] (pull-to-refresh, page mount)
+  /// still replaces the snapshot and resets this to `false`.
   bool get hasPaginatedBeyondFirstPage =>
-      _liveFeeds.any((feed) => feed.pagesLoaded > 1);
+      _liveFeeds.isNotEmpty && _liveFeeds.every((feed) => feed.pagesLoaded > 1);
 
   /// Releases the current page-depth guard after the feed UI is gone, and
   /// collapses any deep-scrolled accumulation back to the first page.
@@ -845,16 +848,46 @@ class NotificationRepository {
     return _refreshResultFor(null);
   }
 
+  /// Refreshes every live feed that a first-page replace would not collapse.
+  ///
+  /// Feeds the user scrolled past page 1 are skipped rather than rebuilt, so
+  /// a deep-scrolled tab loses neither its position nor its accumulated
+  /// items — and, unlike a single global guard, does not suppress the
+  /// refresh for the tabs that are still on page 1.
+  ///
+  /// Each feed is refreshed independently: one feed's failure must not stop
+  /// the others from refreshing. The first error is rethrown only when no
+  /// feed applied a snapshot, so a partial success still advances the
+  /// coordinator's cooldown instead of re-running the whole fan-out on
+  /// every trigger.
   Future<bool> _refreshAppliedForLiveFeeds() async {
-    final feeds = _liveFeeds.toList();
-    if (feeds.isEmpty) {
+    final live = _liveFeeds.toList(growable: false);
+    if (live.isEmpty) {
       return _refreshResult().then((result) => result.applied);
     }
 
+    final feeds = live
+        .where((feed) => feed.pagesLoaded <= 1)
+        .toList(growable: false);
+    // Every live feed is deep-scrolled — refreshing any of them would
+    // collapse it, and falling back to the unfiltered feed would collapse
+    // that one too.
+    if (feeds.isEmpty) return false;
+
     var applied = false;
+    Object? firstError;
+    StackTrace? firstStackTrace;
     for (final feed in feeds) {
-      final result = await _refreshResultFor(feed.filter);
-      applied = applied || result.applied;
+      try {
+        final result = await _refreshResultFor(feed.filter);
+        applied = applied || result.applied;
+      } catch (e, s) {
+        firstError ??= e;
+        firstStackTrace ??= s;
+      }
+    }
+    if (!applied && firstError != null) {
+      Error.throwWithStackTrace(firstError, firstStackTrace!);
     }
     return applied;
   }

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -100,6 +100,21 @@ class _VideoMetadataResult {
   final bool notFound;
 }
 
+class _NotificationFeed {
+  _NotificationFeed({required this.filter})
+    : snapshot = BehaviorSubject<NotificationPage>.seeded(
+        NotificationPage.empty,
+      );
+
+  final NotificationKind? filter;
+  final BehaviorSubject<NotificationPage> snapshot;
+
+  String? lastCursor;
+  String? lastCursorId;
+  int fetchGeneration = 0;
+  int pagesLoaded = 0;
+}
+
 /// Number of notifications loaded per page.
 ///
 /// Bounds both the cold-start cache hydration and the first-page REST
@@ -157,16 +172,14 @@ class NotificationRepository {
   final BlockedNotificationFilter? _blockFilter;
   final AuthHeadersProvider? _authHeadersProvider;
 
-  /// Last cursor returned by the API, used for pagination.
-  String? _lastCursor;
-  String? _lastCursorId;
+  final Map<NotificationKind?, _NotificationFeed> _feeds = {};
 
-  /// Monotonic token bumped by [refresh] so in-flight page fetches from a
-  /// replaced pagination stream skip their post-await writes.
-  int _fetchGeneration = 0;
+  _NotificationFeed _feedFor(NotificationKind? filter) =>
+      _feeds.putIfAbsent(filter, () => _NotificationFeed(filter: filter));
 
-  /// Count of page fetches applied since the last first-page emission.
-  int _pagesLoaded = 0;
+  _NotificationFeed get _allFeed => _feedFor(null);
+
+  Iterable<_NotificationFeed> get _liveFeeds => _feeds.values;
 
   /// Reactive snapshot of the enriched, grouped notification feed.
   ///
@@ -174,15 +187,15 @@ class NotificationRepository {
   /// badge cubit (badge count). Every mutation — [getNotifications],
   /// [refresh], [markAsRead], [markAllAsRead] — updates this subject so
   /// consumers can never diverge.
-  final BehaviorSubject<NotificationPage> _snapshot =
-      BehaviorSubject<NotificationPage>.seeded(NotificationPage.empty);
+  BehaviorSubject<NotificationPage> get _snapshot => _allFeed.snapshot;
 
   /// Stream of the latest [NotificationPage] snapshot.
   ///
   /// Use this for screen-level rendering. For badge counts, prefer
   /// [watchUnreadCount] — it is `.distinct()`-filtered so the badge
   /// only rebuilds on actual count changes.
-  Stream<NotificationPage> watchSnapshot() => _snapshot.stream;
+  Stream<NotificationPage> watchSnapshot({NotificationKind? filter}) =>
+      _feedFor(filter).snapshot.stream;
 
   /// Stream of the unread badge count derived from the consolidated
   /// visible list.
@@ -200,7 +213,11 @@ class NotificationRepository {
   ///
   /// Called when the repository is no longer needed (e.g. on auth flip
   /// when a new repository instance replaces this one).
-  Future<void> close() => _snapshot.close();
+  Future<void> close() async {
+    for (final feed in _liveFeeds) {
+      await feed.snapshot.close();
+    }
+  }
 
   /// Whether [close] has been called on this repository.
   ///
@@ -216,7 +233,7 @@ class NotificationRepository {
   /// user-visible paginated feed back to page 1. An explicit [refresh]
   /// (pull-to-refresh, page mount) still replaces the snapshot and resets
   /// this to `false`.
-  bool get hasPaginatedBeyondFirstPage => _pagesLoaded > 1;
+  bool get hasPaginatedBeyondFirstPage => _allFeed.pagesLoaded > 1;
 
   /// Releases the current page-depth guard after the feed UI is gone, and
   /// collapses any deep-scrolled accumulation back to the first page.
@@ -244,7 +261,7 @@ class NotificationRepository {
         current.copyWith(items: current.items.take(_pageSize).toList()),
       );
     }
-    _pagesLoaded = _snapshot.value.items.isEmpty ? 0 : 1;
+    _allFeed.pagesLoaded = _snapshot.value.items.isEmpty ? 0 : 1;
   }
 
   /// Fetches the next page of notifications.
@@ -269,18 +286,24 @@ class NotificationRepository {
   Future<NotificationPage> getNotifications({
     String? cursor,
     String? cursorId,
-  }) async =>
-      (await _getNotificationsResult(cursor: cursor, cursorId: cursorId)).page;
+    NotificationKind? filter,
+  }) async => (await _getNotificationsResult(
+    cursor: cursor,
+    cursorId: cursorId,
+    filter: filter,
+  )).page;
 
   Future<({NotificationPage page, bool applied})> _getNotificationsResult({
     String? cursor,
     String? cursorId,
+    NotificationKind? filter,
   }) async {
-    final generation = _fetchGeneration;
-    final effectiveCursor = cursor ?? _lastCursor;
+    final feed = _feedFor(filter);
+    final generation = feed.fetchGeneration;
+    final effectiveCursor = cursor ?? feed.lastCursor;
     final effectiveCursorId = cursor != null
         ? cursorId
-        : cursorId ?? _lastCursorId;
+        : cursorId ?? feed.lastCursorId;
     final isFirstPage = effectiveCursor == null;
 
     try {
@@ -288,21 +311,24 @@ class NotificationRepository {
           ? await _fetchWithRetry(
               cursor: effectiveCursor,
               cursorId: effectiveCursorId,
+              filter: filter,
             )
           : await _fetchOnce(
               cursor: effectiveCursor,
               cursorId: effectiveCursorId,
+              filter: filter,
             );
-      if (generation != _fetchGeneration) {
-        return (page: _snapshot.value, applied: false);
+      if (generation != feed.fetchGeneration) {
+        return (page: feed.snapshot.value, applied: false);
       }
 
-      _lastCursor = response.nextCursor;
-      _lastCursorId = response.nextCursorId;
+      feed
+        ..lastCursor = response.nextCursor
+        ..lastCursorId = response.nextCursorId;
 
       final items = await _enrichAndGroup(response.notifications);
-      if (generation != _fetchGeneration) {
-        return (page: _snapshot.value, applied: false);
+      if (generation != feed.fetchGeneration) {
+        return (page: feed.snapshot.value, applied: false);
       }
 
       final page = NotificationPage(
@@ -312,10 +338,10 @@ class NotificationRepository {
         nextCursorId: response.nextCursorId,
         hasMore: response.hasMore,
       );
-      _pagesLoaded = isFirstPage ? 1 : _pagesLoaded + 1;
-      _emitSnapshotForPage(page, isFirstPage: isFirstPage);
+      feed.pagesLoaded = isFirstPage ? 1 : feed.pagesLoaded + 1;
+      _emitSnapshotForPage(feed, page, isFirstPage: isFirstPage);
 
-      if (isFirstPage) {
+      if (isFirstPage && filter == null) {
         unawaited(_persistSnapshot(items));
       }
       return (page: page, applied: true);
@@ -327,8 +353,8 @@ class NotificationRepository {
         error: e,
         stackTrace: s,
       );
-      if (isFirstPage && generation == _fetchGeneration) {
-        _markRefreshError();
+      if (isFirstPage && generation == feed.fetchGeneration) {
+        _markRefreshError(feed);
       }
       rethrow;
     }
@@ -339,13 +365,16 @@ class NotificationRepository {
   Future<NotificationResponse> _fetchOnce({
     required String? cursor,
     required String? cursorId,
+    required NotificationKind? filter,
   }) async {
+    final types = _serverTypesForFilter(filter);
     final requestUrl = _funnelcakeApiClient
         .notificationsUri(
           pubkey: _userPubkey,
           limit: _pageSize,
           cursor: cursor,
           cursorId: cursorId,
+          types: types,
         )
         .toString();
     final authHeaders = _authHeadersProvider != null
@@ -356,6 +385,7 @@ class NotificationRepository {
       limit: _pageSize,
       cursor: cursor,
       cursorId: cursorId,
+      types: types,
       requestUri: Uri.parse(requestUrl),
       authHeaders: authHeaders,
     );
@@ -365,6 +395,7 @@ class NotificationRepository {
   Future<NotificationResponse> _fetchWithRetry({
     required String? cursor,
     required String? cursorId,
+    required NotificationKind? filter,
   }) async {
     Object? lastError;
     StackTrace? lastStack;
@@ -374,7 +405,11 @@ class NotificationRepository {
       attempt++
     ) {
       try {
-        return await _fetchOnce(cursor: cursor, cursorId: cursorId);
+        return await _fetchOnce(
+          cursor: cursor,
+          cursorId: cursorId,
+          filter: filter,
+        );
       } on Exception catch (e, s) {
         if (!_isTransient(e) ||
             attempt == _NotificationRetryConfig.maxAttempts - 1) {
@@ -433,10 +468,10 @@ class NotificationRepository {
 
   /// Stamps the snapshot with `lastRefreshError: true` so the UI can
   /// render an inline error affordance while keeping cached items.
-  void _markRefreshError() {
-    final current = _snapshot.value;
+  void _markRefreshError(_NotificationFeed feed) {
+    final current = feed.snapshot.value;
     if (current.lastRefreshError) return;
-    _snapshot.add(current.copyWith(lastRefreshError: true));
+    feed.snapshot.add(current.copyWith(lastRefreshError: true));
   }
 
   /// Best-effort load of cached rows into the snapshot on construction.
@@ -482,7 +517,7 @@ class NotificationRepository {
   Future<void> _enrichCachedPlaceholders(
     List<NotificationItem> placeholders,
   ) async {
-    final generation = _fetchGeneration;
+    final generation = _allFeed.fetchGeneration;
     try {
       final pubkeys = placeholders
           .map(
@@ -512,7 +547,7 @@ class NotificationRepository {
         videosFuture,
       ).wait;
 
-      if (generation != _fetchGeneration) return;
+      if (generation != _allFeed.fetchGeneration) return;
 
       final current = _snapshot.value;
       if (!_sameNotificationIds(current.items, placeholders)) return;
@@ -757,6 +792,19 @@ class NotificationRepository {
     NotificationKind.system => 'system',
   };
 
+  static List<String>? _serverTypesForFilter(NotificationKind? filter) =>
+      switch (filter) {
+        null => null,
+        NotificationKind.like => const ['reaction', 'zap'],
+        NotificationKind.comment => const ['comment', 'reply', 'mention'],
+        NotificationKind.repost => const ['repost'],
+        NotificationKind.follow => const ['follow'],
+        NotificationKind.mention => const ['mention'],
+        NotificationKind.likeComment => const ['reaction', 'zap'],
+        NotificationKind.reply => const ['reply'],
+        NotificationKind.system => null,
+      };
+
   static final math.Random _jitter = math.Random();
 
   /// Refreshes notifications from the beginning (no cursor).
@@ -778,10 +826,23 @@ class NotificationRepository {
   }
 
   Future<({NotificationPage page, bool applied})> _refreshResult() {
-    _fetchGeneration++;
-    _lastCursor = null;
-    _lastCursorId = null;
-    return _getNotificationsResult();
+    return _refreshResultFor(null);
+  }
+
+  Future<({NotificationPage page, bool applied})> _refreshResultFor(
+    NotificationKind? filter,
+  ) {
+    final feed = _feedFor(filter);
+    feed
+      ..fetchGeneration = feed.fetchGeneration + 1
+      ..lastCursor = null
+      ..lastCursorId = null;
+    return _getNotificationsResult(filter: filter);
+  }
+
+  /// Refreshes one filtered notification feed from the beginning.
+  Future<NotificationPage> refreshFeed(NotificationKind? filter) {
+    return _refreshResultFor(filter).then((result) => result.page);
   }
 
   /// Fetches the page after the last one applied to the snapshot.
@@ -791,8 +852,34 @@ class NotificationRepository {
   /// [refresh] reset the stream — so a racing load-more can never turn
   /// into a duplicate first-page fetch.
   Future<NotificationPage?> loadNextPage() async {
-    if (_lastCursor == null) return null;
-    return getNotifications();
+    return loadNextPageFor(null);
+  }
+
+  /// Fetches the page after the last one applied to [filter]'s snapshot.
+  Future<NotificationPage?> loadNextPageFor(NotificationKind? filter) async {
+    final feed = _feedFor(filter);
+    if (feed.lastCursor == null) return null;
+    return getNotifications(filter: filter);
+  }
+
+  Map<_NotificationFeed, NotificationPage> _snapshotValuesByFeed() => {
+    for (final feed in _liveFeeds) feed: feed.snapshot.value,
+  };
+
+  Map<_NotificationFeed, int> _pagesLoadedByFeed() => {
+    for (final feed in _liveFeeds) feed: feed.pagesLoaded,
+  };
+
+  void _restoreSnapshots(Map<_NotificationFeed, NotificationPage> values) {
+    for (final entry in values.entries) {
+      entry.key.snapshot.add(entry.value);
+    }
+  }
+
+  void _restorePagesLoaded(Map<_NotificationFeed, int> values) {
+    for (final entry in values.entries) {
+      entry.key.pagesLoaded = entry.value;
+    }
   }
 
   /// Marks specific notifications as read on the server and locally.
@@ -806,10 +893,16 @@ class NotificationRepository {
     if (ids.isEmpty) return;
 
     final idSet = ids.toSet();
-    final before = _snapshot.value;
-    final pagesLoadedBefore = _pagesLoaded;
-    _snapshot.add(before.copyWith(items: _flipIsRead(before.items, idSet)));
-    final notificationIds = _expandServerNotificationIds(before.items, idSet);
+    final before = _snapshotValuesByFeed();
+    final pagesLoadedBefore = _pagesLoadedByFeed();
+    for (final feed in _liveFeeds) {
+      final page = feed.snapshot.value;
+      feed.snapshot.add(page.copyWith(items: _flipIsRead(page.items, idSet)));
+    }
+    final notificationIds = _expandServerNotificationIds(
+      before.values.expand((page) => page.items),
+      idSet,
+    );
 
     try {
       // Sign the exact URL + body the request will use, otherwise the
@@ -835,8 +928,8 @@ class NotificationRepository {
         await _notificationsDao.markAsRead(id, ownerPubkey: _userPubkey);
       }
     } catch (_) {
-      _pagesLoaded = pagesLoadedBefore;
-      _snapshot.add(before);
+      _restorePagesLoaded(pagesLoadedBefore);
+      _restoreSnapshots(before);
       rethrow;
     }
   }
@@ -849,11 +942,16 @@ class NotificationRepository {
   /// introduced by PR #4034 at the repository layer so every consumer
   /// (badge cubit, feed bloc) recovers consistently.
   Future<void> markAllAsRead() async {
-    final before = _snapshot.value;
-    if (before.items.every((n) => n.isRead)) return;
-    final pagesLoadedBefore = _pagesLoaded;
+    final before = _snapshotValuesByFeed();
+    if (before.values.every((page) => page.items.every((n) => n.isRead))) {
+      return;
+    }
+    final pagesLoadedBefore = _pagesLoadedByFeed();
 
-    _snapshot.add(before.copyWith(items: _flipAllRead(before.items)));
+    for (final feed in _liveFeeds) {
+      final page = feed.snapshot.value;
+      feed.snapshot.add(page.copyWith(items: _flipAllRead(page.items)));
+    }
 
     try {
       final url = _funnelcakeApiClient
@@ -871,8 +969,8 @@ class NotificationRepository {
 
       await _notificationsDao.markAllAsRead(ownerPubkey: _userPubkey);
     } catch (_) {
-      _pagesLoaded = pagesLoadedBefore;
-      _snapshot.add(before);
+      _restorePagesLoaded(pagesLoadedBefore);
+      _restoreSnapshots(before);
       rethrow;
     }
   }
@@ -903,16 +1001,17 @@ class NotificationRepository {
   /// Together these keep a logical event that reappears on a later page
   /// from duplicating its existing row (#4264).
   void _emitSnapshotForPage(
+    _NotificationFeed feed,
     NotificationPage page, {
     required bool isFirstPage,
   }) {
     if (isFirstPage) {
-      _snapshot.add(page);
+      feed.snapshot.add(page);
       return;
     }
-    final current = _snapshot.value;
+    final current = feed.snapshot.value;
     final mergedItems = _mergeAppendedPage(current.items, page.items);
-    _snapshot.add(page.copyWith(items: mergedItems));
+    feed.snapshot.add(page.copyWith(items: mergedItems));
   }
 
   /// Returns the merged item list for a non-first-page emission.
@@ -928,10 +1027,14 @@ class NotificationRepository {
     };
     final allIds = <String>{for (final n in result) n.id};
     final videoGroupIndex = <(String, NotificationKind), int>{};
+    final followIndex = <String, int>{};
     for (var i = 0; i < result.length; i++) {
       final item = result[i];
       if (item is VideoNotification) {
         videoGroupIndex[(item.videoEventId, item.type)] = i;
+      } else if (item is ActorNotification &&
+          item.type == NotificationKind.follow) {
+        followIndex[item.actor.pubkey] = i;
       }
     }
 
@@ -949,6 +1052,18 @@ class NotificationRepository {
           continue;
         }
       }
+      if (item is ActorNotification && item.type == NotificationKind.follow) {
+        final idx = followIndex[item.actor.pubkey];
+        if (idx != null) {
+          result[idx] = _mergeAppendedFollow(
+            result[idx] as ActorNotification,
+            item,
+          );
+          allSourceEventIds.addAll(item.sourceEventIds);
+          allIds.add(item.id);
+          continue;
+        }
+      }
       final hasOverlap = item.sourceEventIds.any(allSourceEventIds.contains);
       if (hasOverlap) continue;
       // Fallback: catch same-id repeats when sourceEventIds is empty (server
@@ -958,8 +1073,30 @@ class NotificationRepository {
       appended.add(item);
       allSourceEventIds.addAll(item.sourceEventIds);
       allIds.add(item.id);
+      if (item is ActorNotification && item.type == NotificationKind.follow) {
+        followIndex[item.actor.pubkey] = result.length + appended.length - 1;
+      }
     }
     return [...result, ...appended];
+  }
+
+  static ActorNotification _mergeAppendedFollow(
+    ActorNotification existing,
+    ActorNotification incoming,
+  ) {
+    final existingIsNewer = !existing.timestamp.isBefore(incoming.timestamp);
+    final latest = existingIsNewer ? existing : incoming;
+    return latest.copyWith(
+      isRead: existing.isRead && incoming.isRead,
+      sourceEventIds: <String>{
+        ...existing.sourceEventIds,
+        ...incoming.sourceEventIds,
+      }.toList(),
+      notificationIds: <String>{
+        ...existing.notificationIds,
+        ...incoming.notificationIds,
+      }.toList(),
+    );
   }
 
   /// Merges [incoming] (from a REST pagination page) into [existing] (a
@@ -1055,7 +1192,7 @@ class NotificationRepository {
   /// those rows. Unknown ids pass through so callers can still mark a raw id
   /// that is not present in the current snapshot.
   static List<String> _expandServerNotificationIds(
-    List<NotificationItem> items,
+    Iterable<NotificationItem> items,
     Set<String> ids,
   ) {
     final expanded = <String>{};

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -263,6 +263,10 @@ class NotificationRepository {
   /// `refresh()` would impose anyway, so this only brings that bound forward
   /// to feed-close instead of next-open.
   void resetPaginationDepth({NotificationKind? filter}) {
+    if (_closed) {
+      return;
+    }
+
     final feed = _feedFor(filter);
     final current = feed.snapshot.value;
     if (current.items.length > _pageSize) {

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -179,12 +179,74 @@ class NotificationRepository {
     if (_closed) {
       throw StateError('NotificationRepository is closed');
     }
-    return _feeds.putIfAbsent(filter, () => _NotificationFeed(filter: filter));
+    final existing = _feeds[filter];
+    if (existing != null) return existing;
+    final feed = _NotificationFeed(filter: filter);
+    _feeds[filter] = feed;
+    if (filter != null) _seedFilteredFeed(feed);
+    return feed;
   }
 
   _NotificationFeed get _allFeed => _feedFor(null);
 
   Iterable<_NotificationFeed> get _liveFeeds => _feeds.values;
+
+  /// Seeds a freshly minted filtered feed from the unfiltered feed's rows.
+  ///
+  /// Only the unfiltered feed reads and writes the DAO, so without this a
+  /// category tab starts at [NotificationPage.empty] with no cache path at
+  /// all: on a cold start with no network its first fetch fails against an
+  /// empty list, and the bloc renders the full-screen failure body instead
+  /// of cached rows plus the inline refresh-error banner. Before per-tab
+  /// feeds every tab read the same hydrated snapshot and degraded to a
+  /// cached subset.
+  ///
+  /// Placeholder-grade by construction: the feed's page count stays 0 and
+  /// its own first-page fetch replaces these rows wholesale.
+  void _seedFilteredFeed(_NotificationFeed feed) {
+    if (feed.pagesLoaded > 0) return;
+    final source = _feeds[null];
+    if (source == null) return;
+    final items = source.snapshot.value.items
+        .where((item) => _belongsInFeed(item, feed.filter))
+        .toList();
+    if (items.isEmpty) return;
+    feed.snapshot.add(
+      // Seeded rows are a degraded view; assume more is available until the
+      // feed's own refresh resolves. Mirrors [_hydrateFromCache].
+      feed.snapshot.value.copyWith(items: items, hasMore: true),
+    );
+  }
+
+  /// Re-seeds every live filtered feed that has not fetched yet.
+  ///
+  /// The repository is constructed when [ProfileRepository] becomes
+  /// available, which on a cold start can land after the inbox has already
+  /// mounted its tabs — so hydration finishes with the filtered feeds
+  /// already minted and empty.
+  void _seedFilteredFeedsFromAllFeed() {
+    for (final feed in _liveFeeds.toList()) {
+      if (feed.filter == null) continue;
+      if (feed.snapshot.value.items.isNotEmpty) continue;
+      _seedFilteredFeed(feed);
+    }
+  }
+
+  /// Whether [item] belongs in the tab identified by [filter].
+  ///
+  /// Mirrors the server-side `types` mapping in [_serverTypesForFilter] for
+  /// rows that were fetched without it (cache hydration, cross-feed seed).
+  bool _belongsInFeed(NotificationItem item, NotificationKind? filter) =>
+      switch (filter) {
+        null => true,
+        NotificationKind.comment => _belongsInCommentsFeed(item),
+        // `reaction`/`zap` map to a video like or a comment like depending on
+        // the target, and both belong in the Likes tab.
+        NotificationKind.like =>
+          item.type == NotificationKind.like ||
+              item.type == NotificationKind.likeComment,
+        _ => item.type == filter,
+      };
 
   /// Reactive snapshot of the enriched, grouped notification feed.
   ///
@@ -521,6 +583,7 @@ class NotificationRepository {
           hasMore: true,
         ),
       );
+      _seedFilteredFeedsFromAllFeed();
       unawaited(_enrichCachedPlaceholders(items));
     } on Exception catch (e, s) {
       Log.error(

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -928,14 +928,6 @@ class NotificationRepository {
     return getNotifications(filter: filter);
   }
 
-  Map<_NotificationFeed, NotificationPage> _snapshotValuesByFeed() => {
-    for (final feed in _liveFeeds) feed: feed.snapshot.value,
-  };
-
-  Map<_NotificationFeed, int> _pagesLoadedByFeed() => {
-    for (final feed in _liveFeeds) feed: feed.pagesLoaded,
-  };
-
   void _restoreSnapshots(Map<_NotificationFeed, NotificationPage> values) {
     for (final entry in values.entries) {
       entry.key.snapshot.add(entry.value);
@@ -955,20 +947,29 @@ class NotificationRepository {
   /// failure, restores the pre-write snapshot so subscribers see the
   /// authoritative state, and rethrows so callers can surface the
   /// error.
+  ///
+  /// Rollback is scoped to the feeds the flip actually changed. Capturing
+  /// every live feed would revert a tab that landed a fresh page while the
+  /// POST was in flight — the common case being a tab swipe during the
+  /// `markAllAsRead` that runs on inbox open.
   Future<void> markAsRead(List<String> ids) async {
     if (ids.isEmpty) return;
 
     final idSet = ids.toSet();
-    final before = _snapshotValuesByFeed();
-    final pagesLoadedBefore = _pagesLoadedByFeed();
-    for (final feed in _liveFeeds) {
+    final itemsBefore = <NotificationItem>[];
+    final snapshotsBefore = <_NotificationFeed, NotificationPage>{};
+    final pagesLoadedBefore = <_NotificationFeed, int>{};
+    for (final feed in _liveFeeds.toList()) {
       final page = feed.snapshot.value;
+      itemsBefore.addAll(page.items);
+      if (!page.items.any((n) => !n.isRead && _matchesMarkReadId(n, idSet))) {
+        continue;
+      }
+      snapshotsBefore[feed] = page;
+      pagesLoadedBefore[feed] = feed.pagesLoaded;
       feed.snapshot.add(page.copyWith(items: _flipIsRead(page.items, idSet)));
     }
-    final notificationIds = _expandServerNotificationIds(
-      before.values.expand((page) => page.items),
-      idSet,
-    );
+    final notificationIds = _expandServerNotificationIds(itemsBefore, idSet);
 
     try {
       // Sign the exact URL + body the request will use, otherwise the
@@ -995,7 +996,7 @@ class NotificationRepository {
       }
     } catch (_) {
       _restorePagesLoaded(pagesLoadedBefore);
-      _restoreSnapshots(before);
+      _restoreSnapshots(snapshotsBefore);
       rethrow;
     }
   }
@@ -1007,17 +1008,21 @@ class NotificationRepository {
   /// restores the pre-write snapshot — preserves the rollback semantics
   /// introduced by PR #4034 at the repository layer so every consumer
   /// (badge cubit, feed bloc) recovers consistently.
+  ///
+  /// As in [markAsRead], only the feeds this call actually flipped are
+  /// captured for rollback, so a tab that paginated while the POST was in
+  /// flight keeps its fresher page.
   Future<void> markAllAsRead() async {
-    final before = _snapshotValuesByFeed();
-    if (before.values.every((page) => page.items.every((n) => n.isRead))) {
-      return;
-    }
-    final pagesLoadedBefore = _pagesLoadedByFeed();
-
-    for (final feed in _liveFeeds) {
+    final snapshotsBefore = <_NotificationFeed, NotificationPage>{};
+    final pagesLoadedBefore = <_NotificationFeed, int>{};
+    for (final feed in _liveFeeds.toList()) {
       final page = feed.snapshot.value;
+      if (page.items.every((n) => n.isRead)) continue;
+      snapshotsBefore[feed] = page;
+      pagesLoadedBefore[feed] = feed.pagesLoaded;
       feed.snapshot.add(page.copyWith(items: _flipAllRead(page.items)));
     }
+    if (snapshotsBefore.isEmpty) return;
 
     try {
       final url = _funnelcakeApiClient
@@ -1036,7 +1041,7 @@ class NotificationRepository {
       await _notificationsDao.markAllAsRead(ownerPubkey: _userPubkey);
     } catch (_) {
       _restorePagesLoaded(pagesLoadedBefore);
-      _restoreSnapshots(before);
+      _restoreSnapshots(snapshotsBefore);
       rethrow;
     }
   }

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -881,7 +881,10 @@ class NotificationRepository {
       try {
         final result = await _refreshResultFor(feed.filter);
         applied = applied || result.applied;
-      } catch (e, s) {
+      } on Object catch (e, s) {
+        // Deliberately broad: one feed's failure — typed
+        // FunnelcakeException or an Error — must not stop the others.
+        // The original type and stack are preserved by the rethrow below.
         firstError ??= e;
         firstStackTrace ??= s;
       }

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -923,8 +923,17 @@ class NotificationRepository {
   /// feed applied a snapshot, so a partial success still advances the
   /// coordinator's cooldown instead of re-running the whole fan-out on
   /// every trigger.
+  ///
+  /// A filtered feed is only refreshed while something is subscribed to it.
+  /// [_feeds] is append-only, so without that gate a user who swiped through
+  /// the five tabs once would pay five REST requests — and five NIP-98
+  /// signatures, which are not free on a remote signer — on every later
+  /// resume, forever. The unfiltered feed is always refreshed: the badge
+  /// reads it whether or not the inbox is on screen.
   Future<bool> _refreshAppliedForLiveFeeds() async {
-    final live = _liveFeeds.toList(growable: false);
+    final live = _liveFeeds
+        .where((feed) => feed.filter == null || feed.snapshot.hasListener)
+        .toList(growable: false);
     if (live.isEmpty) {
       return _refreshResult().then((result) => result.applied);
     }

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -55,18 +55,21 @@ void main() {
         limit: any(named: 'limit'),
         cursor: any(named: 'cursor'),
         cursorId: any(named: 'cursorId'),
+        types: any(named: 'types'),
       ),
     ).thenAnswer((invocation) {
       final pubkey = invocation.namedArguments[#pubkey] as String;
       final limit = invocation.namedArguments[#limit] as int? ?? 50;
       final cursor = invocation.namedArguments[#cursor] as String?;
       final cursorId = invocation.namedArguments[#cursorId] as String?;
+      final types = invocation.namedArguments[#types] as List<String>?;
       final effectiveBefore =
           cursor ?? DateTime.now().millisecondsSinceEpoch.toString();
       final queryParameters = <String, String>{
         'limit': '$limit',
         'before': effectiveBefore,
         'before_id': ?cursorId,
+        if (types != null && types.isNotEmpty) 'types': types.join(','),
       };
       return Uri.parse(
         'https://api.example.com/api/users/$pubkey/notifications',
@@ -177,6 +180,7 @@ void main() {
         pubkey: any(named: 'pubkey'),
         cursor: any(named: 'cursor'),
         cursorId: any(named: 'cursorId'),
+        types: any(named: 'types'),
         requestUri: any(named: 'requestUri'),
         authHeaders: any(named: 'authHeaders'),
         limit: any(named: 'limit'),
@@ -344,6 +348,105 @@ void main() {
           );
         },
       );
+
+      test('signs filtered notifications URL with server types', () async {
+        var signedUrl = '';
+        repository = NotificationRepository(
+          funnelcakeApiClient: funnelcakeApiClient,
+          profileRepository: profileRepository,
+          notificationsDao: notificationsDao,
+          userPubkey: userPubkey,
+          authHeadersProvider: (url, method, {body}) async {
+            signedUrl = url;
+            return {'Authorization': 'Nostr test-token'};
+          },
+        );
+        stubNotifications([]);
+        stubProfiles({});
+
+        await repository.getNotifications(filter: NotificationKind.follow);
+
+        expect(
+          signedUrl,
+          startsWith(
+            'https://api.example.com/api/users/$userPubkey/notifications',
+          ),
+        );
+        final signedUri = Uri.parse(signedUrl);
+        expect(signedUri.queryParameters['types'], equals('follow'));
+      });
+
+      test('maps likes tab to reaction and zap server types', () async {
+        var signedUrl = '';
+        repository = NotificationRepository(
+          funnelcakeApiClient: funnelcakeApiClient,
+          profileRepository: profileRepository,
+          notificationsDao: notificationsDao,
+          userPubkey: userPubkey,
+          authHeadersProvider: (url, method, {body}) async {
+            signedUrl = url;
+            return {'Authorization': 'Nostr test-token'};
+          },
+        );
+        stubNotifications([]);
+        stubProfiles({});
+
+        await repository.getNotifications(filter: NotificationKind.like);
+
+        final signedUri = Uri.parse(signedUrl);
+        expect(signedUri.queryParameters['types'], equals('reaction,zap'));
+      });
+
+      test('keeps independent cursors for filtered feeds', () async {
+        var signedUrl = '';
+        repository = NotificationRepository(
+          funnelcakeApiClient: funnelcakeApiClient,
+          profileRepository: profileRepository,
+          notificationsDao: notificationsDao,
+          userPubkey: userPubkey,
+          authHeadersProvider: (url, method, {body}) async {
+            signedUrl = url;
+            return {'Authorization': 'Nostr test-token'};
+          },
+        );
+        stubProfiles({});
+        when(
+          () => funnelcakeApiClient.getNotifications(
+            pubkey: any(named: 'pubkey'),
+            cursor: any(named: 'cursor'),
+            cursorId: any(named: 'cursorId'),
+            types: any(named: 'types'),
+            requestUri: any(named: 'requestUri'),
+            authHeaders: any(named: 'authHeaders'),
+            limit: any(named: 'limit'),
+          ),
+        ).thenAnswer((invocation) async {
+          final types = invocation.namedArguments[#types] as List<String>?;
+          final cursor = invocation.namedArguments[#cursor] as String?;
+          if (types?.contains('follow') ?? false) {
+            return NotificationResponse(
+              notifications: const [],
+              unreadCount: 0,
+              hasMore: cursor == null,
+              nextCursor: cursor == null ? 'follow_cursor' : null,
+            );
+          }
+          return NotificationResponse(
+            notifications: const [],
+            unreadCount: 0,
+            hasMore: cursor == null,
+            nextCursor: cursor == null ? 'like_cursor' : null,
+          );
+        });
+
+        await repository.getNotifications(filter: NotificationKind.follow);
+        await repository.getNotifications(filter: NotificationKind.like);
+        await repository.loadNextPageFor(NotificationKind.follow);
+
+        final signedUri = Uri.parse(signedUrl);
+        expect(signedUri.queryParameters['types'], equals('follow'));
+        expect(signedUri.queryParameters['before'], equals('follow_cursor'));
+      });
 
       test('explicit cursor override does not leak stored cursor id', () async {
         var signedUrl = '';
@@ -1285,6 +1388,76 @@ void main() {
         expect(follow.type, equals(NotificationKind.follow));
         expect(follow.actor.pubkey, equals('follower_pub'));
         expect(follow.timestamp, equals(fresh));
+      });
+
+      test('same follower is consolidated across appended pages', () async {
+        final stale = DateTime(2025);
+        final fresh = DateTime(2025, 1, 10);
+        var call = 0;
+        when(
+          () => funnelcakeApiClient.getNotifications(
+            pubkey: any(named: 'pubkey'),
+            cursor: any(named: 'cursor'),
+            cursorId: any(named: 'cursorId'),
+            types: any(named: 'types'),
+            requestUri: any(named: 'requestUri'),
+            authHeaders: any(named: 'authHeaders'),
+            limit: any(named: 'limit'),
+          ),
+        ).thenAnswer((_) async {
+          call++;
+          return call == 1
+              ? NotificationResponse(
+                  notifications: [
+                    makeNotification(
+                      id: 'follow_stale',
+                      sourceEventId: 'follow_evt_stale',
+                      sourcePubkey: 'follower_pub',
+                      notificationType: 'follow',
+                      sourceKind: 3,
+                      referencedEventId: null,
+                      createdAt: stale,
+                      read: true,
+                    ),
+                  ],
+                  unreadCount: 0,
+                  hasMore: true,
+                  nextCursor: 'cursor_1',
+                )
+              : NotificationResponse(
+                  notifications: [
+                    makeNotification(
+                      id: 'follow_fresh',
+                      sourceEventId: 'follow_evt_fresh',
+                      sourcePubkey: 'follower_pub',
+                      notificationType: 'follow',
+                      sourceKind: 3,
+                      referencedEventId: null,
+                      createdAt: fresh,
+                    ),
+                  ],
+                  unreadCount: 1,
+                  hasMore: false,
+                );
+        });
+        stubProfiles({
+          'follower_pub': makeProfile('follower_pub', displayName: 'Follower'),
+        });
+
+        await repository.getNotifications(filter: NotificationKind.follow);
+        await repository.loadNextPageFor(NotificationKind.follow);
+
+        final page = await repository
+            .watchSnapshot(filter: NotificationKind.follow)
+            .first;
+        expect(page.items, hasLength(1));
+        final follow = page.items.single as ActorNotification;
+        expect(follow.timestamp, equals(fresh));
+        expect(follow.isRead, isFalse);
+        expect(
+          follow.notificationIds,
+          containsAll(['follow_stale', 'follow_fresh']),
+        );
       });
     });
 
@@ -3694,6 +3867,52 @@ void main() {
             authHeaders: any(named: 'authHeaders'),
           ),
         );
+      });
+
+      test('updates matching rows in every live filtered snapshot', () async {
+        when(
+          () => funnelcakeApiClient.markNotificationsRead(
+            pubkey: any(named: 'pubkey'),
+            notificationIds: any(named: 'notificationIds'),
+            authHeaders: any(named: 'authHeaders'),
+          ),
+        ).thenAnswer(
+          (_) async => const MarkReadResponse(success: true, markedCount: 1),
+        );
+        when(
+          () => notificationsDao.markAsRead(
+            any(),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer((_) async => true);
+        stubProfiles({
+          'follower_pub': makeProfile('follower_pub', displayName: 'Follower'),
+        });
+        stubNotifications([
+          makeNotification(
+            id: 'follow_notification',
+            sourceEventId: 'follow_event',
+            sourcePubkey: 'follower_pub',
+            notificationType: 'follow',
+            sourceKind: 3,
+            referencedEventId: null,
+          ),
+        ], unreadCount: 1);
+
+        await repository.getNotifications();
+        await repository.getNotifications(filter: NotificationKind.follow);
+
+        await repository.markAsRead(['follow_notification']);
+
+        final allItem = (await repository.watchSnapshot().first).items.single;
+        final followItem =
+            (await repository
+                    .watchSnapshot(filter: NotificationKind.follow)
+                    .first)
+                .items
+                .single;
+        expect(allItem.isRead, isTrue);
+        expect(followItem.isRead, isTrue);
       });
 
       test('expands a grouped row to every raw notification id before '

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -4885,6 +4885,49 @@ void main() {
 
         expect(repository.hasPaginatedBeyondFirstPage, isTrue);
       });
+
+      test('markAllAsRead rollback keeps a page that landed mid-flight on a '
+          'feed it never flipped', () async {
+        stubProfiles({});
+        stubNotifications([makeNotification()], unreadCount: 1);
+        await repository.refresh();
+        // The inbox mounts all five tabs, so the Follows feed is already live
+        // when the POST starts — it just holds nothing to flip yet.
+        stubNotifications([]);
+        await repository.refreshFeed(NotificationKind.follow);
+
+        final markGate = Completer<MarkReadResponse>();
+        when(
+          () => funnelcakeApiClient.markNotificationsRead(
+            pubkey: any(named: 'pubkey'),
+            authHeaders: any(named: 'authHeaders'),
+          ),
+        ).thenAnswer((_) => markGate.future);
+        final markFuture = repository.markAllAsRead();
+
+        // The user swipes to Follows while the mark-read POST is in flight.
+        stubNotifications([
+          makeNotification(
+            id: 'follow_1',
+            sourcePubkey: 'pubkey_follower',
+            sourceEventId: 'evt_follow_1',
+            sourceKind: 3,
+            notificationType: 'follow',
+            referencedEventId: null,
+          ),
+        ]);
+        await repository.refreshFeed(NotificationKind.follow);
+
+        markGate.completeError(const FunnelcakeException('boom'));
+        await expectLater(markFuture, throwsA(isA<FunnelcakeException>()));
+
+        final follows = await repository
+            .watchSnapshot(filter: NotificationKind.follow)
+            .first;
+        expect(follows.items, hasLength(1));
+        // The unfiltered feed was flipped, so it still rolls back.
+        expect(await repository.watchUnreadCount().first, equals(1));
+      });
     });
 
     group('cross-page dedupe in page-merge (#4264)', () {

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -4550,6 +4550,16 @@ void main() {
         expect(repository.isClosed, isTrue);
       });
 
+      test('resetPaginationDepth is a no-op after close()', () async {
+        await repository.close();
+
+        expect(
+          () =>
+              repository.resetPaginationDepth(filter: NotificationKind.follow),
+          returnsNormally,
+        );
+      });
+
       test('emits snapshot after refresh', () async {
         stubProfiles({
           'pubkey_alice': makeProfile('pubkey_alice', displayName: 'Alice'),

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -2859,6 +2859,103 @@ void main() {
         );
       });
 
+      test('filtered feeds seed from the hydrated unfiltered rows', () async {
+        when(
+          () => notificationsDao.getAllNotifications(
+            limit: any(named: 'limit'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer(
+          (_) async => [
+            NotificationRow(
+              id: 'cached_like',
+              type: 'like',
+              fromPubkey: 'cached_actor',
+              timestamp: 1700000000,
+              targetEventId: 'cached_video',
+              hasCommentTarget: false,
+              isRead: false,
+              cachedAt: DateTime(2026),
+            ),
+            NotificationRow(
+              id: 'cached_follow',
+              type: 'follow',
+              fromPubkey: 'cached_follower',
+              timestamp: 1700000001,
+              hasCommentTarget: false,
+              isRead: false,
+              cachedAt: DateTime(2026),
+            ),
+          ],
+        );
+
+        final hydrated = NotificationRepository(
+          funnelcakeApiClient: funnelcakeApiClient,
+          profileRepository: profileRepository,
+          notificationsDao: notificationsDao,
+          userPubkey: userPubkey,
+        );
+        addTearDown(hydrated.close);
+        // Give the unawaited hydration a chance to resolve.
+        await Future<void>.delayed(Duration.zero);
+
+        // Only the unfiltered feed reads the DAO, so without the cross-feed
+        // seed a category tab starts empty and a failed first fetch renders
+        // the full-screen failure body instead of cached rows.
+        final follows = await hydrated
+            .watchSnapshot(filter: NotificationKind.follow)
+            .first;
+        expect(follows.items.map((n) => n.id), equals(['cached_follow']));
+        final likes = await hydrated
+            .watchSnapshot(filter: NotificationKind.like)
+            .first;
+        expect(likes.items.map((n) => n.id), equals(['cached_like']));
+      });
+
+      test('filtered feeds mounted before hydration are seeded too', () async {
+        final daoGate = Completer<List<NotificationRow>>();
+        when(
+          () => notificationsDao.getAllNotifications(
+            limit: any(named: 'limit'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer((_) => daoGate.future);
+
+        final hydrated = NotificationRepository(
+          funnelcakeApiClient: funnelcakeApiClient,
+          profileRepository: profileRepository,
+          notificationsDao: notificationsDao,
+          userPubkey: userPubkey,
+        );
+        addTearDown(hydrated.close);
+
+        // The repository is built when ProfileRepository resolves, which on a
+        // cold start can land after the inbox already mounted its tabs.
+        final emissions = <NotificationPage>[];
+        final sub = hydrated
+            .watchSnapshot(filter: NotificationKind.follow)
+            .listen(emissions.add);
+        addTearDown(sub.cancel);
+
+        daoGate.complete([
+          NotificationRow(
+            id: 'cached_follow',
+            type: 'follow',
+            fromPubkey: 'cached_follower',
+            timestamp: 1700000001,
+            hasCommentTarget: false,
+            isRead: false,
+            cachedAt: DateTime(2026),
+          ),
+        ]);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+          emissions.last.items.map((n) => n.id),
+          equals(['cached_follow']),
+        );
+      });
+
       test('hydration is a no-op when DAO is empty', () async {
         when(
           () => notificationsDao.getAllNotifications(

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -3612,6 +3612,77 @@ void main() {
 
         await expectLater(staleRefresh, completion(isFalse));
       });
+
+      test('refreshApplied leaves a deep-scrolled feed intact', () async {
+        stubProfiles({});
+        stubNotifications(
+          [makeNotification()],
+          nextCursor: 'c1',
+          hasMore: true,
+        );
+        await repository.refreshFeed(NotificationKind.like);
+        stubNotifications(
+          [
+            makeNotification(
+              id: 'n2',
+              sourceEventId: 'evt2',
+              referencedEventId: 'video_2',
+            ),
+          ],
+          nextCursor: 'c2',
+          hasMore: true,
+        );
+        await repository.loadNextPageFor(NotificationKind.like);
+
+        stubNotifications([]);
+        await repository.refreshApplied();
+
+        // A first-page replace would have collapsed Likes back to one
+        // page under the user; it must be skipped, not refreshed.
+        final likes = await repository
+            .watchSnapshot(filter: NotificationKind.like)
+            .first;
+        expect(likes.items, hasLength(2));
+        // Likes is the only live feed and it is deep-scrolled, so there is
+        // genuinely nothing left for a resume refresh to serve.
+        expect(repository.hasPaginatedBeyondFirstPage, isTrue);
+      });
+
+      test('refreshApplied keeps refreshing after one feed fails', () async {
+        stubProfiles({});
+        stubNotifications([makeNotification()]);
+        await repository.refreshFeed(NotificationKind.like);
+
+        // The unfiltered feed is created first, so without per-feed error
+        // isolation its failure would abort the whole fan-out.
+        when(
+          () => funnelcakeApiClient.getNotifications(
+            pubkey: any(named: 'pubkey'),
+            cursor: any(named: 'cursor'),
+            cursorId: any(named: 'cursorId'),
+            types: any(named: 'types', that: isNull),
+            requestUri: any(named: 'requestUri'),
+            authHeaders: any(named: 'authHeaders'),
+            limit: any(named: 'limit'),
+          ),
+        ).thenThrow(
+          const FunnelcakeApiException(message: 'boom', statusCode: 500),
+        );
+
+        await expectLater(repository.refreshApplied(), completion(isTrue));
+
+        verify(
+          () => funnelcakeApiClient.getNotifications(
+            pubkey: any(named: 'pubkey'),
+            cursor: any(named: 'cursor'),
+            cursorId: any(named: 'cursorId'),
+            types: const ['reaction', 'zap'],
+            requestUri: any(named: 'requestUri'),
+            authHeaders: any(named: 'authHeaders'),
+            limit: any(named: 'limit'),
+          ),
+        ).called(greaterThanOrEqualTo(1));
+      });
     });
 
     group('loadNextPage', () {
@@ -3827,6 +3898,34 @@ void main() {
 
         stubNotifications([]);
         await repository.refresh();
+
+        expect(repository.hasPaginatedBeyondFirstPage, isFalse);
+      });
+
+      test('false while any live feed is still on its first page', () async {
+        stubProfiles({});
+        stubNotifications(
+          [makeNotification()],
+          nextCursor: 'c1',
+          hasMore: true,
+        );
+        await repository.refreshFeed(NotificationKind.like);
+        stubNotifications(
+          [
+            makeNotification(
+              id: 'n2',
+              sourceEventId: 'evt2',
+              referencedEventId: 'video_2',
+            ),
+          ],
+          nextCursor: 'c2',
+          hasMore: true,
+        );
+        await repository.loadNextPageFor(NotificationKind.like);
+
+        // Likes is two pages deep, but the unfiltered feed is not — a
+        // resume refresh can still serve it, so the guard must stay open.
+        await repository.refreshFeed(null);
 
         expect(repository.hasPaginatedBeyondFirstPage, isFalse);
       });

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -397,6 +397,76 @@ void main() {
         expect(signedUri.queryParameters['types'], equals('reaction,zap'));
       });
 
+      test('comment feed keeps comment-target mentions', () async {
+        stubNotifications([
+          makeNotification(
+            id: 'comment_mention',
+            notificationType: 'mention',
+            sourceKind: 1,
+            referencedEventId: null,
+            targetCommentId: 'comment_target',
+          ),
+        ]);
+        stubProfiles({
+          'pubkey_alice': makeProfile('pubkey_alice', displayName: 'Alice'),
+        });
+
+        final page = await repository.getNotifications(
+          filter: NotificationKind.comment,
+        );
+
+        expect(page.items, hasLength(1));
+        final item = page.items.single as ActorNotification;
+        expect(item.type, equals(NotificationKind.mention));
+        expect(item.hasCommentTarget, isTrue);
+      });
+
+      test('comment feed keeps nested replies', () async {
+        stubNotifications([
+          makeNotification(
+            id: 'nested_reply',
+            notificationType: 'reply',
+            sourceKind: 1111,
+            referencedEventId: 'parent_comment',
+            rootEventId: 'root_video',
+            targetCommentId: 'parent_comment',
+            isReferencedVideo: false,
+          ),
+        ]);
+        stubProfiles({
+          'pubkey_alice': makeProfile('pubkey_alice', displayName: 'Alice'),
+        });
+
+        final page = await repository.getNotifications(
+          filter: NotificationKind.comment,
+        );
+
+        expect(page.items, hasLength(1));
+        expect(page.items.single.type, equals(NotificationKind.reply));
+      });
+
+      test('comment feed excludes video mentions', () async {
+        stubNotifications([
+          makeNotification(
+            id: 'video_mention',
+            sourceEventId: 'video_source',
+            notificationType: 'mention',
+            sourceKind: 34236,
+            referencedEventId: 'mentioned_video',
+            rootEventId: 'mentioned_video',
+          ),
+        ]);
+        stubProfiles({
+          'pubkey_alice': makeProfile('pubkey_alice', displayName: 'Alice'),
+        });
+
+        final page = await repository.getNotifications(
+          filter: NotificationKind.comment,
+        );
+
+        expect(page.items, isEmpty);
+      });
+
       test('keeps independent cursors for filtered feeds', () async {
         var signedUrl = '';
         repository = NotificationRepository(
@@ -3820,6 +3890,45 @@ void main() {
           expect(after.map((n) => n.id).toList(), equals(expectedKeptIds));
         },
       );
+
+      test('resetPaginationDepth collapses a filtered feed snapshot', () async {
+        stubProfiles({
+          for (var i = 0; i < 25; i++)
+            'follower_$i': makeProfile(
+              'follower_$i',
+              displayName: 'Follower $i',
+            ),
+        });
+        stubNotifications([
+          for (var i = 0; i < 25; i++)
+            makeNotification(
+              id: 'follow_$i',
+              sourcePubkey: 'follower_$i',
+              sourceEventId: 'follow_evt_$i',
+              notificationType: 'follow',
+              sourceKind: 3,
+              referencedEventId: null,
+              createdAt: DateTime(2025).subtract(Duration(minutes: i)),
+            ),
+        ], hasMore: true);
+        await repository.getNotifications(filter: NotificationKind.follow);
+        final before =
+            (await repository
+                    .watchSnapshot(filter: NotificationKind.follow)
+                    .first)
+                .items;
+        expect(before, hasLength(25));
+        final expectedKeptIds = before.take(20).map((n) => n.id).toList();
+
+        repository.resetPaginationDepth(filter: NotificationKind.follow);
+
+        final after =
+            (await repository
+                    .watchSnapshot(filter: NotificationKind.follow)
+                    .first)
+                .items;
+        expect(after.map((n) => n.id).toList(), equals(expectedKeptIds));
+      });
     });
 
     group('markAsRead', () {

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -3717,6 +3717,10 @@ void main() {
           nextCursor: 'c1',
           hasMore: true,
         );
+        final likesSubscription = repository
+            .watchSnapshot(filter: NotificationKind.like)
+            .listen((_) {});
+        addTearDown(likesSubscription.cancel);
         await repository.refreshFeed(NotificationKind.like);
         stubNotifications(
           [
@@ -3745,10 +3749,60 @@ void main() {
         expect(repository.hasPaginatedBeyondFirstPage, isTrue);
       });
 
+      test(
+        'refreshApplied skips filtered feeds nobody is listening to',
+        () async {
+          stubProfiles({});
+          stubNotifications([makeNotification()]);
+          // Open and close the Likes tab: its feed stays in the map, but the
+          // bloc's subscription is gone.
+          final likes = repository
+              .watchSnapshot(filter: NotificationKind.like)
+              .listen((_) {});
+          await repository.refreshFeed(NotificationKind.like);
+          await likes.cancel();
+          // The badge keeps the unfiltered feed subscribed app-wide.
+          final all = repository.watchSnapshot().listen((_) {});
+          addTearDown(all.cancel);
+          await repository.refreshFeed(null);
+
+          clearInteractions(funnelcakeApiClient);
+          await repository.refreshApplied();
+
+          verify(
+            () => funnelcakeApiClient.getNotifications(
+              pubkey: any(named: 'pubkey'),
+              cursor: any(named: 'cursor'),
+              cursorId: any(named: 'cursorId'),
+              types: any(named: 'types', that: isNull),
+              requestUri: any(named: 'requestUri'),
+              authHeaders: any(named: 'authHeaders'),
+              limit: any(named: 'limit'),
+            ),
+          ).called(1);
+          verifyNever(
+            () => funnelcakeApiClient.getNotifications(
+              pubkey: any(named: 'pubkey'),
+              cursor: any(named: 'cursor'),
+              cursorId: any(named: 'cursorId'),
+              types: const ['reaction', 'zap'],
+              requestUri: any(named: 'requestUri'),
+              authHeaders: any(named: 'authHeaders'),
+              limit: any(named: 'limit'),
+            ),
+          );
+        },
+      );
+
       test('refreshApplied keeps refreshing after one feed fails', () async {
         stubProfiles({});
         stubNotifications([makeNotification()]);
+        final likes = repository
+            .watchSnapshot(filter: NotificationKind.like)
+            .listen((_) {});
+        addTearDown(likes.cancel);
         await repository.refreshFeed(NotificationKind.like);
+        await repository.refreshFeed(null);
 
         // The unfiltered feed is created first, so without per-feed error
         // isolation its failure would abort the whole fan-out.

--- a/mobile/test/notifications/badge_converges_after_tap_read_back_test.dart
+++ b/mobile/test/notifications/badge_converges_after_tap_read_back_test.dart
@@ -57,7 +57,7 @@ class _FakeNotificationRepository extends Fake
   }
 
   @override
-  void resetPaginationDepth() {}
+  void resetPaginationDepth({NotificationKind? filter}) {}
 
   @override
   Future<NotificationPage> refreshFeed(NotificationKind? filter) async =>

--- a/mobile/test/notifications/badge_converges_after_tap_read_back_test.dart
+++ b/mobile/test/notifications/badge_converges_after_tap_read_back_test.dart
@@ -32,7 +32,8 @@ class _FakeNotificationRepository extends Fake
   final List<List<String>> markedReadCalls = [];
 
   @override
-  Stream<NotificationPage> watchSnapshot() => _snapshot.stream;
+  Stream<NotificationPage> watchSnapshot({NotificationKind? filter}) =>
+      _snapshot.stream;
 
   @override
   Stream<int> watchUnreadCount() => _snapshot.stream
@@ -57,6 +58,14 @@ class _FakeNotificationRepository extends Fake
 
   @override
   void resetPaginationDepth() {}
+
+  @override
+  Future<NotificationPage> refreshFeed(NotificationKind? filter) async =>
+      _snapshot.value;
+
+  @override
+  Future<NotificationPage?> loadNextPageFor(NotificationKind? filter) async =>
+      _snapshot.value;
 
   @override
   Future<void> close() => _snapshot.close();
@@ -179,41 +188,35 @@ void main() {
       },
     );
 
-    test(
-      'tapping every unread item converges badge to 0',
-      () async {
-        final bloc = NotificationFeedBloc(
-          notificationRepository: repository,
-          followRepository: followRepository,
-        );
-        addTearDown(bloc.close);
-        final badge = NotificationBadgeCubit(repository: repository);
-        addTearDown(badge.close);
+    test('tapping every unread item converges badge to 0', () async {
+      final bloc = NotificationFeedBloc(
+        notificationRepository: repository,
+        followRepository: followRepository,
+      );
+      addTearDown(bloc.close);
+      final badge = NotificationBadgeCubit(repository: repository);
+      addTearDown(badge.close);
 
-        await Future<void>.delayed(Duration.zero);
-        expect(badge.state, equals(3));
+      await Future<void>.delayed(Duration.zero);
+      expect(badge.state, equals(3));
 
-        bloc.add(const NotificationFeedItemTapped('n1'));
-        await Future<void>.delayed(Duration.zero);
-        bloc.add(const NotificationFeedItemTapped('n2'));
-        await Future<void>.delayed(Duration.zero);
-        bloc.add(const NotificationFeedItemTapped('n3'));
-        await Future<void>.delayed(Duration.zero);
+      bloc.add(const NotificationFeedItemTapped('n1'));
+      await Future<void>.delayed(Duration.zero);
+      bloc.add(const NotificationFeedItemTapped('n2'));
+      await Future<void>.delayed(Duration.zero);
+      bloc.add(const NotificationFeedItemTapped('n3'));
+      await Future<void>.delayed(Duration.zero);
 
-        expect(badge.state, equals(0));
-        expect(
-          repository.markedReadCalls,
-          equals([
-            ['n1'],
-            ['n2'],
-            ['n3'],
-          ]),
-        );
-        expect(
-          bloc.state.notifications.every((n) => n.isRead),
-          isTrue,
-        );
-      },
-    );
+      expect(badge.state, equals(0));
+      expect(
+        repository.markedReadCalls,
+        equals([
+          ['n1'],
+          ['n2'],
+          ['n3'],
+        ]),
+      );
+      expect(bloc.state.notifications.every((n) => n.isRead), isTrue);
+    });
   });
 }

--- a/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
+++ b/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
@@ -96,7 +96,11 @@ void main() {
         () => mockNotificationRepo.markAsRead(any()),
       ).thenAnswer((_) async {});
       when(() => mockNotificationRepo.markAllAsRead()).thenAnswer((_) async {});
-      when(() => mockNotificationRepo.resetPaginationDepth()).thenReturn(null);
+      when(
+        () => mockNotificationRepo.resetPaginationDepth(
+          filter: any(named: 'filter'),
+        ),
+      ).thenReturn(null);
     });
 
     tearDown(() async {
@@ -119,7 +123,9 @@ void main() {
 
       await bloc.close();
 
-      verify(() => mockNotificationRepo.resetPaginationDepth()).called(1);
+      verify(
+        () => mockNotificationRepo.resetPaginationDepth(filter: null),
+      ).called(1);
     });
 
     test('subscribes to the filtered snapshot for tab feeds', () async {
@@ -131,7 +137,11 @@ void main() {
         () =>
             mockNotificationRepo.watchSnapshot(filter: NotificationKind.follow),
       ).called(1);
-      verifyNever(() => mockNotificationRepo.resetPaginationDepth());
+      verify(
+        () => mockNotificationRepo.resetPaginationDepth(
+          filter: NotificationKind.follow,
+        ),
+      ).called(1);
     });
 
     group('snapshot projection', () {
@@ -370,6 +380,39 @@ void main() {
 
     group('NotificationFeedLoadMore', () {
       blocTest<NotificationFeedBloc, NotificationFeedState>(
+        'continues past an empty page from the bloc',
+        build: createBloc,
+        seed: () => NotificationFeedState(
+          status: NotificationFeedStatus.loaded,
+          hasMore: false,
+        ),
+        act: (_) async {
+          snapshotController.add(
+            NotificationPage(items: const [], unreadCount: 0, hasMore: true),
+          );
+          await Future<void>.delayed(Duration.zero);
+        },
+        expect: () => [
+          NotificationFeedState(
+            status: NotificationFeedStatus.loaded,
+            hasMore: true,
+          ),
+          NotificationFeedState(
+            status: NotificationFeedStatus.loaded,
+            hasMore: true,
+            isLoadingMore: true,
+          ),
+          NotificationFeedState(
+            status: NotificationFeedStatus.loaded,
+            hasMore: true,
+          ),
+        ],
+        verify: (_) {
+          verify(() => mockNotificationRepo.loadNextPageFor(null)).called(1);
+        },
+      );
+
+      blocTest<NotificationFeedBloc, NotificationFeedState>(
         'no-op when hasMore is false',
         build: createBloc,
         seed: () => NotificationFeedState(
@@ -408,7 +451,7 @@ void main() {
       );
 
       blocTest<NotificationFeedBloc, NotificationFeedState>(
-        'recovers isLoadingMore on loadNextPage failure',
+        'recovers isLoadingMore on loadNextPage failure and stops retrying',
         setUp: () {
           when(
             () => mockNotificationRepo.loadNextPageFor(null),
@@ -419,7 +462,11 @@ void main() {
           status: NotificationFeedStatus.loaded,
           hasMore: true,
         ),
-        act: (bloc) => bloc.add(NotificationFeedLoadMore()),
+        act: (bloc) async {
+          bloc.add(NotificationFeedLoadMore());
+          await Future<void>.delayed(Duration.zero);
+          bloc.add(NotificationFeedLoadMore());
+        },
         expect: () => [
           NotificationFeedState(
             status: NotificationFeedStatus.loaded,
@@ -432,6 +479,9 @@ void main() {
           ),
         ],
         errors: () => [isA<Exception>()],
+        verify: (_) {
+          verify(() => mockNotificationRepo.loadNextPageFor(null)).called(1);
+        },
       );
 
       blocTest<NotificationFeedBloc, NotificationFeedState>(

--- a/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
+++ b/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
@@ -84,13 +84,13 @@ void main() {
 
       when(() => mockFollowRepo.isFollowing(any())).thenReturn(false);
       when(
-        () => mockNotificationRepo.watchSnapshot(),
+        () => mockNotificationRepo.watchSnapshot(filter: any(named: 'filter')),
       ).thenAnswer((_) => snapshotController.stream);
       when(
-        () => mockNotificationRepo.refresh(),
+        () => mockNotificationRepo.refreshFeed(any()),
       ).thenAnswer((_) async => NotificationPage.empty);
       when(
-        () => mockNotificationRepo.loadNextPage(),
+        () => mockNotificationRepo.loadNextPageFor(any()),
       ).thenAnswer((_) async => NotificationPage.empty);
       when(
         () => mockNotificationRepo.markAsRead(any()),
@@ -108,12 +108,30 @@ void main() {
       followRepository: mockFollowRepo,
     );
 
+    NotificationFeedBloc createFollowBloc() => NotificationFeedBloc(
+      notificationRepository: mockNotificationRepo,
+      followRepository: mockFollowRepo,
+      filter: NotificationKind.follow,
+    );
+
     test('resets pagination depth when the feed closes', () async {
       final bloc = createBloc();
 
       await bloc.close();
 
       verify(() => mockNotificationRepo.resetPaginationDepth()).called(1);
+    });
+
+    test('subscribes to the filtered snapshot for tab feeds', () async {
+      final bloc = createFollowBloc();
+
+      await bloc.close();
+
+      verify(
+        () =>
+            mockNotificationRepo.watchSnapshot(filter: NotificationKind.follow),
+      ).called(1);
+      verifyNever(() => mockNotificationRepo.resetPaginationDepth());
     });
 
     group('snapshot projection', () {
@@ -199,7 +217,7 @@ void main() {
           // Seen-on-open advances the server watermark AFTER the refresh so
           // the badge clears and thereafter shows "new since last seen".
           verifyInOrder([
-            () => mockNotificationRepo.refresh(),
+            () => mockNotificationRepo.refreshFeed(null),
             () => mockNotificationRepo.markAllAsRead(),
           ]);
         },
@@ -221,7 +239,7 @@ void main() {
         ],
         errors: () => [isA<Exception>()],
         verify: (_) {
-          verify(() => mockNotificationRepo.refresh()).called(1);
+          verify(() => mockNotificationRepo.refreshFeed(null)).called(1);
           verify(() => mockNotificationRepo.markAllAsRead()).called(1);
         },
       );
@@ -250,7 +268,7 @@ void main() {
               .having((r) => r.unwrap(), 'unwrap', isA<StateError>()),
         ],
         verify: (_) {
-          verify(() => mockNotificationRepo.refresh()).called(1);
+          verify(() => mockNotificationRepo.refreshFeed(null)).called(1);
           verify(() => mockNotificationRepo.markAllAsRead()).called(1);
         },
       );
@@ -259,7 +277,7 @@ void main() {
         'emits failure with refreshError when refresh throws and cache is empty',
         setUp: () {
           when(
-            () => mockNotificationRepo.refresh(),
+            () => mockNotificationRepo.refreshFeed(null),
           ).thenThrow(Exception('boom'));
         },
         build: createBloc,
@@ -279,7 +297,7 @@ void main() {
         'items',
         setUp: () {
           when(
-            () => mockNotificationRepo.refresh(),
+            () => mockNotificationRepo.refreshFeed(null),
           ).thenThrow(Exception('boom'));
         },
         build: createBloc,
@@ -328,7 +346,7 @@ void main() {
         'failure with refreshError',
         setUp: () {
           when(
-            () => mockNotificationRepo.refresh(),
+            () => mockNotificationRepo.refreshFeed(null),
           ).thenThrow(StateError('invariant'));
         },
         build: createBloc,
@@ -361,7 +379,7 @@ void main() {
         act: (bloc) => bloc.add(NotificationFeedLoadMore()),
         expect: () => <NotificationFeedState>[],
         verify: (_) {
-          verifyNever(() => mockNotificationRepo.loadNextPage());
+          verifyNever(() => mockNotificationRepo.loadNextPageFor(null));
         },
       );
 
@@ -385,7 +403,7 @@ void main() {
           ),
         ],
         verify: (_) {
-          verify(() => mockNotificationRepo.loadNextPage()).called(1);
+          verify(() => mockNotificationRepo.loadNextPageFor(null)).called(1);
         },
       );
 
@@ -393,7 +411,7 @@ void main() {
         'recovers isLoadingMore on loadNextPage failure',
         setUp: () {
           when(
-            () => mockNotificationRepo.loadNextPage(),
+            () => mockNotificationRepo.loadNextPageFor(null),
           ).thenThrow(Exception('boom'));
         },
         build: createBloc,
@@ -421,7 +439,7 @@ void main() {
         'recovers isLoadingMore',
         setUp: () {
           when(
-            () => mockNotificationRepo.loadNextPage(),
+            () => mockNotificationRepo.loadNextPageFor(null),
           ).thenThrow(StateError('invariant'));
         },
         build: createBloc,
@@ -466,7 +484,7 @@ void main() {
           NotificationFeedState(status: NotificationFeedStatus.loaded),
         ],
         verify: (_) {
-          verify(() => mockNotificationRepo.refresh()).called(1);
+          verify(() => mockNotificationRepo.refreshFeed(null)).called(1);
           // Pull-to-refresh shows current unread; only opening (Started)
           // advances the seen watermark (#4708).
           verifyNever(() => mockNotificationRepo.markAllAsRead());
@@ -478,7 +496,7 @@ void main() {
         'empty',
         setUp: () {
           when(
-            () => mockNotificationRepo.refresh(),
+            () => mockNotificationRepo.refreshFeed(null),
           ).thenThrow(Exception('boom'));
         },
         build: createBloc,
@@ -498,7 +516,7 @@ void main() {
         'items',
         setUp: () {
           when(
-            () => mockNotificationRepo.refresh(),
+            () => mockNotificationRepo.refreshFeed(null),
           ).thenThrow(Exception('boom'));
         },
         build: createBloc,
@@ -560,7 +578,7 @@ void main() {
         'failure with refreshError',
         setUp: () {
           when(
-            () => mockNotificationRepo.refresh(),
+            () => mockNotificationRepo.refreshFeed(null),
           ).thenThrow(StateError('invariant'));
         },
         build: createBloc,

--- a/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
+++ b/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
@@ -412,6 +412,37 @@ void main() {
         },
       );
 
+      test('continues past an empty page when the snapshot lands during '
+          '_onStarted', () async {
+        final emptyWithMore = NotificationPage(
+          items: const [],
+          unreadCount: 0,
+          hasMore: true,
+        );
+        // Mirrors the repository: `_getNotificationsResult` emits the
+        // snapshot before `refreshFeed` completes, so `_onSnapshotChanged`
+        // runs while `_onStarted` still holds `isRefreshing: true` and
+        // `status: initial`. Nothing emits afterwards, so unless the
+        // continuation is re-checked at the tail of `_onStarted` the tab
+        // settles empty with `hasMore: true` and never paginates.
+        when(
+          () => mockNotificationRepo.refreshFeed(NotificationKind.follow),
+        ).thenAnswer((_) async {
+          snapshotController.add(emptyWithMore);
+          await Future<void>.value();
+          await Future<void>.value();
+          return emptyWithMore;
+        });
+
+        final bloc = createFollowBloc()..add(NotificationFeedStarted());
+        addTearDown(bloc.close);
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+
+        verify(
+          () => mockNotificationRepo.loadNextPageFor(NotificationKind.follow),
+        ).called(1);
+      });
+
       blocTest<NotificationFeedBloc, NotificationFeedState>(
         'no-op when hasMore is false',
         build: createBloc,

--- a/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
+++ b/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
@@ -482,7 +482,8 @@ void main() {
       );
 
       blocTest<NotificationFeedBloc, NotificationFeedState>(
-        'recovers isLoadingMore on loadNextPage failure and stops retrying',
+        'recovers isLoadingMore on loadNextPage failure and still retries '
+        'when the user scrolls again',
         setUp: () {
           when(
             () => mockNotificationRepo.loadNextPageFor(null),
@@ -508,10 +509,22 @@ void main() {
             status: NotificationFeedStatus.loaded,
             hasMore: true,
           ),
+          NotificationFeedState(
+            status: NotificationFeedStatus.loaded,
+            hasMore: true,
+            isLoadingMore: true,
+          ),
+          NotificationFeedState(
+            status: NotificationFeedStatus.loaded,
+            hasMore: true,
+          ),
         ],
-        errors: () => [isA<Exception>()],
+        errors: () => [isA<Exception>(), isA<Exception>()],
+        // A load-more failure emits no snapshot and shows no error
+        // affordance, so latching it would strand the user with a list
+        // that silently refuses to paginate for the rest of the session.
         verify: (_) {
-          verify(() => mockNotificationRepo.loadNextPageFor(null)).called(1);
+          verify(() => mockNotificationRepo.loadNextPageFor(null)).called(2);
         },
       );
 

--- a/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
+++ b/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
@@ -443,6 +443,42 @@ void main() {
         ).called(1);
       });
 
+      test('runs the documented number of empty-page continuations', () async {
+        final emptyWithMore = NotificationPage(
+          items: const [],
+          unreadCount: 0,
+          hasMore: true,
+        );
+        when(
+          () => mockNotificationRepo.refreshFeed(NotificationKind.follow),
+        ).thenAnswer((_) async {
+          snapshotController.add(emptyWithMore);
+          await Future<void>.value();
+          await Future<void>.value();
+          return emptyWithMore;
+        });
+        // Each continuation's page also filters down to nothing, and its
+        // snapshot lands while `isLoadingMore` is still true — so the next
+        // continuation is deferred and only fires if `_onLoadMore` flushes
+        // it. Without that flush the cap is effectively 1.
+        when(
+          () => mockNotificationRepo.loadNextPageFor(NotificationKind.follow),
+        ).thenAnswer((_) async {
+          snapshotController.add(emptyWithMore);
+          await Future<void>.value();
+          await Future<void>.value();
+          return emptyWithMore;
+        });
+
+        final bloc = createFollowBloc()..add(NotificationFeedStarted());
+        addTearDown(bloc.close);
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        verify(
+          () => mockNotificationRepo.loadNextPageFor(NotificationKind.follow),
+        ).called(3);
+      });
+
       blocTest<NotificationFeedBloc, NotificationFeedState>(
         'no-op when hasMore is false',
         build: createBloc,

--- a/mobile/test/notifications/view/inbox_notifications_page_test.dart
+++ b/mobile/test/notifications/view/inbox_notifications_page_test.dart
@@ -40,14 +40,12 @@ void main() {
       mockInviteCubit = _MockInviteStatusCubit();
 
       when(
-        () => mockNotificationRepo.watchSnapshot(),
+        () => mockNotificationRepo.watchSnapshot(filter: any(named: 'filter')),
       ).thenAnswer((_) => const Stream<NotificationPage>.empty());
       when(
-        () => mockNotificationRepo.refresh(),
+        () => mockNotificationRepo.refreshFeed(any()),
       ).thenAnswer((_) async => NotificationPage.empty);
-      when(
-        () => mockNotificationRepo.markAllAsRead(),
-      ).thenAnswer((_) async {});
+      when(() => mockNotificationRepo.markAllAsRead()).thenAnswer((_) async {});
       when(() => mockFollowRepo.isFollowing(any())).thenReturn(false);
       when(() => mockInviteCubit.state).thenReturn(InviteStatusState());
       when(mockInviteCubit.load).thenAnswer((_) async {});
@@ -77,7 +75,7 @@ void main() {
       // Opening the inbox refreshes and marks notifications seen (advances the
       // server read watermark) so the badge reflects "new since last seen"
       // (#4708).
-      verify(() => mockNotificationRepo.refresh()).called(1);
+      verify(() => mockNotificationRepo.refreshFeed(null)).called(1);
       verify(() => mockNotificationRepo.markAllAsRead()).called(1);
     });
 
@@ -120,7 +118,7 @@ void main() {
         // Exactly one refresh and one mark-seen across the whole inbox-open
         // lifecycle, even after all five filter views have mounted — the
         // shared bloc opens once, not once per tab.
-        verify(() => mockNotificationRepo.refresh()).called(1);
+        verify(() => mockNotificationRepo.refreshFeed(null)).called(1);
         verify(() => mockNotificationRepo.markAllAsRead()).called(1);
         // Confirm all five filter views actually mounted — guards
         // against the test silently passing because TabBarView never
@@ -162,9 +160,7 @@ void main() {
 
       testWidgets(
         'renders the singular label when exactly one invite is left',
-        (
-          tester,
-        ) async {
+        (tester) async {
           when(() => mockInviteCubit.state).thenReturn(
             const InviteStatusState(
               status: InviteStatusLoadingStatus.loaded,

--- a/mobile/test/notifications/view/inbox_notifications_page_test.dart
+++ b/mobile/test/notifications/view/inbox_notifications_page_test.dart
@@ -136,6 +136,32 @@ void main() {
       },
     );
 
+    testWidgets('keeps visited tab blocs alive across tab switches', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      verify(() => mockNotificationRepo.refreshFeed(null)).called(1);
+      verify(() => mockNotificationRepo.markAllAsRead()).called(1);
+      clearInteractions(mockNotificationRepo);
+
+      await tester.tap(find.byType(Tab).at(1));
+      await tester.pumpAndSettle();
+
+      verify(
+        () => mockNotificationRepo.refreshFeed(NotificationKind.like),
+      ).called(1);
+      verifyNever(() => mockNotificationRepo.markAllAsRead());
+      clearInteractions(mockNotificationRepo);
+
+      await tester.tap(find.byType(Tab).at(0));
+      await tester.pumpAndSettle();
+
+      verifyNever(() => mockNotificationRepo.refreshFeed(null));
+      verifyNever(() => mockNotificationRepo.markAllAsRead());
+    });
+
     group('invite banner', () {
       // Restores show/hide coverage that the deleted
       // notifications_screen_test.dart asserted before #3567 removed

--- a/mobile/test/notifications/view/inbox_notifications_page_test.dart
+++ b/mobile/test/notifications/view/inbox_notifications_page_test.dart
@@ -1,6 +1,6 @@
 // ABOUTME: Widget tests for InboxNotificationsPage — verifies that opening
-// ABOUTME: the inbox refreshes once and marks notifications seen on open
-// ABOUTME: (advances the read watermark) without fanning out across tabs (#4708).
+// ABOUTME: the inbox marks notifications seen once (advances the read
+// ABOUTME: watermark, #4708) and that each tab opens its own filtered feed.
 
 // ignore_for_file: prefer_const_constructors
 
@@ -11,12 +11,12 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:follow_repository/follow_repository.dart';
 import 'package:invite_api_client/invite_api_client.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
 import 'package:notification_repository/notification_repository.dart';
 import 'package:openvine/blocs/invite_status/invite_status_cubit.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/notifications/providers/notification_repository_provider.dart';
 import 'package:openvine/notifications/view/inbox_notifications_page.dart';
-import 'package:openvine/notifications/view/notifications_view.dart';
 
 import '../../helpers/test_provider_overrides.dart';
 
@@ -101,29 +101,38 @@ void main() {
     );
 
     testWidgets(
-      'does not fan out refresh or mark-seen across the five filter tabs',
+      'opens each tab against its own server-filtered feed and marks seen '
+      'only on the All tab',
       (tester) async {
         await tester.pumpWidget(buildSubject());
         await tester.pumpAndSettle();
 
-        // Swipe through the four non-default tabs. Each visit mounts a
-        // fresh NotificationsView but they share one NotificationFeedBloc;
-        // the contract is that none of them triggers another refresh or an
-        // additional mark-seen.
-        for (var i = 1; i < 5; i++) {
-          await tester.tap(find.byType(Tab).at(i));
+        // Tab order is load-bearing: each index must open the feed its label
+        // promises, or a transposed entry silently shows e.g. reposts under
+        // Comments.
+        const tabFilters = <NotificationKind>[
+          NotificationKind.like,
+          NotificationKind.comment,
+          NotificationKind.follow,
+          NotificationKind.repost,
+        ];
+
+        verify(() => mockNotificationRepo.refreshFeed(null)).called(1);
+
+        for (var i = 0; i < tabFilters.length; i++) {
+          await tester.tap(find.byType(Tab).at(i + 1));
           await tester.pumpAndSettle();
+
+          // Asserted per tap, not as a set at the end — a set assertion
+          // passes even when two tabs are swapped.
+          verify(
+            () => mockNotificationRepo.refreshFeed(tabFilters[i]),
+          ).called(1);
         }
 
-        // Exactly one refresh and one mark-seen across the whole inbox-open
-        // lifecycle, even after all five filter views have mounted — the
-        // shared bloc opens once, not once per tab.
-        verify(() => mockNotificationRepo.refreshFeed(null)).called(1);
+        // The seen watermark advances on open only, and only for the
+        // unfiltered feed (#4708) — never once per filter tab.
         verify(() => mockNotificationRepo.markAllAsRead()).called(1);
-        // Confirm all five filter views actually mounted — guards
-        // against the test silently passing because TabBarView never
-        // built the off-default children.
-        expect(find.byType(NotificationsView), findsWidgets);
       },
     );
 

--- a/mobile/test/notifications/view/notification_pages_repo_swap_test.dart
+++ b/mobile/test/notifications/view/notification_pages_repo_swap_test.dart
@@ -57,9 +57,11 @@ void main() {
 
       for (final repo in [mockNotificationRepoA, mockNotificationRepoB]) {
         when(
-          repo.watchSnapshot,
+          () => repo.watchSnapshot(filter: any(named: 'filter')),
         ).thenAnswer((_) => const Stream<NotificationPage>.empty());
-        when(repo.refresh).thenAnswer((_) async => NotificationPage.empty);
+        when(
+          () => repo.refreshFeed(any()),
+        ).thenAnswer((_) async => NotificationPage.empty);
         when(repo.markAllAsRead).thenAnswer((_) async {});
       }
 
@@ -263,9 +265,11 @@ void main() {
 
       for (final repo in [mockNotificationRepoA, mockNotificationRepoB]) {
         when(
-          repo.watchSnapshot,
+          () => repo.watchSnapshot(filter: any(named: 'filter')),
         ).thenAnswer((_) => const Stream<NotificationPage>.empty());
-        when(repo.refresh).thenAnswer((_) async => NotificationPage.empty);
+        when(
+          () => repo.refreshFeed(any()),
+        ).thenAnswer((_) async => NotificationPage.empty);
         when(repo.markAllAsRead).thenAnswer((_) async {});
       }
 

--- a/mobile/test/notifications/view/notifications_page_test.dart
+++ b/mobile/test/notifications/view/notifications_page_test.dart
@@ -57,10 +57,11 @@ void main() {
         mockFollowRepo = _MockFollowRepository();
 
         when(
-          () => mockNotificationRepo.watchSnapshot(),
+          () =>
+              mockNotificationRepo.watchSnapshot(filter: any(named: 'filter')),
         ).thenAnswer((_) => const Stream<NotificationPage>.empty());
         when(
-          () => mockNotificationRepo.refresh(),
+          () => mockNotificationRepo.refreshFeed(any()),
         ).thenAnswer((_) async => NotificationPage.empty);
         when(
           () => mockNotificationRepo.markAllAsRead(),
@@ -84,12 +85,10 @@ void main() {
         await tester.pumpWidget(buildSubject());
         await tester.pumpAndSettle();
 
-        verify(() => mockNotificationRepo.refresh()).called(1);
+        verify(() => mockNotificationRepo.refreshFeed(null)).called(1);
       });
 
-      testWidgets('marks notifications seen on open', (
-        tester,
-      ) async {
+      testWidgets('marks notifications seen on open', (tester) async {
         await tester.pumpWidget(buildSubject());
         await tester.pumpAndSettle();
 

--- a/mobile/test/notifications/view/notifications_view_test.dart
+++ b/mobile/test/notifications/view/notifications_view_test.dart
@@ -382,7 +382,7 @@ void main() {
         expect(find.byType(LinearProgressIndicator), findsNothing);
       });
 
-      testWidgets('dispatches load-more for an empty loaded feed with more', (
+      testWidgets('does not dispatch load-more from empty-state build', (
         tester,
       ) async {
         when(() => mockBloc.state).thenReturn(
@@ -392,7 +392,7 @@ void main() {
         await _pumpView(tester, mockBloc);
         await tester.pump();
 
-        verify(() => mockBloc.add(const NotificationFeedLoadMore())).called(1);
+        verifyNever(() => mockBloc.add(const NotificationFeedLoadMore()));
       });
     });
 

--- a/mobile/test/notifications/view/notifications_view_test.dart
+++ b/mobile/test/notifications/view/notifications_view_test.dart
@@ -42,11 +42,7 @@ class _MockNostrClient extends Mock implements NostrClient {}
 class _MockVideosRepository extends Mock implements VideosRepository {}
 
 /// Pumps [NotificationsView] inside the required providers.
-Future<void> _pumpView(
-  WidgetTester tester,
-  NotificationFeedBloc bloc, {
-  NotificationKind? kindFilter,
-}) async {
+Future<void> _pumpView(WidgetTester tester, NotificationFeedBloc bloc) async {
   await tester.pumpWidget(
     ProviderScope(
       child: MaterialApp(
@@ -55,7 +51,7 @@ Future<void> _pumpView(
         theme: ThemeData.dark(),
         home: BlocProvider<NotificationFeedBloc>.value(
           value: bloc,
-          child: Scaffold(body: NotificationsView(kindFilter: kindFilter)),
+          child: const Scaffold(body: NotificationsView()),
         ),
       ),
     ),
@@ -384,6 +380,19 @@ void main() {
 
         expect(find.byType(NotificationEmptyState), findsOneWidget);
         expect(find.byType(LinearProgressIndicator), findsNothing);
+      });
+
+      testWidgets('dispatches load-more for an empty loaded feed with more', (
+        tester,
+      ) async {
+        when(() => mockBloc.state).thenReturn(
+          NotificationFeedState(status: NotificationFeedStatus.loaded),
+        );
+
+        await _pumpView(tester, mockBloc);
+        await tester.pump();
+
+        verify(() => mockBloc.add(const NotificationFeedLoadMore())).called(1);
       });
     });
 
@@ -1319,126 +1328,6 @@ void main() {
           expect(result.videoArgs, isEmpty);
           expect(result.profileNpubs, hasLength(1));
           expect(result.profileNpubs.single, startsWith('npub'));
-        },
-      );
-    });
-
-    group('kindFilter', () {
-      final mixed = <NotificationItem>[
-        ActorNotification(
-          id: 'a1',
-          type: NotificationKind.follow,
-          actor: ActorInfo(pubkey: 'a', displayName: 'Alice'),
-          timestamp: DateTime(2026),
-        ),
-        ActorNotification(
-          id: 'a2',
-          type: NotificationKind.mention,
-          actor: ActorInfo(pubkey: 'b', displayName: 'Bob'),
-          timestamp: DateTime(2026),
-        ),
-        ActorNotification(
-          id: 'a3',
-          type: NotificationKind.likeComment,
-          actor: ActorInfo(pubkey: 'c', displayName: 'Carol'),
-          timestamp: DateTime(2026),
-        ),
-        ActorNotification(
-          id: 'a4',
-          type: NotificationKind.mention,
-          actor: ActorInfo(pubkey: 'f', displayName: 'Fran'),
-          timestamp: DateTime(2026),
-          targetEventId: 'comment-mention',
-          hasCommentTarget: true,
-        ),
-        VideoNotification(
-          id: 'v1',
-          type: NotificationKind.like,
-          videoEventId: 'video1',
-          actors: const [ActorInfo(pubkey: 'd', displayName: 'Dan')],
-          totalCount: 1,
-          timestamp: DateTime(2026),
-        ),
-        VideoNotification(
-          id: 'v2',
-          type: NotificationKind.comment,
-          videoEventId: 'video2',
-          actors: const [ActorInfo(pubkey: 'e', displayName: 'Eve')],
-          totalCount: 1,
-          timestamp: DateTime(2026),
-        ),
-        VideoNotification(
-          id: 'v3',
-          type: NotificationKind.mention,
-          videoEventId: 'video3',
-          actors: const [ActorInfo(pubkey: 'g', displayName: 'Gail')],
-          totalCount: 1,
-          timestamp: DateTime(2026),
-        ),
-      ];
-
-      testWidgets('null filter renders every notification', (tester) async {
-        when(() => mockBloc.state).thenReturn(
-          NotificationFeedState(
-            status: NotificationFeedStatus.loaded,
-            notifications: mixed,
-          ),
-        );
-
-        await _pumpView(tester, mockBloc);
-
-        expect(find.byType(NotificationListItem), findsNWidgets(7));
-      });
-
-      testWidgets('follow filter renders only follow notifications', (
-        tester,
-      ) async {
-        when(() => mockBloc.state).thenReturn(
-          NotificationFeedState(
-            status: NotificationFeedStatus.loaded,
-            notifications: mixed,
-          ),
-        );
-
-        await _pumpView(tester, mockBloc, kindFilter: NotificationKind.follow);
-
-        expect(find.byType(NotificationListItem), findsOneWidget);
-      });
-
-      testWidgets(
-        'like filter also matches likeComment so likes-on-comments appear',
-        (tester) async {
-          when(() => mockBloc.state).thenReturn(
-            NotificationFeedState(
-              status: NotificationFeedStatus.loaded,
-              notifications: mixed,
-            ),
-          );
-
-          await _pumpView(tester, mockBloc, kindFilter: NotificationKind.like);
-
-          // VideoNotification(like) + ActorNotification(likeComment) = 2.
-          expect(find.byType(NotificationListItem), findsNWidgets(2));
-        },
-      );
-
-      testWidgets(
-        'comment filter includes comment mentions but not video mentions',
-        (tester) async {
-          when(() => mockBloc.state).thenReturn(
-            NotificationFeedState(
-              status: NotificationFeedStatus.loaded,
-              notifications: mixed,
-            ),
-          );
-
-          await _pumpView(
-            tester,
-            mockBloc,
-            kindFilter: NotificationKind.comment,
-          );
-
-          expect(find.byType(NotificationListItem), findsNWidgets(2));
         },
       );
     });


### PR DESCRIPTION
## Summary

- Fetch notification tabs as independent repository feeds with server-side `types` filters instead of widget-layer filtering over one mixed page.
- Give each filtered feed its own cursor/snapshot while keeping read-state updates shared across live feeds.
- Wire inbox tabs to per-filter blocs, remove presentation-layer filtering, and keep empty filtered tabs paginating when the server reports more rows.
- Consolidate follow notifications across appended pages so the same follower does not appear twice after pagination.

Closes #6428

## Tests

- `flutter analyze`
- `flutter test test/src/funnelcake_api_client_notification_test.dart`
- `flutter test test/src/notification_repository_test.dart`
- `flutter test test/notifications/bloc/notification_feed_bloc_test.dart test/notifications/view/notifications_view_test.dart test/notifications/view/inbox_notifications_page_test.dart test/notifications/view/notifications_page_test.dart test/notifications/badge_converges_after_tap_read_back_test.dart`
- Pre-push hook analyzer and changed-file tests
