### PR TITLE
fix(nostr): let a relay CLOSED frame terminate its pending query

### DIFF
--- a/mobile/packages/nostr_sdk/lib/relay/relay.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay.dart
@@ -177,6 +177,13 @@ abstract class Relay {
     return false;
   }
 
+  /// Drops a pending one-shot query without sending `CLOSE`.
+  ///
+  /// Used when the relay itself ended the subscription (a `CLOSED` frame), so
+  /// echoing a `CLOSE` back would name a subscription the relay has already
+  /// forgotten. Returns whether [id] named a pending query.
+  bool discardQuery(String id) => _queries.remove(id) != null;
+
   bool checkQuery(String id) {
     return _queries[id] != null;
   }

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -652,6 +652,31 @@ class RelayPool {
     return next;
   }
 
+  /// Fires the one-shot query callback for [subId] once no relay still has it
+  /// pending, then forgets the callback.
+  ///
+  /// Both terminal frames route here: `EOSE` (the relay finished sending
+  /// stored events) and `CLOSED` (the relay ended the subscription without
+  /// finishing). Either way the caller must be released rather than left to
+  /// burn its whole timeout budget.
+  void _fireQueryCompleteIfSettled(String subId) {
+    final callback = _queryCompleteCallbacks[subId];
+    if (callback == null) return;
+
+    final list = [
+      ..._relaysSnapshot(),
+      ..._tempRelaysSnapshot(),
+      ..._cacheRelaysSnapshot(),
+    ];
+    for (final r in list) {
+      // Some relay still owes us a terminal frame for this query.
+      if (r.checkQuery(subId)) return;
+    }
+
+    _queryCompleteCallbacks.remove(subId);
+    callback();
+  }
+
   Future<void> _onEvent(Relay relay, List<dynamic> json) async {
     final messageType = _stringAt(relay, json, 0, 'message type');
     if (messageType == null) return;
@@ -677,12 +702,17 @@ class RelayPool {
       log('📡 Raw message from ${relay.url}: $json');
     }
 
-    // #5863: when an off-main verify worker is wired, serialize EVENT/EOSE
-    // per relay so the asynchronous verify preserves in-order delivery — an
-    // EOSE must not complete a query before its preceding events finish
-    // verifying. With no worker the original synchronous path runs unchanged.
+    // #5863: when an off-main verify worker is wired, serialize the frames
+    // that carry or terminate a query per relay so the asynchronous verify
+    // preserves in-order delivery — a terminal frame must not complete a query
+    // before its preceding events finish verifying. CLOSED is terminal too: a
+    // relay may stream part of a stored replay and then abandon it, so
+    // completing on CLOSED out of order would drop the events already in
+    // flight. With no worker the original synchronous path runs unchanged.
     if (_verifyWorker != null &&
-        (messageType == 'EVENT' || messageType == 'EOSE')) {
+        (messageType == 'EVENT' ||
+            messageType == 'EOSE' ||
+            messageType == 'CLOSED')) {
       return _enqueueOrdered(
         relay,
         () => _dispatchTypedFrame(relay, json, messageType),
@@ -819,28 +849,7 @@ class RelayPool {
       }
       var isQuery = await relay.checkAndCompleteQuery(subId);
       if (isQuery) {
-        // is Query find if need to callback
-        var callback = _queryCompleteCallbacks[subId];
-        if (callback != null) {
-          // need to callback, check if all relay complete query
-          final list = [
-            ..._relaysSnapshot(),
-            ..._tempRelaysSnapshot(),
-            ..._cacheRelaysSnapshot(),
-          ];
-          bool completeQuery = true;
-          for (var r in list) {
-            if (r.checkQuery(subId)) {
-              // this relay hadn't compltete query
-              completeQuery = false;
-              break;
-            }
-          }
-          if (completeQuery) {
-            callback();
-            _queryCompleteCallbacks.remove(subId);
-          }
-        }
+        _fireQueryCompleteIfSettled(subId);
       } else {
         // Handle EOSE for long-running subscriptions
         final subscription = _subscriptions[subId];
@@ -1078,6 +1087,20 @@ class RelayPool {
       // Check if this is a COUNT query being refused
       if (relay.hasCountQuery(subscriptionId)) {
         relay.failCountQuery(subscriptionId, reason);
+      }
+
+      // A REQ the relay refused or abandoned is terminal for that relay: no
+      // EVENT and no EOSE will follow, so nothing else would ever settle the
+      // query. Funnelcake sends this when the stored-event query errors or the
+      // stored replay is backpressured (funnelcake
+      // `crates/relay/src/handler.rs:117`, `:405`, `:433`, `:488`). Without
+      // this the caller waits out its entire timeout and reports a timeout for
+      // what was really a refusal.
+      //
+      // Distinguishing "relay refused" from "relay had nothing" in the
+      // returned record is out of scope here and tracked by #6238.
+      if (relay.discardQuery(subscriptionId)) {
+        _fireQueryCompleteIfSettled(subscriptionId);
       }
     }
   }

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -95,6 +95,8 @@ class RelayPool {
 
   final Map<String, Function> _queryCompleteCallbacks = {};
 
+  final Set<String> _queryFanoutInProgress = {};
+
   /// Tracks which relays have sent EOSE for each subscription.
   /// Used to determine when all relays have finished sending stored events.
   final Map<String, Set<String>> _subscriptionEoseRelays = {};
@@ -219,6 +221,13 @@ class RelayPool {
     // Without that guard a permanent allow-list rejection would be tracked
     // and hang until the publish deadline instead of failing fast.
     return _isRestrictedReason(message) &&
+        relay.relayStatus.alwaysAuth &&
+        !relay.relayStatus.authed;
+  }
+
+  bool _shouldReplayQueryAfterAuth(Relay relay, String reason) {
+    if (_isExplicitAuthRequiredReason(reason)) return true;
+    return _isRestrictedReason(reason) &&
         relay.relayStatus.alwaysAuth &&
         !relay.relayStatus.authed;
   }
@@ -662,6 +671,7 @@ class RelayPool {
   void _fireQueryCompleteIfSettled(String subId) {
     final callback = _queryCompleteCallbacks[subId];
     if (callback == null) return;
+    if (_queryFanoutInProgress.contains(subId)) return;
 
     final list = [
       ..._relaysSnapshot(),
@@ -1089,17 +1099,10 @@ class RelayPool {
         relay.failCountQuery(subscriptionId, reason);
       }
 
-      // A REQ the relay refused or abandoned is terminal for that relay: no
-      // EVENT and no EOSE will follow, so nothing else would ever settle the
-      // query. Funnelcake sends this when the stored-event query errors or the
-      // stored replay is backpressured (funnelcake
-      // `crates/relay/src/handler.rs:117`, `:405`, `:433`, `:488`). Without
-      // this the caller waits out its entire timeout and reports a timeout for
-      // what was really a refusal.
-      //
-      // Distinguishing "relay refused" from "relay had nothing" in the
-      // returned record is out of scope here and tracked by #6238.
-      if (relay.discardQuery(subscriptionId)) {
+      // A refused/abandoned REQ is terminal unless it is the pre-AUTH probe
+      // that must stay saved for replay after NIP-42 succeeds.
+      if (!_shouldReplayQueryAfterAuth(relay, reason) &&
+          relay.discardQuery(subscriptionId)) {
         _fireQueryCompleteIfSettled(subscriptionId);
       }
     }
@@ -1279,6 +1282,7 @@ class RelayPool {
       // completion callback so a query cancelled before EOSE doesn't leak a
       // never-fired callback in [_queryCompleteCallbacks].
       _queryCompleteCallbacks.remove(id);
+      _queryFanoutInProgress.remove(id);
 
       // check query and send close
       var it = _relaysSnapshot();
@@ -1357,6 +1361,7 @@ class RelayPool {
     Subscription subscription = Subscription(filters, onEvent, id: id);
     if (onComplete != null) {
       _queryCompleteCallbacks[subscription.id] = onComplete;
+      _queryFanoutInProgress.add(subscription.id);
     }
 
     // Collect futures so we can await them before the early-completion
@@ -1407,23 +1412,18 @@ class RelayPool {
       }
     }
 
-    // Wait for all sends to complete (and saveQuery to run) before
-    // checking whether any relay accepted the query.
-    await Future.wait(queryFutures);
-
-    // If no relay accepted the query (all sends failed), fire onComplete
-    // immediately so callers don't wait for the full timeout.
-    if (onComplete != null) {
-      final list = [
-        ..._relaysSnapshot(),
-        ..._tempRelaysSnapshot(),
-        ..._cacheRelaysSnapshot(),
-      ];
-      final anyPending = list.any((r) => r.checkQuery(subscription.id));
-      if (!anyPending) {
-        _queryCompleteCallbacks.remove(subscription.id);
-        onComplete();
+    try {
+      // Wait for all sends to complete (and saveQuery to run) before allowing
+      // terminal frames to decide whether every relay has settled.
+      await Future.wait(queryFutures);
+    } finally {
+      if (onComplete != null) {
+        _queryFanoutInProgress.remove(subscription.id);
       }
+    }
+
+    if (onComplete != null) {
+      _fireQueryCompleteIfSettled(subscription.id);
     }
 
     return subscription.id;

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_closed_frame_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_closed_frame_test.dart
@@ -1,0 +1,141 @@
+// ABOUTME: Regression tests for CLOSED frames terminating a pending REQ.
+// ABOUTME: A relay that CLOSEs a query must not strand the caller until timeout.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:nostr_sdk/relay/client_connected.dart';
+
+/// Relay that records the REQ it was sent and answers only when the test says
+/// so — never EVENT, never EOSE.
+///
+/// This mirrors Funnelcake, which replies `CLOSED` with no EOSE when the
+/// stored-event query fails or the stored replay is backpressured
+/// (`crates/relay/src/handler.rs:117`, `:405`, `:433`, `:488`).
+class _ClosedOnReqRelay extends Relay {
+  _ClosedOnReqRelay(String url) : super(url, RelayStatus(url));
+
+  String? capturedSubId;
+
+  @override
+  Future<bool> doConnect() async {
+    relayStatus.connected = ClientConnected.connected;
+    return true;
+  }
+
+  @override
+  Future<void> disconnect() async {
+    relayStatus.connected = ClientConnected.disconnect;
+  }
+
+  @override
+  Future<bool> send(
+    List<dynamic> message, {
+    bool? forceSend,
+    bool queueIfFailed = true,
+    bool skipReconnect = false,
+    DateTime? deadline,
+  }) async {
+    if (message.isNotEmpty && message[0] == 'REQ' && message.length > 1) {
+      capturedSubId = message[1] as String;
+    }
+    return true;
+  }
+
+  Future<void> deliver(List<dynamic> json) async {
+    final handler = onMessage;
+    expect(handler, isNotNull, reason: 'RelayPool did not wire onMessage');
+    final dynamic result = handler!(this, json);
+    if (result is Future) {
+      await result;
+    }
+  }
+
+  /// Yields until the pool has registered the REQ as a pending query, so the
+  /// CLOSED lands after `saveQuery` exactly as a network round trip would.
+  Future<String> awaitPendingQuery() async {
+    for (var i = 0; i < 1000; i++) {
+      final subId = capturedSubId;
+      if (subId != null && checkQuery(subId)) return subId;
+      await Future<void>.delayed(Duration.zero);
+    }
+    fail('RelayPool never registered a pending query for the REQ');
+  }
+}
+
+void main() {
+  group('RelayPool CLOSED frame handling', () {
+    Relay dummyTempRelay(String url) => RelayBase(url, RelayStatus(url));
+
+    test('CLOSED on a pending REQ completes the query without waiting for '
+        'the full timeout', () async {
+      final signer = LocalNostrSigner(
+        '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12',
+      );
+      final nostr = Nostr(signer, [], dummyTempRelay);
+      final relay = _ClosedOnReqRelay('wss://closed.example');
+
+      expect(await nostr.relayPool.add(relay), isTrue);
+
+      const timeout = Duration(seconds: 2);
+      final stopwatch = Stopwatch()..start();
+      final pending = nostr.queryEventsDetailed([
+        {
+          'ids': [
+            '0739befe110ec68c28a33650b84c10b356015ec3b8401787d05a84ae285c976a',
+          ],
+          'limit': 1,
+        },
+      ], timeout: timeout);
+
+      final subId = await relay.awaitPendingQuery();
+      await relay.deliver(['CLOSED', subId, 'error: query failed']);
+
+      final result = await pending;
+      stopwatch.stop();
+
+      expect(result.events, isEmpty);
+      expect(
+        stopwatch.elapsed,
+        lessThan(timeout ~/ 2),
+        reason:
+            'CLOSED should terminate the query immediately; instead the '
+            'caller waited ${stopwatch.elapsedMilliseconds}ms of the '
+            '${timeout.inMilliseconds}ms budget',
+      );
+      expect(
+        result.timedOut,
+        isFalse,
+        reason: 'a relay-refused query is not a timeout',
+      );
+      expect(
+        relay.checkQuery(subId),
+        isFalse,
+        reason: 'the refused query must not stay pending on the relay',
+      );
+    });
+
+    test('EOSE still completes a pending REQ', () async {
+      final signer = LocalNostrSigner(
+        '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12',
+      );
+      final nostr = Nostr(signer, [], dummyTempRelay);
+      final relay = _ClosedOnReqRelay('wss://eose.example');
+
+      expect(await nostr.relayPool.add(relay), isTrue);
+
+      const timeout = Duration(seconds: 2);
+      final pending = nostr.queryEventsDetailed([
+        {
+          'kinds': [1],
+        },
+      ], timeout: timeout);
+
+      final subId = await relay.awaitPendingQuery();
+      await relay.deliver(['EOSE', subId]);
+
+      final result = await pending;
+      expect(result.timedOut, isFalse);
+      expect(result.events, isEmpty);
+    });
+  });
+}

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_closed_frame_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_closed_frame_test.dart
@@ -1,20 +1,23 @@
 // ABOUTME: Regression tests for CLOSED frames terminating a pending REQ.
 // ABOUTME: A relay that CLOSEs a query must not strand the caller until timeout.
 
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:nostr_sdk/relay/client_connected.dart';
 
 /// Relay that records the REQ it was sent and answers only when the test says
 /// so — never EVENT, never EOSE.
-///
-/// This mirrors Funnelcake, which replies `CLOSED` with no EOSE when the
-/// stored-event query fails or the stored replay is backpressured
-/// (`crates/relay/src/handler.rs:117`, `:405`, `:433`, `:488`).
-class _ClosedOnReqRelay extends Relay {
-  _ClosedOnReqRelay(String url) : super(url, RelayStatus(url));
+class _ControlledQueryRelay extends Relay {
+  _ControlledQueryRelay(String url, {Completer<void>? reqSendGate})
+    : _reqSendGate = reqSendGate,
+      super(url, RelayStatus(url));
 
   String? capturedSubId;
+  String? capturedAuthEventId;
+  final List<List<dynamic>> sentMessages = [];
+  final Completer<void>? _reqSendGate;
 
   @override
   Future<bool> doConnect() async {
@@ -35,8 +38,15 @@ class _ClosedOnReqRelay extends Relay {
     bool skipReconnect = false,
     DateTime? deadline,
   }) async {
+    sentMessages.add(message);
     if (message.isNotEmpty && message[0] == 'REQ' && message.length > 1) {
       capturedSubId = message[1] as String;
+      await _reqSendGate?.future;
+    } else if (message.isNotEmpty &&
+        message[0] == 'AUTH' &&
+        message.length > 1 &&
+        message[1] is Map) {
+      capturedAuthEventId = (message[1] as Map)['id'] as String?;
     }
     return true;
   }
@@ -50,8 +60,6 @@ class _ClosedOnReqRelay extends Relay {
     }
   }
 
-  /// Yields until the pool has registered the REQ as a pending query, so the
-  /// CLOSED lands after `saveQuery` exactly as a network round trip would.
   Future<String> awaitPendingQuery() async {
     for (var i = 0; i < 1000; i++) {
       final subId = capturedSubId;
@@ -59,6 +67,15 @@ class _ClosedOnReqRelay extends Relay {
       await Future<void>.delayed(Duration.zero);
     }
     fail('RelayPool never registered a pending query for the REQ');
+  }
+
+  Future<void> awaitReqCount(int count) async {
+    for (var i = 0; i < 1000; i++) {
+      final reqCount = sentMessages.where((m) => m.first == 'REQ').length;
+      if (reqCount >= count) return;
+      await Future<void>.delayed(Duration.zero);
+    }
+    fail('RelayPool sent fewer than $count REQ frames');
   }
 }
 
@@ -72,12 +89,11 @@ void main() {
         '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12',
       );
       final nostr = Nostr(signer, [], dummyTempRelay);
-      final relay = _ClosedOnReqRelay('wss://closed.example');
+      final relay = _ControlledQueryRelay('wss://closed.example');
 
       expect(await nostr.relayPool.add(relay), isTrue);
 
       const timeout = Duration(seconds: 2);
-      final stopwatch = Stopwatch()..start();
       final pending = nostr.queryEventsDetailed([
         {
           'ids': [
@@ -91,17 +107,8 @@ void main() {
       await relay.deliver(['CLOSED', subId, 'error: query failed']);
 
       final result = await pending;
-      stopwatch.stop();
 
       expect(result.events, isEmpty);
-      expect(
-        stopwatch.elapsed,
-        lessThan(timeout ~/ 2),
-        reason:
-            'CLOSED should terminate the query immediately; instead the '
-            'caller waited ${stopwatch.elapsedMilliseconds}ms of the '
-            '${timeout.inMilliseconds}ms budget',
-      );
       expect(
         result.timedOut,
         isFalse,
@@ -119,7 +126,7 @@ void main() {
         '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12',
       );
       final nostr = Nostr(signer, [], dummyTempRelay);
-      final relay = _ClosedOnReqRelay('wss://eose.example');
+      final relay = _ControlledQueryRelay('wss://eose.example');
 
       expect(await nostr.relayPool.add(relay), isTrue);
 
@@ -137,5 +144,102 @@ void main() {
       expect(result.timedOut, isFalse);
       expect(result.events, isEmpty);
     });
+
+    test('auth-required CLOSED keeps the query for post-AUTH replay', () async {
+      final signer = LocalNostrSigner(
+        '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12',
+      );
+      final nostr = Nostr(signer, [], dummyTempRelay);
+      final relay = _ControlledQueryRelay('wss://auth-required.example');
+
+      expect(await nostr.relayPool.add(relay), isTrue);
+
+      var completedEarly = false;
+      final pending = nostr.queryEventsDetailed(
+        [
+          {
+            'kinds': [1],
+          },
+        ],
+        sendAfterAuth: true,
+        timeout: const Duration(seconds: 2),
+      );
+      unawaited(
+        pending.whenComplete(() {
+          completedEarly = true;
+        }),
+      );
+
+      final subId = await relay.awaitPendingQuery();
+      await relay.deliver(['AUTH', 'test-challenge']);
+      await relay.deliver(['CLOSED', subId, 'auth-required: sign in']);
+
+      await Future<void>.delayed(Duration.zero);
+      expect(completedEarly, isFalse);
+      expect(relay.checkQuery(subId), isTrue);
+
+      final authEventId = relay.capturedAuthEventId;
+      expect(authEventId, isNotNull);
+
+      await relay.deliver(['OK', authEventId, true, '']);
+      await relay.awaitReqCount(2);
+      expect(relay.checkQuery(subId), isTrue);
+
+      await relay.deliver(['EOSE', subId]);
+
+      final result = await pending;
+      expect(result.timedOut, isFalse);
+      expect(result.events, isEmpty);
+      expect(relay.checkQuery(subId), isFalse);
+    });
+
+    test(
+      'CLOSED does not complete before query fan-out is registered',
+      () async {
+        final signer = LocalNostrSigner(
+          '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12',
+        );
+        final nostr = Nostr(signer, [], dummyTempRelay);
+        final slowSend = Completer<void>();
+        final refusedRelay = _ControlledQueryRelay('wss://refused.example');
+        final slowRelay = _ControlledQueryRelay(
+          'wss://slow.example',
+          reqSendGate: slowSend,
+        );
+
+        expect(await nostr.relayPool.add(refusedRelay), isTrue);
+        expect(await nostr.relayPool.add(slowRelay), isTrue);
+
+        var completedEarly = false;
+        final pending = nostr.queryEventsDetailed([
+          {
+            'kinds': [1],
+          },
+        ], timeout: const Duration(seconds: 2));
+        unawaited(
+          pending.whenComplete(() {
+            completedEarly = true;
+          }),
+        );
+
+        final refusedSubId = await refusedRelay.awaitPendingQuery();
+        await refusedRelay.deliver([
+          'CLOSED',
+          refusedSubId,
+          'error: query failed',
+        ]);
+
+        slowSend.complete();
+        final slowSubId = await slowRelay.awaitPendingQuery();
+        await Future<void>.delayed(Duration.zero);
+        expect(completedEarly, isFalse);
+
+        await slowRelay.deliver(['EOSE', slowSubId]);
+
+        final result = await pending;
+        expect(result.timedOut, isFalse);
+        expect(result.events, isEmpty);
+      },
+    );
   });
 }


### PR DESCRIPTION
## Description

`RelayPool` handled a `CLOSED` frame by logging it and failing a matching NIP-45 COUNT query, but did nothing for a pending `REQ`. The query's completion callback stayed armed in `_queryCompleteCallbacks` and the relay kept the subscription in `_queries`, so nothing ever settled the query - the caller blocked for its entire timeout and then reported `timedOut: true` for what was actually a relay refusal. At the 5s `queryEvents` default that turns every refused one-shot fetch into a 5s stall returning an empty list.

Funnelcake reaches that path whenever the stored-event query errors or the stored replay is backpressured (`crates/relay/src/handler.rs:117`, `:405`, `:433`, `:488`) - it sends `CLOSED` with no `EOSE`.

Found while tracing a bug report where tapping a mention notification landed on the actor's profile instead of the video. `NotificationTargetResolver` falls back to the profile when `fetchEventById` returns null, and every failed tap in the attached log took exactly 5.00s - the `queryEvents` timeout. The target event was live on the relay the whole time and returns `EVENT` + `EOSE` in ~1.2s to a direct probe.

### Changes

- `Relay.discardQuery` drops a pending query **without** sending `CLOSE`, since the relay has already forgotten that subscription.
- The `CLOSED` branch settles a pending `REQ` and releases the caller, except for auth-retryable `CLOSED` reasons that must keep the query saved for post-AUTH replay.
- Query completion is gated until initial relay fan-out has finished registering accepted sends, so a fast terminal frame from one relay cannot complete before a slower relay has joined the pending query set.
- `CLOSED` now rides the per-relay ordered tail alongside `EVENT`/`EOSE` (#5863). A relay can stream part of a stored replay before abandoning it, so settling the query out of order would drop events still being verified.
- EOSE's completion logic is extracted into `_fireQueryCompleteIfSettled` and reused, so both terminal frames settle a query identically. The helper removes the callback before invoking it, matching `query()`'s existing remove-then-call ordering so a re-entrant callback cannot double-fire.

**Related Issue:** Fixes #6453. Relates to #6238.

## Out of Scope

Distinguishing "relay refused" from "relay had nothing" in the value returned by `queryEventsDetailed` - that needs a new field on the result record and is #6238's scope. This PR only stops the caller from burning its whole timeout budget.

The notification-routing half of the original report is already fixed on `main` by #6299 and is not touched here.

## Verification

- `flutter test test/unit/relay_pool_closed_frame_test.dart` in `packages/nostr_sdk` - 4 passing
- `flutter test test/unit/relay_pool_auth_test.dart` in `packages/nostr_sdk` - 12 passing
- `flutter test test/unit/relay_pool_concurrency_test.dart` in `packages/nostr_sdk` - 15 passing
- `flutter analyze` in `packages/nostr_sdk` - no issues
- `flutter test` in `packages/nostr_sdk` - 400 passing
- `flutter test` in `packages/nostr_client` - 297 passing
- pre-push hook - no merge conflicts, analysis clean, changed CLOSED-frame test passing

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
