### PR TITLE
fix(stop-motion): steady the first editor open after a capture

### DIFF
--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -1509,14 +1509,10 @@ class VideoRecorderBloc
     VideoRecorderMode mode, {
     required bool keepAutosavedDraft,
   }) {
-    // An assemble owns the captured stills until it resolves: it saves them to
-    // the library across an await, while this method deletes them and clears
-    // the clip manager. Switching mode mid-assemble would delete the stills out
-    // from under the save and leave the library row pointing at missing files,
-    // so the switch is dropped instead. The mode wheel is already gated while
-    // assembling; this keeps the invariant if anything else ever dispatches.
-    if (state.stopMotionStatus == StopMotionStatus.assembling) return;
-
+    // No assembling-status guard: the assemble is synchronous, so a mode switch
+    // cannot land inside it, and the `ready` it leaves behind already carries an
+    // empty frame list — so the discard below is a no-op and the queued library
+    // write has nothing to lose.
     final previousMode = state.recorderMode;
     final previousFrames = state.stopMotionFrames;
     emit(
@@ -1822,6 +1818,10 @@ class VideoRecorderBloc
     final frames = state.stopMotionFrames;
     if (frames.isEmpty) return;
 
+    // Never painted (the handler is synchronous, so this is superseded before
+    // the next frame) — but required: without a distinct state in between, a
+    // second assemble of the same failing frame list emits a state equal to the
+    // current one, which `emit` drops, and the failure snackbar never re-fires.
     emit(state.copyWith(stopMotionStatus: StopMotionStatus.assembling));
 
     try {

--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -1641,16 +1641,14 @@ class VideoRecorderBloc
       return;
     }
 
-    // An assemble owns the captured stills once it starts: it reads the frame
-    // list, saves it, then clears it. A still added to that list mid-assemble
-    // is either missed by the save or re-persisted afterwards as a phantom
-    // one-frame session, so the capture is dropped instead. `ready` (assemble
-    // done, navigation pending) is dropped here too so a tap in that ~1-frame
-    // window skips the native capture the after-await guard would only delete.
-    if (state.stopMotionStatus == StopMotionStatus.assembling ||
-        state.stopMotionStatus == StopMotionStatus.ready) {
-      return;
-    }
+    // An assemble hands the captured stills to the clip manager and clears
+    // them; a still appended after that would be re-persisted as a phantom
+    // one-frame session. `ready` (assemble done, navigation pending) is what
+    // catches it — no assembling-status check, because the assemble is
+    // synchronous, so it is never the current state while this runs. Dropping
+    // the tap here also skips a native capture the after-await guard below
+    // would only delete.
+    if (state.stopMotionStatus == StopMotionStatus.ready) return;
 
     unawaited(HapticService.recordingFeedback());
     // Shutter feedback must fire NOW — the native capture below takes
@@ -1685,16 +1683,16 @@ class VideoRecorderBloc
     }
 
     // The recorder can move off this session across the await above. "Next"
-    // stays tappable, so an assemble can claim it (status → assembling, then
-    // ready); the mode wheel stays live during an idle capture, so a swipe can
-    // discard it (_applyRecorderMode clears the frames and leaves stop-motion,
-    // status idle). In every case the session this still belonged to is gone,
-    // so appending it now would race the in-flight save or re-persist a phantom
-    // one-frame session — on the new mode, for a swipe — so it is dropped with
-    // its file. Only idle (still shooting) and failure (assemble bailed, stills
-    // retained) while still in stop-motion own the session here.
+    // stays tappable, so an assemble can claim it — synchronously, so `ready`
+    // is what it leaves behind, never `assembling`; the mode wheel stays live
+    // during an idle capture, so a swipe can discard it (_applyRecorderMode
+    // clears the frames and leaves stop-motion, status idle). Either way the
+    // session this still belonged to is gone, so appending it now would
+    // re-persist a phantom one-frame session — on the new mode, for a swipe —
+    // so it is dropped with its file. Only idle (still shooting) and failure
+    // (assemble bailed, stills retained) while still in stop-motion own the
+    // session here.
     if (!state.recorderMode.capturesStills ||
-        state.stopMotionStatus == StopMotionStatus.assembling ||
         state.stopMotionStatus == StopMotionStatus.ready) {
       unawaited(_deleteFrameFile(photo.filePath));
       return;

--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -1612,13 +1612,15 @@ class VideoRecorderBloc
 
   // === Stop-motion handlers ===
 
-  /// Hold duration of one captured still: the editor's default
-  /// frames-per-image at the render frame rate, so the library preview, the
-  /// timeline, and the assembled clip all agree.
-  static final Duration _stopMotionPerFrame =
-      StopMotionFrameOps.framesPerImageToDuration(
-        StopMotionFrameOps.defaultFramesPerImage,
-      );
+  /// Hold duration of one captured still in a session of [frameCount] stills,
+  /// at the render frame rate, so the library preview, the timeline, and the
+  /// assembled clip all agree.
+  ///
+  /// A session too short to fill a second on its own is stretched to it
+  /// ([StopMotionFrameOps.initialHold]): three stills at the default hold play
+  /// in an eighth of a second, which the editor only shows as a flicker.
+  static Duration _stopMotionHold(int frameCount) =>
+      StopMotionFrameOps.initialHold(frameCount);
 
   /// Stable library-clip id for the capture session that begins with
   /// [firstFramePath]. The first frame's filename is unique per session and
@@ -1782,9 +1784,10 @@ class VideoRecorderBloc
   /// where a still that goes missing mid-session gets dropped.
   Future<void> _persistStopMotionSession(List<String> framePaths) async {
     if (framePaths.isEmpty) return;
+    final hold = _stopMotionHold(framePaths.length);
     final frames = [
       for (final path in framePaths)
-        StopMotionClipFrame(path: path, duration: _stopMotionPerFrame),
+        StopMotionClipFrame(path: path, duration: hold),
     ];
     final saved = await _readClipManager().saveStopMotionSessionToLibrary(
       id: _stopMotionSessionId(framePaths.first),
@@ -1805,22 +1808,24 @@ class VideoRecorderBloc
   }
 
   /// Saves the captured frames as a frames-based stop-motion clip in the clip
-  /// manager (and the library), then emits [StopMotionStatus.ready].
+  /// manager, then emits [StopMotionStatus.ready] for the editor handoff.
   ///
   /// The frames are the source of truth; no mp4 is rendered here. The editor
   /// previews the frames via the stop-motion player and only renders an mp4 at
-  /// publish.
-  Future<void> _onStopMotionAssembleRequested(
+  /// publish. Synchronous by design: nothing here is worth making the user wait
+  /// for (the library save is queued, see [_ingestStopMotionClip]), so no
+  /// progress UI ever gets a frame to paint in.
+  void _onStopMotionAssembleRequested(
     VideoRecorderStopMotionAssembleRequested event,
     Emitter<VideoRecorderBlocState> emit,
-  ) async {
+  ) {
     final frames = state.stopMotionFrames;
     if (frames.isEmpty) return;
 
     emit(state.copyWith(stopMotionStatus: StopMotionStatus.assembling));
 
     try {
-      await _ingestStopMotionClip(frames);
+      _ingestStopMotionClip(frames);
     } catch (e, stackTrace) {
       Log.warning(
         '⚠️ Stop-motion ingest failed',
@@ -1841,23 +1846,34 @@ class VideoRecorderBloc
   }
 
   /// Adds the captured [framePaths] to the clip manager as a frames-based
-  /// stop-motion clip and saves it to the library. Frame files are kept (not
+  /// stop-motion clip and queues its library save. Frame files are kept (not
   /// deleted) since they are the clip's source of truth.
   ///
   /// Reuses the capture session's library id so the row already written during
-  /// capture is updated in place rather than duplicated.
-  Future<void> _ingestStopMotionClip(List<String> framePaths) async {
+  /// capture is updated in place rather than duplicated. That row exists by the
+  /// time the user taps "Next" (capture upserts it on every still) and the
+  /// editor reads the clip from the clip manager, not the library — so the save
+  /// is queued behind the capture-time writes rather than awaited, and the
+  /// handoff to the editor stays instant.
+  void _ingestStopMotionClip(List<String> framePaths) {
     final clipManager = _readClipManager();
 
     // Drop unreadable captures; a session with no readable still is a failed
-    // assemble (surfaced by the caller's failure snackbar).
-    final frames = StopMotionFrameOps.existingFrames([
+    // assemble (surfaced by the caller's failure snackbar). Filtered before the
+    // hold is computed so the stretch to a minimum length counts only the
+    // stills that actually make it into the clip.
+    final readablePaths = [
       for (final path in framePaths)
-        StopMotionClipFrame(path: path, duration: _stopMotionPerFrame),
-    ]);
-    if (frames.isEmpty) {
+        if (StopMotionFrameOps.isReadableImage(path)) path,
+    ];
+    if (readablePaths.isEmpty) {
       throw StateError('No readable stop-motion stills to assemble');
     }
+    final hold = _stopMotionHold(readablePaths.length);
+    final frames = [
+      for (final path in readablePaths)
+        StopMotionClipFrame(path: path, duration: hold),
+    ];
 
     final clip = clipManager.addStopMotionClip(
       id: _stopMotionSessionId(framePaths.first),
@@ -1873,14 +1889,18 @@ class VideoRecorderBloc
       (c) => c.id == clip.id,
       orElse: () => clip,
     );
-    final saved = await clipManager.saveClipToLibrary(updatedClip);
-    if (!saved) {
-      Log.warning(
-        '⚠️ Stop-motion clip save to library failed for ${clip.id}',
-        name: 'VideoRecorderBloc',
-        category: LogCategory.video,
-      );
-    }
+    unawaited(
+      _enqueueStopMotionSessionWrite(() async {
+        final saved = await clipManager.saveClipToLibrary(updatedClip);
+        if (!saved) {
+          Log.warning(
+            '⚠️ Stop-motion clip save to library failed for ${clip.id}',
+            name: 'VideoRecorderBloc',
+            category: LogCategory.video,
+          );
+        }
+      }),
+    );
   }
 
   /// Discards an abandoned capture session: deletes its frame files and drops

--- a/mobile/lib/blocs/video_recorder/video_recorder_state.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_state.dart
@@ -1,11 +1,18 @@
 part of 'video_recorder_bloc.dart';
 
-/// Lifecycle of the stop-motion "assemble captured frames into one video" step.
+/// Lifecycle of the stop-motion "collect captured stills into one clip" step.
 enum StopMotionStatus {
   /// No assembly in progress.
   idle,
 
-  /// Captured frames are being encoded into a single video.
+  /// The assemble has claimed the captured stills.
+  ///
+  /// Transient by construction: the assemble is synchronous (no mp4 is encoded
+  /// — the stills are the clip), so this is emitted and superseded within one
+  /// handler and never survives to a build. It is not a "show a spinner" state;
+  /// it exists so consecutive assembles of the same frame list are distinct
+  /// emissions, since [Bloc.emit] drops a state equal to the current one and a
+  /// repeated failure would otherwise never reach the UI.
   assembling,
 
   /// Assembly finished; the clip is in the manager and the editor can open.

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -3362,7 +3362,6 @@
     "videoRecorderCaptureCloseLabel": "ገጠመ",
     "videoRecorderCaptureNextLabel": "ቀጥሎ",
     "videoRecorderLipSyncAddAudioFirst": "ከመቅረጽ በፊት ኦዲዮ ያክሉ",
-    "videoRecorderStopMotionAssembling": "ቪዲዮዎን በመፍጠር ላይ…",
     "videoRecorderStopMotionAssembleFailed": "ቪዲዮውን መፍጠር አልተቻለም። እንደገና ይሞክሩ።",
     "videoRecorderToggleFlashLabel": "ብልጭታ ቀያይር",
     "videoRecorderCycleTimerLabel": "የዑደት ሰዓት ቆጣሪ",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -3063,7 +3063,6 @@
     "videoRecorderCaptureCloseLabel": "إغلاق",
     "videoRecorderCaptureNextLabel": "التالي",
     "videoRecorderLipSyncAddAudioFirst": "أضف صوتًا قبل التسجيل",
-    "videoRecorderStopMotionAssembling": "جارٍ إنشاء الفيديو…",
     "videoRecorderStopMotionAssembleFailed": "تعذّر إنشاء الفيديو. حاول مرة أخرى.",
     "videoRecorderClipDeletedMessage": "تم نقل المقطع إلى المهملات",
     "videoRecorderClipUndoLabel": "تراجع",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -3037,7 +3037,6 @@
     "videoRecorderCaptureCloseLabel": "Затвори",
     "videoRecorderCaptureNextLabel": "Следваща",
     "videoRecorderLipSyncAddAudioFirst": "Добавете аудио преди запис",
-    "videoRecorderStopMotionAssembling": "Създаване на видеото…",
     "videoRecorderStopMotionAssembleFailed": "Видеото не можа да се създаде. Опитайте отново.",
     "videoRecorderToggleFlashLabel": "Превключване на светкавицата",
     "videoRecorderCycleTimerLabel": "Цикъл таймер",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2787,7 +2787,6 @@
     "videoRecorderCaptureCloseLabel": "Schließen",
     "videoRecorderCaptureNextLabel": "Weiter",
     "videoRecorderLipSyncAddAudioFirst": "Audio vor der Aufnahme hinzufügen",
-    "videoRecorderStopMotionAssembling": "Video wird erstellt…",
     "videoRecorderStopMotionAssembleFailed": "Video konnte nicht erstellt werden. Bitte erneut versuchen.",
     "videoRecorderToggleFlashLabel": "Blitz ein-/ausschalten",
     "videoRecorderCycleTimerLabel": "Timer wechseln",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -4809,10 +4809,6 @@
   "@videoRecorderLipSyncAddAudioFirst": {
     "description": "Snackbar shown when the user taps the record button in lip-sync mode without first selecting a sound."
   },
-  "videoRecorderStopMotionAssembling": "Creating your video…",
-  "@videoRecorderStopMotionAssembling": {
-    "description": "Loading label shown while captured stop-motion frames are being encoded into one video."
-  },
   "videoRecorderStopMotionAssembleFailed": "Couldn't create the video. Try again.",
   "@videoRecorderStopMotionAssembleFailed": {
     "description": "Snackbar shown when assembling captured stop-motion frames into a video failed."

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2795,7 +2795,6 @@
     "videoRecorderCaptureCloseLabel": "Cerrar",
     "videoRecorderCaptureNextLabel": "Siguiente",
     "videoRecorderLipSyncAddAudioFirst": "Agrega audio antes de grabar",
-    "videoRecorderStopMotionAssembling": "Creando tu vídeo…",
     "videoRecorderStopMotionAssembleFailed": "No se pudo crear el vídeo. Inténtalo de nuevo.",
     "videoRecorderToggleFlashLabel": "Activar o desactivar flash",
     "videoRecorderCycleTimerLabel": "Cambiar temporizador",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1739,7 +1739,6 @@
     "videoRecorderCaptureCloseLabel": "Isara",
     "videoRecorderCaptureNextLabel": "Susunod",
     "videoRecorderLipSyncAddAudioFirst": "Magdagdag ng audio bago mag-record",
-    "videoRecorderStopMotionAssembling": "Ginagawa ang iyong video…",
     "videoRecorderStopMotionAssembleFailed": "Hindi magawa ang video. Subukan ulit.",
     "videoRecorderToggleFlashLabel": "I-toggle ang flash",
     "videoRecorderCycleTimerLabel": "I-cycle ang timer",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2787,7 +2787,6 @@
     "videoRecorderCaptureCloseLabel": "Fermer",
     "videoRecorderCaptureNextLabel": "Suivant",
     "videoRecorderLipSyncAddAudioFirst": "Ajoutez de l'audio avant d'enregistrer",
-    "videoRecorderStopMotionAssembling": "Création de la vidéo…",
     "videoRecorderStopMotionAssembleFailed": "Impossible de créer la vidéo. Réessayez.",
     "videoRecorderToggleFlashLabel": "Activer/désactiver le flash",
     "videoRecorderCycleTimerLabel": "Changer le minuteur",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -3070,7 +3070,6 @@
     "videoRecorderCaptureCloseLabel": "Tutup",
     "videoRecorderCaptureNextLabel": "Berikutnya",
     "videoRecorderLipSyncAddAudioFirst": "Tambahkan audio sebelum merekam",
-    "videoRecorderStopMotionAssembling": "Membuat video Anda…",
     "videoRecorderStopMotionAssembleFailed": "Tidak dapat membuat video. Coba lagi.",
     "videoRecorderClipDeletedMessage": "Klip dipindahkan ke sampah",
     "videoRecorderClipUndoLabel": "Urungkan",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2787,7 +2787,6 @@
     "videoRecorderCaptureCloseLabel": "Chiudi",
     "videoRecorderCaptureNextLabel": "Avanti",
     "videoRecorderLipSyncAddAudioFirst": "Aggiungi audio prima di registrare",
-    "videoRecorderStopMotionAssembling": "Creazione del video…",
     "videoRecorderStopMotionAssembleFailed": "Impossibile creare il video. Riprova.",
     "videoRecorderToggleFlashLabel": "Attiva/disattiva flash",
     "videoRecorderCycleTimerLabel": "Cambia timer",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -3063,7 +3063,6 @@
     "videoRecorderCaptureCloseLabel": "閉じる",
     "videoRecorderCaptureNextLabel": "次へ",
     "videoRecorderLipSyncAddAudioFirst": "録画する前にオーディオを追加してください",
-    "videoRecorderStopMotionAssembling": "動画を作成しています…",
     "videoRecorderStopMotionAssembleFailed": "動画を作成できませんでした。もう一度お試しください。",
     "videoRecorderClipDeletedMessage": "クリップをゴミ箱に移動しました",
     "videoRecorderClipUndoLabel": "元に戻す",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -2394,7 +2394,6 @@
     "videoRecorderCaptureCloseLabel": "닫기",
     "videoRecorderCaptureNextLabel": "다음",
     "videoRecorderLipSyncAddAudioFirst": "녹화하기 전에 오디오를 추가하세요",
-    "videoRecorderStopMotionAssembling": "동영상을 만드는 중…",
     "videoRecorderStopMotionAssembleFailed": "동영상을 만들지 못했습니다. 다시 시도해 주세요.",
     "videoRecorderClipDeletedMessage": "클립이 휴지통으로 이동되었습니다",
     "videoRecorderClipUndoLabel": "실행 취소",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2787,7 +2787,6 @@
     "videoRecorderCaptureCloseLabel": "Sluiten",
     "videoRecorderCaptureNextLabel": "Volgende",
     "videoRecorderLipSyncAddAudioFirst": "Voeg audio toe vóór de opname",
-    "videoRecorderStopMotionAssembling": "Je video wordt gemaakt…",
     "videoRecorderStopMotionAssembleFailed": "Kan de video niet maken. Probeer het opnieuw.",
     "videoRecorderToggleFlashLabel": "Flitser in-/uitschakelen",
     "videoRecorderCycleTimerLabel": "Timer wisselen",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2787,7 +2787,6 @@
     "videoRecorderCaptureCloseLabel": "Zamknij",
     "videoRecorderCaptureNextLabel": "Dalej",
     "videoRecorderLipSyncAddAudioFirst": "Dodaj audio przed nagraniem",
-    "videoRecorderStopMotionAssembling": "Tworzenie filmu…",
     "videoRecorderStopMotionAssembleFailed": "Nie udało się utworzyć filmu. Spróbuj ponownie.",
     "videoRecorderToggleFlashLabel": "Przełącz lampę błyskową",
     "videoRecorderCycleTimerLabel": "Zmień timer",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2787,7 +2787,6 @@
     "videoRecorderCaptureCloseLabel": "Fechar",
     "videoRecorderCaptureNextLabel": "Próximo",
     "videoRecorderLipSyncAddAudioFirst": "Adicione áudio antes de gravar",
-    "videoRecorderStopMotionAssembling": "Criando seu vídeo…",
     "videoRecorderStopMotionAssembleFailed": "Não foi possível criar o vídeo. Tente novamente.",
     "videoRecorderToggleFlashLabel": "Alternar flash",
     "videoRecorderCycleTimerLabel": "Alternar temporizador",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2787,7 +2787,6 @@
     "videoRecorderCaptureCloseLabel": "Închide",
     "videoRecorderCaptureNextLabel": "Următorul",
     "videoRecorderLipSyncAddAudioFirst": "Adaugă audio înainte de înregistrare",
-    "videoRecorderStopMotionAssembling": "Se creează videoclipul…",
     "videoRecorderStopMotionAssembleFailed": "Videoclipul nu a putut fi creat. Încearcă din nou.",
     "videoRecorderToggleFlashLabel": "Activează/dezactivează blițul",
     "videoRecorderCycleTimerLabel": "Schimbă temporizatorul",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2787,7 +2787,6 @@
     "videoRecorderCaptureCloseLabel": "Stäng",
     "videoRecorderCaptureNextLabel": "Nästa",
     "videoRecorderLipSyncAddAudioFirst": "Lägg till ljud innan inspelning",
-    "videoRecorderStopMotionAssembling": "Skapar din video…",
     "videoRecorderStopMotionAssembleFailed": "Det gick inte att skapa videon. Försök igen.",
     "videoRecorderToggleFlashLabel": "Växla blixt",
     "videoRecorderCycleTimerLabel": "Växla timer",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -3070,7 +3070,6 @@
     "videoRecorderCaptureCloseLabel": "Kapat",
     "videoRecorderCaptureNextLabel": "İleri",
     "videoRecorderLipSyncAddAudioFirst": "Kayıttan önce ses ekleyin",
-    "videoRecorderStopMotionAssembling": "Videon oluşturuluyor…",
     "videoRecorderStopMotionAssembleFailed": "Video oluşturulamadı. Tekrar deneyin.",
     "videoRecorderClipDeletedMessage": "Klip çöp kutusuna taşındı",
     "videoRecorderClipUndoLabel": "Geri al",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -14238,12 +14238,6 @@ abstract class AppLocalizations {
   /// **'Add audio before recording'**
   String get videoRecorderLipSyncAddAudioFirst;
 
-  /// Loading label shown while captured stop-motion frames are being encoded into one video.
-  ///
-  /// In en, this message translates to:
-  /// **'Creating your video…'**
-  String get videoRecorderStopMotionAssembling;
-
   /// Snackbar shown when assembling captured stop-motion frames into a video failed.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -8065,9 +8065,6 @@ class AppLocalizationsAm extends AppLocalizations {
   String get videoRecorderLipSyncAddAudioFirst => 'ከመቅረጽ በፊት ኦዲዮ ያክሉ';
 
   @override
-  String get videoRecorderStopMotionAssembling => 'ቪዲዮዎን በመፍጠር ላይ…';
-
-  @override
   String get videoRecorderStopMotionAssembleFailed =>
       'ቪዲዮውን መፍጠር አልተቻለም። እንደገና ይሞክሩ።';
 

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -8181,9 +8181,6 @@ class AppLocalizationsAr extends AppLocalizations {
   String get videoRecorderLipSyncAddAudioFirst => 'أضف صوتًا قبل التسجيل';
 
   @override
-  String get videoRecorderStopMotionAssembling => 'جارٍ إنشاء الفيديو…';
-
-  @override
   String get videoRecorderStopMotionAssembleFailed =>
       'تعذّر إنشاء الفيديو. حاول مرة أخرى.';
 

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -8306,9 +8306,6 @@ class AppLocalizationsBg extends AppLocalizations {
   String get videoRecorderLipSyncAddAudioFirst => 'Добавете аудио преди запис';
 
   @override
-  String get videoRecorderStopMotionAssembling => 'Създаване на видеото…';
-
-  @override
   String get videoRecorderStopMotionAssembleFailed =>
       'Видеото не можа да се създаде. Опитайте отново.';
 

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -8329,9 +8329,6 @@ class AppLocalizationsDe extends AppLocalizations {
       'Audio vor der Aufnahme hinzufügen';
 
   @override
-  String get videoRecorderStopMotionAssembling => 'Video wird erstellt…';
-
-  @override
   String get videoRecorderStopMotionAssembleFailed =>
       'Video konnte nicht erstellt werden. Bitte erneut versuchen.';
 

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -8218,9 +8218,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get videoRecorderLipSyncAddAudioFirst => 'Add audio before recording';
 
   @override
-  String get videoRecorderStopMotionAssembling => 'Creating your video…';
-
-  @override
   String get videoRecorderStopMotionAssembleFailed =>
       'Couldn\'t create the video. Try again.';
 

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -8310,9 +8310,6 @@ class AppLocalizationsEs extends AppLocalizations {
       'Agrega audio antes de grabar';
 
   @override
-  String get videoRecorderStopMotionAssembling => 'Creando tu vídeo…';
-
-  @override
   String get videoRecorderStopMotionAssembleFailed =>
       'No se pudo crear el vídeo. Inténtalo de nuevo.';
 

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -8324,9 +8324,6 @@ class AppLocalizationsFil extends AppLocalizations {
       'Magdagdag ng audio bago mag-record';
 
   @override
-  String get videoRecorderStopMotionAssembling => 'Ginagawa ang iyong video…';
-
-  @override
   String get videoRecorderStopMotionAssembleFailed =>
       'Hindi magawa ang video. Subukan ulit.';
 

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -8337,9 +8337,6 @@ class AppLocalizationsFr extends AppLocalizations {
       'Ajoutez de l\'audio avant d\'enregistrer';
 
   @override
-  String get videoRecorderStopMotionAssembling => 'Création de la vidéo…';
-
-  @override
   String get videoRecorderStopMotionAssembleFailed =>
       'Impossible de créer la vidéo. Réessayez.';
 

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -8203,9 +8203,6 @@ class AppLocalizationsId extends AppLocalizations {
       'Tambahkan audio sebelum merekam';
 
   @override
-  String get videoRecorderStopMotionAssembling => 'Membuat video Anda…';
-
-  @override
   String get videoRecorderStopMotionAssembleFailed =>
       'Tidak dapat membuat video. Coba lagi.';
 

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -8308,9 +8308,6 @@ class AppLocalizationsIt extends AppLocalizations {
       'Aggiungi audio prima di registrare';
 
   @override
-  String get videoRecorderStopMotionAssembling => 'Creazione del video…';
-
-  @override
   String get videoRecorderStopMotionAssembleFailed =>
       'Impossibile creare il video. Riprova.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -7905,9 +7905,6 @@ class AppLocalizationsJa extends AppLocalizations {
   String get videoRecorderLipSyncAddAudioFirst => '録画する前にオーディオを追加してください';
 
   @override
-  String get videoRecorderStopMotionAssembling => '動画を作成しています…';
-
-  @override
   String get videoRecorderStopMotionAssembleFailed =>
       '動画を作成できませんでした。もう一度お試しください。';
 

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -7928,9 +7928,6 @@ class AppLocalizationsKo extends AppLocalizations {
   String get videoRecorderLipSyncAddAudioFirst => '녹화하기 전에 오디오를 추가하세요';
 
   @override
-  String get videoRecorderStopMotionAssembling => '동영상을 만드는 중…';
-
-  @override
   String get videoRecorderStopMotionAssembleFailed =>
       '동영상을 만들지 못했습니다. 다시 시도해 주세요.';
 

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -8269,9 +8269,6 @@ class AppLocalizationsNl extends AppLocalizations {
       'Voeg audio toe vóór de opname';
 
   @override
-  String get videoRecorderStopMotionAssembling => 'Je video wordt gemaakt…';
-
-  @override
   String get videoRecorderStopMotionAssembleFailed =>
       'Kan de video niet maken. Probeer het opnieuw.';
 

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -8405,9 +8405,6 @@ class AppLocalizationsPl extends AppLocalizations {
   String get videoRecorderLipSyncAddAudioFirst => 'Dodaj audio przed nagraniem';
 
   @override
-  String get videoRecorderStopMotionAssembling => 'Tworzenie filmu…';
-
-  @override
   String get videoRecorderStopMotionAssembleFailed =>
       'Nie udało się utworzyć filmu. Spróbuj ponownie.';
 

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -8286,9 +8286,6 @@ class AppLocalizationsPt extends AppLocalizations {
       'Adicione áudio antes de gravar';
 
   @override
-  String get videoRecorderStopMotionAssembling => 'Criando seu vídeo…';
-
-  @override
   String get videoRecorderStopMotionAssembleFailed =>
       'Não foi possível criar o vídeo. Tente novamente.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -8408,9 +8408,6 @@ class AppLocalizationsRo extends AppLocalizations {
       'Adaugă audio înainte de înregistrare';
 
   @override
-  String get videoRecorderStopMotionAssembling => 'Se creează videoclipul…';
-
-  @override
   String get videoRecorderStopMotionAssembleFailed =>
       'Videoclipul nu a putut fi creat. Încearcă din nou.';
 

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -8230,9 +8230,6 @@ class AppLocalizationsSv extends AppLocalizations {
       'Lägg till ljud innan inspelning';
 
   @override
-  String get videoRecorderStopMotionAssembling => 'Skapar din video…';
-
-  @override
   String get videoRecorderStopMotionAssembleFailed =>
       'Det gick inte att skapa videon. Försök igen.';
 

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -8204,9 +8204,6 @@ class AppLocalizationsTr extends AppLocalizations {
   String get videoRecorderLipSyncAddAudioFirst => 'Kayıttan önce ses ekleyin';
 
   @override
-  String get videoRecorderStopMotionAssembling => 'Videon oluşturuluyor…';
-
-  @override
   String get videoRecorderStopMotionAssembleFailed =>
       'Video oluşturulamadı. Tekrar deneyin.';
 

--- a/mobile/lib/models/stop_motion/stop_motion_frame_ops.dart
+++ b/mobile/lib/models/stop_motion/stop_motion_frame_ops.dart
@@ -3,6 +3,7 @@
 
 import 'dart:io';
 
+import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/services/video_editor/stop_motion_render_service.dart';
@@ -32,7 +33,13 @@ abstract class StopMotionFrameOps {
   /// second — the editor preview reads as a flicker looping past rather than a
   /// clip — so a short session is stretched to fill at least this long before
   /// it first reaches the editor (see [initialFramesPerImage]).
-  static const Duration minimumInitialDuration = Duration(seconds: 1);
+  ///
+  /// Deliberately *is* the editor's Done gate and the renderer's loop-to-length
+  /// minimum rather than a second one-second constant: the stretch exists so a
+  /// short capture clears that gate instead of being bounced with "capture at
+  /// least 1 second", so the two must never drift apart.
+  static const Duration minimumInitialDuration =
+      VideoEditorConstants.stopMotionMinOutputDuration;
 
   /// Frames-per-image for a freshly captured session of [frameCount] stills:
   /// [defaultFramesPerImage] once there are enough stills to fill
@@ -41,10 +48,21 @@ abstract class StopMotionFrameOps {
   static int initialFramesPerImage(int frameCount) {
     if (frameCount <= 0) return defaultFramesPerImage;
     final outputFrames = durationToFramesPerImage(minimumInitialDuration);
-    return (outputFrames / frameCount).ceil().clamp(
+    final framesPerImage = (outputFrames / frameCount).ceil().clamp(
       defaultFramesPerImage,
       maxFramesPerImage,
     );
+    // Output frames divide the minimum evenly; whole microseconds don't, and
+    // [framesPerImageToDuration] rounds. 3 stills (8 frames each) sum to
+    // 999,999µs and 12 stills (2 each) to 999,996µs — just under the gate,
+    // which compares summed durations, not frame counts. One extra frame is
+    // always enough to cover it: a frame is ~41ms against a ≤4µs shortfall.
+    if (framesPerImage < maxFramesPerImage &&
+        framesPerImageToDuration(framesPerImage) * frameCount <
+            minimumInitialDuration) {
+      return framesPerImage + 1;
+    }
+    return framesPerImage;
   }
 
   /// Hold for one still in a freshly captured session of [frameCount] stills

--- a/mobile/lib/models/stop_motion/stop_motion_frame_ops.dart
+++ b/mobile/lib/models/stop_motion/stop_motion_frame_ops.dart
@@ -24,7 +24,14 @@ abstract class StopMotionFrameOps {
   /// Highest number of output frames a still may be held for.
   static const int maxFramesPerImage = 300;
 
-  /// Default hold for a freshly captured still: 1 output frame at 24fps.
+  /// Fallback hold of 1 output frame at 24fps: the floor
+  /// [initialFramesPerImage] clamps to, and what
+  /// [globalDefaultFramesPerImage] falls back to for an empty frame list.
+  ///
+  /// *Not* the hold a freshly captured still gets — that is
+  /// [initialFramesPerImage], which stretches a short session to fill
+  /// [minimumInitialDuration]. Nothing outside this file uses this constant;
+  /// a new capture path wanting a starting hold wants [initialHold].
   static const int defaultFramesPerImage = 1;
 
   /// Shortest a freshly captured session plays for.

--- a/mobile/lib/models/stop_motion/stop_motion_frame_ops.dart
+++ b/mobile/lib/models/stop_motion/stop_motion_frame_ops.dart
@@ -26,6 +26,32 @@ abstract class StopMotionFrameOps {
   /// Default hold for a freshly captured still: 1 output frame at 24fps.
   static const int defaultFramesPerImage = 1;
 
+  /// Shortest a freshly captured session plays for.
+  ///
+  /// A handful of stills at [defaultFramesPerImage] is over in a fraction of a
+  /// second — the editor preview reads as a flicker looping past rather than a
+  /// clip — so a short session is stretched to fill at least this long before
+  /// it first reaches the editor (see [initialFramesPerImage]).
+  static const Duration minimumInitialDuration = Duration(seconds: 1);
+
+  /// Frames-per-image for a freshly captured session of [frameCount] stills:
+  /// [defaultFramesPerImage] once there are enough stills to fill
+  /// [minimumInitialDuration] on their own, and an evenly shared longer hold
+  /// below that — a lone still is held for the full second.
+  static int initialFramesPerImage(int frameCount) {
+    if (frameCount <= 0) return defaultFramesPerImage;
+    final outputFrames = durationToFramesPerImage(minimumInitialDuration);
+    return (outputFrames / frameCount).ceil().clamp(
+      defaultFramesPerImage,
+      maxFramesPerImage,
+    );
+  }
+
+  /// Hold for one still in a freshly captured session of [frameCount] stills
+  /// (see [initialFramesPerImage]).
+  static Duration initialHold(int frameCount) =>
+      framesPerImageToDuration(initialFramesPerImage(frameCount));
+
   /// Hold duration for a still shown for [framesPerImage] output frames at the
   /// default frame rate. [framesPerImage] is clamped to
   /// [minFramesPerImage]..[maxFramesPerImage].

--- a/mobile/lib/screens/video_editor/video_editor_screen.dart
+++ b/mobile/lib/screens/video_editor/video_editor_screen.dart
@@ -368,8 +368,11 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen>
     if (capturedFrames.isEmpty) return;
 
     final targetFrames = target.stopMotionFrames ?? const [];
-    // Fresh captures arrive with the app default hold; adopt the session's
-    // global default so they don't drift from the stills already in the clip.
+    // Fresh captures arrive stretched to fill a second on their own
+    // ([StopMotionFrameOps.initialHold]) — one still added from here would
+    // splice into a long clip at a 1s hold — so the session's global default
+    // is re-applied, both to undo that stretch and to keep the new stills from
+    // drifting from the ones already in the clip.
     final newFrames = StopMotionFrameOps.setGlobalHold(
       capturedFrames,
       StopMotionFrameOps.globalDefaultFramesPerImage(targetFrames),

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_thumbnail.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_thumbnail.dart
@@ -24,6 +24,14 @@ class VideoEditorThumbnail extends ConsumerWidget {
       child: clip.thumbnailPath != null
           ? ClipThumbnailImage(
               path: clip.thumbnailPath!,
+              // A stop-motion clip's thumbnail is a raw full-resolution camera
+              // still (several MB decoded), and the stop-motion player decodes
+              // the same file at this height right after — bounding the decode
+              // keeps the placeholder from stalling on it, and both share one
+              // image-cache entry instead of decoding twice.
+              cacheHeight:
+                  (contentSize.height * MediaQuery.devicePixelRatioOf(context))
+                      .round(),
               placeholder: SizedBox.fromSize(size: contentSize),
             )
           : SizedBox.fromSize(

--- a/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_capture_stack.dart
+++ b/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_capture_stack.dart
@@ -183,25 +183,29 @@ class VideoRecorderCaptureStack extends ConsumerWidget {
           // Countdown overlay
           const VideoRecorderCountdownOverlay(),
 
-          // Stop-motion: encodes captured frames into one clip, then opens the
-          // editor; shows a blocking overlay while assembling.
-          _StopMotionAssembleOverlay(fromEditor: fromEditor),
+          // Stop-motion: collects the captured stills into one clip, then opens
+          // the editor.
+          _StopMotionAssembleListener(fromEditor: fromEditor),
         ],
       ),
     );
   }
 }
 
-/// Drives the stop-motion assemble step: a blocking progress overlay while
-/// encoding, navigation to the editor on success, and a snackbar on failure.
-class _StopMotionAssembleOverlay extends ConsumerWidget {
-  const _StopMotionAssembleOverlay({required this.fromEditor});
+/// Drives the stop-motion assemble step: navigation to the editor on success,
+/// and a snackbar on failure.
+///
+/// Renders nothing. The assemble collects the captured stills into a clip
+/// synchronously and queues the library write, so the `assembling` status never
+/// survives a frame — a progress overlay could only ever flash.
+class _StopMotionAssembleListener extends ConsumerWidget {
+  const _StopMotionAssembleListener({required this.fromEditor});
 
   final bool fromEditor;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return BlocConsumer<VideoRecorderBloc, VideoRecorderBlocState>(
+    return BlocListener<VideoRecorderBloc, VideoRecorderBlocState>(
       listenWhen: (previous, current) =>
           previous.stopMotionStatus != current.stopMotionStatus,
       listener: (context, state) {
@@ -224,31 +228,7 @@ class _StopMotionAssembleOverlay extends ConsumerWidget {
             break;
         }
       },
-      buildWhen: (previous, current) =>
-          previous.stopMotionStatus != current.stopMotionStatus,
-      builder: (context, state) {
-        // The spinner animates continuously, so only mount it while assembling
-        // (a permanently-animating child never lets `pumpAndSettle` settle).
-        if (state.stopMotionStatus != StopMotionStatus.assembling) {
-          return const SizedBox.shrink();
-        }
-        return ColoredBox(
-          color: VineTheme.surfaceBackground.withValues(alpha: 0.7),
-          child: Center(
-            child: Column(
-              mainAxisSize: .min,
-              spacing: 16,
-              children: [
-                const CircularProgressIndicator(color: VineTheme.primary),
-                Text(
-                  context.l10n.videoRecorderStopMotionAssembling,
-                  style: VineTheme.bodyMediumFont(),
-                ),
-              ],
-            ),
-          ),
-        );
-      },
+      child: const SizedBox.shrink(),
     );
   }
 }

--- a/mobile/lib/widgets/video_recorder/video_recorder_bottom_bar.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_bottom_bar.dart
@@ -18,19 +18,16 @@ class VideoRecorderBottomBar extends StatelessWidget {
       (VideoRecorderBloc b) => (
         isRecording: b.state.isRecording,
         recorderMode: b.state.recorderMode,
-        isAssembling: b.state.stopMotionStatus == StopMotionStatus.assembling,
       ),
     );
-    // The bar fades out while recording, and an assemble is mid-flight over the
-    // captured stills — a mode switch during either would discard work the user
-    // can't get back. Opacity alone still hit-tests, so the gate has to ignore
-    // pointers rather than just fade.
-    final isLocked = state.isRecording || state.isAssembling;
 
     return SafeArea(
       top: false,
+      // The bar fades out while recording — a mode switch there would discard
+      // work the user can't get back. Opacity alone still hit-tests, so the
+      // gate has to ignore pointers rather than just fade.
       child: IgnorePointer(
-        ignoring: isLocked,
+        ignoring: state.isRecording,
         child: AnimatedOpacity(
           duration: const Duration(milliseconds: 220),
           opacity: state.isRecording ? 0 : 1,

--- a/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
+++ b/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
@@ -3045,6 +3045,59 @@ void main() {
           verifyNever(() => clipManager.saveClipToLibrary(any()));
         },
       );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'retrying a failing assemble re-emits failure',
+        setUp: () {
+          when(
+            () => clipManager.addStopMotionClip(
+              id: any(named: 'id'),
+              frames: any(named: 'frames'),
+              originalAspectRatio: any(named: 'originalAspectRatio'),
+              targetAspectRatio: any(named: 'targetAspectRatio'),
+              duration: any(named: 'duration'),
+              thumbnailPath: any(named: 'thumbnailPath'),
+              lensMetadata: any(named: 'lensMetadata'),
+            ),
+          ).thenThrow(Exception('ingest failed'));
+        },
+        build: buildBloc,
+        seed: () => VideoRecorderBlocState(
+          recorderMode: VideoRecorderMode.stopMotion,
+          stopMotionFrames: [frameAPath],
+        ),
+        act: (bloc) async {
+          bloc.add(const VideoRecorderStopMotionAssembleRequested());
+          await Future<void>.delayed(Duration.zero);
+          bloc.add(const VideoRecorderStopMotionAssembleRequested());
+        },
+        errors: () => [isA<Exception>(), isA<Exception>()],
+        // The snackbar fires on the status *transition*, and `emit` drops a
+        // state equal to the current one — so the transient `assembling` in
+        // between is what lets a second identical failure reach the UI.
+        expect: () => [
+          isA<VideoRecorderBlocState>().having(
+            (s) => s.stopMotionStatus,
+            'status',
+            StopMotionStatus.assembling,
+          ),
+          isA<VideoRecorderBlocState>().having(
+            (s) => s.stopMotionStatus,
+            'status',
+            StopMotionStatus.failure,
+          ),
+          isA<VideoRecorderBlocState>().having(
+            (s) => s.stopMotionStatus,
+            'status',
+            StopMotionStatus.assembling,
+          ),
+          isA<VideoRecorderBlocState>().having(
+            (s) => s.stopMotionStatus,
+            'status',
+            StopMotionStatus.failure,
+          ),
+        ],
+      );
     });
   });
 }

--- a/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
+++ b/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
@@ -2475,24 +2475,6 @@ void main() {
       );
 
       blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
-        'a frame captured while assembling is dropped',
-        build: buildBloc,
-        seed: () => const VideoRecorderBlocState(
-          recorderMode: VideoRecorderMode.stopMotion,
-          stopMotionStatus: StopMotionStatus.assembling,
-        ),
-        act: (bloc) => bloc.add(const VideoRecorderStopMotionFrameCaptured()),
-        wait: const Duration(milliseconds: 20),
-        verify: (bloc) {
-          // The assemble owns the session: it reads the frame list, saves it,
-          // then clears it. A still appended here races that save.
-          verifyNever(() => cameraService.capturePhoto());
-          expect(bloc.state.stopMotionFrames, isEmpty);
-          expect(bloc.state.stopMotionStatus, StopMotionStatus.assembling);
-        },
-      );
-
-      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
         'a frame captured while ready (assemble done, navigation pending) '
         'skips the wasted native capture',
         build: buildBloc,

--- a/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
+++ b/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
@@ -12,6 +12,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart' as model show AspectRatio, AudioEvent;
 import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/stop_motion/stop_motion_frame_ops.dart';
 import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
 import 'package:openvine/models/video_recorder/video_recorder_flash_mode.dart';
@@ -2977,6 +2978,42 @@ void main() {
           verify(() => clipManager.saveClipToLibrary(any())).called(1);
           expect(bloc.state.stopMotionStatus, StopMotionStatus.ready);
           expect(bloc.state.stopMotionFrames, isEmpty);
+        },
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'ingest stretches a session too short to fill the minimum duration',
+        setUp: stubClipIngest,
+        build: buildBloc,
+        seed: () => VideoRecorderBlocState(
+          recorderMode: VideoRecorderMode.stopMotion,
+          stopMotionFrames: [frameAPath],
+        ),
+        act: (bloc) =>
+            bloc.add(const VideoRecorderStopMotionAssembleRequested()),
+        verify: (bloc) {
+          final captured = verify(
+            () => clipManager.addStopMotionClip(
+              id: any(named: 'id'),
+              frames: captureAny(named: 'frames'),
+              originalAspectRatio: any(named: 'originalAspectRatio'),
+              targetAspectRatio: any(named: 'targetAspectRatio'),
+              duration: captureAny(named: 'duration'),
+              thumbnailPath: any(named: 'thumbnailPath'),
+              lensMetadata: any(named: 'lensMetadata'),
+            ),
+          )..called(1);
+          // Captured values follow the method's parameter declaration order:
+          // frames is declared before duration.
+          final frames = captured.captured[0] as List<StopMotionClipFrame>;
+          expect(
+            frames.single.duration,
+            StopMotionFrameOps.minimumInitialDuration,
+          );
+          expect(
+            captured.captured[1],
+            StopMotionFrameOps.minimumInitialDuration,
+          );
         },
       );
 

--- a/mobile/test/models/stop_motion/stop_motion_frame_ops_test.dart
+++ b/mobile/test/models/stop_motion/stop_motion_frame_ops_test.dart
@@ -51,6 +51,48 @@ void main() {
     });
   });
 
+  group('initialFramesPerImage / initialHold', () {
+    test('holds a lone still for the whole minimum duration', () {
+      expect(
+        StopMotionFrameOps.initialHold(1),
+        StopMotionFrameOps.minimumInitialDuration,
+      );
+    });
+
+    test('a short session fills at least the minimum duration', () {
+      // Counted in output frames: the per-frame microsecond conversion rounds,
+      // so summing the holds can land a microsecond under the second.
+      final minimumOutputFrames = StopMotionFrameOps.durationToFramesPerImage(
+        StopMotionFrameOps.minimumInitialDuration,
+      );
+      for (var frameCount = 1; frameCount <= 24; frameCount++) {
+        expect(
+          StopMotionFrameOps.initialFramesPerImage(frameCount) * frameCount,
+          greaterThanOrEqualTo(minimumOutputFrames),
+          reason: '$frameCount still(s) fall short of the minimum',
+        );
+      }
+    });
+
+    test('keeps the default hold once the stills fill it on their own', () {
+      expect(
+        StopMotionFrameOps.initialFramesPerImage(24),
+        StopMotionFrameOps.defaultFramesPerImage,
+      );
+      expect(
+        StopMotionFrameOps.initialFramesPerImage(100),
+        StopMotionFrameOps.defaultFramesPerImage,
+      );
+    });
+
+    test('falls back to the default hold for an empty session', () {
+      expect(
+        StopMotionFrameOps.initialFramesPerImage(0),
+        StopMotionFrameOps.defaultFramesPerImage,
+      );
+    });
+  });
+
   group('removeFrame', () {
     test('removes the frame at the index', () {
       final result = StopMotionFrameOps.removeFrame(framesOf([1, 1, 1]), 1);

--- a/mobile/test/models/stop_motion/stop_motion_frame_ops_test.dart
+++ b/mobile/test/models/stop_motion/stop_motion_frame_ops_test.dart
@@ -59,16 +59,14 @@ void main() {
       );
     });
 
-    test('a short session fills at least the minimum duration', () {
-      // Counted in output frames: the per-frame microsecond conversion rounds,
-      // so summing the holds can land a microsecond under the second.
-      final minimumOutputFrames = StopMotionFrameOps.durationToFramesPerImage(
-        StopMotionFrameOps.minimumInitialDuration,
-      );
-      for (var frameCount = 1; frameCount <= 24; frameCount++) {
+    test('a session of any size fills at least the minimum duration', () {
+      // Asserted on summed *duration*, which is what the editor's Done gate
+      // compares — counting output frames instead hides the rounding in
+      // framesPerImageToDuration (3 and 12 stills land 1µs and 4µs short).
+      for (var frameCount = 1; frameCount <= 40; frameCount++) {
         expect(
-          StopMotionFrameOps.initialFramesPerImage(frameCount) * frameCount,
-          greaterThanOrEqualTo(minimumOutputFrames),
+          StopMotionFrameOps.initialHold(frameCount) * frameCount,
+          greaterThanOrEqualTo(StopMotionFrameOps.minimumInitialDuration),
           reason: '$frameCount still(s) fall short of the minimum',
         );
       }

--- a/mobile/test/widgets/video_editor/main_editor/video_editor_thumbnail_test.dart
+++ b/mobile/test/widgets/video_editor/main_editor/video_editor_thumbnail_test.dart
@@ -1,8 +1,14 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/clip_manager_state.dart';
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_thumbnail.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
 
 void main() {
   testWidgets('VideoEditorThumbnail renders safely with no clips', (
@@ -26,4 +32,67 @@ void main() {
     expect(find.byType(Image), findsNothing);
     expect(find.byType(CircularProgressIndicator), findsNothing);
   });
+
+  testWidgets('bounds the thumbnail decode to the content height', (
+    tester,
+  ) async {
+    const contentSize = Size(90, 160);
+    final thumbnailPath = '${Directory.systemTemp.path}/editor_thumbnail.png';
+    final clip = DivineVideoClip(
+      id: 'clip_thumbnail_test',
+      video: EditorVideo.file('/path/to/video.mp4'),
+      duration: const Duration(seconds: 2),
+      recordedAt: DateTime(2026),
+      targetAspectRatio: .vertical,
+      originalAspectRatio: 9 / 16,
+      thumbnailPath: thumbnailPath,
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          clipManagerProvider.overrideWith(
+            () => _TestClipManagerNotifier([clip]),
+          ),
+        ],
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: VideoEditorThumbnail(contentSize: contentSize),
+          ),
+        ),
+      ),
+    );
+
+    // The decode is bounded to the same height (in device pixels) the
+    // stop-motion player asks for, so the two share one image-cache entry
+    // rather than decoding the raw camera still twice. Asserting on the
+    // ResizeImage pins both the bound and the cache key the sharing needs.
+    final image = tester.widget<Image>(find.byType(Image)).image;
+    expect(
+      image,
+      isA<ResizeImage>()
+          .having(
+            (r) => r.height,
+            'height',
+            (contentSize.height * tester.view.devicePixelRatio).round(),
+          )
+          .having((r) => r.width, 'width', isNull)
+          .having(
+            (r) => r.imageProvider,
+            'imageProvider',
+            isA<FileImage>().having((f) => f.file.path, 'path', thumbnailPath),
+          ),
+    );
+  });
+}
+
+class _TestClipManagerNotifier extends ClipManagerNotifier {
+  _TestClipManagerNotifier(this._initialClips);
+
+  final List<DivineVideoClip> _initialClips;
+
+  @override
+  ClipManagerState build() => ClipManagerState(clips: _initialClips);
 }


### PR DESCRIPTION
Closes #6466

## Description

Recording a handful of stop-motion stills and tapping Next produced two things video recordings don't have: the editor preview flickering, and a loading overlay flashing on the way in. Both are fixed here.

**Short sessions now play for at least a second.** Freshly captured stills were held for `defaultFramesPerImage` (one output frame each), so three photos played in an eighth of a second — the editor loop read as a flicker, not a clip. `StopMotionFrameOps.initialFramesPerImage` now derives a shared hold from the number of stills so a new session fills at least `minimumInitialDuration` (a lone still is held for the full second, i.e. 24 frames at the render frame rate). It is a starting point, not a floor: the frames-per-image control stays fully editable, and nothing re-stretches a clip on later opens, so a deliberate choice is never overridden. The hold is computed after unreadable stills are filtered out, so it counts only what actually lands in the clip.

**The assemble no longer blocks the handoff.** Tapping Next showed a "Creating your video…" progress overlay until `StopMotionStatus.ready`. That overlay dates from when assemble encoded an mp4; today the stills are the source of truth until publish, and the only remaining wait was a library save for a row that capture already upserts on every still. That save now goes through the existing `_enqueueStopMotionSessionWrite` queue (so it stays ordered behind the capture-time writes) instead of being awaited, the assemble handler runs synchronously, and the overlay it fed is deleted along with its now-unused l10n key. `StopMotionStatus.assembling` itself stays — it still gates the mode wheel and drops stills captured mid-assemble — it just no longer survives a frame, so nothing can paint on it.

**The editor's setup placeholder decodes bounded.** `VideoEditorThumbnail` rendered `clip.thumbnailPath` with no `cacheHeight`. For a stop-motion clip that path is a raw full-resolution camera still, decoded at full size and then decoded again moments later by `StopMotionPlayer` at its own height. It is now bounded to the same height the player uses, so the two share one image-cache entry.

**Related Issue:** 

## Out of Scope

Stop-motion clips recorded before this change keep their old short hold when opened from the library. Stretching those on open would mean re-writing a hold the user may have chosen deliberately — a global frames-per-image change isn't recorded as an override, so there's no way to tell the two apart.

## Verification

- `flutter analyze lib test` — clean
- `flutter test test/models/stop_motion/stop_motion_frame_ops_test.dart test/blocs/video_recorder/video_recorder_bloc_test.dart test/widgets/video_recorder test/widgets/video_editor/main_editor test/l10n/arb_consistency_test.dart` — 514 tests, all passing
- New coverage: the minimum-duration invariant across session sizes in `stop_motion_frame_ops_test.dart`, and an ingest test pinning that a single-still session reaches the clip manager at the minimum duration
- Manual on a real Samsung Galaxy: recorded 1, 3 and many stills, opened the editor from each, checked the preview plays instead of flickering, that no overlay flashes on the way in, and that the session still shows up correctly in the library

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore