### PR TITLE
fix(support): count live creator analytics engagement

### DIFF
--- a/mobile/lib/features/creator_analytics/creator_analytics_repository.dart
+++ b/mobile/lib/features/creator_analytics/creator_analytics_repository.dart
@@ -20,6 +20,7 @@ class CreatorAnalyticsDiagnostics {
     required this.videosHydratedByViewsEndpoint,
     required this.sourcesUsed,
     required this.fetchedAt,
+    this.videoCatalogTruncated = false,
   });
 
   final int totalVideos;
@@ -29,6 +30,7 @@ class CreatorAnalyticsDiagnostics {
   final int videosHydratedByViewsEndpoint;
   final Set<AnalyticsDataSource> sourcesUsed;
   final DateTime fetchedAt;
+  final bool videoCatalogTruncated;
 
   bool get hasAnyViewData => videosWithAnyViews > 0;
 }
@@ -97,12 +99,12 @@ class FunnelcakeCreatorAnalyticsRepository
     final sourcesUsed = <AnalyticsDataSource>{};
 
     final socialFuture = _getSocialCounts(pubkey);
-    final authored = await _fetchAuthorVideos(pubkey);
-    if (authored.isNotEmpty) {
+    final authorResult = await _fetchAuthorVideos(pubkey);
+    if (authorResult.videos.isNotEmpty) {
       sourcesUsed.add(AnalyticsDataSource.authorVideos);
     }
 
-    final bulkResult = await _enrichVideosWithBulkStats(authored);
+    final bulkResult = await _enrichVideosWithBulkStats(authorResult.videos);
     var hydratedVideos = bulkResult.videos;
     if (bulkResult.hydratedCount > 0) {
       sourcesUsed.add(AnalyticsDataSource.bulkVideoStats);
@@ -136,17 +138,19 @@ class FunnelcakeCreatorAnalyticsRepository
         videosHydratedByViewsEndpoint: endpointResult.hydratedCount,
         sourcesUsed: sourcesUsed,
         fetchedAt: DateTime.now(),
+        videoCatalogTruncated: authorResult.truncated,
       ),
     );
   }
 
-  Future<List<VideoEvent>> _fetchAuthorVideos(
+  Future<_AuthorVideosResult> _fetchAuthorVideos(
     String pubkey, {
     int maxPages = 4,
     int pageSize = 100,
   }) async {
     final collected = <VideoEvent>[];
     int? before;
+    var truncated = false;
 
     for (var page = 0; page < maxPages; page++) {
       final result = await _client.getVideosByAuthor(
@@ -160,15 +164,15 @@ class FunnelcakeCreatorAnalyticsRepository
       final batch = videos.toVideoEvents();
       collected.addAll(batch);
 
-      if (batch.length < pageSize) break;
+      final hasMore = result.hasMore ?? videos.length >= pageSize;
+      if (!hasMore) break;
 
-      final oldestCreatedAt = batch.fold<int>(
-        1 << 31,
-        (oldest, video) => video.createdAt > 0 && video.createdAt < oldest
-            ? video.createdAt
-            : oldest,
-      );
+      final oldestCreatedAt = videos.fold<int>(1 << 31, (oldest, video) {
+        final createdAt = video.createdAt.millisecondsSinceEpoch ~/ 1000;
+        return createdAt > 0 && createdAt < oldest ? createdAt : oldest;
+      });
       if (oldestCreatedAt == (1 << 31)) break;
+      truncated = page == maxPages - 1;
       before = oldestCreatedAt - 1;
       if (before <= 0) break;
     }
@@ -177,9 +181,10 @@ class FunnelcakeCreatorAnalyticsRepository
     // p-tagged collaborator rather than the event author. Mirrors the profile
     // feed's getAuthorFeed filter. Edit siblings are collapsed later, after
     // hydration, by the caller.
-    return collected
+    final authored = collected
         .where((video) => !video.isRepost && video.pubkey == pubkey)
         .toList();
+    return _AuthorVideosResult(videos: authored, truncated: truncated);
   }
 
   Future<_HydrationResult> _enrichVideosWithBulkStats(
@@ -220,11 +225,22 @@ class FunnelcakeCreatorAnalyticsRepository
         mergedTags['views'] = stats.views!.toString();
         updated = true;
       }
+      if (video.nostrLikeCount != stats.reactions ||
+          video.nostrCommentCount != stats.comments ||
+          video.nostrRepostCount != stats.reposts) {
+        updated = true;
+      }
       if (updated) hydratedCount++;
 
       return video.copyWith(
         rawTags: mergedTags,
         originalLoops: stats.embeddedLoops ?? video.originalLoops,
+        originalLikes: video.originalLikes,
+        originalComments: video.originalComments,
+        originalReposts: video.originalReposts,
+        nostrLikeCount: stats.reactions,
+        nostrCommentCount: stats.comments,
+        nostrRepostCount: stats.reposts,
       );
     }).toList();
 
@@ -293,6 +309,13 @@ class _HydrationResult {
 
   final List<VideoEvent> videos;
   final int hydratedCount;
+}
+
+class _AuthorVideosResult {
+  const _AuthorVideosResult({required this.videos, required this.truncated});
+
+  final List<VideoEvent> videos;
+  final bool truncated;
 }
 
 /// Extracts view-like counts from known tags and fallbacks.

--- a/mobile/lib/screens/comments/comments_screen.dart
+++ b/mobile/lib/screens/comments/comments_screen.dart
@@ -26,7 +26,6 @@ import 'package:openvine/providers/video_reply_context_provider.dart';
 import 'package:openvine/screens/comments/widgets/widgets.dart';
 import 'package:openvine/screens/video_recorder_screen.dart';
 import 'package:openvine/utils/pause_aware_modals.dart';
-import 'package:openvine/widgets/video_feed_item/live_engagement_counts.dart';
 
 /// Maps any of the three per-bloc errors to a localized user-facing string.
 ///
@@ -325,9 +324,7 @@ abstract final class CommentsScreen {
 ///
 /// Public-by-test only: production callers should use [CommentsScreen.show].
 @visibleForTesting
-void disposeCommentsSheetController(
-  DraggableScrollableController controller,
-) {
+void disposeCommentsSheetController(DraggableScrollableController controller) {
   if (controller.isAttached) {
     controller.jumpTo(controller.size);
   }

--- a/mobile/lib/screens/creator_analytics_screen.dart
+++ b/mobile/lib/screens/creator_analytics_screen.dart
@@ -853,7 +853,7 @@ class _TopVideoRow extends StatelessWidget {
             const SizedBox(width: 8),
             Text(
               performance.engagementRate == null
-                  ? 'N/A'
+                  ? context.l10n.analyticsNa
                   : '${(performance.engagementRate! * 100).toStringAsFixed(1)}%',
               style: VineTheme.bodySmallFont(color: VineTheme.vineGreen),
               textAlign: TextAlign.right,
@@ -1342,9 +1342,9 @@ class _VideoPerformance {
   });
 
   factory _VideoPerformance.fromVideo(VideoEvent video) {
-    final likes = video.originalLikes ?? 0;
-    final comments = video.originalComments ?? 0;
-    final reposts = video.originalReposts ?? 0;
+    final likes = liveLikeCountSeed(video) ?? 0;
+    final comments = liveCommentCountSeed(video) ?? 0;
+    final reposts = liveRepostCountSeed(video) ?? 0;
     final views = extractViewLikeCount(video);
     final interactions = likes + comments + reposts;
     final engagementRate = (views != null && views > 0)
@@ -1352,7 +1352,7 @@ class _VideoPerformance {
         : null;
     final displayTitle = video.title?.trim().isNotEmpty == true
         ? video.title!.trim()
-        : 'Video ${video.id.substring(0, math.min(8, video.id.length))}';
+        : video.id;
 
     return _VideoPerformance(
       video: video,

--- a/mobile/lib/widgets/video_feed_item/actions/comment_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/comment_action_button.dart
@@ -8,7 +8,6 @@ import 'package:openvine/blocs/video_interactions/video_interactions_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/screens/comments/comments.dart';
 import 'package:openvine/widgets/video_feed_item/actions/video_action_button.dart';
-import 'package:openvine/widgets/video_feed_item/live_engagement_counts.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Comment action button with count display for video overlay.
@@ -25,11 +24,9 @@ class CommentActionButton extends StatelessWidget {
     super.key,
   });
 
-  const CommentActionButton.preview({
-    this.onInteracted,
-    super.key,
-  }) : video = null,
-       isPreviewMode = true;
+  const CommentActionButton.preview({this.onInteracted, super.key})
+    : video = null,
+      isPreviewMode = true;
 
   final VideoEvent? video;
   final bool isPreviewMode;

--- a/mobile/lib/widgets/video_feed_item/actions/repost_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/repost_action_button.dart
@@ -12,7 +12,6 @@ import 'package:openvine/blocs/video_interactions/video_interactions_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/screens/video_engagement/video_engagement_list_screen.dart';
 import 'package:openvine/widgets/video_feed_item/actions/video_action_button.dart';
-import 'package:openvine/widgets/video_feed_item/live_engagement_counts.dart';
 
 /// Repost action button with count display for video overlay.
 ///
@@ -33,12 +32,10 @@ class RepostActionButton extends StatelessWidget {
     this.onInteracted,
   });
 
-  const RepostActionButton.preview({
-    super.key,
-    this.onInteracted,
-  }) : video = null,
-       isPreviewMode = true,
-       isOwnVideo = false;
+  const RepostActionButton.preview({super.key, this.onInteracted})
+    : video = null,
+      isPreviewMode = true,
+      isOwnVideo = false;
 
   final VideoEvent? video;
   final bool isPreviewMode;

--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -38,7 +38,6 @@ import 'package:openvine/widgets/video_feed_item/blurred_video_backdrop.dart';
 import 'package:openvine/widgets/video_feed_item/content_warning_helpers.dart';
 import 'package:openvine/widgets/video_feed_item/double_tap_heart_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/double_tap_like_helpers.dart';
-import 'package:openvine/widgets/video_feed_item/live_engagement_counts.dart';
 import 'package:openvine/widgets/video_feed_item/moderated_content_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/paused_video_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/subtitle_overlay.dart';

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_stats_row.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_stats_row.dart
@@ -8,7 +8,6 @@ import 'package:models/models.dart';
 import 'package:openvine/blocs/video_interactions/video_interactions_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/utils/string_utils.dart';
-import 'package:openvine/widgets/video_feed_item/live_engagement_counts.dart';
 
 /// Horizontal stats row displaying engagement counts for a video.
 ///

--- a/mobile/packages/models/lib/models.dart
+++ b/mobile/packages/models/lib/models.dart
@@ -21,6 +21,7 @@ export 'src/dm_shared_video_ref.dart';
 export 'src/feed_type.dart';
 export 'src/hashtag_search_result.dart';
 export 'src/home_feed_response.dart';
+export 'src/live_engagement_counts.dart';
 export 'src/log_entry.dart';
 export 'src/logging_types.dart';
 export 'src/monetization_link.dart';

--- a/mobile/packages/models/lib/src/live_engagement_counts.dart
+++ b/mobile/packages/models/lib/src/live_engagement_counts.dart
@@ -1,7 +1,7 @@
-// ABOUTME: Engagement count seed policy for feed action controls.
+// ABOUTME: Engagement count seed policy for user-visible video metrics.
 // ABOUTME: Preserves archival Vine baselines while adding live Divine counts.
 
-import 'package:models/models.dart';
+import 'package:models/src/video_event.dart';
 
 int? _sumNullableCounts(int? archivedCount, int? liveCount) {
   if (archivedCount == null && liveCount == null) return null;
@@ -14,15 +14,15 @@ int? _maxNullableCounts(int? firstCount, int? secondCount) {
   return firstCount > secondCount ? firstCount : secondCount;
 }
 
-/// Display reaction count suitable for seeding [VideoInteractionsBloc].
+/// Display reaction count preserving archival Vine metrics as the baseline.
 int? liveLikeCountSeed(VideoEvent video) =>
     _sumNullableCounts(video.originalLikes, video.nostrLikeCount);
 
-/// Display comment/reply count suitable for seeding [VideoInteractionsBloc].
+/// Display comment/reply count preserving archival Vine metrics as the baseline.
 int? liveCommentCountSeed(VideoEvent video) =>
     _sumNullableCounts(video.originalComments, video.nostrCommentCount);
 
-/// Display repost count suitable for seeding [VideoInteractionsBloc].
+/// Display repost count preserving archival Vine metrics as the baseline.
 int? liveRepostCountSeed(VideoEvent video) {
   final liveRepostCount = video.nostrRepostCount;
   final visibleReposterCount = video.reposterPubkeys?.isEmpty ?? true

--- a/mobile/packages/models/test/src/live_engagement_counts_test.dart
+++ b/mobile/packages/models/test/src/live_engagement_counts_test.dart
@@ -1,9 +1,8 @@
 // ABOUTME: Regression tests for feed action counter display seeds.
 // ABOUTME: Preserves archival Vine baselines while adding live Divine counts.
 
-import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart';
-import 'package:openvine/widgets/video_feed_item/live_engagement_counts.dart';
+import 'package:test/test.dart';
 
 void main() {
   VideoEvent videoWith({

--- a/mobile/test/features/creator_analytics/creator_analytics_repository_test.dart
+++ b/mobile/test/features/creator_analytics/creator_analytics_repository_test.dart
@@ -31,6 +31,9 @@ VideoStats _videoStats({
   required String pubkey,
   String? dTag,
   int createdAtSeconds = 1739350000,
+  int reactions = 2,
+  int comments = 1,
+  int reposts = 0,
   int? loops,
   int? views,
   Map<String, String> rawTags = const {},
@@ -44,10 +47,10 @@ VideoStats _videoStats({
     title: id,
     thumbnail: 'thumb',
     videoUrl: 'videoUrl',
-    reactions: 2,
-    comments: 1,
-    reposts: 0,
-    engagementScore: 0,
+    reactions: reactions,
+    comments: comments,
+    reposts: reposts,
+    engagementScore: reactions + comments + reposts,
     loops: loops,
     views: views,
     rawTags: rawTags,
@@ -78,7 +81,7 @@ void main() {
   });
 
   group('FunnelcakeCreatorAnalyticsRepository', () {
-    test('hydrates views from bulk stats when available', () async {
+    test('hydrates views and live engagement from bulk stats', () async {
       const pubkey = 'pubkey';
       final api = MockFunnelcakeApiClient();
 
@@ -112,7 +115,14 @@ void main() {
         ),
       ).thenAnswer(
         (_) async => VideosByAuthorResponse(
-          videos: [_videoStats(id: 'a', pubkey: pubkey)],
+          videos: [
+            _videoStats(
+              id: 'a',
+              pubkey: pubkey,
+              reactions: 0,
+              comments: 0,
+            ),
+          ],
         ),
       );
 
@@ -125,6 +135,12 @@ void main() {
       expect(snapshot.diagnostics.videosWithAnyViews, 1);
       expect(snapshot.diagnostics.videosMissingViews, 0);
       expect(snapshot.videos.first.rawTags['views'], '15');
+      expect(snapshot.videos.first.originalLikes, isNull);
+      expect(snapshot.videos.first.originalComments, isNull);
+      expect(snapshot.videos.first.originalReposts, isNull);
+      expect(snapshot.videos.first.nostrLikeCount, 4);
+      expect(snapshot.videos.first.nostrCommentCount, 2);
+      expect(snapshot.videos.first.nostrRepostCount, 1);
     });
 
     test(
@@ -312,6 +328,107 @@ void main() {
       // surviving-id list rather than the (unreachable) single-leak list.
       verify(() => api.getBulkVideoStats(['authored'])).called(1);
       verifyNever(() => api.getVideoViews('collaborator-leak'));
+    });
+
+    test(
+      'continues pagination when a full raw page contains expired videos',
+      () async {
+        const pubkey = 'pubkey';
+        final api = MockFunnelcakeApiClient();
+        var calls = 0;
+        final expiredAt =
+            (DateTime.now().millisecondsSinceEpoch ~/ 1000) - 3600;
+
+        when(() => api.isAvailable).thenReturn(true);
+        when(() => api.getSocialCounts(pubkey)).thenAnswer((_) async => null);
+        when(
+          () => api.getBulkVideoStats(any()),
+        ).thenAnswer((_) async => const BulkVideoStatsResponse(stats: {}));
+        when(() => api.getVideoViews(any())).thenAnswer((_) async => 0);
+        when(
+          () => api.getVideosByAuthor(
+            pubkey: pubkey,
+            limit: 100,
+            before: any(named: 'before'),
+          ),
+        ).thenAnswer((_) async {
+          calls++;
+          if (calls == 1) {
+            return VideosByAuthorResponse(
+              videos: [
+                for (var i = 0; i < 99; i++)
+                  _videoStats(
+                    id: 'page-1-$i',
+                    pubkey: pubkey,
+                    createdAtSeconds: 1739350000 - i,
+                    views: 1,
+                  ),
+                _videoStats(
+                  id: 'expired',
+                  pubkey: pubkey,
+                  createdAtSeconds: 1739349900,
+                  views: 1,
+                  rawTags: {'expiration': '$expiredAt'},
+                ),
+              ],
+            );
+          }
+          return VideosByAuthorResponse(
+            videos: [_videoStats(id: 'page-2', pubkey: pubkey, views: 1)],
+            hasMore: false,
+          );
+        });
+
+        final repo = FunnelcakeCreatorAnalyticsRepository(api);
+        final snapshot = await repo.fetchCreatorAnalytics(pubkey);
+
+        expect(snapshot.diagnostics.totalVideos, 100);
+        expect(snapshot.videos.map((video) => video.id), contains('page-2'));
+        expect(
+          snapshot.videos.map((video) => video.id),
+          isNot(contains('expired')),
+        );
+        expect(snapshot.diagnostics.videoCatalogTruncated, isFalse);
+      },
+    );
+
+    test('marks diagnostics truncated when the page cap is reached', () async {
+      const pubkey = 'pubkey';
+      final api = MockFunnelcakeApiClient();
+      var calls = 0;
+
+      when(() => api.isAvailable).thenReturn(true);
+      when(() => api.getSocialCounts(pubkey)).thenAnswer((_) async => null);
+      when(
+        () => api.getBulkVideoStats(any()),
+      ).thenAnswer((_) async => const BulkVideoStatsResponse(stats: {}));
+      when(() => api.getVideoViews(any())).thenAnswer((_) async => 0);
+      when(
+        () => api.getVideosByAuthor(
+          pubkey: pubkey,
+          limit: 100,
+          before: any(named: 'before'),
+        ),
+      ).thenAnswer((_) async {
+        final page = calls++;
+        return VideosByAuthorResponse(
+          videos: [
+            for (var i = 0; i < 100; i++)
+              _videoStats(
+                id: 'page-$page-$i',
+                pubkey: pubkey,
+                createdAtSeconds: 1739350000 - (page * 100) - i,
+                views: 1,
+              ),
+          ],
+        );
+      });
+
+      final repo = FunnelcakeCreatorAnalyticsRepository(api);
+      final snapshot = await repo.fetchCreatorAnalytics(pubkey);
+
+      expect(snapshot.diagnostics.totalVideos, 400);
+      expect(snapshot.diagnostics.videoCatalogTruncated, isTrue);
     });
   });
 }

--- a/mobile/test/screens/creator_analytics_screen_test.dart
+++ b/mobile/test/screens/creator_analytics_screen_test.dart
@@ -20,75 +20,145 @@ class _MockCreatorAnalyticsRepository extends Mock
     implements CreatorAnalyticsRepository {}
 
 void main() {
+  Future<void> pumpAnalyticsScreen(
+    WidgetTester tester, {
+    required List<VideoEvent> videos,
+  }) async {
+    final authService = _MockAuthService();
+    final repository = _MockCreatorAnalyticsRepository();
+    final now = DateTime.now();
+
+    when(() => authService.currentPublicKeyHex).thenReturn('a' * 64);
+    when(() => repository.fetchCreatorAnalytics(any())).thenAnswer(
+      (_) async => CreatorAnalyticsSnapshot(
+        videos: videos,
+        socialCounts: SocialCounts(
+          pubkey: 'a' * 64,
+          followerCount: 10,
+          followingCount: 2,
+        ),
+        diagnostics: CreatorAnalyticsDiagnostics(
+          totalVideos: videos.length,
+          videosWithAnyViews: videos.length,
+          videosMissingViews: 0,
+          videosHydratedByBulkStats: 1,
+          videosHydratedByViewsEndpoint: 0,
+          sourcesUsed: const {AnalyticsDataSource.bulkVideoStats},
+          fetchedAt: now,
+        ),
+      ),
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authServiceProvider.overrideWithValue(authService),
+          creatorAnalyticsRepositoryProvider.overrideWithValue(repository),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          theme: VineTheme.theme,
+          home: const CreatorAnalyticsScreen(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  VideoEvent analyticsVideo({
+    required String id,
+    required int views,
+    int? originalLikes,
+    int? originalComments,
+    int? originalReposts,
+    int? nostrLikeCount,
+    int? nostrCommentCount,
+    int? nostrRepostCount,
+  }) {
+    final now = DateTime.now();
+    return VideoEvent(
+      id: id,
+      pubkey: 'a' * 64,
+      createdAt: now.millisecondsSinceEpoch ~/ 1000,
+      content: 'Analytics fixture video',
+      timestamp: now,
+      title: 'Analytics Fixture Video',
+      rawTags: {'views': '$views'},
+      originalLikes: originalLikes,
+      originalComments: originalComments,
+      originalReposts: originalReposts,
+      originalLoops: views,
+      nostrLikeCount: nostrLikeCount,
+      nostrCommentCount: nostrCommentCount,
+      nostrRepostCount: nostrRepostCount,
+    );
+  }
+
   testWidgets(
     'CreatorAnalyticsScreen constrains content width on wide screens',
-    (
-      tester,
-    ) async {
+    (tester) async {
       tester.view.physicalSize = const Size(900, 1200);
       tester.view.devicePixelRatio = 1;
       addTearDown(tester.view.resetPhysicalSize);
       addTearDown(tester.view.resetDevicePixelRatio);
 
-      final authService = _MockAuthService();
-      final repository = _MockCreatorAnalyticsRepository();
-
-      when(() => authService.currentPublicKeyHex).thenReturn('a' * 64);
-      when(
-        () => repository.fetchCreatorAnalytics(any()),
-      ).thenAnswer((_) async {
-        final now = DateTime.now();
-        return CreatorAnalyticsSnapshot(
-          videos: [
-            VideoEvent(
-              id: 'video-1',
-              pubkey: 'a' * 64,
-              createdAt: now.millisecondsSinceEpoch ~/ 1000,
-              content: 'Analytics fixture video',
-              timestamp: now,
-              title: 'Analytics Fixture Video',
-              rawTags: const {'views': '120'},
-              originalLikes: 12,
-              originalComments: 4,
-              originalReposts: 2,
-              originalLoops: 120,
-            ),
-          ],
-          socialCounts: SocialCounts(
-            pubkey: 'a' * 64,
-            followerCount: 10,
-            followingCount: 2,
+      await pumpAnalyticsScreen(
+        tester,
+        videos: [
+          analyticsVideo(
+            id: 'video-1',
+            views: 120,
+            nostrLikeCount: 19,
+            nostrCommentCount: 7,
+            nostrRepostCount: 1,
           ),
-          diagnostics: CreatorAnalyticsDiagnostics(
-            totalVideos: 1,
-            videosWithAnyViews: 1,
-            videosMissingViews: 0,
-            videosHydratedByBulkStats: 1,
-            videosHydratedByViewsEndpoint: 0,
-            sourcesUsed: const {AnalyticsDataSource.bulkVideoStats},
-            fetchedAt: now,
-          ),
-        );
-      });
-
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [
-            authServiceProvider.overrideWithValue(authService),
-            creatorAnalyticsRepositoryProvider.overrideWithValue(repository),
-          ],
-          child: MaterialApp(
-            localizationsDelegates: AppLocalizations.localizationsDelegates,
-            supportedLocales: AppLocalizations.supportedLocales,
-            theme: VineTheme.theme,
-            home: const CreatorAnalyticsScreen(),
-          ),
-        ),
+        ],
       );
-      await tester.pumpAndSettle();
 
       final listViewWidth = tester.getSize(find.byType(ListView).first).width;
       expect(listViewWidth, moreOrLessEquals(600));
     },
   );
+
+  testWidgets('counts native Divine engagement in creator analytics', (
+    tester,
+  ) async {
+    await pumpAnalyticsScreen(
+      tester,
+      videos: [
+        analyticsVideo(
+          id: 'native-video',
+          views: 120,
+          nostrLikeCount: 19,
+          nostrCommentCount: 7,
+          nostrRepostCount: 1,
+        ),
+      ],
+    );
+
+    expect(find.text('27'), findsWidgets);
+  });
+
+  testWidgets('adds archived and live engagement for restored Vines', (
+    tester,
+  ) async {
+    await pumpAnalyticsScreen(
+      tester,
+      videos: [
+        analyticsVideo(
+          id: 'mixed-video',
+          views: 200,
+          originalLikes: 10,
+          originalComments: 1,
+          originalReposts: 4,
+          nostrLikeCount: 2,
+          nostrCommentCount: 3,
+          nostrRepostCount: 5,
+        ),
+      ],
+    );
+
+    expect(find.text('25'), findsWidgets);
+  });
 }


### PR DESCRIPTION
## Summary
- move the shared live engagement display-count policy into the models package
- hydrate Creator Analytics videos with live bulk-stats reactions/comments/reposts
- calculate Creator Analytics interaction KPIs from archived + live engagement counts
- continue analytics pagination through expired rows and record when the page cap truncates results
- clean up touched analytics fallbacks to use localized N/A and full event ids

## Verification
- flutter test test/src/live_engagement_counts_test.dart (from mobile/packages/models)
- flutter test test/features/creator_analytics/creator_analytics_repository_test.dart
- flutter test test/screens/creator_analytics_screen_test.dart
- flutter analyze lib test
- pre-push changed-file analyzer/tests

Closes #6427