### PR TITLE
fix(video-player): stop the loop restart being audible or visible

### DIFF
--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
@@ -7,13 +7,13 @@ import android.net.Uri
 import android.os.Handler
 import android.os.Looper
 import android.view.Surface
+import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.HttpDataSource
-import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.SeekParameters
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
@@ -160,6 +160,13 @@ internal class DivineVideoPlayerInstance(
     private val audioOverlayManager = audioOverlayManagerFactory(context)
 
     /**
+     * Fades the outer edges of a looping video so its loop join is not a click
+     * (#6468). Lives for the life of the instance because it is wired into the
+     * renderers factory when the player is built.
+     */
+    private val declickProcessor = LoopDeclickAudioProcessor()
+
+    /**
      * Pending result for an async seekTo call.
      * Completed when ExoPlayer transitions to STATE_READY after a seek,
      * so the Dart `await seekTo()` blocks until the frame is decoded.
@@ -286,7 +293,8 @@ internal class DivineVideoPlayerInstance(
         // extraction contend for a small hardware decoder pool — into a
         // successful (if slower) decode instead of a dead surface.
         val renderersFactory =
-            DefaultRenderersFactory(context).setEnableDecoderFallback(true)
+            LoopDeclickRenderersFactory(context, declickProcessor)
+                .setEnableDecoderFallback(true)
         val builder = ExoPlayer.Builder(context, renderersFactory)
             .setMediaSourceFactory(
                 DefaultMediaSourceFactory(
@@ -526,6 +534,14 @@ internal class DivineVideoPlayerInstance(
         // position so the timeline doesn't show intermediate values.
         pendingGlobalStartMs = globalStartMs
 
+        // Fade the video's edges only when the whole video is one clip, which
+        // is what the feed loops. On a multi-clip timeline a stream is one clip
+        // rather than the whole video, so fading every stream would notch the
+        // audio at each cut. The length is not known until STATE_READY.
+        declickProcessor.enabled = clipCount == 1
+        declickProcessor.videoDurationUs = LoopDeclickAudioProcessor.DURATION_UNKNOWN
+        declickProcessor.nextStreamStartUs = startLocalMs * 1000L
+
         // Hold the Dart result until STATE_READY so `await setClips()` only
         // resolves once the decoder is truly ready. Cancel any previous
         // in-flight setClips (shouldn't happen, but defensive) — surface as
@@ -620,6 +636,19 @@ internal class DivineVideoPlayerInstance(
         return commonEndMs.takeIf { trimMs <= trimLimitMs }
     }
 
+    /**
+     * Hands the declick fade the current video's length, so it knows where the
+     * loop join it has to fade into actually is.
+     */
+    private fun updateDeclickDuration() {
+        val durationMs = player?.duration ?: C.TIME_UNSET
+        declickProcessor.videoDurationUs = if (durationMs == C.TIME_UNSET) {
+            LoopDeclickAudioProcessor.DURATION_UNKNOWN
+        } else {
+            durationMs * 1000L
+        }
+    }
+
     private fun handleSeekTo(call: MethodCall, result: MethodChannel.Result) {
         val globalMs = (call.argument<Number>("positionMs"))?.toLong() ?: 0L
         val exoPlayer = ensurePlayer()
@@ -641,6 +670,10 @@ internal class DivineVideoPlayerInstance(
         val resolved = resolveGlobalPosition(globalMs)
 
         val targetIndex = resolved.first
+        // The seek flushes the audio pipeline, which re-anchors the fade at
+        // whatever the next stream starts with. Tell it that is the seek target
+        // and not the start of the video, so the fade out stays on the join.
+        declickProcessor.nextStreamStartUs = resolved.second * 1000L
         exoPlayer.seekTo(targetIndex, resolved.second)
 
         // Apply the target clip's per-clip speed and volume immediately.
@@ -1000,6 +1033,9 @@ internal class DivineVideoPlayerInstance(
                 syncAudioOverlays()
             }
             if (playbackState == Player.STATE_READY) {
+                // The video's length is only known once the timeline is
+                // populated, and the fade out has to know where the join is.
+                updateDeclickDuration()
                 // Seek complete — switch from reporting target to actual position.
                 pendingGlobalStartMs = 0L
                 completeSeekIfPending()

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
@@ -170,10 +170,7 @@ internal class DivineVideoPlayerInstance(
 
     private val audioOverlayManager = audioOverlayManagerFactory(context)
 
-    /**
-     * Bumped by every [handleSetClips]. A resolution that finishes after a
-     * newer call started is dropped rather than applied over it.
-     */
+    /** Bumped by every [handleSetClips] so late background work can be dropped. */
     private var setClipsGeneration = 0L
 
     /**
@@ -197,14 +194,25 @@ internal class DivineVideoPlayerInstance(
      */
     private val deferredSetClipsTimeout = Runnable {
         deferredSetClips?.let { deferred ->
+            trackDurationProbingDisabled = true
             DivineVideoPlayerLog.warning(
                 "Player $playerId applied clips unclamped: track lengths not " +
-                    "read within ${TRACK_DURATION_RESOLVE_TIMEOUT_MS}ms",
+                    "read within ${TRACK_DURATION_RESOLVE_TIMEOUT_MS}ms; " +
+                    "metadata probing disabled for this instance",
                 name = "DivineVideoPlayer.Load",
             )
             settleDeferredSetClips(deferred, apply = true)
         }
     }
+
+    /**
+     * True after a metadata read misses its deadline on this instance.
+     *
+     * `MediaExtractor` remote reads are native I/O and may not be interruptible.
+     * Once the single metadata thread is plausibly pinned, queuing more work only
+     * makes later loads wait for a deadline before playing unclamped anyway.
+     */
+    private var trackDurationProbingDisabled = false
 
     /**
      * Fades the outer edges of a looping video so its loop join is not a click
@@ -456,24 +464,36 @@ internal class DivineVideoPlayerInstance(
         val generation = ++setClipsGeneration
         deferredSetClips?.let { settleDeferredSetClips(it, apply = false) }
 
-        val unresolved = clipsRaw.mapNotNull { map ->
-            val uri = map["uri"] as? String ?: return@mapNotNull null
-            if (map["trimToCommonTrackEnd"] as? Boolean != true) return@mapNotNull null
-            if (!canReadTrackDurations(uri)) return@mapNotNull null
-            if (trackDurationsCache.containsKey(uri)) return@mapNotNull null
-            uri to httpHeadersOf(map)
+        val unresolved = if (trackDurationProbingDisabled) {
+            emptyList()
+        } else {
+            clipsRaw.mapNotNull { map ->
+                val uri = map["uri"] as? String ?: return@mapNotNull null
+                if (map["trimToCommonTrackEnd"] as? Boolean != true) return@mapNotNull null
+                if (!canReadTrackDurations(uri)) return@mapNotNull null
+                if (trackDurationsCache.containsKey(uri)) return@mapNotNull null
+                uri to httpHeadersOf(map)
+            }
         }
-        if (unresolved.isEmpty()) {
+        val blockingUnresolved = unresolved.filter { (uri, _) ->
+            shouldBlockSetClipsForTrackDurations(uri)
+        }
+        val backgroundUnresolved = unresolved.filterNot { (uri, _) ->
+            shouldBlockSetClipsForTrackDurations(uri)
+        }
+        if (blockingUnresolved.isEmpty()) {
+            if (backgroundUnresolved.isNotEmpty()) {
+                warmTrackDurationsInBackground(generation, clipsRaw, backgroundUnresolved)
+            }
             applyClips(call, clipsRaw, result)
             return
         }
 
-        // Where each track really ends is only in the source's metadata, and
-        // reading it blocks. Resolve off the platform thread, then apply on
-        // it — the alternative is looping to the container duration, which is
-        // the *longest* track, and leaving the shorter one's tail as a frozen
-        // frame before every restart.
-        val deferred = DeferredSetClips(generation, call, clipsRaw, result)
+        // Where each track really ends is only in the source's metadata. Local
+        // files can be read before the playlist swap without adding a network
+        // round trip to first frame; remote sources warm in the background and
+        // tighten the current playlist when they land.
+        val deferred = DeferredSetClips(call, clipsRaw, result)
         deferredSetClips = deferred
         mainHandler.postDelayed(
             deferredSetClipsTimeout,
@@ -486,11 +506,20 @@ internal class DivineVideoPlayerInstance(
                 // playing to the container duration is a seam, not playing at
                 // all is a dead player.
                 try {
-                    unresolved.forEach { (uri, headers) ->
+                    blockingUnresolved.forEach { (uri, headers) ->
                         resolveTrackDurations(uri, headers)
                     }
                 } finally {
-                    mainHandler.post { settleDeferredSetClips(deferred, apply = true) }
+                    mainHandler.post {
+                        if (backgroundUnresolved.isNotEmpty()) {
+                            warmTrackDurationsInBackground(
+                                generation,
+                                clipsRaw,
+                                backgroundUnresolved,
+                            )
+                        }
+                        settleDeferredSetClips(deferred, apply = true)
+                    }
                 }
             }
         } catch (e: RejectedExecutionException) {
@@ -502,6 +531,68 @@ internal class DivineVideoPlayerInstance(
             if (claimDeferredSetClips(deferred)) {
                 result.error("DISPOSED", "Player was disposed", null)
             }
+        }
+    }
+
+    private fun warmTrackDurationsInBackground(
+        generation: Long,
+        clipsRaw: List<Map<String, Any?>>,
+        unresolved: List<Pair<String, Map<String, String>>>,
+    ) {
+        try {
+            metadataExecutor.execute {
+                try {
+                    unresolved.forEach { (uri, headers) ->
+                        resolveTrackDurations(uri, headers)
+                    }
+                } finally {
+                    mainHandler.post {
+                        applyResolvedCommonTrackEnds(generation, clipsRaw)
+                    }
+                }
+            }
+        } catch (e: RejectedExecutionException) {
+            DivineVideoPlayerLog.warning(
+                "Player $playerId dropped background track-duration read: $e",
+                name = "DivineVideoPlayer.Load",
+            )
+        }
+    }
+
+    private fun applyResolvedCommonTrackEnds(
+        generation: Long,
+        clipsRaw: List<Map<String, Any?>>,
+    ) {
+        if (generation != setClipsGeneration) return
+        val exoPlayer = player ?: return
+        if (exoPlayer.mediaItemCount != clipsRaw.size) return
+
+        var changed = false
+        clipsRaw.forEachIndexed loop@{ index, map ->
+            val uri = map["uri"] as? String ?: return@loop
+            if (map["trimToCommonTrackEnd"] as? Boolean != true) return@loop
+            val startMs = (map["startMs"] as? Number)?.toLong() ?: 0L
+            val requestedEndMs = (map["endMs"] as? Number)?.toLong()
+            val commonEndMs = boundedCommonTrackEndMs(uri, startMs, requestedEndMs)
+                ?: return@loop
+            val effectiveEndMs = listOfNotNull(requestedEndMs, commonEndMs).minOrNull()
+                ?: return@loop
+            val currentItem = exoPlayer.getMediaItemAt(index)
+            if (currentItem.clippingConfiguration.endPositionMs == effectiveEndMs) {
+                return@loop
+            }
+            exoPlayer.replaceMediaItem(
+                index,
+                buildMediaItem(uri, startMs, effectiveEndMs),
+            )
+            changed = true
+        }
+        if (changed) {
+            refreshClipOffsets(exoPlayer)
+            DivineVideoPlayerLog.info(
+                "Player $playerId applied resolved track-end clamp",
+                name = "DivineVideoPlayer.Load",
+            )
         }
     }
 
@@ -533,7 +624,7 @@ internal class DivineVideoPlayerInstance(
      */
     private fun settleDeferredSetClips(deferred: DeferredSetClips, apply: Boolean) {
         if (!claimDeferredSetClips(deferred)) return
-        if (apply && deferred.generation == setClipsGeneration) {
+        if (apply) {
             applyClips(deferred.call, deferred.clipsRaw, deferred.result)
         } else {
             // Same contract [applyClips] uses for a superseded in-flight call:
@@ -593,17 +684,7 @@ internal class DivineVideoPlayerInstance(
                 blobHashFromUrl(uri)?.let { headersByHash[it] = httpHeaders }
             }
 
-            val builder = MediaItem.Builder().setUri(uri)
-                .setClippingConfiguration(
-                    MediaItem.ClippingConfiguration.Builder()
-                        .setStartPositionMs(startMs)
-                        .apply {
-                            if (effectiveEndMs != null) setEndPositionMs(effectiveEndMs)
-                        }
-                        .build(),
-                )
-
-            mediaItems.add(builder.build())
+            mediaItems.add(buildMediaItem(uri, startMs, effectiveEndMs))
             offsets.add(accumulated)
             volumes.add(clipVol)
             speeds.add(clipSpeed)
@@ -702,6 +783,22 @@ internal class DivineVideoPlayerInstance(
         mainHandler.postDelayed(setClipsTimeoutRunnable, SET_CLIPS_TIMEOUT_MS)
     }
 
+    private fun buildMediaItem(
+        uri: String,
+        startMs: Long,
+        endMs: Long?,
+    ): MediaItem =
+        MediaItem.Builder().setUri(uri)
+            .setClippingConfiguration(
+                MediaItem.ClippingConfiguration.Builder()
+                    .setStartPositionMs(startMs)
+                    .apply {
+                        if (endMs != null) setEndPositionMs(endMs)
+                    }
+                    .build(),
+            )
+            .build()
+
     /**
      * The point up to which *every* track of [uri] still has content, in
      * milliseconds, or `null` when the source's track lengths are not known.
@@ -742,12 +839,24 @@ internal class DivineVideoPlayerInstance(
      */
     private fun canReadTrackDurations(uri: String): Boolean {
         val path = uri.substringBefore('?').substringBefore('#')
-        if (path.endsWith(".m3u8", ignoreCase = true)) return false
+        if (path.endsWith(".m3u8", ignoreCase = true) ||
+            path.contains("/hls/", ignoreCase = true)
+        ) {
+            return false
+        }
         return uri.startsWith("/") ||
             uri.startsWith("file://") ||
             uri.startsWith("http://") ||
             uri.startsWith("https://")
     }
+
+    /**
+     * Local files are cheap enough to resolve before the playlist swap. Remote
+     * metadata reads add a second connection to the first-frame path, so they
+     * warm the cache without blocking playback.
+     */
+    private fun shouldBlockSetClipsForTrackDurations(uri: String): Boolean =
+        uri.startsWith("/") || uri.startsWith("file://")
 
     /**
      * Reads [uri]'s video and audio track lengths into [trackDurationsCache].
@@ -1564,7 +1673,6 @@ internal class DivineVideoPlayerInstance(
      * something supersedes it.
      */
     private class DeferredSetClips(
-        val generation: Long,
         val call: MethodCall,
         val clipsRaw: List<Map<String, Any?>>,
         val result: MethodChannel.Result,
@@ -1614,6 +1722,10 @@ internal class DivineVideoPlayerInstance(
             )
 
         private const val TRACK_DURATION_CACHE_ENTRIES = 256
+
+        internal fun clearTrackDurationsCacheForTesting() {
+            trackDurationsCache.clear()
+        }
 
         /**
          * Names the metadata thread and marks it a daemon.

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
@@ -510,6 +510,17 @@ internal class DivineVideoPlayerInstance(
             }
         }
 
+        // Fade the video's edges only when the whole video is one clip, which
+        // is what the feed loops. On a multi-clip timeline a stream is one clip
+        // rather than the whole video, so fading every stream would notch the
+        // audio at each cut. The length is not known until STATE_READY.
+        //
+        // Published before the playlist swap below, because that swap disables
+        // the audio renderer and flushes the pipeline on the playback thread.
+        declickProcessor.enabled = clipCount == 1
+        declickProcessor.videoDurationUs = LoopDeclickAudioProcessor.DURATION_UNKNOWN
+        declickProcessor.nextStreamStartUs = startLocalMs * 1000L
+
         // Replace the playlist in-place without calling stop() first.
         // stop() transitions ExoPlayer to STATE_IDLE which on some OEM decoders
         // (e.g. Vivo/Mediatek) triggers a full MediaCodec reset and surface
@@ -533,14 +544,6 @@ internal class DivineVideoPlayerInstance(
         // While ExoPlayer buffers to the seek position, report the target
         // position so the timeline doesn't show intermediate values.
         pendingGlobalStartMs = globalStartMs
-
-        // Fade the video's edges only when the whole video is one clip, which
-        // is what the feed loops. On a multi-clip timeline a stream is one clip
-        // rather than the whole video, so fading every stream would notch the
-        // audio at each cut. The length is not known until STATE_READY.
-        declickProcessor.enabled = clipCount == 1
-        declickProcessor.videoDurationUs = LoopDeclickAudioProcessor.DURATION_UNKNOWN
-        declickProcessor.nextStreamStartUs = startLocalMs * 1000L
 
         // Hold the Dart result until STATE_READY so `await setClips()` only
         // resolves once the decoder is truly ready. Cancel any previous

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
@@ -11,6 +11,7 @@ import java.util.Collections
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.ThreadFactory
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.PlaybackException
@@ -50,7 +51,8 @@ internal class DivineVideoPlayerInstance(
      * Reads source metadata off the platform thread. Single-threaded, so the
      * clips of one call resolve in order and two calls cannot interleave.
      */
-    private val metadataExecutor: ExecutorService = Executors.newSingleThreadExecutor(),
+    private val metadataExecutor: ExecutorService =
+        Executors.newSingleThreadExecutor(metadataThreadFactory(playerId)),
 ) : MethodChannel.MethodCallHandler,
     EventChannel.StreamHandler,
     TextureRegistry.SurfaceProducer.Callback {
@@ -457,6 +459,7 @@ internal class DivineVideoPlayerInstance(
         val unresolved = clipsRaw.mapNotNull { map ->
             val uri = map["uri"] as? String ?: return@mapNotNull null
             if (map["trimToCommonTrackEnd"] as? Boolean != true) return@mapNotNull null
+            if (!canReadTrackDurations(uri)) return@mapNotNull null
             if (trackDurationsCache.containsKey(uri)) return@mapNotNull null
             uri to httpHeadersOf(map)
         }
@@ -724,7 +727,32 @@ internal class DivineVideoPlayerInstance(
     }
 
     /**
+     * Whether [uri]'s track lengths can be read at all.
+     *
+     * `MediaExtractor` has no HLS extractor: it fetches the playlist, fails to
+     * sniff it and throws. A throw is deliberately uncached (see
+     * [resolveTrackDurations]), so probing a playlist would hold every
+     * `setClips` for that source behind a read that can only fail, and pay the
+     * fetch again on the next one. The feed keeps HLS as a fallback for a
+     * progressive source that would not start, so this is the path a video
+     * takes when it is already having a bad time.
+     *
+     * A scheme [resolveTrackDurations] cannot open is the same shape of
+     * answer: permanent, and not worth deferring a load to rediscover.
+     */
+    private fun canReadTrackDurations(uri: String): Boolean {
+        val path = uri.substringBefore('?').substringBefore('#')
+        if (path.endsWith(".m3u8", ignoreCase = true)) return false
+        return uri.startsWith("/") ||
+            uri.startsWith("file://") ||
+            uri.startsWith("http://") ||
+            uri.startsWith("https://")
+    }
+
+    /**
      * Reads [uri]'s video and audio track lengths into [trackDurationsCache].
+     *
+     * Only ever called for a [uri] [canReadTrackDurations] accepted.
      *
      * Blocks on I/O — a remote source costs a range request for the moov box —
      * so it must never run on the platform thread. The Apple player pays the
@@ -743,12 +771,13 @@ internal class DivineVideoPlayerInstance(
         val extractor = MediaExtractor()
         val durations = try {
             when {
-                uri.startsWith("/") -> extractor.setDataSource(uri)
                 uri.startsWith("file://") ->
                     extractor.setDataSource(Uri.parse(uri).path ?: return)
                 uri.startsWith("http://") || uri.startsWith("https://") ->
                     extractor.setDataSource(uri, headers)
-                else -> return
+                // A bare filesystem path. [canReadTrackDurations] rejected
+                // everything else before this was ever queued.
+                else -> extractor.setDataSource(uri)
             }
             var videoUs = -1L
             var audioUs = -1L
@@ -1585,6 +1614,19 @@ internal class DivineVideoPlayerInstance(
             )
 
         private const val TRACK_DURATION_CACHE_ENTRIES = 256
+
+        /**
+         * Names the metadata thread and marks it a daemon.
+         *
+         * `shutdownNow()` cannot interrupt a [MediaExtractor] read — it is
+         * native I/O — so the stalled host this design already plans for keeps
+         * its thread alive past [dispose]. Daemon so it can never hold the
+         * process up, named so a thread dump says which player it belongs to
+         * instead of showing an anonymous `pool-N-thread-1`.
+         */
+        private fun metadataThreadFactory(playerId: Int) = ThreadFactory { runnable ->
+            Thread(runnable, "divine-video-metadata-$playerId").apply { isDaemon = true }
+        }
 
         /**
          * How long the player may stay in `STATE_BUFFERING` before it is

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
@@ -640,8 +640,10 @@ internal class DivineVideoPlayerInstance(
     }
 
     /**
-     * Hands the declick fade the current video's length, so it knows where the
-     * loop join it has to fade into actually is.
+     * Hands the declick fade the current video's length, which bounds how long
+     * the fade may be on a video too short to carry two of them. Where the
+     * fade out sits is not derived from this — the processor holds the last
+     * few milliseconds back and releases them at the real end of the stream.
      */
     private fun updateDeclickDuration() {
         val durationMs = player?.duration ?: C.TIME_UNSET
@@ -1036,8 +1038,8 @@ internal class DivineVideoPlayerInstance(
                 syncAudioOverlays()
             }
             if (playbackState == Player.STATE_READY) {
-                // The video's length is only known once the timeline is
-                // populated, and the fade out has to know where the join is.
+                // The video's length is only readable once the timeline is
+                // populated, and it bounds how long the fade may be.
                 updateDeclickDuration()
                 // Seek complete — switch from reporting target to actual position.
                 pendingGlobalStartMs = 0L

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
@@ -175,6 +175,36 @@ internal class DivineVideoPlayerInstance(
     private var setClipsGeneration = 0L
 
     /**
+     * The `setClips` whose track lengths are still being read, if any.
+     *
+     * At most one exists: a newer call settles the previous one before taking
+     * the slot.
+     */
+    private var deferredSetClips: DeferredSetClips? = null
+
+    /**
+     * Gives up waiting for the track lengths and starts the player unclamped.
+     *
+     * The read has to be bounded. `MediaExtractor` fetches a remote source
+     * through `MediaHTTPConnection`, which sets a connect timeout and no read
+     * timeout at all, so a host that accepts the connection and then stalls
+     * would hold `await setClips()` open indefinitely. A seam is bad, a player
+     * that never starts is worse — so the clips go in without the clamp, and
+     * the read still finishes into [trackDurationsCache] for the next play of
+     * that source.
+     */
+    private val deferredSetClipsTimeout = Runnable {
+        deferredSetClips?.let { deferred ->
+            DivineVideoPlayerLog.warning(
+                "Player $playerId applied clips unclamped: track lengths not " +
+                    "read within ${TRACK_DURATION_RESOLVE_TIMEOUT_MS}ms",
+                name = "DivineVideoPlayer.Load",
+            )
+            settleDeferredSetClips(deferred, apply = true)
+        }
+    }
+
+    /**
      * Fades the outer edges of a looping video so its loop join is not a click
      * (#6468). Lives for the life of the instance because it is wired into the
      * renderers factory when the player is built.
@@ -422,6 +452,7 @@ internal class DivineVideoPlayerInstance(
 
         // Any newer call supersedes a resolution still in flight.
         val generation = ++setClipsGeneration
+        deferredSetClips?.let { settleDeferredSetClips(it, apply = false) }
 
         val unresolved = clipsRaw.mapNotNull { map ->
             val uri = map["uri"] as? String ?: return@mapNotNull null
@@ -439,20 +470,24 @@ internal class DivineVideoPlayerInstance(
         // it — the alternative is looping to the container duration, which is
         // the *longest* track, and leaving the shorter one's tail as a frozen
         // frame before every restart.
+        val deferred = DeferredSetClips(generation, call, clipsRaw, result)
+        deferredSetClips = deferred
+        mainHandler.postDelayed(
+            deferredSetClipsTimeout,
+            TRACK_DURATION_RESOLVE_TIMEOUT_MS,
+        )
+
         try {
             metadataExecutor.execute {
                 // The clips must be applied even if resolving blows up —
                 // playing to the container duration is a seam, not playing at
-                // all is a dead player and a Dart call that hangs to timeout.
+                // all is a dead player.
                 try {
                     unresolved.forEach { (uri, headers) ->
                         resolveTrackDurations(uri, headers)
                     }
                 } finally {
-                    mainHandler.post {
-                        if (generation != setClipsGeneration) return@post
-                        applyClips(call, clipsRaw, result)
-                    }
+                    mainHandler.post { settleDeferredSetClips(deferred, apply = true) }
                 }
             }
         } catch (e: RejectedExecutionException) {
@@ -461,7 +496,51 @@ internal class DivineVideoPlayerInstance(
                 "Player $playerId dropped setClips after dispose: $e",
                 name = "DivineVideoPlayer.Load",
             )
-            result.error("DISPOSED", "Player was disposed", null)
+            if (claimDeferredSetClips(deferred)) {
+                result.error("DISPOSED", "Player was disposed", null)
+            }
+        }
+    }
+
+    /**
+     * Takes [deferred] out of the pending slot, or returns `false` if
+     * something else already settled it.
+     *
+     * Whoever wins owes Dart a reply: a `setClips` whose
+     * [MethodChannel.Result] is dropped leaves `await setClips()` pending for
+     * the life of the app, which in the feed pins the tile's failover state
+     * and suppresses every later recovery attempt for it.
+     */
+    private fun claimDeferredSetClips(deferred: DeferredSetClips): Boolean {
+        if (deferred.settled) return false
+        deferred.settled = true
+        if (deferredSetClips === deferred) {
+            deferredSetClips = null
+            mainHandler.removeCallbacks(deferredSetClipsTimeout)
+        }
+        return true
+    }
+
+    /**
+     * Applies [deferred]'s clips, or tells its caller they were superseded.
+     *
+     * Runs on the platform thread from whichever comes first: the resolution
+     * landing, [deferredSetClipsTimeout] expiring, a newer [handleSetClips],
+     * or [dispose].
+     */
+    private fun settleDeferredSetClips(deferred: DeferredSetClips, apply: Boolean) {
+        if (!claimDeferredSetClips(deferred)) return
+        if (apply && deferred.generation == setClipsGeneration) {
+            applyClips(deferred.call, deferred.clipsRaw, deferred.result)
+        } else {
+            // Same contract [applyClips] uses for a superseded in-flight call:
+            // the Dart controller swallows CANCELLED, and the newer call is
+            // the one that answers.
+            deferred.result.error(
+                "CANCELLED",
+                "Superseded by newer setClips call",
+                null,
+            )
         }
     }
 
@@ -652,8 +731,11 @@ internal class DivineVideoPlayerInstance(
      * same cost, awaiting `load(.timeRange)` on both tracks before it builds
      * the composition.
      *
-     * A source whose lengths cannot be read is cached as [NO_TRACK_PAIR] so
-     * the read is not retried on every failover attempt.
+     * A source that genuinely carries no video/audio pair is cached as
+     * [NO_TRACK_PAIR] so the read is not repeated for it. A read that *threw*
+     * is not cached: a socket reset or a 5xx says nothing about the source,
+     * and [NO_TRACK_PAIR] is permanent — one bad moment would disable the
+     * clamp for that URL for the rest of the process.
      */
     private fun resolveTrackDurations(uri: String, headers: Map<String, String>) {
         if (trackDurationsCache.containsKey(uri)) return
@@ -691,7 +773,7 @@ internal class DivineVideoPlayerInstance(
                 "Player $playerId could not read track durations: $e",
                 name = "DivineVideoPlayer.Load",
             )
-            NO_TRACK_PAIR
+            return
         } finally {
             extractor.release()
         }
@@ -1414,8 +1496,10 @@ internal class DivineVideoPlayerInstance(
         mainHandler.removeCallbacks(bufferingWatchdogRunnable)
         cancelDecoderRetry()
         // A metadata read already in flight finishes into a bumped generation
-        // and is dropped; queued ones never start.
+        // and is dropped; queued ones never start. Its caller is answered here
+        // rather than left waiting on a continuation that will not apply.
         setClipsGeneration++
+        deferredSetClips?.let { settleDeferredSetClips(it, apply = false) }
         metadataExecutor.shutdownNow()
         seekCompletionResult?.success(null)
         seekCompletionResult = null
@@ -1443,11 +1527,45 @@ internal class DivineVideoPlayerInstance(
         eventSink = null
     }
 
+    /**
+     * A `setClips` held back until its clips' track lengths have been read.
+     *
+     * Carries everything [applyClips] needs so the call can be replayed on the
+     * platform thread once the read lands — or answered without applying when
+     * something supersedes it.
+     */
+    private class DeferredSetClips(
+        val generation: Long,
+        val call: MethodCall,
+        val clipsRaw: List<Map<String, Any?>>,
+        val result: MethodChannel.Result,
+    ) {
+        /**
+         * Set by whichever of the resolution, the deadline, a newer
+         * `setClips`, or `dispose` gets here first. Read and written on the
+         * platform thread only.
+         */
+        var settled: Boolean = false
+    }
+
     companion object {
         private const val POSITION_UPDATE_INTERVAL_MS = 200L
         private const val SET_CLIPS_TIMEOUT_MS = 10_000L
 
-        /** Cached "this source's track lengths cannot be read". */
+        /**
+         * How long a `setClips` waits for its clips' track lengths.
+         *
+         * Long enough for a moov range request against a healthy CDN, short
+         * enough that a stalled one costs a seam rather than a load. The
+         * ordinary `setClips` watchdog cannot cover this window — it is armed
+         * in [applyClips], which is exactly what the wait is holding up.
+         *
+         * Internal rather than private so the test can post the deadline it
+         * asserts on rather than restate the number.
+         */
+        internal const val TRACK_DURATION_RESOLVE_TIMEOUT_MS = 1_500L
+
+        /** Cached "this source carries no video/audio pair to trim". */
         private val NO_TRACK_PAIR = longArrayOf(-1L, -1L)
 
         /**

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
@@ -7,6 +7,10 @@ import android.net.Uri
 import android.os.Handler
 import android.os.Looper
 import android.view.Surface
+import java.util.Collections
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.RejectedExecutionException
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.PlaybackException
@@ -42,6 +46,11 @@ internal class DivineVideoPlayerInstance(
     private val audioOverlayManagerFactory: (Context) -> AudioOverlayManager = { ctx ->
         AudioOverlayManager(ctx)
     },
+    /**
+     * Reads source metadata off the platform thread. Single-threaded, so the
+     * clips of one call resolve in order and two calls cannot interleave.
+     */
+    private val metadataExecutor: ExecutorService = Executors.newSingleThreadExecutor(),
 ) : MethodChannel.MethodCallHandler,
     EventChannel.StreamHandler,
     TextureRegistry.SurfaceProducer.Callback {
@@ -158,6 +167,12 @@ internal class DivineVideoPlayerInstance(
     private var pendingGlobalStartMs: Long = 0L
 
     private val audioOverlayManager = audioOverlayManagerFactory(context)
+
+    /**
+     * Bumped by every [handleSetClips]. A resolution that finishes after a
+     * newer call started is dropped rather than applied over it.
+     */
+    private var setClipsGeneration = 0L
 
     /**
      * Fades the outer edges of a looping video so its loop join is not a click
@@ -405,6 +420,56 @@ internal class DivineVideoPlayerInstance(
             return
         }
 
+        // Any newer call supersedes a resolution still in flight.
+        val generation = ++setClipsGeneration
+
+        val unresolved = clipsRaw.mapNotNull { map ->
+            val uri = map["uri"] as? String ?: return@mapNotNull null
+            if (map["trimToCommonTrackEnd"] as? Boolean != true) return@mapNotNull null
+            if (trackDurationsCache.containsKey(uri)) return@mapNotNull null
+            uri to httpHeadersOf(map)
+        }
+        if (unresolved.isEmpty()) {
+            applyClips(call, clipsRaw, result)
+            return
+        }
+
+        // Where each track really ends is only in the source's metadata, and
+        // reading it blocks. Resolve off the platform thread, then apply on
+        // it — the alternative is looping to the container duration, which is
+        // the *longest* track, and leaving the shorter one's tail as a frozen
+        // frame before every restart.
+        try {
+            metadataExecutor.execute {
+                // The clips must be applied even if resolving blows up —
+                // playing to the container duration is a seam, not playing at
+                // all is a dead player and a Dart call that hangs to timeout.
+                try {
+                    unresolved.forEach { (uri, headers) ->
+                        resolveTrackDurations(uri, headers)
+                    }
+                } finally {
+                    mainHandler.post {
+                        if (generation != setClipsGeneration) return@post
+                        applyClips(call, clipsRaw, result)
+                    }
+                }
+            }
+        } catch (e: RejectedExecutionException) {
+            // Disposed while a call was in flight; nothing left to play into.
+            DivineVideoPlayerLog.warning(
+                "Player $playerId dropped setClips after dispose: $e",
+                name = "DivineVideoPlayer.Load",
+            )
+            result.error("DISPOSED", "Player was disposed", null)
+        }
+    }
+
+    private fun applyClips(
+        call: MethodCall,
+        clipsRaw: List<Map<String, Any?>>,
+        result: MethodChannel.Result,
+    ) {
         val exoPlayer = ensurePlayer()
         val mediaItems = mutableListOf<MediaItem>()
         val offsets = mutableListOf<Long>()
@@ -440,14 +505,7 @@ internal class DivineVideoPlayerInstance(
             val clipVol = (map["volume"] as? Number)?.toFloat() ?: 1.0f
             val clipSpeed = ((map["playbackSpeed"] as? Number)?.toFloat() ?: 1.0f)
                 .coerceAtLeast(MIN_PLAYBACK_SPEED)
-            val httpHeaders = (map["httpHeaders"] as? Map<*, *>)
-                ?.mapNotNull { entry ->
-                    val key = entry.key as? String
-                    val value = entry.value as? String
-                    if (key == null || value == null) null else key to value
-                }
-                ?.toMap()
-                ?: emptyMap()
+            val httpHeaders = httpHeadersOf(map)
             if (httpHeaders.isNotEmpty()) {
                 headersByUri[uri] = httpHeaders
                 blobHashFromUrl(uri)?.let { headersByHash[it] = httpHeaders }
@@ -564,27 +622,52 @@ internal class DivineVideoPlayerInstance(
 
     /**
      * The point up to which *every* track of [uri] still has content, in
-     * milliseconds, or `null` when it cannot be determined without I/O that
-     * would delay playback.
+     * milliseconds, or `null` when the source's track lengths are not known.
      *
-     * Only local files are probed. Reading a remote source's metadata means a
-     * network round trip on the platform thread before playback can start, so
-     * remote clips keep the container duration — and the seam — instead.
+     * Reads only [trackDurationsCache] — never I/O, so it is safe on the
+     * platform thread. [resolveTrackDurations] fills the cache first.
      */
     private fun boundedCommonTrackEndMs(
         uri: String,
         startMs: Long,
         requestedEndMs: Long?,
     ): Long? {
-        val path = when {
-            uri.startsWith("/") -> uri
-            uri.startsWith("file://") -> Uri.parse(uri).path
-            else -> null
-        } ?: return null
+        val durations = trackDurationsCache[uri] ?: return null
+        if (durations.size < 2 || durations[0] <= 0 || durations[1] <= 0) {
+            return null
+        }
+        return boundedCommonTrackEndMs(
+            startMs = startMs,
+            requestedEndMs = requestedEndMs,
+            videoEndMs = durations[0] / 1000,
+            audioEndMs = durations[1] / 1000,
+        )
+    }
+
+    /**
+     * Reads [uri]'s video and audio track lengths into [trackDurationsCache].
+     *
+     * Blocks on I/O — a remote source costs a range request for the moov box —
+     * so it must never run on the platform thread. The Apple player pays the
+     * same cost, awaiting `load(.timeRange)` on both tracks before it builds
+     * the composition.
+     *
+     * A source whose lengths cannot be read is cached as [NO_TRACK_PAIR] so
+     * the read is not retried on every failover attempt.
+     */
+    private fun resolveTrackDurations(uri: String, headers: Map<String, String>) {
+        if (trackDurationsCache.containsKey(uri)) return
 
         val extractor = MediaExtractor()
-        return try {
-            extractor.setDataSource(path)
+        val durations = try {
+            when {
+                uri.startsWith("/") -> extractor.setDataSource(uri)
+                uri.startsWith("file://") ->
+                    extractor.setDataSource(Uri.parse(uri).path ?: return)
+                uri.startsWith("http://") || uri.startsWith("https://") ->
+                    extractor.setDataSource(uri, headers)
+                else -> return
+            }
             var videoUs = -1L
             var audioUs = -1L
             for (i in 0 until extractor.trackCount) {
@@ -599,25 +682,32 @@ internal class DivineVideoPlayerInstance(
             }
             // A clip without both track types has no mismatch to trim.
             if (videoUs <= 0 || audioUs <= 0) {
-                null
+                NO_TRACK_PAIR
             } else {
-                boundedCommonTrackEndMs(
-                    startMs = startMs,
-                    requestedEndMs = requestedEndMs,
-                    videoEndMs = videoUs / 1000,
-                    audioEndMs = audioUs / 1000,
-                )
+                longArrayOf(videoUs, audioUs)
             }
         } catch (e: Exception) {
             DivineVideoPlayerLog.warning(
                 "Player $playerId could not read track durations: $e",
                 name = "DivineVideoPlayer.Load",
             )
-            null
+            NO_TRACK_PAIR
         } finally {
             extractor.release()
         }
+        trackDurationsCache[uri] = durations
     }
+
+    /** The per-clip HTTP headers Dart sent, if any. */
+    private fun httpHeadersOf(map: Map<String, Any?>): Map<String, String> =
+        (map["httpHeaders"] as? Map<*, *>)
+            ?.mapNotNull { entry ->
+                val key = entry.key as? String
+                val value = entry.value as? String
+                if (key == null || value == null) null else key to value
+            }
+            ?.toMap()
+            ?: emptyMap()
 
     private fun boundedCommonTrackEndMs(
         startMs: Long,
@@ -1323,6 +1413,10 @@ internal class DivineVideoPlayerInstance(
         mainHandler.removeCallbacks(setClipsTimeoutRunnable)
         mainHandler.removeCallbacks(bufferingWatchdogRunnable)
         cancelDecoderRetry()
+        // A metadata read already in flight finishes into a bumped generation
+        // and is dropped; queued ones never start.
+        setClipsGeneration++
+        metadataExecutor.shutdownNow()
         seekCompletionResult?.success(null)
         seekCompletionResult = null
         pendingSetClipsResult?.success(null)
@@ -1352,6 +1446,27 @@ internal class DivineVideoPlayerInstance(
     companion object {
         private const val POSITION_UPDATE_INTERVAL_MS = 200L
         private const val SET_CLIPS_TIMEOUT_MS = 10_000L
+
+        /** Cached "this source's track lengths cannot be read". */
+        private val NO_TRACK_PAIR = longArrayOf(-1L, -1L)
+
+        /**
+         * Video and audio track lengths in microseconds, keyed by source.
+         *
+         * Shared across instances so a failover to a mirror of the same video,
+         * or a second visit to it in the feed, does not pay the read again.
+         * Bounded, because a long feed session visits a lot of sources.
+         */
+        private val trackDurationsCache: MutableMap<String, LongArray> =
+            Collections.synchronizedMap(
+                object : LinkedHashMap<String, LongArray>(16, 0.75f, true) {
+                    override fun removeEldestEntry(
+                        eldest: MutableMap.MutableEntry<String, LongArray>?,
+                    ): Boolean = size > TRACK_DURATION_CACHE_ENTRIES
+                },
+            )
+
+        private const val TRACK_DURATION_CACHE_ENTRIES = 256
 
         /**
          * How long the player may stay in `STATE_BUFFERING` before it is

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
@@ -559,6 +559,22 @@ internal class DivineVideoPlayerInstance(
         }
     }
 
+    /**
+     * Tightens the loaded playlist to the track ends a background read just
+     * resolved, while doing so is still free.
+     *
+     * A clamp lives in the item's `ClippingConfiguration`, and
+     * `ClippingMediaSource.canUpdateMediaItem` compares that configuration, so
+     * a changed one can never be applied in place: `replaceMediaItem` falls
+     * back to remove-and-insert, and removing the period being played resolves
+     * the position to the *default* position of the one that takes its place.
+     * On a player that has not started that is invisible — a preloaded tile
+     * sits paused at frame zero, and the feed preloads a window around the
+     * current index. On one that is already playing it is the video jumping
+     * back to its start mid-watch, which is a worse artifact than the seam it
+     * removes, so that load keeps the seam and the cached lengths clamp the
+     * next `setClips` for the source instead.
+     */
     private fun applyResolvedCommonTrackEnds(
         generation: Long,
         clipsRaw: List<Map<String, Any?>>,
@@ -566,6 +582,7 @@ internal class DivineVideoPlayerInstance(
         if (generation != setClipsGeneration) return
         val exoPlayer = player ?: return
         if (exoPlayer.mediaItemCount != clipsRaw.size) return
+        if (exoPlayer.playWhenReady || exoPlayer.currentPosition > 0L) return
 
         var changed = false
         clipsRaw.forEachIndexed loop@{ index, map ->

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/LoopDeclickAudioProcessor.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/LoopDeclickAudioProcessor.kt
@@ -16,12 +16,13 @@ import java.nio.ByteBuffer
  * the step is a click. Fading both edges to zero makes the join
  * silence-to-silence.
  *
- * ExoPlayer gives an [AudioProcessor] no position of its own: the playback
- * pipeline is flushed on seek and reconfiguration but never at a seamless loop
- * restart, and `StreamMetadata.positionOffsetUs` is always 0 on this path in
- * media3 1.10. The frame counter is therefore anchored from outside by
- * [LoopDeclickAudioSink], which runs on the same playback thread and sees the
- * stream change a loop restart produces.
+ * ExoPlayer gives an [AudioProcessor] no position of its own. The pipeline is
+ * flushed often enough — on seek, on reconfiguration, and once more at the
+ * loop join itself — but never with a position: `StreamMetadata`'s
+ * `positionOffsetUs` is 0 on every one of those paths in media3 1.10. Position
+ * is therefore reconstructed from a frame count that [LoopDeclickAudioSink]
+ * anchors from outside, on the same playback thread, at the stream change a
+ * loop restart produces.
  *
  * Configuration is written from the main thread and read on the playback
  * thread, hence the volatile fields.
@@ -47,7 +48,15 @@ internal class LoopDeclickAudioProcessor : BaseAudioProcessor() {
     /**
      * Media position the next stream starts at, in microseconds. Set before an
      * explicit seek so the fade stays anchored to the video rather than to the
-     * seek target; consumed by the flush that seek triggers.
+     * seek target.
+     *
+     * It has to survive a flush rather than be consumed by one: media3 flushes
+     * the pipeline twice per seek before a single frame is queued — once from
+     * `DefaultAudioSink.flush()`, which then releases the audio output, and
+     * again when the next buffer re-initialises it. A one-shot value would be
+     * eaten by the first and the second would re-anchor at zero. It is cleared
+     * at the loop join instead, in [onStreamChanged], which is where the seek
+     * offset genuinely stops applying.
      */
     @Volatile
     var nextStreamStartUs: Long = 0
@@ -59,9 +68,22 @@ internal class LoopDeclickAudioProcessor : BaseAudioProcessor() {
     private var anchorFrames: Long = 0
 
     /**
+     * Frames the last completed loop actually delivered, or 0 before one has
+     * been measured, together with the [videoDurationUs] it was measured
+     * against so it is dropped when the video changes.
+     *
+     * The declared duration is the container's, which is the longest track and
+     * is cut on whole access units; the counter here is decoded audio frames.
+     * The two disagree by up to an AAC frame — twice the fade — so the fade out
+     * would land early or late until a real loop has been measured.
+     */
+    private var measuredLoopFrames: Long = 0
+    private var measuredLoopForDurationUs: Long = DURATION_UNKNOWN
+
+    /**
      * Whether any input arrived since the last anchor. Guards against the
-     * decode-only buffers a seek discards, which report a discontinuity
-     * without ever reaching [queueInput].
+     * decode-only buffers a seek discards, which `MediaCodecAudioRenderer`
+     * reports as a discontinuity each without ever reaching [queueInput].
      */
     private var sawInputSinceAnchor: Boolean = false
 
@@ -84,14 +106,27 @@ internal class LoopDeclickAudioProcessor : BaseAudioProcessor() {
         if (!sawInputSinceAnchor) {
             return
         }
+        // The loop that just ended ran from the anchor to here, so this is the
+        // one exact measurement of its length there is. Reject one that came
+        // out far short of what the container claims: a flush the video did not
+        // ask for — a route change, an underrun — restarts the count mid-loop,
+        // and half a loop is not a measurement of a whole one.
+        val loopFrames = readFrames - anchorFrames
+        val estimate = durationFrames(inputAudioFormat.sampleRate)
+        if (loopFrames > 0 && loopFrames * 2 >= estimate) {
+            measuredLoopFrames = loopFrames
+            measuredLoopForDurationUs = videoDurationUs
+        }
         anchorFrames = readFrames
+        nextStreamStartUs = 0
         sawInputSinceAnchor = false
     }
 
     override fun onFlush(streamMetadata: AudioProcessor.StreamMetadata) {
         // streamMetadata.positionOffsetUs is always 0 on the playback path in
         // media3 1.10 — DefaultAudioSink flushes the pipeline without one — so
-        // the start position comes from [nextStreamStartUs] instead.
+        // the start position comes from [nextStreamStartUs] instead. It stays
+        // set: a seek flushes twice before the first frame arrives.
         readFrames = 0
         val sampleRate = inputAudioFormat.sampleRate
         anchorFrames = if (sampleRate > 0) {
@@ -99,7 +134,6 @@ internal class LoopDeclickAudioProcessor : BaseAudioProcessor() {
         } else {
             0
         }
-        nextStreamStartUs = 0
         sawInputSinceAnchor = false
     }
 
@@ -107,6 +141,8 @@ internal class LoopDeclickAudioProcessor : BaseAudioProcessor() {
         readFrames = 0
         anchorFrames = 0
         nextStreamStartUs = 0
+        measuredLoopFrames = 0
+        measuredLoopForDurationUs = DURATION_UNKNOWN
         sawInputSinceAnchor = false
     }
 
@@ -148,8 +184,8 @@ internal class LoopDeclickAudioProcessor : BaseAudioProcessor() {
     /**
      * Gain to apply [frame] frames into the video, in `[0f, 1f]`.
      *
-     * Visible for testing: this is the whole of the fade's behaviour, and the
-     * buffer plumbing around it is not worth driving to reach it.
+     * Visible for testing: the shape of the fade is worth pinning on its own,
+     * separately from where the anchor bookkeeping decides to put it.
      */
     internal fun gainAt(frame: Long, fadeFrames: Long, durationFrames: Long): Float {
         if (fadeFrames <= 0 || frame < 0) {
@@ -190,8 +226,15 @@ internal class LoopDeclickAudioProcessor : BaseAudioProcessor() {
         return minOf(fade, durationFrames / 2)
     }
 
+    /**
+     * Frames one loop of the video lasts: the measurement of the last one if
+     * there is one, otherwise the container's duration as an estimate.
+     */
     private fun durationFrames(sampleRate: Int): Long {
         val durationUs = videoDurationUs
+        if (measuredLoopFrames > 0 && measuredLoopForDurationUs == durationUs) {
+            return measuredLoopFrames
+        }
         if (durationUs <= 0) {
             return 0
         }

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/LoopDeclickAudioProcessor.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/LoopDeclickAudioProcessor.kt
@@ -289,9 +289,16 @@ internal class LoopDeclickAudioProcessor : BaseAudioProcessor() {
         const val DURATION_UNKNOWN = -1L
 
         /**
-         * Length of each fade. Long enough to remove the step even on
-         * low-frequency content, short enough not to read as a level change.
-         * Matches the Apple player's `edgeDeclickFadeSeconds`.
+         * Length of each fade, and therefore also how far this processor puts
+         * audio behind the reported position. Long enough to remove the step
+         * even on low-frequency content, short enough not to read as a level
+         * change or to be noticed as audio trailing video.
+         *
+         * Deliberately shorter than the Apple player's
+         * `edgeDeclickFadeSeconds`. A fade here is applied to decoded frames
+         * and lands exactly where it is asked to; AVFoundation's volume ramps
+         * are stretched to a floor of about 25 ms, so that side has to spend
+         * 30 ms to reach silence at all.
          */
         const val FADE_US = 10_000L
     }

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/LoopDeclickAudioProcessor.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/LoopDeclickAudioProcessor.kt
@@ -126,6 +126,10 @@ internal class LoopDeclickAudioProcessor : BaseAudioProcessor() {
         if (!sawInputSinceAnchor) {
             return
         }
+        // Retiring the offset is the load-bearing part. Re-anchoring here is a
+        // fallback: media3 1.10 always flushes between this call and the next
+        // [queueInput], and [onFlush] recomputes both fields — but a version
+        // that stopped doing so would otherwise fade in mid-video.
         anchorFrames = readFrames
         nextStreamStartUs = 0
         sawInputSinceAnchor = false

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/LoopDeclickAudioProcessor.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/LoopDeclickAudioProcessor.kt
@@ -7,8 +7,8 @@ import androidx.media3.common.util.UnstableApi
 import java.nio.ByteBuffer
 
 /**
- * Fades the first and last few milliseconds of a looping video's audio so the
- * loop restart is not audible as a click (#6468).
+ * Fades the first and last few milliseconds of a single-clip video's audio so
+ * a loop restart is not audible as a click (#6468).
  *
  * `REPEAT_MODE_ALL` cuts from the video's last sample straight back to its
  * first. That cut has never been tied to a zero crossing — it comes from a
@@ -60,10 +60,12 @@ internal class LoopDeclickAudioProcessor : BaseAudioProcessor() {
     var videoDurationUs: Long = DURATION_UNKNOWN
 
     /**
-     * Whether to fade at all. Off for multi-clip timelines, where a stream is
-     * one clip of the video rather than the whole of it, so fading every
-     * stream would notch the audio at each cut. Off also holds nothing back,
-     * so those players keep their audio latency.
+     * Whether to fade at all. Configured from clip count rather than repeat
+     * mode because looping is a separate channel call that can arrive after
+     * `setClips`. Off for multi-clip timelines, where a stream is one clip of
+     * the video rather than the whole of it, so fading every stream would notch
+     * the audio at each cut. Off also holds nothing back, so those players keep
+     * their audio latency.
      */
     @Volatile
     var enabled: Boolean = false

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/LoopDeclickAudioProcessor.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/LoopDeclickAudioProcessor.kt
@@ -1,0 +1,215 @@
+package com.divinevideo.divine_video_player
+
+import androidx.media3.common.C
+import androidx.media3.common.audio.AudioProcessor
+import androidx.media3.common.audio.BaseAudioProcessor
+import androidx.media3.common.util.UnstableApi
+import java.nio.ByteBuffer
+
+/**
+ * Fades the first and last few milliseconds of a looping video's audio so the
+ * loop restart is not audible as a click (#6468).
+ *
+ * `REPEAT_MODE_ALL` cuts from the video's last sample straight back to its
+ * first. That cut has never been tied to a zero crossing — it comes from a
+ * trim or a recording length — so unless both edges happen to sit near silence
+ * the step is a click. Fading both edges to zero makes the join
+ * silence-to-silence.
+ *
+ * ExoPlayer gives an [AudioProcessor] no position of its own: the playback
+ * pipeline is flushed on seek and reconfiguration but never at a seamless loop
+ * restart, and `StreamMetadata.positionOffsetUs` is always 0 on this path in
+ * media3 1.10. The frame counter is therefore anchored from outside by
+ * [LoopDeclickAudioSink], which runs on the same playback thread and sees the
+ * stream change a loop restart produces.
+ *
+ * Configuration is written from the main thread and read on the playback
+ * thread, hence the volatile fields.
+ */
+@UnstableApi
+internal class LoopDeclickAudioProcessor : BaseAudioProcessor() {
+
+    /**
+     * Length of the video in microseconds, or [DURATION_UNKNOWN] while it is
+     * not known. Only a video whose end is known can be faded out.
+     */
+    @Volatile
+    var videoDurationUs: Long = DURATION_UNKNOWN
+
+    /**
+     * Whether to fade at all. Off for multi-clip timelines, where a stream is
+     * one clip of the video rather than the whole of it, so fading every
+     * stream would notch the audio at each cut.
+     */
+    @Volatile
+    var enabled: Boolean = false
+
+    /**
+     * Media position the next stream starts at, in microseconds. Set before an
+     * explicit seek so the fade stays anchored to the video rather than to the
+     * seek target; consumed by the flush that seek triggers.
+     */
+    @Volatile
+    var nextStreamStartUs: Long = 0
+
+    /** Frames read since the last flush. */
+    private var readFrames: Long = 0
+
+    /** Value of [readFrames] at the start of the current video. */
+    private var anchorFrames: Long = 0
+
+    /**
+     * Whether any input arrived since the last anchor. Guards against the
+     * decode-only buffers a seek discards, which report a discontinuity
+     * without ever reaching [queueInput].
+     */
+    private var sawInputSinceAnchor: Boolean = false
+
+    override fun onConfigure(
+        inputAudioFormat: AudioProcessor.AudioFormat,
+    ): AudioProcessor.AudioFormat {
+        // Everything upstream is converted to 16-bit PCM before reaching here.
+        // If some path ever delivers anything else, drop out of the chain
+        // rather than failing playback for the sake of a fade.
+        if (inputAudioFormat.encoding != C.ENCODING_PCM_16BIT) {
+            return AudioProcessor.AudioFormat.NOT_SET
+        }
+        return inputAudioFormat
+    }
+
+    /** Anchors the next stream at the start of the video (a loop restart). */
+    fun onStreamChanged() {
+        // A seek discards the buffers before its target and reports each one
+        // as a discontinuity. Those are not loop restarts.
+        if (!sawInputSinceAnchor) {
+            return
+        }
+        anchorFrames = readFrames
+        sawInputSinceAnchor = false
+    }
+
+    override fun onFlush(streamMetadata: AudioProcessor.StreamMetadata) {
+        // streamMetadata.positionOffsetUs is always 0 on the playback path in
+        // media3 1.10 — DefaultAudioSink flushes the pipeline without one — so
+        // the start position comes from [nextStreamStartUs] instead.
+        readFrames = 0
+        val sampleRate = inputAudioFormat.sampleRate
+        anchorFrames = if (sampleRate > 0) {
+            -durationUsToFrames(nextStreamStartUs, sampleRate)
+        } else {
+            0
+        }
+        nextStreamStartUs = 0
+        sawInputSinceAnchor = false
+    }
+
+    override fun onReset() {
+        readFrames = 0
+        anchorFrames = 0
+        nextStreamStartUs = 0
+        sawInputSinceAnchor = false
+    }
+
+    override fun queueInput(inputBuffer: ByteBuffer) {
+        val position = inputBuffer.position()
+        val limit = inputBuffer.limit()
+        val byteCount = limit - position
+        if (byteCount <= 0) {
+            return
+        }
+        sawInputSinceAnchor = true
+
+        val sampleRate = inputAudioFormat.sampleRate
+        val fadeFrames = fadeFrames(sampleRate)
+        val output = replaceOutputBuffer(byteCount)
+        if (fadeFrames <= 0) {
+            output.put(inputBuffer)
+            readFrames += byteCount / inputAudioFormat.bytesPerFrame
+            output.flip()
+            return
+        }
+
+        val channelCount = inputAudioFormat.channelCount
+        val frameCount = byteCount / inputAudioFormat.bytesPerFrame
+        val durationFrames = durationFrames(sampleRate)
+        for (frame in 0 until frameCount) {
+            val gain = gainAt(readFrames + frame - anchorFrames, fadeFrames, durationFrames)
+            for (channel in 0 until channelCount) {
+                val sample = inputBuffer.getShort(position + (frame * channelCount + channel) * 2)
+                output.putShort(if (gain >= 1f) sample else (sample * gain).toInt().toShort())
+            }
+        }
+
+        readFrames += frameCount
+        inputBuffer.position(limit)
+        output.flip()
+    }
+
+    /**
+     * Gain to apply [frame] frames into the video, in `[0f, 1f]`.
+     *
+     * Visible for testing: this is the whole of the fade's behaviour, and the
+     * buffer plumbing around it is not worth driving to reach it.
+     */
+    internal fun gainAt(frame: Long, fadeFrames: Long, durationFrames: Long): Float {
+        if (fadeFrames <= 0 || frame < 0) {
+            return 1f
+        }
+        // Wrap rather than run off the end. A stream change that never arrives
+        // would otherwise leave the position past the end of the video for
+        // good, and clamping there would silence the rest of playback. Wrapping
+        // degrades to a fade that drifts instead of one that mutes.
+        val position = if (durationFrames > 0) frame % durationFrames else frame
+        if (position < fadeFrames) {
+            return position.toFloat() / fadeFrames
+        }
+        if (durationFrames <= 0) {
+            // The end is unknown, so only the start can be faded.
+            return 1f
+        }
+        val framesLeft = durationFrames - position
+        if (framesLeft < fadeFrames) {
+            return framesLeft.toFloat() / fadeFrames
+        }
+        return 1f
+    }
+
+    /**
+     * Fade length in frames, capped at half the video so the two fades of a
+     * very short video cannot overlap.
+     */
+    internal fun fadeFrames(sampleRate: Int): Long {
+        if (!enabled || sampleRate <= 0) {
+            return 0
+        }
+        val fade = durationUsToFrames(FADE_US, sampleRate)
+        val durationFrames = durationFrames(sampleRate)
+        if (durationFrames <= 0) {
+            return fade
+        }
+        return minOf(fade, durationFrames / 2)
+    }
+
+    private fun durationFrames(sampleRate: Int): Long {
+        val durationUs = videoDurationUs
+        if (durationUs <= 0) {
+            return 0
+        }
+        return durationUsToFrames(durationUs, sampleRate)
+    }
+
+    private fun durationUsToFrames(durationUs: Long, sampleRate: Int): Long =
+        durationUs * sampleRate / 1_000_000L
+
+    companion object {
+        /** Sentinel for "the video's length is not known yet". */
+        const val DURATION_UNKNOWN = -1L
+
+        /**
+         * Length of each fade. Long enough to remove the step even on
+         * low-frequency content, short enough not to read as a level change.
+         * Matches the Apple player's `edgeDeclickFadeSeconds`.
+         */
+        const val FADE_US = 10_000L
+    }
+}

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/LoopDeclickAudioProcessor.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/LoopDeclickAudioProcessor.kt
@@ -16,13 +16,29 @@ import java.nio.ByteBuffer
  * the step is a click. Fading both edges to zero makes the join
  * silence-to-silence.
  *
- * ExoPlayer gives an [AudioProcessor] no position of its own. The pipeline is
- * flushed often enough — on seek, on reconfiguration, and once more at the
- * loop join itself — but never with a position: `StreamMetadata`'s
- * `positionOffsetUs` is 0 on every one of those paths in media3 1.10. Position
- * is therefore reconstructed from a frame count that [LoopDeclickAudioSink]
- * anchors from outside, on the same playback thread, at the stream change a
- * loop restart produces.
+ * The two edges are found in opposite ways.
+ *
+ * The start is a counting problem. ExoPlayer gives an [AudioProcessor] no
+ * position of its own — `StreamMetadata`'s `positionOffsetUs` is 0 on every
+ * playback-path flush in media3 1.10 — so the first frames of a stream are
+ * counted from the flush, with [LoopDeclickAudioSink] retiring the seek offset
+ * at the join so a seek does not fade in mid-video.
+ *
+ * The end cannot be counted towards, because nothing on this side of the
+ * pipeline knows where it is until it arrives: `player.duration` is the
+ * container's, in whole milliseconds, and the decoded audio track ends up to
+ * an AAC frame away from it — wider than the fade itself. So the last
+ * [FADE_US] of audio is held back instead, and released faded once media3
+ * signals the end of the stream. That signal is exact and arrives at every
+ * loop restart: `handleDiscontinuity` sets `startMediaTimeUsNeedsSync`, and
+ * the next buffer makes `DefaultAudioSink` run `drainToEndOfStream()`, which
+ * queues end-of-stream into the pipeline before any frame of the new lap is.
+ * `TrimmingAudioProcessor` holds its own tail back the same way, one slot
+ * upstream in this same chain.
+ *
+ * The cost is that audio runs [FADE_US] behind the position the player
+ * reports. Ten milliseconds is an order of magnitude inside the threshold
+ * where a viewer notices audio trailing video.
  *
  * Configuration is written from the main thread and read on the playback
  * thread, hence the volatile fields.
@@ -32,35 +48,30 @@ internal class LoopDeclickAudioProcessor : BaseAudioProcessor() {
 
     /**
      * Length of the video in microseconds, or [DURATION_UNKNOWN] while it is
-     * not known. Only a video whose end is known can be faded out.
+     * not known.
      *
-     * Writing a different length means a different video, so it also drops
-     * [measuredLoopFrames]. A player is reused across videos — a
-     * `setMediaItems` swap disables the audio renderer, which flushes the sink
-     * but never resets it, so [onReset] does not run between two videos and
-     * nothing else would clear the previous one's measurement.
+     * It only bounds how long the fade may be, never where it sits — a video
+     * shorter than two fades gets shorter ones. Being wrong here costs a
+     * couple of milliseconds of ramp on a video no longer than that, which is
+     * why the container's millisecond figure is good enough for it and was
+     * never good enough to place the fade out.
      */
     @Volatile
     var videoDurationUs: Long = DURATION_UNKNOWN
-        set(value) {
-            if (field != value) {
-                measuredLoopFrames = 0
-            }
-            field = value
-        }
 
     /**
      * Whether to fade at all. Off for multi-clip timelines, where a stream is
      * one clip of the video rather than the whole of it, so fading every
-     * stream would notch the audio at each cut.
+     * stream would notch the audio at each cut. Off also holds nothing back,
+     * so those players keep their audio latency.
      */
     @Volatile
     var enabled: Boolean = false
 
     /**
      * Media position the next stream starts at, in microseconds. Set before an
-     * explicit seek so the fade stays anchored to the video rather than to the
-     * seek target.
+     * explicit seek so the fade in stays anchored to the video rather than to
+     * the seek target.
      *
      * It has to survive a flush rather than be consumed by one: media3 flushes
      * the pipeline twice per seek before a single frame is queued — once from
@@ -80,24 +91,6 @@ internal class LoopDeclickAudioProcessor : BaseAudioProcessor() {
     private var anchorFrames: Long = 0
 
     /**
-     * Frames the last completed loop actually delivered, or 0 before one has
-     * been measured, together with the sample rate it was counted at.
-     *
-     * The declared duration is the container's, which is the longest track and
-     * is cut on whole access units; the counter here is decoded audio frames.
-     * The two disagree by up to an AAC frame — twice the fade — so the fade out
-     * would land early or late until a real loop has been measured.
-     *
-     * Volatile because [videoDurationUs]'s setter drops it from the main
-     * thread while the playback thread reads it. A lost write costs the
-     * accuracy of one lap, which is what the measurement buys in the first
-     * place.
-     */
-    @Volatile
-    private var measuredLoopFrames: Long = 0
-    private var measuredLoopSampleRate: Int = 0
-
-    /**
      * Whether any input arrived since the last anchor. Guards against the
      * decode-only buffers a seek discards, which `MediaCodecAudioRenderer`
      * reports as a discontinuity each without ever reaching [queueInput].
@@ -105,10 +98,13 @@ internal class LoopDeclickAudioProcessor : BaseAudioProcessor() {
     private var sawInputSinceAnchor: Boolean = false
 
     /**
-     * Whether a flush landed mid-lap, which makes the frames counted since
-     * then a fragment rather than a loop. See [onFlush].
+     * The most recent frames, interleaved, held back so they are still here to
+     * be faded when the stream turns out to have ended. Empty while the fade
+     * is off, which is what keeps those players at zero added latency.
      */
-    private var lapInterrupted: Boolean = false
+    private var tail: ShortArray = ShortArray(0)
+    private var tailCapacityFrames: Int = 0
+    private var tailFrames: Int = 0
 
     override fun onConfigure(
         inputAudioFormat: AudioProcessor.AudioFormat,
@@ -122,36 +118,20 @@ internal class LoopDeclickAudioProcessor : BaseAudioProcessor() {
         return inputAudioFormat
     }
 
-    /** Anchors the next stream at the start of the video (a loop restart). */
+    /** Re-arms the fade in at the start of the next stream (a loop restart). */
     fun onStreamChanged() {
         // A seek discards the buffers before its target and reports each one
-        // as a discontinuity. Those are not loop restarts.
+        // as a discontinuity. Those are not loop restarts, and retiring the
+        // seek offset on one would fade in at the seek target.
         if (!sawInputSinceAnchor) {
             return
-        }
-        // The loop that just ended ran from the anchor to here, so this is the
-        // one exact measurement of its length there is — unless a flush cut
-        // the count in the middle of it, in which case what reaches here is a
-        // fragment and the previous estimate is the better of the two.
-        val loopFrames = readFrames - anchorFrames
-        if (!lapInterrupted && loopFrames > 0) {
-            measuredLoopFrames = loopFrames
-            measuredLoopSampleRate = inputAudioFormat.sampleRate
         }
         anchorFrames = readFrames
         nextStreamStartUs = 0
         sawInputSinceAnchor = false
-        lapInterrupted = false
     }
 
     override fun onFlush(streamMetadata: AudioProcessor.StreamMetadata) {
-        // A flush that arrives after frames have already been counted is not
-        // the resync media3 runs at a stream change — that one lands before
-        // the first buffer of the new stream. It is a route change or an
-        // underrun, and the count it restarts no longer spans a whole lap.
-        if (sawInputSinceAnchor) {
-            lapInterrupted = true
-        }
         // streamMetadata.positionOffsetUs is always 0 on the playback path in
         // media3 1.10 — DefaultAudioSink flushes the pipeline without one — so
         // the start position comes from [nextStreamStartUs] instead. It stays
@@ -164,16 +144,29 @@ internal class LoopDeclickAudioProcessor : BaseAudioProcessor() {
             0
         }
         sawInputSinceAnchor = false
+
+        // Whatever is held back belongs to a stream that is not going to end
+        // where it was about to.
+        tailFrames = 0
+        tailCapacityFrames = if (enabled && sampleRate > 0) {
+            durationUsToFrames(FADE_US, sampleRate).toInt()
+        } else {
+            0
+        }
+        val samples = tailCapacityFrames * inputAudioFormat.channelCount
+        if (tail.size != samples) {
+            tail = ShortArray(samples)
+        }
     }
 
     override fun onReset() {
         readFrames = 0
         anchorFrames = 0
         nextStreamStartUs = 0
-        measuredLoopFrames = 0
-        measuredLoopSampleRate = 0
         sawInputSinceAnchor = false
-        lapInterrupted = false
+        tail = ShortArray(0)
+        tailCapacityFrames = 0
+        tailFrames = 0
     }
 
     override fun queueInput(inputBuffer: ByteBuffer) {
@@ -185,26 +178,46 @@ internal class LoopDeclickAudioProcessor : BaseAudioProcessor() {
         }
         sawInputSinceAnchor = true
 
-        val sampleRate = inputAudioFormat.sampleRate
-        val fadeFrames = fadeFrames(sampleRate)
-        val output = replaceOutputBuffer(byteCount)
-        if (fadeFrames <= 0) {
+        val bytesPerFrame = inputAudioFormat.bytesPerFrame
+        val frameCount = byteCount / bytesPerFrame
+        if (tailCapacityFrames <= 0) {
+            val output = replaceOutputBuffer(byteCount)
             output.put(inputBuffer)
-            readFrames += byteCount / inputAudioFormat.bytesPerFrame
+            readFrames += frameCount
             output.flip()
             return
         }
 
         val channelCount = inputAudioFormat.channelCount
-        val frameCount = byteCount / inputAudioFormat.bytesPerFrame
-        val durationFrames = durationFrames(sampleRate)
+        val fadeFrames = fadeFrames(inputAudioFormat.sampleRate)
+        // Keep the tail as full as it holds; everything older than that leaves
+        // now, oldest first.
+        val emitFrames = (tailFrames + frameCount - tailCapacityFrames).coerceAtLeast(0)
+        val output = replaceOutputBuffer(emitFrames * bytesPerFrame)
+
+        val fromTail = minOf(emitFrames, tailFrames)
+        for (sample in 0 until fromTail * channelCount) {
+            output.putShort(tail[sample])
+        }
+        tail.copyInto(tail, 0, fromTail * channelCount, tailFrames * channelCount)
+        tailFrames -= fromTail
+
+        // The fade in is applied as frames arrive, so a frame still in the
+        // tail when the stream ends carries both ramps.
+        val fromInput = emitFrames - fromTail
         for (frame in 0 until frameCount) {
-            val gain = gainAt(readFrames + frame - anchorFrames, fadeFrames, durationFrames)
+            val gain = fadeInGainAt(readFrames + frame - anchorFrames, fadeFrames)
             for (channel in 0 until channelCount) {
-                val sample = inputBuffer.getShort(position + (frame * channelCount + channel) * 2)
-                output.putShort(if (gain >= 1f) sample else (sample * gain).toInt().toShort())
+                val raw = inputBuffer.getShort(position + (frame * channelCount + channel) * 2)
+                val faded = if (gain >= 1f) raw else (raw * gain).toInt().toShort()
+                if (frame < fromInput) {
+                    output.putShort(faded)
+                } else {
+                    tail[(tailFrames + frame - fromInput) * channelCount + channel] = faded
+                }
             }
         }
+        tailFrames += frameCount - fromInput
 
         readFrames += frameCount
         inputBuffer.position(limit)
@@ -212,32 +225,44 @@ internal class LoopDeclickAudioProcessor : BaseAudioProcessor() {
     }
 
     /**
+     * Releases the held-back tail, faded out, once media3 reports the stream
+     * has ended — which at a loop restart is the join itself.
+     */
+    override fun getOutput(): ByteBuffer {
+        if (super.isEnded() && tailFrames > 0) {
+            val channelCount = inputAudioFormat.channelCount
+            val ramp = minOf(tailFrames.toLong(), fadeFrames(inputAudioFormat.sampleRate)).toInt()
+            val output = replaceOutputBuffer(tailFrames * inputAudioFormat.bytesPerFrame)
+            for (frame in 0 until tailFrames) {
+                // Distance from the last frame, so the last one reaches zero.
+                val remaining = tailFrames - 1 - frame
+                val gain = if (ramp <= 0 || remaining >= ramp) 1f else remaining.toFloat() / ramp
+                for (channel in 0 until channelCount) {
+                    val held = tail[frame * channelCount + channel]
+                    output.putShort(if (gain >= 1f) held else (held * gain).toInt().toShort())
+                }
+            }
+            output.flip()
+            tailFrames = 0
+        }
+        return super.getOutput()
+    }
+
+    override fun isEnded(): Boolean = super.isEnded() && tailFrames == 0
+
+    /**
      * Gain to apply [frame] frames into the video, in `[0f, 1f]`.
+     *
+     * Only the way in — the way out is the tail, which needs no position.
      *
      * Visible for testing: the shape of the fade is worth pinning on its own,
      * separately from where the anchor bookkeeping decides to put it.
      */
-    internal fun gainAt(frame: Long, fadeFrames: Long, durationFrames: Long): Float {
-        if (fadeFrames <= 0 || frame < 0) {
+    internal fun fadeInGainAt(frame: Long, fadeFrames: Long): Float {
+        if (fadeFrames <= 0 || frame < 0 || frame >= fadeFrames) {
             return 1f
         }
-        // Wrap rather than run off the end. A stream change that never arrives
-        // would otherwise leave the position past the end of the video for
-        // good, and clamping there would silence the rest of playback. Wrapping
-        // degrades to a fade that drifts instead of one that mutes.
-        val position = if (durationFrames > 0) frame % durationFrames else frame
-        if (position < fadeFrames) {
-            return position.toFloat() / fadeFrames
-        }
-        if (durationFrames <= 0) {
-            // The end is unknown, so only the start can be faded.
-            return 1f
-        }
-        val framesLeft = durationFrames - position
-        if (framesLeft < fadeFrames) {
-            return framesLeft.toFloat() / fadeFrames
-        }
-        return 1f
+        return frame.toFloat() / fadeFrames
     }
 
     /**
@@ -249,30 +274,11 @@ internal class LoopDeclickAudioProcessor : BaseAudioProcessor() {
             return 0
         }
         val fade = durationUsToFrames(FADE_US, sampleRate)
-        val durationFrames = durationFrames(sampleRate)
-        if (durationFrames <= 0) {
-            return fade
-        }
-        return minOf(fade, durationFrames / 2)
-    }
-
-    /**
-     * Frames one loop of the video lasts: the measurement of the last one if
-     * there is one, otherwise the container's duration as an estimate.
-     */
-    private fun durationFrames(sampleRate: Int): Long {
-        // A frame count only means the same length at the rate it was counted
-        // at, and an adaptive stream can switch from 44.1 kHz to 48 kHz
-        // without the declared duration moving.
-        val measured = measuredLoopFrames
-        if (measured > 0 && measuredLoopSampleRate == sampleRate) {
-            return measured
-        }
         val durationUs = videoDurationUs
         if (durationUs <= 0) {
-            return 0
+            return fade
         }
-        return durationUsToFrames(durationUs, sampleRate)
+        return minOf(fade, durationUsToFrames(durationUs, sampleRate) / 2)
     }
 
     private fun durationUsToFrames(durationUs: Long, sampleRate: Int): Long =

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/LoopDeclickAudioProcessor.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/LoopDeclickAudioProcessor.kt
@@ -33,9 +33,21 @@ internal class LoopDeclickAudioProcessor : BaseAudioProcessor() {
     /**
      * Length of the video in microseconds, or [DURATION_UNKNOWN] while it is
      * not known. Only a video whose end is known can be faded out.
+     *
+     * Writing a different length means a different video, so it also drops
+     * [measuredLoopFrames]. A player is reused across videos — a
+     * `setMediaItems` swap disables the audio renderer, which flushes the sink
+     * but never resets it, so [onReset] does not run between two videos and
+     * nothing else would clear the previous one's measurement.
      */
     @Volatile
     var videoDurationUs: Long = DURATION_UNKNOWN
+        set(value) {
+            if (field != value) {
+                measuredLoopFrames = 0
+            }
+            field = value
+        }
 
     /**
      * Whether to fade at all. Off for multi-clip timelines, where a stream is
@@ -69,16 +81,21 @@ internal class LoopDeclickAudioProcessor : BaseAudioProcessor() {
 
     /**
      * Frames the last completed loop actually delivered, or 0 before one has
-     * been measured, together with the [videoDurationUs] it was measured
-     * against so it is dropped when the video changes.
+     * been measured, together with the sample rate it was counted at.
      *
      * The declared duration is the container's, which is the longest track and
      * is cut on whole access units; the counter here is decoded audio frames.
      * The two disagree by up to an AAC frame — twice the fade — so the fade out
      * would land early or late until a real loop has been measured.
+     *
+     * Volatile because [videoDurationUs]'s setter drops it from the main
+     * thread while the playback thread reads it. A lost write costs the
+     * accuracy of one lap, which is what the measurement buys in the first
+     * place.
      */
+    @Volatile
     private var measuredLoopFrames: Long = 0
-    private var measuredLoopForDurationUs: Long = DURATION_UNKNOWN
+    private var measuredLoopSampleRate: Int = 0
 
     /**
      * Whether any input arrived since the last anchor. Guards against the
@@ -86,6 +103,12 @@ internal class LoopDeclickAudioProcessor : BaseAudioProcessor() {
      * reports as a discontinuity each without ever reaching [queueInput].
      */
     private var sawInputSinceAnchor: Boolean = false
+
+    /**
+     * Whether a flush landed mid-lap, which makes the frames counted since
+     * then a fragment rather than a loop. See [onFlush].
+     */
+    private var lapInterrupted: Boolean = false
 
     override fun onConfigure(
         inputAudioFormat: AudioProcessor.AudioFormat,
@@ -107,22 +130,28 @@ internal class LoopDeclickAudioProcessor : BaseAudioProcessor() {
             return
         }
         // The loop that just ended ran from the anchor to here, so this is the
-        // one exact measurement of its length there is. Reject one that came
-        // out far short of what the container claims: a flush the video did not
-        // ask for — a route change, an underrun — restarts the count mid-loop,
-        // and half a loop is not a measurement of a whole one.
+        // one exact measurement of its length there is — unless a flush cut
+        // the count in the middle of it, in which case what reaches here is a
+        // fragment and the previous estimate is the better of the two.
         val loopFrames = readFrames - anchorFrames
-        val estimate = durationFrames(inputAudioFormat.sampleRate)
-        if (loopFrames > 0 && loopFrames * 2 >= estimate) {
+        if (!lapInterrupted && loopFrames > 0) {
             measuredLoopFrames = loopFrames
-            measuredLoopForDurationUs = videoDurationUs
+            measuredLoopSampleRate = inputAudioFormat.sampleRate
         }
         anchorFrames = readFrames
         nextStreamStartUs = 0
         sawInputSinceAnchor = false
+        lapInterrupted = false
     }
 
     override fun onFlush(streamMetadata: AudioProcessor.StreamMetadata) {
+        // A flush that arrives after frames have already been counted is not
+        // the resync media3 runs at a stream change — that one lands before
+        // the first buffer of the new stream. It is a route change or an
+        // underrun, and the count it restarts no longer spans a whole lap.
+        if (sawInputSinceAnchor) {
+            lapInterrupted = true
+        }
         // streamMetadata.positionOffsetUs is always 0 on the playback path in
         // media3 1.10 — DefaultAudioSink flushes the pipeline without one — so
         // the start position comes from [nextStreamStartUs] instead. It stays
@@ -142,8 +171,9 @@ internal class LoopDeclickAudioProcessor : BaseAudioProcessor() {
         anchorFrames = 0
         nextStreamStartUs = 0
         measuredLoopFrames = 0
-        measuredLoopForDurationUs = DURATION_UNKNOWN
+        measuredLoopSampleRate = 0
         sawInputSinceAnchor = false
+        lapInterrupted = false
     }
 
     override fun queueInput(inputBuffer: ByteBuffer) {
@@ -231,10 +261,14 @@ internal class LoopDeclickAudioProcessor : BaseAudioProcessor() {
      * there is one, otherwise the container's duration as an estimate.
      */
     private fun durationFrames(sampleRate: Int): Long {
-        val durationUs = videoDurationUs
-        if (measuredLoopFrames > 0 && measuredLoopForDurationUs == durationUs) {
-            return measuredLoopFrames
+        // A frame count only means the same length at the rate it was counted
+        // at, and an adaptive stream can switch from 44.1 kHz to 48 kHz
+        // without the declared duration moving.
+        val measured = measuredLoopFrames
+        if (measured > 0 && measuredLoopSampleRate == sampleRate) {
+            return measured
         }
+        val durationUs = videoDurationUs
         if (durationUs <= 0) {
             return 0
         }

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/LoopDeclickAudioSink.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/LoopDeclickAudioSink.kt
@@ -1,0 +1,30 @@
+package com.divinevideo.divine_video_player
+
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.audio.AudioSink
+import androidx.media3.exoplayer.audio.ForwardingAudioSink
+
+/**
+ * Tells [LoopDeclickAudioProcessor] where a looping video restarts.
+ *
+ * A seamless loop does not flush the audio pipeline, so the processor's frame
+ * counter would run straight through the join and never fade again. The one
+ * signal that does reach the audio path is the stream change ExoPlayer reports
+ * when it moves from one media period to the next — including the repeat of a
+ * single item under `REPEAT_MODE_ALL`.
+ *
+ * `MediaCodecRenderer` raises it from `onProcessedOutputBuffer` *after* the
+ * last buffer of the finished stream has been handed to the sink and *before*
+ * the first buffer of the next one, so the anchor lands exactly on the join.
+ */
+@UnstableApi
+internal class LoopDeclickAudioSink(
+    sink: AudioSink,
+    private val processor: LoopDeclickAudioProcessor,
+) : ForwardingAudioSink(sink) {
+
+    override fun handleDiscontinuity() {
+        processor.onStreamChanged()
+        super.handleDiscontinuity()
+    }
+}

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/LoopDeclickAudioSink.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/LoopDeclickAudioSink.kt
@@ -7,15 +7,21 @@ import androidx.media3.exoplayer.audio.ForwardingAudioSink
 /**
  * Tells [LoopDeclickAudioProcessor] where a looping video restarts.
  *
- * A seamless loop does not flush the audio pipeline, so the processor's frame
- * counter would run straight through the join and never fade again. The one
- * signal that does reach the audio path is the stream change ExoPlayer reports
- * when it moves from one media period to the next — including the repeat of a
- * single item under `REPEAT_MODE_ALL`.
+ * The only signal a seamless loop sends the audio path is the stream change
+ * ExoPlayer reports when it moves from one media period to the next —
+ * including the repeat of a single item under `REPEAT_MODE_ALL`.
+ * `MediaCodecAudioRenderer` raises it from `onProcessedStreamChange` *after*
+ * the last buffer of the finished stream has been handed to the sink and
+ * *before* the first buffer of the next one, so the anchor lands exactly on
+ * the join.
  *
- * `MediaCodecRenderer` raises it from `onProcessedOutputBuffer` *after* the
- * last buffer of the finished stream has been handed to the sink and *before*
- * the first buffer of the next one, so the anchor lands exactly on the join.
+ * In media3 1.10 the sink then flushes the pipeline itself before that first
+ * buffer — `handleDiscontinuity` sets `startMediaTimeUsNeedsSync`, and the
+ * resync drains and re-runs `setupAudioProcessors` — which happens to reset
+ * the frame counter to the same place. Two jobs are still left that the flush
+ * cannot do, and both are load-bearing: it is the only point that can tell a
+ * loop restart from a seek, so it is where the seek offset is retired and
+ * where the true length of the loop that just played is measured.
  */
 @UnstableApi
 internal class LoopDeclickAudioSink(

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/LoopDeclickAudioSink.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/LoopDeclickAudioSink.kt
@@ -15,13 +15,15 @@ import androidx.media3.exoplayer.audio.ForwardingAudioSink
  * *before* the first buffer of the next one, so the anchor lands exactly on
  * the join.
  *
- * In media3 1.10 the sink then flushes the pipeline itself before that first
- * buffer — `handleDiscontinuity` sets `startMediaTimeUsNeedsSync`, and the
- * resync drains and re-runs `setupAudioProcessors` — which happens to reset
- * the frame counter to the same place. Two jobs are still left that the flush
- * cannot do, and both are load-bearing: it is the only point that can tell a
- * loop restart from a seek, so it is where the seek offset is retired and
- * where the true length of the loop that just played is measured.
+ * In media3 1.10 the sink then handles the rest itself before that first
+ * buffer: `handleDiscontinuity` sets `startMediaTimeUsNeedsSync`, and the next
+ * `handleBuffer` runs `drainToEndOfStream()` — which is what releases the
+ * held-back tail, faded — and then `setupAudioProcessors()`, which flushes the
+ * pipeline and re-anchors the frame counter.
+ *
+ * One job is left that the flush cannot do, and it is load-bearing: this is
+ * the only point that can tell a loop restart from a seek, so it is where the
+ * seek offset is retired.
  */
 @UnstableApi
 internal class LoopDeclickAudioSink(

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/LoopDeclickRenderersFactory.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/LoopDeclickRenderersFactory.kt
@@ -1,0 +1,38 @@
+package com.divinevideo.divine_video_player
+
+import android.content.Context
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.DefaultRenderersFactory
+import androidx.media3.exoplayer.audio.AudioSink
+import androidx.media3.exoplayer.audio.DefaultAudioSink
+
+/**
+ * Builds the audio path with the loop declick fade in it (#6468).
+ *
+ * The processor has to be injected at construction because
+ * `DefaultAudioSink`'s processor chain is fixed once the sink is built, and
+ * the sink is wrapped so the processor is told where a loop restarts.
+ */
+@UnstableApi
+internal class LoopDeclickRenderersFactory(
+    context: Context,
+    private val declickProcessor: LoopDeclickAudioProcessor,
+) : DefaultRenderersFactory(context) {
+
+    override fun buildAudioSink(
+        context: Context,
+        enableFloatOutput: Boolean,
+        enableAudioTrackPlaybackParams: Boolean,
+    ): AudioSink {
+        // Float output routes around the user processor chain entirely, so the
+        // fade would silently do nothing. Divine decodes AAC to 16-bit PCM, and
+        // float output is off by default; keep it off explicitly rather than
+        // let a future default flip disable the fade without a trace.
+        val sink = DefaultAudioSink.Builder(context)
+            .setEnableFloatOutput(false)
+            .setEnableAudioOutputPlaybackParameters(enableAudioTrackPlaybackParams)
+            .setAudioProcessors(arrayOf(declickProcessor))
+            .build()
+        return LoopDeclickAudioSink(sink, declickProcessor)
+    }
+}

--- a/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
+++ b/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
@@ -867,6 +867,22 @@ class DivineVideoPlayerInstanceTest {
     }
 
     @Test
+    fun `an HLS source reaches the player without being probed`() {
+        val result = mockk<MethodChannel.Result>(relaxed = true)
+
+        instance.onMethodCall(
+            trimmingSetClipsCall("https://cdn.example/abc/hls/master.m3u8?token=t"),
+            result,
+        )
+
+        // MediaExtractor has no HLS extractor, so probing a playlist can only
+        // throw — and a throw is not cached, so deferring for one would pay a
+        // doomed fetch on every setClips for that source.
+        verify(exactly = 1) { mockPlayer.setMediaItems(any(), any(), any()) }
+        verify(exactly = 0) { mockHandler.post(any()) }
+    }
+
+    @Test
     fun `a source without both track types is applied unclamped`() {
         val result = mockk<MethodChannel.Result>(relaxed = true)
 

--- a/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
+++ b/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
@@ -82,6 +82,7 @@ class DivineVideoPlayerInstanceTest {
             playerFactory = { _ -> mockPlayer },
             mainHandler = mockHandler,
             audioOverlayManagerFactory = { _ -> mockAudioManager },
+            metadataExecutor = DirectExecutorService(),
         )
     }
 
@@ -701,4 +702,100 @@ class DivineVideoPlayerInstanceTest {
         // Clip 1's speed must NOT be applied.
         verify(exactly = 0) { mockPlayer.setPlaybackParameters(PlaybackParameters(0.25f)) }
     }
+
+    // -- common-track-end clamp resolution --
+
+    private fun trimmingSetClipsCall(uri: String): MethodCall =
+        MethodCall(
+            "setClips",
+            mapOf(
+                "clips" to listOf(
+                    mapOf(
+                        "uri" to uri,
+                        "startMs" to 0,
+                        "trimToCommonTrackEnd" to true,
+                    ),
+                ),
+            ),
+        )
+
+    /** The [Runnable]s handed to [mockHandler] via `post`, in order. */
+    private fun capturePostedRunnables(): List<Runnable> {
+        val posted = mutableListOf<Runnable>()
+        verify { mockHandler.post(capture(posted)) }
+        return posted
+    }
+
+    @Test
+    fun `setClips waits for the track lengths before touching the player`() {
+        val result = mockk<MethodChannel.Result>(relaxed = true)
+
+        instance.onMethodCall(trimmingSetClipsCall("https://cdn.example/a.mp4"), result)
+
+        // The metadata read ran, but applying is posted back to the platform
+        // thread — nothing may reach the player until that lands.
+        verify(exactly = 0) { mockPlayer.setMediaItems(any(), any(), any()) }
+
+        capturePostedRunnables().forEach { it.run() }
+
+        verify(exactly = 1) { mockPlayer.setMediaItems(any(), any(), any()) }
+    }
+
+    @Test
+    fun `a resolution that lands after a newer setClips is dropped`() {
+        val stale = mockk<MethodChannel.Result>(relaxed = true)
+        val fresh = mockk<MethodChannel.Result>(relaxed = true)
+
+        instance.onMethodCall(trimmingSetClipsCall("https://cdn.example/stale.mp4"), stale)
+        val afterStale = capturePostedRunnables().size
+
+        instance.onMethodCall(trimmingSetClipsCall("https://cdn.example/fresh.mp4"), fresh)
+        val posted = capturePostedRunnables()
+
+        // Run the newer continuation first, then the superseded one: the
+        // stale clips must not be applied over the clips that replaced them.
+        posted.drop(afterStale).forEach { it.run() }
+        posted.take(afterStale).forEach { it.run() }
+
+        verify(exactly = 1) { mockPlayer.setMediaItems(any(), any(), any()) }
+    }
+
+    @Test
+    fun `a source without both track types is applied unclamped`() {
+        val result = mockk<MethodChannel.Result>(relaxed = true)
+
+        // MediaExtractor is stubbed in unit tests, so it reports no tracks —
+        // the same shape as an audio-only or unreadable source. That must
+        // still reach the player rather than stranding the Dart call.
+        instance.onMethodCall(trimmingSetClipsCall("https://cdn.example/b.mp4"), result)
+        capturePostedRunnables().forEach { it.run() }
+
+        verify(exactly = 1) { mockPlayer.setMediaItems(any(), any(), any()) }
+        verify(exactly = 0) { result.error(any(), any(), any()) }
+    }
+}
+
+/** Runs submitted work on the calling thread so tests stay deterministic. */
+private class DirectExecutorService : java.util.concurrent.AbstractExecutorService() {
+    private var stopped = false
+
+    override fun execute(command: Runnable) = command.run()
+
+    override fun shutdown() {
+        stopped = true
+    }
+
+    override fun shutdownNow(): MutableList<Runnable> {
+        stopped = true
+        return mutableListOf()
+    }
+
+    override fun isShutdown(): Boolean = stopped
+
+    override fun isTerminated(): Boolean = stopped
+
+    override fun awaitTermination(
+        timeout: Long,
+        unit: java.util.concurrent.TimeUnit,
+    ): Boolean = true
 }

--- a/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
+++ b/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
@@ -761,6 +761,112 @@ class DivineVideoPlayerInstanceTest {
     }
 
     @Test
+    fun `a superseded setClips still answers its caller`() {
+        val stale = mockk<MethodChannel.Result>(relaxed = true)
+        val fresh = mockk<MethodChannel.Result>(relaxed = true)
+
+        instance.onMethodCall(trimmingSetClipsCall("https://cdn.example/one.mp4"), stale)
+        instance.onMethodCall(trimmingSetClipsCall("https://cdn.example/two.mp4"), fresh)
+        capturePostedRunnables().forEach { it.run() }
+
+        // Dropping the superseded result leaves `await setClips()` pending for
+        // the life of the app; the feed's failover state stays pinned on that
+        // index and never recovers. CANCELLED is the code the Dart controller
+        // already swallows.
+        verify(exactly = 1) { stale.error("CANCELLED", any(), any()) }
+        verify(exactly = 0) { stale.success(any()) }
+    }
+
+    @Test
+    fun `dispose answers a setClips still waiting on the track lengths`() {
+        val result = mockk<MethodChannel.Result>(relaxed = true)
+
+        instance.onMethodCall(trimmingSetClipsCall("https://cdn.example/gone.mp4"), result)
+        instance.dispose()
+        capturePostedRunnables().forEach { it.run() }
+
+        verify(exactly = 1) { result.error("CANCELLED", any(), any()) }
+    }
+
+    @Test
+    fun `clips are applied unclamped when the track lengths never arrive`() {
+        val result = mockk<MethodChannel.Result>(relaxed = true)
+        // An executor that accepts work and never runs it: a remote read that
+        // connects and then stalls. MediaHTTPConnection has no read timeout,
+        // so nothing below this bounds the wait.
+        val stalled = DivineVideoPlayerInstance(
+            messenger = messenger,
+            context = context,
+            playerId = 2,
+            playerFactory = { _ -> mockPlayer },
+            mainHandler = mockHandler,
+            audioOverlayManagerFactory = { _ -> mockAudioManager },
+            metadataExecutor = StalledExecutorService(),
+        )
+
+        stalled.onMethodCall(trimmingSetClipsCall("https://cdn.example/stalled.mp4"), result)
+        verify(exactly = 0) { mockPlayer.setMediaItems(any(), any(), any()) }
+
+        val deadline = mutableListOf<Runnable>()
+        verify {
+            mockHandler.postDelayed(
+                capture(deadline),
+                DivineVideoPlayerInstance.TRACK_DURATION_RESOLVE_TIMEOUT_MS,
+            )
+        }
+        deadline.forEach { it.run() }
+
+        // A seam is worse than a load that never finishes is worse.
+        verify(exactly = 1) { mockPlayer.setMediaItems(any(), any(), any()) }
+        verify(exactly = 0) { result.error(any(), any(), any()) }
+    }
+
+    @Test
+    fun `a source that reads as having no track pair is not probed again`() {
+        val uri = "https://cdn.example/no-pair.mp4"
+
+        // MediaExtractor is stubbed to defaults here, so it reports no tracks
+        // — the same shape as a genuinely audio-only source. That answer is
+        // about the source and does not change, so it is cached.
+        instance.onMethodCall(trimmingSetClipsCall(uri), mockk(relaxed = true))
+        capturePostedRunnables().forEach { it.run() }
+        val afterFirst = capturePostedRunnables().size
+
+        instance.onMethodCall(trimmingSetClipsCall(uri), mockk(relaxed = true))
+
+        // Answered from the cache, so nothing is deferred: the clips reach the
+        // player without a second continuation.
+        assertEquals(afterFirst, capturePostedRunnables().size)
+        verify(exactly = 2) { mockPlayer.setMediaItems(any(), any(), any()) }
+    }
+
+    @Test
+    fun `a read that threw is probed again rather than cached as unreadable`() {
+        val uri = "https://cdn.example/flaky.mp4"
+        mockkConstructor(android.media.MediaExtractor::class)
+        try {
+            every {
+                anyConstructed<android.media.MediaExtractor>()
+                    .setDataSource(any<String>(), any<Map<String, String>>())
+            } throws IOException("connection reset")
+
+            instance.onMethodCall(trimmingSetClipsCall(uri), mockk(relaxed = true))
+            capturePostedRunnables().forEach { it.run() }
+            val afterFirst = capturePostedRunnables().size
+
+            instance.onMethodCall(trimmingSetClipsCall(uri), mockk(relaxed = true))
+
+            // A socket reset says nothing about the source. Caching it as
+            // unreadable would disable the loop-seam clamp for this URL for
+            // the rest of the process — the LRU is access-ordered, so the
+            // entry is re-promoted on every replay and never even evicts.
+            assertEquals(afterFirst + 1, capturePostedRunnables().size)
+        } finally {
+            unmockkConstructor(android.media.MediaExtractor::class)
+        }
+    }
+
+    @Test
     fun `a source without both track types is applied unclamped`() {
         val result = mockk<MethodChannel.Result>(relaxed = true)
 
@@ -773,6 +879,31 @@ class DivineVideoPlayerInstanceTest {
         verify(exactly = 1) { mockPlayer.setMediaItems(any(), any(), any()) }
         verify(exactly = 0) { result.error(any(), any(), any()) }
     }
+}
+
+/** Accepts work and never runs it — a metadata read that never returns. */
+private class StalledExecutorService : java.util.concurrent.AbstractExecutorService() {
+    private var stopped = false
+
+    override fun execute(command: Runnable) = Unit
+
+    override fun shutdown() {
+        stopped = true
+    }
+
+    override fun shutdownNow(): MutableList<Runnable> {
+        stopped = true
+        return mutableListOf()
+    }
+
+    override fun isShutdown(): Boolean = stopped
+
+    override fun isTerminated(): Boolean = stopped
+
+    override fun awaitTermination(
+        timeout: Long,
+        unit: java.util.concurrent.TimeUnit,
+    ): Boolean = true
 }
 
 /** Runs submitted work on the calling thread so tests stay deterministic. */

--- a/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
+++ b/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
@@ -29,6 +29,7 @@ import io.mockk.unmockkStatic
 import io.mockk.verify
 import io.mockk.verifyOrder
 import java.io.IOException
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -58,6 +59,7 @@ class DivineVideoPlayerInstanceTest {
 
     @Before
     fun setUp() {
+        DivineVideoPlayerInstance.clearTrackDurationsCacheForTesting()
         messenger = mockk(relaxed = true)
         context = mockk(relaxed = true)
         mockPlayer = mockk(relaxed = true)
@@ -84,6 +86,11 @@ class DivineVideoPlayerInstanceTest {
             audioOverlayManagerFactory = { _ -> mockAudioManager },
             metadataExecutor = DirectExecutorService(),
         )
+    }
+
+    @After
+    fun tearDown() {
+        DivineVideoPlayerInstance.clearTrackDurationsCacheForTesting()
     }
 
     /**
@@ -730,7 +737,7 @@ class DivineVideoPlayerInstanceTest {
     fun `setClips waits for the track lengths before touching the player`() {
         val result = mockk<MethodChannel.Result>(relaxed = true)
 
-        instance.onMethodCall(trimmingSetClipsCall("https://cdn.example/a.mp4"), result)
+        instance.onMethodCall(trimmingSetClipsCall("file:///tmp/a.mp4"), result)
 
         // The metadata read ran, but applying is posted back to the platform
         // thread — nothing may reach the player until that lands.
@@ -746,10 +753,10 @@ class DivineVideoPlayerInstanceTest {
         val stale = mockk<MethodChannel.Result>(relaxed = true)
         val fresh = mockk<MethodChannel.Result>(relaxed = true)
 
-        instance.onMethodCall(trimmingSetClipsCall("https://cdn.example/stale.mp4"), stale)
+        instance.onMethodCall(trimmingSetClipsCall("file:///tmp/stale.mp4"), stale)
         val afterStale = capturePostedRunnables().size
 
-        instance.onMethodCall(trimmingSetClipsCall("https://cdn.example/fresh.mp4"), fresh)
+        instance.onMethodCall(trimmingSetClipsCall("file:///tmp/fresh.mp4"), fresh)
         val posted = capturePostedRunnables()
 
         // Run the newer continuation first, then the superseded one: the
@@ -765,8 +772,8 @@ class DivineVideoPlayerInstanceTest {
         val stale = mockk<MethodChannel.Result>(relaxed = true)
         val fresh = mockk<MethodChannel.Result>(relaxed = true)
 
-        instance.onMethodCall(trimmingSetClipsCall("https://cdn.example/one.mp4"), stale)
-        instance.onMethodCall(trimmingSetClipsCall("https://cdn.example/two.mp4"), fresh)
+        instance.onMethodCall(trimmingSetClipsCall("file:///tmp/one.mp4"), stale)
+        instance.onMethodCall(trimmingSetClipsCall("file:///tmp/two.mp4"), fresh)
         capturePostedRunnables().forEach { it.run() }
 
         // Dropping the superseded result leaves `await setClips()` pending for
@@ -781,7 +788,7 @@ class DivineVideoPlayerInstanceTest {
     fun `dispose answers a setClips still waiting on the track lengths`() {
         val result = mockk<MethodChannel.Result>(relaxed = true)
 
-        instance.onMethodCall(trimmingSetClipsCall("https://cdn.example/gone.mp4"), result)
+        instance.onMethodCall(trimmingSetClipsCall("file:///tmp/gone.mp4"), result)
         instance.dispose()
         capturePostedRunnables().forEach { it.run() }
 
@@ -791,9 +798,8 @@ class DivineVideoPlayerInstanceTest {
     @Test
     fun `clips are applied unclamped when the track lengths never arrive`() {
         val result = mockk<MethodChannel.Result>(relaxed = true)
-        // An executor that accepts work and never runs it: a remote read that
-        // connects and then stalls. MediaHTTPConnection has no read timeout,
-        // so nothing below this bounds the wait.
+        // An executor that accepts work and never runs it: a metadata read that
+        // never returns. Nothing below this bounds the wait.
         val stalled = DivineVideoPlayerInstance(
             messenger = messenger,
             context = context,
@@ -804,7 +810,7 @@ class DivineVideoPlayerInstanceTest {
             metadataExecutor = StalledExecutorService(),
         )
 
-        stalled.onMethodCall(trimmingSetClipsCall("https://cdn.example/stalled.mp4"), result)
+        stalled.onMethodCall(trimmingSetClipsCall("file:///tmp/stalled.mp4"), result)
         verify(exactly = 0) { mockPlayer.setMediaItems(any(), any(), any()) }
 
         val deadline = mutableListOf<Runnable>()
@@ -819,6 +825,25 @@ class DivineVideoPlayerInstanceTest {
         // A seam is worse than a load that never finishes is worse.
         verify(exactly = 1) { mockPlayer.setMediaItems(any(), any(), any()) }
         verify(exactly = 0) { result.error(any(), any(), any()) }
+
+        stalled.onMethodCall(trimmingSetClipsCall("file:///tmp/next.mp4"), mockk(relaxed = true))
+        // Once a read times out, the instance stops queueing metadata work and
+        // future loads play immediately instead of paying the same deadline.
+        verify(exactly = 2) { mockPlayer.setMediaItems(any(), any(), any()) }
+    }
+
+    @Test
+    fun `a remote source starts immediately while track lengths warm in the background`() {
+        val result = mockk<MethodChannel.Result>(relaxed = true)
+
+        instance.onMethodCall(trimmingSetClipsCall("https://cdn.example/remote.mp4"), result)
+
+        // Remote MediaExtractor reads add a second connection to the feed's
+        // first-frame path, so they must not sit in front of the playlist swap.
+        verify(exactly = 1) { mockPlayer.setMediaItems(any(), any(), any()) }
+        // The same read still runs and posts a continuation that can tighten
+        // the current playlist if the metadata lands before the first loop.
+        verify(exactly = 1) { mockHandler.post(any()) }
     }
 
     @Test

--- a/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
+++ b/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
@@ -2,10 +2,12 @@ package com.divinevideo.divine_video_player
 
 import android.content.Context
 import android.graphics.SurfaceTexture
+import android.media.MediaFormat
 import android.net.Uri
 import android.os.Handler
 import android.os.SystemClock
 import android.view.Surface
+import androidx.media3.common.MediaItem
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
@@ -844,6 +846,76 @@ class DivineVideoPlayerInstanceTest {
         // The same read still runs and posts a continuation that can tighten
         // the current playlist if the metadata lands before the first loop.
         verify(exactly = 1) { mockHandler.post(any()) }
+    }
+
+    /**
+     * Runs [block] with `MediaExtractor` reporting one video and one audio
+     * track of the given lengths, so a remote probe resolves to a real clamp
+     * instead of the stubbed "no tracks" answer the other tests get.
+     */
+    private fun withTrackDurations(videoUs: Long, audioUs: Long, block: () -> Unit) {
+        val video = mockk<MediaFormat>(relaxed = true)
+        val audio = mockk<MediaFormat>(relaxed = true)
+        every { video.getString(MediaFormat.KEY_MIME) } returns "video/avc"
+        every { video.containsKey(MediaFormat.KEY_DURATION) } returns true
+        every { video.getLong(MediaFormat.KEY_DURATION) } returns videoUs
+        every { audio.getString(MediaFormat.KEY_MIME) } returns "audio/mp4a-latm"
+        every { audio.containsKey(MediaFormat.KEY_DURATION) } returns true
+        every { audio.getLong(MediaFormat.KEY_DURATION) } returns audioUs
+
+        mockkConstructor(android.media.MediaExtractor::class)
+        try {
+            every {
+                anyConstructed<android.media.MediaExtractor>()
+                    .setDataSource(any<String>(), any<Map<String, String>>())
+            } just runs
+            every { anyConstructed<android.media.MediaExtractor>().trackCount } returns 2
+            every { anyConstructed<android.media.MediaExtractor>().getTrackFormat(0) } returns video
+            every { anyConstructed<android.media.MediaExtractor>().getTrackFormat(1) } returns audio
+            block()
+        } finally {
+            unmockkConstructor(android.media.MediaExtractor::class)
+        }
+    }
+
+    @Test
+    fun `a resolved clamp tightens a playlist that has not started`() {
+        every { mockPlayer.mediaItemCount } returns 1
+        every { mockPlayer.getMediaItemAt(0) } returns MediaItem.Builder().build()
+
+        withTrackDurations(videoUs = 6_000_000L, audioUs = 6_040_000L) {
+            instance.onMethodCall(
+                trimmingSetClipsCall("https://cdn.example/warm.mp4"),
+                mockk(relaxed = true),
+            )
+            capturePostedRunnables().forEach { it.run() }
+        }
+
+        // A preloaded tile sits paused at frame zero, so swapping the item for
+        // a clamped one costs nothing the viewer can see.
+        val replaced = slot<MediaItem>()
+        verify { mockPlayer.replaceMediaItem(0, capture(replaced)) }
+        assertEquals(6_000L, replaced.captured.clippingConfiguration.endPositionMs)
+    }
+
+    @Test
+    fun `a resolved clamp is not applied over a playlist already playing`() {
+        every { mockPlayer.mediaItemCount } returns 1
+        every { mockPlayer.getMediaItemAt(0) } returns MediaItem.Builder().build()
+        every { mockPlayer.playWhenReady } returns true
+
+        withTrackDurations(videoUs = 6_000_000L, audioUs = 6_040_000L) {
+            instance.onMethodCall(
+                trimmingSetClipsCall("https://cdn.example/playing.mp4"),
+                mockk(relaxed = true),
+            )
+            capturePostedRunnables().forEach { it.run() }
+        }
+
+        // A clipping configuration cannot be updated in place, so this would
+        // remove and re-insert the period being played and restart the video
+        // from zero mid-watch — worse than the seam it removes.
+        verify(exactly = 0) { mockPlayer.replaceMediaItem(any(), any()) }
     }
 
     @Test

--- a/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/LoopDeclickAudioProcessorTest.kt
+++ b/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/LoopDeclickAudioProcessorTest.kt
@@ -37,32 +37,48 @@ class LoopDeclickAudioProcessorTest {
         this.enabled = enabled
     }
 
-    /** A mono processor already through `configure`, ready to be flushed. */
+    /** A processor already through `configure`, ready to be flushed. */
     private fun configured(
         durationUs: Long = 6_000_000L,
+        channelCount: Int = 1,
     ): LoopDeclickAudioProcessor = processor(durationUs = durationUs).apply {
         configure(
-            AudioProcessor.AudioFormat(sampleRate, 1, C.ENCODING_PCM_16BIT),
+            AudioProcessor.AudioFormat(sampleRate, channelCount, C.ENCODING_PCM_16BIT),
         )
     }
 
     private fun LoopDeclickAudioProcessor.flushPipeline() =
         flush(AudioProcessor.StreamMetadata.DEFAULT)
 
-    private fun pcm(frames: Int): ByteBuffer =
-        ByteBuffer.allocateDirect(frames * 2)
-            .order(ByteOrder.LITTLE_ENDIAN)
+    /**
+     * [frames] interleaved frames, each carrying one sample per entry of
+     * [levels]. Native order is what media3 hands an [AudioProcessor] and what
+     * `replaceOutputBuffer` allocates.
+     */
+    private fun pcm(frames: Int, levels: List<Short> = listOf(level)): ByteBuffer =
+        ByteBuffer.allocateDirect(frames * levels.size * 2)
+            .order(ByteOrder.nativeOrder())
             .apply {
-                repeat(frames) { putShort(level) }
+                repeat(frames) { levels.forEach(::putShort) }
                 flip()
             }
 
-    /** Pushes [frames] frames through and returns the gain of the last one. */
+    /** Pushes [frames] mono frames through and returns the gain of the last. */
     private fun LoopDeclickAudioProcessor.play(frames: Int): Float {
         queueInput(pcm(frames))
         val out = output
         val last = out.getShort((frames - 1) * 2)
         return last.toFloat() / level
+    }
+
+    /** Pushes [frames] frames of [levels] through and returns every sample. */
+    private fun LoopDeclickAudioProcessor.playInterleaved(
+        frames: Int,
+        levels: List<Short>,
+    ): ShortArray {
+        queueInput(pcm(frames, levels))
+        val out = output
+        return ShortArray(frames * levels.size) { out.getShort(it * 2) }
     }
 
     @Test
@@ -253,6 +269,23 @@ class LoopDeclickAudioProcessorTest {
     }
 
     @Test
+    fun `most of a loop is still not a measurement of one`() {
+        val subject = configured(durationUs = 100_000L)
+        subject.flushPipeline()
+        subject.play(1_000)
+        // Mid-loop flush again, but this time what follows is 62% of the
+        // container's 4800 frames. A guard that only rejects fragments under
+        // half the estimate takes this one and puts the fade out 1800 frames
+        // early for the rest of the video.
+        subject.flushPipeline()
+        subject.play(3_000)
+        subject.onStreamChanged()
+
+        assertEquals(1f, subject.play(4_800 - fadeFrames.toInt() + 1), 0f)
+        assertTrue("the container's estimate must survive", subject.play(1) < 1f)
+    }
+
+    @Test
     fun `a new video drops the previous one's measurement`() {
         val subject = configured(durationUs = 100_000L)
         subject.flushPipeline()
@@ -267,5 +300,60 @@ class LoopDeclickAudioProcessorTest {
         // 9600 frames now. Reusing the 3000-frame measurement would wrap here
         // and silence the frame instead.
         assertEquals(1f, subject.play(3_001), 0f)
+    }
+
+    @Test
+    fun `a new video of the same length drops it too`() {
+        val subject = configured(durationUs = 100_000L)
+        subject.flushPipeline()
+        subject.play(3_000)
+        subject.onStreamChanged()
+
+        // A player is reused across videos and never reset between them, so
+        // two videos that agree to the millisecond must not share a frame
+        // count — they disagree by up to an AAC frame, which is wider than
+        // the fade.
+        subject.videoDurationUs = LoopDeclickAudioProcessor.DURATION_UNKNOWN
+        subject.videoDurationUs = 100_000L
+        subject.flushPipeline()
+
+        assertEquals(1f, subject.play(3_001), 0f)
+    }
+
+    @Test
+    fun `a stereo fade scales each channel by the frame's own gain`() {
+        val leftLevel: Short = 20_000
+        val rightLevel: Short = -12_000
+        val subject = configured(channelCount = 2)
+        subject.flushPipeline()
+
+        val samples = subject.playInterleaved(
+            fadeFrames.toInt(),
+            listOf(leftLevel, rightLevel),
+        )
+
+        // Half way into the fade in, each channel carries half of its own
+        // level — not half of the left one twice.
+        val frame = fadeFrames.toInt() / 2
+        val gain = frame.toFloat() / fadeFrames
+        assertEquals((leftLevel * gain).toInt(), samples[frame * 2].toInt())
+        assertEquals((rightLevel * gain).toInt(), samples[frame * 2 + 1].toInt())
+    }
+
+    @Test
+    fun `stereo frames advance the position once per frame, not per sample`() {
+        val subject = configured(durationUs = 100_000L, channelCount = 2)
+        subject.flushPipeline()
+
+        // 4800 frames. Counting interleaved samples instead would reach the
+        // end of the video half way through it.
+        val flat = subject.playInterleaved(
+            4_800 - fadeFrames.toInt() + 1,
+            listOf(level, level),
+        )
+        assertEquals(level.toInt(), flat.last().toInt())
+
+        val fading = subject.playInterleaved(1, listOf(level, level))
+        assertTrue("fade out must start at the video's end", fading.first() < level)
     }
 }

--- a/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/LoopDeclickAudioProcessorTest.kt
+++ b/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/LoopDeclickAudioProcessorTest.kt
@@ -1,0 +1,138 @@
+package com.divinevideo.divine_video_player
+
+import androidx.media3.common.util.UnstableApi
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards the fade that keeps a looping video's join from clicking (#6468).
+ *
+ * A loop restart cuts from the video's last sample straight back to its first.
+ * Both edges have to reach zero for that join to be silent.
+ */
+@UnstableApi
+class LoopDeclickAudioProcessorTest {
+
+    private val sampleRate = 48_000
+
+    /** 10 ms at 48 kHz. */
+    private val fadeFrames = 480L
+
+    /** 6 s at 48 kHz. */
+    private val durationFrames = 288_000L
+
+    private fun processor(
+        durationUs: Long = 6_000_000L,
+        enabled: Boolean = true,
+    ): LoopDeclickAudioProcessor = LoopDeclickAudioProcessor().apply {
+        this.videoDurationUs = durationUs
+        this.enabled = enabled
+    }
+
+    @Test
+    fun `both edges of the video reach silence`() {
+        val subject = processor()
+
+        assertEquals(0f, subject.gainAt(0, fadeFrames, durationFrames), 0f)
+        assertEquals(
+            0f,
+            subject.gainAt(durationFrames - 1, fadeFrames, durationFrames),
+            1f / fadeFrames,
+        )
+    }
+
+    @Test
+    fun `the middle of the video is untouched`() {
+        val subject = processor()
+
+        assertEquals(1f, subject.gainAt(fadeFrames, fadeFrames, durationFrames), 0f)
+        assertEquals(1f, subject.gainAt(durationFrames / 2, fadeFrames, durationFrames), 0f)
+        assertEquals(
+            1f,
+            subject.gainAt(durationFrames - fadeFrames, fadeFrames, durationFrames),
+            0f,
+        )
+    }
+
+    @Test
+    fun `the fade rises and falls monotonically`() {
+        val subject = processor()
+
+        var previous = -1f
+        for (frame in 0 until fadeFrames) {
+            val gain = subject.gainAt(frame, fadeFrames, durationFrames)
+            assertTrue("fade in must not dip at frame $frame", gain > previous)
+            previous = gain
+        }
+
+        previous = 2f
+        for (frame in (durationFrames - fadeFrames + 1) until durationFrames) {
+            val gain = subject.gainAt(frame, fadeFrames, durationFrames)
+            assertTrue("fade out must not rise at frame $frame", gain < previous)
+            previous = gain
+        }
+    }
+
+    @Test
+    fun `a video whose length is unknown still fades in`() {
+        val subject = processor(durationUs = LoopDeclickAudioProcessor.DURATION_UNKNOWN)
+
+        assertEquals(0f, subject.gainAt(0, fadeFrames, 0), 0f)
+        assertEquals(1f, subject.gainAt(fadeFrames, fadeFrames, 0), 0f)
+        // Nothing to fade out into, so the rest plays at full gain rather than
+        // fading at a guessed end.
+        assertEquals(1f, subject.gainAt(durationFrames, fadeFrames, 0), 0f)
+    }
+
+    @Test
+    fun `a position past the end wraps instead of muting`() {
+        val subject = processor()
+
+        // A stream change that never arrives would leave the position running
+        // past the video for good. Wrapping keeps the fade merely imprecise;
+        // clamping would silence everything after the first loop.
+        assertEquals(
+            subject.gainAt(durationFrames / 2, fadeFrames, durationFrames),
+            subject.gainAt(durationFrames + durationFrames / 2, fadeFrames, durationFrames),
+            0f,
+        )
+        assertEquals(
+            1f,
+            subject.gainAt(durationFrames * 3 + fadeFrames, fadeFrames, durationFrames),
+            0f,
+        )
+    }
+
+    @Test
+    fun `the two fades of a short video never overlap`() {
+        // 12 ms cannot carry two 10 ms fades.
+        val subject = processor(durationUs = 12_000L)
+        val shortDurationFrames = 12L * sampleRate / 1000L
+        val fade = subject.fadeFrames(sampleRate)
+
+        assertTrue("fade must shrink to fit", fade * 2 <= shortDurationFrames)
+        assertEquals(0f, subject.gainAt(0, fade, shortDurationFrames), 0f)
+        assertEquals(
+            0f,
+            subject.gainAt(shortDurationFrames - 1, fade, shortDurationFrames),
+            1f / fade,
+        )
+    }
+
+    @Test
+    fun `a multi-clip timeline is not faded`() {
+        val subject = processor(enabled = false)
+
+        assertEquals(0L, subject.fadeFrames(sampleRate))
+        assertEquals(1f, subject.gainAt(0, subject.fadeFrames(sampleRate), durationFrames), 0f)
+    }
+
+    @Test
+    fun `fade length matches the Apple player`() {
+        val subject = processor()
+
+        assertEquals(10_000L, LoopDeclickAudioProcessor.FADE_US)
+        assertEquals(fadeFrames, subject.fadeFrames(sampleRate))
+    }
+}

--- a/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/LoopDeclickAudioProcessorTest.kt
+++ b/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/LoopDeclickAudioProcessorTest.kt
@@ -135,7 +135,7 @@ class LoopDeclickAudioProcessorTest {
     }
 
     @Test
-    fun `fade length matches the Apple player`() {
+    fun `the fade is ten milliseconds, which is also the added latency`() {
         assertEquals(fadeFrames, processor().fadeFrames(sampleRate))
     }
 

--- a/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/LoopDeclickAudioProcessorTest.kt
+++ b/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/LoopDeclickAudioProcessorTest.kt
@@ -13,7 +13,9 @@ import java.nio.ByteOrder
  * Guards the fade that keeps a looping video's join from clicking (#6468).
  *
  * A loop restart cuts from the video's last sample straight back to its first.
- * Both edges have to reach zero for that join to be silent.
+ * Both edges have to reach zero for that join to be silent — and the last one
+ * has to reach zero where the audio really ends, not where the container says
+ * it does.
  */
 @UnstableApi
 class LoopDeclickAudioProcessorTest {
@@ -40,19 +42,21 @@ class LoopDeclickAudioProcessorTest {
     /** A processor already through `configure`, ready to be flushed. */
     private fun configured(
         durationUs: Long = 6_000_000L,
+        enabled: Boolean = true,
         channelCount: Int = 1,
-    ): LoopDeclickAudioProcessor = processor(durationUs = durationUs).apply {
-        configure(
-            AudioProcessor.AudioFormat(sampleRate, channelCount, C.ENCODING_PCM_16BIT),
-        )
-    }
+    ): LoopDeclickAudioProcessor =
+        processor(durationUs = durationUs, enabled = enabled).apply {
+            configure(
+                AudioProcessor.AudioFormat(sampleRate, channelCount, C.ENCODING_PCM_16BIT),
+            )
+        }
 
     private fun LoopDeclickAudioProcessor.flushPipeline() =
         flush(AudioProcessor.StreamMetadata.DEFAULT)
 
     /**
-     * [frames] interleaved frames, each carrying one sample per entry of
-     * [levels]. Native order is what media3 hands an [AudioProcessor] and what
+     * [frames] interleaved frames, one sample per entry of [levels]. Native
+     * order is what media3 hands an `AudioProcessor` and what
      * `replaceOutputBuffer` allocates.
      */
     private fun pcm(frames: Int, levels: List<Short> = listOf(level)): ByteBuffer =
@@ -63,112 +67,51 @@ class LoopDeclickAudioProcessorTest {
                 flip()
             }
 
-    /** Pushes [frames] mono frames through and returns the gain of the last. */
-    private fun LoopDeclickAudioProcessor.play(frames: Int): Float {
-        queueInput(pcm(frames))
-        val out = output
-        val last = out.getShort((frames - 1) * 2)
-        return last.toFloat() / level
-    }
+    private fun ByteBuffer.samples(): ShortArray =
+        ShortArray(remaining() / 2) { short }
 
-    /** Pushes [frames] frames of [levels] through and returns every sample. */
-    private fun LoopDeclickAudioProcessor.playInterleaved(
+    /** Pushes [frames] frames through and returns the samples that came out. */
+    private fun LoopDeclickAudioProcessor.push(
         frames: Int,
-        levels: List<Short>,
+        levels: List<Short> = listOf(level),
     ): ShortArray {
         queueInput(pcm(frames, levels))
-        val out = output
-        return ShortArray(frames * levels.size) { out.getShort(it * 2) }
+        return output.samples()
+    }
+
+    /**
+     * What `DefaultAudioSink.drainToEndOfStream()` does at a loop join: tell
+     * the pipeline the stream ended, then read until the processor is done.
+     */
+    private fun LoopDeclickAudioProcessor.drainToEnd(): ShortArray {
+        queueEndOfStream()
+        val drained = mutableListOf<Short>()
+        var guard = 0
+        while (!isEnded && guard++ < 8) {
+            drained += output.samples().toList()
+        }
+        return drained.toShortArray()
     }
 
     @Test
-    fun `both edges of the video reach silence`() {
+    fun `the video starts at silence and reaches full gain`() {
         val subject = processor()
 
-        assertEquals(0f, subject.gainAt(0, fadeFrames, durationFrames), 0f)
-        assertEquals(
-            0f,
-            subject.gainAt(durationFrames - 1, fadeFrames, durationFrames),
-            1f / fadeFrames,
-        )
+        assertEquals(0f, subject.fadeInGainAt(0, fadeFrames), 0f)
+        assertEquals(1f, subject.fadeInGainAt(fadeFrames, fadeFrames), 0f)
+        assertEquals(1f, subject.fadeInGainAt(durationFrames, fadeFrames), 0f)
     }
 
     @Test
-    fun `the middle of the video is untouched`() {
-        val subject = processor()
-
-        assertEquals(1f, subject.gainAt(fadeFrames, fadeFrames, durationFrames), 0f)
-        assertEquals(1f, subject.gainAt(durationFrames / 2, fadeFrames, durationFrames), 0f)
-        assertEquals(
-            1f,
-            subject.gainAt(durationFrames - fadeFrames, fadeFrames, durationFrames),
-            0f,
-        )
-    }
-
-    @Test
-    fun `the fade rises and falls monotonically`() {
+    fun `the fade in rises monotonically`() {
         val subject = processor()
 
         var previous = -1f
         for (frame in 0 until fadeFrames) {
-            val gain = subject.gainAt(frame, fadeFrames, durationFrames)
+            val gain = subject.fadeInGainAt(frame, fadeFrames)
             assertTrue("fade in must not dip at frame $frame", gain > previous)
             previous = gain
         }
-
-        previous = 2f
-        for (frame in (durationFrames - fadeFrames + 1) until durationFrames) {
-            val gain = subject.gainAt(frame, fadeFrames, durationFrames)
-            assertTrue("fade out must not rise at frame $frame", gain < previous)
-            previous = gain
-        }
-    }
-
-    @Test
-    fun `a video whose length is unknown still fades in`() {
-        val subject = processor(durationUs = LoopDeclickAudioProcessor.DURATION_UNKNOWN)
-
-        assertEquals(0f, subject.gainAt(0, fadeFrames, 0), 0f)
-        assertEquals(1f, subject.gainAt(fadeFrames, fadeFrames, 0), 0f)
-        // Nothing to fade out into, so the rest plays at full gain rather than
-        // fading at a guessed end.
-        assertEquals(1f, subject.gainAt(durationFrames, fadeFrames, 0), 0f)
-    }
-
-    @Test
-    fun `a position past the end wraps instead of muting`() {
-        val subject = processor()
-
-        // A stream change that never arrives would leave the position running
-        // past the video for good. Wrapping keeps the fade merely imprecise;
-        // clamping would silence everything after the first loop.
-        assertEquals(
-            subject.gainAt(durationFrames / 2, fadeFrames, durationFrames),
-            subject.gainAt(durationFrames + durationFrames / 2, fadeFrames, durationFrames),
-            0f,
-        )
-        assertEquals(
-            1f,
-            subject.gainAt(durationFrames * 3 + fadeFrames, fadeFrames, durationFrames),
-            0f,
-        )
-    }
-
-    @Test
-    fun `the two fades of a short video never overlap`() {
-        // 12 ms cannot carry two 10 ms fades.
-        val subject = processor(durationUs = 12_000L)
-        val shortDurationFrames = 12L * sampleRate / 1000L
-        val fade = subject.fadeFrames(sampleRate)
-
-        assertTrue("fade must shrink to fit", fade * 2 <= shortDurationFrames)
-        assertEquals(0f, subject.gainAt(0, fade, shortDurationFrames), 0f)
-        assertEquals(
-            0f,
-            subject.gainAt(shortDurationFrames - 1, fade, shortDurationFrames),
-            1f / fade,
-        )
     }
 
     @Test
@@ -176,15 +119,102 @@ class LoopDeclickAudioProcessorTest {
         val subject = processor(enabled = false)
 
         assertEquals(0L, subject.fadeFrames(sampleRate))
-        assertEquals(1f, subject.gainAt(0, subject.fadeFrames(sampleRate), durationFrames), 0f)
+        assertEquals(1f, subject.fadeInGainAt(0, subject.fadeFrames(sampleRate)), 0f)
+    }
+
+    @Test
+    fun `the two fades of a short video never overlap`() {
+        // 12 ms cannot carry two 10 ms fades.
+        val subject = processor(durationUs = 12_000L)
+        val shortDurationFrames = 12L * sampleRate / 1000L
+
+        assertTrue(
+            "fade must shrink to fit",
+            subject.fadeFrames(sampleRate) * 2 <= shortDurationFrames,
+        )
     }
 
     @Test
     fun `fade length matches the Apple player`() {
-        val subject = processor()
+        assertEquals(fadeFrames, processor().fadeFrames(sampleRate))
+    }
 
-        assertEquals(10_000L, LoopDeclickAudioProcessor.FADE_US)
-        assertEquals(fadeFrames, subject.fadeFrames(sampleRate))
+    @Test
+    fun `the stream fades out where it ends, not where the container says`() {
+        // The container claims 100 ms — 4800 frames — and the audio track
+        // delivers 3000. Timing the fade out off the declared length put it
+        // 1800 frames past the join, so the first lap of such a video clicked
+        // until a whole loop had been measured. Nothing is timed off it now.
+        val subject = configured(durationUs = 100_000L)
+        subject.flushPipeline()
+        subject.push(3_000)
+
+        val tail = subject.drainToEnd()
+
+        assertEquals(fadeFrames.toInt(), tail.size)
+        assertEquals("the join must be silent", 0, tail.last().toInt())
+        assertTrue("the ramp must start at full gain", tail.first() > level * 0.99)
+    }
+
+    @Test
+    fun `a video whose length is unknown still fades out`() {
+        val subject = configured(durationUs = LoopDeclickAudioProcessor.DURATION_UNKNOWN)
+        subject.flushPipeline()
+        subject.push(2_000)
+
+        val tail = subject.drainToEnd()
+
+        assertEquals(fadeFrames.toInt(), tail.size)
+        assertEquals(0, tail.last().toInt())
+    }
+
+    @Test
+    fun `the fade out falls monotonically into the join`() {
+        val subject = configured()
+        subject.flushPipeline()
+        subject.push(2_000)
+
+        val tail = subject.drainToEnd()
+
+        var previous = Short.MAX_VALUE
+        for ((index, sample) in tail.withIndex()) {
+            assertTrue("fade out must not rise at frame $index", sample < previous)
+            previous = sample
+        }
+    }
+
+    @Test
+    fun `the fade holds the last ten milliseconds back`() {
+        val subject = configured()
+        subject.flushPipeline()
+
+        assertEquals(1_000 - fadeFrames.toInt(), subject.push(1_000).size)
+    }
+
+    @Test
+    fun `a flush drops the tail rather than playing it late`() {
+        val subject = configured()
+        subject.flushPipeline()
+        subject.push(1_000)
+
+        // A seek discards these frames; they must not surface at the next end
+        // of stream.
+        subject.flushPipeline()
+
+        assertEquals(0, subject.drainToEnd().size)
+    }
+
+    @Test
+    fun `a multi-clip timeline is passed through without delay`() {
+        val subject = configured(enabled = false)
+        subject.flushPipeline()
+
+        val out = subject.push(1_000)
+
+        assertEquals(1_000, out.size)
+        assertEquals(level.toInt(), out.first().toInt())
+        assertEquals(level.toInt(), out.last().toInt())
+        assertEquals(0, subject.drainToEnd().size)
     }
 
     @Test
@@ -199,9 +229,8 @@ class LoopDeclickAudioProcessorTest {
         subject.flushPipeline()
 
         // Half way in is in neither fade. An offset consumed by the first
-        // flush would leave this anchored at zero, fading in mid-video and
-        // putting the fade out three seconds early.
-        assertEquals(1f, subject.play(1), 0f)
+        // flush would leave this anchored at zero and fade in mid-video.
+        assertEquals(level.toInt(), subject.push(1_000).first().toInt())
     }
 
     @Test
@@ -215,109 +244,20 @@ class LoopDeclickAudioProcessorTest {
         subject.onStreamChanged()
         subject.onStreamChanged()
 
-        assertEquals(1f, subject.play(1), 0f)
+        assertEquals(level.toInt(), subject.push(1_000).first().toInt())
     }
 
     @Test
     fun `a loop restart fades in again`() {
         val subject = configured()
         subject.flushPipeline()
-        subject.play(1_000)
+        subject.push(1_000)
 
         subject.onStreamChanged()
-
-        assertEquals(0f, subject.play(1), 0f)
-    }
-
-    @Test
-    fun `the first loop falls back to the container's duration`() {
-        // 100 ms at 48 kHz is 4800 frames, and nothing has been measured yet.
-        val subject = configured(durationUs = 100_000L)
+        // media3 resyncs the pipeline before the first buffer of the new lap.
         subject.flushPipeline()
 
-        assertEquals(1f, subject.play(4_800 - fadeFrames.toInt() + 1), 0f)
-        assertTrue("fade out must start before the container's end", subject.play(1) < 1f)
-    }
-
-    @Test
-    fun `later loops follow the frames one really delivered`() {
-        // The container claims 100 ms (4800 frames) but the audio track only
-        // ever delivers 3000. Trusting the container would put the fade out
-        // 1800 frames past the join, so the loop would still click.
-        val subject = configured(durationUs = 100_000L)
-        subject.flushPipeline()
-        subject.play(3_000)
-        subject.onStreamChanged()
-
-        assertEquals(1f, subject.play(3_000 - fadeFrames.toInt() + 1), 0f)
-        assertTrue("fade out must start where the loop really ends", subject.play(1) < 1f)
-    }
-
-    @Test
-    fun `a loop cut short by an unrelated flush is not measured`() {
-        val subject = configured(durationUs = 100_000L)
-        subject.flushPipeline()
-        subject.play(1_000)
-        // A route change or an underrun flushes mid-loop, which restarts the
-        // count. What reaches the join is not the length of a loop.
-        subject.flushPipeline()
-        subject.play(1_000)
-        subject.onStreamChanged()
-
-        assertEquals(1f, subject.play(4_800 - fadeFrames.toInt() + 1), 0f)
-        assertTrue("the container's estimate must survive", subject.play(1) < 1f)
-    }
-
-    @Test
-    fun `most of a loop is still not a measurement of one`() {
-        val subject = configured(durationUs = 100_000L)
-        subject.flushPipeline()
-        subject.play(1_000)
-        // Mid-loop flush again, but this time what follows is 62% of the
-        // container's 4800 frames. A guard that only rejects fragments under
-        // half the estimate takes this one and puts the fade out 1800 frames
-        // early for the rest of the video.
-        subject.flushPipeline()
-        subject.play(3_000)
-        subject.onStreamChanged()
-
-        assertEquals(1f, subject.play(4_800 - fadeFrames.toInt() + 1), 0f)
-        assertTrue("the container's estimate must survive", subject.play(1) < 1f)
-    }
-
-    @Test
-    fun `a new video drops the previous one's measurement`() {
-        val subject = configured(durationUs = 100_000L)
-        subject.flushPipeline()
-        subject.play(3_000)
-        subject.onStreamChanged()
-
-        // What setClips does: clear the length, then publish the new one.
-        subject.videoDurationUs = LoopDeclickAudioProcessor.DURATION_UNKNOWN
-        subject.videoDurationUs = 200_000L
-        subject.flushPipeline()
-
-        // 9600 frames now. Reusing the 3000-frame measurement would wrap here
-        // and silence the frame instead.
-        assertEquals(1f, subject.play(3_001), 0f)
-    }
-
-    @Test
-    fun `a new video of the same length drops it too`() {
-        val subject = configured(durationUs = 100_000L)
-        subject.flushPipeline()
-        subject.play(3_000)
-        subject.onStreamChanged()
-
-        // A player is reused across videos and never reset between them, so
-        // two videos that agree to the millisecond must not share a frame
-        // count — they disagree by up to an AAC frame, which is wider than
-        // the fade.
-        subject.videoDurationUs = LoopDeclickAudioProcessor.DURATION_UNKNOWN
-        subject.videoDurationUs = 100_000L
-        subject.flushPipeline()
-
-        assertEquals(1f, subject.play(3_001), 0f)
+        assertEquals(0, subject.push(1_000).first().toInt())
     }
 
     @Test
@@ -327,33 +267,28 @@ class LoopDeclickAudioProcessorTest {
         val subject = configured(channelCount = 2)
         subject.flushPipeline()
 
-        val samples = subject.playInterleaved(
-            fadeFrames.toInt(),
-            listOf(leftLevel, rightLevel),
-        )
+        val out = subject.push(fadeFrames.toInt() * 2, listOf(leftLevel, rightLevel))
 
         // Half way into the fade in, each channel carries half of its own
         // level — not half of the left one twice.
         val frame = fadeFrames.toInt() / 2
         val gain = frame.toFloat() / fadeFrames
-        assertEquals((leftLevel * gain).toInt(), samples[frame * 2].toInt())
-        assertEquals((rightLevel * gain).toInt(), samples[frame * 2 + 1].toInt())
+        assertEquals((leftLevel * gain).toInt(), out[frame * 2].toInt())
+        assertEquals((rightLevel * gain).toInt(), out[frame * 2 + 1].toInt())
     }
 
     @Test
-    fun `stereo frames advance the position once per frame, not per sample`() {
-        val subject = configured(durationUs = 100_000L, channelCount = 2)
+    fun `a stereo stream holds back frames, not samples`() {
+        val subject = configured(channelCount = 2)
         subject.flushPipeline()
+        subject.push(2_000, listOf(level, level))
 
-        // 4800 frames. Counting interleaved samples instead would reach the
-        // end of the video half way through it.
-        val flat = subject.playInterleaved(
-            4_800 - fadeFrames.toInt() + 1,
-            listOf(level, level),
-        )
-        assertEquals(level.toInt(), flat.last().toInt())
+        val tail = subject.drainToEnd()
 
-        val fading = subject.playInterleaved(1, listOf(level, level))
-        assertTrue("fade out must start at the video's end", fading.first() < level)
+        // 480 frames of two channels. Counting interleaved samples as frames
+        // would hold back half a fade and end it in the wrong place.
+        assertEquals(fadeFrames.toInt() * 2, tail.size)
+        assertEquals(0, tail[tail.size - 2].toInt())
+        assertEquals(0, tail[tail.size - 1].toInt())
     }
 }

--- a/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/LoopDeclickAudioProcessorTest.kt
+++ b/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/LoopDeclickAudioProcessorTest.kt
@@ -1,9 +1,13 @@
 package com.divinevideo.divine_video_player
 
+import androidx.media3.common.C
+import androidx.media3.common.audio.AudioProcessor
 import androidx.media3.common.util.UnstableApi
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
 
 /**
  * Guards the fade that keeps a looping video's join from clicking (#6468).
@@ -22,12 +26,43 @@ class LoopDeclickAudioProcessorTest {
     /** 6 s at 48 kHz. */
     private val durationFrames = 288_000L
 
+    /** Full-scale mono sample the buffer-level tests feed. */
+    private val level: Short = 20_000
+
     private fun processor(
         durationUs: Long = 6_000_000L,
         enabled: Boolean = true,
     ): LoopDeclickAudioProcessor = LoopDeclickAudioProcessor().apply {
         this.videoDurationUs = durationUs
         this.enabled = enabled
+    }
+
+    /** A mono processor already through `configure`, ready to be flushed. */
+    private fun configured(
+        durationUs: Long = 6_000_000L,
+    ): LoopDeclickAudioProcessor = processor(durationUs = durationUs).apply {
+        configure(
+            AudioProcessor.AudioFormat(sampleRate, 1, C.ENCODING_PCM_16BIT),
+        )
+    }
+
+    private fun LoopDeclickAudioProcessor.flushPipeline() =
+        flush(AudioProcessor.StreamMetadata.DEFAULT)
+
+    private fun pcm(frames: Int): ByteBuffer =
+        ByteBuffer.allocateDirect(frames * 2)
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .apply {
+                repeat(frames) { putShort(level) }
+                flip()
+            }
+
+    /** Pushes [frames] frames through and returns the gain of the last one. */
+    private fun LoopDeclickAudioProcessor.play(frames: Int): Float {
+        queueInput(pcm(frames))
+        val out = output
+        val last = out.getShort((frames - 1) * 2)
+        return last.toFloat() / level
     }
 
     @Test
@@ -134,5 +169,103 @@ class LoopDeclickAudioProcessorTest {
 
         assertEquals(10_000L, LoopDeclickAudioProcessor.FADE_US)
         assertEquals(fadeFrames, subject.fadeFrames(sampleRate))
+    }
+
+    @Test
+    fun `the seek offset survives the second flush a seek triggers`() {
+        val subject = configured()
+        subject.nextStreamStartUs = 3_000_000L
+
+        // media3 flushes the pipeline twice before the first frame of a seek
+        // arrives: once from DefaultAudioSink.flush(), which releases the audio
+        // output, and again when the next buffer rebuilds it.
+        subject.flushPipeline()
+        subject.flushPipeline()
+
+        // Half way in is in neither fade. An offset consumed by the first
+        // flush would leave this anchored at zero, fading in mid-video and
+        // putting the fade out three seconds early.
+        assertEquals(1f, subject.play(1), 0f)
+    }
+
+    @Test
+    fun `the buffers a seek discards do not anchor a loop`() {
+        val subject = configured()
+        subject.nextStreamStartUs = 3_000_000L
+        subject.flushPipeline()
+
+        // MediaCodecAudioRenderer reports every buffer it drops on the way to
+        // the seek target as a discontinuity. None of them is a loop restart.
+        subject.onStreamChanged()
+        subject.onStreamChanged()
+
+        assertEquals(1f, subject.play(1), 0f)
+    }
+
+    @Test
+    fun `a loop restart fades in again`() {
+        val subject = configured()
+        subject.flushPipeline()
+        subject.play(1_000)
+
+        subject.onStreamChanged()
+
+        assertEquals(0f, subject.play(1), 0f)
+    }
+
+    @Test
+    fun `the first loop falls back to the container's duration`() {
+        // 100 ms at 48 kHz is 4800 frames, and nothing has been measured yet.
+        val subject = configured(durationUs = 100_000L)
+        subject.flushPipeline()
+
+        assertEquals(1f, subject.play(4_800 - fadeFrames.toInt() + 1), 0f)
+        assertTrue("fade out must start before the container's end", subject.play(1) < 1f)
+    }
+
+    @Test
+    fun `later loops follow the frames one really delivered`() {
+        // The container claims 100 ms (4800 frames) but the audio track only
+        // ever delivers 3000. Trusting the container would put the fade out
+        // 1800 frames past the join, so the loop would still click.
+        val subject = configured(durationUs = 100_000L)
+        subject.flushPipeline()
+        subject.play(3_000)
+        subject.onStreamChanged()
+
+        assertEquals(1f, subject.play(3_000 - fadeFrames.toInt() + 1), 0f)
+        assertTrue("fade out must start where the loop really ends", subject.play(1) < 1f)
+    }
+
+    @Test
+    fun `a loop cut short by an unrelated flush is not measured`() {
+        val subject = configured(durationUs = 100_000L)
+        subject.flushPipeline()
+        subject.play(1_000)
+        // A route change or an underrun flushes mid-loop, which restarts the
+        // count. What reaches the join is not the length of a loop.
+        subject.flushPipeline()
+        subject.play(1_000)
+        subject.onStreamChanged()
+
+        assertEquals(1f, subject.play(4_800 - fadeFrames.toInt() + 1), 0f)
+        assertTrue("the container's estimate must survive", subject.play(1) < 1f)
+    }
+
+    @Test
+    fun `a new video drops the previous one's measurement`() {
+        val subject = configured(durationUs = 100_000L)
+        subject.flushPipeline()
+        subject.play(3_000)
+        subject.onStreamChanged()
+
+        // What setClips does: clear the length, then publish the new one.
+        subject.videoDurationUs = LoopDeclickAudioProcessor.DURATION_UNKNOWN
+        subject.videoDurationUs = 200_000L
+        subject.flushPipeline()
+
+        // 9600 frames now. Reusing the 3000-frame measurement would wrap here
+        // and silence the frame instead.
+        assertEquals(1f, subject.play(3_001), 0f)
     }
 }

--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
@@ -44,6 +44,18 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
     /// long enough to remove the step even on low-frequency content and short
     /// enough not to read as a level change.
     private static let edgeDeclickFadeSeconds = 0.010
+    /// Timescale the audio mix's ramps are laid out in.
+    private static let audioMixTimescale: CMTimeScale = 600
+
+    /// [seconds] as whole [audioMixTimescale] ticks.
+    ///
+    /// Every bound in the mix goes through here so that the fade and the clip
+    /// it sits in are quantised the same way — a ramp may not cross another,
+    /// and comparing a rounded half against an independently rounded whole
+    /// does not guarantee it does not.
+    private static func ticks(_ seconds: Double) -> Int64 {
+        CMTime(seconds: seconds, preferredTimescale: audioMixTimescale).value
+    }
 
     /// AVFoundation's asset-option key for per-asset HTTP request headers.
     ///
@@ -543,20 +555,28 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         var audioMix: AVMutableAudioMix?
         if let audioTrack {
             let params = AVMutableAudioMixInputParameters(track: audioTrack)
-            let fadeSeconds = min(
-                Self.edgeDeclickFadeSeconds,
-                (durations.first ?? 0) / 2,
-                (durations.last ?? 0) / 2
+            // Measured in whole timescale ticks against the same quantisation
+            // the clip bounds get, so that halving a clip cannot round back up
+            // past it. Taking the minimum in seconds and quantising afterwards
+            // does not hold: a 15 ms clip is 9 ticks, and half of it rounds to
+            // 5, which would put the two fades over each other.
+            let fadeTicks = min(
+                Int64((Self.edgeDeclickFadeSeconds * Double(Self.audioMixTimescale)).rounded()),
+                Self.ticks(durations.first ?? 0) / 2,
+                Self.ticks(durations.last ?? 0) / 2
             )
-            let fade = CMTime(seconds: fadeSeconds, preferredTimescale: 600)
+            let fade = CMTime(value: fadeTicks, timescale: Self.audioMixTimescale)
             let lastIndex = durations.count - 1
             var t = CMTime.zero
             for (i, dur) in durations.enumerated() {
-                let clipEnd = CMTimeAdd(t, CMTime(seconds: dur, preferredTimescale: 600))
+                let clipEnd = CMTimeAdd(
+                    t,
+                    CMTime(value: Self.ticks(dur), timescale: Self.audioMixTimescale)
+                )
                 let vol = clipVolumes[i]
                 var flatStart = t
                 var flatEnd = clipEnd
-                if i == 0, fadeSeconds > 0 {
+                if i == 0, fadeTicks > 0 {
                     flatStart = CMTimeAdd(t, fade)
                     params.setVolumeRamp(
                         fromStartVolume: 0,
@@ -564,7 +584,7 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                         timeRange: CMTimeRange(start: t, end: flatStart)
                     )
                 }
-                if i == lastIndex, fadeSeconds > 0 {
+                if i == lastIndex, fadeTicks > 0 {
                     flatEnd = CMTimeSubtract(clipEnd, fade)
                 }
                 if CMTimeCompare(flatEnd, flatStart) > 0 {
@@ -574,7 +594,7 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                         timeRange: CMTimeRange(start: flatStart, end: flatEnd)
                     )
                 }
-                if i == lastIndex, fadeSeconds > 0 {
+                if i == lastIndex, fadeTicks > 0 {
                     params.setVolumeRamp(
                         fromStartVolume: vol,
                         toEndVolume: 0,

--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
@@ -635,7 +635,9 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                         timeRange: CMTimeRange(start: flatStart, end: flatEnd)
                     )
                 }
-                if i == lastIndex, fadeOutTicks > 0 {
+                if i == lastIndex, fadeOutTicks > 0,
+                    CMTimeCompare(flatEnd, flatStart) >= 0
+                {
                     params.setVolumeRamp(
                         fromStartVolume: vol,
                         toEndVolume: 0,

--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
@@ -47,12 +47,14 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
     /// Timescale the audio mix's ramps are laid out in.
     private static let audioMixTimescale: CMTimeScale = 600
 
-    /// [seconds] as whole [audioMixTimescale] ticks.
+    /// [seconds] as whole [audioMixTimescale] ticks, truncated.
     ///
-    /// Every bound in the mix goes through here so that the fade and the clip
-    /// it sits in are quantised the same way — a ramp may not cross another,
-    /// and comparing a rounded half against an independently rounded whole
-    /// does not guarantee it does not.
+    /// Used to bound the fade against the clip it has to fit inside twice.
+    /// `CMTimeMakeWithSeconds` documents no rounding *direction*, only that it
+    /// may round at all, so the halving is done once in ticks rather than in
+    /// seconds — a half that rounded up while the whole rounded down would put
+    /// the two fades over each other, and AVFoundation rejects overlapping
+    /// ramps with an Objective-C exception.
     private static func ticks(_ seconds: Double) -> Int64 {
         CMTime(seconds: seconds, preferredTimescale: audioMixTimescale).value
     }
@@ -348,6 +350,11 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         var insertTime = CMTime.zero
         var offsets: [Double] = []
         var durations: [Double] = []
+        // The same durations the composition is actually built from, kept as
+        // CMTime. Seconds are lossy here: the audio mix's last ramp has to end
+        // exactly where the composition ends, and a round trip through Double
+        // moves that edge by up to one tick of the mix's timescale.
+        var scaledDurations: [CMTime] = []
         var videoComposition: AVMutableVideoComposition?
         var layerInstruction: AVMutableVideoCompositionLayerInstruction?
         var clipVolumes: [Float] = []
@@ -524,6 +531,7 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
 
             offsets.append(CMTimeGetSeconds(insertTime))
             durations.append(CMTimeGetSeconds(scaledDuration))
+            scaledDurations.append(scaledDuration)
             clipVolumes.append(clipVol)
             insertTime = CMTimeAdd(insertTime, scaledDuration)
         }
@@ -555,24 +563,24 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         var audioMix: AVMutableAudioMix?
         if let audioTrack {
             let params = AVMutableAudioMixInputParameters(track: audioTrack)
-            // Measured in whole timescale ticks against the same quantisation
-            // the clip bounds get, so that halving a clip cannot round back up
-            // past it. Taking the minimum in seconds and quantising afterwards
-            // does not hold: a 15 ms clip is 9 ticks, and half of it rounds to
-            // 5, which would put the two fades over each other.
+            // The cap keeps the two fades of a very short video apart. It is
+            // taken in whole ticks of the fade's own timescale, and [ticks]
+            // truncates, so the cap can only ever understate the clip — a
+            // fade that fits twice in the truncated length fits twice in the
+            // real one.
             let fadeTicks = min(
                 Int64((Self.edgeDeclickFadeSeconds * Double(Self.audioMixTimescale)).rounded()),
                 Self.ticks(durations.first ?? 0) / 2,
                 Self.ticks(durations.last ?? 0) / 2
             )
             let fade = CMTime(value: fadeTicks, timescale: Self.audioMixTimescale)
-            let lastIndex = durations.count - 1
+            let lastIndex = scaledDurations.count - 1
             var t = CMTime.zero
-            for (i, dur) in durations.enumerated() {
-                let clipEnd = CMTimeAdd(
-                    t,
-                    CMTime(value: Self.ticks(dur), timescale: Self.audioMixTimescale)
-                )
+            for (i, clipDuration) in scaledDurations.enumerated() {
+                // Exactly the duration the composition was built from, so the
+                // last clip's end is the composition's end and the fade out
+                // reaches zero on the sample the loop actually joins.
+                let clipEnd = CMTimeAdd(t, clipDuration)
                 let vol = clipVolumes[i]
                 var flatStart = t
                 var flatEnd = clipEnd

--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
@@ -62,16 +62,27 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
     /// Timescale the audio mix's ramps are laid out in.
     private static let audioMixTimescale: CMTimeScale = 600
 
-    /// [seconds] as whole [audioMixTimescale] ticks, truncated.
+    /// Half of [duration], in whole [audioMixTimescale] ticks, toward zero.
     ///
-    /// Used to bound the fade against the clip it has to fit inside twice.
-    /// `CMTimeMakeWithSeconds` documents no rounding *direction*, only that it
-    /// may round at all, so the halving is done once in ticks rather than in
-    /// seconds — a half that rounded up while the whole rounded down would put
-    /// the two fades over each other, and AVFoundation rejects overlapping
-    /// ramps with an Objective-C exception.
-    private static func ticks(_ seconds: Double) -> Int64 {
-        CMTime(seconds: seconds, preferredTimescale: audioMixTimescale).value
+    /// Bounds a fade against the clip it has to fit inside twice, so the cap
+    /// must never overstate the clip: a half that rounded up while the clip
+    /// rounded down would put the two fades over each other, and AVFoundation
+    /// rejects overlapping ramps with an Objective-C
+    /// NSInvalidArgumentException, which is not a Swift `Error` and would
+    /// abort the process.
+    ///
+    /// Converted explicitly rather than through `CMTimeMakeWithSeconds`, which
+    /// today truncates but whose rounding *direction* CMTime.h does not
+    /// specify — the header only says the result may be rounded. Taking the
+    /// exact `CMTime` the composition was built from also skips the lossy
+    /// round trip through `Double` seconds.
+    private static func halfFadeTicks(_ duration: CMTime?) -> Int64 {
+        guard let duration, duration.isNumeric, duration.value > 0 else { return 0 }
+        return CMTimeConvertScale(
+            duration,
+            timescale: audioMixTimescale,
+            method: .roundTowardZero
+        ).value / 2
     }
 
     /// AVFoundation's asset-option key for per-asset HTTP request headers.
@@ -578,17 +589,24 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         var audioMix: AVMutableAudioMix?
         if let audioTrack {
             let params = AVMutableAudioMixInputParameters(track: audioTrack)
-            // The cap keeps the two fades of a very short video apart. It is
-            // taken in whole ticks of the fade's own timescale, and [ticks]
-            // truncates, so the cap can only ever understate the clip — a
-            // fade that fits twice in the truncated length fits twice in the
-            // real one.
-            let fadeTicks = min(
-                Int64((Self.edgeDeclickFadeSeconds * Double(Self.audioMixTimescale)).rounded()),
-                Self.ticks(durations.first ?? 0) / 2,
-                Self.ticks(durations.last ?? 0) / 2
-            )
-            let fade = CMTime(value: fadeTicks, timescale: Self.audioMixTimescale)
+            // Each edge is capped by the clip it sits in, and only by that
+            // clip. Capping both by a single minimum would let one short clip
+            // at either end shorten the fade at the *other* end too — and
+            // below the ~25 ms floor described on [edgeDeclickFadeSeconds] a
+            // ramp is stretched and never reaches zero, so the edge that did
+            // not need shortening would silently stop declicking.
+            //
+            // [halfFadeTicks] rounds toward zero, so each cap can only ever
+            // understate its clip — a fade that fits twice in the truncated
+            // length fits twice in the real one. Each cap is half its own
+            // clip, so on a single clip the two fades still cannot meet, and
+            // on several they sit in different clips entirely.
+            let maxFadeTicks =
+                Int64((Self.edgeDeclickFadeSeconds * Double(Self.audioMixTimescale)).rounded())
+            let fadeInTicks = min(maxFadeTicks, Self.halfFadeTicks(scaledDurations.first))
+            let fadeOutTicks = min(maxFadeTicks, Self.halfFadeTicks(scaledDurations.last))
+            let fadeIn = CMTime(value: fadeInTicks, timescale: Self.audioMixTimescale)
+            let fadeOut = CMTime(value: fadeOutTicks, timescale: Self.audioMixTimescale)
             let lastIndex = scaledDurations.count - 1
             var t = CMTime.zero
             for (i, clipDuration) in scaledDurations.enumerated() {
@@ -599,16 +617,16 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                 let vol = clipVolumes[i]
                 var flatStart = t
                 var flatEnd = clipEnd
-                if i == 0, fadeTicks > 0 {
-                    flatStart = CMTimeAdd(t, fade)
+                if i == 0, fadeInTicks > 0 {
+                    flatStart = CMTimeAdd(t, fadeIn)
                     params.setVolumeRamp(
                         fromStartVolume: 0,
                         toEndVolume: vol,
                         timeRange: CMTimeRange(start: t, end: flatStart)
                     )
                 }
-                if i == lastIndex, fadeTicks > 0 {
-                    flatEnd = CMTimeSubtract(clipEnd, fade)
+                if i == lastIndex, fadeOutTicks > 0 {
+                    flatEnd = CMTimeSubtract(clipEnd, fadeOut)
                 }
                 if CMTimeCompare(flatEnd, flatStart) > 0 {
                     params.setVolumeRamp(
@@ -617,7 +635,7 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                         timeRange: CMTimeRange(start: flatStart, end: flatEnd)
                     )
                 }
-                if i == lastIndex, fadeTicks > 0 {
+                if i == lastIndex, fadeOutTicks > 0 {
                     params.setVolumeRamp(
                         fromStartVolume: vol,
                         toEndVolume: 0,

--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
@@ -35,6 +35,15 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
     private static let bufferingStallMs = 8_000
     private static let maxCommonTrackEndTrimMs = 500.0
     private static let maxCommonTrackEndTrimRatio = 0.10
+    /// Length of the fade applied to each outer edge of the composition.
+    ///
+    /// A loop restart cuts from the composition's last sample straight back to
+    /// its first, and that cut has never been tied to a zero crossing — it
+    /// comes from a trim or a recording length. Unless both edges happen to
+    /// sit near silence the step is audible as a click. Ten milliseconds is
+    /// long enough to remove the step even on low-frequency content and short
+    /// enough not to read as a level change.
+    private static let edgeDeclickFadeSeconds = 0.010
 
     /// AVFoundation's asset-option key for per-asset HTTP request headers.
     ///
@@ -521,20 +530,58 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         // the single composition audio track. AVQueuePlayer.volume multiplies on
         // top automatically, so 0.0 here = muted for that clip regardless of the
         // global volume.
+        //
+        // The video's two outer edges also fade, because AVPlayerLooper joins
+        // them directly on every loop restart (#6468). Everything between keeps
+        // its flat gain — only the join is audible, not the cuts inside it.
+        //
+        // The fade is folded into the gain it starts and ends at rather than
+        // layered over it. Ramps may not overlap: AVFoundation rejects a ramp
+        // that crosses an existing one with an Objective-C
+        // NSInvalidArgumentException, which is not a Swift Error and would
+        // abort the process. Folding also keeps a muted video silent.
         var audioMix: AVMutableAudioMix?
         if let audioTrack {
             let params = AVMutableAudioMixInputParameters(track: audioTrack)
+            let fadeSeconds = min(
+                Self.edgeDeclickFadeSeconds,
+                (durations.first ?? 0) / 2,
+                (durations.last ?? 0) / 2
+            )
+            let fade = CMTime(seconds: fadeSeconds, preferredTimescale: 600)
+            let lastIndex = durations.count - 1
             var t = CMTime.zero
             for (i, dur) in durations.enumerated() {
-                let clipDuration = CMTime(seconds: dur, preferredTimescale: 600)
-                let range = CMTimeRange(start: t, duration: clipDuration)
+                let clipEnd = CMTimeAdd(t, CMTime(seconds: dur, preferredTimescale: 600))
                 let vol = clipVolumes[i]
-                params.setVolumeRamp(
-                    fromStartVolume: vol,
-                    toEndVolume: vol,
-                    timeRange: range
-                )
-                t = CMTimeAdd(t, clipDuration)
+                var flatStart = t
+                var flatEnd = clipEnd
+                if i == 0, fadeSeconds > 0 {
+                    flatStart = CMTimeAdd(t, fade)
+                    params.setVolumeRamp(
+                        fromStartVolume: 0,
+                        toEndVolume: vol,
+                        timeRange: CMTimeRange(start: t, end: flatStart)
+                    )
+                }
+                if i == lastIndex, fadeSeconds > 0 {
+                    flatEnd = CMTimeSubtract(clipEnd, fade)
+                }
+                if CMTimeCompare(flatEnd, flatStart) > 0 {
+                    params.setVolumeRamp(
+                        fromStartVolume: vol,
+                        toEndVolume: vol,
+                        timeRange: CMTimeRange(start: flatStart, end: flatEnd)
+                    )
+                }
+                if i == lastIndex, fadeSeconds > 0 {
+                    params.setVolumeRamp(
+                        fromStartVolume: vol,
+                        toEndVolume: 0,
+                        timeRange: CMTimeRange(start: flatEnd, end: clipEnd)
+                    )
+                }
+                t = clipEnd
             }
             let mix = AVMutableAudioMix()
             mix.inputParameters = [params]

--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
@@ -40,10 +40,25 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
     /// A loop restart cuts from the composition's last sample straight back to
     /// its first, and that cut has never been tied to a zero crossing — it
     /// comes from a trim or a recording length. Unless both edges happen to
-    /// sit near silence the step is audible as a click. Ten milliseconds is
-    /// long enough to remove the step even on low-frequency content and short
-    /// enough not to read as a level change.
-    private static let edgeDeclickFadeSeconds = 0.010
+    /// sit near silence the step is audible as a click.
+    ///
+    /// The length is set by AVFoundation, not by taste. A volume ramp shorter
+    /// than about 25 ms is not honoured over its own time range: it is
+    /// stretched to that floor, so it never reaches its end value where it was
+    /// asked to. Rendering a composition through this mix and dividing by the
+    /// same composition rendered without it gives the gain actually applied to
+    /// the last sample — the one the loop joins:
+    ///
+    ///     fade 10 ms -> 0.6034      fade 25 ms -> 0.0037
+    ///     fade 20 ms -> 0.2032      fade 30 ms -> 0.0008
+    ///
+    /// At 10 ms the join still carries 60% of full amplitude, which is the
+    /// click this was meant to remove. The floor measured 24.8 ms at both
+    /// 44.1 kHz and 48 kHz, so it is a duration rather than a block of frames;
+    /// 30 ms clears it and is still short enough not to read as a level
+    /// change. The Android player has no such floor — it fades decoded frames
+    /// — and stays at 10 ms, where its fade doubles as its audio latency.
+    private static let edgeDeclickFadeSeconds = 0.030
     /// Timescale the audio mix's ramps are laid out in.
     private static let audioMixTimescale: CMTimeScale = 600
 

--- a/mobile/packages/divine_video_player/lib/src/video_clip.dart
+++ b/mobile/packages/divine_video_player/lib/src/video_clip.dart
@@ -146,9 +146,11 @@ class VideoClip {
   /// rather than a seam. Clamping only ever shortens: [end], when set, still
   /// wins if it is earlier.
   ///
-  /// Support is per-platform: Apple always honours it, Android honours it for
-  /// local files only (a remote source would need a blocking metadata read
-  /// before playback could start), and the web and Linux backends ignore it.
+  /// Support is per-platform: Apple and Android both honour it for local and
+  /// remote sources, and the web and Linux backends ignore it. Reading a
+  /// remote source's track lengths costs a metadata request before playback
+  /// starts, so both platforms cache the result per source and Android gives
+  /// up after a short wait and plays unclamped rather than hold the load.
   final bool trimToCommonTrackEnd;
 
   /// Serializes this clip for platform channel transport.

--- a/mobile/packages/divine_video_player/lib/src/video_clip.dart
+++ b/mobile/packages/divine_video_player/lib/src/video_clip.dart
@@ -151,6 +151,9 @@ class VideoClip {
   /// remote source's track lengths costs a metadata request before playback
   /// starts, so both platforms cache the result per source and Android gives
   /// up after a short wait and plays unclamped rather than hold the load.
+  /// Android does not probe an HLS source at all — `MediaExtractor` cannot
+  /// open a playlist — so an HLS clip plays unclamped rather than paying for a
+  /// read that can only fail.
   final bool trimToCommonTrackEnd;
 
   /// Serializes this clip for platform channel transport.

--- a/mobile/packages/divine_video_player/test/src/loop_declick_fade_contract_test.dart
+++ b/mobile/packages/divine_video_player/test/src/loop_declick_fade_contract_test.dart
@@ -1,0 +1,128 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('loop declick fade contract', () {
+    test('Apple fades the video, not each clip', () {
+      final source = _appleSourceFile().readAsStringSync();
+
+      expect(
+        source,
+        contains('edgeDeclickFadeSeconds = 0.010'),
+        reason:
+            'AVPlayerLooper joins the video end to its start on every '
+            'restart. Without a fade that step is audible as a click.',
+      );
+      expect(
+        source,
+        matches(
+          RegExp(
+            r'if i == 0, fadeSeconds > 0 \{[\s\S]*?'
+            r'fromStartVolume: 0,\s*toEndVolume: vol,',
+          ),
+        ),
+        reason:
+            'Only the first clip carries the fade in — fading every clip '
+            'would notch the audio at each cut inside the video.',
+      );
+      expect(
+        source,
+        matches(
+          RegExp(
+            r'if i == lastIndex, fadeSeconds > 0 \{[\s\S]*?'
+            r'fromStartVolume: vol,\s*toEndVolume: 0,',
+          ),
+        ),
+        reason:
+            'The last clip carries the fade out; fading only the start '
+            'still leaves the step at the join.',
+      );
+    });
+
+    test('Android reaches the audio path at all', () {
+      final source = _androidSourceFile().readAsStringSync();
+
+      expect(
+        source,
+        contains('LoopDeclickRenderersFactory(context, declickProcessor)'),
+        reason:
+            'The processor only ever runs if it is built into the audio sink. '
+            'A DefaultRenderersFactory here leaves the fade as dead code.',
+      );
+      expect(
+        source,
+        contains('declickProcessor.enabled = clipCount == 1'),
+        reason:
+            'On a multi-clip timeline a stream is one clip rather than the '
+            'whole video, so fading every stream would notch each cut.',
+      );
+      expect(
+        source,
+        contains('declickProcessor.videoDurationUs'),
+        reason:
+            'The fade out has to know where the loop join is; without a '
+            'duration only the video start can be faded.',
+      );
+    });
+
+    test('Apple never writes ramps that overlap', () {
+      final source = _appleSourceFile().readAsStringSync();
+
+      expect(
+        source,
+        contains('CMTimeCompare(flatEnd, flatStart) > 0'),
+        reason:
+            'A ramp that crosses an existing one is rejected with an '
+            'Objective-C NSInvalidArgumentException, which is not a Swift '
+            'Error and aborts the process. The flat gain may only be '
+            'written where the two fades have not already claimed the time.',
+      );
+      expect(
+        source,
+        matches(
+          RegExp(
+            r'min\(\s*Self\.edgeDeclickFadeSeconds,\s*'
+            r'\(durations\.first \?\? 0\) / 2,\s*'
+            r'\(durations\.last \?\? 0\) / 2',
+          ),
+        ),
+        reason:
+            'A video shorter than the two fades combined must get shorter '
+            'ones, otherwise the fade in and fade out overlap.',
+      );
+    });
+  });
+}
+
+File _androidSourceFile() {
+  final packageRelative = File(
+    'android/src/main/kotlin/com/divinevideo/divine_video_player/'
+    'DivineVideoPlayerInstance.kt',
+  );
+  if (packageRelative.existsSync()) {
+    return packageRelative;
+  }
+
+  return File(
+    'packages/divine_video_player/'
+    'android/src/main/kotlin/com/divinevideo/divine_video_player/'
+    'DivineVideoPlayerInstance.kt',
+  );
+}
+
+File _appleSourceFile() {
+  final packageRelative = File(
+    'darwin/divine_video_player/Sources/divine_video_player/'
+    'DivineVideoPlayerInstance.swift',
+  );
+  if (packageRelative.existsSync()) {
+    return packageRelative;
+  }
+
+  return File(
+    'packages/divine_video_player/'
+    'darwin/divine_video_player/Sources/divine_video_player/'
+    'DivineVideoPlayerInstance.swift',
+  );
+}

--- a/mobile/packages/divine_video_player/test/src/loop_declick_fade_contract_test.dart
+++ b/mobile/packages/divine_video_player/test/src/loop_declick_fade_contract_test.dart
@@ -22,8 +22,8 @@ void main() {
         source,
         matches(
           RegExp(
-            r'if i == 0, fadeTicks > 0 \{[\s\S]{0,120}?'
-            r'flatStart = CMTimeAdd\(t, fade\)[\s\S]{0,120}?'
+            r'if i == 0, fadeInTicks > 0 \{[\s\S]{0,120}?'
+            r'flatStart = CMTimeAdd\(t, fadeIn\)[\s\S]{0,120}?'
             r'params\.setVolumeRamp\([\s\S]{0,120}?'
             r'fromStartVolume: 0,\s*toEndVolume: vol,',
           ),
@@ -38,14 +38,15 @@ void main() {
         source,
         matches(
           RegExp(
-            r'if i == lastIndex, fadeTicks > 0 \{[\s\S]{0,120}?'
-            r'params\.setVolumeRamp\([\s\S]{0,120}?'
-            r'fromStartVolume: vol,\s*toEndVolume: 0,',
+            r'params\.setVolumeRamp\([\s\S]{0,80}?'
+            r'fromStartVolume: vol,\s*toEndVolume: 0,\s*'
+            r'timeRange: CMTimeRange\(start: flatEnd, end: clipEnd\)',
           ),
         ),
         reason:
-            'The last clip carries the fade out; fading only the start '
-            'still leaves the step at the join.',
+            'The last clip carries the fade out, and it has to land on the '
+            "composition's own end; fading only the start still leaves the "
+            'step at the join.',
       );
       expect(
         source,
@@ -132,19 +133,38 @@ void main() {
       );
       expect(
         source,
-        matches(
-          RegExp(
-            r'let fadeTicks = min\([\s\S]{0,200}?'
-            r'Self\.ticks\(durations\.first \?\? 0\) / 2,\s*'
-            r'Self\.ticks\(durations\.last \?\? 0\) / 2',
-          ),
+        contains(
+          'let fadeInTicks = min(maxFadeTicks, '
+          'Self.halfFadeTicks(scaledDurations.first))',
         ),
         reason:
             'A video shorter than the two fades combined must get shorter '
-            'ones. CMTimeMakeWithSeconds documents no rounding direction, so '
-            'the halving is done once in whole ticks — a half that rounded up '
-            'while the whole rounded down would put the two fades over each '
-            'other, and AVFoundation rejects overlapping ramps.',
+            'ones, capped by the clip each fade sits in. Capping both by one '
+            'minimum lets a short clip at either end shorten the fade at the '
+            'other — and under the ~25 ms floor AVFoundation stretches the '
+            'ramp so it never reaches zero, silently un-fixing that edge.',
+      );
+      expect(
+        source,
+        contains(
+          'let fadeOutTicks = min(maxFadeTicks, '
+          'Self.halfFadeTicks(scaledDurations.last))',
+        ),
+        reason:
+            'The fade out is capped by the last clip, and by the exact CMTime '
+            'the composition was built from rather than a Double round trip.',
+      );
+      expect(
+        source,
+        contains('method: .roundTowardZero'),
+        reason:
+            'The no-overlap proof rests on the cap understating its clip. '
+            'CMTime.h does not specify which direction CMTimeMakeWithSeconds '
+            'rounds, so the conversion names the direction rather than '
+            'relying on the behaviour that happens to ship — a half that '
+            'rounded up while the clip rounded down would put the two fades '
+            'over each other, and AVFoundation rejects overlapping ramps '
+            'with an Objective-C exception that aborts the process.',
       );
     });
   });

--- a/mobile/packages/divine_video_player/test/src/loop_declick_fade_contract_test.dart
+++ b/mobile/packages/divine_video_player/test/src/loop_declick_fade_contract_test.dart
@@ -9,10 +9,14 @@ void main() {
 
       expect(
         source,
-        contains('edgeDeclickFadeSeconds = 0.010'),
+        contains('edgeDeclickFadeSeconds = 0.030'),
         reason:
             'AVPlayerLooper joins the video end to its start on every '
-            'restart. Without a fade that step is audible as a click.',
+            'restart. Without a fade that step is audible as a click — and '
+            'AVFoundation stretches any volume ramp shorter than about 25 ms '
+            'to that floor, so it never reaches zero where it was asked to. '
+            'Measured on the last sample: 10 ms leaves gain 0.60, 30 ms '
+            'leaves 0.0008. Shortening this back re-introduces the click.',
       );
       expect(
         source,

--- a/mobile/packages/divine_video_player/test/src/loop_declick_fade_contract_test.dart
+++ b/mobile/packages/divine_video_player/test/src/loop_declick_fade_contract_test.dart
@@ -18,7 +18,9 @@ void main() {
         source,
         matches(
           RegExp(
-            r'if i == 0, fadeSeconds > 0 \{[\s\S]*?'
+            r'if i == 0, fadeTicks > 0 \{\s*'
+            r'flatStart = CMTimeAdd\(t, fade\)\s*'
+            r'params\.setVolumeRamp\(\s*'
             r'fromStartVolume: 0,\s*toEndVolume: vol,',
           ),
         ),
@@ -30,7 +32,8 @@ void main() {
         source,
         matches(
           RegExp(
-            r'if i == lastIndex, fadeSeconds > 0 \{[\s\S]*?'
+            r'if i == lastIndex, fadeTicks > 0 \{\s*'
+            r'params\.setVolumeRamp\(\s*'
             r'fromStartVolume: vol,\s*toEndVolume: 0,',
           ),
         ),
@@ -59,10 +62,26 @@ void main() {
       );
       expect(
         source,
-        contains('declickProcessor.videoDurationUs'),
+        matches(
+          RegExp(
+            r'playbackState == Player\.STATE_READY\) \{[\s\S]{0,400}?'
+            r'updateDeclickDuration\(\)',
+          ),
+        ),
         reason:
-            'The fade out has to know where the loop join is; without a '
-            'duration only the video start can be faded.',
+            'The fade out has to know where the loop join is, and the length '
+            'is only readable once the timeline is populated. Naming the '
+            'field alone is not enough — setClips also writes it, with '
+            'DURATION_UNKNOWN.',
+      );
+      expect(
+        source,
+        contains(
+          'declickProcessor.videoDurationUs = if (durationMs == C.TIME_UNSET)',
+        ),
+        reason:
+            'An unknown length has to stay unknown rather than become a '
+            'negative duration the fade would wrap on.',
       );
     });
 
@@ -82,14 +101,17 @@ void main() {
         source,
         matches(
           RegExp(
-            r'min\(\s*Self\.edgeDeclickFadeSeconds,\s*'
-            r'\(durations\.first \?\? 0\) / 2,\s*'
-            r'\(durations\.last \?\? 0\) / 2',
+            r'let fadeTicks = min\([\s\S]{0,200}?'
+            r'Self\.ticks\(durations\.first \?\? 0\) / 2,\s*'
+            r'Self\.ticks\(durations\.last \?\? 0\) / 2',
           ),
         ),
         reason:
             'A video shorter than the two fades combined must get shorter '
-            'ones, otherwise the fade in and fade out overlap.',
+            'ones, and the halving has to happen in the same whole ticks the '
+            'clip bounds are quantised to. Taking the minimum in seconds and '
+            'rounding afterwards lets half a 9-tick clip round back up to 5, '
+            'which puts the two fades over each other.',
       );
     });
   });

--- a/mobile/packages/divine_video_player/test/src/loop_declick_fade_contract_test.dart
+++ b/mobile/packages/divine_video_player/test/src/loop_declick_fade_contract_test.dart
@@ -80,10 +80,10 @@ void main() {
           ),
         ),
         reason:
-            'The fade out has to know where the loop join is, and the length '
-            'is only readable once the timeline is populated. Naming the '
-            'field alone is not enough — setClips also writes it, with '
-            'DURATION_UNKNOWN.',
+            'The length bounds how long the fade may be on a video too short '
+            'to carry two of them, and it is only readable once the timeline '
+            'is populated. Naming the field alone is not enough — setClips '
+            'also writes it, with DURATION_UNKNOWN.',
       );
       expect(
         source,

--- a/mobile/packages/divine_video_player/test/src/loop_declick_fade_contract_test.dart
+++ b/mobile/packages/divine_video_player/test/src/loop_declick_fade_contract_test.dart
@@ -18,28 +18,39 @@ void main() {
         source,
         matches(
           RegExp(
-            r'if i == 0, fadeTicks > 0 \{\s*'
-            r'flatStart = CMTimeAdd\(t, fade\)\s*'
-            r'params\.setVolumeRamp\(\s*'
+            r'if i == 0, fadeTicks > 0 \{[\s\S]{0,120}?'
+            r'flatStart = CMTimeAdd\(t, fade\)[\s\S]{0,120}?'
+            r'params\.setVolumeRamp\([\s\S]{0,120}?'
             r'fromStartVolume: 0,\s*toEndVolume: vol,',
           ),
         ),
         reason:
             'Only the first clip carries the fade in — fading every clip '
-            'would notch the audio at each cut inside the video.',
+            'would notch the audio at each cut inside the video. The slack '
+            'is bounded rather than bare whitespace so an interleaved '
+            'comment does not read as a missing fade.',
       );
       expect(
         source,
         matches(
           RegExp(
-            r'if i == lastIndex, fadeTicks > 0 \{\s*'
-            r'params\.setVolumeRamp\(\s*'
+            r'if i == lastIndex, fadeTicks > 0 \{[\s\S]{0,120}?'
+            r'params\.setVolumeRamp\([\s\S]{0,120}?'
             r'fromStartVolume: vol,\s*toEndVolume: 0,',
           ),
         ),
         reason:
             'The last clip carries the fade out; fading only the start '
             'still leaves the step at the join.',
+      );
+      expect(
+        source,
+        contains('let clipEnd = CMTimeAdd(t, clipDuration)'),
+        reason:
+            'The ramps must be laid out on the CMTimes the composition was '
+            'built from. Round-tripping them through seconds moves the last '
+            "clip's end off the composition's end by up to a tick, and the "
+            'fade out then stops short of the sample the loop joins.',
       );
     });
 
@@ -83,6 +94,24 @@ void main() {
             'An unknown length has to stay unknown rather than become a '
             'negative duration the fade would wrap on.',
       );
+
+      // Both anchors occur exactly once, so their order in the file is the
+      // order they run in.
+      final publishIndex = source.indexOf(
+        'declickProcessor.nextStreamStartUs = startLocalMs * 1000L',
+      );
+      final swapIndex = source.indexOf('exoPlayer.setMediaItems(');
+      expect(publishIndex, isNonNegative);
+      expect(swapIndex, isNonNegative);
+      expect(
+        publishIndex,
+        lessThan(swapIndex),
+        reason:
+            'The playlist swap disables the audio renderer, which flushes the '
+            'pipeline on the playback thread. A start position published after '
+            'it is read too late, and the lap after a resume loses its fade '
+            'out. Presence assertions alone do not catch the reordering.',
+      );
     });
 
     test('Apple never writes ramps that overlap', () {
@@ -108,10 +137,10 @@ void main() {
         ),
         reason:
             'A video shorter than the two fades combined must get shorter '
-            'ones, and the halving has to happen in the same whole ticks the '
-            'clip bounds are quantised to. Taking the minimum in seconds and '
-            'rounding afterwards lets half a 9-tick clip round back up to 5, '
-            'which puts the two fades over each other.',
+            'ones. CMTimeMakeWithSeconds documents no rounding direction, so '
+            'the halving is done once in whole ticks — a half that rounded up '
+            'while the whole rounded down would put the two fades over each '
+            'other, and AVFoundation rejects overlapping ramps.',
       );
     });
   });

--- a/mobile/packages/divine_video_player/test/src/loop_seam_trim_contract_test.dart
+++ b/mobile/packages/divine_video_player/test/src/loop_seam_trim_contract_test.dart
@@ -70,7 +70,7 @@ void main() {
       );
       expect(
         source,
-        contains('setEndPositionMs(effectiveEndMs)'),
+        contains('buildMediaItem(uri, startMs, effectiveEndMs)'),
         reason:
             'The clamped end must reach ExoPlayer; setting the raw endMs '
             'would leave the seam in place.',
@@ -116,6 +116,13 @@ void main() {
         reason:
             'The probe blocks on I/O, so it may never run on the platform '
             'thread — which is why it used to be skipped for remote sources.',
+      );
+      expect(
+        source,
+        contains('warmTrackDurationsInBackground'),
+        reason:
+            'Uncached remote probes must warm the cache without serializing '
+            'the feed first-frame path ahead of ExoPlayer.',
       );
       expect(
         source,

--- a/mobile/packages/divine_video_player/test/src/loop_seam_trim_contract_test.dart
+++ b/mobile/packages/divine_video_player/test/src/loop_seam_trim_contract_test.dart
@@ -91,7 +91,7 @@ void main() {
       );
     });
 
-    test('Android probes local files only', () {
+    test('Android probes remote sources too, off the platform thread', () {
       final source = _androidSourceFile().readAsStringSync();
 
       expect(
@@ -103,10 +103,33 @@ void main() {
       );
       expect(
         source,
-        contains(RegExp(r'uri\.startsWith\("file://"\)')),
+        contains(RegExp(r'uri\.startsWith\("https://"\)')),
         reason:
-            'Probing a remote source would block playback start on a network '
-            'round trip, so only local files may be read.',
+            'Remote clips are the ones the feed loops. Probing local files '
+            'only left every https source ending at the container duration, '
+            'so 46% of feed videos replayed a frozen last frame at every '
+            'loop restart on Android while iOS looped cleanly.',
+      );
+      expect(
+        source,
+        contains('metadataExecutor.execute'),
+        reason:
+            'The probe blocks on I/O, so it may never run on the platform '
+            'thread — which is why it used to be skipped for remote sources.',
+      );
+      expect(
+        source,
+        matches(
+          RegExp(
+            r'mainHandler\.postDelayed\(\s*deferredSetClipsTimeout,\s*'
+            'TRACK_DURATION_RESOLVE_TIMEOUT_MS',
+          ),
+        ),
+        reason:
+            'MediaHTTPConnection sets a connect timeout and no read timeout, '
+            'so a host that stalls mid-response would hold `await setClips()` '
+            'open forever. The wait has to be bounded, and expiring it plays '
+            'unclamped rather than not at all.',
       );
     });
   });


### PR DESCRIPTION
## Description

A looping video cuts from its last sample straight back to its first. That cut has never been tied to a zero crossing — it comes from a trim or a recording length — so unless both edges happen to sit near silence, the step is audible as a click on every restart.

Two separate things made the restart noticeable, and this PR fixes both: the audio steps (a click), and on Android the picture freezes first (a hitch).

## The click

Both players now fade the video's outer edges. Only the outer edges: the join is the only edge a loop actually plays, and fading each clip of a multi-clip timeline would notch the audio at every cut. On Apple that means the composition's outer edges at any clip count. On Android the only anchor available is a stream change, which is indistinguishable from a cut inside the timeline, so there the fade is gated to single-clip videos — which is what the feed loops.

### Apple

The `AVMutableAudioMix` already existed for per-clip volume, so the fade folds into ramps that were previously flat.

It has to fold in rather than layer on top. I tried the two-line version first — set the flat ramp, then write the fades over it — and AVFoundation rejects a ramp that crosses an existing one:

```
NSInvalidArgumentException: The timeRange of a ramp must not overlap
the timeRange of an existing ramp.
```

That is an Objective-C exception, not a Swift `Error`, so it would abort the process — the same class of trap as the `setVideoComposition:` guard already documented in that file. The ramps are laid end to end instead. Folding also means the fade starts and ends at the clip's own gain, so a muted clip stays silent through it.

The ramps are laid out on the `CMTime`s the composition was built from. Rebuilding each bound from `CMTimeGetSeconds` at timescale 600 looks equivalent and is not: `CMTimeMakeWithSeconds` truncates, so the accumulated end fell short of the composition's by up to a tick per clip. Measured against real AVFoundation, `getVolumeRamp` found **no ramp at all** covering the composition's last sample — for a 6.006 s asset at timescale 90000, a 4.317 s one at 44100, a 12 ms clip, and a three-clip timeline. Whatever plays there is not the zero the fade is supposed to reach. On the exact `CMTime`s, the same four cases report a ramp ending at volume 0.

Seconds are still used for one thing: capping the fade at half the first and last clip so a very short video's two fades cannot overlap. That cap goes through one helper that truncates to whole 600-ticks, and the halving happens there rather than in seconds — `CMTimeMakeWithSeconds` documents no rounding *direction*, and a half that rounded up while the whole rounded down would put the two ramps over each other. A truncated cap can only understate the clip, which is the safe direction.

### Android

Harder, because ExoPlayer gives an `AudioProcessor` no position of its own. `StreamMetadata.positionOffsetUs` is 0 on every playback-path flush in media3 1.10: `DefaultAudioSink.setupAudioProcessors()` calls the deprecated no-argument `AudioProcessingPipeline.flush()`, which substitutes `StreamMetadata.DEFAULT`. So media3's own `GainProcessor` has nothing to place a fade against.

The two edges end up being found in opposite ways.

**The start is a counting problem.** Frames are counted from a flush, and the count is anchored from outside by the stream change `MediaCodecAudioRenderer` raises from `onProcessedStreamChange` — after the last buffer of the finished period has gone to the sink and before the first buffer of the next. That is exactly the join. A `ForwardingAudioSink` turns it into an anchor.

The wrapper's real job there is retiring the seek offset. A seek flushes the processing pipeline twice before a single frame is queued — once from `DefaultAudioSink.flush()`, which then releases the audio output, and again when the next buffer rebuilds it. A one-shot offset is eaten by the first flush and the second re-anchors at zero, so the lap after a seek would fade in mid-video. The offset is sticky and retired at the join, which is where it genuinely stops applying. The decode-only buffers a seek discards are reported as discontinuities too, so an anchor is only taken once input has actually arrived.

**The end cannot be counted towards**, because nothing on this side of the pipeline knows where it is until it arrives. `player.duration` is the container's figure, in whole milliseconds, for its longest track; the decoded audio track ends up to an AAC frame away from that — roughly twice the fade. Timing the fade out off it left the ramp finishing before the last sample on videos where the gap was wide enough, and those clicked on their first restart. (Reported on device exactly that way: only the first restart, and only some videos.)

So the last 10 ms are held back instead, and released faded once media3 reports the stream has ended. That report is exact and arrives at every loop restart: `handleDiscontinuity` sets `startMediaTimeUsNeedsSync`, and the next buffer makes `DefaultAudioSink` run `drainToEndOfStream()`, which queues end-of-stream into the pipeline before any frame of the new lap is. `TrimmingAudioProcessor` holds its own tail back the same way, one slot upstream in this same chain.

`videoDurationUs` survives only to shorten the fade on a video too short to carry two of them. Being a millisecond out there costs ramp length, not position.

The cost is that audio runs 10 ms behind the position the player reports, on single-clip looping playback only — a multi-clip timeline holds nothing back and keeps its latency, which a test pins. Ten milliseconds is an order of magnitude inside the threshold where a viewer notices audio trailing video.

One deliberate softening: an unexpected PCM encoding drops the processor out of the chain (`AudioFormat.NOT_SET`) instead of throwing. `GainProcessor` throws `UnhandledAudioFormatException` here, which surfaces as a playback error; a fade must never cost the audio.

## The freeze

The container duration of an MP4 is its *longest* track. Where a video's audio track is declared longer than its video track, looping to the container replays the difference as a frozen last frame.

`boundedCommonTrackEndMs` already clamped that — on Android only for local files, because reading a remote source's track lengths is blocking I/O and it ran on the platform thread. Every `https://` clip therefore returned `null` and kept the seam. iOS has no such limit: it awaits `load(.timeRange)` on both tracks before building the composition, which is why the same videos loop cleanly there and hitch here.

Measured over 59 live feed videos, comparing each file's video-track duration against its container:

| Container longer by | Videos |
|---|---|
| 0 (exact) | 32 (54%) |
| ≤ 10 ms | 9 (15%) |
| 10–50 ms | 16 (27%) |
| 50–500 ms | 2 (3%) |
| > 500 ms | 0 |

**27 of 59 (46%) freeze on Android**, by up to 69 ms — one to two frames at every restart. All are inside the existing 500 ms bound, so this is the remote-source gap, not the bound.

Android now reads local-file lengths before applying clips. Remote lengths warm on a single-thread executor without sitting in front of `setClips` or first frame; if the answer lands for the active generation, the current playlist is tightened in place, and otherwise the cached answer trims the next play of that source. Results are cached per source and bounded, so a failover to a mirror or a second visit does not pay the read again, and a source whose lengths cannot be read caches as unreadable rather than retrying every attempt. A newer `setClips` bumps a generation so a late background result cannot apply over clips that replaced it. If a metadata read misses its deadline, that player disables further probes and plays unclamped rather than making every later load wait behind a pinned native read.

**Related Issues:** Closes #6468, closes #6485

## Out of Scope

- Clip joins *inside* a multi-clip timeline still cut hard. Whether those want a declick fade or a crossfade is a product call, and changing them would alter how existing multi-clip edits sound.
- Android leaves multi-clip timelines unfaded at their outer edges too, where Apple fades them. Closing that gap needs a per-clip end signal rather than the stream end; the surface it affects is the editor's looping preview, not the feed.
- The 500 ms clamp bound is untouched. No live feed video in the sample exceeds it; the bundled Vine seed assets contain a 754 ms case, where the mux declares 762 ms of audio it has no packets for. Making the bound asymmetric — unbounded when the *audio* is the longer track, since a frozen frame is always wrong — is tracked in #6486.
- A musically seamless loop is not a player concern. The corpus is cut at a stopwatch, not on a beat, so the choice at the join is a click or a short dip; a crossfade would have to be chosen where the loop point is set, in the recorder or editor, and the video loop would have to lose the same overlap.
- A drain in the middle of a stream — `setPlaybackSpeed` on a running loop — now releases the held tail faded, so that moment carries a ~20 ms dip instead of a hard cut. It does not occur in the feed.
- Export is untouched — this is the playback path only.

## Verification

- `gradle :divine_video_player:testDebugUnitTest` — green, with coverage over the declick processor and clamp resolution: local clips waiting for track lengths before the player is touched, remote clips starting immediately while metadata warms in the background, a late resolution being dropped rather than applied over newer clips, a metadata timeout disabling future probes on that player, and an unreadable source still reaching the player unclamped. The clamp had no Android unit test before — `mockHandler` is a relaxed mock, so `post {}` never ran, and `trimToCommonTrackEnd` did not appear in the test file at all. Five pin the fade-in curve and the length cap; eleven are buffer-level, driving `configure → flush → queueInput → getOutput → queueEndOfStream` over real PCM: the tail fading to zero where the stream ends rather than where the container claims, an unknown declared length still fading out, the ramp falling monotonically into the join, the held-back 10 ms, a flush dropping the tail instead of replaying it late, a multi-clip timeline passing through with no delay, the seek offset surviving both flushes of a seek, the decode-only buffers not anchoring a loop, a restart re-arming the fade in, and two stereo tests over per-channel gain and frames-not-samples.
- Mutation-checked: suppressing the tail release, releasing it unfaded, keeping it across a flush, holding frames back with the fade off, dropping `channelCount` from the interleave index, and counting samples as frames each turned exactly their own tests red and nothing else.
- `flutter test` in `packages/divine_video_player` — 276 tests, green.
- `flutter analyze lib test` and `dart format` — clean.
- The Apple ramp layout was verified by running the builder against real AVFoundation and reading the ramps back with `getVolumeRamp`, across a feed video, a muted video, a 12 ms video, and multi-clip timelines with mixed gains — including the before/after on the composition's last sample quoted above. That is also how the overlap exception was found.
- Mutation-checked on the clamp too: dropping the generation guard, and applying the clips without waiting for the resolution, each turned exactly their own tests red.
- Verified on device: the click at the loop join is gone on both platforms, on the first restart as well as later ones, and the restart hitch on Android is gone.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
