### PR TITLE
fix(comments): keep composer buttons visible above the keyboard

### DIFF
--- a/mobile/lib/screens/comments/widgets/comments_empty_state.dart
+++ b/mobile/lib/screens/comments/widgets/comments_empty_state.dart
@@ -15,69 +15,76 @@ class CommentsEmptyState extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => Center(
-    child: Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: [
-        if (isClassicVine) ...[
-          Container(
-            margin: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
-            padding: const EdgeInsets.all(16),
-            decoration: BoxDecoration(
-              color: VineTheme.accentOrange.withValues(alpha: 0.3),
-              borderRadius: BorderRadius.circular(12),
-              border: Border.all(
-                color: VineTheme.accentOrange.withValues(alpha: 0.5),
-              ),
-            ),
-            child: Column(
-              children: [
-                const Icon(
-                  Icons.history,
-                  color: VineTheme.contentWarningAmber,
-                  size: 32,
+    // Scrollable so the empty state shrinks gracefully when the open
+    // keyboard squeezes the sheet's list area to near zero; a fixed Column
+    // overflows in that space (debug overflow banner, clipped copy in
+    // release).
+    child: SingleChildScrollView(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (isClassicVine) ...[
+            Container(
+              margin: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+              padding: const EdgeInsets.all(16),
+              decoration: BoxDecoration(
+                color: VineTheme.accentOrange.withValues(alpha: 0.3),
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(
+                  color: VineTheme.accentOrange.withValues(alpha: 0.5),
                 ),
-                const SizedBox(height: 12),
-                Text(
-                  context.l10n.commentsEmptyClassicVineTitle,
-                  style: const TextStyle(
+              ),
+              child: Column(
+                children: [
+                  const Icon(
+                    Icons.history,
                     color: VineTheme.contentWarningAmber,
-                    fontSize: 16,
-                    fontWeight: FontWeight.bold,
+                    size: 32,
                   ),
-                ),
-                const SizedBox(height: 8),
-                Text(
-                  context.l10n.commentsEmptyClassicVineMessage,
-                  textAlign: TextAlign.center,
-                  style: const TextStyle(
-                    color: VineTheme.onSurfaceVariant,
-                    fontSize: 14,
+                  const SizedBox(height: 12),
+                  Text(
+                    context.l10n.commentsEmptyClassicVineTitle,
+                    style: const TextStyle(
+                      color: VineTheme.contentWarningAmber,
+                      fontSize: 16,
+                      fontWeight: FontWeight.bold,
+                    ),
                   ),
-                ),
-              ],
-            ),
-          ),
-          const SizedBox(height: 16),
-        ],
-        Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(
-              context.l10n.commentsEmptyTitle,
-              textAlign: TextAlign.center,
-              style: VineTheme.titleLargeFont(color: VineTheme.onSurface),
-            ),
-            const SizedBox(height: 4),
-            Text(
-              context.l10n.commentsEmptySubtitle,
-              textAlign: TextAlign.center,
-              style: VineTheme.bodyMediumFont(
-                color: VineTheme.onSurfaceVariant,
+                  const SizedBox(height: 8),
+                  Text(
+                    context.l10n.commentsEmptyClassicVineMessage,
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(
+                      color: VineTheme.onSurfaceVariant,
+                      fontSize: 14,
+                    ),
+                  ),
+                ],
               ),
             ),
+            const SizedBox(height: 16),
           ],
-        ),
-      ],
+          Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                context.l10n.commentsEmptyTitle,
+                textAlign: TextAlign.center,
+                style: VineTheme.titleLargeFont(color: VineTheme.onSurface),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                context.l10n.commentsEmptySubtitle,
+                textAlign: TextAlign.center,
+                style: VineTheme.bodyMediumFont(
+                  color: VineTheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
     ),
   );
 }

--- a/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet.dart
+++ b/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet.dart
@@ -650,6 +650,10 @@ class _KeyboardAwareBottomInput extends StatelessWidget {
     required this.includeSafeArea,
   });
 
+  /// Gap kept between a raised keyboard and the bottom input so
+  /// keyboard-height variance cannot swallow the input's bottom edge.
+  static const double _keyboardClearance = 12;
+
   final Widget child;
   final bool includeSafeArea;
 
@@ -657,10 +661,20 @@ class _KeyboardAwareBottomInput extends StatelessWidget {
   Widget build(BuildContext context) {
     // Let the bottom input ride the keyboard in both scrollable and fixed
     // sheet layouts so composers stay visible while typing.
+    //
+    // The clearance keeps the input from sitting flush against the keyboard
+    // top. Real keyboards vary in reported height while typing (predictive
+    // bar appearing, inset animation lag), and a flush composer puts its
+    // bottom-anchored action buttons (send, dismiss) under the keyboard.
+    final keyboardInset = MediaQuery.viewInsetsOf(context).bottom;
     final paddedInput = AnimatedPadding(
       duration: const Duration(milliseconds: 180),
       curve: Curves.easeOutCubic,
-      padding: EdgeInsets.only(bottom: MediaQuery.viewInsetsOf(context).bottom),
+      padding: EdgeInsets.only(
+        bottom: keyboardInset > 0
+            ? keyboardInset + _keyboardClearance
+            : keyboardInset,
+      ),
       child: child,
     );
 

--- a/mobile/packages/divine_ui/test/src/bottom_sheet/vine_bottom_sheet_test.dart
+++ b/mobile/packages/divine_ui/test/src/bottom_sheet/vine_bottom_sheet_test.dart
@@ -112,6 +112,136 @@ void main() {
       expect(inputRect.bottom, lessThanOrEqualTo(800 - keyboardHeight));
     });
 
+    testWidgets(
+      'modal sheet keeps multiline bottomInput and its action buttons fully '
+      'above the keyboard',
+      (tester) async {
+        tester.view
+          ..physicalSize = const Size(400, 800)
+          ..devicePixelRatio = 1;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+        addTearDown(tester.view.resetViewInsets);
+
+        const keyboardHeight = 300.0;
+        final draggableController = DraggableScrollableController();
+        final focusNode = FocusNode();
+        addTearDown(focusNode.dispose);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Builder(
+                builder: (context) => Center(
+                  child: GestureDetector(
+                    onTap: () {
+                      // Mirror the comments sheet: draggable modal with snap
+                      // sizes and a multiline composer row (text field +
+                      // trailing action buttons) in the bottomInput slot.
+                      unawaited(
+                        VineBottomSheet.show<void>(
+                          context: context,
+                          snap: true,
+                          snapSizes: const [0.7, 0.93],
+                          initialChildSize: 0.7,
+                          minChildSize: 0.5,
+                          maxChildSize: 0.93,
+                          draggableController: draggableController,
+                          title: const Text('0 Comments'),
+                          bottomInput: Padding(
+                            key: const Key('composer-input'),
+                            padding: const EdgeInsets.all(16),
+                            child: Row(
+                              crossAxisAlignment: CrossAxisAlignment.end,
+                              children: [
+                                Expanded(
+                                  child: TextField(
+                                    key: const Key('composer-field'),
+                                    focusNode: focusNode,
+                                    maxLines: 5,
+                                    minLines: 1,
+                                  ),
+                                ),
+                                const SizedBox(width: 8),
+                                const SizedBox(
+                                  key: Key('send-button'),
+                                  width: 40,
+                                  height: 40,
+                                ),
+                              ],
+                            ),
+                          ),
+                          buildScrollBody: (scrollController) => ListView(
+                            controller: scrollController,
+                            children: const [SizedBox(height: 400)],
+                          ),
+                        ),
+                      );
+                    },
+                    child: const Text('open sheet'),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('open sheet'));
+        await tester.pumpAndSettle();
+
+        // Grow the composer to several lines like a long comment draft.
+        await tester.enterText(
+          find.byKey(const Key('composer-field')),
+          'line one\nline two\nline three\nline four\nline five',
+        );
+        await tester.pumpAndSettle();
+
+        // Keyboard opens.
+        tester.view.viewInsets = const FakeViewPadding(
+          bottom: keyboardHeight,
+        );
+        focusNode.requestFocus();
+        await tester.pumpAndSettle();
+
+        final inputRect = tester.getRect(
+          find.byKey(const Key('composer-input')),
+        );
+        final fieldRect = tester.getRect(
+          find.byKey(const Key('composer-field')),
+        );
+        final sendRect = tester.getRect(find.byKey(const Key('send-button')));
+        const keyboardTop = 800 - keyboardHeight;
+
+        // The composer must not sit flush against the keyboard: real devices
+        // show keyboard-height variance (predictive bar appearing, inset
+        // animation lag), and a flush composer puts its bottom-anchored
+        // action buttons under the keyboard. Require visible clearance.
+        const keyboardClearance = 12.0;
+        expect(
+          inputRect.bottom,
+          lessThanOrEqualTo(keyboardTop - keyboardClearance),
+          reason:
+              'composer bottom ${inputRect.bottom} sits flush at the keyboard '
+              'top $keyboardTop with less than ${keyboardClearance}px '
+              'clearance, so its action buttons can slip under the keyboard',
+        );
+        expect(
+          fieldRect.bottom,
+          lessThanOrEqualTo(keyboardTop),
+          reason:
+              'composer text field bottom ${fieldRect.bottom} dips under the '
+              'keyboard top $keyboardTop',
+        );
+        expect(
+          sendRect.bottom,
+          lessThanOrEqualTo(keyboardTop),
+          reason:
+              'send button bottom ${sendRect.bottom} dips under the keyboard '
+              'top $keyboardTop',
+        );
+      },
+    );
+
     testWidgets('content is scrollable when expanded', (tester) async {
       await tester.pumpWidget(
         MaterialApp(

--- a/mobile/test/screens/comments/comments_empty_state_test.dart
+++ b/mobile/test/screens/comments/comments_empty_state_test.dart
@@ -50,6 +50,31 @@ void main() {
 
         expect(find.byType(Center), findsOneWidget);
       });
+
+      testWidgets(
+        'does not overflow when the open keyboard squeezes the sheet',
+        (tester) async {
+          // The comments sheet's list area shrinks to almost nothing when the
+          // keyboard is up on a small sheet fraction; the empty state must
+          // shrink with it instead of overflowing (RenderFlex overflow fails
+          // the test automatically via FlutterError).
+          await tester.pumpWidget(
+            const MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(
+                body: SizedBox(
+                  height: 40,
+                  child: CommentsEmptyState(isClassicVine: false),
+                ),
+              ),
+            ),
+          );
+
+          final l10n = lookupAppLocalizations(const Locale('en'));
+          expect(find.text(l10n.commentsEmptyTitle), findsOneWidget);
+        },
+      );
     });
 
     group('Classic Vine state', () {


### PR DESCRIPTION
Closes #6455

## Description

While writing a comment, the composer pill sat flush against the keyboard top. The send and keyboard-dismiss buttons anchor to the composer's bottom edge, and real keyboards vary in reported height while typing (predictive bar appearing, inset animation lag), so those buttons slipped under the keyboard and became unreachable (see issue screenshot).

Two fixes, one per commit:

1. **`VineBottomSheet` keyboard clearance** (`divine_ui`): `_KeyboardAwareBottomInput` lifted bottom inputs by exactly `viewInsets.bottom`. Now adds a 12px clearance above a raised keyboard, for every sheet that uses the `bottomInput` slot (comments, share message composer, user picker, etc.).
2. **Empty-state overflow**: with the keyboard up, the comments sheet's list area can shrink to near zero and the empty state's fixed `Column` overflowed (debug overflow banner, clipped "Get the party started!" copy in release). Wrapped in a `SingleChildScrollView` so it shrinks gracefully.

**Related Issue:** Reported via screenshot — comment composer submit/cancel buttons hidden behind the keyboard while typing a multi-line comment.

## Out of Scope

- The focus-driven sheet-expand behavior (`#5947`) is untouched.
- No changes to the inline feed composer bar (`inline_comment_composer_bar.dart`), which manages its own inset math.

## Verification

- New regression test in `divine_ui`: modal sheet + draggable snap sizes + multiline composer + injected 300px keyboard inset; asserts composer and action buttons stay above the keyboard with clearance (fails before the fix).
- New regression test: `CommentsEmptyState` pumped into a 40px-high slot no longer overflows (fails before the fix).
- `flutter test` green: full `divine_ui` package suite (662 tests), full `test/screens/comments/` suite (115 tests), `test/goldens/` verify.
- `flutter analyze` clean in `mobile` and `mobile/packages/divine_ui`.
- Reproduced on iPhone 16 Pro Max simulator (iOS 26) with Maestro before the fix (buttons flush/clipped at keyboard top, 9.2px overflow banner); re-ran after the fix: buttons fully visible with clear gap above the keyboard, no overflow banner.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)