### PR TITLE
fix(video-player): seek fresh Darwin players to start time too

### DIFF
--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
@@ -260,9 +260,7 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                     self.addTimeObserver()
                     self.observeCurrentItem()
                     self.configureQueue(with: playerItem)
-                    if startPositionMs > 0 {
-                        await newPlayer.seek(to: startTime, toleranceBefore: .zero, toleranceAfter: .zero)
-                    }
+                    await newPlayer.seek(to: startTime, toleranceBefore: .zero, toleranceAfter: .zero)
                     self.textureOutput?.forceRefresh(for: startTime)
                 }
 

--- a/mobile/packages/divine_video_player/test/src/apple_threading_contract_test.dart
+++ b/mobile/packages/divine_video_player/test/src/apple_threading_contract_test.dart
@@ -78,6 +78,31 @@ void main() {
         contains('clearBufferingWatchdog(resetReported: true)'),
       );
     });
+
+    test('seeks new players to the same start time as reused players', () {
+      final source = _appleSourceFile().readAsStringSync();
+
+      expect(
+        source,
+        contains(
+          'await newPlayer.seek(to: startTime, '
+          'toleranceBefore: .zero, toleranceAfter: .zero)',
+        ),
+        reason:
+            'Feed playback often creates a fresh native player. The leading '
+            'black-frame skip must apply there too, otherwise position stays '
+            'at 0ms until stale playback failover trips.',
+      );
+      expect(
+        source,
+        isNot(
+          contains(
+            'if startPositionMs > 0 {\n'
+            '                        await newPlayer.seek(to: startTime',
+          ),
+        ),
+      );
+    });
   });
 }
 


### PR DESCRIPTION
## Summary

- The leading black-frame skip (`seek(to: startTime)`) only ran under `if startPositionMs > 0` and only on the reused-player path — freshly created native players stayed at 0ms until stale-playback failover tripped.
- Always seek new players to `startTime`, matching the reused-player path.
- Adds an `apple_threading_contract_test` case pinning the behavior.

Recovered from the `fix-darwin-single-clip-playback` worktree. The playback-source-order half of that worktree was dropped: main already went further (progressive-first with preload rationale), so that part was obsolete.

## Test plan

- [x] `flutter test test/src/apple_threading_contract_test.dart` — 5 pass (1 new)
- [ ] Device verification of single-clip start frame (Darwin)