### PR TITLE
chore(deps): correct the c2pa_flutter pin's removal condition

### DIFF
--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -137,8 +137,9 @@ dependencies:
   # unrelated third-party FFI rewrite — different author, c2pa-rs 0.75.x, no
   # RemoteSigner.) Pinned by immutable commit (tag 0.0.3) so a moved tag cannot
   # silently change the build.
-  # TODO(#6166): revert to a pub/version dep if guardianproject publishes
-  # c2pa_flutter to pub.dev.
+  # TODO(#6166): moving off this pin needs a differently-named pub package —
+  # guardianproject cannot publish as `c2pa_flutter` (name permanently taken),
+  # so it is a rename plus API migration, not a version-constraint swap.
   c2pa_flutter:
     git:
       url: https://github.com/guardianproject/c2pa-flutter.git


### PR DESCRIPTION
## Description

The `c2pa_flutter` git pin carried a `TODO(#6166)` promising to "revert to a pub/version dep if guardianproject publishes `c2pa_flutter` to pub.dev." That condition can never be met, so the TODO was pointing at a wait that will never end.

`c2pa_flutter` on pub.dev is permanently held by an unrelated third-party package (Township-Innovation, `0.1.0`, published 2026-02-10, still the only version, `publisherId: null`). pub.dev does not recycle package names, so guardianproject cannot publish under that name. If they ever publish, it will be under a different name — making the move a rename plus API migration rather than a version-constraint swap.

This PR only rewords the TODO to say that. The pin itself is unchanged and stays: I downloaded `c2pa_flutter-0.1.0.tar.gz` (sha256 matched pub.dev's reported hash) and it contains **zero** occurrences of `RemoteSigner`, which `mobile/lib/services/c2pa_signing_service.dart:487` constructs. Three services and three tests import `package:c2pa_flutter/c2pa.dart`.

The pin is also still exactly current: guardianproject/c2pa-flutter `main` HEAD *is* the pinned SHA (`ahead_by: 0, behind_by: 0`), and tag `0.0.3` still resolves to it — the tag has not moved.

**Related Issue:** Relates to #6166

## Out of Scope

- Changing the pin, its ref, or the plugin itself — the pin is correct and stays.
- Closing #6166. It stays open, re-scoped to the rename+migration framing; details posted there.
- The native layers are also GitHub-sourced inside the plugin (`com.github.redaranj:c2pa-android:0.0.9-beta.7` via JitPack; `redaranj/c2pa-ios` exact `0.0.9-beta.7` via SPM), so a future pub.dev publish would de-git only the Dart layer. Noted on the issue, not addressed here.

## Verification

- `flutter pub get` from `mobile/` — resolves cleanly; `pubspec.lock` unchanged, confirming the comment-only edit does not alter resolution.
- `git status` after the edit shows only `mobile/pubspec.yaml` modified (no lock or `Package.resolved` churn).
- No Dart files touched, so analyze/test suites are unaffected (pre-commit hook confirmed "No Dart files staged").

## Type of Change

- [x] 🗑️ Chore
