### PR TITLE
fix(models): map top-level proof fields on REST video stats rows

### DIFF
--- a/mobile/packages/models/lib/src/video_stats.dart
+++ b/mobile/packages/models/lib/src/video_stats.dart
@@ -352,6 +352,26 @@ class VideoStats {
       rawTags['platform'] = platform;
     }
 
+    // Funnelcake list/stats rows expose ProofMode/C2PA/verification as
+    // top-level fields, not inside `event.tags`, so the tag loop above never
+    // captures them. Map them under the same keys the VideoEvent proof getters
+    // read so REST/feed-loaded videos keep their verification signals instead
+    // of decaying to an unverified shell (which also poisons the shared cache
+    // for the detail view). Relay-shaped payloads already carry the tags, so
+    // only fill keys the tag loop didn't set.
+    for (final key in const [
+      'verification',
+      'proofmode',
+      'device_attestation',
+      'c2pa_manifest_id',
+    ]) {
+      if (rawTags.containsKey(key)) continue;
+      final value = eventData[key] ?? json[key] ?? statsData[key];
+      if (value is String && value.isNotEmpty) {
+        rawTags[key] = value;
+      }
+    }
+
     // Parse categories from Funnelcake VLM classification.
     final categoriesRaw = json['categories'] ?? eventData['categories'];
     final categories = categoriesRaw is List

--- a/mobile/packages/models/test/src/video_stats_test.dart
+++ b/mobile/packages/models/test/src/video_stats_test.dart
@@ -1351,6 +1351,40 @@ void main() {
         },
       );
 
+      test(
+        'maps Funnelcake top-level proof fields into rawTags for list rows',
+        () {
+          final stats = VideoStats.fromJson(const {
+            'id': 'test-id',
+            'pubkey': 'test-pubkey',
+            'created_at': 1700000000,
+            'kind': 34236,
+            'd_tag': 'video-1',
+            'title': 'Test',
+            'tags': [
+              ['d', 'video-1'],
+              ['imeta', 'url https://example.com/video.mp4'],
+            ],
+            'verification': 'verified_mobile',
+            'proofmode':
+                '{"videoHash":"abc","pgpSignature":"sig",'
+                '"deviceAttestation":"att","c2paManifestId":"urn:c2pa:1"}',
+            'device_attestation': '{"keyID":"k"}',
+            'c2pa_manifest_id': 'urn:c2pa:1',
+          });
+
+          final video = stats.toVideoEvent();
+
+          expect(video.rawTags['verification'], equals('verified_mobile'));
+          expect(video.rawTags['c2pa_manifest_id'], equals('urn:c2pa:1'));
+          expect(video.hasProofMode, isTrue);
+          expect(video.hasProofModeC2paManifestId, isTrue);
+          expect(video.hasProofModeDeviceAttestation, isTrue);
+          expect(video.hasProofModePgpFingerprint, isTrue);
+          expect(video.hasProofModeManifest, isTrue);
+        },
+      );
+
       test('converts to VideoEvent with all fields', () {
         final stats = VideoStats(
           id: 'test-id',


### PR DESCRIPTION
Closes #6458

## Summary

- Funnelcake list/stats rows expose `verification`/`proofmode`/`device_attestation`/`c2pa_manifest_id` as **top-level fields**, not inside `event.tags`, so the tag loop in `VideoStats` never captured them.
- Result: REST/feed-loaded videos decayed to an unverified shell, and the shared cache poisoned the detail view too.
- Fix: fill those keys from `eventData`/`json`/`statsData` when the tag loop didn't set them (relay-shaped payloads unaffected).

Recovered uncommitted work from the `appstore-screenshots` worktree (follow-up to #6355).

## Test plan

- [x] `flutter test test/src/video_stats_test.dart` — 71 pass (2 new regression tests)
- [x] `flutter analyze` clean on `packages/models`